### PR TITLE
Remove timeout_hint_us from WriteOptions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * Remove disableDataSync option.
+* Remove timeout_hint_us option from WriteOptions. The option has been deprecated and has no effect since 3.13.0.
 
 ## 5.2.0 (02/08/2017)
 ### Public API Change

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4646,9 +4646,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   if (my_batch == nullptr) {
     return Status::Corruption("Batch is nullptr!");
   }
-  if (write_options.timeout_hint_us != 0) {
-    return Status::InvalidArgument("timeout_hint_us is deprecated");
-  }
 
   Status status;
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3363,15 +3363,6 @@ TEST_P(DBTestWithParam, FIFOCompactionTest) {
 }
 #endif  // ROCKSDB_LITE
 
-// verify that we correctly deprecated timeout_hint_us
-TEST_F(DBTest, SimpleWriteTimeoutTest) {
-  WriteOptions write_opt;
-  write_opt.timeout_hint_us = 0;
-  ASSERT_OK(Put(Key(1), Key(1) + std::string(100, 'v'), write_opt));
-  write_opt.timeout_hint_us = 10;
-  ASSERT_NOK(Put(Key(1), Key(1) + std::string(100, 'v'), write_opt));
-}
-
 #ifndef ROCKSDB_LITE
 /*
  * This test is not reliable enough as it heavily depends on disk behavior.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1577,9 +1577,6 @@ struct WriteOptions {
   // and the write may got lost after a crash.
   bool disableWAL;
 
-  // The option is deprecated. It's not used anymore.
-  uint64_t timeout_hint_us;
-
   // If true and if user is trying to write to column families that don't exist
   // (they were dropped),  ignore the write (don't return an error). If there
   // are multiple writes in a WriteBatch, other writes will succeed.
@@ -1593,7 +1590,6 @@ struct WriteOptions {
   WriteOptions()
       : sync(false),
         disableWAL(false),
-        timeout_hint_us(0),
         ignore_missing_column_families(false),
         no_slowdown(false) {}
 };


### PR DESCRIPTION
Summary:
The option has been deprecated for two years and has no effect. Removing.

Test Plan:
    make all check