### PR TITLE
rocks_lua_compaction_filter: add unused attribute to a variable

### DIFF
--- a/utilities/lua/rocks_lua_compaction_filter.cc
+++ b/utilities/lua/rocks_lua_compaction_filter.cc
@@ -158,7 +158,7 @@ const char* RocksLuaCompactionFilter::Name() const {
         "return value is not a string while string is expected");
   } else {
     const char* name_buf = lua_tostring(lua_state, -1);
-    const size_t name_size = lua_strlen(lua_state, -1);
+    const size_t name_size __attribute__((unused)) = lua_strlen(lua_state, -1);
     assert(name_buf[name_size] == '\0');
     assert(strlen(name_buf) <= name_size);
     name_ = name_buf;


### PR DESCRIPTION
Release build shows warning without this fix.