### PR TITLE
Previously WARN level logging became FATAL level logging in the Java API

### DIFF
--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -54,6 +54,9 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level,
       case rocksdb::InfoLogLevel::INFO_LEVEL:
         jlog_level = InfoLogLevelJni::INFO_LEVEL(env);
         break;
+      case rocksdb::InfoLogLevel::WARN_LEVEL:
+        jlog_level = InfoLogLevelJni::WARN_LEVEL(env);
+        break;
       case rocksdb::InfoLogLevel::ERROR_LEVEL:
         jlog_level = InfoLogLevelJni::ERROR_LEVEL(env);
         break;


### PR DESCRIPTION
WARN level logging is now correctly logged at WARN level via the Java API, previously it was mistakenly logged at FATAL level.