### PR TITLE
Fix 2PC with concurrent memtable insert

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -317,7 +317,7 @@ void WriteThread::LaunchParallelFollowers(ParallelGroup* pg,
 
   while (w != pg->last_writer) {
     // Writers that won't write don't get sequence allotment
-    if (!w->CallbackFailed()) {
+    if (!w->CallbackFailed() && w->ShouldWriteToMemtable()) {
       sequence += WriteBatchInternal::Count(w->batch);
     }
     w = w->link_newer;


### PR DESCRIPTION
Summary:
If concurrent memtable insert is enabled, and one prepare command and a normal command are grouped into a commit group, the sequence ID will be calculated incorrectly.

Test Plan: Will make sure it doesn't break existing tests. Ideally we should add a unit test to verify it. But since it is alread broken, I would fix it first and add unit tests as a follow-up.