### PR TITLE
Fix repair_test on ROCKSDB_LITE

### DIFF
--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -3,6 +3,8 @@
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
 
+#ifndef ROCKSDB_LITE
+
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -277,3 +279,13 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+#else
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  fprintf(stderr, "SKIPPED as RepairDB is not supported in ROCKSDB_LITE\n");
+  return 0;
+}
+
+#endif  // ROCKSDB_LITE


### PR DESCRIPTION
RepairDB isn't included in ROCKSDB_LITE, so don't test it.

Test Plan: `OPT="-DROCKSDB_LITE -g" make -j64 check`