### PR TITLE
Fix travis (compile for clang < 3.9)

### DIFF
--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -228,7 +228,7 @@ class FaultInjectionTest : public testing::Test,
     return Status::OK();
   }
 
-#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -228,7 +228,7 @@ class FaultInjectionTest : public testing::Test,
     return Status::OK();
   }
 
-#if defined(__clang__)
+#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -14,7 +14,7 @@
 namespace rocksdb {
 
 // This function may intentionally do a left shift on a -ve number
-#if defined(__clang__)
+#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -14,7 +14,7 @@
 namespace rocksdb {
 
 // This function may intentionally do a left shift on a -ve number
-#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))

--- a/utilities/col_buf_encoder.cc
+++ b/utilities/col_buf_encoder.cc
@@ -46,7 +46,7 @@ ColBufEncoder *ColBufEncoder::NewColBufEncoder(
   return nullptr;
 }
 
-#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))

--- a/utilities/col_buf_encoder.cc
+++ b/utilities/col_buf_encoder.cc
@@ -46,7 +46,7 @@ ColBufEncoder *ColBufEncoder::NewColBufEncoder(
   return nullptr;
 }
 
-#if defined(__clang__)
+#if __clang_major__ > 3 || (__clang_major__ > 3 && __clang_minor__ >= 9)
 __attribute__((__no_sanitize__("undefined")))
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
 __attribute__((__no_sanitize_undefined__))


### PR DESCRIPTION
Travis fail because it uses clang 3.6 which don't recognize 
`__attribute__((__no_sanitize__("undefined")))`