### PR TITLE
Add Option to Skip Flushing in TableBuilder

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -43,11 +43,12 @@ TableBuilder* NewTableBuilder(
         int_tbl_prop_collector_factories,
     uint32_t column_family_id, WritableFileWriter* file,
     const CompressionType compression_type,
-    const CompressionOptions& compression_opts, const bool skip_filters) {
+    const CompressionOptions& compression_opts, 
+    const bool skip_filters, const bool skip_flush) {
   return ioptions.table_factory->NewTableBuilder(
       TableBuilderOptions(ioptions, internal_comparator,
                           int_tbl_prop_collector_factories, compression_type,
-                          compression_opts, skip_filters),
+                          compression_opts, skip_filters, skip_flush),
       column_family_id, file);
 }
 
@@ -86,7 +87,8 @@ Status BuildTable(
 
       builder = NewTableBuilder(
           ioptions, internal_comparator, int_tbl_prop_collector_factories,
-          column_family_id, file_writer.get(), compression, compression_opts);
+          column_family_id, file_writer.get(), compression, compression_opts,
+          false, env_options.skip_table_builder_flush);
     }
 
     MergeHelper merge(env, internal_comparator.user_comparator(),

--- a/db/builder.h
+++ b/db/builder.h
@@ -41,7 +41,8 @@ TableBuilder* NewTableBuilder(
     uint32_t column_family_id, WritableFileWriter* file,
     const CompressionType compression_type,
     const CompressionOptions& compression_opts,
-    const bool skip_filters = false);
+    const bool skip_filters = false,
+    const bool skip_flush = false);
 
 // Build a Table file from the contents of *iter.  The generated file
 // will be named according to number specified in meta. On success, the rest of

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -939,11 +939,12 @@ Status CompactionJob::OpenCompactionOutputFile(
   // data is going to be found
   bool skip_filters =
       cfd->ioptions()->optimize_filters_for_hits && bottommost_level_;
+  bool skip_flush = db_options_.skip_table_builder_flush;
   sub_compact->builder.reset(NewTableBuilder(
       *cfd->ioptions(), cfd->internal_comparator(),
       cfd->int_tbl_prop_collector_factories(), cfd->GetID(),
       sub_compact->outfile.get(), sub_compact->compaction->output_compression(),
-      cfd->ioptions()->compression_opts, skip_filters));
+      cfd->ioptions()->compression_opts, skip_filters, skip_flush));
   LogFlush(db_options_.info_log);
   return s;
 }

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -376,6 +376,12 @@ DEFINE_int32(compaction_readahead_size, 0, "Compaction readahead size");
 DEFINE_int32(random_access_max_buffer_size, 1024 * 1024,
              "Maximum windows randomaccess buffer size");
 
