### PR TITLE
fixes 1228: rockdbjni loadLibraryFromJarToTemp fails when file is already present

### DIFF
--- a/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
+++ b/java/src/main/java/org/rocksdb/NativeLibraryLoader.java
@@ -87,6 +87,10 @@ public class NativeLibraryLoader {
       temp = File.createTempFile(tempFilePrefix, tempFileSuffix);
     } else {
       temp = new File(tmpDir, jniLibraryFileName);
+      if (temp.exists() && !temp.delete()) {
+        throw new RuntimeException("File: " + temp.getAbsolutePath()
+            + " already exists and cannot be removed.");
+      }
       if (!temp.createNewFile()) {
         throw new RuntimeException("File: " + temp.getAbsolutePath()
             + " could not be created.");

--- a/java/src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
+++ b/java/src/test/java/org/rocksdb/NativeLibraryLoaderTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.util.Environment;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 
@@ -27,5 +28,14 @@ public class NativeLibraryLoaderTest {
         Environment.getJniLibraryFileName("rocksdb"));
     assertThat(Files.exists(path)).isTrue();
     assertThat(Files.isReadable(path)).isTrue();
+  }
+
+  @Test
+  public void overridesExistingLibrary() throws IOException {
+    File first = NativeLibraryLoader.getInstance().loadLibraryFromJarToTemp(
+        temporaryFolder.getRoot().getAbsolutePath());
+    NativeLibraryLoader.getInstance().loadLibraryFromJarToTemp(
+        temporaryFolder.getRoot().getAbsolutePath());
+    assertThat(first.exists()).isTrue();
   }
 }


### PR DESCRIPTION
overriding existing library in tmp folder