### PR TITLE
Add DB::DeleteRange for the default cf

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5903,6 +5903,13 @@ Status DB::SingleDelete(const WriteOptions& opt,
 }
 
 Status DB::DeleteRange(const WriteOptions& opt,
+                       const Slice& begin_key, const Slice& end_key) {
+  WriteBatch batch;
+  batch.DeleteRange(begin_key, end_key);
+  return Write(opt, &batch);
+}
+
+Status DB::DeleteRange(const WriteOptions& opt,
                        ColumnFamilyHandle* column_family,
                        const Slice& begin_key, const Slice& end_key) {
   WriteBatch batch;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -251,6 +251,8 @@ class DB {
   // Consider setting ReadOptions::ignore_range_deletions = true to speed
   // up reads for key(s) that are known to be unaffected by range deletions.
   virtual Status DeleteRange(const WriteOptions& options,
+                             const Slice& begin_key, const Slice& end_key);
+  virtual Status DeleteRange(const WriteOptions& options,
                              ColumnFamilyHandle* column_family,
                              const Slice& begin_key, const Slice& end_key);
 
@@ -586,7 +588,7 @@ class DB {
   virtual bool GetAggregatedIntProperty(const Slice& property,
                                         uint64_t* value) = 0;
 
-  // Flags for DB::GetSizeApproximation that specify whether memtable 
+  // Flags for DB::GetSizeApproximation that specify whether memtable
   // stats should be included, or file stats approximation or both
   enum SizeApproximationFlags : uint8_t {
     NONE = 0,


### PR DESCRIPTION
Hi,

This PR adds `DB::DeleteRange` method for the default cf. PTAL.