### PR TITLE
Add WriteOptions.no_slowdown

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5045,7 +5045,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
     StopWatch sw(env_, stats_, WRITE_STALL, &time_delayed);
     auto delay = write_controller_.GetDelay(env_, num_bytes);
     if (delay > 0) {
-      if (write_options.no_sleep) {
+      if (write_options.no_slowdown) {
         return Status::Incomplete();
       }
       mutex_.Unlock();
@@ -5057,7 +5057,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
     }
 
     while (bg_error_.ok() && write_controller_.IsStopped()) {
-      if (write_options.no_sleep) {
+      if (write_options.no_slowdown) {
         return Status::Incomplete();
       }
       delayed = true;
@@ -5065,7 +5065,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
       bg_cv_.Wait();
     }
   }
-  assert(!delayed || !write_options.no_sleep);
+  assert(!delayed || !write_options.no_slowdown);
   if (delayed) {
     default_cf_internal_stats_->AddDBStats(InternalStats::WRITE_STALL_MICROS,
                                            time_delayed);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -643,7 +643,7 @@ class DBImpl : public DB {
 
   // num_bytes: for slowdown case, delay time is calculated based on
   //            `num_bytes` going through.
-  Status DelayWrite(uint64_t num_bytes);
+  Status DelayWrite(uint64_t num_bytes, const WriteOptions& write_options);
 
   Status ScheduleFlushes(WriteContext* context);
 

--- a/db/db_io_failure_test.cc
+++ b/db/db_io_failure_test.cc
@@ -33,7 +33,7 @@ TEST_F(DBIOFailureTest, DropWrites) {
     // Force out-of-space errors
     env_->drop_writes_.store(true, std::memory_order_release);
     env_->sleep_counter_.Reset();
-    env_->no_sleep_ = true;
+    env_->no_slowdown_ = true;
     for (int i = 0; i < 5; i++) {
       if (option_config_ != kUniversalCompactionMultiLevel &&
           option_config_ != kUniversalSubcompactions) {

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -322,7 +322,7 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
-  env_->no_sleep_ = true;
+  env_->no_slowdown_ = true;
   env_->time_elapse_only_sleep_ = true;
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -241,7 +241,7 @@ TEST_F(DBTest, SkipDelay) {
       WriteOptions wo;
       wo.sync = sync;
       wo.disableWAL = disableWAL;
-      wo.no_sleep = true;
+      wo.no_slowdown = true;
       dbfull()->Put(wo, "foo", "bar");
       // We need the 2nd write to trigger delay. This is because delay is
       // estimated based on the last write size which is 0 for the first write.
@@ -251,7 +251,7 @@ TEST_F(DBTest, SkipDelay) {
       token.reset();
 
       token = dbfull()->TEST_write_controler().GetDelayToken(1000000000);
-      wo.no_sleep = false;
+      wo.no_slowdown = false;
       ASSERT_OK(dbfull()->Put(wo, "foo3", "bar3"));
       ASSERT_GE(sleep_count.load(), 1);
       token.reset();
@@ -4930,7 +4930,7 @@ TEST_F(DBTest, MergeTestTime) {
   SetPerfLevel(kEnableTime);
   this->env_->addon_time_.store(0);
   this->env_->time_elapse_only_sleep_ = true;
-  this->env_->no_sleep_ = true;
+  this->env_->no_slowdown_ = true;
   Options options = CurrentOptions();
   options.statistics = rocksdb::CreateDBStatistics();
   options.merge_operator.reset(new DelayedMergeOperator(this));
@@ -5375,7 +5375,7 @@ TEST_F(DBTest, DelayedWriteRate) {
   Options options = CurrentOptions();
   env_->SetBackgroundThreads(1, Env::LOW);
   options.env = env_;
-  env_->no_sleep_ = true;
+  env_->no_slowdown_ = true;
   options.write_buffer_size = 100000000;
   options.max_write_buffer_number = 256;
   options.max_background_compactions = 1;
@@ -5429,7 +5429,7 @@ TEST_F(DBTest, DelayedWriteRate) {
   ASSERT_LT(env_->addon_time_.load(),
             static_cast<int64_t>(estimated_sleep_time * 2));
 
-  env_->no_sleep_ = false;
+  env_->no_slowdown_ = false;
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   sleeping_task_low.WakeUp();
   sleeping_task_low.WaitUntilDone();

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -19,7 +19,7 @@ SpecialEnv::SpecialEnv(Env* base)
       sleep_counter_(this),
       addon_time_(0),
       time_elapse_only_sleep_(false),
-      no_sleep_(false) {
+      no_slowdown_(false) {
   delay_sstable_sync_.store(false, std::memory_order_release);
   drop_writes_.store(false, std::memory_order_release);
   no_space_.store(false, std::memory_order_release);

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -428,10 +428,10 @@ class SpecialEnv : public EnvWrapper {
 
   virtual void SleepForMicroseconds(int micros) override {
     sleep_counter_.Increment();
-    if (no_sleep_ || time_elapse_only_sleep_) {
+    if (no_slowdown_ || time_elapse_only_sleep_) {
       addon_time_.fetch_add(micros);
     }
-    if (!no_sleep_) {
+    if (!no_slowdown_) {
       target()->SleepForMicroseconds(micros);
     }
   }
@@ -520,7 +520,7 @@ class SpecialEnv : public EnvWrapper {
 
   bool time_elapse_only_sleep_;
 
-  bool no_sleep_;
+  bool no_slowdown_;
 
   std::atomic<bool> is_wal_sync_thread_safe_{true};
 };

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -268,9 +268,9 @@ size_t WriteThread::EnterAsBatchGroupLeader(
       break;
     }
 
-    if (!w->no_sleep && leader->no_sleep) {
-      // Do not include a write that requests fail on request delays into
-      // a batch that is ok with it
+    if (w->no_sleep != leader->no_sleep) {
+      // Do not mix writes that are ok with delays with the ones that
+      // request fail on delays.
       break;
     }
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -268,7 +268,7 @@ size_t WriteThread::EnterAsBatchGroupLeader(
       break;
     }
 
-    if (w->no_sleep != leader->no_sleep) {
+    if (w->no_slowdown != leader->no_slowdown) {
       // Do not mix writes that are ok with delays with the ones that
       // request fail on delays.
       break;

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -268,6 +268,12 @@ size_t WriteThread::EnterAsBatchGroupLeader(
       break;
     }
 
+    if (!w->no_sleep && leader->no_sleep) {
+      // Do not include a write that requests fail on request delays into
+      // a batch that is ok with it
+      break;
+    }
+
     if (!w->disableWAL && leader->disableWAL) {
       // Do not include a write that needs WAL into a batch that has
       // WAL disabled.

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -79,7 +79,7 @@ class WriteThread {
   struct Writer {
     WriteBatch* batch;
     bool sync;
-    bool no_sleep;
+    bool no_slowdown;
     bool disableWAL;
     bool disable_memtable;
     uint64_t log_used;  // log number that this batch was inserted into
@@ -100,7 +100,7 @@ class WriteThread {
     Writer()
         : batch(nullptr),
           sync(false),
-          no_sleep(false),
+          no_slowdown(false),
           disableWAL(false),
           disable_memtable(false),
           log_used(0),

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -79,6 +79,7 @@ class WriteThread {
   struct Writer {
     WriteBatch* batch;
     bool sync;
+    bool no_sleep;
     bool disableWAL;
     bool disable_memtable;
     uint64_t log_used;  // log number that this batch was inserted into
@@ -99,6 +100,7 @@ class WriteThread {
     Writer()
         : batch(nullptr),
           sync(false),
+          no_sleep(false),
           disableWAL(false),
           disable_memtable(false),
           log_used(0),

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1569,11 +1569,16 @@ struct WriteOptions {
   // Default: false
   bool ignore_missing_column_families;
 
+  // If true and we need to wait or sleep for the write request, fails
+  // immediately with Status::Incomplete().
+  bool no_sleep;
+
   WriteOptions()
       : sync(false),
         disableWAL(false),
         timeout_hint_us(0),
-        ignore_missing_column_families(false) {}
+        ignore_missing_column_families(false),
+        no_sleep(false) {}
 };
 
 // Options that control flush operations

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1571,14 +1571,14 @@ struct WriteOptions {
 
   // If true and we need to wait or sleep for the write request, fails
   // immediately with Status::Incomplete().
-  bool no_sleep;
+  bool no_slowdown;
 
   WriteOptions()
       : sync(false),
         disableWAL(false),
         timeout_hint_us(0),
         ignore_missing_column_families(false),
-        no_sleep(false) {}
+        no_slowdown(false) {}
 };
 
 // Options that control flush operations


### PR DESCRIPTION
Summary:
If the WriteOptions.no_slowdown flag is set AND we need to wait or sleep for
the write request, then fail immediately with Status::Incomplete().

Test Plan:
unit test added