### PR TITLE
Eliminate stdout message when launching a posix thread.

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -1393,9 +1393,6 @@ class PosixEnv : public Env {
                          nullptr,
                          &ThreadPool::BGThreadWrapper,
                          this));
-        fprintf(stdout,
-                "Created bg thread 0x%lx\n",
-                (unsigned long)t);
 
         // Set the thread name to aid debugging
 #if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)


### PR DESCRIPTION
This seems out of place as it's the only time RocksDB prints to stdout in the normal course of operations. A list of thread IDs can still be retrieved from the LOG file: `cut -d ' ' -f2 LOG | sort | uniq | egrep -x '[0-9a-f]+'`
