### PR TITLE
G++ 4.7 - Fix broken build

### DIFF
--- a/util/sst_dump_tool.cc
+++ b/util/sst_dump_tool.cc
@@ -9,7 +9,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "db/dbformat.h"
 #include "db/memtable.h"


### PR DESCRIPTION
G++ 4.7 does not include  __STDC_FORMAT_MACROS if including "inttypes.h"
therefore RocksDB cannot be build. A solution to this is either defining the macros or including <cinttypes>. This pull request includes the second option.
