### PR TITLE
direct reads refactor

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -708,14 +708,6 @@ class RandomRWFile {
   // If false you must pass aligned buffer to Write()
   virtual bool UseDirectIO() const { return false; }
 
-  const size_t c_DefaultPageSize = 4 * 1024;
-
-  // Use the returned alignment value to allocate aligned
-  // buffer for Write() when UseDirectIO() returns true
-  virtual size_t GetRequiredBufferAlignment() const {
-    return c_DefaultPageSize;
-  }
-
   // Use the returned alignment value to allocate
   // aligned buffer for Direct I/O
   virtual size_t GetRequiredBufferAlignment() const { return kDefaultPageSize; }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -716,6 +716,10 @@ class RandomRWFile {
     return c_DefaultPageSize;
   }
 
+  // Use the returned alignment value to allocate
+  // aligned buffer for Direct I/O
+  virtual size_t GetRequiredBufferAlignment() const { return kDefaultPageSize; }
+
   // Used by the file_reader_writer to decide if the ReadAhead wrapper
   // should simply forward the call and do not enact read_ahead buffering or locking.
   // The implementation below takes care of reading ahead

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -411,7 +411,6 @@ class SequentialFile {
   SequentialFile() { }
   virtual ~SequentialFile();
 
-
   // Read up to "n" bytes from the file.  "scratch[0..n-1]" may be
   // written by this routine.  Sets "*result" to the data that was
   // read (including if fewer than "n" bytes were successfully read).
@@ -437,9 +436,7 @@ class SequentialFile {
 
   // Use the returned alignment value to allocate
   // aligned buffer for Direct I/O
-  virtual size_t GetRequiredBufferAlignment() const {
-    return kDefaultPageSize;
-  }
+  virtual size_t GetRequiredBufferAlignment() const { return kDefaultPageSize; }
 
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
@@ -448,12 +445,11 @@ class SequentialFile {
     return Status::NotSupported("InvalidateCache not supported.");
   }
 
-  // Positioned Read for Direct I/O
-  // If Direct I/O enabled, offset, n and scratch should be aligned properly
-  virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result, char* scratch) {
+  // Positioned Read for direct I/O
+  virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result,
+                                char* scratch) {
     return Status::NotSupported();
   }
-
 };
 
 // A file abstraction for randomly reading the contents of a file.
@@ -515,9 +511,7 @@ class RandomAccessFile {
 
   // Use the returned alignment value to allocate
   // aligned buffer for Direct I/O
-  virtual size_t GetRequiredBufferAlignment() const {
-    return kDefaultPageSize;
-  }
+  virtual size_t GetRequiredBufferAlignment() const { return kDefaultPageSize; }
 
   // Remove any kind of caching of data from the offset to offset+length
   // of this file. If the length is 0, then it refers to the end of file.
@@ -601,9 +595,7 @@ class WritableFile {
 
   // Use the returned alignment value to allocate
   // aligned buffer for Direct I/O
-  virtual size_t GetRequiredBufferAlignment() const {
-    return kDefaultPageSize;
-  }
+  virtual size_t GetRequiredBufferAlignment() const { return kDefaultPageSize; }
   /*
    * Change the priority in rate limiter if rate limiting is enabled.
    * If rate limiting is not enabled, this call has no effect.

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -446,6 +446,7 @@ class SequentialFile {
   }
 
   // Positioned Read for direct I/O
+  // If Direct I/O enabled, offset, n, and scratch should be properly aligned
   virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result,
                                 char* scratch) {
     return Status::NotSupported();

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -433,6 +433,11 @@ class WinRandomRWFile : private WinFileData,
   // buffer for Write() when UseDirectIO() returns true
   virtual size_t GetRequiredBufferAlignment() const override;
 
+  // Use the returned alignment value to allocate
+  // aligned buffer for Write() when UseOSBuffer()
+  // returns false
+  virtual size_t GetRequiredBufferAlignment() const override;
+
   // Used by the file_reader_writer to decide if the ReadAhead wrapper
   // should simply forward the call and do not enact read_ahead buffering or
   // locking.

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -433,11 +433,6 @@ class WinRandomRWFile : private WinFileData,
   // buffer for Write() when UseDirectIO() returns true
   virtual size_t GetRequiredBufferAlignment() const override;
 
-  // Use the returned alignment value to allocate
-  // aligned buffer for Write() when UseOSBuffer()
-  // returns false
-  virtual size_t GetRequiredBufferAlignment() const override;
-
   // Used by the file_reader_writer to decide if the ReadAhead wrapper
   // should simply forward the call and do not enact read_ahead buffering or
   // locking.

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -78,9 +78,11 @@ public:
     return cursize_;
   }
 
-  char* BufferStart() const {
+  const char* BufferStart() const {
     return bufstart_;
   }
+
+  char* BufferStart() { return bufstart_; }
 
   void Clear() {
     cursize_ = 0;

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -58,6 +58,14 @@ public:
 
   AlignedBuffer& operator=(const AlignedBuffer&) = delete;
 
+  static bool isAligned(const void* ptr, size_t alignment) {
+    return reinterpret_cast<uintptr_t>(ptr) % alignment == 0;
+  }
+
+  static bool isAligned(size_t n, size_t alignment) {
+    return n % alignment == 0;
+  }
+
   size_t Alignment() const {
     return alignment_;
   }
@@ -70,7 +78,7 @@ public:
     return cursize_;
   }
 
-  const char* BufferStart() const {
+  char* BufferStart() const {
     return bufstart_;
   }
 

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -9,6 +9,7 @@
 
 #include "util/file_reader_writer.h"
 
+#include <iostream>
 #include <algorithm>
 #include <mutex>
 
@@ -22,12 +23,41 @@
 namespace rocksdb {
 
 Status SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
-  Status s = file_->Read(n, result, scratch);
+  Status s;
+  if (UseDirectIO()) {
+    size_t offset = offset_.fetch_add(n);
+    size_t alignment = file_->GetRequiredBufferAlignment();
+    size_t aligned_offset = TruncateToPageBoundary(alignment, offset);
+    size_t offset_advance = offset - aligned_offset;
+    size_t size = Roundup(offset + n, alignment) - aligned_offset;
+    size_t r = 0;
+    AlignedBuffer buf;
+    buf.Alignment(alignment);
+    buf.AllocateNewBuffer(size);
+    Slice tmp;
+    s = file_->PositionedRead(aligned_offset, size, &tmp, buf.BufferStart());
+    if (s.ok() && offset_advance < tmp.size()) {
+      buf.Size(tmp.size());
+      r = buf.Read(scratch, offset_advance,
+                   std::min(tmp.size() - offset_advance, n));
+    }
+    *result = Slice(scratch, r);
+
+  } else {
+    s = file_->Read(n, result, scratch);
+  }
   IOSTATS_ADD(bytes_read, result->size());
   return s;
 }
 
-Status SequentialFileReader::Skip(uint64_t n) { return file_->Skip(n); }
+Status SequentialFileReader::Skip(uint64_t n) {
+  if (UseDirectIO()) {
+    offset_ += n;
+    return Status::OK();
+  } else {
+    return file_->Skip(n);
+  }
+}
 
 Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
                                     char* scratch) const {
@@ -37,7 +67,26 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
     StopWatch sw(env_, stats_, hist_type_,
                  (stats_ != nullptr) ? &elapsed : nullptr);
     IOSTATS_TIMER_GUARD(read_nanos);
-    s = file_->Read(offset, n, result, scratch);
+    if (UseDirectIO()) {
+      size_t alignment = file_->GetRequiredBufferAlignment();
+      size_t aligned_offset = TruncateToPageBoundary(alignment, offset);
+      size_t offset_advance = offset - aligned_offset;
+      size_t size = Roundup(offset + n, alignment) - aligned_offset;
+      size_t r = 0;
+      AlignedBuffer buf;
+      buf.Alignment(alignment);
+      buf.AllocateNewBuffer(size);
+      Slice tmp;
+      s = file_->Read(aligned_offset, size, &tmp, buf.BufferStart());
+      if (s.ok() && offset_advance < tmp.size()) {
+        buf.Size(tmp.size());
+        r = buf.Read(scratch, offset_advance,
+                            std::min(tmp.size() - offset_advance, n));
+      }
+      *result = Slice(scratch, r);
+    } else {
+      s = file_->Read(offset, n, result, scratch);
+    }
     IOSTATS_ADD_IF_POSITIVE(bytes_read, result->size());
   }
   if (stats_ != nullptr && file_read_hist_ != nullptr) {

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -7,11 +7,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
-#include <string>
 #include <atomic>
+#include <string>
+#include "port/port.h"
 #include "rocksdb/env.h"
 #include "util/aligned_buffer.h"
-#include "port/port.h"
 
 namespace rocksdb {
 
@@ -49,6 +49,9 @@ class SequentialFileReader {
   SequentialFile* file() { return file_.get(); }
 
   bool UseDirectIO() const { return file_->UseDirectIO(); }
+
+ protected:
+  Status DirectRead(size_t n, Slice* result, char* scratch);
 };
 
 class RandomAccessFileReader {
@@ -92,6 +95,10 @@ class RandomAccessFileReader {
   RandomAccessFile* file() { return file_.get(); }
 
   bool UseDirectIO() const { return file_->UseDirectIO(); }
+
+ protected:
+  Status DirectRead(uint64_t offset, size_t n, Slice* result,
+                    char* scratch) const;
 };
 
 // Use posix write to write data to a file.

--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -58,28 +58,6 @@ const size_t kPageSize = sysconf(_SC_PAGESIZE);
 const size_t kPageSize = 4 * 1024;
 #endif
 
-std::unique_ptr<void, void (&)(void*)> NewAligned(const size_t size) {
-  void* ptr = nullptr;
-  if (posix_memalign(&ptr, 4 * 1024, size) != 0) {
-    return std::unique_ptr<char, void (&)(void*)>(nullptr, free);
-  }
-  std::unique_ptr<void, void (&)(void*)> uptr(ptr, free);
-  return uptr;
-}
-
-size_t Upper(const size_t size, const size_t fac) {
-  if (size % fac == 0) {
-    return size;
-  }
-  return size + (fac - size % fac);
-}
-
-size_t Lower(const size_t size, const size_t fac) {
-  if (size % fac == 0) {
-    return size;
-  }
-  return size - (size % fac);
-}
 
 bool IsSectorAligned(const size_t off) { return off % kSectorSize == 0; }
 
@@ -87,89 +65,32 @@ static bool IsPageAligned(const void* ptr) {
   return uintptr_t(ptr) % (kPageSize) == 0;
 }
 
-Status ReadAligned(int fd, Slice* data, const uint64_t offset,
-                   const size_t size, char* scratch) {
-  assert(IsSectorAligned(offset));
-  assert(IsSectorAligned(size));
-  assert(IsPageAligned(scratch));
-
-  size_t bytes_read = 0;
-  ssize_t status = -1;
-  while (bytes_read < size) {
-    status =
-        pread(fd, scratch + bytes_read, size - bytes_read, offset + bytes_read);
-    if (status <= 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      break;
-    }
-    bytes_read += status;
-    if (status % static_cast<ssize_t>(kSectorSize) != 0) {
-      // Bytes reads don't fill sectors. Should only happen at the end
-      // of the file.
-      break;
-    }
-  }
-
-  *data = Slice(scratch, bytes_read);
-  return status < 0 ? Status::IOError(strerror(errno)) : Status::OK();
 }
-
-Status ReadUnaligned(int fd, Slice* data, const uint64_t offset,
-                     const size_t size, char* scratch) {
-  assert(scratch);
-  assert(!IsSectorAligned(offset) || !IsSectorAligned(size) ||
-         !IsPageAligned(scratch));
-
-  const uint64_t aligned_off = Lower(offset, kSectorSize);
-  const size_t aligned_size = Upper(size + (offset - aligned_off), kSectorSize);
-  auto aligned_scratch = NewAligned(aligned_size);
-  assert(aligned_scratch);
-  if (!aligned_scratch) {
-    return Status::IOError("Unable to allocate");
-  }
-
-  assert(IsSectorAligned(aligned_off));
-  assert(IsSectorAligned(aligned_size));
-  assert(aligned_scratch);
-  assert(IsPageAligned(aligned_scratch.get()));
-  assert(offset + size <= aligned_off + aligned_size);
-
-  Slice scratch_slice;
-  Status s = ReadAligned(fd, &scratch_slice, aligned_off, aligned_size,
-                         reinterpret_cast<char*>(aligned_scratch.get()));
-
-  // copy data upto min(size, what was read)
-  memcpy(scratch, reinterpret_cast<char*>(aligned_scratch.get()) +
-                      (offset % kSectorSize),
-         std::min(size, scratch_slice.size()));
-  *data = Slice(scratch, std::min(size, scratch_slice.size()));
-  return s;
-}
-
-Status DirectIORead(int fd, Slice* result, size_t off, size_t n,
-                    char* scratch) {
-  if (IsSectorAligned(off) && IsSectorAligned(n) && IsPageAligned(scratch)) {
-    return ReadAligned(fd, result, off, n, scratch);
-  }
-  return ReadUnaligned(fd, result, off, n, scratch);
-}
-}  // namespace
 
 /*
  * PosixSequentialFile
  */
-PosixSequentialFile::PosixSequentialFile(const std::string& fname, FILE* f,
-                                         const EnvOptions& options)
+PosixSequentialFile::PosixSequentialFile(const std::string& fname, FILE* file,
+                                         int fd, const EnvOptions& options)
     : filename_(fname),
-      file_(f),
-      fd_(fileno(f)),
-      use_direct_io_(options.use_direct_reads) {}
+      file_(file),
+      fd_(fd),
+      use_direct_io_(options.use_direct_reads) {
+  assert(!options.use_direct_reads || !options.use_mmap_reads);
+}
 
-PosixSequentialFile::~PosixSequentialFile() { fclose(file_); }
+PosixSequentialFile::~PosixSequentialFile() {
+  if (!UseDirectIO()) {
+    assert(file_);
+    fclose(file_);
+  } else {
+    assert(fd_);
+    close(fd_);
+  }
+}
 
 Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
+  assert(result != nullptr && !UseDirectIO());
   Status s;
   size_t r = 0;
   do {
@@ -187,11 +108,41 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
       s = IOError(filename_, errno);
     }
   }
-  if (use_direct_io_) {
-    // we need to fadvise away the entire range of pages because
-    // we do not want readahead pages to be cached.
-    Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
+  // we need to fadvise away the entire range of pages because
+  // we do not want readahead pages to be cached under buffered io
+  Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
+  return s;
+}
+
+Status PosixSequentialFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
+                                 char* scratch) {
+  Status s;
+  ssize_t r = -1;
+  size_t left = n;
+  char* ptr = scratch;
+  assert(UseDirectIO());
+  while (left > 0) {
+    r = pread(fd_, ptr, left, static_cast<off_t>(offset));
+    if (r <= 0) {
+      if (r == -1 && errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    ptr += r;
+    offset += r;
+    left -= r;
+    if (r % static_cast<ssize_t>(GetRequiredBufferAlignment()) != 0) {
+      // Bytes reads don't fill sectors. Should only happen at the end
+      // of the file.
+      break;
+    }
   }
+  if (r < 0) {
+    // An error: return a non-ok status
+    s = IOError(filename_, errno);
+  }
+  *result = Slice(scratch, (r < 0) ? 0 : n - left);
   return s;
 }
 
@@ -206,32 +157,15 @@ Status PosixSequentialFile::InvalidateCache(size_t offset, size_t length) {
 #ifndef OS_LINUX
   return Status::OK();
 #else
-  // free OS pages
-  int ret = Fadvise(fd_, offset, length, POSIX_FADV_DONTNEED);
-  if (ret == 0) {
-    return Status::OK();
+  if (!UseDirectIO()) {
+    // free OS pages
+    int ret = Fadvise(fd_, offset, length, POSIX_FADV_DONTNEED);
+    if (ret != 0) {
+      return IOError(filename_, errno);
+    }
   }
-  return IOError(filename_, errno);
+  return Status::OK();
 #endif
-}
-
-/*
- * PosixDirectIOSequentialFile
- */
-Status PosixDirectIOSequentialFile::Read(size_t n, Slice* result,
-                                         char* scratch) {
-  const size_t off = off_.fetch_add(n);
-  return DirectIORead(fd_, result, off, n, scratch);
-}
-
-Status PosixDirectIOSequentialFile::Skip(uint64_t n) {
-  off_ += n;
-  return Status::OK();
-}
-
-Status PosixDirectIOSequentialFile::InvalidateCache(size_t /*offset*/,
-                                                    size_t /*length*/) {
-  return Status::OK();
 }
 
 /*
@@ -295,6 +229,7 @@ size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
 PosixRandomAccessFile::PosixRandomAccessFile(const std::string& fname, int fd,
                                              const EnvOptions& options)
     : filename_(fname), fd_(fd), use_direct_io_(options.use_direct_reads) {
+  assert(!options.use_direct_reads || !options.use_mmap_reads);
   assert(!options.use_mmap_reads || sizeof(void*) < 8);
 }
 
@@ -308,9 +243,8 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
   char* ptr = scratch;
   while (left > 0) {
     r = pread(fd_, ptr, left, static_cast<off_t>(offset));
-
     if (r <= 0) {
-      if (errno == EINTR) {
+      if (r == -1 && errno == EINTR) {
         continue;
       }
       break;
@@ -318,19 +252,22 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
     ptr += r;
     offset += r;
     left -= r;
+    if (UseDirectIO() && r % static_cast<ssize_t>(GetRequiredBufferAlignment()) != 0) {
+      // Bytes reads don't fill sectors. Should only happen at the end
+      // of the file.
+      break;
+    }
   }
-
-  *result = Slice(scratch, (r < 0) ? 0 : n - left);
   if (r < 0) {
     // An error: return a non-ok status
     s = IOError(filename_, errno);
   }
-
-  if (use_direct_io_) {
+  if (!UseDirectIO()) {
     // we need to fadvise away the entire range of pages because
     // we do not want readahead pages to be cached.
     Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
   }
+  *result = Slice(scratch, (r < 0) ? 0 : n - left);
   return s;
 }
 
@@ -341,6 +278,9 @@ size_t PosixRandomAccessFile::GetUniqueId(char* id, size_t max_size) const {
 #endif
 
 void PosixRandomAccessFile::Hint(AccessPattern pattern) {
+  if (UseDirectIO()) {
+    return;
+  }
   switch (pattern) {
     case NORMAL:
       Fadvise(fd_, 0, 0, POSIX_FADV_NORMAL);
@@ -364,6 +304,9 @@ void PosixRandomAccessFile::Hint(AccessPattern pattern) {
 }
 
 Status PosixRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
+  if (UseDirectIO()) {
+    return Status::OK();
+  }
 #ifndef OS_LINUX
   return Status::OK();
 #else
@@ -374,15 +317,6 @@ Status PosixRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
   }
   return IOError(filename_, errno);
 #endif
-}
-
-/*
- * PosixDirectIORandomAccessFile
- */
-Status PosixDirectIORandomAccessFile::Read(uint64_t offset, size_t n,
-                                           Slice* result, char* scratch) const {
-  Status s = DirectIORead(fd_, result, offset, n, scratch);
-  return s;
 }
 
 /*
@@ -467,7 +401,6 @@ Status PosixMmapFile::UnmapCurrentRegion() {
 Status PosixMmapFile::MapNewRegion() {
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   assert(base_ == nullptr);
-
   TEST_KILL_RANDOM("PosixMmapFile::UnmapCurrentRegion:0", rocksdb_kill_odds);
   // we can't fallocate with FALLOC_FL_KEEP_SIZE here
   if (allow_fallocate_) {

--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -114,8 +114,8 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
   return s;
 }
 
-Status PosixSequentialFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
-                                 char* scratch) {
+Status PosixSequentialFile::PositionedRead(uint64_t offset, size_t n,
+                                           Slice* result, char* scratch) {
   Status s;
   ssize_t r = -1;
   size_t left = n;
@@ -252,7 +252,8 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
     ptr += r;
     offset += r;
     left -= r;
-    if (UseDirectIO() && r % static_cast<ssize_t>(GetRequiredBufferAlignment()) != 0) {
+    if (UseDirectIO() &&
+        r % static_cast<ssize_t>(GetRequiredBufferAlignment()) != 0) {
       // Bytes reads don't fill sectors. Should only happen at the end
       // of the file.
       break;

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -41,11 +41,7 @@ class PosixSequentialFile : public SequentialFile {
   std::string filename_;
   FILE* file_;
   int fd_;
-<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
   bool use_direct_io_;
-=======
-  bool direct_io_;
->>>>>>> fix bugs
 
  public:
   PosixSequentialFile(const std::string& fname, FILE* file, int fd,
@@ -57,11 +53,7 @@ class PosixSequentialFile : public SequentialFile {
                                 char* scratch) override;
   virtual Status Skip(uint64_t n) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
-  virtual bool UseDirectIO() const { return use_direct_io_; }
-=======
-  virtual bool UseDirectIO() const override { return direct_io_; }
->>>>>>> fix bugs
+  virtual bool UseDirectIO() const override { return use_direct_io_; }
 };
 
 class PosixRandomAccessFile : public RandomAccessFile {
@@ -82,11 +74,7 @@ class PosixRandomAccessFile : public RandomAccessFile {
 #endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
-  virtual bool UseDirectIO() const { return use_direct_io_; }
-=======
-  virtual bool UseDirectIO() const override { return direct_io_; }
->>>>>>> fix bugs
+  virtual bool UseDirectIO() const override { return use_direct_io_; }
 };
 
 class PosixWritableFile : public WritableFile {

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -41,18 +41,27 @@ class PosixSequentialFile : public SequentialFile {
   std::string filename_;
   FILE* file_;
   int fd_;
+<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
   bool use_direct_io_;
+=======
+  bool direct_io_;
+>>>>>>> fix bugs
 
  public:
-  PosixSequentialFile(const std::string& fname, FILE* file,
-                      int fd, const EnvOptions& options);
+  PosixSequentialFile(const std::string& fname, FILE* file, int fd,
+                      const EnvOptions& options);
   virtual ~PosixSequentialFile();
 
   virtual Status Read(size_t n, Slice* result, char* scratch) override;
-  virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result, char* scratch) override;
+  virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result,
+                                char* scratch) override;
   virtual Status Skip(uint64_t n) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
+<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
   virtual bool UseDirectIO() const { return use_direct_io_; }
+=======
+  virtual bool UseDirectIO() const override { return direct_io_; }
+>>>>>>> fix bugs
 };
 
 class PosixRandomAccessFile : public RandomAccessFile {
@@ -73,7 +82,11 @@ class PosixRandomAccessFile : public RandomAccessFile {
 #endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
+<<<<<<< 6ce8c34b1cc069f7e526f99bff6b15b985eb23b2
   virtual bool UseDirectIO() const { return use_direct_io_; }
+=======
+  virtual bool UseDirectIO() const override { return direct_io_; }
+>>>>>>> fix bugs
 };
 
 class PosixWritableFile : public WritableFile {

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -44,30 +44,15 @@ class PosixSequentialFile : public SequentialFile {
   bool use_direct_io_;
 
  public:
-  PosixSequentialFile(const std::string& fname, FILE* f,
-                      const EnvOptions& options);
+  PosixSequentialFile(const std::string& fname, FILE* file,
+                      int fd, const EnvOptions& options);
   virtual ~PosixSequentialFile();
 
   virtual Status Read(size_t n, Slice* result, char* scratch) override;
+  virtual Status PositionedRead(uint64_t offset, size_t n, Slice* result, char* scratch) override;
   virtual Status Skip(uint64_t n) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-};
-
-class PosixDirectIOSequentialFile : public SequentialFile {
- public:
-  explicit PosixDirectIOSequentialFile(const std::string& filename, int fd)
-      : filename_(filename), fd_(fd) {}
-
-  virtual ~PosixDirectIOSequentialFile() {}
-
-  Status Read(size_t n, Slice* result, char* scratch) override;
-  Status Skip(uint64_t n) override;
-  Status InvalidateCache(size_t offset, size_t length) override;
-
- private:
-  const std::string filename_;
-  int fd_ = -1;
-  std::atomic<size_t> off_{0};  // read offset
+  virtual bool UseDirectIO() const { return use_direct_io_; }
 };
 
 class PosixRandomAccessFile : public RandomAccessFile {
@@ -88,21 +73,7 @@ class PosixRandomAccessFile : public RandomAccessFile {
 #endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-};
-
-// Direct IO random access file direct IO implementation
-class PosixDirectIORandomAccessFile : public PosixRandomAccessFile {
- public:
-  explicit PosixDirectIORandomAccessFile(const std::string& filename, int fd)
-      : PosixRandomAccessFile(filename, fd, EnvOptions()) {}
-  virtual ~PosixDirectIORandomAccessFile() {}
-
-  Status Read(uint64_t offset, size_t n, Slice* result,
-              char* scratch) const override;
-  virtual void Hint(AccessPattern pattern) override {}
-  Status InvalidateCache(size_t offset, size_t length) override {
-    return Status::OK();
-  }
+  virtual bool UseDirectIO() const { return use_direct_io_; }
 };
 
 class PosixWritableFile : public WritableFile {


### PR DESCRIPTION
direct IO reads refactoring
remove unnecessary classes and unified interfaces
tested with db_bench

need more change for options and ON/OFF for different files.
Since disabled is default, it should be fine now