### PR TITLE
Fix compiler error on darwin/clang

### DIFF
--- a/utilities/transactions/optimistic_transaction_impl.cc
+++ b/utilities/transactions/optimistic_transaction_impl.cc
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <inttypes.h>
 
 #include "db/column_family.h"
 #include "db/db_impl.h"
@@ -304,9 +305,9 @@ Status OptimisticTransactionImpl::CheckTransactionForConflicts(DB* db) {
         char msg[255];
         snprintf(
             msg, sizeof(msg),
-            "Could not commit transaction with write at SequenceNumber %llu "
+            "Could not commit transaction with write at SequenceNumber %" PRIu64 " "
             "as the MemTable only contains changes newer than SequenceNumber "
-            "%llu.",
+            "%" PRIu64 ".",
             key_seq, earliest_seq);
         result = Status::Busy(msg);
       } else {

--- a/utilities/transactions/optimistic_transaction_impl.cc
+++ b/utilities/transactions/optimistic_transaction_impl.cc
@@ -304,9 +304,9 @@ Status OptimisticTransactionImpl::CheckTransactionForConflicts(DB* db) {
         char msg[255];
         snprintf(
             msg, sizeof(msg),
-            "Could not commit transaction with write at SequenceNumber %lu "
+            "Could not commit transaction with write at SequenceNumber %llu "
             "as the MemTable only contains changes newer than SequenceNumber "
-            "%lu.",
+            "%llu.",
             key_seq, earliest_seq);
         result = Status::Busy(msg);
       } else {


### PR DESCRIPTION
error: format specifies type 'unsigned long' but the argument has type 'SequenceNumber'
      (aka 'unsigned long long') [-Werror,-Wformat]