### PR TITLE
Fix MockTable ID storage

### DIFF
--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -77,7 +77,7 @@ Status MockTableFactory::NewTableReader(
 TableBuilder* MockTableFactory::NewTableBuilder(
     const TableBuilderOptions& table_builder_options, uint32_t column_family_id,
     WritableFileWriter* file) const {
-  uint32_t id = GetAndWriteNextID(file->writable_file());
+  uint32_t id = GetAndWriteNextID(file);
 
   return new MockTableBuilder(id, &file_system_);
 }
@@ -90,12 +90,14 @@ Status MockTableFactory::CreateMockTable(Env* env, const std::string& fname,
     return s;
   }
 
-  uint32_t id = GetAndWriteNextID(file.get());
+  WritableFileWriter file_writer(std::move(file), EnvOptions());
+
+  uint32_t id = GetAndWriteNextID(&file_writer);
   file_system_.files.insert({id, std::move(file_contents)});
   return Status::OK();
 }
 
-uint32_t MockTableFactory::GetAndWriteNextID(WritableFile* file) const {
+uint32_t MockTableFactory::GetAndWriteNextID(WritableFileWriter* file) const {
   uint32_t next_id = next_id_.fetch_add(1);
   char buf[4];
   EncodeFixed32(buf, next_id);

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -176,7 +176,7 @@ class MockTableFactory : public TableFactory {
   void AssertLatestFile(const stl_wrappers::KVMap& file_contents);
 
  private:
-  uint32_t GetAndWriteNextID(WritableFile* file) const;
+  uint32_t GetAndWriteNextID(WritableFileWriter* file) const;
   uint32_t GetIDFromFile(RandomAccessFileReader* file) const;
 
   mutable MockTableFileSystem file_system_;


### PR DESCRIPTION
  On Windows two tests fail that use MockTable:
  flush_job_test and compaction_job_test with the following message:
  compaction_job_test_je.exe : Assertion failed: result.size() == 4,
  file c:\dev\rocksdb\rocksdb\table\mock_table.cc, line 110

  Investigation reveals that this failure occurs when a 4 byte
  ID written to a beginning of the physically open file (main
  contents remains in a in-memory map) can not be read back.

  The reason for the failure is that the ID is written directly
  to a WritableFile bypassing WritableFileWriter. The side effect of that
  is that pending_sync_ never becomes true so the file is never flushed,
  however, the direct cause of the failure is that the filesize_ member
  of the WritableFileWriter remains zero. At Close() the file is truncated
  to that size and the file becomes empty so the ID can not be read back.