### PR TITLE
Disable DBTest.RepeatedWritesToSameKey

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1252,7 +1252,9 @@ TEST_F(DBTest, MinLevelToCompress2) {
   MinLevelHelper(this, options);
 }
 
-TEST_F(DBTest, RepeatedWritesToSameKey) {
+// This test may fail because of a legit case that multiple L0 files
+// are trivial moved to L1.
+TEST_F(DBTest, DISABLED_RepeatedWritesToSameKey) {
   do {
     Options options = CurrentOptions();
     options.env = env_;


### PR DESCRIPTION
The verification condition of the test DBTest.RepeatedWritesToSameKey doesn't hold anymore after 3ce3bb3da2486c2c18a332128dda7c05a91abb85.
Disable the test for now before we find a way to replace it.

Test Plan: Run the test and make sure it is disabled.