### PR TITLE
Fix FB internal CI build failure

### DIFF
--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -101,7 +101,7 @@ void HistogramStat::Add(uint64_t value) {
   // of any operation. Each individual value is atomic and the order of updates
   // by concurrent threads is tolerable.
   const size_t index = bucketMapper.IndexForValue(value);
-  assert(index < num_buckets_ && index >= 0);
+  assert(index < num_buckets_);
   buckets_[index].fetch_add(1, std::memory_order_relaxed);
 
   uint64_t old_min = min();


### PR DESCRIPTION
11:30:29 from ./util/histogram.h:13,
11:30:29 from util/histogram.cc:18:
11:30:29 util/histogram.cc: In member function ‘void rocksdb::HistogramStat::Add(uint64_t)’:
11:30:29 util/histogram.cc:104:40: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]
11:30:29 assert(index < num_buckets_ && index >= 0);
11:30:29 ^