### PR TITLE
Fix backwards compatibility with Win7 and before.

### DIFF
--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -1637,6 +1637,7 @@ class WinEnv : public Env {
     return s;
   }
 
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
   virtual uint64_t NowMicros() override {
     // all std::chrono clocks on windows proved to return
     // values that may repeat that is not good enough for some uses.
@@ -1658,6 +1659,18 @@ class WinEnv : public Env {
     li.QuadPart /= c_FtToMicroSec;
     return li.QuadPart;
   }
+#else
+  virtual uint64_t NowMicros() override {
+      // On Windows 7 and below, where GetSystemTimePreciseAsFileTime is not
+      // available, use QueryPerformanceCounter. Note that this may cause some
+      // of the tests to fail.
+      LARGE_INTEGER li;
+      QueryPerformanceCounter(&li);
+      li.QuadPart *= std::micro::den;
+      li.QuadPart /= perf_counter_frequency_;
+      return li.QuadPart;
+  }
+#endif // (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
 
   virtual uint64_t NowNanos() override {
     // all std::chrono clocks on windows have the same resolution that is only


### PR DESCRIPTION
Commit f14c3363 introduced the use of GetSystemTimePreciseAsFileTime,
which is only available on Win8 and above. This breaks backwards runtime
compatibility with earlier Windows versions.

This commit partially reverts the aforementioned commit, guarded in a
compile-time macro. By default, this patch has no effect on the code
base. However, if the _WIN32_WINNT macro is explicitly set to a Windows
a Windows version older than Win8, then we use the backwards-compatible
implementation.