### PR TITLE
fix rate limiter test flakiness

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2824,7 +2824,7 @@ TEST_F(DBTest, RateLimitingTest) {
   // Most intervals should've been drained (interval time is 100ms, elapsed is
   // micros)
   ASSERT_GT(rate_limiter_drains, elapsed / 100000 / 2);
-  ASSERT_LE(rate_limiter_drains, elapsed / 100000);
+  ASSERT_LE(rate_limiter_drains, elapsed / 100000 + 1);
   double ratio = env_->bytes_written_ * 1000000 / elapsed / raw_rate;
   fprintf(stderr, "write rate ratio = %.2lf, expected 0.7\n", ratio);
   ASSERT_TRUE(ratio < 0.8);
@@ -2850,7 +2850,7 @@ TEST_F(DBTest, RateLimitingTest) {
   // Most intervals should've been drained (interval time is 100ms, elapsed is
   // micros)
   ASSERT_GT(rate_limiter_drains, elapsed / 100000 / 2);
-  ASSERT_LE(rate_limiter_drains, elapsed / 100000);
+  ASSERT_LE(rate_limiter_drains, elapsed / 100000 + 1);
   ratio = env_->bytes_written_ * 1000000 / elapsed / raw_rate;
   fprintf(stderr, "write rate ratio = %.2lf, expected 0.5\n", ratio);
   ASSERT_LT(ratio, 0.6);


### PR DESCRIPTION
fix when elapsed time spans non-integral number of intervals since the rate limiter may still be drained during a partial interval.