### PR TITLE
Return Status from TableCache::NewIterator()

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -181,17 +181,22 @@ Status BuildTable(
 
     if (s.ok() && !empty) {
       // Verify that the table is usable
-      std::unique_ptr<InternalIterator> it(table_cache->NewIterator(
-          ReadOptions(), env_options, internal_comparator, meta->fd, nullptr,
+      InternalIterator* table_iter;
+      s = table_cache->NewIterator(
+          ReadOptions(), env_options, internal_comparator, meta->fd, &table_iter,
+          nullptr,
           (internal_stats == nullptr) ? nullptr
                                       : internal_stats->GetFileReadHist(0),
           false /* for_compaction */, nullptr /* arena */,
-          false /* skip_filter */, level));
-      s = it->status();
-      if (s.ok() && paranoid_file_checks) {
-        for (it->SeekToFirst(); it->Valid(); it->Next()) {
+          false /* skip_filter */, level);
+      std::unique_ptr<InternalIterator> table_iter_guard;
+      if (s.ok()) {
+        table_iter_guard.reset(table_iter);
+        if (paranoid_file_checks) {
+          for (table_iter->SeekToFirst(); table_iter->Valid(); table_iter->Next()) {
+          }
+          s = table_iter->status();
         }
-        s = it->status();
       }
     }
   }

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -183,8 +183,8 @@ Status BuildTable(
       // Verify that the table is usable
       InternalIterator* table_iter;
       s = table_cache->NewIterator(
-          ReadOptions(), env_options, internal_comparator, meta->fd, &table_iter,
-          nullptr,
+          ReadOptions(), env_options, internal_comparator, meta->fd,
+          &table_iter, nullptr,
           (internal_stats == nullptr) ? nullptr
                                       : internal_stats->GetFileReadHist(0),
           false /* for_compaction */, nullptr /* arena */,
@@ -193,7 +193,8 @@ Status BuildTable(
       if (s.ok()) {
         table_iter_guard.reset(table_iter);
         if (paranoid_file_checks) {
-          for (table_iter->SeekToFirst(); table_iter->Valid(); table_iter->Next()) {
+          for (table_iter->SeekToFirst(); table_iter->Valid();
+               table_iter->Next()) {
           }
           s = table_iter->status();
         }

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1007,14 +1007,15 @@ Status CompactionJob::FinishCompactionOutputFile(
     // Verify that the table is usable
     InternalIterator* iter;
     s = cfd->table_cache()->NewIterator(
-        ReadOptions(), env_options_, cfd->internal_comparator(), meta->fd, &iter,
-        nullptr, cfd->internal_stats()->GetFileReadHist(
-                     compact_->compaction->output_level()),
+        ReadOptions(), env_options_, cfd->internal_comparator(), meta->fd,
+        &iter, nullptr, cfd->internal_stats()->GetFileReadHist(
+                            compact_->compaction->output_level()),
         false);
 
     if (s.ok()) {
       if (paranoid_file_checks_) {
-        for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {}
+        for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        }
         s = iter->status();
       }
       delete iter;

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -69,11 +69,12 @@ class LevelIterator : public InternalIterator {
       delete file_iter_;
     }
 
-    file_iter_ = cfd_->table_cache()->NewIterator(
+    Status s = cfd_->table_cache()->NewIterator(
         read_options_, *(cfd_->soptions()), cfd_->internal_comparator(),
-        files_[file_index_]->fd, nullptr /* table_reader_ptr */, nullptr,
-        false);
-
+        files_[file_index_]->fd, &file_iter_);
+    if (!s.ok()) {
+      file_iter_ = NewErrorInternalIterator(s);
+    }
     file_iter_->SetPinnedItersMgr(pinned_iters_mgr_);
   }
   void SeekToLast() override {
@@ -567,8 +568,13 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
       l0_iters_.push_back(nullptr);
       continue;
     }
-    l0_iters_.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), cfd_->internal_comparator(), l0->fd));
+    l0_iters_.emplace_back();
+    Status s = cfd_->table_cache()->NewIterator(
+        read_options_, *cfd_->soptions(), cfd_->internal_comparator(), l0->fd,
+        &l0_iters_.back());
+    if (!s.ok()) {
+      l0_iters_.back() = NewErrorInternalIterator(s);
+    }
   }
   BuildLevelIterators(vstorage);
   current_ = nullptr;
@@ -621,9 +627,13 @@ void ForwardIterator::RenewIterators() {
       }
       continue;
     }
-    l0_iters_new.push_back(cfd_->table_cache()->NewIterator(
+    l0_iters_new.emplace_back();
+    Status s = cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
-        l0_files_new[inew]->fd));
+        l0_files_new[inew]->fd, &l0_iters_new.back());
+    if (!s.ok()) {
+      l0_iters_new.back() = NewErrorInternalIterator(s);
+    }
   }
 
   for (auto* f : l0_iters_) {
@@ -673,9 +683,12 @@ void ForwardIterator::ResetIncompleteIterators() {
       continue;
     }
     DeleteIterator(l0_iters_[i]);
-    l0_iters_[i] = cfd_->table_cache()->NewIterator(
+    Status s = cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
-        l0_files[i]->fd);
+        l0_files[i]->fd, &l0_iters_[i]);
+    if (!s.ok()) {
+      l0_iters_[i] = NewErrorInternalIterator(s);
+    }
     l0_iters_[i]->SetPinnedItersMgr(pinned_iters_mgr_);
   }
 

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -467,9 +467,9 @@ class Repairer {
     }
     InternalIterator* iter = nullptr;
     if (status.ok()) {
-      status = table_cache_->NewIterator(
-          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta.fd,
-          &iter);
+      status = table_cache_->NewIterator(ReadOptions(), env_options_,
+                                         cfd->internal_comparator(), t->meta.fd,
+                                         &iter);
     }
     if (status.ok()) {
       bool empty = true;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -465,9 +465,13 @@ class Repairer {
         status = Status::Corruption(dbname_, "inconsistent column family name");
       }
     }
