### PR TITLE
fix a few compile warnings

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -255,7 +255,7 @@ class IterKey {
 
   Slice GetKey() const { return Slice(key_, key_size_); }
 
-  const size_t Size() { return key_size_; }
+  size_t Size() { return key_size_; }
 
   void Clear() { key_size_ = 0; }
 

--- a/db/snapshot.h
+++ b/db/snapshot.h
@@ -71,7 +71,7 @@ class SnapshotList {
   }
 
   // get the sequence number of the most recent snapshot
-  const SequenceNumber GetNewest() {
+  SequenceNumber GetNewest() {
     if (empty()) {
       return 0;
     }

--- a/table/block_prefix_index.cc
+++ b/table/block_prefix_index.cc
@@ -210,8 +210,8 @@ Status BlockPrefixIndex::Create(const SliceTransform* internal_prefix_extractor,
   return s;
 }
 
-const uint32_t BlockPrefixIndex::GetBlocks(const Slice& key,
-                                           uint32_t** blocks) {
+uint32_t BlockPrefixIndex::GetBlocks(const Slice& key,
+                                     uint32_t** blocks) {
   Slice prefix = internal_prefix_extractor_->Transform(key);
 
   uint32_t bucket = PrefixToBucket(prefix, num_buckets_);

--- a/table/block_prefix_index.h
+++ b/table/block_prefix_index.h
@@ -23,7 +23,7 @@ class BlockPrefixIndex {
   // the key, based on the prefix.
   // Returns the total number of relevant blocks, 0 means the key does
   // not exist.
-  const uint32_t GetBlocks(const Slice& key, uint32_t** blocks);
+  uint32_t GetBlocks(const Slice& key, uint32_t** blocks);
 
   size_t ApproximateMemoryUsage() const {
     return sizeof(BlockPrefixIndex) +

--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -53,7 +53,7 @@ HistogramBucketMapper::HistogramBucketMapper()
   }
 }
 
-const size_t HistogramBucketMapper::IndexForValue(const uint64_t value) const {
+size_t HistogramBucketMapper::IndexForValue(const uint64_t value) const {
   if (value >= maxBucketValue_) {
     return bucketValues_.size() - 1;
   } else if ( value >= minBucketValue_ ) {

--- a/util/histogram.h
+++ b/util/histogram.h
@@ -23,10 +23,10 @@ class HistogramBucketMapper {
   HistogramBucketMapper();
 
   // converts a value to the bucket index.
-  const size_t IndexForValue(const uint64_t value) const;
+  size_t IndexForValue(const uint64_t value) const;
   // number of buckets required.
 
-  const size_t BucketCount() const {
+  size_t BucketCount() const {
     return bucketValues_.size();
   }
 
@@ -64,6 +64,8 @@ class HistogramImpl {
   virtual double Average() const;
   virtual double StandardDeviation() const;
   virtual void Data(HistogramData * const data) const;
+
+  virtual ~HistogramImpl() {}
 
  private:
   // To be able to use HistogramImpl as thread local variable, its constructor

--- a/utilities/spatialdb/spatial_db.cc
+++ b/utilities/spatialdb/spatial_db.cc
@@ -7,7 +7,10 @@
 
 #include "rocksdb/utilities/spatial_db.h"
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <string>
 #include <vector>


### PR DESCRIPTION
1, const qualifiers on return types make no sense and will trigger a compile warning: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]

2, class HistogramImpl has virtual functions and thus should have a virtual destructor

3, with some toolchain, the macro __STDC_FORMAT_MACROS is predefined and thus should be checked before define
