### PR TITLE
DeleteRange unsupported in non-block-based tables

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -27,6 +27,7 @@
 #include "db/version_set.h"
 #include "db/write_controller.h"
 #include "memtable/hash_skiplist_rep.h"
+#include "table/block_based_table_factory.h"
 #include "util/autovector.h"
 #include "util/compression.h"
 #include "util/options_helper.h"
@@ -359,6 +360,8 @@ ColumnFamilyData::ColumnFamilyData(
       initial_cf_options_(SanitizeOptions(db_options, cf_options)),
       ioptions_(db_options, initial_cf_options_),
       mutable_cf_options_(initial_cf_options_),
+      is_delete_range_supported_(strcmp(cf_options.table_factory->Name(),
+                                        BlockBasedTableFactory().Name()) == 0),
       write_buffer_manager_(write_buffer_manager),
       mem_(nullptr),
       imm_(ioptions_.min_write_buffer_number_to_merge,

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -220,6 +220,8 @@ class ColumnFamilyData {
   // options.
   ColumnFamilyOptions GetLatestCFOptions() const;
 
+  bool is_delete_range_supported() { return is_delete_range_supported_; }
+
 #ifndef ROCKSDB_LITE
   // REQUIRES: DB mutex held
   Status SetOptions(
@@ -353,6 +355,8 @@ class ColumnFamilyData {
   const ColumnFamilyOptions initial_cf_options_;
   const ImmutableCFOptions ioptions_;
   MutableCFOptions mutable_cf_options_;
+
+  const bool is_delete_range_supported_;
 
   std::unique_ptr<TableCache> table_cache_;
 


### PR DESCRIPTION
Summary:
Return an error from DeleteRange() (or Write() if the user is using the
low-level WriteBatch API) if an unsupported table type is configured.

Test Plan: unit test

Reviewers: sdong, IslamAbdelRahman, lightmark, yhchiang

Subscribers: andrewkr, wanning, dhruba, leveldb

Differential Revision: https://reviews.facebook.net/D65331