### PR TITLE
fixes #1212: rocksdbjni maven build does not escape slashes in groovy script

### DIFF
--- a/java/rocksjni.pom
+++ b/java/rocksjni.pom
@@ -102,7 +102,7 @@
                                 <name>Xenu</name>
                             </defaults>
                             <source>
-                                String fileContents = new File("${project.basedir}/../include/rocksdb/version.h").getText('UTF-8')
+                                String fileContents = new File(project.basedir.absolutePath + '/../include/rocksdb/version.h').getText('UTF-8')
                                 matcher = (fileContents =~ /(?s).*ROCKSDB_MAJOR ([0-9]+).*?/)
                                 String major_version = matcher.getAt(0).getAt(1)
                                 matcher = (fileContents =~ /(?s).*ROCKSDB_MINOR ([0-9]+).*?/)


### PR DESCRIPTION
using gmaven property so that script is not broken by embedding unescaped Windows-style path

Please check the issue description.