### PR TITLE
fix compression choice when snappy unavailable

### DIFF
--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -520,9 +520,11 @@ enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
     return rocksdb::kLZ4HCCompression;
   else if (!strcasecmp(ctype, "zstd"))
     return rocksdb::kZSTDNotFinalCompression;
+  else if (!strcasecmp(ctype, "default"))
+    return rocksdb::DefaultCompressionType();
 
   fprintf(stdout, "Cannot parse compression type '%s'\n", ctype);
-  return rocksdb::kSnappyCompression; //default value
+  return rocksdb::DefaultCompressionType(); //default value
 }
 
 std::string ColumnFamilyName(size_t i) {
@@ -536,10 +538,10 @@ std::string ColumnFamilyName(size_t i) {
 }
 }  // namespace
 
-DEFINE_string(compression_type, "snappy",
+DEFINE_string(compression_type, "default",
               "Algorithm to use to compress the database");
 static enum rocksdb::CompressionType FLAGS_compression_type_e =
-    rocksdb::kSnappyCompression;
+    rocksdb::DefaultCompressionType();
 
 DEFINE_int32(compression_level, -1,
              "Compression level. For zlib this should be -1 for the "

--- a/db/db_dynamic_level_test.cc
+++ b/db/db_dynamic_level_test.cc
@@ -72,8 +72,10 @@ TEST_F(DBTestDynamicLevel, DynamicLevelMaxBytesBase) {
 
       options.compression_per_level.resize(3);
       options.compression_per_level[0] = kNoCompression;
-      options.compression_per_level[1] = kLZ4Compression;
-      options.compression_per_level[2] = kSnappyCompression;
+      options.compression_per_level[1] =
+          LZ4_Supported() ? kLZ4Compression : DefaultCompressionType();
+      options.compression_per_level[2] =
+          Snappy_Supported() ? kSnappyCompression : DefaultCompressionType();
 
       DestroyAndReopen(options);
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -65,6 +65,18 @@ enum CompressionType : char {
   kZSTDNotFinalCompression = 0x40,
 };
 
+// default compression types: prefer fast compression, or none if the faster
+// options (snappy, lz4) are unavailable
+inline CompressionType DefaultCompressionType() {
+#if   defined(SNAPPY)
+  return kSnappyCompression;
+#elif defined(LZ4)
+  return kLZ4Compression;
+#else
+  return kNoCompression;
+#endif
+}
+
 enum CompactionStyle : char {
   // level based compaction style
   kCompactionStyleLevel = 0x0,

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -345,16 +345,18 @@ enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
     return rocksdb::kLZ4HCCompression;
   else if (!strcasecmp(ctype, "zstd"))
     return rocksdb::kZSTDNotFinalCompression;
+  else if (!strcasecmp(ctype, "default"))
+    return rocksdb::DefaultCompressionType();
 
   fprintf(stdout, "Cannot parse compression type '%s'\n", ctype);
-  return rocksdb::kSnappyCompression; //default value
+  return rocksdb::DefaultCompressionType();
 }
 }  // namespace
 
-DEFINE_string(compression_type, "snappy",
+DEFINE_string(compression_type, "default",
               "Algorithm to use to compress the database");
 static enum rocksdb::CompressionType FLAGS_compression_type_e =
-    rocksdb::kSnappyCompression;
+    rocksdb::DefaultCompressionType();
 
 DEFINE_string(hdfs, "", "Name of hdfs environment");
 // posix or hdfs environment

--- a/util/options.cc
+++ b/util/options.cc
@@ -86,7 +86,7 @@ ColumnFamilyOptions::ColumnFamilyOptions()
       max_write_buffer_number(2),
       min_write_buffer_number_to_merge(1),
       max_write_buffer_number_to_maintain(0),
-      compression(Snappy_Supported() ? kSnappyCompression : kNoCompression),
+      compression(DefaultCompressionType()),
       prefix_extractor(nullptr),
       num_levels(7),
       level0_file_num_compaction_trigger(4),
@@ -633,7 +633,7 @@ ColumnFamilyOptions* ColumnFamilyOptions::OptimizeLevelStyleCompaction(
     if (i < 2) {
       compression_per_level[i] = kNoCompression;
     } else {
-      compression_per_level[i] = kSnappyCompression;
+      compression_per_level[i] = DefaultCompressionType();
     }
   }
   return this;

--- a/utilities/leveldb_options/leveldb_options.cc
+++ b/utilities/leveldb_options/leveldb_options.cc
@@ -29,7 +29,7 @@ LevelDBOptions::LevelDBOptions()
       block_cache(nullptr),
       block_size(4096),
       block_restart_interval(16),
-      compression(kSnappyCompression),
+      compression(DefaultCompressionType()),
       filter_policy(nullptr) {}
 
 Options ConvertOptions(const LevelDBOptions& leveldb_options) {


### PR DESCRIPTION
OptimizeLevelStyleCompaction unconditionally defaulted to kSnappyCompression,
which is a problem if it's not supported. Checks for and uses it, LZ4, or no
compression if neither are around.
