### PR TITLE
util/arena.cc: FreeBSD: More portable use of mmap(MAP_ANON)

### DIFF
--- a/util/arena.cc
+++ b/util/arena.cc
@@ -119,7 +119,7 @@ char* Arena::AllocateFromHugePage(size_t bytes) {
   huge_blocks_.reserve(huge_blocks_.size() + 1);
 
   void* addr = mmap(nullptr, bytes, (PROT_READ | PROT_WRITE),
-                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), 0, 0);
+                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), -1, 0);
 
   if (addr == MAP_FAILED) {
     return nullptr;


### PR DESCRIPTION
From the Linux manual:
  MAP_ANONYMOUS
     The  mapping  is  not  backed  by any file; its contents
     are initialized to zero.  The fd and offset arguments are
     ignored; however, some implementations require fd to be -1
     if MAP_ANONYMOUS (or MAP_ANON) is specified, and portable
     applications  should  ensure  this.

FreeBSD is such a case, it wil just return an error.

Signed-off-by: Willem jan Withagen <wjw@digiware.nl>