### PR TITLE
Concurrent write operations

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -178,6 +178,7 @@ else
     # Test whether fallocate is available
     $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null  <<EOF
       #include <fcntl.h>
+      #include <linux/falloc.h>
       int main() {
 	int fd = open("/dev/null", 0);
   fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0, 1024);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -509,7 +509,7 @@ MemTable* ColumnFamilyData::ConstructNewMemtable(
     const MutableCFOptions& mutable_cf_options) {
   assert(current_ != nullptr);
   return new MemTable(internal_comparator_, ioptions_,
-                      mutable_cf_options, write_buffer_);
+                      mutable_cf_options, write_buffer_ ,options_.allow_concurrent_write_operations);
 }
 
 void ColumnFamilyData::CreateNewMemtable(
@@ -717,6 +717,13 @@ Status ColumnFamilyData::SetOptions(
   Status s = GetMutableOptionsFromStrings(mutable_cf_options_, options_map,
                                           &new_mutable_cf_options);
   if (s.ok()) {
+  
+    if (options_.allow_concurrent_write_operations) 
+    {
+	  if (new_mutable_cf_options.filter_deletes) 
+		  return Status::NotSupported("filter_deletes=true is not compatible with concurrent write operations");	   
+    }       
+  
     mutable_cf_options_ = new_mutable_cf_options;
     mutable_cf_options_.RefreshDerivedOptions(ioptions_);
   }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -977,6 +977,8 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
     std::string scratch;
     Slice record;
     WriteBatch batch;
+	bool mayHaveUnsortedRecordsInLogFile = false; // concurrent writes may change the order of the stored records 
+	bool firstRecord = true;
     while (reader.ReadRecord(&record, &scratch) && status.ok()) {
       if (record.size() < 12) {
         reporter.Corruption(record.size(),
@@ -997,13 +999,30 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       if (!status.ok()) {
         return status;
       }
-      const SequenceNumber last_seq = WriteBatchInternal::Sequence(&batch) +
-                                      WriteBatchInternal::Count(&batch) - 1;
+	  
+      const SequenceNumber first_seq = WriteBatchInternal::Sequence(&batch);
+	  
+      const SequenceNumber last_seq =  first_seq + WriteBatchInternal::Count(&batch) - 1;
+
+	  if(firstRecord) 
+	  {
+		firstRecord = false;
+	  }
+	  else // !firstRecord
+	  {
+		if(*max_sequence != first_seq-1)
+		{
+		    mayHaveUnsortedRecordsInLogFile = true;
+		}
+	  }
+									  
+									  
       if (last_seq > *max_sequence) {
         *max_sequence = last_seq;
       }
 
-      if (!read_only) {
+      // if some records are not sorted according to the sequence numbers, then we are not allow to flush before the end of the log file 
+      if (!read_only && !mayHaveUnsortedRecordsInLogFile) { 
         // we can do this because this is called before client has access to the
         // DB and there is only a single thread operating on DB
         ColumnFamilyData* cfd;
@@ -1031,9 +1050,33 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       return status;
     }
 
+    if (!read_only) // we have just encountered the end of log file
+	{ 
+      // we can do this because this is called before client has access to the
+      // DB and there is only a single thread operating on DB
+      ColumnFamilyData* cfd;
+
+      while ((cfd = flush_scheduler_.GetNextColumnFamily()) != nullptr) {
+        cfd->Unref();
+        // If this asserts, it means that InsertInto failed in
+        // filtering updates to already-flushed column families
+        assert(cfd->GetLogNumber() <= log_number);
+        auto iter = version_edits.find(cfd->GetID());
+        assert(iter != version_edits.end());
+        VersionEdit* edit = &iter->second;
+        status = WriteLevel0TableForRecovery(cfd, cfd->mem(), edit);
+        if (!status.ok()) {
+          // Reflect errors immediately so that conditions like full
+          // file-systems cause the DB::Open() to fail.
+          return status;
+        }
+        cfd->CreateNewMemtable(*cfd->GetLatestMutableCFOptions());
+      }
+    }	
+	
     flush_scheduler_.Clear();
     if (versions_->LastSequence() < *max_sequence) {
-      versions_->SetLastSequence(*max_sequence);
+      versions_->SetLargerLatestSequences(*max_sequence);
     }
   }
 
@@ -1753,10 +1796,14 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
   Status s;
   {
     WriteContext context;
-    InstrumentedMutexLock guard_lock(&mutex_);
+	if (db_options_.allow_concurrent_write_operations) updatesSynchronizer.LockWrite(); 
+	mutex_.Lock(); 	
+    
 
     if (cfd->imm()->size() == 0 && cfd->mem()->IsEmpty()) {
       // Nothing to flush
+	  if (db_options_.allow_concurrent_write_operations) updatesSynchronizer.UnlockWrite();	        
+  	  mutex_.Unlock();		  
       return Status::OK();
     }
 
@@ -1774,6 +1821,8 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     // schedule flush
     SchedulePendingFlush(cfd);
     MaybeScheduleFlushOrCompaction();
+	if (db_options_.allow_concurrent_write_operations) updatesSynchronizer.UnlockWrite();
+	mutex_.Unlock();		
   }
 
   if (s.ok() && flush_options.wait) {
@@ -2694,6 +2743,23 @@ Status DBImpl::CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                   ColumnFamilyHandle** handle) {
   Status s;
   *handle = nullptr;
+  
+ if (db_options_.allow_concurrent_write_operations)  
+  {
+	  if (!cf_options.memtable_factory->PermitsConcurrentWriteOperations())
+		  return Status::NotSupported("Memtable does not support concurrent write operations");
+
+	  if (cf_options.prefix_extractor != nullptr)
+		  return Status::NotSupported("prefix_extractor!=null is not compatible with concurrent write operations");
+
+	  if (cf_options.inplace_update_support)
+		  return Status::NotSupported("inplace_update_support==true is not compatible with concurrent write operations");
+
+	  if (cf_options.filter_deletes)
+		  return Status::NotSupported("filter_deletes=true is not compatible with concurrent write operations");
+  }  
+  
+  
   {
     InstrumentedMutexLock l(&mutex_);
 
@@ -3009,7 +3075,7 @@ const Snapshot* DBImpl::GetSnapshot() {
   InstrumentedMutexLock l(&mutex_);
   // returns null if the underlying memtable does not support snapshot.
   if (!is_snapshot_supported_) return nullptr;
-  return snapshots_.New(versions_->LastSequence(), unix_time);
+  return snapshots_.New(versions_->LastStableSequence(), unix_time);
 }
 
 void DBImpl::ReleaseSnapshot(const Snapshot* s) {
@@ -3038,7 +3104,155 @@ Status DBImpl::Delete(const WriteOptions& write_options,
   return DB::Delete(write_options, column_family, key);
 }
 
-Status DBImpl::Write(const WriteOptions& write_options, WriteBatch* my_batch) {
+Status DBImpl::Write(const WriteOptions& write_options, WriteBatch* my_batch) 
+{
+	if (!db_options_.allow_concurrent_write_operations)
+		return SerialWrite(write_options, my_batch);
+	
+	PERF_TIMER_GUARD(write_pre_and_post_process_time);    
+	
+    uint64_t max_total_wal_size = (db_options_.max_total_wal_size == 0)
+                                   ? 4 * max_total_in_memory_state_
+                                    : db_options_.max_total_wal_size; 
+	
+	
+	// If this write can be executed concurrently with other writes 
+	if (write_options.sync == false &&
+		write_options.timeout_hint_us == 0 &&  // no timeout
+		total_log_size_ < max_total_wal_size && 
+		my_batch != NULL &&
+		my_batch->IsSimpleBatch() &&
+		bg_error_.ok() &&
+		!write_buffer_.ShouldFlush() &&
+		flush_scheduler_.Empty() &&
+		!write_controller_.IsStopped() &&
+		!(write_controller_.GetDelay() > 0)
+		)
+	{
+		PERF_TIMER_STOP(write_pre_and_post_process_time);
+
+		return ConcurrentWrite(write_options, my_batch);
+	}
+
+	Status status = Status::OK();
+
+	updatesSynchronizer.LockWrite();
+	
+	PERF_TIMER_STOP(write_pre_and_post_process_time);
+	
+	status = SerialWrite(write_options, my_batch);
+	
+	PERF_TIMER_START(write_pre_and_post_process_time);
+
+	updatesSynchronizer.UnlockWrite();
+
+	return status;
+}
+
+Status DBImpl::ConcurrentWrite(const WriteOptions& write_options, WriteBatch* my_batch) 
+{
+	PERF_TIMER_GUARD(write_pre_and_post_process_time);
+
+	assert(db_options_.allow_concurrent_write_operations);
+	assert(my_batch!=NULL && my_batch->IsSimpleBatch());
+
+	Status status = Status::OK();
+	
+	uint64_t last_sequence;
+	uint32_t column_family;
+	unsigned char type;
+	Slice key; 
+	Slice value;
+	status = my_batch->GetSimpleUpdateData(&column_family, &type, &key, &value);
+	if(!status.ok()) return status;
+
+	updatesSynchronizer.LockRead();
+
+	ColumnFamilySet* cfs = versions_->GetColumnFamilySet();
+	
+	ColumnFamilyData* cfd = nullptr;
+	{
+	    // TODO(GG): consider removing this lock. It is currently used to protect: *cfs, default_cf_internal_stats_, and the WAL
+		InstrumentedMutexLock l(&mutex_); 
+
+		cfd = cfs->GetColumnFamily(column_family);  
+		
+		if(cfd == nullptr)
+		{
+			updatesSynchronizer.UnlockRead();
+			return  Status::InvalidArgument("Invalid column family");
+		}
+		// if cfd!=null, then the column family cannot be removed before the method returns
+
+		last_sequence = versions_->IncreaseSequenceNumberAndAndToActiveSet(1); 
+		WriteBatchInternal::SetSequence(my_batch, last_sequence);
+
+		RecordTick(stats_, WRITE_DONE_BY_SELF);
+		default_cf_internal_stats_->AddDBStats(InternalStats::WRITE_DONE_BY_SELF, 1); 
+		RecordTick(stats_, NUMBER_KEYS_WRITTEN, 1);
+		const uint64_t batch_size = WriteBatchInternal::ByteSize(my_batch);
+		RecordTick(stats_, BYTES_WRITTEN, batch_size);
+		default_cf_internal_stats_->AddDBStats(InternalStats::BYTES_WRITTEN, batch_size);
+		if (write_options.disableWAL && !flush_on_destroy_) flush_on_destroy_ = true; 
+
+		PERF_TIMER_STOP(write_pre_and_post_process_time);
+		
+		
+		if (!write_options.disableWAL) {	
+		  uint64_t log_size = 0;
+		  PERF_TIMER_GUARD(write_wal_time);
+
+		  Slice log_entry = WriteBatchInternal::Contents(my_batch); 
+		  status = log_->AddRecord(log_entry);
+		  total_log_size_ += log_entry.size();
+		  alive_log_files_.back().AddSize(log_entry.size());
+		  log_empty_ = false;
+		  log_size = log_entry.size();
+		  RecordTick(stats_, WAL_FILE_BYTES, log_size);
+	  
+		  default_cf_internal_stats_->AddDBStats(
+			   InternalStats::WAL_FILE_SYNCED, 1);
+		  default_cf_internal_stats_->AddDBStats(
+			   InternalStats::WAL_FILE_BYTES, log_size);
+		  
+		}
+	}	
+
+	{
+		PERF_TIMER_GUARD(write_memtable_time);
+
+		MemTable* mem = cfd->mem();
+		mem->Add(last_sequence, (ValueType)type , key, value); 
+		
+		if(mem->ShouldScheduleFlush())
+		{		  
+		  InstrumentedMutexLock l(&mutex_);
+		  if(mem->ShouldScheduleFlush()) {
+			flush_scheduler_.ScheduleFlush(cfd); 
+			mem->MarkFlushScheduled();		    
+		  }		
+		}
+		
+		versions_->RemoveFromActiveSet(last_sequence);
+
+		// atomically assign max of current value and last_sequence
+		SetMaxTickerCount(stats_, SEQUENCE_NUMBER, last_sequence);
+	}
+
+	PERF_TIMER_START(write_pre_and_post_process_time);
+
+	updatesSynchronizer.UnlockRead();
+
+	if (db_options_.paranoid_checks && !status.ok() && bg_error_.ok()) {
+		bg_error_ = status; // stop compaction & fail any further writes
+	}
+	
+	return status;
+}
+
+
+Status DBImpl::SerialWrite(const WriteOptions& write_options, WriteBatch* my_batch) 
+{
   if (my_batch == nullptr) {
     return Status::Corruption("Batch is nullptr!");
   }
@@ -3107,7 +3321,7 @@ Status DBImpl::Write(const WriteOptions& write_options, WriteBatch* my_batch) {
     Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
         "Flushing all column families with data in WAL number %" PRIu64
         ". Total log size is %" PRIu64 " while max_total_wal_size is %" PRIu64,
-        flush_column_family_if_log_file, total_log_size_, max_total_wal_size);
+        flush_column_family_if_log_file, total_log_size_.load(), max_total_wal_size);
     // no need to refcount because drop is happening in write thread, so can't
     // happen while we're in the write thread
     for (auto cfd : *versions_->GetColumnFamilySet()) {
@@ -3261,7 +3475,7 @@ Status DBImpl::Write(const WriteOptions& write_options, WriteBatch* my_batch) {
             InternalStats::WAL_FILE_BYTES, log_size);
       }
       if (status.ok()) {
-        versions_->SetLastSequence(last_sequence);
+        versions_->SetLargerLatestSequences(last_sequence);
       }
     }
   }
@@ -3350,6 +3564,7 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
 // REQUIRES: this thread is currently at the front of the writer queue
 Status DBImpl::SetNewMemtableAndNewLogFile(ColumnFamilyData* cfd,
                                            WriteContext* context) {
+  assert(!db_options_.allow_concurrent_write_operations || updatesSynchronizer.isWriting());										   
   mutex_.AssertHeld();
   unique_ptr<WritableFile> lfile;
   log::Writer* new_log = nullptr;
@@ -3367,9 +3582,13 @@ Status DBImpl::SetNewMemtableAndNewLogFile(ColumnFamilyData* cfd,
   Status s;
   {
     if (creating_new_log) {
+	  EnvOptions logOptions = env_->OptimizeForLogWrite(env_options_);
+	  if(db_options_.allow_concurrent_write_operations && db_options_.allow_mmap_writes) 
+	     logOptions.use_mmap_writes = true ; // TODO(GG): faster for concurrent logging	
+	
       s = env_->NewWritableFile(
           LogFileName(db_options_.wal_dir, new_log_number), &lfile,
-          env_->OptimizeForLogWrite(env_options_));
+          logOptions);
       if (s.ok()) {
         // Our final size should be less than write_buffer_size
         // (compression, etc) but err on the side of caution.
@@ -3878,9 +4097,15 @@ Status DB::Open(const DBOptions& db_options, const std::string& dbname,
     uint64_t new_log_number = impl->versions_->NewFileNumber();
     unique_ptr<WritableFile> lfile;
     EnvOptions soptions(db_options);
+	
+    EnvOptions logOptions = impl->db_options_.env->OptimizeForLogWrite(soptions);
+	  if(db_options.allow_concurrent_write_operations && db_options.allow_mmap_writes) 
+	     logOptions.use_mmap_writes = true ; // TODO(GG): faster for concurrent logging	
+		 
     s = impl->db_options_.env->NewWritableFile(
         LogFileName(impl->db_options_.wal_dir, new_log_number), &lfile,
-        impl->db_options_.env->OptimizeForLogWrite(soptions));
+        logOptions);
+		
     if (s.ok()) {
       lfile->SetPreallocationBlockSize(1.1 * max_write_buffer_size);
       impl->logfile_number_ = new_log_number;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1021,7 +1021,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         *max_sequence = last_seq;
       }
 
-      // if some records are not sorted according to the sequence numbers, then we are not allow to flush before the end of the log file 
+      // if some records are not sorted according to the sequence numbers, then we don't want to flush them before reaching the end of the log file (otherwise we may lose some records)
       if (!read_only && !mayHaveUnsortedRecordsInLogFile) { 
         // we can do this because this is called before client has access to the
         // DB and there is only a single thread operating on DB
@@ -3184,7 +3184,7 @@ Status DBImpl::ConcurrentWrite(const WriteOptions& write_options, WriteBatch* my
 		}
 		// if cfd!=null, then the column family cannot be removed before the method returns
 
-		last_sequence = versions_->IncreaseSequenceNumberAndAndToActiveSet(1); 
+		last_sequence = versions_->IncreaseSequenceNumberAndAddToActiveSet(1); 
 		WriteBatchInternal::SetSequence(my_batch, last_sequence);
 
 		RecordTick(stats_, WRITE_DONE_BY_SELF);

--- a/db/flush_scheduler.h
+++ b/db/flush_scheduler.h
@@ -9,6 +9,7 @@
 #include <deque>
 #include <set>
 #include <vector>
+#include <atomic>
 
 namespace rocksdb {
 
@@ -16,9 +17,10 @@ class ColumnFamilyData;
 
 // This class is thread-compatible. It's should only be accessed from single
 // write thread (between BeginWrite() and EndWrite())
+// Only the method Empty() is thread-safe: it can be invoked by several concurrent threads 
 class FlushScheduler {
  public:
-  FlushScheduler() = default;
+  FlushScheduler() ;
   ~FlushScheduler() = default;
 
   void ScheduleFlush(ColumnFamilyData* cfd);
@@ -32,6 +34,7 @@ class FlushScheduler {
 
  private:
   std::deque<ColumnFamilyData*> column_families_;
+  std::atomic_bool 	is_empty_;
 #ifndef NDEBUG
   std::set<ColumnFamilyData*> column_families_set_;
 #endif  // NDEBUG

--- a/db/memtable_allocator.cc
+++ b/db/memtable_allocator.cc
@@ -13,10 +13,10 @@
 #include "db/writebuffer.h"
 #include "util/arena.h"
 
-namespace rocksdb {
+namespace rocksdb { 
 
-MemTableAllocator::MemTableAllocator(Arena* arena, WriteBuffer* write_buffer)
-    : arena_(arena), write_buffer_(write_buffer), bytes_allocated_(0) {
+MemTableAllocator::MemTableAllocator(Allocator* allocator, WriteBuffer* write_buffer)
+    : allocator_(allocator), write_buffer_(write_buffer), bytes_allocated_(0) {
 }
 
 MemTableAllocator::~MemTableAllocator() {
@@ -27,7 +27,7 @@ char* MemTableAllocator::Allocate(size_t bytes) {
   assert(write_buffer_ != nullptr);
   bytes_allocated_ += bytes;
   write_buffer_->ReserveMem(bytes);
-  return arena_->Allocate(bytes);
+  return allocator_->Allocate(bytes);
 }
 
 char* MemTableAllocator::AllocateAligned(size_t bytes, size_t huge_page_size,
@@ -35,7 +35,7 @@ char* MemTableAllocator::AllocateAligned(size_t bytes, size_t huge_page_size,
   assert(write_buffer_ != nullptr);
   bytes_allocated_ += bytes;
   write_buffer_->ReserveMem(bytes);
-  return arena_->AllocateAligned(bytes, huge_page_size, logger);
+  return allocator_->AllocateAligned(bytes, huge_page_size, logger);
 }
 
 void MemTableAllocator::DoneAllocating() {
@@ -46,7 +46,7 @@ void MemTableAllocator::DoneAllocating() {
 }
 
 size_t MemTableAllocator::BlockSize() const {
-  return arena_->BlockSize();
+  return allocator_->BlockSize();
 }
 
 }  // namespace rocksdb

--- a/db/memtable_allocator.h
+++ b/db/memtable_allocator.h
@@ -12,6 +12,7 @@
 
 #pragma once
 #include "util/allocator.h"
+#include <atomic>
 
 namespace rocksdb {
  
@@ -36,7 +37,7 @@ class MemTableAllocator : public Allocator {
  private:
   Allocator* allocator_;
   WriteBuffer* write_buffer_;
-  size_t bytes_allocated_;
+  std::atomic<size_t> bytes_allocated_;
 
   // No copying allowed
   MemTableAllocator(const MemTableAllocator&);

--- a/db/memtable_allocator.h
+++ b/db/memtable_allocator.h
@@ -14,14 +14,13 @@
 #include "util/allocator.h"
 
 namespace rocksdb {
-
-class Arena;
+ 
 class Logger;
 class WriteBuffer;
 
 class MemTableAllocator : public Allocator {
  public:
-  explicit MemTableAllocator(Arena* arena, WriteBuffer* write_buffer);
+  explicit MemTableAllocator(Allocator* allocator, WriteBuffer* write_buffer);
   ~MemTableAllocator();
 
   // Allocator interface
@@ -35,7 +34,7 @@ class MemTableAllocator : public Allocator {
   void DoneAllocating();
 
  private:
-  Arena* arena_;
+  Allocator* allocator_;
   WriteBuffer* write_buffer_;
   size_t bytes_allocated_;
 

--- a/db/sequence_num_mgr.h
+++ b/db/sequence_num_mgr.h
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <atomic>
+#include <set>
+#include <limits.h>
+#include "util/instrumented_mutex.h"
+#include "util/read_write_lock.h"
+
+#define SMALL_ARRAY_SIZE (32) 
+
+#define BOTTOM (ULLONG_MAX)
+ 
+namespace rocksdb {
+	
+class SequenceNumberMgr
+{
+private:
+	class AdHocSmallSet 
+	{
+	public:
+
+		AdHocSmallSet() 
+		{
+			for(int i=0; i < SMALL_ARRAY_SIZE ; i++)
+				m_Array[i].store(0);
+			m_setIsEmpty.store(true);
+		}
+
+		~AdHocSmallSet()
+		{
+		}
+
+		void Insert(uint64_t item) 
+		{
+			for(int j=0; j < SMALL_ARRAY_SIZE ; j++)
+			{				
+				int i = (j + (int)item) % SMALL_ARRAY_SIZE; // TODO: consider using the current cpu/core id
+
+				if(m_Array[i].load() == 0)
+				{
+					uint64_t c = 0;
+					if(m_Array[i].compare_exchange_strong(c,item))					
+						return;
+				}
+			}
+
+			// the array is full (from the point of view of this thread)
+			{
+				InstrumentedMutexLock l(&m_lock);
+
+				m_Set.insert(item);
+				m_setIsEmpty.store(false);
+			}
+		}
+
+
+		void Remove(uint64_t item) 
+		{
+			for(int j=0; j < SMALL_ARRAY_SIZE ; j++)
+			{				
+				int i = (j + (int)item) % SMALL_ARRAY_SIZE; // TODO: consider using the current cpu/core id
+
+				if(m_Array[i].load() == item)
+				{					
+					if(m_Array[i].compare_exchange_strong(item,0))					
+						return;
+				}
+			}
+
+			if(!m_setIsEmpty.load()) 
+			{
+				InstrumentedMutexLock l(&m_lock);
+				std::set<uint64_t>::iterator it = m_Set.find(item);
+				m_Set.erase (it);
+				if(m_Set.empty()) m_setIsEmpty.store(true);
+			}
+		}
+
+		uint64_t FindMin()
+		{
+			uint64_t currentMin = BOTTOM ;
+
+			for(int i=0; i < SMALL_ARRAY_SIZE ; i++)
+			{		
+				uint64_t x = m_Array[i].load();
+				if(x != 0 && (x < currentMin))
+					currentMin = x;					
+			}
+
+			if(!m_setIsEmpty.load()) 
+			{
+				InstrumentedMutexLock l(&m_lock);
+				uint64_t firstItemInSet = *(m_Set.begin());
+				if(firstItemInSet < currentMin)
+					currentMin = firstItemInSet;
+
+			}
+
+			return currentMin;
+		}
+
+
+		bool IsEmpty()
+		{
+			for(int i=0; i < SMALL_ARRAY_SIZE ; i++)
+			{
+				if(m_Array[i] != 0)
+					return false;
+			}
+
+			if(!m_setIsEmpty.load()) 
+			{
+				InstrumentedMutexLock l(&m_lock);
+				return  m_Set.empty();
+			}
+			else 
+				return true; // empty
+		}
+
+	private:
+
+		std::atomic<uint64_t> m_Array[SMALL_ARRAY_SIZE]; 
+		std::set<uint64_t> m_Set;
+		std::atomic<bool> m_setIsEmpty;
+
+		InstrumentedMutex m_lock ; 
+	};
+
+public:
+	SequenceNumberMgr() : 
+		m_last_sequnce_number(0),
+		m_last_stable_sequnce_number(0),
+		m_setOfUsedNumbers()
+	{
+	}
+
+	uint64_t CreateNew(unsigned short toAdd)
+	{
+		uint64_t v ;
+		uint64_t ts;
+
+		if(toAdd==0) toAdd = 1; // TODO: corner case
+
+		while(true)
+		{
+			v = m_last_sequnce_number.fetch_add(toAdd);
+			ts = v + toAdd;
+			m_setOfUsedNumbers.Insert(ts);
+			if(ts <= m_last_stable_sequnce_number.load())
+				m_setOfUsedNumbers.Remove(ts);
+			else
+				break;
+		}
+		return ts;
+	}
+
+	void Finish(uint64_t seq_num)
+	{
+		m_setOfUsedNumbers.Remove(seq_num);
+	}
+
+
+	uint64_t LastVersion() const
+	{
+		uint64_t r = m_last_sequnce_number.load();
+		return r;
+	}
+
+	uint64_t LastStableVersion() 
+	{ 
+		uint64_t ts   = m_last_sequnce_number.load();
+		uint64_t ts_a = m_setOfUsedNumbers.FindMin();
+		if(ts_a != BOTTOM) ts = ts_a - 1;
+		while(true)
+		{
+			uint64_t expected = m_last_stable_sequnce_number.load();
+			if(expected >= ts) break;
+			if(m_last_stable_sequnce_number.compare_exchange_strong(expected, ts)) break;				
+		}
+
+		while(true)
+		{
+			Backoff backoff;
+			uint64_t snapTime = m_last_stable_sequnce_number.load();
+			uint64_t currMin = m_setOfUsedNumbers.FindMin();			
+			
+			if(currMin==BOTTOM || snapTime < currMin) return snapTime;
+			backoff.wait() ;			
+		}
+	}
+
+	void Reset(uint64_t seq_num)
+	{
+		assert( m_setOfUsedNumbers.IsEmpty() ); 
+		m_last_sequnce_number.store(seq_num);
+		m_last_stable_sequnce_number.store(seq_num);
+	}
+
+private:
+
+	std::atomic<uint64_t>  m_last_sequnce_number;
+	std::atomic<uint64_t>  m_last_stable_sequnce_number;
+
+	AdHocSmallSet    m_setOfUsedNumbers ;
+  
+};
+
+}  // namespace rocksdb
+
+
+

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -583,7 +583,7 @@ class VersionSet {
   }  
   
   // atomically increase sequence number and insert it to the active set (for concurrent writes)
-  uint64_t IncreaseSequenceNumberAndAndToActiveSet(unsigned short a)
+  uint64_t IncreaseSequenceNumberAndAddToActiveSet(unsigned short a)
   {
 	  uint64_t newVal = sequence_number_mgr_.CreateNew(a);
 	  return newVal;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -38,6 +38,7 @@
 #include "db/write_controller.h"
 #include "rocksdb/env.h"
 #include "util/instrumented_mutex.h"
+#include "db/sequence_num_mgr.h"
 
 namespace rocksdb {
 
@@ -561,17 +562,41 @@ class VersionSet {
   // Allocate and return a new file number
   uint64_t NewFileNumber() { return next_file_number_.fetch_add(1); }
 
-  // Return the last sequence number.
-  uint64_t LastSequence() const {
-    return last_sequence_.load(std::memory_order_acquire);
-  }
+  // Return the latest sequence number
+  uint64_t LastSequence() const { return sequence_number_mgr_.LastVersion(); }
 
-  // Set the last sequence number to s.
+  // Return the latest sequence number that represents an immutable snapshot
+  uint64_t LastStableSequence() { return sequence_number_mgr_.LastStableVersion(); }
+  
+  // Set the last sequence number to s (if it is smaller than s)
+  void SetLargerLatestSequences(uint64_t s) {
+
+	  if(s > sequence_number_mgr_.LastVersion())
+	  {
+		  sequence_number_mgr_.Reset(s);
+	  }
+  }  
+  
+    // Set the last sequence number to s.
   void SetLastSequence(uint64_t s) {
-    assert(s >= last_sequence_);
-    last_sequence_.store(s, std::memory_order_release);
+		  sequence_number_mgr_.Reset(s);
+  }  
+  
+  // atomically increase sequence number and insert it to the active set (for concurrent writes)
+  uint64_t IncreaseSequenceNumberAndAndToActiveSet(unsigned short a)
+  {
+	  uint64_t newVal = sequence_number_mgr_.CreateNew(a);
+	  return newVal;
+  }
+  
+  // remove sequence number s from the active set (for concurrent writes)
+  void RemoveFromActiveSet(uint64_t s)
+  {
+	  sequence_number_mgr_.Finish(s);
   }
 
+  
+  
   // Mark the specified file number as used.
   // REQUIRED: this is only called during single-threaded recovery
   void MarkFileNumberUsedDuringRecovery(uint64_t number);
@@ -657,7 +682,7 @@ class VersionSet {
   std::atomic<uint64_t> next_file_number_;
   uint64_t manifest_file_number_;
   uint64_t pending_manifest_file_number_;
-  std::atomic<uint64_t> last_sequence_;
+  SequenceNumberMgr sequence_number_mgr_;
   uint64_t prev_log_number_;  // 0 or backing store for memtable being compacted
 
   // Opened lazily

--- a/db/write_controller.cc
+++ b/db/write_controller.cc
@@ -10,7 +10,7 @@
 namespace rocksdb {
 
 std::unique_ptr<WriteControllerToken> WriteController::GetStopToken() {
-  ++total_stopped_;
+  total_stopped_++;;
   return std::unique_ptr<WriteControllerToken>(new StopWriteToken(this));
 }
 
@@ -20,17 +20,17 @@ std::unique_ptr<WriteControllerToken> WriteController::GetDelayToken(
   return std::unique_ptr<WriteControllerToken>(
       new DelayWriteToken(this, delay_us));
 }
-
-bool WriteController::IsStopped() const { return total_stopped_ > 0; }
-uint64_t WriteController::GetDelay() const { return total_delay_us_; }
+ 
+bool WriteController::IsStopped() const { return total_stopped_.load() > 0; }
+uint64_t WriteController::GetDelay() const {  return total_delay_us_.load(); }
 
 StopWriteToken::~StopWriteToken() {
-  assert(controller_->total_stopped_ >= 1);
-  --controller_->total_stopped_;
+  assert(controller_->total_stopped_.load() >= 1);
+  controller_->total_stopped_--;
 }
 
 DelayWriteToken::~DelayWriteToken() {
-  assert(controller_->total_delay_us_ >= delay_us_);
+  assert(controller_->total_delay_us_.load() >= delay_us_);
   controller_->total_delay_us_ -= delay_us_;
 }
 

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -6,17 +6,16 @@
 #pragma once
 
 #include <stdint.h>
-
+#include <atomic>
 #include <memory>
 
 namespace rocksdb {
 
 class WriteControllerToken;
-
+ 
 // WriteController is controlling write stalls in our write code-path. Write
 // stalls happen when compaction can't keep up with write rate.
-// All of the methods here (including WriteControllerToken's destructors) need
-// to be called while holding DB mutex
+// All of the methods here are thread-safe
 class WriteController {
  public:
   WriteController() : total_stopped_(0), total_delay_us_(0) {}
@@ -39,8 +38,8 @@ class WriteController {
   friend class StopWriteToken;
   friend class DelayWriteToken;
 
-  int total_stopped_;
-  uint64_t total_delay_us_;
+  std::atomic<int> total_stopped_;
+  std::atomic<uint64_t> total_delay_us_;
 };
 
 class WriteControllerToken {

--- a/db/writebuffer.h
+++ b/db/writebuffer.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <atomic>
+ 
 namespace rocksdb {
 
 class WriteBuffer {
@@ -20,7 +22,7 @@ class WriteBuffer {
 
   ~WriteBuffer() {}
 
-  size_t memory_usage() const { return memory_used_; }
+  size_t memory_usage() const { return memory_used_.load(); }
   size_t buffer_size() const { return buffer_size_; }
 
   // Should only be called from write thread
@@ -29,12 +31,12 @@ class WriteBuffer {
   }
 
   // Should only be called from write thread
-  void ReserveMem(size_t mem) { memory_used_ += mem; }
-  void FreeMem(size_t mem) { memory_used_ -= mem; }
+  void ReserveMem(size_t mem) { memory_used_.fetch_add(mem); }
+  void FreeMem(size_t mem) { memory_used_.fetch_sub(mem); }
 
  private:
   const size_t buffer_size_;
-  size_t memory_used_;
+  std::atomic<size_t> memory_used_;
 
   // No copying allowed
   WriteBuffer(const WriteBuffer&);

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -187,6 +187,9 @@ class MemTableRepFactory {
                                          const SliceTransform*,
                                          Logger* logger) = 0;
   virtual const char* Name() const = 0;
+  
+  // returns true, iff the MemTableRep permits concurrent write operations (i.e., thread-safety is not violated by concurrent writes)
+  virtual bool PermitsConcurrentWriteOperations() const { return false; }   
 };
 
 // This uses a skip list to store keys. It is the default.
@@ -300,5 +303,21 @@ extern MemTableRepFactory* NewHashLinkListRepFactory(
 extern MemTableRepFactory* NewHashCuckooRepFactory(
     size_t write_buffer_size, size_t average_data_size = 64,
     unsigned int hash_function_count = 4);
+	
+	
+class LockFreeSkipListFactory : public MemTableRepFactory {
+public:
+	
+    virtual MemTableRep* CreateMemTableRep(const MemTableRep::KeyComparator&,
+                                           MemTableAllocator*,
+                                           const SliceTransform*,
+                                           Logger* logger) ;
+	
+	virtual const char* Name() const override { return "LockFreeSkipListFactory"; }
+	virtual bool PermitsConcurrentWriteOperations() const override { return true; }
+};	
+	
+	
+	
 #endif  // ROCKSDB_LITE
 }  // namespace rocksdb

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -981,6 +981,10 @@ struct DBOptions {
   // wasting spin time.
   // Default: false
   bool use_adaptive_mutex;
+  
+  // Allow rocksdb to concurrently execute write operations (the memtable is required to support concurrent write operations) 
+  // Default: false 
+  bool allow_concurrent_write_operations;     
 
   // Create DBOptions with default values for all fields
   DBOptions();

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -284,6 +284,7 @@ class Statistics {
 
   virtual void recordTick(uint32_t tickerType, uint64_t count = 0) = 0;
   virtual void setTickerCount(uint32_t tickerType, uint64_t count) = 0;
+  virtual void setMaxTickerCount(uint32_t tickerType, uint64_t count) = 0;
   virtual void measureTime(uint32_t histogramType, uint64_t time) = 0;
 
   // String representation of the statistic object.

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -28,7 +28,7 @@
 #include <string>
 #include "rocksdb/status.h"
 #include "rocksdb/write_batch_base.h"
-
+ 
 namespace rocksdb {
 
 class Slice;
@@ -145,6 +145,14 @@ class WriteBatch : public WriteBatchBase {
     // implementation always returns true.
     virtual bool Continue();
   };
+  
+  bool IsSimpleBatch();
+  
+  // Assumes that the batch contains a single put/delete update
+  // Returns the family id, type, key and value of the update
+  Status GetSimpleUpdateData(uint32_t* column_family, unsigned char* type, Slice* key, Slice* value);
+  
+  
   Status Iterate(Handler* handler) const;
 
   // Retrieve the serialized version of this batch.

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -15,6 +15,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <cstdlib>
+#include <thread>
 #include "util/logging.h"
 
 namespace rocksdb {
@@ -132,6 +133,18 @@ void RWMutex::WriteUnlock() { PthreadCall("write unlock", pthread_rwlock_unlock(
 void InitOnce(OnceType* once, void (*initializer)()) {
   PthreadCall("once", pthread_once(once, initializer));
 }
+
+int GetNumberOfProcessors()
+{
+    return std::thread::hardware_concurrency();
+}
+
+int GetCurrentProcessor()
+{
+	int nProcessor = ::sched_getcpu();
+	return nProcessor == -1 ? 0 : (unsigned int)nProcessor;
+}
+
 
 }  // namespace port
 }  // namespace rocksdb

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -135,6 +135,12 @@ typedef pthread_once_t OnceType;
 #define LEVELDB_ONCE_INIT PTHREAD_ONCE_INIT
 extern void InitOnce(OnceType* once, void (*initializer)());
 
+// Returns the number of available processors (cpu cores)
+int GetNumberOfProcessors();
+
+// Returns the ID of the current processor (the ID is a number between 0 and GetNumberOfProcessors()-1)
+int GetCurrentProcessor();
+
 #define CACHE_LINE_SIZE 64U
 
 #define PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)

--- a/src.mk
+++ b/src.mk
@@ -90,6 +90,8 @@ LIB_SOURCES =                                                   \
   util/histogram.cc                                             \
   util/instrumented_mutex.cc                                    \
   util/iostats_context.cc                                       \
+  util/lockfreeskiplistrep.cc                                   \
+  util/concurrent_arena.cc                                      \
   utilities/backupable/backupable_db.cc                         \
   utilities/convenience/convenience.cc                          \
   utilities/checkpoint/checkpoint.cc                            \

--- a/util/concurrent_arena.cc
+++ b/util/concurrent_arena.cc
@@ -1,0 +1,154 @@
+#include <thread>
+#include "port/port.h"
+#include "util/concurrent_arena.h"
+#include "util/mutexlock.h"
+  
+namespace rocksdb {
+
+	static const size_t kMaxBlockSizeOfConcurrentArena = 2 * 1024 * 1024; // 2 MB
+	static const int    kMaxNumberOfConcurrentArenas   = 16;
+
+	static size_t OptimizeBlockSizeForConcurrentArena(size_t block_size)
+	{
+	   if(block_size <= kMaxBlockSizeOfConcurrentArena)
+		  return block_size;
+	   else
+		  return kMaxBlockSizeOfConcurrentArena;
+	}
+
+	static int NumberOfConcurrentArenas()
+	{
+		int numProcessors = port::GetNumberOfProcessors();
+		
+		if(numProcessors <= kMaxNumberOfConcurrentArenas)
+		   return numProcessors;
+		else 
+		   return kMaxNumberOfConcurrentArenas;
+	}
+
+	SimpleConcurrentArena::SimpleConcurrentArena(bool disableConcurrency, size_t block_size, size_t huge_page_size) :
+		disableConcurrency_(disableConcurrency),
+		nConcurrentAreans_(disableConcurrency ? 1 : NumberOfConcurrentArenas()), 
+		pDescriptors_(new InternalDesc[nConcurrentAreans_])
+	{
+	    assert(nConcurrentAreans_>=1);
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			Arena* p = new Arena(OptimizeBlockSizeForConcurrentArena(block_size),huge_page_size);
+			pDescriptors_[i].pArena = p;
+			pDescriptors_[i].approximateMemoryUsage = p->ApproximateMemoryUsage();;
+			pDescriptors_[i].memoryAllocatedBytes = p->MemoryAllocatedBytes();
+			pDescriptors_[i].allocatedAndUnused = p->AllocatedAndUnused();
+			pDescriptors_[i].irregularBlockNum = p->IrregularBlockNum();
+
+			if (disableConcurrency_)
+				pDescriptors_[i].pMutex = nullptr;
+			else
+				pDescriptors_[i].pMutex = new port::Mutex();
+		}
+	}
+
+
+
+	SimpleConcurrentArena::~SimpleConcurrentArena()
+	{
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			delete pDescriptors_[i].pArena;
+			if (pDescriptors_[i].pMutex != nullptr) delete pDescriptors_[i].pMutex;
+		}
+		
+		delete pDescriptors_;
+
+	}
+
+	char* SimpleConcurrentArena::Allocate(size_t bytes)
+	{
+		int i = 0;
+		if (nConcurrentAreans_ > 1)
+		{
+			i = port::GetCurrentProcessor() % nConcurrentAreans_; 
+		}
+
+		if (disableConcurrency_)
+		{
+			return pDescriptors_[i].pArena->Allocate(bytes);
+		}
+		else
+		{
+			MutexLock l(pDescriptors_[i].pMutex);
+			return pDescriptors_[i].pArena->Allocate(bytes);
+		}
+	}
+
+	char* SimpleConcurrentArena::AllocateAligned(size_t bytes, size_t huge_page_size, Logger* logger)
+	{
+		int i = 0;
+		if (nConcurrentAreans_ > 1)
+		{
+			i = port::GetCurrentProcessor() % nConcurrentAreans_; 
+		}
+
+		if (disableConcurrency_)
+		{
+			return pDescriptors_[i].pArena->AllocateAligned(bytes, huge_page_size, logger);
+		}
+		else
+		{
+			MutexLock l(pDescriptors_[i].pMutex);
+			return pDescriptors_[i].pArena->AllocateAligned(bytes, huge_page_size, logger);
+		}
+
+	}
+
+	size_t SimpleConcurrentArena::ApproximateMemoryUsage() const
+	{
+		size_t r = 0;
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			r += pDescriptors_[i].pArena->ApproximateMemoryUsage();
+		}
+
+		return r;
+	}
+
+	size_t SimpleConcurrentArena::MemoryAllocatedBytes() const
+	{
+		size_t r = 0;
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			r += pDescriptors_[i].pArena->MemoryAllocatedBytes();
+		}
+
+		return r;
+	}
+
+	size_t SimpleConcurrentArena::AllocatedAndUnused() const
+	{
+		size_t r = 0;
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			r += pDescriptors_[i].pArena->AllocatedAndUnused();
+		}
+
+		return r;
+
+	}
+
+	size_t SimpleConcurrentArena::IrregularBlockNum() const
+	{
+		size_t r = 0;
+		for (int i = 0; i < nConcurrentAreans_; i++)
+		{
+			r += pDescriptors_[i].pArena->IrregularBlockNum();
+		}
+
+		return r;
+	}
+
+	size_t SimpleConcurrentArena::BlockSize() const
+	{
+		return pDescriptors_[0].pArena->BlockSize();
+	}
+	
+}

--- a/util/concurrent_arena.h
+++ b/util/concurrent_arena.h
@@ -1,0 +1,53 @@
+#pragma once
+#include "util/allocator.h"
+#include "util/arena.h"
+ 
+namespace rocksdb {
+ 
+class Logger;
+
+class SimpleConcurrentArena : public Allocator {
+ public:
+  // No copying allowed
+  SimpleConcurrentArena(const SimpleConcurrentArena&) = delete;
+  void operator=(const SimpleConcurrentArena&) = delete;
+
+  explicit SimpleConcurrentArena(bool disableConcurrency, size_t block_size = Arena::kMinBlockSize, size_t huge_page_size = 0);
+  ~SimpleConcurrentArena();
+
+  char* Allocate(size_t bytes) override;
+
+  char* AllocateAligned(size_t bytes, size_t huge_page_size = 0,
+                        Logger* logger = nullptr) override;
+
+  size_t ApproximateMemoryUsage() const ;  
+
+  size_t MemoryAllocatedBytes() const ;
+
+  size_t AllocatedAndUnused() const ;
+
+  // If an allocation is too big, we'll allocate an irregular block with the
+  // same size of that allocation.
+  size_t IrregularBlockNum() const ;
+
+  size_t BlockSize() const override ;
+
+ private: 
+ 
+ 	struct InternalDesc
+	{
+		Arena* pArena;
+		size_t approximateMemoryUsage;
+		size_t memoryAllocatedBytes;
+		size_t allocatedAndUnused;
+		size_t irregularBlockNum;
+		port::Mutex* pMutex;
+	};
+
+	const bool disableConcurrency_;
+	const int nConcurrentAreans_;
+	InternalDesc* const pDescriptors_;
+ 
+};
+
+}  // namespace rocksdb

--- a/util/lockfreeSkipList.h
+++ b/util/lockfreeSkipList.h
@@ -1,0 +1,330 @@
+#pragma once
+  
+#include <assert.h>
+#include <atomic>
+#include <stdlib.h>
+#include "port/port.h"
+#include "util/allocator.h"
+#include "util/random.h"
+#include "rocksdb/env.h"
+
+// Lock-free cncurrent skip-list. 
+// This skip-list is a variant of the algorithm in Chapter 14.4 of the book: The Art of Multiprocessor Programming, 2008, Herlihy and Shavit.
+// It does not support delete operations, and includes iterators that guarantee  weak-consistency.
+
+namespace rocksdb {
+
+	template<typename TItem, typename UserComparator>
+	class LockFreeSkipList {
+
+	private:
+
+		const static int MAX_LEVEL = 32;
+
+		// Internal skip-list node
+		struct Node 
+		{
+			Node(TItem x, int height) {
+				value = x; 
+				topLevel = height;
+				for (int i = 0; i < height + 1; i++)  
+				{
+					next[i] = nullptr;
+				}
+			}
+			TItem value;
+			int topLevel;			
+			std::atomic<Node*> next[1]; // the actual size of this array is height+1 (allocated externally)
+		};
+
+		// Random level generator 
+		// Inspired by the random level generator from Doug Lea's ConcurrentSkipListMap.java 
+		// (based on a pseudo-random function that was used in turbo pascal)
+		class RandomLevelGenerator
+		{
+		public:
+			RandomLevelGenerator(){
+				currentState_.store((unsigned int)Env::Default()->NowMicros(), std::memory_order_relaxed);
+			}
+			int nextRandomLevel() {
+				unsigned int num = currentState_.load(std::memory_order_relaxed) * 134775813 + 1;
+				currentState_.store(num, std::memory_order_relaxed);
+
+				num = num | 1;
+				unsigned int one = 1;
+				for (int i = 0; i <= 31; i++)
+				{
+					if ((num & (one << (31 - i))) != 0)
+					{
+						return i % MAX_LEVEL;
+					}
+				}
+				assert(0);
+				return 0;
+			}
+
+		private:
+			std::atomic<unsigned int>    currentState_;
+		};
+
+		friend class Iterator;
+		RandomLevelGenerator rand;
+		Allocator* allocator_;
+		UserComparator& cmp_;
+		Node* pHead_;
+		Node* pTail_;
+
+		bool find(TItem x, Node** preds, Node** succs, bool stopIfFound)
+		{
+			Node* pred ;
+			Node* curr ;
+			Node* succ ;
+			bool stop  ;
+			bool found ;
+			int maxLevel = MAX_LEVEL;
+		start:
+			pred = nullptr;
+			curr = nullptr;
+			succ = nullptr;
+			stop = false;
+			found = false;
+
+			pred = pHead_;
+			for (int level = maxLevel; level >= 0 && !stop; level--) {
+				curr = pred->next[level].load(std::memory_order_relaxed);
+				while (true) {
+					succ = curr->next[level].load(std::memory_order_relaxed);
+
+					// read validation
+					if (curr != pred->next[level].load(std::memory_order_acquire) ||
+						succ != curr->next[level].load(std::memory_order_acquire))
+						goto start; // restart
+
+					if (curr == pTail_) break;
+					int icmp = cmp_(curr->value, x);
+					if (icmp<0){
+						pred = curr;
+						curr = succ;
+					}
+					else {
+						if (icmp == 0) found = true;
+						if (stopIfFound && icmp == 0) stop = true;
+						break;
+					}
+				}
+				preds[level] = pred;
+				succs[level] = curr;
+			}
+			return found;
+		}
+
+		Node* find_minimal_larger_equal(TItem x) const
+		{
+			const Node* pPred = nullptr;
+			Node* pCurr = nullptr;
+
+			int nCmp = 1;
+
+			pPred = pHead_;
+
+			for (int level = (int)MAX_LEVEL; level >= 0; level--)
+			{
+				pCurr = pPred->next[level].load(std::memory_order_acquire);
+
+				if (pCurr == pTail_) continue;
+
+				nCmp = cmp_(pCurr->value, x);
+
+				while (nCmp < 0)
+				{
+					pPred = pCurr;
+					pCurr = pPred->next[level].load(std::memory_order_acquire);
+
+					if (pCurr == pTail_) break;
+
+					nCmp = cmp_(pCurr->value, x);
+				}
+			}
+
+			return pCurr; // note that it may return the tail
+		}
+
+		Node* find_node_before_tail()
+		{
+			Node* pPred = nullptr;
+			Node* pCurr = nullptr;
+
+			pPred = pHead_;
+
+			for (int level = (int)MAX_LEVEL; level >= 0; level--)
+			{				
+				while (true)
+				{
+					pCurr = pPred->next[level].load(std::memory_order_acquire);
+
+					if (pCurr == pTail_) break;
+
+					pPred = pCurr;
+				}
+			}
+
+			return pPred;
+		}
+	
+
+
+		Node* find_maximal_smaller(TItem x)
+		{
+			Node* preds[MAX_LEVEL + 1];
+			Node* succs[MAX_LEVEL + 1];
+
+			find(x, preds, succs, false);
+
+			return preds[0]; // note that it may return the head
+		}
+
+	public:		
+
+		LockFreeSkipList(UserComparator& userComparator, Allocator* allocator)
+			: allocator_(allocator), cmp_(userComparator)
+			 
+		{
+			char* mem = allocator_->AllocateAligned(sizeof(Node)+MAX_LEVEL * sizeof(std::atomic<Node*>));
+			pTail_ = new (mem)Node((TItem)nullptr, MAX_LEVEL);
+
+			mem = allocator_->AllocateAligned(sizeof(Node)+MAX_LEVEL * sizeof(std::atomic<Node*>));
+			pHead_ = new (mem)Node((TItem)nullptr, MAX_LEVEL);
+
+			for (int i = 0; i < MAX_LEVEL + 1; i++) {
+				pHead_->next[i].store(pTail_);
+			}
+		}
+
+		bool contains(const TItem x) const
+		{
+			Node* n = find_minimal_larger_equal(x);
+			if (n == pTail_) return false;
+			bool r = (cmp_(n->value, x) == 0);
+			return r;
+		}
+
+		bool insert(TItem x) {
+			
+			int topLevel = rand.nextRandomLevel() + 1;
+			Node* preds[MAX_LEVEL + 1];
+			Node* succs[MAX_LEVEL + 1];
+
+			while (true) {
+				bool found = find(x, preds, succs, true);
+				if (found)
+				{
+					return false;
+				}
+				else
+				{
+					char* mem = allocator_->AllocateAligned(sizeof(Node)+ topLevel * sizeof(std::atomic<Node*>));
+					Node* newNode = new (mem)Node(x, topLevel);
+
+					
+					for (int level = 0; level <= topLevel; level++)
+					{
+						Node* succ = succs[level];
+						newNode->next[level].store(succ, std::memory_order_relaxed);
+					}
+					Node* pred = preds[0];
+					Node* succ = succs[0];
+					newNode->next[0].store(succ, std::memory_order_relaxed);
+					if (!pred->next[0].compare_exchange_strong(succ, newNode, std::memory_order_release, std::memory_order_relaxed))
+					{
+						continue;  // restart
+					}
+					for (int level = 1; level <= topLevel; level++)
+					{
+						while (true) {
+							pred = preds[level];
+							succ = succs[level];
+							if (pred->next[level].compare_exchange_strong(succ, newNode, std::memory_order_release, std::memory_order_relaxed)) break;
+							find(x, preds, succs, false);
+						}
+					}
+					return true;
+				}
+			}
+		}
+		 
+		class Iterator
+		{
+		private:
+			LockFreeSkipList* pList_;
+			Node* current_;
+		public:
+			Iterator(LockFreeSkipList* l) : pList_(l), current_(l->pHead_->next[0])
+			{
+			}
+
+			bool Valid() const
+			{
+				return (current_ != pList_->pTail_) && (current_ != pList_->pHead_);
+			}
+
+			TItem& item() const
+			{
+				assert(Valid());
+				TItem& i = current_->value;
+				return i;
+			}
+
+			void Next()
+			{
+				assert(Valid());
+				current_ = current_->next[0];
+			}
+
+			void Prev()
+			{
+				assert(Valid());
+				TItem& theItem = item();
+				Node* n = pList_->find_maximal_smaller(theItem);
+				current_ = n;
+			}
+
+			void Seek(const TItem& target)
+			{
+				Node* n = pList_->find_minimal_larger_equal(target);
+				current_ = n;
+			}
+
+			void SeekToFirst()
+			{
+				current_ = pList_->pHead_->next[0];
+			}
+
+
+			void SeekToLast()
+			{
+				current_ = pList_->find_node_before_tail();
+
+				/*
+				// a naive alternative implementation
+				Node* prev = nullptr;
+				Node* curr = pList_->pHead_->next[0];
+				while (curr != pList_->pTail_)
+				{
+					prev = curr;
+					curr = curr->next[0];
+				}
+				assert(prev != nullptr);
+				current_ = prev;
+				*/
+			}
+		};
+
+	};
+
+}
+
+
+
+
+
+

--- a/util/lockfreeskiplistrep.cc
+++ b/util/lockfreeskiplistrep.cc
@@ -1,0 +1,129 @@
+
+#include "rocksdb/memtablerep.h"
+#include "db/memtable.h"
+#include "util/lockfreeSkipList.h"
+#include "util/arena.h" 
+#include "util/coding.h"
+   
+namespace rocksdb {
+	namespace {
+		class LockFreeSkipListRep : public MemTableRep {
+			LockFreeSkipList<char*, const MemTableRep::KeyComparator&> skip_list_;
+		public:
+			explicit LockFreeSkipListRep(const MemTableRep::KeyComparator& compare, MemTableAllocator* allocator)
+				: MemTableRep(allocator), skip_list_(compare, allocator)  
+			{
+			}
+
+			// Insert key into the list.
+			// REQUIRES: nothing that compares equal to key is currently in the list.
+			virtual void Insert(KeyHandle handle) override {
+				skip_list_.insert(static_cast<char*>(handle));
+			}
+
+			// Returns true iff an entry that compares equal to key is in the list.
+			virtual bool Contains(const char* key) const override {
+				return skip_list_.contains((char *const)key);
+			}
+
+			virtual size_t ApproximateMemoryUsage() override {
+				// All memory is allocated through arena; nothing to report here
+				return 0;
+			}
+
+			virtual void Get(const LookupKey& k, void* callback_args,
+				bool(*callback_func)(void* arg, 
+				const char* entry)) override {
+				LockFreeSkipListRep::Iterator iter(&skip_list_);
+				Slice dummy_slice;
+				for (iter.Seek(dummy_slice, k.memtable_key().data());
+					iter.Valid() && callback_func(callback_args, iter.key());
+					iter.Next()) {
+				}
+			}
+
+			virtual ~LockFreeSkipListRep() override { }
+
+			// Iteration over the contents of a skip list
+			class Iterator : public MemTableRep::Iterator {
+				LockFreeSkipList<char*, const MemTableRep::KeyComparator&>::Iterator iter_;
+			public:
+				// Initialize an iterator over the specified list.
+				// The returned iterator is not valid.
+				explicit Iterator(LockFreeSkipList<char*, const MemTableRep::KeyComparator&>* list) : iter_(list) { }
+
+				virtual ~Iterator() override { }
+
+				// Returns true iff the iterator is positioned at a valid node.
+				virtual bool Valid() const override {
+					return iter_.Valid();
+				}
+
+				// Returns the key at the current position.
+				// REQUIRES: Valid()
+				virtual const char* key() const override {
+					return iter_.item();
+				}
+
+				// Advances to the next position.
+				// REQUIRES: Valid()
+				virtual void Next() override {
+					iter_.Next();
+				}
+
+				// Advances to the previous position.
+				// REQUIRES: Valid()
+				virtual void Prev() override {
+					iter_.Prev();
+				}
+
+				// Advance to the first entry with a key >= target
+				virtual void Seek(const Slice& user_key, const char* memtable_key)
+					override {
+					if (memtable_key != nullptr) {
+						iter_.Seek((char *const)memtable_key);
+					}
+					else {
+						iter_.Seek((char *const)EncodeKey(&tmp_, user_key));
+					}
+				}
+
+				// Position at the first entry in list.
+				// Final state of iterator is Valid() iff list is not empty.
+				virtual void SeekToFirst() override {
+					iter_.SeekToFirst();
+				}
+
+				// Position at the last entry in list.
+				// Final state of iterator is Valid() iff list is not empty.
+				virtual void SeekToLast() override {
+					iter_.SeekToLast();
+				}
+			protected:
+				std::string tmp_;       // For passing to EncodeKey
+			};
+
+			virtual MemTableRep::Iterator* GetIterator(Arena* arena = nullptr) override {
+				if (arena == nullptr) {
+					return new LockFreeSkipListRep::Iterator(&skip_list_);
+				}
+				else {
+					auto mem = arena->AllocateAligned(sizeof(LockFreeSkipListRep::Iterator));
+					return new (mem)LockFreeSkipListRep::Iterator(&skip_list_);
+				}
+			}
+		};
+	}
+
+   MemTableRep* LockFreeSkipListFactory::CreateMemTableRep(const MemTableRep::KeyComparator& compare,
+                                         MemTableAllocator* allocator,
+                                         const SliceTransform*,
+                                         Logger* logger) 
+	{
+		return new LockFreeSkipListRep(compare, allocator); 
+	}										 
+	
+
+} // namespace rocksdb
+
+

--- a/util/options.cc
+++ b/util/options.cc
@@ -252,6 +252,7 @@ DBOptions::DBOptions()
       db_write_buffer_size(0),
       access_hint_on_compaction_start(NORMAL),
       use_adaptive_mutex(false),
+	  allow_concurrent_write_operations(false),
       bytes_per_sync(0),
       enable_thread_tracking(false) {
 }
@@ -295,6 +296,7 @@ DBOptions::DBOptions(const Options& options)
       db_write_buffer_size(options.db_write_buffer_size),
       access_hint_on_compaction_start(options.access_hint_on_compaction_start),
       use_adaptive_mutex(options.use_adaptive_mutex),
+	  allow_concurrent_write_operations(options.allow_concurrent_write_operations),
       bytes_per_sync(options.bytes_per_sync),
       enable_thread_tracking(options.enable_thread_tracking) {}
 
@@ -358,6 +360,8 @@ void DBOptions::Dump(Logger* log) const {
         access_hints[access_hint_on_compaction_start]);
     Log(log, "                      Options.use_adaptive_mutex: %d",
         use_adaptive_mutex);
+	Log(log, "                      Options.allow_concurrent_write_operations: %d",
+        allow_concurrent_write_operations);
     Log(log, "                            Options.rate_limiter: %p",
         rate_limiter.get());
     Log(log, "                          Options.bytes_per_sync: %" PRIu64,

--- a/util/read_write_lock.h
+++ b/util/read_write_lock.h
@@ -1,0 +1,173 @@
+#pragma once
+#include <atomic>
+#include "rocksdb/env.h"
+  
+// Simple Read-Write lock
+// In order to avoid starvation of writers,  this lock prefer writers over readers
+// Inspired by the read-write lock algorithm of libcds (See http://libcds.sourceforge.net/ by Maxim Khiszinsky)
+
+namespace rocksdb {
+
+	class Backoff 
+	{
+	private:
+		static const size_t  cStart = (1 << 4);
+		static const size_t  cEnd = (1 << 14);
+
+		size_t  current_;
+	
+	public:
+		Backoff()
+		{
+			reset();
+		}
+
+		void wait()
+		{
+			if (current_ <= cEnd) {
+				for (size_t i = 0; i < current_; i++); // nop
+				current_ *= 2;
+			}
+			else
+			{
+				Env::Default()->SleepForMicroseconds(1000);
+				reset();
+			}
+
+		}
+		void reset()
+		{
+			current_ = cStart;
+		}
+	};
+
+
+	class ReadWriteLock
+	{
+	private:
+		union Data {
+			struct {
+				unsigned int numberOfReadersThatOwnTheLock : 32 / 2;
+				unsigned int numberOfWriters			   : 32 / 2 - 1;
+				unsigned int lockedInWriteMode			   : 1;
+			};
+			uint32_t all; 
+		};
+
+		volatile std::atomic<uint32_t> state_;
+
+	public:
+		ReadWriteLock()
+		{
+			state_.store(0);
+		}
+		~ReadWriteLock()
+		{
+			assert(state_.load() == 0);
+		}
+
+		void LockRead()
+		{
+			Data expectedData;
+			Data newData;
+			Backoff backoff;
+			while (true) 
+			{
+				expectedData.all = state_.load();
+				newData.all = expectedData.all;
+				expectedData.lockedInWriteMode = 0;
+				expectedData.numberOfWriters = 0;
+				newData.numberOfReadersThatOwnTheLock++;
+				newData.lockedInWriteMode = 0;
+				newData.numberOfWriters = 0;
+				if (state_.compare_exchange_strong(expectedData.all, newData.all))
+					break;
+				backoff.wait();
+			}
+		}
+
+
+		void UnlockRead()
+		{
+			Data expectedData;
+			Data newData;
+			Backoff backoff;
+			while (true) 
+			{
+				expectedData.all = state_.load();
+				newData.all = expectedData.all;
+				newData.numberOfReadersThatOwnTheLock--;
+				assert(expectedData.lockedInWriteMode == 0);
+				if (state_.compare_exchange_strong(expectedData.all, newData.all))
+					break;
+				backoff.wait();
+			}
+		}
+
+
+		void LockWrite()
+		{
+			Data expectedData;
+			Data newData;
+			Backoff backoff;
+
+			while (true) {
+				expectedData.all = state_.load();
+				newData.all = expectedData.all;
+				newData.numberOfWriters++;
+				if (state_.compare_exchange_strong(expectedData.all, newData.all))
+					break;
+				backoff.wait();
+			}
+
+			backoff.reset();
+
+
+			while (true) {
+				expectedData.all = state_.load();
+				newData.all = expectedData.all;
+				expectedData.numberOfReadersThatOwnTheLock = 0;
+				expectedData.lockedInWriteMode = 0;
+				newData.numberOfReadersThatOwnTheLock = 0;
+				newData.lockedInWriteMode = 1;
+				if (state_.compare_exchange_strong(expectedData.all, newData.all))
+					break;
+				backoff.wait();
+			}
+		}
+
+
+		void UnlockWrite()
+		{
+			Data expectedData;
+			Data newData;
+			Backoff backoff;
+
+			while (true) {
+				expectedData.all = state_.load();
+				newData.all = expectedData.all;
+				assert(expectedData.lockedInWriteMode == 1);
+				assert(expectedData.numberOfReadersThatOwnTheLock == 0);
+				newData.lockedInWriteMode = 0;
+				newData.numberOfWriters--;
+				if (state_.compare_exchange_strong(expectedData.all, newData.all))
+					break;
+				backoff.wait();
+			}
+		}
+
+		bool isWriting() const
+		{
+			Data data;
+			data.all = state_.load();
+			return data.lockedInWriteMode == 1;
+		}
+
+		bool isReading() const
+		{
+			Data data;
+			data.all = state_.load();
+			return data.numberOfReadersThatOwnTheLock != 0;
+		}
+	};
+};

--- a/util/statistics.h
+++ b/util/statistics.h
@@ -39,6 +39,7 @@ class StatisticsImpl : public Statistics {
                              HistogramData* const data) const override;
 
   virtual void setTickerCount(uint32_t ticker_type, uint64_t count) override;
+  void setMaxTickerCount(uint32_t tickerType, uint64_t count) override;  
   virtual void recordTick(uint32_t ticker_type, uint64_t count) override;
   virtual void measureTime(uint32_t histogram_type, uint64_t value) override;
 
@@ -85,6 +86,12 @@ inline void SetTickerCount(Statistics* statistics, uint32_t ticker_type,
   if (statistics) {
     statistics->setTickerCount(ticker_type, count);
   }
+}
+
+inline void SetMaxTickerCount(Statistics* statistics, uint32_t ticker_type,	uint64_t count) {
+	if (statistics) {
+		statistics->setMaxTickerCount(ticker_type, count);
+	}
 }
 
 }

--- a/util/thread_status_util_debug.cc
+++ b/util/thread_status_util_debug.cc
@@ -20,10 +20,11 @@ void ThreadStatusUtil::TEST_SetStateDelay(
   states_delay[state].store(micro, std::memory_order_relaxed);
 }
 
-void ThreadStatusUtil::TEST_StateDelay(
-    const ThreadStatus::StateType state) {
-  Env::Default()->SleepForMicroseconds(
-      states_delay[state].load(std::memory_order_relaxed));
+void ThreadStatusUtil::TEST_StateDelay(const ThreadStatus::StateType state) {
+  auto delay = states_delay[state].load(std::memory_order_relaxed);
+  if (delay > 0) {
+    Env::Default()->SleepForMicroseconds(delay);
+  }
 }
 
 #endif  // !NDEBUG


### PR DESCRIPTION
The goal of this patch is to improve write performance by permitting concurrent execution of write operations. It includes concurrency control that synchronizes between concurrent write operations, compactions, and snapshot creations.
This patch is a simple variant of the algorithm presented in the EuroSys'2015 paper: "Scaling Concurrent Log-Structured Data Stores" . It supports concurrent write operations + WAL + consistent snapshots.
The patch is enabled when DBOptions::allow_concurrent_write_operations== true

Here are some performance results on a Xeon E5620 machine with 2 quad-core CPUs:

Before:
-------
./db_bench  --benchmarks=fillrandom --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=16000000 --threads=1
fillrandom   :       4.571 micros/op 218747 ops/sec;   24.2 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=8000000 --threads=2
fillrandom   :       9.831 micros/op 101717 ops/sec;   11.3 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=4000000 --threads=4
fillrandom   :      10.660 micros/op 93812 ops/sec;   10.4 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=2000000 --threads=8
fillrandom   :      11.087 micros/op 90196 ops/sec;   10.0 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=1000000 --threads=16
fillrandom   :      11.328 micros/op 88276 ops/sec;    9.8 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=16000000 --threads=1
fillrandom   :       7.541 micros/op 132602 ops/sec;   14.7 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=8000000 --threads=2
fillrandom   :      14.022 micros/op 71315 ops/sec;    7.9 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=4000000 --threads=4
fillrandom   :      13.898 micros/op 71952 ops/sec;    8.0 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=2000000 --threads=8
fillrandom   :      13.561 micros/op 73741 ops/sec;    8.2 MB/s

./db_bench  --benchmarks=fillrandom --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=1000000 --threads=16
fillrandom   :      13.049 micros/op 76635 ops/sec;    8.5 MB/s


After:
-------
./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=16000000 --threads=1
fillrandom   :       3.624 micros/op 275972 ops/sec;   30.5 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=8000000 --threads=2
fillrandom   :       2.444 micros/op 409086 ops/sec;   45.3 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=4000000 --threads=4
fillrandom   :       1.499 micros/op 667317 ops/sec;   73.8 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=2000000 --threads=8
fillrandom   :       1.235 micros/op 809447 ops/sec;   89.5 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=1 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=1000000 --threads=16
fillrandom   :       1.234 micros/op 810624 ops/sec;   89.7 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=16000000 --threads=1
fillrandom   :       4.249 micros/op 235328 ops/sec;   26.0 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=8000000 --threads=2
fillrandom   :       3.263 micros/op 306432 ops/sec;   33.9 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=4000000 --threads=4
fillrandom   :       2.908 micros/op 343906 ops/sec;   38.0 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=2000000 --threads=8
fillrandom   :       2.623 micros/op 381304 ops/sec;   42.2 MB/s

./db_bench  --benchmarks=fillrandom --memtablerep=lock_free_skip_list --concurrent_writes=1 --disable_wal=0 --write_buffer_size=134217728 --max_background_compactions=10 --max_write_buffer_number=15 --mmap_write=1 --num=1000000 --threads=16
fillrandom   :       2.995 micros/op 333911 ops/sec;   36.9 MB/s