+DEFINE_int32(writable_file_max_buffer_size, 1024 * 1024, 
+             "Maximum write buffer for Writeable File");
+
+DEFINE_int32(skip_table_builder_flush, false, "Skip flushing block in "
+             "table builder ");
+
 DEFINE_int32(bloom_bits, -1, "Bloom filter bits per key. Negative means"
              " use default settings.");
 DEFINE_int32(memtable_bloom_bits, 0, "Bloom filter bits per key for memtable. "
@@ -2299,6 +2305,8 @@ class Benchmark {
         FLAGS_new_table_reader_for_compaction_inputs;
     options.compaction_readahead_size = FLAGS_compaction_readahead_size;
     options.random_access_max_buffer_size = FLAGS_random_access_max_buffer_size;
+    options.writable_file_max_buffer_size = FLAGS_writable_file_max_buffer_size;
+    options.skip_table_builder_flush = FLAGS_skip_table_builder_flush;
     options.statistics = dbstats;
     if (FLAGS_enable_io_prio) {
       FLAGS_env->LowerThreadPoolIOPriority(Env::LOW);

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -43,6 +43,12 @@ Status GetBlockBasedTableOptionsFromMap(
     BlockBasedTableOptions* new_table_options,
     bool input_strings_escaped = false);
 
+Status GetPlainTableOptionsFromMap(
+    const PlainTableOptions& table_options,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    PlainTableOptions* new_table_options,
+    bool input_strings_escaped = false);
+
 // Take a string representation of option names and  values, apply them into the
 // base_options, and return the new options as a result. The string has the
 // following format:
@@ -73,6 +79,11 @@ Status GetBlockBasedTableOptionsFromString(
     const BlockBasedTableOptions& table_options,
     const std::string& opts_str,
     BlockBasedTableOptions* new_table_options);
+
+Status GetPlainTableOptionsFromString(
+    const PlainTableOptions& table_options,
+    const std::string& opts_str,
+    PlainTableOptions* new_table_options);
 
 Status GetOptionsFromString(const Options& base_options,
                             const std::string& opts_str, Options* new_options);

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -94,6 +94,12 @@ struct EnvOptions {
   // See DBOPtions doc
   size_t random_access_max_buffer_size;
 
+  // See DBOptions doc
+  size_t writable_file_max_buffer_size = 1024 * 1024;
+
+  // See DBOptions doc
+  bool skip_table_builder_flush = false;
+
   // If not nullptr, write rate limiting is enabled for flush and compaction
   RateLimiter* rate_limiter = nullptr;
 };

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1089,6 +1089,27 @@ struct DBOptions {
   // Default: 1 Mb
   size_t random_access_max_buffer_size;
 
+  // This is the maximum buffer size that is used by WritableFileWriter.
+  // On Windows, we need to maintain an aligned buffer for writes. 
+  // We allow the buffer to grow until it's size hits the limit. 
+  //
+  // Default: 1024 * 1024 (1 MB)
+  size_t writable_file_max_buffer_size;
+
+  // If true, block will not be explictly flushed to disk during building
+  // a SstTable. Instead, buffer in WritableFileWriter will take 
+  // care of the flushing when it is full. 
+  //
+  // On Windows, this option helps a lot when unbuffered I/O 
+  // (allow_os_buffer = false) is used, since it avoids small 
+  // unbuffered disk write. 
+  //
+  // User may also adjust writable_file_max_buffer_size to optimize disk I/O 
+  // size. 
+  //
+  // Default: false
+  bool skip_table_builder_flush;
+
   // Use adaptive mutex, which spins in the user space before resorting
   // to kernel. This could reduce context switch when the mutex is not
   // heavily contended. However, if the mutex is hot, we could end up

--- a/table/block_based_table_builder.h
+++ b/table/block_based_table_builder.h
@@ -42,7 +42,8 @@ class BlockBasedTableBuilder : public TableBuilder {
           int_tbl_prop_collector_factories,
       uint32_t column_family_id, WritableFileWriter* file,
       const CompressionType compression_type,
-      const CompressionOptions& compression_opts, const bool skip_filters);
+      const CompressionOptions& compression_opts, 
+      const bool skip_filters, const bool skip_flush);
 
   // REQUIRES: Either Finish() or Abandon() has been called.
   ~BlockBasedTableBuilder();
@@ -100,6 +101,8 @@ class BlockBasedTableBuilder : public TableBuilder {
   // the same data block.  Most clients should not need to use this method.
   // REQUIRES: Finish(), Abandon() have not been called
   void Flush();
+
+  void SealDataBlock();
 
   // Some compression libraries fail when the raw size is bigger than int. If
   // uncompressed size is bigger than kCompressionSizeLimit, don't compress it

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -69,7 +69,8 @@ TableBuilder* BlockBasedTableFactory::NewTableBuilder(
       table_builder_options.int_tbl_prop_collector_factories, column_family_id,
       file, table_builder_options.compression_type,
       table_builder_options.compression_opts,
-      table_builder_options.skip_filters);
+      table_builder_options.skip_filters,
+      table_builder_options.skip_flush);
 
   return table_builder;
 }

--- a/table/plain_table_factory.cc
+++ b/table/plain_table_factory.cc
@@ -21,8 +21,9 @@ Status PlainTableFactory::NewTableReader(
   return PlainTableReader::Open(
       table_reader_options.ioptions, table_reader_options.env_options,
       table_reader_options.internal_comparator, std::move(file), file_size,
-      table, bloom_bits_per_key_, hash_table_ratio_, index_sparseness_,
-      huge_page_tlb_size_, full_scan_mode_);
+      table, table_options_.bloom_bits_per_key, table_options_.hash_table_ratio, 
+      table_options_.index_sparseness, table_options_.huge_page_tlb_size, 
+      table_options_.full_scan_mode);
 }
 
 TableBuilder* PlainTableFactory::NewTableBuilder(
@@ -35,9 +36,10 @@ TableBuilder* PlainTableFactory::NewTableBuilder(
   return new PlainTableBuilder(
       table_builder_options.ioptions,
       table_builder_options.int_tbl_prop_collector_factories, column_family_id,
-      file, user_key_len_, encoding_type_, index_sparseness_,
-      bloom_bits_per_key_, 6, huge_page_tlb_size_, hash_table_ratio_,
-      store_index_in_file_);
+      file, table_options_.user_key_len, table_options_.encoding_type, 
+      table_options_.index_sparseness, table_options_.bloom_bits_per_key, 6, 
+      table_options_.huge_page_tlb_size, table_options_.hash_table_ratio,
+      table_options_.store_index_in_file);
 }
 
 std::string PlainTableFactory::GetPrintableTableOptions() const {
@@ -47,30 +49,34 @@ std::string PlainTableFactory::GetPrintableTableOptions() const {
   char buffer[kBufferSize];
 
   snprintf(buffer, kBufferSize, "  user_key_len: %u\n",
-           user_key_len_);
+           table_options_.user_key_len);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  bloom_bits_per_key: %d\n",
-           bloom_bits_per_key_);
+           table_options_.bloom_bits_per_key);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  hash_table_ratio: %lf\n",
-           hash_table_ratio_);
+           table_options_.hash_table_ratio);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  index_sparseness: %" ROCKSDB_PRIszt "\n",
-           index_sparseness_);
+           table_options_.index_sparseness);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  huge_page_tlb_size: %" ROCKSDB_PRIszt "\n",
-           huge_page_tlb_size_);
+           table_options_.huge_page_tlb_size);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  encoding_type: %d\n",
-           encoding_type_);
+           table_options_.encoding_type);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  full_scan_mode: %d\n",
-           full_scan_mode_);
+           table_options_.full_scan_mode);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  store_index_in_file: %d\n",
-           store_index_in_file_);
+           table_options_.store_index_in_file);
   ret.append(buffer);
   return ret;
