### PR TITLE
Make DBImpl::has_unpersisted_data_ atomic

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -998,8 +998,7 @@ class DBImpl : public DB {
   // A flag indicating whether the current rocksdb database has any
   // data that is not yet persisted into either WAL or SST file.
   // Used when disableWAL is true.
-  bool has_unpersisted_data_;
-
+  std::atomic<bool> has_unpersisted_data_;
 
   // if an attempt was made to flush all column families that
   // the oldest log depends on but uncommited data in the oldest


### PR DESCRIPTION
Summary:
Seems to me `has_unpersisted_data_` is read from read thread and write
from write thread concurrently without synchronization. Making it an
atomic.

I update the logic not because seeing any problem with it, but it just confuse me.

Test Plan:
  make all check