### PR TITLE
NewLRUCache() to pick number of shard bits based on capacity if not given

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 * Added EventListener::OnExternalFileIngested which will be called when IngestExternalFile() add a file successfully.
 * BackupEngine::Open and BackupEngineReadOnly::Open now always return error statuses matching those of the backup Env.
 * Added new overloaded function GetApproximateSizes that allows to specify if memtable stats should be computed only without computing SST files' stats approximations.
+* NewLRUCache() will determine number of shard bits automatically based on capacity, if the user doesn't pass one. This also impacts the default block cache when the user doesn't explict provide one.
 
 ### Bug Fixes
 * Fix the bug that if 2PC is enabled, checkpoints may loss some recent transactions.

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -41,7 +41,10 @@ class CorruptionTest : public testing::Test {
   DB* db_;
 
   CorruptionTest() {
-    tiny_cache_ = NewLRUCache(100);
+    // If LRU cache shard bit is smaller than 2 (or -1 which will automatically
+    // set it to 0), test SequenceNumberRecovery will fail, likely because of a
+    // bug in recovery code. Keep it 4 for now to make the test passes.
+    tiny_cache_ = NewLRUCache(100, 2);
     options_.wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
     options_.env = &env_;
     dbname_ = test::TmpDir() + "/corruption_test";

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -39,8 +39,10 @@ class Cache;
 // is set, insert to the cache will fail when cache is full. User can also
 // set percentage of the cache reserves for high priority entries via
 // high_pri_pool_pct.
+// num_shard_bits = -1 means it is automatically determined: every shard
+// will be at least 512KB and number of shard bits will not exceed 6.
 extern std::shared_ptr<Cache> NewLRUCache(size_t capacity,
-                                          int num_shard_bits = 6,
+                                          int num_shard_bits = -1,
                                           bool strict_capacity_limit = false,
                                           double high_pri_pool_ratio = 0.0);
 
@@ -50,7 +52,7 @@ extern std::shared_ptr<Cache> NewLRUCache(size_t capacity,
 //
 // Return nullptr if it is not supported.
 extern std::shared_ptr<Cache> NewClockCache(size_t capacity,
-                                            int num_shard_bits = 6,
+                                            int num_shard_bits = -1,
                                             bool strict_capacity_limit = false);
 
 class Cache {

--- a/util/clock_cache.cc
+++ b/util/clock_cache.cc
@@ -695,6 +695,9 @@ class ClockCache : public ShardedCache {
 
 std::shared_ptr<Cache> NewClockCache(size_t capacity, int num_shard_bits,
                                      bool strict_capacity_limit) {
+  if (num_shard_bits < 0) {
+    num_shard_bits = GetDefaultCacheShardBits(capacity);
+  }
   return std::make_shared<ClockCache>(capacity, num_shard_bits,
                                       strict_capacity_limit);
 }

--- a/util/lru_cache.cc
+++ b/util/lru_cache.cc
@@ -483,6 +483,9 @@ std::shared_ptr<Cache> NewLRUCache(size_t capacity, int num_shard_bits,
     // invalid high_pri_pool_ratio
     return nullptr;
   }
+  if (num_shard_bits < 0) {
+    num_shard_bits = GetDefaultCacheShardBits(capacity);
+  }
   return std::make_shared<LRUCache>(capacity, num_shard_bits,
                                     strict_capacity_limit, high_pri_pool_ratio);
 }

--- a/util/sharded_cache.cc
+++ b/util/sharded_cache.cc
@@ -145,5 +145,17 @@ std::string ShardedCache::GetPrintableOptions() const {
   ret.append(GetShard(0)->GetPrintableOptions());
   return ret;
 }
+int GetDefaultCacheShardBits(size_t capacity) {
+  int num_shard_bits = 0;
+  size_t min_shard_size = 512L * 1024L;  // Every shard is at least 512KB.
+  size_t num_shards = capacity / min_shard_size;
+  while (num_shards >>= 1) {
+    if (++num_shard_bits >= 6) {
+      // No more than 6.
+      return num_shard_bits;
+    }
+  }
+  return num_shard_bits;
+}
 
 }  // namespace rocksdb

--- a/util/sharded_cache.h
+++ b/util/sharded_cache.h
@@ -78,6 +78,8 @@ class ShardedCache : public Cache {
   virtual void EraseUnRefEntries() override;
   virtual std::string GetPrintableOptions() const override;
 
+  int GetNumShardBits() const { return num_shard_bits_; }
+
  private:
   static inline uint32_t HashSlice(const Slice& s) {
     return Hash(s.data(), s.size(), 0);
@@ -94,5 +96,7 @@ class ShardedCache : public Cache {
   bool strict_capacity_limit_;
   std::atomic<uint64_t> last_id_;
 };
+
+extern int GetDefaultCacheShardBits(size_t capacity);
 
 }  // namespace rocksdb


### PR DESCRIPTION
If the users use the NewLRUCache() without passing in the number of shard bits, instead of using hard-coded 6, we'll determine it based on capacity.

Test Plan: Add a unit test