### PR TITLE
solve the problem of table_factory_to_write_ = nullptr

### DIFF
--- a/table/adaptive_table_factory.cc
+++ b/table/adaptive_table_factory.cc
@@ -20,9 +20,6 @@ AdaptiveTableFactory::AdaptiveTableFactory(
       block_based_table_factory_(block_based_table_factory),
       plain_table_factory_(plain_table_factory),
       cuckoo_table_factory_(cuckoo_table_factory) {
-  if (!table_factory_to_write_) {
-    table_factory_to_write_ = block_based_table_factory_;
-  }
   if (!plain_table_factory_) {
     plain_table_factory_.reset(NewPlainTableFactory());
   }
@@ -31,6 +28,9 @@ AdaptiveTableFactory::AdaptiveTableFactory(
   }
   if (!cuckoo_table_factory_) {
     cuckoo_table_factory_.reset(NewCuckooTableFactory());
+  }
+  if (!table_factory_to_write_) {
+    table_factory_to_write_ = block_based_table_factory_;
   }
 }
 


### PR DESCRIPTION
when use "NewAdaptiveTableFactory()", i.e. no parameters, so table_factory_to_write, block_based_table_factory,  plain_table_factory, cuckoo_table_factory use the default value "nullptr"

NewAdaptiveTableFactory() => AdaptiveTableFactory(table_factory_to_write, block_based_table_factory, plain_table_factory, cuckoo_table_factory):

if (!table_factory_to_write_) {
    table_factory_to_write_ = block_based_table_factory_;
  }
  if (!plain_table_factory_) {
    plain_table_factory_.reset(NewPlainTableFactory());
  }
  if (!block_based_table_factory_) {
    block_based_table_factory_.reset(NewBlockBasedTableFactory());
  }
  if (!cuckoo_table_factory_) {
    cuckoo_table_factory_.reset(NewCuckooTableFactory());
  }

table_factory_to_write_ = nullptr
plain_table_factory_ != nullptr
block_based_table_factory_ != nullptr
cuckoo_table_factory_ != nullptr

when executes "AdaptiveTableFactory::NewTableBuilder", an error occurred because of "table_factory_to_write_->NewTableBuilder" (table_factory_to_write_ = nullptr)