### PR TITLE
delete transactions recovered from stale logs

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1445,6 +1445,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
 
   bool stop_replay_by_wal_filter = false;
   bool stop_replay_for_corruption = false;
+  bool first_log_in_recover = true;
   bool flushed = false;
   for (auto log_number : log_numbers) {
     // The previous incarnation may not have written any MANIFEST
@@ -1512,6 +1513,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
     std::string scratch;
     Slice record;
     WriteBatch batch;
+    bool first_record_in_log = true;
 
     while (!stop_replay_by_wal_filter &&
            reader.ReadRecord(&record, &scratch,
@@ -1524,6 +1526,14 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       }
       WriteBatchInternal::SetContents(&batch, record);
       SequenceNumber sequence = WriteBatchInternal::Sequence(&batch);
+
+      // If we detect a gap in our log stream then we have been reading in
+      // stale log data and should remove all recovered 2pc transactions because
+      // the commit/rollback marker could have been in the missing log.
+      if (allow_2pc() && first_record_in_log && !first_log_in_recover &&
+          (*next_sequence != sequence)) {
+        DeleteAllRecoveredTransactions();
+      }
 
       if (immutable_db_options_.wal_recovery_mode ==
           WALRecoveryMode::kPointInTimeRecovery) {
@@ -1659,6 +1669,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
                                  *next_sequence);
         }
       }
+      first_record_in_log = false;
     }
 
     if (!status.ok()) {
@@ -1689,6 +1700,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         (versions_->LastSequence() <= last_sequence)) {
       versions_->SetLastSequence(last_sequence);
     }
+    first_log_in_recover = false;
   }
 
   // True if there's any data in the WALs; if not, we can skip re-processing

--- a/util/fault_injection_test_env.cc
+++ b/util/fault_injection_test_env.cc
@@ -198,6 +198,9 @@ Status FaultInjectionTestEnv::NewWritableFile(const std::string& fname,
 }
 
 Status FaultInjectionTestEnv::DeleteFile(const std::string& f) {
+  if (ignore_deletes_) {
+    return Status::OK();
+  }
   if (!IsFilesystemActive()) {
     return Status::Corruption("Not Active");
   }

--- a/util/fault_injection_test_env.h
+++ b/util/fault_injection_test_env.h
@@ -93,7 +93,8 @@ class TestDirectory : public Directory {
 class FaultInjectionTestEnv : public EnvWrapper {
  public:
   explicit FaultInjectionTestEnv(Env* base)
-      : EnvWrapper(base), filesystem_active_(true) {}
+      : EnvWrapper(base), filesystem_active_(true),
+                          ignore_deletes_(false) {}
   virtual ~FaultInjectionTestEnv() {}
 
   Status NewDirectory(const std::string& name,

--- a/util/fault_injection_test_env.h
+++ b/util/fault_injection_test_env.h
@@ -142,6 +142,10 @@ class FaultInjectionTestEnv : public EnvWrapper {
     MutexLock l(&mutex_);
     SetFilesystemActiveNoLock(active);
   }
+
+  void SetIgnoreDeletes(bool ignore_deletes) {
+    ignore_deletes_ = ignore_deletes;
+  }
   void AssertNoOpenFile() { assert(open_files_.empty()); }
 
  private:
@@ -151,6 +155,7 @@ class FaultInjectionTestEnv : public EnvWrapper {
   std::unordered_map<std::string, std::set<std::string>>
       dir_to_new_files_since_last_sync_;
   bool filesystem_active_;  // Record flushes, syncs, writes
+  bool ignore_deletes_;     // silently ignore deletes
 };
 
 }  // namespace rocksdb

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1594,6 +1594,9 @@ TEST_P(TransactionTest, InvalidPrepareFromLogGap) {
   s = db->Get(read_options, "cats", &value);
   ASSERT_OK(s);
   ASSERT_EQ(value, "dogs1");
+
+  delete txn1;
+  delete txn2;
 }
 
 TEST_P(TransactionTest, FirstWriteTest) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1518,6 +1518,84 @@ TEST_P(TransactionTest, TwoPhaseOutOfOrderDelete) {
   ASSERT_EQ(value, "dogs4");
 }
 
+TEST_P(TransactionTest, InvalidPrepareFromLogGap) {
+  DBImpl* db_impl = reinterpret_cast<DBImpl*>(db->GetRootDB());
+  WriteOptions wal_on, wal_off;
+  wal_on.sync = true;
+  wal_on.disableWAL = false;
+  wal_off.disableWAL = true;
+  ReadOptions read_options;
+  TransactionOptions txn_options;
+
+  std::string value;
+  Status s;
+
+  Transaction* txn1 = db->BeginTransaction(wal_on, txn_options);
+  Transaction* txn2 = db->BeginTransaction(wal_on, txn_options);
+
+  s = txn1->SetName("txn1");
+  ASSERT_OK(s);
+  s = txn2->SetName("txn2");
+  ASSERT_OK(s);
+
+  // operations on first log
+  s = txn1->Put(Slice("cats"), Slice("dogs1"));
+  ASSERT_OK(s);
+  s = txn1->Prepare();
+  ASSERT_OK(s);
+
+  s = db->Put(wal_on, "dummy", "dummy");
+  ASSERT_OK(s);
+
+  env->SetIgnoreDeletes(true);
+  s = db_impl->TEST_FlushMemTable(true);
+  env->SetIgnoreDeletes(false);
+  ASSERT_OK(s);
+
+  // operations on second log
+  s = db->Put(wal_on, "dummy", "dummy");
+  ASSERT_OK(s);
+
+  s = txn1->Commit();
+  ASSERT_OK(s);
+
+  // second 2pc trans just to grab file number
+  // for deleteion
+  s = txn2->Prepare();
+  ASSERT_OK(s);
+  auto missing_log_num = txn2->GetLogNumber();
+  s = txn2->Commit();
+  ASSERT_OK(s);
+
+  // on to log 3...
+  env->SetIgnoreDeletes(true);
+  s = db_impl->TEST_FlushMemTable(true);
+  env->SetIgnoreDeletes(false);
+  ASSERT_OK(s);
+
+  s = db->Put(wal_on, "dummy", "dummy2");
+  ASSERT_OK(s);
+
+  s = env->DeleteFile(LogFileName(dbname, missing_log_num));
+  ASSERT_OK(s);
+
+  // kill and reopen
+  env->SetFilesystemActive(false);
+  ReOpenNoDelete();
+
+  // this guy shouldn't exist even though we deleted his
+  // commit but not his prepare
+  ASSERT_TRUE(db->GetTransactionByName("txn1") == nullptr);
+
+  s = db->Get(read_options, "dummy", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ(value, "dummy2");
+
+  s = db->Get(read_options, "cats", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ(value, "dogs1");
+}
+
 TEST_P(TransactionTest, FirstWriteTest) {
   WriteOptions write_options;
 


### PR DESCRIPTION
It may be possible for a scenario to arise where stale WAL logs are deleted out of order. This has the potential to create a gap in the logs read from on recovery.

consider scenario:
transaction is prepared in log A.
transaction is committed in log B.
current log is C, A and B are release.
log B is deleted.
recovery happens.

In this scenario the transaction would be recovered as if is had not been committed because we cannot have reliable knowledge that only log C was needed for recovery. It IS possible to detect that log B was missing and that all logs before must have been released in the previous incarnation. We use this knowledge to clear all recovered transactions when we detect a gap.