### PR TITLE
Print cache options to info log

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 #include <memory>
+#include <string>
 #include "rocksdb/slice.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
@@ -166,6 +167,8 @@ class Cache {
   // Remove all entries.
   // Prerequisit: no entry is referenced.
   virtual void EraseUnRefEntries() = 0;
+
+  virtual std::string GetPrintableOptions() const { return ""; }
 
  private:
   // No copying allowed

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -116,6 +116,10 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
            table_options_.cache_index_and_filter_blocks);
   ret.append(buffer);
   snprintf(buffer, kBufferSize,
+           "  cache_index_and_filter_blocks_with_high_priority: %d\n",
+           table_options_.cache_index_and_filter_blocks_with_high_priority);
+  ret.append(buffer);
+  snprintf(buffer, kBufferSize,
            "  pin_l0_filter_and_index_blocks_in_cache: %d\n",
            table_options_.pin_l0_filter_and_index_blocks_in_cache);
   ret.append(buffer);
@@ -135,9 +139,28 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
            static_cast<void*>(table_options_.block_cache.get()));
   ret.append(buffer);
   if (table_options_.block_cache) {
-    snprintf(buffer, kBufferSize, "  block_cache_size: %" ROCKSDB_PRIszt "\n",
-             table_options_.block_cache->GetCapacity());
-    ret.append(buffer);
+    const char* block_cache_name = table_options_.block_cache->Name();
+    if (block_cache_name != nullptr) {
+      snprintf(buffer, kBufferSize, "  block_cache_name: %s\n",
+               block_cache_name);
+      ret.append(buffer);
+    }
+    ret.append("  block_cache_options:\n");
+    ret.append(table_options_.block_cache->GetPrintableOptions());
+  }
+  snprintf(buffer, kBufferSize, "  block_cache_compressed: %p\n",
+           static_cast<void*>(table_options_.block_cache_compressed.get()));
+  ret.append(buffer);
+  if (table_options_.block_cache_compressed) {
+    const char* block_cache_compressed_name =
+        table_options_.block_cache_compressed->Name();
+    if (block_cache_compressed_name != nullptr) {
+      snprintf(buffer, kBufferSize, "  block_cache_name: %s\n",
+               block_cache_compressed_name);
+      ret.append(buffer);
+    }
+    ret.append("  block_cache_compressed_options:\n");
+    ret.append(table_options_.block_cache_compressed->GetPrintableOptions());
   }
   snprintf(buffer, kBufferSize, "  persistent_cache: %p\n",
            static_cast<void*>(table_options_.persistent_cache.get()));
@@ -146,15 +169,6 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
     snprintf(buffer, kBufferSize, "  persistent_cache_options:\n");
     ret.append(buffer);
     ret.append(table_options_.persistent_cache->GetPrintableOptions());
-  }
-  snprintf(buffer, kBufferSize, "  block_cache_compressed: %p\n",
-           static_cast<void*>(table_options_.block_cache_compressed.get()));
-  ret.append(buffer);
-  if (table_options_.block_cache_compressed) {
-    snprintf(buffer, kBufferSize,
-             "  block_cache_compressed_size: %" ROCKSDB_PRIszt "\n",
-             table_options_.block_cache_compressed->GetCapacity());
-    ret.append(buffer);
   }
   snprintf(buffer, kBufferSize, "  block_size: %" ROCKSDB_PRIszt "\n",
            table_options_.block_size);

