### PR TITLE
Enable DBTest.GroupCommit as it runs in a reasonlable time now.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ build:
   verbosity: minimal
 test:
 test_script:
-- ps: build_tools\run_ci_db_test.ps1 -EnableRerun -Run db_test2 -Concurrency 8
-- ps: build_tools\run_ci_db_test.ps1 -EnableRerun -Run db_test -Exclude DBTest.GroupCommitTest -Concurrency 10
-- ps: build_tools\run_ci_db_test.ps1 -Run env_test -Concurrency 1
+- ps: build_tools\run_ci_db_test.ps1 -Run db_test2 -Concurrency 8
+- ps: build_tools\run_ci_db_test.ps1 -Run db_test -Concurrency 8
+- ps: build_tools\run_ci_db_test.ps1 -Run env_test,env_basic_test -Concurrency 2
 


### PR DESCRIPTION
  Remove ReRuns as they only waste time.
  Add env_basic_test to get more foundation coverage.