### PR TITLE
fixed a compilation error on macosx(mavericks)

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1398,11 +1398,13 @@ class PosixEnv : public Env {
                 (unsigned long)t);
 
         // Set the thread name to aid debugging
-#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ) && (__GLIBC_PREREQ(2, 12))
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
+#if defined(__GLIBC_PREREQ(2, 12))
         char name_buf[16];
         snprintf(name_buf, sizeof name_buf, "rocksdb:bg%zu", bgthreads_.size());
         name_buf[sizeof name_buf - 1] = '\0';
         pthread_setname_np(t, name_buf);
+#endif
 #endif
 
         bgthreads_.push_back(t);


### PR DESCRIPTION
hi, I just compiled the latest sources on my local mac os x (mavericks).
in compiling, there is a single compilation errors like this. 

```
util/env_posix.cc:1401:71: error: missing binary operator before token "("
```

my compiler is same with the recommended version.

```
[junyoung@junyoung-2:/opt/rocksdb]$ g++ --version
g++ (GCC) 4.7.3
Copyright (C) 2012 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

and os information is here

```
[junyoung@junyoung-2:/opt/rocksdb]$ uname -a
Darwin junyoung-2.local 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
```

to fix the problem I mentioned. we need to apply the following patch to the trunk.

```
diff --git a/util/env_posix.cc b/util/env_posix.cc
index 16c3d1c..fc97465 100644
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1398,12 +1398,14 @@ class PosixEnv : public Env {
                 (unsigned long)t);

         // Set the thread name to aid debugging
-#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ) && (__GLIBC_PREREQ(2, 12))
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
+#if defined(__GLIBC_PREREQ(2, 12))
         char name_buf[16];
         snprintf(name_buf, sizeof name_buf, "rocksdb:bg%zu", bgthreads_.size());
         name_buf[sizeof name_buf - 1] = '\0';
         pthread_setname_np(t, name_buf);
 #endif
+#endif

         bgthreads_.push_back(t);
       }
```
