### PR TITLE
Parallize persistent_cache_test and transaction_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,9 @@ PARALLEL_TEST = \
 	fault_injection_test \
 	inlineskiplist_test \
 	manual_compaction_test \
-	table_test
+	persistent_cache_test \
+	table_test \
+	transaction_test
 
 SUBSET := $(TESTS)
 ifdef ROCKSDBTESTS_START


### PR DESCRIPTION
Summary:
Parallize persistent_cache_test and transaction_test

Test Plan:
`make check`