### PR TITLE
[RocksJava] Fix precision problem in rocksjni

### DIFF
--- a/java/rocksjni/backupablejni.cc
+++ b/java/rocksjni/backupablejni.cc
@@ -103,10 +103,11 @@ jintArray Java_org_rocksdb_BackupableDB_getCorruptedBackups(
   reinterpret_cast<rocksdb::BackupableDB*>(jhandle)->
       GetCorruptedBackups(&backup_ids);
   // store backupids in int array
-  const int kIdSize = backup_ids.size();
+  const std::vector<rocksdb::BackupID>::size_type
+      kIdSize = backup_ids.size();
   int int_backup_ids[kIdSize];
   for (std::vector<rocksdb::BackupID>::size_type i = 0;
-      i != backup_ids.size(); i++) {
+      i != kIdSize; i++) {
     int_backup_ids[i] = backup_ids[i];
   }
   // Store ints in java array

--- a/java/rocksjni/restorejni.cc
+++ b/java/rocksjni/restorejni.cc
@@ -156,10 +156,12 @@ jintArray Java_org_rocksdb_RestoreBackupableDB_getCorruptedBackups(
   reinterpret_cast<rocksdb::RestoreBackupableDB*>(jhandle)->
       GetCorruptedBackups(&backup_ids);
   // store backupids in int array
-  const int kIdSize = backup_ids.size();
+  const std::vector<rocksdb::BackupID>::size_type
+        kIdSize = backup_ids.size();
+
   int int_backup_ids[kIdSize];
   for (std::vector<rocksdb::BackupID>::size_type i = 0;
-      i != backup_ids.size(); i++) {
+      i != kIdSize; i++) {
     int_backup_ids[i] = backup_ids[i];
   }
   // Store ints in java array


### PR DESCRIPTION
Precision problem while building RocksJava 3.8.1, having a OS with 4byte integers.

Solves: https://github.com/facebook/rocksdb/issues/418
