### PR TITLE
add listener events when compaction/flush starts, expose listener event callbacks to the C API wrapper

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1922,6 +1922,12 @@ Status DBImpl::FlushMemTableToOutputFile(
     s = SyncClosedLogs(job_context);
   }
 
+#ifndef ROCKSDB_LITE
+    // may temporarily unlock and lock the mutex.
+    NotifyOnFlushStarted(cfd, &file_meta, mutable_cf_options,
+                           job_context->job_id, flush_job.GetTableProperties());
+#endif  // ROCKSDB_LITE
+
   // Within flush_job.Run, rocksdb may call event listener to notify
   // file creation and deletion.
   //
@@ -1972,6 +1978,50 @@ Status DBImpl::FlushMemTableToOutputFile(
 #endif  // ROCKSDB_LITE
   }
   return s;
+}
+
+void DBImpl::NotifyOnFlushStarted(ColumnFamilyData* cfd,
+                                    FileMetaData* file_meta,
+                                    const MutableCFOptions& mutable_cf_options,
+                                    int job_id, TableProperties prop) {
+#ifndef ROCKSDB_LITE
+  if (immutable_db_options_.listeners.size() == 0U) {
+    return;
+  }
+  mutex_.AssertHeld();
+  if (shutting_down_.load(std::memory_order_acquire)) {
+    return;
+  }
+  bool triggered_writes_slowdown =
+      (cfd->current()->storage_info()->NumLevelFiles(0) >=
+       mutable_cf_options.level0_slowdown_writes_trigger);
+  bool triggered_writes_stop =
+      (cfd->current()->storage_info()->NumLevelFiles(0) >=
+       mutable_cf_options.level0_stop_writes_trigger);
+  // release lock while notifying events
+  mutex_.Unlock();
+  {
+    FlushJobInfo info;
+    info.cf_name = cfd->GetName();
+    // TODO(yhchiang): make db_paths dynamic in case flush does not
+    //                 go to L0 in the future.
+    info.file_path = MakeTableFileName(immutable_db_options_.db_paths[0].path,
+                                       file_meta->fd.GetNumber());
+    info.thread_id = env_->GetThreadID();
+    info.job_id = job_id;
+    info.triggered_writes_slowdown = triggered_writes_slowdown;
+    info.triggered_writes_stop = triggered_writes_stop;
+    info.smallest_seqno = file_meta->smallest_seqno;
+    info.largest_seqno = file_meta->largest_seqno;
+    info.table_properties = prop;
+    for (auto listener : immutable_db_options_.listeners) {
+      listener->OnFlushStarted(this, info);
+    }
+  }
+  mutex_.Lock();
+  // no need to signal bg_cv_ as it will be signaled at the end of the
+  // flush process.
+#endif  // ROCKSDB_LITE
 }
 
 void DBImpl::NotifyOnFlushCompleted(ColumnFamilyData* cfd,
@@ -2365,6 +2415,52 @@ Status DBImpl::ContinueBackgroundWork() {
     MaybeScheduleFlushOrCompaction();
   }
   return Status::OK();
+}
+
+void DBImpl::NotifyOnCompactionStarted(
+    ColumnFamilyData* cfd, Compaction *c,
+    const int job_id) {
+#ifndef ROCKSDB_LITE
+  if (immutable_db_options_.listeners.size() == 0U) {
+    return;
+  }
+  mutex_.AssertHeld();
+  if (shutting_down_.load(std::memory_order_acquire)) {
+    return;
+  }
+  // release lock while notifying events
+  mutex_.Unlock();
+  {
+    CompactionJobInfo info;
+    info.cf_name = cfd->GetName();
+    info.thread_id = env_->GetThreadID();
+    info.job_id = job_id;
+    info.base_input_level = c->start_level();
+    info.output_level = c->output_level();
+    info.table_properties = c->GetOutputTableProperties();
+    info.compaction_reason = c->compaction_reason();
+    for (size_t i = 0; i < c->num_input_levels(); ++i) {
+      for (const auto fmd : *c->inputs(i)) {
+        auto fn = TableFileName(immutable_db_options_.db_paths, fmd->fd.GetNumber(),
+                                fmd->fd.GetPathId());
+        info.input_files.push_back(fn);
+        if (info.table_properties.count(fn) == 0) {
+          std::shared_ptr<const TableProperties> tp;
+          auto s = cfd->current()->GetTableProperties(&tp, fmd, &fn);
+          if (s.ok()) {
+            info.table_properties[fn] = tp;
+          }
+        }
+      }
+    }
+    for (auto listener : immutable_db_options_.listeners) {
+      listener->OnCompactionStarted(this, info);
+    }
+  }
+  mutex_.Lock();
+  // no need to signal bg_cv_ as it will be signaled at the end of the
+  // flush process.
+#endif  // ROCKSDB_LITE
 }
 
 void DBImpl::NotifyOnCompactionCompleted(
@@ -3527,6 +3623,12 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         }
       }
     }
