### PR TITLE
Use NowNanos() rather than NowMicros() in write_controller.cc and rate_limiter.cc

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5147,7 +5147,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
       delayed = true;
       TEST_SYNC_POINT("DBImpl::DelayWrite:Sleep");
       // hopefully we don't have to sleep more than 2 billion microseconds
-      env_->SleepForMicroseconds(static_cast<int>(delay));
+      env_->SleepForNanoseconds(static_cast<int>(delay));
       mutex_.Lock();
     }
 

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -440,6 +440,16 @@ class SpecialEnv : public EnvWrapper {
     }
   }
 
+  virtual void SleepForNanoseconds(int nanos) override {
+    sleep_counter_.Increment();
+    if (no_slowdown_ || time_elapse_only_sleep_) {
+      addon_time_.fetch_add(nanos/1000);
+    }
+    if (!no_slowdown_) {
+      target()->SleepForNanoseconds(nanos);
+    }
+  }
+
   virtual Status GetCurrentTime(int64_t* unix_time) override {
     Status s;
     if (!time_elapse_only_sleep_) {

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -36,7 +36,7 @@ class WriteController {
   // When an actor (column family) requests a delay token, total delay for all
   // writes to the DB will be controlled under the delayed write rate. Every
   // write needs to call GetDelay() with number of bytes writing to the DB,
-  // which returns number of microseconds to sleep.
+  // which returns number of nanoseconds to sleep.
   std::unique_ptr<WriteControllerToken> GetDelayToken(
       uint64_t delayed_write_rate);
   // When an actor (column family) requests a moderate token, compaction
@@ -49,7 +49,7 @@ class WriteController {
   bool NeedSpeedupCompaction() const {
     return IsStopped() || NeedsDelay() || total_compaction_pressure_ > 0;
   }
-  // return how many microseconds the caller needs to sleep after the call
+  // return how many nanoseconds the caller needs to sleep after the call
   // num_bytes: how many number of bytes to put into the DB.
   // Prerequisite: DB mutex held.
   uint64_t GetDelay(Env* env, uint64_t num_bytes);

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -132,6 +132,10 @@ class HdfsEnv : public Env {
     posixEnv->SleepForMicroseconds(micros);
   }
 
+  virtual void SleepForNanoseconds(int nanos) {
+    posixEnv->SleepForNanoseconds(nanos);
+  }
+
   virtual Status GetHostName(char* name, uint64_t len) {
     return posixEnv->GetHostName(name, len);
   }
@@ -343,6 +347,8 @@ class HdfsEnv : public Env {
   virtual uint64_t NowMicros() override { return 0; }
 
   virtual void SleepForMicroseconds(int micros) override {}
+
+  virtual void SleepForNanoseconds(int nanos) override {};
 
   virtual Status GetHostName(char* name, uint64_t len) override {
     return notsup;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -334,6 +334,9 @@ class Env {
   // Sleep/delay the thread for the perscribed number of micro-seconds.
   virtual void SleepForMicroseconds(int micros) = 0;
 
+  // Sleep/delay the thread for the perscribed number of nano-seconds.
+  virtual void SleepForNanoseconds(int nanos) = 0;
+
   // Get the current host name.
   virtual Status GetHostName(char* name, uint64_t len) = 0;
 
@@ -985,6 +988,11 @@ class EnvWrapper : public Env {
   void SleepForMicroseconds(int micros) override {
     target_->SleepForMicroseconds(micros);
   }
+
+  void SleepForNanoseconds(int nanos) override {
+    target_->SleepForNanoseconds(nanos);
+  }
+
   Status GetHostName(char* name, uint64_t len) override {
     return target_->GetHostName(name, len);
   }

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -872,6 +872,10 @@ void  WinEnvThreads::SleepForMicroseconds(int micros) {
   std::this_thread::sleep_for(std::chrono::microseconds(micros));
 }
 
+void WinEnvThreads::SleepForNanoseconds(int nanos) {
+  std::this_thread::sleep_for(std::chrono::nanoseconds(nanos));
+}
+
 void WinEnvThreads::SetBackgroundThreads(int num, Env::Priority pri) {
   assert(pri >= Env::Priority::LOW && pri <= Env::Priority::HIGH);
   thread_pools_[pri].SetBackgroundThreads(num);
@@ -1047,6 +1051,10 @@ uint64_t WinEnv::GetThreadID() const {
 
 void WinEnv::SleepForMicroseconds(int micros) {
   return winenv_threads_.SleepForMicroseconds(micros);
+}
+
+void WinEnv::SleepForNanoseconds(int nanos) {
+  return winenv_threads_.SleepForNanoseconds(nanos);
 }
 
 // Allow increasing the number of worker threads.

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -64,6 +64,8 @@ public:
 
   void SleepForMicroseconds(int micros);
 
+  void SleepForNanoseconds(int nanos);
+
   // Allow increasing the number of worker threads.
   void SetBackgroundThreads(int num, Env::Priority pri);
 
@@ -273,6 +275,8 @@ public:
   uint64_t GetThreadID() const override;
 
   void SleepForMicroseconds(int micros) override;
+
+  void SleepForNanoseconds(int nanos) override;
 
   // Allow increasing the number of worker threads.
   void SetBackgroundThreads(int num, Env::Priority pri) override;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -675,6 +675,10 @@ class PosixEnv : public Env {
 
   virtual void SleepForMicroseconds(int micros) override { usleep(micros); }
 
+  virtual void SleepForNanoseconds(int nanos) override {
+    std::this_thread::sleep_for(std::chrono::nanoseconds(nanos));
+  }
+
   virtual Status GetHostName(char* name, uint64_t len) override {
     int ret = gethostname(name, static_cast<size_t>(len));
     if (ret < 0) {

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -67,7 +67,7 @@ class GenericRateLimiter : public RateLimiter {
 
   const int64_t kMinRefillBytesPerPeriod = 100;
 
-  const int64_t refill_period_us_;
+  const int64_t refill_period_ns_;
   // This variable can be changed dynamically.
   std::atomic<int64_t> refill_bytes_per_period_;
   Env* const env_;
@@ -79,7 +79,7 @@ class GenericRateLimiter : public RateLimiter {
   int64_t total_requests_[Env::IO_TOTAL];
   int64_t total_bytes_through_[Env::IO_TOTAL];
   int64_t available_bytes_;
-  int64_t next_refill_us_;
+  int64_t next_refill_ns_;
 
   int32_t fairness_;
   Random rnd_;


### PR DESCRIPTION
[RocksDB] write_controller.cc and rate_limiter.cc should use NowNanos()
rather than NowMicros()