### PR TITLE
Fix tx test case

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3419,11 +3419,11 @@ class Benchmark {
             continue;
           }
         }
-        writes_ /= open_options_.max_bytes_for_level_multiplier;
+        writes_ /= static_cast<int64_t>(open_options_.max_bytes_for_level_multiplier);
       }
       for (size_t i = 0; i < num_db; i++) {
         if (sorted_runs[i].size() < num_levels - 1) {
-          fprintf(stderr, "n is too small to fill %lu levels\n", num_levels);
+          fprintf(stderr, "n is too small to fill %" ROCKSDB_PRIszt " levels\n", num_levels);
           exit(1);
         }
       }
@@ -3470,11 +3470,11 @@ class Benchmark {
           }
           num_files_at_level0[i] = meta.levels[0].files.size();
         }
-        writes_ *= static_cast<double>(100) / (ratio + 200);
+        writes_ =  static_cast<int64_t>(writes_* static_cast<double>(100) / (ratio + 200));
       }
       for (size_t i = 0; i < num_db; i++) {
         if (sorted_runs[i].size() < num_levels) {
-          fprintf(stderr, "n is too small to fill %lu levels\n", num_levels);
+          fprintf(stderr, "n is too small to fill %" ROCKSDB_PRIszt  " levels\n", num_levels);
           exit(1);
         }
       }
@@ -3583,7 +3583,7 @@ class Benchmark {
     for (size_t k = 0; k < num_db; k++) {
       auto db = db_list[k];
       fprintf(stdout,
-              "---------------------- DB %lu LSM ---------------------\n", k);
+              "---------------------- DB %" ROCKSDB_PRIszt " LSM ---------------------\n", k);
       db->GetColumnFamilyMetaData(&meta);
       for (auto& levelMeta : meta.levels) {
         if (levelMeta.files.empty()) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -223,8 +223,13 @@ TEST_P(TransactionTest, WaitingTxn) {
 
   auto cf_iterator = lock_data.begin();
 
-  // Column family is 1 (cfa).
-  ASSERT_EQ(cf_iterator->first, 1);
+  // The iterator points to an unordered_multimap
+  // thus the test can not assume any particular order.
+
+  // Column family is 1 or 0 (cfa).
+  if (cf_iterator->first != 1 && cf_iterator->first != 0) {
+    ASSERT_FALSE(true);
+  }
   // The locked key is "foo" and is locked by txn1
   ASSERT_EQ(cf_iterator->second.key, "foo");
   ASSERT_EQ(cf_iterator->second.ids.size(), 1);
@@ -232,8 +237,10 @@ TEST_P(TransactionTest, WaitingTxn) {
 
   cf_iterator++;
 
-  // Column family is 0 (default).
-  ASSERT_EQ(cf_iterator->first, 0);
+  // Column family is 0 (default) or 1.
+  if (cf_iterator->first != 1 && cf_iterator->first != 0) {
+    ASSERT_FALSE(true);
+  }
   // The locked key is "foo" and is locked by txn1
   ASSERT_EQ(cf_iterator->second.key, "foo");
   ASSERT_EQ(cf_iterator->second.ids.size(), 1);


### PR DESCRIPTION
The test case assumes a particular order of returned column family lock information although the container used is unordered.
c:\dev\RocksDb\rocksdb\build>debug\transaction_test_je.exe --gtest_filter=DBAsBaseDB/TransactionTest.WaitingTxn/0
Note: Google Test filter = DBAsBaseDB/TransactionTest.WaitingTxn/0
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBAsBaseDB/TransactionTest
[ RUN      ] DBAsBaseDB/TransactionTest.WaitingTxn/0
c:\dev\rocksdb\rocksdb\utilities\transactions\transaction_test.cc(227): error: Value of: 1
Expected: cf_iterator->first
Which is: 0
Assertion failed: refs_.load(std::memory_order_relaxed) == 0, file c:\dev\rocksdb\rocksdb\db\column_family.cc, line 426
