### PR TITLE
Fix in HistogramWindowingImpl

### DIFF
--- a/util/histogram_windowing.cc
+++ b/util/histogram_windowing.cc
@@ -14,10 +14,6 @@
 
 namespace rocksdb {
 
-namespace {
-  const HistogramBucketMapper bucketMapper;
-}
-
 HistogramWindowingImpl::HistogramWindowingImpl() {
   env_ = Env::Default();
   window_stats_.reset(new HistogramStat[num_windows_]);
@@ -36,8 +32,7 @@ HistogramWindowingImpl::HistogramWindowingImpl(
   Clear();
 }
 
-HistogramWindowingImpl::~HistogramWindowingImpl(){
-  window_stats_.release();
+HistogramWindowingImpl::~HistogramWindowingImpl() {
 }
 
 void HistogramWindowingImpl::Clear() {
@@ -85,7 +80,7 @@ void HistogramWindowingImpl::Merge(const HistogramWindowingImpl& other) {
   uint64_t cur_window = current_window();
   uint64_t other_cur_window = other.current_window();
   // going backwards for alignment
-  for (unsigned int i = 0; 
+  for (unsigned int i = 0;
                     i < std::min(num_windows_, other.num_windows_); i++) {
     uint64_t window_index =
         (cur_window + num_windows_ - i) % num_windows_;
@@ -147,7 +142,7 @@ void HistogramWindowingImpl::SwapHistoryBucket() {
     last_swap_time_.store(env_->NowMicros(), std::memory_order_relaxed);
 
     uint64_t curr_window = current_window();
-    uint64_t next_window = (curr_window == num_windows_ - 1) ? 
+    uint64_t next_window = (curr_window == num_windows_ - 1) ?
                                                     0 : curr_window + 1;
 
     // subtract next buckets from totals and swap to next buckets
@@ -160,7 +155,7 @@ void HistogramWindowingImpl::SwapHistoryBucket() {
       }
 
       if (stats_.min() == stats_to_drop.min()) {
-        uint64_t new_min = bucketMapper.LastValue();
+        uint64_t new_min = std::numeric_limits<uint64_t>::max();
         for (unsigned int i = 0; i < num_windows_; i++) {
           if (i != next_window) {
             uint64_t m = window_stats_[i].min();


### PR DESCRIPTION
@kradhakrishnan

In file included from unity.cc:109:0:
util/histogram_windowing.cc:18:31: error: redefinition of â€˜const rocksdb::HistogramBucketMapper rocksdb::{anonymous}::bucketMapperâ€™
const HistogramBucketMapper bucketMapper;
^
In file included from unity.cc:108:0:
util/histogram.cc:77:31: note: â€˜const rocksdb::HistogramBucketMapper rocksdb::{anonymous}::bucketMapperâ€™ previously declared here
const HistogramBucketMapper bucketMapper;

valgrind error:

==627965== 5,768 bytes in 1 blocks are definitely lost in loss record 10 of 10
==627965== at 0x4C2B9C4: operator new (in /usr/local/fbcode/gcc-4.9-glibc-2.20/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==627965== by 0x5B230F: rocksdb::HistogramWindowingImpl::HistogramWindowingImpl() (histogram_windowing.cc:23)
==627965== by 0x411246: rocksdb::HistogramTest_ClearHistogram_Test::TestBody() (histogram_test.cc:112)
==627965== by 0x6DF027: HandleSehExceptionsInMethodIfSupported (gtest-all.cc:3822)
==627965== by 0x6DF027: void testing::internal::HandleExceptionsInMethodIfSupported(testing::Test, void (testing::Test::)(), char const*) (gtest-all.cc:3858)
==627965== by 0x6D415C: testing::Test::Run() (gtest-all.cc:3895)
==627965== by 0x6D41E8: testing::TestInfo::Run() clone .part.562
==627965== by 0x6D4354: Run (gtest-all.cc:4045)
==627965== by 0x6D4354: testing::TestCase::Run() clone .part.563
==627965== by 0x6D4714: Run (gtest-all.cc:6026)
==627965== by 0x6D4714: testing::internal::UnitTestImpl::RunAllTests() (gtest-all.cc:6060)
==627965== by 0x6D492B: HandleSehExceptionsInMethodIfSupported (gtest-all.cc:3822)
==627965== by 0x6D492B: HandleExceptionsInMethodIfSupported (gtest-all.cc:3858)
==627965== by 0x6D492B: testing::UnitTest::Run() (gtest-all.cc:5681)
==627965== by 0x4158E2: RUN_ALL_TESTS (gtest.h:20722)
==627965== by 0x4158E2: main (histogram_test.cc:209)