### PR TITLE
Collapse range deletions for faster range scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1254,6 +1254,9 @@ statistics_test: util/statistics_test.o $(LIBOBJECTS) $(TESTHARNESS)
 lru_cache_test: util/lru_cache_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
+range_del_aggregator_test: db/range_del_aggregator_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
 
 #-------------------------------------------------
 # make install related stuff

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -83,8 +83,8 @@ Status BuildTable(
   meta->fd.file_size = 0;
   iter->SeekToFirst();
   range_del_iter->SeekToFirst();
-  std::unique_ptr<RangeDelAggregator> range_del_agg(
-      new RangeDelAggregator(internal_comparator, snapshots));
+  std::unique_ptr<RangeDelAggregator> range_del_agg(new RangeDelAggregator(
+      internal_comparator, snapshots, false /* collapse_tombstones */));
   s = range_del_agg->AddTombstones(std::move(range_del_iter));
   if (!s.ok()) {
     // may be non-ok if a range tombstone key is unparsable

--- a/db/compaction_iterator_test.cc
+++ b/db/compaction_iterator_test.cc
@@ -25,7 +25,8 @@ class CompactionIteratorTest : public testing::Test {
                      SequenceNumber last_sequence) {
     std::unique_ptr<InternalIterator> range_del_iter(
         new test::VectorIterator(range_del_ks, range_del_vs));
-    range_del_agg_.reset(new RangeDelAggregator(icmp_, snapshots_));
+    range_del_agg_.reset(new RangeDelAggregator(
+        icmp_, snapshots_, true /* collapse_tombstones */));
     ASSERT_OK(range_del_agg_->AddTombstones(std::move(range_del_iter)));
 
     merge_helper_.reset(new MergeHelper(Env::Default(), cmp_, nullptr, nullptr,

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -660,7 +660,8 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
   assert(sub_compact != nullptr);
   ColumnFamilyData* cfd = sub_compact->compaction->column_family_data();
   std::unique_ptr<RangeDelAggregator> range_del_agg(
-      new RangeDelAggregator(cfd->internal_comparator(), existing_snapshots_));
+      new RangeDelAggregator(cfd->internal_comparator(), existing_snapshots_,
+                             true /* collapse_tombstones */));
   std::unique_ptr<InternalIterator> input(versions_->MakeInputIterator(
       sub_compact->compaction, range_del_agg.get()));
 

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -262,7 +262,8 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   Arena arena;
   {
     RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
-                                     {} /* snapshots */);
+                                     {} /* snapshots */,
+                                     true /* collapse_tombstones */);
     ScopedArenaIterator iter(
         dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[1]));
     iter->SeekToFirst();
@@ -352,7 +353,8 @@ TEST_F(DBTestCompactionFilter, CompactionFilter) {
   count = 0;
   {
     RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
-                                     {} /* snapshots */);
+                                     {} /* snapshots */,
+                                     true /* collapse_tombstones */);
     ScopedArenaIterator iter(
         dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[1]));
     iter->SeekToFirst();
@@ -571,7 +573,8 @@ TEST_F(DBTestCompactionFilter, CompactionFilterContextManual) {
     int total = 0;
     Arena arena;
     RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
-                                     {} /* snapshots */);
+                                     {} /* snapshots */,
+                                     true /* collapse_tombstones */);
     ScopedArenaIterator iter(
         dbfull()->NewInternalIterator(&arena, &range_del_agg));
     iter->SeekToFirst();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3981,7 +3981,8 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
   // Prepare to store a list of merge operations if merge occurs.
   MergeContext merge_context;
-  RangeDelAggregator range_del_agg(cfd->internal_comparator(), {snapshot});
+  RangeDelAggregator range_del_agg(cfd->internal_comparator(), {snapshot},
+                                   false /* collapse_tombstones */);
 
   Status s;
   // First look in the memtable, then in the immutable memtable (if any).
