### PR TITLE
fix deleterange asan issue

### DIFF
--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -89,9 +89,10 @@ class RangeDelAggregator {
   Status AddTombstones(InternalIterator* input, bool arena);
   TombstoneMap& GetTombstoneMap(SequenceNumber seq);
 
-  PinnedIteratorsManager pinned_iters_mgr_;
   StripeMap stripe_map_;
   const InternalKeyComparator icmp_;
-  Arena arena_;
+  Arena arena_;  // must be destroyed after pinned_iters_mgr_ which references
+                 // memory in this arena
+  PinnedIteratorsManager pinned_iters_mgr_;
 };
 }  // namespace rocksdb


### PR DESCRIPTION
pinned_iters_mgr_ pins iterators allocated with arena_, so we should order the
instance variable declarations such that the pinned iterators have their destructors
executed before the arena is destroyed.