+}
+
+const PlainTableOptions& PlainTableFactory::GetTableOptions() const {
+  return table_options_;
 }
 
 extern TableFactory* NewPlainTableFactory(const PlainTableOptions& options) {

--- a/table/plain_table_factory.h
+++ b/table/plain_table_factory.h
@@ -142,26 +142,23 @@ class PlainTableFactory : public TableFactory {
   // huge_page_tlb_size determines whether to allocate hash indexes from huge
   // page TLB and the page size if allocating from there. See comments of
   // Arena::AllocateAligned() for details.
-  explicit PlainTableFactory(const PlainTableOptions& options =
-                                 PlainTableOptions())
-      : user_key_len_(options.user_key_len),
-        bloom_bits_per_key_(options.bloom_bits_per_key),
-        hash_table_ratio_(options.hash_table_ratio),
-        index_sparseness_(options.index_sparseness),
-        huge_page_tlb_size_(options.huge_page_tlb_size),
-        encoding_type_(options.encoding_type),
-        full_scan_mode_(options.full_scan_mode),
-        store_index_in_file_(options.store_index_in_file) {}
+  explicit PlainTableFactory(const PlainTableOptions& table_options =
+                             PlainTableOptions())
+      : table_options_(table_options) {};
+
   const char* Name() const override { return "PlainTable"; }
   Status NewTableReader(const TableReaderOptions& table_reader_options,
                         unique_ptr<RandomAccessFileReader>&& file,
                         uint64_t file_size,
                         unique_ptr<TableReader>* table) const override;
+  
   TableBuilder* NewTableBuilder(
       const TableBuilderOptions& table_builder_options,
       uint32_t column_family_id, WritableFileWriter* file) const override;
 
   std::string GetPrintableTableOptions() const override;
+
+  const PlainTableOptions& GetTableOptions() const;
 
   static const char kValueTypeSeqId0 = 0xFF;
 
@@ -172,14 +169,7 @@ class PlainTableFactory : public TableFactory {
   }
 
  private:
-  uint32_t user_key_len_;
-  int bloom_bits_per_key_;
-  double hash_table_ratio_;
-  size_t index_sparseness_;
-  size_t huge_page_tlb_size_;
-  EncodingType encoding_type_;
-  bool full_scan_mode_;
-  bool store_index_in_file_;
+  PlainTableOptions table_options_;
 };
 
 }  // namespace rocksdb

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -114,7 +114,8 @@ Status SstFileWriter::Open(const std::string& file_path) {
 
   TableBuilderOptions table_builder_options(
       r->ioptions, r->internal_comparator, &int_tbl_prop_collector_factories,
-      compression_type, r->ioptions.compression_opts, false);
+      compression_type, r->ioptions.compression_opts, false, 
+      r->env_options.skip_table_builder_flush);
   r->file_writer.reset(
       new WritableFileWriter(std::move(sst_file), r->env_options));
   r->builder.reset(r->ioptions.table_factory->NewTableBuilder(

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -44,13 +44,15 @@ struct TableBuilderOptions {
       const std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
           _int_tbl_prop_collector_factories,
       CompressionType _compression_type,
-      const CompressionOptions& _compression_opts, bool _skip_filters)
+      const CompressionOptions& _compression_opts, 
+      bool _skip_filters, bool _skip_flush)
       : ioptions(_ioptions),
         internal_comparator(_internal_comparator),
         int_tbl_prop_collector_factories(_int_tbl_prop_collector_factories),
         compression_type(_compression_type),
         compression_opts(_compression_opts),
-        skip_filters(_skip_filters) {}
+        skip_filters(_skip_filters),
+        skip_flush(_skip_flush) {}
   const ImmutableCFOptions& ioptions;
   const InternalKeyComparator& internal_comparator;
   const std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
@@ -58,6 +60,7 @@ struct TableBuilderOptions {
   CompressionType compression_type;
   const CompressionOptions& compression_opts;
   bool skip_filters = false;
+  bool skip_flush = false;
 };
 
 // TableBuilder provides the interface used to build a Table

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -98,7 +98,8 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
     tb = opts.table_factory->NewTableBuilder(
         TableBuilderOptions(ioptions, ikc, &int_tbl_prop_collector_factories,
                             CompressionType::kNoCompression,
-                            CompressionOptions(), false),
+                            CompressionOptions(), false, 
+                            env_options.skip_table_builder_flush),
         0, file_writer.get());
   } else {
     s = DB::Open(opts, dbname, &db);

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -273,7 +273,8 @@ class TableConstructor: public Constructor {
     builder.reset(ioptions.table_factory->NewTableBuilder(
         TableBuilderOptions(ioptions, internal_comparator,
                             &int_tbl_prop_collector_factories,
-                            options.compression, CompressionOptions(), false),
+                            options.compression, CompressionOptions(), 
+                            false, options.skip_table_builder_flush),
         TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
         file_writer_.get()));
 
@@ -1845,7 +1846,8 @@ TEST_F(PlainTableTest, BasicPlainTableProperties) {
       int_tbl_prop_collector_factories;
   std::unique_ptr<TableBuilder> builder(factory.NewTableBuilder(
       TableBuilderOptions(ioptions, ikc, &int_tbl_prop_collector_factories,
-                          kNoCompression, CompressionOptions(), false),
+                          kNoCompression, CompressionOptions(),
+                          false, options.skip_table_builder_flush),
       TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
       file_writer.get()));
 

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -61,7 +61,7 @@ void createSST(const std::string& file_name,
   tb.reset(opts.table_factory->NewTableBuilder(
       TableBuilderOptions(imoptions, ikc, &int_tbl_prop_collector_factories,
                           CompressionType::kNoCompression, CompressionOptions(),
-                          false),
+                          false, env_options.skip_table_builder_flush),
       TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
       file_writer.get()));
 

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -177,7 +177,7 @@ int SstFileReader::ShowAllCompressionSizes(size_t block_size) {
                                     : CompressionType(i + 1)) {
     CompressionOptions compress_opt;
     TableBuilderOptions tb_opts(imoptions, ikc, &block_based_table_factories, i,
-                                compress_opt, false);
+                                compress_opt, false, false);
     uint64_t file_size = CalculateCompressedTableSize(tb_opts, block_size);
     fprintf(stdout, "Compression: %s", compress_type.find(i)->second);
     fprintf(stdout, " Size: %" PRIu64 "\n", file_size);

--- a/util/env.cc
+++ b/util/env.cc
@@ -295,7 +295,14 @@ void AssignEnvOptions(EnvOptions* env_options, const DBOptions& options) {
   env_options->compaction_readahead_size = options.compaction_readahead_size;
   env_options->random_access_max_buffer_size =
       options.random_access_max_buffer_size;
+<<<<<<< HEAD
+  env_options->random_access_max_buffer_size = options.random_access_max_buffer_size;
+=======
+>>>>>>> origin/SkipFlush
   env_options->rate_limiter = options.rate_limiter.get();
+  env_options->writable_file_max_buffer_size = 
+                  options.writable_file_max_buffer_size;
+  env_options->skip_table_builder_flush = options.skip_table_builder_flush;
   env_options->allow_fallocate = options.allow_fallocate;
 }
 

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -21,10 +21,6 @@
 
 namespace rocksdb {
 
-namespace {
-  const size_t c_OneMb = (1 << 20);
-}
-
 Status SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
   Status s = file_->Read(n, result, scratch);
   IOSTATS_ADD(bytes_read, result->size());
@@ -76,9 +72,9 @@ Status WritableFileWriter::Append(const Slice& data) {
       }
     }
 
-    if (buf_.Capacity() < c_OneMb) {
+    if (buf_.Capacity() < max_buffer_size_) {
       size_t desiredCapacity = buf_.Capacity() * 2;
-      desiredCapacity = std::min(desiredCapacity, c_OneMb);
+      desiredCapacity = std::min(desiredCapacity, max_buffer_size_);
       buf_.AllocateNewBuffer(desiredCapacity);
     }
     assert(buf_.CurrentSize() == 0);
@@ -102,9 +98,9 @@ Status WritableFileWriter::Append(const Slice& data) {
         // We double the buffer here because
         // Flush calls do not keep up with the incoming bytes
         // This is the only place when buffer is changed with unbuffered I/O
-        if (buf_.Capacity() < c_OneMb) {
+        if (buf_.Capacity() < max_buffer_size_) {
           size_t desiredCapacity = buf_.Capacity() * 2;
-          desiredCapacity = std::min(desiredCapacity, c_OneMb);
+          desiredCapacity = std::min(desiredCapacity, max_buffer_size_);
           buf_.AllocateNewBuffer(desiredCapacity);
         }
       }
@@ -155,7 +151,6 @@ Status WritableFileWriter::Close() {
 
   return s;
 }
-
 
 // write out the cached data to the OS cache
 Status WritableFileWriter::Flush() {

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -93,6 +93,7 @@ class WritableFileWriter {
  private:
   std::unique_ptr<WritableFile> writable_file_;
   AlignedBuffer           buf_;
+  size_t                  max_buffer_size_;
   // Actually written data size can be used for truncate
   // not counting padding data
   uint64_t                filesize_;
@@ -113,6 +114,7 @@ class WritableFileWriter {
                      const EnvOptions& options)
       : writable_file_(std::move(file)),
         buf_(),
+        max_buffer_size_(options.writable_file_max_buffer_size),
         filesize_(0),
         next_write_offset_(0),
         pending_sync_(false),

--- a/util/options.cc
+++ b/util/options.cc
@@ -251,6 +251,8 @@ DBOptions::DBOptions()
       new_table_reader_for_compaction_inputs(false),
       compaction_readahead_size(0),
       random_access_max_buffer_size(1024 * 1024),
+      writable_file_max_buffer_size(1024 * 1024),
+      skip_table_builder_flush(false),
       use_adaptive_mutex(false),
       bytes_per_sync(0),
       wal_bytes_per_sync(0),
@@ -313,6 +315,8 @@ DBOptions::DBOptions(const Options& options)
           options.new_table_reader_for_compaction_inputs),
       compaction_readahead_size(options.compaction_readahead_size),
       random_access_max_buffer_size(options.random_access_max_buffer_size),
+      writable_file_max_buffer_size(options.writable_file_max_buffer_size),
+      skip_table_builder_flush(options.skip_table_builder_flush),
       use_adaptive_mutex(options.use_adaptive_mutex),
       bytes_per_sync(options.bytes_per_sync),
       wal_bytes_per_sync(options.wal_bytes_per_sync),
@@ -412,6 +416,13 @@ void DBOptions::Dump(Logger* log) const {
         "               Options.random_access_max_buffer_size: %" ROCKSDB_PRIszt
         "d",
         random_access_max_buffer_size);
+    Header(log,
+         "              Options.writable_file_max_buffer_size: %" ROCKSDB_PRIszt
+         "d",
+         writable_file_max_buffer_size);
+    Header(log,
+         "              Options.skip_table_builder_flush: %d",
+         skip_table_builder_flush);
     Header(log, "                      Options.use_adaptive_mutex: %d",
         use_adaptive_mutex);
     Header(log, "                            Options.rate_limiter: %p",

--- a/util/options_helper.h
+++ b/util/options_helper.h
@@ -87,6 +87,7 @@ enum class OptionType {
   kFilterPolicy,
   kFlushBlockPolicyFactory,
   kChecksumType,
+  kEncodingType,
   kUnknown
 };
 
@@ -181,8 +182,19 @@ static std::unordered_map<std::string, OptionTypeInfo> db_options_type_info = {
      {offsetof(struct DBOptions, compaction_readahead_size), OptionType::kSizeT,
       OptionVerificationType::kNormal}},
     {"random_access_max_buffer_size",
-     {offsetof(struct DBOptions, random_access_max_buffer_size),
+<<<<<<< HEAD
+     { offsetof(struct DBOptions, random_access_max_buffer_size), 
       OptionType::kSizeT, OptionVerificationType::kNormal}},
+=======
+     { offsetof(struct DBOptions, random_access_max_buffer_size), OptionType::kSizeT,
+      OptionVerificationType::kNormal}},
+>>>>>>> origin/SkipFlush
+    {"writable_file_max_buffer_size",
+     {offsetof(struct DBOptions, writable_file_max_buffer_size),  
+      OptionType::kSizeT, OptionVerificationType::kNormal}},
+    {"skip_table_builder_flush",
+     {offsetof(struct DBOptions, skip_table_builder_flush),  
+      OptionType::kBoolean, OptionVerificationType::kNormal}},
     {"use_adaptive_mutex",
      {offsetof(struct DBOptions, use_adaptive_mutex), OptionType::kBoolean,
       OptionVerificationType::kNormal}},
@@ -462,6 +474,34 @@ static std::unordered_map<std::string,
     {"format_version",
      {offsetof(struct BlockBasedTableOptions, format_version),
       OptionType::kUInt32T, OptionVerificationType::kNormal}}};
+
+static std::unordered_map<std::string, 
+                          OptionTypeInfo> plain_table_type_info = {
+      {"user_key_len", 
+       {offsetof(struct PlainTableOptions, user_key_len),
+        OptionType::kUInt32T, OptionVerificationType::kNormal}},
+      {"bloom_bits_per_key", 
+       {offsetof(struct PlainTableOptions, bloom_bits_per_key),
+        OptionType::kInt, OptionVerificationType::kNormal}},
+      {"hash_table_ratio", 
+       {offsetof(struct PlainTableOptions, hash_table_ratio),
+        OptionType::kDouble, OptionVerificationType::kNormal}},
+      {"index_sparseness", 
+       {offsetof(struct PlainTableOptions, index_sparseness),
+        OptionType::kSizeT, OptionVerificationType::kNormal}},
+      {"huge_page_tlb_size", 
+       {offsetof(struct PlainTableOptions, huge_page_tlb_size),
+        OptionType::kSizeT, OptionVerificationType::kNormal}},
+      {"encoding_type", 
+       {offsetof(struct PlainTableOptions, encoding_type),
+        OptionType::kEncodingType, OptionVerificationType::kByName}},
+      {"full_scan_mode", 
+       {offsetof(struct PlainTableOptions, full_scan_mode),
+        OptionType::kBoolean, OptionVerificationType::kNormal}},
+      {"store_index_in_file", 
+       {offsetof(struct PlainTableOptions, store_index_in_file),
+        OptionType::kBoolean, OptionVerificationType::kNormal}}};  
+
 }  // namespace rocksdb
 
 #endif  // !ROCKSDB_LITE

--- a/util/options_test.cc
+++ b/util/options_test.cc
@@ -23,6 +23,7 @@
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/leveldb_options.h"
 #include "table/block_based_table_factory.h"
+#include "table/plain_table_factory.h"
 #include "util/options_helper.h"
 #include "util/options_parser.h"
 #include "util/random.h"
@@ -339,7 +340,13 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"use_adaptive_mutex", "false"},
       {"new_table_reader_for_compaction_inputs", "true"},
       {"compaction_readahead_size", "100"},
+      {"random_access_max_buffer_size", "3145728" },
+      {"writable_file_max_buffer_size", "314159"},
+      {"skip_table_builder_flush", "true"},
+<<<<<<< HEAD
       {"random_access_max_buffer_size", "3145728"},
+=======
+>>>>>>> origin/SkipFlush
       {"bytes_per_sync", "47"},
       {"wal_bytes_per_sync", "48"},
   };
@@ -451,6 +458,8 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.new_table_reader_for_compaction_inputs, true);
   ASSERT_EQ(new_db_opt.compaction_readahead_size, 100);
   ASSERT_EQ(new_db_opt.random_access_max_buffer_size, 3145728);
