### PR TITLE
Compaction::IsTrivialMove relaxing

### DIFF
--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -206,9 +206,9 @@ Compaction::~Compaction() {
 
 bool Compaction::InputCompressionMatchesOutput() const {
   int base_level = input_vstorage_->base_level();
-  bool matches =
-      (GetCompressionType(immutable_cf_options_, input_vstorage_, mutable_cf_options_,
-                          start_level_, base_level) == output_compression_);
+  bool matches = (GetCompressionType(immutable_cf_options_, input_vstorage_,
+                                     mutable_cf_options_, start_level_,
+                                     base_level) == output_compression_);
   if (matches) {
     TEST_SYNC_POINT("Compaction::InputCompressionMatchesOutput:Matches");
     return true;
@@ -225,8 +225,7 @@ bool Compaction::IsTrivialMove() const {
   // filter to be applied to that level, and thus cannot be a trivial move.
 
   // Check if start level have files with overlapping ranges
-  if (start_level_ == 0 &&
-      input_vstorage_->level0_non_overlapping() == false) {
+  if (start_level_ == 0 && input_vstorage_->level0_non_overlapping() == false) {
     // We cannot move files from L0 to L1 if the files are overlapping
     return false;
   }
@@ -255,13 +254,14 @@ bool Compaction::IsTrivialMove() const {
   // assert inputs_.size() == 1
 
   for (const auto& file : inputs_.front().files) {
-    std::vector<FileMetaData *> file_grand_parents;
+    std::vector<FileMetaData*> file_grand_parents;
     if (output_level_ + 1 >= number_levels_) {
       continue;
     }
     input_vstorage_->GetOverlappingInputs(output_level_ + 1, &file->smallest,
-                                    &file->largest, &file_grand_parents);
-    const auto compaction_size = file->fd.GetFileSize() + TotalFileSize(file_grand_parents);
+                                          &file->largest, &file_grand_parents);
+    const auto compaction_size =
+        file->fd.GetFileSize() + TotalFileSize(file_grand_parents);
     if (compaction_size > max_compaction_bytes_) {
       return false;
     }
@@ -290,8 +290,7 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
   // Maybe use binary search to find right entry instead of linear search?
   const Comparator* user_cmp = cfd_->user_comparator();
   for (int lvl = output_level_ + 1; lvl < number_levels_; lvl++) {
-    const std::vector<FileMetaData*>& files =
-        input_vstorage_->LevelFiles(lvl);
+    const std::vector<FileMetaData*>& files = input_vstorage_->LevelFiles(lvl);
     for (; level_ptrs->at(lvl) < files.size(); level_ptrs->at(lvl)++) {
       auto* f = files[level_ptrs->at(lvl)];
       if (user_cmp->Compare(user_key, f->largest.user_key()) <= 0) {

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -150,7 +150,7 @@ Compaction::Compaction(VersionStorageInfo* vstorage,
                        bool _manual_compaction, double _score,
                        bool _deletion_compaction,
                        CompactionReason _compaction_reason)
-    : vstorage_(vstorage),
+    : input_vstorage_(vstorage),
       start_level_(_inputs[0].level),
       output_level_(_output_level),
       max_output_file_size_(_target_file_size),
@@ -205,9 +205,9 @@ Compaction::~Compaction() {
 }
 
 bool Compaction::InputCompressionMatchesOutput() const {
-  int base_level = vstorage_->base_level();
+  int base_level = input_vstorage_->base_level();
   bool matches =
-      (GetCompressionType(immutable_cf_options_, vstorage_, mutable_cf_options_,
+      (GetCompressionType(immutable_cf_options_, input_vstorage_, mutable_cf_options_,
                           start_level_, base_level) == output_compression_);
   if (matches) {
     TEST_SYNC_POINT("Compaction::InputCompressionMatchesOutput:Matches");
@@ -226,7 +226,7 @@ bool Compaction::IsTrivialMove() const {
 
   // Check if start level have files with overlapping ranges
   if (start_level_ == 0 &&
-      input_version_->storage_info()->level0_non_overlapping() == false) {
+      input_vstorage_->level0_non_overlapping() == false) {
     // We cannot move files from L0 to L1 if the files are overlapping
     return false;
   }
@@ -255,13 +255,14 @@ bool Compaction::IsTrivialMove() const {
   // assert inputs_.size() == 1
 
   for (const auto& file : inputs_.front().files) {
-    std::vector<FileMetaData *> fileGrandparents;
+    std::vector<FileMetaData *> file_grand_parents;
     if (output_level_ + 1 >= number_levels_) {
       continue;
     }
-    vstorage_->GetOverlappingInputs(output_level_ + 1, &file->smallest,
-                                    &file->largest, &fileGrandparents);
-    if (TotalFileSize(fileGrandparents) > max_compaction_bytes_) {
+    input_vstorage_->GetOverlappingInputs(output_level_ + 1, &file->smallest,
+                                    &file->largest, &file_grand_parents);
+    const auto compaction_size = file->fd.GetFileSize() + TotalFileSize(file_grand_parents);
+    if (compaction_size > max_compaction_bytes_) {
       return false;
     }
   }
@@ -290,7 +291,7 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
   const Comparator* user_cmp = cfd_->user_comparator();
   for (int lvl = output_level_ + 1; lvl < number_levels_; lvl++) {
     const std::vector<FileMetaData*>& files =
-        input_version_->storage_info()->LevelFiles(lvl);
+        input_vstorage_->LevelFiles(lvl);
     for (; level_ptrs->at(lvl) < files.size(); level_ptrs->at(lvl)++) {
       auto* f = files[level_ptrs->at(lvl)];
       if (user_cmp->Compare(user_key, f->largest.user_key()) <= 0) {
@@ -362,7 +363,7 @@ void Compaction::ReleaseCompactionFiles(Status status) {
 
 void Compaction::ResetNextCompactionIndex() {
   assert(input_version_ != nullptr);
-  input_version_->storage_info()->ResetNextCompactionIndex(start_level_);
+  input_vstorage_->ResetNextCompactionIndex(start_level_);
 }
 
 namespace {

--- a/db/compaction.h
+++ b/db/compaction.h
@@ -258,6 +258,8 @@ class Compaction {
   static bool IsFullCompaction(VersionStorageInfo* vstorage,
                                const std::vector<CompactionInputFiles>& inputs);
 
+  VersionStorageInfo* vstorage_;
+
   const int start_level_;    // the lowest level to be compacted
   const int output_level_;  // levels to which output files are stored
   uint64_t max_output_file_size_;

--- a/db/compaction.h
+++ b/db/compaction.h
@@ -258,7 +258,7 @@ class Compaction {
   static bool IsFullCompaction(VersionStorageInfo* vstorage,
                                const std::vector<CompactionInputFiles>& inputs);
 
-  VersionStorageInfo* vstorage_;
+  VersionStorageInfo* input_vstorage_;
 
   const int start_level_;    // the lowest level to be compacted
   const int output_level_;  // levels to which output files are stored

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -119,9 +119,6 @@ class CompactionPicker {
                                   const Slice& largest_user_key,
                                   int level) const;
 
- protected:
-  int NumberLevels() const { return ioptions_.num_levels; }
-
   // Stores the minimal range that covers all entries in inputs in
   // *smallest, *largest.
   // REQUIRES: inputs is not empty
@@ -140,6 +137,9 @@ class CompactionPicker {
   // REQUIRES: inputs is not empty (at least on entry have one file)
   void GetRange(const std::vector<CompactionInputFiles>& inputs,
                 InternalKey* smallest, InternalKey* largest) const;
+
+ protected:
+  int NumberLevels() const { return ioptions_.num_levels; }
 
   // Add more files to the inputs on "level" to make sure that
   // no newer version of a key is compacted to "level+1" while leaving an older

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -1178,20 +1178,20 @@ TEST_F(CompactionPickerTest, MaxCompactionBytesNotHit) {
 }
 
 TEST_F(CompactionPickerTest, IsTrivialMoveOn) {
-  mutable_cf_options_.max_bytes_for_level_base = 1000000u;
-  mutable_cf_options_.max_compaction_bytes = 10000u;
+  mutable_cf_options_.max_bytes_for_level_base = 10000u;
+  mutable_cf_options_.max_compaction_bytes = 10001u;
   ioptions_.level_compaction_dynamic_level_bytes = false;
   NewVersionStorage(6, kCompactionStyleLevel);
   // A compaction should be triggered and pick file 2
-  Add(1, 1U, "100", "150", 300000U);
-  Add(1, 2U, "151", "200", 300001U);
-  Add(1, 3U, "201", "250", 300000U);
-  Add(1, 4U, "251", "300", 300000U);
+  Add(1, 1U, "100", "150", 3000U);
+  Add(1, 2U, "151", "200", 3001U);
+  Add(1, 3U, "201", "250", 3000U);
+  Add(1, 4U, "251", "300", 3000U);
 
-  Add(3, 5U, "120", "130", 9000U);
-  Add(3, 6U, "170", "180", 9000U);
-  Add(3, 5U, "220", "230", 9000U);
-  Add(3, 5U, "270", "280", 9000U);
+  Add(3, 5U, "120", "130", 7000U);
+  Add(3, 6U, "170", "180", 7000U);
+  Add(3, 5U, "220", "230", 7000U);
+  Add(3, 5U, "270", "280", 7000U);
   UpdateVersionStorageInfo();
 
   std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -1177,6 +1177,50 @@ TEST_F(CompactionPickerTest, MaxCompactionBytesNotHit) {
   ASSERT_EQ(5U, compaction->input(1, 0)->fd.GetNumber());
 }
 
+TEST_F(CompactionPickerTest, IsTrivialMoveOn) {
+  mutable_cf_options_.max_bytes_for_level_base = 1000000u;
+  mutable_cf_options_.max_compaction_bytes = 10000u;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  NewVersionStorage(6, kCompactionStyleLevel);
+  // A compaction should be triggered and pick file 2
+  Add(1, 1U, "100", "150", 300000U);
+  Add(1, 2U, "151", "200", 300001U);
+  Add(1, 3U, "201", "250", 300000U);
+  Add(1, 4U, "251", "300", 300000U);
+
+  Add(3, 5U, "120", "130", 9000U);
+  Add(3, 6U, "170", "180", 9000U);
+  Add(3, 5U, "220", "230", 9000U);
+  Add(3, 5U, "270", "280", 9000U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+    cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  ASSERT_TRUE(compaction->IsTrivialMove());
+}
+
+TEST_F(CompactionPickerTest, IsTrivialMoveOff) {
+  mutable_cf_options_.max_bytes_for_level_base = 1000000u;
+  mutable_cf_options_.max_compaction_bytes = 10000u;
+  ioptions_.level_compaction_dynamic_level_bytes = false;
+  NewVersionStorage(6, kCompactionStyleLevel);
+  // A compaction should be triggered and pick all files from level 1
+  Add(1, 1U, "100", "150", 300000U, 0, 0);
+  Add(1, 2U, "150", "200", 300000U, 0, 0);
+  Add(1, 3U, "200", "250", 300000U, 0, 0);
+  Add(1, 4U, "250", "300", 300000U, 0, 0);
+
+  Add(3, 5U, "120", "130", 6000U);
+  Add(3, 6U, "140", "150", 6000U);
+  UpdateVersionStorageInfo();
+
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+    cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
+  ASSERT_FALSE(compaction->IsTrivialMove());
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
IsTrivialMove returns true if no input file overlaps with output_level+1 with more than max_compaction_bytes_ bytes.