### PR TITLE
Cross platform fix for Java benchmark shell script.

### DIFF
--- a/java/jdb_bench.sh
+++ b/java/jdb_bench.sh
@@ -1,1 +1,7 @@
-java -server -d64 -XX:NewSize=4m -XX:+AggressiveOpts -Djava.library.path=.:../ -cp "rocksdbjni.jar:.:./*" org.rocksdb.benchmark.DbBenchmark $@
+PLATFORM=64
+if [ `getconf LONG_BIT` != "64" ]
+then
+  PLATFORM=32
+fi
+echo "Running benchmark in $PLATFORM-Bit mode."
+java -server -d$PLATFORM -XX:NewSize=4m -XX:+AggressiveOpts -Djava.library.path=.:../ -cp "rocksdbjni.jar:.:./*" org.rocksdb.benchmark.DbBenchmark $@


### PR DESCRIPTION
The script detects now if run on a 32-Bit or a 64-Bit system and runs the JVM in 32-Bit or in 64-Bit depending on the detected architecture.

Tested on Linux-32Bit and works with bash, dash and sh shells.
