### PR TITLE
disable test: DeleteSchedulerTest.DynamicRateLimiting1

### DIFF
--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -423,7 +423,7 @@ TEST_F(DeleteSchedulerTest, MoveToTrashError) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-TEST_F(DeleteSchedulerTest, DynamicRateLimiting1) {
+TEST_F(DeleteSchedulerTest, DISABLED_DynamicRateLimiting1) {
   std::vector<uint64_t> penalties;
   int bg_delete_file = 0;
   int fg_delete_file = 0;


### PR DESCRIPTION
temporarily disable since it isn't working on travis.

Test Plan: 
```
$ TEST_TMPDIR=/dev/shm ./delete_scheduler_test
...
[  PASSED  ] 8 tests.

YOU HAVE 1 DISABLED TEST
```