### PR TITLE
More granular steps in the Makefile for Java Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1374,6 +1374,12 @@ rocksdbjava: $(java_libobjects)
 jclean:
 	cd java;$(MAKE) clean;
 
+jtest_compile: rocksdbjava
+	cd java;$(MAKE) java_test
+
+jtest_run:
+	cd java;$(MAKE) run_test
+
 jtest: rocksdbjava
 	cd java;$(MAKE) sample;$(MAKE) test;
 

--- a/java/Makefile
+++ b/java/Makefile
@@ -181,7 +181,9 @@ java_test: resolve_test_deps
 		$(TEST_SRC)/org/rocksdb/*.java
 	$(AM_V_at)javah -cp $(MAIN_CLASSES):$(TEST_CLASSES) -d $(NATIVE_INCLUDE) -jni $(NATIVE_JAVA_TEST_CLASSES)
 
-test: java resolve_test_deps java_test
+test: java resolve_test_deps java_test run_test
+
+run_test:
 	java -ea -Xcheck:jni -Djava.library.path=target -cp "$(MAIN_CLASSES):$(TEST_CLASSES):$(JAVA_TESTCLASSPATH):target/*" org.rocksdb.test.RocksJunitRunner $(JAVA_TESTS)
 
 db_bench: java


### PR DESCRIPTION
* Separate targets for the compilation and execution steps of `make jtest`, now provides in addition:
  * make `jtest_compile`
  * make `jtest_run`

* This is useful for running all Java tests or just a single Java test after compilation.
* Also useful when compiling with ASAN: https://github.com/facebook/rocksdb/wiki/JNI-Debugging