### PR TITLE
[Fix #1494] Specify shell in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 
 #-----------------------------------------------
 
+BASH_EXISTS := $(shell which bash)
+SHELL := $(shell which bash)
+
 CLEAN_FILES = # deliberately empty, so we can append below.
 CFLAGS += ${EXTRA_CFLAGS}
 CXXFLAGS += ${EXTRA_CXXFLAGS}


### PR DESCRIPTION
Check for and force bash as shell in makefile, in order to prevent build errors on systems with other default shells.

Ideally, the fix for this issue would be to ensure the makefile works on a number of popular shells, but as it seems bash is the current standard for this project, this fix should be good enough.