### PR TITLE
Add JNI interface to set max_table_files_size for FIFO compaction

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1136,6 +1136,27 @@ jbyte Java_org_rocksdb_Options_compactionStyle(
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setMaxTableFilesSizeFIFO
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_options_fifo.max_table_files_size =
+    static_cast<long>(jmax_table_files_size);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    maxTableFilesSizeFIFO
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(
+    JNIEnv* env, jobject jobj, jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_options_fifo.max_table_files_size;
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    numLevels
  * Signature: (J)I
  */
@@ -2269,6 +2290,27 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>
       (jhandle)->compaction_style;
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    setMaxTableFilesSizeFIFO
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->compaction_options_fifo.max_table_files_size =
+    static_cast<long>(jmax_table_files_size);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    maxTableFilesSizeFIFO
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
+    JNIEnv* env, jobject jobj, jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->compaction_options_fifo.max_table_files_size;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -469,6 +469,20 @@ public class ColumnFamilyOptions extends RocksObject
   }
 
   @Override
+  public ColumnFamilyOptions setMaxTableFilesSizeFIFO(
+      final long maxTableFilesSize) {
+    assert(maxTableFilesSize > 0); // unsigned native type
+    assert(isInitialized());
+    setMaxTableFilesSizeFIFO(nativeHandle_, maxTableFilesSize);
+    return this;
+  }
+
+  @Override
+  public long maxTableFilesSizeFIFO() {
+    return maxTableFilesSizeFIFO(nativeHandle_);
+  }
+
+  @Override
   public ColumnFamilyOptions setVerifyChecksumsInCompaction(
       final boolean verifyChecksumsInCompaction) {
     setVerifyChecksumsInCompaction(
@@ -740,6 +754,9 @@ public class ColumnFamilyOptions extends RocksObject
   private native boolean disableAutoCompactions(long handle);
   private native void setCompactionStyle(long handle, byte compactionStyle);
   private native byte compactionStyle(long handle);
+   private native void setMaxTableFilesSizeFIFO(
+      long handle, long max_table_files_size);
+  private native long maxTableFilesSizeFIFO(long handle);
   private native void setPurgeRedundantKvsWhileFlush(
       long handle, boolean purgeRedundantKvsWhileFlush);
   private native boolean purgeRedundantKvsWhileFlush(long handle);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -838,6 +838,27 @@ public interface ColumnFamilyOptionsInterface {
   CompactionStyle compactionStyle();
 
   /**
+   * FIFO compaction option.
+   * The oldest table file will be deleted
+   * once the sum of table files reaches this size.
+   * The default value is 1GB (1 * 1024 * 1024 * 1024).
+   *
+   * @param maxTableFilesSize the size limit of the total sum of table files.
+   * @return the instance of the current Object.
+   */
+  Object setMaxTableFilesSizeFIFO(long maxTableFilesSize);
+
+  /**
+   * FIFO compaction option.
+   * The oldest table file will be deleted
+   * once the sum of table files reaches this size.
+   * The default value is 1GB (1 * 1024 * 1024 * 1024).
+   *
+   * @return the size limit of the total sum of table files.
+   */
+  long maxTableFilesSizeFIFO();
+
+  /**
    * If true, compaction will verify checksum on every read that happens
    * as part of compaction
    * Default: true

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -438,6 +438,20 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setMaxTableFilesSizeFIFO(
+    final long maxTableFilesSize) {
+    assert(maxTableFilesSize > 0); // unsigned native type
+    assert(isInitialized());
+    setMaxTableFilesSizeFIFO(nativeHandle_, maxTableFilesSize);
+    return this;
+  }
+
+  @Override
+  public long maxTableFilesSizeFIFO() {
+    return maxTableFilesSizeFIFO(nativeHandle_);
+  }
+
+  @Override
   public int tableCacheNumshardbits() {
     assert(isInitialized());
     return tableCacheNumshardbits(nativeHandle_);
@@ -1135,6 +1149,9 @@ public class Options extends RocksObject
   private native void setMaxManifestFileSize(
       long handle, long maxManifestFileSize);
   private native long maxManifestFileSize(long handle);
+  private native void setMaxTableFilesSizeFIFO(
+      long handle, long maxTableFilesSize);
+  private native long maxTableFilesSizeFIFO(long handle);
   private native void setTableCacheNumshardbits(
       long handle, int tableCacheNumshardbits);
   private native int tableCacheNumshardbits(long handle);

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -723,4 +723,23 @@ public class ColumnFamilyOptionsTest {
       }
     }
   }
+
+  @Test
+  public void maxTableFilesSizeFIFO() {
+    ColumnFamilyOptions opt = null;
+    try {
+      opt = new ColumnFamilyOptions();
+      long longValue = rand.nextLong();
+      // Size has to be positive
+      longValue = (longValue < 0) ? -longValue : longValue;
+      longValue = (longValue == 0) ? longValue + 1 : longValue;
+      opt.setMaxTableFilesSizeFIFO(longValue);
+      assertThat(opt.maxTableFilesSizeFIFO()).
+          isEqualTo(longValue);
+    } finally {
+      if (opt != null) {
+        opt.dispose();
+      }
+    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1109,6 +1109,25 @@ public class OptionsTest {
   }
 
   @Test
+  public void maxTableFilesSizeFIFO() {
+    Options opt = null;
+    try {
+      opt = new Options();
+      long longValue = rand.nextLong();
+      // Size has to be positive
+      longValue = (longValue < 0) ? -longValue : longValue;
+      longValue = (longValue == 0) ? longValue + 1 : longValue;
+      opt.setMaxTableFilesSizeFIFO(longValue);
+      assertThat(opt.maxTableFilesSizeFIFO()).
+          isEqualTo(longValue);
+    } finally {
+      if (opt != null) {
+        opt.dispose();
+      }
+    }
+  }
+
+  @Test
   public void rateLimiterConfig() {
     Options options = null;
     Options anotherOptions = null;


### PR DESCRIPTION
This PR adds JNI calls to set/get the max_table_files_size option for FIFO compaction.

The java API call is setMaxTableFilesSizeFIFO on Options and ColumnFamilyOptions. It does not directly expose the FIFO options struct since there is only one option to set.