### PR TITLE
Fix Windows build

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1616,7 +1616,7 @@ Status BackupEngineImpl::BackupMeta::LoadFromFile(
       std::string abs_path = backup_dir + "/" + filename;
       try {
         size = abs_path_to_size.at(abs_path);
-      } catch (std::out_of_range& e) {
+      } catch (std::out_of_range&) {
         return Status::NotFound("Size missing for pathname: " + abs_path);
       }
     }


### PR DESCRIPTION
c:\projects\rocksdb\utilities\backupable\backupable_db.cc(1619): warning C4101: 'e' : unreferenced local variable [C:\projects\rocksdb\build\rocksdblib.vcxproj]