### PR TITLE
New Statistics to track Compression/Decompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ java/javadoc
 scan_build_report/
 t
 LOG
+
+db_logs/

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1189,6 +1189,12 @@ bool MinLevelToCompress(CompressionType& type, Options& options, int wbits,
   } else if (LZ4_Supported()) {
     type = kLZ4Compression;
     fprintf(stderr, "using lz4\n");
+  } else if (XPRESS_Supported()) {
+    type = kXpressCompression;
+    fprintf(stderr, "using xpress\n");
+  } else if (ZSTD_Supported()) {
+    type = kZSTDNotFinalCompression;
+    fprintf(stderr, "using ZSTD\n");
   } else {
     fprintf(stderr, "skipping test, compression disabled\n");
     return false;
@@ -4698,6 +4704,12 @@ TEST_F(DBTest, CompressionStatsTest) {
   } else if (LZ4_Supported()) {
     type = kLZ4Compression;
     fprintf(stderr, "using lz4\n");
+  } else if (XPRESS_Supported()) {
+    type = kXpressCompression;
+    fprintf(stderr, "using xpress\n");
+  } else if (ZSTD_Supported()) {
+    type = kZSTDNotFinalCompression;
+    fprintf(stderr, "using ZSTD\n");
   } else {
     fprintf(stderr, "skipping test, compression disabled\n");
     return;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4683,6 +4683,68 @@ TEST_F(DBTest, EncodeDecompressedBlockSizeTest) {
   }
 }
 
+TEST_F(DBTest, CompressionStatsTest) {
+  CompressionType type;
+
+  if (Snappy_Supported()) {
+    type = kSnappyCompression;
+    fprintf(stderr, "using snappy\n");
+  } else if (Zlib_Supported()) {
+    type = kZlibCompression;
+    fprintf(stderr, "using zlib\n");
+  } else if (BZip2_Supported()) {
+    type = kBZip2Compression;
+    fprintf(stderr, "using bzip2\n");
+  } else if (LZ4_Supported()) {
+    type = kLZ4Compression;
+    fprintf(stderr, "using lz4\n");
+  } else {
+    fprintf(stderr, "skipping test, compression disabled\n");
+    return;
+  }
+
+  Options options = CurrentOptions();
+  options.compression = type;
+  options.statistics = rocksdb::CreateDBStatistics();
+  DestroyAndReopen(options);
+
+  int kNumKeysWritten = 100000;
+
+  // Check that compressions occur and are counted when compression is turned on
+  Random rnd(301);
+  for (int i = 0; i < kNumKeysWritten; ++i) {
+    // compressible string
+    ASSERT_OK(Put(Key(i), RandomString(&rnd, 128) + std::string(128, 'a')));
+  }
+  ASSERT_GT(options.statistics->getTickerCount(NUMBER_BLOCK_COMPRESSED), 0);
+
+  for (int i = 0; i < kNumKeysWritten; ++i) {
+    auto r = Get(Key(i));
+  }
+  ASSERT_GT(options.statistics->getTickerCount(NUMBER_BLOCK_DECOMPRESSED), 0);
+
+  options.compression = kNoCompression;
+  DestroyAndReopen(options);
+  uint64_t currentCompressions =
+            options.statistics->getTickerCount(NUMBER_BLOCK_COMPRESSED);
+  uint64_t currentDecompressions =
+            options.statistics->getTickerCount(NUMBER_BLOCK_DECOMPRESSED);
+
+  // Check that compressions do not occur when turned off
+  for (int i = 0; i < kNumKeysWritten; ++i) {
+    // compressible string
+    ASSERT_OK(Put(Key(i), RandomString(&rnd, 128) + std::string(128, 'a')));
+  }
+  ASSERT_EQ(options.statistics->getTickerCount(NUMBER_BLOCK_COMPRESSED)
+            - currentCompressions, 0);
+
+  for (int i = 0; i < kNumKeysWritten; ++i) {
+    auto r = Get(Key(i));
+  }
+  ASSERT_EQ(options.statistics->getTickerCount(NUMBER_BLOCK_DECOMPRESSED)
+            - currentDecompressions, 0);
+}
+
 TEST_F(DBTest, MutexWaitStatsDisabledByDefault) {
   Options options = CurrentOptions();
   options.create_if_missing = true;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4718,6 +4718,7 @@ TEST_F(DBTest, CompressionStatsTest) {
   Options options = CurrentOptions();
   options.compression = type;
   options.statistics = rocksdb::CreateDBStatistics();
+  options.statistics->stats_level_ = StatsLevel::kAll;
   DestroyAndReopen(options);
 
   int kNumKeysWritten = 100000;

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -331,20 +331,19 @@ class TestPlainTableFactory : public PlainTableFactory {
     TableProperties* props = nullptr;
     auto s =
         ReadTableProperties(file.get(), file_size, kPlainTableMagicNumber,
-                            table_reader_options.ioptions.env,
-                            table_reader_options.ioptions.info_log, &props);
+                            table_reader_options.ioptions, &props);
     EXPECT_TRUE(s.ok());
 
     if (store_index_in_file_) {
       BlockHandle bloom_block_handle;
       s = FindMetaBlock(file.get(), file_size, kPlainTableMagicNumber,
-                        table_reader_options.ioptions.env,
+                        table_reader_options.ioptions,
                         BloomBlockBuilder::kBloomBlock, &bloom_block_handle);
       EXPECT_TRUE(s.ok());
 
       BlockHandle index_block_handle;
       s = FindMetaBlock(file.get(), file_size, kPlainTableMagicNumber,
-                        table_reader_options.ioptions.env,
+                        table_reader_options.ioptions,
                         PlainTableIndexBuilder::kPlainTableIndexBlock,
                         &index_block_handle);
       EXPECT_TRUE(s.ok());

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -276,7 +276,7 @@ void TestCustomizedTablePropertiesCollector(
           new test::StringSource(fwf->contents())));
   TableProperties* props;
   Status s = ReadTableProperties(fake_file_reader.get(), fwf->contents().size(),
-                                 magic_number, Env::Default(), nullptr, &props);
+                                 magic_number, ioptions, &props);
   std::unique_ptr<TableProperties> props_guard(props);
   ASSERT_OK(s);
 
@@ -417,7 +417,7 @@ void TestInternalKeyPropertiesCollector(
     TableProperties* props;
     Status s =
         ReadTableProperties(reader.get(), fwf->contents().size(), magic_number,
-                            Env::Default(), nullptr, &props);
+                            ioptions, &props);
     ASSERT_OK(s);
 
     std::unique_ptr<TableProperties> props_guard(props);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -597,8 +597,7 @@ Status Version::GetTableProperties(std::shared_ptr<const TableProperties>* tp,
       new RandomAccessFileReader(std::move(file)));
   s = ReadTableProperties(
       file_reader.get(), file_meta->fd.GetFileSize(),
-      Footer::kInvalidTableMagicNumber /* table's magic number */, vset_->env_,
-      ioptions->info_log, &raw_table_properties);
+      Footer::kInvalidTableMagicNumber /* table's magic number */, *ioptions, &raw_table_properties);
   if (!s.ok()) {
     return s;
   }

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -179,6 +179,11 @@ enum Tickers : uint32_t {
   NUMBER_SUPERVERSION_ACQUIRES,
   NUMBER_SUPERVERSION_RELEASES,
   NUMBER_SUPERVERSION_CLEANUPS,
+
+  // # of compressions/decompressions executed
+  NUMBER_BLOCK_COMPRESSED,
+  NUMBER_BLOCK_DECOMPRESSED,
+
   NUMBER_BLOCK_NOT_COMPRESSED,
   MERGE_OPERATION_TOTAL_TIME,
   FILTER_OPERATION_TOTAL_TIME,
@@ -269,6 +274,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {NUMBER_SUPERVERSION_ACQUIRES, "rocksdb.number.superversion_acquires"},
     {NUMBER_SUPERVERSION_RELEASES, "rocksdb.number.superversion_releases"},
     {NUMBER_SUPERVERSION_CLEANUPS, "rocksdb.number.superversion_cleanups"},
+    {NUMBER_BLOCK_COMPRESSED, "rocksdb.number.block.compressed"},
+    {NUMBER_BLOCK_DECOMPRESSED, "rocksdb.number.block.decompressed"},
     {NUMBER_BLOCK_NOT_COMPRESSED, "rocksdb.number.block.not_compressed"},
     {MERGE_OPERATION_TOTAL_TIME, "rocksdb.merge.operation.time.nanos"},
     {FILTER_OPERATION_TOTAL_TIME, "rocksdb.filter.operation.time.nanos"},
@@ -313,6 +320,14 @@ enum Histograms : uint32_t {
   BYTES_PER_READ,
   BYTES_PER_WRITE,
   BYTES_PER_MULTIGET,
+
+  // number of bytes compressed/decompressed
+  // number of bytes is when uncompressed; i.e. before/after respectively
+  BYTES_COMPRESSED,
+  BYTES_DECOMPRESSED,
+  COMPRESSION_TIMES_NANOS,
+  DECOMPRESSION_TIMES_NANOS,
+
   HISTOGRAM_ENUM_MAX,  // TODO(ldemailly): enforce HistogramsNameMap match
 };
 
@@ -343,6 +358,10 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {BYTES_PER_READ, "rocksdb.bytes.per.read"},
     {BYTES_PER_WRITE, "rocksdb.bytes.per.write"},
     {BYTES_PER_MULTIGET, "rocksdb.bytes.per.multiget"},
+    {BYTES_COMPRESSED, "rocksdb.bytes.compressed"},
+    {BYTES_DECOMPRESSED, "rocksdb.bytes.decompressed"},
+    {COMPRESSION_TIMES_NANOS, "rocksdb.compression.times.nanos"},
+    {DECOMPRESSION_TIMES_NANOS, "rocksdb.decompression.times.nanos"},
 };
 
 struct HistogramData {

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -376,6 +376,9 @@ enum StatsLevel {
   // Collect all stats except the counters requiring to get time inside the
   // mutex lock.
   kExceptTimeForMutex,
+  // Collect all stats expect time inside mutex lock AND time spent on
+  // compression
+  kExceptDetailedTimers,
   // Collect all stats, including measuring duration of mutex operations.
   // If getting time is expensive on the platform to run, it can
   // reduce scalability to more threads, especially for writes.

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -703,7 +703,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     type = kNoCompression;
     block_contents = raw_block_contents;
   }
-  else if(type != kNoCompression){
+  else if (type != kNoCompression) {
     MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS, 
       timer.ElapsedNanos());
     MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED, 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -703,7 +703,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     type = kNoCompression;
     block_contents = raw_block_contents;
   }
-  else{
+  else if(type != kNoCompression){
     MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS, 
       timer.ElapsedNanos());
     MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED, 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -651,11 +651,15 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
   auto type = r->compression_type;
   Slice block_contents;
   bool abort_compression = false;
+  
+  StopWatchNano timer(r->ioptions.env, true);
+
   if (raw_block_contents.size() < kCompressionSizeLimit) {
     Slice compression_dict;
     if (is_data_block && r->compression_dict && r->compression_dict->size()) {
       compression_dict = *r->compression_dict;
     }
+
     block_contents = CompressBlock(raw_block_contents, r->compression_opts,
                                    &type, r->table_options.format_version,
                                    compression_dict, &r->compressed_output);
@@ -668,7 +672,8 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
       BlockContents contents;
       Status stat = UncompressBlockContentsForCompressionType(
           block_contents.data(), block_contents.size(), &contents,
-          r->table_options.format_version, compression_dict, type);
+          r->table_options.format_version, compression_dict, type,
+          r->ioptions);
 
       if (stat.ok()) {
         bool compressed_ok = contents.data.compare(raw_block_contents) == 0;
@@ -697,6 +702,13 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     RecordTick(r->ioptions.statistics, NUMBER_BLOCK_NOT_COMPRESSED);
     type = kNoCompression;
     block_contents = raw_block_contents;
+  }
+  else{
+    MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS, 
+      timer.ElapsedNanos());
+    MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED, 
+      raw_block_contents.size());
+    RecordTick(r->ioptions.statistics, NUMBER_BLOCK_COMPRESSED);
   }
 
   WriteRawBlock(block_contents, type, handle);

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -762,7 +762,7 @@ Status BlockBasedTableBuilder::status() const {
   return rep_->status;
 }
 
-static void DeleteCachedBlock(const Slice& key, void* value) {
+static void DeleteCachelock(const Slice& key, void* value) {
   Block* block = reinterpret_cast<Block*>(value);
   delete block;
 }

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -652,7 +652,8 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
   Slice block_contents;
   bool abort_compression = false;
   
-  StopWatchNano timer(r->ioptions.env, true);
+  StopWatchNano timer(r->ioptions.env,
+    ShouldReportDetailedTime(r->ioptions.env, r->ioptions.statistics));
 
   if (raw_block_contents.size() < kCompressionSizeLimit) {
     Slice compression_dict;
@@ -703,7 +704,9 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     type = kNoCompression;
     block_contents = raw_block_contents;
   }
-  else if (type != kNoCompression) {
+  else if (type != kNoCompression &&
+            ShouldReportDetailedTime(r->ioptions.env, 
+              r->ioptions.statistics)) {
     MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS, 
       timer.ElapsedNanos());
     MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED, 
@@ -762,7 +765,7 @@ Status BlockBasedTableBuilder::status() const {
   return rep_->status;
 }
 
-static void DeleteCachelock(const Slice& key, void* value) {
+static void DeleteCachedBlock(const Slice& key, void* value) {
   Block* block = reinterpret_cast<Block*>(value);
   delete block;
 }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1546,8 +1546,6 @@ Status BlockBasedTable::CreateIndexReader(
   auto file = rep_->file.get();
   auto comparator = &rep_->internal_comparator;
   const Footer& footer = rep_->footer;
-  Statistics* stats = rep_->ioptions.statistics;
-
   if (index_type_on_file == BlockBasedTableOptions::kHashSearch &&
       rep_->ioptions.prefix_extractor == nullptr) {
     Log(InfoLogLevel::WARN_LEVEL, rep_->ioptions.info_log,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -177,8 +177,8 @@ class BlockBasedTable : public TableReader {
   //    dictionary.
   static Status GetDataBlockFromCache(
       const Slice& block_cache_key, const Slice& compressed_block_cache_key,
-      Cache* block_cache, Cache* block_cache_compressed, Statistics* statistics,
-      const ReadOptions& read_options,
+      Cache* block_cache, Cache* block_cache_compressed,
+      const ImmutableCFOptions &ioptions, const ReadOptions& read_options,
       BlockBasedTable::CachableEntry<Block>* block, uint32_t format_version,
       const Slice& compression_dict);
 
@@ -195,7 +195,7 @@ class BlockBasedTable : public TableReader {
   static Status PutDataBlockToCache(
       const Slice& block_cache_key, const Slice& compressed_block_cache_key,
       Cache* block_cache, Cache* block_cache_compressed,
-      const ReadOptions& read_options, Statistics* statistics,
+      const ReadOptions& read_options, const ImmutableCFOptions &ioptions,
       CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
       const Slice& compression_dict);
 

--- a/table/cuckoo_table_builder_test.cc
+++ b/table/cuckoo_table_builder_test.cc
@@ -49,12 +49,16 @@ class CuckooBuilderTest : public testing::Test {
     uint64_t read_file_size;
     ASSERT_OK(env_->GetFileSize(fname, &read_file_size));
 
+	Options options;
+	options.allow_mmap_reads = true;
+	ImmutableCFOptions ioptions(options);
+
     // Assert Table Properties.
     TableProperties* props = nullptr;
     unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(std::move(read_file)));
     ASSERT_OK(ReadTableProperties(file_reader.get(), read_file_size,
-                                  kCuckooTableMagicNumber, env_, nullptr,
+                                  kCuckooTableMagicNumber, ioptions,
                                   &props));
     // Check unused bucket.
     std::string unused_key = props->user_collected_properties[

--- a/table/cuckoo_table_reader.cc
+++ b/table/cuckoo_table_reader.cc
@@ -45,7 +45,7 @@ CuckooTableReader::CuckooTableReader(
   }
   TableProperties* props = nullptr;
   status_ = ReadTableProperties(file_.get(), file_size, kCuckooTableMagicNumber,
-      ioptions.env, ioptions.info_log, &props);
+      ioptions, &props);
   if (!status_.ok()) {
     return;
   }

--- a/table/format.h
+++ b/table/format.h
@@ -24,6 +24,8 @@ class Block;
 class RandomAccessFile;
 struct ReadOptions;
 
+extern bool ShouldReportDetailedTime(Env* env, Statistics* stats);
+
 // the length of the magic number in bytes.
 const int kMagicNumberLengthByte = 8;
 

--- a/table/format.h
+++ b/table/format.h
@@ -212,10 +212,9 @@ struct BlockContents {
 extern Status ReadBlockContents(
     RandomAccessFileReader* file, const Footer& footer,
     const ReadOptions& options, const BlockHandle& handle,
-    BlockContents* contents, Env* env, bool do_uncompress = true,
-    const Slice& compression_dict = Slice(),
-    const PersistentCacheOptions& cache_options = PersistentCacheOptions(),
-    Logger* info_log = nullptr);
+    BlockContents* contents, const ImmutableCFOptions &ioptions,
+    bool do_uncompress = true, const Slice& compression_dict = Slice(),
+    const PersistentCacheOptions& cache_options = PersistentCacheOptions());
 
 // The 'data' points to the raw block contents read in from file.
 // This method allocates a new heap buffer and the raw block
@@ -227,7 +226,8 @@ extern Status ReadBlockContents(
 extern Status UncompressBlockContents(const char* data, size_t n,
                                       BlockContents* contents,
                                       uint32_t compress_format_version,
-                                      const Slice& compression_dict);
+                                      const Slice& compression_dict,
+                                      const ImmutableCFOptions &ioptions);
 
 // This is an extension to UncompressBlockContents that accepts
 // a specific compression type. This is used by un-wrapped blocks
@@ -235,7 +235,7 @@ extern Status UncompressBlockContents(const char* data, size_t n,
 extern Status UncompressBlockContentsForCompressionType(
     const char* data, size_t n, BlockContents* contents,
     uint32_t compress_format_version, const Slice& compression_dict,
-    CompressionType compression_type);
+    CompressionType compression_type, const ImmutableCFOptions &ioptions);
 
 // Implementation details follow.  Clients should ignore,
 

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -94,7 +94,7 @@ bool NotifyCollectTableCollectorsOnFinish(
 //          *table_properties will point to a heap-allocated TableProperties
 //          object, otherwise value of `table_properties` will not be modified.
 Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
-                      const Footer& footer, Env* env, Logger* logger,
+                      const Footer& footer, const ImmutableCFOptions &ioptions,
                       TableProperties** table_properties);
 
 // Directly read the properties from the properties block of a plain table.
@@ -102,8 +102,9 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
 //          *table_properties will point to a heap-allocated TableProperties
 //          object, otherwise value of `table_properties` will not be modified.
 Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
-                           uint64_t table_magic_number, Env* env,
-                           Logger* info_log, TableProperties** properties);
+                           uint64_t table_magic_number,
+                           const ImmutableCFOptions &ioptions,
+                           TableProperties** properties);
 
 // Find the meta block from the meta index block.
 Status FindMetaBlock(InternalIterator* meta_index_iter,
@@ -112,7 +113,8 @@ Status FindMetaBlock(InternalIterator* meta_index_iter,
 
 // Find the meta block
 Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
-                     uint64_t table_magic_number, Env* env,
+                     uint64_t table_magic_number,
+                     const ImmutableCFOptions &ioptions,
                      const std::string& meta_block_name,
                      BlockHandle* block_handle);
 
@@ -120,7 +122,8 @@ Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
 // from `file` and initialize `contents` with contents of this block.
 // Return Status::OK in case of success.
 Status ReadMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
-                     uint64_t table_magic_number, Env* env,
+                     uint64_t table_magic_number,
+                     const ImmutableCFOptions &ioptions,
                      const std::string& meta_block_name,
                      BlockContents* contents);
 

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -128,7 +128,7 @@ Status PlainTableReader::Open(const ImmutableCFOptions& ioptions,
 
   TableProperties* props = nullptr;
   auto s = ReadTableProperties(file.get(), file_size, kPlainTableMagicNumber,
-                               ioptions.env, ioptions.info_log, &props);
+                               ioptions, &props);
   if (!s.ok()) {
     return s;
   }
@@ -293,13 +293,13 @@ Status PlainTableReader::PopulateIndex(TableProperties* props,
 
   BlockContents bloom_block_contents;
   auto s = ReadMetaBlock(file_info_.file.get(), file_size_,
-                         kPlainTableMagicNumber, ioptions_.env,
+                         kPlainTableMagicNumber, ioptions_,
                          BloomBlockBuilder::kBloomBlock, &bloom_block_contents);
   bool index_in_file = s.ok();
 
   BlockContents index_block_contents;
   s = ReadMetaBlock(
-      file_info_.file.get(), file_size_, kPlainTableMagicNumber, ioptions_.env,
+      file_info_.file.get(), file_size_, kPlainTableMagicNumber, ioptions_,
       PlainTableIndexBuilder::kPlainTableIndexBlock, &index_block_contents);
 
   index_in_file &= s.ok();

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2064,7 +2064,7 @@ TEST_F(PlainTableTest, BasicPlainTableProperties) {
 
   TableProperties* props = nullptr;
   auto s = ReadTableProperties(file_reader.get(), ss->contents().size(),
-                               kPlainTableMagicNumber, Env::Default(), nullptr,
+                               kPlainTableMagicNumber, ioptions,
                                &props);
   std::unique_ptr<TableProperties> props_guard(props);
   ASSERT_OK(s);

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -219,8 +219,7 @@ Status SstFileReader::ReadTableProperties(uint64_t table_magic_number,
                                           uint64_t file_size) {
   TableProperties* table_properties = nullptr;
   Status s = rocksdb::ReadTableProperties(file, file_size, table_magic_number,
-                                          options_.env, options_.info_log.get(),
-                                          &table_properties);
+                                          ioptions_, &table_properties);
   if (s.ok()) {
     table_properties_.reset(table_properties);
   } else {

--- a/util/coding.h
+++ b/util/coding.h
@@ -154,7 +154,8 @@ inline void EncodeFixed64(char* buf, uint64_t value) {
 // Pull the last 8 bits and cast it to a character
 inline void PutFixed32(std::string* dst, uint32_t value) {
 #if __BYTE_ORDER__ == __LITTLE_ENDIAN__
-  dst->append(static_cast<const char*>(&value), sizeof(value));
+  dst->append(const_cast<const char*>(reinterpret_cast<char*>(&value)),
+    sizeof(value));
 #else
   char buf[sizeof(value)];
   EncodeFixed32(buf, value);
@@ -164,7 +165,8 @@ inline void PutFixed32(std::string* dst, uint32_t value) {
 
 inline void PutFixed64(std::string* dst, uint64_t value) {
 #if __BYTE_ORDER__ == __LITTLE_ENDIAN__
-  dst->append(static_const<const char*>(&value), sizeof(value));
+  dst->append(const_cast<const char*>(reinterpret_cast<char*>(&value)),
+    sizeof(value));
 #else
   char buf[sizeof(value)];
   EncodeFixed64(buf, value);


### PR DESCRIPTION
Added new statistics that our team wants to be able to track:
Tickers:
```
NUMBER_BLOCK_COMPRESSED      // number of compressions that occur
NUMBER_BLOCK_DECOMPRESSED    // number of decompressions that occur
```
Histograms:
```
BYTES_COMPRESSED             // tracks size of compressions
BYTES_DECOMPRESSED           // tracks size of decompressions
COMPRESSION_TIMES_NANOS      // tracks time spent on each compression
DECOMPRESSION_TIMES_NANOS    // tracks time spent on each decompression
```
As can be seen from the change list, adding these statistics required modification of existing function definitions. To track the new statistics, an environment pointer and statistics pointer are required in the `WriteBlock()` function of `block_based_table_builder.cc` and the `UncompressBlockContentsForCompressionType()` function in `format.cc`. To achieve this, the necessary function signatures have been changed to pass a reference to the `ImmutableCFOptions` object `ioptions`. Besides encapsulating the environment and statistics pointer, `ioptions` also holds `info_log`, allowing this parameter to be removed from the signatures of the modified functions.

Tests for the new counters can be found in `db/db_test.cc`.

Note that `DECOMPRESSION_TIMES_NANOS` can replace `block_decompress_time` in `perf_context.h`, which is almost certainly inaccurate. This counter is only updated from `ReadBlockContents()` in `format.cc` before a call to `UncompressBlockContents()` that may or may not happen (it's inside an `if`). This is also not the only place from which `UncompressBlockContents()` is called, so `block_decompress_time` isn't tracking all decompressions. `DECOMPRESSION_TIMES_NANOS`, on the other hand, is updated directly from within `UncompressBlockContentsForCompressionType()`, guaranteeing its accuracy.