### PR TITLE
Replace naked calls to operator new and delete (Fixes #222)

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -300,7 +300,6 @@ uint32_t Block::NumRestarts() const {
 Block::Block(const BlockContents& contents)
     : data_(contents.data.data()),
       size_(contents.data.size()),
-      owned_(contents.heap_allocated),
       cachable_(contents.cachable),
       compression_type_(contents.compression_type) {
   if (size_ < sizeof(uint32_t)) {
@@ -315,10 +314,29 @@ Block::Block(const BlockContents& contents)
   }
 }
 
-Block::~Block() {
-  if (owned_) {
-    delete[] data_;
+Block::Block(BlockContents&& contents)
+    : contents_(std::move(contents)),
+      data_(contents.data.data()),
+      size_(contents.data.size()),
+      cachable_(contents.cachable),
+      compression_type_(contents.compression_type) {
+  if (size_ < sizeof(uint32_t)) {
+    size_ = 0;  // Error marker
+  } else {
+    restart_offset_ = size_ - (1 + NumRestarts()) * sizeof(uint32_t);
+    if (restart_offset_ > size_ - sizeof(uint32_t)) {
+      // The size is too small for NumRestarts() and therefore
+      // restart_offset_ wrapped around.
+      size_ = 0;
+    }
   }
+
+  if (contents.heap_allocated) {
+    contents_.allocation = std::unique_ptr<char const[]>(contents.data.data());
+  }
+}
+
+Block::~Block() {
 }
 
 Iterator* Block::NewIterator(const Comparator* cmp, BlockIter* iter) {

--- a/table/block.h
+++ b/table/block.h
@@ -15,6 +15,8 @@
 #include "rocksdb/options.h"
 #include "db/dbformat.h"
 
+#include "format.h"
+
 namespace rocksdb {
 
 struct BlockContents;
@@ -26,6 +28,7 @@ class BlockPrefixIndex;
 class Block {
  public:
   // Initialize the block with the specified contents.
+  explicit Block(BlockContents&& contents);
   explicit Block(const BlockContents& contents);
 
   ~Block();
@@ -54,10 +57,10 @@ class Block {
   size_t ApproximateMemoryUsage() const;
 
  private:
+  BlockContents contents_;
   const char* data_;
   size_t size_;
   uint32_t restart_offset_;     // Offset in data_ of restart array
-  bool owned_;                  // Block owns data_[]
   bool cachable_;
   CompressionType compression_type_;
   std::unique_ptr<BlockHashIndex> hash_index_;

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "db/dbformat.h"
 
@@ -630,7 +631,7 @@ Status BlockBasedTableBuilder::InsertBlockInCache(const Slice& block_contents,
     results.heap_allocated = true;
     results.compression_type = type;
 
-    Block* block = new Block(results);
+    Block* block = new Block(std::move(results));
 
     // make cache key by appending the file offset to the cache prefix id
     char* end = EncodeVarint64(

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -93,7 +93,7 @@ TEST(BlockTest, SimpleTest) {
   contents.data = rawblock;
   contents.cachable = false;
   contents.heap_allocated = false;
-  Block reader(contents);
+  Block reader(std::move(contents));
 
   // read contents of block sequentially
   int count = 0;
@@ -149,7 +149,7 @@ BlockContents GetBlockContents(std::unique_ptr<BlockBuilder> *builder,
   return contents;
 }
 
-void CheckBlockContents(BlockContents contents, const int max_key,
+void CheckBlockContents(const BlockContents &contents, const int max_key,
                         const std::vector<std::string> &keys,
                         const std::vector<std::string> &values) {
   const size_t prefix_size = 6;

--- a/table/format.h
+++ b/table/format.h
@@ -160,8 +160,10 @@ static const size_t kBlockTrailerSize = 5;
 struct BlockContents {
   Slice data;           // Actual contents of data
   bool cachable;        // True iff data can be cached
-  bool heap_allocated;  // True iff caller should delete[] data.data()
+  bool heap_allocated;  // True iff caller should delete[] data.data() or the unique_ptr will handle it
   CompressionType compression_type;
+  std::unique_ptr<char const[]> allocation;
+
 };
 
 // Read the block identified by "handle" from "file".  On failure

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -152,7 +152,7 @@ Status ReadProperties(const Slice &handle_value, RandomAccessFile *file,
     return s;
   }
 
-  Block properties_block(block_contents);
+  Block properties_block(std::move(block_contents));
   std::unique_ptr<Iterator> iter(
       properties_block.NewIterator(BytewiseComparator()));
 
@@ -237,7 +237,7 @@ Status ReadTableProperties(RandomAccessFile* file, uint64_t file_size,
   if (!s.ok()) {
     return s;
   }
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
   std::unique_ptr<Iterator> meta_iter(
       metaindex_block.NewIterator(BytewiseComparator()));
 
@@ -291,7 +291,7 @@ Status FindMetaBlock(RandomAccessFile* file, uint64_t file_size,
   if (!s.ok()) {
     return s;
   }
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
 
   std::unique_ptr<Iterator> meta_iter;
   meta_iter.reset(metaindex_block.NewIterator(BytewiseComparator()));
@@ -321,7 +321,7 @@ Status ReadMetaBlock(RandomAccessFile* file, uint64_t file_size,
   }
 
   // Finding metablock
-  Block metaindex_block(metaindex_contents);
+  Block metaindex_block(std::move(metaindex_contents));
 
   std::unique_ptr<Iterator> meta_iter;
   meta_iter.reset(metaindex_block.NewIterator(BytewiseComparator()));

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -254,7 +254,7 @@ class BlockConstructor: public Constructor {
     contents.data = data_;
     contents.cachable = false;
     contents.heap_allocated = false;
-    block_ = new Block(contents);
+    block_ = new Block(std::move(contents));
     return Status::OK();
   }
   virtual Iterator* NewIterator() const {


### PR DESCRIPTION
This replaces a mishmash of pointers in the Block and BlockContents classes with
std::unique_ptr. It also changes the semantics of BlockContents to be limited to
use as a constructor parameter for Block objects, as it owns any block buffers
handed to it.

Previous discussion here: https://github.com/tdfischer/rocksdb/pull/1
