### PR TITLE
Change DB::GetApproximateSizes for more flexibility needed for MyRocks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
+* Added new overloaded function GetApproximateSizes that supports getting memtable stats only without including approximate stats based on SST files.
+
+### Public API Change
 * Support dynamically change `delete_obsolete_files_period_micros` option via SetDBOptions().
 * Added EventListener::OnExternalFileIngested which will be called when IngestExternalFile() add a file successfully.
 * BackupEngine::Open and BackupEngineReadOnly::Open now always return error statuses matching those of the backup Env.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,10 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
-* Added new overloaded function GetApproximateSizes that supports getting memtable stats only without including approximate stats based on SST files.
-
-### Public API Change
 * Support dynamically change `delete_obsolete_files_period_micros` option via SetDBOptions().
 * Added EventListener::OnExternalFileIngested which will be called when IngestExternalFile() add a file successfully.
 * BackupEngine::Open and BackupEngineReadOnly::Open now always return error statuses matching those of the backup Env.
+* Added new overloaded function GetApproximateSizes that allows to specify if memtable stats should be computed only without computing SST files' stats approximations.
 
 ### Bug Fixes
 * Fix the bug that if 2PC is enabled, checkpoints may loss some recent transactions.

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5534,9 +5534,9 @@ ColumnFamilyHandle* DBImpl::GetColumnFamilyHandleUnlocked(
 
 void DBImpl::GetApproximateSizes(ColumnFamilyHandle* column_family,
                                  const Range* range, int n, uint64_t* sizes,
-                                 SizeApproximationFlags include_flags) {
-  assert(include_flags & SizeApproximationFlags::INCLUDE_FILES ||
-         include_flags & SizeApproximationFlags::INCLUDE_MEMTABLES);
+                                 uint8_t include_flags) {
+  assert(include_flags & DB::SizeApproximationFlags::INCLUDE_FILES ||
+         include_flags & DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
   Version* v;
   auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
   auto cfd = cfh->cfd();
@@ -5547,10 +5547,10 @@ void DBImpl::GetApproximateSizes(ColumnFamilyHandle* column_family,
     // Convert user_key into a corresponding internal key.
     InternalKey k1(range[i].start, kMaxSequenceNumber, kValueTypeForSeek);
     InternalKey k2(range[i].limit, kMaxSequenceNumber, kValueTypeForSeek);
-    if (include_flags & SizeApproximationFlags::INCLUDE_FILES) {
+    if (include_flags & DB::SizeApproximationFlags::INCLUDE_FILES) {
       sizes[i] = versions_->ApproximateSize(v, k1.Encode(), k2.Encode());
     }
-    if (include_flags & SizeApproximationFlags::INCLUDE_MEMTABLES) {
+    if (include_flags & DB::SizeApproximationFlags::INCLUDE_MEMTABLES) {
       sizes[i] += sv->mem->ApproximateSize(k1.Encode(), k2.Encode());
       sizes[i] += sv->imm->ApproximateSize(k1.Encode(), k2.Encode());
     }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -138,7 +138,7 @@ class DBImpl : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   SizeApproximationFlags include_flags
+                                   uint8_t include_flags 
                                    = INCLUDE_FILES) override;
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -138,7 +138,8 @@ class DBImpl : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   bool include_memtable = false) override;
+                                   SizeApproximationFlags include_flags
+                                   = INCLUDE_FILES) override;
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,
                               ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1407,17 +1407,21 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   std::string start = Key(50);
   std::string end = Key(60);
   Range r(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  auto include_both = DB::SizeApproximationFlags(
+                        DB::SizeApproximationFlags::INCLUDE_FILES &
+                        DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_GT(size, 6000);
   ASSERT_LT(size, 204800);
   // Zero if not including mem table
-  db_->GetApproximateSizes(&r, 1, &size, false);
+  db_->GetApproximateSizes(&r, 1, &size, 
+                           DB::SizeApproximationFlags::INCLUDE_FILES);
   ASSERT_EQ(size, 0);
 
   start = Key(500);
   end = Key(600);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_EQ(size, 0);
 
   for (int i = 0; i < N; i++) {
@@ -1427,13 +1431,13 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   start = Key(500);
   end = Key(600);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_EQ(size, 0);
 
   start = Key(100);
   end = Key(1020);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_GT(size, 6000);
 
   options.max_write_buffer_number = 8;
@@ -1456,28 +1460,29 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   start = Key(100);
   end = Key(300);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_EQ(size, 0);
 
   start = Key(1050);
   end = Key(1080);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_GT(size, 6000);
 
   start = Key(2100);
   end = Key(2300);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size, true);
+  db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_EQ(size, 0);
 
   start = Key(1050);
   end = Key(1080);
   r = Range(start, end);
   uint64_t size_with_mt, size_without_mt;
-  db_->GetApproximateSizes(&r, 1, &size_with_mt, true);
+  db_->GetApproximateSizes(&r, 1, &size_with_mt, include_both);
   ASSERT_GT(size_with_mt, 6000);
-  db_->GetApproximateSizes(&r, 1, &size_without_mt, false);
+  db_->GetApproximateSizes(&r, 1, &size_without_mt,
+                           DB::SizeApproximationFlags::INCLUDE_FILES);
   ASSERT_EQ(size_without_mt, 0);
 
   Flush();
@@ -1489,8 +1494,9 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   start = Key(1050);
   end = Key(1080);
   r = Range(start, end);
-  db_->GetApproximateSizes(&r, 1, &size_with_mt, true);
-  db_->GetApproximateSizes(&r, 1, &size_without_mt, false);
+  db_->GetApproximateSizes(&r, 1, &size_with_mt, include_both);
+  db_->GetApproximateSizes(&r, 1, &size_without_mt,
+                           DB::SizeApproximationFlags::INCLUDE_FILES);
   ASSERT_GT(size_with_mt, size_without_mt);
   ASSERT_GT(size_without_mt, 6000);
 }
@@ -2813,7 +2819,8 @@ class ModelDB : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   bool include_memtable) override {
+                                   DB::SizeApproximationFlags include_flags
+                                   = INCLUDE_FILES) override {
     for (int i = 0; i < n; i++) {
       sizes[i] = 0;
     }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1408,14 +1408,13 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   std::string end = Key(60);
   Range r(start, end);
   auto include_both = DB::SizeApproximationFlags(
-                        DB::SizeApproximationFlags::INCLUDE_FILES &
+                        DB::SizeApproximationFlags::INCLUDE_FILES |
                         DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
   db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_GT(size, 6000);
   ASSERT_LT(size, 204800);
   // Zero if not including mem table
-  db_->GetApproximateSizes(&r, 1, &size, 
-                           DB::SizeApproximationFlags::INCLUDE_FILES);
+  db_->GetApproximateSizes(&r, 1, &size);
   ASSERT_EQ(size, 0);
 
   start = Key(500);
@@ -1481,8 +1480,7 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   uint64_t size_with_mt, size_without_mt;
   db_->GetApproximateSizes(&r, 1, &size_with_mt, include_both);
   ASSERT_GT(size_with_mt, 6000);
-  db_->GetApproximateSizes(&r, 1, &size_without_mt,
-                           DB::SizeApproximationFlags::INCLUDE_FILES);
+  db_->GetApproximateSizes(&r, 1, &size_without_mt);
   ASSERT_EQ(size_without_mt, 0);
 
   Flush();
@@ -1495,8 +1493,7 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   end = Key(1080);
   r = Range(start, end);
   db_->GetApproximateSizes(&r, 1, &size_with_mt, include_both);
-  db_->GetApproximateSizes(&r, 1, &size_without_mt,
-                           DB::SizeApproximationFlags::INCLUDE_FILES);
+  db_->GetApproximateSizes(&r, 1, &size_without_mt);
   ASSERT_GT(size_with_mt, size_without_mt);
   ASSERT_GT(size_without_mt, 6000);
 }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1407,9 +1407,8 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   std::string start = Key(50);
   std::string end = Key(60);
   Range r(start, end);
-  auto include_both = DB::SizeApproximationFlags(
-                        DB::SizeApproximationFlags::INCLUDE_FILES |
-                        DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+  uint8_t include_both = DB::SizeApproximationFlags::INCLUDE_FILES |
+                         DB::SizeApproximationFlags::INCLUDE_MEMTABLES;
   db_->GetApproximateSizes(&r, 1, &size, include_both);
   ASSERT_GT(size, 6000);
   ASSERT_LT(size, 204800);
@@ -2816,7 +2815,7 @@ class ModelDB : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   DB::SizeApproximationFlags include_flags
+                                   uint8_t include_flags
                                    = INCLUDE_FILES) override {
     for (int i = 0; i < n; i++) {
       sizes[i] = 0;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -613,6 +613,29 @@ class DB {
                         include_flags);
   }
 
+  // Deprecated versions of GetApproximateSizes
+  ROCKSDB_DEPRECATED_FUNC virtual void GetApproximateSizes(
+      const Range* range, int n, uint64_t* sizes,
+      bool include_memtable) {
+    auto include_flags = DB::SizeApproximationFlags::INCLUDE_FILES;
+    if (include_memtable)
+      include_flags = DB::SizeApproximationFlags(
+                          include_flags |
+                          DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+    GetApproximateSizes(DefaultColumnFamily(), range, n, sizes, include_flags);
+  }
+  ROCKSDB_DEPRECATED_FUNC virtual void GetApproximateSizes(
+      ColumnFamilyHandle* column_family,
+      const Range* range, int n, uint64_t* sizes,
+      bool include_memtable) {
+    auto include_flags = DB::SizeApproximationFlags::INCLUDE_FILES;
+    if (include_memtable)
+      include_flags = DB::SizeApproximationFlags(
+                          include_flags |
+                          DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+    GetApproximateSizes(column_family, range, n, sizes, include_flags);
+  }
+
   // Compact the underlying storage for the key range [*begin,*end].
   // The actual compaction interval might be superset of [*begin, *end].
   // In particular, deleted and overwritten versions are discarded,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -586,6 +586,8 @@ class DB {
   virtual bool GetAggregatedIntProperty(const Slice& property,
                                         uint64_t* value) = 0;
 
+  // Flags for DB::GetSizeApproximation that specify whether memtable 
+  // stats should be included, or file stats approximation or both
   enum SizeApproximationFlags : uint8_t {
     NONE = 0,
     INCLUDE_MEMTABLES = 1,
@@ -602,12 +604,13 @@ class DB {
   // If include_flags defines whether the returned size should include
   // the recently written data in the mem-tables (if
   // the mem-table type supports it), data serialized to disk, or both.
+  // include_flags should be of type DB::SizeApproximationFlags
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   SizeApproximationFlags include_flags
+                                   uint8_t include_flags
                                    = INCLUDE_FILES) = 0;
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes,
-                                   SizeApproximationFlags include_flags
+                                   uint8_t include_flags
                                    = INCLUDE_FILES) {
     GetApproximateSizes(DefaultColumnFamily(), range, n, sizes,
                         include_flags);
@@ -617,22 +620,20 @@ class DB {
   ROCKSDB_DEPRECATED_FUNC virtual void GetApproximateSizes(
       const Range* range, int n, uint64_t* sizes,
       bool include_memtable) {
-    auto include_flags = DB::SizeApproximationFlags::INCLUDE_FILES;
-    if (include_memtable)
-      include_flags = DB::SizeApproximationFlags(
-                          include_flags |
-                          DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+    uint8_t include_flags = SizeApproximationFlags::INCLUDE_FILES;
+    if (include_memtable) {
+      include_flags |= SizeApproximationFlags::INCLUDE_MEMTABLES;
+    }
     GetApproximateSizes(DefaultColumnFamily(), range, n, sizes, include_flags);
   }
   ROCKSDB_DEPRECATED_FUNC virtual void GetApproximateSizes(
       ColumnFamilyHandle* column_family,
       const Range* range, int n, uint64_t* sizes,
       bool include_memtable) {
-    auto include_flags = DB::SizeApproximationFlags::INCLUDE_FILES;
-    if (include_memtable)
-      include_flags = DB::SizeApproximationFlags(
-                          include_flags |
-                          DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+    uint8_t include_flags = SizeApproximationFlags::INCLUDE_FILES;
+    if (include_memtable) {
+      include_flags |= SizeApproximationFlags::INCLUDE_MEMTABLES;
+    }
     GetApproximateSizes(column_family, range, n, sizes, include_flags);
   }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -586,6 +586,12 @@ class DB {
   virtual bool GetAggregatedIntProperty(const Slice& property,
                                         uint64_t* value) = 0;
 
+  enum SizeApproximationFlags : uint8_t {
+    NONE = 0,
+    INCLUDE_MEMTABLES = 1,
+    INCLUDE_FILES = 1 << 1
+  };
+
   // For each i in [0,n-1], store in "sizes[i]", the approximate
   // file system space used by keys in "[range[i].start .. range[i].limit)".
   //
@@ -593,16 +599,18 @@ class DB {
   // if the user data compresses by a factor of ten, the returned
   // sizes will be one-tenth the size of the corresponding user data size.
   //
-  // If include_memtable is set to true, then the result will also
-  // include those recently written data in the mem-tables if
-  // the mem-table type supports it.
+  // If include_flags defines whether the returned size should include
+  // the recently written data in the mem-tables (if
+  // the mem-table type supports it), data serialized to disk, or both.
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   bool include_memtable = false) = 0;
+                                   SizeApproximationFlags include_flags
+                                   = INCLUDE_FILES) = 0;
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes,
-                                   bool include_memtable = false) {
+                                   SizeApproximationFlags include_flags
+                                   = INCLUDE_FILES) {
     GetApproximateSizes(DefaultColumnFamily(), range, n, sizes,
-                        include_memtable);
+                        include_flags);
   }
 
   // Compact the underlying storage for the key range [*begin,*end].

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -161,7 +161,7 @@ class StackableDB : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* r, int n, uint64_t* sizes,
-                                   SizeApproximationFlags include_flags
+                                   uint8_t include_flags
                                    = INCLUDE_FILES) override {
     return db_->GetApproximateSizes(column_family, r, n, sizes,
                                     include_flags);

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -161,9 +161,10 @@ class StackableDB : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* r, int n, uint64_t* sizes,
-                                   bool include_memtable = false) override {
+                                   SizeApproximationFlags include_flags
+                                   = INCLUDE_FILES) override {
     return db_->GetApproximateSizes(column_family, r, n, sizes,
-                                    include_memtable);
+                                    include_flags);
   }
 
   using DB::CompactRange;


### PR DESCRIPTION
Added an option to GetApproximateSizes to exclude file stats, as MyRocks has those counted exactly and we need only stats from memtables.