### PR TITLE
util/logging.cc: buffer of insufficient size (gcc-7 -Werror=format-length)

### DIFF
--- a/util/logging.cc
+++ b/util/logging.cc
@@ -98,7 +98,7 @@ std::string NumberToString(uint64_t num) {
 }
 
 std::string NumberToHumanString(int64_t num) {
-  char buf[16];
+  char buf[19];
   int64_t absnum = num < 0 ? -num : num;
   if (absnum < 10000) {
     snprintf(buf, sizeof(buf), "%" PRIi64, num);


### PR DESCRIPTION
util/logging.cc:100:13: error: output may be truncated before the last format character [-Werror=format-length=]
 std::string NumberToHumanString(int64_t num) {
             ^~~~~~~~~~~~~~~~~~~
util/logging.cc:106:59: note: format output between 3 and 19 bytes into a destination of size 16
     snprintf(buf, sizeof(buf), "%" PRIi64 "K", num / 1000);
