### PR TITLE
move debug variable under ifndef NDEBUG

### DIFF
--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -114,8 +114,11 @@ class CondVar;
 class Mutex {
  public:
 
-   /* implicit */ Mutex(bool adaptive = false) : locked_(false) {
-  }
+   /* implicit */ Mutex(bool adaptive = false)
+#ifndef NDEBUG
+     : locked_(false)
+#endif
+   { }
 
   ~Mutex();
 


### PR DESCRIPTION
Need to move debug variable under #ifndef NDEBUG. Sorry it was missed earlier.

Changes are in Windows port only.