### PR TITLE
Bug: paralle_group status updated in WriteThread::CompleteParallelWorker

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -333,7 +333,7 @@ bool WriteThread::CompleteParallelWorker(Writer* w) {
 
   auto* pg = w->parallel_group;
   if (!w->status.ok()) {
-    std::lock_guard<std::mutex> guard(w->StateMutex());
+    std::lock_guard<std::mutex> guard(pg->leader->StateMutex());
     pg->status = w->status;
   }
 


### PR DESCRIPTION
Multi-write thread may update the status of the parallel_group in
WriteThread::CompleteParallelWorker if the status of Writer is not ok!
When copy write status to the paralle_group, the write thread just hold the
mutex of the the writer processed by itself. it is useless. The thread
should held the the leader of the parallel_group instead.