### PR TITLE
Add DBWithTTL::Open to C header as rocksdb_with_ttl_open

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -31,6 +31,7 @@
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/table.h"
 #include "rocksdb/rate_limiter.h"
+#include "rocksdb/utilities/db_ttl.h"
 #include "rocksdb/utilities/backupable_db.h"
 #include "utilities/merge_operators.h"
 
@@ -47,6 +48,7 @@ using rocksdb::CompressionType;
 using rocksdb::WALRecoveryMode;
 using rocksdb::DB;
 using rocksdb::DBOptions;
+using rocksdb::DBWithTTL;
 using rocksdb::Env;
 using rocksdb::EnvOptions;
 using rocksdb::InfoLogLevel;
@@ -423,6 +425,21 @@ rocksdb_t* rocksdb_open(
     char** errptr) {
   DB* db;
   if (SaveError(errptr, DB::Open(options->rep, std::string(name), &db))) {
+    return nullptr;
+  }
+  rocksdb_t* result = new rocksdb_t;
+  result->rep = db;
+  return result;
+}
+
+rocksdb_t* rocksdb_with_ttl_open(
+    const rocksdb_options_t* options,
+    const char* name,
+    int32_t ttl,
+    unsigned char read_only,
+    char** errptr) {
+  DBWithTTL* db;
+  if (SaveError(errptr, DBWithTTL::Open(options->rep, std::string(name), &db, ttl, read_only))) {
     return nullptr;
   }
   rocksdb_t* result = new rocksdb_t;

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1092,6 +1092,27 @@ int main(int argc, char** argv) {
     CheckNoError(err);
   }
 
+  StartPhase("open_with_ttl");
+  {
+    // Create database with TTL-based storage format.
+    rocksdb_close(db);
+    rocksdb_destroy_db(options, dbname, &err);
+    CheckNoError(err);
+    db = rocksdb_with_ttl_open(options, dbname, 1, 0, &err);
+    CheckNoError(err);
+
+    // Ensure basic put and get function.
+    rocksdb_put(db, woptions, "foo", 3, "hello", 5, &err);
+    CheckGet(db, roptions, "foo", "hello");
+
+    // Restore the standard storage format.
+    rocksdb_close(db);
+    rocksdb_destroy_db(options, dbname, &err);
+    CheckNoError(err);
+    db = rocksdb_open(options, dbname, &err);
+    CheckNoError(err);
+  }
+
   StartPhase("cleanup");
   rocksdb_close(db);
   rocksdb_options_destroy(options);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -116,6 +116,10 @@ typedef struct rocksdb_ratelimiter_t     rocksdb_ratelimiter_t;
 extern ROCKSDB_LIBRARY_API rocksdb_t* rocksdb_open(
     const rocksdb_options_t* options, const char* name, char** errptr);
 
+extern ROCKSDB_LIBRARY_API rocksdb_t* rocksdb_with_ttl_open(
+    const rocksdb_options_t* options, const char* name, int32_t ttl,
+    unsigned char read_only, char** errptr);
+
 extern ROCKSDB_LIBRARY_API rocksdb_t* rocksdb_open_for_read_only(
     const rocksdb_options_t* options, const char* name,
     unsigned char error_if_log_file_exist, char** errptr);


### PR DESCRIPTION
Fixes #1649. I've only added a test for the basic C-to-C++ mapping (including a sanity check of read-after-write); DBWithTTL seems to already have comprehensive tests for the internal TTL functionality.