### PR TITLE
Add KEEP_DB env var option

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -73,8 +73,7 @@ DBTestBase::~DBTestBase() {
   options.db_paths.emplace_back(dbname_ + "_3", 0);
   options.db_paths.emplace_back(dbname_ + "_4", 0);
 
-  const char* keep_db = getenv("KEEP_DB");
-  if (keep_db && keep_db[0] == '1') {
+  if (getenv("KEEP_DB")) {
     printf("DB is still at %s\n", dbname_.c_str());
   } else {
     EXPECT_OK(DestroyDB(dbname_, options));

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -72,7 +72,13 @@ DBTestBase::~DBTestBase() {
   options.db_paths.emplace_back(dbname_ + "_2", 0);
   options.db_paths.emplace_back(dbname_ + "_3", 0);
   options.db_paths.emplace_back(dbname_ + "_4", 0);
-  EXPECT_OK(DestroyDB(dbname_, options));
+
+  const char* keep_db = getenv("KEEP_DB");
+  if (keep_db && keep_db[0] == '1') {
+    printf("DB is still at %s\n", dbname_.c_str());
+  } else {
+    EXPECT_OK(DestroyDB(dbname_, options));
+  }
   delete env_;
 }
 


### PR DESCRIPTION
When debugging tests, it's useful to preserve the DB to investigate it and check the logs
This will allow us to set KEEP_DB=1 to preserve the DB