### PR TITLE
rate limit auto-tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,7 @@ set(SOURCES
         util/threadpool_imp.cc
         util/transaction_test_util.cc
         util/xxhash.cc
+        utilities/auto_tuners/rate_limiter_auto_tuner.cc
         utilities/backupable/backupable_db.cc
         utilities/blob_db/blob_db.cc
         utilities/blob_db/blob_db_impl.cc

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -94,7 +94,6 @@
 #include "util/log_buffer.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
-#include "util/rate_limiter.h"
 #include "util/sst_file_manager_impl.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -94,6 +94,7 @@
 #include "util/log_buffer.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
+#include "util/rate_limiter.h"
 #include "util/sst_file_manager_impl.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -67,6 +67,7 @@
 #include "options/options_parser.h"
 #include "port/likely.h"
 #include "port/port.h"
+#include "rocksdb/auto_tuner.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/db.h"
@@ -198,6 +199,9 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname)
                                  &write_controller_));
   column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(versions_->GetColumnFamilySet()));
+  for (auto& auto_tuner : initial_db_options_.auto_tuners) {
+    auto_tuner->Init(this, initial_db_options_);
+  }
 
   DumpRocksDBBuildVersion(immutable_db_options_.info_log.get());
   DumpDBFileSummary(immutable_db_options_, dbname_);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -199,9 +199,11 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname)
                                  &write_controller_));
   column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(versions_->GetColumnFamilySet()));
+#ifndef ROCKSDB_LITE
   for (auto& auto_tuner : initial_db_options_.auto_tuners) {
     auto_tuner->Init(this, initial_db_options_);
   }
+#endif  // ROCKSDB_LITE
 
   DumpRocksDBBuildVersion(immutable_db_options_.info_log.get());
   DumpDBFileSummary(immutable_db_options_, dbname_);

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -125,6 +125,17 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.avoid_flush_during_recovery = false;
   }
 
+#ifndef ROCKSDB_LITE
+  // TODO(andrewkr): this is a temporary workaround to support auto-tuned rate
+  // limiter before we've written a scheduler/executor for auto-tuners. It does
+  // the scheduling/execution in a wrapper around the provided rate limiter.
+  if (!result.auto_tuners.empty()) {
+    assert(result.rate_limiter != nullptr);
+    assert(result.auto_tuners.size() == 1);
+    result.rate_limiter.reset(
+        new AdaptiveRateLimiter(result.rate_limiter, result.auto_tuners[0]));
+  }
+#endif  // ROCKSDB_LITE
   return result;
 }
 

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -126,15 +126,6 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   }
 
 #ifndef ROCKSDB_LITE
-  // statistics must be enabled (i.e., non-nullptr); info_log is optional
-  if (!result.auto_tuners.empty()) {
-    assert(result.statistics != nullptr);
-  }
-  for (auto& auto_tuner : result.auto_tuners) {
-    auto_tuner->SetLogger(result.info_log.get());
-    auto_tuner->SetStatistics(result.statistics.get());
-  }
-
   // TODO(andrewkr): this is a temporary workaround to support auto-tuned rate
   // limiter before we've written a scheduler/executor for auto-tuners. It does
   // the scheduling/execution in a wrapper around the provided rate limiter.

--- a/include/rocksdb/auto_tuner.h
+++ b/include/rocksdb/auto_tuner.h
@@ -2,6 +2,8 @@
 //  This source code is licensed under the BSD-style license found in the
 //  LICENSE file in the root directory of this source tree. An additional grant
 //  of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 
 #pragma once
 #ifndef ROCKSDB_LITE
@@ -9,6 +11,7 @@
 #include <chrono>
 #include <memory>
 
