### PR TITLE
Fixing initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD License
 
 For rocksdb software
 
-Copyright (c) 2014, Facebook, Inc.
+Copyright (c) 2013-present, Facebook, Inc.
 All rights reserved.
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright

As the current license was applied back in 2013 ( As per the commit -  9cd221094cb14f3192228f7d )

Adding present in the year range , to follow suit with other facebook license (For eg - https://github.com/facebook/react/blob/master/LICENSE )