### PR TITLE
Revert "delete fallocate with punch_hole"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,7 +21,6 @@
 
 ### Bug Fixes
 * Fix the bug that iterator may skip keys
-* Remove calling fallocate with FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE flag to circumvent a kernel bug that changes file size after this call on XFS
 
 ## 5.2.0 (02/08/2017)
 ### Public API Change

--- a/util/io_posix.cc
+++ b/util/io_posix.cc
@@ -751,6 +751,29 @@ Status PosixWritableFile::Close() {
     // but it will be nice to log these errors.
     int dummy __attribute__((unused));
     dummy = ftruncate(fd_, filesize_);
+#if defined(ROCKSDB_FALLOCATE_PRESENT) && !defined(TRAVIS)
+    // in some file systems, ftruncate only trims trailing space if the
+    // new file size is smaller than the current size. Calling fallocate
+    // with FALLOC_FL_PUNCH_HOLE flag to explicitly release these unused
+    // blocks. FALLOC_FL_PUNCH_HOLE is supported on at least the following
+    // filesystems:
+    //   XFS (since Linux 2.6.38)
+    //   ext4 (since Linux 3.0)
+    //   Btrfs (since Linux 3.7)
+    //   tmpfs (since Linux 3.5)
+    // We ignore error since failure of this operation does not affect
+    // correctness.
+    // TRAVIS - this code does not work on TRAVIS filesystems.
+    // the FALLOC_FL_KEEP_SIZE option is expected to not change the size
+    // of the file, but it does. Simple strace report will show that.
+    // While we work with Travis-CI team to figure out if this is a
+    // quirk of Docker/AUFS, we will comment this out.
+    IOSTATS_TIMER_GUARD(allocate_nanos);
+    if (allow_fallocate_) {
+      fallocate(fd_, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, filesize_,
+                block_size * last_allocated_block - filesize_);
+    }
+#endif
   }
 
   if (close(fd_) < 0) {


### PR DESCRIPTION
This reverts commit 0fd574926cc9be7309c2247092d6b337fb022a5d.
It breaks tmpfs on kernel 4.0 or earlier. We will wait for the fix before remove this part