### PR TITLE
RocksDB changes to support unity build:

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -49,15 +49,6 @@ ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {
 
 uint32_t ColumnFamilyHandleImpl::GetID() const { return cfd()->GetID(); }
 
-namespace {
-// Fix user-supplied options to be reasonable
-template <class T, class V>
-static void ClipToRange(T* ptr, V minvalue, V maxvalue) {
-  if (static_cast<V>(*ptr) > maxvalue) *ptr = maxvalue;
-  if (static_cast<V>(*ptr) < minvalue) *ptr = minvalue;
-}
-}  // anonymous namespace
-
 ColumnFamilyOptions SanitizeOptions(const InternalKeyComparator* icmp,
                                     const InternalFilterPolicy* ipolicy,
                                     const ColumnFamilyOptions& src) {

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -18,7 +18,7 @@
 
 namespace rocksdb {
 
-static uint64_t TotalFileSize(const std::vector<FileMetaData*>& files) {
+uint64_t TotalFileSize(const std::vector<FileMetaData*>& files) {
   uint64_t sum = 0;
   for (size_t i = 0; i < files.size() && files[i]; i++) {
     sum += files[i]->file_size;

--- a/db/compaction.h
+++ b/db/compaction.h
@@ -10,7 +10,11 @@
 #pragma once
 #include "db/version_set.h"
 
+#include <vector>
+
 namespace rocksdb {
+
+struct FileMetaData;
 
 class Version;
 class ColumnFamilyData;
@@ -154,5 +158,8 @@ class Compaction {
   // to pick up the next file to be compacted from files_by_size_
   void ResetNextCompactionIndex();
 };
+
+// Utility function
+extern uint64_t TotalFileSize(const std::vector<FileMetaData*>& files);
 
 }  // namespace rocksdb

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -19,14 +19,6 @@ namespace rocksdb {
 
 namespace {
 
-uint64_t TotalFileSize(const std::vector<FileMetaData*>& files) {
-  uint64_t sum = 0;
-  for (size_t i = 0; i < files.size() && files[i]; i++) {
-    sum += files[i]->file_size;
-  }
-  return sum;
-}
-
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, int op2) {
   if (op1 == 0) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -252,15 +252,6 @@ struct DBImpl::CompactionState {
   }
 };
 
-namespace {
-// Fix user-supplied options to be reasonable
-template <class T, class V>
-static void ClipToRange(T* ptr, V minvalue, V maxvalue) {
-  if (static_cast<V>(*ptr) > maxvalue) *ptr = maxvalue;
-  if (static_cast<V>(*ptr) < minvalue) *ptr = minvalue;
-}
-}  // anonymous namespace
-
 Options SanitizeOptions(const std::string& dbname,
                         const InternalKeyComparator* icmp,
                         const InternalFilterPolicy* ipolicy,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -632,4 +632,11 @@ CompressionType GetCompressionType(const Options& options, int level,
 // Determine compression type for L0 file written by memtable flush.
 CompressionType GetCompressionFlush(const Options& options);
 
+// Fix user-supplied options to be reasonable
+template <class T, class V>
+inline void ClipToRange(T* ptr, V minvalue, V maxvalue) {
+  if (static_cast<V>(*ptr) > maxvalue) *ptr = maxvalue;
+  if (static_cast<V>(*ptr) < minvalue) *ptr = minvalue;
+}
+
 }  // namespace rocksdb

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -45,7 +45,6 @@ namespace rocksdb {
 
 extern const std::string kHashIndexPrefixesBlock;
 extern const std::string kHashIndexPrefixesMetadataBlock;
-namespace {
 
 typedef BlockBasedTableOptions::IndexType IndexType;
 
@@ -334,8 +333,6 @@ Slice CompressBlock(const Slice& raw,
   *type = kNoCompression;
   return raw;
 }
-
-}  // anonymous namespace
 
 // kBlockBasedTableMagicNumber was picked by running
 //    echo rocksdb.table.block_based | sha1sum

--- a/table/merger.cc
+++ b/table/merger.cc
@@ -23,7 +23,7 @@
 #include "util/autovector.h"
 
 namespace rocksdb {
-namespace {
+namespace merger {
 typedef std::priority_queue<
           IteratorWrapper*,
           std::vector<IteratorWrapper*>,
@@ -43,7 +43,7 @@ MaxIterHeap NewMaxIterHeap(const Comparator* comparator) {
 MinIterHeap NewMinIterHeap(const Comparator* comparator) {
   return MinIterHeap(MinIteratorComparator(comparator));
 }
-}  // namespace
+}  // namespace merger
 
 const size_t kNumIterReserve = 4;
 
@@ -56,8 +56,8 @@ class MergingIterator : public Iterator {
         current_(nullptr),
         use_heap_(true),
         direction_(kForward),
-        maxHeap_(NewMaxIterHeap(comparator_)),
-        minHeap_(NewMinIterHeap(comparator_)) {
+        maxHeap_(merger::NewMaxIterHeap(comparator_)),
+        minHeap_(merger::NewMinIterHeap(comparator_)) {
     children_.resize(n);
     for (int i = 0; i < n; i++) {
       children_[i].Set(children[i]);
@@ -274,8 +274,8 @@ class MergingIterator : public Iterator {
     kReverse
   };
   Direction direction_;
-  MaxIterHeap maxHeap_;
-  MinIterHeap minHeap_;
+  merger::MaxIterHeap maxHeap_;
+  merger::MinIterHeap minHeap_;
 };
 
 void MergingIterator::FindSmallest() {
@@ -302,8 +302,8 @@ void MergingIterator::FindLargest() {
 
 void MergingIterator::ClearHeaps() {
   use_heap_ = true;
-  maxHeap_ = NewMaxIterHeap(comparator_);
-  minHeap_ = NewMinIterHeap(comparator_);
+  maxHeap_ = merger::NewMaxIterHeap(comparator_);
+  minHeap_ = merger::NewMinIterHeap(comparator_);
 }
 
 Iterator* NewMergingIterator(const Comparator* cmp, Iterator** list, int n,

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -15,9 +15,6 @@
 namespace rocksdb {
 
 namespace {
-static uint32_t BloomHash(const Slice& key) {
-  return Hash(key.data(), key.size(), 0xbc9f1d34);
-}
 
 class BloomFilterPolicy : public FilterPolicy {
  private:

--- a/util/dynamic_bloom.cc
+++ b/util/dynamic_bloom.cc
@@ -14,9 +14,6 @@
 namespace rocksdb {
 
 namespace {
-static uint32_t BloomHash(const Slice& key) {
-  return Hash(key.data(), key.size(), 0xbc9f1d34);
-}
 
 uint32_t GetNumBlocks(uint32_t total_bits) {
   uint32_t num_blocks = (total_bits + CACHE_LINE_SIZE * 8 - 1) /

--- a/util/hash.h
+++ b/util/hash.h
@@ -17,4 +17,8 @@ namespace rocksdb {
 
 extern uint32_t Hash(const char* data, size_t n, uint32_t seed);
 
+inline uint32_t BloomHash(const Slice& key) {
+  return Hash(key.data(), key.size(), 0xbc9f1d34);
+}
+
 }


### PR DESCRIPTION
This set of changes allows RocksDB to be compiled as a "unity build" (http://buffered.io/posts/the-magic-of-unity-builds/). I realize that this is an odd use-case: we inline the entire rocksdb repository within our own respotory using `git subtree` (http://blogs.atlassian.com/2013/05/alternatives-to-git-submodule-git-subtree/). But the RocksDB sources only needed very minor cosmetic changes. Mostly eliminating duplicate symbols in different translation units. And also, moving some identifiers out of anonymous namespaces to prevent compilation warnings when those symbols appear as data members of classes in non-anonymous namespaces.

Here's the source file used to compile RocksDB as a unity build:
https://github.com/ripple/rippled/blob/develop/src/ripple/unity/rocksdb.cpp
