### PR TITLE
util/histogram.cc: HistogramStat::toString buffer insufficient

### DIFF
--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -189,7 +189,7 @@ double HistogramStat::StandardDeviation() const {
 std::string HistogramStat::ToString() const {
   uint64_t cur_num = num();
   std::string r;
-  char buf[200];
+  char buf[1650];
   snprintf(buf, sizeof(buf),
            "Count: %" PRIu64 " Average: %.4f  StdDev: %.2f\n",
            cur_num, Average(), StandardDeviation());


### PR DESCRIPTION
Increased buffer size to 1650.

util/histogram.cc: In member function 'std::__cxx11::string rocksdb::HistogramStat::ToString() const':
util/histogram.cc:189:13: error: '%.2f' directive output truncated writing between 4 and 313 bytes into a region of size 0 [-Werror=format-length=]
 std::string HistogramStat::ToString() const {
             ^~~~~~~~~~~~~
util/histogram.cc:205:30: note: format output between 69 and 1614 bytes into a destination of size 200
            Percentile(99.99));
                              ^
cc1plus: all warnings being treated as errors
Makefile:1521: recipe for target 'util/histogram.o' failed