### PR TITLE
add CALL_AND_LOG macro

### DIFF
--- a/util/logging.h
+++ b/util/logging.h
@@ -52,6 +52,10 @@
   rocksdb::LogToBuffer(LOG_BUF, MAX_LOG_SIZE, PREPEND_FILE_LINE(FMT), \
                        ##__VA_ARGS__)
 
+#define CALL_AND_LOG(LGR, FNC, ...)              \
+  ROCKS_LOG_INFO(LGR, "Calling " TOSTRING(FNC)); \
+  FNC(##__VA_ARGS__)
+
 namespace rocksdb {
 
 class Slice;


### PR DESCRIPTION
Add CALL_AND_LOG macro that will call the function and log that we have called it (with file/line info)

also add more logging for  MaybeScheduleFlushOrCompaction() function

sample log lines
```
2017/03/16-18:08:56.371776 7ffb887f4700 [db/db_impl.cc:4007] Calling MaybeScheduleFlushOrCompaction
2017/03/16-18:08:56.371783 7ffb887f4700 [db/db_impl.cc:3076] Scheduled 1 flushes and 0 compactions, (0 unscheduled flushes 0 unscheduled compactions)
```