### PR TITLE
Transaction::Commit() adds a parameter for not cleaning the write batch

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -137,8 +137,8 @@ class Transaction {
   // may be returned if this transaction has lived for longer than
   // TransactionOptions.expiration.
   // clear_batch: if true, clear the local batch if commit succeeds. If false,
-  //              the users are responsible for calling Clear(). Before that,
-  //              the iterator created by GetIterator() previously
+  //              the users are responsible for calling ClearTxn(). Before
+  //              that, the iterator created by GetIterator() previously
   //              will stil be valid, and Get() can still be used.
   //
   virtual Status Commit(bool clear_batch = true) = 0;
@@ -407,7 +407,7 @@ class Transaction {
   virtual bool IsDeadlockDetect() const { return false; }
 
   // Clear local batch. Should only be called after transaction commits.
-  virtual void ClearBatch() = 0;
+  virtual Status ClearTxn() = 0;
 
   virtual TransactionID GetWaitingTxn(uint32_t* column_family_id,
                                       const std::string** key) const {

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -136,7 +136,12 @@ class Transaction {
   // If this transaction was created by a TransactionDB(), Status::Expired()
   // may be returned if this transaction has lived for longer than
   // TransactionOptions.expiration.
-  virtual Status Commit() = 0;
+  // clear_batch: if true, clear the local batch if commit succeeds. If false,
+  //              the users are responsible for calling Clear(). Before that,
+  //              the iterator created by GetIterator() previously
+  //              will stil be valid, and Get() can still be used.
+  //
+  virtual Status Commit(bool clear_batch = true) = 0;
 
   // Discard all batched writes in this transaction.
   virtual Status Rollback() = 0;
@@ -400,6 +405,9 @@ class Transaction {
   virtual TransactionID GetID() const { return 0; }
 
   virtual bool IsDeadlockDetect() const { return false; }
+
+  // Clear local batch. Should only be called after transaction commits.
+  virtual void ClearBatch() = 0;
 
   virtual TransactionID GetWaitingTxn(uint32_t* column_family_id,
                                       const std::string** key) const {

--- a/utilities/transactions/optimistic_transaction_impl.cc
+++ b/utilities/transactions/optimistic_transaction_impl.cc
@@ -57,7 +57,7 @@ Status OptimisticTransactionImpl::Prepare() {
       "Two phase commit not supported for optimistic transactions.");
 }
 
-Status OptimisticTransactionImpl::Commit() {
+Status OptimisticTransactionImpl::Commit(bool clear_batch) {
   // Set up callback which will call CheckTransactionForConflicts() to
   // check whether this transaction is safe to be committed.
   OptimisticTransactionCallback callback(this);
@@ -73,7 +73,7 @@ Status OptimisticTransactionImpl::Commit() {
   Status s = db_impl->WriteWithCallback(
       write_options_, GetWriteBatch()->GetWriteBatch(), &callback);
 
-  if (s.ok()) {
+  if (s.ok() && clear_batch) {
     Clear();
   }
 

--- a/utilities/transactions/optimistic_transaction_impl.h
+++ b/utilities/transactions/optimistic_transaction_impl.h
@@ -40,7 +40,7 @@ class OptimisticTransactionImpl : public TransactionBaseImpl {
 
   Status Prepare() override;
 
-  Status Commit() override;
+  Status Commit(bool clear_batch = true) override;
 
   Status Rollback() override;
 
@@ -63,6 +63,8 @@ class OptimisticTransactionImpl : public TransactionBaseImpl {
   //
   // Should only be called on writer thread.
   Status CheckTransactionForConflicts(DB* db);
+
+  void ClearBatch() override { Clear(); }
 
   void Clear() override;
 

--- a/utilities/transactions/optimistic_transaction_impl.h
+++ b/utilities/transactions/optimistic_transaction_impl.h
@@ -64,7 +64,13 @@ class OptimisticTransactionImpl : public TransactionBaseImpl {
   // Should only be called on writer thread.
   Status CheckTransactionForConflicts(DB* db);
 
-  void ClearBatch() override { Clear(); }
+  Status ClearTxn() override {
+    if (txn_state_.load() != COMMITED) {
+      return Status::InvalidArgument("Transaction is not committed");
+    }
+    Clear();
+    return Status::OK();
+  }
 
   void Clear() override;
 

--- a/utilities/transactions/transaction_impl.h
+++ b/utilities/transactions/transaction_impl.h
@@ -96,7 +96,13 @@ class TransactionImpl : public TransactionBaseImpl {
   int64_t GetDeadlockDetectDepth() const { return deadlock_detect_depth_; }
 
   // Clear local batch. Should only be called after transaction commits.
-  void ClearBatch() override { Clear(); }
+  Status ClearTxn() override {
+    if (txn_state_.load() != COMMITED) {
+      return Status::InvalidArgument("Transaction is not committed");
+    }
+    Clear();
+    return Status::OK();
+  }
 
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/transactions/transaction_impl.h
+++ b/utilities/transactions/transaction_impl.h
@@ -42,7 +42,7 @@ class TransactionImpl : public TransactionBaseImpl {
 
   Status Prepare() override;
 
-  Status Commit() override;
+  Status Commit(bool clear_batch = true) override;
 
   Status CommitBatch(WriteBatch* batch);
 
@@ -94,6 +94,9 @@ class TransactionImpl : public TransactionBaseImpl {
   bool IsDeadlockDetect() const override { return deadlock_detect_; }
 
   int64_t GetDeadlockDetectDepth() const { return deadlock_detect_depth_; }
+
+  // Clear local batch. Should only be called after transaction commits.
+  void ClearBatch() override { Clear(); }
 
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -170,6 +170,44 @@ TEST_P(TransactionTest, SuccessTest) {
   delete txn;
 }
 
+TEST_P(TransactionTest, CommitNotClearTest) {
+  WriteOptions write_options;
+  ReadOptions read_options;
+  string value;
+  Status s;
+
+  db->Put(write_options, Slice("foo"), Slice("bar"));
+
+  Transaction* txn = db->BeginTransaction(write_options, TransactionOptions());
+  ASSERT_TRUE(txn);
+
+  s = txn->Put(Slice("foo"), Slice("bar2"));
+  ASSERT_OK(s);
+
+  std::unique_ptr<Iterator> itr(txn->GetIterator(read_options));
+  itr->Seek("foo");
+
+  s = txn->Commit(false);
+  ASSERT_OK(s);
+
+  ASSERT_TRUE(itr->Valid());
+  ASSERT_EQ("foo", itr->key().ToString());
+  ASSERT_EQ("bar2", itr->value().ToString());
+  itr.reset();
+
+  s = txn->Get(read_options, "foo", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ(value, "bar2");
+
+  txn->ClearBatch();
+
+  s = db->Get(read_options, "foo", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ(value, "bar2");
+
+  delete txn;
+}
+
 TEST_P(TransactionTest, WaitingTxn) {
   WriteOptions write_options;
   ReadOptions read_options;

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -187,6 +187,8 @@ TEST_P(TransactionTest, CommitNotClearTest) {
   std::unique_ptr<Iterator> itr(txn->GetIterator(read_options));
   itr->Seek("foo");
 
+  ASSERT_NOK(txn->ClearTxn());
+
   s = txn->Commit(false);
   ASSERT_OK(s);
 
@@ -199,7 +201,7 @@ TEST_P(TransactionTest, CommitNotClearTest) {
   ASSERT_OK(s);
   ASSERT_EQ(value, "bar2");
 
-  txn->ClearBatch();
+  ASSERT_OK(txn->ClearTxn());
 
   s = db->Get(read_options, "foo", &value);
   ASSERT_OK(s);


### PR DESCRIPTION
Summary:
Add a parameter to allow users to continue using the iterator even after committing a transaction.

Test Plan: Add a unit test