+#include "rocksdb/db.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
@@ -28,23 +31,48 @@ class AutoTuner {
   // Desired interval between calls to Tune().
   virtual std::chrono::milliseconds GetInterval() = 0;
 
-  // These are called during DB::Open with the final statistics and info logger
-  // objects.
-  void SetStatistics(Statistics* stats) { stats_ = stats; }
-  void SetLogger(Logger* logger) { logger_ = logger; }
+  // Initializes state that isn't available to at construction time because
+  // DB::Open(), which creates the DB object and sanitizes options, hasn't been
+  // called yet.
+  //
+  // AutoTuner implementors may wish to override this function to access other
+  // DBOptions members. If so, AutoTuner::Init() must still be called by the
+  // overriding function.
+  virtual void Init(DB* db, const DBOptions& init_db_options) {
+    assert(!init_);
+    db_ = db;
+    stats_ = init_db_options.statistics.get();
+    logger_ = init_db_options.info_log.get();
+    init_ = true;
+  }
 
  protected:
+  DB* GetDB() {
+    assert(init_);
+    return db_;
+  }
+  Statistics* GetStatistics() {
+    assert(init_);
+    return stats_;
+  }
+  Logger* GetLogger() {
+    assert(init_);
+    return logger_;
+  }
+
+ private:
+  DB* db_ = nullptr;
   Statistics* stats_ = nullptr;
   Logger* logger_ = nullptr;
+  bool init_ = false;
 };
 
 // This rate limiter dynamically adjusts I/O rate limit to try to keep the
 // percentage of drained intervals in the watermarked range.
 //
-// This auto-tuner assumes stats and rate_limiter objects are used for a single
+// This auto-tuner assumes DBOptions::rate_limiter objects are used for a single
 // database only.
 //
-// @param rate_limiter Rate limiter that we'll be adjusting
 // @param rate_limiter_interval Duration of rate limiter interval (ms)
 // @param low_watermark_pct Below this percentage of drained intervals, decrease
 //    rate limit by adjust_factor_pct
@@ -54,7 +82,6 @@ class AutoTuner {
 // @param min_bytes_per_sec Rate limit will not be adjusted below this rate
 // @param max_bytes_per_sec Rate limit will not be adjusted above this rate
 AutoTuner* NewRateLimiterAutoTuner(
-    std::shared_ptr<RateLimiter> rate_limiter,
     std::chrono::milliseconds rate_limiter_interval, int low_watermark_pct,
     int high_watermark_pct, int adjust_factor_pct, int64_t min_bytes_per_sec,
     int64_t max_bytes_per_sec);

--- a/include/rocksdb/auto_tuner.h
+++ b/include/rocksdb/auto_tuner.h
@@ -1,0 +1,57 @@
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+#ifndef ROCKSDB_LITE
+
+#include <chrono>
+#include <memory>
+
+#include "rocksdb/rate_limiter.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+
+// An AutoTuner changes dynamic options at regular intervals based on statistics
+// data. They can be configured in DBOptions::auto_tuners.
+class AutoTuner {
+ public:
+  virtual ~AutoTuner() {}
+
+  // Invoked approximately every GetInterval() milliseconds to examine
+  // statistics and adjust dynamic options accordingly.
+  virtual Status Tune(std::chrono::milliseconds now) = 0;
+
+  // Desired interval between calls to Tune().
+  virtual std::chrono::milliseconds GetInterval() = 0;
+};
+
+// This rate limiter dynamically adjusts I/O rate limit to try to keep the
+// percentage of drained intervals in the watermarked range.
+//
+// This auto-tuner assumes stats and rate_limiter objects are used for a single
+// database only.
+//
+// @param stats Stats from which we get drained intervals percentage
+// @param rate_limiter Rate limiter that we'll be adjusting
+// @param rate_limiter_interval Duration of rate limiter interval (ms)
+// @param low_watermark_pct Below this percentage of drained intervals, decrease
+//    rate limit by adjust_factor_pct
+// @param high_watermark_pct Above this percentage of drained intervals,
+//    increase rate limit by adjust_factor_pct
+// @param adjust_factor_pct Percentage by which we increase/decrease rate limit
+// @param init_bytes_per_sec Initial value of rate limiter
+// @param min_bytes_per_sec Rate limit will not be adjusted below this rate
+// @param max_bytes_per_sec Rate limit will not be adjusted above this rate
+AutoTuner* NewRateLimiterAutoTuner(
+    const std::shared_ptr<Statistics>& stats, RateLimiter* rate_limiter,
+    std::chrono::milliseconds rate_limiter_interval, int low_watermark_pct,
+    int high_watermark_pct, int adjust_factor_pct, int64_t init_bytes_per_sec,
+    int64_t min_bytes_per_sec, int64_t max_bytes_per_sec);
+
+}  // namespace rocksdb
+
+#endif  // ROCKSDB_LITE

