### PR TITLE
intentional fallthough (prevents gcc-7/clang-4 error)

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -735,6 +735,7 @@ void MemTable::Update(SequenceNumber seq,
             return;
           }
         }
+	// fallthrough
         default:
           // If the latest value is kTypeDeletion, kTypeMerge or kTypeLogData
           // we don't have enough space for update inplace


### PR DESCRIPTION
db/memtable.cc: In member function 'void rocksdb::MemTable::Update(rocksdb::SequenceNumber, const rocksdb::Slice&, const rocksdb::Slice&)':
db/memtable.cc:736:11: error: this statement may fall through [-Werror=implicit-fallthrough=]
           }
           ^
db/memtable.cc:738:9: note: here
         default:
         ^~~~~~~
cc1plus: all warnings being treated as errors

closes #1650