### PR TITLE
cast to signed char in ldb_cmd_test for ppc64le

### DIFF
--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -26,7 +26,7 @@ TEST_F(LdbCmdTest, HexToString) {
     auto actual = rocksdb::LDBCommand::HexToString(inPair.first);
     auto expected = inPair.second;
     for (unsigned int i = 0; i < actual.length(); i++) {
-      EXPECT_EQ(expected[i], static_cast<int>(actual[i]));
+      EXPECT_EQ(expected[i], static_cast<int>((signed char) actual[i]));
     }
     auto reverse = rocksdb::LDBCommand::StringToHex(actual);
     EXPECT_STRCASEEQ(inPair.first.c_str(), reverse.c_str());


### PR DESCRIPTION
char is unsigned on power by default causing this test to fail with the FF case. ppc64 return 255 while x86 returned -1. Casting works on both platforms.