### PR TITLE
Fix MSVC compile error in 32 bit compilation

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -1698,13 +1698,14 @@ TEST_F(DBIteratorTest, IteratorWithLocalStatistics) {
     t.join();
   }
 
-  ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_NEXT), total_next);
+  ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_NEXT), (uint64_t)total_next);
   ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_NEXT_FOUND),
-            total_next_found);
-  ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_PREV), total_prev);
+            (uint64_t)total_next_found);
+  ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_PREV), (uint64_t)total_prev);
   ASSERT_EQ(TestGetTickerCount(options, NUMBER_DB_PREV_FOUND),
-            total_prev_found);
-  ASSERT_EQ(TestGetTickerCount(options, ITER_BYTES_READ), total_bytes);
+            (uint64_t)total_prev_found);
+  ASSERT_EQ(TestGetTickerCount(options, ITER_BYTES_READ), (uint64_t)total_bytes);
+
 }
 
 TEST_F(DBIteratorTest, ReadAhead) {


### PR DESCRIPTION
Passing std::atomic<uint64_t> variables to ASSERT_EQ()
results in compile error
C2718 'const T1': actual parameter with requested alignment of 8 won't be aligned.

VS2015 defines std::atomic as specially aligned type ( with 'alignas'),
however the compiler does not like declspec(align)ed  function
arguments.

Worked around by casting std::atomic<uint64_t> types to uint64_t
in ASSERT_EQ.