### PR TITLE
[RocksJava] ColumnFamilyDescriptor alignment with listColumnFamilies

### DIFF
--- a/java/RocksDBColumnFamilySample.java
+++ b/java/RocksDBColumnFamilySample.java
@@ -33,7 +33,8 @@ public class RocksDBColumnFamilySample {
 
       // create column family
       columnFamilyHandle = db.createColumnFamily(
-          new ColumnFamilyDescriptor("new_cf", new ColumnFamilyOptions()));
+          new ColumnFamilyDescriptor("new_cf".getBytes(),
+          new ColumnFamilyOptions()));
       assert(columnFamilyHandle != null);
 
     } finally {
@@ -56,7 +57,7 @@ public class RocksDBColumnFamilySample {
         RocksDB.DEFAULT_COLUMN_FAMILY, new ColumnFamilyOptions()));
     // open the new one, too
     columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
-        "new_cf", new ColumnFamilyOptions()));
+        "new_cf".getBytes(), new ColumnFamilyOptions()));
     List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
     try {
       db = RocksDB.open(new DBOptions(), db_path,

--- a/java/org/rocksdb/ColumnFamilyDescriptor.java
+++ b/java/org/rocksdb/ColumnFamilyDescriptor.java
@@ -16,7 +16,8 @@ public class ColumnFamilyDescriptor {
    * options,</p>
    *
    * @param columnFamilyName name of column family.
-   * @deprecated will be removed in RocksDB 3.10.0. Use {}
+   * @deprecated will be removed in RocksDB 3.10.0. Use
+   * {@link #ColumnFamilyDescriptor(byte[])} instead.
    */
   @Deprecated
   public ColumnFamilyDescriptor(final String columnFamilyName){
@@ -41,7 +42,8 @@ public class ColumnFamilyDescriptor {
    * @param columnFamilyName name of column family.
    * @param columnFamilyOptions options to be used with
    *     column family.
-   * @deprecated will be removed in RocksDB 3.10.0. Use {}
+   * @deprecated will be removed in RocksDB 3.10.0. Use
+   * {@link #ColumnFamilyDescriptor(byte[], ColumnFamilyOptions)} instead.
    */
   @Deprecated
   public ColumnFamilyDescriptor(final String columnFamilyName,

--- a/java/org/rocksdb/ColumnFamilyDescriptor.java
+++ b/java/org/rocksdb/ColumnFamilyDescriptor.java
@@ -16,8 +16,21 @@ public class ColumnFamilyDescriptor {
    * options,</p>
    *
    * @param columnFamilyName name of column family.
+   * @deprecated will be removed in RocksDB 3.10.0. Use {}
    */
+  @Deprecated
   public ColumnFamilyDescriptor(final String columnFamilyName){
+    this(columnFamilyName.getBytes(), new ColumnFamilyOptions());
+  }
+
+  /**
+   * <p>Creates a new Column Family using a name and default
+   * options,</p>
+   *
+   * @param columnFamilyName name of column family.
+   * @since 3.10.0
+   */
+  public ColumnFamilyDescriptor(final byte[] columnFamilyName) {
     this(columnFamilyName, new ColumnFamilyOptions());
   }
 
@@ -28,8 +41,24 @@ public class ColumnFamilyDescriptor {
    * @param columnFamilyName name of column family.
    * @param columnFamilyOptions options to be used with
    *     column family.
+   * @deprecated will be removed in RocksDB 3.10.0. Use {}
    */
+  @Deprecated
   public ColumnFamilyDescriptor(final String columnFamilyName,
+      final ColumnFamilyOptions columnFamilyOptions) {
+    this(columnFamilyName.getBytes(), columnFamilyOptions);
+  }
+
+  /**
+   * <p>Creates a new Column Family using a name and custom
+   * options.</p>
+   *
+   * @param columnFamilyName name of column family.
+   * @param columnFamilyOptions options to be used with
+   *     column family.
+   * @since 3.10.0
+   */
+  public ColumnFamilyDescriptor(final byte[] columnFamilyName,
       final ColumnFamilyOptions columnFamilyOptions) {
     columnFamilyName_ = columnFamilyName;
     columnFamilyOptions_ = columnFamilyOptions;
@@ -39,8 +68,9 @@ public class ColumnFamilyDescriptor {
    * Retrieve name of column family.
    *
    * @return column family name.
+   * @since 3.10.0
    */
-  public String columnFamilyName() {
+  public byte[] columnFamilyName() {
     return columnFamilyName_;
   }
 
@@ -53,6 +83,6 @@ public class ColumnFamilyDescriptor {
     return columnFamilyOptions_;
   }
 
-  private final String columnFamilyName_;
+  private final byte[] columnFamilyName_;
   private final ColumnFamilyOptions columnFamilyOptions_;
 }

--- a/java/org/rocksdb/RocksDB.java
+++ b/java/org/rocksdb/RocksDB.java
@@ -16,7 +16,7 @@ import org.rocksdb.util.Environment;
  * indicates sth wrong at the RocksDB library side and the call failed.
  */
 public class RocksDB extends RocksObject {
-  public static final String DEFAULT_COLUMN_FAMILY = "default";
+  public static final byte[] DEFAULT_COLUMN_FAMILY = "default".getBytes();
   public static final int NOT_FOUND = -1;
 
   static {

--- a/java/org/rocksdb/test/AbstractComparatorTest.java
+++ b/java/org/rocksdb/test/AbstractComparatorTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractComparatorTest {
         new ArrayList<>();
     cfDescriptors.add(new ColumnFamilyDescriptor(
         RocksDB.DEFAULT_COLUMN_FAMILY));
-    cfDescriptors.add(new ColumnFamilyDescriptor("new_cf",
+    cfDescriptors.add(new ColumnFamilyDescriptor("new_cf".getBytes(),
         new ColumnFamilyOptions().setComparator(
             getAscendingIntKeyComparator())));
     List<ColumnFamilyHandle> cfHandles = new ArrayList<>();

--- a/java/org/rocksdb/test/ColumnFamilyTest.java
+++ b/java/org/rocksdb/test/ColumnFamilyTest.java
@@ -68,7 +68,7 @@ public class ColumnFamilyTest {
       dbOptions.setCreateIfMissing(true);
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath());
-      db.createColumnFamily(new ColumnFamilyDescriptor("new_cf",
+      db.createColumnFamily(new ColumnFamilyDescriptor("new_cf".getBytes(),
           new ColumnFamilyOptions()));
       db.close();
       List<byte[]> columnFamilyNames;
@@ -102,7 +102,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -191,12 +191,12 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
       tmpColumnFamilyHandle = db.createColumnFamily(
-          new ColumnFamilyDescriptor("tmpCF", new ColumnFamilyOptions()));
+          new ColumnFamilyDescriptor("tmpCF".getBytes(), new ColumnFamilyOptions()));
       db.put(tmpColumnFamilyHandle, "key".getBytes(), "value".getBytes());
       db.dropColumnFamily(tmpColumnFamilyHandle);
       tmpColumnFamilyHandle.dispose();
@@ -226,7 +226,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -273,7 +273,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -322,7 +322,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf"));
+      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfDescriptors, columnFamilyHandleList);
@@ -367,7 +367,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -409,7 +409,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -459,7 +459,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -487,7 +487,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -515,7 +515,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);
@@ -543,7 +543,7 @@ public class ColumnFamilyTest {
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
       cfNames.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
-      cfNames.add(new ColumnFamilyDescriptor("new_cf"));
+      cfNames.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
 
       db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath(),
           cfNames, columnFamilyHandleList);

--- a/java/org/rocksdb/test/KeyMayExistTest.java
+++ b/java/org/rocksdb/test/KeyMayExistTest.java
@@ -37,8 +37,8 @@ public class KeyMayExistTest {
           new ArrayList<>();
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
-      cfDescriptors.add(new ColumnFamilyDescriptor("default"));
-      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf"));
+      cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf".getBytes()));
       db = RocksDB.open(options,
           dbFolder.getRoot().getAbsolutePath(),
           cfDescriptors, columnFamilyHandleList);

--- a/java/org/rocksdb/test/MergeTest.java
+++ b/java/org/rocksdb/test/MergeTest.java
@@ -8,7 +8,6 @@ package org.rocksdb.test;
 import java.util.List;
 import java.util.ArrayList;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,10 +72,10 @@ public class MergeTest {
 
       List<ColumnFamilyDescriptor> cfDescriptors =
           new ArrayList<>();
-      cfDescriptors.add(new ColumnFamilyDescriptor("default",
+      cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY,
           new ColumnFamilyOptions().setMergeOperatorName(
               "stringappend")));
-      cfDescriptors.add(new ColumnFamilyDescriptor("default",
+      cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY,
           new ColumnFamilyOptions().setMergeOperatorName(
               "stringappend")));
       db = RocksDB.open(opt, db_path_string,
@@ -158,10 +157,10 @@ public class MergeTest {
           new ArrayList<>();
       List<ColumnFamilyHandle> columnFamilyHandleList =
           new ArrayList<>();
-      cfDescriptors.add(new ColumnFamilyDescriptor("default",
+      cfDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY,
           new ColumnFamilyOptions().setMergeOperator(
               stringAppendOperator)));
-      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf",
+      cfDescriptors.add(new ColumnFamilyDescriptor("new_cf".getBytes(),
           new ColumnFamilyOptions().setMergeOperator(
               stringAppendOperator)));
       db = RocksDB.open(opt, db_path_string,
@@ -178,7 +177,7 @@ public class MergeTest {
 
       // Test also with createColumnFamily
       columnFamilyHandle = db.createColumnFamily(
-          new ColumnFamilyDescriptor("new_cf2",
+          new ColumnFamilyDescriptor("new_cf2".getBytes(),
               new ColumnFamilyOptions().setMergeOperator(stringAppendOperator)));
       // writing xx under cfkey2
       db.put(columnFamilyHandle, "cfkey2".getBytes(), "xx".getBytes());

--- a/java/org/rocksdb/test/ReadOnlyTest.java
+++ b/java/org/rocksdb/test/ReadOnlyTest.java
@@ -58,9 +58,9 @@ public class ReadOnlyTest {
       db = RocksDB.open(
           dbFolder.getRoot().getAbsolutePath(), cfDescriptors, columnFamilyHandleList);
       columnFamilyHandleList.add(db.createColumnFamily(
-          new ColumnFamilyDescriptor("new_cf", new ColumnFamilyOptions())));
+          new ColumnFamilyDescriptor("new_cf".getBytes(), new ColumnFamilyOptions())));
       columnFamilyHandleList.add(db.createColumnFamily(
-          new ColumnFamilyDescriptor("new_cf2", new ColumnFamilyOptions())));
+          new ColumnFamilyDescriptor("new_cf2".getBytes(), new ColumnFamilyOptions())));
       db.put(columnFamilyHandleList.get(2), "key2".getBytes(),
           "value2".getBytes());
 
@@ -75,7 +75,7 @@ public class ReadOnlyTest {
           new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY,
               new ColumnFamilyOptions()));
       cfDescriptors.add(
-          new ColumnFamilyDescriptor("new_cf2", new ColumnFamilyOptions()));
+          new ColumnFamilyDescriptor("new_cf2".getBytes(), new ColumnFamilyOptions()));
       db3 = RocksDB.openReadOnly(
           dbFolder.getRoot().getAbsolutePath(), cfDescriptors, readOnlyColumnFamilyHandleList2);
       assertThat(new String(db3.get(readOnlyColumnFamilyHandleList2.get(1),

--- a/java/org/rocksdb/test/RocksDBTest.java
+++ b/java/org/rocksdb/test/RocksDBTest.java
@@ -370,7 +370,7 @@ public class RocksDBTest {
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
           RocksDB.DEFAULT_COLUMN_FAMILY));
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
-          "new_cf",
+          "new_cf".getBytes(),
           new ColumnFamilyOptions().
               setDisableAutoCompactions(true).
               setCompactionStyle(CompactionStyle.LEVEL).
@@ -501,7 +501,7 @@ public class RocksDBTest {
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
           RocksDB.DEFAULT_COLUMN_FAMILY));
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
-          "new_cf",
+          "new_cf".getBytes(),
           new ColumnFamilyOptions().
               setDisableAutoCompactions(true).
               setCompactionStyle(CompactionStyle.LEVEL).
@@ -556,7 +556,7 @@ public class RocksDBTest {
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
           RocksDB.DEFAULT_COLUMN_FAMILY));
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
-          "new_cf",
+          "new_cf".getBytes(),
           new ColumnFamilyOptions().
               setDisableAutoCompactions(true).
               setCompactionStyle(CompactionStyle.LEVEL).
@@ -670,7 +670,7 @@ public class RocksDBTest {
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
           RocksDB.DEFAULT_COLUMN_FAMILY));
       columnFamilyDescriptors.add(new ColumnFamilyDescriptor(
-          "new_cf",
+          "new_cf".getBytes(),
           new ColumnFamilyOptions().
               setDisableAutoCompactions(true).
               setCompactionStyle(CompactionStyle.LEVEL).

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -172,7 +172,7 @@ class ColumnFamilyDescriptorJni {
   static jmethodID getColumnFamilyNameMethod(JNIEnv* env) {
     static jmethodID mid = env->GetMethodID(
         getColumnFamilyDescriptorClass(env),
-        "columnFamilyName", "()Ljava/lang/String;");
+        "columnFamilyName", "()[B");
     assert(mid != nullptr);
     return mid;
   }

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -93,11 +93,11 @@ jobject
       jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
           jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-          env)));
+              env)));
       // get CF Options
       jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
-          env));
+              env));
       rocksdb::ColumnFamilyOptions* cfOptions =
           rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 
@@ -178,11 +178,11 @@ jobject Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2Ljava_util_List_2I(
       jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
           jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-          env)));
+              env)));
       // get CF Options
       jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
-          env));
+              env));
       rocksdb::ColumnFamilyOptions* cfOptions =
           rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 
