### PR TITLE
plain_table_reader.cc:517: bytes_read must be initialized

### DIFF
--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -514,7 +514,7 @@ Status PlainTableReader::Next(PlainTableKeyDecoder* decoder, uint32_t* offset,
     return Status::Corruption("Offset is out of file size");
   }
 
-  uint32_t bytes_read;
+  uint32_t bytes_read = 0;
   Status s = decoder->NextKey(*offset, parsed_key, internal_key, value,
                               &bytes_read, seekable);
   if (!s.ok()) {


### PR DESCRIPTION
plain_table_reader.cc:517: bytes_read is not initialized any where, it should be initialized at definition.