### PR TITLE
sst_dump support for range deletion

### DIFF
--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -265,6 +265,8 @@ class BlockBasedTable : public TableReader {
   // Helper functions for DumpTable()
   Status DumpIndexBlock(WritableFile* out_file);
   Status DumpDataBlocks(WritableFile* out_file);
+  void DumpKeyValue(const Slice& key, const Slice& value,
+                    WritableFile* out_file);
 
   // No copying allowed
   explicit BlockBasedTable(const TableReader&) = delete;


### PR DESCRIPTION
Change DumpTable() so we can see the range deletion meta-block.

Test Plan: try it out
```
$ ./sst_dump --file=./tmp/000007.sst --command=raw
$ grep 'Range deletions' -A3 ./tmp/000007_dump.txt
Range deletions:
--------------------------------------
HEX    61: 7A
ASCII  a : z
```