### PR TITLE
Added naming of backup engine threads

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -647,8 +647,10 @@ Status BackupEngineImpl::Initialize() {
   // background
   for (int t = 0; t < options_.max_background_operations; t++) {
     threads_.emplace_back([this]() {
-#ifdef OS_LINUX
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
       pthread_setname_np(pthread_self(), "backup_engine");
+#endif
 #endif
       CopyOrCreateWorkItem work_item;
       while (files_to_copy_or_create_.read(work_item)) {

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -647,7 +647,9 @@ Status BackupEngineImpl::Initialize() {
   // background
   for (int t = 0; t < options_.max_background_operations; t++) {
     threads_.emplace_back([this]() {
+#ifdef OS_LINUX
       pthread_setname_np(pthread_self(), "backup_engine");
+#endif
       CopyOrCreateWorkItem work_item;
       while (files_to_copy_or_create_.read(work_item)) {
         CopyOrCreateResult result;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -659,7 +659,7 @@ Status BackupEngineImpl::Initialize() {
       }
     });
   }
-
+  pthread_setname_np(pthread_self(), "backup_engine");
   ROCKS_LOG_INFO(options_.info_log, "Initialized BackupEngine");
 
   return Status::OK();

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -647,6 +647,7 @@ Status BackupEngineImpl::Initialize() {
   // background
   for (int t = 0; t < options_.max_background_operations; t++) {
     threads_.emplace_back([this]() {
+      pthread_setname_np(pthread_self(), "backup_engine");
       CopyOrCreateWorkItem work_item;
       while (files_to_copy_or_create_.read(work_item)) {
         CopyOrCreateResult result;
@@ -659,7 +660,6 @@ Status BackupEngineImpl::Initialize() {
       }
     });
   }
-  pthread_setname_np(pthread_self(), "backup_engine");
   ROCKS_LOG_INFO(options_.info_log, "Initialized BackupEngine");
 
   return Status::OK();


### PR DESCRIPTION
Changed the naming of backup engine threads from "ldb" to "backup_engine"
Test Plan:
<img width="1573" alt="screen shot 2017-03-29 at 10 23 46 am" src="https://cloud.githubusercontent.com/assets/7945758/24468074/e8a83e86-146b-11e7-8944-3552e2272759.png">
