### PR TITLE
Fix clang warning regarding implicit conversion

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -601,7 +601,8 @@ TEST_F(DBCompactionTest, ZeroSeqIdCompaction) {
   CompactionOptions compact_opt;
   compact_opt.compression = kNoCompression;
   compact_opt.output_file_size_limit = 4096;
-  const int key_len = compact_opt.output_file_size_limit / 5;
+  const size_t key_len =
+    static_cast<size_t>(compact_opt.output_file_size_limit) / 5;
 
   options = CurrentOptions(options);
   DestroyAndReopen(options);


### PR DESCRIPTION
~~~
db/db_compaction_test.cc:604:58: error: implicit conversion loses integer precision: 'unsigned long long' to 'const int'
      [-Werror,-Wshorten-64-to-32]
  const int key_len = compact_opt.output_file_size_limit / 5;
            ~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
~~~