### PR TITLE
Fix a bug that mistakenly disable regression_test.sh to update commit

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -89,8 +89,8 @@ function main {
 
   init_arguments $test_root_dir
 
-#  checkout_rocksdb $commit
-#  build_db_bench
+  checkout_rocksdb $commit
+  build_db_bench
 
   setup_test_directory
 


### PR DESCRIPTION
Summary:
Fix a bug that mistakenly disable regression_test.sh to update commit

Test Plan:
regression_test.sh