--- a/include/rocksdb/auto_tuner.h
+++ b/include/rocksdb/auto_tuner.h
@@ -27,6 +27,15 @@ class AutoTuner {
 
   // Desired interval between calls to Tune().
   virtual std::chrono::milliseconds GetInterval() = 0;
+
+  // These are called during DB::Open with the final statistics and info logger
+  // objects.
+  void SetStatistics(Statistics* stats) { stats_ = stats; }
+  void SetLogger(Logger* logger) { logger_ = logger; }
+
+ protected:
+  Statistics* stats_ = nullptr;
+  Logger* logger_ = nullptr;
 };
 
 // This rate limiter dynamically adjusts I/O rate limit to try to keep the
@@ -35,7 +44,6 @@ class AutoTuner {
 // This auto-tuner assumes stats and rate_limiter objects are used for a single
 // database only.
 //
-// @param stats Stats from which we get drained intervals percentage
 // @param rate_limiter Rate limiter that we'll be adjusting
 // @param rate_limiter_interval Duration of rate limiter interval (ms)
 // @param low_watermark_pct Below this percentage of drained intervals, decrease
@@ -43,14 +51,13 @@ class AutoTuner {
 // @param high_watermark_pct Above this percentage of drained intervals,
 //    increase rate limit by adjust_factor_pct
 // @param adjust_factor_pct Percentage by which we increase/decrease rate limit
-// @param init_bytes_per_sec Initial value of rate limiter
 // @param min_bytes_per_sec Rate limit will not be adjusted below this rate
 // @param max_bytes_per_sec Rate limit will not be adjusted above this rate
 AutoTuner* NewRateLimiterAutoTuner(
-    const std::shared_ptr<Statistics>& stats, RateLimiter* rate_limiter,
+    std::shared_ptr<RateLimiter> rate_limiter,
     std::chrono::milliseconds rate_limiter_interval, int low_watermark_pct,
-    int high_watermark_pct, int adjust_factor_pct, int64_t init_bytes_per_sec,
-    int64_t min_bytes_per_sec, int64_t max_bytes_per_sec);
+    int high_watermark_pct, int adjust_factor_pct, int64_t min_bytes_per_sec,
+    int64_t max_bytes_per_sec);
 
 }  // namespace rocksdb
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -18,7 +18,6 @@
 #include <unordered_map>
 
 #include "rocksdb/advanced_options.h"
-#include "rocksdb/auto_tuner.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/env.h"
 #include "rocksdb/listener.h"
