### PR TITLE
only use MAP_HUGETLB when the kernel supports it

### DIFF
--- a/util/arena.cc
+++ b/util/arena.cc
@@ -83,9 +83,8 @@ char* Arena::AllocateAligned(size_t bytes, size_t huge_page_tlb_size,
     size_t reserved_size =
         ((bytes - 1U) / huge_page_tlb_size + 1U) * huge_page_tlb_size;
     assert(reserved_size >= bytes);
-
     void* addr = mmap(nullptr, reserved_size, (PROT_READ | PROT_WRITE),
-                       (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), 0, 0);
+                      (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), 0, 0);
 
     if (addr == MAP_FAILED) {
       Warn(logger, "AllocateAligned fail to allocate huge TLB pages: %s",


### PR DESCRIPTION
- for compilation on kernels older than 2.6.34
