### PR TITLE
 Fix Windows environment issues

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -205,7 +205,7 @@ TEST_F(DBTest, OpenWhenOpen) {
 
   ASSERT_EQ(Status::Code::kIOError, s.code());
   ASSERT_EQ(Status::SubCode::kNone, s.subcode());
-  ASSERT_TRUE(strncmp("lock ", s.getState(), 5) == 0);
+  ASSERT_TRUE(strstr(s.getState(), "lock ") != nullptr);
 
   delete db2;
 }

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -361,6 +361,8 @@ Status WinEnvIO::FileExists(const std::string& fname) {
 
 Status WinEnvIO::GetChildren(const std::string& dir,
   std::vector<std::string>* result) {
+
+  result->clear();
   std::vector<std::string> output;
 
   Status status;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3430,11 +3430,11 @@ class Benchmark {
             continue;
           }
         }
-        writes_ /= open_options_.max_bytes_for_level_multiplier;
+        writes_ /= static_cast<int64_t>(open_options_.max_bytes_for_level_multiplier);
       }
       for (size_t i = 0; i < num_db; i++) {
         if (sorted_runs[i].size() < num_levels - 1) {
-          fprintf(stderr, "n is too small to fill %lu levels\n", num_levels);
+          fprintf(stderr, "n is too small to fill %" ROCKSDB_PRIszt " levels\n", num_levels);
           exit(1);
         }
       }
@@ -3481,11 +3481,11 @@ class Benchmark {
           }
           num_files_at_level0[i] = meta.levels[0].files.size();
         }
-        writes_ *= static_cast<double>(100) / (ratio + 200);
+        writes_ =  static_cast<int64_t>(writes_* static_cast<double>(100) / (ratio + 200));
       }
       for (size_t i = 0; i < num_db; i++) {
         if (sorted_runs[i].size() < num_levels) {
-          fprintf(stderr, "n is too small to fill %lu levels\n", num_levels);
+          fprintf(stderr, "n is too small to fill %" ROCKSDB_PRIszt  " levels\n", num_levels);
           exit(1);
         }
       }
@@ -3594,7 +3594,7 @@ class Benchmark {
     for (size_t k = 0; k < num_db; k++) {
       auto db = db_list[k];
       fprintf(stdout,
-              "---------------------- DB %lu LSM ---------------------\n", k);
+              "---------------------- DB %" ROCKSDB_PRIszt " LSM ---------------------\n", k);
       db->GetColumnFamilyMetaData(&meta);
       for (auto& levelMeta : meta.levels) {
         if (levelMeta.files.empty()) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -223,8 +223,13 @@ TEST_P(TransactionTest, WaitingTxn) {
 
   auto cf_iterator = lock_data.begin();
 
-  // Column family is 1 (cfa).
-  ASSERT_EQ(cf_iterator->first, 1);
+  // The iterator points to an unordered_multimap
+  // thus the test can not assume any particular order.
+
+  // Column family is 1 or 0 (cfa).
+  if (cf_iterator->first != 1 && cf_iterator->first != 0) {
+    ASSERT_FALSE(true);
+  }
   // The locked key is "foo" and is locked by txn1
   ASSERT_EQ(cf_iterator->second.key, "foo");
   ASSERT_EQ(cf_iterator->second.ids.size(), 1);
@@ -232,8 +237,10 @@ TEST_P(TransactionTest, WaitingTxn) {
 
   cf_iterator++;
 
-  // Column family is 0 (default).
-  ASSERT_EQ(cf_iterator->first, 0);
+  // Column family is 0 (default) or 1.
+  if (cf_iterator->first != 1 && cf_iterator->first != 0) {
+    ASSERT_FALSE(true);
+  }
   // The locked key is "foo" and is locked by txn1
   ASSERT_EQ(cf_iterator->second.key, "foo");
   ASSERT_EQ(cf_iterator->second.ids.size(), 1);


### PR DESCRIPTION
     Enable directIO on WritableFileImpl::Append
     with offset being current length of the file.
     Enable UniqueID tests on Windows, disable others but
     leeting them to compile. Unique tests are valuable to
     detect failures on different filesystems and upcoming
     ReFS.
     Clear output in WinEnv Getchildren.This is different from
     previous strategy, do not touch output on failure.
     Make sure DBTest.OpenWhenOpen works with windows error message