### PR TITLE
Mmap reads should not return error if reading past file

### DIFF
--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -233,13 +233,14 @@ class WinMmapReadableFile : public RandomAccessFile {
                       char* scratch) const override {
     Status s;
 
-    if (offset + n > length_) {
+    if (offset > length_) {
       *result = Slice();
-      s = IOError(fileName_, EINVAL);
-    } else {
-      *result =
-          Slice(reinterpret_cast<const char*>(mapped_region_) + offset, n);
+      return IOError(fileName_, EINVAL);
+    } else if (offset + n > length_) {
+      n = length_ - offset;
     }
+    *result =
+        Slice(reinterpret_cast<const char*>(mapped_region_) + offset, n);
     return s;
   }
 


### PR DESCRIPTION
Summary:
  This mirrors  https://reviews.facebook.net/D45645
  Currently, mmap returns IOError when user tries to read
  data past the end of the file. This diff changes the behavior.
  Now, we return just the bytes that we can, and report the size
  we returned via a Slice result. This is consistent with non-mmap
  behavior and also pread() system call.