### PR TITLE
[RocksJava] 32-Bit adjustments

### DIFF
--- a/java/rocksjni/memtablejni.cc
+++ b/java/rocksjni/memtablejni.cc
@@ -27,7 +27,7 @@ jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
         static_cast<int32_t>(jheight),
         static_cast<int32_t>(jbranching_factor)));
   }
-  rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   return 0;
 }
 
@@ -52,7 +52,7 @@ jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
         static_cast<bool>(jif_log_bucket_dist_when_flash),
         static_cast<int32_t>(jthreshold_use_skiplist)));
   }
-  rocksdb::RocksDBExceptionJni::ThrowNew(env,
+  rocksdb::IllegalArgumentExceptionJni::ThrowNew(env,
       !statusBucketCount.ok()?statusBucketCount:statusHugePageTlb);
   return 0;
 }
@@ -69,7 +69,7 @@ jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
     return reinterpret_cast<jlong>(new rocksdb::VectorRepFactory(
         static_cast<size_t>(jreserved_size)));
   }
-  rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   return 0;
 }
 
@@ -85,6 +85,6 @@ jlong Java_org_rocksdb_SkipListMemTableConfig_newMemTableFactoryHandle0(
     return reinterpret_cast<jlong>(new rocksdb::SkipListFactory(
         static_cast<size_t>(jlookahead)));
   }
