### PR TITLE
Disable Visual Studio Warning C4351 and Add some type casts to suppress warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4800 /wd4996")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4800 /wd4996 /wd4351")
 
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -481,7 +481,8 @@ std::unique_ptr<WriteControllerToken> SetupDelay(
     // because of hitting the max write buffer number.
     if (prev_compaction_neeed_bytes > 0 &&
         prev_compaction_neeed_bytes <= compaction_needed_bytes) {
-      write_rate /= kSlowdownRatio;
+      write_rate = static_cast<uint64_t>(static_cast<double>(write_rate) /
+                                         kSlowdownRatio);
       if (write_rate < kMinWriteRate) {
         write_rate = kMinWriteRate;
       }
@@ -489,7 +490,8 @@ std::unique_ptr<WriteControllerToken> SetupDelay(
       // We are speeding up by ratio of kSlowdownRatio when we have paid
       // compaction debt. But we'll never speed up to faster than the write rate
       // given by users.
-      write_rate *= kSlowdownRatio;
+      write_rate = static_cast<uint64_t>(static_cast<double>(write_rate) *
+                                         kSlowdownRatio);
       if (write_rate > max_write_rate) {
         write_rate = max_write_rate;
       }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -580,8 +580,8 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
                         &files);  // Ignore errors
       for (std::string file : files) {
         // TODO(icanadi) clean up this mess to avoid having one-off "/" prefixes
-        job_context->full_scan_candidate_files.emplace_back("/" + file,
-                                                            path_id);
+        job_context->full_scan_candidate_files.emplace_back(
+            "/" + file, static_cast<uint32_t>(path_id));
       }
     }
 

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -190,7 +190,8 @@ class Repairer {
               assert(path_id == 0);
               logs_.push_back(number);
             } else if (type == kTableFile) {
-              table_fds_.emplace_back(number, path_id, 0);
+              table_fds_.emplace_back(number, static_cast<uint32_t>(path_id),
+                                      0);
             } else {
               // Ignore other files
             }


### PR DESCRIPTION
Currently Windows build is broken because of Warning C4351. Disable the warning before figuring out the right way to fix it.