### PR TITLE
Fix Windows Build broken by a recent commit

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2965,7 +2965,6 @@ TEST_F(DBTest, DynamicMemtableOptions) {
   const uint64_t k64KB = 1 << 16;
   const uint64_t k128KB = 1 << 17;
   const uint64_t k5KB = 5 * 1024;
-  const int kNumPutsBeforeWaitForFlush = 64;
   Options options;
   options.env = env_;
   options.create_if_missing = true;
@@ -2981,6 +2980,7 @@ TEST_F(DBTest, DynamicMemtableOptions) {
   DestroyAndReopen(options);
 
   auto gen_l0_kb = [this](int size) {
+    const int kNumPutsBeforeWaitForFlush = 64;
     Random rnd(301);
     for (int i = 0; i < size; i++) {
       ASSERT_OK(Put(Key(i), RandomString(&rnd, 1024)));


### PR DESCRIPTION
Windows build was broken by f4fce4751e16e5789bc7db60b88996298b97e47c and the error is:

c:\projects\rocksdb\db\db_test.cc(2993): error C3493: 'kNumPutsBeforeWaitForFlush' cannot be implicitly captured because no default capture mode has been specified
