### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+compiler: gcc
+before_install:
+# As of this writing (10 May 2014) the Travis build environment is Ubuntu 12.04,
+# which needs the following ugly dependency incantations to build RocksDB:
+ - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+ - sudo apt-get update -qq
+ - sudo apt-get install -y -qq gcc-4.8 g++-4.8 zlib1g-dev libbz2-dev libsnappy-dev libjemalloc-dev
+ - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+ - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+ - wget https://gflags.googlecode.com/files/libgflags0_2.0-1_amd64.deb
+ - sudo dpkg -i libgflags0_2.0-1_amd64.deb
+ - wget https://gflags.googlecode.com/files/libgflags-dev_2.0-1_amd64.deb
+ - sudo dpkg -i libgflags-dev_2.0-1_amd64.deb
+# Lousy hack to disable use and testing of fallocate, which doesn't behave quite
+# as EnvPosixTest::AllocateTest expects within the Travis OpenVZ environment.
+ - sed -i "s/fallocate(/HACK_NO_fallocate(/" build_tools/build_detect_platform
+script: make check -j8
+


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) is a free continuous integration system used by many public GitHub projects, particularly useful for testing pull requests automatically (as well as all pushes to the repo). I came up with this script to tell Travis how to run RocksDB's `make check`. [Example build on my fork](https://travis-ci.org/mlin/rocksdb)

NB, this commit is necessary but not sufficient for Travis to work on your repo. An admin of the facebook GitHub org would also need to follow the Travis [Getting started instructions](http://docs.travis-ci.com/user/getting-started/) and flip the switch for the rocksdb repo. There are some security considerations there.

Interestingly, `fallocate` within Travis' OpenVZ containers don't seem to behave exactly as one of RocksDB's test cases expects. I'm not sure what file system is being used underneath, but going by Docker's example it might be somewhat exotic like AUFS or btrfs. I put in a lousy hack to disable use and testing of fallocate in Travis.
