### PR TITLE
Allow adding external v1 sst file with no global seqno support

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -309,6 +309,7 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
   } else if (file_to_ingest->version == 1) {
     // SST file V1 should not have global seqno field
     assert(seqno_iter == uprops.end());
+    file_to_ingest->original_seqno = 0;
     if (ingestion_options_.allow_blocking_flush ||
             ingestion_options_.allow_global_seqno) {
       return Status::InvalidArgument(
@@ -439,7 +440,7 @@ Status ExternalSstFileIngestionJob::AssignLevelForIngestedFile(
 
 Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
     IngestedFileInfo* file_to_ingest, SequenceNumber seqno) {
-  if (file_to_ingest->original_seqno == seqno || file_to_ingest->version == 1) {
+  if (file_to_ingest->original_seqno == seqno) {
     // This file already have the correct global seqno
     return Status::OK();
   } else if (!ingestion_options_.allow_global_seqno) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -439,7 +439,7 @@ Status ExternalSstFileIngestionJob::AssignLevelForIngestedFile(
 
 Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
     IngestedFileInfo* file_to_ingest, SequenceNumber seqno) {
-  if (file_to_ingest->original_seqno == seqno) {
+  if (file_to_ingest->original_seqno == seqno || file_to_ingest->version == 1) {
     // This file already have the correct global seqno
     return Status::OK();
   } else if (!ingestion_options_.allow_global_seqno) {


### PR DESCRIPTION
This is a follow up fix for https://github.com/facebook/rocksdb/pull/1783. After it, we should be able to ingest external v1 sst files with no global seqno field. 