### PR TITLE
Remove Arena in RangeDelAggregator

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -62,7 +62,7 @@ Status BuildTable(
     const std::string& dbname, Env* env, const ImmutableCFOptions& ioptions,
     const MutableCFOptions& mutable_cf_options, const EnvOptions& env_options,
     TableCache* table_cache, InternalIterator* iter,
-    ScopedArenaIterator&& range_del_iter, FileMetaData* meta,
+    std::unique_ptr<InternalIterator> range_del_iter, FileMetaData* meta,
     const InternalKeyComparator& internal_comparator,
     const std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
         int_tbl_prop_collector_factories,

--- a/db/builder.h
+++ b/db/builder.h
@@ -65,7 +65,7 @@ extern Status BuildTable(
     const std::string& dbname, Env* env, const ImmutableCFOptions& options,
     const MutableCFOptions& mutable_cf_options, const EnvOptions& env_options,
     TableCache* table_cache, InternalIterator* iter,
-    ScopedArenaIterator&& range_del_iter, FileMetaData* meta,
+    std::unique_ptr<InternalIterator> range_del_iter, FileMetaData* meta,
     const InternalKeyComparator& internal_comparator,
     const std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
         int_tbl_prop_collector_factories,

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -256,7 +256,7 @@ Status FlushJob::WriteLevel0Table() {
           "[%s] [JOB %d] Flushing memtable with next log file: %" PRIu64 "\n",
           cfd_->GetName().c_str(), job_context_->job_id, m->GetNextLogNumber());
       memtables.push_back(m->NewIterator(ro, &arena));
-      range_del_iters.push_back(m->NewRangeTombstoneIterator(ro, &arena));
+      range_del_iters.push_back(m->NewRangeTombstoneIterator(ro));
       total_num_entries += m->num_entries();
       total_num_deletes += m->num_deletes();
       total_memory_usage += m->ApproximateMemoryUsage();
@@ -274,9 +274,9 @@ Status FlushJob::WriteLevel0Table() {
       ScopedArenaIterator iter(
           NewMergingIterator(&cfd_->internal_comparator(), &memtables[0],
                              static_cast<int>(memtables.size()), &arena));
-      ScopedArenaIterator range_del_iter(NewMergingIterator(
+      std::unique_ptr<InternalIterator> range_del_iter(NewMergingIterator(
           &cfd_->internal_comparator(), &range_del_iters[0],
-          static_cast<int>(range_del_iters.size()), &arena));
+          static_cast<int>(range_del_iters.size())));
       Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
           "[%s] [JOB %d] Level-0 flush table #%" PRIu64 ": started",
           cfd_->GetName().c_str(), job_context_->job_id, meta_.fd.GetNumber());

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -161,8 +161,7 @@ class MemTable {
   //        those allocated in arena.
   InternalIterator* NewIterator(const ReadOptions& read_options, Arena* arena);
 
-  InternalIterator* NewRangeTombstoneIterator(const ReadOptions& read_options,
-                                              Arena* arena);
+  InternalIterator* NewRangeTombstoneIterator(const ReadOptions& read_options);
 
   // Add an entry into memtable that maps key to value at the
   // specified sequence number and with the specified type.

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -156,8 +156,8 @@ Status MemTableListVersion::AddRangeTombstoneIterators(
     RangeDelAggregator* range_del_agg) {
   assert(range_del_agg != nullptr);
   for (auto& m : memlist_) {
-    ScopedArenaIterator range_del_iter(
-        m->NewRangeTombstoneIterator(read_opts, arena));
+    std::unique_ptr<InternalIterator> range_del_iter(
+        m->NewRangeTombstoneIterator(read_opts));
     Status s = range_del_agg->AddTombstones(std::move(range_del_iter));
     if (!s.ok()) {
       return s;

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -57,7 +57,6 @@ class RangeDelAggregator {
   // Adds tombstones to the tombstone aggregation structure maintained by this
   // object.
   // @return non-OK status if any of the tombstone keys are corrupted.
-  Status AddTombstones(ScopedArenaIterator input);
   Status AddTombstones(std::unique_ptr<InternalIterator> input);
 
   // Writes tombstones covering a range to a table builder.
@@ -83,7 +82,6 @@ class RangeDelAggregator {
   void AddToBuilder(TableBuilder* builder, const Slice* lower_bound,
                     const Slice* upper_bound, FileMetaData* meta,
                     bool bottommost_level = false);
-  Arena* GetArena() { return &arena_; }
   bool IsEmpty();
 
  private:
@@ -103,13 +101,11 @@ class RangeDelAggregator {
   // once the first range deletion is encountered.
   void InitRep(const std::vector<SequenceNumber>& snapshots);
 
-  Status AddTombstones(InternalIterator* input, bool arena);
   TombstoneMap& GetTombstoneMap(SequenceNumber seq);
 
   SequenceNumber upper_bound_;
-  Arena arena_;  // must be destroyed after pinned_iters_mgr_ which references
-                 // memory in this arena
   std::unique_ptr<Rep> rep_;
   const InternalKeyComparator icmp_;
 };
+
 }  // namespace rocksdb

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -381,7 +381,7 @@ class Repairer {
       status = BuildTable(
           dbname_, env_, *cfd->ioptions(), *cfd->GetLatestMutableCFOptions(),
           env_options_, table_cache_, iter.get(),
-          ScopedArenaIterator(mem->NewRangeTombstoneIterator(ro, &arena)),
+          std::unique_ptr<InternalIterator>(mem->NewRangeTombstoneIterator(ro)),
           &meta, cfd->internal_comparator(),
           cfd->int_tbl_prop_collector_factories(), cfd->GetID(), cfd->GetName(),
           {}, kMaxSequenceNumber, kNoCompression, CompressionOptions(), false,


### PR DESCRIPTION
The Arena construction/destruction introduced significant overhead to read-heavy workload just by creating empty vectors for its blocks, so avoid it in RangeDelAggregator.

Test Plan: batched benchmarking together with https://github.com/facebook/rocksdb/pull/1548