### PR TITLE
Break stalls when no bg work is happening

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5126,8 +5126,6 @@ uint64_t DBImpl::GetMaxTotalWalSize() const {
              : mutable_db_options_.max_total_wal_size;
 }
 
-static const int kMaxStallSleepMicros = 100000;
-
 // REQUIRES: mutex_ is held
 // REQUIRES: this thread is currently at the front of the writer queue
 Status DBImpl::DelayWrite(uint64_t num_bytes,

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5134,30 +5134,30 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
   bool delayed = false;
   {
     StopWatch sw(env_, stats_, WRITE_STALL, &time_delayed);
-    uint64_t stall_start = env_->NowNanos();
     uint64_t delay = write_controller_.GetDelay(env_, num_bytes);
     if (delay > 0) {
       if (write_options.no_slowdown) {
         return Status::Incomplete();
       }
-      TEST_SYNC_POINT_CALLBACK("DBImpl::DelayWrite:Sleep", &delay);
+      TEST_SYNC_POINT("DBImpl::DelayWrite:Sleep");
 
       mutex_.Unlock();
       // We will delay the write until we have slept for delay ms or
       // we don't need a delay anymore
-      const uint64_t kDelayInterval = 10000;
-      uint64_t stall_end = stall_start + (delay * std::milli::den);
+      const uint64_t kDelayInterval = 1000;
+      uint64_t stall_end = sw.start_time() + delay;
       while (write_controller_.NeedsDelay()) {
-        if (env_->NowNanos() >= stall_end) {
+        if (env_->NowMicros() >= stall_end) {
           // We already delayed this write `delay` microseconds
           break;
         }
 
         delayed = true;
-        // Sleep for 0.01 seconds
+        // Sleep for 0.001 seconds
         env_->SleepForMicroseconds(kDelayInterval);
       }
       mutex_.Lock();
+
     }
 
     while (bg_error_.ok() && write_controller_.IsStopped()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5139,7 +5139,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
       if (write_options.no_slowdown) {
         return Status::Incomplete();
       }
-      delayed = true;
+      TEST_SYNC_POINT_CALLBACK("DBImpl::DelayWrite:Sleep", &delay);
 
       // We will delay the write until the wall clock reach stall_end or
       // we don't have any flushes or compactions running in the bg
@@ -5150,7 +5150,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
           break;
         }
 
-        TEST_SYNC_POINT("DBImpl::DelayWrite:Sleep");
+        delayed = true;
         bg_cv_.TimedWait(static_cast<int>(stall_end - now));
       }
     }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4831,15 +4831,6 @@ TEST_F(DBTest, DelayedWriteRate) {
 
   CreateAndReopenWithCF({"pikachu"}, options);
 
-  uint64_t total_delay = 0;
-  rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::DelayWrite:Sleep", [&](void* arg) {
-        uint64_t delay = *(static_cast<uint64_t*>(arg));
-        total_delay += delay;
-      });
-  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
-
-
   // Block compactions
   test::SleepingBackgroundTask sleeping_task_low;
   env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_low,
@@ -4876,8 +4867,10 @@ TEST_F(DBTest, DelayedWriteRate) {
                                      kIncSlowdownRatio * kIncSlowdownRatio);
   }
   // Estimate the total sleep time fall into the rough range.
-  ASSERT_GT(total_delay, static_cast<int64_t>(estimated_sleep_time / 2));
-  ASSERT_LT(total_delay, static_cast<int64_t>(estimated_sleep_time * 2));
+  ASSERT_GT(env_->addon_time_.load(),
+            static_cast<int64_t>(estimated_sleep_time / 2));
+  ASSERT_LT(env_->addon_time_.load(),
+            static_cast<int64_t>(estimated_sleep_time * 2));
 
   env_->no_slowdown_ = false;
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();

--- a/db/write_controller.cc
+++ b/db/write_controller.cc
@@ -44,7 +44,7 @@ uint64_t WriteController::GetDelay(Env* env, uint64_t num_bytes) {
   if (total_stopped_ > 0) {
     return 0;
   }
-  if (total_delayed_ == 0) {
+  if (total_delayed_.load() == 0) {
     return 0;
   }
 
@@ -115,7 +115,7 @@ StopWriteToken::~StopWriteToken() {
 
 DelayWriteToken::~DelayWriteToken() {
   controller_->total_delayed_--;
-  assert(controller_->total_delayed_ >= 0);
+  assert(controller_->total_delayed_.load() >= 0);
 }
 
 CompactionPressureToken::~CompactionPressureToken() {

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <atomic>
 #include <memory>
 
 namespace rocksdb {
@@ -45,7 +46,7 @@ class WriteController {
 
   // these three metods are querying the state of the WriteController
   bool IsStopped() const;
-  bool NeedsDelay() const { return total_delayed_ > 0; }
+  bool NeedsDelay() const { return total_delayed_.load() > 0; }
   bool NeedSpeedupCompaction() const {
     return IsStopped() || NeedsDelay() || total_compaction_pressure_ > 0;
   }
@@ -87,7 +88,7 @@ class WriteController {
   friend class CompactionPressureToken;
 
   int total_stopped_;
-  int total_delayed_;
+  std::atomic<int> total_delayed_;
   int total_compaction_pressure_;
   uint64_t bytes_left_;
   uint64_t last_refill_time_;

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -40,6 +40,8 @@ class StopWatch {
     }
   }
 
+  uint64_t start_time() const { return start_time_; }
+
  private:
   Env* const env_;
   Statistics* statistics_;


### PR DESCRIPTION
Current stall will keep sleeping even if there is no Flush/Compactions to wait for, I changed the logic to break the stall if we are not flushing or compacting

db_bench command used
```
# fillrandom
# memtable size = 10MB
# value size = 1 MB
# num = 1000
# use /dev/shm
./db_bench --benchmarks="fillrandom,stats" --value_size=1048576 --write_buffer_size=10485760 --num=1000 --delayed_write_rate=XXXXX  --db="/dev/shm/new_stall" | grep "Cumulative stall"
```

```
Current results

# delayed_write_rate = 1000 Kb/sec
Cumulative stall: 00:00:9.031 H:M:S

# delayed_write_rate = 200 Kb/sec
Cumulative stall: 00:00:22.314 H:M:S

# delayed_write_rate = 100 Kb/sec
Cumulative stall: 00:00:42.784 H:M:S

# delayed_write_rate = 50 Kb/sec
Cumulative stall: 00:01:23.785 H:M:S

# delayed_write_rate = 25 Kb/sec
Cumulative stall: 00:02:45.702 H:M:S
```

```
New results

# delayed_write_rate = 1000 Kb/sec
Cumulative stall: 00:00:9.017 H:M:S

# delayed_write_rate = 200 Kb/sec
Cumulative stall: 00:00:11.530 H:M:S

# delayed_write_rate = 100 Kb/sec
Cumulative stall: 00:00:11.977 H:M:S

# delayed_write_rate = 50 Kb/sec
Cumulative stall: 00:00:11.380 H:M:S

# delayed_write_rate = 25 Kb/sec
Cumulative stall: 00:00:12.182 H:M:S
```