### PR TITLE
Add a memtable-only iterator option

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3918,8 +3918,10 @@ InternalIterator* DBImpl::NewInternalIterator(
   }
   if (s.ok()) {
     // Collect iterators for files in L0 - Ln
-    super_version->current->AddIterators(read_options, env_options_,
-                                         &merge_iter_builder, range_del_agg);
+    if (read_options.read_tier != kMemtableTier) {
+      super_version->current->AddIterators(read_options, env_options_,
+                                           &merge_iter_builder, range_del_agg);
+    }
     internal_iter = merge_iter_builder.Finish();
     IterState* cleanup =
         new IterState(this, &mutex_, super_version,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -888,10 +888,11 @@ struct Options : public DBOptions, public ColumnFamilyOptions {
 enum ReadTier {
   kReadAllTier = 0x0,     // data in memtable, block cache, OS cache or storage
   kBlockCacheTier = 0x1,  // data in memtable or block cache
-  kPersistedTier = 0x2    // persisted data.  When WAL is disabled, this option
+  kPersistedTier = 0x2,   // persisted data.  When WAL is disabled, this option
                           // will skip data in memtable.
                           // Note that this ReadTier currently only supports
                           // Get and MultiGet and does not support iterators.
+  kMemtableTier = 0x3
 };
 
 // Options that control read operations

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -892,7 +892,7 @@ enum ReadTier {
                           // will skip data in memtable.
                           // Note that this ReadTier currently only supports
                           // Get and MultiGet and does not support iterators.
-  kMemtableTier = 0x3
+  kMemtableTier = 0x3     // data in memtable. used for memtable-only iterators.
 };
 
 // Options that control read operations


### PR DESCRIPTION
This PR is to support a way to iterate over all the keys that are just in memtables. 

Test Plan:
- Added a new unit-test
- make check