### PR TITLE
Avoid cache lookups for range deletion meta-block

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1489,13 +1489,30 @@ InternalIterator* BlockBasedTable::NewIterator(const ReadOptions& read_options,
 InternalIterator* BlockBasedTable::NewRangeTombstoneIterator(
     const ReadOptions& read_options) {
   if (rep_->range_del_handle.IsNull()) {
+    // The block didn't exist, nullptr indicates no range tombstones.
     return nullptr;
+  }
+  if (rep_->range_del_entry.cache_handle != nullptr) {
+    // We have a handle to an uncompressed block cache entry that's held for
+    // this table's lifetime. Increment its refcount before returning an
+    // iterator based on it since the returned iterator may outlive this table
+    // reader.
+    assert(rep_->range_del_entry.value != nullptr);
+    Cache* block_cache = rep_->table_options.block_cache.get();
+    assert(block_cache != nullptr);
+    block_cache->Ref(rep_->range_del_entry.cache_handle);
+
+    auto iter = rep_->range_del_entry.value->NewIterator(
+        &rep_->internal_comparator, nullptr /* iter */,
+        true /* total_order_seek */, rep_->ioptions.statistics);
+    iter->RegisterCleanup(&ReleaseCachedEntry, block_cache,
+                          rep_->range_del_entry.cache_handle);
+    return iter;
   }
   std::string str;
   rep_->range_del_handle.EncodeTo(&str);
-  // Even though range_del_entry already references the meta-block when block
-  // cache is enabled, we still call the below function to get another reference
-  // since the caller may need the iterator beyond this table reader's lifetime.
+  // The meta-block exists but isn't in uncompressed block cache (maybe because
+  // it is disabled), so go through the full lookup process.
   return NewDataBlockIterator(rep_, read_options, Slice(str));
 }
 


### PR DESCRIPTION
I added the Cache::Ref() function a couple weeks ago (#1761) to make this feature possible. Like other meta-blocks, rep_->range_del_entry holds a cache handle to pin the range deletion block in uncompressed block cache for the duration of the table reader's lifetime. We can reuse this cache handle to create an iterator over this meta-block without any cache lookup. Ref() is used to increment the cache handle's refcount in case the returned iterator outlives the table reader.

Test Plan:

Measurements:
- random read perf before this diff: 12.0 MB/s
- random read perf after this diff: 13.4 MB/s
- baseline random read perf (using -expand_range_tombstones): 15-16 MB/s

Commands:
- fill db:
```./db_bench -benchmarks=fillrandom -write_buffer_size=67108864 -level0_file_num_compaction_trigger=4 -max_background_compactions=32 -level0_slowdown_writes_trigger=8 -level0_stop_writes_trigger=12 -num_levels=4 -min_level_to_compress=2 -compression_type=zlib -compression_ratio=0.5 -block_size=16384 -open_files=10000 -target_file_size_base=67108864 -max_bytes_for_level_base=268435456 -writes_per_range_tombstone=50000 -range_tombstone_width=50000 -max_num_range_tombstones=1000 -num=50000000```
- random read:
```./db_bench -benchmarks=readrandom -readonly -use_existing_db=true -open_files=10000 -num=50000000 -reads=1000000 -cache_size=1073741824 -threads=32```
