### PR TITLE
Make WriteBatchWithIndex moveble

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -12,6 +12,7 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <memory>
 #include <string>
 
 #include "rocksdb/comparator.h"
@@ -205,7 +206,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
  private:
   struct Rep;
-  Rep* rep;
+  std::unique_ptr<Rep> rep;
 };
 
 }  // namespace rocksdb

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -570,7 +570,7 @@ WriteBatchWithIndex::WriteBatchWithIndex(
     bool overwrite_key)
     : rep(new Rep(default_index_comparator, reserved_bytes, overwrite_key)) {}
 
-WriteBatchWithIndex::~WriteBatchWithIndex() { delete rep; }
+WriteBatchWithIndex::~WriteBatchWithIndex() {}
 
 WriteBatch* WriteBatchWithIndex::GetWriteBatch() { return &rep->write_batch; }
 


### PR DESCRIPTION
`WriteBatchWithIndex` has an incorrect implicitly-generated move constructor (it will copy the pointer causing a double-free on destruction). Just switch to `unique_ptr` so we get correct move semantics for free.