### PR TITLE
Add compaction_iterator and delete_scheduler tests to Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ set(C_TESTS db/c_test.c)
 set(TESTS
         db/column_family_test.cc
         db/compact_files_test.cc
+        db/compaction_iterator_test.cc
         db/compaction_job_test.cc
         db/compaction_job_stats_test.cc
         db/compaction_picker_test.cc
@@ -365,6 +366,7 @@ set(TESTS
         util/cache_test.cc
         util/coding_test.cc
         util/crc32c_test.cc
+        util/delete_scheduler_test.cc
         util/dynamic_bloom_test.cc
         util/env_test.cc
         util/event_logger_test.cc


### PR DESCRIPTION
There are two tests missing from the Windows build because they were added after it was developed.  This includes them in Windows builds.

db/compaction_iterator_test
util/delete_scheduler_test

Both tests appear to be passing.