### PR TITLE
Use async file handle for better parallelism on Windows

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1199,7 +1199,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         bool batch_changed = false;
 
         WalFilter::WalProcessingOption wal_processing_option =
-            db_options_.wal_filter->LogRecord(log_number, fname, batch,
+            db_options_.wal_filter->LogRecordFound(log_number, fname, batch,
                                               &new_batch, &batch_changed);
 
         switch (wal_processing_option) {

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -502,7 +502,7 @@ TEST_F(DBTest2, WalFilterTestWithColumnFamilies) {
       cf_name_id_map_ = cf_name_id_map;
     }
 
-    virtual WalProcessingOption LogRecord(unsigned long long log_number,
+    virtual WalProcessingOption LogRecordFound(unsigned long long log_number,
       const std::string& log_file_name,
       const WriteBatch& batch,
       WriteBatch* new_batch,

--- a/include/rocksdb/wal_filter.h
+++ b/include/rocksdb/wal_filter.h
@@ -75,11 +75,12 @@ class WalFilter {
   // @returns               Processing option for the current record.
   //                        Please see WalProcessingOption enum above for
   //                        details.
-  virtual WalProcessingOption LogRecord(unsigned long long log_number,
+  virtual WalProcessingOption LogRecordFound(unsigned long long log_number,
                                         const std::string& log_file_name,
                                         const WriteBatch& batch,
                                         WriteBatch* new_batch,
                                         bool* batch_changed) {
+    // Default implementation falls back to older function for compatibility
     return LogRecord(batch, new_batch, batch_changed);
   }
 


### PR DESCRIPTION
Use async file handle and wrap sync API on top of async API. This provides better parallelism on Windows.

The change is in Windows port only.

The previous commit (583157f) already has a PR open. 

So this change would be for async file handle only once that PR is merged.