### PR TITLE
Fix introduced in 2ab7065 was reverted by 18285c1.

### DIFF
--- a/db/memtablerep_bench.cc
+++ b/db/memtablerep_bench.cc
@@ -132,8 +132,6 @@ DEFINE_int64(seed, 0,
              "Seed base for random number generators. "
              "When 0 it is deterministic.");
 
-static rocksdb::Env* FLAGS_env = rocksdb::Env::Default();
-
 namespace rocksdb {
 
 namespace {


### PR DESCRIPTION
Fix introduced in 2ab7065 was reverted by 18285c1.

Corrects:

db/memtablerep_bench.cc:135:22: error: ‘FLAGS_env’ defined but not used [-Werror=unused-variable]
 static rocksdb::Env* FLAGS_env = rocksdb::Env::Default();
                      ^
cc1plus: all warnings being treated as errors
Makefile:1147: recipe for target 'db/memtablerep_bench.o' failed