### PR TITLE
Release.md - Remove version change instruction

### DIFF
--- a/java/RELEASE.md
+++ b/java/RELEASE.md
@@ -41,8 +41,6 @@ Set ~/.m2/settings.xml to contain:
       </servers>
     </settings>
 
-Then update rocksjni.pom's version tag to reflect the release version.
-
 From RocksDB's root directory, first build the Java static JARs:
 
     make jclean clean rocksdbjavastaticpublish


### PR DESCRIPTION
The version change instruction is obsolete with the change
that maven pulls versioning information from version.h.

@adamretter can you look into this.

See as reference: https://github.com/facebook/rocksdb/commit/b8d5e3f08e075fb37af73fdd9dceb7d369f38dd7