### PR TITLE
Remove use of deprecated LZ4 function

### DIFF
--- a/util/compression.h
+++ b/util/compression.h
@@ -553,9 +553,15 @@ inline bool LZ4_Compress(const CompressionOptions& opts,
     LZ4_loadDict(stream, compression_dict.data(),
                  static_cast<int>(compression_dict.size()));
   }
+#if LZ4_VERSION_NUMBER >= 10700  // r129+
+  outlen = LZ4_compress_fast_continue(
+      stream, input, &(*output)[output_header_len], static_cast<int>(length),
+      compress_bound, 1);
+#else  // up to r128
   outlen = LZ4_compress_limitedOutput_continue(
       stream, input, &(*output)[output_header_len], static_cast<int>(length),
       compress_bound);
+#endif
   LZ4_freeStream(stream);
 #else   // up to r123
   outlen = LZ4_compress_limitedOutput(input, &(*output)[output_header_len],


### PR DESCRIPTION
Summary:
LZ4 1.7.3 emits warnings when calling the deprecated function `LZ4_compress_limitedOutput_continue()`.  Starting in r129, LZ4 introduces `LZ4_compress_fast_continue()` as a replacement, and the two functions calls are [exactly equivalent](https://github.com/lz4/lz4/blob/dev/lib/lz4.c#L1408).

Test Plan:
`make all` with LZ4-1.7.3.
`make all` with LZ4-r127 failed on a lua test, but the the compression built.
Continuous build.
