### PR TITLE
Enable C4267 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4244 /wd4267 /wd4800 /wd4996")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4244 /wd4800 /wd4996")
 
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -128,8 +128,8 @@ bool Compaction::TEST_IsBottommostLevel(
 bool Compaction::IsFullCompaction(
     VersionStorageInfo* vstorage,
     const std::vector<CompactionInputFiles>& inputs) {
-  int num_files_in_compaction = 0;
-  int total_num_files = 0;
+  size_t num_files_in_compaction = 0;
+  size_t total_num_files = 0;
   for (int l = 0; l < vstorage->num_levels(); l++) {
     total_num_files += vstorage->NumLevelFiles(l);
   }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -160,7 +160,7 @@ const SstFileMetaData* PickFileRandomly(
       auto result = rand->Uniform(file_id);
       return &(level_meta.files[result]);
     }
-    file_id -= level_meta.files.size();
+    file_id -= static_cast<uint32_t>(level_meta.files.size());
   }
   assert(false);
   return nullptr;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2171,7 +2171,7 @@ TEST_F(DBTest, RecoverWithTableHandle) {
 
     std::vector<std::vector<FileMetaData>> files;
     dbfull()->TEST_GetFilesMetaData(handles_[1], &files);
-    int total_files = 0;
+    size_t total_files = 0;
     for (const auto& level : files) {
       total_files += level.size();
     }

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -661,14 +661,14 @@ uint64_t DBTestBase::SizeAtLevel(int level) {
   return sum;
 }
 
-int DBTestBase::TotalLiveFiles(int cf) {
+size_t DBTestBase::TotalLiveFiles(int cf) {
   ColumnFamilyMetaData cf_meta;
   if (cf == 0) {
     db_->GetColumnFamilyMetaData(&cf_meta);
   } else {
     db_->GetColumnFamilyMetaData(handles_[cf], &cf_meta);
   }
-  int num_files = 0;
+  size_t num_files = 0;
   for (auto& level : cf_meta.levels) {
     num_files += level.files.size();
   }

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -583,7 +583,7 @@ class DBTestBase : public testing::Test {
 
   uint64_t SizeAtLevel(int level);
 
-  int TotalLiveFiles(int cf = 0);
+  size_t TotalLiveFiles(int cf = 0);
 
   size_t CountLiveFiles();
 #endif  // ROCKSDB_LITE

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -47,7 +47,7 @@ Status Writer::AddRecord(const Slice& slice) {
   Status s;
   bool begin = true;
   do {
-    const int leftover = kBlockSize - block_offset_;
+    const int64_t leftover = kBlockSize - block_offset_;
     assert(leftover >= 0);
     if (leftover < header_size) {
       // Switch to a new block
@@ -62,7 +62,7 @@ Status Writer::AddRecord(const Slice& slice) {
     }
 
     // Invariant: we never leave < header_size bytes in a block.
-    assert(static_cast<int>(kBlockSize) - block_offset_ >= header_size);
+    assert(static_cast<int64_t>(kBlockSize - block_offset_) >= header_size);
 
     const size_t avail = kBlockSize - block_offset_ - header_size;
     const size_t fragment_length = (left < avail) ? left : avail;

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -83,7 +83,7 @@ class Writer {
 
  private:
   unique_ptr<WritableFileWriter> dest_;
-  int block_offset_;       // Current offset in block
+  size_t block_offset_;       // Current offset in block
   uint64_t log_number_;
   bool recycle_log_files_;
 

--- a/port/win/win_logger.cc
+++ b/port/win/win_logger.cc
@@ -124,7 +124,8 @@ void WinLogger::Logv(const char* format, va_list ap) {
     const size_t write_size = p - base;
 
     DWORD bytesWritten = 0;
-    BOOL ret = WriteFile(file_, base, write_size, &bytesWritten, NULL);
+    BOOL ret = WriteFile(file_, base, static_cast<DWORD>(write_size),
+      &bytesWritten, NULL);
     if (ret == FALSE) {
       std::string errSz = GetWindowsErrSz(GetLastError());
       fprintf(stderr, errSz.c_str());

--- a/util/coding.h
+++ b/util/coding.h
@@ -184,11 +184,11 @@ inline void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
 
 inline void PutLengthPrefixedSliceParts(std::string* dst,
                                         const SliceParts& slice_parts) {
-  uint32_t total_bytes = 0;
+  size_t total_bytes = 0;
   for (int i = 0; i < slice_parts.num_parts; ++i) {
     total_bytes += slice_parts.parts[i].size();
   }
-  PutVarint32(dst, total_bytes);
+  PutVarint32(dst, static_cast<uint32_t>(total_bytes));
   for (int i = 0; i < slice_parts.num_parts; ++i) {
     dst->append(slice_parts.parts[i].data(), slice_parts.parts[i].size());
   }

--- a/util/options_builder.cc
+++ b/util/options_builder.cc
@@ -127,8 +127,8 @@ void OptimizeForLevel(int read_amplification_threshold,
   const int kMaxFileNumCompactionTrigger = 4;
   const int kMinLevel0StopTrigger = 3;
 
-  int file_num_buffer =
-      kInitialLevel0TotalSize / options->write_buffer_size + 1;
+  int file_num_buffer = static_cast<int>(
+      kInitialLevel0TotalSize / options->write_buffer_size + 1);
 
   if (level0_stop_writes_trigger > file_num_buffer) {
     // Have sufficient room for multiple level 0 files

--- a/utilities/document/json_document_builder.cc
+++ b/utilities/document/json_document_builder.cc
@@ -4,6 +4,9 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 
 #ifndef ROCKSDB_LITE
+#include <assert.h>
+#include <limits>
+#include <stdint.h>
 #include "rocksdb/utilities/json_document.h"
 #include "third-party/fbson/FbsonWriter.h"
 
@@ -38,7 +41,9 @@ bool JSONDocumentBuilder::WriteEndObject() {
 
 bool JSONDocumentBuilder::WriteKeyValue(const std::string& key,
                                         const JSONDocument& value) {
-  size_t bytesWritten = writer_->writeKey(key.c_str(), key.size());
+  assert(key.size() <= std::numeric_limits<uint8_t>::max());
+  size_t bytesWritten = writer_->writeKey(key.c_str(),
+    static_cast<uint8_t>(key.size()));
   if (bytesWritten == 0) {
     return false;
   }


### PR DESCRIPTION
* conversion from 'size_t' to 'type', by add static_cast
* extend type from int to int64_t

Tested:
* by build solution on Windows, Linux locally,
* run tests
