### PR TITLE
Add missing tests, fix db_sanity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ set(TESTS
         db/log_test.cc
         db/memtable_list_test.cc
         db/merge_test.cc
+        db/merge_helper_test.cc
         db/perf_context_test.cc
         db/plain_table_db_test.cc
         db/prefix_test.cc
@@ -307,6 +308,7 @@ set(TESTS
         util/event_logger_test.cc
         util/filelock_test.cc
         util/file_reader_writer_test.cc
+        util/heap_test.cc
         util/histogram_test.cc
         util/manual_compaction_test.cc
         util/memenv_test.cc

--- a/tools/db_sanity_test.cc
+++ b/tools/db_sanity_test.cc
@@ -38,7 +38,7 @@ class SanityTest {
     options.create_if_missing = true;
     std::string dbname = path_ + Name();
     DestroyDB(dbname, options);
-    DB* db;
+    DB* db = nullptr;
     Status s = DB::Open(options, dbname, &db);
     std::unique_ptr<DB> db_guard(db);
     if (!s.ok()) {
@@ -55,7 +55,7 @@ class SanityTest {
     return db->Flush(FlushOptions());
   }
   Status Verify() {
-    DB* db;
+    DB* db = nullptr;
     std::string dbname = path_ + Name();
     Status s = DB::Open(GetOptions(), dbname, &db);
     std::unique_ptr<DB> db_guard(db);


### PR DESCRIPTION
 Add heap_test, merge_helper_test
 Fix uninitialized pointers in db_sanity_test that cause SIGSEV when DB::Open fails in case compression is not linked.