### PR TITLE
Remove incorrect statistics warning

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -946,8 +946,6 @@ struct DBOptions {
   uint64_t max_total_wal_size = 0;
 
   // If non-null, then we should collect metrics about database operations
-  // Statistics objects should not be shared between DB instances as
-  // it does not use any locks to prevent concurrent updates.
   std::shared_ptr<Statistics> statistics = nullptr;
 
   // If true, then the contents of manifest and data files are not synced


### PR DESCRIPTION
statistics are always concurrently updated regardless of whether a single instance or multiple instances are used. remove the warning since it's unnecessarily preventing people from sharing stats objects across rocksdb instances.

replace #1819 which was having some problem with our internal tools.