### PR TITLE
Say that an unsupported compression type is not supported in ShowAllCompressionSizes

### DIFF
--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -34,6 +34,7 @@
 #include "table/plain_table_factory.h"
 #include "tools/ldb_cmd.h"
 #include "util/random.h"
+#include "util/compression.h"
 
 #include "port/port.h"
 
@@ -194,15 +195,19 @@ int SstFileReader::ShowAllCompressionSizes(size_t block_size) {
   };
 
   for (auto& i : compressions) {
-    CompressionOptions compress_opt;
-    std::string column_family_name;
-    TableBuilderOptions tb_opts(imoptions, ikc, &block_based_table_factories,
-                                i.first, compress_opt,
-                                nullptr /* compression_dict */,
-                                false /* skip_filters */, column_family_name);
-    uint64_t file_size = CalculateCompressedTableSize(tb_opts, block_size);
-    fprintf(stdout, "Compression: %s", i.second);
-    fprintf(stdout, " Size: %" PRIu64 "\n", file_size);
+    if (CompressionTypeSupported(i.first)) {
+      CompressionOptions compress_opt;
+      std::string column_family_name;
+      TableBuilderOptions tb_opts(imoptions, ikc, &block_based_table_factories,
+                                  i.first, compress_opt,
+                                  nullptr /* compression_dict */,
+                                  false /* skip_filters */, column_family_name);
+      uint64_t file_size = CalculateCompressedTableSize(tb_opts, block_size);
+      fprintf(stdout, "Compression: %s", i.second);
+      fprintf(stdout, " Size: %" PRIu64 "\n", file_size);
+    } else {
+      fprintf(stdout, "Unsupported compression type: %s.\n", i.second);
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Update:

"Size is not shown" is not printed.

./sst_dump_test result after the update:

...
Compression: kNoCompression Size: 28056
Compression: kSnappyCompression Size: 7066
Compression: kZlibCompression Size: 3868
Compression: kBZip2Compression Size: 2896
Unsupported compression type: kLZ4Compression. 
Unsupported compression type: kLZ4HCCompression. 
Unsupported compression type: kXpressCompression. 
Unsupported compression type: kZSTDNotFinalCompression.
...

The previous information about the pull request:

Included util/compression.h in headers
Added if-else with the condition CompressionTypeSupported in the for loop of ShowAllCompressionSizes

Test plan is to run ./sst_dump_test to verify the code of the pull request.