### PR TITLE
disable UBSAN for functions with intentional -ve shift / overflow

### DIFF
--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -230,8 +230,8 @@ class FaultInjectionTest : public testing::Test,
 
 #if defined(__clang__)
 __attribute__((__no_sanitize__("undefined")))
-#elif defined(__GNUC__)
-__attribute__((no_sanitize_undefined))
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
+__attribute__((__no_sanitize_undefined__))
 #endif
   // Return the ith key
   Slice Key(int i, std::string* storage) const {

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -228,6 +228,11 @@ class FaultInjectionTest : public testing::Test,
     return Status::OK();
   }
 
+#if defined(__clang__)
+__attribute__((__no_sanitize__("undefined")))
+#elif defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+#endif
   // Return the ith key
   Slice Key(int i, std::string* storage) const {
     int num = i;

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -13,6 +13,12 @@
 
 namespace rocksdb {
 
+// This function may intentionally do a left shift on a -ve number
+#if defined(__clang__)
+__attribute__((__no_sanitize__("undefined")))
+#elif defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+#endif
 uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   // Similar to murmur hash
   const uint32_t m = 0xc6a4a793;

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -16,8 +16,8 @@ namespace rocksdb {
 // This function may intentionally do a left shift on a -ve number
 #if defined(__clang__)
 __attribute__((__no_sanitize__("undefined")))
-#elif defined(__GNUC__)
-__attribute__((no_sanitize_undefined))
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
+__attribute__((__no_sanitize_undefined__))
 #endif
 uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   // Similar to murmur hash

--- a/utilities/col_buf_encoder.cc
+++ b/utilities/col_buf_encoder.cc
@@ -48,8 +48,8 @@ ColBufEncoder *ColBufEncoder::NewColBufEncoder(
 
 #if defined(__clang__)
 __attribute__((__no_sanitize__("undefined")))
-#elif defined(__GNUC__)
-__attribute__((no_sanitize_undefined))
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
+__attribute__((__no_sanitize_undefined__))
 #endif
 size_t FixedLengthColBufEncoder::Append(const char *buf) {
   if (nullable_) {

--- a/utilities/col_buf_encoder.cc
+++ b/utilities/col_buf_encoder.cc
@@ -46,6 +46,11 @@ ColBufEncoder *ColBufEncoder::NewColBufEncoder(
   return nullptr;
 }
 
+#if defined(__clang__)
+__attribute__((__no_sanitize__("undefined")))
+#elif defined(__GNUC__)
+__attribute__((no_sanitize_undefined))
+#endif
 size_t FixedLengthColBufEncoder::Append(const char *buf) {
   if (nullable_) {
     if (buf == nullptr) {


### PR DESCRIPTION
disable UBSAN for functions with intentional left shift on -ve number / overflow

These functions are
rocksdb:: Hash
FixedLengthColBufEncoder::Append
FaultInjectionTest:: Key