### PR TITLE
Remove bashism from `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ $(parallel_tests): $(PARALLEL_TEST)
       -e '/^(\s*)(\S+)/; !$$1 and do {$$p=$$2; break};'	\
       -e 'print qq! $$p$$2!'`; \
 	for TEST_NAME in $$TEST_NAMES; do \
-		TEST_SCRIPT=t/run-$$TEST_BINARY-$${TEST_NAME//\//-}; \
+		TEST_SCRIPT=t/run-$$TEST_BINARY-`echo $$TEST_NAME|sed -e 's/\//-/g'`; \
 		echo "  GEN     " $$TEST_SCRIPT; \
     printf '%s\n' \
       '#!/bin/sh' \
@@ -630,7 +630,7 @@ check_0:
 	} \
 	  | $(prioritize_long_running_tests)				\
 	  | grep -E '$(tests-regexp)'					\
-	  | build_tools/gnu_parallel -j$(J) --plain --joblog=LOG $$eta --gnu '{} >& t/log-{/}'
+	  | build_tools/gnu_parallel -j$(J) --plain --joblog=LOG $$eta --gnu '{} >t/log-{/} 2>&1'
 
 .PHONY: valgrind_check_0
 valgrind_check_0:


### PR DESCRIPTION
The tests run by `make check` require Bash. On Debian you'd need to run
the test as `make SHELL=/bin/bash check`. This commit makes it work on
all POSIX compatible shells (tested on Debian with `dash`).

This is a follow-up on #1225 which was reverted as it didn't create the
logs files correctly.
