### PR TITLE
Dump compression dictionary meta-block

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1965,8 +1965,8 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file) {
   }
 
   // Output compression dictionary
-  auto compression_dict = rep_->compression_dict_block->data;
-  if (!compression_dict.empty()) {
+  if (rep_->compression_dict_block != nullptr) {
+    auto compression_dict = rep_->compression_dict_block->data;
     out_file->Append(
         "Compression Dictionary:\n"
         "--------------------------------------\n");

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1963,6 +1963,21 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file) {
   if (!s.ok()) {
     return s;
   }
+
+  // Output compression dictionary
+  auto compression_dict = rep_->compression_dict_block->data;
+  if (!compression_dict.empty()) {
+    out_file->Append(
+        "Compression Dictionary:\n"
+        "--------------------------------------\n");
+    out_file->Append("  size (bytes): ");
+    out_file->Append(rocksdb::ToString(compression_dict.size()));
+    out_file->Append("\n\n");
+    out_file->Append("  HEX    ");
+    out_file->Append(compression_dict.ToString(true).c_str());
+    out_file->Append("\n\n");
+  }
+
   // Output range deletions block
   auto* range_del_iter = NewRangeTombstoneIterator(ReadOptions());
   if (range_del_iter != nullptr) {


### PR DESCRIPTION
make sst_dump print size/contents of the dictionary meta-block for easier debugging

Test Plan: ran `sst_dump --command=raw` on a file compressed with dictionary, verified it looked as expected