### PR TITLE
utilities/backupable: backup should limit the copy size of wal.

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -448,7 +448,11 @@ rocksdb_backup_engine_t* rocksdb_backup_engine_open(
     const rocksdb_options_t* options, const char* path, char** errptr) {
   BackupEngine* be;
   if (SaveError(errptr, BackupEngine::Open(options->rep.env,
-                                           BackupableDBOptions(path, nullptr, true, options->rep.info_log.get()), &be))) {
+                                           BackupableDBOptions(path,
+                                                               nullptr,
+                                                               true,
+                                                               options->rep.info_log.get()),
+                                           &be))) {
     return nullptr;
   }
   rocksdb_backup_engine_t* result = new rocksdb_backup_engine_t;

--- a/db/c.cc
+++ b/db/c.cc
@@ -448,7 +448,7 @@ rocksdb_backup_engine_t* rocksdb_backup_engine_open(
     const rocksdb_options_t* options, const char* path, char** errptr) {
   BackupEngine* be;
   if (SaveError(errptr, BackupEngine::Open(options->rep.env,
-                                           BackupableDBOptions(path), &be))) {
+                                           BackupableDBOptions(path, nullptr, true, options->rep.info_log.get()), &be))) {
     return nullptr;
   }
   rocksdb_backup_engine_t* result = new rocksdb_backup_engine_t;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -781,13 +781,13 @@ Status BackupEngineImpl::CreateNewBackupWithMetadata(
         manifest_fname.size(), 0 /* size_limit */, false /* shared_checksum */,
         progress_callback, manifest_fname.substr(1) + "\n");
   }
-  Log(options_.info_log, "begin add wal files for backup -- %lu",
+  Log(options_.info_log, "begin add wal files for backup -- " ROCKSDB_PRIszt,
       live_wal_files.size());
   // Add a CopyOrCreateWorkItem to the channel for each WAL file
   for (size_t i = 0; s.ok() && i < live_wal_files.size(); ++i) {
     uint64_t size_bytes = live_wal_files[i]->SizeFileBytes();
     if (live_wal_files[i]->Type() == kAliveLogFile) {
-      Log(options_.info_log, "add wal file for backup %s -- %llu",
+      Log(options_.info_log, "add wal file for backup %s -- " PRIu64,
           live_wal_files[i]->PathName().c_str(), size_bytes);
       // we only care about live log files
       // copy the file into backup_dir/files/<new backup>/

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -781,13 +781,13 @@ Status BackupEngineImpl::CreateNewBackupWithMetadata(
         manifest_fname.size(), 0 /* size_limit */, false /* shared_checksum */,
         progress_callback, manifest_fname.substr(1) + "\n");
   }
-  Log(options_.info_log, "begin add wal files for backup -- " ROCKSDB_PRIszt,
+  Log(options_.info_log, "begin add wal files for backup -- %" ROCKSDB_PRIszt,
       live_wal_files.size());
   // Add a CopyOrCreateWorkItem to the channel for each WAL file
   for (size_t i = 0; s.ok() && i < live_wal_files.size(); ++i) {
     uint64_t size_bytes = live_wal_files[i]->SizeFileBytes();
     if (live_wal_files[i]->Type() == kAliveLogFile) {
-      Log(options_.info_log, "add wal file for backup %s -- " PRIu64,
+      Log(options_.info_log, "add wal file for backup %s -- %" PRIu64,
           live_wal_files[i]->PathName().c_str(), size_bytes);
       // we only care about live log files
       // copy the file into backup_dir/files/<new backup>/

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -506,7 +506,6 @@ BackupEngineImpl::BackupEngineImpl(Env* db_env,
     options_.restore_rate_limiter.reset(
         NewGenericRateLimiter(options_.restore_rate_limit));
   }
-          
 }
 
 BackupEngineImpl::~BackupEngineImpl() {
@@ -783,14 +782,13 @@ Status BackupEngineImpl::CreateNewBackupWithMetadata(
         progress_callback, manifest_fname.substr(1) + "\n");
   }
   Log(options_.info_log, "begin add wal files for backup -- %lu",
-        live_wal_files.size());
-  // Pre-fetch sizes for WAL files
+      live_wal_files.size());
   // Add a CopyOrCreateWorkItem to the channel for each WAL file
   for (size_t i = 0; s.ok() && i < live_wal_files.size(); ++i) {
     uint64_t size_bytes = live_wal_files[i]->SizeFileBytes();
     if (live_wal_files[i]->Type() == kAliveLogFile) {
       Log(options_.info_log, "add wal file for backup %s -- %llu",
-            live_wal_files[i]->PathName().c_str(), size_bytes);
+          live_wal_files[i]->PathName().c_str(), size_bytes);
       // we only care about live log files
       // copy the file into backup_dir/files/<new backup>/
       s = AddBackupFileWorkItem(live_dst_paths, backup_items_to_finish,


### PR DESCRIPTION
Summary: Since the backup work as snapshot, we should only copy
 the bytes of the wal while we get the alive files.