### PR TITLE
Fix double-counted deletion stat

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -308,7 +308,6 @@ void CompactionIterator::NextFromInput() {
             // to know that a write happened in this snapshot (Rule 2 above).
             // Clear the value and output the SingleDelete. (The value will be
             // outputted on the next iteration.)
-            ++iter_stats_.num_record_drop_hidden;
 
             // Setting valid_ to true will output the current SingleDelete
             valid_ = true;


### PR DESCRIPTION
Both the single deletion and the value are included in compaction outputs, so no need to update the stat for the value's deletion yet, otherwise it'd be double-counted.