### PR TITLE
fixes 1220: rocksjni build fails on Windows due to variable-size array declaration

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1104,7 +1104,7 @@ std::vector<rocksdb::CompressionType> rocksdb_compression_vector_helper(
  */
 jbyteArray rocksdb_compression_list_helper(JNIEnv* env,
     std::vector<rocksdb::CompressionType> compressionLevels) {
-  jbyte* jbuf = new jbyte[compressionLevels.size()];
+  std::unique_ptr<jbyte[]> jbuf = std::make_unique<jbyte[]>(compressionLevels.size());
   for (std::vector<rocksdb::CompressionType>::size_type i = 0;
         i != compressionLevels.size(); i++) {
       jbuf[i] = compressionLevels[i];
@@ -1113,7 +1113,7 @@ jbyteArray rocksdb_compression_list_helper(JNIEnv* env,
   jbyteArray jcompressionLevels = env->NewByteArray(
       static_cast<jsize>(compressionLevels.size()));
   env->SetByteArrayRegion(jcompressionLevels, 0,
-      static_cast<jsize>(compressionLevels.size()), jbuf);
+      static_cast<jsize>(compressionLevels.size()), jbuf.get());
   return jcompressionLevels;
 }
 

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1104,7 +1104,7 @@ std::vector<rocksdb::CompressionType> rocksdb_compression_vector_helper(
  */
 jbyteArray rocksdb_compression_list_helper(JNIEnv* env,
     std::vector<rocksdb::CompressionType> compressionLevels) {
-  jbyte jbuf[compressionLevels.size()];
+  jbyte* jbuf = new jbyte[compressionLevels.size()];
   for (std::vector<rocksdb::CompressionType>::size_type i = 0;
         i != compressionLevels.size(); i++) {
       jbuf[i] = compressionLevels[i];

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -115,14 +115,14 @@ jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
   // check if open operation was successful
   if (s.ok()) {
     jsize resultsLen = 1 + len_cols; //db handle + column family handles
-    jlong* results = new jlong[resultsLen];
+    std::unique_ptr<jlong[]> results = std::make_unique<jlong[]>(resultsLen);
     results[0] = reinterpret_cast<jlong>(db);
     for(int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);
     }
 
     jlongArray jresults = env->NewLongArray(resultsLen);
-    env->SetLongArrayRegion(jresults, 0, resultsLen, results);
+    env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
     return jresults;
   } else {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -115,7 +115,7 @@ jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
   // check if open operation was successful
   if (s.ok()) {
     jsize resultsLen = 1 + len_cols; //db handle + column family handles
-    jlong results[resultsLen];
+    jlong* results = new jlong[resultsLen];
     results[0] = reinterpret_cast<jlong>(db);
     for(int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);

--- a/java/rocksjni/ttl.cc
+++ b/java/rocksjni/ttl.cc
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "include/org_rocksdb_TtlDB.h"
 #include "rocksdb/utilities/db_ttl.h"
@@ -95,14 +96,14 @@ jlongArray
   // check if open operation was successful
   if (s.ok()) {
     jsize resultsLen = 1 + len_cols; //db handle + column family handles
-    jlong* results = new jlong[resultsLen];
+    std::unique_ptr<jlong[]> results = std::make_unique<jlong[]>(resultsLen);
     results[0] = reinterpret_cast<jlong>(db);
     for(int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);
     }
 
     jlongArray jresults = env->NewLongArray(resultsLen);
-    env->SetLongArrayRegion(jresults, 0, resultsLen, results);
+    env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
     return jresults;
   } else {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);

--- a/java/rocksjni/ttl.cc
+++ b/java/rocksjni/ttl.cc
@@ -95,7 +95,7 @@ jlongArray
   // check if open operation was successful
   if (s.ok()) {
     jsize resultsLen = 1 + len_cols; //db handle + column family handles
-    jlong results[resultsLen];
+    jlong* results = new jlong[resultsLen];
     results[0] = reinterpret_cast<jlong>(db);
     for(int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);


### PR DESCRIPTION
using new keyword to create variable-size arrays in order to satisfy most of the compilers