### PR TITLE
Use monotonic time points in write_controller.cc and rate_limiter.cc

### DIFF
--- a/db/write_controller.cc
+++ b/db/write_controller.cc
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <ratio>
 #include "rocksdb/env.h"
 
 namespace rocksdb {
@@ -56,7 +57,7 @@ uint64_t WriteController::GetDelay(Env* env, uint64_t num_bytes) {
   }
   // The frequency to get time inside DB mutex is less than one per refill
   // interval.
-  auto time_now = env->NowMicros();
+  auto time_now = NowMicrosMonotonic(env);
 
   uint64_t sleep_debt = 0;
   uint64_t time_since_last_refill = 0;
@@ -101,6 +102,10 @@ uint64_t WriteController::GetDelay(Env* env, uint64_t num_bytes) {
       sleep_debt;
   last_refill_time_ = time_now + sleep_amount;
   return sleep_amount;
+}
+
+uint64_t WriteController::NowMicrosMonotonic(Env* env) {
+    return env->NowNanos() / std::milli::den;
 }
 
 StopWriteToken::~StopWriteToken() {

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -78,6 +78,9 @@ class WriteController {
   uint64_t max_delayed_write_rate() const { return max_delayed_write_rate_; }
 
  private:
+  uint64_t NowMicrosMonotonic(Env* env);
+
+ private:
   friend class WriteControllerToken;
   friend class StopWriteToken;
   friend class DelayWriteToken;

--- a/db/write_controller_test.cc
+++ b/db/write_controller_test.cc
@@ -3,6 +3,8 @@
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
+#include <ratio>
+
 #include "db/write_controller.h"
 
 #include "rocksdb/env.h"
@@ -16,7 +18,7 @@ class TimeSetEnv : public EnvWrapper {
  public:
   explicit TimeSetEnv() : EnvWrapper(nullptr) {}
   uint64_t now_micros_ = 6666;
-  virtual uint64_t NowMicros() override { return now_micros_; }
+  virtual uint64_t NowNanos() override { return now_micros_ * std::milli::den; }
 };
 
 TEST_F(WriteControllerTest, ChangeDelayRateTest) {

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -318,15 +318,16 @@ class Env {
   virtual Status NewLogger(const std::string& fname,
                            shared_ptr<Logger>* result) = 0;
 
-  // Returns the number of micro-seconds since some fixed point in time. Only
-  // useful for computing deltas of time.
-  // However, it is often used as system time such as in GenericRateLimiter
+  // Returns the number of micro-seconds since some fixed point in time.
+  // It is often used as system time such as in GenericRateLimiter
   // and other places so a port needs to return system time in order to work.
   virtual uint64_t NowMicros() = 0;
 
   // Returns the number of nano-seconds since some fixed point in time. Only
   // useful for computing deltas of time in one run.
-  // Default implementation simply relies on NowMicros
+  // Default implementation simply relies on NowMicros.
+  // In platform-specific implementations, NowNanos() should return time points
+  // that are MONOTONIC.
   virtual uint64_t NowNanos() {
     return NowMicros() * 1000;
   }
@@ -982,6 +983,7 @@ class EnvWrapper : public Env {
     return target_->NewLogger(fname, result);
   }
   uint64_t NowMicros() override { return target_->NowMicros(); }
+
   void SleepForMicroseconds(int micros) override {
     target_->SleepForMicroseconds(micros);
   }

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -61,6 +61,9 @@ class GenericRateLimiter : public RateLimiter {
  private:
   void Refill();
   int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec);
+  uint64_t NowMicrosMonotonic(Env* env) {
+    return env->NowNanos() / std::milli::den;
+  }
 
   // This mutex guard all internal states
   mutable port::Mutex request_mutex_;


### PR DESCRIPTION
summary: NowMicros() provides non-monotonic time. When wall clock is
synchronized or changed, the non-monotonicity time points will affect write rate
controllers. This patch changes write_controller.cc and rate_limiter.cc to use
monotonic time points.