### PR TITLE
[RocksJava] Remove deprecated methods

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -696,27 +696,6 @@ void Java_org_rocksdb_Options_setTableCacheNumshardbits(
 }
 
 /*
- * Class:     org_rocksdb_Options
- * Method:    tableCacheRemoveScanCountLimit
- * Signature: (J)I
- */
-jint Java_org_rocksdb_Options_tableCacheRemoveScanCountLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  // deprecated
-  return 0;
-}
-
-/*
- * Class:     org_rocksdb_Options
- * Method:    setTableCacheRemoveScanCountLimit
- * Signature: (JI)V
- */
-void Java_org_rocksdb_Options_setTableCacheRemoveScanCountLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint limit) {
-  // deprecated
-}
-
-/*
  * Method:    useFixedLengthPrefixExtractor
  * Signature: (JI)V
  */
@@ -3499,27 +3478,6 @@ jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
       table_cache_numshardbits;
-}
-
-/*
- * Class:     org_rocksdb_DBOptions
- * Method:    setTableCacheRemoveScanCountLimit
- * Signature: (JI)V
- */
-void Java_org_rocksdb_DBOptions_setTableCacheRemoveScanCountLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint limit) {
-  // deprecated
-}
-
-/*
- * Class:     org_rocksdb_DBOptions
- * Method:    tableCacheRemoveScanCountLimit
- * Signature: (J)I
- */
-jint Java_org_rocksdb_DBOptions_tableCacheRemoveScanCountLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  // deprecated
-  return 0;
 }
 
 /*

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -892,28 +892,6 @@ void Java_org_rocksdb_Options_setIsFdCloseOnExec(
 
 /*
  * Class:     org_rocksdb_Options
- * Method:    skipLogErrorOnRecovery
- * Signature: (J)Z
- */
-jboolean Java_org_rocksdb_Options_skipLogErrorOnRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)
-      ->skip_log_error_on_recovery;
-}
-
-/*
- * Class:     org_rocksdb_Options
- * Method:    setSkipLogErrorOnRecovery
- * Signature: (JZ)V
- */
-void Java_org_rocksdb_Options_setSkipLogErrorOnRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean skip) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->skip_log_error_on_recovery =
-      static_cast<bool>(skip);
-}
-
-/*
- * Class:     org_rocksdb_Options
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
@@ -3695,28 +3673,6 @@ void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
 jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->is_fd_close_on_exec;
-}
-
-/*
- * Class:     org_rocksdb_DBOptions
- * Method:    setSkipLogErrorOnRecovery
- * Signature: (JZ)V
- */
-void Java_org_rocksdb_DBOptions_setSkipLogErrorOnRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean skip) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->skip_log_error_on_recovery =
-      static_cast<bool>(skip);
-}
-
-/*
- * Class:     org_rocksdb_DBOptions
- * Method:    skipLogErrorOnRecovery
- * Signature: (J)Z
- */
-jboolean Java_org_rocksdb_DBOptions_skipLogErrorOnRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->skip_log_error_on_recovery;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/ColumnFamilyDescriptor.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyDescriptor.java
@@ -16,39 +16,10 @@ public class ColumnFamilyDescriptor {
    * options,</p>
    *
    * @param columnFamilyName name of column family.
-   * @deprecated will be removed in RocksDB 3.10.0. Use
-   * {@link #ColumnFamilyDescriptor(byte[])} instead.
-   */
-  @Deprecated
-  public ColumnFamilyDescriptor(final String columnFamilyName){
-    this(columnFamilyName.getBytes(), new ColumnFamilyOptions());
-  }
-
-  /**
-   * <p>Creates a new Column Family using a name and default
-   * options,</p>
-   *
-   * @param columnFamilyName name of column family.
    * @since 3.10.0
    */
   public ColumnFamilyDescriptor(final byte[] columnFamilyName) {
     this(columnFamilyName, new ColumnFamilyOptions());
-  }
-
-  /**
-   * <p>Creates a new Column Family using a name and custom
-   * options.</p>
-   *
-   * @param columnFamilyName name of column family.
-   * @param columnFamilyOptions options to be used with
-   *     column family.
-   * @deprecated will be removed in RocksDB 3.10.0. Use
-   * {@link #ColumnFamilyDescriptor(byte[], ColumnFamilyOptions)} instead.
-   */
-  @Deprecated
-  public ColumnFamilyDescriptor(final String columnFamilyName,
-      final ColumnFamilyOptions columnFamilyOptions) {
-    this(columnFamilyName.getBytes(), columnFamilyOptions);
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -495,22 +495,6 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
   }
 
   @Override
-  @Deprecated
-  public DBOptions setSkipLogErrorOnRecovery(
-      final boolean skip) {
-    assert(isInitialized());
-    setSkipLogErrorOnRecovery(nativeHandle_, skip);
-    return this;
-  }
-
-  @Override
-  @Deprecated
-  public boolean skipLogErrorOnRecovery() {
-    assert(isInitialized());
-    return skipLogErrorOnRecovery(nativeHandle_);
-  }
-
-  @Override
   public DBOptions setStatsDumpPeriodSec(
       final int statsDumpPeriodSec) {
     assert(isInitialized());
@@ -670,9 +654,6 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
   private native void setIsFdCloseOnExec(
       long handle, boolean isFdCloseOnExec);
   private native boolean isFdCloseOnExec(long handle);
-  private native void setSkipLogErrorOnRecovery(
-      long handle, boolean skip);
-  private native boolean skipLogErrorOnRecovery(long handle);
   private native void setStatsDumpPeriodSec(
       long handle, int statsDumpPeriodSec);
   private native int statsDumpPeriodSec(long handle);

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -383,20 +383,6 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
   }
 
   @Override
-  public DBOptions setTableCacheRemoveScanCountLimit(
-      final int limit) {
-    assert(isInitialized());
-    setTableCacheRemoveScanCountLimit(nativeHandle_, limit);
-    return this;
-  }
-
-  @Override
-  public int tableCacheRemoveScanCountLimit() {
-    assert(isInitialized());
-    return tableCacheRemoveScanCountLimit(nativeHandle_);
-  }
-
-  @Override
   public DBOptions setWalTtlSeconds(
       final long walTtlSeconds) {
     assert(isInitialized());
@@ -632,9 +618,6 @@ public class DBOptions extends RocksObject implements DBOptionsInterface {
   private native void setTableCacheNumshardbits(
       long handle, int tableCacheNumshardbits);
   private native int tableCacheNumshardbits(long handle);
-  private native void setTableCacheRemoveScanCountLimit(
-      long handle, int limit);
-  private native int tableCacheRemoveScanCountLimit(long handle);
   private native void setWalTtlSeconds(long handle, long walTtlSeconds);
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -716,31 +716,6 @@ public interface DBOptionsInterface {
   boolean isFdCloseOnExec();
 
   /**
-   * Skip log corruption error on recovery (If client is ok with
-   * losing most recent changes)
-   * Default: false
-   *
-   * @param skip true if log corruption errors are skipped during recovery.
-   * @return the instance of the current Object.
-   *
-   * @deprecated will be removed in RocksDB 3.11.0. Not used anymore.
-   */
-  @Deprecated
-  Object setSkipLogErrorOnRecovery(boolean skip);
-
-  /**
-   * Skip log corruption error on recovery (If client is ok with
-   * losing most recent changes)
-   * Default: false
-   *
-   * @return true if log corruption errors are skipped during recovery.
-   *
-   * @deprecated will be removed in RocksDB 3.11.0. Not used anymore.
-   */
-  @Deprecated
-  boolean skipLogErrorOnRecovery();
-
-  /**
    * if not zero, dump rocksdb.stats to LOG every stats_dump_period_sec
    * Default: 3600 (1 hour)
    *

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -506,39 +506,6 @@ public interface DBOptionsInterface {
   int tableCacheNumshardbits();
 
   /**
-   * During data eviction of table's LRU cache, it would be inefficient
-   * to strictly follow LRU because this piece of memory will not really
-   * be released unless its refcount falls to zero. Instead, make two
-   * passes: the first pass will release items with refcount = 1,
-   * and if not enough space releases after scanning the number of
-   * elements specified by this parameter, we will remove items in LRU
-   * order.
-   *
-   * @param limit scan count limit
-   * @return the instance of the current Object.
-   *
-   * @deprecated This function is depreciated.
-   */
-  @Deprecated
-  Object setTableCacheRemoveScanCountLimit(int limit);
-
-  /**
-   * During data eviction of table's LRU cache, it would be inefficient
-   * to strictly follow LRU because this piece of memory will not really
-   * be released unless its refcount falls to zero. Instead, make two
-   * passes: the first pass will release items with refcount = 1,
-   * and if not enough space releases after scanning the number of
-   * elements specified by this parameter, we will remove items in LRU
-   * order.
-   *
-   * @return scan count limit
-   *
-   * @deprecated This function is depreciated.
-   */
-  @Deprecated
-  int tableCacheRemoveScanCountLimit();
-
-  /**
    * {@link #walTtlSeconds()} and {@link #walSizeLimitMB()} affect how archived logs
    * will be deleted.
    * <ol>

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -557,21 +557,6 @@ public class Options extends RocksObject
   }
 
   @Override
-  @Deprecated
-  public boolean skipLogErrorOnRecovery() {
-    assert(isInitialized());
-    return skipLogErrorOnRecovery(nativeHandle_);
-  }
-
-  @Override
-  @Deprecated
-  public Options setSkipLogErrorOnRecovery(final boolean skip) {
-    assert(isInitialized());
-    setSkipLogErrorOnRecovery(nativeHandle_, skip);
-    return this;
-  }
-
-  @Override
   public int statsDumpPeriodSec() {
     assert(isInitialized());
     return statsDumpPeriodSec(nativeHandle_);
@@ -1189,9 +1174,6 @@ public class Options extends RocksObject
   private native void setIsFdCloseOnExec(
       long handle, boolean isFdCloseOnExec);
   private native boolean isFdCloseOnExec(long handle);
-  private native void setSkipLogErrorOnRecovery(
-      long handle, boolean skip);
-  private native boolean skipLogErrorOnRecovery(long handle);
   private native void setStatsDumpPeriodSec(
       long handle, int statsDumpPeriodSec);
   private native int statsDumpPeriodSec(long handle);

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -452,20 +452,6 @@ public class Options extends RocksObject
   }
 
   @Override
-  public int tableCacheRemoveScanCountLimit() {
-    assert(isInitialized());
-    return tableCacheRemoveScanCountLimit(nativeHandle_);
-  }
-
-  @Override
-  public Options setTableCacheRemoveScanCountLimit(
-      final int limit) {
-    assert(isInitialized());
-    setTableCacheRemoveScanCountLimit(nativeHandle_, limit);
-    return this;
-  }
-
-  @Override
   public long walTtlSeconds() {
     assert(isInitialized());
     return walTtlSeconds(nativeHandle_);
@@ -1152,9 +1138,6 @@ public class Options extends RocksObject
   private native void setTableCacheNumshardbits(
       long handle, int tableCacheNumshardbits);
   private native int tableCacheNumshardbits(long handle);
-  private native void setTableCacheRemoveScanCountLimit(
-      long handle, int limit);
-  private native int tableCacheRemoveScanCountLimit(long handle);
   private native void setWalTtlSeconds(long handle, long walTtlSeconds);
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -474,21 +474,6 @@ public class DBOptionsTest {
   }
 
   @Test
-  public void skipLogErrorOnRecovery() {
-    DBOptions opt = null;
-    try {
-      opt = new DBOptions();
-      boolean boolValue = rand.nextBoolean();
-      opt.setSkipLogErrorOnRecovery(boolValue);
-      assertThat(opt.skipLogErrorOnRecovery()).isEqualTo(boolValue);
-    } finally {
-      if (opt != null) {
-        opt.dispose();
-      }
-    }
-  }
-
-  @Test
   public void statsDumpPeriodSec() {
     DBOptions opt = null;
     try {

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -921,21 +921,6 @@ public class OptionsTest {
   }
 
   @Test
-  public void skipLogErrorOnRecovery() {
-    Options opt = null;
-    try {
-      opt = new Options();
-      boolean boolValue = rand.nextBoolean();
-      opt.setSkipLogErrorOnRecovery(boolValue);
-      assertThat(opt.skipLogErrorOnRecovery()).isEqualTo(boolValue);
-    } finally {
-      if (opt != null) {
-        opt.dispose();
-      }
-    }
-  }
-
-  @Test
   public void statsDumpPeriodSec() {
     Options opt = null;
     try {


### PR DESCRIPTION
Summary:
- Removed deprecated ColumnFamilyDescriptor constructor methods
- Removed deprecated skipLogErrorOnRecovery methods
- Removed deprecated tableCacheRemoveScanCountLimit methods

Test Plan:
make rocksdbjava
make jtest

Reviewers: yhchiang, adamretter, ankgup87

Subscribers: dhruba

Differential Revision: https://reviews.facebook.net/D37191