### PR TITLE
[cmake] Support Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,100 +1,76 @@
-# This cmake build is for Windows 64-bit only.
-#
-# Prerequisites:
-#     You must have Visual Studio 2013 Update 4 installed. Start the Developer Command Prompt window that is a part of Visual Studio installation.
-#     Run the build commands from within the Developer Command Prompt window to have paths to the compiler and runtime libraries set.
-#     You must have git.exe in your %PATH% environment variable.
-#
-# To build Rocksdb for Windows is as easy as 1-2-3-4-5:
-#
-# 1. Update paths to third-party libraries in thirdparty.inc file
-# 2. Create a new directory for build artifacts
-#        mkdir build
-#        cd build
-# 3. Run cmake to generate project files for Windows, add more options to enable required third-party libraries.
-#    See thirdparty.inc for more information.
-#        sample command: cmake -G "Visual Studio 12 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
-#        OR for VS Studio 15 cmake -G "Visual Studio 14 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
-# 4. Then build the project in debug mode (you may want to add /m[:<N>] flag to run msbuild in <N> parallel threads
-#                                          or simply /m ot use all avail cores)
-#        msbuild rocksdb.sln
-#
-#        rocksdb.sln build features exclusions of test only code in Release. If you build ALL_BUILD then everything
-#        will be attempted but test only code does not build in Release mode.
-#
-# 5. And release mode (/m[:<N>] is also supported)
-#        msbuild rocksdb.sln /p:Configuration=Release
-#
-
 cmake_minimum_required(VERSION 2.6)
 project(rocksdb)
 
+# Windows build depends on this being included early-on
+if (WIN64)
 include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
-execute_process(COMMAND powershell -Command "Get-Date -format MM_dd_yyyy" OUTPUT_VARIABLE DATE)
-execute_process(COMMAND powershell -Command "Get-Date -format HH:mm:ss" OUTPUT_VARIABLE TIME)
-string(REGEX REPLACE "(..)_(..)_..(..).*" "\\1/\\2/\\3" DATE ${DATE})
-string(REGEX REPLACE "(..):(.....).*" " \\1:\\2" TIME ${TIME})
-string(CONCAT GIT_DATE_TIME ${DATE} ${TIME})
+endif (WIN64)
 
-find_package(Git)
+execute_process(COMMAND
+    "./build_tools/version.sh" "major"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE ROCKSDB_VERSION_MAJOR
+)
+string(STRIP "${ROCKSDB_VERSION_MAJOR}" ROCKSDB_VERSION_MAJOR)
 
-if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    execute_process(COMMAND $ENV{COMSPEC} /C ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} rev-parse HEAD OUTPUT_VARIABLE GIT_SHA)
-else()
-    set(GIT_SHA 0)
-endif()
+execute_process(COMMAND
+    "./build_tools/version.sh" "minor"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE ROCKSDB_VERSION_MINOR
+)
+string(STRIP "${ROCKSDB_VERSION_MINOR}" ROCKSDB_VERSION_MINOR)
 
-string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA ${GIT_SHA})
+execute_process(COMMAND
+    "./build_tools/version.sh" "patch"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE ROCKSDB_VERSION_PATCH
+)
+string(STRIP "${ROCKSDB_VERSION_PATCH}" ROCKSDB_VERSION_PATCH)
+
+set(ROCKSDB_VERSION "${ROCKSDB_VERSION_MAJOR}.${ROCKSDB_VERSION_MINOR}.${ROCKSDB_VERSION_PATCH}")
+message(STATUS "rocksdb: ${ROCKSDB_VERSION}")
 
 set(BUILD_VERSION_CC ${CMAKE_CURRENT_SOURCE_DIR}/util/build_version.cc)
-
 add_custom_command(OUTPUT ${BUILD_VERSION_CC}
-    COMMAND echo "#include \"build_version.h\"" > ${BUILD_VERSION_CC}
-    COMMAND echo "const char* rocksdb_build_git_sha = \"rocksdb_build_git_sha:${GIT_SHA}\";" >> ${BUILD_VERSION_CC}
-    COMMAND echo "const char* rocksdb_build_git_datetime = \"rocksdb_build_git_datetime:${GIT_DATE_TIME}\";" >> ${BUILD_VERSION_CC}
-    COMMAND echo const char* rocksdb_build_compile_date = __DATE__\; >> ${BUILD_VERSION_CC}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_tools/create_version_cc.sh
+      ${BUILD_VERSION_CC}
 )
