### PR TITLE
Disable auto compactions in memory_test and re-enable the test

### DIFF
--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -93,7 +93,7 @@ class MemoryTest : public testing::Test {
   std::vector<uint64_t> usage_history_[MemoryUtil::kNumUsageTypes];
 };
 
-TEST_F(MemoryTest, DISABLED_SharedBlockCacheTotal) {
+TEST_F(MemoryTest, SharedBlockCacheTotal) {
   std::vector<DB*> dbs;
   std::vector<uint64_t> usage_by_type;
   const int kNumDBs = 10;
@@ -104,6 +104,7 @@ TEST_F(MemoryTest, DISABLED_SharedBlockCacheTotal) {
   opt.write_buffer_size = kKeySize + kValueSize;
   opt.max_write_buffer_number = 10;
   opt.min_write_buffer_number_to_merge = 10;
+  opt.disable_auto_compactions = true;
   BlockBasedTableOptions bbt_opts;
   bbt_opts.block_cache = NewLRUCache(4096 * 1000 * 10);
   for (int i = 0; i < kNumDBs; ++i) {
@@ -144,7 +145,7 @@ TEST_F(MemoryTest, DISABLED_SharedBlockCacheTotal) {
   }
 }
 
-TEST_F(MemoryTest, DISABLED_MemTableAndTableReadersTotal) {
+TEST_F(MemoryTest, MemTableAndTableReadersTotal) {
   std::vector<DB*> dbs;
   std::vector<uint64_t> usage_by_type;
   std::vector<std::vector<ColumnFamilyHandle*>> vec_handles;
@@ -157,6 +158,7 @@ TEST_F(MemoryTest, DISABLED_MemTableAndTableReadersTotal) {
   opt.write_buffer_size = kKeySize + kValueSize;
   opt.max_write_buffer_number = 10;
   opt.min_write_buffer_number_to_merge = 10;
+  opt.disable_auto_compactions = true;
 
   std::vector<ColumnFamilyDescriptor> cf_descs = {
       {kDefaultColumnFamilyName, ColumnFamilyOptions(opt)},


### PR DESCRIPTION
Summary: Auto-compactions will change memory usage of DB but memory_test
didn't take it into account. This PR disable auto compactions in the
test and hopefully it fixes its flakyness.

Test Plan:
UBSAN build used to catch the flakyness. Run `make ubsan_check` and it
passes.