### PR TITLE
Support underlying put API

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -407,6 +407,21 @@ public class RocksDB extends RocksObject {
   }
 
   /**
+   * Set the database entry for "key" to "value".
+   *
+   * @param key the specified key to be inserted.
+   * @param value the value associated with the specified key.
+   * @param length how many bytes to copy from value to tht database entry.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final byte[] key, final byte[] value, final int length) 
+      throws RocksDBException {
+    put(nativeHandle_, key, key.length, value, length);
+  }
+
+  /**
    * Set the database entry for "key" to "value" in the specified
    * column family.
    *

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -407,21 +407,6 @@ public class RocksDB extends RocksObject {
   }
 
   /**
-   * Set the database entry for "key" to "value".
-   *
-   * @param key the specified key to be inserted.
-   * @param value the value associated with the specified key.
-   * @param length how many bytes to copy from value to tht database entry.
-   *
-   * @throws RocksDBException thrown if error happens in underlying
-   *    native library.
-   */
-  public void put(final byte[] key, final byte[] value, final int length) 
-      throws RocksDBException {
-    put(nativeHandle_, key, key.length, value, length);
-  }
-
-  /**
    * Set the database entry for "key" to "value" in the specified
    * column family.
    *
@@ -480,6 +465,87 @@ public class RocksDB extends RocksObject {
         value.length, columnFamilyHandle.nativeHandle_);
   }
 
+  /**
+   * Set the database entry for "key" to "value".
+   *
+   * @param key a buffer containing the key to be inserted.
+   * @param keyLength how many bytes in key to use as the database key. 
+   * @param value a buffer containing the value associated with the specified key.
+   * @param valueLength how many bytes to copy from value to the database entry.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final byte[] key, final int keyLength,
+                  final byte[] value, final int valueLength) throws RocksDBException {
+    put(nativeHandle_, key, keyLength, value, valueLength);
+  }
+
+  /**
+   * Set the database entry for "key" to "value" for the specified
+   * column family.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param key a buffer containing the key to be inserted.
+   * @param keyLength how many bytes in key to use as the database key. 
+   * @param value a buffer containing the value associated with the specified key.
+   * @param valueLength how many bytes to copy from value to the database entry.
+   *
+   * throws IllegalArgumentException if column family is not present
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final int keyLength, 
+                  final byte[] value, final int valueLength) throws RocksDBException {
+    put(nativeHandle_, key, keyLength, value, valueLength,
+        columnFamilyHandle.nativeHandle_);
+  }
+
+  /**
+   * Set the database entry for "key" to "value".
+   *
+   * @param writeOpts {@link org.rocksdb.WriteOptions} instance.
+   * @param key a buffer containing the key to be inserted.
+   * @param keyLength how many bytes in key to use as the database key. 
+   * @param value a buffer containing the value associated with the specified key.
+   * @param valueLength how many bytes to copy from value to the database entry.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final WriteOptions writeOpts, final byte[] key, final int keyLength,
+                  final byte[] value, final int valueLength) throws RocksDBException {
+    put(nativeHandle_, writeOpts.nativeHandle_, key, keyLength, value, valueLength);
+  }
+
+  /**
+   * Set the database entry for "key" to "value" for the specified
+   * column family.
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param writeOpts {@link org.rocksdb.WriteOptions} instance.
+   * @param key a buffer containing the key to be inserted.
+   * @param keyLength how many bytes in key to use as the database key. 
+   * @param value a buffer containing the value associated with the specified key.
+   * @param valueLength how many bytes to copy from value to the database entry.
+   *
+   * throws IllegalArgumentException if column family is not present
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final ColumnFamilyHandle columnFamilyHandle,
+                  final WriteOptions writeOpts, 
+                  final byte[] key, final int keyLength, 
+                  final byte[] value, final int valueLength) throws RocksDBException {
+    put(nativeHandle_,  writeOpts.nativeHandle_, 
+        key, keyLength, value, valueLength,
+        columnFamilyHandle.nativeHandle_);
+  }
+  
   /**
    * If the key definitely does not exist in the database, then this method
    * returns false, else true.


### PR DESCRIPTION
It is common practice to pre-allocate arrays so in high write
situations you don't need to keep
creating large array objects. As the current API requires full array,
this means an array needs to be
copied before passing to RocksDB.

By supporting the underlying C API, an additional memory copy can be
avoided leading to
a big saving in GC in high write circumstances.
