### PR TITLE
Ensure Correct Behavior of StatsLevel kExceptDetailedTimers and kExceptTimeForMutex 

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4720,7 +4720,7 @@ TEST_F(DBTest, CompressionStatsTest) {
   Options options = CurrentOptions();
   options.compression = type;
   options.statistics = rocksdb::CreateDBStatistics();
-  options.statistics->stats_level_ = StatsLevel::kAll;
+  options.statistics->stats_level_ = StatsLevel::kExceptTimeForMutex;
   DestroyAndReopen(options);
 
   int kNumKeysWritten = 100000;

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -393,12 +393,12 @@ struct HistogramData {
 };
 
 enum StatsLevel {
+  // Collect all stats except time inside mutex lock AND time spent on
+  // compression.
+  kExceptDetailedTimers,
   // Collect all stats except the counters requiring to get time inside the
   // mutex lock.
   kExceptTimeForMutex,
-  // Collect all stats except time inside mutex lock AND time spent on
-  // compression
-  kExceptDetailedTimers,
   // Collect all stats, including measuring duration of mutex operations.
   // If getting time is expensive on the platform to run, it can
   // reduce scalability to more threads, especially for writes.

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -396,7 +396,7 @@ enum StatsLevel {
   // Collect all stats except the counters requiring to get time inside the
   // mutex lock.
   kExceptTimeForMutex,
-  // Collect all stats expect time inside mutex lock AND time spent on
+  // Collect all stats except time inside mutex lock AND time spent on
   // compression
   kExceptDetailedTimers,
   // Collect all stats, including measuring duration of mutex operations.
@@ -429,7 +429,7 @@ class Statistics {
     return type < HISTOGRAM_ENUM_MAX;
   }
 
-  StatsLevel stats_level_ = kExceptTimeForMutex;
+  StatsLevel stats_level_ = kExceptDetailedTimers;
 };
 
 // Create a concrete DBStatistics object

--- a/table/format.cc
+++ b/table/format.cc
@@ -44,7 +44,7 @@ const uint32_t DefaultStackBufferSize = 5000;
 
 bool ShouldReportDetailedTime(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&
-         stats->stats_level_ != kExceptDetailedTimers;
+         stats->stats_level_ > kExceptDetailedTimers;
 }
 
 void BlockHandle::EncodeTo(std::string* dst) const {

--- a/table/format.cc
+++ b/table/format.cc
@@ -44,7 +44,7 @@ const uint32_t DefaultStackBufferSize = 5000;
 
 bool ShouldReportDetailedTime(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&
-         stats->stats_level_ > kExceptDetailedTimers;
+         stats->stats_level_ != kExceptDetailedTimers;
 }
 
 void BlockHandle::EncodeTo(std::string* dst) const {

--- a/util/instrumented_mutex.cc
+++ b/util/instrumented_mutex.cc
@@ -11,8 +11,7 @@ namespace rocksdb {
 namespace {
 bool ShouldReportToStats(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&
-          stats->stats_level_ != kExceptTimeForMutex &&
-          stats->stats_level_ != kExceptDetailedTimers;
+          stats->stats_level_ > kExceptTimeForMutex;
 }
 }  // namespace
 

--- a/util/instrumented_mutex.cc
+++ b/util/instrumented_mutex.cc
@@ -11,7 +11,8 @@ namespace rocksdb {
 namespace {
 bool ShouldReportToStats(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&
-         stats->stats_level_ != kExceptTimeForMutex;
+          stats->stats_level_ != kExceptTimeForMutex &&
+          stats->stats_level_ != kExceptDetailedTimers;
 }
 }  // namespace
 


### PR DESCRIPTION
Currently, setting the stats level to `kExceptTimeForMutex` will also turn off "detailed timers" (compression timing), while setting it to `kExceptDetailedTimers` will cause mutex timers to run. This is because `InstrumentedMutex` checks if stats should be reported with:
`stats->stats_level_ != kExceptTimeForMutex`

And compression stats are controlled by:
`stats->stats_level_ > kExceptDetailedTimers` (the value of kExceptTimeForMutex is less than kExceptDetailedTimers)

This pull request corrects this behavior so that `kExceptDetailedTimers` turns off both compression and mutex statistics while `kExceptTimeForMutex` leaves compression stats on. To keep compression stats off by default, the default stats level is also changed to `kExceptDetailedTimers`.