### PR TITLE
Fix suggested compact range

### DIFF
--- a/db/db_impl_experimental.cc
+++ b/db/db_impl_experimental.cc
@@ -30,7 +30,7 @@ Status DBImpl::SuggestCompactRange(ColumnFamilyHandle* column_family,
   auto cfd = cfh->cfd();
   InternalKey start_key, end_key;
   if (begin != nullptr) {
-    start_key.SetMaxPossibleForUserKey(*begin);
+    start_key.SetMinPossibleForUserKey(*begin);
   }
   if (end != nullptr) {
     end_key.SetMinPossibleForUserKey(*end);


### PR DESCRIPTION
`mongo::RocksCompactionScheduled::reportSkippedDeletionsAboveThreshold` method is called when cursor skips number of deletions above threshold value while skanning `prefix`.  But when it comes to `DBImpl::SuggestCompactRange` it sets `start_key` with the `SetMaxPossibleForUserKey()` call. And `end_key` is set with `SetMinPossibleForUserKey()` for the next prefix. Thus the suggested range [begin_key,end_key] is empty.
I propose to to fix this by using `SetMinPossibleForUserKey()` for begin_key initialization. This way the whole range of keys for provided `prefix` will be suggested for compaction.