### PR TITLE
[Fix #1491] Increase buffer size

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -918,7 +918,7 @@ int InternalStats::DumpCFMapStats(
 }
 
 void InternalStats::DumpCFStats(std::string* value) {
-  char buf[1000];
+  char buf[2000];
   // Per-ColumnFamily stats
   PrintLevelStatsHeader(buf, sizeof(buf), cfd_->GetName());
   value->append(buf);


### PR DESCRIPTION
When compiling with GCC>=7.0.0, "db/internal_stats.cc" fails to compile as the data being written to the buffer potentially exceeds its size.

This fix simply doubles the size of the buffer, thus accommodating the max possible data size.