### PR TITLE
Add a notice on gflags installation in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,10 @@ makes use of SSE4, add 'USE_SSE=1' before your make commands, like this: `USE_SS
               cd gflags
               ./configure && make && sudo make install
 
+      **Notice**: Once installed, please add the include path for gflags to your CPATH env var and the
+      lib path to LIBRARY_PATH. If installed with default settings, the lib will be /usr/local/lib
+      and the include path will be /usr/local/include.
+
     * Install snappy:
 
               wget https://github.com/google/snappy/releases/download/1.1.4/snappy-1.1.4.tar.gz


### PR DESCRIPTION
Summary:
Add a notice on gflags installation to help people build and install
RocksDB from source code correctly.
Please see https://github.com/facebook/rocksdb/issues/1775