### PR TITLE
Remove fadvise with direct IO read

### DIFF
--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -265,11 +265,6 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
     // An error: return a non-ok status
     s = IOError(filename_, errno);
   }
-  if (!use_direct_io()) {
-    // we need to fadvise away the entire range of pages because
-    // we do not want readahead pages to be cached.
-    Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
-  }
   *result = Slice(scratch, (r < 0) ? 0 : n - left);
   return s;
 }


### PR DESCRIPTION
Summary:
Remove the logic since we don't use buffer cache with direct IO. Resolve
read regression we currently have.

Test Plan:
  db_bench --benchmarks=readwhilewriting --num=10000000 --threads=16
compare with 5.0 branch and previous revisions and see no regression.