### PR TITLE
Fix the wrong address for PREFETCH in DynamicBloom::Prefetch

### DIFF
--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -128,7 +128,7 @@ inline bool DynamicBloom::MayContain(const Slice& key) const {
 inline void DynamicBloom::Prefetch(uint32_t h) {
   if (kNumBlocks != 0) {
     uint32_t b = ((h >> 11 | (h << 21)) % kNumBlocks) * (CACHE_LINE_SIZE * 8);
-    PREFETCH(&(data_[b]), 0, 3);
+    PREFETCH(&(data_[b / 8]), 0, 3);
   }
 }
 


### PR DESCRIPTION
Summary:
- Change data_[b] to data_[b / 8] in DynamicBloom::Prefetch, as b means the b-th bit in data_ and data_[b / 8] is the proper byte in data_.  
