### PR TITLE
fixes #1210: rocksdb/java/CMakeLists.txt lacks cmake_minimum_required

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 2.6)
+
 set(JNI_NATIVE_SOURCES
         rocksjni/backupenginejni.cc
         rocksjni/backupablejni.cc


### PR DESCRIPTION
specifying minimum cmake version so that no warning has to be suppressed