### PR TITLE
Hide usage of compaction_options_fifo from lite build

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2776,8 +2776,10 @@ class Benchmark {
     options.allow_mmap_writes = FLAGS_mmap_write;
     options.use_direct_reads = FLAGS_use_direct_reads;
     options.use_direct_writes = FLAGS_use_direct_writes;
+#ifndef ROCKSDB_LITE
     options.compaction_options_fifo = CompactionOptionsFIFO(
        FLAGS_fifo_compaction_max_table_files_size_mb * 1024 * 1024);
+#endif  // ROCKSDB_LITE
     if (FLAGS_prefix_size != 0) {
       options.prefix_extractor.reset(
           NewFixedPrefixTransform(FLAGS_prefix_size));


### PR DESCRIPTION
Summary:
...to fix lite build error.

Test Plan:
  make OPT="-DROCKSDB_LITE" all