### PR TITLE
travis: For linux, do all tests under gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,6 @@ matrix:
   exclude:
   - os: osx
     compiler: gcc
-  - os: linux
-    compiler: gcc
-    env: JOB_NAME=java_test
-  - os: linux
-    compiler: gcc
-    env: JOB_NAME=unittests ROCKSDBTESTS_END=db_block_cache_test
 
 before_script:
   - if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then CXX=clang++-3.6; fi


### PR DESCRIPTION
apologies @yiwu-arbug, I thought I'd included this part of the commit.

Seems as though "JOB_NAME=unittests ROCKSDBTESTS_END=db_block_cache_test" has space issues and it did occasional previously too. May need to look up splitting tests more.