### PR TITLE
[Fix #1618] Remove unnecessary header include

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -27,7 +27,6 @@
 #include "util/file_util.h"
 #include "util/mutexlock.h"
 #include "util/sync_point.h"
-#include "util/testharness.h"
 
 namespace rocksdb {
 


### PR DESCRIPTION
Remove "util/testharness.h" from list of includes for "db/db_filesnapshot.cc", as it wasn't being used and thus caused an extraneous dependency on gtest.