### PR TITLE
BW-Tree implementation for Memtable; Request for review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ TESTS = \
 	filelock_test \
 	filename_test \
 	block_based_filter_block_test \
+	btree_test \
 	full_filter_block_test \
 	histogram_test \
 	log_test \
@@ -491,6 +492,9 @@ table_test: table/table_test.o $(LIBOBJECTS) $(TESTHARNESS)
 
 block_test: table/block_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(CXX) table/block_test.o $(LIBOBJECTS) $(TESTHARNESS) $(EXEC_LDFLAGS) -o $@ $(LDFLAGS) $(COVERAGEFLAGS)
+
+btree_test: db/btree_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(CXX) db/btree_test.o $(LIBOBJECTS) $(TESTHARNESS) $(EXEC_LDFLAGS) -o $@ $(LDFLAGS) $(COVERAGEFLAGS)
 
 skiplist_test: db/skiplist_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(CXX) db/skiplist_test.o $(LIBOBJECTS) $(TESTHARNESS) $(EXEC_LDFLAGS) -o $@ $(LDFLAGS) $(COVERAGEFLAGS)

--- a/db/btree.h
+++ b/db/btree.h
@@ -1,0 +1,660 @@
+//  Copyright (c) 2013, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// Thread safety
+// -------------
+//
+// Writes require external synchronization, most likely a mutex.
+// Reads require a guarantee that the BTree will not be destroyed
+// while the read is in progress.  Apart from that, reads progress
+// without any internal locking or synchronization.(B-link tree)
+//
+//
+
+#pragma once
+#include <assert.h>
+#include <stdlib.h>
+#include <stack>
+#include "util/arena.h"
+#include "port/port.h"
+#include "util/arena.h"
+
+namespace rocksdb {
+
+template<typename Key, class Comparator>
+class BTree {
+ private:
+  struct Node;
+  struct IndexEntry;
+
+ public:
+  // Create a new BTree object that will use "cmp" for comparing keys,
+  // and will allocate memory using "*arena".  Objects allocated in the arena
+  // must remain allocated for the lifetime of the skiplist object.
+  //
+  // TODO Actually I'll create node from existing node when inserting, and after relink other references,
+  // I'll remove the original node from memory. Is it possible to do that with arena?
+  explicit BTree(Comparator cmp, Arena* arena, 
+    int32_t fanOutFactor = 128, int32_t maxNodeSize = 128);
+
+  // Insert key into the tree.
+  // REQUIRES: nothing that compares equal to key is currently in the tree.
+  void Insert(const Key& key);
+
+  // Returns true iff an entry that compares equal to key is in the tree.
+  bool Contains(const Key& key) const;
+
+  // Iteration over the contents of a btree
+  class Iterator {
+   public:
+    // Initialize an iterator over the specified tree.
+    // The returned iterator is not valid.
+    explicit Iterator(const BTree* tree);
+
+    // Change the underlying btree used for this iterator
+    // This enables us not changing the iterator without deallocating
+    // an old one and then allocating a new one
+    void SetTree(const BTree* tree);
+
+    // Returns true iff the iterator is positioned at a valid node.
+    bool Valid() const;
+
+    // Returns the key at the current position.
+    // REQUIRES: Valid()
+    const Key& key() const;
+
+    // Advances to the next position.
+    // REQUIRES: Valid()
+    void Next();
+
+    // Advances to the previous position.
+    // REQUIRES: Valid()
+    void Prev();
+
+    // Advance to the first entry with a key >= target
+    void Seek(const Key& target);
+
+    // Position at the first entry in tree.
+    // Final state of iterator is Valid() iff list is not empty.
+    void SeekToFirst();
+
+    // Position at the last entry in tree.
+    // Final state of iterator is Valid() iff list is not empty.
+    void SeekToLast();
+
+   private:
+    const BTree* tree_;
+    Node* node_; // leaf node logically used as the first on the delta nodes chain
+    std::vector<IndexEntry> aggregated_; // Maintain snapshot
+    int offset_; // cursor into aggretaged_ vector
+    
+    // TODO 
+    // In order to prevent invalidating the iterator, I'll use Epoch mechanism [Levandoski]
+    // to defer garbage collect unused nodes. Since the only two access patterns are when inserting and
+    // Accessing Iterator, one can implement Epoch around those two usecases
+
+    // Aggregate node chain's content into single sorted aggregated vector
+    void aggregateToVector() {
+      aggregated_.clear();
+      int chainDepth = node_->depth();
+      std::vector<int> idx(chainDepth, 0);
+      std::vector<int> numEntries(chainDepth, 0);
+      int vectorSize = 0;
+      for (int i = 0; i < chainDepth; i++) {
+        vectorSize += (*node_)[i]->numEntries;
+        numEntries[i] = (*node_)[i]->numEntries;
+      }
+      aggregated_.resize(vectorSize);
+      for (int i = 0; i < vectorSize; i++) {
+        Key min = nullptr;
+        int minNodeIdx = -1;
+        for (int j = 0; j < chainDepth; j++) {
+          if (idx[j] < numEntries[j]) {
+            Key compared = node_->entries[idx[j]].key;
+            if (min == nullptr || tree_->compare_(compared, min) < 0) {
+              min = compared;
+              minNodeIdx = j;
+            }  
+          }
+        }
+        assert(minNodeIdx != -1 && min != nullptr);
+        int accesingIdx = idx[minNodeIdx]++;
+        aggregated_[i] = (*node_)[minNodeIdx]->entries[accesingIdx];
+      }
+    }
+  };
+
+  // Maps from logical node id to physical pointer to a Node. Adopted from Bw-Tree.
+  class MappingTable {
+  public:
+    MappingTable(Arena* arena, int capacity = 10000) 
+    : arena_(arena), capacity_(capacity) {
+      char* mem = arena_->AllocateAligned(sizeof(Node*) * capacity);
+      table_ = (Node**) mem; 
+      size_ = 0;
+    }
+
+    Node* getNode(int pid) const {
+      assert(pid < size_);
+      return table_[pid];
+    }
+
+    // No need to synchronize since externally synchronized, and newly being added
+    int addNode(Node* node) {
+      assert(size_ < capacity_);
+      int pid = size_;
+      table_[pid] = node;
+      size_++;
+      return pid;
+    }
+
+    void updateNode(int pid, Node* node) {
+      assert(pid < size_);
+      // TODO Do I need memory barrier here?
+      table_[pid] = node;
+    }
+    
+  private:
+    Arena* const arena_;
+    Node** table_;
+    int capacity_;
+    int size_;
+  };
+
+ private:
+  const int32_t kFanOut_;
+  const int32_t kMaxNodeSize_;
+
+  // Immutable after construction
+  Comparator const compare_;
+  Arena* const arena_;    // Arena used for allocations of nodes
+  MappingTable mappingTable_;
+  int rootPid_;
+
+  Node* NewNode(int numEntries, int8_t type);
+  bool Equal(const Key& a, const Key& b) const { return (compare_(a, b) == 0); }
+
+  // Return the earliest node that comes at or after key.
+  // Return nullptr for first element if there is no such node.
+  std::tuple<Node*, int, int, std::unique_ptr<class std::stack<Node*> > > FindGreaterOrEqual(const Key& key) const;
+
+  // Return the latest node with a key < key.
+  // Return nullptr if there is no such node.
+  std::tuple<Node*, int, int> FindLessThan(const Key& key) const;
+
+  // Return nullptr if tree is empty
+  std::tuple<Node*, int, int> FindFirst() const;
+
+  // Return the last node in the tree.
+  // Return nullptr if tree is empty.
+  std::tuple<Node*, int, int, std::unique_ptr<std::stack<Node*> > > FindLast() const;
+
+  bool splitIsNecessary(Node* node);
+
+  std::tuple<Node*, Node*> splitWithAddedEntry(Node* node, int depthIndex, int entryIndex, const IndexEntry & entry);
+
+  // No copying allowed
+  BTree(const BTree&);
+  void operator=(const BTree&);
+};
+
+template<typename Key, class Comparator>
+struct BTree<Key, Comparator>::IndexEntry {
+  Key key;
+  union {
+    int32_t pid; // logical pointer to next level node at mapping table
+    Key obj; // actual pointer to object  
+  };
+};
+
+// Implementation details follow
+template<typename Key, class Comparator>
+struct BTree<Key, Comparator>::Node {
+  explicit Node(int32_t ne, int8_t t)
+  : type(t), numEntries(ne) {
+    nextDelta = nullptr;
+    highKey = nullptr;
+    // lowKey = nullptr;
+    linkPtrPid = -1;
+    lowPtrPid = -1;
+  }
+
+  static const uint8_t NODE_TYPE_INDEX = 0;
+  static const uint8_t NODE_TYPE_LEAF = 1;
+
+  int32_t pid;
+  int8_t type;
+  Node* nextDelta;
+  Key highKey; // inclusive, upper bound of current node's keys(except at root node)
+  // Key lowKey; // exclusive
+  int32_t linkPtrPid;
+  int32_t lowPtrPid; // Pointer to child node with range (-infty, k0]
+  int32_t const numEntries;
+  IndexEntry entries[1];
+
+  // Depth of btree delta nodes chain
+  int depth() {
+    int depth = 0;
+    Node* node = this;
+    while (node != nullptr) {
+      depth++;
+      node = node->nextDelta;
+    }
+    return depth;
+  }
+
+  Node* operator[](int index) {
+    assert(index >= 0);
+    Node* ret = this;
+    while (index > 0) {
+      ret = ret->nextDelta;
+      if (ret == nullptr) return nullptr;
+      index--;
+    }
+    return ret;
+  }
+
+  int numEntriesSum() {
+    int sum = 0;
+    Node* node = this;
+    while (node != nullptr) {
+      sum += node->numEntries;
+      node = node->nextDelta;
+    }
+    return sum;
+  }
+ private: 
+};
+
+template<typename Key, class Comparator>
+typename BTree<Key, Comparator>::Node*
+BTree<Key, Comparator>::NewNode(int numEntries, int8_t type) {
+  char* mem = arena_->AllocateAligned(sizeof(Node) + sizeof(IndexEntry) * (numEntries - 1));
+  return new (mem) Node(numEntries, type);
+}
+
+template<typename Key, class Comparator>
+inline BTree<Key, Comparator>::Iterator::Iterator(const BTree* tree) {
+  SetTree(tree);
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::SetTree(const BTree* tree) {
+  tree_ = tree;
+  node_ = nullptr;
+  offset_ = -1;
+}
+
+template<typename Key, class Comparator>
+inline bool BTree<Key, Comparator>::Iterator::Valid() const {
+  return node_ != nullptr;
+  // TODO return fase if we are pointing to rightmost index entry of the rightmost node
+}
+
+template<typename Key, class Comparator>
+inline const Key& BTree<Key, Comparator>::Iterator::key() const {
+  assert(Valid());
+  return aggregated_[offset_].obj;
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::Next() {
+  assert(Valid());
+  if (offset_ == (int)(aggregated_.size() - 1)) {
+    node_ = tree_->mappingTable_.getNode(node_->linkPtrPid);
+    if (node_ == nullptr) {
+      offset_ = -1;
+      return;
+    }
+    aggregateToVector();
+    offset_ = 0;
+  } else {
+    offset_++;
+  }
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::Prev() {
+  // We search for the last node that falls before key.
+  assert(Valid());
+  if (offset_ == 0) {
+    Key currentKey = aggregated_[0].key;
+    auto tuple = tree_->FindLessThan(currentKey);
+    node_ = std::get<0>(tuple);
+    if (node_ == nullptr) { // Reached beginning of the tree.
+      offset_ = -1;
+      return;
+    }
+    aggregateToVector();
+    // A possible corner case would be that a new key lower than current 
+    // node's lowest was added and it was prepended in the current node.
+    // Then we shouldn't just start from the back end of the vector
+    offset_ = -1;
+    for (int i = aggregated_.size() - 1; i >= 0; i--) {
+      if (tree_->compare_(currentKey, aggregated_[i].key) < 0) {
+        offset_ = i;
+        break;
+      }
+    }
+    assert(offset != -1);
+  } else {
+    offset_--;
+  }
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::Seek(const Key& target) {
+  auto tuple = tree_->FindGreaterOrEqual(target);
+  node_ = std::get<0>(tuple);
+  if (node_ == nullptr) {
+    offset_ = -1;
+    return;
+  }
+  Key key = (*node_)[std::get<1>(tuple)]->entries[std::get<2>(tuple)].key;
+  aggregateToVector();
+  //TODO Could improve by using Binary search
+  offset_ = -1;
+  for (int i = 0; i < (int)aggregated_.size(); i++) {
+    if (tree_->compare_(aggregated_[i].key, key) == 0) {
+      offset_ = i;
+      break;
+    }
+  }
+  assert(offset_ != -1);
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::SeekToFirst() {
+  auto tuple = tree_->FindFirst();
+  node_ = std::get<0>(tuple);
+  if (node_ == nullptr) {
+    offset_ = -1;  
+    return;
+  }
+  aggregateToVector();
+  offset_ = 0;
+}
+
+template<typename Key, class Comparator>
+inline void BTree<Key, Comparator>::Iterator::SeekToLast() {
+  auto tuple = tree_->FindLast();
+  node_ = std::get<0>(tuple);
+  if (node_ == nullptr) {
+    offset_ = -1;
+    return;
+  }
+  aggregateToVector();
+  offset_ = aggregated_.size() - 1;
+}
+
+template<typename Key, class Comparator>
+std::tuple<typename BTree<Key, Comparator>::Node*, int, int, std::unique_ptr<class std::stack<typename BTree<Key, Comparator>::Node*> > > 
+BTree<Key, Comparator>::FindGreaterOrEqual(const Key& key) const {
+  Node* x = mappingTable_.getNode(rootPid_);
+  auto stack = std::unique_ptr<class std::stack<Node*> >(new std::stack<Node*>());
+  
+  int depthIndex = 0;
+  int entryIndex = -1;
+  while (true) {
+    assert(x != nullptr);
+    // TODO In case parent routed us to wrong(being splitted) node,
+    // We might need to look at the next linked node
+    // We can conveniently check with high_key
+    if (x->highKey != nullptr && compare_(key, x->highKey) > 0) {
+      // searching key is greater than highest key in this node
+      if (x->linkPtrPid == -1) {
+        // Reached the end of the tree
+        return std::make_tuple(nullptr, -1, -1, std::move(stack));
+      }
+      // Move to next node on the same level
+      x = mappingTable_.getNode(x->linkPtrPid);
+      continue;
+    }
+    stack->push(x);
+
+    Key curLowestKey = nullptr;
+    int depth = x->depth();
+    for (int i = 0; i < depth; i++) {// Iterate through delta chains
+      int left = 0;
+      int right = (*x)[i]->numEntries;
+      int middle = -1;
+      // Binary search
+      while (left < right) {
+        middle = (left + right) / 2;
+        int compared = compare_(key, (*x)[i]->entries[middle].key);
+        if (compared == 0) {
+          break;
+        } else if (compared < 0) {
+          // Search left
+          right = middle;
+        } else {
+          // Search right
+          left = middle + 1;
+        }
+      }
+      assert(left == right);
+      int selectedIndex = left;// This index is either equal key, or least greatest than search key on this depth
+      // In case we are at root node, and highKey is not defined but key is greater than any root node's keys
+      if (selectedIndex < (*x)[i]->numEntries) {
+        Key selectedKey = (*x)[i]->entries[selectedIndex].key;
+        assert(compare_(selectedKey, key) >= 0); // If we got here, selectedKey should always greater than or equal to search key
+        if (curLowestKey == nullptr || compare_(selectedKey, curLowestKey) < 0) {
+          // key <= selectedKey < curLowestKey
+          curLowestKey = selectedKey;
+          depthIndex = i;
+          entryIndex = selectedIndex;
+        }
+      }
+    }
+
+    if ((*x)[depthIndex]->type == Node::NODE_TYPE_INDEX) {
+      if (entryIndex == 0) {
+        // our search key is less than any of the nodes' entries
+        x = mappingTable_.getNode((*x)[depthIndex]->lowPtrPid);
+      } else if (curLowestKey == nullptr) { 
+        // We are at root and search key is greater than any root nodes' entries
+        int numEntries = (*x)[depthIndex]->numEntries;
+        x = mappingTable_.getNode((*x)[depthIndex]->entries[numEntries - 1].pid);
+      } else {
+        x = mappingTable_.getNode((*x)[depthIndex]->entries[entryIndex - 1].pid);
+      }
+    } else {
+      // We are at the leaf
+      if (curLowestKey == nullptr) {
+        // Current node is root node, and search key is greater than highest key in root node
+        // Reached the end of the tree, and greater or equal key not found
+        return std::make_tuple(nullptr, -1, -1, std::move(stack));
+      } else {
+        return std::make_tuple(x, depthIndex, entryIndex, std::move(stack)); 
+      }
+    }
+  }
+}
+
+template<typename Key, class Comparator>
+typename std::tuple<typename BTree<Key, Comparator>::Node*, int, int>
+BTree<Key, Comparator>::FindLessThan(const Key& key) const {
+  // TODO TBD. Similar to FindGreaterOrEqualTo
+  return std::make_tuple(nullptr, -1, -1);
+}
+
+template<typename Key, class Comparator>
+typename std::tuple<typename BTree<Key, Comparator>::Node*, int, int>
+BTree<Key, Comparator>::FindFirst()
+    const {
+  return std::make_tuple(nullptr, -1, -1);
+}
+
+template<typename Key, class Comparator>
+typename std::tuple<typename BTree<Key, Comparator>::Node*, int, int, std::unique_ptr<class std::stack<typename BTree<Key, Comparator>::Node*> > >
+BTree<Key, Comparator>::FindLast()
+    const {
+  return std::make_tuple(nullptr, -1, -1, nullptr);
+}
+
+template<typename Key, class Comparator>
+BTree<Key, Comparator>::BTree(const Comparator cmp, Arena* arena, int32_t fanOutFactor, int32_t maxNodeSize)
+    : kFanOut_(fanOutFactor),
+      kMaxNodeSize_(maxNodeSize),
+      compare_(cmp),
+      arena_(arena),
+      mappingTable_(arena) {
+  assert(kFanOut_ > 0);
+  assert(kMaxNodeSize_ > 0);
+  Node* root = NewNode(0, Node::NODE_TYPE_LEAF);
+  rootPid_ = mappingTable_.addNode(root);
+}
+
+template<typename Key, class Comparator>
+bool BTree<Key, Comparator>::splitIsNecessary(Node* node) {
+  assert(node != nullptr);
+  return node->numEntriesSum() >= kMaxNodeSize_;
+}
+
+// Create two new Nodes 
+template<typename Key, class Comparator>
+typename std::tuple<typename BTree<Key, Comparator>::Node*, typename BTree<Key, Comparator>::Node*> 
+BTree<Key, Comparator>::splitWithAddedEntry(Node* node, int depthIndex, int entryIndex, const IndexEntry & entry) {
+  // Split function must consolidate the original and new node, so that calculating numEntries
+  // would return correct value.
+  int chainDepth = node->depth();
+  int newSize = 1; // number of total elements in node including the element to be added
+  std::vector<int> idx(chainDepth, 0);
+  std::vector<int> numEntries(chainDepth, 0);
+  for (int i = 0; i < chainDepth; i++) {
+    numEntries[i] = (*node)[i]->numEntries;
+    newSize += (*node)[i]->numEntries;
+  }
+  
+  Node* left = NewNode(newSize / 2, node->type);
+  Node* right = NewNode(newSize - left->numEntries, node->type);
+
+  bool newEntryAdded = false;
+  Node* cur;
+  int nodeIndex = 0;
+  for (int i = 0; i < newSize; i++) {
+    if (i < left->numEntries) {
+      cur = left;
+      nodeIndex = i;
+    } else {
+      cur = right;
+      nodeIndex = i - left->numEntries;
+    }
+
+    Key min = nullptr;
+    int minNodeIdx = -1;
+    for (int j = 0; j < chainDepth; j++) {
+      if (idx[j] < numEntries[j]) {
+        Key compared = node->entries[idx[j]].key;
+        if (min == nullptr || compare_(compared, min) < 0) {
+          min = compared;
+          minNodeIdx = j;
+        }  
+      }
+    }
+    if (!newEntryAdded && compare_(entry.key, min) < 0) {
+      // First time entry's key is smaller than min key
+      cur->entries[nodeIndex] = entry;
+      newEntryAdded = true;
+      continue;//Do calculation again
+    }
+
+    assert(minNodeIdx != -1 && min != nullptr);
+    int accesingIdx = idx[minNodeIdx]++;
+    cur->entries[nodeIndex] = (*node)[minNodeIdx]->entries[accesingIdx];
+  }
+
+  // Extract right node's low ptr, only if node is non-leaf
+  if (node->type == Node::NODE_TYPE_INDEX) {
+    right->lowPtrPid = left->entries[left->numEntries - 1].pid;
+    left->entries[left->numEntries - 1].pid = -1;
+  }
+
+  right->pid = mappingTable_.addNode(right);
+  right->nextDelta = nullptr;
+  right->highKey = node->highKey;
+  right->linkPtrPid = node->linkPtrPid;
+
+  left->pid = node->pid;
+  left->nextDelta = nullptr;
+  left->highKey = left->entries[left->numEntries - 1].key;
+  left->linkPtrPid = right->pid;
+  left->lowPtrPid = node->lowPtrPid;  
+
+  mappingTable_.updateNode(left->pid, left);
+  return std::make_tuple(left, right);
+}
+
+template<typename Key, class Comparator>
+void BTree<Key, Comparator>::Insert(const Key& key) {
+  Node* node;
+  int depthIndex;
+  int entryIndex;
+  unique_ptr<std::stack<Node*> > stack;
+  std::tie(node, depthIndex, entryIndex, stack) = FindGreaterOrEqual(key);
+
+  // Our data structure does not allow duplicate insertion
+  assert(node == nullptr || !Equal(key, (*node)[depthIndex]->entries[entryIndex].key));
+
+  if (node == nullptr) {
+    // Need to insert at the end of the tree
+    std::tie(node, depthIndex, entryIndex, stack) = FindLast();
+  }
+  
+  IndexEntry newEntry;
+  newEntry.key = key;
+  newEntry.obj = key;
+  while (!stack->empty()) {
+    node = stack->top();
+    stack->pop();
+    if (splitIsNecessary(node)) {
+      Node* left;
+      Node* right;
+      std::tie(left, right) = splitWithAddedEntry(node, depthIndex, entryIndex, newEntry);
+      // left->right->old left's next are all connected at this point.
+      // IndexEntry to insert on the upper level
+      newEntry.key = left->highKey;
+      newEntry.pid = right->pid;
+      if (stack->empty()) {
+        // We are at the top of the tree, but need to split.(We need to create a new root)
+        // TODO
+      }
+    } else {
+      // Append a delta to current node and then exit
+      // TODO In case delta chain depth is too deep, we should consolidate the node,
+      // instead of attaching yet another delta node.
+      Node* delta = NewNode(1, node->type);
+      delta->pid = node->pid;
+      delta->nextDelta = node;
+      delta->highKey = node->highKey;
+      delta->linkPtrPid = node->linkPtrPid;
+      delta->lowPtrPid = node->lowPtrPid;
+      assert(delta->numEntries == 1);
+      delta->entries[0] = newEntry;
+
+      mappingTable_.updateNode(delta->pid, delta);
+      break;
+    }
+  }
+}
+
+template<typename Key, class Comparator>
+bool BTree<Key, Comparator>::Contains(const Key& key) const {
+  Node* node;
+  int depthIndex;
+  int entryIndex;
+  std::tie(node, depthIndex, entryIndex, std::ignore) = FindGreaterOrEqual(key);
+  if (node != nullptr && Equal(key, (*node)[depthIndex]->entries[entryIndex].key)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+}  // namespace rocksdb

--- a/db/btree.h
+++ b/db/btree.h
@@ -450,11 +450,7 @@ BTree<Key, Comparator>::splitWithAddedEntry(Node* node, const IndexEntry & newEn
       cur = right;
       nodeIndex = 0;
     }
-
-    // if (!newEntryAdded && (i >= node->numEntries || compare_(entry.key, node->entries[i].key) < 0)) {
-    //   // Insert entry into current index, at the first time 
-    //   cur->entries[nodeIndex] = entry;
-    //   newEntryAdded = true;
+    
     if (!newEntryAdded &&
         i < node->numEntries && 
         compare_(newEntry.key, node->entries[i].key) < 0) {
@@ -547,10 +543,6 @@ void BTree<Key, Comparator>::Insert(const Key& key) {
       bool newEntryAdded = false;
       bool prevEntryUpdated = (updateEntryKey == nullptr);
       while (nodeIndex < newSize) {
-        // if (!newEntryAdded && (i >= node->numEntries || compare_(newEntry.key, node->entries[i].key) < 0)) {
-        //   // Insert entry into current index, at the first time 
-        //   newNode->entries[nodeIndex] = newEntry;
-        //   newEntryAdded = true;
         if (!newEntryAdded &&
             i < node->numEntries && 
             compare_(newEntry.key, node->entries[i].key) < 0) {

--- a/db/btree.h
+++ b/db/btree.h
@@ -102,7 +102,7 @@ class BTree {
   // Maps from logical node id to physical pointer to a Node. Adopted from Bw-Tree.
   class MappingTable {
   public:
-    MappingTable(Arena* arena, int capacity = 50000) 
+    MappingTable(Arena* arena, int capacity = 400000) 
     : arena_(arena), capacity_(capacity), size_(reinterpret_cast<void*>(0)) {
       char* mem = arena_->AllocateAligned(sizeof(Node*) * capacity);
       table_ = (Node**) mem; 

--- a/db/btree.h
+++ b/db/btree.h
@@ -438,6 +438,12 @@ BTree<Key, Comparator>::splitWithAddedEntry(Node* node, const IndexEntry & newEn
   
   Node* left = NewNode(newSize / 2, node->type);
   Node* right = NewNode(newSize - left->numEntries, node->type);
+  right->pid = mappingTable_.addNode(right);
+  right->highPtrPid = node->highPtrPid;
+  right->linkPtrPid = node->linkPtrPid;
+
+  left->pid = node->pid;
+  left->linkPtrPid = right->pid;
 
   bool newEntryAdded = false;
   bool prevEntryUpdated = (updateEntryKey == nullptr);
@@ -480,13 +486,6 @@ BTree<Key, Comparator>::splitWithAddedEntry(Node* node, const IndexEntry & newEn
     }
     nodeIndex++;
   }
-
-  right->pid = mappingTable_.addNode(right);
-  right->highPtrPid = node->highPtrPid;
-  right->linkPtrPid = node->linkPtrPid;
-
-  left->pid = node->pid;
-  left->linkPtrPid = right->pid;
 
   mappingTable_.updateNode(left->pid, left);
   return std::make_tuple(left, right);
@@ -538,6 +537,9 @@ void BTree<Key, Comparator>::Insert(const Key& key) {
     } else { // Split is unnecessary; Copy current node and replace it after inserting a new IndexEntry
       int newSize = 1 + node->numEntries;
       Node* newNode = NewNode(newSize, node->type);
+      newNode->pid = node->pid;
+      newNode->highPtrPid = node->highPtrPid;
+      newNode->linkPtrPid = node->linkPtrPid;
       int nodeIndex = 0;
       int i = 0;
       bool newEntryAdded = false;
@@ -572,10 +574,6 @@ void BTree<Key, Comparator>::Insert(const Key& key) {
         }
         nodeIndex++;
       }
-
-      newNode->pid = node->pid;
-      newNode->highPtrPid = node->highPtrPid;
-      newNode->linkPtrPid = node->linkPtrPid;
       mappingTable_.updateNode(newNode->pid, newNode);
       break;
     }

--- a/db/btree.h
+++ b/db/btree.h
@@ -479,8 +479,11 @@ BTree<Key, Comparator>::splitWithAddedEntry(Node* node, const IndexEntry & entry
   return std::make_tuple(left, right);
 }
 
+int print_counter = 0;
+
 template<typename Key, class Comparator>
 void BTree<Key, Comparator>::Insert(const Key& key) {
+  printf("Inserting key : %s, count : %d\n", key, ++print_counter);
   Node* node;
   int entryIndex;
   unique_ptr<std::stack<Node*> > stack;
@@ -518,8 +521,9 @@ void BTree<Key, Comparator>::Insert(const Key& key) {
         newRoot->entries[0].key = left->entries[left->numEntries - 1].key;
         newRoot->entries[0].pid = left->pid;
         newRoot->highPtrPid = right->pid;
-        newRoot->pid = rootPid_;
-        mappingTable_.updateNode(rootPid_, newRoot);
+        newRoot->pid = mappingTable_.addNode(newRoot);
+        // TODO Potentially Memory barrier
+        rootPid_ = newRoot->pid;
       }
     } else { // Split is unnecessary; Copy current node and replace it after inserting a new IndexEntry
       int newSize = 1 + node->numEntries;

--- a/db/btree_test.cc
+++ b/db/btree_test.cc
@@ -196,12 +196,12 @@ class ConcurrentTest {
 
   // Per-key generation
   struct State {
-    port::AtomicPointer generation[K];
-    void Set(int k, intptr_t v) {
-      generation[k].Release_Store(reinterpret_cast<void*>(v));
+    std::atomic<int> generation[K];
+    void Set(int k, int v) {
+      generation[k].store(v, std::memory_order_release);
     }
-    intptr_t Get(int k) {
-      return reinterpret_cast<intptr_t>(generation[k].Acquire_Load());
+    int Get(int k) {
+      return generation[k].load(std::memory_order_acquire);
     }
 
     State() {
@@ -226,7 +226,7 @@ class ConcurrentTest {
   // REQUIRES: External synchronization
   void WriteStep(Random* rnd) {
     const uint32_t k = rnd->Next() % K;
-    const intptr_t g = current_.Get(k) + 1;
+    const int g = current_.Get(k) + 1;
     const Key key = MakeKey(k, g);
     tree_.Insert(key);
     current_.Set(k, g);
@@ -260,11 +260,10 @@ class ConcurrentTest {
         // Note that generation 0 is never inserted, so it is ok if
         // <*,0,*> is missing.
         ASSERT_TRUE((gen(pos) == 0U) ||
-                    (gen(pos) > (uint64_t)initial_state.Get(key(pos)))
-                    ) << "key: " << key(pos)
-                      << "; gen: " << gen(pos)
-                      << "; initgen: "
-                      << initial_state.Get(key(pos));
+                    (gen(pos) > static_cast<uint64_t>(initial_state.Get(
+                                    static_cast<int>(key(pos))))))
+            << "key: " << key(pos) << "; gen: " << gen(pos)
+            << "; initgen: " << initial_state.Get(static_cast<int>(key(pos)));
 
         // Advance to next key in the valid key space
         if (key(pos) < key(current)) {
@@ -308,7 +307,7 @@ class TestState {
  public:
   ConcurrentTest t_;
   int seed_;
-  port::AtomicPointer quit_flag_;
+  std::atomic<bool> quit_flag_;
 
   enum ReaderState {
     STARTING,
@@ -318,7 +317,7 @@ class TestState {
 
   explicit TestState(int s)
       : seed_(s),
-        quit_flag_(nullptr),
+        quit_flag_(false),
         state_(STARTING),
         state_cv_(&mu_) {}
 
@@ -348,7 +347,7 @@ static void ConcurrentReader(void* arg) {
   Random rnd(state->seed_);
   int64_t reads = 0;
   state->Change(TestState::RUNNING);
-  while (!state->quit_flag_.Acquire_Load()) {
+  while (!state->quit_flag_.load(std::memory_order_acquire)) {
     state->t_.ReadStep(&rnd);
     ++reads;
   }
@@ -367,10 +366,10 @@ static void RunConcurrent(int run) {
     TestState state(seed + 1);
     Env::Default()->Schedule(ConcurrentReader, &state);
     state.Wait(TestState::RUNNING);
-    for (int i = 0; i < kSize; i++) {
+    for (int k = 0; k < kSize; k++) {
       state.t_.WriteStep(&rnd);
     }
-    state.quit_flag_.Release_Store(&state);  // Any non-nullptr arg will do
+    state.quit_flag_.store(true, std::memory_order_release);
     state.Wait(TestState::DONE);
   }
 }

--- a/db/btree_test.cc
+++ b/db/btree_test.cc
@@ -116,20 +116,20 @@ TEST(BTreeTest, InsertAndLookup) {
   }
 
   // Backward iteration test
-  // {
-  //   BTree<Key, TestComparator>::Iterator iter(&tree);
-  //   iter.SeekToLast();
+  {
+    BTree<Key, TestComparator>::Iterator iter(&tree);
+    iter.SeekToLast();
 
-  //   // Compare against model iterator
-  //   for (std::set<Key>::reverse_iterator model_iter = keys.rbegin();
-  //        model_iter != keys.rend();
-  //        ++model_iter) {
-  //     ASSERT_TRUE(iter.Valid());
-  //     ASSERT_EQ(*model_iter, iter.key());
-  //     iter.Prev();
-  //   }
-  //   ASSERT_TRUE(!iter.Valid());
-  // }
+    // Compare against model iterator
+    for (std::set<Key>::reverse_iterator model_iter = keys.rbegin();
+         model_iter != keys.rend();
+         ++model_iter) {
+      ASSERT_TRUE(iter.Valid());
+      ASSERT_EQ(*model_iter, iter.key());
+      iter.Prev();
+    }
+    ASSERT_TRUE(!iter.Valid());
+  }
 }
 
 // We want to make sure that with a single writer and multiple

--- a/db/btree_test.cc
+++ b/db/btree_test.cc
@@ -53,36 +53,26 @@ TEST(BTreeTest, Empty) {
 
 
 TEST(BTreeTest, InsertAndLookup) {
-  std::cout << "Here" << std::endl;
-  const int N = 500000;
-  const int R = 2500000;
+  const int N = 50000;
+  const int R = 250000;
   Random rnd(1000);
   std::set<Key> keys;
   Arena arena;
   TestComparator cmp;
-  int maxNodeSize = 32;
+  int maxNodeSize = 8;
   BTree<Key, TestComparator> tree(cmp, &arena, maxNodeSize);
-  int count = 0;
   for (int i = 0; i < N; i++) {
     Key key = rnd.Next() % R;
     if (keys.insert(key).second) {
-      count++;
-      printf("inserting=%llu, count=%d\n", key, count);
       tree.Insert(key);
       ASSERT_TRUE(tree.Contains(key));
     }
   }
 
-  printf("size of set = %lu\n", keys.size());
-  
-
   for (int i = 0; i < R; i++) {
-    // printf("i=%d, ", i);
     if (tree.Contains(i)) {
-      // printf(", contains=true\n");
       ASSERT_EQ(keys.count(i), 1U);
     } else {
-      // printf(", contains=false\n");
       ASSERT_EQ(keys.count(i), 0U);
     }
   }
@@ -126,26 +116,26 @@ TEST(BTreeTest, InsertAndLookup) {
   }
 
   // Backward iteration test
-  {
-    BTree<Key, TestComparator>::Iterator iter(&tree);
-    iter.SeekToLast();
+  // {
+  //   BTree<Key, TestComparator>::Iterator iter(&tree);
+  //   iter.SeekToLast();
 
-    // Compare against model iterator
-    for (std::set<Key>::reverse_iterator model_iter = keys.rbegin();
-         model_iter != keys.rend();
-         ++model_iter) {
-      ASSERT_TRUE(iter.Valid());
-      ASSERT_EQ(*model_iter, iter.key());
-      iter.Prev();
-    }
-    ASSERT_TRUE(!iter.Valid());
-  }
+  //   // Compare against model iterator
+  //   for (std::set<Key>::reverse_iterator model_iter = keys.rbegin();
+  //        model_iter != keys.rend();
+  //        ++model_iter) {
+  //     ASSERT_TRUE(iter.Valid());
+  //     ASSERT_EQ(*model_iter, iter.key());
+  //     iter.Prev();
+  //   }
+  //   ASSERT_TRUE(!iter.Valid());
+  // }
 }
 
 // We want to make sure that with a single writer and multiple
 // concurrent readers (with no synchronization other than when a
 // reader's iterator is created), the reader always observes all the
-// data that was present in the skip list when the iterator was
+// data that was present in the btree when the iterator was
 // constructor.  Because insertions are happening concurrently, we may
 // also observe new values that were inserted since the iterator was
 // constructed, but we should never miss any values that were present
@@ -166,230 +156,230 @@ TEST(BTreeTest, InsertAndLookup) {
 // calls to Next() and Seek().  For every key we encounter, we
 // check that it is either expected given the initial snapshot or has
 // been concurrently added since the iterator started.
-// class ConcurrentTest {
-//  private:
-//   static const uint32_t K = 4;
+class ConcurrentTest {
+ private:
+  static const uint32_t K = 4;
 
-//   static uint64_t key(Key key) { return (key >> 40); }
-//   static uint64_t gen(Key key) { return (key >> 8) & 0xffffffffu; }
-//   static uint64_t hash(Key key) { return key & 0xff; }
+  static uint64_t key(Key key) { return (key >> 40); }
+  static uint64_t gen(Key key) { return (key >> 8) & 0xffffffffu; }
+  static uint64_t hash(Key key) { return key & 0xff; }
 
-//   static uint64_t HashNumbers(uint64_t k, uint64_t g) {
-//     uint64_t data[2] = { k, g };
-//     return Hash(reinterpret_cast<char*>(data), sizeof(data), 0);
-//   }
+  static uint64_t HashNumbers(uint64_t k, uint64_t g) {
+    uint64_t data[2] = { k, g };
+    return Hash(reinterpret_cast<char*>(data), sizeof(data), 0);
+  }
 
-//   static Key MakeKey(uint64_t k, uint64_t g) {
-//     assert(sizeof(Key) == sizeof(uint64_t));
-//     assert(k <= K);  // We sometimes pass K to seek to the end of the skiplist
-//     assert(g <= 0xffffffffu);
-//     return ((k << 40) | (g << 8) | (HashNumbers(k, g) & 0xff));
-//   }
+  static Key MakeKey(uint64_t k, uint64_t g) {
+    assert(sizeof(Key) == sizeof(uint64_t));
+    assert(k <= K);  // We sometimes pass K to seek to the end of the btree
+    assert(g <= 0xffffffffu);
+    return ((k << 40) | (g << 8) | (HashNumbers(k, g) & 0xff));
+  }
 
-//   static bool IsValidKey(Key k) {
-//     return hash(k) == (HashNumbers(key(k), gen(k)) & 0xff);
-//   }
+  static bool IsValidKey(Key k) {
+    return hash(k) == (HashNumbers(key(k), gen(k)) & 0xff);
+  }
 
-//   static Key RandomTarget(Random* rnd) {
-//     switch (rnd->Next() % 10) {
-//       case 0:
-//         // Seek to beginning
-//         return MakeKey(0, 0);
-//       case 1:
-//         // Seek to end
-//         return MakeKey(K, 0);
-//       default:
-//         // Seek to middle
-//         return MakeKey(rnd->Next() % K, 0);
-//     }
-//   }
+  static Key RandomTarget(Random* rnd) {
+    switch (rnd->Next() % 10) {
+      case 0:
+        // Seek to beginning
+        return MakeKey(0, 0);
+      case 1:
+        // Seek to end
+        return MakeKey(K, 0);
+      default:
+        // Seek to middle
+        return MakeKey(rnd->Next() % K, 0);
+    }
+  }
 
-//   // Per-key generation
-//   struct State {
-//     port::AtomicPointer generation[K];
-//     void Set(int k, intptr_t v) {
-//       generation[k].Release_Store(reinterpret_cast<void*>(v));
-//     }
-//     intptr_t Get(int k) {
-//       return reinterpret_cast<intptr_t>(generation[k].Acquire_Load());
-//     }
+  // Per-key generation
+  struct State {
+    port::AtomicPointer generation[K];
+    void Set(int k, intptr_t v) {
+      generation[k].Release_Store(reinterpret_cast<void*>(v));
+    }
+    intptr_t Get(int k) {
+      return reinterpret_cast<intptr_t>(generation[k].Acquire_Load());
+    }
 
-//     State() {
-//       for (unsigned int k = 0; k < K; k++) {
-//         Set(k, 0);
-//       }
-//     }
-//   };
+    State() {
+      for (unsigned int k = 0; k < K; k++) {
+        Set(k, 0);
+      }
+    }
+  };
 
-//   // Current state of the test
-//   State current_;
+  // Current state of the test
+  State current_;
 
-//   Arena arena_;
+  Arena arena_;
 
-//   // SkipList is not protected by mu_.  We just use a single writer
-//   // thread to modify it.
-//   SkipList<Key, TestComparator> list_;
+  // BTree is not protected by mu_.  We just use a single writer
+  // thread to modify it.
+  BTree<Key, TestComparator> tree_;
 
-//  public:
-//   ConcurrentTest() : list_(TestComparator(), &arena_) {}
+ public:
+  ConcurrentTest() : tree_(TestComparator(), &arena_, 8) {}
 
-//   // REQUIRES: External synchronization
-//   void WriteStep(Random* rnd) {
-//     const uint32_t k = rnd->Next() % K;
-//     const intptr_t g = current_.Get(k) + 1;
-//     const Key key = MakeKey(k, g);
-//     list_.Insert(key);
-//     current_.Set(k, g);
-//   }
+  // REQUIRES: External synchronization
+  void WriteStep(Random* rnd) {
+    const uint32_t k = rnd->Next() % K;
+    const intptr_t g = current_.Get(k) + 1;
+    const Key key = MakeKey(k, g);
+    tree_.Insert(key);
+    current_.Set(k, g);
+  }
 
-//   void ReadStep(Random* rnd) {
-//     // Remember the initial committed state of the skiplist.
-//     State initial_state;
-//     for (unsigned int k = 0; k < K; k++) {
-//       initial_state.Set(k, current_.Get(k));
-//     }
+  void ReadStep(Random* rnd) {
+    // Remember the initial committed state of the btree.
+    State initial_state;
+    for (unsigned int k = 0; k < K; k++) {
+      initial_state.Set(k, current_.Get(k));
+    }
 
-//     Key pos = RandomTarget(rnd);
-//     SkipList<Key, TestComparator>::Iterator iter(&list_);
-//     iter.Seek(pos);
-//     while (true) {
-//       Key current;
-//       if (!iter.Valid()) {
-//         current = MakeKey(K, 0);
-//       } else {
-//         current = iter.key();
-//         ASSERT_TRUE(IsValidKey(current)) << current;
-//       }
-//       ASSERT_LE(pos, current) << "should not go backwards";
+    Key pos = RandomTarget(rnd);
+    BTree<Key, TestComparator>::Iterator iter(&tree_);
+    iter.Seek(pos);
+    while (true) {
+      Key current;
+      if (!iter.Valid()) {
+        current = MakeKey(K, 0);
+      } else {
+        current = iter.key();
+        ASSERT_TRUE(IsValidKey(current)) << current;
+      }
+      ASSERT_LE(pos, current) << "should not go backwards";
 
-//       // Verify that everything in [pos,current) was not present in
-//       // initial_state.
-//       while (pos < current) {
-//         ASSERT_LT(key(pos), K) << pos;
+      // Verify that everything in [pos,current) was not present in
+      // initial_state.
+      while (pos < current) {
+        ASSERT_LT(key(pos), K) << pos;
 
-//         // Note that generation 0 is never inserted, so it is ok if
-//         // <*,0,*> is missing.
-//         ASSERT_TRUE((gen(pos) == 0U) ||
-//                     (gen(pos) > (uint64_t)initial_state.Get(key(pos)))
-//                     ) << "key: " << key(pos)
-//                       << "; gen: " << gen(pos)
-//                       << "; initgen: "
-//                       << initial_state.Get(key(pos));
+        // Note that generation 0 is never inserted, so it is ok if
+        // <*,0,*> is missing.
+        ASSERT_TRUE((gen(pos) == 0U) ||
+                    (gen(pos) > (uint64_t)initial_state.Get(key(pos)))
+                    ) << "key: " << key(pos)
+                      << "; gen: " << gen(pos)
+                      << "; initgen: "
+                      << initial_state.Get(key(pos));
 
-//         // Advance to next key in the valid key space
-//         if (key(pos) < key(current)) {
-//           pos = MakeKey(key(pos) + 1, 0);
-//         } else {
-//           pos = MakeKey(key(pos), gen(pos) + 1);
-//         }
-//       }
+        // Advance to next key in the valid key space
+        if (key(pos) < key(current)) {
+          pos = MakeKey(key(pos) + 1, 0);
+        } else {
+          pos = MakeKey(key(pos), gen(pos) + 1);
+        }
+      }
 
-//       if (!iter.Valid()) {
-//         break;
-//       }
+      if (!iter.Valid()) {
+        break;
+      }
 
-//       if (rnd->Next() % 2) {
-//         iter.Next();
-//         pos = MakeKey(key(pos), gen(pos) + 1);
-//       } else {
-//         Key new_target = RandomTarget(rnd);
-//         if (new_target > pos) {
-//           pos = new_target;
-//           iter.Seek(new_target);
-//         }
-//       }
-//     }
-//   }
-// };
-// const uint32_t ConcurrentTest::K;
+      if (rnd->Next() % 2) {
+        iter.Next();
+        pos = MakeKey(key(pos), gen(pos) + 1);
+      } else {
+        Key new_target = RandomTarget(rnd);
+        if (new_target > pos) {
+          pos = new_target;
+          iter.Seek(new_target);
+        }
+      }
+    }
+  }
+};
+const uint32_t ConcurrentTest::K;
 
-// // Simple test that does single-threaded testing of the ConcurrentTest
-// // scaffolding.
-// TEST(SkipTest, ConcurrentWithoutThreads) {
-//   ConcurrentTest test;
-//   Random rnd(test::RandomSeed());
-//   for (int i = 0; i < 10000; i++) {
-//     test.ReadStep(&rnd);
-//     test.WriteStep(&rnd);
-//   }
-// }
+// Simple test that does single-threaded testing of the ConcurrentTest
+// scaffolding.
+TEST(BTreeTest, ConcurrentWithoutThreads) {
+  ConcurrentTest test;
+  Random rnd(test::RandomSeed());
+  for (int i = 0; i < 10000; i++) {
+    test.ReadStep(&rnd);
+    test.WriteStep(&rnd);
+  }
+}
 
-// class TestState {
-//  public:
-//   ConcurrentTest t_;
-//   int seed_;
-//   port::AtomicPointer quit_flag_;
+class TestState {
+ public:
+  ConcurrentTest t_;
+  int seed_;
+  port::AtomicPointer quit_flag_;
 
-//   enum ReaderState {
-//     STARTING,
-//     RUNNING,
-//     DONE
-//   };
+  enum ReaderState {
+    STARTING,
+    RUNNING,
+    DONE
+  };
 
-//   explicit TestState(int s)
-//       : seed_(s),
-//         quit_flag_(nullptr),
-//         state_(STARTING),
-//         state_cv_(&mu_) {}
+  explicit TestState(int s)
+      : seed_(s),
+        quit_flag_(nullptr),
+        state_(STARTING),
+        state_cv_(&mu_) {}
 
-//   void Wait(ReaderState s) {
-//     mu_.Lock();
-//     while (state_ != s) {
-//       state_cv_.Wait();
-//     }
-//     mu_.Unlock();
-//   }
+  void Wait(ReaderState s) {
+    mu_.Lock();
+    while (state_ != s) {
+      state_cv_.Wait();
+    }
+    mu_.Unlock();
+  }
 
-//   void Change(ReaderState s) {
-//     mu_.Lock();
-//     state_ = s;
-//     state_cv_.Signal();
-//     mu_.Unlock();
-//   }
+  void Change(ReaderState s) {
+    mu_.Lock();
+    state_ = s;
+    state_cv_.Signal();
+    mu_.Unlock();
+  }
 
-//  private:
-//   port::Mutex mu_;
-//   ReaderState state_;
-//   port::CondVar state_cv_;
-// };
+ private:
+  port::Mutex mu_;
+  ReaderState state_;
+  port::CondVar state_cv_;
+};
 
-// static void ConcurrentReader(void* arg) {
-//   TestState* state = reinterpret_cast<TestState*>(arg);
-//   Random rnd(state->seed_);
-//   int64_t reads = 0;
-//   state->Change(TestState::RUNNING);
-//   while (!state->quit_flag_.Acquire_Load()) {
-//     state->t_.ReadStep(&rnd);
-//     ++reads;
-//   }
-//   state->Change(TestState::DONE);
-// }
+static void ConcurrentReader(void* arg) {
+  TestState* state = reinterpret_cast<TestState*>(arg);
+  Random rnd(state->seed_);
+  int64_t reads = 0;
+  state->Change(TestState::RUNNING);
+  while (!state->quit_flag_.Acquire_Load()) {
+    state->t_.ReadStep(&rnd);
+    ++reads;
+  }
+  state->Change(TestState::DONE);
+}
 
-// static void RunConcurrent(int run) {
-//   const int seed = test::RandomSeed() + (run * 100);
-//   Random rnd(seed);
-//   const int N = 1000;
-//   const int kSize = 1000;
-//   for (int i = 0; i < N; i++) {
-//     if ((i % 100) == 0) {
-//       fprintf(stderr, "Run %d of %d\n", i, N);
-//     }
-//     TestState state(seed + 1);
-//     Env::Default()->Schedule(ConcurrentReader, &state);
-//     state.Wait(TestState::RUNNING);
-//     for (int i = 0; i < kSize; i++) {
-//       state.t_.WriteStep(&rnd);
-//     }
-//     state.quit_flag_.Release_Store(&state);  // Any non-nullptr arg will do
-//     state.Wait(TestState::DONE);
-//   }
-// }
+static void RunConcurrent(int run) {
+  const int seed = test::RandomSeed() + (run * 100);
+  Random rnd(seed);
+  const int N = 1000;
+  const int kSize = 1000;
+  for (int i = 0; i < N; i++) {
+    if ((i % 100) == 0) {
+      fprintf(stderr, "Run %d of %d\n", i, N);
+    }
+    TestState state(seed + 1);
+    Env::Default()->Schedule(ConcurrentReader, &state);
+    state.Wait(TestState::RUNNING);
+    for (int i = 0; i < kSize; i++) {
+      state.t_.WriteStep(&rnd);
+    }
+    state.quit_flag_.Release_Store(&state);  // Any non-nullptr arg will do
+    state.Wait(TestState::DONE);
+  }
+}
 
-// TEST(SkipTest, Concurrent1) { RunConcurrent(1); }
-// TEST(SkipTest, Concurrent2) { RunConcurrent(2); }
-// TEST(SkipTest, Concurrent3) { RunConcurrent(3); }
-// TEST(SkipTest, Concurrent4) { RunConcurrent(4); }
-// TEST(SkipTest, Concurrent5) { RunConcurrent(5); }
+TEST(BTreeTest, Concurrent1) { RunConcurrent(1); }
+TEST(BTreeTest, Concurrent2) { RunConcurrent(2); }
+TEST(BTreeTest, Concurrent3) { RunConcurrent(3); }
+TEST(BTreeTest, Concurrent4) { RunConcurrent(4); }
+TEST(BTreeTest, Concurrent5) { RunConcurrent(5); }
 
 }  // namespace rocksdb
 

--- a/db/btree_test.cc
+++ b/db/btree_test.cc
@@ -1,0 +1,387 @@
+//  Copyright (c) 2013, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "db/btree.h"
+#include <set>
+#include "rocksdb/env.h"
+#include "util/arena.h"
+#include "util/hash.h"
+#include "util/random.h"
+#include "util/testharness.h"
+#include <iostream>
+
+namespace rocksdb {
+
+typedef uint64_t Key;
+
+struct TestComparator {
+  int operator()(const Key& a, const Key& b) const {
+    if (a < b) {
+      return -1;
+    } else if (a > b) {
+      return +1;
+    } else {
+      return 0;
+    }
+  }
+};
+
+class BTreeTest { };
+
+TEST(BTreeTest, Empty) {
+  Arena arena;
+  TestComparator cmp;
+  BTree<Key, TestComparator> list(cmp, &arena);
+  ASSERT_TRUE(!list.Contains(10));
+
+  BTree<Key, TestComparator>::Iterator iter(&list);
+  ASSERT_TRUE(!iter.Valid());
+  iter.SeekToFirst();
+  ASSERT_TRUE(!iter.Valid());
+  iter.Seek(100);
+  ASSERT_TRUE(!iter.Valid());
+  iter.SeekToLast();
+  ASSERT_TRUE(!iter.Valid());
+}
+
+
+
+// TEST(SkipTest, InsertAndLookup) {
+//   std::cout << "Here" << std::endl;
+//   const int N = 2000;
+//   const int R = 5000;
+//   Random rnd(1000);
+//   std::set<Key> keys;
+//   Arena arena;
+//   TestComparator cmp;
+//   SkipList<Key, TestComparator> list(cmp, &arena);
+//   for (int i = 0; i < N; i++) {
+//     Key key = rnd.Next() % R;
+//     if (keys.insert(key).second) {
+//       list.Insert(key);
+//     }
+//   }
+
+//   for (int i = 0; i < R; i++) {
+//     if (list.Contains(i)) {
+//       ASSERT_EQ(keys.count(i), 1U);
+//     } else {
+//       ASSERT_EQ(keys.count(i), 0U);
+//     }
+//   }
+
+//   // Simple iterator tests
+//   {
+//     SkipList<Key, TestComparator>::Iterator iter(&list);
+//     ASSERT_TRUE(!iter.Valid());
+
+//     iter.Seek(0);
+//     ASSERT_TRUE(iter.Valid());
+//     ASSERT_EQ(*(keys.begin()), iter.key());
+
+//     iter.SeekToFirst();
+//     ASSERT_TRUE(iter.Valid());
+//     ASSERT_EQ(*(keys.begin()), iter.key());
+
+//     iter.SeekToLast();
+//     ASSERT_TRUE(iter.Valid());
+//     ASSERT_EQ(*(keys.rbegin()), iter.key());
+//   }
+
+//   // Forward iteration test
+//   for (int i = 0; i < R; i++) {
+//     SkipList<Key, TestComparator>::Iterator iter(&list);
+//     iter.Seek(i);
+
+//     // Compare against model iterator
+//     std::set<Key>::iterator model_iter = keys.lower_bound(i);
+//     for (int j = 0; j < 3; j++) {
+//       if (model_iter == keys.end()) {
+//         ASSERT_TRUE(!iter.Valid());
+//         break;
+//       } else {
+//         ASSERT_TRUE(iter.Valid());
+//         ASSERT_EQ(*model_iter, iter.key());
+//         ++model_iter;
+//         iter.Next();
+//       }
+//     }
+//   }
+
+//   // Backward iteration test
+//   {
+//     SkipList<Key, TestComparator>::Iterator iter(&list);
+//     iter.SeekToLast();
+
+//     // Compare against model iterator
+//     for (std::set<Key>::reverse_iterator model_iter = keys.rbegin();
+//          model_iter != keys.rend();
+//          ++model_iter) {
+//       ASSERT_TRUE(iter.Valid());
+//       ASSERT_EQ(*model_iter, iter.key());
+//       iter.Prev();
+//     }
+//     ASSERT_TRUE(!iter.Valid());
+//   }
+// }
+
+// // We want to make sure that with a single writer and multiple
+// // concurrent readers (with no synchronization other than when a
+// // reader's iterator is created), the reader always observes all the
+// // data that was present in the skip list when the iterator was
+// // constructor.  Because insertions are happening concurrently, we may
+// // also observe new values that were inserted since the iterator was
+// // constructed, but we should never miss any values that were present
+// // at iterator construction time.
+// //
+// // We generate multi-part keys:
+// //     <key,gen,hash>
+// // where:
+// //     key is in range [0..K-1]
+// //     gen is a generation number for key
+// //     hash is hash(key,gen)
+// //
+// // The insertion code picks a random key, sets gen to be 1 + the last
+// // generation number inserted for that key, and sets hash to Hash(key,gen).
+// //
+// // At the beginning of a read, we snapshot the last inserted
+// // generation number for each key.  We then iterate, including random
+// // calls to Next() and Seek().  For every key we encounter, we
+// // check that it is either expected given the initial snapshot or has
+// // been concurrently added since the iterator started.
+// class ConcurrentTest {
+//  private:
+//   static const uint32_t K = 4;
+
+//   static uint64_t key(Key key) { return (key >> 40); }
+//   static uint64_t gen(Key key) { return (key >> 8) & 0xffffffffu; }
+//   static uint64_t hash(Key key) { return key & 0xff; }
+
+//   static uint64_t HashNumbers(uint64_t k, uint64_t g) {
+//     uint64_t data[2] = { k, g };
+//     return Hash(reinterpret_cast<char*>(data), sizeof(data), 0);
+//   }
+
+//   static Key MakeKey(uint64_t k, uint64_t g) {
+//     assert(sizeof(Key) == sizeof(uint64_t));
+//     assert(k <= K);  // We sometimes pass K to seek to the end of the skiplist
+//     assert(g <= 0xffffffffu);
+//     return ((k << 40) | (g << 8) | (HashNumbers(k, g) & 0xff));
+//   }
+
+//   static bool IsValidKey(Key k) {
+//     return hash(k) == (HashNumbers(key(k), gen(k)) & 0xff);
+//   }
+
+//   static Key RandomTarget(Random* rnd) {
+//     switch (rnd->Next() % 10) {
+//       case 0:
+//         // Seek to beginning
+//         return MakeKey(0, 0);
+//       case 1:
+//         // Seek to end
+//         return MakeKey(K, 0);
+//       default:
+//         // Seek to middle
+//         return MakeKey(rnd->Next() % K, 0);
+//     }
+//   }
+
+//   // Per-key generation
+//   struct State {
+//     port::AtomicPointer generation[K];
+//     void Set(int k, intptr_t v) {
+//       generation[k].Release_Store(reinterpret_cast<void*>(v));
+//     }
+//     intptr_t Get(int k) {
+//       return reinterpret_cast<intptr_t>(generation[k].Acquire_Load());
+//     }
+
+//     State() {
+//       for (unsigned int k = 0; k < K; k++) {
+//         Set(k, 0);
+//       }
+//     }
+//   };
+
+//   // Current state of the test
+//   State current_;
+
+//   Arena arena_;
+
+//   // SkipList is not protected by mu_.  We just use a single writer
+//   // thread to modify it.
+//   SkipList<Key, TestComparator> list_;
+
+//  public:
+//   ConcurrentTest() : list_(TestComparator(), &arena_) {}
+
+//   // REQUIRES: External synchronization
+//   void WriteStep(Random* rnd) {
+//     const uint32_t k = rnd->Next() % K;
+//     const intptr_t g = current_.Get(k) + 1;
+//     const Key key = MakeKey(k, g);
+//     list_.Insert(key);
+//     current_.Set(k, g);
+//   }
+
+//   void ReadStep(Random* rnd) {
+//     // Remember the initial committed state of the skiplist.
+//     State initial_state;
+//     for (unsigned int k = 0; k < K; k++) {
+//       initial_state.Set(k, current_.Get(k));
+//     }
+
+//     Key pos = RandomTarget(rnd);
+//     SkipList<Key, TestComparator>::Iterator iter(&list_);
+//     iter.Seek(pos);
+//     while (true) {
+//       Key current;
+//       if (!iter.Valid()) {
+//         current = MakeKey(K, 0);
+//       } else {
+//         current = iter.key();
+//         ASSERT_TRUE(IsValidKey(current)) << current;
+//       }
+//       ASSERT_LE(pos, current) << "should not go backwards";
+
+//       // Verify that everything in [pos,current) was not present in
+//       // initial_state.
+//       while (pos < current) {
+//         ASSERT_LT(key(pos), K) << pos;
+
+//         // Note that generation 0 is never inserted, so it is ok if
+//         // <*,0,*> is missing.
+//         ASSERT_TRUE((gen(pos) == 0U) ||
+//                     (gen(pos) > (uint64_t)initial_state.Get(key(pos)))
+//                     ) << "key: " << key(pos)
+//                       << "; gen: " << gen(pos)
+//                       << "; initgen: "
+//                       << initial_state.Get(key(pos));
+
+//         // Advance to next key in the valid key space
+//         if (key(pos) < key(current)) {
+//           pos = MakeKey(key(pos) + 1, 0);
+//         } else {
+//           pos = MakeKey(key(pos), gen(pos) + 1);
+//         }
+//       }
+
+//       if (!iter.Valid()) {
+//         break;
+//       }
+
+//       if (rnd->Next() % 2) {
+//         iter.Next();
+//         pos = MakeKey(key(pos), gen(pos) + 1);
+//       } else {
+//         Key new_target = RandomTarget(rnd);
+//         if (new_target > pos) {
+//           pos = new_target;
+//           iter.Seek(new_target);
+//         }
+//       }
+//     }
+//   }
+// };
+// const uint32_t ConcurrentTest::K;
+
+// // Simple test that does single-threaded testing of the ConcurrentTest
+// // scaffolding.
+// TEST(SkipTest, ConcurrentWithoutThreads) {
+//   ConcurrentTest test;
+//   Random rnd(test::RandomSeed());
+//   for (int i = 0; i < 10000; i++) {
+//     test.ReadStep(&rnd);
+//     test.WriteStep(&rnd);
+//   }
+// }
+
+// class TestState {
+//  public:
+//   ConcurrentTest t_;
+//   int seed_;
+//   port::AtomicPointer quit_flag_;
+
+//   enum ReaderState {
+//     STARTING,
+//     RUNNING,
+//     DONE
+//   };
+
+//   explicit TestState(int s)
+//       : seed_(s),
+//         quit_flag_(nullptr),
+//         state_(STARTING),
+//         state_cv_(&mu_) {}
+
+//   void Wait(ReaderState s) {
+//     mu_.Lock();
+//     while (state_ != s) {
+//       state_cv_.Wait();
+//     }
+//     mu_.Unlock();
+//   }
+
+//   void Change(ReaderState s) {
+//     mu_.Lock();
+//     state_ = s;
+//     state_cv_.Signal();
+//     mu_.Unlock();
+//   }
+
+//  private:
+//   port::Mutex mu_;
+//   ReaderState state_;
+//   port::CondVar state_cv_;
+// };
+
+// static void ConcurrentReader(void* arg) {
+//   TestState* state = reinterpret_cast<TestState*>(arg);
+//   Random rnd(state->seed_);
+//   int64_t reads = 0;
+//   state->Change(TestState::RUNNING);
+//   while (!state->quit_flag_.Acquire_Load()) {
+//     state->t_.ReadStep(&rnd);
+//     ++reads;
+//   }
+//   state->Change(TestState::DONE);
+// }
+
+// static void RunConcurrent(int run) {
+//   const int seed = test::RandomSeed() + (run * 100);
+//   Random rnd(seed);
+//   const int N = 1000;
+//   const int kSize = 1000;
+//   for (int i = 0; i < N; i++) {
+//     if ((i % 100) == 0) {
+//       fprintf(stderr, "Run %d of %d\n", i, N);
+//     }
+//     TestState state(seed + 1);
+//     Env::Default()->Schedule(ConcurrentReader, &state);
+//     state.Wait(TestState::RUNNING);
+//     for (int i = 0; i < kSize; i++) {
+//       state.t_.WriteStep(&rnd);
+//     }
+//     state.quit_flag_.Release_Store(&state);  // Any non-nullptr arg will do
+//     state.Wait(TestState::DONE);
+//   }
+// }
+
+// TEST(SkipTest, Concurrent1) { RunConcurrent(1); }
+// TEST(SkipTest, Concurrent2) { RunConcurrent(2); }
+// TEST(SkipTest, Concurrent3) { RunConcurrent(3); }
+// TEST(SkipTest, Concurrent4) { RunConcurrent(4); }
+// TEST(SkipTest, Concurrent5) { RunConcurrent(5); }
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  return rocksdb::test::RunAllTests();
+}

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -289,6 +289,8 @@ DEFINE_bool(use_existing_db, false, "If true, do not destroy the existing"
 
 DEFINE_string(db, "", "Use the db with the following name.");
 
+DEFINE_int64(btree_fanout, 64, "Fanout factor of BTree memtable representation");
+
 static bool ValidateCacheNumshardbits(const char* flagname, int32_t value) {
   if (value >= 20) {
     fprintf(stderr, "Invalid value for --%s: %d, must be < 20\n",
@@ -1971,7 +1973,7 @@ class Benchmark {
             options.write_buffer_size, FLAGS_key_size + FLAGS_value_size));
         break;
       case kBTree:
-        options.memtable_factory.reset(new BTreeFactory());
+        options.memtable_factory.reset(new BTreeFactory(FLAGS_btree_fanout));
         break;
 #else
       default:

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -1973,7 +1973,7 @@ class Benchmark {
             options.write_buffer_size, FLAGS_key_size + FLAGS_value_size));
         break;
       case kBTree:
-        options.memtable_factory.reset(new BTreeFactory(FLAGS_btree_fanout));
+        options.memtable_factory.reset(new BTreeFactory((int32_t) FLAGS_btree_fanout));
         break;
 #else
       default:

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -554,7 +554,8 @@ enum RepFactory {
   kPrefixHash,
   kVectorRep,
   kHashLinkedList,
-  kCuckoo
+  kCuckoo,
+  kBTree
 };
 
 namespace {
@@ -563,6 +564,8 @@ enum RepFactory StringToRepFactory(const char* ctype) {
 
   if (!strcasecmp(ctype, "skip_list"))
     return kSkipList;
+  else if (!strcasecmp(ctype, "btree"))
+    return kBTree;
   else if (!strcasecmp(ctype, "prefix_hash"))
     return kPrefixHash;
   else if (!strcasecmp(ctype, "vector"))
@@ -1184,6 +1187,9 @@ class Benchmark {
         break;
       case kCuckoo:
         fprintf(stdout, "Memtablerep: cuckoo\n");
+        break;
+      case kBTree:
+        fprintf(stdout, "Memtablerep: btree\n");
         break;
     }
     fprintf(stdout, "Perf Level: %d\n", FLAGS_perf_level);
@@ -1963,6 +1969,9 @@ class Benchmark {
       case kCuckoo:
         options.memtable_factory.reset(NewHashCuckooRepFactory(
             options.write_buffer_size, FLAGS_key_size + FLAGS_value_size));
+        break;
+      case kBTree:
+        options.memtable_factory.reset(new BTreeFactory());
         break;
 #else
       default:

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1730,9 +1730,6 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
 
     // SetNewMemtableAndNewLogFile() will release and reacquire mutex
     // during execution
-    /**
-     * Need to put an assertFalse()
-     */
     s = SetNewMemtableAndNewLogFile(cfd, &context);
     write_thread_.ExitWriteThread(&w, &w, s);
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1730,6 +1730,9 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
 
     // SetNewMemtableAndNewLogFile() will release and reacquire mutex
     // during execution
+    /**
+     * Need to put an assertFalse()
+     */
     s = SetNewMemtableAndNewLogFile(cfd, &context);
     write_thread_.ExitWriteThread(&w, &w, s);
 

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -213,7 +213,8 @@ class BTreeFactory : public MemTableRepFactory {
   explicit BTreeFactory(int32_t maxNodeSize = 64) : maxNodeSize_(maxNodeSize) {}
 
   virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
-                                         Arena*, const SliceTransform*,
+                                         MemTableAllocator*, 
+                                         const SliceTransform*,
                                          Logger* logger) override;
   virtual const char* Name() const override { return "BTreeFactory"; }
 

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -208,6 +208,18 @@ class SkipListFactory : public MemTableRepFactory {
   const size_t lookahead_;
 };
 
+class BTreeFactory : public MemTableRepFactory {
+ public:
+  explicit BTreeFactory() {}
+
+  virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
+                                         Arena*, const SliceTransform*,
+                                         Logger* logger) override;
+  virtual const char* Name() const override { return "BTreeFactory"; }
+
+ private:
+};
+
 #ifndef ROCKSDB_LITE
 // This creates MemTableReps that are backed by an std::vector. On iteration,
 // the vector is sorted. This is useful for workloads where iteration is very

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -210,7 +210,7 @@ class SkipListFactory : public MemTableRepFactory {
 
 class BTreeFactory : public MemTableRepFactory {
  public:
-  explicit BTreeFactory() {}
+  explicit BTreeFactory(int32_t maxNodeSize = 64) : maxNodeSize_(maxNodeSize) {}
 
   virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
                                          Arena*, const SliceTransform*,
@@ -218,6 +218,7 @@ class BTreeFactory : public MemTableRepFactory {
   virtual const char* Name() const override { return "BTreeFactory"; }
 
  private:
+  int32_t maxNodeSize_;
 };
 
 #ifndef ROCKSDB_LITE

--- a/util/btreerep.cc
+++ b/util/btreerep.cc
@@ -15,8 +15,8 @@ class BTreeRep : public MemTableRep {
   BTree<const char*, const MemTableRep::KeyComparator&> tree_;
 
 public:
-  explicit BTreeRep(const MemTableRep::KeyComparator& compare, Arena* arena)
-    : MemTableRep(arena), cmp_(compare), tree_(cmp_, arena) {
+  explicit BTreeRep(const MemTableRep::KeyComparator& compare, Arena* arena, int32_t maxNodeSize = 64)
+    : MemTableRep(arena), cmp_(compare), tree_(cmp_, arena, maxNodeSize) {
   }
 
   // Insert key into the list.
@@ -121,7 +121,7 @@ public:
 MemTableRep* BTreeFactory::CreateMemTableRep(
     const MemTableRep::KeyComparator& compare, Arena* arena,
     const SliceTransform* transform, Logger* logger) {
-  return new BTreeRep(compare, arena);
+  return new BTreeRep(compare, arena, maxNodeSize_);
 }
 
 } // namespace rocksdb

--- a/util/btreerep.cc
+++ b/util/btreerep.cc
@@ -15,8 +15,8 @@ class BTreeRep : public MemTableRep {
   BTree<const char*, const MemTableRep::KeyComparator&> tree_;
 
 public:
-  explicit BTreeRep(const MemTableRep::KeyComparator& compare, Arena* arena, int32_t maxNodeSize = 64)
-    : MemTableRep(arena), cmp_(compare), tree_(cmp_, arena, maxNodeSize) {
+  explicit BTreeRep(const MemTableRep::KeyComparator& compare, MemTableAllocator* allocator, int32_t maxNodeSize = 64)
+      : MemTableRep(allocator), cmp_(compare), tree_(cmp_, allocator, maxNodeSize) {
   }
 
   // Insert key into the list.
@@ -31,8 +31,7 @@ public:
   }
 
   virtual size_t ApproximateMemoryUsage() override {
-    // All memory is allocated through arena; nothing to report here
-    // TODO is this true for BTree? Yup
+    // All memory is allocated through allocator; nothing to report here
     return 0;
   }
 
@@ -119,9 +118,9 @@ public:
 }
 
 MemTableRep* BTreeFactory::CreateMemTableRep(
-    const MemTableRep::KeyComparator& compare, Arena* arena,
+    const MemTableRep::KeyComparator& compare, MemTableAllocator* allocator,
     const SliceTransform* transform, Logger* logger) {
-  return new BTreeRep(compare, arena, maxNodeSize_);
+  return new BTreeRep(compare, allocator, maxNodeSize_);
 }
 
 } // namespace rocksdb

--- a/util/btreerep.cc
+++ b/util/btreerep.cc
@@ -1,0 +1,127 @@
+//  Copyright (c) 2013, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+#include "rocksdb/memtablerep.h"
+#include "db/memtable.h"
+#include "db/btree.h"
+#include "util/arena.h"
+
+namespace rocksdb {
+namespace {
+class BTreeRep : public MemTableRep {
+  const MemTableRep::KeyComparator& cmp_;
+  BTree<const char*, const MemTableRep::KeyComparator&> tree_;
+
+public:
+  explicit BTreeRep(const MemTableRep::KeyComparator& compare, Arena* arena)
+    : MemTableRep(arena), cmp_(compare), tree_(cmp_, arena) {
+  }
+
+  // Insert key into the list.
+  // REQUIRES: nothing that compares equal to key is currently in the list.
+  virtual void Insert(KeyHandle handle) override {
+    tree_.Insert(static_cast<char*>(handle));
+  }
+
+  // Returns true iff an entry that compares equal to key is in the list.
+  virtual bool Contains(const char* key) const override {
+    return tree_.Contains(key);
+  }
+
+  virtual size_t ApproximateMemoryUsage() override {
+    // All memory is allocated through arena; nothing to report here
+    // TODO is this true for BTree? Yup
+    return 0;
+  }
+
+  virtual void Get(const LookupKey& k, void* callback_args,
+                   bool (*callback_func)(void* arg,
+                                         const char* entry)) override {
+    BTreeRep::Iterator iter(&tree_);
+    Slice dummy_slice;
+    for (iter.Seek(dummy_slice, k.memtable_key().data());
+         iter.Valid() && callback_func(callback_args, iter.key());
+         iter.Next()) {
+    }
+  }
+
+  virtual ~BTreeRep() override { }
+
+  // Iteration over the contents of a B-Tree
+  class Iterator : public MemTableRep::Iterator {
+    BTree<const char*, const MemTableRep::KeyComparator&>::Iterator iter_;
+   public:
+    // Initialize an iterator over the specified tree.
+    // The returned iterator is not valid.
+    explicit Iterator(
+      const BTree<const char*, const MemTableRep::KeyComparator&>* tree
+    ) : iter_(tree) { }
+
+    virtual ~Iterator() override { }
+
+    // Returns true iff the iterator is positioned at a valid node.
+    virtual bool Valid() const override {
+      return iter_.Valid();
+    }
+
+    // Returns the key at the current position.
+    // REQUIRES: Valid()
+    virtual const char* key() const override {
+      return iter_.key();
+    }
+
+    // Advances to the next position.
+    // REQUIRES: Valid()
+    virtual void Next() override {
+      iter_.Next();
+    }
+
+    // Advances to the previous position.
+    // REQUIRES: Valid()
+    virtual void Prev() override {
+      iter_.Prev();
+    }
+
+    // Advance to the first entry with a key >= target
+    virtual void Seek(const Slice& user_key, const char* memtable_key)
+        override {
+      if (memtable_key != nullptr) {
+        iter_.Seek(memtable_key);
+      } else {
+        iter_.Seek(EncodeKey(&tmp_, user_key));
+      }
+    }
+
+    // Position at the first entry in list.
+    // Final state of iterator is Valid() iff list is not empty.
+    virtual void SeekToFirst() override {
+      iter_.SeekToFirst();
+    }
+
+    // Position at the last entry in list.
+    // Final state of iterator is Valid() iff list is not empty.
+    virtual void SeekToLast() override {
+      iter_.SeekToLast();
+    }
+   protected:
+    std::string tmp_;       // For passing to EncodeKey
+  };
+
+  virtual MemTableRep::Iterator* GetIterator(Arena* arena = nullptr) override {
+    void *mem =
+        arena ? arena->AllocateAligned(sizeof(BTreeRep::Iterator))
+              : operator new(sizeof(BTreeRep::Iterator));
+      return new (mem) BTreeRep::Iterator(&tree_);
+  }
+};
+}
+
+MemTableRep* BTreeFactory::CreateMemTableRep(
+    const MemTableRep::KeyComparator& compare, Arena* arena,
+    const SliceTransform* transform, Logger* logger) {
+  return new BTreeRep(compare, arena);
+}
+
+} // namespace rocksdb


### PR DESCRIPTION
Fixed build issue from https://github.com/facebook/rocksdb/pull/486

In reply to @mdcallag, the original paper uses CAS(compare and swap) to synchronize updates of MappingTable(a table that maintains logical pages(nodes) to physical pages(nodes)). Since RocksDB guarantees that there is only one writer, my implementation does not need to utilize CAS to ensure that there are no multiple writers.

---

This is a BW-Tree implementation of Memtable for RocksDB.
It was done as part of Facebook Open Academy.
The original paper by Microsoft Research can be viewed at http://research.microsoft.com/pubs/178758/bw-tree-icde2013-final.pdf