@@ -1189,11 +1189,11 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(
   jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
       jcf_descriptor,
       rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-      env)));
+          env)));
   // get CF Options
   jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
       rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
-      env));
+          env));
   rocksdb::ColumnFamilyOptions* cfOptions =
       rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -74,8 +74,8 @@ jobject
   rocksdb::DB* db = nullptr;
   const char* db_path = env->GetStringUTFChars(jdb_path, 0);
 
-  std::vector<const char*> cfnames_to_free;
-  std::vector<jstring> jcfnames_for_free;
+  std::vector<jbyte*> cfnames_to_free;
+  std::vector<jbyteArray> jcfnames_for_free;
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   std::vector<rocksdb::ColumnFamilyHandle* > handles;
@@ -90,9 +90,10 @@ jobject
       jobject jcf_descriptor = env->CallObjectMethod(iteratorObj,
           rocksdb::ListJni::getNextMethod(env));
       // get ColumnFamilyName
-      jstring jstr = (jstring) env->CallObjectMethod(jcf_descriptor,
+      jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
+          jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-          env));
+          env)));
       // get CF Options
       jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
@@ -100,12 +101,13 @@ jobject
       rocksdb::ColumnFamilyOptions* cfOptions =
           rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 
-      const char* cfname = env->GetStringUTFChars(jstr, 0);
+      jbyte* cfname = env->GetByteArrayElements(byteArray, 0);
 
       // free allocated cfnames after call to open
       cfnames_to_free.push_back(cfname);
