### PR TITLE
Fix random access alignment

### DIFF
--- a/build_tools/run_ci_db_test.ps1
+++ b/build_tools/run_ci_db_test.ps1
@@ -50,7 +50,8 @@ Write-Output "Root: $RootFolder, WorkFolder: $WorkFolder"
 
 # Use JEMALLOC executables
 if($Run -ceq "db_test" -or
-   $Run -ceq "db_test2" ) {
+   $Run -ceq "db_test2" -or
+   $Run -ceq "db_basic_test") {
 
    $file_name = $Run
 
@@ -150,7 +151,7 @@ function MakeAndAdd([string]$token, $HashTable) {
 # Test executable name -> Log file
 function Discover-TestBinaries([string]$Pattern, $HashTable) {
 
-    $Exclusions = @("db_test*", "db_sanity_test*")
+    $Exclusions = @("db_test*", "db_sanity_test*", "db_basic_test*")
 
     $p = -join ($BinariesFolder, $pattern)
 
@@ -164,7 +165,8 @@ function Discover-TestBinaries([string]$Pattern, $HashTable) {
 $TestsToRun = [ordered]@{}
 
 if($Run -ceq "db_test" -or
-   $Run -ceq "db_test2") {
+   $Run -ceq "db_test2" -or
+   $Run -ceq "db_basic_test") {
     Normalize-DbTests -HashTable $TestsToRun
 } elseif($Run -ceq "tests") {
     if($EnableJE) {
@@ -237,7 +239,8 @@ function RunJobs($TestToLog, [int]$ConcurrencyVal, [bool]$AddForRerun)
             $log_path = ($TestToLog.$k)
 
             if($Run -ceq "db_test" -or
-               $Run -ceq "db_test2") {
+               $Run -ceq "db_test2" -or
+               $Run -ceq "db_basic_test") {
               $job = Start-Job -Name $k -ScriptBlock $InvokeTestCase -ArgumentList @($db_test,$k,$log_path)
             } else {
               [string]$Exe =  -Join ($BinariesFolder, $k)

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -723,12 +723,9 @@ WinRandomAccessImpl::WinRandomAccessImpl(WinFileData* file_base,
 
   assert(!options.use_mmap_reads);
 
-  // Direct access, use internal buffer for reads
-  if (file_base_->use_direct_io()) {
-    // Do not allocate the buffer either until the first request or
-    // until there is a call to allocate a read-ahead buffer
-    buffer_.Alignment(alignment);
-  }
+  // Do not allocate the buffer either until the first request or
+  // until there is a call to allocate a read-ahead buffer
+  buffer_.Alignment(alignment);
 }
 
 inline


### PR DESCRIPTION
This fixes an issue when the most recent readers assume that alignment is always set even if direct io is off.
Also adjust slightly appveyor script to run db_basic_test cases concurrently.