### PR TITLE
DeleteRange support for db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3311,8 +3311,9 @@ class Benchmark {
           GenerateKeyFromInt(begin_num + range_tombstone_width_, FLAGS_num,
                              &end_key);
           if (FLAGS_use_blob_db) {
-            s = db_with_cfh->db->DeleteRange(write_options_, begin_key,
-                                             end_key);
+            s = db_with_cfh->db->DeleteRange(
+                write_options_, db_with_cfh->db->DefaultColumnFamily(),
+                begin_key, end_key);
           } else if (FLAGS_num_column_families <= 1) {
             batch.DeleteRange(begin_key, end_key);
           } else {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -536,6 +536,16 @@ DEFINE_bool(optimize_filters_for_hits, false,
 DEFINE_uint64(delete_obsolete_files_period_micros, 0,
               "Ignored. Left here for backward compatibility");
 
+DEFINE_int64(writes_per_range_tombstone, 0,
+             "Number of writes between range "
+             "tombstones");
+
+DEFINE_int64(range_tombstone_width, 100, "Number of keys in tombstone's range");
+
+DEFINE_int64(max_num_range_tombstones, 0,
+             "Maximum number of range tombstones "
+             "to insert.");
+
 #ifndef ROCKSDB_LITE
 DEFINE_bool(optimistic_transaction_db, false,
             "Open a OptimisticTransactionDB instance. "
@@ -1733,6 +1743,9 @@ class Benchmark {
   int prefix_size_;
   int64_t keys_per_prefix_;
   int64_t entries_per_batch_;
+  int64_t writes_per_range_tombstone_;
+  int64_t range_tombstone_width_;
+  int64_t max_num_range_tombstones_;
   WriteOptions write_options_;
   Options open_options_;  // keep options around to properly destroy db later
   int64_t reads_;
@@ -2152,6 +2165,9 @@ class Benchmark {
       value_size_ = FLAGS_value_size;
       key_size_ = FLAGS_key_size;
       entries_per_batch_ = FLAGS_batch_size;
+      writes_per_range_tombstone_ = FLAGS_writes_per_range_tombstone;
+      range_tombstone_width_ = FLAGS_range_tombstone_width;
+      max_num_range_tombstones_ = FLAGS_max_num_range_tombstones;
       write_options_ = WriteOptions();
       read_random_exp_range_ = FLAGS_read_random_exp_range;
       if (FLAGS_sync) {
@@ -3236,7 +3252,13 @@ class Benchmark {
 
     std::unique_ptr<const char[]> key_guard;
     Slice key = AllocateKey(&key_guard);
+    std::unique_ptr<const char[]> begin_key_guard;
+    Slice begin_key = AllocateKey(&begin_key_guard);
+    std::unique_ptr<const char[]> end_key_guard;
+    Slice end_key = AllocateKey(&end_key_guard);
+
     int64_t stage = 0;
+    int64_t num_written = 0;
     while (!duration.Done(entries_per_batch_)) {
       if (duration.GetStage() != stage) {
         stage = duration.GetStage();
@@ -3279,6 +3301,25 @@ class Benchmark {
                     gen.Generate(value_size_));
         }
         bytes += value_size_ + key_size_;
+        ++num_written;
+        if (writes_per_range_tombstone_ > 0 &&
+            num_written / writes_per_range_tombstone_ <
+                max_num_range_tombstones_ &&
+            num_written % writes_per_range_tombstone_ == 0) {
+          int64_t begin_num = key_gens[id]->Next();
+          GenerateKeyFromInt(begin_num, FLAGS_num, &begin_key);
+          GenerateKeyFromInt(begin_num + range_tombstone_width_, FLAGS_num,
+                             &end_key);
+          if (FLAGS_use_blob_db) {
+            s = db_with_cfh->db->DeleteRange(write_options_, begin_key,
+                                             end_key);
+          } else if (FLAGS_num_column_families <= 1) {
+            batch.DeleteRange(begin_key, end_key);
+          } else {
+            batch.DeleteRange(db_with_cfh->GetCfh(rand_num), begin_key,
+                              end_key);
+          }
+        }
       }
       if (!FLAGS_use_blob_db) {
         s = db_with_cfh->db->Write(write_options_, &batch);


### PR DESCRIPTION
Summary:
Added a few options to configure when to add range tombstones during
any benchmark involving writes.

Test Plan:
ran locally, verified with sst_dump that the range tombstones are
added and considered during flush/compaction

Differential Revision: https://reviews.facebook.net/D64287