### PR TITLE
Make use of portable `uint64_t` type to make possible 64-bit file access

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -570,7 +570,7 @@ class WritableFile {
   // This asks the OS to initiate flushing the cached data to disk,
   // without waiting for completion.
   // Default implementation does nothing.
-  virtual Status RangeSync(off_t offset, off_t nbytes) { return Status::OK(); }
+  virtual Status RangeSync(uint64_t offset, uint64_t nbytes) { return Status::OK(); }
 
   // PrepareWrite performs any necessary preparation for a write
   // before the write actually occurs.  This allows for pre-allocation
@@ -590,8 +590,8 @@ class WritableFile {
     if (new_last_preallocated_block > last_preallocated_block_) {
       size_t num_spanned_blocks =
         new_last_preallocated_block - last_preallocated_block_;
-      Allocate(static_cast<off_t>(block_size * last_preallocated_block_),
-               static_cast<off_t>(block_size * num_spanned_blocks));
+      Allocate(block_size * last_preallocated_block_,
+               block_size * num_spanned_blocks);
       last_preallocated_block_ = new_last_preallocated_block;
     }
   }
@@ -600,7 +600,7 @@ class WritableFile {
   /*
    * Pre-allocate space for a file.
    */
-  virtual Status Allocate(off_t offset, off_t len) {
+  virtual Status Allocate(uint64_t offset, uint64_t len) {
     return Status::OK();
   }
 
@@ -920,10 +920,10 @@ class WritableFileWrapper : public WritableFile {
   }
 
  protected:
-  Status Allocate(off_t offset, off_t len) override {
+  Status Allocate(uint64_t offset, uint64_t len) override {
     return target_->Allocate(offset, len);
   }
-  Status RangeSync(off_t offset, off_t nbytes) override {
+  Status RangeSync(uint64_t offset, uint64_t nbytes) override {
     return target_->RangeSync(offset, nbytes);
   }
 

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -61,12 +61,6 @@ ThreadStatusUpdater* CreateThreadStatusUpdater() {
   return new ThreadStatusUpdater();
 }
 
-// A wrapper for fadvise, if the platform doesn't support fadvise,
-// it will simply return Status::NotSupport.
-int Fadvise(int fd, off_t offset, size_t len, int advice) {
-  return 0;  // simply do nothing.
-}
-
 inline Status IOErrorFromWindowsError(const std::string& context, DWORD err) {
   return Status::IOError(context, GetWindowsErrSz(err));
 }
@@ -605,7 +599,7 @@ class WinMmapFile : public WritableFile {
     return Status::OK();
   }
 
-  virtual Status Allocate(off_t offset, off_t len) override {
+  virtual Status Allocate(uint64_t offset, uint64_t len) override {
     return Status::OK();
   }
 };
@@ -1053,7 +1047,7 @@ class WinWritableFile : public WritableFile {
     return filesize_;
   }
 
-  virtual Status Allocate(off_t offset, off_t len) override {
+  virtual Status Allocate(uint64_t offset, uint64_t len) override {
     Status status;
     TEST_KILL_RANDOM("WinWritableFile::Allocate", rocksdb_kill_odds);
 

--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -971,11 +971,11 @@ TEST_F(EnvPosixTest, WritableFileWrapper) {
     }
 
    protected:
-    Status Allocate(off_t offset, off_t len) override {
+    Status Allocate(uint64_t offset, uint64_t len) override {
       inc(11);
       return Status::OK();
     }
-    Status RangeSync(off_t offset, off_t nbytes) override {
+    Status RangeSync(uint64_t offset, uint64_t nbytes) override {
       inc(12);
       return Status::OK();
     }

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -248,7 +248,7 @@ Status WritableFileWriter::SyncInternal(bool use_fsync) {
   return s;
 }
 
-Status WritableFileWriter::RangeSync(off_t offset, off_t nbytes) {
+Status WritableFileWriter::RangeSync(uint64_t offset, uint64_t nbytes) {
   IOSTATS_TIMER_GUARD(range_sync_nanos);
   TEST_SYNC_POINT("WritableFileWriter::RangeSync:0");
   return writable_file_->RangeSync(offset, nbytes);

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -162,7 +162,7 @@ class WritableFileWriter {
   Status WriteUnbuffered();
   // Normal write
   Status WriteBuffered(const char* data, size_t size);
-  Status RangeSync(off_t offset, off_t nbytes);
+  Status RangeSync(uint64_t offset, uint64_t nbytes);
   size_t RequestToken(size_t bytes, bool align);
   Status SyncInternal(bool use_fsync);
 };

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -47,8 +47,8 @@ TEST_F(WritableFileWriterTest, RangeSync) {
     }
 
    protected:
-    Status Allocate(off_t offset, off_t len) override { return Status::OK(); }
-    Status RangeSync(off_t offset, off_t nbytes) override {
+    Status Allocate(uint64_t offset, uint64_t len) override { return Status::OK(); }
+    Status RangeSync(uint64_t offset, uint64_t nbytes) override {
       EXPECT_EQ(offset % 4096, 0u);
       EXPECT_EQ(nbytes % 4096, 0u);
 

--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -478,12 +478,15 @@ Status PosixMmapFile::InvalidateCache(size_t offset, size_t length) {
 }
 
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-Status PosixMmapFile::Allocate(off_t offset, off_t len) {
+Status PosixMmapFile::Allocate(uint64_t offset, uint64_t len) {
+  assert(offset <= std::numeric_limits<off_t>::max());
+  assert(len <= std::numeric_limits<off_t>::max());
   TEST_KILL_RANDOM("PosixMmapFile::Allocate:0", rocksdb_kill_odds);
   int alloc_status = 0;
   if (allow_fallocate_) {
     alloc_status = fallocate(
-        fd_, fallocate_with_keep_size_ ? FALLOC_FL_KEEP_SIZE : 0, offset, len);
+        fd_, fallocate_with_keep_size_ ? FALLOC_FL_KEEP_SIZE : 0,
+          static_cast<off_t>(offset), static_cast<off_t>(len));
   }
   if (alloc_status == 0) {
     return Status::OK();
@@ -606,13 +609,16 @@ Status PosixWritableFile::InvalidateCache(size_t offset, size_t length) {
 }
 
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-Status PosixWritableFile::Allocate(off_t offset, off_t len) {
+Status PosixWritableFile::Allocate(uint64_t offset, uint64_t len) {
+  assert(offset <= std::numeric_limits<off_t>::max());
+  assert(len <= std::numeric_limits<off_t>::max());
   TEST_KILL_RANDOM("PosixWritableFile::Allocate:0", rocksdb_kill_odds);
   IOSTATS_TIMER_GUARD(allocate_nanos);
   int alloc_status = 0;
   if (allow_fallocate_) {
     alloc_status = fallocate(
-        fd_, fallocate_with_keep_size_ ? FALLOC_FL_KEEP_SIZE : 0, offset, len);
+        fd_, fallocate_with_keep_size_ ? FALLOC_FL_KEEP_SIZE : 0,
+        static_cast<off_t>(offset), static_cast<off_t>(len));
   }
   if (alloc_status == 0) {
     return Status::OK();
@@ -621,8 +627,11 @@ Status PosixWritableFile::Allocate(off_t offset, off_t len) {
   }
 }
 
-Status PosixWritableFile::RangeSync(off_t offset, off_t nbytes) {
-  if (sync_file_range(fd_, offset, nbytes, SYNC_FILE_RANGE_WRITE) == 0) {
+Status PosixWritableFile::RangeSync(uint64_t offset, uint64_t nbytes) {
+  assert(offset <= std::numeric_limits<off_t>::max());
+  assert(nbytes <= std::numeric_limits<off_t>::max());
+  if (sync_file_range(fd_, static_cast<off_t>(offset),
+      static_cast<off_t>(nbytes), SYNC_FILE_RANGE_WRITE) == 0) {
     return Status::OK();
   } else {
     return IOError(filename_, errno);

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -90,8 +90,8 @@ class PosixWritableFile : public WritableFile {
   virtual uint64_t GetFileSize() override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-  virtual Status Allocate(off_t offset, off_t len) override;
-  virtual Status RangeSync(off_t offset, off_t nbytes) override;
+  virtual Status Allocate(uint64_t offset, uint64_t len) override;
+  virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
   virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif
 };
@@ -157,7 +157,7 @@ class PosixMmapFile : public WritableFile {
   virtual uint64_t GetFileSize() override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 #ifdef ROCKSDB_FALLOCATE_PRESENT
-  virtual Status Allocate(off_t offset, off_t len) override;
+  virtual Status Allocate(uint64_t offset, uint64_t len) override;
 #endif
 };
 

--- a/util/random.cc
+++ b/util/random.cc
@@ -6,9 +6,10 @@
 
 #include "util/random.h"
 
-#include <pthread.h>
 #include <stdint.h>
 #include <string.h>
+#include <thread>
+#include <utility>
 
 #include "port/likely.h"
 #include "util/thread_local.h"
@@ -27,10 +28,8 @@ Random* Random::GetTLSInstance() {
 
   auto rv = tls_instance;
   if (UNLIKELY(rv == nullptr)) {
-    const pthread_t self = pthread_self();
-    uint32_t seed = 0;
-    memcpy(&seed, &self, sizeof(seed));
-    rv = new (&tls_instance_bytes) Random(seed);
+    size_t seed = std::hash<std::thread::id>()(std::this_thread::get_id());
+    rv = new (&tls_instance_bytes) Random((uint32_t)seed);
     tls_instance = rv;
   }
   return rv;

--- a/util/random.h
+++ b/util/random.h
@@ -18,8 +18,12 @@ namespace rocksdb {
 // package.
 class Random {
  private:
-  static constexpr uint32_t M = 2147483647L;  // 2^31-1
-  static constexpr uint64_t A = 16807;        // bits 14, 8, 7, 5, 2, 1, 0
+  enum : uint32_t {
+    M = 2147483647L  // 2^31-1
+  };
+  enum : uint64_t {
+    A = 16807  // bits 14, 8, 7, 5, 2, 1, 0
+  };
 
   uint32_t seed_;
 
@@ -27,7 +31,7 @@ class Random {
 
  public:
   // This is the largest value that can be returned from Next()
-  static constexpr uint32_t kMaxNext = M;
+  enum : uint32_t { kMaxNext = M };
 
   explicit Random(uint32_t s) : seed_(GoodSeed(s)) {}
 


### PR DESCRIPTION
  in 64-bit.

  Currently, a signed off_t type is being used for the following
  interfaces for both offset and the length in bytes:
  * `Allocate`
  * `RangeSync`

  On Linux `off_t` is automatically either 32 or 64-bit depending on
  the platform. On Windows it is always a 32-bit signed long which
  limits file access and in particular space pre-allocation
  to effectively 2 Gb.

  Proposal is to replace off_t with uint64_t as a portable type
  always access files with 64-bit interfaces.

  May need to modify posix code but lack resources to test it.