### PR TITLE
Show sandcastle URL in phabricator

### DIFF
--- a/arcanist_util/config/RocksDBCommonHelper.php
+++ b/arcanist_util/config/RocksDBCommonHelper.php
@@ -21,7 +21,7 @@ function postURL($diffID, $url) {
   assert(is_numeric($diffID));
   assert(strlen($url) > 0);
 
-  $cmd = 'echo \'{"diff_id": "' . $diffID . '", '
+  $cmd = 'echo \'{"diff_id": ' . $diffID . ', '
          . '"name":"click here for sandcastle tests for D' . $diffID . '", '
          . '"link":"' . $url . '"}\' | '
          . 'arc call-conduit '

--- a/arcanist_util/config/RocksDBCommonHelper.php
+++ b/arcanist_util/config/RocksDBCommonHelper.php
@@ -35,7 +35,7 @@ function buildUpdateTestStatusCmd($diffID, $test, $status) {
   assert(strlen($test) > 0);
   assert(strlen($status) > 0);
 
-  $cmd = 'echo \'{"diff_id": "' . $diffID . '", '
+  $cmd = 'echo \'{"diff_id": ' . $diffID . ', '
          . '"name":"' . $test . '", '
          . '"result":"' . $status . '"}\' | '
          . 'arc call-conduit '


### PR DESCRIPTION
We are passing a string as diff_id which make conduit call fail

```
$ echo '{"diff_id": "20982117", "name":"click here for sandcastle tests for D20982117", "link":"https://our.intern.facebook.com/intern/sandcastle/1984718793/"}' | arc call-conduit differential.updateunitresults
{"error":"ERR-CONDUIT-CORE","errorMessage":"ERR-CONDUIT-CORE: Argument 1 passed to EntDiffPropertiesUpdateMutationBuilder::setDiffNumber() must be an instance of int, string given","response":null}
```

fix it by removing double quotes