### PR TITLE
rocksdb_create_mem_env to allow C libraries to create mem env

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2132,6 +2132,13 @@ rocksdb_env_t* rocksdb_create_default_env() {
   return result;
 }
 
+rocksdb_env_t* rocksdb_create_mem_env() {
+  rocksdb_env_t* result = new rocksdb_env_t;
+  result->rep = rocksdb::NewMemEnv(Env::Default());
+  result->is_default = false;
+  return result;
+}
+
 void rocksdb_env_set_background_threads(rocksdb_env_t* env, int n) {
   env->rep->SetBackgroundThreads(n);
 }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -835,6 +835,7 @@ extern ROCKSDB_LIBRARY_API void rocksdb_cache_destroy(rocksdb_cache_t* cache);
 /* Env */
 
 extern ROCKSDB_LIBRARY_API rocksdb_env_t* rocksdb_create_default_env();
+extern ROCKSDB_LIBRARY_API rocksdb_env_t* rocksdb_create_mem_env();
 extern ROCKSDB_LIBRARY_API void rocksdb_env_set_background_threads(
     rocksdb_env_t* env, int n);
 extern ROCKSDB_LIBRARY_API void


### PR DESCRIPTION
This is useful for C libraries wrapping rocksdb, especially for tests that create a real rocksdb instance.