### PR TITLE
DBWithTTL: Support explicit expiration times

### DIFF
--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -43,6 +43,10 @@ class DBWithTTLImpl : public DBWithTTL {
                             const std::string& column_family_name,
                             ColumnFamilyHandle** handle) override;
 
+  Status PutWithExpiration(const WriteOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     const Slice& val, int32_t exptime);
+
   using StackableDB::Put;
   virtual Status Put(const WriteOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
@@ -66,11 +70,17 @@ class DBWithTTLImpl : public DBWithTTL {
                            std::string* value,
                            bool* value_found = nullptr) override;
 
+  Status MergeWithExpiration(const WriteOptions& options,
+                       ColumnFamilyHandle* column_family, const Slice& key,
+                       const Slice& value, int32_t exptime);
+
   using StackableDB::Merge;
   virtual Status Merge(const WriteOptions& options,
                        ColumnFamilyHandle* column_family, const Slice& key,
                        const Slice& value) override;
 
+  Status WriteWithExpiration(const WriteOptions& opts, WriteBatch* updates,
+			     int32_t expiration_time);
   virtual Status Write(const WriteOptions& opts, WriteBatch* updates) override;
 
   using StackableDB::NewIterator;
@@ -81,7 +91,8 @@ class DBWithTTLImpl : public DBWithTTL {
 
   static bool IsStale(const Slice& value, int32_t ttl, Env* env);
 
-  static Status AppendTS(const Slice& val, std::string* val_with_ts, Env* env);
+  static Status AppendExpiration(const Slice& val, std::string* val_with_ts,
+				 Env* env, int32_t exptime);
 
   static Status SanityCheckTimestamp(const Slice& str);
 


### PR DESCRIPTION
Addresses the C++ part of #1651.

This PR changes the semantics of the timestamp appended to entries to consider them expiration times. Combined with treating the CF/DB opening TTL as a "grace TTL," we can preserve backwards compatibility for the API and on-disk data.

For the new functions, I went with an explicit expiration instead of a TTL because runtimes like PHP have a set request time that many frameworks like to use as the base timestamp for all things generated in the request. This is both more predictable and faster (fewer syscalls).

This approach satisfies the existing use case as well as two new ones:

 * Users of the existing API won't notice any change. Assuming we make my suggested terminology changes, their writes will be "expired" immediately but retained for the grace period specified at the DB/CF level. This is only a change to terminology, not behavior.
 * Users who only want per-item expirations can open the DB/CF with (grace) TTL=1 and mostly rely on entry expirations. Because `DBWithTTL` never promises any time bound on removal of expired items, an extra second of retention won't affect use.
 * Users who want per-item TTLs but retention after expiration can use both explicit expirations at write time and a grace TTL for the DB/CF. This helps the Drupal cache case of reads with a flag that allows returning expired results.

Questions:

 * Are folks okay with changing the terminology to be based on expirations and grace times? I'm thinking the current `int32_t ttl` in `DBWithTTL::Open` would become `int32_t grace_ttl`. I think this more effectively conveys how behavior will change if you open the DB with different grace TTLs at different times.
 * Are the current PR's `WithExpiration` variants preferred, or should I update it to pick based on parameter types (while using the same method names)?

Outstanding tasks:

- [ ] Add unit tests for explicit expirations
- [ ] Fix language consistency: move to "expirations" and "grace TTL."
- [ ] C bindings (probably in a new PR after this lands)
- [ ] Update the wiki: https://github.com/facebook/rocksdb/wiki/Time-to-Live