### PR TITLE
PinnableSlice

### DIFF
--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -42,8 +42,8 @@ size_t CompactedDBImpl::FindFile(const Slice& key) {
   return right;
 }
 
-Status CompactedDBImpl::GetAndPin(const ReadOptions& options,
-     ColumnFamilyHandle*, const Slice& key, PinnableSlice* pSlice) {
+Status CompactedDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle*,
+                            const Slice& key, PinnableSlice* pSlice) {
   GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
                          GetContext::kNotFound, key, pSlice, nullptr, nullptr,
                          nullptr, nullptr);
@@ -76,10 +76,10 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
   for (auto* r : reader_list) {
     if (r != nullptr) {
       PinnableSlice pSlice;
-      std::string &value = (*values)[idx];
+      std::string& value = (*values)[idx];
       GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                             GetContext::kNotFound, keys[idx], &pSlice,
-                             nullptr, nullptr, nullptr, nullptr);
+                             GetContext::kNotFound, keys[idx], &pSlice, nullptr,
+                             nullptr, nullptr, nullptr);
       LookupKey lkey(keys[idx], kMaxSequenceNumber);
       r->Get(options, lkey.internal_key(), &get_context);
       value.assign(pSlice.data(), pSlice.size());

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -42,10 +42,10 @@ size_t CompactedDBImpl::FindFile(const Slice& key) {
   return right;
 }
 
