### PR TITLE
Clarify ldb column family argument

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1770,7 +1770,7 @@ void ChangeCompactionStyleCommand::DoCommand() {
   // verify compaction result
   files_per_level = "";
   int num_files = 0;
-  for (int i = 0; i < db_->NumberLevels(); i++) {
+  for (int i = 0; i < db_->NumberLevels(GetCfHandle()); i++) {
     db_->GetProperty(GetCfHandle(),
                      "rocksdb.num-files-at-level" + NumberToString(i),
                      &property);

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -29,15 +29,15 @@ void LDBCommandRunner::PrintHelp(const char* exec_name) {
              " : Values are input/output as hex\n");
   ret.append("  --" + LDBCommand::ARG_HEX +
              " : Both keys and values are input/output as hex\n");
-  ret.append(
-      "  --" + LDBCommand::ARG_CF_NAME +
-      " : name of the column family to operate on. default: default column "
-      "family\n");
   ret.append("\n");
 
   ret.append(
       "The following optional parameters control the database "
       "internals:\n");
+  ret.append(
+      "  --" + LDBCommand::ARG_CF_NAME +
+      "=<string> : name of the column family to operate on. default: default "
+      "column family\n");
   ret.append("  --" + LDBCommand::ARG_TTL +
              " with 'put','get','scan','dump','query','batchput'"
              " : DB supports ttl and value is internally timestamp-suffixed\n");


### PR DESCRIPTION
move the argument description to the right section, make it clearer that the '=' sign is required, and use it in one subcommand where it seemed forgotten before.