### PR TITLE
Remove Ticker::SEQUENCE_NUMBER

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Introduce DB::DeleteRange for optimized deletion of large ranges of contiguous keys.
 * Support dynamically change `delayed_write_rate` option via SetDBOptions().
 * Options::allow_concurrent_memtable_write and Options::enable_write_thread_adaptive_yield are now true by default.
+* Remove Tickers::SEQUENCE_NUMBER to avoid confusion if statistics object is shared among RocksDB instance. Alternatively DB::GetLatestSequenceNumber() can be used to get the same value.
 
 ### New Features
 * Add avoid_flush_during_shutdown option, which speeds up DB shutdown by not flushing unpersisted data (i.e. with disableWAL = true). Unpersisted data will be lost. The options is dynamically changeable via SetDBOptions().

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1348,7 +1348,6 @@ Status DBImpl::Recover(
         }
       }
     }
-    SetTickerCount(stats_, SEQUENCE_NUMBER, versions_->LastSequence());
   }
 
   // Initial value
@@ -4644,7 +4643,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
     if (write_thread_.CompleteParallelWorker(&w)) {
       // we're responsible for early exit
       auto last_sequence = w.parallel_group->last_sequence;
-      SetTickerCount(stats_, SEQUENCE_NUMBER, last_sequence);
       versions_->SetLastSequence(last_sequence);
       write_thread_.EarlyExitParallelGroup(&w);
     }
@@ -4956,7 +4954,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
 
       if (!exit_completed_early && w.status.ok()) {
-        SetTickerCount(stats_, SEQUENCE_NUMBER, last_sequence);
         versions_->SetLastSequence(last_sequence);
         if (!need_log_sync) {
           write_thread_.ExitAsBatchGroupLeader(&w, last_writer, w.status);

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -152,7 +152,6 @@ enum Tickers : uint32_t {
   // written to storage because key does not exist
   NUMBER_FILTERED_DELETES,
   NUMBER_MERGE_FAILURES,
-  SEQUENCE_NUMBER,
 
   // number of times bloom was checked before creating iterator on a
   // file, and the number of times the check was useful in avoiding
@@ -280,7 +279,6 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {NUMBER_MULTIGET_BYTES_READ, "rocksdb.number.multiget.bytes.read"},
     {NUMBER_FILTERED_DELETES, "rocksdb.number.deletes.filtered"},
     {NUMBER_MERGE_FAILURES, "rocksdb.number.merge.failures"},
-    {SEQUENCE_NUMBER, "rocksdb.sequence.number"},
     {BLOOM_FILTER_PREFIX_CHECKED, "rocksdb.bloom.filter.prefix.checked"},
     {BLOOM_FILTER_PREFIX_USEFUL, "rocksdb.bloom.filter.prefix.useful"},
     {NUMBER_OF_RESEEKS_IN_ITERATION, "rocksdb.number.reseeks.iteration"},

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -87,7 +87,6 @@ public enum TickerType {
   // written to storage because key does not exist
   NUMBER_FILTERED_DELETES(36),
   NUMBER_MERGE_FAILURES(37),
-  SEQUENCE_NUMBER(38),
 
   // number of times bloom was checked before creating iterator on a
   // file, and the number of times the check was useful in avoiding


### PR DESCRIPTION
Summary:
Remove the ticker count because:
* Having to reset the ticker count in WriteImpl is ineffiecent;
* It doesn't make sense to have it as a ticker count if multiple db
  instance share a statistics object.

Test Plan:
`make all check`