### PR TITLE
crc32c: choose function in static initialization

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -333,17 +333,14 @@ static bool isSSE42() {
 }
 
 typedef void (*Function)(uint64_t*, uint8_t const**);
-static Function func = nullptr;
 
 static inline Function Choose_CRC32() {
   return isSSE42() ? Fast_CRC32 : Slow_CRC32;
 }
 
+static Function func = Choose_CRC32();
+
 static inline void CRC32(uint64_t* l, uint8_t const **p) {
-  if (func != nullptr) {
-    return func(l, p);
-  }
-  func = Choose_CRC32();
   func(l, p);
 }
 


### PR DESCRIPTION
crc32c: choose function in static initialization

Before: 4.430 micros/op 225732 ops/sec; 881.8 MB/s (4K per op)
After: 4.125 micros/op 242425 ops/sec; 947.0 MB/s (4K per op)
