### PR TITLE
Fix clang warnings

### DIFF
--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -27,7 +27,7 @@ class DBTestXactLogIterator : public DBTestBase {
     Status status = dbfull()->GetUpdatesSince(seq, &iter);
     EXPECT_OK(status);
     EXPECT_TRUE(iter->Valid());
-    return std::move(iter);
+    return iter;
   }
 };
 

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -329,8 +329,8 @@ Status WalManager::GetSortedWalsOfType(const std::string& path,
         return s;
       }
 
-      log_files.push_back(std::move(std::unique_ptr<LogFile>(
-          new LogFileImpl(number, log_type, sequence, size_bytes))));
+      log_files.push_back(std::unique_ptr<LogFile>(
+          new LogFileImpl(number, log_type, sequence, size_bytes)));
     }
   }
   CompareLogByPointer compare_log_files;

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -95,7 +95,7 @@ class WalManagerTest : public testing::Test {
     Status status = wal_manager_->GetUpdatesSince(
         seq, &iter, TransactionLogIterator::ReadOptions(), versions_.get());
     EXPECT_OK(status);
-    return std::move(iter);
+    return iter;
   }
 
   std::unique_ptr<MockEnv> env_;
@@ -184,7 +184,7 @@ std::vector<std::uint64_t> ListSpecificFiles(
       }
     }
   }
-  return std::move(file_numbers);
+  return file_numbers;
 }
 
 int CountRecords(TransactionLogIterator* iter) {

--- a/util/options_sanity_check.h
+++ b/util/options_sanity_check.h
@@ -23,7 +23,7 @@ enum OptionsSanityCheckLevel : unsigned char {
 
 // The sanity check level for DB options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
-    sanity_level_db_options;
+    sanity_level_db_options {};
 
 // The sanity check level for column-family options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
@@ -35,7 +35,7 @@ static const std::unordered_map<std::string, OptionsSanityCheckLevel>
 
 // The sanity check level for block-based table options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
-    sanity_level_bbt_options;
+    sanity_level_bbt_options {};
 
 OptionsSanityCheckLevel DBOptionSanityCheckLevel(
     const std::string& options_name);

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -521,10 +521,10 @@ Status BackupEngineImpl::Initialize() {
       continue;
     }
     assert(backups_.find(backup_id) == backups_.end());
-    backups_.insert(std::move(
+    backups_.insert(
         std::make_pair(backup_id, unique_ptr<BackupMeta>(new BackupMeta(
                                       GetBackupMetaFile(backup_id),
-                                      &backuped_file_infos_, backup_env_)))));
+                                      &backuped_file_infos_, backup_env_))));
   }
 
   latest_backup_id_ = 0;
@@ -619,10 +619,10 @@ Status BackupEngineImpl::CreateNewBackup(
 
   BackupID new_backup_id = latest_backup_id_ + 1;
   assert(backups_.find(new_backup_id) == backups_.end());
-  auto ret = backups_.insert(std::move(
+  auto ret = backups_.insert(
       std::make_pair(new_backup_id, unique_ptr<BackupMeta>(new BackupMeta(
                                         GetBackupMetaFile(new_backup_id),
-                                        &backuped_file_infos_, backup_env_)))));
+                                        &backuped_file_infos_, backup_env_))));
   assert(ret.second == true);
   auto& new_backup = ret.first->second;
   new_backup->RecordTimestamp();

--- a/utilities/document/json_document.cc
+++ b/utilities/document/json_document.cc
@@ -307,7 +307,7 @@ JSONDocument JSONDocument::operator[](const std::string& key) const {
   assert(foundValue != nullptr);
   // No need to save paths in const objects
   JSONDocument ans(foundValue, false);
-  return std::move(ans);
+  return ans;
 }
 
 size_t JSONDocument::Count() const {
@@ -330,7 +330,7 @@ JSONDocument JSONDocument::operator[](size_t i) const {
   auto arrayVal = reinterpret_cast<fbson::ArrayVal*>(value_);
   auto foundValue = arrayVal->get(static_cast<int>(i));
   JSONDocument ans(foundValue, false);
-  return std::move(ans);
+  return ans;
 }
 
 bool JSONDocument::IsNull() const {

--- a/utilities/flashcache/flashcache.cc
+++ b/utilities/flashcache/flashcache.cc
@@ -103,7 +103,7 @@ class FlashcacheAwareEnv : public EnvWrapper {
 std::unique_ptr<Env> NewFlashcacheAwareEnv(Env* base,
                                            const int cachedev_fd) {
   std::unique_ptr<Env> ret(new FlashcacheAwareEnv(base, cachedev_fd));
-  return std::move(ret);
+  return ret;
 }
 
 int FlashcacheBlacklistCurrentThread(Env* flashcache_aware_env) {


### PR DESCRIPTION
I try to compile using clang 3.7 under Arch Linux.
73b175a7738a53cf9a906ef1389962378c7ddf72 fixes all warning regarding `std::move`.
1aef02f67b0129784cf8373d2f82e4c6742fc94c fixes a compile error. Actually the original code is valid. But clang uses `libstdc++` under Linux, and `libstdc++` does not proper implement `std::unordered_map` (it lacks user-provided default constructor, see https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/unordered_map.h#L132). Defining const object without user-provided default constructor is invalid (http://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a), and clang rejects to compile (but gcc accepts it). So I create this commit as a workaround to let it compiled.