### PR TITLE
Switch logv with loglevel to virtual

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 
 ### Public API changes
 * Deprecated skip_log_error_on_recovery option
+* Logger method logv with log level parameter is now virtual
 
 ### 3.9.0 (12/8/2014)
 

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -14,6 +14,7 @@ namespace rocksdb {
 
 class CountingLogger : public Logger {
  public:
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) override { log_count++; }
   size_t log_count;
 };

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -79,6 +79,7 @@ class FakeRandomeAccessFile : public RandomAccessFile {
 
 class DumbLogger : public Logger {
  public:
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) { }
   virtual size_t GetLogFileSize() const { return 0; }
 };

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -633,7 +633,7 @@ class Logger {
   // and format.  Any log with level under the internal log level
   // of *this (see @SetInfoLogLevel and @GetInfoLogLevel) will not be
   // printed.
-  void Logv(const InfoLogLevel log_level, const char* format, va_list ap) {
+  virtual void Logv(const InfoLogLevel log_level, const char* format, va_list ap) {
     static const char* kInfoLogLevelNames[5] = {"DEBUG", "INFO", "WARN",
                                                 "ERROR", "FATAL"};
     if (log_level < log_level_) {

--- a/util/auto_roll_logger.h
+++ b/util/auto_roll_logger.h
@@ -40,6 +40,7 @@ class AutoRollLogger : public Logger {
     ResetLogger();
   }
 
+  using Logger::Logv;
   void Logv(const char* format, va_list ap);
 
   // Write a header entry to the log. All header information will be written

--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -735,6 +735,7 @@ TEST(EnvPosixTest, PosixRandomRWFileTest) {
 
 class TestLogger : public Logger {
  public:
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) override {
     log_count++;
 
@@ -808,6 +809,7 @@ TEST(EnvPosixTest, LogBufferTest) {
 class TestLogger2 : public Logger {
  public:
   explicit TestLogger2(size_t max_log_size) : max_log_size_(max_log_size) {}
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) override {
     char new_format[2000];
     std::fill_n(new_format, sizeof(new_format), '2');

--- a/util/mock_env.cc
+++ b/util/mock_env.cc
@@ -322,6 +322,8 @@ class TestMemLogger : public Logger {
     }
     last_flush_micros_ = env_->NowMicros();
   }
+
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) {
     // We try twice: the first time with a fixed-size stack allocated buffer,
     // and the second time with a much larger dynamically allocated buffer.

--- a/util/options_test.cc
+++ b/util/options_test.cc
@@ -36,6 +36,7 @@ class OptionsTest {};
 
 class StderrLogger : public Logger {
  public:
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) override {
     vprintf(format, ap);
     printf("\n");

--- a/util/posix_logger.h
+++ b/util/posix_logger.h
@@ -58,6 +58,8 @@ class PosixLogger : public Logger {
     }
     last_flush_micros_ = env_->NowMicros();
   }
+
+  using Logger::Logv;
   virtual void Logv(const char* format, va_list ap) {
     const uint64_t thread_id = (*gettid_)();
 


### PR DESCRIPTION
I would like to alter `void Logv(const InfoLogLevel log_level, const char* format, va_list ap)` to virtual. That`s because i would like to add a Logger for RocksJava. 

Logging from a higher level API would require to know about the log level which is not easily accessible from `virtual void Logv(const char* format, va_list ap)`. It would also offer the possibility to override the loglevel from API, what`s not possible if this method remains as is.

@igorcanadi can you look into this please?  

I checked the build using `make all` and everything compiles.