### PR TITLE
Get unique_ptr to use delete[] for char[] in DumpMallocStats

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -604,7 +604,7 @@ static void DumpMallocStats(std::string* stats) {
 #ifdef ROCKSDB_JEMALLOC
   MallocStatus mstat;
   const uint kMallocStatusLen = 1000000;
-  std::unique_ptr<char> buf{new char[kMallocStatusLen + 1]};
+  std::unique_ptr<char[]> buf{new char[kMallocStatusLen + 1]};
   mstat.cur = buf.get();
   mstat.end = buf.get() + kMallocStatusLen;
   malloc_stats_print(GetJemallocStatus, &mstat, "");


### PR DESCRIPTION
Avoid mismatched free() / delete / delete [] in DumpMallocStats