### PR TITLE
Fix heap use after free ASAN/Valgrind

### DIFF
--- a/include/rocksdb/utilities/lua/rocks_lua_compaction_filter.h
+++ b/include/rocksdb/utilities/lua/rocks_lua_compaction_filter.h
@@ -161,7 +161,8 @@ class RocksLuaCompactionFilter : public rocksdb::CompactionFilter {
   explicit RocksLuaCompactionFilter(const RocksLuaCompactionFilterOptions& opt)
       : options_(opt),
         lua_state_wrapper_(opt.lua_script, opt.libraries),
-        error_count_(0) {}
+        error_count_(0),
+        name_("") {}
 
   virtual bool Filter(int level, const Slice& key, const Slice& existing_value,
                       std::string* new_value,
@@ -180,6 +181,7 @@ class RocksLuaCompactionFilter : public rocksdb::CompactionFilter {
   RocksLuaCompactionFilterOptions options_;
   LuaStateWrapper lua_state_wrapper_;
   mutable int error_count_;
+  mutable std::string name_;
 };
 
 }  // namespace lua

--- a/utilities/lua/rocks_lua_compaction_filter.cc
+++ b/utilities/lua/rocks_lua_compaction_filter.cc
@@ -134,7 +134,7 @@ bool RocksLuaCompactionFilter::Filter(int level, const Slice& key,
 }
 
 const char* RocksLuaCompactionFilter::Name() const {
-  std::string name = "";
+  name_ = "";
   auto* lua_state = lua_state_wrapper_.GetLuaState();
   // push the right function into the lua stack
   lua_getglobal(lua_state, kNameFunctionName.c_str());
@@ -146,7 +146,7 @@ const char* RocksLuaCompactionFilter::Name() const {
                 lua_tostring(lua_state, -1));
     // pops out the lua error from stack
     lua_pop(lua_state, 1);
-    return name.c_str();
+    return name_.c_str();
   }
 
   // check the return value
@@ -159,10 +159,10 @@ const char* RocksLuaCompactionFilter::Name() const {
     const size_t name_size = lua_strlen(lua_state, -1);
     assert(name_buf[name_size] == '\0');
     assert(strlen(name_buf) <= name_size);
-    name = name_buf;
+    name_ = name_buf;
   }
   lua_pop(lua_state, 1);
-  return name.c_str();
+  return name_.c_str();
 }
 
 /* Not yet supported

--- a/utilities/lua/rocks_lua_compaction_filter.cc
+++ b/utilities/lua/rocks_lua_compaction_filter.cc
@@ -134,7 +134,9 @@ bool RocksLuaCompactionFilter::Filter(int level, const Slice& key,
 }
 
 const char* RocksLuaCompactionFilter::Name() const {
-  name_ = "";
+  if (name_ != "") {
+    return name_.c_str();
+  }
   auto* lua_state = lua_state_wrapper_.GetLuaState();
   // push the right function into the lua stack
   lua_getglobal(lua_state, kNameFunctionName.c_str());


### PR DESCRIPTION
Dont use c_str() of temp std::string in RocksLuaCompactionFilter::Name()