### PR TITLE
Enable conditionally using adaptive mutexes

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -90,7 +90,19 @@ class CondVar;
 
 class Mutex {
  public:
-  /* implicit */ Mutex(bool adaptive = false);
+// We want to give users opportunity to default all the mutexes to adaptive if
+// not specified otherwise. This enables a quick way to conduct various
+// performance related experiements.
+//
+// NB! Support for adaptive mutexes is turned on by definining
+// ROCKSDB_PTHREAD_ADAPTIVE_MUTEX during the compilation. If you use RocksDB
+// build environment then this happens automatically; otherwise it's up to the
+// consumer to define the identifier.
+#ifdef ROCKSDB_DEFAULT_TO_ADAPTIVE_MUTEX
+  explicit Mutex(bool adaptive = true);
+#else
+  explicit Mutex(bool adaptive = false);
+#endif
   ~Mutex();
 
   void Lock();


### PR DESCRIPTION
To support scenarios where we want all instances of `Mutex` be adaptive
we're adding a conditional `#define` so that the desired behavior can be
easily enabled.