### PR TITLE
EnvWrapper: add ReuseWritableFile

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -768,6 +768,12 @@ class EnvWrapper : public Env {
                          const EnvOptions& options) override {
     return target_->NewWritableFile(f, r, options);
   }
+  Status ReuseWritableFile(const std::string& fname,
+			   const std::string& old_fname,
+			   unique_ptr<WritableFile>* r,
+			   const EnvOptions& options) {
+    return target_->ReuseWritableFile(fname, old_fname, r, options);
+  }
   virtual Status NewDirectory(const std::string& name,
                               unique_ptr<Directory>* result) override {
     return target_->NewDirectory(name, result);


### PR DESCRIPTION
Missed this when the new call was added.

By the way, I also made a MirrorEnv implementation that takes two Env's and does all operations on both, and compares the return values and read results.  This was hugely helpful in writing my own Env implementation.. any interest upstream?

https://github.com/liewegas/ceph/blob/wip-bluestore/src/os/bluestore/MirrorEnv.h