### PR TITLE
Avoid logs_ operation out of DB mutex

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4785,6 +4785,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
     // and protects against concurrent loggers and concurrent writes
     // into memtables
   }
+  log::Writer* cur_log_writer = logs_.back().writer;
 
   mutex_.Unlock();
 
@@ -4872,7 +4873,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       WriteBatchInternal::SetSequence(merged_batch, current_sequence);
 
       Slice log_entry = WriteBatchInternal::Contents(merged_batch);
-      status = logs_.back().writer->AddRecord(log_entry);
+      status = cur_log_writer->AddRecord(log_entry);
       total_log_size_ += log_entry.size();
       alive_log_files_.back().AddSize(log_entry.size());
       log_empty_ = false;


### PR DESCRIPTION
Summary: logs_.back() is called out of DB mutex, which can cause data race. We move the access into the DB mutex protection area.

Test Plan: Run all existing tests.