### PR TITLE
Add Xpress and ZSTD CompressionType values to C header

### DIFF
--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -753,7 +753,9 @@ enum {
   rocksdb_zlib_compression = 2,
   rocksdb_bz2_compression = 3,
   rocksdb_lz4_compression = 4,
-  rocksdb_lz4hc_compression = 5
+  rocksdb_lz4hc_compression = 5,
+  rocksdb_xpress_compression = 6,
+  rocksdb_zstd_compression = 7
 };
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression(
     rocksdb_options_t*, int);


### PR DESCRIPTION
This PR copies the missing CompressionType values 
```cpp
enum CompressionType : unsigned char {
  ...
  kXpressCompression = 0x6,
  kZSTD = 0x7,
  ...
};
```
into the C header.