### PR TITLE
fix a compile warning

### DIFF
--- a/util/histogram.h
+++ b/util/histogram.h
@@ -64,6 +64,8 @@ class HistogramImpl {
   virtual double Average() const;
   virtual double StandardDeviation() const;
   virtual void Data(HistogramData * const data) const;
+  
+  virtual ~HistogramImpl() {}
 
  private:
   // To be able to use HistogramImpl as thread local variable, its constructor


### PR DESCRIPTION
Class HistogramImpl has virtual functions and thus should have a virtual destructor. Otherwise, a compile error will be triggered by this flag 

```
-Werror=non-virtual-dtor

error: 'class rocksdb::HistogramImpl' has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
```
