### PR TITLE
Show More DB Stats in info logs

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -639,13 +639,20 @@ void DBImpl::MaybeDumpStats() {
       default_cf_internal_stats_->GetStringProperty(
           *db_property_info, DB::Properties::kDBStats, &stats);
     }
-    if (immutable_db_options_.dump_malloc_stats) {
-      DumpMallocStats(&stats);
-    }
     Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log,
         "------- DUMPING STATS -------");
     Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log, "%s",
         stats.c_str());
+    if (immutable_db_options_.dump_malloc_stats) {
+      stats.clear();
+      DumpMallocStats(&stats);
+      if (!stats.empty()) {
+        Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log,
+            "------- Malloc STATS -------");
+        Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log, "%s",
+            stats.c_str());
+      }
+    }
 #endif  // !ROCKSDB_LITE
 
     PrintStatistics();

--- a/util/posix_logger.h
+++ b/util/posix_logger.h
@@ -80,7 +80,7 @@ class PosixLogger : public Logger {
         bufsize = sizeof(buffer);
         base = buffer;
       } else {
-        bufsize = 30000;
+        bufsize = 65536;
         base = new char[bufsize];
       }
       char* p = base;


### PR DESCRIPTION
DB Stats now are truncated if there are too many CFs. Extend the buffer size to allow more to be printed out. Also, separate out malloc to another log line.