### PR TITLE
Fix deadlock when calling getMergedHistogram

### DIFF
--- a/util/statistics.cc
+++ b/util/statistics.cc
@@ -51,9 +51,11 @@ uint64_t StatisticsImpl::getTickerCount(uint32_t tickerType) const {
 
 std::unique_ptr<HistogramImpl>
 StatisticsImpl::HistogramInfo::getMergedHistogram() const {
-  MutexLock lock(&merge_lock);
   std::unique_ptr<HistogramImpl> res_hist(new HistogramImpl());
-  res_hist->Merge(merged_hist);
+  {
+    MutexLock lock(&merge_lock);
+    res_hist->Merge(merged_hist);
+  }
   thread_value->Fold(
       [](void* curr_ptr, void* res) {
         auto tmp_res_hist = static_cast<HistogramImpl*>(res);


### PR DESCRIPTION
When calling StatisticsImpl::HistogramInfo::getMergedHistogram(), if
there is a dying thread, which is calling
ThreadLocalPtr::StaticMeta::OnThreadExit() to merge its thread values to
HistogramInfo, deadlock will occur. Because the former try to hold
merge_lock then ThreadMeta::mutex_, but the later try to hold
ThreadMeta::mutex_ then merge_lock. In short, the locking order isn't
the same.

This patch addressed this issue by releasing merge_lock before folding
thread values.