### PR TITLE
Fix build on FreeBSD i386

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -610,7 +610,7 @@ class Stats {
             "", bytes_mb, rate, (100*writes_)/done_, done_);
     fprintf(stdout, "%-12s: Wrote %ld times\n", "", writes_);
     fprintf(stdout, "%-12s: Deleted %ld times\n", "", deletes_);
-    fprintf(stdout, "%-12s: Single deleted %ld times\n", "", single_deletes_);
+    fprintf(stdout, "%-12s: Single deleted %zu times\n", "", single_deletes_);
     fprintf(stdout, "%-12s: %ld read and %ld found the key\n", "",
             gets_, founds_);
     fprintf(stdout, "%-12s: Prefix scanned %ld times\n", "", prefixes_);


### PR DESCRIPTION
The error message is as follows:
```
tools/db_stress.cc:593:62: error: format specifies type 'long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
    fprintf(stdout, "%-12s: Single deleted %ld times\n", "", single_deletes_);
                                           ~~~               ^~~~~~~~~~~~~~~
                                           %zu
1 error generated.
Makefile:1133: recipe for target 'tools/db_stress.o' failed
gmake[1]: *** [tools/db_stress.o] Error 1
gmake[1]: Leaving directory '/wrkdirs/usr/ports/databases/rocksdb/work/rocksdb-4.1'
*** Error code 1

Stop.
make: stopped in /usr/ports/databases/rocksdb
```