### PR TITLE
Adding GetApproximateMemTableStats method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Added new overloaded function GetApproximateSizes that allows to specify if memtable stats should be computed only without computing SST files' stats approximations.
 * NewLRUCache() will determine number of shard bits automatically based on capacity, if the user doesn't pass one. This also impacts the default block cache when the user doesn't explict provide one.
 * Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.
+* Added new function GetApproximateMemTableStats that approximates both number of records and size of memtables.
 
 ### Bug Fixes
 * Fix the bug that if 2PC is enabled, checkpoints may loss some recent transactions.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -141,9 +141,10 @@ class DBImpl : public DB {
                                    uint8_t include_flags
                                    = INCLUDE_FILES) override;
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(
-      ColumnFamilyHandle* column_family,
-      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override;
+  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                           const Range& range,
+                                           uint64_t* const count,
+                                           uint64_t* const size) override;
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,
                               ColumnFamilyHandle* column_family,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -140,6 +140,10 @@ class DBImpl : public DB {
                                    const Range* range, int n, uint64_t* sizes,
                                    uint8_t include_flags
                                    = INCLUDE_FILES) override;
+  using DB::GetApproximateMemTableStats;
+  virtual void GetApproximateMemTableStats(
+      ColumnFamilyHandle* column_family,
+      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override;
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,
                               ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1516,7 +1516,7 @@ TEST_F(DBTest, GetApproximateMemTableStats) {
   std::string start = Key(50);
   std::string end = Key(60);
   Range r(start, end);
-  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  db_->GetApproximateMemTableStats(r, &count, &size);
   ASSERT_GT(count, 0);
   ASSERT_LE(count, N);
   ASSERT_GT(size, 6000);
@@ -1525,7 +1525,7 @@ TEST_F(DBTest, GetApproximateMemTableStats) {
   start = Key(500);
   end = Key(600);
   r = Range(start, end);
-  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  db_->GetApproximateMemTableStats(r, &count, &size);
   ASSERT_EQ(count, 0);
   ASSERT_EQ(size, 0);
 
@@ -1534,7 +1534,7 @@ TEST_F(DBTest, GetApproximateMemTableStats) {
   start = Key(50);
   end = Key(60);
   r = Range(start, end);
-  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  db_->GetApproximateMemTableStats(r, &count, &size);
   ASSERT_EQ(count, 0);
   ASSERT_EQ(size, 0);
 
@@ -1545,7 +1545,7 @@ TEST_F(DBTest, GetApproximateMemTableStats) {
   start = Key(100);
   end = Key(1020);
   r = Range(start, end);
-  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  db_->GetApproximateMemTableStats(r, &count, &size);
   ASSERT_GT(count, 20);
   ASSERT_GT(size, 6000);
 }
@@ -2875,13 +2875,12 @@ class ModelDB : public DB {
     }
   }
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(
-      ColumnFamilyHandle* column_family,
-      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override {
-    for (int i = 0; i < n; i++) {
-      counts[i] = 0;
-      sizes[i] = 0;
-    }
+  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                           const Range& range,
+                                           uint64_t* const count,
+                                           uint64_t* const size) override {
+    *count = 0;
+    *size = 0;
   }
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1497,6 +1497,59 @@ TEST_F(DBTest, ApproximateSizesMemTable) {
   ASSERT_GT(size_without_mt, 6000);
 }
 
+TEST_F(DBTest, GetApproximateMemTableStats) {
+  Options options = CurrentOptions();
+  options.write_buffer_size = 100000000;
+  options.compression = kNoCompression;
+  options.create_if_missing = true;
+  DestroyAndReopen(options);
+
+  const int N = 128;
+  Random rnd(301);
+  for (int i = 0; i < N; i++) {
+    ASSERT_OK(Put(Key(i), RandomString(&rnd, 1024)));
+  }
+
+  uint64_t count;
+  uint64_t size;
+
+  std::string start = Key(50);
+  std::string end = Key(60);
+  Range r(start, end);
+  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  ASSERT_GT(count, 0);
+  ASSERT_LE(count, N);
+  ASSERT_GT(size, 6000);
+  ASSERT_LT(size, 204800);
+
+  start = Key(500);
+  end = Key(600);
+  r = Range(start, end);
+  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  ASSERT_EQ(count, 0);
+  ASSERT_EQ(size, 0);
+
+  Flush();
+
+  start = Key(50);
+  end = Key(60);
+  r = Range(start, end);
+  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  ASSERT_EQ(count, 0);
+  ASSERT_EQ(size, 0);
+
+  for (int i = 0; i < N; i++) {
+    ASSERT_OK(Put(Key(1000 + i), RandomString(&rnd, 1024)));
+  }
+
+  start = Key(100);
+  end = Key(1020);
+  r = Range(start, end);
+  db_->GetApproximateMemTableStats(&r, 1, &count, &size);
+  ASSERT_GT(count, 20);
+  ASSERT_GT(size, 6000);
+}
+
 TEST_F(DBTest, ApproximateSizes) {
   do {
     Options options = CurrentOptions();
@@ -2818,6 +2871,15 @@ class ModelDB : public DB {
                                    uint8_t include_flags
                                    = INCLUDE_FILES) override {
     for (int i = 0; i < n; i++) {
+      sizes[i] = 0;
+    }
+  }
+  using DB::GetApproximateMemTableStats;
+  virtual void GetApproximateMemTableStats(
+      ColumnFamilyHandle* column_family,
+      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override {
+    for (int i = 0; i < n; i++) {
+      counts[i] = 0;
       sizes[i] = 0;
     }
   }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -326,7 +326,13 @@ class MemTable {
     return table_->IsSnapshotSupported() && !moptions_.inplace_update_support;
   }
 
-  uint64_t ApproximateSize(const Slice& start_ikey, const Slice& end_ikey);
+  struct MemTableStats {
+    uint64_t size;
+    uint64_t count;
+  };
+
+  MemTableStats ApproximateStats(const Slice& start_ikey,
+                                 const Slice& end_ikey);
 
   // Get the lock associated for the key
   port::RWMutex* GetLock(const Slice& key);

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -191,8 +191,7 @@ uint64_t MemTableListVersion::GetTotalNumEntries() const {
 }
 
 MemTable::MemTableStats MemTableListVersion::ApproximateStats(
-    const Slice& start_ikey,
-    const Slice& end_ikey) {
+    const Slice& start_ikey, const Slice& end_ikey) {
   MemTable::MemTableStats total_stats = {0, 0};
   for (auto& m : memlist_) {
     auto mStats = m->ApproximateStats(start_ikey, end_ikey);

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -190,13 +190,16 @@ uint64_t MemTableListVersion::GetTotalNumEntries() const {
   return total_num;
 }
 
-uint64_t MemTableListVersion::ApproximateSize(const Slice& start_ikey,
-                                              const Slice& end_ikey) {
-  uint64_t total_size = 0;
+MemTable::MemTableStats MemTableListVersion::ApproximateStats(
+    const Slice& start_ikey,
+    const Slice& end_ikey) {
+  MemTable::MemTableStats total_stats = {0, 0};
   for (auto& m : memlist_) {
-    total_size += m->ApproximateSize(start_ikey, end_ikey);
+    auto mStats = m->ApproximateStats(start_ikey, end_ikey);
+    total_stats.size += mStats.size;
+    total_stats.count += mStats.count;
   }
-  return total_size;
+  return total_stats;
 }
 
 uint64_t MemTableListVersion::GetTotalNumDeletes() const {

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -95,7 +95,8 @@ class MemTableListVersion {
 
   uint64_t GetTotalNumDeletes() const;
 
-  uint64_t ApproximateSize(const Slice& start_ikey, const Slice& end_ikey);
+  MemTable::MemTableStats ApproximateStats(const Slice& start_ikey,
+                                           const Slice& end_ikey);
 
   // Returns the value of MemTable::GetEarliestSequenceNumber() on the most
   // recent MemTable in this list or kMaxSequenceNumber if the list is empty.

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -618,12 +618,14 @@ class DB {
 
   // The method is similar to GetApproximateSizes, except it
   // returns approximate number of records in memtables.
-  virtual void GetApproximateMemTableStats(
-      ColumnFamilyHandle* column_family,
-      const Range* range, int n, uint64_t* counts, uint64_t* sizes) = 0;
-  virtual void GetApproximateMemTableStats(const Range* range, int n,
-                                           uint64_t* counts, uint64_t* sizes) {
-    GetApproximateMemTableStats(DefaultColumnFamily(), range, n, counts, sizes);
+  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                           const Range& range,
+                                           uint64_t* const count,
+                                           uint64_t* const size) = 0;
+  virtual void GetApproximateMemTableStats(const Range& range,
+                                           uint64_t* const count,
+                                           uint64_t* const size) {
+    GetApproximateMemTableStats(DefaultColumnFamily(), range, count, size);
   }
 
   // Deprecated versions of GetApproximateSizes

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -616,6 +616,16 @@ class DB {
                         include_flags);
   }
 
+  // The method is similar to GetApproximateSizes, except it
+  // returns approximate number of records in memtables.
+  virtual void GetApproximateMemTableStats(
+      ColumnFamilyHandle* column_family,
+      const Range* range, int n, uint64_t* counts, uint64_t* sizes) = 0;
+  virtual void GetApproximateMemTableStats(const Range* range, int n,
+                                           uint64_t* counts, uint64_t* sizes) {
+    GetApproximateMemTableStats(DefaultColumnFamily(), range, n, counts, sizes);
+  }
+
   // Deprecated versions of GetApproximateSizes
   ROCKSDB_DEPRECATED_FUNC virtual void GetApproximateSizes(
       const Range* range, int n, uint64_t* sizes,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -168,11 +168,11 @@ class StackableDB : public DB {
   }
 
   using DB::GetApproximateMemTableStats;
-  virtual void GetApproximateMemTableStats(
-      ColumnFamilyHandle* column_family,
-      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override {
-    return db_->GetApproximateMemTableStats(column_family, range,
-                                            n, counts, sizes);
+  virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
+                                           const Range& range,
+                                           uint64_t* const count,
+                                           uint64_t* const size) override {
+    return db_->GetApproximateMemTableStats(column_family, range, count, size);
   }
 
   using DB::CompactRange;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -167,6 +167,14 @@ class StackableDB : public DB {
                                     include_flags);
   }
 
+  using DB::GetApproximateMemTableStats;
+  virtual void GetApproximateMemTableStats(
+      ColumnFamilyHandle* column_family,
+      const Range* range, int n, uint64_t* counts, uint64_t* sizes) override {
+    return db_->GetApproximateMemTableStats(column_family, range,
+                                            n, counts, sizes);
+  }
+
   using DB::CompactRange;
   virtual Status CompactRange(const CompactRangeOptions& options,
                               ColumnFamilyHandle* column_family,


### PR DESCRIPTION
Added method that returns approx num of entries as well as size for memtables.