### PR TITLE
resolution for java build problem introduced by 5ec53f3edf62bec1b690ce12...

### DIFF
--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -206,7 +206,8 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
   options.memtable_factory = factory;
   rocksdb::MemTable* mem = new rocksdb::MemTable(
       cmp, rocksdb::ImmutableCFOptions(options),
-      rocksdb::MemTableOptions(rocksdb::MutableCFOptions(options), options));
+      rocksdb::MemTableOptions(rocksdb::MutableCFOptions(options,
+          rocksdb::ImmutableCFOptions(options)), options));
   mem->Ref();
   std::string state;
   rocksdb::ColumnFamilyMemTablesDefault cf_mems_default(mem, &options);


### PR DESCRIPTION
In https://github.com/facebook/rocksdb/commit/5ec53f3edf62bec1b690ce12fb21a6c52203f3c8 the Java code was not adjusted which lead to a non working Java build. This commit resolves the build problem.

Referring issue is: https://github.com/facebook/rocksdb/issues/328
