### PR TITLE
Handle full final subcompaction output file with range deletions

### DIFF
--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -896,7 +896,9 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
         "Database shutdown or Column family drop during compaction");
   }
   if (status.ok() && sub_compact->builder == nullptr &&
+      sub_compact->outputs.size() == 0 &&
       range_del_agg->ShouldAddTombstones(bottommost_level_)) {
+    // handle subcompaction containing only range deletions
     status = OpenCompactionOutputFile(sub_compact);
   }
   if (status.ok() && sub_compact->builder != nullptr) {


### PR DESCRIPTION
This conditional should only open a new file that's dedicated to range deletions when it's the sole output of the subcompaction. Previously, we created such a file whenever the table builder was nullptr, which would've also been the case whenever the CompactionIterator's final key coincided with the final output table becoming full.

Test plan: https://gist.github.com/ajkr/efe3a1efe056df66c6aa287bfbb0a0a2 (please review my API diff so I can start including end-to-end tests together with the bugs they fix :))