### PR TITLE
Latest versions of Jemalloc library do not require je_init()/je_unint()

### DIFF
--- a/port/win/port_win.cc
+++ b/port/win/port_win.cc
@@ -233,6 +233,8 @@ int GetMaxOpenFiles() { return -1; }
 
 #include "jemalloc/jemalloc.h"
 
+#ifndef JEMALLOC_NON_INIT
+
 namespace rocksdb {
 
 namespace port {
@@ -277,6 +279,8 @@ JEMALLOC_SECTION(".CRT$XCT") JEMALLOC_ATTR(used) static const void(
 #endif  // _WIN64
 
 }  // extern "C"
+
+#endif // JEMALLOC_NON_INIT
 
 // Global operators to be replaced by a linker
 

--- a/thirdparty.inc
+++ b/thirdparty.inc
@@ -8,6 +8,7 @@ set(USE_SNAPPY_DEFAULT 0)        # SNAPPY is disabled by default, enable with -D
 set(USE_LZ4_DEFAULT 0)           # LZ4 is disabled by default, enable with -DLZ4=1 cmake command line agrument
 set(USE_ZLIB_DEFAULT 0)          # ZLIB is disabled by default, enable with -DZLIB=1 cmake command line agrument
 set(USE_JEMALLOC_DEFAULT 0)      # JEMALLOC is disabled by default, enable with -DJEMALLOC=1 cmake command line agrument
+set(USE_JENONINIT_DEFAULT 1)     # Default is enabled do not call je_init/je_uninit as the newer versions do not have it disable with -DJENONINIT=0
 
 #
 # This example assumes all the libraries locate in directories under THIRDPARTY_HOME environment variable
@@ -208,7 +209,7 @@ endif ()
 
 if (${USE_JEMALLOC} EQUAL 1)
   message(STATUS "JEMALLOC library is enabled")
-  set(JEMALLOC_CXX_FLAGS -DJEMALLOC)
+  set(JEMALLOC_CXX_FLAGS "-DJEMALLOC -DJEMALLOC_EXPORT= ")
   
   if(DEFINED ENV{JEMALLOC_INCLUDE})
     set(JEMALLOC_INCLUDE $ENV{JEMALLOC_INCLUDE})
@@ -228,6 +229,18 @@ if (${USE_JEMALLOC} EQUAL 1)
   include_directories(${JEMALLOC_INCLUDE})
   set (THIRDPARTY_LIBS ${THIRDPARTY_LIBS} ${JEMALLOC_LIBS})
   set (ARTIFACT_SUFFIX "_je")
+  
+  set(USE_JENONINIT USE_JENONINIT_DEFAULT)
+ 
+  if(JENONINIT)
+    set(USE_JENONINIT ${JENONINIT})
+  endif()
+  
+  if(${USE_JENONINIT} EQUAL 1)
+    add_definitions(-DJEMALLOC_NON_INIT)
+    message(STATUS "JEMALLOC NONINIT version")
+  endif()
+  
 else ()
   set (ARTIFACT_SUFFIX "")
   message(STATUS "JEMALLOC library is disabled")


### PR DESCRIPTION
  calls. #ifdef in the source code and make this a default build option.