### PR TITLE
fix non-existing type (uint) for mac compilation

### DIFF
--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -397,7 +397,7 @@ bool TransactionLockMgr::IncrementWaiters(
 
   const auto* next_ids = &wait_ids;
   for (int tail = 0, head = 0; head < txn->GetDeadlockDetectDepth(); head++) {
-    uint i = 0;
+    uint32_t i = 0;
     if (next_ids) {
       for (; i < next_ids->size() && tail + i < txn->GetDeadlockDetectDepth();
            i++) {


### PR DESCRIPTION
Test Plan: on linux, ```make check -j64```
will also let travis mac tests run