### PR TITLE
Fix rocksdb::Status::getState

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -205,18 +205,8 @@ TEST_F(DBTest, OpenWhenOpen) {
 
   ASSERT_EQ(Status::Code::kIOError, s.code());
   ASSERT_EQ(Status::SubCode::kNone, s.subcode());
+  ASSERT_TRUE(strncmp("lock ", s.getState(), 5) == 0);
 
-  const char* const state = s.getState();
-  const size_t size_len = sizeof(uint32_t);
-  uint32_t* size = new uint32_t();
-  memcpy(size, state, size_len);
-  char* const msg = new char[*size];
-  memcpy(msg, state + size_len, *size);
-
-  ASSERT_TRUE(strncmp("lock ", msg, 5) == 0);
-
-  delete [] msg;
-  delete size;
   delete db2;
 }
 

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -75,10 +75,7 @@ class Status {
 
   SubCode subcode() const { return subcode_; }
 
-  // Returns a string indicating the message of the Status
-  // The first sizeof(uint32_t) bytes are the length of the string followed by
-  // the string characters themselves. The size is given because the string
-  // is not null terminated.
+  // Returns a C style string indicating the message of the Status
   const char* getState() const { return state_; }
 
   // Return a success status.

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -75,6 +75,10 @@ class Status {
 
   SubCode subcode() const { return subcode_; }
 
+  // Returns a string indicating the message of the Status
+  // The first sizeof(uint32_t) bytes are the length of the string followed by
+  // the string characters themselves. The size is given because the string
+  // is not null terminated.
   const char* getState() const { return state_; }
 
   // Return a success status.

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -121,15 +121,7 @@ class StatusJni : public RocksDBNativeClass<rocksdb::Status*, StatusJni> {
     jstring jstate = nullptr;
     if (status.getState() != nullptr) {
       const char* const state = status.getState();
-      const size_t size_len = sizeof(uint32_t);
-      uint32_t* size = new uint32_t();
-      memcpy(size, state, size_len);
-      char* const msg = new char[*size + 1];  // +1 for the null terminator
-      memcpy(msg, state + size_len, *size);
-      msg[*size] = '\0';  // add null terminator
-      jstate = env->NewStringUTF(msg);
-      delete [] msg;
-      delete size;
+      jstate = env->NewStringUTF(state);
     }
     return env->NewObject(getJClass(env), mid, toJavaStatusCode(status.code()),
                           toJavaStatusSubCode(status.subcode()), jstate);

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -120,8 +120,16 @@ class StatusJni : public RocksDBNativeClass<rocksdb::Status*, StatusJni> {
 
     jstring jstate = nullptr;
     if (status.getState() != nullptr) {
-      std::string s(status.getState());
-      jstate = env->NewStringUTF(s.c_str());
+      const char* const state = status.getState();
+      const size_t size_len = sizeof(uint32_t);
+      uint32_t* size = new uint32_t();
+      memcpy(size, state, size_len);
+      char* const msg = new char[*size + 1];  // +1 for the null terminator
+      memcpy(msg, state + size_len, *size);
+      msg[*size] = '\0';  // add null terminator
+      jstate = env->NewStringUTF(msg);
+      delete [] msg;
+      delete size;
     }
     return env->NewObject(getJClass(env), mid, toJavaStatusCode(status.code()),
                           toJavaStatusSubCode(status.subcode()), jstate);

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class RocksDBTest {
 
@@ -39,6 +40,21 @@ public class RocksDBTest {
          final RocksDB db = RocksDB.open(opt,
              dbFolder.getRoot().getAbsolutePath())) {
       assertThat(db).isNotNull();
+    }
+  }
+
+  @Test
+  public void openWhenOpen() throws RocksDBException {
+    final String dbPath = dbFolder.getRoot().getAbsolutePath();
+
+    try(final RocksDB db1 = RocksDB.open(dbPath)) {
+      try(final RocksDB db2 = RocksDB.open(dbPath)) {
+        fail("Should have thrown an exception when opening the same db twice");
+      } catch(final RocksDBException e) {
+        assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.IOError);
+        assertThat(e.getStatus().getSubCode()).isEqualTo(Status.SubCode.None);
+        assertThat(e.getStatus().getState()).startsWith("lock ");
+      }
     }
   }
 

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -47,10 +47,10 @@ public class RocksDBTest {
   public void openWhenOpen() throws RocksDBException {
     final String dbPath = dbFolder.getRoot().getAbsolutePath();
 
-    try(final RocksDB db1 = RocksDB.open(dbPath)) {
-      try(final RocksDB db2 = RocksDB.open(dbPath)) {
+    try (final RocksDB db1 = RocksDB.open(dbPath)) {
+      try (final RocksDB db2 = RocksDB.open(dbPath)) {
         fail("Should have thrown an exception when opening the same db twice");
-      } catch(final RocksDBException e) {
+      } catch (final RocksDBException e) {
         assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.IOError);
         assertThat(e.getStatus().getSubCode()).isEqualTo(Status.SubCode.None);
         assertThat(e.getStatus().getState()).startsWith("lock ");

--- a/util/status.cc
+++ b/util/status.cc
@@ -28,13 +28,14 @@ Status::Status(Code _code, SubCode _subcode, const Slice& msg, const Slice& msg2
   const uint32_t len1 = static_cast<uint32_t>(msg.size());
   const uint32_t len2 = static_cast<uint32_t>(msg2.size());
   const uint32_t size = len1 + (len2 ? (2 + len2) : 0);
-  char* result = new char[size + 4];
-  memcpy(result, &size, sizeof(size));
-  memcpy(result + 4, msg.data(), len1);
+  const size_t size_len = sizeof(size);
+  char* const result = new char[size_len + size];
+  memcpy(result, &size, size_len);
+  memcpy(result + size_len, msg.data(), len1);
   if (len2) {
-    result[4 + len1] = ':';
-    result[5 + len1] = ' ';
-    memcpy(result + 6 + len1, msg2.data(), len2);
+    result[size_len + len1] = ':';
+    result[size_len + 1 + len1] = ' ';
+    memcpy(result + size_len + 2 + len1, msg2.data(), len2);
   }
   state_ = result;
 }

--- a/util/status.cc
+++ b/util/status.cc
@@ -7,15 +7,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include "rocksdb/status.h"
 #include <stdio.h>
 #include <cstring>
 #include "port/port.h"
-#include "rocksdb/status.h"
 
 namespace rocksdb {
 
 const char* Status::CopyState(const char* state) {
-  char* const result = new char[std::strlen(state) + 1];  // +1 for the null terminator
+  char* const result =
+      new char[std::strlen(state) + 1];  // +1 for the null terminator
   std::strcpy(result, state);
   return result;
 }


### PR DESCRIPTION
This fixes the Java API for Status#getState use in Native code and also simplifies the implementation of rocksdb::Status::getState.
Closes https://github.com/facebook/rocksdb/issues/1688