### PR TITLE
Add GetSupportedCompressions() convenience function

### DIFF
--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -288,6 +288,8 @@ Status GetStringFromColumnFamilyOptions(std::string* opts_str,
 Status GetStringFromCompressionType(std::string* compression_str,
                                     CompressionType compression_type);
 
+std::vector<CompressionType> GetSupportedCompressions();
+
 Status GetBlockBasedTableOptionsFromString(
     const BlockBasedTableOptions& table_options,
     const std::string& opts_str,

--- a/util/options_helper.cc
+++ b/util/options_helper.cc
@@ -1080,6 +1080,17 @@ Status GetStringFromCompressionType(std::string* compression_str,
   }
 }
 
+std::vector<CompressionType> GetSupportedCompressions() {
+  std::vector<CompressionType> supported_compressions;
+  for (const auto& comp_to_name : compression_type_string_map) {
+    CompressionType t = comp_to_name.second;
+    if (t != kDisableCompressionOption && CompressionTypeSupported(t)) {
+      supported_compressions.push_back(t);
+    }
+  }
+  return supported_compressions;
+}
+
 bool SerializeSingleBlockBasedTableOption(
     std::string* opt_string, const BlockBasedTableOptions& bbt_options,
     const std::string& name, const std::string& delimiter) {


### PR DESCRIPTION
This function will return a list of supported compression types in RocksDB
This is needed for MyRocks https://github.com/facebook/mysql-5.6/pull/446