### PR TITLE
Enable Windows warnings C4307 C4309 C4512 C4701

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ add_custom_command(OUTPUT ${BUILD_VERSION_CC}
 add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4200 /wd4244 /wd4267 /wd4305 /wd4307 /wd4309 /wd4512 /wd4701 /wd4702 /wd4800 /wd4804 /wd4996")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4200 /wd4244 /wd4267 /wd4305 /wd4702 /wd4800 /wd4804 /wd4996")
 
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize

--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -635,7 +635,7 @@ DEFINE_double(soft_rate_limit, 0.0, "");
 
 DEFINE_double(hard_rate_limit, 0.0, "DEPRECATED");
 
-DEFINE_uint64(hard_pending_compaction_bytes_limit, 128u * 1024 * 1024 * 1024,
+DEFINE_uint64(hard_pending_compaction_bytes_limit, 128ull * 1024 * 1024 * 1024,
               "Stop writes if pending compaction bytes exceed this number");
 
 DEFINE_uint64(delayed_write_rate, 2097152u,

--- a/table/plain_table_factory.h
+++ b/table/plain_table_factory.h
@@ -160,7 +160,7 @@ class PlainTableFactory : public TableFactory {
 
   const PlainTableOptions& GetTableOptions() const;
 
-  static const char kValueTypeSeqId0 = 0xFF;
+  static const char kValueTypeSeqId0 = char(0xFF);
 
   // Sanitizes the specified DB Options.
   Status SanitizeOptions(const DBOptions& db_opts,

--- a/util/options.cc
+++ b/util/options.cc
@@ -225,7 +225,7 @@ DBOptions::DBOptions()
       use_fsync(false),
       db_log_dir(""),
       wal_dir(""),
-      delete_obsolete_files_period_micros(6 * 60 * 60 * 1000000UL),
+      delete_obsolete_files_period_micros(6ULL * 60 * 60 * 1000000),
       max_background_compactions(1),
       max_subcompactions(1),
       max_background_flushes(1),


### PR DESCRIPTION
  Enable C4307 'operator' : integral constant overflow
  Longs and ints on Windows are 32-bit hence the overflow
  Enable C4309 'conversion' : truncation of constant value
  Enable C4512 'class' : assignment operator could not be generated
  Enable C4701 Potentially uninitialized local variable 'name' used