### PR TITLE
fix append bug in DumpDBFileSummary()

### DIFF
--- a/util/db_info_dumper.cc
+++ b/util/db_info_dumper.cc
@@ -62,7 +62,7 @@ void DumpDBFileSummary(const DBOptions& options, const std::string& dbname) {
         break;
       case kLogFile:
         env->GetFileSize(dbname + "/" + file, &file_size);
-        char str[8];
+        char str[16];
         snprintf(str, sizeof(str), "%" PRIu64, file_size);
         wal_info.append(file).append(" size: ").
             append(str).append(" ; ");
@@ -115,7 +115,7 @@ void DumpDBFileSummary(const DBOptions& options, const std::string& dbname) {
       if (ParseFileName(file, &number, &type)) {
         if (type == kLogFile) {
           env->GetFileSize(options.wal_dir + "/" + file, &file_size);
-          char str[8];
+          char str[16];
           snprintf(str, sizeof(str), "%" PRIu64, file_size);
           wal_info.append(file).append(" size: ").
               append(str).append(" ; ");

--- a/util/db_info_dumper.cc
+++ b/util/db_info_dumper.cc
@@ -65,7 +65,7 @@ void DumpDBFileSummary(const DBOptions& options, const std::string& dbname) {
         char str[8];
         snprintf(str, sizeof(str), "%" PRIu64, file_size);
         wal_info.append(file).append(" size: ").
-            append(str, sizeof(str)).append(" ;");
+            append(str).append(" ; ");
         break;
       case kTableFile:
         if (++file_num < 10) {
@@ -118,7 +118,7 @@ void DumpDBFileSummary(const DBOptions& options, const std::string& dbname) {
           char str[8];
           snprintf(str, sizeof(str), "%" PRIu64, file_size);
           wal_info.append(file).append(" size: ").
-              append(str, sizeof(str)).append(" ;");
+              append(str).append(" ; ");
         }
       }
     }


### PR DESCRIPTION
The original "append(str, sizeof(str))" would make wal_info string truncated.