### PR TITLE
[RocksJava] Fixed test failures

### DIFF
--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -368,11 +368,19 @@ void Java_org_rocksdb_WBWIRocksIterator_entry1(
   const rocksdb::WriteEntry& we = it->Entry();
   jobject jwe = rocksdb::WBWIRocksIteratorJni::getWriteEntry(env, jobj);
   rocksdb::WriteEntryJni::setWriteType(env, jwe, we.type);
-  rocksdb::WriteEntryJni::setKey(env, jwe, &we.key);
+
+  char* buf = new char[we.key.size()];
+  memcpy(buf, we.key.data(), we.key.size());
+  auto* key_slice = new rocksdb::Slice(buf, we.key.size());
+  rocksdb::WriteEntryJni::setKey(env, jwe, key_slice);
+
   if (we.type == rocksdb::kDeleteRecord || we.type == rocksdb::kLogDataRecord) {
     // set native handle of value slice to null if no value available
-    rocksdb::WriteEntryJni::setValue(env, jwe, NULL);
+    rocksdb::WriteEntryJni::setValue(env, jwe, nullptr);
   } else {
-    rocksdb::WriteEntryJni::setValue(env, jwe, &we.value);
+    char* value_buf = new char[we.value.size()];
+    memcpy(value_buf, we.value.data(), we.value.size());
+    auto* value_slice = new rocksdb::Slice(value_buf, we.value.size());
+    rocksdb::WriteEntryJni::setValue(env, jwe, value_slice);
   }
 }

--- a/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
+++ b/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
@@ -231,6 +231,34 @@ public class WriteBatchWithIndexTest {
     }
   }
 
+  @Test
+  public void zeroByteTests() {
+    final WriteBatchWithIndex wbwi = new WriteBatchWithIndex(true);
+    byte[] zeroByteValue = new byte[] { 0, 0 };
+
+    //add zero byte value
+    wbwi.put(zeroByteValue, zeroByteValue);
+
+    ByteBuffer buffer = ByteBuffer.allocateDirect(zeroByteValue.length);
+    buffer.put(zeroByteValue);
+
+    WBWIRocksIterator.WriteEntry[] expected = {
+        new WBWIRocksIterator.WriteEntry(WBWIRocksIterator.WriteType.PUT,
+            new DirectSlice(buffer, zeroByteValue.length),
+            new DirectSlice(buffer, zeroByteValue.length))
+    };
+    WBWIRocksIterator it = null;
+    try {
+      it = wbwi.newIterator();
+      it.seekToFirst();
+      assertThat(it.entry().equals(expected[0])).isTrue();
+    } finally {
+      if(it != null) {
+        it.dispose();
+      }
+    }
+  }
+
   private byte[] toArray(final ByteBuffer buf) {
     final byte[] ary = new byte[buf.remaining()];
     buf.get(ary);


### PR DESCRIPTION
Summary:
The option bottommost_level_compaction was introduced lately.
This option breaks the Java API behavior. To prevent the library
from doing so we set that option to a fixed value in Java.

In future we are going to remove that portion and replace the
hardcoded options using a more flexible way.

Fixed bug introduced by WriteBatchWithIndex Patch

Lately icanadi changed the behavior of WriteBatchWithIndex.
See commit: 821cff1

This commit solves problems introduced by above mentioned commit.

Test Plan:
make rocksdbjava
make jtest

Reviewers: yhchiang, adamretter, ankgup87

Subscribers: dhruba

Differential Revision: https://reviews.facebook.net/D40647