### PR TITLE
Aggregate range tombstones in unsorted vector for faster Get()

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -467,7 +467,7 @@ void CompactionIterator::NextFromInput() {
       // 1. new user key -OR-
       // 2. different snapshot stripe
       bool should_delete = range_del_agg_->ShouldDelete(
-          key_, RangeDelAggregator::RangePositioningMode::kForwardTraversal);
+          key_, RangePositioningMode::kForwardTraversal);
       if (should_delete) {
         ++iter_stats_.num_record_drop_hidden;
         ++iter_stats_.num_record_drop_range_del;

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -194,8 +194,7 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       if (range_del_agg != nullptr &&
 
           range_del_agg->ShouldDelete(
-              iter->key(),
-              RangeDelAggregator::RangePositioningMode::kForwardTraversal) &&
+              iter->key(), RangePositioningMode::kForwardTraversal) &&
           filter != CompactionFilter::Decision::kRemoveAndSkipUntil) {
         filter = CompactionFilter::Decision::kRemove;
       }

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -22,6 +22,38 @@
 
 namespace rocksdb {
 
+// Some tombstone collections maintain position info across calls to
+// ShouldDelete(). The caller may wish to specify a mode to optimize
+// positioning the iterator during the next call to ShouldDelete(). The
+// non-kFullScan modes are only available for ordered/collapsed collections.
+//
+// For example, if we invoke Next() on an iterator, kForwardTraversal should
+// be specified to advance one-by-one through deletions until one is found
+// with its interval containing the key. This will typically be faster than
+// doing a full binary search (kBinarySearch).
+enum RangePositioningMode {
+  kFullScan,
+  kForwardTraversal,
+  kBackwardTraversal,
+  kBinarySearch,
+};
+
+class TombstoneCollection {
+ public:
+  explicit TombstoneCollection(const InternalKeyComparator& icmp)
+      : icmp_(icmp) {}
+  virtual ~TombstoneCollection() {}
+  virtual Status AddTombstone(RangeTombstone tombstone) = 0;
+  virtual bool ShouldDelete(const ParsedInternalKey& parsed,
+                            RangePositioningMode mode) = 0;
+  virtual size_t GetSize() = 0;
+  virtual void InvalidatePositions() = 0;
+  virtual std::vector<RangeTombstone> GetTombstones() = 0;
+
+ protected:
+  const InternalKeyComparator& icmp_;
+};
+
 // A RangeDelAggregator aggregates range deletion tombstones as they are
 // encountered in memtables/SST files. It provides methods that check whether a
 // key is covered by range tombstones or write the relevant tombstones to a new
@@ -52,27 +84,11 @@ class RangeDelAggregator {
                      SequenceNumber upper_bound,
                      bool collapse_deletions = false);
 
-  // We maintain position in the tombstone map across calls to ShouldDelete. The
-  // caller may wish to specify a mode to optimize positioning the iterator
-  // during the next call to ShouldDelete. The non-kFullScan modes are only
-  // available when deletion collapsing is enabled.
-  //
-  // For example, if we invoke Next() on an iterator, kForwardTraversal should
-  // be specified to advance one-by-one through deletions until one is found
-  // with its interval containing the key. This will typically be faster than
-  // doing a full binary search (kBinarySearch).
-  enum RangePositioningMode {
-    kFullScan,  // used iff collapse_deletions_ == false
-    kForwardTraversal,
-    kBackwardTraversal,
-    kBinarySearch,
-  };
-
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.
   // @param mode If collapse_deletions_ is true, this dictates how we will find
   //             the deletion whose interval contains this key. Otherwise, its
-  //             value must be kFullScan indicating linear scan from beginning..
+  //             value must be kFullScan indicating linear scan from beginning.
   bool ShouldDelete(const ParsedInternalKey& parsed,
                     RangePositioningMode mode = kFullScan);
   bool ShouldDelete(const Slice& internal_key,
@@ -89,7 +105,7 @@ class RangeDelAggregator {
   // if it's an iterator that just seeked to an arbitrary position. The effect
   // of invalidation is that the following call to ShouldDelete() will binary
   // search for its tombstone.
-  void InvalidateTombstoneMapPositions();
+  void InvalidatePositions();
 
   // Writes tombstones covering a range to a table builder.
   // @param extend_before_min_key If true, the range of tombstones to be added
@@ -118,26 +134,10 @@ class RangeDelAggregator {
   bool IsEmpty();
 
  private:
-  // Maps tombstone user start key -> tombstone object
-  typedef std::multimap<Slice, RangeTombstone, stl_wrappers::LessOfComparator>
-      TombstoneMap;
-  // Also maintains position in TombstoneMap last seen by ShouldDelete(). The
-  // end iterator indicates invalidation (e.g., if AddTombstones() changes the
-  // underlying map). End iterator cannot be invalidated.
-  struct PositionalTombstoneMap {
-    explicit PositionalTombstoneMap(TombstoneMap _raw_map)
-        : raw_map(std::move(_raw_map)), iter(raw_map.end()) {}
-    PositionalTombstoneMap(const PositionalTombstoneMap&) = delete;
-    PositionalTombstoneMap(PositionalTombstoneMap&& other)
-        : raw_map(std::move(other.raw_map)), iter(raw_map.end()) {}
-
-    TombstoneMap raw_map;
-    TombstoneMap::const_iterator iter;
-  };
-
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
   // their seqnums are greater than the next smaller snapshot's seqnum.
-  typedef std::map<SequenceNumber, PositionalTombstoneMap> StripeMap;
+  typedef std::map<SequenceNumber, std::unique_ptr<TombstoneCollection>>
+      StripeMap;
 
   struct Rep {
     StripeMap stripe_map_;
@@ -148,8 +148,9 @@ class RangeDelAggregator {
   // once the first range deletion is encountered.
   void InitRep(const std::vector<SequenceNumber>& snapshots);
 
-  PositionalTombstoneMap& GetPositionalTombstoneMap(SequenceNumber seq);
-  Status AddTombstone(RangeTombstone tombstone);
+  std::unique_ptr<TombstoneCollection> NewTombstoneCollection(
+      bool collapsed_deletions);
+  TombstoneCollection* GetTombstoneCollection(SequenceNumber seq);
 
   SequenceNumber upper_bound_;
   std::unique_ptr<Rep> rep_;

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -52,13 +52,11 @@ void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
       parsed_key.sequence = expected_point.seq;
       parsed_key.type = kTypeValue;
       ASSERT_FALSE(range_del_agg.ShouldDelete(
-          parsed_key,
-          RangeDelAggregator::RangePositioningMode::kForwardTraversal));
+          parsed_key, RangePositioningMode::kForwardTraversal));
       if (parsed_key.sequence > 0) {
         --parsed_key.sequence;
         ASSERT_TRUE(range_del_agg.ShouldDelete(
-            parsed_key,
-            RangeDelAggregator::RangePositioningMode::kForwardTraversal));
+            parsed_key, RangePositioningMode::kForwardTraversal));
       }
     }
   }


### PR DESCRIPTION
Introduced TombstoneCollection interface, which has two concrete
implementations: TombstoneVector and CollapsedTombstoneMap.

- TombstoneVector is used in the Get() path, where only one key needs to be
  checked, so it's not worthwhile to build a sorted/collapsed representation of
  the tombstones
- CollapsedTombstoneMap is used in the iterator paths (including for
  flushes/compactions), where many lookups are done so building the collapsed
  representation benefits performance.

Most of this diff is moving the RangeDelAggregator collection-specific logic
into CollapsedTombstoneMap. The logic in TombstoneVector is new because we
haven't stored tombstones in an unsorted vector before. Collection-agnostic
logic remains in RangeDelAggregator.

In my randomread benchmark on a DB with 1k range deletions, this diff increased
throughput 9.5 -> 12.0 MB/s.