### PR TITLE
Improve CI build and fix Windows build breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # 3. Run cmake to generate project files for Windows, add more options to enable required third-party libraries.
 #    See thirdparty.inc for more information.
 #        cmake -G "Visual Studio 12 Win64" .. <more options>
-# 4. Then build the project in debug mode (you may want to add /m:<N> flag to run msbuild in <N> parallel threads)
+# 4. Then build the project in debug mode (you may want to add /m[:<N>] flag to run msbuild in <N> parallel threads)
 #        msbuild ALL_BUILD.vcxproj
-# 5. And release mode (/m:<N> is also supported)
+# 5. And release mode (/m[:<N>] is also supported)
 #        msbuild ALL_BUILD.vcxproj /p:Configuration=Release
 #
 
@@ -58,7 +58,7 @@ else()
 endif()
 
 if((${OPTIMIZE_DEBUG} EQUAL 1))
-   message("Debug optimization is enabled")
+   message(STATUS "Debug optimization is enabled")
    set(CMAKE_CXX_FLAGS_DEBUG "/Oxt /MDd")
 else()
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /RTC1 /Gm /MDd")
@@ -153,6 +153,7 @@ set(SOURCES
         table/get_context.cc
         table/iterator.cc
         table/merger.cc
+        table/sst_file_writer.cc
         table/meta_blocks.cc
         table/mock_table.cc
         table/plain_table_builder.cc
@@ -271,8 +272,9 @@ set(APPS
         util/cache_bench.cc
 )
 
+set(C_TESTS db/c_test.c)
+
 set(TESTS
-        db/c_test.c
         db/column_family_test.cc
         db/compact_files_test.cc
         db/compaction_job_test.cc
@@ -367,8 +369,17 @@ set(EXES ${APPS} ${TESTS})
 
 foreach(sourcefile ${EXES})
     string(REPLACE ".cc" "" exename ${sourcefile})
-    string(REPLACE ".c" "" exename ${exename})
     string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
     add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
     target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
 endforeach(sourcefile ${EXES})
+
+# C executables must link to a shared object
+set(C_EXES ${C_TESTS})
+
+foreach(sourcefile ${C_EXES})
+    string(REPLACE ".c" "" exename ${sourcefile})
+    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
+    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb${ARTIFACT_SUFFIX})
+endforeach(sourcefile ${C_TESTS})

--- a/appveyordailytests.yml
+++ b/appveyordailytests.yml
@@ -11,3 +11,12 @@ build:
 test:
 test_script:
 - ps: build_tools\run_ci_db_test.ps1
+notifications:
+  - provider: Email
+    to:
+      - svmtrocksdb@microsoft.com
+    subject: "Build {{status}}"
+    message: "{{message}}, {{commitId}}, ..."
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: true

--- a/thirdparty.inc
+++ b/thirdparty.inc
@@ -35,7 +35,7 @@ else ()
 endif ()
 
 if (${USE_GFLAGS} EQUAL 1)
-  message("GFLAGS library is enabled")
+  message(STATUS "GFLAGS library is enabled")
   set(GFLAGS_CXX_FLAGS -DGFLAGS=gflags)
   set(GFLAGS_LIBS debug ${GFLAGS_LIB_DEBUG} optimized ${GFLAGS_LIB_RELEASE})
 
@@ -43,7 +43,7 @@ if (${USE_GFLAGS} EQUAL 1)
   include_directories(${GFLAGS_INCLUDE})
   set (THIRDPARTY_LIBS ${THIRDPARTY_LIBS} ${GFLAGS_LIBS})
 else ()
-  message("GFLAGS library is disabled")
+  message(STATUS "GFLAGS library is disabled")
 endif ()
 
 # ================================================== SNAPPY ==================================================
@@ -65,7 +65,7 @@ else ()
 endif ()
 
 if (${USE_SNAPPY} EQUAL 1)
-  message("SNAPPY library is enabled")
+  message(STATUS "SNAPPY library is enabled")
   set(SNAPPY_CXX_FLAGS -DSNAPPY)
   set(SNAPPY_LIBS debug ${SNAPPY_LIB_DEBUG} optimized ${SNAPPY_LIB_RELEASE})
 
@@ -73,7 +73,7 @@ if (${USE_SNAPPY} EQUAL 1)
   include_directories(${SNAPPY_INCLUDE})
   set (THIRDPARTY_LIBS ${THIRDPARTY_LIBS} ${SNAPPY_LIBS})
 else ()
-  message("SNAPPY library is disabled")
+  message(STATUS "SNAPPY library is disabled")
 endif ()
 
 # ================================================== LZ4 ==================================================
@@ -95,7 +95,7 @@ else ()
 endif ()
 
 if (${USE_LZ4} EQUAL 1)
-  message("LZ4 library is enabled")
+  message(STATUS "LZ4 library is enabled")
   set(LZ4_CXX_FLAGS -DLZ4)
   set(LZ4_LIBS debug ${LZ4_LIB_DEBUG} optimized ${LZ4_LIB_RELEASE})
 
@@ -103,7 +103,7 @@ if (${USE_LZ4} EQUAL 1)
   include_directories(${LZ4_INCLUDE})
   set (THIRDPARTY_LIBS ${THIRDPARTY_LIBS} ${LZ4_LIBS})
 else ()
-  message("LZ4 library is disabled")
+  message(STATUS "LZ4 library is disabled")
 endif ()
 
 # ================================================== ZLIB ==================================================
@@ -125,7 +125,7 @@ else ()
 endif ()
 
 if (${USE_ZLIB} EQUAL 1)
-  message("ZLIB library is enabled")
+  message(STATUS "ZLIB library is enabled")
   set(ZLIB_CXX_FLAGS -DZLIB)
   set(ZLIB_LIBS debug ${ZLIB_LIB_DEBUG} optimized ${ZLIB_LIB_RELEASE})
 
@@ -133,7 +133,7 @@ if (${USE_ZLIB} EQUAL 1)
   include_directories(${ZLIB_INCLUDE})
   set (THIRDPARTY_LIBS ${THIRDPARTY_LIBS} ${ZLIB_LIBS})
 else ()
-  message("ZLIB library is disabled")
+  message(STATUS "ZLIB library is disabled")
 endif ()
 
 #
@@ -155,7 +155,7 @@ else ()
 endif ()
 
 if (${USE_JEMALLOC} EQUAL 1)
-  message("JEMALLOC library is enabled")
+  message(STATUS "JEMALLOC library is enabled")
   set(JEMALLOC_CXX_FLAGS -DJEMALLOC)
   set(JEMALLOC_LIBS debug ${JEMALLOC_LIB_DEBUG} optimized ${JEMALLOC_LIB_RELEASE})
 
@@ -165,5 +165,5 @@ if (${USE_JEMALLOC} EQUAL 1)
   set (ARTIFACT_SUFFIX "_je")
 else ()
   set (ARTIFACT_SUFFIX "")
-  message("JEMALLOC library is disabled")
+  message(STATUS "JEMALLOC library is disabled")
 endif ()

--- a/util/options_parser.cc
+++ b/util/options_parser.cc
@@ -18,6 +18,8 @@
 #include "util/options_helper.h"
 #include "util/string_util.h"
 
+#include "port/port.h"
+
 namespace rocksdb {
 
 static const std::string option_file_header =


### PR DESCRIPTION
  Add missing file from CMake that breaks a build
  Add port include to options_parser that makes use of snprintf
  Is there a way to enforce CMake additions for internal changes that seem to come
  w/o a PR?
  Add notifications for daily appveyor