### PR TITLE
Store internal keys in TombstoneMap

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -17,7 +17,7 @@ RangeDelAggregator::RangeDelAggregator(
   for (auto snapshot : snapshots) {
     stripe_map_.emplace(
         snapshot,
-        TombstoneMap(stl_wrappers::LessOfComparator(icmp_.user_comparator())));
+        TombstoneMap(stl_wrappers::LessOfComparator(&icmp_)));
   }
   // Data newer than any snapshot falls in this catch-all stripe
   stripe_map_.emplace(kMaxSequenceNumber, TombstoneMap());
@@ -87,7 +87,7 @@ Status RangeDelAggregator::AddTombstones(InternalIterator* input, bool arena) {
     }
     RangeTombstone tombstone(parsed_key, input->value());
     auto& tombstone_map = GetTombstoneMap(tombstone.seq_);
-    tombstone_map.emplace(tombstone.start_key_.ToString(),
+    tombstone_map.emplace(input->key(),
                           std::move(tombstone));
     input->Next();
   }

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -15,9 +15,8 @@ RangeDelAggregator::RangeDelAggregator(
     : icmp_(icmp) {
   pinned_iters_mgr_.StartPinning();
   for (auto snapshot : snapshots) {
-    stripe_map_.emplace(
-        snapshot,
-        TombstoneMap(stl_wrappers::LessOfComparator(&icmp_)));
+    stripe_map_.emplace(snapshot,
+                        TombstoneMap(stl_wrappers::LessOfComparator(&icmp_)));
   }
   // Data newer than any snapshot falls in this catch-all stripe
   stripe_map_.emplace(kMaxSequenceNumber, TombstoneMap());
@@ -87,8 +86,7 @@ Status RangeDelAggregator::AddTombstones(InternalIterator* input, bool arena) {
     }
     RangeTombstone tombstone(parsed_key, input->value());
     auto& tombstone_map = GetTombstoneMap(tombstone.seq_);
-    tombstone_map.emplace(input->key(),
-                          std::move(tombstone));
+    tombstone_map.emplace(input->key(), std::move(tombstone));
     input->Next();
   }
   return Status::OK();

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -74,8 +74,8 @@ class RangeDelAggregator {
   bool IsEmpty();
 
  private:
-  // Maps tombstone start key -> tombstone object
-  typedef std::map<std::string, RangeTombstone, stl_wrappers::LessOfComparator>
+  // Maps tombstone internal start key -> tombstone object
+  typedef std::map<Slice, RangeTombstone, stl_wrappers::LessOfComparator>
       TombstoneMap;
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
   // their seqnums are greater than the next smaller snapshot's seqnum.

--- a/util/kv_map.h
+++ b/util/kv_map.h
@@ -22,6 +22,9 @@ struct LessOfComparator {
   bool operator()(const std::string& a, const std::string& b) const {
     return cmp->Compare(Slice(a), Slice(b)) < 0;
   }
+  bool operator()(const Slice& a, const Slice& b) const {
+    return cmp->Compare(a, b) < 0;
+  }
 
   const Comparator* cmp;
 };


### PR DESCRIPTION
This fixes a correctness issue where ranges with same begin key would overwrite each other.

This diff uses InternalKey as TombstoneMap's key such that all tombstones have unique keys even when their start keys overlap. We also update TombstoneMap to use an internal key comparator.

End-to-end tests pass and are here (https://gist.github.com/ajkr/851ffe4c1b8a15a68d33025be190a7d9) but cannot be included yet since the DeleteRange() API is yet to be checked in. Note both tests failed before this fix.