### PR TITLE
Added SstFileWriter construtor without explicit comparator to JNI api

### DIFF
--- a/java/rocksjni/sst_file_writerjni.cc
+++ b/java/rocksjni/sst_file_writerjni.cc
@@ -22,7 +22,7 @@
  * Method:    newSstFileWriter
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter(JNIEnv *env, jclass jcls,
+jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJJ(JNIEnv *env, jclass jcls,
                                                       jlong jenvoptions,
                                                       jlong joptions,
                                                       jlong jcomparator) {
@@ -32,6 +32,22 @@ jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter(JNIEnv *env, jclass jcls,
   auto *comparator = reinterpret_cast<const rocksdb::Comparator *>(jcomparator);
   rocksdb::SstFileWriter *sst_file_writer =
       new rocksdb::SstFileWriter(*env_options, *options, comparator);
+  return reinterpret_cast<jlong>(sst_file_writer);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileWriter
+ * Method:    newSstFileWriter
+ * Signature: (JJ)J
+ */
+jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJ(JNIEnv *env, jclass jcls,
+                                                      jlong jenvoptions,
+                                                      jlong joptions) {
+  auto *env_options =
+      reinterpret_cast<const rocksdb::EnvOptions *>(jenvoptions);
+  auto *options = reinterpret_cast<const rocksdb::Options *>(joptions);
+  rocksdb::SstFileWriter *sst_file_writer =
+      new rocksdb::SstFileWriter(*env_options, *options);
   return reinterpret_cast<jlong>(sst_file_writer);
 }
 

--- a/java/src/main/java/org/rocksdb/SstFileWriter.java
+++ b/java/src/main/java/org/rocksdb/SstFileWriter.java
@@ -16,6 +16,11 @@ public class SstFileWriter extends RocksObject {
         envOptions.nativeHandle_, options.nativeHandle_, comparator.getNativeHandle()));
   }
 
+  public SstFileWriter(final EnvOptions envOptions, final Options options) {
+    super(newSstFileWriter(
+        envOptions.nativeHandle_, options.nativeHandle_));
+  }
+
   public void open(final String filePath) throws RocksDBException {
     open(nativeHandle_, filePath);
   }
@@ -34,6 +39,9 @@ public class SstFileWriter extends RocksObject {
 
   private native static long newSstFileWriter(
       final long envOptionsHandle, final long optionsHandle, final long userComparatorHandle);
+
+  private native static long newSstFileWriter(final long envOptionsHandle,
+      final long optionsHandle);
 
   private native void open(final long handle, final String filePath) throws RocksDBException;
 


### PR DESCRIPTION
Adding API missing after https://github.com/facebook/rocksdb/commit/1ffbdfd9a7637b6517053842386d71df2cd00d9b#diff-b94146418eed4a9c1bf324041b95b279.

@adamretter  @IslamAbdelRahman 

Tested locally.