### PR TITLE
Fix deadlock between (WriterThread/Compaction/IngestExternalFile)

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -6437,15 +6437,17 @@ Status DBImpl::IngestExternalFile(
     return status;
   }
 
+  TEST_SYNC_POINT("DBImpl::AddFile:Start");
   {
     // Lock db mutex
     InstrumentedMutexLock l(&mutex_);
     TEST_SYNC_POINT("DBImpl::AddFile:MutexLock");
-    num_running_ingest_file_++;
 
     // Stop writes to the DB
     WriteThread::Writer w;
     write_thread_.EnterUnbatched(&w, &mutex_);
+
+    num_running_ingest_file_++;
 
     // Figure out if we need to flush the memtable first
     bool need_flush = false;


### PR DESCRIPTION
A deadlock is possible if this happen

(1) Writer thread is stopped because it's waiting for compaction to finish
(2) Compaction is waiting for current IngestExternalFile() calls to finish
(3) IngestExternalFile() is waiting to be able to acquire the writer thread
(4) WriterThread is held by stopped writes that are waiting for compactions to finish

This patch fix the issue by not incrementing num_running_ingest_file_ except when we acquire the writer thread.

This patch include a unittest to reproduce the described scenario 