### PR TITLE
Collapse range deletions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,6 +417,7 @@ TESTS = \
 	persistent_cache_test \
 	statistics_test \
 	lua_test \
+	range_del_aggregator_test \
 	lru_cache_test \
 
 PARALLEL_TEST = \
@@ -1302,6 +1303,9 @@ lru_cache_test: util/lru_cache_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 lua_test: utilities/lua/rocks_lua_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+range_del_aggregator_test: db/range_del_aggregator_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -123,7 +123,8 @@ class DBIter: public Iterator {
         prefix_same_as_start_(prefix_same_as_start),
         pin_thru_lifetime_(pin_data),
         total_order_seek_(total_order_seek),
-        range_del_agg_(ioptions.internal_comparator, s) {
+        range_del_agg_(ioptions.internal_comparator, s,
+                       true /* collapse_deletions */) {
     RecordTick(statistics_, NO_ITERATORS);
     prefix_extractor_ = ioptions.prefix_extractor;
     max_skip_ = max_sequential_skip_in_iterations;

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -41,7 +41,7 @@ TEST_F(DBRangeDelTest, NonBlockBasedTableNotSupported) {
 
 TEST_F(DBRangeDelTest, FlushOutputHasOnlyRangeTombstones) {
   ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "dr1",
-                             "dr1"));
+                             "dr2"));
   ASSERT_OK(db_->Flush(FlushOptions()));
   ASSERT_EQ(1, NumTableFilesAtLevel(0));
 }

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -528,6 +528,7 @@ struct RangeTombstone {
   Slice start_key_;
   Slice end_key_;
   SequenceNumber seq_;
+  RangeTombstone() = default;
   RangeTombstone(Slice sk, Slice ek, SequenceNumber sn)
       : start_key_(sk), end_key_(ek), seq_(sn) {}
 

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -528,10 +528,10 @@ struct RangeTombstone {
   Slice start_key_;
   Slice end_key_;
   SequenceNumber seq_;
-  explicit RangeTombstone(Slice sk, Slice ek, SequenceNumber sn)
+  RangeTombstone(Slice sk, Slice ek, SequenceNumber sn)
       : start_key_(sk), end_key_(ek), seq_(sn) {}
 
-  explicit RangeTombstone(ParsedInternalKey parsed_key, Slice value) {
+  RangeTombstone(ParsedInternalKey parsed_key, Slice value) {
     start_key_ = parsed_key.user_key;
     seq_ = parsed_key.sequence;
     end_key_ = value;

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -111,7 +111,8 @@ class RangeDelAggregator {
   SequenceNumber upper_bound_;
   std::unique_ptr<Rep> rep_;
   const InternalKeyComparator& icmp_;
-  const bool for_write_;  // collapse range deletions if going to write them
+  // collapse range deletions so they're binary searchable
+  const bool collapse_deletions_;
 };
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -32,22 +32,24 @@ class RangeDelAggregator {
   //    stripes, which is the seqnum range between consecutive snapshots,
   //    including the higher snapshot and excluding the lower one. Currently,
   //    this is used by ShouldDelete() to prevent deletion of keys that are
-  //    covered by range tombstones in other snapshot stripes. In case of writes
-  //    (flush/compaction), all DB snapshots are provided such that no keys are
-  //    removed that are uncovered according to any DB snapshot. In case of read
-  //    (get/iterator), only the user snapshot is provided such that the seqnum
-  //    space is divided into two stripes, where only tombstones in the older
-  //    stripe are considered by ShouldDelete().
+  //    covered by range tombstones in other snapshot stripes. This constructor
+  //    is used for writes (flush/compaction). All DB snapshots are provided
+  //    such that no keys are removed that are uncovered according to any DB
+  //    snapshot.
   // Note this overload does not lazily initialize Rep.
   RangeDelAggregator(const InternalKeyComparator& icmp,
-                     const std::vector<SequenceNumber>& snapshots);
+                     const std::vector<SequenceNumber>& snapshots,
+                     bool for_write = true);
 
   // @param upper_bound Similar to snapshots above, except with a single
   //    snapshot, which allows us to store the snapshot on the stack and defer
   //    initialization of heap-allocating members (in Rep) until the first range
-  //    deletion is encountered.
+  //    deletion is encountered. This constructor is used in case of reads (get/
+  //    iterator), for which only the user snapshot (upper_bound) is provided
+  //    such that the seqnum space is divided into two stripes. Only the older
+  //    stripe will be used by ShouldDelete().
   RangeDelAggregator(const InternalKeyComparator& icmp,
-                     SequenceNumber upper_bound);
+                     SequenceNumber upper_bound, bool for_write = false);
 
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.
@@ -87,8 +89,8 @@ class RangeDelAggregator {
   bool IsEmpty();
 
  private:
-  // Maps tombstone internal start key -> tombstone object
-  typedef std::map<Slice, RangeTombstone, stl_wrappers::LessOfComparator>
+  // Maps tombstone user start key -> tombstone object
+  typedef std::multimap<Slice, RangeTombstone, stl_wrappers::LessOfComparator>
       TombstoneMap;
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
   // their seqnums are greater than the next smaller snapshot's seqnum.
@@ -104,10 +106,12 @@ class RangeDelAggregator {
   void InitRep(const std::vector<SequenceNumber>& snapshots);
 
   TombstoneMap& GetTombstoneMap(SequenceNumber seq);
+  Status AddTombstone(RangeTombstone tombstone);
 
   SequenceNumber upper_bound_;
   std::unique_ptr<Rep> rep_;
   const InternalKeyComparator& icmp_;
+  const bool for_write_;  // collapse range deletions if going to write them
 };
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -39,7 +39,7 @@ class RangeDelAggregator {
   // Note this overload does not lazily initialize Rep.
   RangeDelAggregator(const InternalKeyComparator& icmp,
                      const std::vector<SequenceNumber>& snapshots,
-                     bool for_write = true);
+                     bool collapse_deletions = true);
 
   // @param upper_bound Similar to snapshots above, except with a single
   //    snapshot, which allows us to store the snapshot on the stack and defer
@@ -49,7 +49,8 @@ class RangeDelAggregator {
   //    such that the seqnum space is divided into two stripes. Only the older
   //    stripe will be used by ShouldDelete().
   RangeDelAggregator(const InternalKeyComparator& icmp,
-                     SequenceNumber upper_bound, bool for_write = false);
+                     SequenceNumber upper_bound,
+                     bool collapse_deletions = false);
 
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -1,0 +1,153 @@
+//  Copyright (c) 2016-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#include <algorithm>
+
+#include "db/db_test_util.h"
+#include "db/range_del_aggregator.h"
+#include "rocksdb/comparator.h"
+#include "util/testutil.h"
+
+namespace rocksdb {
+
+class RangeDelAggregatorTest : public testing::Test {};
+
+namespace {
+
+struct ExpectedPoint {
+  Slice begin;
+  SequenceNumber seq;
+};
+
+enum Direction {
+  kForward,
+  kReverse,
+};
+
+void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
+                     const std::vector<ExpectedPoint>& expected_points) {
+  // Test same result regardless of which order the range deletions are added.
+  for (Direction dir : {kForward, kReverse}) {
+    auto icmp = InternalKeyComparator(BytewiseComparator());
+    RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+    std::vector<std::string> keys, values;
+    for (const auto& range_del : range_dels) {
+      auto key_and_value = range_del.Serialize();
+      keys.push_back(key_and_value.first.Encode().ToString());
+      values.push_back(key_and_value.second.ToString());
+    }
+    if (dir == kReverse) {
+      std::reverse(keys.begin(), keys.end());
+      std::reverse(values.begin(), values.end());
+    }
+    std::unique_ptr<test::VectorIterator> range_del_iter(
+        new test::VectorIterator(keys, values));
+    range_del_agg.AddTombstones(std::move(range_del_iter));
+
+    for (const auto expected_point : expected_points) {
+      ParsedInternalKey parsed_key;
+      parsed_key.user_key = expected_point.begin;
+      parsed_key.sequence = expected_point.seq;
+      parsed_key.type = kTypeValue;
+      ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key));
+      if (parsed_key.sequence > 0) {
+        --parsed_key.sequence;
+        ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key));
+      }
+    }
+  }
+}
+
+}  // anonymous namespace
+
+TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}); }
+
+TEST_F(RangeDelAggregatorTest, SameStartAndEnd) {
+  VerifyRangeDels({{"a", "a", 5}}, {{" ", 0}, {"a", 0}, {"b", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, Single) {
+  VerifyRangeDels({{"a", "b", 10}}, {{" ", 0}, {"a", 10}, {"b", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveLeft) {
+  VerifyRangeDels({{"a", "c", 10}, {"b", "d", 5}},
+                  {{" ", 0}, {"a", 10}, {"c", 5}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveRight) {
+  VerifyRangeDels({{"a", "c", 5}, {"b", "d", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapAboveMiddle) {
+  VerifyRangeDels({{"a", "d", 5}, {"b", "c", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 5}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapFully) {
+  VerifyRangeDels({{"a", "d", 10}, {"b", "c", 5}},
+                  {{" ", 0}, {"a", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlapPoint) {
+  VerifyRangeDels({{"a", "b", 5}, {"b", "c", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, SameStartKey) {
+  VerifyRangeDels({{"a", "c", 5}, {"a", "b", 10}},
+                  {{" ", 0}, {"a", 10}, {"b", 5}, {"c", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, SameEndKey) {
+  VerifyRangeDels({{"a", "d", 5}, {"b", "d", 10}},
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
+  VerifyRangeDels(
+      {{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}},
+      {{" ", 0}, {"a", 5}, {"b", 0}, {"c", 10}, {"d", 0}, {"e", 15}, {"f", 0}});
+}
+
+// Note the Cover* tests also test cases where tombstones are inserted under a
+// larger one when VerifyRangeDels() runs them in reverse
+TEST_F(RangeDelAggregatorTest, CoverMultipleFromLeft) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "f", 20}},
+      {{" ", 0}, {"a", 20}, {"f", 15}, {"g", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, CoverMultipleFromRight) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"c", "h", 20}},
+      {{" ", 0}, {"b", 5}, {"c", 20}, {"h", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, CoverMultipleFully) {
+  VerifyRangeDels(
+      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "h", 20}},
+      {{" ", 0}, {"a", 20}, {"h", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, AlternateMultipleAboveBelow) {
+  VerifyRangeDels(
+      {{"b", "d", 15}, {"c", "f", 10}, {"e", "g", 20}, {"a", "h", 5}},
+      {{" ", 0},
+       {"a", 5},
+       {"b", 15},
+       {"d", 10},
+       {"e", 20},
+       {"g", 5},
+       {"h", 0}});
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added a tombstone-collapsing mode to RangeDelAggregator, which eliminates overlap in the TombstoneMap. In this mode, we can check whether a tombstone covers a user key using upper_bound() (i.e., binary search). However, the tradeoff is the overhead to add tombstones is now higher, so at first I've only enabled it for range scans (compaction/flush/user iterators), where we expect a high number of calls to ShouldDelete() for the same tombstones. Point queries like Get() will still use the linear scan approach.

Also in this diff I changed RangeDelAggregator's TombstoneMap to use multimap with user keys instead of map with internal keys. Callers sometimes provided ParsedInternalKey directly, from which it would've required string copying to derive an internal key Slice with which we could search the map.

Test Plan: unit tests