### PR TITLE
Fix CompactRange incorrect buffer release

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1959,8 +1959,8 @@ bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
     s = db->CompactRange(compact_options, &begin_slice, &end_slice);
   }
 
-  env->ReleaseByteArrayElements(jend, begin, JNI_ABORT);
-  env->ReleaseByteArrayElements(jbegin, end, JNI_ABORT);
+  env->ReleaseByteArrayElements(jend, end, JNI_ABORT);
+  env->ReleaseByteArrayElements(jbegin, begin, JNI_ABORT);
 
   if (s.ok()) {
     return true;


### PR DESCRIPTION
While running `make jtest` using IBM Java, it fails at compactRangeToLevel with the below error.

```
Run: org.rocksdb.RocksDBTest testing now -> compactRangeToLevel
JVMJNCK056E JNI error in ReleaseByteArrayElements: Got memory 0x00003FFF94AA8908 from object 0x00000000000C7F78, releasing from 0x00000000000C7F68
JVMJNCK077E Error detected in org/rocksdb/RocksDB.compactRange0(J[BI[BIZII)V

JVMJNCK024E JNI error detected. Aborting.
JVMJNCK025I Use -Xcheck:jni:nonfatal to continue running when errors are detected.

Fatal error: JNI error
Makefile:205: recipe for target 'run_test' failed
make[1]: *** [run_test] Error 87
make[1]: Leaving directory '/home/ubuntu/rocksdb/java'
Makefile:1542: recipe for target 'jtest' failed
make: *** [jtest] Error 2
```

After checking the code, it is vivid that we are messing up the `ReleaseByteArrayElements` args in `rocksdb_compactrange_helper`.

```
   .................
   1959     s = db->CompactRange(compact_options, &begin_slice, &end_slice);
   1960   }
   1961
   1962   env->ReleaseByteArrayElements(jend, **begin**, JNI_ABORT);
   1963   env->ReleaseByteArrayElements(jbegin, **end**, JNI_ABORT);
   1964
   1965   if (s.ok()) {
   1966     return true;
   .................
```

Seems like IBM java tends to be more thorough with its JNI checks when compared to OpenJDK.