### PR TITLE
[RocksJava] MacOSX strip support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,7 +609,7 @@ rocksdbjavastatic: libz.a libbz2.a libsnappy.a
 	cd java;$(MAKE) javalib;
 	rm -f ./java/$(ROCKSDBJNILIB)
 	$(CXX) $(CXXFLAGS) -I./java/. $(JAVA_INCLUDE) -shared -fPIC -o ./java/$(ROCKSDBJNILIB) $(JNI_NATIVE_SOURCES) $(LIBOBJECTS) $(COVERAGEFLAGS) libz.a libbz2.a libsnappy.a
-	cd java;strip $(ROCKSDBJNILIB)
+	cd java;strip -S -x $(ROCKSDBJNILIB)
 	cd java;jar -cf $(ROCKSDB_JAR) org/rocksdb/*.class org/rocksdb/util/*.class HISTORY*.md $(ROCKSDBJNILIB)
 	cd java/javadoc;jar -cf ../$(ROCKSDB_JAVADOCS_JAR) *
 	cd java;jar -cf $(ROCKSDB_SOURCES_JAR) org


### PR DESCRIPTION
Strip support was previous to this request not working on MacOSX.

@adamretter verified this change on his machine.
