### PR TITLE
fix bug of setting smallest_seqno/largest_seqno in BuildTable()

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -173,12 +173,28 @@ Status BuildTable(
             prev_key.assign(keys.front());
             ok = ParseInternalKey(Slice(prev_key), &prev_ikey);
             assert(ok);
+
+            // The front item has the smallest seqno in the merge queue
+            meta->smallest_seqno = std::min(meta->smallest_seqno, prev_ikey.sequence);
+            if (keys.size() == 1) {
+              // If queue size is 1, the smallest seqno is also the largest
+              meta->largest_seqno = std::max(meta->largest_seqno, prev_ikey.sequence);
+            }
+            else {
+              // The back item has the largest seqno in the merge queue
+              ParsedInternalKey temp_ikey;
+              ok = ParseInternalKey(Slice(keys.back()), &temp_ikey);
+              assert(ok);
+              meta->largest_seqno = std::max(meta->largest_seqno, temp_ikey.sequence);
+            }
           } else {
             // Handle Put/Delete-type keys by simply writing them
             builder->Add(key, value);
             prev_key.assign(key.data(), key.size());
             ok = ParseInternalKey(Slice(prev_key), &prev_ikey);
             assert(ok);
+            meta->smallest_seqno = std::min(meta->smallest_seqno, prev_ikey.sequence);
+            meta->largest_seqno = std::max(meta->largest_seqno, prev_ikey.sequence);
           }
         }
 
@@ -194,9 +210,6 @@ Status BuildTable(
 
       // The last key is the largest key
       meta->largest.DecodeFrom(Slice(prev_key));
-      SequenceNumber seqno = GetInternalKeySeqno(Slice(prev_key));
-      meta->smallest_seqno = std::min(meta->smallest_seqno, seqno);
-      meta->largest_seqno = std::max(meta->largest_seqno, seqno);
 
     } else {
       for (; iter->Valid(); iter->Next()) {

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -384,6 +384,10 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append(" ");
     AppendNumberTo(&r, f.fd.GetFileSize());
     r.append(" ");
+    AppendNumberTo(&r, f.smallest_seqno);
+    r.append(" ");
+    AppendNumberTo(&r, f.largest_seqno);
+    r.append(" ");
     r.append(f.smallest.DebugString(hex_key));
     r.append(" .. ");
     r.append(f.largest.DebugString(hex_key));

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1764,8 +1764,8 @@ std::string Version::DebugString(bool hex) const {
   for (int level = 0; level < storage_info_.num_levels_; level++) {
     // E.g.,
     //   --- level 1 ---
-    //   17:123['a' .. 'd']
-    //   20:43['e' .. 'g']
+    //   17:123:[1,100]:['a' .. 'd']
+    //   20:43:[101,200]:['e' .. 'g']
     r.append("--- level ");
     AppendNumberTo(&r, level);
     r.append(" --- version# ");
@@ -1777,7 +1777,11 @@ std::string Version::DebugString(bool hex) const {
       AppendNumberTo(&r, files[i]->fd.GetNumber());
       r.push_back(':');
       AppendNumberTo(&r, files[i]->fd.GetFileSize());
-      r.append("[");
+      r.append(":[");
+      AppendNumberTo(&r, files[i]->smallest_seqno);
+      r.append(",");
+      AppendNumberTo(&r, files[i]->largest_seqno);
+      r.append("]:[");
       r.append(files[i]->smallest.DebugString(hex));
       r.append(" .. ");
       r.append(files[i]->largest.DebugString(hex));


### PR DESCRIPTION
The smallest_seqno/largest_seqno field in struct FileMetaData means the smallest/largest sequence number in the file.

But in BuildTable(), the smallest_seqno is set as the smallest key's sequence number, and the largest_seqno is set as the largest key's sequence number, then the result range [smallest_seqno, largest_seqno] may be subset of the real range.

This bug didn't cause any problem because there is little code depending on the values. One exception is NewestFirstBySeqNo(), which uses smallest_seqno as the first sort key to sort files in level-0. But luckily, all sstables in level-0 don't overlap with each other, so inaccurate smallest_seqno  doesn't cause a problem here.