### PR TITLE
replace sometimes-undefined uint type with unsigned int

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -607,7 +607,7 @@ static void GetJemallocStatus(void* mstat_arg, const char* status) {
 static void DumpMallocStats(std::string* stats) {
 #ifdef ROCKSDB_JEMALLOC
   MallocStatus mstat;
-  const uint kMallocStatusLen = 1000000;
+  const unsigned int kMallocStatusLen = 1000000;
   std::unique_ptr<char[]> buf{new char[kMallocStatusLen + 1]};
   mstat.cur = buf.get();
   mstat.end = buf.get() + kMallocStatusLen;


### PR DESCRIPTION
`uint` is nonstandard and not a built-in type on all compilers; replace it
with the always-valid `unsigned int`. I assume this went unnoticed because
it's inside an `#ifdef ROCKDB_JEMALLOC`.