### PR TITLE
Fix candidate file comparison when using path ids

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -631,7 +631,7 @@ bool CompareCandidateFile(const rocksdb::DBImpl::CandidateFileInfo& first,
   } else if (first.file_name < second.file_name) {
     return false;
   } else {
-    return (first.path_id > first.path_id);
+    return (first.path_id > second.path_id);
   }
 }
 };  // namespace


### PR DESCRIPTION
The function `CompareCandidateFile` incorrectly compares a file's `path_id` against itself and will always return false.

This is my first pull request against `rocksdb` and I have completed the CLA.