-  rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   return 0;
 }

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -189,7 +189,7 @@ void Java_org_rocksdb_Options_setWriteBufferSize(
     reinterpret_cast<rocksdb::Options*>(jhandle)->write_buffer_size =
         jwrite_buffer_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -519,7 +519,7 @@ void Java_org_rocksdb_Options_setMaxLogFileSize(
     reinterpret_cast<rocksdb::Options*>(jhandle)->max_log_file_size =
         max_log_file_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -546,7 +546,7 @@ void Java_org_rocksdb_Options_setLogFileTimeToRoll(
     reinterpret_cast<rocksdb::Options*>(jhandle)->log_file_time_to_roll =
         log_file_time_to_roll;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -572,7 +572,7 @@ void Java_org_rocksdb_Options_setKeepLogFileNum(
     reinterpret_cast<rocksdb::Options*>(jhandle)->keep_log_file_num =
         keep_log_file_num;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -792,7 +792,7 @@ void Java_org_rocksdb_Options_setManifestPreallocationSize(
     reinterpret_cast<rocksdb::Options*>(jhandle)->manifest_preallocation_size =
         preallocation_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -1472,7 +1472,7 @@ void Java_org_rocksdb_Options_setArenaBlockSize(
     reinterpret_cast<rocksdb::Options*>(jhandle)->arena_block_size =
         jarena_block_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -1642,7 +1642,7 @@ void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
     reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_num_locks =
         jinplace_update_num_locks;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -1739,7 +1739,7 @@ void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
     reinterpret_cast<rocksdb::Options*>(jhandle)->max_successive_merges =
         jmax_successive_merges;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -1989,7 +1989,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
         write_buffer_size = jwrite_buffer_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -2564,7 +2564,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
         arena_block_size = jarena_block_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -2735,7 +2735,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
         inplace_update_num_locks = jinplace_update_num_locks;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -2834,7 +2834,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
         max_successive_merges = jmax_successive_merges;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -3312,7 +3312,7 @@ void Java_org_rocksdb_DBOptions_setMaxLogFileSize(
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_log_file_size =
         max_log_file_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -3339,7 +3339,7 @@ void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->log_file_time_to_roll =
         log_file_time_to_roll;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -3365,7 +3365,7 @@ void Java_org_rocksdb_DBOptions_setKeepLogFileNum(
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->keep_log_file_num =
         keep_log_file_num;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -3498,7 +3498,7 @@ void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
         manifest_preallocation_size = preallocation_size;
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
 }
 

--- a/java/samples/src/main/java/RocksDBSample.java
+++ b/java/samples/src/main/java/RocksDBSample.java
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
+import java.lang.IllegalArgumentException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class RocksDBSample {
           .setMaxBackgroundCompactions(10)
           .setCompressionType(CompressionType.SNAPPY_COMPRESSION)
           .setCompactionStyle(CompactionStyle.UNIVERSAL);
-    } catch (RocksDBException e) {
+    } catch (IllegalArgumentException e) {
       assert(false);
     }
 

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -144,8 +144,7 @@ public class ColumnFamilyOptions extends RocksObject
   }
 
   @Override
-  public ColumnFamilyOptions setWriteBufferSize(final long writeBufferSize)
-      throws RocksDBException {
+  public ColumnFamilyOptions setWriteBufferSize(final long writeBufferSize) {
     assert(isInitialized());
     setWriteBufferSize(nativeHandle_, writeBufferSize);
     return this;
@@ -396,8 +395,7 @@ public class ColumnFamilyOptions extends RocksObject
 
   @Override
   public ColumnFamilyOptions setArenaBlockSize(
-      final long arenaBlockSize)
-      throws RocksDBException {
+      final long arenaBlockSize) {
     setArenaBlockSize(nativeHandle_, arenaBlockSize);
     return this;
   }
@@ -483,7 +481,7 @@ public class ColumnFamilyOptions extends RocksObject
 
   @Override
   public ColumnFamilyOptions setMemTableConfig(
-      final MemTableConfig config) throws RocksDBException {
+      final MemTableConfig config) {
     memTableConfig_ = config;
     setMemTableFactory(nativeHandle_, config.newMemTableFactoryHandle());
     return this;
@@ -523,8 +521,7 @@ public class ColumnFamilyOptions extends RocksObject
 
   @Override
   public ColumnFamilyOptions setInplaceUpdateNumLocks(
-      final long inplaceUpdateNumLocks)
-      throws RocksDBException {
+      final long inplaceUpdateNumLocks) {
     setInplaceUpdateNumLocks(nativeHandle_, inplaceUpdateNumLocks);
     return this;
   }
@@ -571,7 +568,7 @@ public class ColumnFamilyOptions extends RocksObject
 
   @Override
   public ColumnFamilyOptions setMaxSuccessiveMerges(
-      final long maxSuccessiveMerges) throws RocksDBException {
+      final long maxSuccessiveMerges) {
     setMaxSuccessiveMerges(nativeHandle_, maxSuccessiveMerges);
     return this;
   }
@@ -644,7 +641,7 @@ public class ColumnFamilyOptions extends RocksObject
   private native void setMergeOperator(
       long handle, long mergeOperatorHandle);
   private native void setWriteBufferSize(long handle, long writeBufferSize)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long writeBufferSize(long handle);
   private native void setMaxWriteBufferNumber(
       long handle, int maxWriteBufferNumber);
@@ -706,7 +703,8 @@ public class ColumnFamilyOptions extends RocksObject
       long handle, int rateLimitDelayMaxMilliseconds);
   private native int rateLimitDelayMaxMilliseconds(long handle);
   private native void setArenaBlockSize(
-      long handle, long arenaBlockSize) throws RocksDBException;
+      long handle, long arenaBlockSize)
+      throws IllegalArgumentException;
   private native long arenaBlockSize(long handle);
   private native void setDisableAutoCompactions(
       long handle, boolean disableAutoCompactions);
@@ -733,7 +731,8 @@ public class ColumnFamilyOptions extends RocksObject
       long handle, boolean inplaceUpdateSupport);
   private native boolean inplaceUpdateSupport(long handle);
   private native void setInplaceUpdateNumLocks(
-      long handle, long inplaceUpdateNumLocks) throws RocksDBException;
+      long handle, long inplaceUpdateNumLocks)
+      throws IllegalArgumentException;
   private native long inplaceUpdateNumLocks(long handle);
   private native void setMemtablePrefixBloomBits(
       long handle, int memtablePrefixBloomBits);
@@ -745,7 +744,8 @@ public class ColumnFamilyOptions extends RocksObject
       long handle, int bloomLocality);
   private native int bloomLocality(long handle);
   private native void setMaxSuccessiveMerges(
-      long handle, long maxSuccessiveMerges) throws RocksDBException;
+      long handle, long maxSuccessiveMerges)
+      throws IllegalArgumentException;
   private native long maxSuccessiveMerges(long handle);
   private native void setMinPartialMergeOperands(
       long handle, int minPartialMergeOperands);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -152,11 +152,10 @@ public interface ColumnFamilyOptionsInterface {
    * Default: 4MB
    * @param writeBufferSize the size of write buffer.
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setWriteBufferSize(long writeBufferSize)
-      throws RocksDBException;
+  Object setWriteBufferSize(long writeBufferSize);
 
   /**
    * Return size of write buffer size.
@@ -701,11 +700,10 @@ public interface ColumnFamilyOptionsInterface {
    *
    * @param arenaBlockSize the size of an arena block
    * @return the reference to the current option.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setArenaBlockSize(long arenaBlockSize)
-      throws RocksDBException;
+  Object setArenaBlockSize(long arenaBlockSize);
 
   /**
    * The size of one block in arena memory allocation.
@@ -850,11 +848,10 @@ public interface ColumnFamilyOptionsInterface {
    *
    * @param config the mem-table config.
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setMemTableConfig(MemTableConfig config)
-      throws RocksDBException;
+  Object setMemTableConfig(MemTableConfig config);
 
   /**
    * Returns the name of the current mem table representation.
@@ -915,11 +912,10 @@ public interface ColumnFamilyOptionsInterface {
    * @param inplaceUpdateNumLocks the number of locks used for
    *     inplace updates.
    * @return the reference to the current option.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setInplaceUpdateNumLocks(long inplaceUpdateNumLocks)
-      throws RocksDBException;
+  Object setInplaceUpdateNumLocks(long inplaceUpdateNumLocks);
 
   /**
    * Number of locks used for inplace update
@@ -1010,11 +1006,10 @@ public interface ColumnFamilyOptionsInterface {
    *
    * @param maxSuccessiveMerges the maximum number of successive merges.
    * @return the reference to the current option.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setMaxSuccessiveMerges(long maxSuccessiveMerges)
-      throws RocksDBException;
+  Object setMaxSuccessiveMerges(long maxSuccessiveMerges);
 
   /**
    * Maximum number of successive merge operations on a key in the memtable.

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -314,7 +314,7 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
 
   @Override
   public DBOptions setMaxLogFileSize(
-      final long maxLogFileSize) throws RocksDBException {
+      final long maxLogFileSize) {
     assert(isInitialized());
     setMaxLogFileSize(nativeHandle_, maxLogFileSize);
     return this;
@@ -328,7 +328,7 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
 
   @Override
   public DBOptions setLogFileTimeToRoll(
-      final long logFileTimeToRoll) throws RocksDBException{
+      final long logFileTimeToRoll) {
     assert(isInitialized());
     setLogFileTimeToRoll(nativeHandle_, logFileTimeToRoll);
     return this;
@@ -342,7 +342,7 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
 
   @Override
   public DBOptions setKeepLogFileNum(
-      final long keepLogFileNum) throws RocksDBException{
+      final long keepLogFileNum) {
     assert(isInitialized());
     setKeepLogFileNum(nativeHandle_, keepLogFileNum);
     return this;
@@ -426,7 +426,7 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
 
   @Override
   public DBOptions setManifestPreallocationSize(
-      final long size) throws RocksDBException {
+      final long size) {
     assert(isInitialized());
     setManifestPreallocationSize(nativeHandle_, size);
     return this;
@@ -634,13 +634,13 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
       long handle, int maxBackgroundFlushes);
   private native int maxBackgroundFlushes(long handle);
   private native void setMaxLogFileSize(long handle, long maxLogFileSize)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long maxLogFileSize(long handle);
   private native void setLogFileTimeToRoll(
-      long handle, long logFileTimeToRoll) throws RocksDBException;
+      long handle, long logFileTimeToRoll) throws IllegalArgumentException;
   private native long logFileTimeToRoll(long handle);
   private native void setKeepLogFileNum(long handle, long keepLogFileNum)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long keepLogFileNum(long handle);
   private native void setMaxManifestFileSize(
       long handle, long maxManifestFileSize);
@@ -656,7 +656,7 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
   private native void setManifestPreallocationSize(
-      long handle, long size) throws RocksDBException;
+      long handle, long size) throws IllegalArgumentException;
   private native long manifestPreallocationSize(long handle);
   private native void setAllowOsBuffer(
       long handle, boolean allowOsBuffer);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -415,11 +415,10 @@ public interface DBOptionsInterface {
    *
    * @param maxLogFileSize the maximum size of a info log file.
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setMaxLogFileSize(long maxLogFileSize)
-      throws RocksDBException;
+  Object setMaxLogFileSize(long maxLogFileSize);
 
   /**
    * Returns the maximum size of a info log file. If the current log file
@@ -438,11 +437,10 @@ public interface DBOptionsInterface {
    *
    * @param logFileTimeToRoll the time interval in seconds.
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setLogFileTimeToRoll(long logFileTimeToRoll)
-      throws RocksDBException;
+  Object setLogFileTimeToRoll(long logFileTimeToRoll);
 
   /**
    * Returns the time interval for the info log file to roll (in seconds).
@@ -460,11 +458,10 @@ public interface DBOptionsInterface {
    *
    * @param keepLogFileNum the maximum number of info log files to be kept.
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setKeepLogFileNum(long keepLogFileNum)
-      throws RocksDBException;
+  Object setKeepLogFileNum(long keepLogFileNum);
 
   /**
    * Returns the maximum number of info log files to be kept.
@@ -638,11 +635,10 @@ public interface DBOptionsInterface {
    *
    * @param size the size in byte
    * @return the instance of the current Object.
-   * @throws org.rocksdb.RocksDBException thrown on 32-Bit platforms while
-   *    overflowing the underlying platform specific value.
+   * @throws java.lang.IllegalArgumentException thrown on 32-Bit platforms
+   *   while overflowing the underlying platform specific value.
    */
-  Object setManifestPreallocationSize(long size)
-      throws RocksDBException;
+  Object setManifestPreallocationSize(long size);
 
   /**
    * Number of bytes to preallocate (via fallocate) the manifest

--- a/java/src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
@@ -154,8 +154,7 @@ public class HashLinkedListMemTableConfig extends MemTableConfig {
     return thresholdUseSkiplist_;
   }
 
-  @Override protected long newMemTableFactoryHandle()
-       throws RocksDBException {
+  @Override protected long newMemTableFactoryHandle() {
     return newMemTableFactoryHandle(bucketCount_, hugePageTlbSize_,
         bucketEntriesLoggingThreshold_, ifLogBucketDistWhenFlush_,
         thresholdUseSkiplist_);
@@ -164,7 +163,7 @@ public class HashLinkedListMemTableConfig extends MemTableConfig {
   private native long newMemTableFactoryHandle(long bucketCount,
       long hugePageTlbSize, int bucketEntriesLoggingThreshold,
       boolean ifLogBucketDistWhenFlush, int thresholdUseSkiplist)
-      throws RocksDBException;
+      throws IllegalArgumentException;
 
   private long bucketCount_;
   private long hugePageTlbSize_;

--- a/java/src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
@@ -90,15 +90,14 @@ public class HashSkipListMemTableConfig extends MemTableConfig {
     return branchingFactor_;
   }
 
-  @Override protected long newMemTableFactoryHandle()
-      throws RocksDBException {
+  @Override protected long newMemTableFactoryHandle() {
     return newMemTableFactoryHandle(
         bucketCount_, height_, branchingFactor_);
   }
 
   private native long newMemTableFactoryHandle(
       long bucketCount, int height, int branchingFactor)
-      throws RocksDBException;
+      throws IllegalArgumentException;
 
   private long bucketCount_;
   private int branchingFactor_;

--- a/java/src/main/java/org/rocksdb/MemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/MemTableConfig.java
@@ -24,10 +24,6 @@ public abstract class MemTableConfig {
    * @see Options#setMemTableConfig(MemTableConfig)
    *
    * @return native handle address to native memory table instance.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *    native library.
    */
-  abstract protected long newMemTableFactoryHandle()
-      throws RocksDBException;
+  abstract protected long newMemTableFactoryHandle();
 }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -190,8 +190,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setWriteBufferSize(final long writeBufferSize)
-      throws RocksDBException {
+  public Options setWriteBufferSize(final long writeBufferSize) {
     assert(isInitialized());
     setWriteBufferSize(nativeHandle_, writeBufferSize);
     return this;
@@ -389,8 +388,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setMaxLogFileSize(final long maxLogFileSize)
-      throws RocksDBException {
+  public Options setMaxLogFileSize(final long maxLogFileSize) {
     assert(isInitialized());
     setMaxLogFileSize(nativeHandle_, maxLogFileSize);
     return this;
@@ -403,8 +401,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setLogFileTimeToRoll(final long logFileTimeToRoll)
-      throws RocksDBException{
+  public Options setLogFileTimeToRoll(final long logFileTimeToRoll) {
     assert(isInitialized());
     setLogFileTimeToRoll(nativeHandle_, logFileTimeToRoll);
     return this;
@@ -417,8 +414,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setKeepLogFileNum(final long keepLogFileNum)
-      throws RocksDBException{
+  public Options setKeepLogFileNum(final long keepLogFileNum) {
     assert(isInitialized());
     setKeepLogFileNum(nativeHandle_, keepLogFileNum);
     return this;
@@ -499,8 +495,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setManifestPreallocationSize(final long size)
-      throws RocksDBException {
+  public Options setManifestPreallocationSize(final long size) {
     assert(isInitialized());
     setManifestPreallocationSize(nativeHandle_, size);
     return this;
@@ -624,8 +619,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setMemTableConfig(final MemTableConfig config)
-      throws RocksDBException {
+  public Options setMemTableConfig(final MemTableConfig config) {
     memTableConfig_ = config;
     setMemTableFactory(nativeHandle_, config.newMemTableFactoryHandle());
     return this;
@@ -901,8 +895,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setArenaBlockSize(final long arenaBlockSize)
-      throws RocksDBException {
+  public Options setArenaBlockSize(final long arenaBlockSize) {
     setArenaBlockSize(nativeHandle_, arenaBlockSize);
     return this;
   }
@@ -988,7 +981,7 @@ public class Options extends RocksObject
 
   @Override
   public Options setInplaceUpdateNumLocks(
-      final long inplaceUpdateNumLocks) throws RocksDBException {
+      final long inplaceUpdateNumLocks) {
     setInplaceUpdateNumLocks(nativeHandle_, inplaceUpdateNumLocks);
     return this;
   }
@@ -1034,8 +1027,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setMaxSuccessiveMerges(long maxSuccessiveMerges)
-      throws RocksDBException {
+  public Options setMaxSuccessiveMerges(long maxSuccessiveMerges) {
     setMaxSuccessiveMerges(nativeHandle_, maxSuccessiveMerges);
     return this;
   }
@@ -1135,13 +1127,13 @@ public class Options extends RocksObject
       long handle, int maxBackgroundFlushes);
   private native int maxBackgroundFlushes(long handle);
   private native void setMaxLogFileSize(long handle, long maxLogFileSize)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long maxLogFileSize(long handle);
   private native void setLogFileTimeToRoll(
-      long handle, long logFileTimeToRoll) throws RocksDBException;
+      long handle, long logFileTimeToRoll) throws IllegalArgumentException;
   private native long logFileTimeToRoll(long handle);
   private native void setKeepLogFileNum(long handle, long keepLogFileNum)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long keepLogFileNum(long handle);
   private native void setMaxManifestFileSize(
       long handle, long maxManifestFileSize);
@@ -1157,7 +1149,7 @@ public class Options extends RocksObject
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
   private native void setManifestPreallocationSize(
-      long handle, long size) throws RocksDBException;
+      long handle, long size) throws IllegalArgumentException;
   private native long manifestPreallocationSize(long handle);
   private native void setAllowOsBuffer(
       long handle, boolean allowOsBuffer);
@@ -1200,7 +1192,7 @@ public class Options extends RocksObject
   private native void setMergeOperator(
       long handle, long mergeOperatorHandle);
   private native void setWriteBufferSize(long handle, long writeBufferSize)
-      throws RocksDBException;
+      throws IllegalArgumentException;
   private native long writeBufferSize(long handle);
   private native void setMaxWriteBufferNumber(
       long handle, int maxWriteBufferNumber);
@@ -1262,7 +1254,7 @@ public class Options extends RocksObject
       long handle, int rateLimitDelayMaxMilliseconds);
   private native int rateLimitDelayMaxMilliseconds(long handle);
   private native void setArenaBlockSize(
-      long handle, long arenaBlockSize) throws RocksDBException;
+      long handle, long arenaBlockSize) throws IllegalArgumentException;
   private native long arenaBlockSize(long handle);
   private native void setDisableAutoCompactions(
       long handle, boolean disableAutoCompactions);
@@ -1289,7 +1281,8 @@ public class Options extends RocksObject
       long handle, boolean inplaceUpdateSupport);
   private native boolean inplaceUpdateSupport(long handle);
   private native void setInplaceUpdateNumLocks(
-      long handle, long inplaceUpdateNumLocks) throws RocksDBException;
+      long handle, long inplaceUpdateNumLocks)
+      throws IllegalArgumentException;
   private native long inplaceUpdateNumLocks(long handle);
   private native void setMemtablePrefixBloomBits(
       long handle, int memtablePrefixBloomBits);
@@ -1301,7 +1294,8 @@ public class Options extends RocksObject
       long handle, int bloomLocality);
   private native int bloomLocality(long handle);
   private native void setMaxSuccessiveMerges(
-      long handle, long maxSuccessiveMerges) throws RocksDBException;
+      long handle, long maxSuccessiveMerges)
+      throws IllegalArgumentException;
   private native long maxSuccessiveMerges(long handle);
   private native void setMinPartialMergeOperands(
       long handle, int minPartialMergeOperands);

--- a/java/src/main/java/org/rocksdb/SkipListMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/SkipListMemTableConfig.java
@@ -43,7 +43,8 @@ public class SkipListMemTableConfig extends MemTableConfig {
     return newMemTableFactoryHandle0(lookahead_);
   }
 
-  private native long newMemTableFactoryHandle0(long lookahead);
+  private native long newMemTableFactoryHandle0(long lookahead)
+      throws IllegalArgumentException;
 
   private long lookahead_;
 }

--- a/java/src/main/java/org/rocksdb/VectorMemTableConfig.java
+++ b/java/src/main/java/org/rocksdb/VectorMemTableConfig.java
@@ -39,6 +39,7 @@ public class VectorMemTableConfig extends MemTableConfig {
     return newMemTableFactoryHandle(reservedSize_);
   }
 
-  private native long newMemTableFactoryHandle(long reservedSize);
+  private native long newMemTableFactoryHandle(long reservedSize)
+      throws IllegalArgumentException;
   private int reservedSize_;
 }


### PR DESCRIPTION
Summary:
Before this change: overflowing size_t values led to a checked Exception.

After that change:

size_t overflows on 32-Bit architecture, throw now an IllegalArgumentException,
which removes the necessity for a developer to catch these Exceptions explicitly.

This is especially an advantage for developers targeting 64-Bit systems because
it is not necessary anymore to catch exceptions which are never thrown on a 64-Bit
system.

Test Plan:
make clean jclean rocksdbjava jtest
mvn -f rocksjni.pom package

Reviewers: adamretter, yhchiang, ankgup87

Subscribers: dhruba

Differential Revision: https://reviews.facebook.net/D34923