### PR TITLE
Fix build error with hdfs

### DIFF
--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -89,7 +89,9 @@ class HdfsEnv : public Env {
 
   virtual Status RenameFile(const std::string& src, const std::string& target);
 
-  virtual Status LinkFile(const std::string& src, const std::string& target);
+  virtual Status LinkFile(const std::string& src, const std::string& target) {
+    return Status::NotSupported(); // not supported
+  }
 
   virtual Status LockFile(const std::string& fname, FileLock** lock);
 

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <sstream>
 #include "rocksdb/status.h"
+#include "util/string_util.h"
 
 #define HDFS_EXISTS 0
 #define HDFS_DOESNT_EXIST -1


### PR DESCRIPTION
* include `util/string_util.h` which contains `ToString` macro in `env_hdfs.cc` to fix ToString not declared error
* implement `LinkFile` function by returning a NotSupported status to avoid LinkFile undefined reference error, because HdfsEnv class defines LinkFile function without implementing it and actually, HDFS does not provide such API in c.
