### PR TITLE
fix for https://github.com/facebook/rocksdb/issues/1122

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -20,7 +20,7 @@ typedef std::unordered_map<std::string, std::shared_ptr<const TableProperties>>
 class DB;
 class Status;
 struct CompactionJobStats;
-enum CompressionType : char;
+enum CompressionType : unsigned char;
 
 enum class TableFileCreationReason {
   kFlush,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -52,7 +52,7 @@ class WalFilter;
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which
 // compression method (if any) is used to compress a block.
-enum CompressionType : char {
+enum CompressionType : unsigned char {
   // NOTE: do not change the values of existing entries, as these are
   // part of the persistent format on disk.
   kNoCompression = 0x0,
@@ -66,7 +66,7 @@ enum CompressionType : char {
   kZSTDNotFinalCompression = 0x40,
 
   // kDisableCompressionOption is used to disable some compression options.
-  kDisableCompressionOption = -1,
+  kDisableCompressionOption = 0xff,
 };
 
 enum CompactionStyle : char {

--- a/include/rocksdb/perf_level.h
+++ b/include/rocksdb/perf_level.h
@@ -13,8 +13,8 @@ namespace rocksdb {
 
 // How much perf stats to collect. Affects perf_context and iostats_context.
 
-enum PerfLevel : char {
-  kUninitialized = -1,            // unknown setting
+enum PerfLevel : unsigned char {
+  kUninitialized = 0xff,            // unknown setting
   kDisable = 0,                   // disable perf stats
   kEnableCount = 1,               // enable only count stats
   kEnableTimeExceptForMutex = 2,  // Other than count stats, also enable time

--- a/include/rocksdb/utilities/leveldb_options.h
+++ b/include/rocksdb/utilities/leveldb_options.h
@@ -21,7 +21,7 @@ class Logger;
 struct Options;
 class Snapshot;
 
-enum CompressionType : char;
+enum CompressionType : unsigned char;
 
 // Options to control the behavior of a database (passed to
 // DB::Open). A LevelDBOptions object can be initialized as though


### PR DESCRIPTION
Errors running "make shared_lib":
./include/rocksdb/options.h:69:32: error: enumerator value -1 is outside the range of underlying type ‘char’
./include/rocksdb/perf_level.h:17:21: error: enumerator value -1 is outside the range of underlying type ‘char’