### PR TITLE
Removed code which prevents `arc lint` from working properly.

### DIFF
--- a/linters/lint_engine/FacebookFbcodeLintEngine.php
+++ b/linters/lint_engine/FacebookFbcodeLintEngine.php
@@ -44,10 +44,6 @@ class FacebookFbcodeLintEngine extends ArcanistLintEngine {
     if (!$this->getCommitHookMode()) {
       $cpp_linters = array();
       $google_linter = new ArcanistCpplintLinter();
-      $google_linter->setConfig(array(
-        'lint.cpplint.prefix' => '',
-        'lint.cpplint.bin' => 'cpplint',
-      ));
       $cpp_linters[] = $linters[] = $google_linter;
       $cpp_linters[] = $linters[] = new FbcodeCppLinter();
       $cpp_linters[] = $linters[] = new PfffCppLinter();


### PR DESCRIPTION
Changed code is not anymore in the API. Methods to access those settings are also marked as deprecated. 

Without setting those configuration attributes `arc lint` works as expected given both repositorys are updated to head and `pep8` is installed.