-      jcfnames_for_free.push_back(jstr);
-      column_families.push_back(rocksdb::ColumnFamilyDescriptor(cfname,
+      jcfnames_for_free.push_back(byteArray);
+      column_families.push_back(rocksdb::ColumnFamilyDescriptor(
+          reinterpret_cast<char *>(cfname),
           *cfOptions));
   }
 
@@ -116,7 +118,7 @@ jobject
   for (std::vector<jbyte*>::size_type i = 0;
       i != cfnames_to_free.size(); i++) {
     // free  cfnames
-    env->ReleaseStringUTFChars(jcfnames_for_free[i], cfnames_to_free[i]);
+    env->ReleaseByteArrayElements(jcfnames_for_free[i], cfnames_to_free[i], 0);
   }
 
   // check if open operation was successful
@@ -157,8 +159,8 @@ jobject Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2Ljava_util_List_2I(
   rocksdb::DB* db = nullptr;
   const char* db_path = env->GetStringUTFChars(jdb_path, 0);
 
-  std::vector<const char*> cfnames_to_free;
-  std::vector<jstring> jcfnames_for_free;
+  std::vector<jbyte*> cfnames_to_free;
+  std::vector<jbyteArray> jcfnames_for_free;
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   std::vector<rocksdb::ColumnFamilyHandle* > handles;
@@ -173,9 +175,10 @@ jobject Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2Ljava_util_List_2I(
       jobject jcf_descriptor = env->CallObjectMethod(iteratorObj,
           rocksdb::ListJni::getNextMethod(env));
       // get ColumnFamilyName
-      jstring jstr = (jstring) env->CallObjectMethod(jcf_descriptor,
+      jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
+          jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-          env));
+          env)));
       // get CF Options
       jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
           rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
