### PR TITLE
Abort compactions more reliably when closing DB

### DIFF
--- a/db/compaction_job.h
+++ b/db/compaction_job.h
@@ -57,7 +57,7 @@ class CompactionJob {
   CompactionJob(int job_id, Compaction* compaction,
                 const ImmutableDBOptions& db_options,
                 const EnvOptions& env_options, VersionSet* versions,
-                std::atomic<bool>* shutting_down, LogBuffer* log_buffer,
+                const std::atomic<bool>* shutting_down, LogBuffer* log_buffer,
                 Directory* db_directory, Directory* output_directory,
                 Statistics* stats, InstrumentedMutex* db_mutex,
                 Status* db_bg_error,
@@ -131,7 +131,7 @@ class CompactionJob {
 
   Env* env_;
   VersionSet* versions_;
-  std::atomic<bool>* shutting_down_;
+  const std::atomic<bool>* shutting_down_;
   LogBuffer* log_buffer_;
   Directory* db_directory_;
   Directory* output_directory_;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -379,6 +379,9 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname)
 void DBImpl::CancelAllBackgroundWork(bool wait) {
   InstrumentedMutexLock l(&mutex_);
 
+  Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
+      "Shutdown: canceling all background work");
+
   if (!shutting_down_.load(std::memory_order_acquire) &&
       has_unpersisted_data_ &&
       !mutable_db_options_.avoid_flush_during_shutdown) {
@@ -503,6 +506,8 @@ DBImpl::~DBImpl() {
     env_->UnlockFile(db_lock_);
   }
 
+  Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
+      "Shutdown complete");
   LogFlush(immutable_db_options_.info_log);
 }
 

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -104,6 +104,10 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
   Status s;
   bool hit_the_next_user_key = false;
   for (; iter->Valid(); iter->Next(), original_key_is_iter = false) {
+    if (IsShuttingDown()) {
+      return Status::ShutdownInProgress();
+    }
+
     ParsedInternalKey ikey;
     assert(keys_.size() == merge_context_.GetNumOperands());
 
@@ -278,10 +282,6 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
     // We haven't seen the beginning of the key nor a Put/Delete.
     // Attempt to use the user's associative merge function to
     // merge the stacked merge operands into a single operand.
-    //
-    // TODO(noetzli) The docblock of MergeUntil suggests that a successful
-    // partial merge returns Status::OK(). Should we change the status code
-    // after a successful partial merge?
     s = Status::MergeInProgress();
     if (merge_context_.GetNumOperands() >= 2 &&
         merge_context_.GetNumOperands() >= min_partial_merge_operands_) {

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -140,6 +140,12 @@ class CompactionFilter {
   //      by kRemoveAndSkipUntil can disappear from a snapshot - beware
   //      if you're using TransactionDB or DB::GetSnapshot().
   //
+  //      Another warning: if value for a key was overwritten or merged into
+  //      (multiple Put()s or Merge()s), and compaction filter skips this key
+  //      with kRemoveAndSkipUntil, it's possible that it will remove only
+  //      the new value, exposing the old value that was supposed to be
+  //      overwritten.
+  //
   //      If you use kRemoveAndSkipUntil, consider also reducing
   //      compaction_readahead_size option.
   //


### PR DESCRIPTION
DB shutdown aborts running compactions by setting an atomic shutting_down=true that CompactionJob periodically checks. Without this PR it checks it before processing every _output_ value. If compaction filter filters everything out, the compaction is uninterruptible. This PR adds checks for shutting_down on every _input_ value (in CompactionIterator and MergeHelper).

There's also some minor code cleanup along the way.