### PR TITLE
Fix clang warning

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4777,7 +4777,7 @@ std::vector<std::uint64_t> ListSpecificFiles(
       }
     }
   }
-  return std::move(file_numbers);
+  return file_numbers;
 }
 
 std::vector<std::uint64_t> ListTableFiles(Env* env, const std::string& path) {


### PR DESCRIPTION
~~~
db/db_test.cc:4780:10: error: moving a local object in a return statement prevents copy elision
      [-Werror,-Wpessimizing-move]
  return std::move(file_numbers);
         ^
db/db_test.cc:4780:10: note: remove std::move call here
  return std::move(file_numbers);
         ^~~~~~~~~~            ~
~~~

`-Wpessimizing-move` was introduced in clang 3.7.