### PR TITLE
Support for xxHash checksums

### DIFF
--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -38,6 +38,8 @@
 #include "hdfs/env_hdfs.h"
 #include "utilities/merge_operators.h"
 
+#include "../xxhash/xxhash.h"
+#include "../xxhash/xxhash.c"
 
 DEFINE_string(benchmarks,
 
@@ -60,6 +62,7 @@ DEFINE_string(benchmarks,
               "randomwithverify,"
               "fill100K,"
               "crc32c,"
+              "xxhash,"
               "snappycomp,"
               "snappyuncomp,"
               "acquireload,"
@@ -103,6 +106,7 @@ DEFINE_string(benchmarks,
               "\tnewiterator   -- repeated iterator creation\n"
               "\tseekrandom    -- N random seeks\n"
               "\tcrc32c        -- repeated crc32c of 4K of data\n"
+              "\txxhash        -- repeated xxHash of 4K of data\n"
               "\tacquireload   -- load N*1000 times\n"
               "Meta operations:\n"
               "\tcompact     -- Compact the entire DB\n"
@@ -1144,6 +1148,8 @@ class Benchmark {
         method = &Benchmark::Compact;
       } else if (name == Slice("crc32c")) {
         method = &Benchmark::Crc32c;
+      } else if (name == Slice("xxhash")) {
+        method = &Benchmark::xxHash;
       } else if (name == Slice("acquireload")) {
         method = &Benchmark::AcquireLoad;
       } else if (name == Slice("snappycomp")) {
@@ -1281,6 +1287,25 @@ class Benchmark {
     }
     // Print so result is not dead
     fprintf(stderr, "... crc=0x%x\r", static_cast<unsigned int>(crc));
+
+    thread->stats.AddBytes(bytes);
+    thread->stats.AddMessage(label);
+  }
+
+  void xxHash(ThreadState* thread) {
+    // Checksum about 500MB of data total
+    const int size = 4096;
+    const char* label = "(4K per op)";
+    std::string data(size, 'x');
+    int64_t bytes = 0;
+    unsigned int xxh32 = 0;
+    while (bytes < 500 * 1048576) {
+      xxh32 = XXH32(data.data(), size, 0);
+      thread->stats.FinishedSingleOp(nullptr);
+      bytes += size;
+    }
+    // Print so result is not dead
+    fprintf(stderr, "... xxh32=0x%x\r", static_cast<unsigned int>(xxh32));
 
     thread->stats.AddBytes(bytes);
     thread->stats.AddMessage(label);


### PR DESCRIPTION
This is the start of a pull request to motivate making the hash function configurable. CRC32C is currently "hard-coded" a bit in the library, so to do this will take a bit of refactoring that might be easier for one of the FB team to do?

Anyway, with level style compaction and when not using compression or using compression only at higher levels, CRC32C is the highest or second highest function (after memcpy) in perf top.

One step to reduce this is to make abd70ecc2b7fe02709955ef14905d1628581b306 configurable again, but ideally one wants some kind of hash checksum.

Presenting xxHash from https://code.google.com/p/xxhash/

$ ./db_bench -benchmarks crc32c,xxhash
CPU: 4 \* Intel(R) Core(TM) i7-3540M CPU @ 3.00GHz
crc32c: 1.311 micros/op 762735 ops/sec; 2979.4 MB/s (4K per op)
xxhash: 0.601 micros/op 1664997 ops/sec; 6503.9 MB/s (4K per op)
