### PR TITLE
Added falloc.h in build_detect_platform

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -177,6 +177,7 @@ else
     # Test whether fallocate is available
     $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null  <<EOF
       #include <fcntl.h>
+      #include <linux/falloc.h>
       int main() {
 	int fd = open("/dev/null", 0);
   fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0, 1024);


### PR DESCRIPTION
On Centos 6, you need to explicitely include linux/falloc.h which is
where the  FALLOC_FL_* flags are defined. Otherwise, the fallocate()
support test defined in build_detect_platform will fail.

Signed-off-by: Pooya Shareghi <shareghi@gmail.com>