### PR TITLE
check backup directory exists before listing children

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1407,16 +1407,18 @@ Status BackupEngineImpl::InsertPathnameToSizeBytes(
     std::unordered_map<std::string, uint64_t>* result) {
   assert(result != nullptr);
   std::vector<Env::FileAttributes> files_attrs;
-  Status status = env->GetChildrenFileAttributes(dir, &files_attrs);
-  if (!status.ok()) {
-    return status;
+  Status status = env->FileExists(dir);
+  if (status.ok()) {
+    status = env->GetChildrenFileAttributes(dir, &files_attrs);
   }
-  const bool slash_needed = dir.empty() || dir.back() != '/';
-  for (const auto& file_attrs : files_attrs) {
-    result->emplace(dir + (slash_needed ? "/" : "") + file_attrs.name,
-                    file_attrs.size_bytes);
+  if (status.ok()) {
+    const bool slash_needed = dir.empty() || dir.back() != '/';
+    for (const auto& file_attrs : files_attrs) {
+      result->emplace(dir + (slash_needed ? "/" : "") + file_attrs.name,
+                      file_attrs.size_bytes);
+    }
   }
-  return Status::OK();
+  return status;
 }
 
 Status BackupEngineImpl::GarbageCollect() {

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1410,13 +1410,14 @@ Status BackupEngineImpl::InsertPathnameToSizeBytes(
   Status status = env->FileExists(dir);
   if (status.ok()) {
     status = env->GetChildrenFileAttributes(dir, &files_attrs);
+  } else if (status.IsNotFound()) {
+    // Insert no entries can be considered success
+    status = Status::OK();
   }
-  if (status.ok()) {
-    const bool slash_needed = dir.empty() || dir.back() != '/';
-    for (const auto& file_attrs : files_attrs) {
-      result->emplace(dir + (slash_needed ? "/" : "") + file_attrs.name,
-                      file_attrs.size_bytes);
-    }
+  const bool slash_needed = dir.empty() || dir.back() != '/';
+  for (const auto& file_attrs : files_attrs) {
+    result->emplace(dir + (slash_needed ? "/" : "") + file_attrs.name,
+                    file_attrs.size_bytes);
   }
   return status;
 }


### PR DESCRIPTION
InsertPathnameToSizeBytes() is called on shared/ and shared_checksum/ directories, which only exist for certain configurations. If we try to list a non-existent directory's contents, some Envs will dump an error message. Let's avoid this by checking whether the directory exists before listing its contents.

Test Plan: used `ldb backup` with internal HDFS env, verified ".../shared_checksum/ not found" error is no longer printed