### PR TITLE
Add C api to get specified statistics

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1909,6 +1909,24 @@ char *rocksdb_options_statistics_get_string(rocksdb_options_t *opt) {
   return nullptr;
 }
 
+uint64_t rocksdb_options_statistics_get_ticker_count(rocksdb_options_t* opt,
+                                                     uint32_t ticker_type) {
+  rocksdb::Statistics* statistics = opt->rep.statistics.get();
+  if (statistics) {
+    return statistics->getTickerCount(ticker_type);
+  }
+  return 0;
+}
+
+char* rocksdb_options_statistics_get_histogram_string(rocksdb_options_t* opt,
+                                                      uint32_t type) {
+  rocksdb::Statistics* statistics = opt->rep.statistics.get();
+  if (statistics) {
+    return strdup(statistics->getHistogramString(type).c_str());
+  }
+  return nullptr;
+}
+
 void rocksdb_options_set_ratelimiter(rocksdb_options_t *opt, rocksdb_ratelimiter_t *limiter) {
   opt->rep.rate_limiter.reset(limiter->rep);
   limiter->rep = nullptr;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -536,8 +536,8 @@ int main(int argc, char** argv) {
 
   StartPhase("statistics");
   {
-    uint64_t block_cache_miss;
-    uint64_t block_cache_hit;
+    uint64_t block_cache_miss __attribute__((unused));
+    uint64_t block_cache_hit __attribute__((unused));
     char* db_get_histogram;
     block_cache_miss = rocksdb_options_statistics_get_ticker_count(
         options, 0 /* Tickers::BLOCK_CACHE_MISS */);

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -335,6 +335,7 @@ int main(int argc, char** argv) {
   rocksdb_options_set_compression_per_level(options, compression_levels, 4);
   rate_limiter = rocksdb_ratelimiter_create(1000 * 1024 * 1024, 100 * 1000, 10);
   rocksdb_options_set_ratelimiter(options, rate_limiter);
+  rocksdb_options_enable_statistics(options);
   rocksdb_ratelimiter_destroy(rate_limiter);
 
   roptions = rocksdb_readoptions_create();
@@ -530,6 +531,22 @@ int main(int argc, char** argv) {
         break;
       }
       Free(&vals[i]);
+    }
+  }
+
+  StartPhase("statistics");
+  {
+    uint64_t block_cache_miss;
+    uint64_t block_cache_hit;
+    char* db_get_histogram;
+    block_cache_miss = rocksdb_options_statistics_get_ticker_count(
+        options, 0 /* Tickers::BLOCK_CACHE_MISS */);
+    block_cache_hit = rocksdb_options_statistics_get_ticker_count(
+        options, 1 /* Tickers::BLOCK_CACHE_HIT */);
+    db_get_histogram = rocksdb_options_statistics_get_histogram_string(
+        options, 0 /* Histograms::DB_GET */);
+    if (db_get_histogram) {
+      free(db_get_histogram);
     }
   }
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -536,8 +536,8 @@ int main(int argc, char** argv) {
 
   StartPhase("statistics");
   {
-    uint64_t block_cache_miss __attribute__((unused));
-    uint64_t block_cache_hit __attribute__((unused));
+    uint64_t block_cache_miss __attribute__((__unused__));
+    uint64_t block_cache_hit __attribute__((__unused__));
     char* db_get_histogram;
     block_cache_miss = rocksdb_options_statistics_get_ticker_count(
         options, 0 /* Tickers::BLOCK_CACHE_MISS */);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -579,6 +579,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_enable_statistics(
 extern ROCKSDB_LIBRARY_API char* rocksdb_options_statistics_get_string(
     rocksdb_options_t* opt);
 
+extern ROCKSDB_LIBRARY_API uint64_t rocksdb_options_statistics_get_ticker_count(
+    rocksdb_options_t* opt, uint32_t ticker_type);
+extern ROCKSDB_LIBRARY_API char*
+rocksdb_options_statistics_get_histogram_string(rocksdb_options_t* opt,
+                                                uint32_t type);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_write_buffer_number(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void


### PR DESCRIPTION
It is helpful when we want to get a specified statistics in these languages that limited to call C api like rust. The `rocksdb_options_statistics_get_string` return the whole statistics in the form of a string is not we want. 