### PR TITLE
Update documentation to point at gcc 4.8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ your make commands, like this: `PORTABLE=1 make static_lib`
 ## Supported platforms
 
 * **Linux - Ubuntu**
-    * Upgrade your gcc to version at least 4.7 to get C++11 support.
+    * Upgrade your gcc to version at least 4.8 to get C++11 support.
     * Install gflags. First, try: `sudo apt-get install libgflags-dev`
       If this doesn't work and you're using Ubuntu, here's a nice tutorial:
       (http://askubuntu.com/questions/312173/installing-gflags-12-04)
@@ -49,8 +49,8 @@ your make commands, like this: `PORTABLE=1 make static_lib`
     * Install zlib. Try: `sudo apt-get install zlib1g-dev`.
     * Install bzip2: `sudo apt-get install libbz2-dev`.
 * **Linux - CentOS**
-    * Upgrade your gcc to version at least 4.7 to get C++11 support:
-      `yum install gcc47-c++`
+    * Upgrade your gcc to version at least 4.8 to get C++11 support:
+      `yum install gcc48-c++`
     * Install gflags:
 
               wget https://gflags.googlecode.com/files/gflags-2.0-no-svn-files.tar.gz
@@ -80,7 +80,7 @@ your make commands, like this: `PORTABLE=1 make static_lib`
         * Update XCode:  run `xcode-select --install` (or install it from XCode App's settting).
         * Install via [homebrew](http://brew.sh/).
             * If you're first time developer in MacOS, you still need to run: `xcode-select --install` in your command line.
-            * run `brew tap homebrew/versions; brew install gcc47 --use-llvm` to install gcc 4.7 (or higher).
+            * run `brew tap homebrew/versions; brew install gcc48 --use-llvm` to install gcc 4.8 (or higher).
     * run `brew install rocksdb`
 
 * **iOS**:

--- a/build_tools/make_package.sh
+++ b/build_tools/make_package.sh
@@ -65,8 +65,8 @@ function main() {
 
   if [[ -d /vagrant ]]; then
     if [[ $OS = "ubuntu" ]]; then
-      package g++-4.7
-      export CXX=g++-4.7
+      package g++-4.8
+      export CXX=g++-4.8
 
       # the deb would depend on libgflags2, but the static lib is the only thing
       # installed by make install

--- a/util/thread_local.cc
+++ b/util/thread_local.cc
@@ -126,9 +126,9 @@ ThreadLocalPtr::StaticMeta* ThreadLocalPtr::Instance() {
   // of using __thread.  The major difference between thread_local and __thread
   // is that thread_local supports dynamic construction and destruction of
   // non-primitive typed variables.  As a result, we can guarantee the
-  // desturction order even when the main thread dies before any child threads.
+  // destruction order even when the main thread dies before any child threads.
   // However, thread_local is not supported in all compilers that accept -std=c++11
-  // (e.g., the default clang on Mac).
+  // (e.g., eg Mac with XCode < 8. XCode 8+ supports thread_local).
   static ThreadLocalPtr::StaticMeta* inst = new ThreadLocalPtr::StaticMeta();
   return inst;
 }

--- a/util/thread_local.cc
+++ b/util/thread_local.cc
@@ -127,9 +127,8 @@ ThreadLocalPtr::StaticMeta* ThreadLocalPtr::Instance() {
   // is that thread_local supports dynamic construction and destruction of
   // non-primitive typed variables.  As a result, we can guarantee the
   // desturction order even when the main thread dies before any child threads.
-  // However, thread_local requires gcc 4.8 and is not supported in all the
-  // compilers that accepts -std=c++11 (e.g., the default clang on Mac), while
-  // the current RocksDB still accept gcc 4.7.
+  // However, thread_local is not supported in all compilers that accept -std=c++11
+  // (e.g., the default clang on Mac).
   static ThreadLocalPtr::StaticMeta* inst = new ThreadLocalPtr::StaticMeta();
   return inst;
 }


### PR DESCRIPTION
Rocksdb currently has many references to std::map.emplace_back()
which is not implemented in gcc 4.7, but valid in gcc 4.8. Confirmed that
it did not build with gcc 4.7, but builds fine with gcc 4.8