+  ASSERT_EQ(new_db_opt.writable_file_max_buffer_size, 314159);
+  ASSERT_EQ(new_db_opt.skip_table_builder_flush, true);
   ASSERT_EQ(new_db_opt.bytes_per_sync, static_cast<uint64_t>(47));
   ASSERT_EQ(new_db_opt.wal_bytes_per_sync, static_cast<uint64_t>(48));
 }
@@ -590,6 +599,23 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_NOK(GetColumnFamilyOptionsFromString(base_cf_opt,
               "optimize_filters_for_hits=junk",
               &new_cf_opt));
+
+  // Nested plain table options
+  // Emtpy
+  ASSERT_OK(GetColumnFamilyOptionsFromString(base_cf_opt,
+            "write_buffer_size=10;max_write_buffer_number=16;"
+            "plain_table_factory={};arena_block_size=1024",
+            &new_cf_opt));
+  ASSERT_TRUE(new_cf_opt.table_factory != nullptr);
+  ASSERT_EQ(new_cf_opt.table_factory->Name(), "PlainTable");
+  // Non-empty
+  ASSERT_OK(GetColumnFamilyOptionsFromString(base_cf_opt,
+            "write_buffer_size=10;max_write_buffer_number=16;"
+            "plain_table_factory={user_key_len=66;bloom_bits_per_key=20;};"
+            "arena_block_size=1024",
+            &new_cf_opt));
+  ASSERT_TRUE(new_cf_opt.table_factory != nullptr);
+  ASSERT_EQ(new_cf_opt.table_factory->Name(), "PlainTable");
 }
 #endif  // !ROCKSDB_LITE
 
