### PR TITLE
[RocksJava] KeyMayExist w/o ColumnFamilies

### DIFF
--- a/java/org/rocksdb/RocksDB.java
+++ b/java/org/rocksdb/RocksDB.java
@@ -426,6 +426,22 @@ public class RocksDB extends RocksObject {
    * This check is potentially lighter-weight than invoking DB::Get(). One way
    * to make this lighter weight is to avoid doing any IOs.
    *
+   * @param key byte array of a key to search for
+   * @param value StringBuffer instance which is a out parameter if a value is
+   *    found in block-cache.
+   * @return boolean value indicating if key does not exist or might exist.
+   */
+  public boolean keyMayExist(byte[] key, StringBuffer value){
+    return keyMayExist(key, key.length, value);
+  }
+
+  /**
+   * If the key definitely does not exist in the database, then this method
+   * returns false, else true.
+   *
+   * This check is potentially lighter-weight than invoking DB::Get(). One way
+   * to make this lighter weight is to avoid doing any IOs.
+   *
    * @param columnFamilyHandle {@link ColumnFamilyHandle} instance
    * @param key byte array of a key to search for
    * @param value StringBuffer instance which is a out parameter if a value is
@@ -436,6 +452,26 @@ public class RocksDB extends RocksObject {
       byte[] key, StringBuffer value){
     return keyMayExist(key, key.length, columnFamilyHandle.nativeHandle_,
         value);
+  }
+
+  /**
+   * If the key definitely does not exist in the database, then this method
+   * returns false, else true.
+   *
+   * This check is potentially lighter-weight than invoking DB::Get(). One way
+   * to make this lighter weight is to avoid doing any IOs.
+   *
+   * @param readOptions {@link ReadOptions} instance
+   * @param columnFamilyHandle {@link ColumnFamilyHandle} instance
+   * @param key byte array of a key to search for
+   * @param value StringBuffer instance which is a out parameter if a value is
+   *    found in block-cache.
+   * @return boolean value indicating if key does not exist or might exist.
+   */
+  public boolean keyMayExist(ReadOptions readOptions,
+      byte[] key, StringBuffer value){
+    return keyMayExist(readOptions.nativeHandle_,
+        key, key.length, value);
   }
 
   /**
@@ -1087,7 +1123,11 @@ public class RocksDB extends RocksObject {
   protected native void write(
       long writeOptHandle, long batchHandle) throws RocksDBException;
   protected native boolean keyMayExist(byte[] key, int keyLen,
+      StringBuffer stringBuffer);
+  protected native boolean keyMayExist(byte[] key, int keyLen,
       long cfHandle, StringBuffer stringBuffer);
+  protected native boolean keyMayExist(long optionsHandle, byte[] key, int keyLen,
+      StringBuffer stringBuffer);
   protected native boolean keyMayExist(long optionsHandle, byte[] key, int keyLen,
       long cfHandle, StringBuffer stringBuffer);
   protected native void merge(

--- a/java/org/rocksdb/test/KeyMayExistTest.java
+++ b/java/org/rocksdb/test/KeyMayExistTest.java
@@ -4,10 +4,7 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 package org.rocksdb.test;
 
-import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.Options;
-import org.rocksdb.RocksDB;
-import org.rocksdb.RocksDBException;
+import org.rocksdb.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,13 +31,39 @@ public class KeyMayExistTest {
       assert(columnFamilyHandleList.size()==2);
 
       db.put("key".getBytes(), "value".getBytes());
+      // Test without column family
       StringBuffer retValue = new StringBuffer();
+      if (db.keyMayExist("key".getBytes(), retValue)) {
+        assert(retValue.toString().equals("value"));
+      } else {
+        assert(false);
+      }
+      // Test without column family but with readOptions
+      retValue = new StringBuffer();
+      if (db.keyMayExist(new ReadOptions(), "key".getBytes(),
+          retValue)) {
+        assert(retValue.toString().equals("value"));
+      } else {
+        assert(false);
+      }
+      // Test with column family
+      retValue = new StringBuffer();
       if (db.keyMayExist(columnFamilyHandleList.get(0), "key".getBytes(),
           retValue)) {
         assert(retValue.toString().equals("value"));
       } else {
         assert(false);
       }
+      // Test with column family and readOptions
+      retValue = new StringBuffer();
+      if (db.keyMayExist(new ReadOptions(),
+          columnFamilyHandleList.get(0), "key".getBytes(),
+          retValue)) {
+        assert(retValue.toString().equals("value"));
+      } else {
+        assert(false);
+      }
+      // KeyMayExist in CF1 must return false
       assert(db.keyMayExist(columnFamilyHandleList.get(1), "key".getBytes(),
           retValue) == false);
       System.out.println("Passed KeyMayExistTest");


### PR DESCRIPTION
Currently there is only support for keyMayExist calls with Column Families in RocksJava. This pull request includes the extension to do keyMayExist calls without CFs.
