### PR TITLE
Tweak Makefile for building on BG/Q

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,16 @@
 
 #-----------------------------------------------
 
+CFLAGS += ${EXTRA_CFLAGS}
+CXXFLAGS += ${EXTRA_CXXFLAGS}
+LDFLAGS += $(EXTRA_LDFLAGS)
+MACHINE ?= $(shell uname -m)
+
 ifneq ($(MAKECMDGOALS),dbg)
-OPT += -O2 -fno-omit-frame-pointer -momit-leaf-frame-pointer
+OPT += -O2 -fno-omit-frame-pointer
+ifneq ($(MACHINE),ppc64) # ppc64 doesn't support -momit-leaf-frame-pointer
+OPT += -momit-leaf-frame-pointer
+endif
 else
 # intentionally left blank
 endif


### PR DESCRIPTION
- Omit some gcc flags not present on Power 
- Allow additional C,CXX,LDFLAGS to point to custom dependency install path
