### PR TITLE
Fix repair issues

### DIFF
--- a/db/repair.cc
+++ b/db/repair.cc
@@ -486,6 +486,7 @@ class Repairer {
         if (empty) {
           empty = false;
           t->meta.smallest.DecodeFrom(key);
+          t->min_sequence = parsed.sequence;
         }
         t->meta.largest.DecodeFrom(key);
         if (parsed.sequence < t->min_sequence) {

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -253,7 +253,9 @@ TEST_F(RepairTest, RepairColumnFamilyOptions) {
   db_->GetPropertiesOfAllTables(handles_[1], &fname_to_props);
   ASSERT_EQ(fname_to_props.size(), 2U);
   for (const auto& fname_and_props : fname_to_props) {
-    ASSERT_EQ(InternalKeyComparator(rev_opts.comparator).Name(),
+    std::string compName (InternalKeyComparator(rev_opts.comparator).Name());
+    compName = compName.substr(compName.find(':') + 1);
+    ASSERT_EQ(compName,
               fname_and_props.second->comparator_name);
   }
 

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -253,9 +253,10 @@ TEST_F(RepairTest, RepairColumnFamilyOptions) {
   db_->GetPropertiesOfAllTables(handles_[1], &fname_to_props);
   ASSERT_EQ(fname_to_props.size(), 2U);
   for (const auto& fname_and_props : fname_to_props) {
-    std::string compName (InternalKeyComparator(rev_opts.comparator).Name());
-    compName = compName.substr(compName.find(':') + 1);
-    ASSERT_EQ(compName,
+    std::string comparator_name (
+      InternalKeyComparator(rev_opts.comparator).Name());
+    comparator_name = comparator_name.substr(comparator_name.find(':') + 1);
+    ASSERT_EQ(comparator_name,
               fname_and_props.second->comparator_name);
   }
 


### PR DESCRIPTION
Record the first parsed sequence number as the minimum
  so we can find the true minimum otherwise everything is larger than zero.
  Fix the comparator name comparision.