### PR TITLE
Fix share_table_files condition in BackupEngine constructor.

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -177,7 +177,7 @@ BackupEngine::BackupEngine(Env* db_env, const BackupableDBOptions& options)
 
   // create all the dirs we need
   backup_env_->CreateDirIfMissing(GetAbsolutePath());
-  if (!options_.share_table_files) {
+  if (options_.share_table_files) {
     backup_env_->CreateDirIfMissing(GetAbsolutePath(GetSharedFileRel()));
   }
   backup_env_->CreateDirIfMissing(GetAbsolutePath(GetPrivateDirRel()));


### PR DESCRIPTION
When I first `make check`, I got an error below.

```
==== Test BackupableDBTest.NoDoubleCopy
utilities/backupable/backupable_db_test.cc:420: IO error: /tmp/rocksdbtest-1000/backupable_db_backup/shared/00010.sst.tmp: No such file or directory
#0   ./backupable_db_test() [0x43846c] ~Status  /home/vagrant/git/rocksdb/./include/rocksdb/status.h:29
#1   ./backupable_db_test() [0x4d9ecb] rocksdb::test::RunAllTests()     /home/vagrant/git/rocksdb/util/testharness.cc:46
#2   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5) [0x2aec24cd2de5] ??        ??:0
#3   ./backupable_db_test() [0x42f71e] _start   ??:?
make: *** [check] Error 1

~$ ls /tmp/rocksdbtest-1000/backupable_db_backup/
LATEST_BACKUP  meta  private
```

`shared` directory that should exists was not created correctly.
So I fixed an if-condition in BackupEngine constructor. Could you accept this PR if this fix is correct?
