### PR TITLE
More accurate error status for BackupEngine::Open

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Public API Change
 * Support dynamically change `delete_obsolete_files_period_micros` option via SetDBOptions().
 * Added EventListener::OnExternalFileIngested which will be called when IngestExternalFile() add a file successfully.
+* BackupEngine::Open and BackupEngineReadOnly::Open now always return error statuses matching those of the backup Env.
 
 ## 5.0.0 (11/17/2016)
 ### Public API Change

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -556,8 +556,10 @@ Status BackupEngineImpl::Initialize() {
   std::vector<std::string> backup_meta_files;
   {
     auto s = backup_env_->GetChildren(GetBackupMetaDir(), &backup_meta_files);
-    if (!s.ok()) {
+    if (s.IsNotFound()) {
       return Status::NotFound(GetBackupMetaDir() + " is missing");
+    } else if (!s.ok()) {
+      return s;
     }
   }
   // create backups_ structure


### PR DESCRIPTION
Summary: Some users are assuming NotFound means the backup does not
exist at the provided path, which is a reasonable assumption. We need to
stop returning NotFound for system errors.

Depends on #1644

Test Plan:

use hdfs env with a path to a non-existent directory:

```
  $ rocks_ldb restore --backup_env_uri=hdfs://redacted/ --backup_dir=asdlkfj --db=./tmp
  ...
  Failed: NotFound: asdlkfj/meta is missing
```
use hdfs env with a wrong configuration, which causes hdfs client to
fail, i.e., is a system error

```
  $ rocks_ldb restore --backup_env_uri=hdfs://redacted/ --backup_dir=asdlkfj --db=./tmp
  ...
  Failed: IO error: hdfsExists call failed with error -1
```