### PR TITLE
Add macros to include file name and line number during Logging

### DIFF
--- a/db/auto_roll_logger_test.cc
+++ b/db/auto_roll_logger_test.cc
@@ -6,21 +6,22 @@
 
 #ifndef ROCKSDB_LITE
 
+#include "db/auto_roll_logger.h"
+#include <errno.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iterator>
 #include <string>
 #include <thread>
 #include <vector>
-#include <cmath>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <algorithm>
-#include "db/auto_roll_logger.h"
 #include "port/port.h"
+#include "rocksdb/db.h"
+#include "util/logging.h"
 #include "util/sync_point.h"
 #include "util/testharness.h"
-#include "rocksdb/db.h"
-#include <sys/stat.h>
-#include <errno.h>
 
 namespace rocksdb {
 
@@ -62,10 +63,10 @@ Env* AutoRollLoggerTest::env = Env::Default();
 // In this test we only want to Log some simple log message with
 // no format. LogMessage() provides such a simple interface and
 // avoids the [format-security] warning which occurs when you
-// call Log(logger, log_message) directly.
+// call ROCKS_LOG_INFO(logger, log_message) directly.
 namespace {
 void LogMessage(Logger* logger, const char* message) {
-  Log(logger, "%s", message);
+  ROCKS_LOG_INFO(logger, "%s", message);
 }
 
 void LogMessage(const InfoLogLevel log_level, Logger* logger,
@@ -332,10 +333,10 @@ TEST_F(AutoRollLoggerTest, InfoLogLevel) {
       logger.SetInfoLogLevel((InfoLogLevel)log_level);
 
       // again, messages with level smaller than log_level will not be logged.
-      Log(InfoLogLevel::HEADER_LEVEL, &logger, "%s", kSampleMessage.c_str());
-      Debug(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_HEADER(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_DEBUG(&logger, "%s", kSampleMessage.c_str());
       Info(&logger, "%s", kSampleMessage.c_str());
-      Warn(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_WARN(&logger, "%s", kSampleMessage.c_str());
       Error(&logger, "%s", kSampleMessage.c_str());
       Fatal(&logger, "%s", kSampleMessage.c_str());
       log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
@@ -411,8 +412,7 @@ TEST_F(AutoRollLoggerTest, LogHeaderTest) {
     } else if (test_num == 1) {
       // HEADER_LEVEL should make this behave like calling Header()
       for (size_t i = 0; i < MAX_HEADERS; i++) {
-        Log(InfoLogLevel::HEADER_LEVEL, &logger, "%s %d",
-            HEADER_STR.c_str(), i);
+        ROCKS_LOG_HEADER(&logger, "%s %d", HEADER_STR.c_str(), i);
       }
     }
 

--- a/db/auto_roll_logger_test.cc
+++ b/db/auto_roll_logger_test.cc
@@ -335,10 +335,10 @@ TEST_F(AutoRollLoggerTest, InfoLogLevel) {
       // again, messages with level smaller than log_level will not be logged.
       ROCKS_LOG_HEADER(&logger, "%s", kSampleMessage.c_str());
       ROCKS_LOG_DEBUG(&logger, "%s", kSampleMessage.c_str());
-      Info(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_INFO(&logger, "%s", kSampleMessage.c_str());
       ROCKS_LOG_WARN(&logger, "%s", kSampleMessage.c_str());
-      Error(&logger, "%s", kSampleMessage.c_str());
-      Fatal(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_ERROR(&logger, "%s", kSampleMessage.c_str());
+      ROCKS_LOG_FATAL(&logger, "%s", kSampleMessage.c_str());
       log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
     }
   }

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -154,8 +154,8 @@ Status CompactedDBImpl::Open(const Options& options,
   std::unique_ptr<CompactedDBImpl> db(new CompactedDBImpl(db_options, dbname));
   Status s = db->Init(options);
   if (s.ok()) {
-    Log(INFO_LEVEL, db->immutable_db_options_.info_log,
-        "Opened the db as fully compacted mode");
+    ROCKS_LOG_INFO(db->immutable_db_options_.info_log,
+                   "Opened the db as fully compacted mode");
     LogFlush(db->immutable_db_options_.info_log);
     *dbptr = db.release();
   }

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -600,7 +600,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
     write_amp = stats.bytes_written /
                 static_cast<double>(stats.bytes_read_non_output_levels);
   }
-  LogToBuffer(
+  ROCKS_LOG_BUFFER(
       log_buffer_,
       "[%s] compacted to: %s, MB/sec: %.1f rd, %.1f wr, level %d, "
       "files in(%d, %d) out(%d) "
@@ -1091,12 +1091,12 @@ Status CompactionJob::FinishCompactionOutputFile(
       tp = sub_compact->builder->GetTableProperties();
       sub_compact->current_output()->table_properties =
           std::make_shared<TableProperties>(tp);
-      Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-          "[%s] [JOB %d] Generated table #%" PRIu64 ": %" PRIu64
-          " keys, %" PRIu64 " bytes%s",
-          cfd->GetName().c_str(), job_id_, output_number, current_entries,
-          current_bytes,
-          meta->marked_for_compaction ? " (need compaction)" : "");
+      ROCKS_LOG_INFO(db_options_.info_log,
+                     "[%s] [JOB %d] Generated table #%" PRIu64 ": %" PRIu64
+                     " keys, %" PRIu64 " bytes%s",
+                     cfd->GetName().c_str(), job_id_, output_number,
+                     current_entries, current_bytes,
+                     meta->marked_for_compaction ? " (need compaction)" : "");
     }
   }
   std::string fname = TableFileName(db_options_.db_paths, meta->fd.GetNumber(),
@@ -1142,17 +1142,16 @@ Status CompactionJob::InstallCompactionResults(
   if (!versions_->VerifyCompactionFileConsistency(compaction)) {
     Compaction::InputLevelSummaryBuffer inputs_summary;
 
-    Log(InfoLogLevel::ERROR_LEVEL, db_options_.info_log,
-        "[%s] [JOB %d] Compaction %s aborted",
-        compaction->column_family_data()->GetName().c_str(), job_id_,
-        compaction->InputLevelSummary(&inputs_summary));
+    ROCKS_LOG_ERROR(db_options_.info_log, "[%s] [JOB %d] Compaction %s aborted",
+                    compaction->column_family_data()->GetName().c_str(),
+                    job_id_, compaction->InputLevelSummary(&inputs_summary));
     return Status::Corruption("Compaction input files inconsistent");
   }
 
   {
     Compaction::InputLevelSummaryBuffer inputs_summary;
-    Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-        "[%s] [JOB %d] Compacted %s => %" PRIu64 " bytes",
+    ROCKS_LOG_INFO(
+        db_options_.info_log, "[%s] [JOB %d] Compacted %s => %" PRIu64 " bytes",
         compaction->column_family_data()->GetName().c_str(), job_id_,
         compaction->InputLevelSummary(&inputs_summary), compact_->total_bytes);
   }
@@ -1200,7 +1199,8 @@ Status CompactionJob::OpenCompactionOutputFile(
   unique_ptr<WritableFile> writable_file;
   Status s = NewWritableFile(env_, fname, &writable_file, env_options_);
   if (!s.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, db_options_.info_log,
+    ROCKS_LOG_ERROR(
+        db_options_.info_log,
         "[%s] [JOB %d] OpenCompactionOutputFiles for table #%" PRIu64
         " fails at NewWritableFile with status %s",
         sub_compact->compaction->column_family_data()->GetName().c_str(),
@@ -1376,14 +1376,14 @@ void CompactionJob::LogCompaction() {
   // we're not logging
   if (db_options_.info_log_level <= InfoLogLevel::INFO_LEVEL) {
     Compaction::InputLevelSummaryBuffer inputs_summary;
-    Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-        "[%s] [JOB %d] Compacting %s, score %.2f", cfd->GetName().c_str(),
-        job_id_, compaction->InputLevelSummary(&inputs_summary),
-        compaction->score());
+    ROCKS_LOG_INFO(
+        db_options_.info_log, "[%s] [JOB %d] Compacting %s, score %.2f",
+        cfd->GetName().c_str(), job_id_,
+        compaction->InputLevelSummary(&inputs_summary), compaction->score());
     char scratch[2345];
     compaction->Summary(scratch, sizeof(scratch));
-    Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-        "[%s] Compaction start summary: %s\n", cfd->GetName().c_str(), scratch);
+    ROCKS_LOG_INFO(db_options_.info_log, "[%s] Compaction start summary: %s\n",
+                   cfd->GetName().c_str(), scratch);
     // build event logger report
     auto stream = event_logger_->Log();
     stream << "job" << job_id_ << "event"

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -34,12 +34,11 @@ Status DBImpl::DisableFileDeletions() {
   InstrumentedMutexLock l(&mutex_);
   ++disable_delete_obsolete_files_;
   if (disable_delete_obsolete_files_ == 1) {
-    Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-        "File Deletions Disabled");
+    ROCKS_LOG_INFO(immutable_db_options_.info_log, "File Deletions Disabled");
   } else {
-    Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log,
-        "File Deletions Disabled, but already disabled. Counter: %d",
-        disable_delete_obsolete_files_);
+    ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                   "File Deletions Disabled, but already disabled. Counter: %d",
+                   disable_delete_obsolete_files_);
   }
   return Status::OK();
 }
@@ -58,12 +57,12 @@ Status DBImpl::EnableFileDeletions(bool force) {
       --disable_delete_obsolete_files_;
     }
     if (disable_delete_obsolete_files_ == 0)  {
-      Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-          "File Deletions Enabled");
+      ROCKS_LOG_INFO(immutable_db_options_.info_log, "File Deletions Enabled");
       should_purge_files = true;
       FindObsoleteFiles(&job_context, true);
     } else {
-      Log(InfoLogLevel::WARN_LEVEL, immutable_db_options_.info_log,
+      ROCKS_LOG_WARN(
+          immutable_db_options_.info_log,
           "File Deletions Enable, but not really enabled. Counter: %d",
           disable_delete_obsolete_files_);
     }
@@ -109,8 +108,8 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
 
     if (!status.ok()) {
       mutex_.Unlock();
-      Log(InfoLogLevel::ERROR_LEVEL, immutable_db_options_.info_log,
-          "Cannot Flush data %s\n", status.ToString().c_str());
+      ROCKS_LOG_ERROR(immutable_db_options_.info_log, "Cannot Flush data %s\n",
+                      status.ToString().c_str());
       return status;
     }
   }

--- a/db/db_impl_experimental.cc
+++ b/db/db_impl_experimental.cc
@@ -61,8 +61,8 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
   assert(column_family);
 
   if (target_level < 1) {
-    Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-        "PromoteL0 FAILED. Invalid target level %d\n", target_level);
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "PromoteL0 FAILED. Invalid target level %d\n", target_level);
     return Status::InvalidArgument("Invalid target level");
   }
 
@@ -75,8 +75,9 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
     const auto* vstorage = cfd->current()->storage_info();
 
     if (target_level >= vstorage->num_levels()) {
-      Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-          "PromoteL0 FAILED. Target level %d does not exist\n", target_level);
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "PromoteL0 FAILED. Target level %d does not exist\n",
+                     target_level);
       job_context.Clean();
       return Status::InvalidArgument("Target level does not exist");
     }
@@ -94,9 +95,9 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
     for (size_t i = 0; i < l0_files.size(); ++i) {
       auto f = l0_files[i];
       if (f->being_compacted) {
-        Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-            "PromoteL0 FAILED. File %" PRIu64 " being compacted\n",
-            f->fd.GetNumber());
+        ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                       "PromoteL0 FAILED. File %" PRIu64 " being compacted\n",
+                       f->fd.GetNumber());
         job_context.Clean();
         return Status::InvalidArgument("PromoteL0 called during L0 compaction");
       }
@@ -104,10 +105,10 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
       if (i == 0) continue;
       auto prev_f = l0_files[i - 1];
       if (icmp->Compare(prev_f->largest, f->smallest) >= 0) {
-        Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-            "PromoteL0 FAILED. Files %" PRIu64 " and %" PRIu64
-            " have overlapping ranges\n",
-            prev_f->fd.GetNumber(), f->fd.GetNumber());
+        ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                       "PromoteL0 FAILED. Files %" PRIu64 " and %" PRIu64
+                       " have overlapping ranges\n",
+                       prev_f->fd.GetNumber(), f->fd.GetNumber());
         job_context.Clean();
         return Status::InvalidArgument("L0 has overlapping files");
       }
@@ -116,8 +117,8 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
     // Check that all levels up to target_level are empty.
     for (int level = 1; level <= target_level; ++level) {
       if (vstorage->NumLevelFiles(level) > 0) {
-        Log(InfoLogLevel::INFO_LEVEL, immutable_db_options_.info_log,
-            "PromoteL0 FAILED. Level %d not empty\n", level);
+        ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                       "PromoteL0 FAILED. Level %d not empty\n", level);
         job_context.Clean();
         return Status::InvalidArgument(
             "All levels up to target_level "

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -20,8 +20,8 @@ namespace rocksdb {
 DBImplReadOnly::DBImplReadOnly(const DBOptions& db_options,
                                const std::string& dbname)
     : DBImpl(db_options, dbname) {
-  Log(INFO_LEVEL, immutable_db_options_.info_log,
-      "Opening the db in read only mode");
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "Opening the db in read only mode");
   LogFlush(immutable_db_options_.info_log);
 }
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -291,9 +291,8 @@ class DBIter: public Iterator {
 inline bool DBIter::ParseKey(ParsedInternalKey* ikey) {
   if (!ParseInternalKey(iter_->key(), ikey)) {
     status_ = Status::Corruption("corrupted internal key in DBIter");
-    Log(InfoLogLevel::ERROR_LEVEL,
-        logger_, "corrupted internal key in DBIter: %s",
-        iter_->key().ToString(true).c_str());
+    ROCKS_LOG_ERROR(logger_, "corrupted internal key in DBIter: %s",
+                    iter_->key().ToString(true).c_str());
     return false;
   } else {
     return true;
@@ -509,8 +508,7 @@ void DBIter::FindNextUserEntryInternal(bool skipping, bool prefix_check) {
 //       iter_ points to the next entry (or invalid)
 void DBIter::MergeValuesNewToOld() {
   if (!merge_operator_) {
-    Log(InfoLogLevel::ERROR_LEVEL,
-        logger_, "Options::merge_operator is null.");
+    ROCKS_LOG_ERROR(logger_, "Options::merge_operator is null.");
     status_ = Status::InvalidArgument("merge_operator_ must be set.");
     valid_ = false;
     return;

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -120,9 +120,9 @@ Status ExternalSstFileIngestionJob::Prepare(
       }
       Status s = env_->DeleteFile(f.internal_file_path);
       if (!s.ok()) {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-            "AddFile() clean up for file %s failed : %s",
-            f.internal_file_path.c_str(), s.ToString().c_str());
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "AddFile() clean up for file %s failed : %s",
+                       f.internal_file_path.c_str(), s.ToString().c_str());
       }
     }
   }
@@ -212,7 +212,8 @@ void ExternalSstFileIngestionJob::UpdateStats() {
     if (f.picked_level == 0) {
       total_l0_files += 1;
     }
-    Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
+    ROCKS_LOG_INFO(
+        db_options_.info_log,
         "[AddFile] External SST file %s was ingested in L%d with path %s "
         "(global_seqno=%" PRIu64 ")\n",
         f.external_file_path.c_str(), f.picked_level,
@@ -233,9 +234,9 @@ void ExternalSstFileIngestionJob::Cleanup(const Status& status) {
     for (IngestedFileInfo& f : files_to_ingest_) {
       Status s = env_->DeleteFile(f.internal_file_path);
       if (!s.ok()) {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-            "AddFile() clean up for file %s failed : %s",
-            f.internal_file_path.c_str(), s.ToString().c_str());
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "AddFile() clean up for file %s failed : %s",
+                       f.internal_file_path.c_str(), s.ToString().c_str());
       }
     }
   } else if (status.ok() && ingestion_options_.move_files) {
@@ -243,7 +244,8 @@ void ExternalSstFileIngestionJob::Cleanup(const Status& status) {
     for (IngestedFileInfo& f : files_to_ingest_) {
       Status s = env_->DeleteFile(f.external_file_path);
       if (!s.ok()) {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
             "%s was added to DB successfully but failed to remove original "
             "file link : %s",
             f.external_file_path.c_str(), s.ToString().c_str());

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -355,9 +355,9 @@ Status MemTableList::InstallMemtableFlushResults(
       }
       if (it == memlist.rbegin() || batch_file_number != m->file_number_) {
         batch_file_number = m->file_number_;
-        LogToBuffer(log_buffer,
-                    "[%s] Level-0 commit table #%" PRIu64 " started",
-                    cfd->GetName().c_str(), m->file_number_);
+        ROCKS_LOG_BUFFER(log_buffer,
+                         "[%s] Level-0 commit table #%" PRIu64 " started",
+                         cfd->GetName().c_str(), m->file_number_);
         edit_list.push_back(&m->edit_);
       }
       batch_count++;
@@ -378,9 +378,9 @@ Status MemTableList::InstallMemtableFlushResults(
       if (s.ok()) {         // commit new state
         while (batch_count-- > 0) {
           MemTable* m = current_->memlist_.back();
-          LogToBuffer(log_buffer, "[%s] Level-0 commit table #%" PRIu64
-                                  ": memtable #%" PRIu64 " done",
-                      cfd->GetName().c_str(), m->file_number_, mem_id);
+          ROCKS_LOG_BUFFER(log_buffer, "[%s] Level-0 commit table #%" PRIu64
+                                       ": memtable #%" PRIu64 " done",
+                           cfd->GetName().c_str(), m->file_number_, mem_id);
           assert(m->file_number_ > 0);
           current_->Remove(m, to_delete);
           ++mem_id;
@@ -389,9 +389,9 @@ Status MemTableList::InstallMemtableFlushResults(
         for (auto it = current_->memlist_.rbegin(); batch_count-- > 0; it++) {
           MemTable* m = *it;
           // commit failed. setup state so that we can flush again.
-          LogToBuffer(log_buffer, "Level-0 commit table #%" PRIu64
-                                  ": memtable #%" PRIu64 " failed",
-                      m->file_number_, mem_id);
+          ROCKS_LOG_BUFFER(log_buffer, "Level-0 commit table #%" PRIu64
+                                       ": memtable #%" PRIu64 " failed",
+                           m->file_number_, mem_id);
           m->flush_completed_ = false;
           m->flush_in_progress_ = false;
           m->edit_.Clear();

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -199,13 +199,13 @@ class Repairer {
       for (size_t i = 0; i < tables_.size(); i++) {
         bytes += tables_[i].meta.fd.GetFileSize();
       }
-      Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-          "**** Repaired rocksdb %s; "
-          "recovered %" ROCKSDB_PRIszt " files; %" PRIu64
-          "bytes. "
-          "Some data may have been lost. "
-          "****",
-          dbname_.c_str(), tables_.size(), bytes);
+      ROCKS_LOG_WARN(db_options_.info_log,
+                     "**** Repaired rocksdb %s; "
+                     "recovered %" ROCKSDB_PRIszt " files; %" PRIu64
+                     "bytes. "
+                     "Some data may have been lost. "
+                     "****",
+                     dbname_.c_str(), tables_.size(), bytes);
     }
     return status;
   }
@@ -291,9 +291,9 @@ class Repairer {
       std::string logname = LogFileName(dbname_, logs_[i]);
       Status status = ConvertLogToTable(logs_[i]);
       if (!status.ok()) {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-            "Log #%" PRIu64 ": ignoring conversion error: %s", logs_[i],
-            status.ToString().c_str());
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "Log #%" PRIu64 ": ignoring conversion error: %s",
+                       logs_[i], status.ToString().c_str());
       }
       ArchiveFile(logname);
     }
@@ -306,9 +306,8 @@ class Repairer {
       uint64_t lognum;
       virtual void Corruption(size_t bytes, const Status& s) override {
         // We print error messages for corruption, but continue repairing.
-        Log(InfoLogLevel::ERROR_LEVEL, info_log,
-            "Log #%" PRIu64 ": dropping %d bytes; %s", lognum,
-            static_cast<int>(bytes), s.ToString().c_str());
+        ROCKS_LOG_ERROR(info_log, "Log #%" PRIu64 ": dropping %d bytes; %s",
+                        lognum, static_cast<int>(bytes), s.ToString().c_str());
       }
     };
 
@@ -357,8 +356,8 @@ class Repairer {
       if (status.ok()) {
         counter += WriteBatchInternal::Count(&batch);
       } else {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-            "Log #%" PRIu64 ": ignoring %s", log, status.ToString().c_str());
+        ROCKS_LOG_WARN(db_options_.info_log, "Log #%" PRIu64 ": ignoring %s",
+                       log, status.ToString().c_str());
         status = Status::OK();  // Keep going with rest of file
       }
     }
@@ -386,9 +385,10 @@ class Repairer {
           cfd->int_tbl_prop_collector_factories(), cfd->GetID(), cfd->GetName(),
           {}, kMaxSequenceNumber, kNoCompression, CompressionOptions(), false,
           nullptr /* internal_stats */, TableFileCreationReason::kRecovery);
-      Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-          "Log #%" PRIu64 ": %d ops saved to Table #%" PRIu64 " %s", log,
-          counter, meta.fd.GetNumber(), status.ToString().c_str());
+      ROCKS_LOG_INFO(db_options_.info_log,
+                     "Log #%" PRIu64 ": %d ops saved to Table #%" PRIu64 " %s",
+                     log, counter, meta.fd.GetNumber(),
+                     status.ToString().c_str());
       if (status.ok()) {
         if (meta.fd.GetFileSize() > 0) {
           table_fds_.push_back(meta.fd);
@@ -412,8 +412,8 @@ class Repairer {
         char file_num_buf[kFormatFileNumberBufSize];
         FormatFileNumber(t.meta.fd.GetNumber(), t.meta.fd.GetPathId(),
                          file_num_buf, sizeof(file_num_buf));
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
-            "Table #%s: ignoring %s", file_num_buf, status.ToString().c_str());
+        ROCKS_LOG_WARN(db_options_.info_log, "Table #%s: ignoring %s",
+                       file_num_buf, status.ToString().c_str());
         ArchiveFile(fname);
       } else {
         tables_.push_back(t);
@@ -438,7 +438,8 @@ class Repairer {
       t->column_family_id = static_cast<uint32_t>(props->column_family_id);
       if (t->column_family_id ==
           TablePropertiesCollectorFactory::Context::kUnknownColumnFamily) {
-        Log(InfoLogLevel::WARN_LEVEL, db_options_.info_log,
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
             "Table #%" PRIu64
             ": column family unknown (probably due to legacy format); "
             "adding to default column family id 0.",
@@ -456,7 +457,8 @@ class Repairer {
     if (status.ok()) {
       cfd = vset_.GetColumnFamilySet()->GetColumnFamily(t->column_family_id);
       if (cfd->GetName() != props->column_family_name) {
-        Log(InfoLogLevel::ERROR_LEVEL, db_options_.info_log,
+        ROCKS_LOG_ERROR(
+            db_options_.info_log,
             "Table #%" PRIu64
             ": inconsistent column family name '%s'; expected '%s' for column "
             "family id %" PRIu32 ".",
@@ -476,9 +478,9 @@ class Repairer {
       for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
         Slice key = iter->key();
         if (!ParseInternalKey(key, &parsed)) {
-          Log(InfoLogLevel::ERROR_LEVEL, db_options_.info_log,
-              "Table #%" PRIu64 ": unparsable key %s", t->meta.fd.GetNumber(),
-              EscapeString(key).c_str());
+          ROCKS_LOG_ERROR(db_options_.info_log,
+                          "Table #%" PRIu64 ": unparsable key %s",
+                          t->meta.fd.GetNumber(), EscapeString(key).c_str());
           continue;
         }
 
@@ -501,9 +503,9 @@ class Repairer {
       }
       delete iter;
 
-      Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log,
-          "Table #%" PRIu64 ": %d entries %s", t->meta.fd.GetNumber(), counter,
-          status.ToString().c_str());
+      ROCKS_LOG_INFO(db_options_.info_log, "Table #%" PRIu64 ": %d entries %s",
+                     t->meta.fd.GetNumber(), counter,
+                     status.ToString().c_str());
     }
     return status;
   }
@@ -563,8 +565,8 @@ class Repairer {
     new_file.append("/");
     new_file.append((slash == nullptr) ? fname.c_str() : slash + 1);
     Status s = env_->RenameFile(fname, new_file);
-    Log(InfoLogLevel::INFO_LEVEL, db_options_.info_log, "Archiving %s: %s\n",
-        fname.c_str(), s.ToString().c_str());
+    ROCKS_LOG_INFO(db_options_.info_log, "Archiving %s: %s\n", fname.c_str(),
+                   s.ToString().c_str());
   }
 };
 

--- a/db/transaction_log_impl.h
+++ b/db/transaction_log_impl.h
@@ -92,13 +92,10 @@ class TransactionLogIteratorImpl : public TransactionLogIterator {
     Env* env;
     Logger* info_log;
     virtual void Corruption(size_t bytes, const Status& s) override {
-      Log(InfoLogLevel::ERROR_LEVEL, info_log,
-          "dropping %" ROCKSDB_PRIszt " bytes; %s", bytes,
-          s.ToString().c_str());
+      ROCKS_LOG_ERROR(info_log, "dropping %" ROCKSDB_PRIszt " bytes; %s", bytes,
+                      s.ToString().c_str());
     }
-    virtual void Info(const char* s) {
-      Log(InfoLogLevel::INFO_LEVEL, info_log, "%s", s);
-    }
+    virtual void Info(const char* s) { ROCKS_LOG_INFO(info_log, "%s", s); }
   } reporter_;
 
   SequenceNumber currentBatchSeq_; // sequence number at start of current batch

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1056,9 +1056,10 @@ bool Version::MaybeInitializeFileMetaData(FileMetaData* file_meta) {
   Status s = GetTableProperties(&tp, file_meta);
   file_meta->init_stats_from_file = true;
   if (!s.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, vset_->db_options_->info_log,
-        "Unable to load table properties for file %" PRIu64 " --- %s\n",
-        file_meta->fd.GetNumber(), s.ToString().c_str());
+    ROCKS_LOG_ERROR(vset_->db_options_->info_log,
+                    "Unable to load table properties for file %" PRIu64
+                    " --- %s\n",
+                    file_meta->fd.GetNumber(), s.ToString().c_str());
     return false;
   }
   if (tp.get() == nullptr) return false;
@@ -2073,9 +2074,9 @@ void VersionStorageInfo::CalculateBaseBytes(const ImmutableCFOptions& ioptions,
         // base_bytes_min. We set it be base_bytes_min.
         base_level_size = base_bytes_min + 1U;
         base_level_ = first_non_empty_level;
-        Warn(ioptions.info_log,
-             "More existing levels in DB than needed. "
-             "max_bytes_for_level_multiplier may not be guaranteed.");
+        ROCKS_LOG_WARN(ioptions.info_log,
+                       "More existing levels in DB than needed. "
+                       "max_bytes_for_level_multiplier may not be guaranteed.");
       } else {
         // Find base level (where L0 data is compacted to).
         base_level_ = first_non_empty_level;
@@ -2381,8 +2382,8 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
     // only one thread can be here at the same time
     if (new_descriptor_log) {
       // create manifest file
-      Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
-          "Creating manifest %" PRIu64 "\n", pending_manifest_file_number_);
+      ROCKS_LOG_INFO(db_options_->info_log, "Creating manifest %" PRIu64 "\n",
+                     pending_manifest_file_number_);
       unique_ptr<WritableFile> descriptor_file;
       EnvOptions opt_env_opts = env_->OptimizeForManifestWrite(env_options_);
       s = NewWritableFile(
@@ -2425,8 +2426,8 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
         s = SyncManifest(env_, db_options_, descriptor_log_->file());
       }
       if (!s.ok()) {
-        Log(InfoLogLevel::ERROR_LEVEL, db_options_->info_log,
-            "MANIFEST write: %s\n", s.ToString().c_str());
+        ROCKS_LOG_ERROR(db_options_->info_log, "MANIFEST write: %s\n",
+                        s.ToString().c_str());
       }
     }
 
@@ -2496,15 +2497,16 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
     for (auto& e : batch_edits) {
       version_edits = version_edits + "\n" + e->DebugString(true);
     }
-    Log(InfoLogLevel::ERROR_LEVEL, db_options_->info_log,
+    ROCKS_LOG_ERROR(
+        db_options_->info_log,
         "[%s] Error in committing version edit to MANIFEST: %s",
         column_family_data ? column_family_data->GetName().c_str() : "<null>",
         version_edits.c_str());
     delete v;
     if (new_descriptor_log) {
-      Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
-        "Deleting manifest %" PRIu64 " current manifest %" PRIu64 "\n",
-        manifest_file_number_, pending_manifest_file_number_);
+      ROCKS_LOG_INFO(db_options_->info_log, "Deleting manifest %" PRIu64
+                                            " current manifest %" PRIu64 "\n",
+                     manifest_file_number_, pending_manifest_file_number_);
       descriptor_log_.reset();
       env_->DeleteFile(
           DescriptorFileName(dbname_, pending_manifest_file_number_));
@@ -2594,9 +2596,8 @@ Status VersionSet::Recover(
     return Status::Corruption("CURRENT file corrupted");
   }
 
-  Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
-      "Recovering from manifest file: %s\n",
-      manifest_filename.c_str());
+  ROCKS_LOG_INFO(db_options_->info_log, "Recovering from manifest file: %s\n",
+                 manifest_filename.c_str());
 
   manifest_filename = dbname_ + "/" + manifest_filename;
   unique_ptr<SequentialFileReader> manifest_file_reader;
@@ -2734,7 +2735,8 @@ Status VersionSet::Recover(
       if (cfd != nullptr) {
         if (edit.has_log_number_) {
           if (cfd->GetLogNumber() > edit.log_number_) {
-            Log(InfoLogLevel::WARN_LEVEL, db_options_->info_log,
+            ROCKS_LOG_WARN(
+                db_options_->info_log,
                 "MANIFEST corruption detected, but ignored - Log numbers in "
                 "records NOT monotonically increasing");
           } else {
@@ -2835,7 +2837,8 @@ Status VersionSet::Recover(
     last_sequence_ = last_sequence;
     prev_log_number_ = previous_log_number;
 
-    Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
+    ROCKS_LOG_INFO(
+        db_options_->info_log,
         "Recovered from manifest file:%s succeeded,"
         "manifest_file_number is %lu, next_file_number is %lu, "
         "last_sequence is %lu, log_number is %lu,"
@@ -2850,9 +2853,9 @@ Status VersionSet::Recover(
       if (cfd->IsDropped()) {
         continue;
       }
-      Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
-          "Column family [%s] (ID %u), log number is %" PRIu64 "\n",
-          cfd->GetName().c_str(), cfd->GetID(), cfd->GetLogNumber());
+      ROCKS_LOG_INFO(db_options_->info_log,
+                     "Column family [%s] (ID %u), log number is %" PRIu64 "\n",
+                     cfd->GetName().c_str(), cfd->GetID(), cfd->GetLogNumber());
     }
   }
 
@@ -3492,7 +3495,8 @@ bool VersionSet::VerifyCompactionFileConsistency(Compaction* c) {
   Version* version = c->column_family_data()->current();
   const VersionStorageInfo* vstorage = version->storage_info();
   if (c->input_version() != version) {
-    Log(InfoLogLevel::INFO_LEVEL, db_options_->info_log,
+    ROCKS_LOG_INFO(
+        db_options_->info_log,
         "[%s] compaction output being applied to a different base version from"
         " input version",
         c->column_family_data()->GetName().c_str());

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -338,7 +338,8 @@ BlockBasedTableBuilder::BlockBasedTableBuilder(
   BlockBasedTableOptions sanitized_table_options(table_options);
   if (sanitized_table_options.format_version == 0 &&
       sanitized_table_options.checksum != kCRC32c) {
-    Log(InfoLogLevel::WARN_LEVEL, ioptions.info_log,
+    ROCKS_LOG_WARN(
+        ioptions.info_log,
         "Silently converting format_version to 1 because checksum is "
         "non-default");
     // silently convert format_version to 1 to keep consistent with current
@@ -489,8 +490,8 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
         if (!compressed_ok) {
           // The result of the compression was invalid. abort.
           abort_compression = true;
-          Log(InfoLogLevel::ERROR_LEVEL, r->ioptions.info_log,
-              "Decompressed block did not match raw block");
+          ROCKS_LOG_ERROR(r->ioptions.info_log,
+                          "Decompressed block did not match raw block");
           r->status =
               Status::Corruption("Decompressed block did not match raw block");
         }

--- a/table/format.cc
+++ b/table/format.cc
@@ -20,12 +20,12 @@
 #include "util/compression.h"
 #include "util/crc32c.h"
 #include "util/file_reader_writer.h"
+#include "util/logging.h"
 #include "util/perf_context_imp.h"
-#include "util/string_util.h"
-#include "util/xxhash.h"
 #include "util/statistics.h"
 #include "util/stop_watch.h"
-
+#include "util/string_util.h"
+#include "util/xxhash.h"
 
 namespace rocksdb {
 
@@ -331,9 +331,9 @@ Status ReadBlockContents(RandomAccessFileReader* file, const Footer& footer,
       // uncompressed page is not found
       if (ioptions.info_log && !status.IsNotFound()) {
         assert(!status.ok());
-        Log(InfoLogLevel::INFO_LEVEL, ioptions.info_log,
-            "Error reading from persistent cache. %s",
-            status.ToString().c_str());
+        ROCKS_LOG_INFO(ioptions.info_log,
+                       "Error reading from persistent cache. %s",
+                       status.ToString().c_str());
       }
     }
   }
@@ -354,8 +354,9 @@ Status ReadBlockContents(RandomAccessFileReader* file, const Footer& footer,
   } else {
     if (ioptions.info_log && !status.IsNotFound()) {
       assert(!status.ok());
-      Log(InfoLogLevel::INFO_LEVEL, ioptions.info_log,
-          "Error reading from persistent cache. %s", status.ToString().c_str());
+      ROCKS_LOG_INFO(ioptions.info_log,
+                     "Error reading from persistent cache. %s",
+                     status.ToString().c_str());
     }
     // cache miss read from device
     if (decompression_requested &&

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -114,7 +114,7 @@ void LogPropertiesCollectionError(
   std::string msg =
     "Encountered error when calling TablePropertiesCollector::" +
     method + "() with collector name: " + name;
-  Log(InfoLogLevel::ERROR_LEVEL, info_log, "%s", msg.c_str());
+  ROCKS_LOG_ERROR(info_log, "%s", msg.c_str());
 }
 
 bool NotifyCollectTableCollectorsOnAdd(
@@ -227,8 +227,7 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
         auto error_msg =
           "Detect malformed value in properties meta-block:"
           "\tkey: " + key + "\tval: " + raw_val.ToString();
-        Log(InfoLogLevel::ERROR_LEVEL, ioptions.info_log, "%s",
-        error_msg.c_str());
+        ROCKS_LOG_ERROR(ioptions.info_log, "%s", error_msg.c_str());
         continue;
       }
       *(pos->second) = val;

--- a/table/plain_table_index.cc
+++ b/table/plain_table_index.cc
@@ -102,9 +102,8 @@ Slice PlainTableIndexBuilder::Finish() {
   BucketizeIndexes(&hash_to_offsets, &entries_per_bucket);
 
   keys_per_prefix_hist_.Add(num_keys_per_prefix_);
-  Log(InfoLogLevel::INFO_LEVEL, ioptions_.info_log,
-      "Number of Keys per prefix Histogram: %s",
-      keys_per_prefix_hist_.ToString().c_str());
+  ROCKS_LOG_INFO(ioptions_.info_log, "Number of Keys per prefix Histogram: %s",
+                 keys_per_prefix_hist_.ToString().c_str());
 
   // From the temp data structure, populate indexes.
   return FillIndexes(hash_to_offsets, entries_per_bucket);
@@ -158,9 +157,9 @@ void PlainTableIndexBuilder::BucketizeIndexes(
 Slice PlainTableIndexBuilder::FillIndexes(
     const std::vector<IndexRecord*>& hash_to_offsets,
     const std::vector<uint32_t>& entries_per_bucket) {
-  Log(InfoLogLevel::DEBUG_LEVEL, ioptions_.info_log,
-      "Reserving %" PRIu32 " bytes for plain table's sub_index",
-      sub_index_size_);
+  ROCKS_LOG_DEBUG(ioptions_.info_log,
+                  "Reserving %" PRIu32 " bytes for plain table's sub_index",
+                  sub_index_size_);
   auto total_allocate_size = GetTotalSize();
   char* allocated = arena_->AllocateAligned(
       total_allocate_size, huge_page_tlb_size_, ioptions_.info_log);
@@ -203,9 +202,9 @@ Slice PlainTableIndexBuilder::FillIndexes(
   }
   assert(sub_index_offset == sub_index_size_);
 
-  Log(InfoLogLevel::DEBUG_LEVEL, ioptions_.info_log,
-      "hash table size: %d, suffix_map length %" ROCKSDB_PRIszt, index_size_,
-      sub_index_size_);
+  ROCKS_LOG_DEBUG(ioptions_.info_log,
+                  "hash table size: %d, suffix_map length %" ROCKSDB_PRIszt,
+                  index_size_, sub_index_size_);
   return Slice(allocated, GetTotalSize());
 }
 

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -18,9 +18,10 @@
 #ifndef OS_WIN
 #include <sys/mman.h>
 #endif
-#include "port/port.h"
 #include <algorithm>
+#include "port/port.h"
 #include "rocksdb/env.h"
+#include "util/logging.h"
 
 namespace rocksdb {
 
@@ -152,8 +153,9 @@ char* Arena::AllocateAligned(size_t bytes, size_t huge_page_size,
 
     char* addr = AllocateFromHugePage(reserved_size);
     if (addr == nullptr) {
-      Warn(logger, "AllocateAligned fail to allocate huge TLB pages: %s",
-           strerror(errno));
+      ROCKS_LOG_WARN(logger,
+                     "AllocateAligned fail to allocate huge TLB pages: %s",
+                     strerror(errno));
       // fail back to malloc
     } else {
       return addr;

--- a/util/cf_options.cc
+++ b/util/cf_options.cc
@@ -109,42 +109,47 @@ uint64_t MutableCFOptions::MaxFileSizeForLevel(int level) const {
 
 void MutableCFOptions::Dump(Logger* log) const {
   // Memtable related options
-  Log(log, "                        write_buffer_size: %" ROCKSDB_PRIszt,
-      write_buffer_size);
-  Log(log, "                  max_write_buffer_number: %d",
-      max_write_buffer_number);
-  Log(log, "                         arena_block_size: %" ROCKSDB_PRIszt,
-      arena_block_size);
-  Log(log, "              memtable_prefix_bloom_ratio: %f",
-      memtable_prefix_bloom_size_ratio);
-  Log(log, "                  memtable_huge_page_size: %" ROCKSDB_PRIszt,
-      memtable_huge_page_size);
-  Log(log, "                    max_successive_merges: %" ROCKSDB_PRIszt,
-      max_successive_merges);
-  Log(log, "                 inplace_update_num_locks: %" ROCKSDB_PRIszt,
-      inplace_update_num_locks);
-  Log(log, "                 disable_auto_compactions: %d",
-      disable_auto_compactions);
-  Log(log, "      soft_pending_compaction_bytes_limit: %" PRIu64,
-      soft_pending_compaction_bytes_limit);
-  Log(log, "      hard_pending_compaction_bytes_limit: %" PRIu64,
-      hard_pending_compaction_bytes_limit);
-  Log(log, "       level0_file_num_compaction_trigger: %d",
-      level0_file_num_compaction_trigger);
-  Log(log, "           level0_slowdown_writes_trigger: %d",
-      level0_slowdown_writes_trigger);
-  Log(log, "               level0_stop_writes_trigger: %d",
-      level0_stop_writes_trigger);
-  Log(log, "                     max_compaction_bytes: %" PRIu64,
-      max_compaction_bytes);
-  Log(log, "                    target_file_size_base: %" PRIu64,
-      target_file_size_base);
-  Log(log, "              target_file_size_multiplier: %d",
-      target_file_size_multiplier);
-  Log(log, "                 max_bytes_for_level_base: %" PRIu64,
-      max_bytes_for_level_base);
-  Log(log, "           max_bytes_for_level_multiplier: %f",
-      max_bytes_for_level_multiplier);
+  ROCKS_LOG_INFO(log,
+                 "                        write_buffer_size: %" ROCKSDB_PRIszt,
+                 write_buffer_size);
+  ROCKS_LOG_INFO(log, "                  max_write_buffer_number: %d",
+                 max_write_buffer_number);
+  ROCKS_LOG_INFO(log,
+                 "                         arena_block_size: %" ROCKSDB_PRIszt,
+                 arena_block_size);
+  ROCKS_LOG_INFO(log, "              memtable_prefix_bloom_ratio: %f",
+                 memtable_prefix_bloom_size_ratio);
+  ROCKS_LOG_INFO(log,
+                 "                  memtable_huge_page_size: %" ROCKSDB_PRIszt,
+                 memtable_huge_page_size);
+  ROCKS_LOG_INFO(log,
+                 "                    max_successive_merges: %" ROCKSDB_PRIszt,
+                 max_successive_merges);
+  ROCKS_LOG_INFO(log,
+                 "                 inplace_update_num_locks: %" ROCKSDB_PRIszt,
+                 inplace_update_num_locks);
+  ROCKS_LOG_INFO(log, "                 disable_auto_compactions: %d",
+                 disable_auto_compactions);
+  ROCKS_LOG_INFO(log, "      soft_pending_compaction_bytes_limit: %" PRIu64,
+                 soft_pending_compaction_bytes_limit);
+  ROCKS_LOG_INFO(log, "      hard_pending_compaction_bytes_limit: %" PRIu64,
+                 hard_pending_compaction_bytes_limit);
+  ROCKS_LOG_INFO(log, "       level0_file_num_compaction_trigger: %d",
+                 level0_file_num_compaction_trigger);
+  ROCKS_LOG_INFO(log, "           level0_slowdown_writes_trigger: %d",
+                 level0_slowdown_writes_trigger);
+  ROCKS_LOG_INFO(log, "               level0_stop_writes_trigger: %d",
+                 level0_stop_writes_trigger);
+  ROCKS_LOG_INFO(log, "                     max_compaction_bytes: %" PRIu64,
+                 max_compaction_bytes);
+  ROCKS_LOG_INFO(log, "                    target_file_size_base: %" PRIu64,
+                 target_file_size_base);
+  ROCKS_LOG_INFO(log, "              target_file_size_multiplier: %d",
+                 target_file_size_multiplier);
+  ROCKS_LOG_INFO(log, "                 max_bytes_for_level_base: %" PRIu64,
+                 max_bytes_for_level_base);
+  ROCKS_LOG_INFO(log, "           max_bytes_for_level_multiplier: %f",
+                 max_bytes_for_level_multiplier);
   std::string result;
   char buf[10];
   for (const auto m : max_bytes_for_level_multiplier_additional) {
@@ -157,14 +162,16 @@ void MutableCFOptions::Dump(Logger* log) const {
     result = "";
   }
 
-  Log(log, "max_bytes_for_level_multiplier_additional: %s", result.c_str());
-  Log(log, "        max_sequential_skip_in_iterations: %" PRIu64,
-      max_sequential_skip_in_iterations);
-  Log(log, "                     paranoid_file_checks: %d",
-      paranoid_file_checks);
-  Log(log, "                       report_bg_io_stats: %d", report_bg_io_stats);
-  Log(log, "                              compression: %d",
-      static_cast<int>(compression));
+  ROCKS_LOG_INFO(log, "max_bytes_for_level_multiplier_additional: %s",
+                 result.c_str());
+  ROCKS_LOG_INFO(log, "        max_sequential_skip_in_iterations: %" PRIu64,
+                 max_sequential_skip_in_iterations);
+  ROCKS_LOG_INFO(log, "                     paranoid_file_checks: %d",
+                 paranoid_file_checks);
+  ROCKS_LOG_INFO(log, "                       report_bg_io_stats: %d",
+                 report_bg_io_stats);
+  ROCKS_LOG_INFO(log, "                              compression: %d",
+                 static_cast<int>(compression));
 }
 
 }  // namespace rocksdb

--- a/util/db_options.cc
+++ b/util/db_options.cc
@@ -16,6 +16,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/sst_file_manager.h"
 #include "rocksdb/wal_filter.h"
+#include "util/logging.h"
 
 namespace rocksdb {
 
@@ -88,120 +89,132 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
 }
 
 void ImmutableDBOptions::Dump(Logger* log) const {
-  Header(log, "                        Options.error_if_exists: %d",
-         error_if_exists);
-  Header(log, "                      Options.create_if_missing: %d",
-         create_if_missing);
-  Header(log, "                        Options.paranoid_checks: %d",
-         paranoid_checks);
-  Header(log, "                                    Options.env: %p", env);
-  Header(log, "                               Options.info_log: %p",
-         info_log.get());
-  Header(log, "                         Options.max_open_files: %d",
-         max_open_files);
-  Header(log, "               Options.max_file_opening_threads: %d",
-         max_file_opening_threads);
-  Header(log, "                              Options.use_fsync: %d", use_fsync);
-  Header(log,
-         "                      Options.max_log_file_size: %" ROCKSDB_PRIszt,
-         max_log_file_size);
-  Header(log, "                 Options.max_manifest_file_size: %" PRIu64,
-         max_manifest_file_size);
-  Header(log,
-         "                  Options.log_file_time_to_roll: %" ROCKSDB_PRIszt,
-         log_file_time_to_roll);
-  Header(log,
-         "                      Options.keep_log_file_num: %" ROCKSDB_PRIszt,
-         keep_log_file_num);
-  Header(log,
-         "                   Options.recycle_log_file_num: %" ROCKSDB_PRIszt,
-         recycle_log_file_num);
-  Header(log, "                        Options.allow_fallocate: %d",
-         allow_fallocate);
-  Header(log, "                       Options.allow_mmap_reads: %d",
-         allow_mmap_reads);
-  Header(log, "                      Options.allow_mmap_writes: %d",
-         allow_mmap_writes);
-  Header(log, "                       Options.use_direct_reads: %d",
-         use_direct_reads);
-  Header(log, "                       Options.use_direct_writes: %d",
-         use_direct_writes);
-  Header(log, "         Options.create_missing_column_families: %d",
-         create_missing_column_families);
-  Header(log, "                             Options.db_log_dir: %s",
-         db_log_dir.c_str());
-  Header(log, "                                Options.wal_dir: %s",
-         wal_dir.c_str());
-  Header(log, "               Options.table_cache_numshardbits: %d",
-         table_cache_numshardbits);
-  Header(log, "                     Options.max_subcompactions: %" PRIu32,
-         max_subcompactions);
-  Header(log, "                 Options.max_background_flushes: %d",
-         max_background_flushes);
-  Header(log, "                        Options.WAL_ttl_seconds: %" PRIu64,
-         wal_ttl_seconds);
-  Header(log, "                      Options.WAL_size_limit_MB: %" PRIu64,
-         wal_size_limit_mb);
-  Header(log,
-         "            Options.manifest_preallocation_size: %" ROCKSDB_PRIszt,
-         manifest_preallocation_size);
-  Header(log, "                    Options.is_fd_close_on_exec: %d",
-         is_fd_close_on_exec);
-  Header(log, "                  Options.stats_dump_period_sec: %u",
-         stats_dump_period_sec);
-  Header(log, "                  Options.advise_random_on_open: %d",
-         advise_random_on_open);
-  Header(log,
-         "                   Options.db_write_buffer_size: %" ROCKSDB_PRIszt,
-         db_write_buffer_size);
-  Header(log, "        Options.access_hint_on_compaction_start: %d",
-         static_cast<int>(access_hint_on_compaction_start));
-  Header(log, " Options.new_table_reader_for_compaction_inputs: %d",
-         new_table_reader_for_compaction_inputs);
-  Header(log,
-         "              Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
-         compaction_readahead_size);
-  Header(log,
-         "          Options.random_access_max_buffer_size: %" ROCKSDB_PRIszt,
-         random_access_max_buffer_size);
-  Header(log,
-         "          Options.writable_file_max_buffer_size: %" ROCKSDB_PRIszt,
-         writable_file_max_buffer_size);
-  Header(log, "                     Options.use_adaptive_mutex: %d",
-         use_adaptive_mutex);
-  Header(log, "                           Options.rate_limiter: %p",
-         rate_limiter.get());
+  ROCKS_LOG_HEADER(log, "                        Options.error_if_exists: %d",
+                   error_if_exists);
+  ROCKS_LOG_HEADER(log, "                      Options.create_if_missing: %d",
+                   create_if_missing);
+  ROCKS_LOG_HEADER(log, "                        Options.paranoid_checks: %d",
+                   paranoid_checks);
+  ROCKS_LOG_HEADER(log, "                                    Options.env: %p",
+                   env);
+  ROCKS_LOG_HEADER(log, "                               Options.info_log: %p",
+                   info_log.get());
+  ROCKS_LOG_HEADER(log, "                         Options.max_open_files: %d",
+                   max_open_files);
+  ROCKS_LOG_HEADER(log, "               Options.max_file_opening_threads: %d",
+                   max_file_opening_threads);
+  ROCKS_LOG_HEADER(log, "                              Options.use_fsync: %d",
+                   use_fsync);
+  ROCKS_LOG_HEADER(
+      log, "                      Options.max_log_file_size: %" ROCKSDB_PRIszt,
+      max_log_file_size);
+  ROCKS_LOG_HEADER(log,
+                   "                 Options.max_manifest_file_size: %" PRIu64,
+                   max_manifest_file_size);
+  ROCKS_LOG_HEADER(
+      log, "                  Options.log_file_time_to_roll: %" ROCKSDB_PRIszt,
+      log_file_time_to_roll);
+  ROCKS_LOG_HEADER(
+      log, "                      Options.keep_log_file_num: %" ROCKSDB_PRIszt,
+      keep_log_file_num);
+  ROCKS_LOG_HEADER(
+      log, "                   Options.recycle_log_file_num: %" ROCKSDB_PRIszt,
+      recycle_log_file_num);
+  ROCKS_LOG_HEADER(log, "                        Options.allow_fallocate: %d",
+                   allow_fallocate);
+  ROCKS_LOG_HEADER(log, "                       Options.allow_mmap_reads: %d",
+                   allow_mmap_reads);
+  ROCKS_LOG_HEADER(log, "                      Options.allow_mmap_writes: %d",
+                   allow_mmap_writes);
+  ROCKS_LOG_HEADER(log, "                       Options.use_direct_reads: %d",
+                   use_direct_reads);
+  ROCKS_LOG_HEADER(log, "                       Options.use_direct_writes: %d",
+                   use_direct_writes);
+  ROCKS_LOG_HEADER(log, "         Options.create_missing_column_families: %d",
+                   create_missing_column_families);
+  ROCKS_LOG_HEADER(log, "                             Options.db_log_dir: %s",
+                   db_log_dir.c_str());
+  ROCKS_LOG_HEADER(log, "                                Options.wal_dir: %s",
+                   wal_dir.c_str());
+  ROCKS_LOG_HEADER(log, "               Options.table_cache_numshardbits: %d",
+                   table_cache_numshardbits);
+  ROCKS_LOG_HEADER(log,
+                   "                     Options.max_subcompactions: %" PRIu32,
+                   max_subcompactions);
+  ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
+                   max_background_flushes);
+  ROCKS_LOG_HEADER(log,
+                   "                        Options.WAL_ttl_seconds: %" PRIu64,
+                   wal_ttl_seconds);
+  ROCKS_LOG_HEADER(log,
+                   "                      Options.WAL_size_limit_MB: %" PRIu64,
+                   wal_size_limit_mb);
+  ROCKS_LOG_HEADER(
+      log, "            Options.manifest_preallocation_size: %" ROCKSDB_PRIszt,
+      manifest_preallocation_size);
+  ROCKS_LOG_HEADER(log, "                    Options.is_fd_close_on_exec: %d",
+                   is_fd_close_on_exec);
+  ROCKS_LOG_HEADER(log, "                  Options.stats_dump_period_sec: %u",
+                   stats_dump_period_sec);
+  ROCKS_LOG_HEADER(log, "                  Options.advise_random_on_open: %d",
+                   advise_random_on_open);
+  ROCKS_LOG_HEADER(
+      log, "                   Options.db_write_buffer_size: %" ROCKSDB_PRIszt,
+      db_write_buffer_size);
+  ROCKS_LOG_HEADER(log, "        Options.access_hint_on_compaction_start: %d",
+                   static_cast<int>(access_hint_on_compaction_start));
+  ROCKS_LOG_HEADER(log, " Options.new_table_reader_for_compaction_inputs: %d",
+                   new_table_reader_for_compaction_inputs);
+  ROCKS_LOG_HEADER(
+      log, "              Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
+      compaction_readahead_size);
+  ROCKS_LOG_HEADER(
+      log, "          Options.random_access_max_buffer_size: %" ROCKSDB_PRIszt,
+      random_access_max_buffer_size);
+  ROCKS_LOG_HEADER(
+      log, "          Options.writable_file_max_buffer_size: %" ROCKSDB_PRIszt,
+      writable_file_max_buffer_size);
+  ROCKS_LOG_HEADER(log, "                     Options.use_adaptive_mutex: %d",
+                   use_adaptive_mutex);
+  ROCKS_LOG_HEADER(log, "                           Options.rate_limiter: %p",
+                   rate_limiter.get());
   Header(
       log, "    Options.sst_file_manager.rate_bytes_per_sec: %" PRIi64,
       sst_file_manager ? sst_file_manager->GetDeleteRateBytesPerSecond() : 0);
-  Header(log, "                         Options.bytes_per_sync: %" PRIu64,
-         bytes_per_sync);
-  Header(log, "                     Options.wal_bytes_per_sync: %" PRIu64,
-         wal_bytes_per_sync);
-  Header(log, "                      Options.wal_recovery_mode: %d",
-         wal_recovery_mode);
-  Header(log, "                 Options.enable_thread_tracking: %d",
-         enable_thread_tracking);
-  Header(log, "        Options.allow_concurrent_memtable_write: %d",
-         allow_concurrent_memtable_write);
-  Header(log, "     Options.enable_write_thread_adaptive_yield: %d",
-         enable_write_thread_adaptive_yield);
-  Header(log, "            Options.write_thread_max_yield_usec: %" PRIu64,
-         write_thread_max_yield_usec);
-  Header(log, "           Options.write_thread_slow_yield_usec: %" PRIu64,
-         write_thread_slow_yield_usec);
+  ROCKS_LOG_HEADER(log,
+                   "                         Options.bytes_per_sync: %" PRIu64,
+                   bytes_per_sync);
+  ROCKS_LOG_HEADER(log,
+                   "                     Options.wal_bytes_per_sync: %" PRIu64,
+                   wal_bytes_per_sync);
+  ROCKS_LOG_HEADER(log, "                      Options.wal_recovery_mode: %d",
+                   wal_recovery_mode);
+  ROCKS_LOG_HEADER(log, "                 Options.enable_thread_tracking: %d",
+                   enable_thread_tracking);
+  ROCKS_LOG_HEADER(log, "        Options.allow_concurrent_memtable_write: %d",
+                   allow_concurrent_memtable_write);
+  ROCKS_LOG_HEADER(log, "     Options.enable_write_thread_adaptive_yield: %d",
+                   enable_write_thread_adaptive_yield);
+  ROCKS_LOG_HEADER(log,
+                   "            Options.write_thread_max_yield_usec: %" PRIu64,
+                   write_thread_max_yield_usec);
+  ROCKS_LOG_HEADER(log,
+                   "           Options.write_thread_slow_yield_usec: %" PRIu64,
+                   write_thread_slow_yield_usec);
   if (row_cache) {
-    Header(log, "                              Options.row_cache: %" PRIu64,
-           row_cache->GetCapacity());
+    ROCKS_LOG_HEADER(
+        log, "                              Options.row_cache: %" PRIu64,
+        row_cache->GetCapacity());
   } else {
-    Header(log, "                              Options.row_cache: None");
+    ROCKS_LOG_HEADER(log,
+                     "                              Options.row_cache: None");
   }
 #ifndef ROCKSDB_LITE
-  Header(log, "                             Options.wal_filter: %s",
-         wal_filter ? wal_filter->Name() : "None");
+  ROCKS_LOG_HEADER(log, "                             Options.wal_filter: %s",
+                   wal_filter ? wal_filter->Name() : "None");
 #endif  // ROCKDB_LITE
-  Header(log, "            Options.avoid_flush_during_recovery: %d",
-         avoid_flush_during_recovery);
+  ROCKS_LOG_HEADER(log, "            Options.avoid_flush_during_recovery: %d",
+                   avoid_flush_during_recovery);
 }
 
 MutableDBOptions::MutableDBOptions()
@@ -222,19 +235,19 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
           options.delete_obsolete_files_period_micros) {}
 
 void MutableDBOptions::Dump(Logger* log) const {
-  Header(log, "            Options.base_background_compactions: %d",
-         base_background_compactions);
-  Header(log, "            Options.max_background_compactions: %d",
-         max_background_compactions);
-  Header(log, "            Options.avoid_flush_during_shutdown: %d",
-         avoid_flush_during_shutdown);
-  Header(log, "            Options.delayed_write_rate : %" PRIu64,
-         delayed_write_rate);
-  Header(log, "            Options.max_total_wal_size: %" PRIu64,
-         max_total_wal_size);
-  Header(log,
-         "            Options.delete_obsolete_files_period_micros: %" PRIu64,
-         delete_obsolete_files_period_micros);
+  ROCKS_LOG_HEADER(log, "            Options.base_background_compactions: %d",
+                   base_background_compactions);
+  ROCKS_LOG_HEADER(log, "            Options.max_background_compactions: %d",
+                   max_background_compactions);
+  ROCKS_LOG_HEADER(log, "            Options.avoid_flush_during_shutdown: %d",
+                   avoid_flush_during_shutdown);
+  ROCKS_LOG_HEADER(log, "            Options.delayed_write_rate : %" PRIu64,
+                   delayed_write_rate);
+  ROCKS_LOG_HEADER(log, "            Options.max_total_wal_size: %" PRIu64,
+                   max_total_wal_size);
+  ROCKS_LOG_HEADER(
+      log, "            Options.delete_obsolete_files_period_micros: %" PRIu64,
+      delete_obsolete_files_period_micros);
 }
 
 }  // namespace rocksdb

--- a/util/delete_scheduler.cc
+++ b/util/delete_scheduler.cc
@@ -12,8 +12,9 @@
 
 #include "port/port.h"
 #include "rocksdb/env.h"
-#include "util/sst_file_manager_impl.h"
+#include "util/logging.h"
 #include "util/mutexlock.h"
+#include "util/sst_file_manager_impl.h"
 #include "util/sync_point.h"
 
 namespace rocksdb {
@@ -64,9 +65,8 @@ Status DeleteScheduler::DeleteFile(const std::string& file_path) {
   std::string path_in_trash;
   s = MoveToTrash(file_path, &path_in_trash);
   if (!s.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "Failed to move %s to trash directory (%s)", file_path.c_str(),
-        trash_dir_.c_str());
+    ROCKS_LOG_ERROR(info_log_, "Failed to move %s to trash directory (%s)",
+                    file_path.c_str(), trash_dir_.c_str());
     s = env_->DeleteFile(file_path);
     if (s.ok() && sst_file_manager_) {
       sst_file_manager_->OnDeleteFile(file_path);
@@ -191,9 +191,8 @@ Status DeleteScheduler::DeleteTrashFile(const std::string& path_in_trash,
 
   if (!s.ok()) {
     // Error while getting file size or while deleting
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "Failed to delete %s from trash -- %s", path_in_trash.c_str(),
-        s.ToString().c_str());
+    ROCKS_LOG_ERROR(info_log_, "Failed to delete %s from trash -- %s",
+                    path_in_trash.c_str(), s.ToString().c_str());
     *deleted_bytes = 0;
   } else {
     *deleted_bytes = file_size;

--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -1075,15 +1075,16 @@ TEST_P(EnvPosixTestWithParam, LogBufferTest) {
   std::fill_n(bytes9000, sizeof(bytes9000), '1');
   bytes9000[sizeof(bytes9000) - 1] = '\0';
 
-  LogToBuffer(&log_buffer, "x%sx", bytes200);
-  LogToBuffer(&log_buffer, "x%sx", bytes600);
-  LogToBuffer(&log_buffer, "x%sx%sx%sx", bytes200, bytes200, bytes200);
-  LogToBuffer(&log_buffer, "x%sx%sx", bytes200, bytes600);
-  LogToBuffer(&log_buffer, "x%sx%sx", bytes600, bytes9000);
+  ROCKS_LOG_BUFFER(&log_buffer, "x%sx", bytes200);
+  ROCKS_LOG_BUFFER(&log_buffer, "x%sx", bytes600);
+  ROCKS_LOG_BUFFER(&log_buffer, "x%sx%sx%sx", bytes200, bytes200, bytes200);
+  ROCKS_LOG_BUFFER(&log_buffer, "x%sx%sx", bytes200, bytes600);
+  ROCKS_LOG_BUFFER(&log_buffer, "x%sx%sx", bytes600, bytes9000);
 
-  LogToBuffer(&log_buffer_debug, "x%sx", bytes200);
+  ROCKS_LOG_BUFFER(&log_buffer_debug, "x%sx", bytes200);
   test_logger.SetInfoLogLevel(DEBUG_LEVEL);
-  LogToBuffer(&log_buffer_debug, "x%sx%sx%sx", bytes600, bytes9000, bytes200);
+  ROCKS_LOG_BUFFER(&log_buffer_debug, "x%sx%sx%sx", bytes600, bytes9000,
+                   bytes200);
 
   ASSERT_EQ(0, test_logger.log_count);
   log_buffer.FlushBufferToLog();
@@ -1124,7 +1125,7 @@ TEST_P(EnvPosixTestWithParam, LogBufferMaxSizeTest) {
     TestLogger2 test_logger(max_log_size);
     test_logger.SetInfoLogLevel(InfoLogLevel::INFO_LEVEL);
     LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL, &test_logger);
-    LogToBuffer(&log_buffer, max_log_size, "%s", bytes9000);
+    ROCKS_LOG_BUFFER_MAX_SZ(&log_buffer, max_log_size, "%s", bytes9000);
     log_buffer.FlushBufferToLog();
   }
 }

--- a/util/event_logger.cc
+++ b/util/event_logger.cc
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <string>
 
+#include "util/logging.h"
 #include "util/string_util.h"
 
 namespace rocksdb {

--- a/util/logging.h
+++ b/util/logging.h
@@ -16,6 +16,42 @@
 #include <string>
 #include "port/port.h"
 
+// Helper macros that include information about file name and line number
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define PREPEND_FILE_LINE(FMT) ("[" __FILE__ ":" TOSTRING(__LINE__) "] " FMT)
+
+// Don't inclide file/line info in HEADER level
+#define ROCKS_LOG_HEADER(LGR, FMT, ...) \
+  rocksdb::Log(InfoLogLevel::HEADER_LEVEL, LGR, FMT, ##__VA_ARGS__)
+
+#define ROCKS_LOG_DEBUG(LGR, FMT, ...)                                 \
+  rocksdb::Log(InfoLogLevel::DEBUG_LEVEL, LGR, PREPEND_FILE_LINE(FMT), \
+               ##__VA_ARGS__)
+
+#define ROCKS_LOG_INFO(LGR, FMT, ...)                                 \
+  rocksdb::Log(InfoLogLevel::INFO_LEVEL, LGR, PREPEND_FILE_LINE(FMT), \
+               ##__VA_ARGS__)
+
+#define ROCKS_LOG_WARN(LGR, FMT, ...)                                 \
+  rocksdb::Log(InfoLogLevel::WARN_LEVEL, LGR, PREPEND_FILE_LINE(FMT), \
+               ##__VA_ARGS__)
+
+#define ROCKS_LOG_ERROR(LGR, FMT, ...)                                 \
+  rocksdb::Log(InfoLogLevel::ERROR_LEVEL, LGR, PREPEND_FILE_LINE(FMT), \
+               ##__VA_ARGS__)
+
+#define ROCKS_LOG_FATAL(LGR, FMT, ...)                                 \
+  rocksdb::Log(InfoLogLevel::FATAL_LEVEL, LGR, PREPEND_FILE_LINE(FMT), \
+               ##__VA_ARGS__)
+
+#define ROCKS_LOG_BUFFER(LOG_BUF, FMT, ...) \
+  rocksdb::LogToBuffer(LOG_BUF, PREPEND_FILE_LINE(FMT), ##__VA_ARGS__)
+
+#define ROCKS_LOG_BUFFER_MAX_SZ(LOG_BUF, MAX_LOG_SIZE, FMT, ...)      \
+  rocksdb::LogToBuffer(LOG_BUF, MAX_LOG_SIZE, PREPEND_FILE_LINE(FMT), \
+                       ##__VA_ARGS__)
+
 namespace rocksdb {
 
 class Slice;

--- a/util/options.cc
+++ b/util/options.cc
@@ -196,91 +196,108 @@ void DBOptions::Dump(Logger* log) const {
 }  // DBOptions::Dump
 
 void ColumnFamilyOptions::Dump(Logger* log) const {
-  Header(log, "              Options.comparator: %s", comparator->Name());
-  Header(log, "          Options.merge_operator: %s",
-      merge_operator ? merge_operator->Name() : "None");
-  Header(log, "       Options.compaction_filter: %s",
-      compaction_filter ? compaction_filter->Name() : "None");
-  Header(log, "       Options.compaction_filter_factory: %s",
+  ROCKS_LOG_HEADER(log, "              Options.comparator: %s",
+                   comparator->Name());
+  ROCKS_LOG_HEADER(log, "          Options.merge_operator: %s",
+                   merge_operator ? merge_operator->Name() : "None");
+  ROCKS_LOG_HEADER(log, "       Options.compaction_filter: %s",
+                   compaction_filter ? compaction_filter->Name() : "None");
+  ROCKS_LOG_HEADER(
+      log, "       Options.compaction_filter_factory: %s",
       compaction_filter_factory ? compaction_filter_factory->Name() : "None");
-  Header(log, "        Options.memtable_factory: %s", memtable_factory->Name());
-  Header(log, "           Options.table_factory: %s", table_factory->Name());
-  Header(log, "           table_factory options: %s",
-      table_factory->GetPrintableTableOptions().c_str());
-  Header(log, "       Options.write_buffer_size: %" ROCKSDB_PRIszt,
-       write_buffer_size);
-  Header(log, " Options.max_write_buffer_number: %d", max_write_buffer_number);
-    if (!compression_per_level.empty()) {
-      for (unsigned int i = 0; i < compression_per_level.size(); i++) {
-        Header(log, "       Options.compression[%d]: %s", i,
-            CompressionTypeToString(compression_per_level[i]).c_str());
-      }
-    } else {
-      Header(log, "         Options.compression: %s",
-          CompressionTypeToString(compression).c_str());
+  ROCKS_LOG_HEADER(log, "        Options.memtable_factory: %s",
+                   memtable_factory->Name());
+  ROCKS_LOG_HEADER(log, "           Options.table_factory: %s",
+                   table_factory->Name());
+  ROCKS_LOG_HEADER(log, "           table_factory options: %s",
+                   table_factory->GetPrintableTableOptions().c_str());
+  ROCKS_LOG_HEADER(log, "       Options.write_buffer_size: %" ROCKSDB_PRIszt,
+                   write_buffer_size);
+  ROCKS_LOG_HEADER(log, " Options.max_write_buffer_number: %d",
+                   max_write_buffer_number);
+  if (!compression_per_level.empty()) {
+    for (unsigned int i = 0; i < compression_per_level.size(); i++) {
+      ROCKS_LOG_HEADER(
+          log, "       Options.compression[%d]: %s", i,
+          CompressionTypeToString(compression_per_level[i]).c_str());
     }
-    Header(log, "                 Options.bottommost_compression: %s",
-           bottommost_compression == kDisableCompressionOption
-               ? "Disabled"
-               : CompressionTypeToString(bottommost_compression).c_str());
-    Header(log, "      Options.prefix_extractor: %s",
+    } else {
+      ROCKS_LOG_HEADER(log, "         Options.compression: %s",
+                       CompressionTypeToString(compression).c_str());
+    }
+    ROCKS_LOG_HEADER(
+        log, "                 Options.bottommost_compression: %s",
+        bottommost_compression == kDisableCompressionOption
+            ? "Disabled"
+            : CompressionTypeToString(bottommost_compression).c_str());
+    ROCKS_LOG_HEADER(
+        log, "      Options.prefix_extractor: %s",
         prefix_extractor == nullptr ? "nullptr" : prefix_extractor->Name());
-    Header(log, "  Options.memtable_insert_with_hint_prefix_extractor: %s",
-           memtable_insert_with_hint_prefix_extractor == nullptr
-               ? "nullptr"
-               : memtable_insert_with_hint_prefix_extractor->Name());
-    Header(log, "            Options.num_levels: %d", num_levels);
-    Header(log, "       Options.min_write_buffer_number_to_merge: %d",
-        min_write_buffer_number_to_merge);
-    Header(log, "    Options.max_write_buffer_number_to_maintain: %d",
-         max_write_buffer_number_to_maintain);
-    Header(log, "           Options.compression_opts.window_bits: %d",
-        compression_opts.window_bits);
-    Header(log, "                 Options.compression_opts.level: %d",
-        compression_opts.level);
-    Header(log, "              Options.compression_opts.strategy: %d",
-        compression_opts.strategy);
-    Header(log,
+    ROCKS_LOG_HEADER(log,
+                     "  Options.memtable_insert_with_hint_prefix_extractor: %s",
+                     memtable_insert_with_hint_prefix_extractor == nullptr
+                         ? "nullptr"
+                         : memtable_insert_with_hint_prefix_extractor->Name());
+    ROCKS_LOG_HEADER(log, "            Options.num_levels: %d", num_levels);
+    ROCKS_LOG_HEADER(log, "       Options.min_write_buffer_number_to_merge: %d",
+                     min_write_buffer_number_to_merge);
+    ROCKS_LOG_HEADER(log, "    Options.max_write_buffer_number_to_maintain: %d",
+                     max_write_buffer_number_to_maintain);
+    ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
+                     compression_opts.window_bits);
+    ROCKS_LOG_HEADER(log, "                 Options.compression_opts.level: %d",
+                     compression_opts.level);
+    ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
+                     compression_opts.strategy);
+    ROCKS_LOG_HEADER(
+        log,
         "        Options.compression_opts.max_dict_bytes: %" ROCKSDB_PRIszt,
         compression_opts.max_dict_bytes);
-    Header(log, "     Options.level0_file_num_compaction_trigger: %d",
-        level0_file_num_compaction_trigger);
-    Header(log, "         Options.level0_slowdown_writes_trigger: %d",
-        level0_slowdown_writes_trigger);
-    Header(log, "             Options.level0_stop_writes_trigger: %d",
-        level0_stop_writes_trigger);
-    Header(log, "                  Options.target_file_size_base: %" PRIu64,
+    ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
+                     level0_file_num_compaction_trigger);
+    ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",
+                     level0_slowdown_writes_trigger);
+    ROCKS_LOG_HEADER(log, "             Options.level0_stop_writes_trigger: %d",
+                     level0_stop_writes_trigger);
+    ROCKS_LOG_HEADER(
+        log, "                  Options.target_file_size_base: %" PRIu64,
         target_file_size_base);
-    Header(log, "            Options.target_file_size_multiplier: %d",
-        target_file_size_multiplier);
-    Header(log, "               Options.max_bytes_for_level_base: %" PRIu64,
+    ROCKS_LOG_HEADER(log, "            Options.target_file_size_multiplier: %d",
+                     target_file_size_multiplier);
+    ROCKS_LOG_HEADER(
+        log, "               Options.max_bytes_for_level_base: %" PRIu64,
         max_bytes_for_level_base);
-    Header(log, "Options.level_compaction_dynamic_level_bytes: %d",
-        level_compaction_dynamic_level_bytes);
-    Header(log, "         Options.max_bytes_for_level_multiplier: %f",
-           max_bytes_for_level_multiplier);
+    ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
+                     level_compaction_dynamic_level_bytes);
+    ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
+                     max_bytes_for_level_multiplier);
     for (size_t i = 0; i < max_bytes_for_level_multiplier_additional.size();
          i++) {
-      Header(log,
-          "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt
-                "]: %d",
-           i, max_bytes_for_level_multiplier_additional[i]);
+      ROCKS_LOG_HEADER(
+          log, "Options.max_bytes_for_level_multiplier_addtl[%" ROCKSDB_PRIszt
+               "]: %d",
+          i, max_bytes_for_level_multiplier_additional[i]);
     }
-    Header(log, "      Options.max_sequential_skip_in_iterations: %" PRIu64,
+    ROCKS_LOG_HEADER(
+        log, "      Options.max_sequential_skip_in_iterations: %" PRIu64,
         max_sequential_skip_in_iterations);
-    Header(log, "                   Options.max_compaction_bytes: %" PRIu64,
-           max_compaction_bytes);
-    Header(log,
-         "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
-         arena_block_size);
-    Header(log, "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
-           soft_pending_compaction_bytes_limit);
-    Header(log, "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
-         hard_pending_compaction_bytes_limit);
-    Header(log, "      Options.rate_limit_delay_max_milliseconds: %u",
-        rate_limit_delay_max_milliseconds);
-    Header(log, "               Options.disable_auto_compactions: %d",
-        disable_auto_compactions);
+    ROCKS_LOG_HEADER(
+        log, "                   Options.max_compaction_bytes: %" PRIu64,
+        max_compaction_bytes);
+    ROCKS_LOG_HEADER(
+        log,
+        "                       Options.arena_block_size: %" ROCKSDB_PRIszt,
+        arena_block_size);
+    ROCKS_LOG_HEADER(log,
+                     "  Options.soft_pending_compaction_bytes_limit: %" PRIu64,
+                     soft_pending_compaction_bytes_limit);
+    ROCKS_LOG_HEADER(log,
+                     "  Options.hard_pending_compaction_bytes_limit: %" PRIu64,
+                     hard_pending_compaction_bytes_limit);
+    ROCKS_LOG_HEADER(log, "      Options.rate_limit_delay_max_milliseconds: %u",
+                     rate_limit_delay_max_milliseconds);
+    ROCKS_LOG_HEADER(log, "               Options.disable_auto_compactions: %d",
+                     disable_auto_compactions);
 
     const auto& it_compaction_style =
         compaction_style_to_string.find(compaction_style);
@@ -291,8 +308,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     } else {
       str_compaction_style = it_compaction_style->second;
     }
-    Header(log, "                        Options.compaction_style: %s",
-           str_compaction_style.c_str());
+    ROCKS_LOG_HEADER(log,
+                     "                        Options.compaction_style: %s",
+                     str_compaction_style.c_str());
 
     const auto& it_compaction_pri =
         compaction_pri_to_string.find(compaction_pri);
@@ -303,55 +321,69 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     } else {
       str_compaction_pri = it_compaction_pri->second;
     }
-    Header(log, "                          Options.compaction_pri: %s",
-           str_compaction_pri.c_str());
-    Header(log, " Options.compaction_options_universal.size_ratio: %u",
-        compaction_options_universal.size_ratio);
-    Header(log, "Options.compaction_options_universal.min_merge_width: %u",
-        compaction_options_universal.min_merge_width);
-    Header(log, "Options.compaction_options_universal.max_merge_width: %u",
-        compaction_options_universal.max_merge_width);
-    Header(log, "Options.compaction_options_universal."
-            "max_size_amplification_percent: %u",
+    ROCKS_LOG_HEADER(log,
+                     "                          Options.compaction_pri: %s",
+                     str_compaction_pri.c_str());
+    ROCKS_LOG_HEADER(log,
+                     " Options.compaction_options_universal.size_ratio: %u",
+                     compaction_options_universal.size_ratio);
+    ROCKS_LOG_HEADER(log,
+                     "Options.compaction_options_universal.min_merge_width: %u",
+                     compaction_options_universal.min_merge_width);
+    ROCKS_LOG_HEADER(log,
+                     "Options.compaction_options_universal.max_merge_width: %u",
+                     compaction_options_universal.max_merge_width);
+    ROCKS_LOG_HEADER(
+        log,
+        "Options.compaction_options_universal."
+        "max_size_amplification_percent: %u",
         compaction_options_universal.max_size_amplification_percent);
-    Header(log,
+    ROCKS_LOG_HEADER(
+        log,
         "Options.compaction_options_universal.compression_size_percent: %d",
         compaction_options_universal.compression_size_percent);
-    Header(log,
-        "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
+    ROCKS_LOG_HEADER(
+        log, "Options.compaction_options_fifo.max_table_files_size: %" PRIu64,
         compaction_options_fifo.max_table_files_size);
     std::string collector_names;
     for (const auto& collector_factory : table_properties_collector_factories) {
       collector_names.append(collector_factory->Name());
       collector_names.append("; ");
     }
-    Header(log, "                  Options.table_properties_collectors: %s",
+    ROCKS_LOG_HEADER(
+        log, "                  Options.table_properties_collectors: %s",
         collector_names.c_str());
-    Header(log, "                  Options.inplace_update_support: %d",
-        inplace_update_support);
-    Header(log,
-         "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
-         inplace_update_num_locks);
+    ROCKS_LOG_HEADER(log,
+                     "                  Options.inplace_update_support: %d",
+                     inplace_update_support);
+    ROCKS_LOG_HEADER(
+        log,
+        "                Options.inplace_update_num_locks: %" ROCKSDB_PRIszt,
+        inplace_update_num_locks);
     // TODO: easier config for bloom (maybe based on avg key/value size)
-    Header(log, "              Options.memtable_prefix_bloom_size_ratio: %f",
-           memtable_prefix_bloom_size_ratio);
+    ROCKS_LOG_HEADER(
+        log, "              Options.memtable_prefix_bloom_size_ratio: %f",
+        memtable_prefix_bloom_size_ratio);
 
-    Header(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
-           memtable_huge_page_size);
-    Header(log, "                          Options.bloom_locality: %d",
-        bloom_locality);
+    ROCKS_LOG_HEADER(log, "  Options.memtable_huge_page_size: %" ROCKSDB_PRIszt,
+                     memtable_huge_page_size);
+    ROCKS_LOG_HEADER(log,
+                     "                          Options.bloom_locality: %d",
+                     bloom_locality);
 
-    Header(log,
-         "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
-         max_successive_merges);
-    Header(log, "               Options.optimize_filters_for_hits: %d",
-        optimize_filters_for_hits);
-    Header(log, "               Options.paranoid_file_checks: %d",
-         paranoid_file_checks);
-    Header(log, "               Options.force_consistency_checks: %d",
-           force_consistency_checks);
-    Header(log, "               Options.report_bg_io_stats: %d",
-           report_bg_io_stats);
+    ROCKS_LOG_HEADER(
+        log,
+        "                   Options.max_successive_merges: %" ROCKSDB_PRIszt,
+        max_successive_merges);
+    ROCKS_LOG_HEADER(log,
+                     "               Options.optimize_filters_for_hits: %d",
+                     optimize_filters_for_hits);
+    ROCKS_LOG_HEADER(log, "               Options.paranoid_file_checks: %d",
+                     paranoid_file_checks);
+    ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
+                     force_consistency_checks);
+    ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
+                     report_bg_io_stats);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/utilities/checkpoint/checkpoint.cc
+++ b/utilities/checkpoint/checkpoint.cc
@@ -122,7 +122,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
   }
 
   size_t wal_size = live_wal_files.size();
-  Log(db_options.info_log,
+  ROCKS_LOG_INFO(
+      db_options.info_log,
       "Started the snapshot process -- creating snapshot in directory %s",
       checkpoint_dir.c_str());
 
@@ -161,7 +162,7 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
     // * if it's kDescriptorFile, limit the size to manifest_file_size
     // * always copy if cross-device link
     if ((type == kTableFile) && same_fs) {
-      Log(db_options.info_log, "Hard Linking %s", src_fname.c_str());
+      ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s", src_fname.c_str());
       s = db_->GetEnv()->LinkFile(db_->GetName() + src_fname,
                                   full_private_path + src_fname);
       if (s.IsNotSupported()) {
@@ -170,7 +171,7 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
       }
     }
     if ((type != kTableFile) || (!same_fs)) {
-      Log(db_options.info_log, "Copying %s", src_fname.c_str());
+      ROCKS_LOG_INFO(db_options.info_log, "Copying %s", src_fname.c_str());
       s = CopyFile(db_->GetEnv(), db_->GetName() + src_fname,
                    full_private_path + src_fname,
                    (type == kDescriptorFile) ? manifest_file_size : 0,
@@ -181,8 +182,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
     s = CreateFile(db_->GetEnv(), full_private_path + current_fname,
                    manifest_fname.substr(1) + "\n");
   }
-  Log(db_options.info_log, "Number of log files %" ROCKSDB_PRIszt,
-      live_wal_files.size());
+  ROCKS_LOG_INFO(db_options.info_log, "Number of log files %" ROCKSDB_PRIszt,
+                 live_wal_files.size());
 
   // Link WAL files. Copy exact size of last one because it is the only one
   // that has changes after the last flush.
@@ -191,8 +192,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
         (live_wal_files[i]->StartSequence() >= sequence_number ||
          live_wal_files[i]->LogNumber() >= min_log_num)) {
       if (i + 1 == wal_size) {
-        Log(db_options.info_log, "Copying %s",
-            live_wal_files[i]->PathName().c_str());
+        ROCKS_LOG_INFO(db_options.info_log, "Copying %s",
+                       live_wal_files[i]->PathName().c_str());
         s = CopyFile(db_->GetEnv(),
                      db_options.wal_dir + live_wal_files[i]->PathName(),
                      full_private_path + live_wal_files[i]->PathName(),
@@ -201,8 +202,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
       }
       if (same_fs) {
         // we only care about live log files
-        Log(db_options.info_log, "Hard Linking %s",
-            live_wal_files[i]->PathName().c_str());
+        ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s",
+                       live_wal_files[i]->PathName().c_str());
         s = db_->GetEnv()->LinkFile(
             db_options.wal_dir + live_wal_files[i]->PathName(),
             full_private_path + live_wal_files[i]->PathName());
@@ -212,8 +213,8 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
         }
       }
       if (!same_fs) {
-        Log(db_options.info_log, "Copying %s",
-            live_wal_files[i]->PathName().c_str());
+        ROCKS_LOG_INFO(db_options.info_log, "Copying %s",
+                       live_wal_files[i]->PathName().c_str());
         s = CopyFile(db_->GetEnv(),
                      db_options.wal_dir + live_wal_files[i]->PathName(),
                      full_private_path + live_wal_files[i]->PathName(), 0,
@@ -239,27 +240,28 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir) {
 
   if (!s.ok()) {
     // clean all the files we might have created
-    Log(db_options.info_log, "Snapshot failed -- %s", s.ToString().c_str());
+    ROCKS_LOG_INFO(db_options.info_log, "Snapshot failed -- %s",
+                   s.ToString().c_str());
     // we have to delete the dir and all its children
     std::vector<std::string> subchildren;
     db_->GetEnv()->GetChildren(full_private_path, &subchildren);
     for (auto& subchild : subchildren) {
       std::string subchild_path = full_private_path + "/" + subchild;
       Status s1 = db_->GetEnv()->DeleteFile(subchild_path);
-      Log(db_options.info_log, "Delete file %s -- %s", subchild_path.c_str(),
-          s1.ToString().c_str());
+      ROCKS_LOG_INFO(db_options.info_log, "Delete file %s -- %s",
+                     subchild_path.c_str(), s1.ToString().c_str());
     }
     // finally delete the private dir
     Status s1 = db_->GetEnv()->DeleteDir(full_private_path);
-    Log(db_options.info_log, "Delete dir %s -- %s", full_private_path.c_str(),
-        s1.ToString().c_str());
+    ROCKS_LOG_INFO(db_options.info_log, "Delete dir %s -- %s",
+                   full_private_path.c_str(), s1.ToString().c_str());
     return s;
   }
 
   // here we know that we succeeded and installed the new snapshot
-  Log(db_options.info_log, "Snapshot DONE. All is good");
-  Log(db_options.info_log, "Snapshot sequence number: %" PRIu64,
-      sequence_number);
+  ROCKS_LOG_INFO(db_options.info_log, "Snapshot DONE. All is good");
+  ROCKS_LOG_INFO(db_options.info_log, "Snapshot sequence number: %" PRIu64,
+                 sequence_number);
 
   return s;
 }

--- a/utilities/merge_operators/uint64add.cc
+++ b/utilities/merge_operators/uint64add.cc
@@ -9,6 +9,7 @@
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/slice.h"
 #include "util/coding.h"
+#include "util/logging.h"
 #include "utilities/merge_operators.h"
 
 using namespace rocksdb;
@@ -51,10 +52,9 @@ class UInt64AddOperator : public AssociativeMergeOperator {
       result = DecodeFixed64(value.data());
     } else if (logger != nullptr) {
       // If value is corrupted, treat it as 0
-      Log(InfoLogLevel::ERROR_LEVEL, logger,
-          "uint64 value corruption, size: %" ROCKSDB_PRIszt
-          " > %" ROCKSDB_PRIszt,
-          value.size(), sizeof(uint64_t));
+      ROCKS_LOG_ERROR(logger, "uint64 value corruption, size: %" ROCKSDB_PRIszt
+                              " > %" ROCKSDB_PRIszt,
+                      value.size(), sizeof(uint64_t));
     }
 
     return result;

--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "port/port.h"
+#include "util/logging.h"
 #include "util/stop_watch.h"
 #include "util/sync_point.h"
 #include "utilities/persistent_cache/block_cache_tier_file.h"
@@ -109,7 +110,7 @@ Status BlockCacheTier::CleanupCacheFolder(const std::string& folder) {
         return status;
       }
     } else {
-      Debug(opt_.log, "Skipping file %s", file.c_str());
+      ROCKS_LOG_DEBUG(opt_.log, "Skipping file %s", file.c_str());
     }
   }
   return Status::OK();
@@ -233,8 +234,8 @@ Status BlockCacheTier::InsertImpl(const Slice& key, const Slice& data) {
 
   while (!cache_file_->Append(key, data, &lba)) {
     if (!cache_file_->Eof()) {
-      Debug(opt_.log, "Error inserting to cache file %d",
-            cache_file_->cacheid());
+      ROCKS_LOG_DEBUG(opt_.log, "Error inserting to cache file %d",
+                      cache_file_->cacheid());
       stats_.write_latency_.Add(timer.ElapsedNanos() / 1000);
       return Status::TryAgain();
     }

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -13,8 +13,9 @@
 #include <memory>
 #include <vector>
 
-#include "util/crc32c.h"
 #include "port/port.h"
+#include "util/crc32c.h"
+#include "util/logging.h"
 
 namespace rocksdb {
 
@@ -201,7 +202,7 @@ bool RandomAccessCacheFile::Open(const bool enable_direct_reads) {
 bool RandomAccessCacheFile::OpenImpl(const bool enable_direct_reads) {
   rwlock_.AssertHeld();
 
-  Debug(log_, "Opening cache file %s", Path().c_str());
+  ROCKS_LOG_DEBUG(log_, "Opening cache file %s", Path().c_str());
 
   std::unique_ptr<RandomAccessFile> file;
   Status status =
@@ -282,19 +283,19 @@ bool WriteableCacheFile::Create(const bool enable_direct_writes,
 
   enable_direct_reads_ = enable_direct_reads;
 
-  Debug(log_, "Creating new cache %s (max size is %d B)", Path().c_str(),
-        max_size_);
+  ROCKS_LOG_DEBUG(log_, "Creating new cache %s (max size is %d B)",
+                  Path().c_str(), max_size_);
 
   Status s = env_->FileExists(Path());
   if (s.ok()) {
-    Warn(log_, "File %s already exists. %s", Path().c_str(),
-         s.ToString().c_str());
+    ROCKS_LOG_WARN(log_, "File %s already exists. %s", Path().c_str(),
+                   s.ToString().c_str());
   }
 
   s = NewWritableCacheFile(env_, Path(), &file_);
   if (!s.ok()) {
-    Warn(log_, "Unable to create file %s. %s", Path().c_str(),
-         s.ToString().c_str());
+    ROCKS_LOG_WARN(log_, "Unable to create file %s. %s", Path().c_str(),
+                   s.ToString().c_str());
     return false;
   }
 
@@ -317,7 +318,7 @@ bool WriteableCacheFile::Append(const Slice& key, const Slice& val, LBA* lba) {
 
   if (!ExpandBuffer(rec_size)) {
     // unable to expand the buffer
-    Debug(log_, "Error expanding buffers. size=%d", rec_size);
+    ROCKS_LOG_DEBUG(log_, "Error expanding buffers. size=%d", rec_size);
     return false;
   }
 
@@ -360,7 +361,7 @@ bool WriteableCacheFile::ExpandBuffer(const size_t size) {
   while (free < size) {
     CacheWriteBuffer* const buf = alloc_->Allocate();
     if (!buf) {
-      Debug(log_, "Unable to allocate buffers");
+      ROCKS_LOG_DEBUG(log_, "Unable to allocate buffers");
       return false;
     }
 

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -233,8 +233,8 @@ class TtlMergeOperator : public MergeOperator {
                            MergeOperationOutput* merge_out) const override {
     const uint32_t ts_len = DBWithTTLImpl::kTSLength;
     if (merge_in.existing_value && merge_in.existing_value->size() < ts_len) {
-      Log(InfoLogLevel::ERROR_LEVEL, merge_in.logger,
-          "Error: Could not remove timestamp from existing value.");
+      ROCKS_LOG_ERROR(merge_in.logger,
+                      "Error: Could not remove timestamp from existing value.");
       return false;
     }
 
@@ -242,7 +242,8 @@ class TtlMergeOperator : public MergeOperator {
     std::vector<Slice> operands_without_ts;
     for (const auto& operand : merge_in.operand_list) {
       if (operand.size() < ts_len) {
-        Log(InfoLogLevel::ERROR_LEVEL, merge_in.logger,
+        ROCKS_LOG_ERROR(
+            merge_in.logger,
             "Error: Could not remove timestamp from operand value.");
         return false;
       }
@@ -282,7 +283,8 @@ class TtlMergeOperator : public MergeOperator {
     // Augment the *new_value with the ttl time-stamp
     int64_t curtime;
     if (!env_->GetCurrentTime(&curtime).ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, merge_in.logger,
+      ROCKS_LOG_ERROR(
+          merge_in.logger,
           "Error: Could not get current time to be attached internally "
           "to the new value.");
       return false;
@@ -303,8 +305,8 @@ class TtlMergeOperator : public MergeOperator {
 
     for (const auto& operand : operand_list) {
       if (operand.size() < ts_len) {
-        Log(InfoLogLevel::ERROR_LEVEL, logger,
-            "Error: Could not remove timestamp from value.");
+        ROCKS_LOG_ERROR(logger,
+                        "Error: Could not remove timestamp from value.");
         return false;
       }
 
@@ -322,7 +324,8 @@ class TtlMergeOperator : public MergeOperator {
     // Augment the *new_value with the ttl time-stamp
     int64_t curtime;
     if (!env_->GetCurrentTime(&curtime).ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, logger,
+      ROCKS_LOG_ERROR(
+          logger,
           "Error: Could not get current time to be attached internally "
           "to the new value.");
       return false;


### PR DESCRIPTION
current logging
```
2017/03/14-14:20:30.393432 7fedde9f5700 (Original Log Time 2017/03/14-14:20:30.393414) [default] Level summary: base level 1 max bytes base 268435456 files[1 0 0 0 0 0 0] max score 0.25
2017/03/14-14:20:30.393438 7fedde9f5700 [JOB 2] Try to delete WAL files size 61417909, prev total WAL file size 73820858, number of live WAL files 2.
2017/03/14-14:20:30.393464 7fedde9f5700 [DEBUG] [JOB 2] Delete /dev/shm/old_logging//MANIFEST-000001 type=3 #1 -- OK
2017/03/14-14:20:30.393472 7fedde9f5700 [DEBUG] [JOB 2] Delete /dev/shm/old_logging//000003.log type=0 #3 -- OK
2017/03/14-14:20:31.427103 7fedd49f1700 [default] New memtable created with log file: #9. Immutable memtables: 0.
2017/03/14-14:20:31.427179 7fedde9f5700 [JOB 3] Syncing log #6
2017/03/14-14:20:31.427190 7fedde9f5700 (Original Log Time 2017/03/14-14:20:31.427170) Calling FlushMemTableToOutputFile with column family [default], flush slots available 1, compaction slots allowed 1, compaction slots scheduled 1
2017/03/14-14:20:31.427194 7fedde9f5700 [default] [JOB 3] Flushing memtable with next log file: 9
2017/03/14-14:20:31.427215 7fedde9f5700 EVENT_LOG_v1 {"time_micros": 1489526431427207, "job": 3, "event": "flush_started", "num_memtables": 1, "num_entries": 468860, "num_deletes": 0, "memory_usage": 65014064}
2017/03/14-14:20:31.427219 7fedde9f5700 [default] [JOB 3] Level-0 flush table #10: started
2017/03/14-14:20:31.701804 7fedde9f5700 EVENT_LOG_v1 {"time_micros": 1489526431701781, "cf_name": "default", "job": 3, "event": "table_file_creation", "file_number": 10, "file_size": 31690882, "table_properties": {"data_size": 31471306, "index_size": 411022, "filter_size": 0, "raw_key_size": 11252640, "raw_average_key_size": 24, "raw_value_size": 46886000, "raw_average_value_size": 100, "num_data_blocks": 14208, "num_entries": 468860, "filter_policy_name": "", "kDeletedKeys": "0", "kMergeOperands": "0"}}
2017/03/14-14:20:31.701820 7fedde9f5700 [default] [JOB 3] Level-0 flush table #10: 31690882 bytes OK
2017/03/14-14:20:31.701907 7fedde9f5700 (Original Log Time 2017/03/14-14:20:31.701832) [default] Level-0 commit table #10 started
2017/03/14-14:20:31.701910 7fedde9f5700 (Original Log Time 2017/03/14-14:20:31.701873) [default] Level-0 commit table #10: memtable #1 done
2017/03/14-14:20:31.701912 7fedde9f5700 (Original Log Time 2017/03/14-14:20:31.701881) EVENT_LOG_v1 {"time_micros": 1489526431701876, "job": 3, "event": "flush_finished", "lsm_state": [2, 0, 0, 0, 0, 0, 0], "immutable_memtables": 0}
2017/03/14-14:20:31.701913 7fedde9f5700 (Original Log Time 2017/03/14-14:20:31.701897) [default] Level summary: base level 1 max bytes base 268435456 files[2 0 0 0 0 0 0] max score 0.50
2017/03/14-14:20:31.701918 7fedde9f5700 [JOB 3] Try to delete WAL files size 61420660, prev total WAL file size 69582091, number of live WAL files 2.
2017/03/14-14:20:31.701933 7fedde9f5700 [DEBUG] [JOB 3] Delete /dev/shm/old_logging//000006.log type=0 #6 -- OK
2017/03/14-14:20:31.822164 7fede55869c0 Shutdown: canceling all background work
2017/03/14-14:20:31.829494 7fede55869c0 Shutdown complete
```

new logging
```
2017/03/14-14:20:37.018909 7fd71dff5700 (Original Log Time 2017/03/14-14:20:37.018888) [db/db_impl.cc:1956] [default] Level summary: base level 1 max bytes base 268435456 files[1 0 0 0 0 0 0] max score 0.25
2017/03/14-14:20:37.018915 7fd71dff5700 [db/db_impl.cc:1047] [JOB 2] Try to delete WAL files size 61418171, prev total WAL file size 74252110, number of live WAL files 2.
2017/03/14-14:20:37.018930 7fd71dff5700 [DEBUG] [db/db_impl.cc:966] [JOB 2] Delete /dev/shm/new_logging//MANIFEST-000001 type=3 #1 -- OK
2017/03/14-14:20:37.018937 7fd71dff5700 [DEBUG] [db/db_impl.cc:966] [JOB 2] Delete /dev/shm/new_logging//000003.log type=0 #3 -- OK
2017/03/14-14:20:38.070707 7fd713ff1700 [db/db_impl.cc:5288] [default] New memtable created with log file: #9. Immutable memtables: 0.
2017/03/14-14:20:38.070847 7fd71dff5700 [db/db_impl.cc:1879] [JOB 3] Syncing log #6
2017/03/14-14:20:38.070865 7fd71dff5700 (Original Log Time 2017/03/14-14:20:38.070830) [db/db_impl.cc:3252] Calling FlushMemTableToOutputFile with column family [default], flush slots available 1, compaction slots allowed 1, compaction slots scheduled 1
2017/03/14-14:20:38.070868 7fd71dff5700 [db/flush_job.cc:264] [default] [JOB 3] Flushing memtable with next log file: 9
2017/03/14-14:20:38.070892 7fd71dff5700 EVENT_LOG_v1 {"time_micros": 1489526438070882, "job": 3, "event": "flush_started", "num_memtables": 1, "num_entries": 468869, "num_deletes": 0, "memory_usage": 65014048}
2017/03/14-14:20:38.070896 7fd71dff5700 [db/flush_job.cc:293] [default] [JOB 3] Level-0 flush table #10: started
2017/03/14-14:20:38.352703 7fd71dff5700 EVENT_LOG_v1 {"time_micros": 1489526438352679, "cf_name": "default", "job": 3, "event": "table_file_creation", "file_number": 10, "file_size": 31691577, "table_properties": {"data_size": 31471966, "index_size": 411052, "filter_size": 0, "raw_key_size": 11252856, "raw_average_key_size": 24, "raw_value_size": 46886900, "raw_average_value_size": 100, "num_data_blocks": 14209, "num_entries": 468869, "filter_policy_name": "", "kDeletedKeys": "0", "kMergeOperands": "0"}}
2017/03/14-14:20:38.352721 7fd71dff5700 [db/flush_job.cc:317] [default] [JOB 3] Level-0 flush table #10: 31691577 bytes OK
2017/03/14-14:20:38.352833 7fd71dff5700 (Original Log Time 2017/03/14-14:20:38.352743) [db/memtable_list.cc:360] [default] Level-0 commit table #10 started
2017/03/14-14:20:38.352836 7fd71dff5700 (Original Log Time 2017/03/14-14:20:38.352792) [db/memtable_list.cc:383] [default] Level-0 commit table #10: memtable #1 done
2017/03/14-14:20:38.352837 7fd71dff5700 (Original Log Time 2017/03/14-14:20:38.352802) EVENT_LOG_v1 {"time_micros": 1489526438352796, "job": 3, "event": "flush_finished", "lsm_state": [2, 0, 0, 0, 0, 0, 0], "immutable_memtables": 0}
2017/03/14-14:20:38.352839 7fd71dff5700 (Original Log Time 2017/03/14-14:20:38.352820) [db/db_impl.cc:1956] [default] Level summary: base level 1 max bytes base 268435456 files[2 0 0 0 0 0 0] max score 0.50
2017/03/14-14:20:38.352845 7fd71dff5700 [db/db_impl.cc:1047] [JOB 3] Try to delete WAL files size 61421839, prev total WAL file size 69581829, number of live WAL files 2.
2017/03/14-14:20:38.352860 7fd71dff5700 [DEBUG] [db/db_impl.cc:966] [JOB 3] Delete /dev/shm/new_logging//000006.log type=0 #6 -- OK
2017/03/14-14:20:38.453229 7fd724a719c0 [db/db_impl.cc:392] Shutdown: canceling all background work
2017/03/14-14:20:38.459462 7fd724a719c0 [db/db_impl.cc:518] Shutdown complete
```