### PR TITLE
BlockBuilder typo improvement

### DIFF
--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -20,8 +20,11 @@ class Comparator;
 
 class BlockBuilder {
  public:
-  BlockBuilder(int block_builder, const Comparator* comparator);
-
+  BlockBuilder(const BlockBuilder&) = delete;
+  void operator=(const BlockBuilder&) = delete;
+  
+  BlockBuilder(int block_restart_interval, const Comparator* comparator);
+  
   // Reset the contents as if the BlockBuilder was just constructed.
   void Reset();
 
@@ -55,10 +58,6 @@ class BlockBuilder {
   int                   counter_;   // Number of entries emitted since restart
   bool                  finished_;  // Has Finish() been called?
   std::string           last_key_;
-
-  // No copying allowed
-  BlockBuilder(const BlockBuilder&);
-  void operator=(const BlockBuilder&);
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
a) more c++11 way noncopyable
b) keep parameter's name of constructor consistent
