### PR TITLE
Added compression report to sst_dump

### DIFF
--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -7,6 +7,7 @@
 #include <map>
 #include "rocksdb/status.h"
 #include "rocksdb/types.h"
+#include "rocksdb/options.h"
 
 namespace rocksdb {
 
@@ -52,6 +53,9 @@ struct TableProperties {
   // The name of the filter policy used in this table.
   // If no filter policy is used, `filter_policy_name` will be an empty string.
   std::string filter_policy_name;
+
+  // the type of compression used for the block
+  rocksdb::CompressionType compression_type = kNoCompression;
 
   // user collected properties
   UserCollectedProperties user_collected_properties;

--- a/table/format.cc
+++ b/table/format.cc
@@ -332,7 +332,7 @@ Status ReadBlockContents(RandomAccessFile* file, const Footer& footer,
 
   compression_type = static_cast<rocksdb::CompressionType>(slice.data()[n]);
 
-  if (found_compression_type != nullptr) {
+  if (found_compression_type != nullptr && compression_type != kNoCompression) {
     *found_compression_type = compression_type;
   }
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -302,7 +302,8 @@ Status ReadBlock(RandomAccessFile* file, const Footer& footer,
 Status ReadBlockContents(RandomAccessFile* file, const Footer& footer,
                          const ReadOptions& options, const BlockHandle& handle,
                          BlockContents* contents, Env* env,
-                         bool decompression_requested) {
+                         bool decompression_requested,
+                         rocksdb::CompressionType* found_compression_type) {
   Status status;
   Slice slice;
   size_t n = static_cast<size_t>(handle.size());
@@ -330,6 +331,10 @@ Status ReadBlockContents(RandomAccessFile* file, const Footer& footer,
   PERF_TIMER_GUARD(block_decompress_time);
 
   compression_type = static_cast<rocksdb::CompressionType>(slice.data()[n]);
+
+  if (found_compression_type != nullptr) {
+    *found_compression_type = compression_type;
+  }
 
   if (decompression_requested && compression_type != kNoCompression) {
     return UncompressBlockContents(slice.data(), n, contents, footer.version());

--- a/table/format.cc
+++ b/table/format.cc
@@ -332,7 +332,7 @@ Status ReadBlockContents(RandomAccessFile* file, const Footer& footer,
 
   compression_type = static_cast<rocksdb::CompressionType>(slice.data()[n]);
 
-  if (found_compression_type != nullptr && compression_type != kNoCompression) {
+  if (found_compression_type != nullptr) {
     *found_compression_type = compression_type;
   }
 

--- a/table/format.h
+++ b/table/format.h
@@ -199,7 +199,8 @@ extern Status ReadBlockContents(RandomAccessFile* file, const Footer& footer,
                                 const ReadOptions& options,
                                 const BlockHandle& handle,
                                 BlockContents* contents, Env* env,
-                                bool do_uncompress);
+                                bool do_uncompress,
+                                rocksdb::CompressionType* found_compression_type = nullptr);
 
 // The 'data' points to the raw block contents read in from file.
 // This method allocates a new heap buffer and the raw block

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -173,7 +173,9 @@ Status ReadProperties(const Slice &handle_value, RandomAccessFile *file,
       {TablePropertiesNames::kFixedKeyLen,
        &new_table_properties->fixed_key_len}, };
 
-  new_table_properties->compression_type = found_compression_type;
+  if (found_compression_type != kNoCompression) {
+    new_table_properties->compression_type = found_compression_type;
+  }
 
   std::string last_key;
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -144,8 +144,9 @@ Status ReadProperties(const Slice &handle_value, RandomAccessFile *file,
   ReadOptions read_options;
   read_options.verify_checksums = false;
   Status s;
+  rocksdb::CompressionType found_compression_type;
   s = ReadBlockContents(file, footer, read_options, handle, &block_contents,
-                        env, false);
+                        env, false, &found_compression_type);
 
   if (!s.ok()) {
     return s;
@@ -171,6 +172,8 @@ Status ReadProperties(const Slice &handle_value, RandomAccessFile *file,
        &new_table_properties->format_version},
       {TablePropertiesNames::kFixedKeyLen,
        &new_table_properties->fixed_key_len}, };
+
+  new_table_properties->compression_type = found_compression_type;
 
   std::string last_key;
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -71,6 +71,9 @@ std::string TableProperties::ToString(
       filter_policy_name.empty() ? std::string("N/A") : filter_policy_name,
       prop_delim, kv_delim);
 
+  AppendProperty(result, "compression",
+                 compression_type, prop_delim, kv_delim);
+
   return result;
 }
 

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -38,6 +38,25 @@ namespace {
   }
 }
 
+std::string GetCompressionString(rocksdb::CompressionType compression_type) {
+  switch (compression_type) {
+    case kNoCompression:
+      return "no_compression";
+    case kSnappyCompression:
+      return "snappy";
+    case kZlibCompression:
+      return "zlib";
+    case kBZip2Compression:
+      return "bzip2";
+    case kLZ4Compression:
+      return "lz4";
+    case kLZ4HCCompression:
+      return "lz4hc";
+    default:
+      return "";
+  }
+}
+
 std::string TableProperties::ToString(
     const std::string& prop_delim,
     const std::string& kv_delim) const {
@@ -71,8 +90,12 @@ std::string TableProperties::ToString(
       filter_policy_name.empty() ? std::string("N/A") : filter_policy_name,
       prop_delim, kv_delim);
 
+  std::ostringstream compression_os;
+  compression_os << compression_type;
+  compression_os << " ";
+  compression_os << GetCompressionString(compression_type);
   AppendProperty(result, "compression",
-                 compression_type, prop_delim, kv_delim);
+                 compression_os.str(), prop_delim, kv_delim);
 
   return result;
 }


### PR DESCRIPTION
This pull request adds a compression field to sst_dump's show-properties report.

The reason is that there is no real way to figure out how compression is actually being used by RocksDB. The LOG specifies what compression is requested, but there are some reasons why the actual data may be compressed differently. For example, compression libraries may not be linked properly (our motivation for this patch), or compression is changed.

This patch allows a user to inspect the sst files directly and verify what compression scheme is actually used.

Signed-off-by: Adam Lugowski alugowski@gmail.com
