### PR TITLE
Fix a bug that doesn't seem to affect anything

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -26,7 +26,7 @@ namespace rocksdb {
 // and the value type is embedded as the low 8 bits in the sequence
 // number in internal keys, we need to use the highest-numbered
 // ValueType, not the lowest).
-const ValueType kValueTypeForSeek = kTypeSingleDeletion;
+const ValueType kValueTypeForSeek = kMaxValue;
 const ValueType kValueTypeForSeekForPrev = kTypeDeletion;
 
 uint64_t PackSequenceAndType(uint64_t seq, ValueType t) {


### PR DESCRIPTION
The comment says "we need to use the highest-numbered ValueType", but the value is actually from the middle of the enum, presumably because it wasn't updated when values were added to the enum. I'm guessing no one ever puts these new enum values into memtables and ssts, and I'm guessing no one uses kValueTypeForSeek for anything except memtables and ssts, so this probably didn't break anything. Fixing it just for cleanness.