### PR TITLE
DeleteRange user iterator support

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -422,8 +422,7 @@ void CompactionIterator::NextFromInput() {
     } else {
       // 1. new user key -OR-
       // 2. different snapshot stripe
-      bool should_delete =
-          range_del_agg_->ShouldDelete(key_, true /* for_compaction */);
+      bool should_delete = range_del_agg_->ShouldDelete(key_);
       if (should_delete) {
         input_->Next();
       } else {

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -261,8 +261,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   int total = 0;
   Arena arena;
   {
+    RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
+                                     {} /* snapshots */);
     ScopedArenaIterator iter(
-        dbfull()->NewInternalIterator(&arena, handles_[1]));
+        dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[1]));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {
@@ -349,8 +351,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   // level Lmax because this record is at the tip
   count = 0;
   {
+    RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
+                                     {} /* snapshots */);
     ScopedArenaIterator iter(
-        dbfull()->NewInternalIterator(&arena, handles_[1]));
+        dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[1]));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {
@@ -566,7 +570,10 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
     int count = 0;
     int total = 0;
     Arena arena;
-    ScopedArenaIterator iter(dbfull()->NewInternalIterator(&arena));
+    RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
+                                     {} /* snapshots */);
+    ScopedArenaIterator iter(
+        dbfull()->NewInternalIterator(&arena, &range_del_agg));
     iter->SeekToFirst();
     ASSERT_OK(iter->status());
     while (iter->Valid()) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -290,7 +290,8 @@ class DBImpl : public DB {
   // The keys of this iterator are internal keys (see format.h).
   // The returned iterator should be deleted when no longer needed.
   InternalIterator* NewInternalIterator(
-      Arena* arena, ColumnFamilyHandle* column_family = nullptr);
+      Arena* arena, RangeDelAggregator* range_del_agg,
+      ColumnFamilyHandle* column_family = nullptr);
 
 #ifndef NDEBUG
   // Extra methods (for testing) that are not in the public DB interface
@@ -525,7 +526,8 @@ class DBImpl : public DB {
   InternalIterator* NewInternalIterator(const ReadOptions&,
                                         ColumnFamilyData* cfd,
                                         SuperVersion* super_version,
-                                        Arena* arena);
+                                        Arena* arena,
+                                        RangeDelAggregator* range_del_agg);
 
   // Except in DB::Open(), WriteOptionsFile can only be called when:
   // 1. WriteThread::Writer::EnterUnbatched() is used.

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -64,8 +64,9 @@ Iterator* DBImplReadOnly::NewIterator(const ReadOptions& read_options,
            : latest_snapshot),
       super_version->mutable_cf_options.max_sequential_skip_in_iterations,
       super_version->version_number);
-  auto internal_iter = NewInternalIterator(
-      read_options, cfd, super_version, db_iter->GetArena());
+  auto internal_iter =
+      NewInternalIterator(read_options, cfd, super_version, db_iter->GetArena(),
+                          db_iter->GetRangeDelAggregator());
   db_iter->SetIterUnderDBIter(internal_iter);
   return db_iter;
 }
@@ -92,8 +93,9 @@ Status DBImplReadOnly::NewIterators(
              : latest_snapshot),
         sv->mutable_cf_options.max_sequential_skip_in_iterations,
         sv->version_number);
-    auto* internal_iter = NewInternalIterator(
-        read_options, cfd, sv, db_iter->GetArena());
+    auto* internal_iter =
+        NewInternalIterator(read_options, cfd, sv, db_iter->GetArena(),
+                            db_iter->GetRangeDelAggregator());
     db_iter->SetIterUnderDBIter(internal_iter);
     iterators->push_back(db_iter);
   }

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <string>
 #include "db/dbformat.h"
+#include "db/range_del_aggregator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
 #include "util/arena.h"
@@ -46,6 +47,7 @@ class ArenaWrappedDBIter : public Iterator {
   // Get the arena to be used to allocate memory for DBIter to be wrapped,
   // as well as child iterators in it.
   virtual Arena* GetArena() { return &arena_; }
+  virtual RangeDelAggregator* GetRangeDelAggregator();
 
   // Set the DB Iterator to be wrapped
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -81,6 +81,9 @@ class MemTableListVersion {
                           read_opts);
   }
 
