### PR TITLE
Fix LRU Ref() for handles with external references only

### DIFF
--- a/util/lru_cache.cc
+++ b/util/lru_cache.cc
@@ -259,14 +259,11 @@ Cache::Handle* LRUCacheShard::Lookup(const Slice& key, uint32_t hash) {
 bool LRUCacheShard::Ref(Cache::Handle* h) {
   LRUHandle* handle = reinterpret_cast<LRUHandle*>(h);
   MutexLock l(&mutex_);
-  if (handle->InCache()) {
-    if (handle->refs == 1) {
-      LRU_Remove(handle);
-    }
-    handle->refs++;
-    return true;
+  if (handle->InCache() && handle->refs == 1) {
+    LRU_Remove(handle);
   }
-  return false;
+  handle->refs++;
+  return true;
 }
 
 void LRUCacheShard::SetHighPriorityPoolRatio(double high_pri_pool_ratio) {


### PR DESCRIPTION
For case !handle->InCache() && handle->refs >= 1 (the third case mentioned in lru_cache.h), the key was overwritten by Insert(). In this case, the refcount can still be incremented, and the cache handle will never enter LRU list. Ref() should succeed in this case so the caller won't need to invoke Lookup() to get another cache handle.