### PR TITLE
stack_trace,cc: The current Stacktrace code does not compile for FreeBSD

### DIFF
--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -6,7 +6,7 @@
 #include "port/stack_trace.h"
 
 #if defined(ROCKSDB_LITE) || !(defined(ROCKSDB_BACKTRACE) || defined(OS_MACOSX)) || \
-    defined(CYGWIN)
+    defined(CYGWIN) || defined(__FreeBSD__)
 
 // noop
 

--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -6,7 +6,7 @@
 #include "port/stack_trace.h"
 
 #if defined(ROCKSDB_LITE) || !(defined(ROCKSDB_BACKTRACE) || defined(OS_MACOSX)) || \
-    defined(CYGWIN) || defined(__FreeBSD__)
+    defined(CYGWIN) || defined(OS_FREEBSD)
 
 // noop
 


### PR DESCRIPTION
So set it to generate empty routines