### PR TITLE
Enable compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ add_custom_command(OUTPUT ${BUILD_VERSION_CC}
 add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4100 /wd4101 /wd4127 /wd4189 /wd4200 /wd4244 /wd4267 /wd4296 /wd4305 /wd4307 /wd4309 /wd4512 /wd4701 /wd4702 /wd4800 /wd4804 /wd4996")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4200 /wd4244 /wd4267 /wd4305 /wd4307 /wd4309 /wd4512 /wd4701 /wd4702 /wd4800 /wd4804 /wd4996")
 
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize

--- a/util/options_helper.cc
+++ b/util/options_helper.cc
@@ -891,7 +891,7 @@ bool ParseColumnFamilyOption(const std::string& name,
           reinterpret_cast<char*>(new_options) + opt_info.offset, opt_info.type,
           value);
     }
-  } catch (std::exception& e) {
+  } catch (const std::exception&) {
     return false;
   }
   return true;
@@ -1058,7 +1058,7 @@ bool ParseDBOption(const std::string& name, const std::string& org_value,
             opt_info.type, value);
       }
     }
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     return false;
   }
   return true;


### PR DESCRIPTION
  C4101 'identifier' : unreferenced local variable
  C4189 'identifier' : local variable is initialized but not referenced
  C4100 'identifier' : unreferenced formal parameter
  C4296 'operator' : expression is always false