@@ -32,6 +31,7 @@
 
 namespace rocksdb {
 
+class AutoTuner;
 class Cache;
 class CompactionFilter;
 class CompactionFilterFactory;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include "rocksdb/advanced_options.h"
+#include "rocksdb/auto_tuner.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/env.h"
 #include "rocksdb/listener.h"
@@ -887,6 +888,16 @@ struct DBOptions {
   // DEFAULT: false
   // Immutable.
   bool allow_ingest_behind = false;
+
+#ifndef ROCKSDB_LITE
+  // A list of AutoTuner objects that will change dynamic options at regular
+  // intervals based on statistics data.
+  //
+  // Currently this feature is experimental and only supports one AutoTuner for
+  // adjusting I/O rate limit. It is also restricted to single-DB mode, where
+  // the rate_limiter and statistics objects are used in one DB only.
+  std::vector<std::shared_ptr<AutoTuner>> auto_tuners;
+#endif  // ROCKSDB_LITE
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/options/options.cc
+++ b/options/options.cc
@@ -192,9 +192,12 @@ DBOptions::DBOptions(const Options& options)
       fail_if_options_file_error(options.fail_if_options_file_error),
       dump_malloc_stats(options.dump_malloc_stats),
       avoid_flush_during_recovery(options.avoid_flush_during_recovery),
-      avoid_flush_during_shutdown(options.avoid_flush_during_shutdown),
-      allow_ingest_behind(options.allow_ingest_behind) {
-}
+#ifndef ROCKSDB_LITE
+      allow_ingest_behind(options.allow_ingest_behind),
+      auto_tuners(options.auto_tuners) {}
+#else
+      allow_ingest_behind(options.allow_ingest_behind) {}
+#endif  // ROCKSDB_LITE
 
 void DBOptions::Dump(Logger* log) const {
     ImmutableDBOptions(*this).Dump(log);

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -21,6 +21,7 @@
 #include "options/options_helper.h"
 #include "options/options_parser.h"
 #include "options/options_sanity_check.h"
+#include "rocksdb/auto_tuner.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/memtablerep.h"
@@ -208,6 +209,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
        sizeof(std::vector<std::shared_ptr<EventListener>>)},
       {offsetof(struct DBOptions, row_cache), sizeof(std::shared_ptr<Cache>)},
       {offsetof(struct DBOptions, wal_filter), sizeof(const WalFilter*)},
+      {offsetof(struct DBOptions, auto_tuners),
+       sizeof(std::vector<std::shared_ptr<AutoTuner>>)},
   };
 
   char* options_ptr = new char[sizeof(DBOptions)];

--- a/src.mk
+++ b/src.mk
@@ -149,6 +149,7 @@ LIB_SOURCES =                                                   \
   util/threadpool_imp.cc                                        \
   util/transaction_test_util.cc                                 \
   util/xxhash.cc                                                \
+  utilities/auto_tuners/rate_limiter_auto_tuner.cc              \
   utilities/backupable/backupable_db.cc                         \
   utilities/blob_db/blob_db.cc                                  \
   utilities/blob_db/blob_db_impl.cc                             \

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -111,9 +111,9 @@ class GenericRateLimiter : public RateLimiter {
 // the scheduling/execution in a wrapper around the provided rate limiter.
 class AdaptiveRateLimiter : public RateLimiter {
  public:
-  AdaptiveRateLimiter(const std::shared_ptr<RateLimiter>& rate_limiter,
-                      const std::shared_ptr<AutoTuner>& tuner)
-      : rate_limiter_(rate_limiter), tuner_(tuner), last_tuned_(0) {}
+  AdaptiveRateLimiter(std::shared_ptr<RateLimiter> rate_limiter,
+                      AutoTuner* tuner)
+      : rate_limiter_(std::move(rate_limiter)), tuner_(tuner), last_tuned_(0) {}
 
   virtual void SetBytesPerSecond(int64_t bytes_per_second) override {
     rate_limiter_->SetBytesPerSecond(bytes_per_second);
@@ -146,8 +146,10 @@ class AdaptiveRateLimiter : public RateLimiter {
   }
 
  private:
+  // useful to make this a shared_ptr since typically it takes its value from
+  // DBOptions::rate_limiter, which is a shared_ptr.
   std::shared_ptr<RateLimiter> rate_limiter_;
-  std::shared_ptr<AutoTuner> tuner_;
+  AutoTuner* tuner_;
   std::mutex tuner_mutex_;
   std::chrono::milliseconds last_tuned_;
 };

--- a/utilities/auto_tuners/rate_limiter_auto_tuner.cc
+++ b/utilities/auto_tuners/rate_limiter_auto_tuner.cc
@@ -5,6 +5,8 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <algorithm>
+
 #include "rocksdb/auto_tuner.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/statistics.h"

--- a/utilities/auto_tuners/rate_limiter_auto_tuner.cc
+++ b/utilities/auto_tuners/rate_limiter_auto_tuner.cc
@@ -1,0 +1,103 @@
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef ROCKSDB_LITE
+
+#include "rocksdb/auto_tuner.h"
+#include "rocksdb/rate_limiter.h"
+#include "rocksdb/statistics.h"
+
+namespace rocksdb {
+
+class RateLimiterAutoTuner : public AutoTuner {
+ public:
+  RateLimiterAutoTuner(const std::shared_ptr<Statistics>& stats,
+                       RateLimiter* rate_limiter,
+                       std::chrono::milliseconds rate_limiter_interval,
+                       int low_watermark_pct, int high_watermark_pct,
+                       int adjust_factor_pct, int64_t init_bytes_per_sec,
+                       int64_t min_bytes_per_sec, int64_t max_bytes_per_sec)
+      : stats_(stats),
+        rate_limiter_(rate_limiter),
+        tuned_time_(0),
+        rate_limiter_interval_(rate_limiter_interval),
+        low_watermark_pct_(low_watermark_pct),
+        high_watermark_pct_(high_watermark_pct),
+        adjust_factor_pct_(adjust_factor_pct),
+        rate_limiter_drains_(0),
+        bytes_per_sec_(init_bytes_per_sec),
+        min_bytes_per_sec_(min_bytes_per_sec),
+        max_bytes_per_sec_(max_bytes_per_sec) {
+    assert(stats_ != nullptr);
+  }
+  virtual Status Tune(std::chrono::milliseconds now) override;
+  virtual std::chrono::milliseconds GetInterval() override;
+
+ private:
+  std::shared_ptr<Statistics> stats_;
+  RateLimiter* rate_limiter_;
+  std::chrono::milliseconds tuned_time_;
+  std::chrono::milliseconds rate_limiter_interval_;
+  int low_watermark_pct_;
+  int high_watermark_pct_;
+  int adjust_factor_pct_;
+  int64_t rate_limiter_drains_;
+  int64_t bytes_per_sec_;
+  int64_t min_bytes_per_sec_;
+  int64_t max_bytes_per_sec_;
+};
+
+Status RateLimiterAutoTuner::Tune(std::chrono::milliseconds now) {
+  std::chrono::milliseconds prev_tuned_time = tuned_time_;
+  tuned_time_ = now;
+  int64_t prev_rate_limiter_drains = rate_limiter_drains_;
+  rate_limiter_drains_ =
+      static_cast<int64_t>(stats_->getTickerCount(NUMBER_RATE_LIMITER_DRAINS));
+
+  if (prev_tuned_time == std::chrono::milliseconds(0)) {
+    // do nothing when no history window
+    return Status::OK();
+  }
+
+  int64_t elapsed_intervals =
+      (tuned_time_ - prev_tuned_time + rate_limiter_interval_ -
+       std::chrono::milliseconds(1)) /
+      rate_limiter_interval_;
+  int64_t drained_pct = (rate_limiter_drains_ - prev_rate_limiter_drains) *
+                        100 / elapsed_intervals;
+  int64_t prev_bytes_per_sec = bytes_per_sec_;
+  if (drained_pct < low_watermark_pct_) {
+    bytes_per_sec_ =
+        std::max(min_bytes_per_sec_,
+                 prev_bytes_per_sec * 100 / (100 + adjust_factor_pct_));
+  } else if (drained_pct > high_watermark_pct_) {
+    bytes_per_sec_ =
+        std::min(max_bytes_per_sec_,
+                 prev_bytes_per_sec * (100 + adjust_factor_pct_) / 100);
+  }
+  if (bytes_per_sec_ != prev_bytes_per_sec) {
+    rate_limiter_->SetBytesPerSecond(bytes_per_sec_);
+  }
+  return Status::OK();
+}
+
+std::chrono::milliseconds RateLimiterAutoTuner::GetInterval() {
+  return 100 * rate_limiter_interval_;
+}
+
+AutoTuner* NewRateLimiterAutoTuner(
+    const std::shared_ptr<Statistics>& stats, RateLimiter* rate_limiter,
+    std::chrono::milliseconds rate_limiter_interval, int low_watermark_pct,
+    int high_watermark_pct, int adjust_factor_pct, int64_t init_bytes_per_sec,
+    int64_t min_bytes_per_sec, int64_t max_bytes_per_sec) {
+  return new RateLimiterAutoTuner(stats, rate_limiter, rate_limiter_interval,
+                                  low_watermark_pct, high_watermark_pct,
+                                  adjust_factor_pct, init_bytes_per_sec,
+                                  min_bytes_per_sec, max_bytes_per_sec);
+}
+
+}  // namespace rocksdb
+
+#endif  // ROCKSDB_LITE


### PR DESCRIPTION
try a simple demand-based dynamic rate limiter. as commented, it adjusts rate limit upwards when demand is consistently high, and downwards when demand is consistently low. what we really should do is estimate the rate needed to prevent L0 from filling up, but let's try something even simpler for the first stab.

Test Plan: tried in db_bench and watched it increase/decrease rate limit. need help coming up with an evaluation plan