### PR TITLE
Expose deleted keys through iteration.

### DIFF
--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -50,6 +50,7 @@ class KVIter : public Iterator {
   }
 
   virtual Slice key() const override { return iter_->first; }
+  virtual bool key_is_deleted() const override { return false; }
   virtual Slice value() const override { return iter_->second; }
   virtual Status status() const override { return Status::OK(); }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4021,7 +4021,8 @@ Iterator* DBImpl::NewIterator(const ReadOptions& read_options,
         kMaxSequenceNumber,
         sv->mutable_cf_options.max_sequential_skip_in_iterations,
         sv->version_number, read_options.iterate_upper_bound,
-        read_options.prefix_same_as_start, read_options.pin_data);
+        read_options.prefix_same_as_start, read_options.pin_data,
+        read_options.skip_deleted_keys);
 #endif
   } else {
     SequenceNumber latest_snapshot = versions_->LastSequence();
@@ -4133,7 +4134,8 @@ Status DBImpl::NewIterators(
           env_, *cfd->ioptions(), cfd->user_comparator(), iter,
           kMaxSequenceNumber,
           sv->mutable_cf_options.max_sequential_skip_in_iterations,
-          sv->version_number, nullptr, false, read_options.pin_data));
+          sv->version_number, nullptr, false, read_options.pin_data,
+          read_options.skip_deleted_keys));
     }
 #endif
   } else {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -30,7 +30,8 @@ extern Iterator* NewDBIterator(
     const Comparator* user_key_comparator, InternalIterator* internal_iter,
     const SequenceNumber& sequence, uint64_t max_sequential_skip_in_iterations,
     uint64_t version_number, const Slice* iterate_upper_bound = nullptr,
-    bool prefix_same_as_start = false, bool pin_data = false);
+    bool prefix_same_as_start = false, bool pin_data = false,
+    bool skip_deleted_keys = true);
 
 // A wrapper iterator which wraps DB Iterator and the arena, with which the DB
 // iterator is supposed be allocated. This class is used as an entry point of
