### PR TITLE
Use size hint for HashMap in multiGet

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -824,7 +824,8 @@ public class RocksDB extends RocksObject {
     final byte[][] values = multiGet(nativeHandle_, keysArray, keyOffsets,
         keyLengths);
 
-    final Map<byte[], byte[]> keyValueMap = new HashMap<>();
+    final Map<byte[], byte[]> keyValueMap =
+      new HashMap<>(computeCapacityHint(values.length));
     for(int i = 0; i < values.length; i++) {
       if(values[i] == null) {
         continue;
@@ -880,7 +881,8 @@ public class RocksDB extends RocksObject {
     final byte[][] values = multiGet(nativeHandle_, keysArray, keyOffsets,
         keyLengths, cfHandles);
 
-    final Map<byte[], byte[]> keyValueMap = new HashMap<>();
+    final Map<byte[], byte[]> keyValueMap =
+      new HashMap<>(computeCapacityHint(values.length));
     for(int i = 0; i < values.length; i++) {
       if (values[i] == null) {
         continue;
@@ -915,7 +917,8 @@ public class RocksDB extends RocksObject {
     final byte[][] values = multiGet(nativeHandle_, opt.nativeHandle_,
         keysArray, keyOffsets, keyLengths);
 
-    final Map<byte[], byte[]> keyValueMap = new HashMap<>();
+    final Map<byte[], byte[]> keyValueMap =
+      new HashMap<>(computeCapacityHint(values.length));
     for(int i = 0; i < values.length; i++) {
       if(values[i] == null) {
         continue;
@@ -971,7 +974,8 @@ public class RocksDB extends RocksObject {
     final byte[][] values = multiGet(nativeHandle_, opt.nativeHandle_,
         keysArray, keyOffsets, keyLengths, cfHandles);
 
-    final Map<byte[], byte[]> keyValueMap = new HashMap<>();
+    final Map<byte[], byte[]> keyValueMap =
+      new HashMap<>(computeCapacityHint(values.length));
     for(int i = 0; i < values.length; i++) {
       if(values[i] == null) {
         continue;
@@ -1949,6 +1953,12 @@ public class RocksDB extends RocksObject {
     setOptions(nativeHandle_, columnFamilyHandle.nativeHandle_,
         mutableColumnFamilyOptions.getKeys(),
         mutableColumnFamilyOptions.getValues());
+  }
+
+  private static int computeCapacityHint(final int estimatedNumberOfItems) {
+    // Default load factor for HashMap is 0.75, so N * 1.5 will be at the load
+    // limit. We add +1 for a buffer.
+    return (int) (estimatedNumberOfItems * 1.5 + 1.0);
   }
 
   /**


### PR DESCRIPTION
For every multiGet call, a HashMap is ultimately created and returned to
the caller. This HashMap is never created with a capacity hint, meaning
that resizes during map buildup are likely. We know the upper bound on
the number of items that will be placed in the map (`values.length`)
which we can use to size the map appropriately on creation.
`values.length` is only an upper bound though because some entries in
`values` can be null.