### PR TITLE
Make test use a compatible type in the size checks.

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1349,8 +1349,8 @@ TEST(DBTest, CompactedDB) {
       std::vector<Slice>({Slice("aaa"), Slice("ccc"), Slice("eee"),
                           Slice("ggg"), Slice("iii"), Slice("kkk")}),
       &values);
-  ASSERT_EQ(status_list.size(), 6);
-  ASSERT_EQ(values.size(), 6);
+  ASSERT_EQ(status_list.size(), static_cast<uint64_t>(6));
+  ASSERT_EQ(values.size(), static_cast<uint64_t>(6));
   ASSERT_OK(status_list[0]);
   ASSERT_EQ(DummyString(kFileSize / 2, 'a'), values[0]);
   ASSERT_TRUE(status_list[1].IsNotFound());


### PR DESCRIPTION
Absent this cast on OSX, make check will fail with the following error:

./util/testharness.h:93:19: error: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Werror,-Wsign-compare]
  BINARY_OP(IsEq, ==)

``` ^~~
./util/testharness.h:86:14: note: expanded from macro 'BINARY_OP'
    if (! (x op y)) {                                   \
             ^
db/db_test.cc:1352:3: note: in instantiation of function template specialization 'rocksdb::test::Tester::IsEq<unsigned long, int>' requested here
  ASSERT_EQ(status_list.size(), 6);
  ^
./util/testharness.h:113:68: note: expanded from macro 'ASSERT_EQ'
#define ASSERT_EQ(a,b) ::rocksdb::test::Tester(__FILE__, __LINE__).IsEq((a),(b))
                                                                   ^
1 error generated.
make: *** [db/db_test.o] Error 1
```
