### PR TITLE
Fixed a bug in DBImpl::MaybeFlushColumnFamilies()

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1038,9 +1038,11 @@ void DBImpl::PurgeObsoleteFiles(const JobContext& state, bool schedule_only) {
     Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
         "[JOB %d] Try to delete WAL files size %" PRIu64
         ", prev total WAL file size %" PRIu64
-        ", number of live WAL files %" ROCKSDB_PRIszt ".\n",
+        ", number of live WAL files %" ROCKSDB_PRIszt
+        ", min log number to keep %" ROCKSDB_PRIszt ".\n",
         state.job_id, state.size_log_to_delete, state.prev_total_log_size,
-        state.num_alive_log_files);
+        state.num_alive_log_files,
+        state.log_number);
   }
 
   std::vector<std::string> old_info_log_files;
@@ -5105,6 +5107,14 @@ void DBImpl::MaybeFlushColumnFamilies() {
   // transactions then we cannot flush this log until those transactions are commited.
 
   unable_to_flush_oldest_log_ = false;
+
+  // Another thread could have removed some logs from alive_log_files_ while
+  // we were in this method. This is possible because SwitchMemtable() unlocks
+  // and re-locks mutex_.
+  if (alive_log_files_.begin()->number != oldest_alive_log) {
+    assert(alive_log_files_.begin()->number > oldest_alive_log);
+    return;
+  }
 
   if (allow_2pc()) {
     if (oldest_log_with_uncommited_prep == 0 ||


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/pull/1893 for description of the OOMs we had because of this. This small bug was there for a long time, but it didn't break anything noticeably until https://github.com/facebook/rocksdb/pull/1768 exposed it by moved getting_flushed check from WriteImpl() into MaybeFlushColumnFamilies(). This triggered some pretty bad OOMs in logdevice. https://github.com/facebook/rocksdb/pull/1893 unexposed the bug; this PR fixes it.

I'm not familiar with how 2pc work (we don't use them). Please check that this code does the right thing when allow_2pc() is enabled; seems right to me.

Optional reading:

Some evidence that this is indeed what was happening: there was this in LOG http://pastebin.com/4hMcDtjp , and after that there were no wal-size-based and memtable-size-based flushes in LOG, until we ran OOM a few hours later. The "Level-0 flush table" and "Try to delete WAL files" messages between "Flushing all column families " and "New memtable created" messages (the latter two are from the same thread) indicate that indeed some WAL cleanup happened in the middle of MaybeFlushColumnFamilies(), and moreover the memtable that was flushed belonged to just the right WAL. This unambiguously points to the race condition that this PR is fixing. Also I used gdb to confirm that during these few hours without flushes, alive_log_files_.begin()->getting_flushed was true, and total_log_size_ was way above GetMaxTotalWalSize(). If you're interested, here's location of the LOG file (facebook only): P57112748