### PR TITLE
Fix #1110, 32-bit build failure on Mac OSX

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -149,7 +149,7 @@ ColumnFamilyOptions SanitizeOptions(const DBOptions& db_options,
   result.comparator = icmp;
   size_t clamp_max = std::conditional<
       sizeof(size_t) == 4, std::integral_constant<size_t, 0xffffffff>,
-      std::integral_constant<size_t, 64ull << 30>>::type::value;
+      std::integral_constant<uint64_t, 64ull << 30>>::type::value;
   ClipToRange(&result.write_buffer_size, ((size_t)64) << 10, clamp_max);
   // if user sets arena_block_size, we trust user to use this value. Otherwise,
   // calculate a proper value from writer_buffer_size;


### PR DESCRIPTION
Using explicit 64-bit type in conditional in platforms above 32-bits

std::conditional does not appear to short circuit before evaluating the third template arg which results in an error because the constant value does not fit in a 32-bit size_t.  This is a warning in a linux environment but an error in Mac OSX

The solution is to just make the third argument type explicitly 64-bit.  The entire expression then either becomes a 32-bit constant or a 64-bit constant holding a 32-bit value, but in either case is assignable to a 32-bit size_t.

This works correctly in the following cases:
32-bit: a 32-bit value will be assigned to a 32-bit size_t.
64-bit: size_t and uint64_t are the same size so the assignment is fine.
\>64-bit: size_t is larger than uint64_t so the assignment is fine.