### PR TITLE
Fix Mac build failure

### DIFF
--- a/utilities/persistent_cache/persistent_cache_bench.cc
+++ b/utilities/persistent_cache/persistent_cache_bench.cc
@@ -224,13 +224,13 @@ class CacheTierBenchmark {
     // Lookup in cache
     StopWatchNano timer(Env::Default(), /*auto_start=*/true);
     std::unique_ptr<char[]> block;
-    uint64_t size;
+    size_t size;
     Status status = cache_->Lookup(key, &block, &size);
     if (!status.ok()) {
       fprintf(stderr, "%s\n", status.ToString().c_str());
     }
     assert(status.ok());
-    assert(size == (uint64_t)FLAGS_iosize);
+    assert(size == (size_t) FLAGS_iosize);
 
     // adjust stats
     const size_t elapsed_micro = timer.ElapsedNanos() / 1000;


### PR DESCRIPTION
We mixed using `uint64_t` and `size_t` somewhere, which leads to a warning in Mac.

Although Travis itself was not working normally, this PR does not break our Linux build (Windows build seems to break somewhere else).