### PR TITLE
Fix fd leak when using direct IOs

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -157,6 +157,7 @@ class PosixEnv : public Env {
       *result = nullptr;
       return IOError(fname, errno);
     } else if (options.use_direct_reads && !options.use_mmap_writes) {
+      fclose(f);
 #ifdef OS_MACOSX
       int flags = O_RDONLY;
 #else
@@ -215,6 +216,7 @@ class PosixEnv : public Env {
       }
       close(fd);
     } else if (options.use_direct_reads) {
+      close(fd);
 #ifdef OS_MACOSX
       int flags = O_RDONLY;
 #else
@@ -269,6 +271,7 @@ class PosixEnv : public Env {
       if (options.use_mmap_writes && !forceMmapOff) {
         result->reset(new PosixMmapFile(fname, fd, page_size_, options));
       } else if (options.use_direct_writes) {
+        close(fd);
 #ifdef OS_MACOSX
         int flags = O_WRONLY | O_APPEND | O_TRUNC | O_CREAT;
 #else


### PR DESCRIPTION
We should close the fd, before overriding it. This bug was
introduced by f89caa127baa086cb100976b14da1a531cf0e823