### PR TITLE
Fix scoped arena iterator

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -664,6 +664,30 @@ class RandomRWFile {
   RandomRWFile() {}
   virtual ~RandomRWFile() {}
 
+  // Indicates if the class makes use of unbuffered I/O
+  virtual bool UseOSBuffer() const {
+    return true;
+  }
+
+  const size_t c_DefaultPageSize = 4 * 1024;
+
+  // This is needed when you want to allocate
+  // AlignedBuffer for use with file I/O classes
+  // Used for unbuffered file I/O when UseOSBuffer() returns false
+  virtual size_t GetRequiredBufferAlignment() const {
+    return c_DefaultPageSize;
+  }
+
+  // Used by the file_reader_writer to decide if the ReadAhead wrapper
+  // should simply forward the call and do not enact buffering or locking.
+  virtual bool ShouldForwardRawRequest() const {
+    return false;
+  }
+
+  // For cases when read-ahead is implemented in the platform dependent
+  // layer
+  virtual void EnableReadAhead() {}
+
   // Write bytes in `data` at  offset `offset`, Returns Status::OK() on success.
   virtual Status Write(uint64_t offset, const Slice& data) = 0;
 
@@ -681,7 +705,6 @@ class RandomRWFile {
 
   virtual Status Close() = 0;
 
- private:
   // No copying allowed
   RandomRWFile(const RandomRWFile&) = delete;
   RandomRWFile& operator=(const RandomRWFile&) = delete;

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -92,6 +92,11 @@ public:
     std::unique_ptr<WritableFile>* result,
     const EnvOptions& options);
 
+  // The returned file will only be accessed by one thread at a time.
+  virtual Status NewRandomRWFile(const std::string& fname,
+    unique_ptr<RandomRWFile>* result,
+    const EnvOptions& options);
+
   virtual Status NewDirectory(const std::string& name,
     std::unique_ptr<Directory>* result);
 
@@ -186,6 +191,11 @@ public:
 
   Status NewWritableFile(const std::string& fname,
     std::unique_ptr<WritableFile>* result,
+    const EnvOptions& options) override;
+
+  // The returned file will only be accessed by one thread at a time.
+  Status NewRandomRWFile(const std::string& fname,
+    unique_ptr<RandomRWFile>* result,
     const EnvOptions& options) override;
 
   Status NewDirectory(const std::string& name,

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -980,7 +980,7 @@ WinWritableFile::~WinWritableFile() {
 
   // Indicates if the class makes use of unbuffered I/O
 bool WinWritableFile::UseOSBuffer() const {
-  return UseOSBuffer();
+  return WinFileData::UseOSBuffer();
 }
 
 size_t WinWritableFile::GetRequiredBufferAlignment() const {
@@ -1043,7 +1043,7 @@ WinRandomRWFile::WinRandomRWFile(const std::string& fname, HANDLE hFile, size_t 
 }
 
 bool WinRandomRWFile::UseOSBuffer() const {
-  return UseOSBuffer();
+  return WinFileData::UseOSBuffer();
 }
 
 size_t WinRandomRWFile::GetRequiredBufferAlignment() const {


### PR DESCRIPTION
This brings down write_batch_test immediately.
Looks like a broken version of std::unique_ptr with custom deletor.
Due to the fact that memory does not go away the code continues to operate on a destroyed internal iterator.