### PR TITLE
Add repair_test to make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,6 +422,7 @@ TESTS = \
 	range_del_aggregator_test \
 	lru_cache_test \
 	object_registry_test \
+	repair_test \
 
 PARALLEL_TEST = \
 	backupable_db_test \


### PR DESCRIPTION
needed so we can proactively find issues like #1858

Test Plan: `make check -j64`, will make sure #1858 is merged first before landing this one because it fixes repair_test failures