### PR TITLE
Replace malloc with new for LRU Cache Handle

### DIFF
--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -58,6 +58,10 @@ int main() {
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/utilities/optimistic_transaction_db.h"
 #include "port/port.h"
+
+
+#include "jemalloc/jemalloc.h"
+
 #include "port/stack_trace.h"
 #include "util/crc32c.h"
 #include "util/compression.h"
@@ -1288,6 +1292,34 @@ class Stats {
         else                            next_report_ += 100000;
         fprintf(stderr, "... finished %" PRIu64 " ops%30s\r", done_, "");
       } else {
+
+        size_t mem_allocated, mem_active, mem_metadata, mem_resident, mem_mapped;
+        size_t sz = sizeof(size_t);
+        je_mallctl("stats.allocated", &mem_allocated, &sz, NULL, 0);
+        je_mallctl("stats.active", &mem_active, &sz, NULL, 0);
+        je_mallctl("stats.metadata", &mem_metadata, &sz, NULL, 0);
+        je_mallctl("stats.resident", &mem_resident, &sz, NULL, 0);
+        je_mallctl("stats.mapped", &mem_mapped, &sz, NULL, 0);
+
+        fprintf(stderr, "[JEMemory] Allocated: %" PRIu64 " Active: %" PRIu64 " Metadata: %" PRIu64 " Resident: %" PRIu64 " Mapped: %" PRIu64 "\n",
+          mem_allocated, mem_active, mem_metadata, mem_resident, mem_mapped);
+
+
+        // je_malloc_stats_print(nullptr, nullptr, "mablh");
+
+        // const char *fileName = "heap_info.out";
+        // je_mallctl("prof.dump", NULL, NULL, &fileName, sizeof(const char *));
+
+        // bool prof_enabled;
+        // size_t sz_bool = sizeof(bool);
+        // je_mallctl("config.prof", &prof_enabled, &sz_bool, NULL, 0);
+        // fprintf(stderr, "Enabled: %s\n", prof_enabled ? "ture" : "false");
+
+
+        // fprintf(stderr, "%s\n", je_malloc_conf);
+
+
+
         double now = FLAGS_env->NowMicros();
         int64_t usecs_since_last = now - last_report_finish_;
 

--- a/port/win/port_win.cc
+++ b/port/win/port_win.cc
@@ -235,6 +235,9 @@ namespace rocksdb {
 namespace port {
 
 __declspec(noinline) void WINAPI InitializeJemalloc() {
+
+  //je_malloc_conf = "prof:true,prof_prefix:jeprof.out";
+
   je_init();
   atexit(je_uninit);
 }

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -74,7 +74,7 @@ struct LRUHandle {
   void Free() {
     assert((refs == 1 && in_cache) || (refs == 0 && !in_cache));
     (*deleter)(key(), value);
-    free(this);
+    delete[] reinterpret_cast<char*>(this);
   }
 };
 
@@ -390,8 +390,8 @@ Cache::Handle* LRUCache::Insert(
   // Allocate the memory here outside of the mutex
   // If the cache is full, we'll have to release it
   // It shouldn't happen very often though.
-  LRUHandle* e =
-      reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
+  LRUHandle* e = reinterpret_cast<LRUHandle*>(
+                    new char[sizeof(LRUHandle) - 1 + key.size()]);
   autovector<LRUHandle*> last_reference_list;
 
   e->value = value;


### PR DESCRIPTION
LRU Cache Handle was using malloc and free. In Windows port, malloc() and free() were not override in the JEmalloc version. 
Replacing them with new and delete such that jemalloc is used for this allocation. 
