### PR TITLE
Remove the Magic number 12 used in record size checks

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1186,7 +1186,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         continue_replay_log &&
         reader.ReadRecord(&record, &scratch, db_options_.wal_recovery_mode) &&
         status.ok()) {
-      if (record.size() < 12) {
+      if (record.size() < WriteBatchInternal::kHeader) {
         reporter.Corruption(record.size(),
                             Status::Corruption("log record too small"));
         continue;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -265,7 +265,7 @@ class Repairer {
     mem->Ref();
     int counter = 0;
     while (reader.ReadRecord(&record, &scratch)) {
-      if (record.size() < 12) {
+      if (record.size() < WriteBatchInternal::kHeader) {
         reporter.Corruption(
             record.size(), Status::Corruption("log record too small"));
         continue;

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -107,7 +107,7 @@ void TransactionLogIteratorImpl::SeekToStartSequence(
     return;
   }
   while (RestrictedRead(&record, &scratch)) {
-    if (record.size() < 12) {
+    if (record.size() < WriteBatchInternal::kHeader) {
       reporter_.Corruption(
         record.size(), Status::Corruption("very small log record"));
       continue;
@@ -167,7 +167,7 @@ void TransactionLogIteratorImpl::NextImpl(bool internal) {
       currentLogReader_->UnmarkEOF();
     }
     while (RestrictedRead(&record, &scratch)) {
-      if (record.size() < 12) {
+      if (record.size() < WriteBatchInternal::kHeader) {
         reporter_.Corruption(
           record.size(), Status::Corruption("very small log record"));
         continue;

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -455,7 +455,7 @@ Status WalManager::ReadFirstLine(const std::string& fname,
 
   if (reader.ReadRecord(&record, &scratch) &&
       (status.ok() || !db_options_.paranoid_checks)) {
-    if (record.size() < 12) {
+    if (record.size() < WriteBatchInternal::kHeader) {
       reporter.Corruption(record.size(),
                           Status::Corruption("log record too small"));
       // TODO read record's till the first no corrupt entry?

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -94,7 +94,8 @@ struct SavePoints {
 
 WriteBatch::WriteBatch(size_t reserved_bytes)
     : save_points_(nullptr), content_flags_(0), rep_() {
-  rep_.reserve((reserved_bytes > WriteBatchInternal::kHeader) ? reserved_bytes : WriteBatchInternal::kHeader);
+  rep_.reserve((reserved_bytes > WriteBatchInternal::kHeader) ? 
+    reserved_bytes : WriteBatchInternal::kHeader);
   rep_.resize(WriteBatchInternal::kHeader);
 }
 
@@ -327,7 +328,9 @@ void WriteBatchInternal::SetSequence(WriteBatch* b, SequenceNumber seq) {
   EncodeFixed64(&b->rep_[0], seq);
 }
 
-size_t WriteBatchInternal::GetFirstOffset(WriteBatch* b) { return WriteBatchInternal::kHeader; }
+size_t WriteBatchInternal::GetFirstOffset(WriteBatch* b) { 
+  return WriteBatchInternal::kHeader; 
+}
 
 void WriteBatchInternal::Put(WriteBatch* b, uint32_t column_family_id,
                              const Slice& key, const Slice& value) {
@@ -838,7 +841,8 @@ void WriteBatchInternal::SetContents(WriteBatch* b, const Slice& contents) {
 void WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src) {
   SetCount(dst, Count(dst) + Count(src));
   assert(src->rep_.size() >= WriteBatchInternal::kHeader);
-  dst->rep_.append(src->rep_.data() + WriteBatchInternal::kHeader, src->rep_.size() - WriteBatchInternal::kHeader);
+  dst->rep_.append(src->rep_.data() + WriteBatchInternal::kHeader, 
+    src->rep_.size() - WriteBatchInternal::kHeader);
   dst->content_flags_.store(
       dst->content_flags_.load(std::memory_order_relaxed) |
           src->content_flags_.load(std::memory_order_relaxed),

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -81,8 +81,6 @@ struct BatchContentClassifier : public WriteBatch::Handler {
 
 }  // anon namespace
 
-// WriteBatch header has an 8-byte sequence number followed by a 4-byte count.
-static const size_t kHeader = 12;
 
 struct SavePoint {
   size_t size;  // size of rep_
@@ -96,8 +94,8 @@ struct SavePoints {
 
 WriteBatch::WriteBatch(size_t reserved_bytes)
     : save_points_(nullptr), content_flags_(0), rep_() {
-  rep_.reserve((reserved_bytes > kHeader) ? reserved_bytes : kHeader);
-  rep_.resize(kHeader);
+  rep_.reserve((reserved_bytes > WriteBatchInternal::kHeader) ? reserved_bytes : WriteBatchInternal::kHeader);
+  rep_.resize(WriteBatchInternal::kHeader);
 }
 
 WriteBatch::WriteBatch(const std::string& rep)

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -63,6 +63,10 @@ class ColumnFamilyMemTablesDefault : public ColumnFamilyMemTables {
 // WriteBatch that we don't want in the public WriteBatch interface.
 class WriteBatchInternal {
  public:
+
+  // WriteBatch header has an 8-byte sequence number followed by a 4-byte count.
+  static const size_t kHeader = 12;
+
   // WriteBatch methods with column_family_id instead of ColumnFamilyHandle*
   static void Put(WriteBatch* batch, uint32_t column_family_id,
                   const Slice& key, const Slice& value);

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1576,7 +1576,7 @@ void DumpWalFile(std::string wal_file, bool print_header, bool print_values,
     }
     while (reader.ReadRecord(&record, &scratch)) {
       row.str("");
-      if (record.size() < 12) {
+      if (record.size() < WriteBatchInternal::kHeader) {
         reporter.Corruption(record.size(),
                             Status::Corruption("log record too small"));
       } else {


### PR DESCRIPTION
In all the places where log records are read, there was a check that record.size() should not be less than 12.
    
This "magic number" seems to be the WriteBatch header (8 byte sequence and 4 byte count). 

Replaced all the places where "12" was used by WriteBatchInternal::kHeader.
