### PR TITLE
util/thread_local.h: silence a clang-build warning

### DIFF
--- a/util/thread_local.h
+++ b/util/thread_local.h
@@ -18,8 +18,12 @@
 #include "util/autovector.h"
 #include "port/port.h"
 
-#if !defined(OS_WIN) && !defined(OS_MACOSX) && !defined(IOS_CROSS_COMPILE)
-#define ROCKSDB_SUPPORT_THREAD_LOCAL
+#ifndef ROCKSDB_SUPPORT_THREAD_LOCAL
+#  if defined(OS_WIN) || defined(OS_MACOSX) || defined(IOS_CROSS_COMPILE)
+#    define ROCKSDB_SUPPORT_THREAD_LOCAL 0
+#  else
+#    define ROCKSDB_SUPPORT_THREAD_LOCAL 1
+#  endif
 #endif
 
 namespace rocksdb {


### PR DESCRIPTION
otherwise clang complains with

/home/jenkins/workspace/ceph-master/src/rocksdb/util/thread_local.h:205:5:
error: macro expansion producing 'defined' has undefined behavior
[-Werror,-Wexpansion-to-defined]
^
/home/jenkins/workspace/ceph-master/src/rocksdb/util/thread_local.h:22:4:
note: expanded from macro 'ROCKSDB_SUPPORT_THREAD_LOCAL'
!defined(OS_WIN) && !defined(OS_MACOSX) && !defined(IOS_CROSS_COMPILE)
^`

Signed-off-by: Kefu Chai <tchaikov@gmail.com>