### PR TITLE
Fix std::out_of_range when DBOptions::keep_log_file_num is zero

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -268,6 +268,10 @@ static Status ValidateOptions(
         "then direct I/O writes (use_direct_writes) must be disabled. ");
   }
 
+  if (db_options.keep_log_file_num == 0) {
+    return Status::InvalidArgument("keep_log_file_num must be greater than 0");
+  }
+
   return Status::OK();
 }
 


### PR DESCRIPTION
We should validate this option, otherwise we may see
std::out_of_range thrown at: db/db_impl.cc:1124

1123     for (unsigned int i = 0; i <= end; i++) {
1124       std::string& to_delete = old_info_log_files.at(i);
1125       std::string full_path_to_delete =
1126           (immutable_db_options_.db_log_dir.empty()