### PR TITLE
fix compile for VS2015

### DIFF
--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -235,7 +235,7 @@ void HistogramStat::Data(HistogramData * const data) const {
   data->median = Median();
   data->percentile95 = Percentile(95);
   data->percentile99 = Percentile(99);
-  data->max = max();
+  data->max = static_cast<double>(max());
   data->average = Average();
   data->standard_deviation = StandardDeviation();
 }


### PR DESCRIPTION
Without the cast, the build will break on Windows. 