### PR TITLE
avoid ASSERT_EQ(false, ...);

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5208,7 +5208,7 @@ TEST_F(DBTest, PauseBackgroundWorkTest) {
   });
   env_->SleepForMicroseconds(200000);
   // make sure the thread is not done
-  ASSERT_EQ(false, done.load());
+  ASSERT_FALSE(done.load());
   db_->ContinueBackgroundWork();
   for (auto& t : threads) {
     t.join();

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1187,9 +1187,9 @@ TEST_F(BlockBasedTableTest, RangeDelBlock) {
       // iterator can still access its metablock's range tombstones.
       c.ResetTableReader();
     }
-    ASSERT_EQ(false, iter->Valid());
+    ASSERT_FALSE(iter->Valid());
     iter->SeekToFirst();
-    ASSERT_EQ(true, iter->Valid());
+    ASSERT_TRUE(iter->Valid());
     for (int i = 0; i < 2; i++) {
       ASSERT_TRUE(iter->Valid());
       ParsedInternalKey parsed_key;


### PR DESCRIPTION
lately it fails on travis due to a compiler bug (see https://github.com/google/googletest/issues/322#issuecomment-125645145). interestingly it seems to affect occurrences of `ASSERT_EQ(false, ...);` but not `ASSERT_EQ(true, ...);`.

Test Plan: wait for travis to finish

