### PR TITLE
[RocksJava] DirectSlice String termination fix

### DIFF
--- a/java/rocksjni/slice.cc
+++ b/java/rocksjni/slice.cc
@@ -28,9 +28,11 @@ void Java_org_rocksdb_AbstractSlice_createNewSliceFromString(
     JNIEnv* env, jobject jobj, jstring jstr) {
 
   const auto* str = env->GetStringUTFChars(jstr, 0);
-  const size_t len = strlen(str);
+  const size_t len = strlen(str) + 1;
   char* buf = new char[len];
-  memcpy(buf, str, len);
+  memcpy(buf, str, len - 1);
+  buf[len-1]='\0';
+
   env->ReleaseStringUTFChars(jstr, str);
 
   const auto* slice = new rocksdb::Slice(buf);

--- a/java/rocksjni/slice.cc
+++ b/java/rocksjni/slice.cc
@@ -28,11 +28,10 @@ void Java_org_rocksdb_AbstractSlice_createNewSliceFromString(
     JNIEnv* env, jobject jobj, jstring jstr) {
 
   const auto* str = env->GetStringUTFChars(jstr, 0);
-  const size_t len = strlen(str) + 1;
-  char* buf = new char[len];
-  memcpy(buf, str, len - 1);
-  buf[len-1]='\0';
-
+  const size_t len = strlen(str);
+  char* buf = new char[len + 1];
+  memcpy(buf, str, len);
+  buf[len] = 0;
   env->ReleaseStringUTFChars(jstr, str);
 
   const auto* slice = new rocksdb::Slice(buf);


### PR DESCRIPTION
DirectSlice fix for non terminated String copy. This lead sometimes
to problems with DirectSliceTest.