### PR TITLE
Update .gitignore file in examples

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -3,5 +3,6 @@ column_families_example
 compact_files_example
 compaction_filter_example
 optimistic_transaction_example
+options_file_example
 simple_example
 transaction_example


### PR DESCRIPTION
options_file_example should be added in .gitignore so that it does not show up as an untracked file in `git status`.

Test plan:
cd examples && make all
Make sure that not untracked files appear on doing a `git status`.
