### PR TITLE
Add missing include for `abort()`

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <stdlib.h>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
Fixes #1233 (again).