### PR TITLE
make total_log_size_ atomic

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -5102,7 +5102,7 @@ void DBImpl::MaybeFlushColumnFamilies() {
                  "Flushing all column families with data in WAL number %" PRIu64
                  ". Total log size is %" PRIu64
                  " while max_total_wal_size is %" PRIu64,
-                 oldest_alive_log, total_log_size_, GetMaxTotalWalSize());
+                 oldest_alive_log, total_log_size_.load(), GetMaxTotalWalSize());
   // no need to refcount because drop is happening in write thread, so can't
   // happen while we're in the write thread
   for (auto cfd : *versions_->GetColumnFamilySet()) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -819,7 +819,7 @@ class DBImpl : public DB {
   std::deque<LogWriterNumber> logs_;
   // Signaled when getting_synced becomes false for some of the logs_.
   InstrumentedCondVar log_sync_cv_;
-  uint64_t total_log_size_;
+  std::atomic<uint64_t> total_log_size_;
   // only used for dynamically adjusting max_total_wal_size. it is a sum of
   // [write_buffer_size * max_write_buffer_number] over all column families
   uint64_t max_total_in_memory_state_;


### PR DESCRIPTION
make total_log_size_ atomic to avoid overflow caused by data race.