### PR TITLE
Missing break in case in DBTestBase::CurrentOptions

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -307,6 +307,7 @@ Options DBTestBase::CurrentOptions(
       break;
     case kManifestFileSize:
       options.max_manifest_file_size = 50;  // 50 bytes
+      break;
     case kPerfOptions:
       options.soft_rate_limit = 2.0;
       options.delayed_write_rate = 8 * 1024 * 1024;


### PR DESCRIPTION
Found by gcc-7 compile error.

This appeared to be a fault as these options seems too different.