@@ -59,6 +60,7 @@ class ArenaWrappedDBIter : public Iterator {
   virtual void Next() override;
   virtual void Prev() override;
   virtual Slice key() const override;
+  virtual bool key_is_deleted() const override;
   virtual Slice value() const override;
   virtual Status status() const override;
 
@@ -78,6 +80,7 @@ extern ArenaWrappedDBIter* NewArenaWrappedDbIterator(
     const Comparator* user_key_comparator, const SequenceNumber& sequence,
     uint64_t max_sequential_skip_in_iterations, uint64_t version_number,
     const Slice* iterate_upper_bound = nullptr,
-    bool prefix_same_as_start = false, bool pin_data = false);
+    bool prefix_same_as_start = false, bool pin_data = false,
+    bool skip_deleted_keys = true);
 
 }  // namespace rocksdb

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3236,6 +3236,7 @@ class ModelDB : public DB {
     virtual Slice key() const override { return iter_->first; }
     virtual Slice value() const override { return iter_->second; }
     virtual Status status() const override { return Status::OK(); }
+    virtual bool key_is_deleted() const override { return false; }
 
    private:
     const KVMap* const map_;

--- a/db/managed_iterator.cc
+++ b/db/managed_iterator.cc
@@ -200,6 +200,11 @@ Slice ManagedIterator::value() const {
   return cached_value_.GetKey();
 }
 
+bool ManagedIterator::key_is_deleted() const {
+  assert(valid_);
+  return cached_key_is_deleted_;
+}
+
 Status ManagedIterator::status() const { return status_; }
 
 void ManagedIterator::RebuildIterator() {
@@ -219,6 +224,7 @@ void ManagedIterator::UpdateCurrent() {
   status_ = Status::OK();
   cached_key_.SetKey(mutable_iter_->key());
   cached_value_.SetKey(mutable_iter_->value());
+  cached_key_is_deleted_ = mutable_iter_->key_is_deleted();
 }
 
 void ManagedIterator::ReleaseIter(bool only_old) {

--- a/db/managed_iterator.h
+++ b/db/managed_iterator.h
@@ -46,6 +46,7 @@ class ManagedIterator : public Iterator {
   virtual void Next() override;
   virtual Slice key() const override;
   virtual Slice value() const override;
+  virtual bool key_is_deleted() const override;
   virtual Status status() const override;
   void ReleaseIter(bool only_old);
   void SetDropOld(bool only_old) {
@@ -73,6 +74,7 @@ class ManagedIterator : public Iterator {
 
   IterKey cached_key_;
   IterKey cached_value_;
+  bool cached_key_is_deleted_ = false;
 
   bool only_drop_old_ = true;
   bool snapshot_created_;

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -85,6 +85,11 @@ class Iterator : public Cleanable {
   // REQUIRES: Valid()
   virtual Slice key() const = 0;
 
+  // Return if the iterator points to a deleted key. Deleted keys are exposed
+  // only when skip_deleted_keys is set to false in ReadOptions.
+  // REQUIRES: Valid()
+  virtual bool key_is_deleted() const = 0;
+
   // Return the value for the current entry.  The underlying storage for
   // the returned slice is valid only until the next modification of
   // the iterator.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1447,6 +1447,12 @@ struct ReadOptions {
   // Default: false
   bool pin_data;
 
+  // Expose deleted keys through the iterator. If set to false, rocksdb will
+  // internally skip over deleted keys. This can be used by users who want a
+  // predictable upper bound for the time taken by Seek()/Next()/Prev().
+  // Default: true
+  bool skip_deleted_keys;
+
   ReadOptions();
   ReadOptions(bool cksum, bool cache);
 };

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -71,6 +71,7 @@ class EmptyIterator : public Iterator {
     assert(false);
     return Slice();
   }
+  bool key_is_deleted() const override { assert(false); return false; }
   Slice value() const override {
     assert(false);
     return Slice();

--- a/util/options.cc
+++ b/util/options.cc
@@ -778,7 +778,8 @@ ReadOptions::ReadOptions()
       managed(false),
       total_order_seek(false),
       prefix_same_as_start(false),
-      pin_data(false) {
+      pin_data(false),
+      skip_deleted_keys(true) {
   XFUNC_TEST("", "managed_options", managed_options, xf_manage_options,
              reinterpret_cast<ReadOptions*>(this));
 }
@@ -793,7 +794,8 @@ ReadOptions::ReadOptions(bool cksum, bool cache)
       managed(false),
       total_order_seek(false),
       prefix_same_as_start(false),
-      pin_data(false) {
+      pin_data(false),
+      skip_deleted_keys(true) {
   XFUNC_TEST("", "managed_options", managed_options, xf_manage_options,
              reinterpret_cast<ReadOptions*>(this));
 }

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -115,6 +115,8 @@ class TtlIterator : public Iterator {
 
   Slice key() const override { return iter_->key(); }
 
+  bool key_is_deleted() const override { return iter_->key_is_deleted(); }
+
   int32_t timestamp() const {
     return DecodeFixed32(iter_->value().data() + iter_->value().size() -
                          DBWithTTLImpl::kTSLength);

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -147,6 +147,11 @@ class BaseDeltaIterator : public Iterator {
                             : delta_iterator_->Entry().value;
   }
 
+  bool key_is_deleted() const override {
+    return current_at_base_ ? base_iterator_->key_is_deleted()
+                            : false /* delta_iterator */;
+  }
+
   Status status() const override {
     if (!status_.ok()) {
       return status_;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -527,6 +527,7 @@ class KVIter : public Iterator {
   virtual Slice key() const { return iter_->first; }
   virtual Slice value() const { return iter_->second; }
   virtual Status status() const { return Status::OK(); }
+  virtual bool key_is_deleted() const { return false; }
 
  private:
   const KVMap* const map_;


### PR DESCRIPTION
When there are too many deleted keys, we are seeing that Seek/Next are taking too long to return. That is resulting in our threads to lock up for a potentially unbounded amount of time. There are techniques to mitigate this problem as documented in https://github.com/facebook/rocksdb/wiki/Delete-A-Range-Of-Keys, but we wanted a predictable upper bound on the time an iteration can take before returning.

I am proposing a change where rocksdb will expose deleted keys through iteration. In this case, it is up to the user code to continuously call Next() until they find a non-deleted valid key. This will give our code the opportunity to periodically check the time and yield the thread if needed.

Before implementing, I also considered an alternative approach of passing a timeout to Seek/Next calls but that would have made the interface/implementation much more complicated.

PTAL. If this change looks acceptable, I will look into implementing some tests in the next round.
