### PR TITLE
Avoid intentional overflow in GetL0ThresholdSpeedupCompaction

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -562,39 +562,20 @@ std::unique_ptr<WriteControllerToken> SetupDelay(
   return write_controller->GetDelayToken(write_rate);
 }
 
-int GetL0ThresholdSpeedupCompaction(int level0_file_num_compaction_trigger,
-                                    int level0_slowdown_writes_trigger) {
+int64_t GetL0ThresholdSpeedupCompaction(
+    int64_t level0_file_num_compaction_trigger,
+    int level0_slowdown_writes_trigger) {
   // SanitizeOptions() ensures it.
   assert(level0_file_num_compaction_trigger <= level0_slowdown_writes_trigger);
 
-  if (level0_file_num_compaction_trigger < 0) {
-    return std::numeric_limits<int>::max();
-  }
-
-  const int twice_level0_trigger = level0_file_num_compaction_trigger * 2;
-
-  // overflow protection
-  if (twice_level0_trigger < 0) {
-    return std::numeric_limits<int>::max();
-  }
-
   // 1/4 of the way between L0 compaction trigger threshold and slowdown
   // condition.
-  const int one_fourth_trigger_slowdown =
-      level0_file_num_compaction_trigger +
-      ((level0_slowdown_writes_trigger - level0_file_num_compaction_trigger) /
-       4);
-
-  // overflow protection
-  if (one_fourth_trigger_slowdown < 0) {
-    return std::numeric_limits<int>::max();
-  }
-
-  assert(twice_level0_trigger >= 0);
-  assert(one_fourth_trigger_slowdown >= 0);
-
   // Or twice as compaction trigger, if it is smaller.
-  return std::min(twice_level0_trigger, one_fourth_trigger_slowdown);
+  return std::min(level0_file_num_compaction_trigger * 2,
+                  level0_file_num_compaction_trigger +
+                      (level0_slowdown_writes_trigger -
+                       level0_file_num_compaction_trigger) /
+                          4);
 }
 }  // namespace
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -562,20 +562,36 @@ std::unique_ptr<WriteControllerToken> SetupDelay(
   return write_controller->GetDelayToken(write_rate);
 }
 
-int64_t GetL0ThresholdSpeedupCompaction(
-    int64_t level0_file_num_compaction_trigger,
-    int level0_slowdown_writes_trigger) {
+
+int GetL0ThresholdSpeedupCompaction(int level0_file_num_compaction_trigger,
+                                    int level0_slowdown_writes_trigger) {
   // SanitizeOptions() ensures it.
   assert(level0_file_num_compaction_trigger <= level0_slowdown_writes_trigger);
+
+  if (level0_file_num_compaction_trigger < 0) {
+    return std::numeric_limits<int>::max();
+  }
+
+  const int64_t twice_level0_trigger =
+      static_cast<int64_t>(level0_file_num_compaction_trigger) * 2;
+
+  const int64_t one_fourth_trigger_slowdown =
+      static_cast<int64_t>(level0_file_num_compaction_trigger) +
+      ((level0_slowdown_writes_trigger - level0_file_num_compaction_trigger) /
+       4);
+
+  assert(twice_level0_trigger >= 0);
+  assert(one_fourth_trigger_slowdown >= 0);
 
   // 1/4 of the way between L0 compaction trigger threshold and slowdown
   // condition.
   // Or twice as compaction trigger, if it is smaller.
-  return std::min(level0_file_num_compaction_trigger * 2,
-                  level0_file_num_compaction_trigger +
-                      (level0_slowdown_writes_trigger -
-                       level0_file_num_compaction_trigger) /
-                          4);
+  int64_t res = std::min(twice_level0_trigger, one_fourth_trigger_slowdown);
+  if (res >= port::kMaxInt32) {
+    return port::kMaxInt32;
+  } else {
+    return res;
+  }
 }
 }  // namespace
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -562,7 +562,6 @@ std::unique_ptr<WriteControllerToken> SetupDelay(
   return write_controller->GetDelayToken(write_rate);
 }
 
-
 int GetL0ThresholdSpeedupCompaction(int level0_file_num_compaction_trigger,
                                     int level0_slowdown_writes_trigger) {
   // SanitizeOptions() ensures it.


### PR DESCRIPTION
https://github.com/facebook/rocksdb/commit/99c052a34f93d119b75eccdcd489ecd581d48ee9 fixes integer overflow in GetL0ThresholdSpeedupCompaction() by checking if int become -ve.
UBSAN will complain about that since this is still an overflow, we can fix the issue by simply using int64_t