### PR TITLE
Avoid dereferencing a null field

### DIFF
--- a/utilities/document/document_db.cc
+++ b/utilities/document/document_db.cc
@@ -385,13 +385,13 @@ class SimpleSortedIndex : public Index {
       override {
     auto value = document.Get(field_);
     if (value == nullptr) {
-      // null
       if (!EncodeJSONPrimitive(JSONDocument(JSONDocument::kNull), key)) {
         assert(false);
       }
-    }
-    if (!EncodeJSONPrimitive(*value, key)) {
-      assert(false);
+    } else {
+      if (!EncodeJSONPrimitive(*value, key)) {
+        assert(false);
+      }
     }
   }
   virtual const Comparator* GetComparator() const override {


### PR DESCRIPTION
If we're going to go to the trouble of checking then the least we can do is **not** dereference a pointer we just discovered is equal to `nullptr`.
