### PR TITLE
Correct geHistogramData() -> getHistogramData()

### DIFF
--- a/java/samples/src/main/java/RocksDBSample.java
+++ b/java/samples/src/main/java/RocksDBSample.java
@@ -231,11 +231,11 @@ public class RocksDBSample {
 
         try {
           for (HistogramType histogramType : HistogramType.values()) {
-            HistogramData data = stats.geHistogramData(histogramType);
+            HistogramData data = stats.getHistogramData(histogramType);
           }
-          System.out.println("geHistogramData() passed.");
+          System.out.println("getHistogramData() passed.");
         } catch (Exception e) {
-          System.out.println("Failed in call to geHistogramData()");
+          System.out.println("Failed in call to getHistogramData()");
           assert (false); //Should never reach here.
         }
 


### PR DESCRIPTION
Fix a typo in `java/samples`:

Correct `geHistogramData()` -> `getHistogramData()`