### PR TITLE
Fix appVeyor Build problem

### DIFF
--- a/include/rocksdb/delete_scheduler.h
+++ b/include/rocksdb/delete_scheduler.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 #include "rocksdb/status.h"
 


### PR DESCRIPTION
As Title

c:\projects\rocksdb\include\rocksdb\delete_scheduler.h(63): error C2039: 'shared_ptr' : is not a member of 'std' [C:\projects\rocksdb\build\delete_scheduler_test.vcxproj]