### PR TITLE
support for capped prefix extractor in java

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -707,6 +707,17 @@ void Java_org_rocksdb_Options_useFixedLengthPrefixExtractor(
 }
 
 /*
+ * Method:    useCappedPrefixExtractor
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_Options_useCappedPrefixExtractor(
+    JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->prefix_extractor.reset(
+      rocksdb::NewCappedPrefixTransform(
+          static_cast<int>(jprefix_length)));
+}
+
+/*
  * Class:     org_rocksdb_Options
  * Method:    walTtlSeconds
  * Signature: (J)J

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -192,6 +192,13 @@ public class ColumnFamilyOptions extends RocksObject
   }
 
   @Override
+  public ColumnFamilyOptions useCappedPrefixExtractor(final int n) {
+    assert(isInitialized());
+    useCappedPrefixExtractor(nativeHandle_, n);
+    return this;
+  }
+
+  @Override
   public ColumnFamilyOptions setCompressionType(final CompressionType compressionType) {
     setCompressionType(nativeHandle_, compressionType.getValue());
     return this;
@@ -694,6 +701,8 @@ public class ColumnFamilyOptions extends RocksObject
       List<Byte> compressionLevels);
   private native List<Byte> compressionPerLevel(long handle);
   private native void useFixedLengthPrefixExtractor(
+      long handle, int prefixLength);
+  private native void useCappedPrefixExtractor(
       long handle, int prefixLength);
   private native void setNumLevels(
       long handle, int numLevels);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -229,6 +229,16 @@ public interface ColumnFamilyOptionsInterface {
    */
   Object useFixedLengthPrefixExtractor(int n);
 
+
+  /**
+   * Same as fixed length prefix extractor, except that when slice is 
+   * shorter than the fixed length, it will use the full key.
+   *
+   * @param n use the first n bytes of a key as its prefix.
+   * @return the reference to the current option.
+   */
+  Object useCappedPrefixExtractor(int n);
+
   /**
    * Compress blocks using the specified compression algorithm.  This
    * parameter can be changed dynamically.

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -668,6 +668,13 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options useCappedPrefixExtractor(final int n) {
+    assert(isInitialized());
+    useCappedPrefixExtractor(nativeHandle_, n);
+    return this;
+  }
+
+  @Override
   public CompressionType compressionType() {
     return CompressionType.values()[compressionType(nativeHandle_)];
   }
@@ -1213,6 +1220,8 @@ public class Options extends RocksObject
       List<Byte> compressionLevels);
   private native List<Byte> compressionPerLevel(long handle);
   private native void useFixedLengthPrefixExtractor(
+      long handle, int prefixLength);
+  private native void useCappedPrefixExtractor(
       long handle, int prefixLength);
   private native void setNumLevels(
       long handle, int numLevels);

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -615,6 +615,21 @@ public class ColumnFamilyOptionsTest {
     }
   }
 
+
+  @Test
+  public void shouldSetTestCappedPrefixExtractor() {
+    ColumnFamilyOptions options = null;
+    try {
+      options = new ColumnFamilyOptions();
+      options.useCappedPrefixExtractor(100);
+      options.useCappedPrefixExtractor(10);
+    } finally {
+      if (options != null) {
+        options.dispose();
+      }
+    }
+  }
+
   @Test
   public void compressionTypes() {
     ColumnFamilyOptions columnFamilyOptions = null;

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1150,6 +1150,21 @@ public class OptionsTest {
   }
 
   @Test
+  public void shouldSetTestCappedPrefixExtractor() {
+    Options options = null;
+    try {
+      options = new Options();
+      options.useCappedPrefixExtractor(100);
+      options.useCappedPrefixExtractor(10);
+    } finally {
+      if (options != null) {
+        options.dispose();
+      }
+    }
+  }
+
+
+  @Test
   public void shouldTestMemTableFactoryName()
       throws RocksDBException {
     Options options = null;


### PR DESCRIPTION
Current fixed length prefix extractor restricts in usage of keys smaller that the prefix length. 