### PR TITLE
Use user_comparator when comparing against iterate_upper_bound.

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -275,7 +275,7 @@ void DBIter::FindNextUserEntryInternal(bool skipping) {
 
     if (ParseKey(&ikey)) {
       if (iterate_upper_bound_ != nullptr &&
-          ikey.user_key.compare(*iterate_upper_bound_) >= 0) {
+          user_comparator_->Compare(ikey.user_key, *iterate_upper_bound_) >= 0) {
         break;
       }
 


### PR DESCRIPTION
Fixes #983.