### PR TITLE
log_reader: fix replay of recycled logs

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -191,6 +191,24 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch,
         }
         break;
 
+      case kBadRecordLen:
+        ReportCorruption(drop_size, "bad record length");
+        if (in_fragmented_record) {
+          ReportCorruption(scratch->size(), "error in middle of record");
+          in_fragmented_record = false;
+          scratch->clear();
+        }
+        break;
+
+      case kBadRecordChecksum:
+        ReportCorruption(drop_size, "checksum mismatch");
+        if (in_fragmented_record) {
+          ReportCorruption(scratch->size(), "error in middle of record");
+          in_fragmented_record = false;
+          scratch->clear();
+        }
+        break;
+
       default: {
         char buf[40];
         snprintf(buf, sizeof(buf), "unknown record type %u", record_type);
@@ -355,8 +373,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
       *drop_size = buffer_.size();
       buffer_.clear();
       if (!eof_) {
-        ReportCorruption(*drop_size, "bad record length");
-        return kBadRecord;
+        return kBadRecordLen;
       }
       // If the end of the file has been reached without reading |length| bytes
       // of payload, assume the writer died in the middle of writing the record.
@@ -388,8 +405,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
         // like a valid log record.
         *drop_size = buffer_.size();
         buffer_.clear();
-        ReportCorruption(*drop_size, "checksum mismatch");
-        return kBadRecord;
+        return kBadRecordChecksum;
       }
     }
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -113,6 +113,9 @@ class Reader {
   // which log number this is
   uint64_t const log_number_;
 
+  // Whether this is a recycled log file
+  bool recycled_;
+
   // Extend record types with the following special values
   enum {
     kEof = kMaxRecordType + 1,

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -126,6 +126,10 @@ class Reader {
     kBadHeader = kMaxRecordType + 3,
     // Returned when we read an old record from a previous user of the log.
     kOldRecord = kMaxRecordType + 4,
+    // Returned when we get a bad record length
+    kBadRecordLen = kMaxRecordType + 5,
+    // Returned when we get a bad record checksum
+    kBadRecordChecksum = kMaxRecordType + 6,
   };
 
   // Skips all blocks that are completely before "initial_offset_".


### PR DESCRIPTION
We aren't correctly handling the case where the header has a bad length
or checksum. Add a test and fix it! As it happens several of the existing
tests weren't behaving as they should in the recycled log case.