### PR TITLE
db/pinned_iterators_manager.h: bugfix

### DIFF
--- a/db/pinned_iterators_manager.h
+++ b/db/pinned_iterators_manager.h
@@ -59,13 +59,11 @@ class PinnedIteratorsManager {
 
     // Remove duplicate pointers
     std::sort(pinned_ptrs_.begin(), pinned_ptrs_.end());
-    std::unique(pinned_ptrs_.begin(), pinned_ptrs_.end());
+    auto unique_end = std::unique(pinned_ptrs_.begin(), pinned_ptrs_.end());
 
-    for (size_t i = 0; i < pinned_ptrs_.size(); i++) {
-      assert(i == 0 || pinned_ptrs_[i].first != pinned_ptrs_[i - 1].first);
-
-      void* ptr = pinned_ptrs_[i].first;
-      ReleaseFunction release_func = pinned_ptrs_[i].second;
+    for (auto i = pinned_ptrs_.begin(); i != unique_end; ++i) {
+      void* ptr = i->first;
+      ReleaseFunction release_func = i->second;
       release_func(ptr);
     }
     pinned_ptrs_.clear();


### PR DESCRIPTION
std::unique(beg, end) returns an iterator of unique_end, data behind unique_end should not be accessed.