### PR TITLE
Statistic for how often rate limiter is drained

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -112,7 +112,8 @@ Status BuildTable(
       }
       file->SetIOPriority(io_priority);
 
-      file_writer.reset(new WritableFileWriter(std::move(file), env_options));
+      file_writer.reset(new WritableFileWriter(std::move(file), env_options,
+                                               ioptions.statistics));
 
       builder = NewTableBuilder(
           ioptions, internal_comparator, int_tbl_prop_collector_factories,

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1222,8 +1222,8 @@ Status CompactionJob::OpenCompactionOutputFile(
   writable_file->SetIOPriority(Env::IO_LOW);
   writable_file->SetPreallocationBlockSize(static_cast<size_t>(
       sub_compact->compaction->OutputFilePreallocationSize()));
-  sub_compact->outfile.reset(
-      new WritableFileWriter(std::move(writable_file), env_options_));
+  sub_compact->outfile.reset(new WritableFileWriter(
+      std::move(writable_file), env_options_, db_options_.statistics.get()));
 
   // If the Column family flag is to only optimize filters for hits,
   // we can skip creating filters if this is the bottommost_level where

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "rocksdb/env.h"
+#include "rocksdb/statistics.h"
 
 namespace rocksdb {
 
@@ -24,7 +25,21 @@ class RateLimiter {
   // Request for token to write bytes. If this request can not be satisfied,
   // the call is blocked. Caller is responsible to make sure
   // bytes <= GetSingleBurstBytes()
-  virtual void Request(const int64_t bytes, const Env::IOPriority pri) = 0;
+  virtual void Request(const int64_t bytes, const Env::IOPriority pri) {
+    // Deprecated. New RateLimiter derived classes should override
+    // Request(const int64_t, const Env::IOPriority, Statistics*) instead.
+    assert(false);
+  }
+
+  // Request for token to write bytes and potentially update statistics. If this
+  // request can not be satisfied, the call is blocked. Caller is responsible to
+  // make sure bytes <= GetSingleBurstBytes().
+  virtual void Request(const int64_t bytes, const Env::IOPriority pri,
+                       Statistics* /* stats */) {
+    // For API compatibility, default implementation calls the older API in
+    // which statistics are unsupported.
+    Request(bytes, pri);
+  }
 
   // Max bytes can be granted in a single burst
   virtual int64_t GetSingleBurstBytes() const = 0;

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -216,6 +216,9 @@ enum Tickers : uint32_t {
   READ_AMP_ESTIMATE_USEFUL_BYTES,  // Estimate of total bytes actually used.
   READ_AMP_TOTAL_READ_BYTES,       // Total size of loaded data blocks.
 
+  // Number of refill intervals where rate limiter's bytes are fully consumed.
+  NUMBER_RATE_LIMITER_DRAINS,
+
   TICKER_ENUM_MAX
 };
 
@@ -318,6 +321,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {ROW_CACHE_MISS, "rocksdb.row.cache.miss"},
     {READ_AMP_ESTIMATE_USEFUL_BYTES, "rocksdb.read.amp.estimate.useful.bytes"},
     {READ_AMP_TOTAL_READ_BYTES, "rocksdb.read.amp.total.read.bytes"},
+    {NUMBER_RATE_LIMITER_DRAINS, "rocksdb.number.rate_limiter.drains"},
 };
 
 /**

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -319,7 +319,7 @@ size_t WritableFileWriter::RequestToken(size_t bytes, bool align) {
       size_t alignment = buf_.Alignment();
       bytes = std::max(alignment, TruncateToPageBoundary(alignment, bytes));
     }
-    rate_limiter_->Request(bytes, io_priority);
+    rate_limiter_->Request(bytes, io_priority, stats_);
   }
   return bytes;
 }

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -119,10 +119,11 @@ class WritableFileWriter {
   uint64_t                last_sync_size_;
   uint64_t                bytes_per_sync_;
   RateLimiter*            rate_limiter_;
+  Statistics* stats_;
 
  public:
   WritableFileWriter(std::unique_ptr<WritableFile>&& file,
-                     const EnvOptions& options)
+                     const EnvOptions& options, Statistics* stats = nullptr)
       : writable_file_(std::move(file)),
         buf_(),
         max_buffer_size_(options.writable_file_max_buffer_size),
@@ -132,8 +133,8 @@ class WritableFileWriter {
         direct_io_(writable_file_->use_direct_io()),
         last_sync_size_(0),
         bytes_per_sync_(options.bytes_per_sync),
-        rate_limiter_(options.rate_limiter) {
-
+        rate_limiter_(options.rate_limiter),
+        stats_(stats) {
     buf_.Alignment(writable_file_->GetRequiredBufferAlignment());
     buf_.AllocateNewBuffer(std::min((size_t)65536, max_buffer_size_));
   }

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -33,7 +33,9 @@ class GenericRateLimiter : public RateLimiter {
   // Request for token to write bytes. If this request can not be satisfied,
   // the call is blocked. Caller is responsible to make sure
   // bytes <= GetSingleBurstBytes()
-  virtual void Request(const int64_t bytes, const Env::IOPriority pri) override;
+  using RateLimiter::Request;
+  virtual void Request(const int64_t bytes, const Env::IOPriority pri,
+                       Statistics* stats) override;
 
   virtual int64_t GetSingleBurstBytes() const override {
     return refill_bytes_per_period_.load(std::memory_order_relaxed);

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -55,9 +55,10 @@ TEST_F(RateLimiterTest, Rate) {
     while (thread_env->NowMicros() < until) {
       for (int i = 0; i < static_cast<int>(r.Skewed(arg->burst) + 1); ++i) {
         arg->limiter->Request(r.Uniform(arg->request_size - 1) + 1,
-                              Env::IO_HIGH);
+                              Env::IO_HIGH, nullptr /* stats */);
       }
-      arg->limiter->Request(r.Uniform(arg->request_size - 1) + 1, Env::IO_LOW);
+      arg->limiter->Request(r.Uniform(arg->request_size - 1) + 1, Env::IO_LOW,
+                            nullptr /* stats */);
     }
   };
 
@@ -110,7 +111,7 @@ TEST_F(RateLimiterTest, LimitChangeTest) {
 
   auto writer = [](void* p) {
     auto* arg = static_cast<Arg*>(p);
-    arg->limiter->Request(arg->request_size, arg->pri);
+    arg->limiter->Request(arg->request_size, arg->pri, nullptr /* stats */);
   };
 
   for (uint32_t i = 1; i <= 16; i <<= 1) {

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1219,7 +1219,7 @@ Status BackupEngineImpl::CopyOrCreateFile(
     }
     s = dest_writer->Append(data);
     if (rate_limiter != nullptr) {
-      rate_limiter->Request(data.size(), Env::IO_LOW);
+      rate_limiter->Request(data.size(), Env::IO_LOW, nullptr /* stats */);
     }
     if (processed_buffer_size > options_.callback_trigger_interval_size) {
       processed_buffer_size -= options_.callback_trigger_interval_size;


### PR DESCRIPTION
This is the metric I plan to use for adaptive rate limiting. A low ratio of drained intervals would indicate write rate can be lowered, while a high ratio indicates we should increase rate limit to avoid eventual stalls.

The Statistics object is passed in RateLimiter::Request() to avoid requiring changes to client code, which would've been necessary if we passed it in the RateLimiter constructor. We pass it for the flush/compaction code paths, which is where the rate limiter is typically used.

Test Plan: updated DBTest.RateLimitingTest