### PR TITLE
fix the TransactionLogIterator.BatchResult leak

### DIFF
--- a/java/src/main/java/org/rocksdb/TransactionLogIterator.java
+++ b/java/src/main/java/org/rocksdb/TransactionLogIterator.java
@@ -76,7 +76,7 @@ public class TransactionLogIterator extends RocksObject {
     public BatchResult(final long sequenceNumber,
         final long nativeHandle) {
       sequenceNumber_ = sequenceNumber;
-      writeBatch_ = new WriteBatch(nativeHandle);
+      writeBatch_ = new WriteBatch(nativeHandle, false);
     }
 
     /**

--- a/java/src/main/java/org/rocksdb/WriteBatch.java
+++ b/java/src/main/java/org/rocksdb/WriteBatch.java
@@ -59,8 +59,21 @@ public class WriteBatch extends AbstractWriteBatch {
    * @param nativeHandle address of native instance.
    */
   WriteBatch(final long nativeHandle) {
+    this(nativeHandle, true);
+  }
+
+  /**
+   * <p>Private WriteBatch constructor which is used to construct
+   * WriteBatch instances from C++ side. As the reference to this
+   * object is also managed from C++ side the handle will be disowned.</p>
+   *
+   * @param nativeHandle address of native instance.
+   * @param disOwn whether to own this reference from the C++ side or not
+   */
+  WriteBatch(final long nativeHandle, boolean disOwn) {
     super(nativeHandle);
-    disOwnNativeHandle();
+    if(disOwn)
+      disOwnNativeHandle();
   }
 
   @Override protected final native void disposeInternal(final long handle);


### PR DESCRIPTION
The java version of TransactionLogIterator.BatchResult has a native handle leak. The following code snippet shows the issue:
        while(true) {
        try (final TransactionLogIterator iter = db.getUpdatesSince(0)) {
          while(iter.isValid()) {
            final TransactionLogIterator.BatchResult batchResult = iter.getBatch();
            try(WriteBatch wb = batchResult.writeBatch()) {
            }
            iter.next();
          }
        }
      }
The root cause is that WriteBatch should own the handle for this case. 