### PR TITLE
Direct I/O Reads Handle the last sector correctly.

### DIFF
--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -105,6 +105,11 @@ Status ReadAligned(int fd, Slice* data, const uint64_t offset,
       break;
     }
     bytes_read += status;
+    if (status % static_cast<ssize_t>(kSectorSize) != 0) {
+      // Bytes reads don't fill sectors. Should only happen at the end
+      // of the file.
+      break;
+    }
   }
 
   *data = Slice(scratch, bytes_read);


### PR DESCRIPTION
Currently, in the Direct I/O read mode, the last sector of the file, if not full, is not handled correctly. If the return value of pread is not multiplier of kSectorSize, we still go ahead and continue reading, even if the buffer is not aligned. With the commit, if the return value is not multiplier of kSectorSize, and all but the last sector has been read, we simply return.