### PR TITLE
Print the missed last layer in cfstats

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -865,7 +865,7 @@ void InternalStats::DumpCFMapStats(std::map<std::string, double>* cf_stats) {
   }
 }
 
-int InternalStats::DumpCFMapStats(
+void InternalStats::DumpCFMapStats(
     std::map<int, std::map<LevelStatType, double>>* levels_stats,
     CompactionStats* compaction_stats_sum) {
   const VersionStorageInfo* vstorage = cfd_->current()->storage_info();
@@ -925,7 +925,6 @@ int InternalStats::DumpCFMapStats(
   PrepareLevelStats(&sum_stats, total_files, total_files_being_compacted,
                     total_file_size, 0, w_amp, *compaction_stats_sum);
   (*levels_stats)[-1] = sum_stats;  //  -1 is for the Sum level
-  return num_levels_to_check;
 }
 
 void InternalStats::DumpCFStats(std::string* value) {
@@ -937,8 +936,8 @@ void InternalStats::DumpCFStats(std::string* value) {
   // Print stats for each level
   std::map<int, std::map<LevelStatType, double>> levels_stats;
   CompactionStats compaction_stats_sum(0);
-  int levels = DumpCFMapStats(&levels_stats, &compaction_stats_sum);
-  for (int l = 0; l < levels; ++l) {
+  DumpCFMapStats(&levels_stats, &compaction_stats_sum);
+  for (int l = 0; l < number_levels_; ++l) {
     if (levels_stats.find(l) != levels_stats.end()) {
       PrintLevelStats(buf, sizeof(buf), "L" + ToString(l), levels_stats[l]);
       value->append(buf);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -273,7 +273,7 @@ class InternalStats {
  private:
   void DumpDBStats(std::string* value);
   void DumpCFMapStats(std::map<std::string, double>* cf_stats);
-  int DumpCFMapStats(
+  void DumpCFMapStats(
       std::map<int, std::map<LevelStatType, double>>* level_stats,
       CompactionStats* compaction_stats_sum);
   void DumpCFStats(std::string* value);


### PR DESCRIPTION
Summary:
Printing compaction stats used to operate on two variable: 
number_levels_: for printing the layer
num_levels_to_check: for updating the compaction score

After this commit: 361010d44738de48ffc4fd9add70caa0891a0719 these two are mixed up and as a result the last layer might not be printed out: https://fb.facebook.com/groups/rocksdb.internal/permalink/1315716625143616/

number_levels_ was used to decide which layers to print: https://github.com/facebook/rocksdb/blob/672300f47f72b28c164fdf98a08171c09e311205/db/internal_stats.cc#L753 but after the patch it is based on the return value of DumpCFMapStats https://github.com/facebook/rocksdb/blob/361010d44738de48ffc4fd9add70caa0891a0719/db/internal_stats.cc#L929 which returns num_levels_to_check: https://github.com/facebook/rocksdb/blob/361010d44738de48ffc4fd9add70caa0891a0719/db/internal_stats.cc#L917
