### PR TITLE
Fix backupable db test

### DIFF
--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -112,8 +112,6 @@ class DummyDB : public StackableDB {
     }
 
     virtual uint64_t SizeFileBytes() const override {
-      // backupabledb should not need this method
-      EXPECT_TRUE(false);
       return 0;
     }
 


### PR DESCRIPTION
#1733 started using SizeFileBytes(), so our dummy log file implementation should stop asserting that this function isn't called.