### PR TITLE
Remove %z Format Specifier and Fix Windows Build of sim_cache.cc

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -11,6 +11,7 @@
 #include "port/stack_trace.h"
 #include "rocksdb/iostats_context.h"
 #include "rocksdb/perf_context.h"
+#include "port/port.h"
 
 namespace rocksdb {
 
@@ -979,7 +980,7 @@ TEST_F(DBIteratorTest, PinnedDataIteratorRandomized) {
 
     {
       // Test Seek to random keys
-      printf("Testing seek on %zu keys\n", random_keys.size());
+      printf("Testing seek on %" ROCKSDB_PRIszt " keys\n", random_keys.size());
       std::vector<Slice> keys_slices;
       std::vector<std::string> true_keys;
       for (auto& k : random_keys) {

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -12,6 +12,7 @@
 #include "rocksdb/sst_file_manager.h"
 #include "rocksdb/sst_file_writer.h"
 #include "util/sst_file_manager_impl.h"
+#include "port/port.h"
 
 namespace rocksdb {
 
@@ -1455,7 +1456,7 @@ TEST_F(DBSSTTest, AddExternalSstFileOverlappingRanges) {
     }
 
     printf(
-        "Total: %zu ranges\n"
+        "Total: %" ROCKSDB_PRIszt " ranges\n"
         "AddFile()|Success: %d ranges\n"
         "AddFile()|RangeConflict: %d ranges\n"
         "Put(): %d ranges\n",

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -134,13 +134,8 @@ class SimCacheImpl : public SimCache {
                "\n");
     res.append("SimCache HITs:    " + std::to_string(get_hit_counter()) + "\n");
     char buff[100];
-#ifdef OS_WIN
-    _snprintf(buff, sizeof(buff), "SimCache HITRATE: %.2f%%\n",
-              get_hit_rate() * 100);
-#else
     snprintf(buff, sizeof(buff), "SimCache HITRATE: %.2f%%\n",
              get_hit_rate() * 100);
-#endif
     res.append(buff);
     return res;
   }

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -5,6 +5,7 @@
 
 #include "rocksdb/utilities/sim_cache.h"
 #include <atomic>
+#include "port/port.h"
 
 namespace rocksdb {
 


### PR DESCRIPTION
The `%zu` and `%z` format specifiers do not work on Windows. This change replaces two instances of `%zu` that managed to sneak in with the `ROCKSDB_PRIszt` macro defined in each port header file.