### PR TITLE
std::remove_if requires <algorithm>

### DIFF
--- a/util/env_basic_test.cc
+++ b/util/env_basic_test.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "rocksdb/env.h"
 #include "rocksdb/utilities/env_registry.h"


### PR DESCRIPTION
fixes error (that occurred on gcc-7):

error:

util/env_basic_test.cc: In member function 'virtual rocksdb::Status rocksdb::NormalizingEnvWrapper::GetChildren(const string&, std::vector<std::__cxx11::basic_string<char> >*)':
util/env_basic_test.cc:27:21: error: 'remove_if' is not a member of 'std'
       result->erase(std::remove_if(result->begin(), result->end(),
                     ^~~