### PR TITLE
Using smart pointers to manage ownership of block allocations

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7487,7 +7487,7 @@ TEST(DBTest, SimpleWriteTimeoutTest) {
   ASSERT_OK(Put(Key(2), Key(2) + std::string(100000, 'v'), write_opt));
   // As the only two write buffers are full in this moment, the third
   // Put is expected to be timed-out.
-  write_opt.timeout_hint_us = 300;
+  write_opt.timeout_hint_us = 3;
   ASSERT_TRUE(
       Put(Key(3), Key(3) + std::string(100000, 'v'), write_opt).IsTimedOut());
 }

--- a/table/block.cc
+++ b/table/block.cc
@@ -297,8 +297,9 @@ uint32_t Block::NumRestarts() const {
   return DecodeFixed32(data_ + size_ - sizeof(uint32_t));
 }
 
-Block::Block(const BlockContents& contents)
-    : data_(contents.data.data()),
+Block::Block(BlockContents&& contents)
+    : contents_(std::move(contents)),
+      data_(contents.data.data()),
       size_(contents.data.size()),
       owned_(contents.heap_allocated),
       cachable_(contents.cachable),

--- a/table/block.h
+++ b/table/block.h
@@ -15,6 +15,8 @@
 #include "rocksdb/options.h"
 #include "db/dbformat.h"
 
+#include "format.h"
+
 namespace rocksdb {
 
 struct BlockContents;
@@ -26,7 +28,7 @@ class BlockPrefixIndex;
 class Block {
  public:
   // Initialize the block with the specified contents.
-  explicit Block(const BlockContents& contents);
+  explicit Block(BlockContents&& contents);
 
   ~Block();
 
@@ -54,6 +56,7 @@ class Block {
   size_t ApproximateMemoryUsage() const;
 
  private:
+  BlockContents contents_;
   const char* data_;
   size_t size_;
   uint32_t restart_offset_;     // Offset in data_ of restart array

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -630,7 +630,7 @@ Status BlockBasedTableBuilder::InsertBlockInCache(const Slice& block_contents,
     results.heap_allocated = true;
     results.compression_type = type;
 
-    Block* block = new Block(results);
+    Block* block = new Block(std::move(results));
 
     // make cache key by appending the file offset to the cache prefix id
     char* end = EncodeVarint64(

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -93,7 +93,7 @@ TEST(BlockTest, SimpleTest) {
   contents.data = rawblock;
   contents.cachable = false;
   contents.heap_allocated = false;
-  Block reader(contents);
+  Block reader(std::move(contents));
 
   // read contents of block sequentially
   int count = 0;
@@ -149,13 +149,13 @@ BlockContents GetBlockContents(std::unique_ptr<BlockBuilder> *builder,
   return contents;
 }
 
-void CheckBlockContents(BlockContents contents, const int max_key,
+void CheckBlockContents(BlockContents &contents, const int max_key,
                         const std::vector<std::string> &keys,
                         const std::vector<std::string> &values) {
   const size_t prefix_size = 6;
   // create block reader
-  Block reader1(contents);
-  Block reader2(contents);
+  Block reader1(std::move(contents));
+  Block reader2(std::move(contents));
 
   std::unique_ptr<const SliceTransform> prefix_extractor(
       NewFixedPrefixTransform(prefix_size));

--- a/table/format.h
+++ b/table/format.h
@@ -162,6 +162,7 @@ struct BlockContents {
   bool cachable;        // True iff data can be cached
   bool heap_allocated;  // True iff caller should delete[] data.data()
   CompressionType compression_type;
+  std::unique_ptr<char[]> allocation;
 };
 
 // Read the block identified by "handle" from "file".  On failure

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -152,7 +152,7 @@ Status ReadProperties(const Slice &handle_value, RandomAccessFile *file,
     return s;
   }
 
-  Block properties_block(block_contents);
+  Block properties_block(std::move(block_contents));
   std::unique_ptr<Iterator> iter(
       properties_block.NewIterator(BytewiseComparator()));
 
@@ -237,7 +237,7 @@ Status ReadTableProperties(RandomAccessFile* file, uint64_t file_size,
   if (!s.ok()) {
     return s;
   }
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
   std::unique_ptr<Iterator> meta_iter(
       metaindex_block.NewIterator(BytewiseComparator()));
 
@@ -291,7 +291,7 @@ Status FindMetaBlock(RandomAccessFile* file, uint64_t file_size,
   if (!s.ok()) {
     return s;
   }
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
 
   std::unique_ptr<Iterator> meta_iter;
   meta_iter.reset(metaindex_block.NewIterator(BytewiseComparator()));
@@ -321,7 +321,7 @@ Status ReadMetaBlock(RandomAccessFile* file, uint64_t file_size,
   }
 
   // Finding metablock
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
 
   std::unique_ptr<Iterator> meta_iter;
   meta_iter.reset(metaindex_block.NewIterator(BytewiseComparator()));

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -254,7 +254,7 @@ class BlockConstructor: public Constructor {
     contents.data = data_;
     contents.cachable = false;
     contents.heap_allocated = false;
-    block_ = new Block(contents);
+    block_ = new Block(std::move(contents));
     return Status::OK();
   }
   virtual Iterator* NewIterator() const {


### PR DESCRIPTION
This is a first pass at a solution to bug #222, a merge request opened for initial discussion of a solution.

Unit tests crash due to a double delete. In the constructor for a block, one passes in a BlockContents object. The Block's data_ field is set to the underlying Slice's pointer to the data. When passing in a BlockContents object that is allocated on the stack, the unique_ptr deletes the previously allocated memory once it goes out of scope, leaving the Block with a dangling pointer. An example can be pulled from block_based_table_builder.cc in BlockBasedTableBuilder::InsertBlockInCache:

``` c++
[...]
std::unique_ptr<char[]> ubuf(new char[size+1]);
ubuf[size] = type;

BlockContents results;
Slice sl(ubuf.get(), size);
results.data = sl;
results.cachable = true;
results.allocation = std::move(buf);
results.compression_type = type;

Block *block = new Block(results);
[...]
```

I'm not sure of the best way to proceed from here, but my gut tells me that sticking a std::unique_ptr in here will end up touching a lot more code than initially expected.
