### PR TITLE
instructing people to use java7 for hdfs environment

### DIFF
--- a/hdfs/README
+++ b/hdfs/README
@@ -12,7 +12,7 @@ underlying filesystem.
 If you want to compile rocksdb with hdfs support, please set the following
 environment variables appropriately (also defined in setup.sh for convenience)
    USE_HDFS=1
-   JAVA_HOME=/usr/local/jdk-6u22-64
+   JAVA_HOME=/usr/local/jdk-7u79-64
    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/jdk-6u22-64/jre/lib/amd64/server:/usr/local/jdk-6u22-64/jre/lib/amd64/:./snappy/libs
    make clean all db_bench
 


### PR DESCRIPTION
We tested to use the HDFS environment for rocksDB backup. From our experience, the hdfsConnect() will constantly crash on large rocksdb instances (1.5-3G).  It is related to this JDK6 bug:
http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6964776

After we change to jvm7, the issue goes away. So change readme to suggest people use java7 to run the hdfs environemnt.