### PR TITLE
Report memory usage by memtable insert hints map.

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -491,6 +491,7 @@ TEST_F(DBPropertiesTest, NumImmutableMemTable) {
 
     std::string big_value(1000000 * 2, 'x');
     std::string num;
+    uint64_t value;
     SetPerfLevel(kEnableTime);
     ASSERT_TRUE(GetPerfLevel() == kEnableTime);
 
@@ -555,11 +556,11 @@ TEST_F(DBPropertiesTest, NumImmutableMemTable) {
     ASSERT_TRUE(dbfull()->GetProperty(
         handles_[1], DB::Properties::kNumImmutableMemTableFlushed, &num));
     ASSERT_EQ(num, "3");
-    ASSERT_TRUE(dbfull()->GetProperty(
-        handles_[1], "rocksdb.cur-size-active-mem-table", &num));
+    ASSERT_TRUE(dbfull()->GetIntProperty(
+        handles_[1], "rocksdb.cur-size-active-mem-table", &value));
     // "384" is the size of the metadata of two empty skiplists, this would
     // break if we change the default skiplist implementation
-    ASSERT_EQ(num, "384");
+    ASSERT_GE(value, 384);
 
     uint64_t int_num;
     uint64_t base_total_size;

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -6,15 +6,18 @@
 
 #include <algorithm>
 #include <cassert>
-#include <stdexcept>
+#include <initializer_list>
 #include <iterator>
+#include <stdexcept>
 #include <vector>
 
 namespace rocksdb {
 
 #ifdef ROCKSDB_LITE
 template <class T, size_t kSize = 8>
-class autovector : public std::vector<T> {};
+class autovector : public std::vector<T> {
+  using std::vector<T>::vector;
+};
 #else
 // A vector that leverages pre-allocated stack-based array to achieve better
 // performance for array with small amount of items.
@@ -165,6 +168,13 @@ class autovector {
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
   autovector() = default;
+
+  autovector(std::initializer_list<T> init_list) {
+    for (const T& item : init_list) {
+      push_back(item);
+    }
+  }
+
   ~autovector() = default;
 
   // -- Immutable operations

--- a/util/memory_usage.h
+++ b/util/memory_usage.h
@@ -1,0 +1,25 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <unordered_map>
+
+namespace rocksdb {
+
+// Helper methods to estimate memroy usage by std containers.
+
+template <class Key, class Value, class Hash>
+size_t ApproximateMemoryUsage(
+    const std::unordered_map<Key, Value, Hash>& umap) {
+  typedef std::unordered_map<Key, Value, Hash> Map;
+  return sizeof(umap) +
+         // Size of all items plus a next pointer for each item.
+         (sizeof(typename Map::value_type) + sizeof(void*)) * umap.size() +
+         // Size of hash buckets.
+         umap.bucket_count() * sizeof(void*);
+}
+
+}  // namespace rocksdb


### PR DESCRIPTION
Summary:
It is hard to measure acutal memory usage by std containers. Even
providing a custom allocator will miss count some of the usage. Here we
only do a wild guess on its memory usage.

Test Plan:
Have a piece of custom code to open a DB, insert multiple keys with hint
and verify the number is report through
DB::Properties::kCurSizeAllMemTables property.