### PR TITLE
RemoveEmptyValueCompactionFilter

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -1,4 +1,5 @@
-NATIVE_JAVA_CLASSES = org.rocksdb.AbstractComparator\
+NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
+        org.rocksdb.AbstractComparator\
 	org.rocksdb.AbstractSlice\
 	org.rocksdb.BackupableDB\
 	org.rocksdb.BackupableDBOptions\

--- a/java/Makefile
+++ b/java/Makefile
@@ -24,6 +24,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.Options\
 	org.rocksdb.PlainTableConfig\
 	org.rocksdb.ReadOptions\
+	org.rocksdb.RemoveEmptyValueCompactionFilter\
 	org.rocksdb.RestoreBackupableDB\
 	org.rocksdb.RestoreOptions\
 	org.rocksdb.RocksDB\

--- a/java/rocksjni/compaction_filter.cc
+++ b/java/rocksjni/compaction_filter.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+// This file implements the "bridge" between Java and C++ for
+// rocksdb::CompactionFilter.
+
+#include <jni.h>
+
+#include "rocksdb/compaction_filter.h"
+
+// <editor-fold desc="org.rocksdb.AbstractCompactionFilter">
+
+/*
+ * Class:     org_rocksdb_AbstractCompactionFilter
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_AbstractCompactionFilter_disposeInternal(
+    JNIEnv* env, jobject jobj, jlong handle) {
+  delete reinterpret_cast<rocksdb::CompactionFilter*>(handle);
+}
+// </editor-fold>

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2055,6 +2055,19 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
 
 /*
  * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    setCompactionFilterHandle
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle__JJ(
+    JNIEnv* env, jobject jobj, jlong jopt_handle,
+    jlong jcompactionfilter_handle) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)->
+      compaction_filter = reinterpret_cast<rocksdb::CompactionFilter*>
+        (jcompactionfilter_handle);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
  * Method:    setWriteBufferSize
  * Signature: (JJ)I
  */

--- a/java/rocksjni/remove_emptyvalue_compactionfilterjni.cc
+++ b/java/rocksjni/remove_emptyvalue_compactionfilterjni.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <jni.h>
+
+#include "include/org_rocksdb_RemoveEmptyValueCompactionFilter.h"
+#include "utilities/compaction_filters/remove_emptyvalue_compactionfilter.h"
+
+
+/*
+ * Class:     org_rocksdb_RemoveEmptyValueCompactionFilter
+ * Method:    createNewRemoveEmptyValueCompactionFilter0
+ * Signature: ()V
+ */
+void Java_org_rocksdb_RemoveEmptyValueCompactionFilter_createNewRemoveEmptyValueCompactionFilter0(
+    JNIEnv* env, jobject jobj) {
+  const rocksdb::RemoveEmptyValueCompactionFilter* compaction_filter =
+      new rocksdb::RemoveEmptyValueCompactionFilter();
+
+  // set the native handle to our native compaction filter
+  static jclass jclazz =
+      env->FindClass("org/rocksdb/RemoveEmptyValueCompactionFilter");
+  static jfieldID fid = env->GetFieldID(jclazz, "nativeHandle_", "J");
+  env->SetLongField(jobj, fid, reinterpret_cast<jlong>(compaction_filter));
+}

--- a/java/src/main/java/org/rocksdb/AbstractCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/AbstractCompactionFilter.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+package org.rocksdb;
+
+/**
+ * A CompactionFilter allows an application to modify/delete a key-value at
+ * the time of compaction.
+ *
+ * At present we just permit an overriding Java class to wrap a C++ implementation
+ */
+public abstract class AbstractCompactionFilter<T extends AbstractSlice<?>>
+    extends RocksObject {
+
+  /**
+   * Deletes underlying C++ comparator pointer.
+   *
+   * Note that this function should be called only after all
+   * RocksDB instances referencing the comparator are closed.
+   * Otherwise an undefined behavior will occur.
+   */
+  @Override protected void disposeInternal() {
+    assert(isInitialized());
+    disposeInternal(nativeHandle_);
+  }
+
+  private native void disposeInternal(long handle);
+}

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -145,6 +145,13 @@ public class ColumnFamilyOptions extends RocksObject
     return this;
   }
 
