### PR TITLE
Remove function from DBImpl that are not used anywhere

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -138,7 +138,7 @@ class DBImpl : public DB {
   using DB::GetApproximateSizes;
   virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes,
-                                   uint8_t include_flags 
+                                   uint8_t include_flags
                                    = INCLUDE_FILES) override;
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,
@@ -431,9 +431,6 @@ class DBImpl : public DB {
   // mutex is held.
   SuperVersion* GetAndRefSuperVersion(uint32_t column_family_id);
 
-  // Same as above, should called without mutex held and not on write thread.
-  SuperVersion* GetAndRefSuperVersionUnlocked(uint32_t column_family_id);
-
   // Un-reference the super version and return it to thread local cache if
   // needed. If it is the last reference of the super version. Clean it up
   // after un-referencing it.
@@ -444,17 +441,10 @@ class DBImpl : public DB {
   // REQUIRED: this function should only be called on the write thread.
   void ReturnAndCleanupSuperVersion(uint32_t colun_family_id, SuperVersion* sv);
 
-  // Same as above, should called without mutex held and not on write thread.
-  void ReturnAndCleanupSuperVersionUnlocked(uint32_t colun_family_id,
-                                            SuperVersion* sv);
-
   // REQUIRED: this function should only be called on the write thread or if the
   // mutex is held.  Return value only valid until next call to this function or
   // mutex is released.
   ColumnFamilyHandle* GetColumnFamilyHandle(uint32_t column_family_id);
-
-  // Same as above, should called without mutex held and not on write thread.
-  ColumnFamilyHandle* GetColumnFamilyHandleUnlocked(uint32_t column_family_id);
 
   // Returns the number of currently running flushes.
   // REQUIREMENT: mutex_ must be held when calling this function.


### PR DESCRIPTION
GetAndRefSuperVersionUnlocked
ReturnAndCleanupSuperVersionUnlocked
GetColumnFamilyHandleUnlocked

Are dead code that are not used any where