### PR TITLE
Fix index seeking in BlockTableReader::PrefixMayMatch.

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1122,7 +1122,7 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key) {
   assert(rep_->ioptions.prefix_extractor != nullptr);
   auto prefix = rep_->ioptions.prefix_extractor->Transform(
       ExtractUserKey(internal_key));
-  InternalKey internal_key_prefix(prefix, 0, kTypeValue);
+  InternalKey internal_key_prefix(prefix, kMaxSequenceNumber, kTypeValue);
   auto internal_prefix = internal_key_prefix.Encode();
 
   bool may_match = true;


### PR DESCRIPTION
PrefixMayMatch previously seeked in the prefix index using an internal
key with a sequence number of 0. This would cause the prefix index seek
to fall off the end if the last key in the index had a user-key greater
than or equal to the key being looked for. Falling off the end of the
index in turn results in PrefixMayMatch returning false if the index is
in memory.