### PR TITLE
added --no_value option to ldb scan to dump key only

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1742,15 +1742,17 @@ Options BatchPutCommand::PrepareOptionsForOpenDB() {
 // ----------------------------------------------------------------------------
 
 ScanCommand::ScanCommand(const vector<string>& params,
-      const map<string, string>& options, const vector<string>& flags) :
-    LDBCommand(options, flags, true,
-               BuildCmdLineOptions({ARG_TTL, ARG_NO_VALUE, ARG_HEX, ARG_KEY_HEX, ARG_TO,
-                                    ARG_VALUE_HEX, ARG_FROM, ARG_TIMESTAMP,
-                                    ARG_MAX_KEYS, ARG_TTL_START, ARG_TTL_END})),
-    start_key_specified_(false),
-    end_key_specified_(false),
-    max_keys_scanned_(-1),
-    no_value_(false) {
+                         const map<string, string>& options,
+                         const vector<string>& flags)
+    : LDBCommand(options, flags, true,
+                 BuildCmdLineOptions(
+                     {ARG_TTL,      ARG_NO_VALUE,  ARG_HEX,    ARG_KEY_HEX,
+                      ARG_TO,       ARG_VALUE_HEX, ARG_FROM,   ARG_TIMESTAMP,
+                      ARG_MAX_KEYS, ARG_TTL_START, ARG_TTL_END})),
+      start_key_specified_(false),
+      end_key_specified_(false),
+      max_keys_scanned_(-1),
+      no_value_(false) {
 
   map<string, string>::const_iterator itr = options.find(ARG_FROM);
   if (itr != options.end()) {
@@ -1769,7 +1771,8 @@ ScanCommand::ScanCommand(const vector<string>& params,
     end_key_specified_ = true;
   }
 
-  vector<string>::const_iterator vitr = std::find(flags.begin(), flags.end(), ARG_NO_VALUE);
+  vector<string>::const_iterator vitr =
+      std::find(flags.begin(), flags.end(), ARG_NO_VALUE);
   if (vitr != flags.end()) {
     no_value_ = true;
   }
@@ -1858,20 +1861,20 @@ void ScanCommand::DoCommand() {
     }
 
     if (no_value_) {
-        fprintf(stdout, "%.*s\n",
-            static_cast<int>(key_slice.size()), key_slice.data());
+      fprintf(stdout, "%.*s\n", static_cast<int>(key_slice.size()),
+              key_slice.data());
     } else {
-        Slice val_slice = it->value();
-        std::string formatted_value;
-        if (is_value_hex_) {
-          formatted_value = "0x" + val_slice.ToString(true /* hex */);
-          val_slice = formatted_value;
-        }
-        fprintf(stdout, "%.*s : %.*s\n",
-            static_cast<int>(key_slice.size()), key_slice.data(),
-            static_cast<int>(val_slice.size()), val_slice.data());
+      Slice val_slice = it->value();
+      std::string formatted_value;
+      if (is_value_hex_) {
+        formatted_value = "0x" + val_slice.ToString(true /* hex */);
+        val_slice = formatted_value;
+      }
+      fprintf(stdout, "%.*s : %.*s\n", static_cast<int>(key_slice.size()),
+              key_slice.data(), static_cast<int>(val_slice.size()),
+              val_slice.data());
     }
-    
+
     num_keys_scanned++;
     if (max_keys_scanned_ >= 0 && num_keys_scanned >= max_keys_scanned_) {
       break;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1847,7 +1847,6 @@ void ScanCommand::DoCommand() {
     }
 
     Slice key_slice = it->key();
-    Slice val_slice = it->value();
 
     std::string formatted_key;
     if (is_key_hex_) {

--- a/tools/ldb_cmd.h
+++ b/tools/ldb_cmd.h
@@ -60,6 +60,7 @@ public:
   static const string ARG_WRITE_BUFFER_SIZE;
   static const string ARG_FILE_SIZE;
   static const string ARG_CREATE_IF_MISSING;
+  static const string ARG_NO_VALUE;
 
   static LDBCommand* InitFromCmdLineArgs(
     const vector<string>& args,
@@ -377,7 +378,7 @@ private:
    */
   bool StringToBool(string val) {
     std::transform(val.begin(), val.end(), val.begin(),
-                   [](char ch) -> char { return ::tolower(ch); });
+                   [](char ch) -> char { return (char)::tolower(ch); });
 
     if (val == "true") {
       return true;
@@ -709,6 +710,7 @@ private:
   bool start_key_specified_;
   bool end_key_specified_;
   int max_keys_scanned_;
+  bool no_value_;
 };
 
 class DeleteCommand : public LDBCommand {

--- a/tools/ldb_cmd.h
+++ b/tools/ldb_cmd.h
@@ -378,7 +378,7 @@ private:
    */
   bool StringToBool(string val) {
     std::transform(val.begin(), val.end(), val.begin(),
-                   [](char ch) -> char { return (char)::tolower(ch); });
+                   [](char ch)->char { return (char)::tolower(ch); });
 
     if (val == "true") {
       return true;


### PR DESCRIPTION
Adding an option to ldb to make it possible to dump keys only, without values.