### PR TITLE
fix a compile error on 32-bit (fixes #634)

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -292,9 +292,11 @@ static inline uint32_t LE_LOAD32(const uint8_t *p) {
 }
 
 #ifdef __SSE4_2__
+#ifdef __LP64__
 static inline uint64_t LE_LOAD64(const uint8_t *p) {
   return DecodeFixed64(reinterpret_cast<const char*>(p));
 }
+#endif
 #endif
 
 static inline void Slow_CRC32(uint64_t* l, uint8_t const **p) {

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -319,9 +319,9 @@ static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
   *l = _mm_crc32_u64(*l, LE_LOAD64(*p));
   *p += 8;
 #else
-  *l = _mm_crc32_u32(*l, LE_LOAD32(*p));
+  *l = _mm_crc32_u32((unsigned int)*l, LE_LOAD32(*p));
   *p += 4;
-  *l = _mm_crc32_u32(*l, LE_LOAD32(*p));
+  *l = _mm_crc32_u32((unsigned int)*l, LE_LOAD32(*p));
   *p += 4;
 #endif
 #else

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -319,9 +319,9 @@ static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
   *l = _mm_crc32_u64(*l, LE_LOAD64(*p));
   *p += 8;
 #else
-  *l = _mm_crc32_u32((unsigned int)*l, LE_LOAD32(*p));
+  *l = _mm_crc32_u32(static_cast<unsigned int>(*l), LE_LOAD32(*p));
   *p += 4;
-  *l = _mm_crc32_u32((unsigned int)*l, LE_LOAD32(*p));
+  *l = _mm_crc32_u32(static_cast<unsigned int>(*l), LE_LOAD32(*p));
   *p += 4;
 #endif
 #else

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -315,8 +315,15 @@ static inline void Slow_CRC32(uint64_t* l, uint8_t const **p) {
 
 static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
 #ifdef __SSE4_2__
+#ifdef __LP64__
   *l = _mm_crc32_u64(*l, LE_LOAD64(*p));
   *p += 8;
+#else
+  *l = _mm_crc32_u32(*l, LE_LOAD32(*p));
+  *p += 4;
+  *l = _mm_crc32_u32(*l, LE_LOAD32(*p));
+  *p += 4;
+#endif
 #else
   Slow_CRC32(l, p);
 #endif


### PR DESCRIPTION
This fixes the compile error on 32-bit mentioned in issue #634.  This allows successful compilation of 32 bit library on Linux.

Debug compilation on OSX still fails because it declares -Wshorten-64-to-32, so you have to turn off warnings as errors to compile.  It does compile after that.

Note that it doesn't appear that the test cases were operational in 32 bit, so I can't evaluate whether any test cases fail as a result of this change.