### PR TITLE
Fixing JNI release build for gcc

### DIFF
--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -61,7 +61,9 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
     rocksdb::ParsedInternalKey ikey;
     memset(reinterpret_cast<void*>(&ikey), 0, sizeof(ikey));
     bool parsed = rocksdb::ParseInternalKey(iter->key(), &ikey);
-    assert(parsed);
+    if (!parsed) {
+      assert(parsed);
+    }
     switch (ikey.type) {
       case rocksdb::kTypeValue:
         state.append("Put(");


### PR DESCRIPTION
Fixing unused variable for release JNI build:
V=1 make rocksdbjavastatic

java/rocksjni/write_batch_test.cc: In function ‘_jbyteArray* Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv*, jclass, jobject)’:
java/rocksjni/write_batch_test.cc:63:10: warning: unused variable ‘parsed’ [-Wunused-variable]
     bool parsed = rocksdb::ParseInternalKey(iter->key(), &ikey);
          ^

@adamretter Can you please review?