### PR TITLE
Eliminate redundant cache lookup with range deletion

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -294,8 +294,7 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
       num_new_table_reader = 0;
       ASSERT_EQ(Key(k), Get(Key(k)));
       // lookup iterator from table cache and no need to create a new one.
-      // a second table cache iterator is created for range tombstones
-      ASSERT_EQ(num_table_cache_lookup, 2);
+      ASSERT_EQ(num_table_cache_lookup, 1);
       ASSERT_EQ(num_new_table_reader, 0);
     }
   }
@@ -318,8 +317,7 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   num_table_cache_lookup = 0;
   num_new_table_reader = 0;
   ASSERT_EQ(Key(1), Get(Key(1)));
-  // a second table cache iterator is created for range tombstones
-  ASSERT_EQ(num_table_cache_lookup, 2);
+  ASSERT_EQ(num_table_cache_lookup, 1);
   ASSERT_EQ(num_new_table_reader, 0);
 
   num_table_cache_lookup = 0;
@@ -338,8 +336,7 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   num_table_cache_lookup = 0;
   num_new_table_reader = 0;
   ASSERT_EQ(Key(1), Get(Key(1)));
-  // a second table cache iterator is created for range tombstones
-  ASSERT_EQ(num_table_cache_lookup, 2);
+  ASSERT_EQ(num_table_cache_lookup, 1);
   ASSERT_EQ(num_new_table_reader, 0);
 
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -305,9 +305,9 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   dbfull()->TEST_WaitForCompact();
   // Preloading iterator issues one table cache lookup and creates
   // a new table reader. One file is created for flush and one for compaction.
-  // Compaction inputs make no table cache look-up for data iterators and one
-  // look-up per compaction input file (three).
-  ASSERT_EQ(num_table_cache_lookup, 5);
+  // Compaction inputs make no table cache look-up for data/range deletion
+  // iterators
+  ASSERT_EQ(num_table_cache_lookup, 2);
   // Create new iterator for:
   // (1) 1 for verifying flush results
   // (2) 3 for compaction input files
@@ -327,9 +327,9 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   cro.target_level = 2;
   cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   db_->CompactRange(cro, nullptr, nullptr);
-  // Only verifying compaction outputs issues two table cache lookup
-  // (one for data block, one for range deletion block).
-  ASSERT_EQ(num_table_cache_lookup, 2);
+  // Only verifying compaction outputs issues one table cache lookup
+  // for both data block and range deletion block).
+  ASSERT_EQ(num_table_cache_lookup, 1);
   // One for compaction input, one for verifying compaction results.
   ASSERT_EQ(num_new_table_reader, 2);
 

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -58,16 +58,6 @@ class TableCache {
       HistogramImpl* file_read_hist = nullptr, bool for_compaction = false,
       Arena* arena = nullptr, bool skip_filters = false, int level = -1);
 
-  // Return an iterator over the range deletion meta-block for the specified
-  // file number.
-  // @param skip_filters Disables loading/accessing the filter block
-  // @param level The level this table is at, -1 for "not set / don't know"
-  InternalIterator* NewRangeDeletionIterator(const ReadOptions& options,
-                                             const InternalKeyComparator& icmp,
-                                             const FileDescriptor& fd,
-                                             HistogramImpl* file_read_hist,
-                                             bool skip_filters, int level);
-
   // If a seek to internal key "k" in specified file finds an entry,
   // call (*handle_result)(arg, found_key, found_value) repeatedly until
   // it returns false.


### PR DESCRIPTION
When we introduced range deletion block, TableCache::Get() and TableCache::NewIterator() each did two table cache lookups, one for range deletion block iterator and another for getting the table reader to which the Get()/NewIterator() is delegated. This extra cache lookup was very CPU-intensive (about 10% overhead in a read-heavy benchmark). We can avoid it by reusing the Cache::Handle created for range deletion block iterator to get the file reader.

Test Plan:

command:

```
bpl=10485760;overlap=10;mcz=2;del=300000000;levels=6;ctrig=4; delay=8; stop=12; wbn=3; mbc=20; mb=67108864;wbs=134217728; dds=0; sync=0; r=10000000; t=32; vs=800; bs=4096; cs=1048576; of=500000; si=1000000; ./db_bench --benchmarks=readrandom --disable_seek_compaction=1 --mmap_read=0 --statistics=1 --histogram=1 --num=$r --threads=$t --value_size=$vs --block_size=$bs --cache_size=$cs --bloom_bits=10 --cache_numshardbits=6 --open_files=$of --verify_checksum=1 --db=/data/del_range_bench --sync=$sync --disable_wal=1 --compression_type=none --stats_interval=$si --compression_ratio=0.5 --disable_data_sync=$dds --write_buffer_size=$wbs --target_file_size_base=$mb --max_write_buffer_number=$wbn --max_background_compactions=$mbc --level0_file_num_compaction_trigger=$ctrig --level0_slowdown_writes_trigger=$delay --level0_stop_writes_trigger=$stop --num_levels=$levels --delete_obsolete_files_period_micros=$del --min_level_to_compress=$mcz --stats_per_interval=1 --max_bytes_for_level_base=$bpl --use_existing_db=1
```

before:

`readrandom   :       0.637 micros/op 1569129 ops/sec; 1221.1 MB/s (10000000 of 10000000 found)`

after:

`readrandom   :       0.581 micros/op 1720966 ops/sec; 1339.3 MB/s (10000000 of 10000000 found)`