### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/utilities/column_aware_encoding_exp.cc
+++ b/utilities/column_aware_encoding_exp.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include <cstdio>
+#include <cstdlib>
 
 #ifndef ROCKSDB_LITE
 #ifdef GFLAGS


### PR DESCRIPTION
```
  CC       utilities/column_aware_encoding_exp.o
utilities/column_aware_encoding_exp.cc:149:5: error: use of undeclared identifier 'exit'
    exit(1);
    ^
utilities/column_aware_encoding_exp.cc:154:5: error: use of undeclared identifier 'exit'
    exit(1);
    ^
utilities/column_aware_encoding_exp.cc:158:5: error: use of undeclared identifier 'exit'
    exit(1);
    ^
3 errors generated.
```