### PR TITLE
Background data block prefetching in database iterators

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -749,6 +749,12 @@ void rocksdb_readoptions_set_snapshot(
   opt->rep.snapshot = (snap ? snap->rep : NULL);
 }
 
+void rocksdb_readoptions_set_prefetch(
+    rocksdb_readoptions_t* opt,
+    unsigned char v) {
+  opt->rep.prefetch = v;
+}
+
 rocksdb_writeoptions_t* rocksdb_writeoptions_create() {
   return new rocksdb_writeoptions_t;
 }

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -242,6 +242,8 @@ DEFINE_int32(cache_remove_scan_count_limit, 32, "");
 DEFINE_bool(verify_checksum, false, "Verify checksum for every block read"
             " from storage");
 
+DEFINE_bool(prefetch, false, "Enable block prefetching in forward sequential reads");
+
 DEFINE_bool(statistics, false, "Database statistics");
 static class std::shared_ptr<rocksdb::Statistics> dbstats;
 
@@ -1627,7 +1629,9 @@ class Benchmark {
   }
 
   void ReadSequential(ThreadState* thread) {
-    Iterator* iter = db_->NewIterator(ReadOptions(FLAGS_verify_checksum, true));
+    ReadOptions opts(FLAGS_verify_checksum, true);
+    opts.prefetch = FLAGS_prefetch;
+    Iterator* iter = db_->NewIterator(opts);
     long long i = 0;
     int64_t bytes = 0;
     for (iter->SeekToFirst(); i < reads_ && iter->Valid(); iter->Next()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -250,7 +250,7 @@ Iterator* Version::NewConcatenatingIterator(const ReadOptions& options,
     }
   }
   return NewTwoLevelIterator(level_iter, &GetFileIterator,
-                             vset_->table_cache_, options, soptions);
+                             vset_->table_cache_, options, soptions, vset_->env_);
 }
 
 void Version::AddIterators(const ReadOptions& options,
@@ -2011,7 +2011,7 @@ Iterator* VersionSet::MakeInputIterator(Compaction* c) {
         // Create concatenating iterator for the files from this level
         list[num++] = NewTwoLevelIterator(
             new Version::LevelFileNumIterator(icmp_, &c->inputs_[which]),
-            &GetFileIterator, table_cache_, options, storage_options_,
+            &GetFileIterator, table_cache_, options, storage_options_, env_,
             true /* for compaction */);
       }
     }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -293,7 +293,9 @@ extern void rocksdb_readoptions_set_fill_cache(
 extern void rocksdb_readoptions_set_snapshot(
     rocksdb_readoptions_t*,
     const rocksdb_snapshot_t*);
-
+extern void rocksdb_readoptions_set_prefetch(
+    rocksdb_readoptions_t*,
+    unsigned char);
 /* Write options */
 
 extern rocksdb_writeoptions_t* rocksdb_writeoptions_create();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -711,20 +711,28 @@ struct ReadOptions {
   // Default: kReadAllTier
   ReadTier read_tier;
 
+  // If true, forward-moving iterators will attempt to use a background thread
+  // to prime caches with upcoming blocks. Can reduce I/O and decompression
+  // stalls during bulk scans of large databases, especially on rotating
+  // disks.
+  bool prefetch;
+
   ReadOptions()
       : verify_checksums(false),
         fill_cache(true),
         prefix_seek(false),
         snapshot(nullptr),
         prefix(nullptr),
-        read_tier(kReadAllTier) {}
+        read_tier(kReadAllTier),
+        prefetch(false) {}
   ReadOptions(bool cksum, bool cache)
       : verify_checksums(cksum),
         fill_cache(cache),
         prefix_seek(false),
         snapshot(nullptr),
         prefix(nullptr),
-        read_tier(kReadAllTier) {}
+        read_tier(kReadAllTier),
+        prefetch(false) {}
 };
 
 // Options that control write operations

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -971,7 +971,9 @@ Iterator* BlockBasedTable::NewIterator(const ReadOptions& options) {
            const_cast<BlockBasedTable*>(this),
            options,
            rep_->soptions,
-           rep_->options.env
+           rep_->options.env,
+           false, // for_compaction
+           true   // can_prefetch: allow block prefetching if requested in options
          );
 }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -970,7 +970,8 @@ Iterator* BlockBasedTable::NewIterator(const ReadOptions& options) {
            &BlockBasedTable::BlockReader,
            const_cast<BlockBasedTable*>(this),
            options,
-           rep_->soptions
+           rep_->soptions,
+           rep_->options.env
          );
 }
 

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -31,6 +31,7 @@ class TwoLevelIterator: public Iterator {
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
+    const Env* env,
     bool for_compaction);
 
   virtual ~TwoLevelIterator();
@@ -76,6 +77,7 @@ class TwoLevelIterator: public Iterator {
   void* arg_;
   const ReadOptions options_;
   const EnvOptions& soptions_;
+  const Env* env_;
   Status status_;
   PeekingIteratorWrapper index_iter_;
   IteratorWrapper data_iter_; // May be nullptr
@@ -91,11 +93,13 @@ TwoLevelIterator::TwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
+    const Env *env,
     bool for_compaction)
     : block_function_(block_function),
       arg_(arg),
       options_(options),
       soptions_(soptions),
