### PR TITLE
Build with clang 3.5 on Linux.

### DIFF
--- a/util/thread_local.cc
+++ b/util/thread_local.cc
@@ -10,7 +10,7 @@
 #include "util/thread_local.h"
 #include "util/mutexlock.h"
 #include "port/likely.h"
-
+#include <stdlib.h>
 
 namespace rocksdb {
 


### PR DESCRIPTION
I got a build failure on linux with clang 3.5:

 /usr/local/bin/clang++   -DCLANG_INCLUDEPATH=/usr/local/lib/clang/3.5.0/include/ -DOS_Linux -DRCT_DB_USE_ROCKSDB -DRCT_HAVE_ZLIB -DROCKSDB_PLATFORM_POSIX -DRTAGS_BIN=\"/home/jhanssen/dev/rtags/bin/\" -Wextra -Wall -Wall -fstack-protector-all -Wstack-protector -std=c++0x -fpic -stdlib=libc++ -std=c++0x -fpic -stdlib=libc++ -O3 -DNDEBUG -I/usr/local/include -isystem src/rct/3rdparty/rocksdb -isystem src/rct/3rdparty/rocksdb/include -Isrc/rct -Isrc/include/rct -Isrc/include/rct/.. -Isrc -Isrc/rct/include -Isrc/rct/include/rct    -fcolor-diagnostics -Wall -MMD -MT src/CMakeFiles/rct.dir/rct/3rdparty/rocksdb/util/thread_local.cc.o -MF "src/CMakeFiles/rct.dir/rct/3rdparty/rocksdb/util/thread_local.cc.o.d" -o src/CMakeFiles/rct.dir/rct/3rdparty/rocksdb/util/thread_local.cc.o -c src/rct/3rdparty/rocksdb/util/thread_local.cc
src/rct/3rdparty/rocksdb/util/thread_local.cc:54:5: error: use of undeclared identifier 'abort'
   abort();
   ^
src/rct/3rdparty/rocksdb/util/thread_local.cc:101:7: error: use of undeclared identifier 'abort'
     abort();
     ^