### PR TITLE
add column family support for TxLog iteration

### DIFF
--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -395,6 +395,46 @@ class WriteBatchHandlerJni : public RocksDBNativeClass<
     assert(mid != nullptr);
     return mid;
   }
+
+  // Get the java method `singleDelete` of org.rocksdb.WriteBatch.Handler.
+  static jmethodID getSingleDeleteMethodId(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getJClass(env), "singleDelete", "([B)V");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+  // Get the java method `put` of org.rocksdb.WriteBatch.Handler.
+  static jmethodID getPutCFMethodId(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getJClass(env), "put", "(I[B[B)V");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+  // Get the java method `merge` of org.rocksdb.WriteBatch.Handler.
+  static jmethodID getMergeCFMethodId(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getJClass(env), "merge", "(I[B[B)V");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+  // Get the java method `delete` of org.rocksdb.WriteBatch.Handler.
+  static jmethodID getDeleteCFMethodId(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getJClass(env), "delete", "(I[B)V");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+  // Get the java method `singleDelete` of org.rocksdb.WriteBatch.Handler.
+  static jmethodID getSingleDeleteCFMethodId(JNIEnv* env) {
+    static jmethodID mid = env->GetMethodID(
+        getJClass(env), "singleDelete", "(I[B)V");
+    assert(mid != nullptr);
+    return mid;
+  }
 };
 
 // The portal class for org.rocksdb.WriteBatchWithIndex

--- a/java/rocksjni/writebatchhandlerjnicallback.h
+++ b/java/rocksjni/writebatchhandlerjnicallback.h
@@ -30,6 +30,13 @@ class WriteBatchHandlerJniCallback : public WriteBatch::Handler {
     void Delete(const Slice& key);
     void LogData(const Slice& blob);
     bool Continue();
+    void SingleDelete(const Slice& key);
+    Status PutCF(uint32_t column_family_id, const Slice& key,
+                 const Slice& value);
+    Status DeleteCF(uint32_t column_family_id, const Slice& key);
+    Status MergeCF(uint32_t column_family_id, const Slice& key,
+                   const Slice& value);
+    Status SingleDeleteCF(uint32_t column_family_id, const Slice& key);
 
  private:
     JNIEnv* m_env;
@@ -40,6 +47,11 @@ class WriteBatchHandlerJniCallback : public WriteBatch::Handler {
     jmethodID m_jDeleteMethodId;
     jmethodID m_jLogDataMethodId;
     jmethodID m_jContinueMethodId;
+    jmethodID m_jPutCFMethodId;
+    jmethodID m_jMergeCFMethodId;
+    jmethodID m_jDeleteCFMethodId;
+    jmethodID m_jSingleDeleteMethodId;
+    jmethodID m_jSingleDeleteCFMethodId;
 };
 }  // namespace rocksdb
 

--- a/java/src/main/java/org/rocksdb/WriteBatch.java
+++ b/java/src/main/java/org/rocksdb/WriteBatch.java
@@ -106,6 +106,12 @@ public class WriteBatch extends AbstractWriteBatch {
     public abstract void delete(byte[] key);
     public abstract void logData(byte[] blob);
 
+    public void singleDelete(byte[] key) {}
+    public void singleDelete(int columnFamilyID, byte[] key) {}
+    public void put(int columnFamilyID, byte[] key, byte[] value) {}
+    public void merge(int columnFamilyID, byte[] key, byte[] value) {}
+    public void delete(int columnFamilyID, byte[] key) {}
+
     /**
      * shouldContinue is called by the underlying iterator
      * WriteBatch::Iterate. If it returns false,


### PR DESCRIPTION
"From Dhruba Borthakur: WriterBatch handler does not expose the column family. If you can make a patch for it and contribute it back to the rocksdb repository, that would be fantastic!" 

This adds some of the supported callbacks from the C++ side. I made the new callback methods non-abstract for backwards compatibility. 