### PR TITLE
ldb support for range delete

### DIFF
--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -374,6 +374,23 @@ class DeleteCommand : public LDBCommand {
   std::string key_;
 };
 
+class DeleteRangeCommand : public LDBCommand {
+ public:
+  static std::string Name() { return "deleterange"; }
+
+  DeleteRangeCommand(const std::vector<std::string>& params,
+                     const std::map<std::string, std::string>& options,
+                     const std::vector<std::string>& flags);
+
+  virtual void DoCommand() override;
+
+  static void Help(std::string& ret);
+
+ private:
+  std::string begin_key_;
+  std::string end_key_;
+};
+
 class PutCommand : public LDBCommand {
  public:
   static std::string Name() { return "put"; }

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -62,6 +62,7 @@ void LDBCommandRunner::PrintHelp(const char* exec_name) {
   BatchPutCommand::Help(ret);
   ScanCommand::Help(ret);
   DeleteCommand::Help(ret);
+  DeleteRangeCommand::Help(ret);
   DBQuerierCommand::Help(ret);
   ApproxSizeCommand::Help(ret);
   CheckConsistencyCommand::Help(ret);


### PR DESCRIPTION
Summary: Add a subcommand to ldb with which we can delete a range of keys.

Test Plan:
  ./ldb dump_wal --walfile=tmp/000077.log
  16,1,17,0,DELETE_RANGE(0) : 0x61 0x62

Differential Revision: https://reviews.facebook.net/D62265