### PR TITLE
gcc-7 requires include <functional> for std::function

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -7,6 +7,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <functional>
+
 #include "db/db_test_util.h"
 #include "port/port.h"
 #include "port/stack_trace.h"

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -3,6 +3,8 @@
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
 
+#include <functional>
+
 #include "db/db_test_util.h"
 #include "port/port.h"
 #include "port/stack_trace.h"

--- a/db/file_indexer.cc
+++ b/db/file_indexer.cc
@@ -9,8 +9,9 @@
 
 #include "db/file_indexer.h"
 #include <algorithm>
-#include "rocksdb/comparator.h"
+#include <functional>
 #include "db/version_edit.h"
+#include "rocksdb/comparator.h"
 
 namespace rocksdb {
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <set>
 #include <thread>
 #include <unordered_map>

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -5,6 +5,7 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <cstdarg>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <string>

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -11,6 +11,7 @@
 #define JAVA_ROCKSJNI_PORTAL_H_
 
 #include <jni.h>
+#include <functional>
 #include <limits>
 #include <string>
 #include <vector>

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -9,11 +9,12 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <algorithm>
+#include <functional>
 #include <memory>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <algorithm>
 
 #include "include/org_rocksdb_RocksDB.h"
 #include "rocksdb/cache.h"

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -34,12 +34,13 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
+#include <functional>
 #include <iostream>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <fstream>
 
 namespace rocksdb {
 

--- a/util/dynamic_bloom_test.cc
+++ b/util/dynamic_bloom_test.cc
@@ -15,13 +15,14 @@ int main() {
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include <gflags/gflags.h>
 #include <inttypes.h>
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <thread>
 #include <vector>
-#include <gflags/gflags.h>
 
 #include "dynamic_bloom.h"
 #include "port/port.h"

--- a/util/fault_injection_test_env.cc
+++ b/util/fault_injection_test_env.cc
@@ -12,6 +12,7 @@
 // file data (or entire files) not protected by a "sync".
 
 #include "util/fault_injection_test_env.h"
+#include <functional>
 #include <utility>
 
 namespace rocksdb {

--- a/util/sync_point.cc
+++ b/util/sync_point.cc
@@ -4,6 +4,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 
 #include "util/sync_point.h"
+#include <functional>
 #include <thread>
 #include "port/port.h"
 #include "util/random.h"

--- a/util/sync_point.h
+++ b/util/sync_point.h
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/util/thread_local.h
+++ b/util/thread_local.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/util/xfunc.h
+++ b/util/xfunc.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <functional>
 #include <string>
 
 #include "rocksdb/options.h"

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <future>
 #include <limits>
 #include <map>

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -9,6 +9,7 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
+#include <functional>
 #include <memory>
 #include <vector>
 

--- a/utilities/persistent_cache/hash_table_evictable.h
+++ b/utilities/persistent_cache/hash_table_evictable.h
@@ -7,6 +7,8 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <functional>
+
 #include "util/random.h"
 #include "utilities/persistent_cache/hash_table.h"
 #include "utilities/persistent_cache/lrulist.h"

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -5,6 +5,7 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <functional>
 #include <string>
 #include <thread>
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -6,6 +6,7 @@
 #ifndef ROCKSDB_LITE
 
 #include <algorithm>
+#include <functional>
 #include <string>
 #include <thread>
 


### PR DESCRIPTION
Fixes compile error:

In file included from ./util/statistics.h:17:0,
                 from ./util/stop_watch.h:8,
                 from ./util/perf_step_timer.h:9,
                 from ./util/iostats_context_imp.h:8,
                 from ./util/posix_logger.h:27,
                 from ./port/util_logger.h:18,
                 from ./db/auto_roll_logger.h:15,
                 from db/auto_roll_logger.cc:6:
./util/thread_local.h:65:16: error: 'function' in namespace 'std' does not name a template type
   typedef std::function<void(void*, void*)> FoldFunc;