@@ -645,6 +671,40 @@ TEST_F(OptionsTest, GetBlockBasedTableOptionsFromString) {
              "cache_index_and_filter_blocks=1;"
              "filter_policy=bloomfilter:4",
              &new_opt));
+}
+#endif  // !ROCKSDB_LITE
+
+
+#ifndef ROCKSDB_LITE  // GetPlainTableOptionsFromString is not supported
+TEST_F(OptionsTest, GetPlainTableOptionsFromString) {
+  PlainTableOptions table_opt;
+  PlainTableOptions new_opt;
+  // make sure default values are overwritten by something else
+  ASSERT_OK(GetPlainTableOptionsFromString(table_opt,
+            "user_key_len=66;bloom_bits_per_key=20;hash_table_ratio=0.5;"
+            "index_sparseness=8;huge_page_tlb_size=4;encoding_type=kPrefix;"
+            "full_scan_mode=true;store_index_in_file=true",
+            &new_opt));
+  ASSERT_EQ(new_opt.user_key_len, 66);
+  ASSERT_EQ(new_opt.bloom_bits_per_key, 20);
+  ASSERT_EQ(new_opt.hash_table_ratio, 0.5);
+  ASSERT_EQ(new_opt.index_sparseness, 8);
+  ASSERT_EQ(new_opt.huge_page_tlb_size, 4);
+  ASSERT_EQ(new_opt.encoding_type, EncodingType::kPrefix);
+  ASSERT_TRUE(new_opt.full_scan_mode);
+  ASSERT_TRUE(new_opt.store_index_in_file);
+
+  // unknown option
+  ASSERT_NOK(GetPlainTableOptionsFromString(table_opt,
+             "user_key_len=66;bloom_bits_per_key=20;hash_table_ratio=0.5;"
+             "bad_option=1",
+             &new_opt));
+
+  // unrecognized EncodingType
+  ASSERT_NOK(GetPlainTableOptionsFromString(table_opt,
+             "user_key_len=66;bloom_bits_per_key=20;hash_table_ratio=0.5;"
+             "encoding_type=kPrefixXX",
+             &new_opt));  
 }
 #endif  // !ROCKSDB_LITE
 


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/issues/792

@sying, as we have discussed, I have added a new option skip_table_builder_flush
 In addition, I make the buffer size configurable through option. This allows user to tune for optimal disk I/O size for flush. 
