### PR TITLE
Inline MemTable::KeyComparator

### DIFF
--- a/db/inlineskiplist.h
+++ b/db/inlineskiplist.h
@@ -211,7 +211,7 @@ class InlineSkipList {
 
   // Return true if key is greater than the data stored in "n".  Null n
   // is considered infinite.  n should not be head_.
-  bool KeyIsAfterNode(const char* key, Node* n) const;
+  inline bool KeyIsAfterNode(const char* key, Node* n) const;
 
   // Returns the earliest node with a key >= key.
   // Return nullptr if there is no such node.

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -329,7 +329,7 @@ class MemTable {
   port::RWMutex* GetLock(const Slice& key);
 
   const InternalKeyComparator& GetInternalKeyComparator() const {
-    return comparator_.comparator();
+    return dynamic_cast<const InternalKeyComparator&>(comparator_.comparator());
   }
 
   const MemTableOptions* GetMemTableOptions() const { return &moptions_; }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -80,15 +80,6 @@ struct MemTablePostProcessInfo {
 // written to (aka the 'immutable memtables').
 class MemTable {
  public:
-  struct KeyComparator : public MemTableRep::KeyComparator {
-    const InternalKeyComparator comparator;
-    explicit KeyComparator(const InternalKeyComparator& c) : comparator(c) { }
-    virtual int operator()(const char* prefix_len_key1,
-                           const char* prefix_len_key2) const override;
-    virtual int operator()(const char* prefix_len_key,
-                           const Slice& key) const override;
-  };
-
   // MemTables are reference counted.  The initial reference count
   // is zero and the caller must call Ref() at least once.
   //
@@ -338,7 +329,7 @@ class MemTable {
   port::RWMutex* GetLock(const Slice& key);
 
   const InternalKeyComparator& GetInternalKeyComparator() const {
-    return comparator_.comparator;
+    return comparator_.comparator();
   }
 
   const MemTableOptions* GetMemTableOptions() const { return &moptions_; }
@@ -350,7 +341,7 @@ class MemTable {
   friend class MemTableBackwardIterator;
   friend class MemTableList;
 
-  KeyComparator comparator_;
+  const MemTableRep::KeyComparator comparator_;
   const MemTableOptions moptions_;
   int refs_;
   const size_t kArenaBlockSize;

--- a/db/memtablerep_bench.cc
+++ b/db/memtablerep_bench.cc
@@ -620,7 +620,7 @@ int main(int argc, char** argv) {
 
   rocksdb::InternalKeyComparator internal_key_comp(
       rocksdb::BytewiseComparator());
-  rocksdb::MemTable::KeyComparator key_comp(internal_key_comp);
+  rocksdb::MemTableRep::KeyComparator key_comp(internal_key_comp);
   rocksdb::Arena arena;
   rocksdb::WriteBufferManager wb(FLAGS_write_buffer_size);
   rocksdb::MemTableAllocator memtable_allocator(&arena, &wb);

--- a/include/rocksdb/coding.h
+++ b/include/rocksdb/coding.h
@@ -1,0 +1,44 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+#pragma once
+
+#include "port/port.h"
+#include "rocksdb/slice.h"
+
+namespace rocksdb {
+
+// Uitility methods used by RocksDB internal for encoding data. We have them
+// in public header only to make them able to be inlined by compiler.
+
+// Internal routine for use by fallback path of GetVarint32Ptr
+extern const char* GetVarint32PtrFallback(const char* p,
+                                          const char* limit,
+                                          uint32_t* value);
+
+// Parse varint32 from [p, limit) and save the value in v. Return a pointer
+// just past the parsed value, or null on error.
+inline const char* GetVarint32Ptr(const char* p,
+                                  const char* limit,
+                                  uint32_t* value) {
+  if (p < limit) {
+    uint32_t result = *(reinterpret_cast<const unsigned char*>(p));
+    if ((result & 128) == 0) {
+      *value = result;
+      return p + 1;
+    }
+  }
+  return GetVarint32PtrFallback(p, limit, value);
+}
+
+// Parse data encoded in the form of len (varint32) + data
+inline Slice GetLengthPrefixedSlice(const char* data) {
+  uint32_t len = 0;
+  // +5: we assume "data" is not corrupted
+  // unsigned char is 7 bits, uint32_t is 32 bits, need 5 unsigned char
+  auto p = GetVarint32Ptr(data, data + 5 /* limit */, &len);
+  return Slice(p, len);
+}
+
+}  // namespace rocksdb

--- a/include/rocksdb/internal_comparator.h
+++ b/include/rocksdb/internal_comparator.h
@@ -1,0 +1,69 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+#pragma once
+
+#include <string>
+
+#include "rocksdb/comparator.h"
+#include "rocksdb/perf_context.h"
+
+namespace rocksdb {
+
+class InternalKey;
+class ParsedInternalKey;
+
+// Returns the user key portion of an internal key.
+inline Slice ExtractUserKey(const Slice& internal_key) {
+  assert(internal_key.size() >= 8);
+  return Slice(internal_key.data(), internal_key.size() - 8);
+}
+
+// A comparator for internal keys that uses a specified comparator for
+// the user key portion and breaks ties by decreasing sequence number.
+class InternalKeyComparator : public Comparator {
+ private:
+  const Comparator* user_comparator_;
+  std::string name_;
+ public:
+  explicit InternalKeyComparator(const Comparator* c) : user_comparator_(c),
+    name_("rocksdb.InternalKeyComparator:" +
+          std::string(user_comparator_->Name())) {
+  }
+  virtual ~InternalKeyComparator() {}
+
+  virtual const char* Name() const override { return name_.c_str(); }
+
+  // Have the method definition in public header in order to make it
+  // able to be inlinded by compiler.
+  virtual int Compare(const Slice& akey, const Slice& bkey) const override {
+    // Order by:
+    //    increasing user key (according to user-supplied comparator)
+    //    decreasing sequence number
+    //    decreasing type (though sequence# should be enough to disambiguate)
+    int r = user_comparator_->Compare(ExtractUserKey(akey), ExtractUserKey(bkey));
+    PERF_COUNTER_ADD(user_key_comparison_count, 1);
+    if (r == 0) {
+      const uint64_t anum = DecodeFixed64(akey.data() + akey.size() - 8);
+      const uint64_t bnum = DecodeFixed64(bkey.data() + bkey.size() - 8);
+      if (anum > bnum) {
+        r = -1;
+      } else if (anum < bnum) {
+        r = +1;
+      }
+    }
+    return r;
+  }
+
+  virtual void FindShortestSeparator(std::string* start,
+                                     const Slice& limit) const override;
+  virtual void FindShortSuccessor(std::string* key) const override;
+
+  const Comparator* user_comparator() const { return user_comparator_; }
+
+  int Compare(const InternalKey& a, const InternalKey& b) const;
+  int Compare(const ParsedInternalKey& a, const ParsedInternalKey& b) const;
+};
+
+}  // namespace rocksdb

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -43,6 +43,7 @@
 namespace rocksdb {
 
 class Arena;
+class InternalKeyComparator;
 class MemTableAllocator;
 class LookupKey;
 class Slice;
@@ -57,15 +58,19 @@ class MemTableRep {
   // concatenated with values.
   class KeyComparator {
    public:
+    KeyComparator(const InternalKeyComparator& cmp);
+
     // Compare a and b. Return a negative value if a is less than b, 0 if they
     // are equal, and a positive value if a is greater than b
-    virtual int operator()(const char* prefix_len_key1,
-                           const char* prefix_len_key2) const = 0;
+    int operator()(const char* prefix_len_key1,
+                   const char* prefix_len_key2) const;
 
-    virtual int operator()(const char* prefix_len_key,
-                           const Slice& key) const = 0;
+    int operator()(const char* prefix_len_key, const Slice& key) const;
 
-    virtual ~KeyComparator() { }
+    const InternalKeyComparator& comparator() const;
+
+   private:
+    const InternalKeyComparator& comparator_;
   };
 
   explicit MemTableRep(MemTableAllocator* allocator) : allocator_(allocator) {}

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -41,12 +41,11 @@
 #include <stdlib.h>
 
 #include "rocksdb/coding.h"
-#include "rocksdb/comparator.h"
+#include "rocksdb/internal_comparator.h"
 
 namespace rocksdb {
 
 class Arena;
-class InternalKeyComparator;
 class MemTableAllocator;
 class LookupKey;
 class Slice;
@@ -61,7 +60,7 @@ class MemTableRep {
   // concatenated with values.
   class KeyComparator {
    public:
-    KeyComparator(const Comparator& cmp) : comparator_(cmp) {}
+    KeyComparator(const InternalKeyComparator& cmp) : comparator_(cmp) {}
 
     // Compare a and b. Return a negative value if a is less than b, 0 if they
     // are equal, and a positive value if a is greater than b
@@ -79,10 +78,10 @@ class MemTableRep {
       return comparator_.Compare(a, key);
     }
 
-    const Comparator& comparator() const { return comparator_; }
+    const InternalKeyComparator& comparator() const { return comparator_; }
 
    private:
-    const Comparator& comparator_;
+    const InternalKeyComparator comparator_;
   };
 
   explicit MemTableRep(MemTableAllocator* allocator) : allocator_(allocator) {}

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -40,6 +40,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "rocksdb/coding.h"
+#include "rocksdb/comparator.h"
+
 namespace rocksdb {
 
 class Arena;
@@ -58,19 +61,28 @@ class MemTableRep {
   // concatenated with values.
   class KeyComparator {
    public:
-    KeyComparator(const InternalKeyComparator& cmp);
+    KeyComparator(const Comparator& cmp) : comparator_(cmp) {}
 
     // Compare a and b. Return a negative value if a is less than b, 0 if they
     // are equal, and a positive value if a is greater than b
     int operator()(const char* prefix_len_key1,
-                   const char* prefix_len_key2) const;
+                   const char* prefix_len_key2) const {
+      // Internal keys are encoded as length-prefixed strings.
+      Slice k1 = GetLengthPrefixedSlice(prefix_len_key1);
+      Slice k2 = GetLengthPrefixedSlice(prefix_len_key2);
+      return comparator_.Compare(k1, k2);
+    }
 
-    int operator()(const char* prefix_len_key, const Slice& key) const;
+    int operator()(const char* prefix_len_key, const Slice& key) const {
+      // Internal keys are encoded as length-prefixed strings.
+      Slice a = GetLengthPrefixedSlice(prefix_len_key);
+      return comparator_.Compare(a, key);
+    }
 
-    const InternalKeyComparator& comparator() const;
+    const Comparator& comparator() const { return comparator_; }
 
    private:
-    const InternalKeyComparator& comparator_;
+    const Comparator& comparator_;
   };
 
   explicit MemTableRep(MemTableAllocator* allocator) : allocator_(allocator) {}

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -135,6 +135,14 @@ extern __declspec(thread) PerfContext perf_context;
 extern __thread PerfContext perf_context;
 #endif
 
-}
+#if defined(NPERF_CONTEXT) || defined(IOS_CROSS_COMPILE)
+#define PERF_COUNTER_ADD(metric, value)
+#else
+// Increase metric value
+#define PERF_COUNTER_ADD(metric, value)     \
+  perf_context.metric += value;
+#endif
+
+}  // namespace rocksdb
 
 #endif

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -26,6 +26,8 @@
 namespace rocksdb {
 namespace port {
 
+const bool kLittleEndian = (__BYTE_ORDER == __LITTLE_ENDIAN);
+
 static int PthreadCall(const char* label, int result) {
   if (result != 0 && result != ETIMEDOUT) {
     fprintf(stderr, "pthread %s: %s\n", label, strerror(result));

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -84,7 +84,7 @@ const uint64_t kMaxUint64 = std::numeric_limits<uint64_t>::max();
 const int64_t kMaxInt64 = std::numeric_limits<int64_t>::max();
 const size_t kMaxSizet = std::numeric_limits<size_t>::max();
 
-static const bool kLittleEndian = PLATFORM_IS_LITTLE_ENDIAN;
+extern const bool kLittleEndian;
 #undef PLATFORM_IS_LITTLE_ENDIAN
 
 class CondVar;

--- a/port/win/port_win.cc
+++ b/port/win/port_win.cc
@@ -31,6 +31,8 @@
 namespace rocksdb {
 namespace port {
 
+const bool kLittleEndian = true;
+
 void gettimeofday(struct timeval* tv, struct timezone* /* tz */) {
   using namespace std::chrono;
 

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -108,7 +108,7 @@ const size_t kMaxSizet = UINT_MAX;
 
 #endif //_MSC_VER
 
-const bool kLittleEndian = true;
+extern const bool kLittleEndian;
 
 class CondVar;
 

--- a/util/coding.h
+++ b/util/coding.h
@@ -81,33 +81,6 @@ extern char* EncodeVarint64(char* dst, uint64_t value);
 // Lower-level versions of Get... that read directly from a character buffer
 // without any bounds checking.
 
-inline uint32_t DecodeFixed32(const char* ptr) {
-  if (port::kLittleEndian) {
-    // Load the raw bytes
-    uint32_t result;
-    memcpy(&result, ptr, sizeof(result));  // gcc optimizes this to a plain load
-    return result;
-  } else {
-    return ((static_cast<uint32_t>(static_cast<unsigned char>(ptr[0])))
-        | (static_cast<uint32_t>(static_cast<unsigned char>(ptr[1])) << 8)
-        | (static_cast<uint32_t>(static_cast<unsigned char>(ptr[2])) << 16)
-        | (static_cast<uint32_t>(static_cast<unsigned char>(ptr[3])) << 24));
-  }
-}
-
-inline uint64_t DecodeFixed64(const char* ptr) {
-  if (port::kLittleEndian) {
-    // Load the raw bytes
-    uint64_t result;
-    memcpy(&result, ptr, sizeof(result));  // gcc optimizes this to a plain load
-    return result;
-  } else {
-    uint64_t lo = DecodeFixed32(ptr);
-    uint64_t hi = DecodeFixed32(ptr + 4);
-    return (hi << 32) | lo;
-  }
-}
-
 // -- Implementation of the functions declared above
 inline void EncodeFixed32(char* buf, uint32_t value) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN

--- a/util/perf_context_imp.h
+++ b/util/perf_context_imp.h
@@ -44,10 +44,6 @@ namespace rocksdb {
 #define PERF_TIMER_MEASURE(metric)        \
   perf_step_timer_ ## metric.Measure();
 
-// Increase metric value
-#define PERF_COUNTER_ADD(metric, value)     \
-  perf_context.metric += value;
-
 #endif
 
-}
+}  // namespace rocksdb


### PR DESCRIPTION
The current call stack when InlinkeSkipList::Insert is called will involve:
(0) BytewiseComparator::Compare()
(1) InternalKeyComparator::Compare()
(2) MemTable::KeyComparator::operator()
(3) InlineSkipList::KeyIsAfterNode()
(4) InlineSkipList::Insert()

(0), (1) and (2) are all virtual methods so they cannot be inlined by compiler. Since the whole key comparison logic is relatively simple, the overhead of function call is not very small. This PR tries to make (1) (2) (3) inline by:
* Remove MemTable::KeyComparator. Move its logic to its parent MemTableRep::KeyComparator and put the definition in public header include/rocksdb/memtablerep.h.
* Move InternalKeyComparator to public header include/rocksdb/internal_comparator.h.
* Move helper function needed by MemTable::KeyComparator and InternalKeyComparator to public header include/rocksdb/coding.h.
* Add "inline" keyword to InlineSkipList::KeyIsAfterNode() to suggest compiler inline it.

To compare the performance with master, I'm running the following command:
./db_bench --benchmarks=filluniquerandomdeterministic --disable_auto_compactions=true --num_levels=1 --disable_wal --write_buffer_size=2000000000 --num=10000000

master (3 times):
filluniquerandomdeterministic :       5.173 micros/op 193322 ops/sec;   21.4 MB/s
filluniquerandomdeterministic :       5.221 micros/op 191532 ops/sec;   21.2 MB/s
filluniquerandomdeterministic :       5.092 micros/op 196394 ops/sec;   21.7 MB/s

with the PR (3 times):
filluniquerandomdeterministic : 4.987 micros/op 200522 ops/sec; 22.2 MB/s
filluniquerandomdeterministic : 5.060 micros/op 197627 ops/sec; 21.9 MB/s
filluniquerandomdeterministic : 5.051 micros/op 197984 ops/sec; 21.9 MB/s

It shows roughly 5% more throughput.

`perf stat` command result:
master: https://gist.github.com/yiwu-arbug/a110a2b230aba171c3f4f608f1f5a38f
with the PR: https://gist.github.com/yiwu-arbug/f37f8e78ee81277d66492dd0dbbe37be

It shows a 10% reduction in number of CPU instructions executed.
