### PR TITLE
Address noexcept and const integer lambda capture on win

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -6327,7 +6327,7 @@ TEST_F(DBTest, DynamicMemtableOptions) {
   options.level0_stop_writes_trigger = 1024;
   DestroyAndReopen(options);
 
-  auto gen_l0_kb = [this](int size) {
+  auto gen_l0_kb = [this, kNumPutsBeforeWaitForFlush](int size) {
     Random rnd(301);
     for (int i = 0; i < size; i++) {
       ASSERT_OK(Put(Key(i), RandomString(&rnd, 1024)));

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -16,7 +16,7 @@
 // in fact, we could use that one
 #define ROCKSDB_PRIszt "zu"
 
-#define NOEXCEPT noexcept
+#define ROCKSDB_NOEXCEPT noexcept
 
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -16,6 +16,8 @@
 // in fact, we could use that one
 #define ROCKSDB_PRIszt "zu"
 
+#define NOEXCEPT noexcept
+
 #undef PLATFORM_IS_LITTLE_ENDIAN
 #if defined(OS_MACOSX)
   #include <machine/endian.h>

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -58,6 +58,8 @@ typedef SSIZE_T ssize_t;
 #define ROCKSDB_PRIszt "Iu"
 #endif
 
+#define NOEXCEPT
+
 #define __attribute__(A)
 
 #ifdef ZLIB

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -58,7 +58,7 @@ typedef SSIZE_T ssize_t;
 #define ROCKSDB_PRIszt "Iu"
 #endif
 
-#define NOEXCEPT
+#define ROCKSDB_NOEXCEPT
 
 #define __attribute__(A)
 

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -18,6 +18,7 @@
 #include "util/logging.h"
 #include "util/string_util.h"
 #include "rocksdb/transaction_log.h"
+#include "port/port.h"
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
@@ -343,9 +344,9 @@ class BackupEngineImpl : public BackupEngine {
     CopyWorkItem(const CopyWorkItem&) = delete;
     CopyWorkItem& operator=(const CopyWorkItem&) = delete;
 
-    CopyWorkItem(CopyWorkItem&& o) noexcept { *this = std::move(o); }
+    CopyWorkItem(CopyWorkItem&& o) NOEXCEPT { *this = std::move(o); }
 
-    CopyWorkItem& operator=(CopyWorkItem&& o) noexcept {
+    CopyWorkItem& operator=(CopyWorkItem&& o) NOEXCEPT {
       src_path = std::move(o.src_path);
       dst_path = std::move(o.dst_path);
       src_env = o.src_env;
@@ -383,11 +384,11 @@ class BackupEngineImpl : public BackupEngine {
     std::string dst_relative;
     BackupAfterCopyWorkItem() {}
 
-    BackupAfterCopyWorkItem(BackupAfterCopyWorkItem&& o) noexcept {
+    BackupAfterCopyWorkItem(BackupAfterCopyWorkItem&& o) NOEXCEPT {
       *this = std::move(o);
     }
 
-    BackupAfterCopyWorkItem& operator=(BackupAfterCopyWorkItem&& o) noexcept {
+    BackupAfterCopyWorkItem& operator=(BackupAfterCopyWorkItem&& o) NOEXCEPT {
       result = std::move(o.result);
       shared = o.shared;
       needed_to_copy = o.needed_to_copy;
@@ -418,11 +419,11 @@ class BackupEngineImpl : public BackupEngine {
     RestoreAfterCopyWorkItem(std::future<CopyResult>&& _result,
                              uint32_t _checksum_value)
         : result(std::move(_result)), checksum_value(_checksum_value) {}
-    RestoreAfterCopyWorkItem(RestoreAfterCopyWorkItem&& o) noexcept {
+    RestoreAfterCopyWorkItem(RestoreAfterCopyWorkItem&& o) NOEXCEPT {
       *this = std::move(o);
     }
 
-    RestoreAfterCopyWorkItem& operator=(RestoreAfterCopyWorkItem&& o) noexcept {
+    RestoreAfterCopyWorkItem& operator=(RestoreAfterCopyWorkItem&& o) NOEXCEPT {
       result = std::move(o.result);
       checksum_value = o.checksum_value;
       return *this;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -344,9 +344,9 @@ class BackupEngineImpl : public BackupEngine {
     CopyWorkItem(const CopyWorkItem&) = delete;
     CopyWorkItem& operator=(const CopyWorkItem&) = delete;
 
-    CopyWorkItem(CopyWorkItem&& o) NOEXCEPT { *this = std::move(o); }
+    CopyWorkItem(CopyWorkItem&& o) ROCKSDB_NOEXCEPT { *this = std::move(o); }
 
-    CopyWorkItem& operator=(CopyWorkItem&& o) NOEXCEPT {
+    CopyWorkItem& operator=(CopyWorkItem&& o) ROCKSDB_NOEXCEPT {
       src_path = std::move(o.src_path);
       dst_path = std::move(o.dst_path);
       src_env = o.src_env;
@@ -384,11 +384,11 @@ class BackupEngineImpl : public BackupEngine {
     std::string dst_relative;
     BackupAfterCopyWorkItem() {}
 
-    BackupAfterCopyWorkItem(BackupAfterCopyWorkItem&& o) NOEXCEPT {
+    BackupAfterCopyWorkItem(BackupAfterCopyWorkItem&& o) ROCKSDB_NOEXCEPT {
       *this = std::move(o);
     }
 
-    BackupAfterCopyWorkItem& operator=(BackupAfterCopyWorkItem&& o) NOEXCEPT {
+    BackupAfterCopyWorkItem& operator=(BackupAfterCopyWorkItem&& o) ROCKSDB_NOEXCEPT {
       result = std::move(o.result);
       shared = o.shared;
       needed_to_copy = o.needed_to_copy;
@@ -419,11 +419,11 @@ class BackupEngineImpl : public BackupEngine {
     RestoreAfterCopyWorkItem(std::future<CopyResult>&& _result,
                              uint32_t _checksum_value)
         : result(std::move(_result)), checksum_value(_checksum_value) {}
-    RestoreAfterCopyWorkItem(RestoreAfterCopyWorkItem&& o) NOEXCEPT {
+    RestoreAfterCopyWorkItem(RestoreAfterCopyWorkItem&& o) ROCKSDB_NOEXCEPT {
       *this = std::move(o);
     }
 
-    RestoreAfterCopyWorkItem& operator=(RestoreAfterCopyWorkItem&& o) NOEXCEPT {
+    RestoreAfterCopyWorkItem& operator=(RestoreAfterCopyWorkItem&& o) ROCKSDB_NOEXCEPT {
       result = std::move(o.result);
       checksum_value = o.checksum_value;
       return *this;


### PR DESCRIPTION
  VS 2013 does not support noexcept.
   Complains about usage of ineteger constant within lambda requiring explicit capture.