### PR TITLE
FreeBSD: malloc_usable_size is in <malloc_np.h>

### DIFF
--- a/table/block.h
+++ b/table/block.h
@@ -13,7 +13,11 @@
 #include <string>
 #include <vector>
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
+#ifdef OS_FREEBSD
+#include <malloc_np.h>
+#else
 #include <malloc.h>
+#endif
 #endif
 
 #include "db/dbformat.h"

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -9,7 +9,11 @@
 
 #include "util/arena.h"
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
+#ifdef OS_FREEBSD
+#include <malloc_np.h>
+#else
 #include <malloc.h>
+#endif
 #endif
 #ifndef OS_WIN
 #include <sys/mman.h>

--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -12,7 +12,11 @@
 #endif
 
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
+#ifdef OS_FREEBSD
+#include <malloc_np.h>
+#else
 #include <malloc.h>
+#endif
 #endif
 #include <sys/types.h>
 


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>