### PR TITLE
[RocksJava] Fixes to latest WriteBatchWithIndex addition

### DIFF
--- a/java/org/rocksdb/AbstractRocksIterator.java
+++ b/java/org/rocksdb/AbstractRocksIterator.java
@@ -8,13 +8,13 @@ package org.rocksdb;
 /**
  * Base class implementation for Rocks Iterators
  * in the Java API
- * <p/>
+ *
  * <p>Multiple threads can invoke const methods on an RocksIterator without
  * external synchronization, but if any of the threads may call a
  * non-const method, all threads accessing the same RocksIterator must use
  * external synchronization.</p>
  *
- * @param P The type of the Parent Object from which the Rocks Iterator was
+ * @param <P> The type of the Parent Object from which the Rocks Iterator was
  *          created. This is used by disposeInternal to avoid double-free
  *          issues with the underlying C++ object.
  * @see org.rocksdb.RocksObject
@@ -78,7 +78,7 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
 
   /**
    * <p>Deletes underlying C++ iterator pointer.</p>
-   * <p/>
+   *
    * <p>Note: the underlying handle can only be safely deleted if the parent
    * instance related to a certain RocksIterator is still valid and initialized.
    * Therefore {@code disposeInternal()} checks if the parent is initialized

--- a/java/org/rocksdb/RocksIteratorInterface.java
+++ b/java/org/rocksdb/RocksIteratorInterface.java
@@ -10,7 +10,7 @@ package org.rocksdb;
  * access to data one entry at a time. Multiple implementations
  * are provided by this library.  In particular, iterators are provided
  * to access the contents of a DB and Write Batch.</p>
- * <p/>
+ *
  * <p>Multiple threads can invoke const methods on an RocksIterator without
  * external synchronization, but if any of the threads may call a
  * non-const method, all threads accessing the same RocksIterator must use
@@ -43,7 +43,7 @@ public interface RocksIteratorInterface {
   /**
    * <p>Position at the first entry in the source whose key is that or
    * past target.</p>
-   * <p/>
+   *
    * <p>The iterator is valid after this call if the source contains
    * a key that comes at or past target.</p>
    *
@@ -55,7 +55,7 @@ public interface RocksIteratorInterface {
   /**
    * <p>Moves to the next entry in the source.  After this call, Valid() is
    * true if the iterator was not positioned at the last entry in the source.</p>
-   * <p/>
+   *
    * <p>REQUIRES: {@link #isValid()}</p>
    */
   public void next();
@@ -63,13 +63,13 @@ public interface RocksIteratorInterface {
   /**
    * <p>Moves to the previous entry in the source.  After this call, Valid() is
    * true if the iterator was not positioned at the first entry in source.</p>
-   * <p/>
+   *
    * <p>REQUIRES: {@link #isValid()}</p>
    */
   public void prev();
 
   /**
-   * <pIf an error has occurred, return it.  Else return an ok status.
+   * <p>If an error has occurred, return it.  Else return an ok status.
    * If non-blocking IO is requested and this operation cannot be
    * satisfied without doing some IO, then this returns Status::Incomplete().</p>
    *

--- a/java/org/rocksdb/test/WriteBatchWithIndexTest.java
+++ b/java/org/rocksdb/test/WriteBatchWithIndexTest.java
@@ -217,19 +217,19 @@ public class WriteBatchWithIndexTest {
 
         it.seek(key);
         assertThat(it.isValid()).isTrue();
-        assertThat(it.entry()).isEqualTo(expected[testOffset]);
+        assertThat(it.entry().equals(expected[testOffset])).isTrue();
       }
 
       //forward iterative access
       int i = 0;
       for(it.seekToFirst(); it.isValid(); it.next()) {
-        assertThat(it.entry()).isEqualTo(expected[i++]);
+        assertThat(it.entry().equals(expected[i++])).isTrue();
       }
 
       //reverse iterative access
       i = expected.length - 1;
       for(it.seekToLast(); it.isValid(); it.prev()) {
-        assertThat(it.entry()).isEqualTo(expected[i--]);
+        assertThat(it.entry().equals(expected[i--])).isTrue();
       }
 
     } finally {


### PR DESCRIPTION
This pull request includes two commits:
- Java8 JavaDoc corrections. Some illegal tags were used which broke JavaDoc generation.
- WriteBatchWithIndex was using incorrect assert statements. These statements make use now as inteded equals method for comparison.