### PR TITLE
fix "make static_lib" error

### DIFF
--- a/util/sst_dump_tool.cc
+++ b/util/sst_dump_tool.cc
@@ -416,7 +416,7 @@ void SSTDumpTool::Run(int argc, char** argv) {
                 "------------------------------\n"
                 "  %s",
                 table_properties->ToString("\n  ", ": ").c_str());
-        fprintf(stdout, "# deleted keys: %zd\n",
+        fprintf(stdout, "# deleted keys: %" PRIu64 "\n",
                 rocksdb::GetDeletedKeys(
                     table_properties->user_collected_properties));
       }


### PR DESCRIPTION
util/sst_dump_tool.cc:421:65: error: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 3 has type ‘uint64_t {aka long long unsigned int}’ [-Werror=format=]
                     table_properties->user_collected_properties));
                                                                 ^
