### PR TITLE
add max to histogram stats

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2158,7 +2158,7 @@ TEST_F(DBTest, GroupCommitTest) {
     ASSERT_TRUE(!itr->Valid());
     delete itr;
 
-    HistogramData hist_data = {0, 0, 0, 0, 0, 0};
+    HistogramData hist_data;
     options.statistics->histogramData(DB_WRITE, &hist_data);
     ASSERT_GT(hist_data.average, 0.0);
   } while (ChangeOptions(kSkipNoSeekToLast));

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2158,7 +2158,7 @@ TEST_F(DBTest, GroupCommitTest) {
     ASSERT_TRUE(!itr->Valid());
     delete itr;
 
-    HistogramData hist_data = {0, 0, 0, 0, 0};
+    HistogramData hist_data = {0, 0, 0, 0, 0, 0};
     options.statistics->histogramData(DB_WRITE, &hist_data);
     ASSERT_GT(hist_data.average, 0.0);
   } while (ChangeOptions(kSkipNoSeekToLast));

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -411,6 +411,9 @@ struct HistogramData {
   double percentile99;
   double average;
   double standard_deviation;
+  // zero-initialize new members since old Statistics::histogramData()
+  // implementations won't write them.
+  double max = 0.0;
 };
 
 enum StatsLevel {

--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -233,6 +233,7 @@ void HistogramStat::Data(HistogramData * const data) const {
   data->median = Median();
   data->percentile95 = Percentile(95);
   data->percentile99 = Percentile(99);
+  data->max = max();
   data->average = Average();
   data->standard_deviation = StandardDeviation();
 }

--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -11,11 +11,13 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#include "util/histogram.h"
+
 #include <inttypes.h>
 #include <cassert>
 #include <math.h>
 #include <stdio.h>
-#include "util/histogram.h"
+
 #include "port/port.h"
 
 namespace rocksdb {

--- a/util/statistics.cc
+++ b/util/statistics.cc
@@ -200,13 +200,10 @@ std::string StatisticsImpl::ToString() const {
       HistogramData hData;
       histogramData(h.first, &hData);
       snprintf(
-          buffer,
-          kBufferSize,
-          "%s statistics Percentiles :=> 50 : %f 95 : %f 99 : %f\n",
-          h.second.c_str(),
-          hData.median,
-          hData.percentile95,
-          hData.percentile99);
+          buffer, kBufferSize,
+          "%s statistics Percentiles :=> 50 : %f 95 : %f 99 : %f 100 : %f\n",
+          h.second.c_str(), hData.median, hData.percentile95,
+          hData.percentile99, hData.max);
       res.append(buffer);
     }
   }


### PR DESCRIPTION
Domas enlightened me about p100 (i.e., max) stats. Let's add them to our histograms.

Test Plan: 
```
./db_bench -statistics -benchmarks=fillrandom -num=100000 -write_buffer_size=1048576 -rate_limiter_bytes_per_sec=1048576
...
rocksdb.db.write.micros statistics Percentiles :=> 50 : 2.923655 95 : 5.334560 99 : 8.709867 100 : 1122733.000000
...
```