+  public ColumnFamilyOptions setCompactionFilter(
+        final AbstractCompactionFilter<? extends AbstractSlice<?>> compactionFilter) {
+    setCompactionFilterHandle(nativeHandle_, compactionFilter.nativeHandle_);
+    compactionFilter_ = compactionFilter;
+    return this;
+  }
+
   @Override
   public ColumnFamilyOptions setWriteBufferSize(final long writeBufferSize) {
     assert(isInitialized());
@@ -680,6 +687,7 @@ public class ColumnFamilyOptions extends RocksObject
       long handle, String name);
   private native void setMergeOperator(
       long handle, long mergeOperatorHandle);
+  private native void setCompactionFilterHandle(long handle, long compactionFilterHandle);
   private native void setWriteBufferSize(long handle, long writeBufferSize)
       throws IllegalArgumentException;
   private native long writeBufferSize(long handle);
@@ -803,4 +811,5 @@ public class ColumnFamilyOptions extends RocksObject
   MemTableConfig memTableConfig_;
   TableFormatConfig tableFormatConfig_;
   AbstractComparator<? extends AbstractSlice<?>> comparator_;
+  AbstractCompactionFilter<? extends AbstractSlice<?>> compactionFilter_;
 }

--- a/java/src/main/java/org/rocksdb/RemoveEmptyValueCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/RemoveEmptyValueCompactionFilter.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2014, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+package org.rocksdb;
+
+/**
+ * Just a Java wrapper around EmptyValueCompactionFilter implemented in C++
+ */
+public class RemoveEmptyValueCompactionFilter extends AbstractCompactionFilter<Slice> {
+  public RemoveEmptyValueCompactionFilter() {
+    super();
+    createNewRemoveEmptyValueCompactionFilter0();
+  }
+
+  private native void createNewRemoveEmptyValueCompactionFilter0();
+}

--- a/src.mk
+++ b/src.mk
@@ -246,6 +246,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/backupablejni.cc                              \
   java/rocksjni/checkpoint.cc                                 \
   java/rocksjni/columnfamilyhandle.cc                         \
+  java/rocksjni/compaction_filter.cc                          \
   java/rocksjni/comparator.cc                                 \
   java/rocksjni/comparatorjnicallback.cc                      \
   java/rocksjni/env.cc                                        \

--- a/src.mk
+++ b/src.mk
@@ -257,6 +257,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/merge_operator.cc                             \
   java/rocksjni/options.cc                                    \
   java/rocksjni/ratelimiterjni.cc                             \
+  java/rocksjni/remove_emptyvalue_compactionfilterjni.cc      \
   java/rocksjni/restorejni.cc                                 \
   java/rocksjni/rocksjni.cc                                   \
   java/rocksjni/slice.cc                                      \

--- a/src.mk
+++ b/src.mk
@@ -98,6 +98,7 @@ LIB_SOURCES =                                                   \
   utilities/backupable/backupable_db.cc                         \
   utilities/convenience/convenience.cc                          \
   utilities/checkpoint/checkpoint.cc                            \
+  utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc    \
   utilities/document/document_db.cc                             \
   utilities/document/json_document_builder.cc                   \
   utilities/document/json_document.cc                           \

--- a/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
+++ b/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef ROCKSDB_LITE
+
+#include <string>
+
+#include "rocksdb/slice.h"
+#include "utilities/compaction_filters/remove_emptyvalue_compactionfilter.h"
+
+namespace rocksdb {
+
+const char* RemoveEmptyValueCompactionFilter::Name() const {
+  return "RemoveEmptyValueCompactionFilter";
+}
+
+bool RemoveEmptyValueCompactionFilter::Filter(int level,
+    const Slice& key,
+    const Slice& existing_value,
+    std::string* new_value,
+    bool* value_changed) const {
+
+  // remove kv pairs that have empty values
+  return existing_value.empty();
+}
+
+}  // namespace rocksdb
+#endif  // !ROCKSDB_LITE

--- a/utilities/compaction_filters/remove_emptyvalue_compactionfilter.h
+++ b/utilities/compaction_filters/remove_emptyvalue_compactionfilter.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2015, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef ROCKSDB_LITE
+
+#pragma once
+
+#include <string>
+
+#include "rocksdb/compaction_filter.h"
+#include "rocksdb/slice.h"
+
+namespace rocksdb {
+
+class RemoveEmptyValueCompactionFilter : public CompactionFilter {
+ public:
+    const char* Name() const override;
+    bool Filter(int level,
+        const Slice& key,
+        const Slice& existing_value,
+        std::string* new_value,
+        bool* value_changed) const override;
+};
+}  // namespace rocksdb
+#endif  // !ROCKSDB_LITE


### PR DESCRIPTION
A general compaction filter that will remove key/value pairs during compaction that have empty-values. Also added support to the Java API for using this.