### PR TITLE
[Fix #591] Add missing copyright header

### DIFF
--- a/examples/c_simple_example.c
+++ b/examples/c_simple_example.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/examples/simple_example.cc
+++ b/examples/simple_example.cc
@@ -2,6 +2,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+
 #include <cstdio>
 #include <string>
 


### PR DESCRIPTION
"examples/c_simple_example.c" did not have a proper copyright header.