### PR TITLE
Fix compile error in trasaction_lock_mgr.cc

### DIFF
--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -397,9 +397,10 @@ bool TransactionLockMgr::IncrementWaiters(
 
   const auto* next_ids = &wait_ids;
   for (int tail = 0, head = 0; head < txn->GetDeadlockDetectDepth(); head++) {
-    uint i = 0;
+    int i = 0;
     if (next_ids) {
-      for (; i < next_ids->size() && tail + i < txn->GetDeadlockDetectDepth();
+      for (; i < static_cast<int>(next_ids->size()) &&
+             tail + i < txn->GetDeadlockDetectDepth();
            i++) {
         queue[tail + i] = (*next_ids)[i];
       }


### PR DESCRIPTION
Summary:
Fix error on mac/windows build since they don't recognize `uint`.

Test Plan:
`make all check`.