### PR TITLE
Remove bashism from `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ $(parallel_tests): $(PARALLEL_TEST)
       -e '/^(\s*)(\S+)/; !$$1 and do {$$p=$$2; break};'	\
       -e 'print qq! $$p$$2!'`; \
 	for TEST_NAME in $$TEST_NAMES; do \
-		TEST_SCRIPT=t/run-$$TEST_BINARY-$${TEST_NAME//\//-}; \
+		TEST_SCRIPT=t/run-$$TEST_BINARY-`echo $$TEST_NAME|sed -e 's/\//-/g'`; \
 		echo "  GEN     " $$TEST_SCRIPT; \
     printf '%s\n' \
       '#!/bin/sh' \
@@ -613,7 +613,7 @@ check_0:
 	} \
 	  | $(prioritize_long_running_tests)				\
 	  | grep -E '$(tests-regexp)'					\
-	  | parallel -j$(J) --joblog=LOG $$eta --gnu '{} >& t/log-{/}'
+	  | parallel -j$(J) --joblog=LOG $$eta --gnu '{} >&2 t/log-{/}'
 
 .PHONY: valgrind_check_0
 valgrind_check_0:


### PR DESCRIPTION
The tests run by `make check` require Bash. On Debian you'd need to run
the test as `make SHELL=/bin/bash check`. This commit makes it work on
all POSIX compatible shells (tested on Debian with `dash`).