### PR TITLE
add a factory method for creating hdfs env

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -947,6 +947,10 @@ class WritableFileWrapper : public WritableFile {
 // *base_env must remain live while the result is in use.
 Env* NewMemEnv(Env* base_env);
 
+// Returns a new environment that is used for HDFS environment.
+// This is a factory method for HdfsEnv declared in hdfs/env_hdfs.h
+Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname);
+
 }  // namespace rocksdb
 
 #endif  // STORAGE_ROCKSDB_INCLUDE_ENV_H_

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -614,7 +614,7 @@ namespace rocksdb {
  }
 
  Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
-	 return Status::NotSupported("Not compiled with hdfs support");
+   return Status::NotSupported("Not compiled with hdfs support");
  }
 
 }

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -596,8 +596,8 @@ Status HdfsEnv::NewLogger(const std::string& fname,
 
 // The factory method for creating an HDFS Env
 Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
-	*hdfs_env = new HdfsEnv(fsname);
-	return Status::OK();
+  *hdfs_env = new HdfsEnv(fsname);
+  return Status::OK();
 }
 }  // namespace rocksdb
 

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -616,7 +616,6 @@ namespace rocksdb {
  Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
    return Status::NotSupported("Not compiled with hdfs support");
  }
-
 }
 
 #endif

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -594,7 +594,7 @@ Status HdfsEnv::NewLogger(const std::string& fname,
   return Status::OK();
 }
 
-	// The factory method for creating an HDFS Env
+// The factory method for creating an HDFS Env
 Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
 	*hdfs_env = new HdfsEnv(fsname);
 	return Status::OK();

--- a/util/env_hdfs.cc
+++ b/util/env_hdfs.cc
@@ -594,6 +594,11 @@ Status HdfsEnv::NewLogger(const std::string& fname,
   return Status::OK();
 }
 
+	// The factory method for creating an HDFS Env
+Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
+	*hdfs_env = new HdfsEnv(fsname);
+	return Status::OK();
+}
 }  // namespace rocksdb
 
 #endif // ROCKSDB_HDFS_FILE_C
@@ -607,6 +612,11 @@ namespace rocksdb {
                                    const EnvOptions& options) {
    return Status::NotSupported("Not compiled with hdfs support");
  }
+
+ Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
+	 return Status::NotSupported("Not compiled with hdfs support");
+ }
+
 }
 
 #endif


### PR DESCRIPTION
There is no way we can use HDFSEnv even if we compile with HDFS and install as shared_lib.
implementing a factory method that creates the HDFS environment.