### PR TITLE
Missing header in build on CentOS 6.5, GCC4.7

### DIFF
--- a/util/options_helper.h
+++ b/util/options_helper.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include <stdexcept>
 #include "util/mutable_cf_options.h"
 #include "rocksdb/status.h"
 


### PR DESCRIPTION
While building RocksJava the build fails on
CentOS because of the missing stdexcept header.

Edit: can be reproduced using the crossbuild-image with `make rocksdbjava`
