### PR TITLE
Move WriteThread::Writer to separate file (pipeline write part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ set(SOURCES
         db/version_edit.cc
         db/version_set.cc
         db/wal_manager.cc
+        db/writer.cc
         db/write_batch.cc
         db/write_batch_base.cc
         db/write_controller.cc

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -33,6 +33,7 @@
 #include "db/wal_manager.h"
 #include "db/write_controller.h"
 #include "db/write_thread.h"
+#include "db/writer.h"
 #include "memtable_list.h"
 #include "port/port.h"
 #include "rocksdb/db.h"
@@ -544,12 +545,12 @@ class DBImpl : public DB {
                                         RangeDelAggregator* range_del_agg);
 
   // Except in DB::Open(), WriteOptionsFile can only be called when:
-  // 1. WriteThread::Writer::EnterUnbatched() is used.
+  // 1. WriteThread::EnterUnbatched() is used.
   // 2. db_mutex is held
   Status WriteOptionsFile();
 
   // The following two functions can only be called when:
-  // 1. WriteThread::Writer::EnterUnbatched() is used.
+  // 1. WriteThread::EnterUnbatched() is used.
   // 2. db_mutex is NOT held
   Status RenameTempFileToOptionsFile(const std::string& file_name);
   Status DeleteObsoleteOptionsFiles();
@@ -697,7 +698,7 @@ class DBImpl : public DB {
   Status PreprocessWrite(const WriteOptions& write_options, bool need_log_sync,
                          bool* logs_getting_syned, WriteContext* write_context);
 
-  Status WriteToWAL(const autovector<WriteThread::Writer*>& write_group,
+  Status WriteToWAL(const autovector<Writer*>& write_group,
                     log::Writer* log_writer, bool need_log_sync,
                     bool need_log_dir_sync, SequenceNumber sequence);
 

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -127,13 +127,13 @@ void DBImpl::TEST_UnlockMutex() {
 }
 
 void* DBImpl::TEST_BeginWrite() {
-  auto w = new WriteThread::Writer();
+  auto w = new Writer();
   write_thread_.EnterUnbatched(w, &mutex_);
   return reinterpret_cast<void*>(w);
 }
 
 void DBImpl::TEST_EndWrite(void* w) {
-  auto writer = reinterpret_cast<WriteThread::Writer*>(w);
+  auto writer = reinterpret_cast<Writer*>(w);
   write_thread_.ExitUnbatched(writer);
   delete writer;
 }

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1240,11 +1240,13 @@ public:
 // 2) During Write(), in a single-threaded write thread
 // 3) During Write(), in a concurrent context where memtables has been cloned
 // The reason is that it calls memtables->Seek(), which has a stateful cache
-Status WriteBatchInternal::InsertInto(
-    const autovector<WriteThread::Writer*>& writers, SequenceNumber sequence,
-    ColumnFamilyMemTables* memtables, FlushScheduler* flush_scheduler,
-    bool ignore_missing_column_families, uint64_t log_number, DB* db,
-    bool concurrent_memtable_writes) {
+Status WriteBatchInternal::InsertInto(const autovector<Writer*>& writers,
+                                      SequenceNumber sequence,
+                                      ColumnFamilyMemTables* memtables,
+                                      FlushScheduler* flush_scheduler,
+                                      bool ignore_missing_column_families,
+                                      uint64_t log_number, DB* db,
+                                      bool concurrent_memtable_writes) {
   MemTableInserter inserter(sequence, memtables, flush_scheduler,
                             ignore_missing_column_families, log_number, db,
                             concurrent_memtable_writes);
@@ -1262,7 +1264,7 @@ Status WriteBatchInternal::InsertInto(
   return Status::OK();
 }
 
-Status WriteBatchInternal::InsertInto(WriteThread::Writer* writer,
+Status WriteBatchInternal::InsertInto(Writer* writer,
                                       ColumnFamilyMemTables* memtables,
                                       FlushScheduler* flush_scheduler,
                                       bool ignore_missing_column_families,

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -9,11 +9,11 @@
 
 #pragma once
 #include <vector>
-#include "db/write_thread.h"
-#include "rocksdb/types.h"
-#include "rocksdb/write_batch.h"
+#include "db/writer.h"
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
+#include "rocksdb/types.h"
+#include "rocksdb/write_batch.h"
 #include "util/autovector.h"
 
 namespace rocksdb {
@@ -151,7 +151,7 @@ class WriteBatchInternal {
   //
   // Under concurrent use, the caller is responsible for making sure that
   // the memtables object itself is thread-local.
-  static Status InsertInto(const autovector<WriteThread::Writer*>& batches,
+  static Status InsertInto(const autovector<Writer*>& batches,
                            SequenceNumber sequence,
                            ColumnFamilyMemTables* memtables,
                            FlushScheduler* flush_scheduler,
@@ -170,8 +170,7 @@ class WriteBatchInternal {
                            SequenceNumber* last_seq_used = nullptr,
                            bool* has_valid_writes = nullptr);
 
-  static Status InsertInto(WriteThread::Writer* writer,
-                           ColumnFamilyMemTables* memtables,
+  static Status InsertInto(Writer* writer, ColumnFamilyMemTables* memtables,
                            FlushScheduler* flush_scheduler,
                            bool ignore_missing_column_families = false,
                            uint64_t log_number = 0, DB* db = nullptr,

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -150,13 +150,12 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                     cur_threads_waiting, cur_threads_waiting + 1));
 
                 // check my state
-                auto* writer = reinterpret_cast<WriteThread::Writer*>(arg);
+                auto* writer = reinterpret_cast<Writer*>(arg);
 
                 if (is_leader) {
-                  ASSERT_TRUE(writer->state ==
-                              WriteThread::State::STATE_GROUP_LEADER);
+                  ASSERT_TRUE(writer->state == Writer::STATE_GROUP_LEADER);
                 } else {
-                  ASSERT_TRUE(writer->state == WriteThread::State::STATE_INIT);
+                  ASSERT_TRUE(writer->state == Writer::STATE_INIT);
                 }
 
                 // (meta test) the first WriteOP should indeed be the first
@@ -178,15 +177,13 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
           rocksdb::SyncPoint::GetInstance()->SetCallBack(
               "WriteThread::JoinBatchGroup:DoneWaiting", [&](void* arg) {
                 // check my state
-                auto* writer = reinterpret_cast<WriteThread::Writer*>(arg);
+                auto* writer = reinterpret_cast<Writer*>(arg);
 
                 if (!allow_batching) {
                   // no batching so everyone should be a leader
-                  ASSERT_TRUE(writer->state ==
-                              WriteThread::State::STATE_GROUP_LEADER);
+                  ASSERT_TRUE(writer->state == Writer::STATE_GROUP_LEADER);
                 } else if (!allow_parallel) {
-                  ASSERT_TRUE(writer->state ==
-                              WriteThread::State::STATE_COMPLETED);
+                  ASSERT_TRUE(writer->state == Writer::STATE_COMPLETED);
                 }
               });
 

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "db/write_callback.h"
+#include "db/writer.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "rocksdb/types.h"
@@ -26,180 +27,6 @@ namespace rocksdb {
 
 class WriteThread {
  public:
-  enum State : uint8_t {
-    // The initial state of a writer.  This is a Writer that is
-    // waiting in JoinBatchGroup.  This state can be left when another
-    // thread informs the waiter that it has become a group leader
-    // (-> STATE_GROUP_LEADER), when a leader that has chosen to be
-    // non-parallel informs a follower that its writes have been committed
-    // (-> STATE_COMPLETED), or when a leader that has chosen to perform
-    // updates in parallel and needs this Writer to apply its batch (->
-    // STATE_PARALLEL_FOLLOWER).
-    STATE_INIT = 1,
-
-    // The state used to inform a waiting Writer that it has become the
-    // leader, and it should now build a write batch group.  Tricky:
-    // this state is not used if newest_writer_ is empty when a writer
-    // enqueues itself, because there is no need to wait (or even to
-    // create the mutex and condvar used to wait) in that case.  This is
-    // a terminal state unless the leader chooses to make this a parallel
-    // batch, in which case the last parallel worker to finish will move
-    // the leader to STATE_COMPLETED.
-    STATE_GROUP_LEADER = 2,
-
-    // A Writer that has returned as a follower in a parallel group.
-    // It should apply its batch to the memtable and then call
-    // CompleteParallelWorker.  When someone calls ExitAsBatchGroupLeader
-    // or EarlyExitParallelGroup this state will get transitioned to
-    // STATE_COMPLETED.
-    STATE_PARALLEL_FOLLOWER = 4,
-
-    // A follower whose writes have been applied, or a parallel leader
-    // whose followers have all finished their work.  This is a terminal
-    // state.
-    STATE_COMPLETED = 8,
-
-    // A state indicating that the thread may be waiting using StateMutex()
-    // and StateCondVar()
-    STATE_LOCKED_WAITING = 16,
-  };
-
-  struct Writer;
-
-  struct ParallelGroup {
-    Writer* leader;
-    Writer* last_writer;
-    SequenceNumber last_sequence;
-    bool early_exit_allowed;
-    // before running goes to zero, status needs leader->StateMutex()
-    Status status;
-    std::atomic<uint32_t> running;
-  };
-
-  // Information kept for every waiting writer.
-  struct Writer {
-    WriteBatch* batch;
-    bool sync;
-    bool no_slowdown;
-    bool disable_wal;
-    bool disable_memtable;
-    uint64_t log_used;  // log number that this batch was inserted into
-    uint64_t log_ref;   // log number that memtable insert should reference
-    bool in_batch_group;
-    WriteCallback* callback;
-    bool made_waitable;          // records lazy construction of mutex and cv
-    std::atomic<uint8_t> state;  // write under StateMutex() or pre-link
-    ParallelGroup* parallel_group;
-    SequenceNumber sequence;  // the sequence number to use
-    Status status;            // status of memtable inserter
-    Status callback_status;   // status returned by callback->Callback()
-    std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;
-    std::aligned_storage<sizeof(std::condition_variable)>::type state_cv_bytes;
-    Writer* link_older;  // read/write only before linking, or as leader
-    Writer* link_newer;  // lazy, read/write only before linking, or as leader
-
-    Writer()
-        : batch(nullptr),
-          sync(false),
-          no_slowdown(false),
-          disable_wal(false),
-          disable_memtable(false),
-          log_used(0),
-          log_ref(0),
-          in_batch_group(false),
-          callback(nullptr),
-          made_waitable(false),
-          state(STATE_INIT),
-          parallel_group(nullptr),
-          link_older(nullptr),
-          link_newer(nullptr) {}
-
-    Writer(const WriteOptions& write_options, WriteBatch* _batch,
-           WriteCallback* _callback, uint64_t _log_ref, bool _disable_memtable)
-        : batch(_batch),
-          sync(write_options.sync),
-          no_slowdown(write_options.no_slowdown),
-          disable_wal(write_options.disableWAL),
-          disable_memtable(_disable_memtable),
-          log_used(0),
-          log_ref(_log_ref),
-          in_batch_group(false),
-          callback(_callback),
-          made_waitable(false),
-          state(STATE_INIT),
-          parallel_group(nullptr),
-          link_older(nullptr),
-          link_newer(nullptr) {}
-
-    ~Writer() {
-      if (made_waitable) {
-        StateMutex().~mutex();
-        StateCV().~condition_variable();
-      }
-    }
-
-    bool CheckCallback(DB* db) {
-      if (callback != nullptr) {
-        callback_status = callback->Callback(db);
-      }
-      return callback_status.ok();
-    }
-
-    void CreateMutex() {
-      if (!made_waitable) {
-        // Note that made_waitable is tracked separately from state
-        // transitions, because we can't atomically create the mutex and
-        // link into the list.
-        made_waitable = true;
-        new (&state_mutex_bytes) std::mutex;
-        new (&state_cv_bytes) std::condition_variable;
-      }
-    }
-
-    // returns the aggregate status of this Writer
-    Status FinalStatus() {
-      if (!status.ok()) {
-        // a non-ok memtable write status takes presidence
-        assert(callback == nullptr || callback_status.ok());
-        return status;
-      } else if (!callback_status.ok()) {
-        // if the callback failed then that is the status we want
-        // because a memtable insert should not have been attempted
-        assert(callback != nullptr);
-        assert(status.ok());
-        return callback_status;
-      } else {
-        // if there is no callback then we only care about
-        // the memtable insert status
-        assert(callback == nullptr || callback_status.ok());
-        return status;
-      }
-    }
-
-    bool CallbackFailed() {
-      return (callback != nullptr) && !callback_status.ok();
-    }
-
-    bool ShouldWriteToMemtable() {
-      return !CallbackFailed() && !disable_memtable;
-    }
-
-    bool ShouldWriteToWAL() { return !CallbackFailed() && !disable_wal; }
-
-    // No other mutexes may be acquired while holding StateMutex(), it is
-    // always last in the order
-    std::mutex& StateMutex() {
-      assert(made_waitable);
-      return *static_cast<std::mutex*>(static_cast<void*>(&state_mutex_bytes));
-    }
-
-    std::condition_variable& StateCV() {
-      assert(made_waitable);
-      return *static_cast<std::condition_variable*>(
-                 static_cast<void*>(&state_cv_bytes));
-    }
-  };
-
   WriteThread(uint64_t max_yield_usec, uint64_t slow_yield_usec);
 
   // IMPORTANT: None of the methods in this class rely on the db mutex
@@ -229,9 +56,8 @@ class WriteThread {
   // Writer** last_writer:   Out-param that identifies the last follower
   // autovector<WriteBatch*>* write_batch_group: Out-param of group members
   // returns:                Total batch group byte size
-  size_t EnterAsBatchGroupLeader(
-      Writer* leader, Writer** last_writer,
-      autovector<WriteThread::Writer*>* write_batch_group);
+  size_t EnterAsBatchGroupLeader(Writer* leader, Writer** last_writer,
+                                 autovector<Writer*>* write_batch_group);
 
   // Causes JoinBatchGroup to return STATE_PARALLEL_FOLLOWER for all of the
   // non-leader members of this write batch group.  Sets Writer::sequence
@@ -274,13 +100,6 @@ class WriteThread {
   // writers.
   void ExitUnbatched(Writer* w);
 
-  struct AdaptationContext {
-    const char* name;
-    std::atomic<int32_t> value;
-
-    explicit AdaptationContext(const char* name0) : name(name0), value(0) {}
-  };
-
  private:
   uint64_t max_yield_usec_;
   uint64_t slow_yield_usec_;
@@ -289,17 +108,7 @@ class WriteThread {
   // elements, adding can be done lock-free by anybody
   std::atomic<Writer*> newest_writer_;
 
-  // Waits for w->state & goal_mask using w->StateMutex().  Returns
-  // the state that satisfies goal_mask.
-  uint8_t BlockingAwaitState(Writer* w, uint8_t goal_mask);
-
-  // Blocks until w->state & goal_mask, returning the state value
-  // that satisfied the predicate.  Uses ctx to adaptively use
-  // std::this_thread::yield() to avoid mutex overheads.  ctx should be
-  // a context-dependent static.
   uint8_t AwaitState(Writer* w, uint8_t goal_mask, AdaptationContext* ctx);
-
-  void SetState(Writer* w, uint8_t new_state);
 
   // Links w into the newest_writer_ list. Sets *linked_as_leader to
   // true if w was linked directly into the leader position.  Safe to

--- a/db/writer.cc
+++ b/db/writer.cc
@@ -1,0 +1,179 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#include "db/writer.h"
+
+#include <chrono>
+
+#include "port/port.h"
+#include "util/random.h"
+
+namespace rocksdb {
+
+uint8_t Writer::BlockingAwaitState(uint8_t goal_mask) {
+  // We're going to block.  Lazily create the mutex.  We guarantee
+  // propagation of this construction to the waker via the
+  // STATE_LOCKED_WAITING state.  The waker won't try to touch the mutex
+  // or the condvar unless they CAS away the STATE_LOCKED_WAITING that
+  // we install below.
+  CreateMutex();
+
+  auto s = state.load(std::memory_order_acquire);
+  assert(s != STATE_LOCKED_WAITING);
+  if ((s & goal_mask) == 0 &&
+      state.compare_exchange_strong(s, STATE_LOCKED_WAITING)) {
+    // we have permission (and an obligation) to use StateMutex
+    std::unique_lock<std::mutex> guard(StateMutex());
+    StateCV().wait(guard, [this] {
+      return state.load(std::memory_order_relaxed) != STATE_LOCKED_WAITING;
+    });
+    s = state.load(std::memory_order_relaxed);
+  }
+  // else tricky.  Goal is met or CAS failed.  In the latter case the waker
+  // must have changed the state, and compare_exchange_strong has updated
+  // our local variable with the new one.  At the moment WriteThread never
+  // waits for a transition across intermediate states, so we know that
+  // since a state change has occurred the goal must have been met.
+  assert((s & goal_mask) != 0);
+  return s;
+}
+
+uint8_t Writer::AwaitState(uint8_t goal_mask, AdaptationContext* ctx,
+                           uint64_t max_yield_usec, uint64_t slow_yield_usec) {
+  uint8_t s;
+
+  // On a modern Xeon each loop takes about 7 nanoseconds (most of which
+  // is the effect of the pause instruction), so 200 iterations is a bit
+  // more than a microsecond.  This is long enough that waits longer than
+  // this can amortize the cost of accessing the clock and yielding.
+  for (uint32_t tries = 0; tries < 200; ++tries) {
+    s = state.load(std::memory_order_acquire);
+    if ((s & goal_mask) != 0) {
+      return s;
+    }
+    port::AsmVolatilePause();
+  }
+
+  // If we're only going to end up waiting a short period of time,
+  // it can be a lot more efficient to call std::this_thread::yield()
+  // in a loop than to block in StateMutex().  For reference, on my 4.0
+  // SELinux test server with support for syscall auditing enabled, the
+  // minimum latency between FUTEX_WAKE to returning from FUTEX_WAIT is
+  // 2.7 usec, and the average is more like 10 usec.  That can be a big
+  // drag on RockDB's single-writer design.  Of course, spinning is a
+  // bad idea if other threads are waiting to run or if we're going to
+  // wait for a long time.  How do we decide?
+  //
+  // We break waiting into 3 categories: short-uncontended,
+  // short-contended, and long.  If we had an oracle, then we would always
+  // spin for short-uncontended, always block for long, and our choice for
+  // short-contended might depend on whether we were trying to optimize
+  // RocksDB throughput or avoid being greedy with system resources.
+  //
+  // Bucketing into short or long is easy by measuring elapsed time.
+  // Differentiating short-uncontended from short-contended is a bit
+  // trickier, but not too bad.  We could look for involuntary context
+  // switches using getrusage(RUSAGE_THREAD, ..), but it's less work
+  // (portability code and CPU) to just look for yield calls that take
+  // longer than we expect.  sched_yield() doesn't actually result in any
+  // context switch overhead if there are no other runnable processes
+  // on the current core, in which case it usually takes less than
+  // a microsecond.
+  //
+  // There are two primary tunables here: the threshold between "short"
+  // and "long" waits, and the threshold at which we suspect that a yield
+  // is slow enough to indicate we should probably block.  If these
+  // thresholds are chosen well then CPU-bound workloads that don't
+  // have more threads than cores will experience few context switches
+  // (voluntary or involuntary), and the total number of context switches
+  // (voluntary and involuntary) will not be dramatically larger (maybe
+  // 2x) than the number of voluntary context switches that occur when
+  // --max_yield_wait_micros=0.
+  //
+  // There's another constant, which is the number of slow yields we will
+  // tolerate before reversing our previous decision.  Solitary slow
+  // yields are pretty common (low-priority small jobs ready to run),
+  // so this should be at least 2.  We set this conservatively to 3 so
+  // that we can also immediately schedule a ctx adaptation, rather than
+  // waiting for the next update_ctx.
+
+  const size_t kMaxSlowYieldsWhileSpinning = 3;
+
+  bool update_ctx = false;
+  bool would_spin_again = false;
+
+  if (max_yield_usec > 0) {
+    update_ctx = Random::GetTLSInstance()->OneIn(256);
+
+    if (update_ctx || ctx->value.load(std::memory_order_relaxed) >= 0) {
+      // we're updating the adaptation statistics, or spinning has >
+      // 50% chance of being shorter than max_yield_usec and causing no
+      // involuntary context switches
+      auto spin_begin = std::chrono::steady_clock::now();
+
+      // this variable doesn't include the final yield (if any) that
+      // causes the goal to be met
+      size_t slow_yield_count = 0;
+
+      auto iter_begin = spin_begin;
+      while ((iter_begin - spin_begin) <=
+             std::chrono::microseconds(max_yield_usec)) {
+        std::this_thread::yield();
+
+        s = state.load(std::memory_order_acquire);
+        if ((s & goal_mask) != 0) {
+          // success
+          would_spin_again = true;
+          break;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        if (now == iter_begin ||
+            now - iter_begin >= std::chrono::microseconds(slow_yield_usec)) {
+          // conservatively count it as a slow yield if our clock isn't
+          // accurate enough to measure the yield duration
+          ++slow_yield_count;
+          if (slow_yield_count >= kMaxSlowYieldsWhileSpinning) {
+            // Not just one ivcsw, but several.  Immediately update ctx
+            // and fall back to blocking
+            update_ctx = true;
+            break;
+          }
+        }
+        iter_begin = now;
+      }
+    }
+  }
+
+  if ((s & goal_mask) == 0) {
+    s = BlockingAwaitState(goal_mask);
+  }
+
+  if (update_ctx) {
+    auto v = ctx->value.load(std::memory_order_relaxed);
+    // fixed point exponential decay with decay constant 1/1024, with +1
+    // and -1 scaled to avoid overflow for int32_t
+    v = v + (v / 1024) + (would_spin_again ? 1 : -1) * 16384;
+    ctx->value.store(v, std::memory_order_relaxed);
+  }
+
+  assert((s & goal_mask) != 0);
+  return s;
+}
+
+void Writer::SetState(uint8_t new_state) {
+  auto s = state.load(std::memory_order_acquire);
+  if (s == STATE_LOCKED_WAITING ||
+      !state.compare_exchange_strong(s, new_state)) {
+    assert(s == STATE_LOCKED_WAITING);
+
+    std::lock_guard<std::mutex> guard(StateMutex());
+    assert(state.load(std::memory_order_relaxed) != new_state);
+    state.store(new_state, std::memory_order_relaxed);
+    StateCV().notify_one();
+  }
+}
+
+}  // namespace rocksdb

--- a/db/writer.h
+++ b/db/writer.h
@@ -1,0 +1,218 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <type_traits>
+
+#include "db/write_callback.h"
+#include "rocksdb/options.h"
+#include "rocksdb/status.h"
+#include "rocksdb/write_batch.h"
+
+namespace rocksdb {
+
+// Utiity structs used by WriteThread.
+
+struct ParallelGroup;
+struct AdaptationContext;
+
+// Information kept for every waiting writer.
+struct Writer {
+  enum State : uint8_t {
+    // The initial state of a writer.  This is a Writer that is
+    // waiting in JoinBatchGroup.  This state can be left when another
+    // thread informs the waiter that it has become a group leader
+    // (-> STATE_GROUP_LEADER), when a leader that has chosen to be
+    // non-parallel informs a follower that its writes have been committed
+    // (-> STATE_COMPLETED), or when a leader that has chosen to perform
+    // updates in parallel and needs this Writer to apply its batch (->
+    // STATE_PARALLEL_FOLLOWER).
+    STATE_INIT = 1,
+
+    // The state used to inform a waiting Writer that it has become the
+    // leader, and it should now build a write batch group.  Tricky:
+    // this state is not used if newest_writer_ is empty when a writer
+    // enqueues itself, because there is no need to wait (or even to
+    // create the mutex and condvar used to wait) in that case.  This is
+    // a terminal state unless the leader chooses to make this a parallel
+    // batch, in which case the last parallel worker to finish will move
+    // the leader to STATE_COMPLETED.
+    STATE_GROUP_LEADER = 2,
+
+    // A Writer that has returned as a follower in a parallel group.
+    // It should apply its batch to the memtable and then call
+    // CompleteParallelWorker.  When someone calls ExitAsBatchGroupLeader
+    // or EarlyExitParallelGroup this state will get transitioned to
+    // STATE_COMPLETED.
+    STATE_PARALLEL_FOLLOWER = 4,
+
+    // A follower whose writes have been applied, or a parallel leader
+    // whose followers have all finished their work.  This is a terminal
+    // state.
+    STATE_COMPLETED = 8,
+
+    // A state indicating that the thread may be waiting using StateMutex()
+    // and StateCondVar()
+    STATE_LOCKED_WAITING = 16,
+  };
+
+  Writer()
+      : batch(nullptr),
+        sync(false),
+        no_slowdown(false),
+        disable_wal(false),
+        disable_memtable(false),
+        log_used(0),
+        log_ref(0),
+        in_batch_group(false),
+        callback(nullptr),
+        made_waitable(false),
+        state(STATE_INIT),
+        parallel_group(nullptr),
+        link_older(nullptr),
+        link_newer(nullptr) {}
+
+  Writer(const WriteOptions& write_options, WriteBatch* _batch,
+         WriteCallback* _callback, uint64_t _log_ref, bool _disable_memtable)
+      : batch(_batch),
+        sync(write_options.sync),
+        no_slowdown(write_options.no_slowdown),
+        disable_wal(write_options.disableWAL),
+        disable_memtable(_disable_memtable),
+        log_used(0),
+        log_ref(_log_ref),
+        in_batch_group(false),
+        callback(_callback),
+        made_waitable(false),
+        state(STATE_INIT),
+        parallel_group(nullptr),
+        link_older(nullptr),
+        link_newer(nullptr) {}
+
+  ~Writer() {
+    if (made_waitable) {
+      StateMutex().~mutex();
+      StateCV().~condition_variable();
+    }
+  }
+
+  bool CheckCallback(DB* db) {
+    if (callback != nullptr) {
+      callback_status = callback->Callback(db);
+    }
+    return callback_status.ok();
+  }
+
+  void CreateMutex() {
+    if (!made_waitable) {
+      // Note that made_waitable is tracked separately from state
+      // transitions, because we can't atomically create the mutex and
+      // link into the list.
+      made_waitable = true;
+      new (&state_mutex_bytes) std::mutex;
+      new (&state_cv_bytes) std::condition_variable;
+    }
+  }
+
+  // returns the aggregate status of this Writer
+  Status FinalStatus() {
+    if (!status.ok()) {
+      // a non-ok memtable write status takes presidence
+      assert(callback == nullptr || callback_status.ok());
+      return status;
+    } else if (!callback_status.ok()) {
+      // if the callback failed then that is the status we want
+      // because a memtable insert should not have been attempted
+      assert(callback != nullptr);
+      assert(status.ok());
+      return callback_status;
+    } else {
+      // if there is no callback then we only care about
+      // the memtable insert status
+      assert(callback == nullptr || callback_status.ok());
+      return status;
+    }
+  }
+
+  bool CallbackFailed() {
+    return (callback != nullptr) && !callback_status.ok();
+  }
+
+  bool ShouldWriteToMemtable() {
+    return !CallbackFailed() && !disable_memtable;
+  }
+
+  bool ShouldWriteToWAL() { return !CallbackFailed() && !disable_wal; }
+
+  // No other mutexes may be acquired while holding StateMutex(), it is
+  // always last in the order
+  std::mutex& StateMutex() {
+    assert(made_waitable);
+    return *static_cast<std::mutex*>(static_cast<void*>(&state_mutex_bytes));
+  }
+
+  std::condition_variable& StateCV() {
+    assert(made_waitable);
+    return *static_cast<std::condition_variable*>(
+        static_cast<void*>(&state_cv_bytes));
+  }
+
+  // Waits for state & goal_mask using StateMutex().  Returns
+  // the state that satisfies goal_mask.
+  uint8_t BlockingAwaitState(uint8_t goal_mask);
+
+  // Blocks until state & goal_mask, returning the state value
+  // that satisfied the predicate.  Uses ctx to adaptively use
+  // std::this_thread::yield() to avoid mutex overheads.  ctx should be
+  // a context-dependent static.
+  uint8_t AwaitState(uint8_t goal_mask, AdaptationContext* ctx,
+                     uint64_t max_yield_usec, uint64_t slow_yield_usec);
+
+  // Setting state to new_state.
+  void SetState(uint8_t new_state);
+
+  WriteBatch* batch;
+  bool sync;
+  bool no_slowdown;
+  bool disable_wal;
+  bool disable_memtable;
+  uint64_t log_used;  // log number that this batch was inserted into
+  uint64_t log_ref;   // log number that memtable insert should reference
+  bool in_batch_group;
+  WriteCallback* callback;
+  bool made_waitable;          // records lazy construction of mutex and cv
+  std::atomic<uint8_t> state;  // write under StateMutex() or pre-link
+  ParallelGroup* parallel_group;
+  SequenceNumber sequence;  // the sequence number to use
+  Status status;            // status of memtable inserter
+  Status callback_status;   // status returned by callback->Callback()
+  std::aligned_storage<sizeof(std::mutex)>::type state_mutex_bytes;
+  std::aligned_storage<sizeof(std::condition_variable)>::type state_cv_bytes;
+  Writer* link_older;  // read/write only before linking, or as leader
+  Writer* link_newer;  // lazy, read/write only before linking, or as leader
+};
+
+struct ParallelGroup {
+  Writer* leader;
+  Writer* last_writer;
+  SequenceNumber last_sequence;
+  bool early_exit_allowed;
+  // before running goes to zero, status needs leader->StateMutex()
+  Status status;
+  std::atomic<uint32_t> running;
+};
+
+struct AdaptationContext {
+  const char* name;
+  std::atomic<int32_t> value;
+
+  explicit AdaptationContext(const char* name0) : name(name0), value(0) {}
+};
+
+}  // namespace rocksdb

--- a/src.mk
+++ b/src.mk
@@ -45,6 +45,7 @@ LIB_SOURCES =                                                   \
   db/version_edit.cc                                            \
   db/version_set.cc                                             \
   db/wal_manager.cc                                             \
+	db/writer.cc                                                  \
   db/write_batch.cc                                             \
   db/write_batch_base.cc                                        \
   db/write_controller.cc                                        \

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -522,7 +522,7 @@ void WriteableCacheFile::ClearBuffers() {
 //
 ThreadedWriter::ThreadedWriter(PersistentCacheTier* const cache,
                                const size_t qdepth, const size_t io_size)
-    : Writer(cache), io_size_(io_size) {
+    : FileWriter(cache), io_size_(io_size) {
   for (size_t i = 0; i < qdepth; ++i) {
     port::Thread th(&ThreadedWriter::ThreadMain, this);
     threads_.push_back(std::move(th));

--- a/utilities/persistent_cache/block_cache_tier_file.h
+++ b/utilities/persistent_cache/block_cache_tier_file.h
@@ -66,14 +66,15 @@ struct LogicalBlockAddress {
 
 typedef LogicalBlockAddress LBA;
 
-// class Writer
+// class FileWriter
 //
-// Writer is the abstraction used for writing data to file. The component can be
+// FileWriter is the abstraction used for writing data to file. The component
+// can be
 // multithreaded. It is the last step of write pipeline
-class Writer {
+class FileWriter {
  public:
-  explicit Writer(PersistentCacheTier* const cache) : cache_(cache) {}
-  virtual ~Writer() {}
+  explicit FileWriter(PersistentCacheTier* const cache) : cache_(cache) {}
+  virtual ~FileWriter() {}
 
   // write buffer to file at the given offset
   virtual void Write(WritableFile* const file, CacheWriteBuffer* buf,
@@ -175,7 +176,7 @@ class RandomAccessCacheFile : public BlockCacheFile {
 class WriteableCacheFile : public RandomAccessCacheFile {
  public:
   explicit WriteableCacheFile(Env* const env, CacheWriteBufferAllocator* alloc,
-                              Writer* writer, const std::string& dir,
+                              FileWriter* writer, const std::string& dir,
                               const uint32_t cache_id, const uint32_t max_size,
                               const std::shared_ptr<Logger>& log)
       : RandomAccessCacheFile(env, dir, cache_id, log),
@@ -233,7 +234,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
   //  The buffers are flushed to disk serially for a given file
 
   CacheWriteBufferAllocator* const alloc_ = nullptr;  // Buffer provider
-  Writer* const writer_ = nullptr;                    // File writer thread
+  FileWriter* const writer_ = nullptr;                // File writer thread
   std::unique_ptr<WritableFile> file_;   // RocksDB Env file abstraction
   std::vector<CacheWriteBuffer*> bufs_;  // Written buffers
   uint32_t size_ = 0;                    // Size of the file
@@ -250,7 +251,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
 //
 // Abstraction to do writing to device. It is part of pipelined architecture.
 //
-class ThreadedWriter : public Writer {
+class ThreadedWriter : public FileWriter {
  public:
   // Representation of IO to device
   struct IO {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1014,7 +1014,7 @@ TEST_P(TransactionTest, TwoPhaseMultiThreadTest) {
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "WriteThread::JoinBatchGroup:Wait", [&](void* arg) {
-        auto* writer = reinterpret_cast<WriteThread::Writer*>(arg);
+        auto* writer = reinterpret_cast<Writer*>(arg);
 
         if (writer->ShouldWriteToWAL()) {
           t_wait_on_prepare.fetch_add(1);


### PR DESCRIPTION
Summary: Yet another refactor to make it easier for me to plugin the
pipeline write code. Moving `WriteThread::Writer` to its separate file and
move state transition methods (`BlockingAwaitState()`, `AwaitState()` and
`SetState()`) to `Writer`. Later I'll reuse the `Writer` class in
pipeline write implementation. I'm also changing the class with the same
name in block_cache_tier_file.h to `FileWriter` since there's naming
conflict.

Stacks on #2042.

Test Plan:
Since there's no logic change, I'll just make sure existing test all
pass.