### PR TITLE
The array is malloced by backtrace_symbols(), and must be freed

### DIFF
--- a/port/stack_trace.cc
+++ b/port/stack_trace.cc
@@ -110,6 +110,7 @@ void PrintStack(int first_frames_to_skip) {
     fprintf(stderr, "#%-2d  ", i - first_frames_to_skip);
     PrintStackTraceLine((symbols != nullptr) ? symbols[i] : nullptr, frames[i]);
   }
+  free(symbols);
 }
 
 static void StackTraceHandler(int sig) {


### PR DESCRIPTION
The address of the array of string pointers is returned as the function result of backtrace_symbols().  This array is malloced by backtrace_symbols(), and must be freed by the caller.