### PR TITLE
pass rocksdb oncall to mysql_mtr_filter otherwise tasks get created w…

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -100,7 +100,7 @@ CONTRUN_NAME="ROCKSDB_CONTRUN_NAME"
 # the value of $ONCALL. If it's a diff then just call `false` to make sure
 # that errors will be properly propagated to the caller.
 if [ ! -z $ONCALL ]; then
-  TASK_CREATION_TOOL="/usr/local/bin/mysql_mtr_filter --rocksdb"
+  TASK_CREATION_TOOL="/usr/local/bin/mysql_mtr_filter --rocksdb --oncall $ONCALL"
 else
   TASK_CREATION_TOOL="false"
 fi


### PR DESCRIPTION
…rong owner

Summary: mysql_mtr_filter script needs proper oncall

Test Plan: Tested by running rocksdb lego determinator to generate command line,
and using the same command line to check that task append happened properly

Reviewers: IslamAbdelRahman