+      env_(env),
       index_iter_(index_iter),
       data_iter_(nullptr),
       for_compaction_(for_compaction) {
@@ -197,9 +201,10 @@ Iterator* NewTwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
+    const Env *env,
     bool for_compaction) {
   return new TwoLevelIterator(index_iter, block_function, arg,
-                              options, soptions, for_compaction);
+                              options, soptions, env, for_compaction);
 }
 
 }  // namespace rocksdb

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -77,7 +77,7 @@ class TwoLevelIterator: public Iterator {
   const ReadOptions options_;
   const EnvOptions& soptions_;
   Status status_;
-  IteratorWrapper index_iter_;
+  PeekingIteratorWrapper index_iter_;
   IteratorWrapper data_iter_; // May be nullptr
   // If data_iter_ is non-nullptr, then "data_block_handle_" holds the
   // "index_value" passed to block_function_ to create the data_iter_.

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -14,6 +14,9 @@
 #include "table/block.h"
 #include "table/format.h"
 #include "table/iterator_wrapper.h"
+#include "port/port.h"
+#include "util/mutexlock.h"
+
 
 namespace rocksdb {
 
@@ -23,6 +26,14 @@ typedef Iterator* (*BlockFunction)(void*, const ReadOptions&,
                                    const EnvOptions& soptions, const Slice&,
                                    bool for_compaction);
 
+struct PrefetchState {
+  port::Mutex mu;
+  bool outstanding;
+  std::string data_block_handle_to_prefetch;
+
+  PrefetchState() : outstanding(false) {}
+};
+
 class TwoLevelIterator: public Iterator {
  public:
   TwoLevelIterator(
@@ -31,8 +42,9 @@ class TwoLevelIterator: public Iterator {
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
-    const Env* env,
-    bool for_compaction);
+    Env* env,
+    bool for_compaction,
+    bool can_prefetch);
 
   virtual ~TwoLevelIterator();
 
@@ -77,7 +89,7 @@ class TwoLevelIterator: public Iterator {
   void* arg_;
   const ReadOptions options_;
   const EnvOptions& soptions_;
-  const Env* env_;
+  Env* env_;
   Status status_;
   PeekingIteratorWrapper index_iter_;
   IteratorWrapper data_iter_; // May be nullptr
@@ -85,6 +97,12 @@ class TwoLevelIterator: public Iterator {
   // "index_value" passed to block_function_ to create the data_iter_.
   std::string data_block_handle_;
   bool for_compaction_;
+  bool can_prefetch_;
+
+  PrefetchState* prefetch_;
+  void MaybeSchedulePrefetch();
+  void PrefetchThread();
+  static void PrefetchThreadEntry(void*);
 };
 
 TwoLevelIterator::TwoLevelIterator(
@@ -93,8 +111,9 @@ TwoLevelIterator::TwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
-    const Env *env,
-    bool for_compaction)
+    Env *env,
+    bool for_compaction,
+    bool can_prefetch)
     : block_function_(block_function),
       arg_(arg),
       options_(options),
@@ -102,10 +121,30 @@ TwoLevelIterator::TwoLevelIterator(
       env_(env),
       index_iter_(index_iter),
       data_iter_(nullptr),
-      for_compaction_(for_compaction) {
+      for_compaction_(for_compaction),
+      can_prefetch_(can_prefetch),
+      prefetch_(nullptr) {
 }
 
 TwoLevelIterator::~TwoLevelIterator() {
+  if (prefetch_ != nullptr) {
+    // Await completion of any outstanding background prefetching task, since
+    // it assumes existence of this
+    // FIXME: avoid spinlock
+    // FIXME: deadlocks if background thread pool size is 0.
+    //        env_->Schedule doesn't give any feedback if this is the case!
+    {
+      MutexLock l0(&prefetch_->mu);
+      prefetch_->data_block_handle_to_prefetch.clear();
+    }
+    while (true) {
+      MutexLock l1(&prefetch_->mu);
+      if (!prefetch_->outstanding) {
+        break;
+      }
+    }
+    delete prefetch_;
+  }
 }
 
 void TwoLevelIterator::Seek(const Slice& target) {
@@ -141,7 +180,6 @@ void TwoLevelIterator::Prev() {
   SkipEmptyDataBlocksBackward();
 }
 
-
 void TwoLevelIterator::SkipEmptyDataBlocksForward() {
   while (data_iter_.iter() == nullptr || (!data_iter_.Valid() &&
         !data_iter_.status().IsIncomplete())) {
@@ -151,6 +189,7 @@ void TwoLevelIterator::SkipEmptyDataBlocksForward() {
       return;
     }
     index_iter_.Next();
+    MaybeSchedulePrefetch();
     InitDataBlock();
     if (data_iter_.iter() != nullptr) data_iter_.SeekToFirst();
   }
@@ -193,6 +232,66 @@ void TwoLevelIterator::InitDataBlock() {
   }
 }
 
+void TwoLevelIterator::PrefetchThreadEntry(void* p) {
+  TwoLevelIterator* it = reinterpret_cast<TwoLevelIterator*>(p);
+  it->PrefetchThread();
+}
+
+// If called for, schedule prefetching (cache-priming) of the next data block
+void TwoLevelIterator::MaybeSchedulePrefetch() {
+  if (can_prefetch_ && options_.prefetch && !for_compaction_ && index_iter_.HasNext()) {
+    // peek at next data block handle
+    Slice next_data_block_handle = index_iter_.NextValue();
+    if (prefetch_ == nullptr) {
+      // lazy initialization of prefetch state
+      prefetch_ = new PrefetchState;
+    }
+    // Update the internal state to signal which block we'd like prefetched
+    MutexLock l(&prefetch_->mu);
+    prefetch_->data_block_handle_to_prefetch.assign(next_data_block_handle.data(),
+                                                    next_data_block_handle.size());
+    // Schedule a prefetching task if there is not already one outstanding.
+    // Note we do not wait for any outstanding prefetch task to complete,
+    // avoiding the need for additional synchronization here. However,
+    // depending on the speed of the iterator's consumer vs. the speed of
+    // prefetching, some prefetching effort may be wasted, and/or some
+    // prefetching opportunities may be missed. That's OK since this is just a
+    // cache-priming optimization.
+    if (!prefetch_->outstanding) {
+      env_->Schedule(&TwoLevelIterator::PrefetchThreadEntry, this, Env::Priority::LOW);
+      prefetch_->outstanding = true;
+    }
+  }
+}
+
+// The prefetching background task
+void TwoLevelIterator::PrefetchThread() {
+  std::string data_block_handle_to_prefetch;
+  assert(prefetch_);
+
+  while (true) {
+    // Loop for as long as we find a new block to prefetch.
+    { // scope MutexLock l
+      MutexLock l(&prefetch_->mu);
+      if (prefetch_->data_block_handle_to_prefetch.empty() || data_block_handle_to_prefetch == prefetch_->data_block_handle_to_prefetch) {
+        prefetch_->outstanding = false;
+        return;
+      }
+      data_block_handle_to_prefetch.assign(prefetch_->data_block_handle_to_prefetch);
+    }
+
+    // Open an iterator for the block and immediately throw it away, thus
+    // priming various caches: HDD, OS/filesystem, compressed blocks,
+    // uncompressed blocks. If the iterator ends up needing the block in the
+    // main thread before we finish prefetching it, it will duplicate some of
+    // our effort, especially decompression. However, we will at least have
+    // helped it by initiating any necessary disk read in advance.
+    Iterator* iter = (*block_function_)(arg_, options_, soptions_, Slice(data_block_handle_to_prefetch),
+                                          for_compaction_);
+    delete iter;
+  }
+}
+
 }  // namespace
 
 Iterator* NewTwoLevelIterator(
@@ -201,10 +300,11 @@ Iterator* NewTwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
-    const Env *env,
-    bool for_compaction) {
+    Env *env,
+    bool for_compaction,
+    bool can_prefetch) {
   return new TwoLevelIterator(index_iter, block_function, arg,
-                              options, soptions, env, for_compaction);
+                              options, soptions, env, for_compaction, can_prefetch);
 }
 
 }  // namespace rocksdb

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -35,6 +35,7 @@ extern Iterator* NewTwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
+    const Env* env,
     bool for_compaction = false);
 
 }  // namespace rocksdb

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -24,6 +24,11 @@ struct ReadOptions;
 //
 // Uses a supplied function to convert an index_iter value into
 // an iterator over the contents of the corresponding block.
+//
+// If can_prefetch and options.prefetch are both true, then the two-level
+// iterator may env->Schedule() tasks on background threads to prefetch
+// upcoming lower-level blocks during forward iteration. In this case,
+// block_function must be thread-safe.
 extern Iterator* NewTwoLevelIterator(
     Iterator* index_iter,
     Iterator* (*block_function)(
@@ -35,7 +40,8 @@ extern Iterator* NewTwoLevelIterator(
     void* arg,
     const ReadOptions& options,
     const EnvOptions& soptions,
-    const Env* env,
-    bool for_compaction = false);
+    Env* env,
+    bool for_compaction = false,
+    bool can_prefetch = false);
 
 }  // namespace rocksdb


### PR DESCRIPTION
**This PR probably isn't ready to merge yet** (see FIXMEs) but I wanted to solicit any early comments/feedback.

Adds a read option for RocksDB iterators to schedule background thread tasks to "prefetch" upcoming data blocks. This can significantly speed up forward sequential scans by overlapping disk I/O and decompression with the reader's activities. The benefit is quite marked on large, universally-compacted databases residing on rotating disk(s), since scanning these incurs a lot of seeks that currently block iterators. The new behavior must be enabled by creating the iterator with ReadOptions.prefetch = true.
