### PR TITLE
"make format" format diff since last commit from master

### DIFF
--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -50,14 +50,15 @@ fi
 set -e
 
 uncommitted_code=`git diff HEAD`
+LAST_MASTER=`git merge-base master HEAD`
 
 # If there's no uncommitted changes, we assume user are doing post-commit
-# format check, in which case we'll check the modified lines from latest commit.
-# Otherwise, we'll check format of the uncommitted code only.
+# format check, in which case we'll check the modified lines since last commit
+# from master. Otherwise, we'll check format of the uncommitted code only.
 if [ -z "$uncommitted_code" ]
 then
   # Check the format of last commit
-  diffs=$(git diff -U0 HEAD^ | $CLANG_FORMAT_DIFF -p 1)
+  diffs=$(git diff -U0 $LAST_MASTER^ | $CLANG_FORMAT_DIFF -p 1)
 else
   # Check the format of uncommitted lines,
   diffs=$(git diff -U0 HEAD | $CLANG_FORMAT_DIFF -p 1)
@@ -97,7 +98,12 @@ then
 fi
 
 # Do in-place format adjustment.
-git diff -U0 HEAD^ | $CLANG_FORMAT_DIFF -i -p 1
+if [ -z "$uncommitted_code" ]
+then
+  git diff -U0 $LAST_MASTER^ | $CLANG_FORMAT_DIFF -i -p 1
+else
+  git diff -U0 HEAD^ | $CLANG_FORMAT_DIFF -i -p 1
+fi
 echo "Files reformatted!"
 
 # Amend to last commit if user do the post-commit format check


### PR DESCRIPTION
Summary:
Update clang-format script to format diff since last commit from master,
instead of just last commit. In our common workflow we usually endup
with multiple commits for a single PR. This change make it easier to
format all stacking changes.

Test Plan:
test locally.