### PR TITLE
include/rocksdb/utilities/env_librados: fix typo

### DIFF
--- a/include/rocksdb/utilities/env_librados.h
+++ b/include/rocksdb/utilities/env_librados.h
@@ -71,7 +71,7 @@ class EnvLibrados : public EnvWrapper {
   //                  the calling process does not have permission to determine
   //                  whether this file exists, or if the path is invalid.
   //         IOError if an IO Error was encountered
-  Status FileExists(const std::string& fname) overrdie;
+  Status FileExists(const std::string& fname) override;
 
   // Store in *result the names of the children of the specified directory.
   // The names are relative to "dir".


### PR DESCRIPTION
Broken by 972f96b3fbae1a4675043bdf4279c9072ad69645

Signed-off-by: Sage Weil <sage@redhat.com>