### PR TITLE
fixed a compilation error on mac os x (mavericks)

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -247,7 +247,7 @@ void BackupEngine::DeleteBackupsNewerThan(uint64_t sequence_number) {
   for (auto backup : backups_) {
     if (backup.second.GetSequenceNumber() > sequence_number) {
       Log(options_.info_log,
-          "Deleting backup %u because sequence number (%lu) is newer than %lu",
+          "Deleting backup %u because sequence number (%llu) is newer than %llu",
           backup.first, backup.second.GetSequenceNumber(), sequence_number);
       backup.second.Delete();
       obsolete_backups_.push_back(backup.first);
@@ -742,9 +742,9 @@ Status BackupEngine::BackupMeta::LoadFromFile(const std::string& backup_dir) {
 
   uint32_t num_files = 0;
   int bytes_read = 0;
-  sscanf(data.data(), "%ld%n", &timestamp_, &bytes_read);
+  sscanf(data.data(), "%lld%n", &timestamp_, &bytes_read);
   data.remove_prefix(bytes_read + 1); // +1 for '\n'
-  sscanf(data.data(), "%lu%n", &sequence_number_, &bytes_read);
+  sscanf(data.data(), "%llu%n", &sequence_number_, &bytes_read);
   data.remove_prefix(bytes_read + 1); // +1 for '\n'
   sscanf(data.data(), "%u%n", &num_files, &bytes_read);
   data.remove_prefix(bytes_read + 1); // +1 for '\n'


### PR DESCRIPTION
in my local computer, there are compilation errors.

```
g++ -g -Wall -Werror -I. -I./include -std=gnu++11  -DROCKSDB_PLATFORM_POSIX  -DOS_MACOSX -DROCKSDB_ATOMIC_PRESENT -DSNAPPY -DGFLAGS -DZLIB -DBZIP2   -DHAVE_JEMALLOC -O2 -fno-omit-frame-pointer -momit-leaf-frame-pointer -Woverloaded-virtual -c utilities/backupable/backupable_db.cc -o utilities/backupable/backupable_db.o 
utilities/backupable/backupable_db.cc:251:25: error: format specifies type 'unsigned long' but the argument has type 'uint64_t'
      (aka 'unsigned long long') [-Werror,-Wformat]
          backup.first, backup.second.GetSequenceNumber(), sequence_number);
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utilities/backupable/backupable_db.cc:251:60: error: format specifies type 'unsigned long' but the argument has type 'uint64_t'
      (aka 'unsigned long long') [-Werror,-Wformat]
          backup.first, backup.second.GetSequenceNumber(), sequence_number);
                                                           ^~~~~~~~~~~~~~~
utilities/backupable/backupable_db.cc:745:32: error: format specifies type 'long *' but the argument has type 'int64_t *'
      (aka 'long long *') [-Werror,-Wformat]
  sscanf(data.data(), "%ld%n", &timestamp_, &bytes_read);
                       ~~~     ^~~~~~~~~~~
                       %lld
utilities/backupable/backupable_db.cc:747:32: error: format specifies type 'unsigned long *' but the argument has type
      'uint64_t *' (aka 'unsigned long long *') [-Werror,-Wformat]
  sscanf(data.data(), "%lu%n", &sequence_number_, &bytes_read);
                       ~~~     ^~~~~~~~~~~~~~~~~
                       %llu
4 errors generated.
```

local environment to compile is

```
$ uname -a; g++ --version
Darwin junyoung.local 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.0
Thread model: posix
```
