### PR TITLE
New subcode for IOError to detect the ESTALE errno

### DIFF
--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -70,6 +70,7 @@ class Status {
     kLockLimit = 3,
     kNoSpace = 4,
     kDeadlock = 5,
+    kStaleFile = 6,
     kMaxSubCode
   };
 

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -26,9 +26,14 @@
 namespace rocksdb {
 
 static Status IOError(const std::string& context, int err_number) {
-  return (err_number == ENOSPC) ?
-      Status::NoSpace(context, strerror(err_number)) :
-      Status::IOError(context, strerror(err_number));
+  switch (err_number) {
+  case ENOSPC:
+    return Status::NoSpace(context, strerror(err_number));
+  case ESTALE:
+    return Status::IOError(Status::kStaleFile);
+  default:
+    return Status::IOError(context, strerror(err_number));
+  }
 }
 
 class PosixHelper {

--- a/util/status_message.cc
+++ b/util/status_message.cc
@@ -12,7 +12,8 @@ const char* Status::msgs[] = {
     "Timeout Acquiring Mutex",                            // kMutexTimeout
     "Timeout waiting to lock key",                        // kLockTimeout
     "Failed to acquire lock due to max_num_locks limit",  // kLockLimit
-    "No space left on device"                             // kNoSpace
+    "No space left on device",                            // kNoSpace
+    "Deadlock"                                            // kDeadlock
 };
 
 }  // namespace rocksdb

--- a/util/status_message.cc
+++ b/util/status_message.cc
@@ -13,7 +13,8 @@ const char* Status::msgs[] = {
     "Timeout waiting to lock key",                        // kLockTimeout
     "Failed to acquire lock due to max_num_locks limit",  // kLockLimit
     "No space left on device",                            // kNoSpace
-    "Deadlock"                                            // kDeadlock
+    "Deadlock",                                           // kDeadlock
+    "Stale file handle"                                   // kStaleFile
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
I'd like to propose a patch to expose a new IOError type with subcode kStaleFile to allow to detect when ESTALE error is returned. This allows the rocksdb consumers to handle this error separately from other IOErrors.

I've also added a missing string representation for the kDeadlock subcode, I believe calling ToString() on Status object with that subcode would result in an out of band access in the msgs array,

Please let me know if you have any questions or would like me to make any changes to this pull request.