### PR TITLE
Handle failed Finish() in SST file writer

### DIFF
--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -189,10 +189,7 @@ Status SstFileWriter::Finish(ExternalSstFileInfo* file_info) {
     if (s.ok()) {
       s = r->file_writer->Close();
     }
-  } else {
-    r->builder->Abandon();
   }
-
   if (!s.ok()) {
     r->ioptions.env->DeleteFile(r->file_info.file_path);
   }


### PR DESCRIPTION
The assertion in Abandon() fails when called after Finish() fails. Finish() already closes the builder so there's no need to call Abandon().

Test Plan: together with D4601137