### PR TITLE
Ensure use-before-move

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -357,7 +357,8 @@ Status RangeDelAggregator::AddTombstone(RangeTombstone tombstone) {
       ++new_range_dels_iter;
     }
   } else {
-    tombstone_map.emplace(tombstone.start_key_, std::move(tombstone));
+    auto key = tombstone.start_key_;
+    tombstone_map.emplace(std::move(key), std::move(tombstone));
   }
   return Status::OK();
 }


### PR DESCRIPTION
This was flagged by a static analyser as a possible use-after-move. This is why I believe the analyser:

Ultimately both parameters get to the perfect-forwarding constructor of `std::pair`, and it isn't specified in which order the `first` and `second` objects in the pair are constructed: if the implementation constructs the `second` object before the `first` then we are using the lvalue-reference to `tombstone.start_key_` after `tombstone` has been moved-from.