### PR TITLE
Fix build error on Windows (AppVeyor)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ set(SOURCES
         util/arena.cc
         util/bloom.cc
         util/build_version.cc
+        util/cf_options.cc
         util/clock_cache.cc
         util/coding.cc
         util/compaction_job_stats_impl.cc
@@ -221,7 +222,6 @@ set(SOURCES
         util/log_buffer.cc
         util/memenv.cc
         util/murmurhash.cc
-        util/mutable_cf_options.cc
         util/options.cc
         util/options_helper.cc
         util/options_parser.cc

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -79,6 +79,7 @@
 #include "table/two_level_iterator.h"
 #include "util/autovector.h"
 #include "util/build_version.h"
+#include "util/cf_options.h"
 #include "util/coding.h"
 #include "util/compression.h"
 #include "util/crc32c.h"

--- a/src.mk
+++ b/src.mk
@@ -88,7 +88,7 @@ LIB_SOURCES =                                                   \
   util/arena.cc                                                 \
   util/bloom.cc                                                 \
   util/build_version.cc                                         \
-	util/clock_cache.cc																						\
+  util/clock_cache.cc                                           \
   util/coding.cc                                                \
   util/comparator.cc                                            \
   util/compaction_job_stats_impl.cc                             \

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -232,7 +232,7 @@ class BlockReadAmpBitmapSlowAndAccurate {
 
   // Return true if any byte in this range was Marked
   bool IsAnyInRangeMarked(size_t start_offset, size_t end_offset) {
-    auto it = marked_ranges_.lower_bound(std::make_pair(start_offset, 0));
+    auto it = marked_ranges_.lower_bound(std::make_pair(start_offset, static_cast<size_t>(0)));
     if (it == marked_ranges_.end()) {
       return false;
     }
@@ -292,7 +292,7 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
     random_entry_offsets.resize(
         std::distance(random_entry_offsets.begin(), it));
 
-    std::vector<std::pair<uint32_t, uint32_t>> random_entries;
+    std::vector<std::pair<size_t, size_t>> random_entries;
     for (size_t i = 0; i < random_entry_offsets.size(); i++) {
       size_t entry_start = random_entry_offsets[i];
       size_t entry_end;
@@ -307,7 +307,7 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
     for (size_t i = 0; i < random_entries.size(); i++) {
       auto &current_entry = random_entries[rnd.Next() % random_entries.size()];
 
-      read_amp_bitmap.Mark(current_entry.first, current_entry.second);
+      read_amp_bitmap.Mark(static_cast<uint32_t>(current_entry.first), static_cast<uint32_t>(current_entry.second));
       read_amp_slow_and_accurate.Mark(current_entry.first,
                                       current_entry.second);
 


### PR DESCRIPTION
CI for Windows (AppVeyor) fails since CMakeLists.txt has a line 'util/mutable_cf_options.cc' which does not exist currently.

```
CMake Error at CMakeLists.txt:307 (add_library):
  Cannot find source file:
    util/mutable_cf_options.cc
  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
CMake Error: CMake can not determine linker language for target: rocksdbli
```