-Status CompactedDBImpl::Get(const ReadOptions& options,
-     ColumnFamilyHandle*, const Slice& key, std::string* value) {
+Status CompactedDBImpl::GetAndPin(const ReadOptions& options,
+     ColumnFamilyHandle*, const Slice& key, PinnableSlice* pSlice) {
   GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                         GetContext::kNotFound, key, value, nullptr, nullptr,
+                         GetContext::kNotFound, key, pSlice, nullptr, nullptr,
                          nullptr, nullptr);
   LookupKey lkey(key, kMaxSequenceNumber);
   files_.files[FindFile(key)].fd.table_reader->Get(
@@ -75,11 +75,14 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
   int idx = 0;
   for (auto* r : reader_list) {
     if (r != nullptr) {
+      PinnableSlice pSlice;
+      std::string &value = (*values)[idx];
       GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                             GetContext::kNotFound, keys[idx], &(*values)[idx],
+                             GetContext::kNotFound, keys[idx], &pSlice,
                              nullptr, nullptr, nullptr, nullptr);
       LookupKey lkey(keys[idx], kMaxSequenceNumber);
       r->Get(options, lkey.internal_key(), &get_context);
+      value.assign(pSlice.data(), pSlice.size());
       if (get_context.State() == GetContext::kFound) {
         statuses[idx] = Status::OK();
       }

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -20,10 +20,10 @@ class CompactedDBImpl : public DBImpl {
                      DB** dbptr);
 
   // Implementations of the DB interface
-  using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override;
+  using DB::GetAndPin;
+  virtual Status GetAndPin(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* value) override;
   using DB::MultiGet;
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -20,10 +20,10 @@ class CompactedDBImpl : public DBImpl {
                      DB** dbptr);
 
   // Implementations of the DB interface
-  using DB::GetAndPin;
-  virtual Status GetAndPin(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* value) override;
+  using DB::Get;
+  virtual Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) override;
   using DB::MultiGet;
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4338,7 +4338,8 @@ bool DBImpl::KeyMayExist(const ReadOptions& read_options,
   ReadOptions roptions = read_options;
   roptions.read_tier = kBlockCacheTier; // read from block cache only
   PinnableSlice pSlice;
-  auto s = GetImpl(roptions, column_family, key, &pSlice, value_found);
+  PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
+  auto s = GetImpl(roptions, column_family, key, pSlicePtr, value_found);
   if (value != nullptr) {
     value->assign(pSlice.data(), pSlice.size());
   }
@@ -6424,8 +6425,7 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
   }
 
   // Check if there is a record for this key in the immutable memtables
-  PinnableSlice* pSlice = nullptr;
-  sv->imm->Get(lkey, pSlice, &s, &merge_context, &range_del_agg, seq,
+  sv->imm->Get(lkey, pSliceNullPtr, &s, &merge_context, &range_del_agg, seq,
                read_options);
 
   if (!(s.ok() || s.IsNotFound() || s.IsMergeInProgress())) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3905,16 +3905,10 @@ ColumnFamilyHandle* DBImpl::DefaultColumnFamily() const {
   return default_cf_handle_;
 }
 
-Status DBImpl::Get(const ReadOptions& read_options,
-                   ColumnFamilyHandle* column_family, const Slice& key,
-                   std::string* value) {
-  return GetImpl(read_options, column_family, key, value, nullptr);
-}
-
 Status DBImpl::GetAndPin(const ReadOptions& read_options,
-                   ColumnFamilyHandle* column_family, const Slice& key,
-                   PinnableSlice* value) {
-  return GetImpl(read_options, column_family, key, nullptr, value);
+                         ColumnFamilyHandle* column_family, const Slice& key,
+                         PinnableSlice* pSlice) {
+  return GetImpl(read_options, column_family, key, pSlice);
 }
 
 // JobContext gets created and destructed outside of the lock --
@@ -3971,9 +3965,7 @@ SuperVersion* DBImpl::InstallSuperVersionAndScheduleWork(
 
 Status DBImpl::GetImpl(const ReadOptions& read_options,
                        ColumnFamilyHandle* column_family, const Slice& key,
-                       std::string* value, PinnableSlice* pSlice,
-                       bool* value_found) {
-  assert(value == nullptr || pSlice == nullptr);
+                       PinnableSlice* pSlice, bool* value_found) {
   StopWatch sw(env_, stats_, DB_GET);
   PERF_TIMER_GUARD(get_snapshot_time);
 
@@ -4004,12 +3996,12 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       (read_options.read_tier == kPersistedTier && has_unpersisted_data_);
   bool done = false;
   if (!skip_memtable) {
-    if (sv->mem->Get(lkey, value, pSlice, &s, &merge_context, &range_del_agg,
+    if (sv->mem->Get(lkey, pSlice, &s, &merge_context, &range_del_agg,
                      read_options)) {
       done = true;
       RecordTick(stats_, MEMTABLE_HIT);
     } else if ((s.ok() || s.IsMergeInProgress()) &&
-               sv->imm->Get(lkey, value, pSlice, &s, &merge_context, &range_del_agg,
+               sv->imm->Get(lkey, pSlice, &s, &merge_context, &range_del_agg,
                             read_options)) {
       done = true;
       RecordTick(stats_, MEMTABLE_HIT);
@@ -4020,7 +4012,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   }
   if (!done) {
     PERF_TIMER_GUARD(get_from_output_files_time);
-    sv->current->Get(read_options, lkey, value, pSlice, &s, &merge_context,
+    sv->current->Get(read_options, lkey, pSlice, &s, &merge_context,
                      &range_del_agg, value_found);
     RecordTick(stats_, MEMTABLE_MISS);
   }
@@ -4031,7 +4023,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
     ReturnAndCleanupSuperVersion(cfd, sv);
 
     RecordTick(stats_, NUMBER_KEYS_READ);
-    size_t size = pSlice != nullptr ? pSlice->size() : value->size();
+    size_t size = pSlice->size();
     RecordTick(stats_, BYTES_READ, size);
     MeasureTime(stats_, BYTES_PER_READ, size);
   }
@@ -4109,26 +4101,30 @@ std::vector<Status> DBImpl::MultiGet(
     bool skip_memtable =
         (read_options.read_tier == kPersistedTier && has_unpersisted_data_);
     bool done = false;
+    PinnableSlice pSlice;
     if (!skip_memtable) {
-      if (super_version->mem->Get(lkey, value, nullptr, &s, &merge_context,
+      if (super_version->mem->Get(lkey, &pSlice, &s, &merge_context,
                                   &range_del_agg, read_options)) {
+        value->assign(pSlice.data(), pSlice.size());
         done = true;
         // TODO(?): RecordTick(stats_, MEMTABLE_HIT)?
-      } else if (super_version->imm->Get(lkey, value, &s, &merge_context,
+      } else if (super_version->imm->Get(lkey, &pSlice, &s, &merge_context,
                                          &range_del_agg, read_options)) {
+        value->assign(pSlice.data(), pSlice.size());
         done = true;
         // TODO(?): RecordTick(stats_, MEMTABLE_HIT)?
       }
     }
     if (!done) {
       PERF_TIMER_GUARD(get_from_output_files_time);
-      super_version->current->Get(read_options, lkey, value, &s, &merge_context,
-                                  &range_del_agg);
+      super_version->current->Get(read_options, lkey, &pSlice, &s,
+                                  &merge_context, &range_del_agg);
+      value->assign(pSlice.data(), pSlice.size());
       // TODO(?): RecordTick(stats_, MEMTABLE_MISS)?
     }
 
     if (s.ok()) {
-      bytes_read += value->size();
+      bytes_read += pSlice.size();
     }
   }
 
@@ -4341,7 +4337,11 @@ bool DBImpl::KeyMayExist(const ReadOptions& read_options,
   }
   ReadOptions roptions = read_options;
   roptions.read_tier = kBlockCacheTier; // read from block cache only
-  auto s = GetImpl(roptions, column_family, key, value, nullptr, value_found);
+  PinnableSlice pSlice;
+  auto s = GetImpl(roptions, column_family, key, &pSlice, value_found);
+  if (value != nullptr) {
+    value->assign(pSlice.data(), pSlice.size());
+  }
 
   // If block_cache is enabled and the index block of the table didn't
   // not present in block_cache, the return value will be Status::Incomplete.
@@ -6404,7 +6404,7 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
   *found_record_for_key = false;
 
   // Check if there is a record for this key in the latest memtable
-  sv->mem->Get(lkey, nullptr, nullptr, &s, &merge_context, &range_del_agg, seq,
+  sv->mem->Get(lkey, nullptr, &s, &merge_context, &range_del_agg, seq,
                read_options);
 
   if (!(s.ok() || s.IsNotFound() || s.IsMergeInProgress())) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -6404,7 +6404,8 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
   *found_record_for_key = false;
 
   // Check if there is a record for this key in the latest memtable
-  sv->mem->Get(lkey, nullptr, &s, &merge_context, &range_del_agg, seq,
+  PinnableSlice* pSliceNullPtr = nullptr;
+  sv->mem->Get(lkey, pSliceNullPtr, &s, &merge_context, &range_del_agg, seq,
                read_options);
 
   if (!(s.ok() || s.IsNotFound() || s.IsMergeInProgress())) {
@@ -6423,7 +6424,8 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
   }
 
   // Check if there is a record for this key in the immutable memtables
-  sv->imm->Get(lkey, nullptr, &s, &merge_context, &range_del_agg, seq,
+  PinnableSlice* pSlice = nullptr;
+  sv->imm->Get(lkey, pSlice, &s, &merge_context, &range_del_agg, seq,
                read_options);
 
   if (!(s.ok() || s.IsNotFound() || s.IsMergeInProgress())) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3905,9 +3905,9 @@ ColumnFamilyHandle* DBImpl::DefaultColumnFamily() const {
   return default_cf_handle_;
 }
 
-Status DBImpl::GetAndPin(const ReadOptions& read_options,
-                         ColumnFamilyHandle* column_family, const Slice& key,
-                         PinnableSlice* pSlice) {
+Status DBImpl::Get(const ReadOptions& read_options,
+                   ColumnFamilyHandle* column_family, const Slice& key,
+                   PinnableSlice* pSlice) {
   return GetImpl(read_options, column_family, key, pSlice);
 }
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -88,10 +88,6 @@ class DBImpl : public DB {
   virtual Status Write(const WriteOptions& options,
                        WriteBatch* updates) override;
 
-  using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override;
   using DB::GetAndPin;
   virtual Status GetAndPin(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
@@ -1092,7 +1088,7 @@ class DBImpl : public DB {
   // Function that Get and KeyMayExist call with no_io true or false
   // Note: 'value_found' from KeyMayExist propagates here
   Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
-                 const Slice& key, std::string* value, PinnableSlice* pSlice,
+                 const Slice& key, PinnableSlice* pSlice,
                  bool* value_found = nullptr);
 
   bool GetIntPropertyInternal(ColumnFamilyData* cfd,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -88,8 +88,8 @@ class DBImpl : public DB {
   virtual Status Write(const WriteOptions& options,
                        WriteBatch* updates) override;
 
-  using DB::GetAndPin;
-  virtual Status GetAndPin(const ReadOptions& options,
+  using DB::Get;
+  virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      PinnableSlice* value) override;
   using DB::MultiGet;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -92,6 +92,10 @@ class DBImpl : public DB {
   virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      std::string* value) override;
+  using DB::GetAndPin;
+  virtual Status GetAndPin(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) override;
   using DB::MultiGet;
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
@@ -1088,7 +1092,7 @@ class DBImpl : public DB {
   // Function that Get and KeyMayExist call with no_io true or false
   // Note: 'value_found' from KeyMayExist propagates here
   Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
-                 const Slice& key, std::string* value,
+                 const Slice& key, std::string* value, PinnableSlice* pSlice,
                  bool* value_found = nullptr);
 
   bool GetIntPropertyInternal(ColumnFamilyData* cfd,

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -40,14 +40,21 @@ Status DBImplReadOnly::Get(const ReadOptions& read_options,
   MergeContext merge_context;
   RangeDelAggregator range_del_agg(cfd->internal_comparator(), snapshot);
   LookupKey lkey(key, snapshot);
-  if (super_version->mem->Get(lkey, value, &s, &merge_context, &range_del_agg,
-                              read_options)) {
+  if (super_version->mem->Get(lkey, value, nullptr, &s, &merge_context,
+                              &range_del_agg, read_options)) {
   } else {
     PERF_TIMER_GUARD(get_from_output_files_time);
     super_version->current->Get(read_options, lkey, value, &s, &merge_context,
                                 &range_del_agg);
   }
   return s;
+}
+
+Status DBImplReadOnly::GetAndPin(const ReadOptions& read_options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* value) {
+  //TODO: implement that
+  return Status::NotSupported("Not supported in readonly mode");
 }
 
 Iterator* DBImplReadOnly::NewIterator(const ReadOptions& read_options,

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -29,9 +29,9 @@ DBImplReadOnly::~DBImplReadOnly() {
 }
 
 // Implementations of the DB interface
-Status DBImplReadOnly::GetAndPin(const ReadOptions& read_options,
-                                 ColumnFamilyHandle* column_family,
-                                 const Slice& key, PinnableSlice* pSlice) {
+Status DBImplReadOnly::Get(const ReadOptions& read_options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* pSlice) {
   Status s;
   SequenceNumber snapshot = versions_->LastSequence();
   auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -19,8 +19,8 @@ class DBImplReadOnly : public DBImpl {
   virtual ~DBImplReadOnly();
 
   // Implementations of the DB interface
-  using DB::GetAndPin;
-  virtual Status GetAndPin(const ReadOptions& options,
+  using DB::Get;
+  virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      PinnableSlice* value) override;
 

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -19,10 +19,6 @@ class DBImplReadOnly : public DBImpl {
   virtual ~DBImplReadOnly();
 
   // Implementations of the DB interface
-  using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override;
   using DB::GetAndPin;
   virtual Status GetAndPin(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -23,6 +23,10 @@ class DBImplReadOnly : public DBImpl {
   virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      std::string* value) override;
+  using DB::GetAndPin;
+  virtual Status GetAndPin(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) override;
 
   // TODO: Implement ReadOnly MultiGet?
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2678,7 +2678,7 @@ class ModelDB : public DB {
   }
   using DB::Get;
   virtual Status Get(const ReadOptions& options, ColumnFamilyHandle* cf,
-                     const Slice& key, std::string* value) override {
+                     const Slice& key, PinnableSlice* pSlice) override {
     return Status::NotSupported(key);
   }
 

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -534,9 +534,9 @@ struct Saver {
 };
 }  // namespace
 
-static void UnrefMemTable(void* s, void*) {
-  reinterpret_cast<MemTable*>(s)->Unref();
-}
+//static void UnrefMemTable(void* s, void*) {
+// reinterpret_cast<MemTable*>(s)->Unref();
+//}
 
 static bool SaveValue(void* arg, const char* entry) {
   Saver* s = reinterpret_cast<Saver*>(arg);
@@ -583,8 +583,9 @@ static bool SaveValue(void* arg, const char* entry) {
                 s->statistics, s->env_);
             s->pSlice->PinSelf();
           } else {
-            s->mem->Ref();
-            s->pSlice->PinSlice(v, UnrefMemTable, s->mem, nullptr);
+            //s->mem->Ref();
+            //s->pSlice->PinSlice(v, UnrefMemTable, s->mem, nullptr);
+            s->pSlice->PinSelf(v);
           }
         }
         if (s->inplace_update_support) {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -186,31 +186,16 @@ class MemTable {
   // returned).  Otherwise, *seq will be set to kMaxSequenceNumber.
   // On success, *s may be set to OK, NotFound, or MergeInProgress.  Any other
   // status returned indicates a corruption or other unexpected error.
-  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
-           const ReadOptions& read_opts);
+  bool Get(const LookupKey& key, PinnableSlice* pSlice, Status* s,
+           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+           SequenceNumber* seq, const ReadOptions& read_opts);
 
-  bool Get(const LookupKey& key, std::string* value,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
-           const ReadOptions& read_opts) {
-    return Get(key, value, nullptr, s, merge_context, range_del_agg, seq,
-               read_opts);
-  }
-  bool Get(const LookupKey& key, std::string* value,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
+  inline bool Get(const LookupKey& key, PinnableSlice* pSlice, Status* s,
+                  MergeContext* merge_context,
+                  RangeDelAggregator* range_del_agg,
+                  const ReadOptions& read_opts) {
     SequenceNumber seq;
-    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq,
-               read_opts);
-  }
-  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
-    SequenceNumber seq;
-    return Get(key, value, pSlice, s, merge_context, range_del_agg, &seq,
-               read_opts);
+    return Get(key, pSlice, s, merge_context, range_del_agg, &seq, read_opts);
   }
 
   // Attempts to update the new_value inplace, else does normal Add

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -198,6 +198,15 @@ class MemTable {
     return Get(key, pSlice, s, merge_context, range_del_agg, &seq, read_opts);
   }
 
+  // deprecated. Use Get with PinnableSlice
+  bool Get(const LookupKey& key, std::string* value, Status* s,
+           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+           SequenceNumber* seq, const ReadOptions& read_opts);
+  // deprecated. Use Get with PinnableSlice
+  bool Get(const LookupKey& key, std::string* value, Status* s,
+           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+           const ReadOptions& read_opts);
+
   // Attempts to update the new_value inplace, else does normal Add
   // Pseudocode
   //   if key exists in current memtable && prev_value is of type kTypeValue

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -186,15 +186,31 @@ class MemTable {
   // returned).  Otherwise, *seq will be set to kMaxSequenceNumber.
   // On success, *s may be set to OK, NotFound, or MergeInProgress.  Any other
   // status returned indicates a corruption or other unexpected error.
-  bool Get(const LookupKey& key, std::string* value, Status* s,
-           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
-           SequenceNumber* seq, const ReadOptions& read_opts);
+  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
+           const ReadOptions& read_opts);
 
-  bool Get(const LookupKey& key, std::string* value, Status* s,
-           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+  bool Get(const LookupKey& key, std::string* value,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
            const ReadOptions& read_opts) {
+    return Get(key, value, nullptr, s, merge_context, range_del_agg, seq,
+               read_opts);
+  }
+  bool Get(const LookupKey& key, std::string* value,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
     SequenceNumber seq;
-    return Get(key, value, s, merge_context, range_del_agg, &seq, read_opts);
+    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq,
+               read_opts);
+  }
+  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
+    SequenceNumber seq;
+    return Get(key, value, pSlice, s, merge_context, range_del_agg, &seq,
+               read_opts);
   }
 
   // Attempts to update the new_value inplace, else does normal Add

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -116,9 +116,12 @@ bool MemTableListVersion::GetFromHistory(const LookupKey& key,
                                          SequenceNumber* seq,
                                          const ReadOptions& read_opts) {
   PinnableSlice pSlice;
-  auto res = GetFromList(&memlist_history_, key, &pSlice, s, merge_context,
+  PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
+  auto res = GetFromList(&memlist_history_, key, pSlicePtr, s, merge_context,
                          range_del_agg, seq, read_opts);
-  value->assign(pSlice.data(), pSlice.size());
+  if (value != nullptr) {
+    value->assign(pSlice.data(), pSlice.size());
+  }
   return res;
 }
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -53,29 +53,16 @@ class MemTableListVersion {
   // If any operation was found for this key, its most recent sequence number
   // will be stored in *seq on success (regardless of whether true/false is
   // returned).  Otherwise, *seq will be set to kMaxSequenceNumber.
-  bool Get(const LookupKey& key, std::string* value, PinnableSlice* slice,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
-           const ReadOptions& read_opts);
-  bool Get(const LookupKey& key, std::string* value, Status* s,
+  bool Get(const LookupKey& key, PinnableSlice* pSlice, Status* s,
            MergeContext* merge_context, RangeDelAggregator* range_del_agg,
-           SequenceNumber* seq, const ReadOptions& read_opts) {
-    return Get(key, value, nullptr, s, merge_context, range_del_agg, seq,
-               read_opts);
-  }
+           SequenceNumber* seq, const ReadOptions& read_opts);
 
-  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
-           Status* s, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
+  inline bool Get(const LookupKey& key, PinnableSlice* pSlice, Status* s,
+                  MergeContext* merge_context,
+                  RangeDelAggregator* range_del_agg,
+                  const ReadOptions& read_opts) {
     SequenceNumber seq;
-    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq,
-               read_opts);
-  }
-  bool Get(const LookupKey& key, std::string* value, Status* s,
-           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
-           const ReadOptions& read_opts) {
-    SequenceNumber seq;
-    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq, read_opts);
+    return Get(key, pSlice, s, merge_context, range_del_agg, &seq, read_opts);
   }
 
   // Similar to Get(), but searches the Memtable history of memtables that
@@ -86,10 +73,10 @@ class MemTableListVersion {
                       MergeContext* merge_context,
                       RangeDelAggregator* range_del_agg, SequenceNumber* seq,
                       const ReadOptions& read_opts);
-  bool GetFromHistory(const LookupKey& key, std::string* value, Status* s,
-                      MergeContext* merge_context,
-                      RangeDelAggregator* range_del_agg,
-                      const ReadOptions& read_opts) {
+  inline bool GetFromHistory(const LookupKey& key, std::string* value,
+                             Status* s, MergeContext* merge_context,
+                             RangeDelAggregator* range_del_agg,
+                             const ReadOptions& read_opts) {
     SequenceNumber seq;
     return GetFromHistory(key, value, s, merge_context, range_del_agg, &seq,
                           read_opts);
@@ -126,7 +113,7 @@ class MemTableListVersion {
   void TrimHistory(autovector<MemTable*>* to_delete);
 
   bool GetFromList(std::list<MemTable*>* list, const LookupKey& key,
-                   std::string* value, PinnableSlice* pSlice, Status* s,
+                   PinnableSlice* pSlice, Status* s,
                    MergeContext* merge_context,
                    RangeDelAggregator* range_del_agg, SequenceNumber* seq,
                    const ReadOptions& read_opts);

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -53,15 +53,29 @@ class MemTableListVersion {
   // If any operation was found for this key, its most recent sequence number
   // will be stored in *seq on success (regardless of whether true/false is
   // returned).  Otherwise, *seq will be set to kMaxSequenceNumber.
+  bool Get(const LookupKey& key, std::string* value, PinnableSlice* slice,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, SequenceNumber* seq,
+           const ReadOptions& read_opts);
   bool Get(const LookupKey& key, std::string* value, Status* s,
            MergeContext* merge_context, RangeDelAggregator* range_del_agg,
-           SequenceNumber* seq, const ReadOptions& read_opts);
+           SequenceNumber* seq, const ReadOptions& read_opts) {
+    return Get(key, value, nullptr, s, merge_context, range_del_agg, seq,
+               read_opts);
+  }
 
+  bool Get(const LookupKey& key, std::string* value, PinnableSlice* pSlice,
+           Status* s, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, const ReadOptions& read_opts) {
+    SequenceNumber seq;
+    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq,
+               read_opts);
+  }
   bool Get(const LookupKey& key, std::string* value, Status* s,
            MergeContext* merge_context, RangeDelAggregator* range_del_agg,
            const ReadOptions& read_opts) {
     SequenceNumber seq;
-    return Get(key, value, s, merge_context, range_del_agg, &seq, read_opts);
+    return Get(key, value, nullptr, s, merge_context, range_del_agg, &seq, read_opts);
   }
 
   // Similar to Get(), but searches the Memtable history of memtables that
@@ -112,7 +126,8 @@ class MemTableListVersion {
   void TrimHistory(autovector<MemTable*>* to_delete);
 
   bool GetFromList(std::list<MemTable*>* list, const LookupKey& key,
-                   std::string* value, Status* s, MergeContext* merge_context,
+                   std::string* value, PinnableSlice* pSlice, Status* s,
+                   MergeContext* merge_context,
                    RangeDelAggregator* range_del_agg, SequenceNumber* seq,
                    const ReadOptions& read_opts);
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -65,6 +65,15 @@ class MemTableListVersion {
     return Get(key, pSlice, s, merge_context, range_del_agg, &seq, read_opts);
   }
 
+  // deprecated. Use Get with PinnableSlice
+  bool Get(const LookupKey& key, std::string* value, Status* s,
+           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+           SequenceNumber* seq, const ReadOptions& read_opts);
+  // deprecated. Use Get with PinnableSlice
+  bool Get(const LookupKey& key, std::string* value, Status* s,
+           MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+           const ReadOptions& read_opts);
+
   // Similar to Get(), but searches the Memtable history of memtables that
   // have already been flushed.  Should only be used from in-memory only
   // queries (such as Transaction validation) as the history may contain

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -928,7 +928,7 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       version_number_(version_number) {}
 
 void Version::Get(const ReadOptions& read_options, const LookupKey& k,
-                  std::string* value, Status* status,
+                  std::string* value, PinnableSlice* pSlice, Status* status,
                   MergeContext* merge_context,
                   RangeDelAggregator* range_del_agg, bool* value_found,
                   bool* key_exists, SequenceNumber* seq) {
@@ -946,7 +946,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
   GetContext get_context(
       user_comparator(), merge_operator_, info_log_, db_statistics_,
       status->ok() ? GetContext::kNotFound : GetContext::kMerge, user_key,
-      value, value_found, merge_context, range_del_agg, this->env_, seq,
+      value, pSlice, value_found, merge_context, range_del_agg, this->env_, seq,
       merge_operator_ ? &pinned_iters_mgr : nullptr);
 
   // Pin blocks that we read to hold merge operands
@@ -1005,9 +1005,17 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     }
     // merge_operands are in saver and we hit the beginning of the key history
     // do a final merge of nullptr and operands;
-    *status = MergeHelper::TimedFullMerge(merge_operator_, user_key, nullptr,
-                                          merge_context->GetOperands(), value,
-                                          info_log_, db_statistics_, env_);
+    if (pSlice == nullptr) {
+      *status = MergeHelper::TimedFullMerge(merge_operator_, user_key, nullptr,
+                                            merge_context->GetOperands(), value,
+                                            info_log_, db_statistics_, env_);
+    } else {
+      std::string* str_value = new std::string();
+      *status = MergeHelper::TimedFullMerge(
+          merge_operator_, user_key, nullptr, merge_context->GetOperands(),
+          str_value, info_log_, db_statistics_, env_);
+      pSlice->PinHeap(str_value);
+    }
   } else {
     if (key_exists != nullptr) {
       *key_exists = false;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1005,12 +1005,12 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     }
     // merge_operands are in saver and we hit the beginning of the key history
     // do a final merge of nullptr and operands;
-    std::string* str_value = pSlice != nullptr ? new std::string() : nullptr;
+    std::string* str_value = pSlice != nullptr ? pSlice->GetSelf() : nullptr;
     *status = MergeHelper::TimedFullMerge(
         merge_operator_, user_key, nullptr, merge_context->GetOperands(),
         str_value, info_log_, db_statistics_, env_);
     if (LIKELY(pSlice != nullptr)) {
-      pSlice->PinHeap(str_value);
+      pSlice->PinSelf();
     }
   } else {
     if (key_exists != nullptr) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -928,7 +928,7 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       version_number_(version_number) {}
 
 void Version::Get(const ReadOptions& read_options, const LookupKey& k,
-                  std::string* value, PinnableSlice* pSlice, Status* status,
+                  PinnableSlice* pSlice, Status* status,
                   MergeContext* merge_context,
                   RangeDelAggregator* range_del_agg, bool* value_found,
                   bool* key_exists, SequenceNumber* seq) {
@@ -946,7 +946,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
   GetContext get_context(
       user_comparator(), merge_operator_, info_log_, db_statistics_,
       status->ok() ? GetContext::kNotFound : GetContext::kMerge, user_key,
-      value, pSlice, value_found, merge_context, range_del_agg, this->env_, seq,
+      pSlice, value_found, merge_context, range_del_agg, this->env_, seq,
       merge_operator_ ? &pinned_iters_mgr : nullptr);
 
   // Pin blocks that we read to hold merge operands
@@ -1005,15 +1005,11 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     }
     // merge_operands are in saver and we hit the beginning of the key history
     // do a final merge of nullptr and operands;
-    if (pSlice == nullptr) {
-      *status = MergeHelper::TimedFullMerge(merge_operator_, user_key, nullptr,
-                                            merge_context->GetOperands(), value,
-                                            info_log_, db_statistics_, env_);
-    } else {
-      std::string* str_value = new std::string();
-      *status = MergeHelper::TimedFullMerge(
-          merge_operator_, user_key, nullptr, merge_context->GetOperands(),
-          str_value, info_log_, db_statistics_, env_);
+    std::string* str_value = pSlice != nullptr ? new std::string() : nullptr;
+    *status = MergeHelper::TimedFullMerge(
+        merge_operator_, user_key, nullptr, merge_context->GetOperands(),
+        str_value, info_log_, db_statistics_, env_);
+    if (LIKELY(pSlice != nullptr)) {
       pSlice->PinHeap(str_value);
     }
   } else {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -457,15 +457,8 @@ class Version {
   // for the key if a key was found.
   //
   // REQUIRES: lock is not held
-  void Get(const ReadOptions& ro, const LookupKey& key, std::string* val,
+  void Get(const ReadOptions&, const LookupKey& key, PinnableSlice* pSlice,
            Status* status, MergeContext* merge_context,
-           RangeDelAggregator* range_del_agg, bool* value_found = nullptr,
-           bool* key_exists = nullptr, SequenceNumber* seq = nullptr) {
-    Get(ro, key, val, nullptr, status, merge_context, range_del_agg,
-        value_found, key_exists, seq);
-  }
-  void Get(const ReadOptions&, const LookupKey& key, std::string* val,
-           PinnableSlice* pSlice, Status* status, MergeContext* merge_context,
            RangeDelAggregator* range_del_agg, bool* value_found = nullptr,
            bool* key_exists = nullptr, SequenceNumber* seq = nullptr);
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -457,8 +457,15 @@ class Version {
   // for the key if a key was found.
   //
   // REQUIRES: lock is not held
-  void Get(const ReadOptions&, const LookupKey& key, std::string* val,
+  void Get(const ReadOptions& ro, const LookupKey& key, std::string* val,
            Status* status, MergeContext* merge_context,
+           RangeDelAggregator* range_del_agg, bool* value_found = nullptr,
+           bool* key_exists = nullptr, SequenceNumber* seq = nullptr) {
+    Get(ro, key, val, nullptr, status, merge_context, range_del_agg,
+        value_found, key_exists, seq);
+  }
+  void Get(const ReadOptions&, const LookupKey& key, std::string* val,
+           PinnableSlice* pSlice, Status* status, MergeContext* merge_context,
            RangeDelAggregator* range_del_agg, bool* value_found = nullptr,
            bool* key_exists = nullptr, SequenceNumber* seq = nullptr);
 

--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -34,7 +34,11 @@ class Cleanable {
   void RegisterCleanup(CleanupFunction function, void* arg1, void* arg2);
   void DelegateCleanupsTo(Cleanable* other);
   // DoCkeanup and also resets the pointers for reuse
-  void Reset();
+  inline void Reset() {
+    DoCleanup();
+    cleanup_.function = nullptr;
+    cleanup_.next = nullptr;
+  }
 
  protected:
   struct Cleanup {
@@ -50,7 +54,17 @@ class Cleanable {
  private:
   // Performs all the cleanups. It does not reset the pointers. Making it private
   // to prevent misuse
-  inline void DoCleanup();
+  inline void DoCleanup() {
+    if (cleanup_.function != nullptr) {
+      (*cleanup_.function)(cleanup_.arg1, cleanup_.arg2);
+      for (Cleanup* c = cleanup_.next; c != nullptr;) {
+        (*c->function)(c->arg1, c->arg2);
+        Cleanup* next = c->next;
+        delete c;
+        c = next;
+      }
+    }
+  }
 };
 
 }  // namespace rocksdb

--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// An iterator yields a sequence of key/value pairs from a source.
+// The following class defines the interface.  Multiple implementations
+// are provided by this library.  In particular, iterators are provided
+// to access the contents of a Table or a DB.
+//
+// Multiple threads can invoke const methods on an Iterator without
+// external synchronization, but if any of the threads may call a
+// non-const method, all threads accessing the same Iterator must use
+// external synchronization.
+
+#ifndef STORAGE_ROCKSDB_INCLUDE_CLEANABLE_H_
+#define STORAGE_ROCKSDB_INCLUDE_CLEANABLE_H_
+
+namespace rocksdb {
+
+class Cleanable {
+ public:
+  Cleanable();
+  ~Cleanable();
+  // Clients are allowed to register function/arg1/arg2 triples that
+  // will be invoked when this iterator is destroyed.
+  //
+  // Note that unlike all of the preceding methods, this method is
+  // not abstract and therefore clients should not override it.
+  typedef void (*CleanupFunction)(void* arg1, void* arg2);
+  void RegisterCleanup(CleanupFunction function, void* arg1, void* arg2);
+  void DelegateCleanupsTo(Cleanable* other);
+  // DoCkeanup and also resets the pointers for reuse
+  void Reset();
+
+ protected:
+  struct Cleanup {
+    CleanupFunction function;
+    void* arg1;
+    void* arg2;
+    Cleanup* next;
+  };
+  Cleanup cleanup_;
+  // It also becomes the owner of c
+  void RegisterCleanup(Cleanup* c);
+
+ private:
+  // Performs all the cleanups. It does not reset the pointers. Making it private
+  // to prevent misuse
+  inline void DoCleanup();
+};
+
+}  // namespace rocksdb
+
+#endif  // STORAGE_ROCKSDB_INCLUDE_CLENABLE_H_

--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -52,7 +52,8 @@ class Cleanable {
   void RegisterCleanup(Cleanup* c);
 
  private:
-  // Performs all the cleanups. It does not reset the pointers. Making it private
+  // Performs all the cleanups. It does not reset the pointers. Making it
+  // private
   // to prevent misuse
   inline void DoCleanup() {
     if (cleanup_.function != nullptr) {

--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -16,8 +16,8 @@
 // non-const method, all threads accessing the same Iterator must use
 // external synchronization.
 
-#ifndef STORAGE_ROCKSDB_INCLUDE_CLEANABLE_H_
-#define STORAGE_ROCKSDB_INCLUDE_CLEANABLE_H_
+#ifndef INCLUDE_ROCKSDB_CLEANABLE_H_
+#define INCLUDE_ROCKSDB_CLEANABLE_H_
 
 namespace rocksdb {
 
@@ -70,4 +70,4 @@ class Cleanable {
 
 }  // namespace rocksdb
 
-#endif  // STORAGE_ROCKSDB_INCLUDE_CLENABLE_H_
+#endif  // INCLUDE_ROCKSDB_CLEANABLE_H_

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -280,14 +280,17 @@ class DB {
   // a status for which Status::IsNotFound() returns true.
   //
   // May return some other Status on an error.
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) = 0;
-  virtual Status GetAndPin(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) {
-    return Status::NotSupported("");
+  inline Status Get(const ReadOptions& options,
+                    ColumnFamilyHandle* column_family, const Slice& key,
+                    std::string* value) {
+    PinnableSlice pSlice;
+    auto s = GetAndPin(options, column_family, key, &pSlice);
+    value->assign(pSlice.data(), pSlice.size());
+    return s;
   }
+  virtual Status GetAndPin(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* value) = 0;
   virtual Status Get(const ReadOptions& options, const Slice& key, std::string* value) {
     return Get(options, DefaultColumnFamily(), key, value);
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -283,6 +283,11 @@ class DB {
   virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      std::string* value) = 0;
+  virtual Status GetAndPin(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) {
+    return Status::NotSupported("");
+  }
   virtual Status Get(const ReadOptions& options, const Slice& key, std::string* value) {
     return Get(options, DefaultColumnFamily(), key, value);
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -284,13 +284,13 @@ class DB {
                     ColumnFamilyHandle* column_family, const Slice& key,
                     std::string* value) {
     PinnableSlice pSlice;
-    auto s = GetAndPin(options, column_family, key, &pSlice);
+    auto s = Get(options, column_family, key, &pSlice);
     value->assign(pSlice.data(), pSlice.size());
     return s;
   }
-  virtual Status GetAndPin(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* value) = 0;
+  virtual Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) = 0;
   virtual Status Get(const ReadOptions& options, const Slice& key, std::string* value) {
     return Get(options, DefaultColumnFamily(), key, value);
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -284,8 +284,11 @@ class DB {
                     ColumnFamilyHandle* column_family, const Slice& key,
                     std::string* value) {
     PinnableSlice pSlice;
-    auto s = Get(options, column_family, key, &pSlice);
-    value->assign(pSlice.data(), pSlice.size());
+    PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
+    auto s = Get(options, column_family, key, pSlicePtr);
+    if (value != nullptr) {
+      value->assign(pSlice.data(), pSlice.size());
+    }
     return s;
   }
   virtual Status Get(const ReadOptions& options,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -286,7 +286,7 @@ class DB {
     PinnableSlice pSlice;
     PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
     auto s = Get(options, column_family, key, pSlicePtr);
-    if (value != nullptr) {
+    if (value != nullptr && s.ok()) {
       value->assign(pSlice.data(), pSlice.size());
     }
     return s;

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -20,42 +20,11 @@
 #define STORAGE_ROCKSDB_INCLUDE_ITERATOR_H_
 
 #include <string>
+#include "rocksdb/cleanable.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 
 namespace rocksdb {
-
-class Cleanable {
- public:
-  Cleanable();
-  ~Cleanable();
-  // Clients are allowed to register function/arg1/arg2 triples that
-  // will be invoked when this iterator is destroyed.
-  //
-  // Note that unlike all of the preceding methods, this method is
-  // not abstract and therefore clients should not override it.
-  typedef void (*CleanupFunction)(void* arg1, void* arg2);
-  void RegisterCleanup(CleanupFunction function, void* arg1, void* arg2);
-  void DelegateCleanupsTo(Cleanable* other);
-  // DoCleanup and also resets the pointers for reuse
-  void Reset();
-
- protected:
-  struct Cleanup {
-    CleanupFunction function;
-    void* arg1;
-    void* arg2;
-    Cleanup* next;
-  };
-  Cleanup cleanup_;
-  // It also becomes the owner of c
-  void RegisterCleanup(Cleanup* c);
-
- private:
-  // Performs all the cleanups. It does not reset the pointers. Making it
-  // private to prevent misuse
-  inline void DoCleanup();
-};
 
 class Iterator : public Cleanable {
  public:

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -163,6 +163,7 @@ class PinnableSlice : public Slice, public Cleanable {
   inline bool IsPinned() { return cleanup_.function != nullptr; }
 
  private:
+  friend class PinnableSlice4Test;
   std::string self_space;
   static void ReleaseCharStrHeap(void* s, void*) {
     delete reinterpret_cast<const char*>(s);

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -122,33 +122,32 @@ class PinnableSlice : public Slice, public Cleanable {
  public:
   PinnableSlice() {}
 
-  void PinSlice(const Slice& s, CleanupFunction f, void* arg1, void* arg2) {
+  inline void PinSlice(const Slice& s, CleanupFunction f, void* arg1,
+                       void* arg2) {
     data_ = s.data();
     size_ = s.size();
     RegisterCleanup(f, arg1, arg2);
   }
 
-  void PinSlice(const Slice& s, Cleanable* cleanable) {
+  inline void PinSlice(const Slice& s, Cleanable* cleanable) {
     data_ = s.data();
     size_ = s.size();
     cleanable->DelegateCleanupsTo(this);
   }
 
-  void PinHeap(const char* s, const size_t n) {
+  inline void PinHeap(const char* s, const size_t n) {
     data_ = s;
     size_ = n;
     RegisterCleanup(ReleaseCharStrHeap, const_cast<char*>(data_), nullptr);
   }
 
-  void PinHeap(std::string* s) {
+  inline void PinHeap(std::string* s) {
     data_ = s->data();
     size_ = s->size();
     RegisterCleanup(ReleaseStringHeap, s, nullptr);
   }
 
-  bool IsPinned() {
-    return cleanup_.function != nullptr;
-  }
+  inline bool IsPinned() { return cleanup_.function != nullptr; }
 
  private:
   static void ReleaseCharStrHeap(void* s, void*) {

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -147,9 +147,23 @@ class PinnableSlice : public Slice, public Cleanable {
     RegisterCleanup(ReleaseStringHeap, s, nullptr);
   }
 
+  inline void PinSelf(const Slice& slice) {
+    self_space.assign(slice.data(), slice.size());
+    data_ = self_space.data();
+    size_ = self_space.size();
+  }
+
+  inline void PinSelf() {
+    data_ = self_space.data();
+    size_ = self_space.size();
+  }
+
+  inline std::string* GetSelf() { return &self_space; }
+
   inline bool IsPinned() { return cleanup_.function != nullptr; }
 
  private:
+  std::string self_space;
   static void ReleaseCharStrHeap(void* s, void*) {
     delete reinterpret_cast<const char*>(s);
   }

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -54,10 +54,10 @@ class StackableDB : public DB {
   }
 
   using DB::Get;
-  virtual Status GetAndPin(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* pSlice) override {
-    return db_->GetAndPin(options, column_family, key, pSlice);
+  virtual Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* pSlice) override {
+    return db_->Get(options, column_family, key, pSlice);
   }
 
   using DB::MultiGet;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -54,10 +54,10 @@ class StackableDB : public DB {
   }
 
   using DB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override {
-    return db_->Get(options, column_family, key, value);
+  virtual Status GetAndPin(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* pSlice) override {
+    return db_->GetAndPin(options, column_family, key, pSlice);
   }
 
   using DB::MultiGet;

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1537,9 +1537,6 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
     BlockIter iiter;
     NewIndexIterator(read_options, &iiter);
 
-    PinnedIteratorsManager* pinned_iters_mgr = get_context->pinned_iters_mgr();
-    bool pin_blocks = pinned_iters_mgr && pinned_iters_mgr->PinningEnabled();
-
     bool done = false;
     for (iiter.Seek(key); iiter.Valid() && !done; iiter.Next()) {
       Slice handle_value = iiter.value();
@@ -1580,17 +1577,12 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
             s = Status::Corruption(Slice());
           }
 
-          if (!get_context->SaveValue(parsed_key, biter.value(), pin_blocks)) {
+          if (!get_context->SaveValue(parsed_key, biter.value(), biter)) {
             done = true;
             break;
           }
         }
         s = biter.status();
-
-        if (pin_blocks && get_context->State() == GetContext::kMerge) {
-          // Pin blocks as long as we are merging
-          biter.DelegateCleanupsTo(pinned_iters_mgr);
-        }
       }
     }
     if (s.ok()) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1577,7 +1577,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
             s = Status::Corruption(Slice());
           }
 
-          if (!get_context->SaveValue(parsed_key, biter.value(), biter)) {
+          if (!get_context->SaveValue(parsed_key, biter.value(), &biter)) {
             done = true;
             break;
           }

--- a/table/cleanable_test.cc
+++ b/table/cleanable_test.cc
@@ -47,6 +47,30 @@ TEST_F(CleanableTest, Register) {
   }
   // ~Cleanable
   ASSERT_EQ(6, res);
+
+  // Test the Reset does cleanup
+  res = 1;
+  {
+    Cleanable c1;
+    c1.RegisterCleanup(Multiplier, &res, &n2);  // res = 2;
+    c1.RegisterCleanup(Multiplier, &res, &n3);  // res = 2 * 3;
+    c1.Reset();
+    ASSERT_EQ(6, res);
+  }
+  // ~Cleanable
+  ASSERT_EQ(6, res);
+
+  // Test Clenable is usable after Reset
+  res = 1;
+  {
+    Cleanable c1;
+    c1.RegisterCleanup(Multiplier, &res, &n2);  // res = 2;
+    c1.Reset();
+    ASSERT_EQ(2, res);
+    c1.RegisterCleanup(Multiplier, &res, &n3);  // res = 2 * 3;
+  }
+  // ~Cleanable
+  ASSERT_EQ(6, res);
 }
 
 // the first Cleanup is on stack and the rest on heap,
@@ -172,6 +196,102 @@ TEST_F(CleanableTest, Delegation) {
   }
   // ~Cleanable
   ASSERT_EQ(5, res);
+}
+
+class PinnableSlice4Test : public PinnableSlice {
+ public:
+  void TestCharStrIsRegistered(char* s) {
+    ASSERT_EQ(cleanup_.function, ReleaseCharStrHeap);
+    ASSERT_EQ(cleanup_.arg1, s);
+    ASSERT_EQ(cleanup_.arg2, nullptr);
+    ASSERT_EQ(cleanup_.next, nullptr);
+  }
+
+  void TestStringIsRegistered(std::string* s) {
+    ASSERT_EQ(cleanup_.function, ReleaseStringHeap);
+    ASSERT_EQ(cleanup_.arg1, s);
+    ASSERT_EQ(cleanup_.arg2, nullptr);
+    ASSERT_EQ(cleanup_.next, nullptr);
+  }
+};
+
+// Putting the PinnableSlice tests here due to similarity to Cleanable tests
+TEST_F(CleanableTest, PinnableSlice) {
+  int n2 = 2;
+  int res = 1;
+  const std::string const_str = "123";
+  const char* const_s = "123";
+
+  {
+    PinnableSlice4Test pSlice;
+    char* s = strdup(const_s);
+    pSlice.PinHeap(s, strlen(const_s));
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_s, str);
+    pSlice.TestCharStrIsRegistered(s);
+  }
+
+  {
+    PinnableSlice4Test pSlice;
+    std::string* heap_str = new std::string(const_str);
+    pSlice.PinHeap(heap_str);
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_str, str);
+    pSlice.TestStringIsRegistered(heap_str);
+  }
+
+  {
+    res = 1;
+    PinnableSlice4Test pSlice;
+    Slice slice(const_str);
+    pSlice.PinSlice(slice, Multiplier, &res, &n2);
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_str, str);
+  }
+  // ~Cleanable
+  ASSERT_EQ(2, res);
+
+  {
+    res = 1;
+    PinnableSlice4Test pSlice;
+    Slice slice(const_str);
+    {
+      Cleanable c1;
+      c1.RegisterCleanup(Multiplier, &res, &n2);  // res = 2;
+      pSlice.PinSlice(slice, &c1);
+    }
+    // ~Cleanable
+    ASSERT_EQ(1, res);  // cleanups must have be delegated to pSlice
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_str, str);
+  }
+  // ~Cleanable
+  ASSERT_EQ(2, res);
+
+  {
+    PinnableSlice4Test pSlice;
+    Slice slice(const_str);
+    pSlice.PinSelf(slice);
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_str, str);
+    ASSERT_EQ(false, pSlice.IsPinned());  // self pinned
+  }
+
+  {
+    PinnableSlice4Test pSlice;
+    std::string* self_str_ptr = pSlice.GetSelf();
+    self_str_ptr->assign(const_str);
+    pSlice.PinSelf();
+    std::string str;
+    str.assign(pSlice.data(), pSlice.size());
+    ASSERT_EQ(const_str, str);
+    ASSERT_EQ(false, pSlice.IsPinned());  // self pinned
+  }
 }
 
 }  // namespace rocksdb

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -123,12 +123,12 @@ class CuckooReaderTest : public testing::Test {
     ASSERT_OK(reader.status());
     // Assume no merge/deletion
     for (uint32_t i = 0; i < num_items; ++i) {
-      std::string value;
+      PinnableSlice value;
       GetContext get_context(ucomp, nullptr, nullptr, nullptr,
                              GetContext::kNotFound, Slice(user_keys[i]), &value,
                              nullptr, nullptr, nullptr, nullptr);
       ASSERT_OK(reader.Get(ReadOptions(), Slice(keys[i]), &get_context));
-      ASSERT_EQ(values[i], value);
+      ASSERT_EQ(values[i], value.data());
     }
   }
   void UpdateKeys(bool with_zero_seqno) {
@@ -333,7 +333,7 @@ TEST_F(CuckooReaderTest, WhenKeyNotFound) {
   AddHashLookups(not_found_user_key, 0, kNumHashFunc);
   ParsedInternalKey ikey(not_found_user_key, 1000, kTypeValue);
   AppendInternalKey(&not_found_key, ikey);
-  std::string value;
+  PinnableSlice value;
   GetContext get_context(ucmp, nullptr, nullptr, nullptr, GetContext::kNotFound,
                          Slice(not_found_key), &value, nullptr, nullptr,
                          nullptr, nullptr);
@@ -346,6 +346,7 @@ TEST_F(CuckooReaderTest, WhenKeyNotFound) {
   ParsedInternalKey ikey2(not_found_user_key2, 1000, kTypeValue);
   std::string not_found_key2;
   AppendInternalKey(&not_found_key2, ikey2);
+  value.Reset();
   GetContext get_context2(ucmp, nullptr, nullptr, nullptr,
                           GetContext::kNotFound, Slice(not_found_key2), &value,
                           nullptr, nullptr, nullptr, nullptr);
@@ -360,6 +361,7 @@ TEST_F(CuckooReaderTest, WhenKeyNotFound) {
   // Add hash values that map to empty buckets.
   AddHashLookups(ExtractUserKey(unused_key).ToString(),
       kNumHashFunc, kNumHashFunc);
+  value.Reset();
   GetContext get_context3(ucmp, nullptr, nullptr, nullptr,
                           GetContext::kNotFound, Slice(unused_key), &value,
                           nullptr, nullptr, nullptr, nullptr);
@@ -433,12 +435,13 @@ void WriteFile(const std::vector<std::string>& keys,
                            test::Uint64Comparator(), nullptr);
   ASSERT_OK(reader.status());
   ReadOptions r_options;
-  std::string value;
+  PinnableSlice value;
   // Assume only the fast path is triggered
   GetContext get_context(nullptr, nullptr, nullptr, nullptr,
                          GetContext::kNotFound, Slice(), &value, nullptr,
                          nullptr, nullptr, nullptr);
   for (uint64_t i = 0; i < num; ++i) {
+    value.Reset();
     value.clear();
     ASSERT_OK(reader.Get(r_options, Slice(keys[i]), &get_context));
     ASSERT_TRUE(Slice(keys[i]) == Slice(&keys[i][0], 4));
@@ -480,7 +483,7 @@ void ReadKeys(uint64_t num, uint32_t batch_size) {
   }
   std::random_shuffle(keys.begin(), keys.end());
 
-  std::string value;
+  PinnableSlice value;
   // Assume only the fast path is triggered
   GetContext get_context(nullptr, nullptr, nullptr, nullptr,
                          GetContext::kNotFound, Slice(), &value, nullptr,

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -128,7 +128,7 @@ class CuckooReaderTest : public testing::Test {
                              GetContext::kNotFound, Slice(user_keys[i]), &value,
                              nullptr, nullptr, nullptr, nullptr);
       ASSERT_OK(reader.Get(ReadOptions(), Slice(keys[i]), &get_context));
-      ASSERT_EQ(values[i], value.data());
+      ASSERT_STREQ(values[i].c_str(), value.data());
     }
   }
   void UpdateKeys(bool with_zero_seqno) {

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -9,6 +9,7 @@
 #include "db/range_del_aggregator.h"
 #include "rocksdb/env.h"
 #include "rocksdb/types.h"
+#include "table/block.h"
 
 namespace rocksdb {
 class MergeContext;
@@ -31,6 +32,14 @@ class GetContext {
              Env* env, SequenceNumber* seq = nullptr,
              PinnedIteratorsManager* _pinned_iters_mgr = nullptr);
 
+  GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
+             Logger* logger, Statistics* statistics, GetState init_state,
+             const Slice& user_key, std::string* ret_value,
+             PinnableSlice* pSlice, bool* value_found,
+             MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+             Env* env, SequenceNumber* seq = nullptr,
+             PinnedIteratorsManager* _pinned_iters_mgr = nullptr);
+
   void MarkKeyMayExist();
 
   // Records this key, value, and any meta-data (such as sequence number and
@@ -39,7 +48,7 @@ class GetContext {
   // Returns True if more keys need to be read (due to merges) or
   //         False if the complete value has been found.
   bool SaveValue(const ParsedInternalKey& parsed_key, const Slice& value,
-                 bool value_pinned = false);
+                 Cleanable* value_pinner = nullptr);
 
   // Simplified version of the previous function. Should only be used when we
   // know that the operation is a Put.
@@ -50,6 +59,8 @@ class GetContext {
   RangeDelAggregator* range_del_agg() { return range_del_agg_; }
 
   PinnedIteratorsManager* pinned_iters_mgr() { return pinned_iters_mgr_; }
+
+  PinnableSlice* GetPSlice() { return pSlice_; }
 
   // If a non-null string is passed, all the SaveValue calls will be
   // logged into the string. The operations can then be replayed on
@@ -69,6 +80,7 @@ class GetContext {
   GetState state_;
   Slice user_key_;
   std::string* value_;
+  PinnableSlice* pSlice_;
   bool* value_found_;  // Is value set correctly? Used by KeyMayExist
   MergeContext* merge_context_;
   RangeDelAggregator* range_del_agg_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -27,15 +27,7 @@ class GetContext {
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
-             const Slice& user_key, std::string* ret_value, bool* value_found,
-             MergeContext* merge_context, RangeDelAggregator* range_del_agg,
-             Env* env, SequenceNumber* seq = nullptr,
-             PinnedIteratorsManager* _pinned_iters_mgr = nullptr);
-
-  GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
-             Logger* logger, Statistics* statistics, GetState init_state,
-             const Slice& user_key, std::string* ret_value,
-             PinnableSlice* pSlice, bool* value_found,
+             const Slice& user_key, PinnableSlice* pSlice, bool* value_found,
              MergeContext* merge_context, RangeDelAggregator* range_del_agg,
              Env* env, SequenceNumber* seq = nullptr,
              PinnedIteratorsManager* _pinned_iters_mgr = nullptr);
@@ -60,8 +52,6 @@ class GetContext {
 
   PinnedIteratorsManager* pinned_iters_mgr() { return pinned_iters_mgr_; }
 
-  PinnableSlice* GetPSlice() { return pSlice_; }
-
   // If a non-null string is passed, all the SaveValue calls will be
   // logged into the string. The operations can then be replayed on
   // another GetContext with replayGetContextLog.
@@ -79,7 +69,6 @@ class GetContext {
 
   GetState state_;
   Slice user_key_;
-  std::string* value_;
   PinnableSlice* pSlice_;
   bool* value_found_;  // Is value set correctly? Used by KeyMayExist
   MergeContext* merge_context_;

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -21,24 +21,6 @@ Cleanable::Cleanable() {
 
 Cleanable::~Cleanable() { DoCleanup(); }
 
-void Cleanable::Reset() {
-  DoCleanup();
-  cleanup_.function = nullptr;
-  cleanup_.next = nullptr;
-}
-
-void Cleanable::DoCleanup() {
-  if (cleanup_.function != nullptr) {
-    (*cleanup_.function)(cleanup_.arg1, cleanup_.arg2);
-    for (Cleanup* c = cleanup_.next; c != nullptr;) {
-      (*c->function)(c->arg1, c->arg2);
-      Cleanup* next = c->next;
-      delete c;
-      c = next;
-    }
-  }
-}
-
 // If the entire linked list was on heap we could have simply add attach one
 // link list to another. However the head is an embeded object to avoid the cost
 // of creating objects for most of the use cases when the Cleanable has only one

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -166,7 +166,7 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
           std::string key = MakeKey(r1, r2, through_db);
           uint64_t start_time = Now(env, measured_by_nanosecond);
           if (!through_db) {
-            std::string value;
+            PinnableSlice value;
             MergeContext merge_context;
             RangeDelAggregator range_del_agg(ikc, {} /* snapshots */);
             GetContext get_context(ioptions.user_comparator,

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1973,7 +1973,7 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
                          GetContext::kNotFound, user_key, &value, nullptr,
                          nullptr, nullptr, nullptr);
   ASSERT_OK(reader->Get(ReadOptions(), user_key, &get_context));
-  ASSERT_EQ(value.data(), "hello");
+  ASSERT_STREQ(value.data(), "hello");
   BlockCachePropertiesSnapshot props(options.statistics.get());
   props.AssertFilterBlockStat(0, 0);
   c3.ResetTableReader();
@@ -2065,7 +2065,7 @@ TEST_F(BlockBasedTableTest, BlockReadCountTest) {
         ASSERT_EQ(perf_context.block_read_count, 1);
       }
       ASSERT_EQ(get_context.State(), GetContext::kFound);
-      ASSERT_EQ(value.data(), "hello");
+      ASSERT_STREQ(value.data(), "hello");
 
       // Get non-existing key
       user_key = "does-not-exist";

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1968,12 +1968,12 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
   ASSERT_OK(c3.Reopen(ioptions4));
   reader = dynamic_cast<BlockBasedTable*>(c3.GetTableReader());
   ASSERT_TRUE(!reader->TEST_filter_block_preloaded());
-  std::string value;
+  PinnableSlice value;
   GetContext get_context(options.comparator, nullptr, nullptr, nullptr,
                          GetContext::kNotFound, user_key, &value, nullptr,
                          nullptr, nullptr, nullptr);
   ASSERT_OK(reader->Get(ReadOptions(), user_key, &get_context));
-  ASSERT_EQ(value, "hello");
+  ASSERT_EQ(value.data(), "hello");
   BlockCachePropertiesSnapshot props(options.statistics.get());
   props.AssertFilterBlockStat(0, 0);
   c3.ResetTableReader();
@@ -2051,7 +2051,7 @@ TEST_F(BlockBasedTableTest, BlockReadCountTest) {
       c.Finish(options, ioptions, table_options,
                GetPlainInternalComparator(options.comparator), &keys, &kvmap);
       auto reader = c.GetTableReader();
-      std::string value;
+      PinnableSlice value;
       GetContext get_context(options.comparator, nullptr, nullptr, nullptr,
                              GetContext::kNotFound, user_key, &value, nullptr,
                              nullptr, nullptr, nullptr);
@@ -2065,13 +2065,14 @@ TEST_F(BlockBasedTableTest, BlockReadCountTest) {
         ASSERT_EQ(perf_context.block_read_count, 1);
       }
       ASSERT_EQ(get_context.State(), GetContext::kFound);
-      ASSERT_EQ(value, "hello");
+      ASSERT_EQ(value.data(), "hello");
 
       // Get non-existing key
       user_key = "does-not-exist";
       internal_key = InternalKey(user_key, 0, kTypeValue);
       encoded_key = internal_key.Encode().ToString();
 
+      value.Reset();
       get_context = GetContext(options.comparator, nullptr, nullptr, nullptr,
                                GetContext::kNotFound, user_key, &value, nullptr,
                                nullptr, nullptr, nullptr);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3784,7 +3784,8 @@ class Benchmark {
           s = db_with_cfh->db->GetAndPin(
               options, db_with_cfh->db->DefaultColumnFamily(), key, &pSlice);
         } else {
-          s = db_with_cfh->db->Get(options, key, &value);
+          s = db_with_cfh->db->Get(
+              options, db_with_cfh->db->DefaultColumnFamily(), key, &value);
         }
       }
       if (s.ok()) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3781,7 +3781,7 @@ class Benchmark {
       } else {
         if (FLAGS_pin_slice == 1) {
           pSlice.Reset();
-          s = db_with_cfh->db->GetAndPin(
+          s = db_with_cfh->db->Get(
               options, db_with_cfh->db->DefaultColumnFamily(), key, &pSlice);
         } else {
           s = db_with_cfh->db->Get(
@@ -3790,7 +3790,8 @@ class Benchmark {
       }
       if (s.ok()) {
         found++;
-        bytes += key.size() + (FLAGS_pin_slice == 1 ? pSlice.size() :  value.size());
+        bytes +=
+            key.size() + (FLAGS_pin_slice == 1 ? pSlice.size() : value.size());
       } else if (!s.IsNotFound()) {
         fprintf(stderr, "Get returned an error: %s\n", s.ToString().c_str());
         abort();

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -229,6 +229,8 @@ DEFINE_bool(reverse_iterator, false,
 
 DEFINE_bool(use_uint64_comparator, false, "use Uint64 user comparator");
 
+DEFINE_bool(pin_slice, false, "use pinnable slice for point lookup");
+
 DEFINE_int64(batch_size, 1, "Batch size");
 
 static bool ValidateKeySize(const char* flagname, int32_t value) {
@@ -3761,6 +3763,7 @@ class Benchmark {
     std::unique_ptr<const char[]> key_guard;
     Slice key = AllocateKey(&key_guard);
     std::string value;
+    PinnableSlice pSlice;
 
     Duration duration(FLAGS_duration, reads_);
     while (!duration.Done(1)) {
@@ -3776,11 +3779,17 @@ class Benchmark {
         s = db_with_cfh->db->Get(options, db_with_cfh->GetCfh(key_rand), key,
                                  &value);
       } else {
-        s = db_with_cfh->db->Get(options, key, &value);
+        if (FLAGS_pin_slice == 1) {
+          pSlice.Reset();
+          s = db_with_cfh->db->GetAndPin(
+              options, db_with_cfh->db->DefaultColumnFamily(), key, &pSlice);
+        } else {
+          s = db_with_cfh->db->Get(options, key, &value);
+        }
       }
       if (s.ok()) {
         found++;
-        bytes += key.size() + value.size();
+        bytes += key.size() + (FLAGS_pin_slice == 1 ? pSlice.size() :  value.size());
       } else if (!s.IsNotFound()) {
         fprintf(stderr, "Get returned an error: %s\n", s.ToString().c_str());
         abort();

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -12,10 +12,55 @@
 #include <cctype>
 #include <sstream>
 
+#include "db/memtable_list.h"
 #include "port/port.h"
 #include "util/file_reader_writer.h"
 
 namespace rocksdb {
+
+// These methods are deprecated and only being used in tests for backward
+// compatibility
+bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
+                              Status* s, MergeContext* merge_context,
+                              RangeDelAggregator* range_del_agg,
+                              SequenceNumber* seq,
+                              const ReadOptions& read_opts) {
+  PinnableSlice pSlice;
+  auto res = Get(key, &pSlice, s, merge_context, range_del_agg, seq, read_opts);
+  if (value != nullptr) {
+    value->assign(pSlice.data(), pSlice.size());
+  }
+  return res;
+}
+
+bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
+                              Status* s, MergeContext* merge_context,
+                              RangeDelAggregator* range_del_agg,
+                              const ReadOptions& read_opts) {
+  SequenceNumber seq;
+  return Get(key, value, s, merge_context, range_del_agg, &seq, read_opts);
+}
+
+bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
+                   MergeContext* merge_context,
+                   RangeDelAggregator* range_del_agg, SequenceNumber* seq,
+                   const ReadOptions& read_opts) {
+  PinnableSlice pSlice;
+  auto res = Get(key, &pSlice, s, merge_context, range_del_agg, seq, read_opts);
+  if (value != nullptr) {
+    value->assign(pSlice.data(), pSlice.size());
+  }
+  return res;
+}
+
+bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
+                   MergeContext* merge_context,
+                   RangeDelAggregator* range_del_agg,
+                   const ReadOptions& read_opts) {
+  SequenceNumber seq;
+  return Get(key, value, s, merge_context, range_del_agg, &seq, read_opts);
+}
+
 namespace test {
 
 Slice RandomString(Random* rnd, int len, std::string* dst) {

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -26,7 +26,8 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                               SequenceNumber* seq,
                               const ReadOptions& read_opts) {
   PinnableSlice pSlice;
-  auto res = Get(key, &pSlice, s, merge_context, range_del_agg, seq, read_opts);
+  PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
+  auto res = Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
   if (value != nullptr) {
     value->assign(pSlice.data(), pSlice.size());
   }
@@ -46,7 +47,8 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
                    RangeDelAggregator* range_del_agg, SequenceNumber* seq,
                    const ReadOptions& read_opts) {
   PinnableSlice pSlice;
-  auto res = Get(key, &pSlice, s, merge_context, range_del_agg, seq, read_opts);
+  PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
+  auto res = Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
   if (value != nullptr) {
     value->assign(pSlice.data(), pSlice.size());
   }

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -27,7 +27,8 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                               const ReadOptions& read_opts) {
   PinnableSlice pSlice;
   PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
-  auto res = Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
+  auto res =
+      Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
   if (value != nullptr) {
     value->assign(pSlice.data(), pSlice.size());
   }
@@ -48,7 +49,8 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
                    const ReadOptions& read_opts) {
   PinnableSlice pSlice;
   PinnableSlice* pSlicePtr = value != nullptr ? &pSlice : nullptr;
-  auto res = Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
+  auto res =
+      Get(key, pSlicePtr, s, merge_context, range_del_agg, seq, read_opts);
   if (value != nullptr) {
     value->assign(pSlice.data(), pSlice.size());
   }

--- a/utilities/document/document_db.cc
+++ b/utilities/document/document_db.cc
@@ -1037,9 +1037,9 @@ class DocumentDBImpl : public DocumentDB {
   }
 
   // RocksDB functions
-  virtual Status GetAndPin(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* pSlice) override {
+  virtual Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* pSlice) override {
     return Status::NotSupported("");
   }
   virtual Status Get(const ReadOptions& options, const Slice& key,

--- a/utilities/document/document_db.cc
+++ b/utilities/document/document_db.cc
@@ -1037,9 +1037,9 @@ class DocumentDBImpl : public DocumentDB {
   }
 
   // RocksDB functions
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override {
+  virtual Status GetAndPin(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* pSlice) override {
     return Status::NotSupported("");
   }
   virtual Status Get(const ReadOptions& options, const Slice& key,

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -200,10 +200,10 @@ Status DBWithTTLImpl::Put(const WriteOptions& options,
   return Write(options, &batch);
 }
 
-Status DBWithTTLImpl::GetAndPin(const ReadOptions& options,
-                                ColumnFamilyHandle* column_family,
-                                const Slice& key, PinnableSlice* pSlice) {
-  Status st = db_->GetAndPin(options, column_family, key, pSlice);
+Status DBWithTTLImpl::Get(const ReadOptions& options,
+                          ColumnFamilyHandle* column_family, const Slice& key,
+                          PinnableSlice* pSlice) {
+  Status st = db_->Get(options, column_family, key, pSlice);
   if (!st.ok()) {
     return st;
   }

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -49,9 +49,9 @@ class DBWithTTLImpl : public DBWithTTL {
                      const Slice& val) override;
 
   using StackableDB::Get;
-  virtual Status GetAndPin(const ReadOptions& options,
-                           ColumnFamilyHandle* column_family, const Slice& key,
-                           PinnableSlice* pSlice) override;
+  virtual Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* pSlice) override;
 
   using StackableDB::MultiGet;
   virtual std::vector<Status> MultiGet(

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -49,9 +49,9 @@ class DBWithTTLImpl : public DBWithTTL {
                      const Slice& val) override;
 
   using StackableDB::Get;
-  virtual Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) override;
+  virtual Status GetAndPin(const ReadOptions& options,
+                           ColumnFamilyHandle* column_family, const Slice& key,
+                           PinnableSlice* pSlice) override;
 
   using StackableDB::MultiGet;
   virtual std::vector<Status> MultiGet(
@@ -86,6 +86,8 @@ class DBWithTTLImpl : public DBWithTTL {
   static Status SanityCheckTimestamp(const Slice& str);
 
   static Status StripTS(std::string* str);
+
+  static Status StripTS(Slice* str);
 
   static const uint32_t kTSLength = sizeof(int32_t);  // size of timestamp
 


### PR DESCRIPTION
Summary:
Currently the point lookup values are copied to a string provided by the user.
This incures an extra memcpy cost. This patch allows doing point lookup
via a PinnableSlice which pins the source memory location (instead of
copying their content) and releases them after the content is consumed
by the user. The old API of Get(string) is translated to the new API
underneath.

 Here is the summary for improvements:
 1. value 100 byte: 1.8%  regular, 1.2% merge values
 2. value 1k   byte: 11.5% regular, 7.5% merge values
 3. value 10k byte: 26% regular,    29.9% merge values

 The improvement for merge could be more if we extend this approach to
 pin the merge output and delay the full merge operation until the user
 actually needs it. We have put that for future work.

PS:
Sometimes we observe a small decrease in performance when switching from
t5452014 to this patch but with the old Get(string) API. The difference
is a little and could be noise. More importantly it is safely
cancelled out when the user does use the new PinnableSlice API. Here is
the summary:
1. value 100 byte: +0.5%  regular, -2.4% merge values
2. value 1k   byte: -1.8% regular,   -0.5% merge values
3. value 10k byte:  -1.5% regular,  -2.15% merge values

Benchmark Details:
TEST_TMPDIR=/dev/shm/v100nocomp/ ./db_bench --benchmarks=fillrandom
--num=1000000 -value_size=100 -compression_type=none
TEST_TMPDIR=/dev/shm/v1000nocomp/ ./db_bench --benchmarks=fillrandom
--num=1000000 -value_size=1000 -compression_type=none
TEST_TMPDIR=/dev/shm/v10000nocomp/ ./db_bench --benchmarks=fillrandom
--num=1000000 -value_size=10000 -compression_type=none
TEST_TMPDIR=/dev/shm/v100nocomp-merge/ ./db_bench
--benchmarks=mergerandom --num=1000000 -value_size=100
-compression_type=none --merge_keys=100000 -merge_operator=max
TEST_TMPDIR=/dev/shm/v1000nocomp-merge/ ./db_bench
--benchmarks=mergerandom --num=1000000 -value_size=1000
-compression_type=none --merge_keys=100000 -merge_operator=max
TEST_TMPDIR=/dev/shm/v10000nocomp-merge/ ./db_bench
--benchmarks=mergerandom --num=1000000 -value_size=10000
-compression_type=none --merge_keys=100000 -merge_operator=max

TEST_TMPDIR=/dev/shm/v100nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=true 2>&1 | tee
scanread-10m-100-mergenon-pslice.txt
TEST_TMPDIR=/dev/shm/v100nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=false 2>&1 | tee
scanread-10m-100-mergenon-nopslice.txt

TEST_TMPDIR=/dev/shm/v100nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120 -pin_slice=true
2>&1 | tee scanreadmerge-10m-100-mergemax-pslice.txt
TEST_TMPDIR=/dev/shm/v100nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120
-pin_slice=false 2>&1 | tee scanreadmerge-10m-100-mergemax-nopslice.txt

TEST_TMPDIR=/dev/shm/v1000nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=true 2>&1 | tee
scanread-10m-1k-mergenon-pslice.txt
TEST_TMPDIR=/dev/shm/v1000nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=false 2>&1 | tee
scanread-10m-1k-mergenon-nopslice.txt

TEST_TMPDIR=/dev/shm/v1000nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120 -pin_slice=true
2>&1 | tee scanreadmerge-10m-1k-mergemax-pslice.txt
TEST_TMPDIR=/dev/shm/v1000nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120
-pin_slice=false 2>&1 | tee scanreadmerge-10m-1k-mergemax-nopslice.txt

TEST_TMPDIR=/dev/shm/v10000nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=true 2>&1 | tee
scanread-10m-10k-mergenon-pslice.txt
TEST_TMPDIR=/dev/shm/v10000nocomp/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -pin_slice=false 2>&1 | tee
scanread-10m-10k-mergenon-nopslice.txt

TEST_TMPDIR=/dev/shm/v10000nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120 -pin_slice=true
2>&1 | tee scanreadmerge-10m-10k-mergemax-pslice.txt
TEST_TMPDIR=/dev/shm/v10000nocomp-merge/ ./db_bench
--benchmarks="readseq,readrandom[X5]"  --use_existing_db --num=1000000
--reads=10000000 --cache_size=10000000000 -threads=32
-compression_type=none -merge_operator=max -duration=120
-pin_slice=false 2>&1 | tee scanreadmerge-10m-10k-mergemax-nopslice.txt

Benchmark Results:
ls -tr | grep ".*-10m-\(100\|1k\|10k\)-merge...-\(no\|\)pslice.txt$" |
xargs -L 1 grep AVG /dev/null
scanread-10m-100-mergenon-pslice.txt:readrandom [AVG    5 runs] :
3005915 ops/sec;  210.6 MB/sec
scanread-10m-100-mergenon-nopslice.txt:readrandom [AVG    5 runs] :
2953754 ops/sec;  207.0 MB/sec
scanreadmerge-10m-100-mergemax-pslice.txt:readrandom [AVG    5 runs] :
766150 ops/sec;    8.5 MB/sec
scanreadmerge-10m-100-mergemax-nopslice.txt:readrandom [AVG    5 runs] :
757289 ops/sec;    8.4 MB/sec
scanread-10m-1k-mergenon-pslice.txt:readrandom [AVG    5 runs] : 5965694
ops/sec; 3661.5 MB/sec
scanread-10m-1k-mergenon-nopslice.txt:readrandom [AVG    5 runs] :
5350749 ops/sec; 3284.1 MB/sec
scanreadmerge-10m-1k-mergemax-pslice.txt:readrandom [AVG    5 runs] :
36379493 ops/sec; 3524.9 MB/sec
scanreadmerge-10m-1k-mergemax-nopslice.txt:readrandom [AVG    5 runs] :
33825001 ops/sec; 3277.4 MB/sec
scanread-10m-10k-mergenon-pslice.txt:readrandom [AVG    5 runs] :
3127471 ops/sec; 18923.0 MB/sec
scanread-10m-10k-mergenon-nopslice.txt:readrandom [AVG    5 runs] :
2474603 ops/sec; 14972.8 MB/sec
scanreadmerge-10m-10k-mergemax-pslice.txt:readrandom [AVG    5 runs] :
29406680 ops/sec; 28090.5 MB/sec
scanreadmerge-10m-10k-mergemax-nopslice.txt:readrandom [AVG    5 runs] :
22828258 ops/sec; 21806.6 MB/sec

Notes: this is an initial patch to get early feedback. Here is the what left to be done:
1. The patch does not merge with master currently. I will fix that once https://github.com/facebook/rocksdb/pull/1711 is merged.
2. It lacks unit tests
3. MultiGet is still using the old API