### PR TITLE
Allow SstFileWriter to Fadvise the file away from page cache

### DIFF
--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1962,8 +1962,8 @@ TEST_F(ExternalSSTFileTest, FadviseTrigger) {
   std::unique_ptr<SstFileWriter> sst_file_writer;
 
   std::string sst_file_path = sst_files_dir_ + "file_fadvise_disable.sst";
-  sst_file_writer.reset(
-      new SstFileWriter(EnvOptions(), options, options.comparator));
+  sst_file_writer.reset(new SstFileWriter(EnvOptions(), options,
+                                          options.comparator, nullptr, false));
   ASSERT_OK(sst_file_writer->Open(sst_file_path));
   for (int i = 0; i < kNumKeys; i++) {
     ASSERT_OK(sst_file_writer->Add(Key(i), Key(i)));

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1967,8 +1967,6 @@ TEST_F(ExternalSSTFileTest, FadviseTrigger) {
   ASSERT_OK(sst_file_writer->Open(sst_file_path));
   for (int i = 0; i < kNumKeys; i++) {
     ASSERT_OK(sst_file_writer->Add(Key(i), Key(i)));
-    // fadvise disabled
-    ASSERT_EQ(total_fadvised_bytes, 0);
   }
   ASSERT_OK(sst_file_writer->Finish());
   // fadvise disabled
@@ -1977,12 +1975,10 @@ TEST_F(ExternalSSTFileTest, FadviseTrigger) {
 
   sst_file_path = sst_files_dir_ + "file_fadvise_enable.sst";
   sst_file_writer.reset(new SstFileWriter(EnvOptions(), options,
-                                          options.comparator, nullptr, 1024));
+                                          options.comparator, nullptr, true));
   ASSERT_OK(sst_file_writer->Open(sst_file_path));
   for (int i = 0; i < kNumKeys; i++) {
     ASSERT_OK(sst_file_writer->Add(Key(i), Key(i)));
-    // fadvise enabled
-    ASSERT_EQ(total_fadvised_bytes, sst_file_writer->FileSize());
   }
   ASSERT_OK(sst_file_writer->Finish());
   // fadvise enabled

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1947,6 +1947,51 @@ TEST_F(ExternalSSTFileTest, SnapshotInconsistencyBug) {
   db_->ReleaseSnapshot(snap);
 }
 
+TEST_F(ExternalSSTFileTest, FadviseTrigger) {
+  Options options = CurrentOptions();
+  const int kNumKeys = 10000;
+
+  size_t total_fadvised_bytes = 0;
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "SstFileWriter::InvalidatePageCache", [&](void* arg) {
+        size_t fadvise_size = *(reinterpret_cast<size_t*>(arg));
+        total_fadvised_bytes += fadvise_size;
+      });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  std::unique_ptr<SstFileWriter> sst_file_writer;
+
+  std::string sst_file_path = sst_files_dir_ + "file_fadvise_disable.sst";
+  sst_file_writer.reset(
+      new SstFileWriter(EnvOptions(), options, options.comparator));
+  ASSERT_OK(sst_file_writer->Open(sst_file_path));
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_OK(sst_file_writer->Add(Key(i), Key(i)));
+    // fadvise disabled
+    ASSERT_EQ(total_fadvised_bytes, 0);
+  }
+  ASSERT_OK(sst_file_writer->Finish());
+  // fadvise disabled
+  ASSERT_EQ(total_fadvised_bytes, 0);
+
+
+  sst_file_path = sst_files_dir_ + "file_fadvise_enable.sst";
+  sst_file_writer.reset(new SstFileWriter(EnvOptions(), options,
+                                          options.comparator, nullptr, 1024));
+  ASSERT_OK(sst_file_writer->Open(sst_file_path));
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_OK(sst_file_writer->Add(Key(i), Key(i)));
+    // fadvise enabled
+    ASSERT_EQ(total_fadvised_bytes, sst_file_writer->FileSize());
+  }
+  ASSERT_OK(sst_file_writer->Finish());
+  // fadvise enabled
+  ASSERT_EQ(total_fadvised_bytes, sst_file_writer->FileSize());
+  ASSERT_GT(total_fadvised_bytes, 0);
+
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+}
+
 #endif  // ROCKSDB_LITE
 
 }  // namespace rocksdb

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -52,7 +52,7 @@ class SstFileWriter {
   SstFileWriter(const EnvOptions& env_options, const Options& options,
                 const Comparator* user_comparator,
                 ColumnFamilyHandle* column_family = nullptr,
-                bool invalidate_page_cache = false);
+                bool invalidate_page_cache = true);
 
   ~SstFileWriter();
 

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -47,9 +47,12 @@ class SstFileWriter {
   // User can pass `column_family` to specify that the the generated file will
   // be ingested into this column_family, note that passing nullptr means that
   // the column_family is unknown.
+  // If fadvise_trigger is passed with a non-zero value, SstFileWriter will
+  // invalidate the os page cache every `fadvise_trigger` bytes for the sst file
   SstFileWriter(const EnvOptions& env_options, const Options& options,
                 const Comparator* user_comparator,
-                ColumnFamilyHandle* column_family = nullptr);
+                ColumnFamilyHandle* column_family = nullptr,
+                uint64_t fadvise_trigger = 0);
 
   ~SstFileWriter();
 
@@ -70,6 +73,8 @@ class SstFileWriter {
   uint64_t FileSize();
 
  private:
+  void InvalidatePageCache(bool closing);
+
   struct Rep;
   Rep* rep_;
 };

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -47,12 +47,12 @@ class SstFileWriter {
   // User can pass `column_family` to specify that the the generated file will
   // be ingested into this column_family, note that passing nullptr means that
   // the column_family is unknown.
-  // If fadvise_trigger is passed with a non-zero value, SstFileWriter will
-  // invalidate the os page cache every `fadvise_trigger` bytes for the sst file
+  // If invalidate_page_cache is set to true, SstFileWriter will give the OS a
+  // hint that this file pages is not needed everytime we write 1MB to the file
   SstFileWriter(const EnvOptions& env_options, const Options& options,
                 const Comparator* user_comparator,
                 ColumnFamilyHandle* column_family = nullptr,
-                uint64_t fadvise_trigger = 0);
+                bool invalidate_page_cache = false);
 
   ~SstFileWriter();
 


### PR DESCRIPTION
Add `fadvise_trigger` option to `SstFileWriter`

If fadvise_trigger is passed with a non-zero value, SstFileWriter will invalidate the os page cache every `fadvise_trigger` bytes for the sst file