### PR TITLE
Use gcc-4.9-glibc-2.20-fb python in precommit_checker

### DIFF
--- a/build_tools/precommit_checker.py
+++ b/build_tools/precommit_checker.py
@@ -1,4 +1,4 @@
-#!/usr/local/fbcode/gcc-4.8.1-glibc-2.17-fb/bin/python2.7
+#!/usr/local/fbcode/gcc-4.9-glibc-2.20-fb/bin/python2.7
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
The gcc-4.8.1-glibc-2.17 platform is deprecated and will be removed
soon.