### PR TITLE
RocksJava Fix after MutableCFOptions change. (relates to f184198)

### DIFF
--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -294,8 +294,8 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
   options.memtable_factory = factory;
   rocksdb::MemTable* mem = new rocksdb::MemTable(
       cmp, rocksdb::ImmutableCFOptions(options),
-      rocksdb::MemTableOptions(rocksdb::MutableCFOptions(options,
-          rocksdb::ImmutableCFOptions(options)), options));
+      rocksdb::MutableCFOptions(options,
+      rocksdb::ImmutableCFOptions(options)));
   mem->Ref();
   std::string state;
   rocksdb::ColumnFamilyMemTablesDefault cf_mems_default(mem, &options);


### PR DESCRIPTION
RocksJava build is broken after commit: f184198.
