### PR TITLE
Destructor of ColumnFamilyData should be called only when Unref() returns true

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -877,11 +877,13 @@ ColumnFamilySet::~ColumnFamilySet() {
   while (column_family_data_.size() > 0) {
     // cfd destructor will delete itself from column_family_data_
     auto cfd = column_family_data_.begin()->second;
-    cfd->Unref();
-    delete cfd;
+    if (cfd->Unref()) {
+      delete cfd;
+    }
   }
-  dummy_cfd_->Unref();
-  delete dummy_cfd_;
+  if (dummy_cfd_->Unref()) {
+    delete dummy_cfd_;
+  }
 }
 
 ColumnFamilyData* ColumnFamilySet::GetDefault() const {


### PR DESCRIPTION

Encountered a bug in a 2-process scenario, where writer opens
the DB in write mode and reader opens in "OpenForReadOnly"

The writer process was creating a column family and dropping it
The reader process was reading the column family, but when
it decided to close the DB handle, it would crash because
the delete of the "cfd" in the ColumnFamilySet was being
done without checking if the ColumnFamilyData::Unref()
has returned true

**Test Plan**: I can't find any 2-process tests in the repository.
Ran "make check" on changes.   There is one failure
in "SpatialDBTest.FeatureSetSerializeTest" which appears
unrelated.

Error output is as follows
_utilities/spatialdb/spatial_db_test.cc:99: Failure
Value of: !deserialized.Deserialize(serialized)
  Actual: false
Expected: true_