### PR TITLE
WritableFileWriter: default buffer size equal min(64k,options.writabl…

### DIFF
--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -124,7 +124,7 @@ class WritableFileWriter {
         rate_limiter_(options.rate_limiter) {
 
     buf_.Alignment(writable_file_->GetRequiredBufferAlignment());
-    buf_.AllocateNewBuffer(65536);
+    buf_.AllocateNewBuffer(std::min((size_t)65536, max_buffer_size_));
   }
 
   WritableFileWriter(const WritableFileWriter&) = delete;


### PR DESCRIPTION
…e_file_max_buffer_size)

If we overwrite WritableFile and has a buffer which has the same
function of buf_. We hope remove the cache function of
WritableFileWriter. So using options.writable_file_max_buffer_size = 0
to disable cache function.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>