### PR TITLE
Cleanup of ThreadStatusUtil structures should use the DB's reference

### DIFF
--- a/util/thread_status_util.cc
+++ b/util/thread_status_util.cc
@@ -144,10 +144,11 @@ void ThreadStatusUtil::EraseColumnFamilyInfo(
 }
 
 void ThreadStatusUtil::EraseDatabaseInfo(const DB* db) {
-  if (thread_updater_local_cache_ == nullptr) {
+  ThreadStatusUpdater* thread_updater = db->GetEnv()->GetThreadStatusUpdater();
+  if (thread_updater == nullptr) {
     return;
   }
-  thread_updater_local_cache_->EraseDatabaseInfo(db);
+  thread_updater->EraseDatabaseInfo(db);
 }
 
 bool ThreadStatusUtil::MaybeInitThreadLocalUpdater(const Env* env) {


### PR DESCRIPTION
instead of thread_local

Summary:

The cleanup path for the rocksdb database might not have the
thread_updater_local_cache_ pointer initialized because the thread
executing the cleanup is likely not a rocksdb thread. This results in a
memory leak detected by Valgrind. The cleanup code path should use the
thread_status_updater pointer obtained from the DB object instead of a
thread local one.

Test Plan:

Run unit tests and myrocks's rocksdb.show_engine test under Valgrind