### PR TITLE
Check expiration with TTL of column family

### DIFF
--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -33,7 +33,16 @@ void DBWithTTLImpl::SanitizeOptions(int32_t ttl, ColumnFamilyOptions* options,
 }
 
 // Open the db inside DBWithTTLImpl because options needs pointer to its ttl
-DBWithTTLImpl::DBWithTTLImpl(DB* db) : DBWithTTL(db) {}
+DBWithTTLImpl::DBWithTTLImpl(
+        DB* db,
+        const std::vector<ColumnFamilyDescriptor>& descriptors,
+        std::vector<int32_t> ttls) : DBWithTTL(db) {
+
+  for (size_t i=0; i < descriptors.size(); ++i) {
+    column_family_ttls_.insert(
+            std::make_pair(descriptors[i].name, ttls[i]));
+  }
+}
 
 DBWithTTLImpl::~DBWithTTLImpl() {
   // Need to stop background compaction before getting rid of the filter
@@ -101,7 +110,7 @@ Status DBWithTTL::Open(
     st = DB::Open(db_options, dbname, column_families_sanitized, handles, &db);
   }
   if (st.ok()) {
-    *dbptr = new DBWithTTLImpl(db);
+    *dbptr = new DBWithTTLImpl(db, column_families_sanitized, ttls);
   } else {
     *dbptr = nullptr;
   }
@@ -170,6 +179,15 @@ bool DBWithTTLImpl::IsStale(const Slice& value, int32_t ttl, Env* env) {
   return (timestamp_value + ttl) < curtime;
 }
 
+bool DBWithTTLImpl::IsStale(const Slice& value, const std::string& column_family_name) {
+  int32_t ttl = 0;
+  auto iter = column_family_ttls_.find(column_family_name);
+  if(iter != column_family_ttls_.end())
+    ttl = iter->second;
+
+  return IsStale(value, ttl, GetBaseDB()->GetEnv());
+}
+
 // Strips the TS from the end of the string
 Status DBWithTTLImpl::StripTS(std::string* str) {
   Status st;
@@ -200,6 +218,11 @@ Status DBWithTTLImpl::Get(const ReadOptions& options,
   if (!st.ok()) {
     return st;
   }
+
+  if (IsStale(*value, column_family->GetName())) {
+    return Status::NotFound();
+  }
+
   return StripTS(value);
 }
 
@@ -207,6 +230,7 @@ std::vector<Status> DBWithTTLImpl::MultiGet(
     const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_family,
     const std::vector<Slice>& keys, std::vector<std::string>* values) {
+  const std::string& column_family_name = column_family[0]->GetName();
   auto statuses = db_->MultiGet(options, column_family, keys, values);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
@@ -214,6 +238,11 @@ std::vector<Status> DBWithTTLImpl::MultiGet(
     }
     statuses[i] = SanityCheckTimestamp((*values)[i]);
     if (!statuses[i].ok()) {
+      continue;
+    }
+
+    if (IsStale((*values)[0], column_family_name)) {
+      statuses[i] = Status::NotFound();
       continue;
     }
     statuses[i] = StripTS(&(*values)[i]);
@@ -227,7 +256,8 @@ bool DBWithTTLImpl::KeyMayExist(const ReadOptions& options,
                                 bool* value_found) {
   bool ret = db_->KeyMayExist(options, column_family, key, value, value_found);
   if (ret && value != nullptr && value_found != nullptr && *value_found) {
-    if (!SanityCheckTimestamp(*value).ok() || !StripTS(value).ok()) {
+    if (!SanityCheckTimestamp(*value).ok() || 
+        IsStale(*value, column_family->GetName()) || !StripTS(value).ok()) {
       return false;
     }
   }

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -241,7 +241,7 @@ std::vector<Status> DBWithTTLImpl::MultiGet(
       continue;
     }
 
-    if (IsStale((*values)[0], column_family_name)) {
+    if (IsStale((*values)[i], column_family_name)) {
       statuses[i] = Status::NotFound();
       continue;
     }

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -31,7 +31,7 @@ class DBWithTTLImpl : public DBWithTTL {
                               Env* env);
 
   explicit DBWithTTLImpl(DB* db,
-                         const std::vector<ColumnFamilyDescriptor>& descriptors,
+                         const std::vector<ColumnFamilyHandle*>* handles,
                          std::vector<int32_t> ttls);
 
   virtual ~DBWithTTLImpl();
@@ -83,7 +83,7 @@ class DBWithTTLImpl : public DBWithTTL {
 
   static bool IsStale(const Slice& value, int32_t ttl, Env* env);
 
-  bool IsStale(const Slice& value, const std::string& column_family_name);
+  bool IsStale(const Slice& value, uint32_t column_family_id);
 
   static Status AppendTS(const Slice& val, std::string* val_with_ts, Env* env);
 
@@ -98,7 +98,7 @@ class DBWithTTLImpl : public DBWithTTL {
   static const int32_t kMaxTimestamp = 2147483647;  // 01/18/2038:7:14PM GMT-8
 
  private:
-  std::map<std::string, int32_t> column_family_ttls_;
+  std::map<uint32_t, int32_t> column_family_ttls_;
 };
 
 class TtlIterator : public Iterator {

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -30,7 +30,9 @@ class DBWithTTLImpl : public DBWithTTL {
   static void SanitizeOptions(int32_t ttl, ColumnFamilyOptions* options,
                               Env* env);
 
-  explicit DBWithTTLImpl(DB* db);
+  explicit DBWithTTLImpl(DB* db,
+                         const std::vector<ColumnFamilyDescriptor>& descriptors,
+                         std::vector<int32_t> ttls);
 
   virtual ~DBWithTTLImpl();
 
@@ -81,6 +83,8 @@ class DBWithTTLImpl : public DBWithTTL {
 
   static bool IsStale(const Slice& value, int32_t ttl, Env* env);
 
+  bool IsStale(const Slice& value, const std::string& column_family_name);
+
   static Status AppendTS(const Slice& val, std::string* val_with_ts, Env* env);
 
   static Status SanityCheckTimestamp(const Slice& str);
@@ -92,6 +96,9 @@ class DBWithTTLImpl : public DBWithTTL {
   static const int32_t kMinTimestamp = 1368146402;  // 05/09/2013:5:40PM GMT-8
 
   static const int32_t kMaxTimestamp = 2147483647;  // 01/18/2038:7:14PM GMT-8
+
+ private:
+  std::map<std::string, int32_t> column_family_ttls_;
 };
 
 class TtlIterator : public Iterator {
@@ -180,6 +187,8 @@ class TtlCompactionFilter : public CompactionFilter {
 
   virtual const char* Name() const override { return "Delete By TTL"; }
 
+  int32_t GetTtl() { return ttl_; }
+
  private:
   int32_t ttl_;
   Env* env_;
@@ -210,6 +219,8 @@ class TtlCompactionFilterFactory : public CompactionFilterFactory {
   virtual const char* Name() const override {
     return "TtlCompactionFilterFactory";
   }
+
+  int32_t GetTtl() { return ttl_; }
 
  private:
   int32_t ttl_;

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -187,8 +187,6 @@ class TtlCompactionFilter : public CompactionFilter {
 
   virtual const char* Name() const override { return "Delete By TTL"; }
 
-  int32_t GetTtl() { return ttl_; }
-
  private:
   int32_t ttl_;
   Env* env_;
@@ -219,8 +217,6 @@ class TtlCompactionFilterFactory : public CompactionFilterFactory {
   virtual const char* Name() const override {
     return "TtlCompactionFilterFactory";
   }
-
-  int32_t GetTtl() { return ttl_; }
 
  private:
   int32_t ttl_;

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -502,7 +502,7 @@ TEST_F(TtlTest, ReadOnlyPresentForever) {
   CloseTtl();
 
   OpenReadOnlyTtl(1);
-  SleepCompactCheck(2, 0, kSampleSize_);       // T=2:Set1 should still be there
+  SleepCompactCheck(2, 0, kSampleSize_, false); // T=2:Set1 should not be there
   CloseTtl();
 }
 


### PR DESCRIPTION
#1445 

DBWithTTL does not return expired data anymore even if before compaction run.

There are two minor points(maybe big)

1) In `MultiGet`, we got multiple column families, but it check expiration of whole values with the ttl of first column family's. I don't have simple but elegant idea to correct this (without modify base implementation of MultiGet)

2) `TtlIterator` still return staled data.

any advice?