### PR TITLE
Fix segmentation fault caused by #1961

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -732,7 +732,9 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         if (rep->table_options.pin_l0_filter_and_index_blocks_in_cache &&
             level == 0) {
           rep->filter_entry = filter_entry;
-          rep->filter_entry.value->SetLevel(level);
+          if (rep->filter_entry.value != nullptr) {
+            rep->filter_entry.value->SetLevel(level);
+          }
         } else {
           filter_entry.Release(table_options.block_cache.get());
         }


### PR DESCRIPTION
Summary:
Fixes #1961 which causes a segfault when filter_policy is nullptr and both
pin_l0_filter_and_index_blocks_in_cache/cache_index_and_filter_blocks
are set.

Test Plan:
TEST_TMPDIR=/data/rate_limit_bench/ ./db_bench -benchmarks=fillrandom
-pin_l0_filter_and_index_blocks_in_cache=true
-cache_index_and_filter_blocks=true

Reviewers:

Subscribers:

Tasks:

Tags:

Blame Revision: