### PR TITLE
Add test DBTest2.GetRaceFlush which can expose a data race bug

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4007,6 +4007,9 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   } else {
     snapshot = versions_->LastSequence();
   }
+
+  TEST_SYNC_POINT("DBImpl::GetImpl:1");
+  TEST_SYNC_POINT("DBImpl::GetImpl:2");
   // Acquire SuperVersion
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
   // Prepare to store a list of merge operations if merge occurs.


### PR DESCRIPTION
Summary:
A current data race issue in Get() and Flush() can cause a Get() to return wrong results when a flush happened in the middle. Disable the test for now.