### PR TITLE
Override DBImplReadOnly::SyncWAL() to return NotSupported.

### DIFF
--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -100,6 +100,11 @@ class DBImplReadOnly : public DBImpl {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
+  using DBImpl::SyncWAL;
+  virtual Status SyncWAL() override {
+    return Status::NotSupported("Not supported operation in read only mode.");
+  }
+
  private:
   friend class DB;
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -244,6 +244,7 @@ TEST_F(DBTest, ReadOnlyDB) {
   ASSERT_OK(ReadOnlyReopen(options));
   ASSERT_EQ("v3", Get("foo"));
   ASSERT_EQ("v2", Get("bar"));
+  ASSERT_TRUE(db_->SyncWAL().IsNotSupported());
 }
 
 TEST_F(DBTest, CompactedDB) {


### PR DESCRIPTION
Previously, calling it caused program abort.