### PR TITLE
Remove unnecessary line in MemTable::RefLogContainingPrepSection()

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -867,8 +867,7 @@ void MemTable::RefLogContainingPrepSection(uint64_t log) {
   assert(log > 0);
   auto cur = min_prep_log_referenced_.load();
   while ((log < cur || cur == 0) &&
-         !min_prep_log_referenced_.compare_exchange_strong(cur, log)) {
-    cur = min_prep_log_referenced_.load();
+         !min_prep_log_referenced_.compare_exchange_weak(cur, log)) {
   }
 }
 


### PR DESCRIPTION
Summary:
`compare_exchange_strong` will update `cur` if it failed. No need to
load it again. Also change to use `compare_exchange_weak` since this is
inside a CAS-loop.

Updating this logic not because I see any problem or any performance
gain, but just looks better.

Test Plan:
  make all check