### PR TITLE
Update the arcanist_util module for the latest version of Arcanist

### DIFF
--- a/arcanist_util/config/FacebookArcanistConfiguration.php
+++ b/arcanist_util/config/FacebookArcanistConfiguration.php
@@ -7,7 +7,7 @@
 class FacebookArcanistConfiguration extends ArcanistConfiguration {
 
   public function didRunWorkflow($command,
-                                 ArcanistBaseWorkflow $workflow,
+                                 ArcanistWorkflow $workflow,
                                  $error_code) {
     if ($command == 'diff' && !$workflow->isRawDiffSource()) {
       $this->startTestsInSandcastle($workflow);

--- a/arcanist_util/cpp_linter/BaseDirectoryScopedFormatLinter.php
+++ b/arcanist_util/cpp_linter/BaseDirectoryScopedFormatLinter.php
@@ -44,7 +44,7 @@ abstract class BaseDirectoryScopedFormatLinter extends ArcanistLinter {
       $futures[$path] = $this->getFormatFuture($path, $changed);
     }
 
-    foreach (Futures($futures)->limit(8) as $p => $f) {
+    foreach (id(new FutureIterator($futures))->limit(8) as $p => $f) {
       $this->rawLintOutput[$p] = $f->resolvex();
     }
   }

--- a/arcanist_util/lint_engine/FacebookFbcodeLintEngine.php
+++ b/arcanist_util/lint_engine/FacebookFbcodeLintEngine.php
@@ -42,14 +42,12 @@ class FacebookFbcodeLintEngine extends ArcanistLintEngine {
     $python_linter = new ArcanistPEP8Linter();
     $linters[] = $python_linter;
 
-    if (!$this->getCommitHookMode()) {
-      $cpp_linters = array();
-      $cpp_linters[] = $linters[] = new ArcanistCpplintLinter();
-      $cpp_linters[] = $linters[] = new FbcodeCppLinter();
+    $cpp_linters = array();
+    $cpp_linters[] = $linters[] = new ArcanistCpplintLinter();
+    $cpp_linters[] = $linters[] = new FbcodeCppLinter();
 
-      $clang_format_linter = new FbcodeClangFormatLinter();
-      $linters[] = $clang_format_linter;
-    }
+    $clang_format_linter = new FbcodeClangFormatLinter();
+    $linters[] = $clang_format_linter;
 
     $spelling_linter = new ArcanistSpellingLinter();
     $linters[] = $spelling_linter;


### PR DESCRIPTION
I have not been able to use `arc` with RocksDB for months and months, and I was under the impression that the problem lay with Arcanist. Eventually I became frustrated enough with this, to look into it on a deeper level - http://stackoverflow.com/questions/37808307/arcanist-error-on-fresh-install-mac-os-x/37825369#37825369

I have now realised that the issue is not with Arcanist but is actually with the RocksDB `arcanist_util` module for Arcanist, which relies on an older version of Arcanist. I have made the changes to bring the module up to date with the latest APIs for Arcanist and libphutil.

Please keep in mind that I am in no sense a PHP developer. I have just made the changes which seemed logical from reading the API. The latest version of `arc lint` now seems to work again with RocksDB... This definitely needs a second pair of eyes ;-)