### PR TITLE
Allow storage backend to store metadata in manifest

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -137,6 +137,11 @@ Status BuildTable(
       StopWatch sw(env, ioptions.statistics, TABLE_SYNC_MICROS);
       file_writer->Sync(ioptions.use_fsync);
     }
+    if (s.ok()) {
+      meta->UpdatePrivateMetadataHandle(
+          file_writer->GetPrivateMetadataHandle());
+    }
+
     if (s.ok() && !empty) {
       s = file_writer->Close();
     }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1483,6 +1483,7 @@ Status DBImpl::FlushMemTableToOutputFile(
                            job_context->job_id, flush_job.GetTableProperties());
   }
 #endif  // ROCKSDB_LITE
+  file_meta.FreePrivateMetadata();
   return s;
 }
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 #include <string>
+#include "rocksdb/env.h"
 #include "rocksdb/cache.h"
 #include "db/dbformat.h"
 #include "util/arena.h"
@@ -72,6 +73,9 @@ struct FileMetaData {
   // Needs to be disposed when refs becomes 0.
   Cache::Handle* table_reader_handle;
 
+  // Private metadata belonging to the storage backend
+  FilePrivateMetadata* priv_meta;
+
   // Stats for compensating deletion entries during compaction
 
   // File size compensated by deletion entry.
@@ -96,6 +100,7 @@ struct FileMetaData {
         smallest_seqno(kMaxSequenceNumber),
         largest_seqno(0),
         table_reader_handle(nullptr),
+        priv_meta(nullptr),
         compensated_file_size(0),
         num_entries(0),
         num_deletions(0),
@@ -113,6 +118,39 @@ struct FileMetaData {
     largest.DecodeFrom(key);
     smallest_seqno = std::min(smallest_seqno, seqno);
     largest_seqno = std::max(largest_seqno, seqno);
+  }
+
+  void UpdatePrivateMetadataHandle(FilePrivateMetadata* handle) {
+    if (handle == nullptr) {
+      priv_meta = nullptr;
+      return;
+    }
+    if (priv_meta == nullptr) {
+      return;
+    }
+    priv_meta->FreePrivateMetadata();
+    priv_meta = handle;
+  }
+
+  void EncodePrivateMetadata(std::string* priv) const {
+    if (priv_meta == nullptr) {
+      return;
+    }
+    priv_meta->EncodePrivateMetadata(priv);
+  }
+
+  void DecodePrivateMetadata(Slice* input) {
+    if (priv_meta == nullptr) {
+      return;
+    }
+    priv_meta->DecodePrivateMetadata(input);
+  }
+
+  void FreePrivateMetadata() {
+    if (priv_meta == nullptr) {
+      return;
+    }
+    priv_meta->FreePrivateMetadata();
   }
 };
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -565,10 +565,15 @@ Status Version::GetTableProperties(std::shared_ptr<const TableProperties>* tp,
     s = ioptions->env->NewRandomAccessFile(
         *fname, &file, vset_->env_options_);
   } else {
-    s = ioptions->env->NewRandomAccessFile(
+    std::string new_fname =
         TableFileName(vset_->db_options_->db_paths, file_meta->fd.GetNumber(),
-                      file_meta->fd.GetPathId()),
-        &file, vset_->env_options_);
+                      file_meta->fd.GetPathId());
+    s = ioptions->env->LoadPrivateMetadata(new_fname, file_meta->priv_meta);
+    if (!s.ok()) {
+      return s;
+    }
+    s = ioptions->env->NewRandomAccessFile(new_fname, &file,
+                                           vset_->env_options_);
   }
   if (!s.ok()) {
     return s;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -41,6 +41,7 @@ class SequentialFile;
 class Slice;
 class WritableFile;
 class Directory;
+class FilePrivateMetadata;
 struct DBOptions;
 class RateLimiter;
 class ThreadStatusUpdater;
@@ -335,6 +336,11 @@ class Env {
   // Returns the ID of the current thread.
   virtual uint64_t GetThreadID() const;
 
+  // Load Env private metadata
+  virtual Status LoadPrivateMetadata(std::string fname, void* metadata) {
+    return Status::OK();
+  }
+
  protected:
   // The pointer to an internal structure that will update the
   // status of each thread.
@@ -344,6 +350,24 @@ class Env {
   // No copying allowed
   Env(const Env&);
   void operator=(const Env&);
+};
+
+class FilePrivateMetadata {
+ public:
+  FilePrivateMetadata() {}
+  virtual ~FilePrivateMetadata() {}
+
+  // Returns in dst the private metadata to be stored in the MANIEST in the
+  // encoding format defined in VersionEdit::EncodeTo
+  virtual void EncodePrivateMetadata(std::string* dst) {}
+
+  // Decodes the private metadata and stores it in this class. This metadata
+  // will be loaded in memory when the storage backend requires it through
+  // Env::LoadPrivateMetadata().
+  virtual void DecodePrivateMetadata(Slice* encoded_meta) {}
+
+  // Free all memory allocated by FilePrivateMetadata
+  virtual void FreePrivateMetadata() {}
 };
 
 // The factory function to construct a ThreadStatusUpdater.  Any Env
@@ -582,6 +606,10 @@ class WritableFile {
       last_preallocated_block_ = new_last_preallocated_block;
     }
   }
+
+  // Returns a handle to the metadata used by the storage backend implementing
+  // WritableFile
+  virtual FilePrivateMetadata* GetMetadataHandle() { return nullptr; }
 
  protected:
   /*

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -154,6 +154,10 @@ class WritableFileWriter {
 
   WritableFile* writable_file() const { return writable_file_.get(); }
 
+  FilePrivateMetadata* GetPrivateMetadataHandle() {
+    return writable_file_->GetMetadataHandle();
+  }
+
  private:
   // Used when os buffering is OFF and we are writing
   // DMA such as in Windows unbuffered mode


### PR DESCRIPTION
Allow storage backend to store private metadata

Summary: This patch provides a set of helper functions that would enable
a storage backend (e.g., posix, HDFS) to store sstable private metadata
in the manifest. This frees the storage backend from implementing its
own metadata mechanisms by reusing the functionality already present in
the manifest. This same idea can be applied to the WAL and MANIFEST; if
the mechanism is correct, patches for these will follow.

Test Plan: This patch has been tested in posix and in a new backend for
OpenChannel SSDs [1], where the private metadata functions have been
implemented. The idea is that testing functions are provided by the
storage backend when used.

[1] https://github.com/OpenChannelSSD
