### PR TITLE
log_reader: fix replay of recycled logs

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -191,6 +191,24 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
         }
         break;
 
+      case kBadRecordLen:
+	ReportCorruption(drop_size, "bad record length");
+	if (in_fragmented_record) {
+          ReportCorruption(scratch->size(), "error in middle of record");
+          in_fragmented_record = false;
+          scratch->clear();
+        }
+        break;
+
+      case kBadRecordChecksum:
+        ReportCorruption(drop_size, "checksum mismatch");
+        if (in_fragmented_record) {
+          ReportCorruption(scratch->size(), "error in middle of record");
+          in_fragmented_record = false;
+          scratch->clear();
+        }
+        break;
+
       default: {
         char buf[40];
         snprintf(buf, sizeof(buf), "unknown record type %u", record_type);
@@ -355,8 +373,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
       *drop_size = buffer_.size();
       buffer_.clear();
       if (!eof_) {
-        ReportCorruption(*drop_size, "bad record length");
-        return kBadRecord;
+        return kBadRecordLen;
       }
       // If the end of the file has been reached without reading |length| bytes
       // of payload, assume the writer died in the middle of writing the record.
@@ -388,8 +405,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
         // like a valid log record.
         *drop_size = buffer_.size();
         buffer_.clear();
-        ReportCorruption(*drop_size, "checksum mismatch");
-        return kBadRecord;
+        return kBadRecordChecksum;
       }
     }
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -126,6 +126,10 @@ class Reader {
     kBadHeader = kMaxRecordType + 3,
     // Returned when we read an old record from a previous user of the log.
     kOldRecord = kMaxRecordType + 4,
+    // Returned when we get a bad record length
+    kBadRecordLen = kMaxRecordType + 5,
+    // Returned when we get a bad record checksum
+    kBadRecordChecksum = kMaxRecordType + 6,
   };
 
   // Skips all blocks that are completely before "initial_offset_".

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -174,6 +174,10 @@ class LogTest : public ::testing::TestWithParam<int> {
                                              3 * header_size;
   }
 
+  Slice *get_reader_contents() {
+    return &reader_contents_;
+  }
+
   void Write(const std::string& msg) {
     writer_.AddRecord(Slice(msg));
   }
@@ -688,6 +692,30 @@ TEST_P(LogTest, ClearEofError2) {
   ASSERT_EQ("EOF", Read());
   ASSERT_EQ(3U, DroppedBytes());
   ASSERT_EQ("OK", MatchError("read error"));
+}
+
+TEST_P(LogTest, Recycle) {
+  if (!GetParam()) {
+    return;  // test is only valid for recycled logs
+  }
+  Write("foo");
+  Write("bar");
+  Write("baz");
+  Write("bif");
+  Write("blitz");
+  while (get_reader_contents()->size() < log::kBlockSize * 2) {
+    Write("xxxxxxxxxxxxxxxx");
+  }
+  unique_ptr<WritableFileWriter> dest_holder(
+    test::GetWritableFileWriter(
+      new test::OverwritingStringSink(get_reader_contents())));
+  Writer recycle_writer(std::move(dest_holder), 123, true);
+  recycle_writer.AddRecord(Slice("foooo"));
+  recycle_writer.AddRecord(Slice("bar"));
+  ASSERT_GE(get_reader_contents()->size(), log::kBlockSize * 2);
+  ASSERT_EQ("foooo", Read());
+  ASSERT_EQ("bar", Read());
+  ASSERT_EQ("EOF", Read());
 }
 
 INSTANTIATE_TEST_CASE_P(bool, LogTest, ::testing::Values(0, 2));

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -231,6 +231,50 @@ class StringSink: public WritableFile {
   size_t last_flush_;
 };
 
+class OverwritingStringSink: public WritableFile {
+ public:
+  std::string contents_;
+
+  explicit OverwritingStringSink(Slice* reader_contents) :
+      WritableFile(),
+      contents_(""),
+      reader_contents_(reader_contents),
+      last_flush_(0) {
+  }
+
+  const std::string& contents() const { return contents_; }
+
+  virtual Status Truncate(uint64_t size) override {
+    contents_.resize(static_cast<size_t>(size));
+    return Status::OK();
+  }
+  virtual Status Close() override { return Status::OK(); }
+  virtual Status Flush() override {
+    if (last_flush_ < contents_.size()) {
+      assert(reader_contents_->size() >= contents_.size());
+      memcpy((char*)reader_contents_->data() + last_flush_,
+	     contents_.data() + last_flush_,
+	     contents_.size() - last_flush_);
+      last_flush_ = contents_.size();
+    }
+    return Status::OK();
+  }
+  virtual Status Sync() override { return Status::OK(); }
+  virtual Status Append(const Slice& slice) override {
+    contents_.append(slice.data(), slice.size());
+    return Status::OK();
+  }
+  void Drop(size_t bytes) {
+    contents_.resize(contents_.size() - bytes);
+    if (last_flush_ > contents_.size())
+      last_flush_ = contents_.size();
+  }
+
+ private:
+  Slice* reader_contents_;
+  size_t last_flush_;
+};
+
 class StringSource: public RandomAccessFile {
  public:
   explicit StringSource(const Slice& contents, uint64_t uniq_id = 0,


### PR DESCRIPTION
We aren't correctly handling the case where the header has a bad length
or checksum.  Add a test and fix it!