### PR TITLE
16384 as e.g .value for compression_max_dict_bytes

### DIFF
--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -46,7 +46,7 @@ void LDBCommandRunner::PrintHelp(const char* exec_name) {
   ret.append("  --" + LDBCommand::ARG_COMPRESSION_TYPE +
              "=<no|snappy|zlib|bzip2|lz4|lz4hc|xpress|zstd>\n");
   ret.append("  --" + LDBCommand::ARG_COMPRESSION_MAX_DICT_BYTES +
-             "=<int,e.g.:14>\n");
+             "=<int,e.g.:16384>\n");
   ret.append("  --" + LDBCommand::ARG_BLOCK_SIZE + "=<block_size_in_bytes>\n");
   ret.append("  --" + LDBCommand::ARG_AUTO_COMPACTION + "=<true|false>\n");
   ret.append("  --" + LDBCommand::ARG_DB_WRITE_BUFFER_SIZE +


### PR DESCRIPTION
Use 16384 as e.g .value for ldb the --compression_max_dict_bytes option.
I think 14 was copy and pasted from the options in the lines above.