+    InternalIterator* iter = nullptr;
     if (status.ok()) {
-      InternalIterator* iter = table_cache_->NewIterator(
-          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta.fd);
+      status = table_cache_->NewIterator(
+          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta.fd,
+          &iter);
+    }
+    if (status.ok()) {
       bool empty = true;
       ParsedInternalKey parsed;
       t->min_sequence = 0;

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -52,14 +52,15 @@ class TableCache {
   //    over this file's meta-block and gives it to this object
   // @param data_iter When non-nullptr, the iterator over the table's data
   //    is returned in "*data_iter".
-  Status NewIterator(
-      const ReadOptions& options, const EnvOptions& toptions,
-      const InternalKeyComparator& internal_comparator,
-      const FileDescriptor& file_fd, InternalIterator** data_iter = nullptr,
-      TableReader** table_reader_ptr = nullptr,
-      HistogramImpl* file_read_hist = nullptr, bool for_compaction = false,
-      Arena* arena = nullptr, bool skip_filters = false, int level = -1,
-      RangeDelAggregator* range_del_agg = nullptr);
+  Status NewIterator(const ReadOptions& options, const EnvOptions& toptions,
+                     const InternalKeyComparator& internal_comparator,
+                     const FileDescriptor& file_fd,
+                     InternalIterator** data_iter = nullptr,
+                     TableReader** table_reader_ptr = nullptr,
+                     HistogramImpl* file_read_hist = nullptr,
+                     bool for_compaction = false, Arena* arena = nullptr,
+                     bool skip_filters = false, int level = -1,
+                     RangeDelAggregator* range_del_agg = nullptr);
 
   // If a seek to internal key "k" in specified file finds an entry,
   // call (*handle_result)(arg, found_key, found_value) repeatedly until

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -39,27 +39,27 @@ class TableCache {
              const EnvOptions& storage_options, Cache* cache);
   ~TableCache();
 
-  // Return an iterator for the specified file number (the corresponding
-  // file length must be exactly "file_size" bytes).  If "tableptr" is
-  // non-nullptr, also sets "*tableptr" to point to the Table object
-  // underlying the returned iterator, or nullptr if no Table object underlies
-  // the returned iterator.  The returned "*tableptr" object is owned by
-  // the cache and should not be deleted, and is valid for as long as the
-  // returned iterator is live.
+  // Creates an iterator for the specified file number (the corresponding
+  // file length must be exactly "file_size" bytes) and sets it to "*data_iter"
+  // if non-nullptr.  If "tableptr" is non-nullptr, also sets "*tableptr" to
+  // point to the Table object underlying the created iterator, or nullptr if
+  // no Table object underlies the created iterator.  The returned "*tableptr"
+  // object is owned by the cache and should not be deleted, and is valid for as
+  // long as the returned iterator is live.
   // @param skip_filters Disables loading/accessing the filter block
   // @param level The level this table is at, -1 for "not set / don't know"
   // @param range_del_agg When non-nullptr, creates a range tombstone iterator
   //    over this file's meta-block and gives it to this object
-  // @param is_range_del_only When set, this function only gives a range
-  //    tombstone iterator to range_del_agg and then returns nullptr
-  InternalIterator* NewIterator(
+  // @param data_iter When non-nullptr, the iterator over the table's data
+  //    is returned in "*data_iter".
+  Status NewIterator(
       const ReadOptions& options, const EnvOptions& toptions,
       const InternalKeyComparator& internal_comparator,
-      const FileDescriptor& file_fd, TableReader** table_reader_ptr = nullptr,
+      const FileDescriptor& file_fd, InternalIterator** data_iter = nullptr,
+      TableReader** table_reader_ptr = nullptr,
       HistogramImpl* file_read_hist = nullptr, bool for_compaction = false,
       Arena* arena = nullptr, bool skip_filters = false, int level = -1,
-      RangeDelAggregator* range_del_agg = nullptr,
-      bool is_range_del_only = false);
+      RangeDelAggregator* range_del_agg = nullptr);
 
   // If a seek to internal key "k" in specified file finds an entry,
   // call (*handle_result)(arg, found_key, found_value) repeatedly until

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3415,8 +3415,8 @@ InternalIterator* VersionSet::MakeInputIterator(
         for (size_t i = 0; i < flevel->num_files; i++) {
           Status s = cfd->table_cache()->NewIterator(
               read_options, env_options_compactions_,
-              cfd->internal_comparator(), flevel->files[i].fd, &list[num], nullptr,
-              nullptr, /* no per level latency histogram*/
+              cfd->internal_comparator(), flevel->files[i].fd, &list[num],
+              nullptr, nullptr, /* no per level latency histogram*/
               true /* for_compaction */, nullptr /* arena */,
               false /* skip_filters */, (int)which /* level */, range_del_agg);
           if (!s.ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -517,11 +517,16 @@ class LevelFileIteratorState : public TwoLevelIteratorState {
     }
     const FileDescriptor* fd =
         reinterpret_cast<const FileDescriptor*>(meta_handle.data());
-    return table_cache_->NewIterator(
-        read_options_, env_options_, icomparator_, *fd,
+    InternalIterator* res;
+    Status s = table_cache_->NewIterator(
+        read_options_, env_options_, icomparator_, *fd, &res,
         nullptr /* don't need reference to table */, file_read_hist_,
         for_compaction_, nullptr /* arena */, skip_filters_, level_,
-        range_del_agg_, false /* is_range_del_only */);
+        range_del_agg_);
+    if (!s.ok()) {
+      res = NewErrorInternalIterator(s, nullptr /* arena */);
+    }
+    return res;
   }
 
   bool PrefixMayMatch(const Slice& internal_key) override {
@@ -833,10 +838,15 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
     // Merge all level zero files together since they may overlap
     for (size_t i = 0; i < storage_info_.LevelFilesBrief(0).num_files; i++) {
       const auto& file = storage_info_.LevelFilesBrief(0).files[i];
-      merge_iter_builder->AddIterator(cfd_->table_cache()->NewIterator(
-          read_options, soptions, cfd_->internal_comparator(), file.fd, nullptr,
-          cfd_->internal_stats()->GetFileReadHist(0), false, arena,
-          false /* skip_filters */, 0 /* level */, range_del_agg));
+      InternalIterator* iter;
+      Status s = cfd_->table_cache()->NewIterator(
+          read_options, soptions, cfd_->internal_comparator(), file.fd, &iter,
+          nullptr, cfd_->internal_stats()->GetFileReadHist(0), false, arena,
+          false /* skip_filters */, 0 /* level */, range_del_agg);
+      if (!s.ok()) {
+        iter = NewErrorInternalIterator(s, arena);
+      }
+      merge_iter_builder->AddIterator(iter);
     }
   } else {
     // For levels > 0, we can use a concatenating iterator that sequentially
@@ -962,15 +972,18 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
   FdWithKeyRange* f = fp.GetNextFile();
   while (f != nullptr) {
     if (!read_options.ignore_range_deletions) {
-      table_cache_->NewIterator(
+      *status = table_cache_->NewIterator(
           read_options, vset_->env_options(), *internal_comparator(), f->fd,
-          nullptr /* table_reader_ptr */,
+          nullptr /* data_iter */, nullptr /* table_reader_ptr */,
           cfd_->internal_stats()->GetFileReadHist(fp.GetHitFileLevel()),
           false /* for_compaction */, nullptr /* arena */,
           IsFilterSkipped(static_cast<int>(fp.GetHitFileLevel()),
                           fp.IsHitFileLastInLevel()),
-          fp.GetCurrentLevel() /* level */, range_del_agg,
-          true /* is_range_del_only */);
+          fp.GetCurrentLevel() /* level */, range_del_agg);
+      // TODO: examine the behavior for corrupted key
+      if (!status->ok()) {
+        return;
+      }
     }
 
     *status = table_cache_->Get(
@@ -3326,13 +3339,16 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
     // "key" falls in the range for this table.  Add the
     // approximate offset of "key" within the table.
     TableReader* table_reader_ptr;
-    InternalIterator* iter = v->cfd_->table_cache()->NewIterator(
+    InternalIterator* iter;
+    Status s = v->cfd_->table_cache()->NewIterator(
         ReadOptions(), env_options_, v->cfd_->internal_comparator(), f.fd,
-        &table_reader_ptr);
+        &iter, &table_reader_ptr);
     if (table_reader_ptr != nullptr) {
       result = table_reader_ptr->ApproximateOffsetOf(key);
     }
-    delete iter;
+    if (s.ok()) {
+      delete iter;
+    }
   }
   return result;
 }
@@ -3397,12 +3413,16 @@ InternalIterator* VersionSet::MakeInputIterator(
       if (c->level(which) == 0) {
         const LevelFilesBrief* flevel = c->input_levels(which);
         for (size_t i = 0; i < flevel->num_files; i++) {
-          list[num++] = cfd->table_cache()->NewIterator(
+          Status s = cfd->table_cache()->NewIterator(
               read_options, env_options_compactions_,
-              cfd->internal_comparator(), flevel->files[i].fd, nullptr,
+              cfd->internal_comparator(), flevel->files[i].fd, &list[num], nullptr,
               nullptr, /* no per level latency histogram*/
               true /* for_compaction */, nullptr /* arena */,
               false /* skip_filters */, (int)which /* level */, range_del_agg);
+          if (!s.ok()) {
+            list[num] = NewErrorInternalIterator(s);
+          }
+          ++num;
         }
       } else {
         // Create concatenating iterator for the files from this level


### PR DESCRIPTION
Now that we use TableCache::NewIterator() for multiple purposes (data
block iterator and range deletion iterator), it is inconvenient to
return non-ok status in the data block iterator since the caller might
not use it. This diff changes TableCache::NewIterator() to update
value-result arguments and return a status code.

This fixes a valgrind error where NewIterator() returns a non-ok status
in data block iterator, and the caller fails to check/free it since the
caller is interested in range deletion block only (https://github.com/facebook/rocksdb/blob/9e7cf3469bc626b092ec48366d12873ecab22b4e/db/version_set.cc#L965-L973).