### PR TITLE
Changing Java multiGet API to return List<byte[]> instead of Map<byte[], byte[]>

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -851,16 +851,17 @@ public class RocksDB extends RocksObject {
   }
 
   /**
-   * Returns a map of keys for which values were found in DB.
+   * Takes a list of keys, and returns a list of values for the given list of
+   * keys. List will contain null for keys which could not be found.
    *
    * @param keys List of keys for which values need to be retrieved.
-   * @return Map where key of map is the key passed by user and value for map
-   * entry is the corresponding value in DB.
+   * @return List of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    *
    * @throws RocksDBException thrown if error happens in underlying
    *    native library.
    */
-  public Map<byte[], byte[]> multiGet(final List<byte[]> keys)
+  public List<byte[]> multiGet(final List<byte[]> keys)
       throws RocksDBException {
     assert(keys.size() != 0);
 
@@ -871,20 +872,8 @@ public class RocksDB extends RocksObject {
       keyLengths[i] = keysArray[i].length;
     }
 
-    final byte[][] values = multiGet(nativeHandle_, keysArray, keyOffsets,
-        keyLengths);
-
-    final Map<byte[], byte[]> keyValueMap =
-        new HashMap<>(computeCapacityHint(values.length));
-    for(int i = 0; i < values.length; i++) {
-      if(values[i] == null) {
-        continue;
-      }
-
-      keyValueMap.put(keys.get(i), values[i]);
-    }
-
-    return keyValueMap;
+    return Arrays.asList(multiGet(nativeHandle_, keysArray, keyOffsets,
+        keyLengths));
   }
 
   private static int computeCapacityHint(final int estimatedNumberOfItems) {
@@ -894,7 +883,8 @@ public class RocksDB extends RocksObject {
   }
 
   /**
-   * Returns a map of keys for which values were found in DB.
+   * Returns a list of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    * <p>
    * Note: Every key needs to have a related column family name in
    * {@code columnFamilyHandleList}.
@@ -903,15 +893,15 @@ public class RocksDB extends RocksObject {
    * @param columnFamilyHandleList {@link java.util.List} containing
    *     {@link org.rocksdb.ColumnFamilyHandle} instances.
    * @param keys List of keys for which values need to be retrieved.
-   * @return Map where key of map is the key passed by user and value for map
-   * entry is the corresponding value in DB.
+   * @return List of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    *
    * @throws RocksDBException thrown if error happens in underlying
    *    native library.
    * @throws IllegalArgumentException thrown if the size of passed keys is not
    *    equal to the amount of passed column family handles.
    */
-  public Map<byte[], byte[]> multiGet(
+  public List<byte[]> multiGet(
       final List<ColumnFamilyHandle> columnFamilyHandleList,
       final List<byte[]> keys) throws RocksDBException,
       IllegalArgumentException {
@@ -934,32 +924,23 @@ public class RocksDB extends RocksObject {
       keyLengths[i] = keysArray[i].length;
     }
 
-    final byte[][] values = multiGet(nativeHandle_, keysArray, keyOffsets,
-        keyLengths, cfHandles);
-
-    final Map<byte[], byte[]> keyValueMap =
-        new HashMap<>(computeCapacityHint(values.length));
-    for(int i = 0; i < values.length; i++) {
-      if (values[i] == null) {
-        continue;
-      }
-      keyValueMap.put(keys.get(i), values[i]);
-    }
-    return keyValueMap;
+    return Arrays.asList(multiGet(nativeHandle_, keysArray, keyOffsets,
+        keyLengths, cfHandles));
   }
 
   /**
-   * Returns a map of keys for which values were found in DB.
+   * Returns a list of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    *
    * @param opt Read options.
    * @param keys of keys for which values need to be retrieved.
-   * @return Map where key of map is the key passed by user and value for map
-   * entry is the corresponding value in DB.
+   * @return List of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    *
    * @throws RocksDBException thrown if error happens in underlying
    *    native library.
    */
-  public Map<byte[], byte[]> multiGet(final ReadOptions opt,
+  public List<byte[]> multiGet(final ReadOptions opt,
       final List<byte[]> keys) throws RocksDBException {
     assert(keys.size() != 0);
 
@@ -970,24 +951,13 @@ public class RocksDB extends RocksObject {
       keyLengths[i] = keysArray[i].length;
     }
 
-    final byte[][] values = multiGet(nativeHandle_, opt.nativeHandle_,
-        keysArray, keyOffsets, keyLengths);
-
-    final Map<byte[], byte[]> keyValueMap =
-        new HashMap<>(computeCapacityHint(values.length));
-    for(int i = 0; i < values.length; i++) {
-      if(values[i] == null) {
-        continue;
-      }
-
-      keyValueMap.put(keys.get(i), values[i]);
-    }
-
-    return keyValueMap;
+    return Arrays.asList(multiGet(nativeHandle_, opt.nativeHandle_,
+        keysArray, keyOffsets, keyLengths));
   }
 
   /**
-   * Returns a map of keys for which values were found in DB.
+   * Returns a list of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    * <p>
    * Note: Every key needs to have a related column family name in
    * {@code columnFamilyHandleList}.
@@ -997,15 +967,15 @@ public class RocksDB extends RocksObject {
    * @param columnFamilyHandleList {@link java.util.List} containing
    *     {@link org.rocksdb.ColumnFamilyHandle} instances.
    * @param keys of keys for which values need to be retrieved.
-   * @return Map where key of map is the key passed by user and value for map
-   * entry is the corresponding value in DB.
+   * @return List of values for the given list of keys. List will contain
+   * null for keys which could not be found.
    *
    * @throws RocksDBException thrown if error happens in underlying
    *    native library.
    * @throws IllegalArgumentException thrown if the size of passed keys is not
    *    equal to the amount of passed column family handles.
    */
-  public Map<byte[], byte[]> multiGet(final ReadOptions opt,
+  public List<byte[]> multiGet(final ReadOptions opt,
       final List<ColumnFamilyHandle> columnFamilyHandleList,
       final List<byte[]> keys) throws RocksDBException {
     assert(keys.size() != 0);
@@ -1027,19 +997,8 @@ public class RocksDB extends RocksObject {
       keyLengths[i] = keysArray[i].length;
     }
 
-    final byte[][] values = multiGet(nativeHandle_, opt.nativeHandle_,
-        keysArray, keyOffsets, keyLengths, cfHandles);
-
-    final Map<byte[], byte[]> keyValueMap
-        = new HashMap<>(computeCapacityHint(values.length));
-    for(int i = 0; i < values.length; i++) {
-      if(values[i] == null) {
-        continue;
-      }
-      keyValueMap.put(keys.get(i), values[i]);
-    }
-
-    return keyValueMap;
+    return Arrays.asList(multiGet(nativeHandle_, opt.nativeHandle_,
+        keysArray, keyOffsets, keyLengths, cfHandles));
   }
 
   /**

--- a/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
@@ -316,19 +316,19 @@ public class ColumnFamilyTest {
         final List<byte[]> keys = Arrays.asList(new byte[][]{
             "key".getBytes(), "newcfkey".getBytes()
         });
-        Map<byte[], byte[]> retValues = db.multiGet(columnFamilyHandleList,
+        List<byte[]> retValues = db.multiGet(columnFamilyHandleList,
             keys);
         assertThat(retValues.size()).isEqualTo(2);
-        assertThat(new String(retValues.get(keys.get(0))))
+        assertThat(new String(retValues.get(0)))
             .isEqualTo("value");
-        assertThat(new String(retValues.get(keys.get(1))))
+        assertThat(new String(retValues.get(1)))
             .isEqualTo("value");
         retValues = db.multiGet(new ReadOptions(), columnFamilyHandleList,
             keys);
         assertThat(retValues.size()).isEqualTo(2);
-        assertThat(new String(retValues.get(keys.get(0))))
+        assertThat(new String(retValues.get(0)))
             .isEqualTo("value");
-        assertThat(new String(retValues.get(keys.get(1))))
+        assertThat(new String(retValues.get(1)))
             .isEqualTo("value");
       } finally {
         for (final ColumnFamilyHandle columnFamilyHandle :

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -152,33 +152,29 @@ public class RocksDBTest {
       List<byte[]> lookupKeys = new ArrayList<>();
       lookupKeys.add("key1".getBytes());
       lookupKeys.add("key2".getBytes());
-      Map<byte[], byte[]> results = db.multiGet(lookupKeys);
+      List<byte[]> results = db.multiGet(lookupKeys);
       assertThat(results).isNotNull();
-      assertThat(results.values()).isNotNull();
-      assertThat(results.values()).
-          contains("value".getBytes(), "12345678".getBytes());
+      assertThat(results).hasSize(lookupKeys.size());
+      assertThat(results).
+          containsExactly("value".getBytes(), "12345678".getBytes());
       // test same method with ReadOptions
       results = db.multiGet(rOpt, lookupKeys);
       assertThat(results).isNotNull();
-      assertThat(results.values()).isNotNull();
-      assertThat(results.values()).
+      assertThat(results).
           contains("value".getBytes(), "12345678".getBytes());
 
       // remove existing key
-      lookupKeys.remove("key2".getBytes());
+      lookupKeys.remove(1);
       // add non existing key
       lookupKeys.add("key3".getBytes());
       results = db.multiGet(lookupKeys);
       assertThat(results).isNotNull();
-      assertThat(results.values()).isNotNull();
-      assertThat(results.values()).
-          contains("value".getBytes());
+      assertThat(results).
+          containsExactly("value".getBytes(), null);
       // test same call with readOptions
       results = db.multiGet(rOpt, lookupKeys);
       assertThat(results).isNotNull();
-      assertThat(results.values()).isNotNull();
-      assertThat(results.values()).
-          contains("value".getBytes());
+      assertThat(results).contains("value".getBytes());
     }
   }
 


### PR DESCRIPTION
Changing Java `multiGet` API to return `List<byte[]>` instead of `Map<byte[], byte[]>`. This is for two reasons:
1. Java arrays implement `equals()` as reference equality instead
of comparing each value. This means a HashMap should never have an array
as key, since anyone calling `get()` with a new array key with the exact same contents
as an existing key will get different results. It happens to work
currently because the `byte[]` reference is used as it is in the `Map` key.
But it is a confusing API for the caller because they cannot make this
assumption.
2. `List<byte[]>` keeps it close to the native API (which returns
`byte[][]`). It avoids the perf cost of creating a `Map`. If a caller does
not need `Map` functionality, the API should not force it unnecessarily,
especially in perf-critical use cases.

Ideally, the existing method should be deprecated and the new one added.
But that would require creating a new method name. multiGet is the best
name for this method. So I am trying to avoid changing it. This should
be a simple change for the clients to make, so as long as the major version
is bumped up, it should be ok to break backwards compatibility. Please suggest
if you think there are better ways to do this. I am not familiar with the rocksdb
versioning protocol.