### PR TITLE
Move out of release build some test code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ set(SOURCES
         table/merger.cc
         table/sst_file_writer.cc
         table/meta_blocks.cc
-        table/mock_table.cc
         table/plain_table_builder.cc
         table/plain_table_factory.cc
         table/plain_table_index.cc
@@ -214,7 +213,6 @@ set(SOURCES
         util/logging.cc
         util/log_buffer.cc
         util/memenv.cc
-        util/mock_env.cc
         util/murmurhash.cc
         util/mutable_cf_options.cc
         util/options.cc
@@ -277,6 +275,8 @@ set(SOURCES
 # and linked to tests. Add test only code that is not #ifdefed for Release here.
 set(TESTUTIL_SOURCE
     db/db_test_util.cc
+    table/mock_table.cc
+    util/mock_env.cc
     util/thread_status_updater_debug.cc
 )
 


### PR DESCRIPTION
This partially addresses issue https://github.com/facebook/rocksdb/issues/935

  testutil.cc and testharness.cc could not be moved out at this time
  as they are used by 4 benchmarks in release builds.