-
-add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4800 /wd4996 /wd4351")
-
-# Used to run CI build and tests so we can run faster
-set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize
-
-if(DEFINED OPTDBG)
-   set(OPTIMIZE_DEBUG ${OPTDBG})
-else()
-   set(OPTIMIZE_DEBUG ${OPTIMIZE_DEBUG_DEFAULT})
-endif()
-
-if((${OPTIMIZE_DEBUG} EQUAL 1))
-   message(STATUS "Debug optimization is enabled")
-   set(CMAKE_CXX_FLAGS_DEBUG "/Oxt /MDd")
-else()
-   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /RTC1 /Gm /MDd")
-endif()
-
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oxt /Zp8 /Gm- /Gy /MD")
-
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
-
-add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DNOMINMAX)
 
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/include)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+
 include_directories(${PROJECT_SOURCE_DIR}/third-party/gtest-1.7.0/fused-src)
-
-set(ROCKSDB_LIBS rocksdblib${ARTIFACT_SUFFIX})
-set(THIRDPARTY_LIBS ${THIRDPARTY_LIBS} gtest)
-set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
-
-set(LIBS ${ROCKSDB_LIBS} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-
 add_subdirectory(third-party/gtest-1.7.0/fused-src/gtest)
+
+find_package(Threads)
+find_package(JeMalloc)
+
+if (JEMALLOC_FOUND)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCKSDB_JEMALLOC")
+endif (JEMALLOC_FOUND)
+
+# These need to come before SOURCES and hence can't be moved
+# to platform specific cmake
+
+if (WIN64)
+set(PLATFORM_SOURCES
+        port/win/io_win.cc
+        port/win/env_win.cc
+        port/win/port_win.cc
+        port/win/win_logger.cc
+        port/win/xpress_win.cc
+)
+endif (WIN64)
+
+if (UNIX)
+set(PLATFORM_SOURCES
+        port/port_posix.cc
+        util/env_posix.cc
+        util/io_posix.cc
+)
+endif (UNIX)
 
 # Main library source code
 set(SOURCES
@@ -153,12 +129,6 @@ set(SOURCES
         memtable/skiplistrep.cc
         memtable/vectorrep.cc
         port/stack_trace.cc
-        port/win/io_win.cc
-        port/win/env_win.cc
-        port/win/env_default.cc
-        port/win/port_win.cc
-        port/win/win_logger.cc
-        port/win/xpress_win.cc
         table/adaptive_table_factory.cc
         table/block.cc
         table/block_based_filter_block.cc
@@ -265,6 +235,7 @@ set(SOURCES
         utilities/merge_operators/uint64add.cc
         utilities/options/options_util.cc
         utilities/redis/redis_lists.cc
+        utilities/simulator_cache/sim_cache.cc
         utilities/spatialdb/spatial_db.cc
         utilities/table_properties_collectors/compact_on_deletion_collector.cc
         utilities/transactions/optimistic_transaction_impl.cc
@@ -278,37 +249,8 @@ set(SOURCES
         utilities/ttl/db_ttl_impl.cc
         utilities/write_batch_with_index/write_batch_with_index.cc
         utilities/write_batch_with_index/write_batch_with_index_internal.cc
+        ${PLATFORM_SOURCES}
 )
-
-# For test util library that is build only in DEBUG mode
-# and linked to tests. Add test only code that is not #ifdefed for Release here.
-set(TESTUTIL_SOURCE
-    db/db_test_util.cc
-    table/mock_table.cc
-    util/mock_env.cc
-    util/fault_injection_test_env.cc
-    util/thread_status_updater_debug.cc
-)
-
-add_library(rocksdblib${ARTIFACT_SUFFIX} ${SOURCES})
-set_target_properties(rocksdblib${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/rocksdblib${ARTIFACT_SUFFIX}.pdb")
-add_dependencies(rocksdblib${ARTIFACT_SUFFIX} GenerateBuildVersion)
-
-add_library(rocksdb${ARTIFACT_SUFFIX} SHARED ${SOURCES})
-set_target_properties(rocksdb${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "-DROCKSDB_DLL -DROCKSDB_LIBRARY_EXPORTS /Fd${CMAKE_CFG_INTDIR}/rocksdb${ARTIFACT_SUFFIX}.pdb")
-add_dependencies(rocksdb${ARTIFACT_SUFFIX} GenerateBuildVersion)
-target_link_libraries(rocksdb${ARTIFACT_SUFFIX} ${LIBS})
-
-if (DEFINED JNI)
-  if (${JNI} EQUAL 1)
-    message(STATUS "JNI library is enabled")
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/java)
-  else()
-    message(STATUS "JNI library is disabled")
-  endif()
-else()
-  message(STATUS "JNI library is disabled")
-endif()
 
 set(APPS
         tools/db_bench.cc
@@ -433,51 +375,10 @@ set(TESTS
         utilities/write_batch_with_index/write_batch_with_index_test.cc
 )
 
-set(EXES ${APPS})
+if (WIN64)
+include(win64.cmake)
+endif (WIN64)
 
-foreach(sourcefile ${EXES})
-    string(REPLACE ".cc" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
-endforeach(sourcefile ${EXES})
-
-# test utilities are only build in debug
-set(TESTUTILLIB testutillib${ARTIFACT_SUFFIX})
-add_library(${TESTUTILLIB} STATIC ${TESTUTIL_SOURCE})
-set_target_properties(${TESTUTILLIB} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/testutillib${ARTIFACT_SUFFIX}.pdb")
-set_target_properties(${TESTUTILLIB}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
-
-# Tests are excluded from Release builds
-set(TEST_EXES ${TESTS})
-
-foreach(sourcefile ${TEST_EXES})
-    string(REPLACE ".cc" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    set_target_properties(${exename}${ARTIFACT_SUFFIX}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS} testutillib${ARTIFACT_SUFFIX})
-endforeach(sourcefile ${TEST_EXES})
-
-# C executables must link to a shared object
-set(C_TEST_EXES ${C_TESTS})
-
-foreach(sourcefile ${C_TEST_EXES})
-    string(REPLACE ".c" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    set_target_properties(${exename}${ARTIFACT_SUFFIX}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX})
-endforeach(sourcefile ${C_TEST_EXES})
+if (UNIX)
+include(linux.cmake)
+endif (UNIX)

--- a/build_tools/create_version_cc.sh
+++ b/build_tools/create_version_cc.sh
@@ -1,0 +1,10 @@
+BUILD_VERSION_CC=$1;
+shift;
+
+GIT_SHA=$(git rev-parse HEAD 2>/dev/null)
+GIT_DATE_TIME=$(date)
+
+echo "#include \"build_version.h\"" > ${BUILD_VERSION_CC}
+echo "const char* rocksdb_build_git_sha = \"${GIT_SHA}\";" >> ${BUILD_VERSION_CC}
+echo "const char* rocksdb_build_git_datetime = \"${GIT_DATE_TIME}\";" >> ${BUILD_VERSION_CC}
+echo "const char* rocksdb_build_compile_date = __DATE__;" >> ${BUILD_VERSION_CC}

--- a/cmake/modules/FindJeMalloc.cmake
+++ b/cmake/modules/FindJeMalloc.cmake
@@ -1,0 +1,45 @@
+# https://github.com/bro/cmake/blob/master/FindJeMalloc.cmake
+# - Try to find jemalloc headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(JeMalloc)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  JEMALLOC_ROOT_DIR Set this variable to the root installation of
+#                    jemalloc if the module has problems finding
+#                    the proper installation path.
+#
+# Variables defined by this module:
+#
+#  JEMALLOC_FOUND             System has jemalloc libs/headers
+#  JEMALLOC_LIBRARIES         The jemalloc library/libraries
+#  JEMALLOC_INCLUDE_DIR       The location of jemalloc headers
+
+find_path(JEMALLOC_ROOT_DIR
+    NAMES include/jemalloc/jemalloc.h
+)
+
+find_library(JEMALLOC_LIBRARIES
+    NAMES jemalloc
+    HINTS ${JEMALLOC_ROOT_DIR}/lib
+)
+
+find_path(JEMALLOC_INCLUDE_DIR
+    NAMES jemalloc/jemalloc.h
+    HINTS ${JEMALLOC_ROOT_DIR}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(JeMalloc DEFAULT_MSG
+    JEMALLOC_LIBRARIES
+    JEMALLOC_INCLUDE_DIR
+)
+
+mark_as_advanced(
+    JEMALLOC_ROOT_DIR
+    JEMALLOC_LIBRARIES
+    JEMALLOC_INCLUDE_DIR
+)

--- a/deb_packaging.cmake
+++ b/deb_packaging.cmake
@@ -1,0 +1,114 @@
+# Derived from https://github.com/IvanSafonov/cmake-deb-packaging
+# Making target for componet
+function(make_deb_target COMPONENT)
+
+    if( COMPONENT )
+        set(TMP_COMPONENT ${COMPONENT})
+        set(COMPONENT "_${COMPONENT}")
+
+        # Install target for component
+        add_custom_target(install${COMPONENT}
+            COMMAND
+             "${CMAKE_COMMAND}" -DCMAKE_INSTALL_COMPONENT=${TMP_COMPONENT}
+             -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+        )
+    endif()
+
+    set(TMP_PACKAGE_DIR "${CMAKE_BINARY_DIR}/cmake_deb_package${COMPONENT}")
+    set(TMP_PACKAGE_DEB_DIR "${TMP_PACKAGE_DIR}/DEBIAN")
+
+    # Check required package fields
+    if( NOT DEB_PACKAGE${COMPONENT}_NAME )
+        message(FATAL_ERROR "Not set package name 'DEB_PACKAGE${COMPONENT}_NAME'")
+    endif()
+    
+    if( NOT DEB_PACKAGE${COMPONENT}_VERSION )
+        set(DEB_PACKAGE${COMPONENT}_VERSION ${CPACK_PACKAGE_VERSION})
+    endif()
+    
+    if( NOT DEB_PACKAGE${COMPONENT}_DESRCIPTION )
+        message(FATAL_ERROR "Not set package description 'DEB_PACKAGE${COMPONENT}_DESRCIPTION'")
+    endif()
+
+    if( NOT DEB_PACKAGE${COMPONENT}_MAINTAINER )
+        set(DEB_PACKAGE${COMPONENT}_MAINTAINER ${CPACK_PACKAGE_CONTACT})
+    endif()
+
+    # Package Architecture
+    if( NOT DEB_PACKAGE${COMPONENT}_ARCH )
+        execute_process(COMMAND
+            dpkg-architecture -qDEB_BUILD_ARCH
+            OUTPUT_VARIABLE CURRENT_ARCH
+        )
+        string(STRIP "${CURRENT_ARCH}" CURRENT_ARCH)
+        set(DEB_PACKAGE${COMPONENT}_ARCH "${CURRENT_ARCH}")
+    endif()
+
+    # Create control file
+    set(GEN_CONTROL_LIST
+        "Package: ${DEB_PACKAGE${COMPONENT}_NAME}"
+        "Version: ${DEB_PACKAGE${COMPONENT}_VERSION}"
+        "Architecture: ${DEB_PACKAGE${COMPONENT}_ARCH}"
+        "Maintainer: ${DEB_PACKAGE${COMPONENT}_MAINTAINER}"
+        "Description: ${DEB_PACKAGE${COMPONENT}_DESRCIPTION}"
+    )
+
+    # Adding field to control file
+    function(add_to_control FIELD_NAME FIELD)
+        if( FIELD )
+            string(REPLACE ";" ", " TMP_FIELD "${FIELD}")
+            set(GEN_CONTROL_LIST
+                ${GEN_CONTROL_LIST}
+                "${FIELD_NAME}: ${TMP_FIELD}"
+                PARENT_SCOPE
+            )
+        endif()
+    endfunction()
+    
+    add_to_control("Section" "${DEB_PACKAGE${COMPONENT}_SECTION}")
+    add_to_control("Origin" "${DEB_PACKAGE${COMPONENT}_ORIGIN}")
+    add_to_control("Bugs" "${DEB_PACKAGE${COMPONENT}_BUGS}")
+    add_to_control("Homepage" "${DEB_PACKAGE${COMPONENT}_HOMEPAGE}")
+    add_to_control("Depends" "${DEB_PACKAGE${COMPONENT}_DEPENDS}")
+    add_to_control("Pre-Depends" "${DEB_PACKAGE${COMPONENT}_PREDEPENDS}")
+    add_to_control("Recommends" "${DEB_PACKAGE${COMPONENT}_RECOMMENDS}")
+    add_to_control("Suggests" "${DEB_PACKAGE${COMPONENT}_SUGGESTS}")
+    add_to_control("Breaks" "${DEB_PACKAGE${COMPONENT}_BREAKS}")
+    add_to_control("Conflicts" "${DEB_PACKAGE${COMPONENT}_CONFLICTS}")
+    add_to_control("Replaces" "${DEB_PACKAGE${COMPONENT}_REPLACES}")
+    add_to_control("Provides" "${DEB_PACKAGE${COMPONENT}_PROVIDES}")
+
+    string(REPLACE ";" "\\n" GEN_CONTROL_STR "${GEN_CONTROL_LIST}")
+
+    set(PACKAGE_FILENAME "${CMAKE_BINARY_DIR}/${DEB_PACKAGE${COMPONENT}_NAME}_${DEB_PACKAGE${COMPONENT}_VERSION}_${DEB_PACKAGE${COMPONENT}_ARCH}.deb")
+
+    # Build package target for component
+    add_custom_target(deb_package${COMPONENT}
+        COMMAND rm -rf ${TMP_PACKAGE_DIR}
+        COMMAND mkdir -p ${TMP_PACKAGE_DEB_DIR}
+        COMMAND echo ${GEN_CONTROL_STR} > ${TMP_PACKAGE_DEB_DIR}/control
+        COMMAND test -z "${DEB_PACKAGE${COMPONENT}_CONTROL_FILES}" || cp ${DEB_PACKAGE${COMPONENT}_CONTROL_FILES} -t ${TMP_PACKAGE_DEB_DIR}
+        COMMAND make DESTDIR=${TMP_PACKAGE_DIR} install${COMPONENT}
+        COMMAND echo -n "Installed-Size: " >> ${TMP_PACKAGE_DEB_DIR}/control
+        COMMAND du -sx --exclude DEBIAN ${TMP_PACKAGE_DIR} | grep -o -E ^[0-9]+ >> ${TMP_PACKAGE_DEB_DIR}/control
+        COMMAND dpkg-deb --build ${TMP_PACKAGE_DIR} ${PACKAGE_FILENAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        VERBATIM
+    )
+endfunction()
+
+# if build multiple packages
+if(DEB_PACKAGE_COMPONENTS)
+    foreach(COMP ${DEB_PACKAGE_COMPONENTS})
+        make_deb_target(${COMP})
+        set(TMP_DEPENDS ${TMP_DEPENDS} "deb_package_${COMP}")
+    endforeach()
+
+    # common target for build all packages
+    add_custom_target(deb_package
+        DEPENDS ${TMP_DEPENDS}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+else()
+    make_deb_target("")
+endif()

--- a/linux.cmake
+++ b/linux.cmake
@@ -1,0 +1,80 @@
+set(CMAKE_CXX_FLAGS "-DOS_LINUX -DROCKSDB_PLATFORM_POSIX -DGFLAGS=gflags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCKSDB_LIB_IO_POSIX")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZLIB -DBZIP2 -DSNAPPY -DLZ4")
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-memcmp")
+endif (CMAKE_COMPILER_IS_GNUCXX)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse4.2 -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
+
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} \
+    -fno-omit-frame-pointer -momit-leaf-frame-pointer -DNDEBUG")
+
+add_library(rocksdb-static STATIC ${SOURCES})
+add_library(rocksdb-shared SHARED ${SOURCES})
+set_target_properties(rocksdb-shared PROPERTIES
+                      VERSION ${ROCKSDB_VERSION}
+                      SOVERSION ${ROCKSDB_VERSION_MAJOR})
+
+set_target_properties(rocksdb-static PROPERTIES
+                      LINKER_LANGUAGE CXX
+                      OUTPUT_NAME "rocksdb")
+set_target_properties(rocksdb-shared PROPERTIES
+                      LINKER_LANGUAGE CXX
+                      OUTPUT_NAME "rocksdb")
+
+set_property(TARGET rocksdb-static PROPERTY CXX_STANDARD 11)
+set_property(TARGET rocksdb-shared PROPERTY CXX_STANDARD 11)
+
+install(TARGETS rocksdb-static COMPONENT devel ARCHIVE DESTINATION lib64)
+install(TARGETS rocksdb-shared COMPONENT runtime DESTINATION lib64)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/rocksdb/"
+        COMPONENT devel
+        DESTINATION include/rocksdb)
+
+# TODO: Figure out how to package all binaries, not just "ldb"
+install(TARGETS ${EXES} RUNTIME
+        DESTINATION bin
+        COMPONENT tools)
+
+foreach(sourcefile ${APPS})
+    string(REPLACE ".cc" "" exename ${sourcefile})
+    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
+    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
+    list(APPEND EXES ${exename}${ARTIFACT_SUFFIX})
+    if (JEMALLOC_FOUND)
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${JEMALLOC_LIBRARIES})
+    endif (JEMALLOC_FOUND)
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb-shared gtest gflags
+                          rt snappy bz2 lz4 z
+                          ${CMAKE_THREAD_LIBS_INIT})
+    set_property(TARGET ${exename}${ARTIFACT_SUFFIX} PROPERTY CXX_STANDARD 11)
+endforeach(sourcefile ${EXES})
+
+
+# Packaging
+set(CPACK_PACKAGE_CONTACT "rocksdb@fb.com")
+set(CPACK_PACKAGE_VERSION "${ROCKSDB_VERSION}")
+set(CPACK_RPM_PACKAGE_RELEASE "1")
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+include(CPack)
+
+set(CMAKE_INSTALL_PREFIX /usr)
+
+# Debian packaging
+set(DEB_PACKAGE_COMPONENTS tools devel runtime)
+
+set(DEB_PACKAGE_tools_NAME "${CMAKE_PROJECT_NAME}-tools")
+set(DEB_PACKAGE_tools_DEPENDS "lib${CMAKE_PROJECT_NAME}")
+set(DEB_PACKAGE_tools_DESRCIPTION "RocksDB tools package")
+
+set(DEB_PACKAGE_runtime_NAME "lib${CMAKE_PROJECT_NAME}")
+set(DEB_PACKAGE_runtime_DESRCIPTION "RocksDB package")
+
+set(DEB_PACKAGE_devel_NAME "lib${CMAKE_PROJECT_NAME}-dev")
+set(DEB_PACKAGE_devel_DESRCIPTION "RocksDB dev package")
+
+include(deb_packaging.cmake)

--- a/win64.cmake
+++ b/win64.cmake
@@ -1,0 +1,158 @@
+# This cmake build is for Windows 64-bit only.
+#
+# Prerequisites:
+#     You must have Visual Studio 2013 Update 4 installed. Start the Developer Command Prompt window that is a part of Visual Studio installation.
+#     Run the build commands from within the Developer Command Prompt window to have paths to the compiler and runtime libraries set.
+#     You must have git.exe in your %PATH% environment variable.
+#
+# To build Rocksdb for Windows is as easy as 1-2-3-4-5:
+#
+# 1. Update paths to third-party libraries in thirdparty.inc file
+# 2. Create a new directory for build artifacts
+#        mkdir build
+#        cd build
+# 3. Run cmake to generate project files for Windows, add more options to enable required third-party libraries.
+#    See thirdparty.inc for more information.
+#        sample command: cmake -G "Visual Studio 12 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
+#        OR for VS Studio 15 cmake -G "Visual Studio 14 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
+# 4. Then build the project in debug mode (you may want to add /m[:<N>] flag to run msbuild in <N> parallel threads
+#                                          or simply /m ot use all avail cores)
+#        msbuild rocksdb.sln
+#
+#        rocksdb.sln build features exclusions of test only code in Release. If you build ALL_BUILD then everything
+#        will be attempted but test only code does not build in Release mode.
+#
+# 5. And release mode (/m[:<N>] is also supported)
+#        msbuild rocksdb.sln /p:Configuration=Release
+#
+
+execute_process(COMMAND powershell -Command "Get-Date -format MM_dd_yyyy" OUTPUT_VARIABLE DATE)
+execute_process(COMMAND powershell -Command "Get-Date -format HH:mm:ss" OUTPUT_VARIABLE TIME)
+string(REGEX REPLACE "(..)_(..)_..(..).*" "\\1/\\2/\\3" DATE ${DATE})
+string(REGEX REPLACE "(..):(.....).*" " \\1:\\2" TIME ${TIME})
+string(CONCAT GIT_DATE_TIME ${DATE} ${TIME})
+
+find_package(Git)
+
+if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(COMMAND $ENV{COMSPEC} /C ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} rev-parse HEAD OUTPUT_VARIABLE GIT_SHA)
+else()
+    set(GIT_SHA 0)
+endif()
+
+string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA ${GIT_SHA})
+
+
+add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4800 /wd4996 /wd4351")
+
+# Used to run CI build and tests so we can run faster
+set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize
+
+if(DEFINED OPTDBG)
+   set(OPTIMIZE_DEBUG ${OPTDBG})
+else()
+   set(OPTIMIZE_DEBUG ${OPTIMIZE_DEBUG_DEFAULT})
+endif()
+
+if((${OPTIMIZE_DEBUG} EQUAL 1))
+   message(STATUS "Debug optimization is enabled")
+   set(CMAKE_CXX_FLAGS_DEBUG "/Oxt /MDd")
+else()
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /RTC1 /Gm /MDd")
+endif()
+
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oxt /Zp8 /Gm- /Gy /MD")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
+
+add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DNOMINMAX)
+
+set(ROCKSDB_LIBS rocksdblib${ARTIFACT_SUFFIX})
+set(THIRDPARTY_LIBS ${THIRDPARTY_LIBS} gtest)
+set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
+
+set(LIBS ${ROCKSDB_LIBS} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+
+# For test util library that is build only in DEBUG mode
+# and linked to tests. Add test only code that is not #ifdefed for Release here.
+set(TESTUTIL_SOURCE
+    db/db_test_util.cc
+    table/mock_table.cc
+    util/fault_injection_test_env.cc
+    util/mock_env.cc
+    util/thread_status_updater_debug.cc
+)
+
+add_library(rocksdblib${ARTIFACT_SUFFIX} ${SOURCES})
+set_target_properties(rocksdblib${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/rocksdblib${ARTIFACT_SUFFIX}.pdb")
+add_dependencies(rocksdblib${ARTIFACT_SUFFIX} GenerateBuildVersion)
+
+add_library(rocksdb${ARTIFACT_SUFFIX} SHARED ${SOURCES})
+set_target_properties(rocksdb${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "-DROCKSDB_DLL -DROCKSDB_LIBRARY_EXPORTS /Fd${CMAKE_CFG_INTDIR}/rocksdb${ARTIFACT_SUFFIX}.pdb")
+add_dependencies(rocksdb${ARTIFACT_SUFFIX} GenerateBuildVersion)
+target_link_libraries(rocksdb${ARTIFACT_SUFFIX} ${LIBS})
+
+if (DEFINED JNI)
+  if (${JNI} EQUAL 1)
+    message(STATUS "JNI library is enabled")
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/java)
+  else()
+    message(STATUS "JNI library is disabled")
+  endif()
+else()
+  message(STATUS "JNI library is disabled")
+endif()
+
+set(EXES ${APPS})
+
+foreach(sourcefile ${EXES})
+    string(REPLACE ".cc" "" exename ${sourcefile})
+    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
+    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
+endforeach(sourcefile ${EXES})
+
+# test utilities are only build in debug
+set(TESTUTILLIB testutillib${ARTIFACT_SUFFIX})
+add_library(${TESTUTILLIB} STATIC ${TESTUTIL_SOURCE})
+set_target_properties(${TESTUTILLIB} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/testutillib${ARTIFACT_SUFFIX}.pdb")
+set_target_properties(${TESTUTILLIB}
+      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
+      )
+
+# Tests are excluded from Release builds
+set(TEST_EXES ${TESTS})
+
+foreach(sourcefile ${TEST_EXES})
+    string(REPLACE ".cc" "" exename ${sourcefile})
+    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
+    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
+    set_target_properties(${exename}${ARTIFACT_SUFFIX}
+      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
+      )
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS} testutillib${ARTIFACT_SUFFIX})
+endforeach(sourcefile ${TEST_EXES})
+
+# C executables must link to a shared object
+set(C_TEST_EXES ${C_TESTS})
+
+foreach(sourcefile ${C_TEST_EXES})
+    string(REPLACE ".c" "" exename ${sourcefile})
+    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
+    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
+    set_target_properties(${exename}${ARTIFACT_SUFFIX}
+      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
+      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
+      )
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX})
+endforeach(sourcefile ${C_TEST_EXES})


### PR DESCRIPTION
Summary:
cmake was previously supported only on windows.
This diff makes it possible to use cmake on linux
and adds support for building debs and rpms.

Distributions may want to package the binaries
differently to meet their standards

Test Plan:
mkdir build
cd build; cmake ..
make -j

Reviewers: IslamAbdelRahman, sdong

Subscribers: andrewkr, dhruba

Differential Revision: https://reviews.facebook.net/D58713