### PR TITLE
Mac OS X jclean fix

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -86,7 +86,6 @@ JAVA_TESTCLASSPATH = $(ROCKSDB_JAR):$(JAVA_JUNIT_JAR):$(JAVA_HAMCR_JAR):$(JAVA_M
 
 clean:
 	-find . -name "*.class" -exec rm {} \;
-	-find . -name "hs*.log" -exec rm {} \;
 	rm -rf include/*
 	rm -rf javadoc/*
 	rm -rf test-libs/


### PR DESCRIPTION
- A fix for the clean target of the Java Makefile so that it works on Mac OS X
- Also I don't think that hs_err_pid.log files should be removed during the clean step as developers may still want them.
