### PR TITLE
Introduced additional built-in Comparator ReverseBytewiseComparator

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -62,6 +62,10 @@ class Comparator {
 // must not be deleted.
 extern const Comparator* BytewiseComparator();
 
+// Return a builtin comparator that uses reverse lexicographic byte-wise
+// ordering. 
+extern const Comparator* ReverseBytewiseComparator();
+
 }  // namespace rocksdb
 
 #endif  // STORAGE_ROCKSDB_INCLUDE_COMPARATOR_H_

--- a/java/org/rocksdb/Options.java
+++ b/java/org/rocksdb/Options.java
@@ -79,6 +79,37 @@ public class Options extends RocksObject {
   }
 
   /**
+   * Use BytewiseComparator instead of the default
+   * comparator used by RocksDB. Currently this comparator
+   * is set by default.
+   *
+   * Note: Comparator can be set once upon database creation. 
+   *
+   * Default: BytewiseComparator.
+   */
+  public void useBytewiseComparator() {
+    assert(isInitialized());
+    useBytewiseComparator(nativeHandle_);
+  }
+
+  private native void useBytewiseComparator(long handle);
+
+  /**
+   * Use ReverseBytewiseComparator instead of the default
+   * comparator used by RocksDB. 
+   *
+   * Note: Comparator can be set once upon database creation.
+   *
+   * Default: BytewiseComparator.
+   */
+  public void useReverseBytewiseComparator() {
+    assert(isInitialized());
+    useReverseBytewiseComparator(nativeHandle_);
+  }
+
+  private native void useReverseBytewiseComparator(long handle);
+
+  /**
    * Amount of data to build up in memory (backed by an unsorted log
    * on disk) before converting to a sorted on-disk file.
    *
@@ -2169,6 +2200,7 @@ public class Options extends RocksObject {
   private native void disposeInternal(long handle);
   private native void setCreateIfMissing(long handle, boolean flag);
   private native boolean createIfMissing(long handle);
+
   private native void setWriteBufferSize(long handle, long writeBufferSize);
   private native long writeBufferSize(long handle);
   private native void setMaxWriteBufferNumber(

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/table.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/rate_limiter.h"
+#include "rocksdb/comparator.h"
 
 /*
  * Class:     org_rocksdb_Options
@@ -61,6 +62,26 @@ void Java_org_rocksdb_Options_setCreateIfMissing(
 jboolean Java_org_rocksdb_Options_createIfMissing(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->create_if_missing;
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    useBytewiseComparator
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_Options_useBytewiseComparator(
+    JNIEnv* env, jobject jobj, jlong jhandle) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->comparator = rocksdb::BytewiseComparator();
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    useReverseBytewiseComparator
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_Options_useReverseBytewiseComparator(
+    JNIEnv* env, jobject jobj, jlong jhandle) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->comparator = rocksdb::ReverseBytewiseComparator();
 }
 
 /*

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -69,18 +69,39 @@ class BytewiseComparatorImpl : public Comparator {
     // *key is a run of 0xffs.  Leave it alone.
   }
 };
-}  // namespace
+
+class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
+ public:
+  ReverseBytewiseComparatorImpl() { }
+
+  virtual const char* Name() const {
+    return "leveldb.ReverseBytewiseComparator";
+  }
+
+  virtual int Compare(const Slice& a, const Slice& b) const {
+    return -a.compare(b);
+  }
+};
+
+}// namespace
 
 static port::OnceType once = LEVELDB_ONCE_INIT;
 static const Comparator* bytewise;
+static const Comparator* rbytewise;
 
 static void InitModule() {
   bytewise = new BytewiseComparatorImpl;
+  rbytewise= new ReverseBytewiseComparatorImpl;
 }
 
 const Comparator* BytewiseComparator() {
   port::InitOnce(&once, InitModule);
   return bytewise;
+}
+
+const Comparator* ReverseBytewiseComparator() {
+  port::InitOnce(&once, InitModule);
+  return rbytewise;
 }
 
 }  // namespace rocksdb


### PR DESCRIPTION
Reverse key handling is under certain conditions essential. E.g. while
using timestamp versioned data access to most recent data might be the standard
usecase.

As comparators were not available using JAVA-API both(default and reverse version) built-in comparators
were exposed via JNI to be set upon database creation time.