@@ -183,12 +186,13 @@ jobject Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2Ljava_util_List_2I(
       rocksdb::ColumnFamilyOptions* cfOptions =
           rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 
-      const char* cfname = env->GetStringUTFChars(jstr, 0);
+      jbyte* cfname = env->GetByteArrayElements(byteArray, 0);
 
       // free allocated cfnames after call to open
       cfnames_to_free.push_back(cfname);
-      jcfnames_for_free.push_back(jstr);
-      column_families.push_back(rocksdb::ColumnFamilyDescriptor(cfname,
+      jcfnames_for_free.push_back(byteArray);
+      column_families.push_back(rocksdb::ColumnFamilyDescriptor(
+          reinterpret_cast<const char *>(cfname),
           *cfOptions));
   }
 
@@ -199,7 +203,7 @@ jobject Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2Ljava_util_List_2I(
   for (std::vector<jbyte*>::size_type i = 0;
       i != cfnames_to_free.size(); i++) {
     // free  cfnames
-    env->ReleaseStringUTFChars(jcfnames_for_free[i], cfnames_to_free[i]);
+    env->ReleaseByteArrayElements(jcfnames_for_free[i], cfnames_to_free[i], 0);
   }
 
   // check if open operation was successful
@@ -1181,9 +1185,11 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(
   rocksdb::ColumnFamilyHandle* handle;
   auto db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
 
-  jstring jstr = (jstring) env->CallObjectMethod(jcf_descriptor,
+  // get ColumnFamilyName
+  jbyteArray byteArray = static_cast<jbyteArray>(env->CallObjectMethod(
+      jcf_descriptor,
       rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyNameMethod(
-      env));
+      env)));
   // get CF Options
   jobject jcf_opt_obj = env->CallObjectMethod(jcf_descriptor,
       rocksdb::ColumnFamilyDescriptorJni::getColumnFamilyOptionsMethod(
@@ -1191,10 +1197,10 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(
   rocksdb::ColumnFamilyOptions* cfOptions =
       rocksdb::ColumnFamilyOptionsJni::getHandle(env, jcf_opt_obj);
 
-  const char* cfname = env->GetStringUTFChars(jstr, 0);
+  jbyte* cfname = env->GetByteArrayElements(byteArray, 0);
   rocksdb::Status s = db_handle->CreateColumnFamily(
-      *cfOptions, cfname, &handle);
-  env->ReleaseStringUTFChars(jstr, cfname);
+      *cfOptions, reinterpret_cast<char *>(cfname), &handle);
+  env->ReleaseByteArrayElements(byteArray, cfname, 0);
 
   if (s.ok()) {
     return reinterpret_cast<jlong>(handle);


### PR DESCRIPTION
Previous to this commit ColumnFamilyDescriptor took a String as name for the ColumnFamily name. String is however encoding dependent which is bad because listColumnFamilies returns byte arrays without any encoding information.

All public API calls were deprecated and flagged to be removed in 3.10.0

Differential: https://reviews.facebook.net/D30525

Solves issue: https://github.com/facebook/rocksdb/pull/441