+  Status AddRangeTombstoneIterators(const ReadOptions& read_opts, Arena* arena,
+                                    RangeDelAggregator* range_del_agg);
+
   void AddIterators(const ReadOptions& options,
                     std::vector<InternalIterator*>* iterator_list,
                     Arena* arena);

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -42,9 +42,8 @@ class RangeDelAggregator {
 
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.
-  bool ShouldDelete(const ParsedInternalKey& parsed,
-                    bool for_compaction = false);
-  bool ShouldDelete(const Slice& internal_key, bool for_compaction = false);
+  bool ShouldDelete(const ParsedInternalKey& parsed);
+  bool ShouldDelete(const Slice& internal_key);
   bool ShouldAddTombstones(bool bottommost_level = false);
 
   // Adds tombstones to the tombstone aggregation structure maintained by this
@@ -72,6 +71,7 @@ class RangeDelAggregator {
                     const Slice* next_table_min_key, FileMetaData* meta,
                     bool bottommost_level = false);
   Arena* GetArena() { return &arena_; }
+  bool IsEmpty();
 
  private:
   // Maps tombstone start key -> tombstone object
@@ -82,7 +82,7 @@ class RangeDelAggregator {
   typedef std::map<SequenceNumber, TombstoneMap> StripeMap;
 
   Status AddTombstones(InternalIterator* input, bool arena);
-  StripeMap::iterator GetStripeMapIter(SequenceNumber seq);
+  TombstoneMap& GetTombstoneMap(SequenceNumber seq);
 
   PinnedIteratorsManager pinned_iters_mgr_;
   StripeMap stripe_map_;

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -223,7 +223,7 @@ InternalIterator* TableCache::NewIterator(
     }
   }
 
-  if (range_del_agg != nullptr) {
+  if (range_del_agg != nullptr && !options.ignore_range_deletions) {
     std::unique_ptr<InternalIterator> iter(
         table_reader->NewRangeTombstoneIterator(options));
     Status s = range_del_agg->AddTombstones(std::move(iter));

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -434,11 +434,12 @@ class Version {
   // yield the contents of this Version when merged together.
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   void AddIterators(const ReadOptions&, const EnvOptions& soptions,
-                    MergeIteratorBuilder* merger_iter_builder);
+                    MergeIteratorBuilder* merger_iter_builder,
+                    RangeDelAggregator* range_del_agg);
 
   void AddIteratorsForLevel(const ReadOptions&, const EnvOptions& soptions,
                             MergeIteratorBuilder* merger_iter_builder,
-                            int level);
+                            int level, RangeDelAggregator* range_del_agg);
 
   // Lookup the value for key.  If found, store it in *val and
   // return OK.  Else return a non-OK status.

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1183,7 +1183,9 @@ void InternalDumpCommand::DoCommand() {
   uint64_t s1=0,s2=0;
   // Setup internal key iterator
   Arena arena;
-  ScopedArenaIterator iter(idb->NewInternalIterator(&arena));
+  RangeDelAggregator range_del_agg(InternalKeyComparator(options_.comparator),
+                                   {} /* snapshots */);
+  ScopedArenaIterator iter(idb->NewInternalIterator(&arena, &range_del_agg));
   Status st = iter->status();
   if (!st.ok()) {
     exec_state_ =

--- a/utilities/date_tiered/date_tiered_db_impl.cc
+++ b/utilities/date_tiered/date_tiered_db_impl.cc
@@ -385,7 +385,8 @@ Iterator* DateTieredDBImpl::NewIterator(const ReadOptions& opts) {
   MergeIteratorBuilder builder(cf_options_.comparator, arena);
   for (auto& item : handle_map_) {
     auto handle = item.second;
-    builder.AddIterator(db_impl->NewInternalIterator(arena, handle));
+    builder.AddIterator(db_impl->NewInternalIterator(
+        arena, db_iter->GetRangeDelAggregator(), handle));
   }
   auto internal_iter = builder.Finish();
   db_iter->SetIterUnderDBIter(internal_iter);


### PR DESCRIPTION
Summary:

Note: reviewed in  https://reviews.facebook.net/D65115

- DBIter maintains a range tombstone accumulator. We don't cleanup obsolete tombstones yet, so if the user seeks back and forth, the same tombstones would be added to the accumulator multiple times.
- DBImpl::NewInternalIterator() (used to make DBIter's underlying iterator) adds memtable/L0 range tombstones, L1+ range tombstones are added on-demand during NewSecondaryIterator() (see D62205)
- DBIter uses ShouldDelete() when advancing to check whether keys are covered by range tombstones

Test Plan:

new end-to-end tests (https://reviews.facebook.net/D63927)