### PR TITLE
Use correct classloader in Java NativeLibraryLoader

### DIFF
--- a/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/org/rocksdb/NativeLibraryLoader.java
@@ -11,11 +11,35 @@ import org.rocksdb.util.Environment;
  * The shared library is extracted to a temp folder and loaded from there.
  */
 public class NativeLibraryLoader {
+  //singleton
+  private static final NativeLibraryLoader instance = new NativeLibraryLoader();
+
   private static final String sharedLibraryName = Environment.getJniLibraryName("rocksdb");
   private static final String tempFilePrefix = "librocksdbjni";
   private static final String tempFileSuffix = "." + Environment.getJniLibraryExtension();
 
-  public static void loadLibraryFromJar(final String tmpDir)
+  /**
+   * Get a reference to the NativeLibraryLoader
+   *
+   * @return The NativeLibraryLoader
+   */
+  public static NativeLibraryLoader getInstance() {
+    return instance;
+  }
+
+  /**
+   * Attempts to extract the native RocksDB library
+   * from the classpath and load it
+   *
+   * @param tmpDir A temporary directory to use
+   *   to copy the native library to. If null,
+   *   or the empty string, we rely on Java's
+   *   {@see java.io.File#createTempFile(String, String) }
+   *   function to provide a temporary location.
+   *   The temporary file will be registered for deletion
+   *   on exit.
+   */
+  public void loadLibraryFromJar(final String tmpDir)
       throws IOException {
     final File temp;
     if(tmpDir == null || tmpDir.equals("")) {
@@ -30,8 +54,8 @@ public class NativeLibraryLoader {
       temp.deleteOnExit();
     }
 
-    // attempt to copy the library from the JAR to the temp destination
-    try(final InputStream is = ClassLoader.getSystemClassLoader().getResourceAsStream(sharedLibraryName)) {
+    // attempt to copy the library from the Jar file to the temp destination
+    try(final InputStream is = getClass().getClassLoader().getResourceAsStream(sharedLibraryName)) {
       if (is == null) {
         throw new RuntimeException(sharedLibraryName + " was not found inside JAR.");
       } else {

--- a/java/org/rocksdb/RocksDB.java
+++ b/java/org/rocksdb/RocksDB.java
@@ -44,7 +44,7 @@ public class RocksDB extends RocksObject {
     }
     try
     {
-      NativeLibraryLoader.loadLibraryFromJar(tmpDir);
+      NativeLibraryLoader.getInstance().loadLibraryFromJar(tmpDir);
     }
     catch (IOException e)
     {


### PR DESCRIPTION
Previously the NativeLibraryLoader attempted to use the SystemClassLoader to load the native library. Not all applications will necessarily explicitly set the SystemClassLoader classpath when they start up, instead they may use custom or 3rd party classloaders (e.g. dependency injection).

This fix, makes sure to load the native library by using the same class loader which loaded the RocksDB Java classes.
