### PR TITLE
Fix min_write_buffer_number_to_merge = 0 bug

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -158,6 +158,10 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   result.min_write_buffer_number_to_merge =
       std::min(result.min_write_buffer_number_to_merge,
                result.max_write_buffer_number - 1);
+  if (result.min_write_buffer_number_to_merge < 1) {
+    result.min_write_buffer_number_to_merge = 1;
+  }
+
   if (result.num_levels < 1) {
     result.num_levels = 1;
   }


### PR DESCRIPTION
It's possible that we set min_write_buffer_number_to_merge to 0.
This should never happen