### PR TITLE
Fix issue where IngestExternalFile insert blocks in block cache with g_seqno=0

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -312,6 +312,11 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
 
   ParsedInternalKey key;
   ReadOptions ro;
+  // During reading the external file we can cache blocks that we read into
+  // the block cache, if we later change the global seqno of this file, we will
+  // have block in cache that will include keys with wrong seqno.
+  // We need to disable fill_cache so that we read from the file without
+  // updating the block cache.
   ro.fill_cache = false;
   std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(ro));
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -311,8 +311,9 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
   file_to_ingest->num_entries = props->num_entries;
 
   ParsedInternalKey key;
-  std::unique_ptr<InternalIterator> iter(
-      table_reader->NewIterator(ReadOptions()));
+  ReadOptions ro;
+  ro.fill_cache = false;
+  std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(ro));
 
   // Get first (smallest) key from file
   iter->SeekToFirst();

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -15,7 +15,7 @@ namespace rocksdb {
 class ExternalSSTFileTest : public DBTestBase {
  public:
   ExternalSSTFileTest() : DBTestBase("/external_sst_file_test") {
-    sst_files_dir_ = test::TmpDir(env_) + "/sst_files/";
+    sst_files_dir_ = dbname_ + "/sst_files/";
     DestroyAndRecreateExternalSSTFilesDir();
   }
 
@@ -1899,24 +1899,31 @@ TEST_F(ExternalSSTFileTest, IngestionListener) {
 TEST_F(ExternalSSTFileTest, SnapshotInconsistencyBug) {
   Options options = CurrentOptions();
   DestroyAndReopen(options);
+  const int kNumKeys = 10000;
 
-  ASSERT_OK(Put("K1", "V1"));
+  // Insert keys using normal path and take a snapshot
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_OK(Put(Key(i), Key(i) + "_V1"));
+  }
   const Snapshot* snap = db_->GetSnapshot();
-  ASSERT_EQ(Get("K1", snap), "V1");
 
+  // Overwrite all keys using IngestExternalFile
   std::string sst_file_path = sst_files_dir_ + "file1.sst";
   SstFileWriter sst_file_writer(EnvOptions(), options, options.comparator);
   ASSERT_OK(sst_file_writer.Open(sst_file_path));
-  ASSERT_OK(sst_file_writer.Add("K1", "V2"));
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_OK(sst_file_writer.Add(Key(i), Key(i) + "_V2"));
+  }
   ASSERT_OK(sst_file_writer.Finish());
-
 
   IngestExternalFileOptions ifo;
   ifo.move_files = true;
   ASSERT_OK(db_->IngestExternalFile({sst_file_path}, ifo));
 
-  ASSERT_EQ(Get("K1", snap), "V1");
-  ASSERT_EQ(Get("K1"), "V2");
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_EQ(Get(Key(i), snap), Key(i) + "_V1");
+    ASSERT_EQ(Get(Key(i)), Key(i) + "_V2");
+  }
 
   db_->ReleaseSnapshot(snap);
 }


### PR DESCRIPTION
When we Ingest an external file we open it to read some metadata and first/last key
during doing that we insert blocks into the block cache with global_seqno = 0

If we move the file (did not copy it) into the DB, we will use these blocks with the wrong seqno in the read path