+  }
+
+  if (c != nullptr) {
+    NotifyOnCompactionStarted(
+        c->column_family_data(), c.get(),
+        job_context->job_id);
   }
 
   if (!c) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -559,9 +559,17 @@ class DBImpl : public DB {
   Status RenameTempFileToOptionsFile(const std::string& file_name);
   Status DeleteObsoleteOptionsFiles();
 
+  void NotifyOnFlushStarted(ColumnFamilyData* cfd, FileMetaData* file_meta,
+                              const MutableCFOptions& mutable_cf_options,
+                              int job_id, TableProperties prop);
+
   void NotifyOnFlushCompleted(ColumnFamilyData* cfd, FileMetaData* file_meta,
                               const MutableCFOptions& mutable_cf_options,
                               int job_id, TableProperties prop);
+
+  void NotifyOnCompactionStarted(ColumnFamilyData* cfd,
+                                 Compaction *c,
+                                 int job_id);
 
   void NotifyOnCompactionCompleted(ColumnFamilyData* cfd,
                                    Compaction *c, const Status &st,

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -216,6 +216,16 @@ struct ExternalFileIngestionInfo {
 class EventListener {
  public:
   // A call-back function to RocksDB which will be called whenever a
+  // registered RocksDB starts flushing a file.  The default implementation is
+  // no-op.
+  //
+  // Note that the this function must be implemented in a way such that
+  // it should not run for an extended period of time before the function
+  // returns.  Otherwise, RocksDB may be blocked.
+  virtual void OnFlushStarted(DB* /*db*/,
+                                const FlushJobInfo& /*flush_job_info*/) {}
+
+  // A call-back function to RocksDB which will be called whenever a
   // registered RocksDB flushes a file.  The default implementation is
   // no-op.
   //
@@ -237,6 +247,22 @@ class EventListener {
   // outside this function call, they should make copies from the
   // returned value.
   virtual void OnTableFileDeleted(const TableFileDeletionInfo& /*info*/) {}
+
+  // A call-back function for RocksDB which will be called whenever
+  // a registered RocksDB starts compaction. The default implementation
+  // is a no-op.
+  //
+  // Note that this function must be implemented in a way such that
+  // it should not run for an extended period of time before the function
+  // returns. Otherwise, RocksDB may be blocked.
+  //
+  // @param db a pointer to the rocksdb instance which just compacted
+  //   a file.
+  // @param ci a reference to a CompactionJobInfo struct. 'ci' is released
+  //  after this function is returned, and must be copied if it is needed
+  //  outside of this function.
+  virtual void OnCompactionStarted(DB* /*db*/,
+                                     const CompactionJobInfo& /*ci*/) {}
 
   // A call-back function for RocksDB which will be called whenever
   // a registered RocksDB compacts a file. The default implementation


### PR DESCRIPTION
This PR contains two separate topics:
1. adding event listener for when compaction and flush starts (there's one already for completion).
2. expose (some of) the event listener functionality to the C api via callbacks.

these changes came out to be quite ugly and contain a fair amount of code (enums and structs) duplication.
please feel free to ignore / reject.