### PR TITLE
Announce the experimetnal two-level index feature in HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 * NewLRUCache() will determine number of shard bits automatically based on capacity, if the user doesn't pass one. This also impacts the default block cache when the user doesn't explict provide one.
 * Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.
 * Added new function GetApproximateMemTableStats that approximates both number of records and size of memtables.
+* (Experimental) Two-level indexing that partition the index and creates a 2nd level index on the partitions. The feature can be enabled by setting kTwoLevelIndexSearch as IndexType and configuring index_per_partition.
 
 ### Bug Fixes
 * Fix the bug that if 2PC is enabled, checkpoints may loss some recent transactions.

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -146,7 +146,7 @@ struct BlockBasedTableOptions {
 
   // Number of index keys per partition of indexes in a multi-level index
   // i.e., the number of data blocks covered by each index partition
-  uint64_t index_per_partition = 2;
+  uint64_t index_per_partition = 1024;
 
   // Use delta encoding to compress keys in blocks.
   // ReadOptions::pin_data requires this option to be disabled.


### PR DESCRIPTION
Summary:
Announce the experimetnal two-level index feature in HISTORY.md. Also updated the default for index_per_partition to 1024.