### PR TITLE
Fix for building RocksDB Java on Mac OS X Yosemite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,11 @@ ROCKSDB_SOURCES_JAR = rocksdbjni-$(ROCKSDB_MAJOR).$(ROCKSDB_MINOR).$(ROCKSDB_PAT
 ifeq ($(PLATFORM), OS_MACOSX)
 ROCKSDBJNILIB = librocksdbjni-osx.jnilib
 ROCKSDB_JAR = rocksdbjni-$(ROCKSDB_MAJOR).$(ROCKSDB_MINOR).$(ROCKSDB_PATCH)-osx.jar
-JAVA_INCLUDE = -I/System/Library/Frameworks/JavaVM.framework/Headers/
+ifneq ("$(wildcard $(JAVA_HOME)/include/darwin)","")
+	JAVA_INCLUDE = -I$(JAVA_HOME)/include -I $(JAVA_HOME)/include/darwin
+else
+	JAVA_INCLUDE = -I/System/Library/Frameworks/JavaVM.framework/Headers/
+endif
 endif
 
 libz.a:


### PR DESCRIPTION
On Mac OSX Java 6 is not available by default, and now even when installed the jni.h file is not present. Instead you need to install Java 7 or 8 on Yosemite and set your JAVA_HOME var. This change should be backwards compatible for those not on Yosemite yet.
