### PR TITLE
Make ExternalSSTFileTest::CompactionDeadlock more deterministic

### DIFF
--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1760,8 +1760,6 @@ TEST_F(ExternalSSTFileTest, CompactionDeadlock) {
   // `DBImpl::AddFile:Start` will wait until we be here
   TEST_SYNC_POINT("ExternalSSTFileTest::DeadLock:1");
 
-  ASSERT_EQ(running_threads.load(), 2);
-
   // Wait for IngestExternalFile() to start and aquire mutex
   TEST_SYNC_POINT("ExternalSSTFileTest::DeadLock:2");
 


### PR DESCRIPTION
It's not always true that `ASSERT_EQ(running_threads.load(), 2);`