### PR TITLE
Change the default of delayed slowdown value to 16MB/s

### DIFF
--- a/DEFAULT_OPTIONS_HISTORY.md
+++ b/DEFAULT_OPTIONS_HISTORY.md
@@ -1,4 +1,11 @@
 # RocksDB default options change log
+## Unreleased
+* Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.
+
+## 5.0 (11/17/2016)
+* Options::allow_concurrent_memtable_write and Options::enable_write_thread_adaptive_yield are now true by default
+* Options.level0_stop_writes_trigger default value changes from 24 to 32.
+
 ## 4.8.0 (5/2/2016)
 * options.max_open_files changes from 5000 to -1. It improves performance, but users need to set file descriptor limit to be large enough and watch memory usage for index and bloom filters.
 * options.base_background_compactions changes from max_background_compactions to 1. When users set higher max_background_compactions but the write throughput is not high, the writes are less spiky to disks.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * BackupEngine::Open and BackupEngineReadOnly::Open now always return error statuses matching those of the backup Env.
 * Added new overloaded function GetApproximateSizes that allows to specify if memtable stats should be computed only without computing SST files' stats approximations.
 * NewLRUCache() will determine number of shard bits automatically based on capacity, if the user doesn't pass one. This also impacts the default block cache when the user doesn't explict provide one.
+* Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.
 
 ### Bug Fixes
 * Fix the bug that if 2PC is enabled, checkpoints may loss some recent transactions.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -423,13 +423,17 @@ struct ColumnFamilyOptions {
   // point. A value <0 means that no writing slow down will be triggered by
   // number of files in level-0.
   //
+  // Default: 20
+  //
   // Dynamically changeable through SetOptions() API
   int level0_slowdown_writes_trigger = 20;
 
   // Maximum number of level-0 files.  We stop writes at this point.
   //
+  // Default: 36
+  //
   // Dynamically changeable through SetOptions() API
-  int level0_stop_writes_trigger = 32;
+  int level0_stop_writes_trigger = 36;
 
   // This does not do anything anymore. Deprecated.
   int max_mem_compaction_level;
@@ -1287,8 +1291,8 @@ struct DBOptions {
   // gets behind further.
   // Unit: byte per second.
   //
-  // Default: 2MB/s
-  uint64_t delayed_write_rate = 2 * 1024U * 1024U;
+  // Default: 16MB/s
+  uint64_t delayed_write_rate = 16 * 1024U * 1024U;
 
   // If true, allow multi-writers to update mem tables in parallel.
   // Only some memtable_factory-s support concurrent writes; currently it

--- a/util/options.cc
+++ b/util/options.cc
@@ -417,6 +417,11 @@ DBOptions* DBOptions::OldDefaults(int rocksdb_major_version,
     max_file_opening_threads = 1;
     table_cache_numshardbits = 4;
   }
+  if (rocksdb_major_version < 5 ||
+      (rocksdb_major_version == 5 && rocksdb_minor_version < 2)) {
+    delayed_write_rate = 2 * 1024U * 1024U;
+  }
+
   max_open_files = 5000;
   base_background_compactions = -1;
   wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
@@ -435,6 +440,8 @@ ColumnFamilyOptions* ColumnFamilyOptions::OldDefaults(
   }
   if (rocksdb_major_version < 5) {
     level0_stop_writes_trigger = 24;
+  } else if (rocksdb_major_version == 5 && rocksdb_minor_version < 2) {
+    level0_stop_writes_trigger = 30;
   }
   compaction_pri = CompactionPri::kByCompensatedSize;
 

--- a/util/options_test.cc
+++ b/util/options_test.cc
@@ -1289,6 +1289,7 @@ TEST_F(OptionsParserTest, DifferentDefault) {
     ASSERT_EQ(10 * 1048576, old_default_opts.max_bytes_for_level_base);
     ASSERT_EQ(5000, old_default_opts.max_open_files);
     ASSERT_EQ(-1, old_default_opts.base_background_compactions);
+    ASSERT_EQ(2 * 1024U * 1024U, old_default_opts.delayed_write_rate);
     ASSERT_EQ(WALRecoveryMode::kTolerateCorruptedTailRecords,
               old_default_opts.wal_recovery_mode);
   }
@@ -1304,6 +1305,7 @@ TEST_F(OptionsParserTest, DifferentDefault) {
     ASSERT_NE(10 * 1048576, old_default_opts.max_bytes_for_level_base);
     ASSERT_NE(4, old_default_opts.table_cache_numshardbits);
     ASSERT_EQ(5000, old_default_opts.max_open_files);
+    ASSERT_EQ(2 * 1024U * 1024U, old_default_opts.delayed_write_rate);
   }
   {
     ColumnFamilyOptions old_default_cf_opts;
@@ -1329,6 +1331,16 @@ TEST_F(OptionsParserTest, DifferentDefault) {
     ASSERT_NE(2 * 1048576, old_default_cf_opts.target_file_size_base);
     ASSERT_EQ(CompactionPri::kByCompensatedSize,
               old_default_cf_opts.compaction_pri);
+  }
+  {
+    Options old_default_opts;
+    old_default_opts.OldDefaults(5, 1);
+    ASSERT_EQ(2 * 1024U * 1024U, old_default_opts.delayed_write_rate);
+  }
+  {
+    Options old_default_opts;
+    old_default_opts.OldDefaults(5, 2);
+    ASSERT_EQ(16 * 1024U * 1024U, old_default_opts.delayed_write_rate);
   }
 
   Options small_opts;


### PR DESCRIPTION
Summary:
Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.

Test Plan: Run all unit tests and write unit tests to old options functions