### PR TITLE
Update RocksDBCommonHelper to use escapeshellarg

### DIFF
--- a/arcanist_util/config/RocksDBCommonHelper.php
+++ b/arcanist_util/config/RocksDBCommonHelper.php
@@ -27,7 +27,7 @@ function postURL($diffID, $url) {
       (int)$diffID,
     'link' => $url
   );
-  $cmd = 'echo ' . escapeshellarg(fb_json_encode($cmd_args))
+  $cmd = 'echo ' . escapeshellarg(json_encode($cmd_args))
          . ' | arc call-conduit differential.updateunitresults';
   shell_exec($cmd);
 }
@@ -42,7 +42,7 @@ function buildUpdateTestStatusCmd($diffID, $test, $status) {
     'name' => $test,
     'result' => $status
   );
-  $cmd = 'echo ' . escapeshellarg(fb_json_encode($cmd_args))
+  $cmd = 'echo ' . escapeshellarg(json_encode($cmd_args))
          . ' | arc call-conduit differential.updateunitresults';
   return $cmd;
 }


### PR DESCRIPTION
Most of the data used here in shell commands is not generated directly from user input but some data (ie: from environment variables) may have been external influenced. It is a good practice to escape this data before using it in a shell command.