### PR TITLE
Fixes needed for compiling on Linux s390x

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -20,7 +20,7 @@ typedef std::unordered_map<std::string, std::shared_ptr<const TableProperties>>
 class DB;
 class Status;
 struct CompactionJobStats;
-enum CompressionType : char;
+enum CompressionType : signed char;
 
 enum class TableFileCreationReason {
   kFlush,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -52,7 +52,7 @@ class WalFilter;
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which
 // compression method (if any) is used to compress a block.
-enum CompressionType : char {
+enum CompressionType : signed char {
   // NOTE: do not change the values of existing entries, as these are
   // part of the persistent format on disk.
   kNoCompression = 0x0,

--- a/include/rocksdb/utilities/leveldb_options.h
+++ b/include/rocksdb/utilities/leveldb_options.h
@@ -21,7 +21,7 @@ class Logger;
 struct Options;
 class Snapshot;
 
-enum CompressionType : char;
+enum CompressionType : signed char;
 
 // Options to control the behavior of a database (passed to
 // DB::Open). A LevelDBOptions object can be initialized as though

--- a/util/options_builder.cc
+++ b/util/options_builder.cc
@@ -3,7 +3,7 @@
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
 
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include "rocksdb/options.h"
 


### PR DESCRIPTION
- Make CompressType explicitly signed char because kDisableCompressionOption = -1 breaks
  on platforms where gcc/g++ defaults to unsigned char.
- Use cmath instead of math.h in util/options_builder.cc since std::log is defined by cmath.