### PR TITLE
CmakeText.txt: 2nd attempt to get the FreeBSD JEMALLOC stuff right

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,9 @@ else()
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     # FreeBSD has jemaloc as default malloc
-    add_definitions(-DROCKSDB_JEMALLOC)
+    # but don't add "add_definitions(-DROCKSDB_JEMALLOC)"
+    # because it'll include explicit jmalloc files
+    # WITH_JEMALLOC allows the use of certain jemalloc functions
     set(WITH_JEMALLOC ON)
   endif()  
   option(WITH_SNAPPY "build with SNAPPY" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
     include_directories(${JEMALLOC_INCLUDE_DIR})
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    # FreeBSD has jemaloc as default malloc
+    # FreeBSD has jemaloc as default malloc!
     # but don't add "add_definitions(-DROCKSDB_JEMALLOC)"
     # because it'll include explicit jmalloc files
     # WITH_JEMALLOC allows the use of certain jemalloc functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ else()
     # but don't add "add_definitions(-DROCKSDB_JEMALLOC)"
     # because it'll include explicit jmalloc files
     # WITH_JEMALLOC allows the use of certain jemalloc functions
+    # add_definitions(-DROCKSDB_JEMALLOC)
     set(WITH_JEMALLOC ON)
   endif()  
   option(WITH_SNAPPY "build with SNAPPY" OFF)


### PR DESCRIPTION
When `-DROCKSDB_JEMALLOC` is set, it will request the inclusion of  `jemalloc/jemalloc.h` 
which is not there on FreeBSD. But the routines are.
So it does compile fine without the -Dstuff...