--- a/util/clock_cache.cc
+++ b/util/clock_cache.cc
@@ -11,6 +11,10 @@
 
 #ifndef SUPPORT_CLOCK_CACHE
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 namespace rocksdb {
 
 std::shared_ptr<Cache> NewClockCache(size_t capacity, int num_shard_bits,

--- a/util/clock_cache.cc
+++ b/util/clock_cache.cc
@@ -11,10 +11,6 @@
 
 #ifndef SUPPORT_CLOCK_CACHE
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 namespace rocksdb {
 
 std::shared_ptr<Cache> NewClockCache(size_t capacity, int num_shard_bits,

--- a/util/lru_cache.cc
+++ b/util/lru_cache.cc
@@ -7,6 +7,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "util/lru_cache.h"
 
 #include <assert.h>
@@ -406,6 +410,17 @@ size_t LRUCacheShard::GetPinnedUsage() const {
   MutexLock l(&mutex_);
   assert(usage_ >= lru_usage_);
   return usage_ - lru_usage_;
+}
+
+std::string LRUCacheShard::GetPrintableOptions() const {
+  const int kBufferSize = 200;
+  char buffer[kBufferSize];
+  {
+    MutexLock l(&mutex_);
+    snprintf(buffer, kBufferSize, "    high_pri_pool_ratio: %.3lf\n",
+             high_pri_pool_ratio_);
+  }
+  return std::string(buffer);
 }
 
 LRUCache::LRUCache(size_t capacity, int num_shard_bits,

--- a/util/lru_cache.cc
+++ b/util/lru_cache.cc
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 
 #include "util/mutexlock.h"
 

--- a/util/lru_cache.h
+++ b/util/lru_cache.h
@@ -8,6 +8,8 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
 
+#include <string>
+
 #include "util/sharded_cache.h"
 
 #include "port/port.h"

--- a/util/lru_cache.h
+++ b/util/lru_cache.h
@@ -190,6 +190,8 @@ class LRUCacheShard : public CacheShard {
 
   virtual void EraseUnRefEntries() override;
 
+  virtual std::string GetPrintableOptions() const override;
+
   void TEST_GetLRUList(LRUHandle** lru, LRUHandle** lru_low_pri);
 
  private:

--- a/util/sharded_cache.cc
+++ b/util/sharded_cache.cc
@@ -12,6 +12,9 @@
 #endif
 
 #include "util/sharded_cache.h"
+
+#include <string>
+
 #include "util/mutexlock.h"
 
 namespace rocksdb {

--- a/util/sharded_cache.cc
+++ b/util/sharded_cache.cc
@@ -7,6 +7,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "util/sharded_cache.h"
 #include "util/mutexlock.h"
 
@@ -112,6 +116,26 @@ void ShardedCache::EraseUnRefEntries() {
   for (int s = 0; s < num_shards; s++) {
     GetShard(s)->EraseUnRefEntries();
   }
+}
+
+std::string ShardedCache::GetPrintableOptions() const {
+  std::string ret;
+  ret.reserve(20000);
+  const int kBufferSize = 200;
+  char buffer[kBufferSize];
+  {
+    MutexLock l(&capacity_mutex_);
+    snprintf(buffer, kBufferSize, "    capacity : %" ROCKSDB_PRIszt "\n",
+             capacity_);
+    ret.append(buffer);
+    snprintf(buffer, kBufferSize, "    num_shard_bits : %d\n", num_shard_bits_);
+    ret.append(buffer);
+    snprintf(buffer, kBufferSize, "    strict_capacity_limit : %d\n",
+             strict_capacity_limit_);
+    ret.append(buffer);
+  }
+  ret.append(GetShard(0)->GetPrintableOptions());
+  return ret;
 }
 
 }  // namespace rocksdb

--- a/util/sharded_cache.h
+++ b/util/sharded_cache.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <atomic>
+#include <string>
 
 #include "port/port.h"
 #include "rocksdb/cache.h"

--- a/util/sharded_cache.h
+++ b/util/sharded_cache.h
@@ -37,6 +37,7 @@ class CacheShard {
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) = 0;
   virtual void EraseUnRefEntries() = 0;
+  virtual std::string GetPrintableOptions() const { return ""; }
 };
 
 // Generic cache interface which shards cache by hash of keys. 2^num_shard_bits
@@ -72,6 +73,7 @@ class ShardedCache : public Cache {
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) override;
   virtual void EraseUnRefEntries() override;
+  virtual std::string GetPrintableOptions() const override;
 
  private:
   static inline uint32_t HashSlice(const Slice& s) {

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -144,6 +144,16 @@ class SimCacheImpl : public SimCache {
     return res;
   }
 
+  virtual std::string GetPrintableOptions() const override {
+    std::string ret;
+    ret.reserve(20000);
+    ret.append("    cache_options:\n");
+    ret.append(cache_->GetPrintableOptions());
+    ret.append("    sim_cache_options:\n");
+    ret.append(key_only_cache_->GetPrintableOptions());
+    return ret;
+  }
+
  private:
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> key_only_cache_;


### PR DESCRIPTION
Summary:
Improve cache options logging to info log.
Also print the value of
cache_index_and_filter_blocks_with_high_priority.

Test Plan:
Test locally. Sample output:
https://gist.github.com/yiwu-arbug/15d86fdadcc933a652bdea8ff5c31bf8