### PR TITLE
rename DBOptions::disableDataSync to DBOptions::disable_data_sync

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -196,7 +196,7 @@ Status BuildTable(const std::string& dbname, Env* env, const Options& options,
     delete builder;
 
     // Finish and check for file errors
-    if (s.ok() && !options.disableDataSync) {
+    if (s.ok() && !options.disable_data_sync) {
       if (options.use_fsync) {
         StopWatch sw(env, options.statistics.get(), TABLE_SYNC_MICROS);
         s = file->Fsync();

--- a/db/c.cc
+++ b/db/c.cc
@@ -1318,7 +1318,7 @@ void rocksdb_options_set_prefix_extractor(
 
 void rocksdb_options_set_disable_data_sync(
     rocksdb_options_t* opt, int disable_data_sync) {
-  opt->rep.disableDataSync = disable_data_sync;
+  opt->rep.disable_data_sync = disable_data_sync;
 }
 
 void rocksdb_options_set_use_fsync(

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -740,7 +740,7 @@ TEST(ColumnFamilyTest, DifferentCompactionStyles) {
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
   db_options_.max_open_files = 20;  // only 10 files in file cache
-  db_options_.disableDataSync = true;
+  db_options_.disable_data_sync = true;
 
   default_cf.compaction_style = kCompactionStyleLevel;
   default_cf.num_levels = 3;

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -1667,7 +1667,7 @@ class Benchmark {
       FLAGS_env->LowerThreadPoolIOPriority(Env::HIGH);
     }
     options.env = FLAGS_env;
-    options.disableDataSync = FLAGS_disable_data_sync;
+    options.disable_data_sync = FLAGS_disable_data_sync;
     options.use_fsync = FLAGS_use_fsync;
     options.wal_dir = FLAGS_wal_dir;
     options.num_levels = FLAGS_num_levels;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1499,7 +1499,7 @@ Status DBImpl::WriteLevel0Table(ColumnFamilyData* cfd,
         cfd->GetName().c_str(), meta.fd.GetNumber(), meta.fd.GetFileSize(),
         s.ToString().c_str());
 
-    if (!options_.disableDataSync) {
+    if (!options_.disable_data_sync) {
       db_directory_->Fsync();
     }
     mutex_.Lock();
@@ -2480,7 +2480,7 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
   compact->builder.reset();
 
   // Finish and check for file errors
-  if (s.ok() && !options_.disableDataSync) {
+  if (s.ok() && !options_.disable_data_sync) {
     if (options_.use_fsync) {
       StopWatch sw(env_, stats_, COMPACTION_OUTFILE_SYNC_MICROS);
       s = compact->outfile->Fsync();
@@ -3233,7 +3233,7 @@ Status DBImpl::DoCompactionWork(CompactionState* compact,
   }
   input.reset();
 
-  if (!options_.disableDataSync) {
+  if (!options_.disable_data_sync) {
     db_directory_->Fsync();
   }
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -148,7 +148,7 @@ process crash.
 
 <p>
 When opening a DB, you can disable syncing of data files by setting
-Options::disableDataSync to true. This can be useful when doing
+Options::disable_data_sync to true. This can be useful when doing
 bulk-loading or big idempotent operations. Once the operation is
 finished, you can manually call sync() to flush all dirty buffers
 to stable storage.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -609,7 +609,7 @@ struct DBOptions {
   // of data. Once the bulk-loading is complete, please issue a
   // sync to the OS to flush all dirty buffesrs to stable storage.
   // Default: false
-  bool disableDataSync;
+  bool disable_data_sync;
 
   // If true, then every store to stable storage will issue a fsync.
   // If false, then every store to stable storage will issue a fdatasync.

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -197,7 +197,7 @@ void Java_org_rocksdb_Options_setMaxOpenFiles(
  */
 jboolean Java_org_rocksdb_Options_disableDataSync(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->disableDataSync;
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->disable_data_sync;
 }
 
 /*
@@ -207,7 +207,7 @@ jboolean Java_org_rocksdb_Options_disableDataSync(
  */
 void Java_org_rocksdb_Options_setDisableDataSync(
     JNIEnv* env, jobject jobj, jlong jhandle, jboolean disableDataSync) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->disableDataSync =
+  reinterpret_cast<rocksdb::Options*>(jhandle)->disable_data_sync =
       static_cast<bool>(disableDataSync);
 }
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1567,7 +1567,7 @@ class StressTest {
     options_.max_open_files = FLAGS_open_files;
     options_.statistics = dbstats;
     options_.env = FLAGS_env;
-    options_.disableDataSync = FLAGS_disable_data_sync;
+    options_.disable_data_sync = FLAGS_disable_data_sync;
     options_.use_fsync = FLAGS_use_fsync;
     options_.allow_mmap_reads = FLAGS_mmap_read;
     rocksdb_kill_odds = FLAGS_kill_random_test;

--- a/util/options.cc
+++ b/util/options.cc
@@ -154,7 +154,7 @@ DBOptions::DBOptions()
       max_open_files(5000),
       max_total_wal_size(0),
       statistics(nullptr),
-      disableDataSync(false),
+      disable_data_sync(false),
       use_fsync(false),
       db_log_dir(""),
       wal_dir(""),
@@ -194,7 +194,7 @@ DBOptions::DBOptions(const Options& options)
       max_open_files(options.max_open_files),
       max_total_wal_size(options.max_total_wal_size),
       statistics(options.statistics),
-      disableDataSync(options.disableDataSync),
+      disable_data_sync(options.disable_data_sync),
       use_fsync(options.use_fsync),
       db_paths(options.db_paths),
       db_log_dir(options.db_log_dir),
@@ -237,7 +237,7 @@ void DBOptions::Dump(Logger* log) const {
     Log(log,"                Options.info_log: %p", info_log.get());
     Log(log,"          Options.max_open_files: %d", max_open_files);
     Log(log,"      Options.max_total_wal_size: %" PRIu64, max_total_wal_size);
-    Log(log, "       Options.disableDataSync: %d", disableDataSync);
+    Log(log, "     Options.disable_data_sync: %d", disable_data_sync);
     Log(log, "             Options.use_fsync: %d", use_fsync);
     Log(log, "     Options.max_log_file_size: %zu", max_log_file_size);
     Log(log, "Options.max_manifest_file_size: %lu",
@@ -436,7 +436,7 @@ Options::PrepareForBulkLoad()
   // no auto compactions please. The application should issue a
   // manual compaction after all data is loaded into L0.
   disable_auto_compactions = true;
-  disableDataSync = true;
+  disable_data_sync = true;
 
   // A manual compaction run should pick all files in L0 in
   // a single compaction run.

--- a/utilities/spatialdb/spatial_db.cc
+++ b/utilities/spatialdb/spatial_db.cc
@@ -629,7 +629,7 @@ DBOptions GetDBOptions(const SpatialDBOptions& options) {
   db_options.env->SetBackgroundThreads(db_options.max_background_flushes,
                                        Env::HIGH);
   if (options.bulk_load) {
-    db_options.disableDataSync = true;
+    db_options.disable_data_sync = true;
   }
   return db_options;
 }


### PR DESCRIPTION
All members in DBOptions use the same code style.
