### PR TITLE
Fix copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD License
 
 For rocksdb software
 
-Copyright (c) 2013, Facebook, Inc.
+Copyright (c) 2014, Facebook, Inc.
 All rights reserved.
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
Fix outdated copyright year (update to 2014)

The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
