### PR TITLE
[RocksJava] Add compression per level to API

### DIFF
--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -498,6 +498,24 @@ class ListJni {
   }
 };
 
+class ByteJni {
+ public:
+  // Get the java class id of java.lang.Byte.
+  static jclass getByteClass(JNIEnv* env) {
+    jclass jclazz = env->FindClass("java/lang/Byte");
+    assert(jclazz != nullptr);
+    return jclazz;
+  }
+
+  // Get the java method id of java.lang.Byte.byteValue.
+  static jmethodID getByteValueMethod(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getByteClass(env), "byteValue", "()B");
+    assert(mid != nullptr);
+    return mid;
+  }
+};
+
 class BackupInfoJni {
  public:
   // Get the java class id of org.rocksdb.BackupInfo.

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -198,6 +200,30 @@ public class ColumnFamilyOptions extends RocksObject
   @Override
   public CompressionType compressionType() {
     return CompressionType.values()[compressionType(nativeHandle_)];
+  }
+
+  @Override
+  public ColumnFamilyOptions setCompressionPerLevel(
+      final List<CompressionType> compressionLevels) {
+    final List<Byte> byteCompressionTypes = new ArrayList<>(
+        compressionLevels.size());
+    for (final CompressionType compressionLevel : compressionLevels) {
+      byteCompressionTypes.add(compressionLevel.getValue());
+    }
+    setCompressionPerLevel(nativeHandle_, byteCompressionTypes);
+    return this;
+  }
+
+  @Override
+  public List<CompressionType> compressionPerLevel() {
+    final List<Byte> byteCompressionTypes =
+        compressionPerLevel(nativeHandle_);
+    final List<CompressionType> compressionLevels = new ArrayList<>();
+    for (final Byte byteCompressionType : byteCompressionTypes) {
+      compressionLevels.add(CompressionType.getCompressionType(
+          byteCompressionType));
+    }
+    return compressionLevels;
   }
 
   @Override
@@ -651,6 +677,9 @@ public class ColumnFamilyOptions extends RocksObject
   private native int minWriteBufferNumberToMerge(long handle);
   private native void setCompressionType(long handle, byte compressionType);
   private native byte compressionType(long handle);
+  private native void setCompressionPerLevel(long handle,
+      List<Byte> compressionLevels);
+  private native List<Byte> compressionPerLevel(long handle);
   private native void useFixedLengthPrefixExtractor(
       long handle, int prefixLength);
   private native void setNumLevels(

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.util.List;
+
 public interface ColumnFamilyOptionsInterface {
 
   /**
@@ -247,6 +249,62 @@ public interface ColumnFamilyOptionsInterface {
    * @return Compression type.
    */
   CompressionType compressionType();
+
+  /**
+   * <p>Different levels can have different compression
+   * policies. There are cases where most lower levels
+   * would like to use quick compression algorithms while
+   * the higher levels (which have more data) use
+   * compression algorithms that have better compression
+   * but could be slower. This array, if non-empty, should
+   * have an entry for each level of the database;
+   * these override the value specified in the previous
+   * field 'compression'.</p>
+   *
+   * <strong>NOTICE</strong>
+   * <p>If {@code level_compaction_dynamic_level_bytes=true},
+   * {@code compression_per_level[0]} still determines {@code L0},
+   * but other elements of the array are based on base level
+   * (the level {@code L0} files are merged to), and may not
+   * match the level users see from info log for metadata.
+   * </p>
+   * <p>If {@code L0} files are merged to {@code level - n},
+   * then, for {@code i&gt;0}, {@code compression_per_level[i]}
+   * determines compaction type for level {@code n+i-1}.</p>
+   *
+   * <strong>Example</strong>
+   * <p>For example, if we have 5 levels, and we determine to
+   * merge {@code L0} data to {@code L4} (which means {@code L1..L3}
+   * will be empty), then the new files go to {@code L4} uses
+   * compression type {@code compression_per_level[1]}.</p>
+   *
+   * <p>If now {@code L0} is merged to {@code L2}. Data goes to
+   * {@code L2} will be compressed according to
+   * {@code compression_per_level[1]}, {@code L3} using
+   * {@code compression_per_level[2]}and {@code L4} using
+   * {@code compression_per_level[3]}. Compaction for each
+   * level can change when data grows.</p>
+   *
+   * <p><strong>Default:</strong> empty</p>
+   *
+   * @param compressionLevels list of
+   *     {@link org.rocksdb.CompressionType} instances.
+   *
+   * @return the reference to the current option.
+   */
+  Object setCompressionPerLevel(
+      List<CompressionType> compressionLevels);
+
+  /**
+   * <p>Return the currently set {@link org.rocksdb.CompressionType}
+   * per instances.</p>
+   *
+   * <p>See: {@link #setCompressionPerLevel(java.util.List)}</p>
+   *
+   * @return list of {@link org.rocksdb.CompressionType}
+   *     instances.
+   */
+  List<CompressionType> compressionPerLevel();
 
   /**
    * Set the number of levels for this database

--- a/java/src/main/java/org/rocksdb/CompressionType.java
+++ b/java/src/main/java/org/rocksdb/CompressionType.java
@@ -46,6 +46,26 @@ public enum CompressionType {
   }
 
   /**
+   * <p>Get the CompressionType enumeration value by
+   * passing the byte identifier to this method.</p>
+   *
+   * <p>If library cannot be found the enumeration
+   * value {@code NO_COMPRESSION} will be returned.</p>
+   *
+   * @param byteIdentifier of CompressionType.
+   *
+   * @return CompressionType instance.
+   */
+  public static CompressionType getCompressionType(byte byteIdentifier) {
+    for (CompressionType compressionType : CompressionType.values()) {
+      if (compressionType.getValue() == byteIdentifier) {
+        return compressionType;
+      }
+    }
+    return CompressionType.NO_COMPRESSION;
+  }
+
+  /**
    * <p>Returns the byte value of the enumerations value.</p>
    *
    * @return byte representation

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -5,6 +5,9 @@
 
 package org.rocksdb;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Options to control the behavior of a database.  It will be used
  * during the creation of a {@link org.rocksdb.RocksDB} (i.e., RocksDB.open()).
@@ -685,6 +688,29 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setCompressionPerLevel(final List<CompressionType> compressionLevels) {
+    final List<Byte> byteCompressionTypes = new ArrayList<>(
+        compressionLevels.size());
+    for (final CompressionType compressionLevel : compressionLevels) {
+      byteCompressionTypes.add(compressionLevel.getValue());
+    }
+    setCompressionPerLevel(nativeHandle_, byteCompressionTypes);
+    return this;
+  }
+
+  @Override
+  public List<CompressionType> compressionPerLevel() {
+    final List<Byte> byteCompressionTypes =
+        compressionPerLevel(nativeHandle_);
+    final List<CompressionType> compressionLevels = new ArrayList<>();
+    for (final Byte byteCompressionType : byteCompressionTypes) {
+      compressionLevels.add(CompressionType.getCompressionType(
+          byteCompressionType));
+    }
+    return compressionLevels;
+  }
+
+  @Override
   public Options setCompressionType(CompressionType compressionType) {
     setCompressionType(nativeHandle_, compressionType.getValue());
     return this;
@@ -1202,6 +1228,9 @@ public class Options extends RocksObject
   private native int minWriteBufferNumberToMerge(long handle);
   private native void setCompressionType(long handle, byte compressionType);
   private native byte compressionType(long handle);
+  private native void setCompressionPerLevel(long handle,
+      List<Byte> compressionLevels);
+  private native List<Byte> compressionPerLevel(long handle);
   private native void useFixedLengthPrefixExtractor(
       long handle, int prefixLength);
   private native void setNumLevels(

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -8,6 +8,8 @@ package org.rocksdb;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 
@@ -630,20 +632,74 @@ public class ColumnFamilyOptionsTest {
 
   @Test
   public void compressionTypes() {
-    ColumnFamilyOptions ColumnFamilyOptions = null;
+    ColumnFamilyOptions columnFamilyOptions = null;
     try {
-      ColumnFamilyOptions = new ColumnFamilyOptions();
+      columnFamilyOptions = new ColumnFamilyOptions();
       for (CompressionType compressionType :
           CompressionType.values()) {
-        ColumnFamilyOptions.setCompressionType(compressionType);
-        assertThat(ColumnFamilyOptions.compressionType()).
+        columnFamilyOptions.setCompressionType(compressionType);
+        assertThat(columnFamilyOptions.compressionType()).
             isEqualTo(compressionType);
         assertThat(CompressionType.valueOf("NO_COMPRESSION")).
             isEqualTo(CompressionType.NO_COMPRESSION);
       }
     } finally {
-      if (ColumnFamilyOptions != null) {
-        ColumnFamilyOptions.dispose();
+      if (columnFamilyOptions != null) {
+        columnFamilyOptions.dispose();
+      }
+    }
+  }
+
+  @Test
+  public void compressionPerLevel() {
+    ColumnFamilyOptions columnFamilyOptions = null;
+    try {
+      columnFamilyOptions = new ColumnFamilyOptions();
+      assertThat(columnFamilyOptions.compressionPerLevel()).isEmpty();
+      List<CompressionType> compressionTypeList = new ArrayList<>();
+      for (int i=0; i < columnFamilyOptions.numLevels(); i++) {
+        compressionTypeList.add(CompressionType.NO_COMPRESSION);
+      }
+      columnFamilyOptions.setCompressionPerLevel(compressionTypeList);
+      compressionTypeList = columnFamilyOptions.compressionPerLevel();
+      for (CompressionType compressionType : compressionTypeList) {
+        assertThat(compressionType).isEqualTo(
+            CompressionType.NO_COMPRESSION);
+      }
+    } finally {
+      if (columnFamilyOptions != null) {
+        columnFamilyOptions.dispose();
+      }
+    }
+  }
+
+  @Test
+  public void differentCompressionsPerLevel() {
+    ColumnFamilyOptions columnFamilyOptions = null;
+    try {
+      columnFamilyOptions = new ColumnFamilyOptions();
+      columnFamilyOptions.setNumLevels(3);
+
+      assertThat(columnFamilyOptions.compressionPerLevel()).isEmpty();
+      List<CompressionType> compressionTypeList = new ArrayList<>();
+
+      compressionTypeList.add(CompressionType.BZLIB2_COMPRESSION);
+      compressionTypeList.add(CompressionType.SNAPPY_COMPRESSION);
+      compressionTypeList.add(CompressionType.LZ4_COMPRESSION);
+
+      columnFamilyOptions.setCompressionPerLevel(compressionTypeList);
+      compressionTypeList = columnFamilyOptions.compressionPerLevel();
+
+      assertThat(compressionTypeList.size()).isEqualTo(3);
+      assertThat(compressionTypeList).
+          containsExactly(
+              CompressionType.BZLIB2_COMPRESSION,
+              CompressionType.SNAPPY_COMPRESSION,
+              CompressionType.LZ4_COMPRESSION);
+
+    } finally {
+      if (columnFamilyOptions != null) {
+        columnFamilyOptions.dispose();
       }
     }
   }

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -1042,6 +1044,61 @@ public class OptionsTest {
     } finally {
       if (options != null) {
         options.dispose();
+      }
+    }
+  }
+
+  @Test
+  public void compressionPerLevel() {
+    ColumnFamilyOptions columnFamilyOptions = null;
+    try {
+      columnFamilyOptions = new ColumnFamilyOptions();
+      assertThat(columnFamilyOptions.compressionPerLevel()).isEmpty();
+      List<CompressionType> compressionTypeList =
+          new ArrayList<>();
+      for (int i=0; i < columnFamilyOptions.numLevels(); i++) {
+        compressionTypeList.add(CompressionType.NO_COMPRESSION);
+      }
+      columnFamilyOptions.setCompressionPerLevel(compressionTypeList);
+      compressionTypeList = columnFamilyOptions.compressionPerLevel();
+      for (final CompressionType compressionType : compressionTypeList) {
+        assertThat(compressionType).isEqualTo(
+            CompressionType.NO_COMPRESSION);
+      }
+    } finally {
+      if (columnFamilyOptions != null) {
+        columnFamilyOptions.dispose();
+      }
+    }
+  }
+
+  @Test
+  public void differentCompressionsPerLevel() {
+    ColumnFamilyOptions columnFamilyOptions = null;
+    try {
+      columnFamilyOptions = new ColumnFamilyOptions();
+      columnFamilyOptions.setNumLevels(3);
+
+      assertThat(columnFamilyOptions.compressionPerLevel()).isEmpty();
+      List<CompressionType> compressionTypeList = new ArrayList<>();
+
+      compressionTypeList.add(CompressionType.BZLIB2_COMPRESSION);
+      compressionTypeList.add(CompressionType.SNAPPY_COMPRESSION);
+      compressionTypeList.add(CompressionType.LZ4_COMPRESSION);
+
+      columnFamilyOptions.setCompressionPerLevel(compressionTypeList);
+      compressionTypeList = columnFamilyOptions.compressionPerLevel();
+
+      assertThat(compressionTypeList.size()).isEqualTo(3);
+      assertThat(compressionTypeList).
+          containsExactly(
+              CompressionType.BZLIB2_COMPRESSION,
+              CompressionType.SNAPPY_COMPRESSION,
+              CompressionType.LZ4_COMPRESSION);
+
+    } finally {
+      if (columnFamilyOptions != null) {
+        columnFamilyOptions.dispose();
       }
     }
   }


### PR DESCRIPTION
Summary:
RocksDB offers the possibility to set different compression types
on a per level basis. This shall be also available using RocksJava.

Test Plan:
make rocksdbjava
make jtest

Reviewers: adamretter, yhchiang, ankgup87

Subscribers: dhruba

Differential Revision: https://reviews.facebook.net/D35577