@@ -4090,7 +4091,8 @@ std::vector<Status> DBImpl::MultiGet(
     LookupKey lkey(keys[i], snapshot);
     auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family[i]);
     RangeDelAggregator range_del_agg(cfh->cfd()->internal_comparator(),
-                                     {snapshot});
+                                     {snapshot},
+                                     false /* collapse_tombstones */);
     auto mgd_iter = multiget_cf_data.find(cfh->cfd()->GetID());
     assert(mgd_iter != multiget_cf_data.end());
     auto mgd = mgd_iter->second;
@@ -6326,7 +6328,8 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
                                        bool* found_record_for_key) {
   Status s;
   MergeContext merge_context;
-  RangeDelAggregator range_del_agg(sv->mem->GetInternalKeyComparator(), {});
+  RangeDelAggregator range_del_agg(sv->mem->GetInternalKeyComparator(), {},
+                                   false /* collapse_tombstones */);
 
   ReadOptions read_options;
   SequenceNumber current_seq = versions_->LastSequence();

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -38,7 +38,8 @@ Status DBImplReadOnly::Get(const ReadOptions& read_options,
   auto cfd = cfh->cfd();
   SuperVersion* super_version = cfd->GetSuperVersion();
   MergeContext merge_context;
-  RangeDelAggregator range_del_agg(cfd->internal_comparator(), {snapshot});
+  RangeDelAggregator range_del_agg(cfd->internal_comparator(), {snapshot},
+                                   false /* collapse_tombstones */);
   LookupKey lkey(key, snapshot);
   if (super_version->mem->Get(lkey, value, &s, &merge_context, &range_del_agg,
                               read_options)) {

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -123,7 +123,8 @@ class DBIter: public Iterator {
         prefix_same_as_start_(prefix_same_as_start),
         pin_thru_lifetime_(pin_data),
         total_order_seek_(total_order_seek),
-        range_del_agg_(InternalKeyComparator(cmp), {s}) {
+        range_del_agg_(InternalKeyComparator(cmp), {s},
+                       true /* collapse_tombstones */) {
     RecordTick(statistics_, NO_ITERATORS);
     prefix_extractor_ = ioptions.prefix_extractor;
     max_skip_ = max_sequential_skip_in_iterations;

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -587,7 +587,8 @@ std::string DBTestBase::AllEntriesFor(const Slice& user_key, int cf) {
   Arena arena;
   auto options = CurrentOptions();
   RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
-                                   {} /* snapshots */);
+                                   {} /* snapshots */,
+                                   true /* collapse_tombstones */);
   ScopedArenaIterator iter;
   if (cf == 0) {
     iter.set(dbfull()->NewInternalIterator(&arena, &range_del_agg));
@@ -996,7 +997,8 @@ void DBTestBase::validateNumberOfEntries(int numValues, int cf) {
   Arena arena;
   auto options = CurrentOptions();
   RangeDelAggregator range_del_agg(InternalKeyComparator(options.comparator),
-                                   {} /* snapshots */);
+                                   {} /* snapshots */,
+                                   true /* collapse_tombstones */);
   if (cf != 0) {
     iter.set(
         dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[cf]));

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -513,10 +513,11 @@ struct RangeTombstone {
   Slice start_key_;
   Slice end_key_;
   SequenceNumber seq_;
-  explicit RangeTombstone(Slice sk, Slice ek, SequenceNumber sn)
+  RangeTombstone() : start_key_(), end_key_(), seq_(0) {}
+  RangeTombstone(Slice sk, Slice ek, SequenceNumber sn)
       : start_key_(sk), end_key_(ek), seq_(sn) {}
 
-  explicit RangeTombstone(ParsedInternalKey parsed_key, Slice value) {
+  RangeTombstone(ParsedInternalKey parsed_key, Slice value) {
     start_key_ = parsed_key.user_key;
     seq_ = parsed_key.sequence;
     end_key_ = value;

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -373,7 +373,8 @@ Status ExternalSstFileIngestionJob::AssignLevelForIngestedFile(
       MergeIteratorBuilder merge_iter_builder(&cfd_->internal_comparator(),
                                               &arena);
       RangeDelAggregator range_del_agg(cfd_->internal_comparator(),
-                                       {} /* snapshots */);
+                                       {} /* snapshots */,
+                                       false /* collapse_tombstones */);
       sv->current->AddIteratorsForLevel(ro, env_options_, &merge_iter_builder,
                                         lvl, &range_del_agg);
       if (!range_del_agg.IsEmpty()) {

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -118,7 +118,8 @@ TEST_F(MemTableListTest, GetTest) {
   Status s;
   MergeContext merge_context;
   InternalKeyComparator ikey_cmp(options.comparator);
-  RangeDelAggregator range_del_agg(ikey_cmp, {} /* snapshots */);
+  RangeDelAggregator range_del_agg(ikey_cmp, {} /* snapshots */,
+                                   false /* collapse_tombstones */);
   autovector<MemTable*> to_delete;
 
   LookupKey lkey("key1", seq);
@@ -225,7 +226,8 @@ TEST_F(MemTableListTest, GetFromHistoryTest) {
   Status s;
   MergeContext merge_context;
   InternalKeyComparator ikey_cmp(options.comparator);
-  RangeDelAggregator range_del_agg(ikey_cmp, {} /* snapshots */);
+  RangeDelAggregator range_del_agg(ikey_cmp, {} /* snapshots */,
+                                   false /* collapse_tombstones */);
   autovector<MemTable*> to_delete;
 
   LookupKey lkey("key1", seq);

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -38,7 +38,8 @@ class RangeDelAggregator {
   //    space is divided into two stripes, where only tombstones in the older
   //    stripe are considered by ShouldDelete().
   RangeDelAggregator(const InternalKeyComparator& icmp,
-                     const std::vector<SequenceNumber>& snapshots);
+                     const std::vector<SequenceNumber>& snapshots,
+                     bool tombstones_collapsed);
 
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.
@@ -87,6 +88,7 @@ class RangeDelAggregator {
   PinnedIteratorsManager pinned_iters_mgr_;
   StripeMap stripe_map_;
   const InternalKeyComparator icmp_;
+  const bool tombstones_collapsed_;
   Arena arena_;
 };
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -1,0 +1,149 @@
+//  Copyright (c) 2016-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#include <algorithm>
+
+#include "db/db_test_util.h"
+#include "db/range_del_aggregator.h"
+#include "rocksdb/comparator.h"
+#include "util/testutil.h"
+
+namespace rocksdb {
+
+class RangeDelAggregatorTest : public testing::Test {};
+
+namespace {
+
+struct ExpectedPoint {
+  Slice begin;
+  SequenceNumber seq;
+};
+
+enum Direction {
+  kForward,
+  kReverse,
+};
+
+void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
+                     const std::vector<ExpectedPoint>& expected_points) {
+  // Test same result regardless of which order the range deletions are added.
+  for (Direction dir : {kForward, kReverse}) {
+    RangeDelAggregator range_del_agg(
+        InternalKeyComparator(BytewiseComparator()), {} /* snapshots */);
+    std::vector<std::string> keys, values;
+    for (const auto& range_del : range_dels) {
+      auto key_and_value = range_del.Serialize();
+      keys.push_back(key_and_value.first.Encode().ToString());
+      values.push_back(key_and_value.second.ToString());
+    }
+    if (dir == kReverse) {
+      std::reverse(keys.begin(), keys.end());
+      std::reverse(values.begin(), values.end());
+    }
+    std::unique_ptr<test::VectorIterator> range_del_iter(
+        new test::VectorIterator(keys, values));
+    range_del_agg.AddTombstones(std::move(range_del_iter));
+
+    for (const auto expected_point : expected_points) {
+      ParsedInternalKey parsed_key;
+      parsed_key.user_key = expected_point.begin;
+      parsed_key.sequence = expected_point.seq;
+      parsed_key.type = kTypeValue;
+      ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key));
+      if (parsed_key.sequence > 0) {
+        --parsed_key.sequence;
+        ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key));
+      }
+    }
+  }
+}
+
+}  // anonymous namespace
+
+TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}); }
+
+TEST_F(RangeDelAggregatorTest, Single) {
+  VerifyRangeDels({{"a", "b", 10}}, {{" ", 0}, {"a", 10}, {"b", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveLeft) {
+  VerifyRangeDels({{"a", "c", 10}, {"b", "d", 5}},
+                  {{" ", 0}, {"a", 10}, {"c", 5}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveRight) {
+  VerifyRangeDels({{"a", "c", 5}, {"b", "d", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveMiddle) {
+  VerifyRangeDels({{"a", "d", 5}, {"b", "c", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 5}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapFully) {
+  VerifyRangeDels({{"a", "d", 10}, {"b", "c", 5}},
+                  {{" ", 0}, {"a", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapPoint) {
+  VerifyRangeDels({{"a", "b", 5}, {"b", "c", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, SameStartKey) {
+  VerifyRangeDels({{"a", "c", 5}, {"a", "b", 10}},
+                  {{" ", 0}, {"a", 10}, {"b", 5}, {"c", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, SameEndKey) {
+  VerifyRangeDels({{"a", "d", 5}, {"b", "d", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
+  VerifyRangeDels(
+      {{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}},
+      {{" ", 0}, {"a", 5}, {"b", 0}, {"c", 10}, {"d", 0}, {"e", 15}, {"f", 0}});
+}
+
+// Note the Cover* tests also test cases where tombstones are inserted under a
+// larger one when VerifyRangeDels() runs them in reverse
+TEST_F(RangeDelAggregatorTest, CoverMultipleFromLeft) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "f", 20}},
+      {{" ", 0}, {"a", 20}, {"f", 15}, {"g", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, CoverMultipleFromRight) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"c", "h", 20}},
+      {{" ", 0}, {"b", 5}, {"c", 20}, {"h", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, CoverMultipleFully) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "h", 20}},
+      {{" ", 0}, {"a", 20}, {"h", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, AlternateMultipleAboveBelow) {
+  VerifyRangeDels(
+      {{"b", "d", 15}, {"c", "f", 10}, {"e", "g", 20}, {"a", "h", 5}},
+      {{" ", 0},
+       {"a", 5},
+       {"b", 15},
+       {"d", 10},
+       {"e", 20},
+       {"g", 5},
+       {"h", 0}});
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -168,7 +168,8 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
           if (!through_db) {
             std::string value;
             MergeContext merge_context;
-            RangeDelAggregator range_del_agg(ikc, {} /* snapshots */);
+            RangeDelAggregator range_del_agg(ikc, {} /* snapshots */,
+                                             false /* collapse_tombstones */);
             GetContext get_context(ioptions.user_comparator,
                                    ioptions.merge_operator, ioptions.info_log,
                                    ioptions.statistics, GetContext::kNotFound,

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1184,7 +1184,8 @@ void InternalDumpCommand::DoCommand() {
   // Setup internal key iterator
   Arena arena;
   RangeDelAggregator range_del_agg(InternalKeyComparator(options_.comparator),
-                                   {} /* snapshots */);
+                                   {} /* snapshots */,
+                                   true /* collapse_tombstones */);
   ScopedArenaIterator iter(idb->NewInternalIterator(&arena, &range_del_agg));
   Status st = iter->status();
   if (!st.ok()) {


### PR DESCRIPTION
Added a tombstone-collapsing mode to RangeDelAggregator, which eliminates overlap in the TombstoneMap. In this mode, we can check whether a tombstone covers an internal key using upper_bound() (i.e., binary search). However, the tradeoff is the overhead to add tombstones is now higher, so at first I've only enabled it for range scans (compaction/flush/user iterators), where we expect a high number of calls to ShouldDelete() for the same tombstones. Point queries like Get() will still use the linear scan approach.