### PR TITLE
sanitize readahead when direct read enabled

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -197,6 +197,10 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.db_paths.emplace_back(dbname, std::numeric_limits<uint64_t>::max());
   }
 
+  if (result.use_direct_reads && result.compaction_readahead_size == 0) {
+    result.compaction_readahead_size = 1024 * 1024 * 10;
+  }
+
   if (result.compaction_readahead_size > 0) {
     result.new_table_reader_for_compaction_inputs = true;
   }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -198,7 +198,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   }
 
   if (result.use_direct_reads && result.compaction_readahead_size == 0) {
-    result.compaction_readahead_size = 1024 * 1024 * 10;
+    result.compaction_readahead_size = 1024 * 1024 * 2;
   }
 
   if (result.compaction_readahead_size > 0) {


### PR DESCRIPTION
./db_bench --benchmarks=fillrandom --write_buffer_size=200000 --num=1000000
HDD
０     readahead: 6079 ops/sec
2MB readahead: 6117 sops/sec