### PR TITLE
Allow incrementing refcount on cache handles

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -102,6 +102,12 @@ class Cache {
   // function.
   virtual Handle* Lookup(const Slice& key, Statistics* stats = nullptr) = 0;
 
+  // Increments the reference count for the handle if it refers to an entry in
+  // the cache. Returns true if refcount was incremented; otherwise, returns
+  // false.
+  // REQUIRES: handle must have been returned by a method on *this.
+  virtual bool Ref(Handle* handle) = 0;
+
   // Release a mapping returned by a previous Lookup().
   // REQUIRES: handle must not have been released yet.
   // REQUIRES: handle must have been returned by a method on *this.

--- a/util/lru_cache.cc
+++ b/util/lru_cache.cc
@@ -256,6 +256,19 @@ Cache::Handle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash) {
   return reinterpret_cast<Cache::Handle*>(e);
 }
 
+bool LRUCacheShard::Ref(Cache::Handle* h) {
+  LRUHandle* handle = reinterpret_cast<LRUHandle*>(h);
+  MutexLock l(&mutex_);
+  if (handle->InCache()) {
+    if (handle->refs == 1) {
+      LRU_Remove(handle);
+    }
+    handle->refs++;
+    return true;
+  }
+  return false;
+}
+
 void LRUCacheShard::SetHighPriorityPoolRatio(double high_pri_pool_ratio) {
   MutexLock l(&mutex_);
   high_pri_pool_ratio_ = high_pri_pool_ratio;

--- a/util/lru_cache.h
+++ b/util/lru_cache.h
@@ -177,6 +177,7 @@ class LRUCacheShard : public CacheShard {
                         Cache::Handle** handle,
                         Cache::Priority priority) override;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) override;
+  virtual bool Ref(Cache::Handle* handle) override;
   virtual void Release(Cache::Handle* handle) override;
   virtual void Erase(const Slice& key, uint32_t hash) override;
 

--- a/util/sharded_cache.cc
+++ b/util/sharded_cache.cc
@@ -58,6 +58,11 @@ Cache::Handle* ShardedCache::Lookup(const Slice& key, Statistics* stats) {
   return GetShard(Shard(hash))->Lookup(key, hash);
 }
 
+bool ShardedCache::Ref(Handle* handle) {
+  uint32_t hash = GetHash(handle);
+  return GetShard(Shard(hash))->Ref(handle);
+}
+
 void ShardedCache::Release(Handle* handle) {
   uint32_t hash = GetHash(handle);
   GetShard(Shard(hash))->Release(handle);

--- a/util/sharded_cache.h
+++ b/util/sharded_cache.h
@@ -29,6 +29,7 @@ class CacheShard {
                         void (*deleter)(const Slice& key, void* value),
                         Cache::Handle** handle, Cache::Priority priority) = 0;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) = 0;
+  virtual bool Ref(Cache::Handle* handle) = 0;
   virtual void Release(Cache::Handle* handle) = 0;
   virtual void Erase(const Slice& key, uint32_t hash) = 0;
   virtual void SetCapacity(size_t capacity) = 0;
@@ -63,6 +64,7 @@ class ShardedCache : public Cache {
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle, Priority priority) override;
   virtual Handle* Lookup(const Slice& key, Statistics* stats) override;
+  virtual bool Ref(Handle* handle) override;
   virtual void Release(Handle* handle) override;
   virtual void Erase(const Slice& key) override;
   virtual uint64_t NewId() override;

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -64,6 +64,8 @@ class SimCacheImpl : public SimCache {
     return cache_->Lookup(key, stats);
   }
 
+  virtual bool Ref(Handle* handle) override { return cache_->Ref(handle); }
+
   virtual void Release(Handle* handle) override { cache_->Release(handle); }
 
   virtual void Erase(const Slice& key) override {


### PR DESCRIPTION
Previously the only way to increment a handle's refcount was to invoke Lookup(), which (1) did hash table lookup to get cache handle, (2) incremented that handle's refcount. For a future DeleteRange optimization, I added a function, Ref(), for when the caller already has a cache handle and only needs to do (2).