### PR TITLE
Implement non-exclusive locks

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -209,10 +209,11 @@ class Transaction {
   // or other errors if this key could not be read.
   virtual Status GetForUpdate(const ReadOptions& options,
                               ColumnFamilyHandle* column_family,
-                              const Slice& key, std::string* value) = 0;
+                              const Slice& key, std::string* value,
+                              bool exclusive = true) = 0;
 
   virtual Status GetForUpdate(const ReadOptions& options, const Slice& key,
-                              std::string* value) = 0;
+                              std::string* value, bool exclusive = true) = 0;
 
   virtual std::vector<Status> MultiGetForUpdate(
       const ReadOptions& options,
@@ -401,10 +402,10 @@ class Transaction {
 
   virtual bool IsDeadlockDetect() const { return false; }
 
-  virtual TransactionID GetWaitingTxn(uint32_t* column_family_id,
-                                      const std::string** key) const {
+  virtual std::vector<TransactionID> GetWaitingTxns(uint32_t* column_family_id,
+                                                    std::string* key) const {
     assert(false);
-    return 0;
+    return std::vector<TransactionID>();
   }
 
   enum TransactionState {

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -104,7 +104,8 @@ struct TransactionOptions {
 
 struct KeyLockInfo {
   std::string key;
-  TransactionID id;
+  std::vector<TransactionID> ids;
+  bool exclusive;
 };
 
 class TransactionDB : public StackableDB {

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -283,11 +283,6 @@ class autovector {
 
   autovector& operator=(const autovector& other) { return assign(other); }
 
-  // move operation are disallowed since it is very hard to make sure both
-  // autovectors are allocated from the same function stack.
-  autovector& operator=(autovector&& other) = delete;
-  autovector(autovector&& other) = delete;
-
   // -- Iterator Operations
   iterator begin() { return iterator(this, 0); }
 

--- a/utilities/transactions/optimistic_transaction_impl.cc
+++ b/utilities/transactions/optimistic_transaction_impl.cc
@@ -86,9 +86,11 @@ Status OptimisticTransactionImpl::Rollback() {
 }
 
 // Record this key so that we can check it for conflicts at commit time.
+//
+// 'exclusive' is unused for OptimisticTransaction.
 Status OptimisticTransactionImpl::TryLock(ColumnFamilyHandle* column_family,
                                           const Slice& key, bool read_only,
-                                          bool untracked) {
+                                          bool exclusive, bool untracked) {
   if (untracked) {
     return Status::OK();
   }

--- a/utilities/transactions/optimistic_transaction_impl.h
+++ b/utilities/transactions/optimistic_transaction_impl.h
@@ -48,7 +48,8 @@ class OptimisticTransactionImpl : public TransactionBaseImpl {
 
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                 bool read_only, bool untracked = false) override;
+                 bool read_only, bool exclusive,
+                 bool untracked = false) override;
 
  private:
   OptimisticTransactionDB* const txn_db_;

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -39,7 +39,8 @@ class TransactionBaseImpl : public Transaction {
   // untracked will be true if called from PutUntracked, DeleteUntracked, or
   // MergeUntracked.
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                         bool read_only, bool untracked = false) = 0;
+                         bool read_only, bool exclusive,
+                         bool untracked = false) = 0;
 
   void SetSavePoint() override;
 
@@ -55,11 +56,12 @@ class TransactionBaseImpl : public Transaction {
 
   Status GetForUpdate(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const Slice& key,
-                      std::string* value) override;
+                      std::string* value, bool exclusive) override;
 
   Status GetForUpdate(const ReadOptions& options, const Slice& key,
-                      std::string* value) override {
-    return GetForUpdate(options, db_->DefaultColumnFamily(), key, value);
+                      std::string* value, bool exclusive) override {
+    return GetForUpdate(options, db_->DefaultColumnFamily(), key, value,
+                        exclusive);
   }
 
   std::vector<Status> MultiGet(
@@ -315,7 +317,7 @@ class TransactionBaseImpl : public Transaction {
   std::shared_ptr<TransactionNotifier> snapshot_notifier_ = nullptr;
 
   Status TryLock(ColumnFamilyHandle* column_family, const SliceParts& key,
-                 bool read_only, bool untracked = false);
+                 bool read_only, bool exclusive, bool untracked = false);
 
   WriteBatchBase* GetBatchForWrite();
 

--- a/utilities/transactions/transaction_db_impl.cc
+++ b/utilities/transactions/transaction_db_impl.cc
@@ -266,8 +266,8 @@ Status TransactionDBImpl::DropColumnFamily(ColumnFamilyHandle* column_family) {
 }
 
 Status TransactionDBImpl::TryLock(TransactionImpl* txn, uint32_t cfh_id,
-                                  const std::string& key) {
-  return lock_mgr_.TryLock(txn, cfh_id, key, GetEnv());
+                                  const std::string& key, bool exclusive) {
+  return lock_mgr_.TryLock(txn, cfh_id, key, GetEnv(), exclusive);
 }
 
 void TransactionDBImpl::UnLock(TransactionImpl* txn,

--- a/utilities/transactions/transaction_db_impl.h
+++ b/utilities/transactions/transaction_db_impl.h
@@ -63,7 +63,8 @@ class TransactionDBImpl : public TransactionDB {
   using StackableDB::DropColumnFamily;
   virtual Status DropColumnFamily(ColumnFamilyHandle* column_family) override;
 
-  Status TryLock(TransactionImpl* txn, uint32_t cfh_id, const std::string& key);
+  Status TryLock(TransactionImpl* txn, uint32_t cfh_id, const std::string& key,
+                 bool exclusive);
 
   void UnLock(TransactionImpl* txn, const TransactionKeyMap* keys);
   void UnLock(TransactionImpl* txn, uint32_t cfh_id, const std::string& key);

--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -22,7 +22,6 @@
 
 #include "rocksdb/slice.h"
 #include "rocksdb/utilities/transaction_db_mutex.h"
-#include "util/autovector.h"
 #include "util/murmurhash.h"
 #include "util/sync_point.h"
 #include "util/thread_local.h"
@@ -31,15 +30,20 @@
 namespace rocksdb {
 
 struct LockInfo {
-  TransactionID txn_id;
+  bool exclusive;
+  autovector<TransactionID> txn_ids;
 
   // Transaction locks are not valid after this time in us
   uint64_t expiration_time;
 
-  LockInfo(TransactionID id, uint64_t time)
-      : txn_id(id), expiration_time(time) {}
+  LockInfo(TransactionID id, uint64_t time, bool ex)
+      : exclusive(ex), expiration_time(time) {
+    txn_ids.push_back(id);
+  }
   LockInfo(const LockInfo& lock_info)
-      : txn_id(lock_info.txn_id), expiration_time(lock_info.expiration_time) {}
+      : exclusive(lock_info.exclusive),
+        txn_ids(lock_info.txn_ids),
+        expiration_time(lock_info.expiration_time) {}
 };
 
 struct LockMapStripe {
@@ -192,7 +196,8 @@ std::shared_ptr<LockMap> TransactionLockMgr::GetLockMap(
 // transaction.
 // If false, sets *expire_time to the expiration time of the lock according
 // to Env->GetMicros() or 0 if no expiration.
-bool TransactionLockMgr::IsLockExpired(const LockInfo& lock_info, Env* env,
+bool TransactionLockMgr::IsLockExpired(TransactionID txn_id,
+                                       const LockInfo& lock_info, Env* env,
                                        uint64_t* expire_time) {
   auto now = env->NowMicros();
 
@@ -203,12 +208,18 @@ bool TransactionLockMgr::IsLockExpired(const LockInfo& lock_info, Env* env,
     // return how many microseconds until lock will be expired
     *expire_time = lock_info.expiration_time;
   } else {
-    bool success =
-        txn_db_impl_->TryStealingExpiredTransactionLocks(lock_info.txn_id);
-    if (!success) {
-      expired = false;
+    for (auto id : lock_info.txn_ids) {
+      if (txn_id == id) {
+        continue;
+      }
+
+      bool success = txn_db_impl_->TryStealingExpiredTransactionLocks(id);
+      if (!success) {
+        expired = false;
+        break;
+      }
+      *expire_time = 0;
     }
-    *expire_time = 0;
   }
 
   return expired;
@@ -216,7 +227,8 @@ bool TransactionLockMgr::IsLockExpired(const LockInfo& lock_info, Env* env,
 
 Status TransactionLockMgr::TryLock(TransactionImpl* txn,
                                    uint32_t column_family_id,
-                                   const std::string& key, Env* env) {
+                                   const std::string& key, Env* env,
+                                   bool exclusive) {
   // Lookup lock map for this column family id
   std::shared_ptr<LockMap> lock_map_ptr = GetLockMap(column_family_id);
   LockMap* lock_map = lock_map_ptr.get();
@@ -233,7 +245,7 @@ Status TransactionLockMgr::TryLock(TransactionImpl* txn,
   assert(lock_map->lock_map_stripes_.size() > stripe_num);
   LockMapStripe* stripe = lock_map->lock_map_stripes_.at(stripe_num);
 
-  LockInfo lock_info(txn->GetID(), txn->GetExpirationTime());
+  LockInfo lock_info(txn->GetID(), txn->GetExpirationTime(), exclusive);
   int64_t timeout = txn->GetLockTimeout();
 
   return AcquireWithTimeout(txn, lock_map, stripe, column_family_id, key, env,
@@ -268,9 +280,9 @@ Status TransactionLockMgr::AcquireWithTimeout(
 
   // Acquire lock if we are able to
   uint64_t expire_time_hint = 0;
-  TransactionID wait_id = 0;
+  autovector<TransactionID> wait_ids;
   result = AcquireLocked(lock_map, stripe, key, env, lock_info,
-                         &expire_time_hint, &wait_id);
+                         &expire_time_hint, &wait_ids);
 
   if (!result.ok() && timeout != 0) {
     // If we weren't able to acquire the lock, we will keep retrying as long
@@ -289,19 +301,19 @@ Status TransactionLockMgr::AcquireWithTimeout(
         cv_end_time = end_time;
       }
 
-      assert(result.IsBusy() || wait_id != 0);
+      assert(result.IsBusy() || wait_ids.size() != 0);
 
       // We are dependent on a transaction to finish, so perform deadlock
       // detection.
-      if (wait_id != 0) {
+      if (wait_ids.size() != 0) {
         if (txn->IsDeadlockDetect()) {
-          if (IncrementWaiters(txn, wait_id)) {
+          if (IncrementWaiters(txn, wait_ids)) {
             result = Status::Busy(Status::SubCode::kDeadlock);
             stripe->stripe_mutex->UnLock();
             return result;
           }
         }
-        txn->SetWaitingTxn(wait_id, column_family_id, &key);
+        txn->SetWaitingTxn(wait_ids, column_family_id, &key);
       }
 
       TEST_SYNC_POINT("TransactionLockMgr::AcquireWithTimeout:WaitingTxn");
@@ -316,10 +328,10 @@ Status TransactionLockMgr::AcquireWithTimeout(
         }
       }
 
-      if (wait_id != 0) {
-        txn->SetWaitingTxn(0, 0, nullptr);
+      if (wait_ids.size() != 0) {
+        txn->ClearWaitingTxn();
         if (txn->IsDeadlockDetect()) {
-          DecrementWaiters(txn, wait_id);
+          DecrementWaiters(txn, wait_ids);
         }
       }
 
@@ -332,7 +344,7 @@ Status TransactionLockMgr::AcquireWithTimeout(
 
       if (result.ok() || result.IsTimedOut()) {
         result = AcquireLocked(lock_map, stripe, key, env, lock_info,
-                               &expire_time_hint, &wait_id);
+                               &expire_time_hint, &wait_ids);
       }
     } while (!result.ok() && !timed_out);
   }
@@ -342,35 +354,40 @@ Status TransactionLockMgr::AcquireWithTimeout(
   return result;
 }
 
-void TransactionLockMgr::DecrementWaiters(const TransactionImpl* txn,
-                                          TransactionID wait_id) {
+void TransactionLockMgr::DecrementWaiters(
+    const TransactionImpl* txn, const autovector<TransactionID>& wait_ids) {
   std::lock_guard<std::mutex> lock(wait_txn_map_mutex_);
-  DecrementWaitersImpl(txn, wait_id);
+  DecrementWaitersImpl(txn, wait_ids);
 }
 
-void TransactionLockMgr::DecrementWaitersImpl(const TransactionImpl* txn,
-                                              TransactionID wait_id) {
+void TransactionLockMgr::DecrementWaitersImpl(
+    const TransactionImpl* txn, const autovector<TransactionID>& wait_ids) {
   auto id = txn->GetID();
   assert(wait_txn_map_.Contains(id));
   wait_txn_map_.Delete(id);
 
-  rev_wait_txn_map_.Get(wait_id)--;
-  if (rev_wait_txn_map_.Get(wait_id) == 0) {
-    rev_wait_txn_map_.Delete(wait_id);
+  for (auto wait_id : wait_ids) {
+    rev_wait_txn_map_.Get(wait_id)--;
+    if (rev_wait_txn_map_.Get(wait_id) == 0) {
+      rev_wait_txn_map_.Delete(wait_id);
+    }
   }
 }
 
-bool TransactionLockMgr::IncrementWaiters(const TransactionImpl* txn,
-                                          TransactionID wait_id) {
+bool TransactionLockMgr::IncrementWaiters(
+    const TransactionImpl* txn, const autovector<TransactionID>& wait_ids) {
   auto id = txn->GetID();
+  std::vector<TransactionID> queue(txn->GetDeadlockDetectDepth());
   std::lock_guard<std::mutex> lock(wait_txn_map_mutex_);
   assert(!wait_txn_map_.Contains(id));
-  wait_txn_map_.Insert(id, wait_id);
+  wait_txn_map_.Insert(id, wait_ids);
 
-  if (rev_wait_txn_map_.Contains(wait_id)) {
-    rev_wait_txn_map_.Get(wait_id)++;
-  } else {
-    rev_wait_txn_map_.Insert(wait_id, 1);
+  for (auto wait_id : wait_ids) {
+    if (rev_wait_txn_map_.Contains(wait_id)) {
+      rev_wait_txn_map_.Get(wait_id)++;
+    } else {
+      rev_wait_txn_map_.Insert(wait_id, 1);
+    }
   }
 
   // No deadlock if nobody is waiting on self.
@@ -378,20 +395,36 @@ bool TransactionLockMgr::IncrementWaiters(const TransactionImpl* txn,
     return false;
   }
 
-  TransactionID next = wait_id;
-  for (int i = 0; i < txn->GetDeadlockDetectDepth(); i++) {
+  const auto* next_ids = &wait_ids;
+  for (int tail = 0, head = 0; head < txn->GetDeadlockDetectDepth(); head++) {
+    uint i = 0;
+    if (next_ids) {
+      for (; i < next_ids->size() && tail + i < txn->GetDeadlockDetectDepth();
+           i++) {
+        queue[tail + i] = (*next_ids)[i];
+      }
+      tail += i;
+    }
+
+    // No more items in the list, meaning no deadlock.
+    if (tail == head) {
+      return false;
+    }
+
+    auto next = queue[head];
     if (next == id) {
-      DecrementWaitersImpl(txn, wait_id);
+      DecrementWaitersImpl(txn, wait_ids);
       return true;
     } else if (!wait_txn_map_.Contains(next)) {
-      return false;
+      next_ids = nullptr;
+      continue;
     } else {
-      next = wait_txn_map_.Get(next);
+      next_ids = &wait_txn_map_.Get(next);
     }
   }
 
   // Wait cycle too big, just assume deadlock.
-  DecrementWaitersImpl(txn, wait_id);
+  DecrementWaitersImpl(txn, wait_ids);
   return true;
 }
 
@@ -404,24 +437,47 @@ Status TransactionLockMgr::AcquireLocked(LockMap* lock_map,
                                          const std::string& key, Env* env,
                                          const LockInfo& txn_lock_info,
                                          uint64_t* expire_time,
-                                         TransactionID* txn_id) {
+                                         autovector<TransactionID>* txn_ids) {
+  assert(txn_lock_info.txn_ids.size() == 1);
+
   Status result;
   // Check if this key is already locked
   if (stripe->keys.find(key) != stripe->keys.end()) {
     // Lock already held
-
     LockInfo& lock_info = stripe->keys.at(key);
-    if (lock_info.txn_id != txn_lock_info.txn_id) {
-      // locked by another txn.  Check if it's expired
-      if (IsLockExpired(lock_info, env, expire_time)) {
-        // lock is expired, can steal it
-        lock_info.txn_id = txn_lock_info.txn_id;
+    assert(lock_info.txn_ids.size() == 1 || !lock_info.exclusive);
+
+    if (lock_info.exclusive || txn_lock_info.exclusive) {
+      if (lock_info.txn_ids.size() == 1 &&
+          lock_info.txn_ids[0] == txn_lock_info.txn_ids[0]) {
+        // The list contains one txn and we're it, so just take it.
+        lock_info.exclusive = txn_lock_info.exclusive;
         lock_info.expiration_time = txn_lock_info.expiration_time;
-        // lock_cnt does not change
       } else {
-        result = Status::TimedOut(Status::SubCode::kLockTimeout);
-        *txn_id = lock_info.txn_id;
+        // Check if it's expired. Skips over txn_lock_info.txn_ids[0] in case
+        // it's there for a shared lock with multiple holders which was not
+        // caught in the first case.
+        if (IsLockExpired(txn_lock_info.txn_ids[0], lock_info, env,
+                          expire_time)) {
+          // lock is expired, can steal it
+          lock_info.txn_ids = txn_lock_info.txn_ids;
+          lock_info.exclusive = txn_lock_info.exclusive;
+          lock_info.expiration_time = txn_lock_info.expiration_time;
+          // lock_cnt does not change
+        } else {
+          result = Status::TimedOut(Status::SubCode::kLockTimeout);
+          *txn_ids = lock_info.txn_ids;
+        }
       }
+    } else {
+      // We are requesting shared access to a shared lock, so just grant it.
+      lock_info.txn_ids.push_back(txn_lock_info.txn_ids[0]);
+      // Using std::max means that expiration time never goes down even when
+      // a transaction is removed from the list. The correct solution would be
+      // to track expiry for every transaction, but this would also work for
+      // now.
+      lock_info.expiration_time =
+          std::max(lock_info.expiration_time, txn_lock_info.expiration_time);
     }
   } else {  // Lock not held.
     // Check lock limit
@@ -442,6 +498,42 @@ Status TransactionLockMgr::AcquireLocked(LockMap* lock_map,
   return result;
 }
 
+void TransactionLockMgr::UnLockKey(const TransactionImpl* txn,
+                                   const std::string& key,
+                                   LockMapStripe* stripe, LockMap* lock_map,
+                                   Env* env) {
+  TransactionID txn_id = txn->GetID();
+
+  auto stripe_iter = stripe->keys.find(key);
+  if (stripe_iter != stripe->keys.end()) {
+    auto& txns = stripe_iter->second.txn_ids;
+    auto txn_it = std::find(txns.begin(), txns.end(), txn_id);
+    // Found the key we locked.  unlock it.
+    if (txn_it != txns.end()) {
+      if (txns.size() == 1) {
+        stripe->keys.erase(stripe_iter);
+      } else {
+        auto last_it = txns.end() - 1;
+        if (txn_it != last_it) {
+          *txn_it = *last_it;
+        }
+        txns.pop_back();
+      }
+
+      if (max_num_locks_ > 0) {
+        // Maintain lock count if there is a limit on the number of locks.
+        assert(lock_map->lock_cnt.load(std::memory_order_relaxed) > 0);
+        lock_map->lock_cnt--;
+      }
+    }
+  } else {
+    // This key is either not locked or locked by someone else.  This should
+    // only happen if the unlocking transaction has expired.
+    assert(txn->GetExpirationTime() > 0 &&
+           txn->GetExpirationTime() < env->NowMicros());
+  }
+}
+
 void TransactionLockMgr::UnLock(TransactionImpl* txn, uint32_t column_family_id,
                                 const std::string& key, Env* env) {
   std::shared_ptr<LockMap> lock_map_ptr = GetLockMap(column_family_id);
@@ -456,26 +548,8 @@ void TransactionLockMgr::UnLock(TransactionImpl* txn, uint32_t column_family_id,
   assert(lock_map->lock_map_stripes_.size() > stripe_num);
   LockMapStripe* stripe = lock_map->lock_map_stripes_.at(stripe_num);
 
-  TransactionID txn_id = txn->GetID();
-
   stripe->stripe_mutex->Lock();
-
-  const auto& iter = stripe->keys.find(key);
-  if (iter != stripe->keys.end() && iter->second.txn_id == txn_id) {
-    // Found the key we locked.  unlock it.
-    stripe->keys.erase(iter);
-    if (max_num_locks_ > 0) {
-      // Maintain lock count if there is a limit on the number of locks.
-      assert(lock_map->lock_cnt.load(std::memory_order_relaxed) > 0);
-      lock_map->lock_cnt--;
-    }
-  } else {
-    // This key is either not locked or locked by someone else.  This should
-    // only happen if the unlocking transaction has expired.
-    assert(txn->GetExpirationTime() > 0 &&
-           txn->GetExpirationTime() < env->NowMicros());
-  }
-
+  UnLockKey(txn, key, stripe, lock_map, env);
   stripe->stripe_mutex->UnLock();
 
   // Signal waiting threads to retry locking
@@ -484,8 +558,6 @@ void TransactionLockMgr::UnLock(TransactionImpl* txn, uint32_t column_family_id,
 
 void TransactionLockMgr::UnLock(const TransactionImpl* txn,
                                 const TransactionKeyMap* key_map, Env* env) {
-  TransactionID txn_id = txn->GetID();
-
   for (auto& key_map_iter : *key_map) {
     uint32_t column_family_id = key_map_iter.first;
     auto& keys = key_map_iter.second;
@@ -520,22 +592,7 @@ void TransactionLockMgr::UnLock(const TransactionImpl* txn,
       stripe->stripe_mutex->Lock();
 
       for (const std::string* key : stripe_keys) {
-        const auto& iter = stripe->keys.find(*key);
-        if (iter != stripe->keys.end() && iter->second.txn_id == txn_id) {
-          // Found the key we locked.  unlock it.
-          stripe->keys.erase(iter);
-          if (max_num_locks_ > 0) {
-            // Maintain lock count if there is a limit on the number of locks.
-            assert(lock_map->lock_cnt.load(std::memory_order_relaxed) > 0);
-            lock_map->lock_cnt--;
-          }
-        } else {
-          // This key is either not locked or locked by someone else.  This
-          // should only
-          // happen if the unlocking transaction has expired.
-          assert(txn->GetExpirationTime() > 0 &&
-                 txn->GetExpirationTime() < env->NowMicros());
-        }
+        UnLockKey(txn, *key, stripe, lock_map, env);
       }
 
       stripe->stripe_mutex->UnLock();
@@ -565,7 +622,13 @@ TransactionLockMgr::LockStatusData TransactionLockMgr::GetLockStatusData() {
     for (const auto& j : stripes) {
       j->stripe_mutex->Lock();
       for (const auto& it : j->keys) {
-        data.insert({i, {it.first, it.second.txn_id}});
+        struct KeyLockInfo info;
+        info.exclusive = it.second.exclusive;
+        info.key = it.first;
+        for (const auto& id : it.second.txn_ids) {
+          info.ids.push_back(id);
+        }
+        data.insert({i, info});
       }
     }
   }

--- a/utilities/transactions/transaction_lock_mgr.h
+++ b/utilities/transactions/transaction_lock_mgr.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "rocksdb/utilities/transaction.h"
+#include "util/autovector.h"
 #include "util/hash_map.h"
 #include "util/instrumented_mutex.h"
 #include "util/thread_local.h"
@@ -47,7 +48,7 @@ class TransactionLockMgr {
   // Attempt to lock key.  If OK status is returned, the caller is responsible
   // for calling UnLock() on this key.
   Status TryLock(TransactionImpl* txn, uint32_t column_family_id,
-                 const std::string& key, Env* env);
+                 const std::string& key, Env* env, bool exclusive);
 
   // Unlock a key locked by TryLock().  txn must be the same Transaction that
   // locked this key.
@@ -91,12 +92,13 @@ class TransactionLockMgr {
   // Maps from waitee -> number of waiters.
   HashMap<TransactionID, int> rev_wait_txn_map_;
   // Maps from waiter -> waitee.
-  HashMap<TransactionID, TransactionID> wait_txn_map_;
+  HashMap<TransactionID, autovector<TransactionID>> wait_txn_map_;
 
   // Used to allocate mutexes/condvars to use when locking keys
   std::shared_ptr<TransactionDBMutexFactory> mutex_factory_;
 
-  bool IsLockExpired(const LockInfo& lock_info, Env* env, uint64_t* wait_time);
+  bool IsLockExpired(TransactionID txn_id, const LockInfo& lock_info, Env* env,
+                     uint64_t* wait_time);
 
   std::shared_ptr<LockMap> GetLockMap(uint32_t column_family_id);
 
@@ -108,11 +110,17 @@ class TransactionLockMgr {
   Status AcquireLocked(LockMap* lock_map, LockMapStripe* stripe,
                        const std::string& key, Env* env,
                        const LockInfo& lock_info, uint64_t* wait_time,
-                       TransactionID* txn_id);
+                       autovector<TransactionID>* txn_ids);
 
-  bool IncrementWaiters(const TransactionImpl* txn, TransactionID wait_id);
-  void DecrementWaiters(const TransactionImpl* txn, TransactionID wait_id);
-  void DecrementWaitersImpl(const TransactionImpl* txn, TransactionID wait_id);
+  void UnLockKey(const TransactionImpl* txn, const std::string& key,
+                 LockMapStripe* stripe, LockMap* lock_map, Env* env);
+
+  bool IncrementWaiters(const TransactionImpl* txn,
+                        const autovector<TransactionID>& wait_ids);
+  void DecrementWaiters(const TransactionImpl* txn,
+                        const autovector<TransactionID>& wait_ids);
+  void DecrementWaitersImpl(const TransactionImpl* txn,
+                            const autovector<TransactionID>& wait_ids);
 
   // No copying allowed
   TransactionLockMgr(const TransactionLockMgr&);


### PR DESCRIPTION
This is an implementation of non-exclusive locks for pessimistic transactions. It is relatively simple and does not prevent starvation (ie. it's possible that request for exclusive access will never be granted if there are always threads holding shared access). It is done by changing `KeyLockInfo` to hold an set a transaction ids, instead of just one, and adding a flag specifying whether this lock is currently held with exclusive access or not.

Some implementation notes:
- Some lock diagnostic functions had to be updated to return a set of transaction ids for a given lock, eg. `GetWaitingTxn` and `GetLockStatusData`.
- Deadlock detection is a bit more complicated since a transaction can now wait on multiple other transactions. A BFS is done in this case, and deadlock detection depth is now just a limit on the number of transactions we visit.
- Expirable transactions do not work efficiently with shared locks at the moment, but that's okay for now.