### PR TITLE
Add separate Read/WriteUnlock methods in MutexRW.

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -366,7 +366,7 @@ static bool SaveValue(void* arg, const char* entry) {
           s->value->assign(v.data(), v.size());
         }
         if (s->inplace_update_support) {
-          s->mem->GetLock(s->key->user_key())->Unlock();
+          s->mem->GetLock(s->key->user_key())->ReadUnlock();
         }
         *(s->found_final_value) = true;
         return false;

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -99,7 +99,9 @@ void RWMutex::ReadLock() { PthreadCall("read lock", pthread_rwlock_rdlock(&mu_))
 
 void RWMutex::WriteLock() { PthreadCall("write lock", pthread_rwlock_wrlock(&mu_)); }
 
-void RWMutex::Unlock() { PthreadCall("unlock", pthread_rwlock_unlock(&mu_)); }
+void RWMutex::ReadUnlock() { PthreadCall("read unlock", pthread_rwlock_unlock(&mu_)); }
+
+void RWMutex::WriteUnlock() { PthreadCall("write unlock", pthread_rwlock_unlock(&mu_)); }
 
 void InitOnce(OnceType* once, void (*initializer)()) {
   PthreadCall("once", pthread_once(once, initializer));

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -120,7 +120,8 @@ class RWMutex {
 
   void ReadLock();
   void WriteLock();
-  void Unlock();
+  void ReadUnlock();
+  void WriteUnlock();
   void AssertHeld() { }
 
  private:

--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -46,7 +46,7 @@ class ReadLock {
   explicit ReadLock(port::RWMutex *mu) : mu_(mu) {
     this->mu_->ReadLock();
   }
-  ~ReadLock() { this->mu_->Unlock(); }
+  ~ReadLock() { this->mu_->ReadUnlock(); }
 
  private:
   port::RWMutex *const mu_;
@@ -66,7 +66,7 @@ class WriteLock {
   explicit WriteLock(port::RWMutex *mu) : mu_(mu) {
     this->mu_->WriteLock();
   }
-  ~WriteLock() { this->mu_->Unlock(); }
+  ~WriteLock() { this->mu_->WriteUnlock(); }
 
  private:
   port::RWMutex *const mu_;

--- a/util/vectorrep.cc
+++ b/util/vectorrep.cc
@@ -252,7 +252,7 @@ void VectorRep::Get(const LookupKey& k, void* callback_args,
     bucket.reset(new Bucket(*bucket_));  // make a copy
   }
   VectorRep::Iterator iter(vector_rep, immutable_ ? bucket_ : bucket, compare_);
-  rwlock_.Unlock();
+  rwlock_.ReadUnlock();
 
   for (iter.Seek(k.user_key(), k.memtable_key().data());
        iter.Valid() && callback_func(callback_args, iter.key()); iter.Next()) {


### PR DESCRIPTION
Some platforms, particularly Windows, do not have a single method that can release both a held reader lock and a held writer lock; instead, a separate method (`ReleaseSRWLockShared` or `ReleaseSRWLockExclusive`) must be called in each case.

This may also be necessary to back `MutexRW` with a `shared_mutex` in C++14; the current language proposal includes both an `unlock()` and a `shared_unlock()` method.
