### PR TITLE
Limit maximum memory used in the WriteBatch representation

### DIFF
--- a/db/write_batch_base.cc
+++ b/db/write_batch_base.cc
@@ -8,86 +8,87 @@
 #include <string>
 
 #include "rocksdb/slice.h"
+#include "rocksdb/status.h"
 
 namespace rocksdb {
 
 // Simple implementation of SlicePart variants of Put().  Child classes
 // can override these method with more performant solutions if they choose.
-void WriteBatchBase::Put(ColumnFamilyHandle* column_family,
-                         const SliceParts& key, const SliceParts& value) {
-  std::string key_buf, value_buf;
-  Slice key_slice(key, &key_buf);
-  Slice value_slice(value, &value_buf);
-
-  Put(column_family, key_slice, value_slice);
-}
-
-void WriteBatchBase::Put(const SliceParts& key, const SliceParts& value) {
-  std::string key_buf, value_buf;
-  Slice key_slice(key, &key_buf);
-  Slice value_slice(value, &value_buf);
-
-  Put(key_slice, value_slice);
-}
-
-void WriteBatchBase::Delete(ColumnFamilyHandle* column_family,
-                            const SliceParts& key) {
-  std::string key_buf;
-  Slice key_slice(key, &key_buf);
-  Delete(column_family, key_slice);
-}
-
-void WriteBatchBase::Delete(const SliceParts& key) {
-  std::string key_buf;
-  Slice key_slice(key, &key_buf);
-  Delete(key_slice);
-}
-
-void WriteBatchBase::SingleDelete(ColumnFamilyHandle* column_family,
-                                  const SliceParts& key) {
-  std::string key_buf;
-  Slice key_slice(key, &key_buf);
-  SingleDelete(column_family, key_slice);
-}
-
-void WriteBatchBase::SingleDelete(const SliceParts& key) {
-  std::string key_buf;
-  Slice key_slice(key, &key_buf);
-  SingleDelete(key_slice);
-}
-
-void WriteBatchBase::DeleteRange(ColumnFamilyHandle* column_family,
-                                 const SliceParts& begin_key,
-                                 const SliceParts& end_key) {
-  std::string begin_key_buf, end_key_buf;
-  Slice begin_key_slice(begin_key, &begin_key_buf);
-  Slice end_key_slice(end_key, &end_key_buf);
-  DeleteRange(column_family, begin_key_slice, end_key_slice);
-}
-
-void WriteBatchBase::DeleteRange(const SliceParts& begin_key,
-                                 const SliceParts& end_key) {
-  std::string begin_key_buf, end_key_buf;
-  Slice begin_key_slice(begin_key, &begin_key_buf);
-  Slice end_key_slice(end_key, &end_key_buf);
-  DeleteRange(begin_key_slice, end_key_slice);
-}
-
-void WriteBatchBase::Merge(ColumnFamilyHandle* column_family,
+Status WriteBatchBase::Put(ColumnFamilyHandle* column_family,
                            const SliceParts& key, const SliceParts& value) {
   std::string key_buf, value_buf;
   Slice key_slice(key, &key_buf);
   Slice value_slice(value, &value_buf);
 
-  Merge(column_family, key_slice, value_slice);
+  return Put(column_family, key_slice, value_slice);
 }
 
-void WriteBatchBase::Merge(const SliceParts& key, const SliceParts& value) {
+Status WriteBatchBase::Put(const SliceParts& key, const SliceParts& value) {
   std::string key_buf, value_buf;
   Slice key_slice(key, &key_buf);
   Slice value_slice(value, &value_buf);
 
-  Merge(key_slice, value_slice);
+  return Put(key_slice, value_slice);
+}
+
+Status WriteBatchBase::Delete(ColumnFamilyHandle* column_family,
+                              const SliceParts& key) {
+  std::string key_buf;
+  Slice key_slice(key, &key_buf);
+  return Delete(column_family, key_slice);
+}
+
+Status WriteBatchBase::Delete(const SliceParts& key) {
+  std::string key_buf;
+  Slice key_slice(key, &key_buf);
+  return Delete(key_slice);
+}
+
+Status WriteBatchBase::SingleDelete(ColumnFamilyHandle* column_family,
+                                    const SliceParts& key) {
+  std::string key_buf;
+  Slice key_slice(key, &key_buf);
+  return SingleDelete(column_family, key_slice);
+}
+
+Status WriteBatchBase::SingleDelete(const SliceParts& key) {
+  std::string key_buf;
+  Slice key_slice(key, &key_buf);
+  return SingleDelete(key_slice);
+}
+
+Status WriteBatchBase::DeleteRange(ColumnFamilyHandle* column_family,
+                                   const SliceParts& begin_key,
+                                   const SliceParts& end_key) {
+  std::string begin_key_buf, end_key_buf;
+  Slice begin_key_slice(begin_key, &begin_key_buf);
+  Slice end_key_slice(end_key, &end_key_buf);
+  return DeleteRange(column_family, begin_key_slice, end_key_slice);
+}
+
+Status WriteBatchBase::DeleteRange(const SliceParts& begin_key,
+                                   const SliceParts& end_key) {
+  std::string begin_key_buf, end_key_buf;
+  Slice begin_key_slice(begin_key, &begin_key_buf);
+  Slice end_key_slice(end_key, &end_key_buf);
+  return DeleteRange(begin_key_slice, end_key_slice);
+}
+
+Status WriteBatchBase::Merge(ColumnFamilyHandle* column_family,
+                             const SliceParts& key, const SliceParts& value) {
+  std::string key_buf, value_buf;
+  Slice key_slice(key, &key_buf);
+  Slice value_slice(value, &value_buf);
+
+  return Merge(column_family, key_slice, value_slice);
+}
+
+Status WriteBatchBase::Merge(const SliceParts& key, const SliceParts& value) {
+  std::string key_buf, value_buf;
+  Slice key_slice(key, &key_buf);
+  Slice value_slice(value, &value_buf);
+
+  return Merge(key_slice, value_slice);
 }
 
 }  // namespace rocksdb

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -861,6 +861,18 @@ TEST_F(WriteBatchTest, SavePointTest) {
   ASSERT_EQ("", PrintContents(&batch2));
 }
 
+TEST_F(WriteBatchTest, MemoryLimitTest) {
+  Status s;
+  // The header size is 12 bytes. The two Puts take 8 bytes which gives total
+  // of 12 + 8 * 2 = 28 bytes.
+  WriteBatch batch(0, 28);
+
+  ASSERT_OK(batch.Put("a", "...."));
+  ASSERT_OK(batch.Put("b", "...."));
+  s = batch.Put("c", "....");
+  ASSERT_TRUE(s.IsMemoryLimit());
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -71,6 +71,7 @@ class Status {
     kNoSpace = 4,
     kDeadlock = 5,
     kStaleFile = 6,
+    kMemoryLimit = 7,
     kMaxSubCode
   };
 
@@ -166,6 +167,11 @@ class Status {
     return Status(kIOError, kNoSpace, msg, msg2);
   }
 
+  static Status MemoryLimit() { return Status(kAborted, kMemoryLimit); }
+  static Status MemoryLimit(const Slice& msg, const Slice& msg2 = Slice()) {
+    return Status(kAborted, kMemoryLimit, msg, msg2);
+  }
+
   // Returns true iff the status indicates success.
   bool ok() const { return code() == kOk; }
 
@@ -222,6 +228,13 @@ class Status {
   // if needed
   bool IsNoSpace() const {
     return (code() == kIOError) && (subcode() == kNoSpace);
+  }
+
+  // Returns true iff the status indicates a memory limit error.  There may be
+  // cases where we limit the memory used in certain operations (eg. the size
+  // of a write batch) in order to avoid out of memory exceptions.
+  bool IsMemoryLimit() const {
+    return (code() == kAborted) && (subcode() == kMemoryLimit);
   }
 
   // Return a string representation of this status suitable for printing.

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -100,6 +100,9 @@ struct TransactionOptions {
 
   // The number of traversals to make during deadlock detection.
   int64_t deadlock_detect_depth = 50;
+
+  // The maximum number of bytes used for the write batch. 0 means no limit.
+  size_t max_write_batch_size = 0;
 };
 
 struct KeyLockInfo {

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -88,42 +88,45 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // interface, or we can't find a column family from the column family handle
   // passed in, backup_index_comparator will be used for the column family.
   // reserved_bytes: reserved bytes in underlying WriteBatch
+  // max_bytes: maximum size of underlying WriteBatch in bytes
   // overwrite_key: if true, overwrite the key in the index when inserting
   //                the same key as previously, so iterator will never
   //                show two entries with the same key.
   explicit WriteBatchWithIndex(
       const Comparator* backup_index_comparator = BytewiseComparator(),
-      size_t reserved_bytes = 0, bool overwrite_key = false);
+      size_t reserved_bytes = 0, bool overwrite_key = false,
+      size_t max_bytes = 0);
+
   virtual ~WriteBatchWithIndex();
 
   using WriteBatchBase::Put;
-  void Put(ColumnFamilyHandle* column_family, const Slice& key,
-           const Slice& value) override;
-
-  void Put(const Slice& key, const Slice& value) override;
-
-  using WriteBatchBase::Merge;
-  void Merge(ColumnFamilyHandle* column_family, const Slice& key,
+  Status Put(ColumnFamilyHandle* column_family, const Slice& key,
              const Slice& value) override;
 
-  void Merge(const Slice& key, const Slice& value) override;
+  Status Put(const Slice& key, const Slice& value) override;
+
+  using WriteBatchBase::Merge;
+  Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
+               const Slice& value) override;
+
+  Status Merge(const Slice& key, const Slice& value) override;
 
   using WriteBatchBase::Delete;
-  void Delete(ColumnFamilyHandle* column_family, const Slice& key) override;
-  void Delete(const Slice& key) override;
+  Status Delete(ColumnFamilyHandle* column_family, const Slice& key) override;
+  Status Delete(const Slice& key) override;
 
   using WriteBatchBase::SingleDelete;
-  void SingleDelete(ColumnFamilyHandle* column_family,
-                    const Slice& key) override;
-  void SingleDelete(const Slice& key) override;
+  Status SingleDelete(ColumnFamilyHandle* column_family,
+                      const Slice& key) override;
+  Status SingleDelete(const Slice& key) override;
 
   using WriteBatchBase::DeleteRange;
-  void DeleteRange(ColumnFamilyHandle* column_family, const Slice& begin_key,
-                   const Slice& end_key) override;
-  void DeleteRange(const Slice& begin_key, const Slice& end_key) override;
+  Status DeleteRange(ColumnFamilyHandle* column_family, const Slice& begin_key,
+                     const Slice& end_key) override;
+  Status DeleteRange(const Slice& begin_key, const Slice& end_key) override;
 
   using WriteBatchBase::PutLogData;
-  void PutLogData(const Slice& blob) override;
+  Status PutLogData(const Slice& blob) override;
 
   using WriteBatchBase::Clear;
   void Clear() override;
@@ -203,6 +206,8 @@ class WriteBatchWithIndex : public WriteBatchBase {
   //         Status::NotFound() if no previous call to SetSavePoint(),
   //         or other Status on corruption.
   Status RollbackToSavePoint() override;
+
+  void SetMaxBytes(size_t max_bytes) override;
 
  private:
   struct Rep;

--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace rocksdb {
 
 class Slice;
@@ -24,59 +26,61 @@ class WriteBatchBase {
   virtual ~WriteBatchBase() {}
 
   // Store the mapping "key->value" in the database.
-  virtual void Put(ColumnFamilyHandle* column_family, const Slice& key,
-                   const Slice& value) = 0;
-  virtual void Put(const Slice& key, const Slice& value) = 0;
+  virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
+                     const Slice& value) = 0;
+  virtual Status Put(const Slice& key, const Slice& value) = 0;
 
   // Variant of Put() that gathers output like writev(2).  The key and value
   // that will be written to the database are concatentations of arrays of
   // slices.
-  virtual void Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                   const SliceParts& value);
-  virtual void Put(const SliceParts& key, const SliceParts& value);
+  virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
+                     const SliceParts& value);
+  virtual Status Put(const SliceParts& key, const SliceParts& value);
 
   // Merge "value" with the existing value of "key" in the database.
   // "key->merge(existing, value)"
-  virtual void Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value) = 0;
-  virtual void Merge(const Slice& key, const Slice& value) = 0;
+  virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
+                       const Slice& value) = 0;
+  virtual Status Merge(const Slice& key, const Slice& value) = 0;
 
   // variant that takes SliceParts
-  virtual void Merge(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value);
-  virtual void Merge(const SliceParts& key, const SliceParts& value);
+  virtual Status Merge(ColumnFamilyHandle* column_family, const SliceParts& key,
+                       const SliceParts& value);
+  virtual Status Merge(const SliceParts& key, const SliceParts& value);
 
   // If the database contains a mapping for "key", erase it.  Else do nothing.
-  virtual void Delete(ColumnFamilyHandle* column_family, const Slice& key) = 0;
-  virtual void Delete(const Slice& key) = 0;
+  virtual Status Delete(ColumnFamilyHandle* column_family,
+                        const Slice& key) = 0;
+  virtual Status Delete(const Slice& key) = 0;
 
   // variant that takes SliceParts
-  virtual void Delete(ColumnFamilyHandle* column_family, const SliceParts& key);
-  virtual void Delete(const SliceParts& key);
+  virtual Status Delete(ColumnFamilyHandle* column_family,
+                        const SliceParts& key);
+  virtual Status Delete(const SliceParts& key);
 
   // If the database contains a mapping for "key", erase it. Expects that the
   // key was not overwritten. Else do nothing.
-  virtual void SingleDelete(ColumnFamilyHandle* column_family,
-                            const Slice& key) = 0;
-  virtual void SingleDelete(const Slice& key) = 0;
+  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
+                              const Slice& key) = 0;
+  virtual Status SingleDelete(const Slice& key) = 0;
 
   // variant that takes SliceParts
-  virtual void SingleDelete(ColumnFamilyHandle* column_family,
-                            const SliceParts& key);
-  virtual void SingleDelete(const SliceParts& key);
+  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
+                              const SliceParts& key);
+  virtual Status SingleDelete(const SliceParts& key);
 
   // If the database contains mappings in the range ["begin_key", "end_key"],
   // erase them. Else do nothing.
-  virtual void DeleteRange(ColumnFamilyHandle* column_family,
-                           const Slice& begin_key, const Slice& end_key) = 0;
-  virtual void DeleteRange(const Slice& begin_key, const Slice& end_key) = 0;
+  virtual Status DeleteRange(ColumnFamilyHandle* column_family,
+                             const Slice& begin_key, const Slice& end_key) = 0;
+  virtual Status DeleteRange(const Slice& begin_key, const Slice& end_key) = 0;
 
   // variant that takes SliceParts
-  virtual void DeleteRange(ColumnFamilyHandle* column_family,
-                           const SliceParts& begin_key,
-                           const SliceParts& end_key);
-  virtual void DeleteRange(const SliceParts& begin_key,
-                           const SliceParts& end_key);
+  virtual Status DeleteRange(ColumnFamilyHandle* column_family,
+                             const SliceParts& begin_key,
+                             const SliceParts& end_key);
+  virtual Status DeleteRange(const SliceParts& begin_key,
+                             const SliceParts& end_key);
 
   // Append a blob of arbitrary size to the records in this batch. The blob will
   // be stored in the transaction log but not in any other file. In particular,
@@ -88,7 +92,7 @@ class WriteBatchBase {
   //
   // Example application: add timestamps to the transaction log for use in
   // replication.
-  virtual void PutLogData(const Slice& blob) = 0;
+  virtual Status PutLogData(const Slice& blob) = 0;
 
   // Clear all updates buffered in this batch.
   virtual void Clear() = 0;
@@ -107,6 +111,9 @@ class WriteBatchBase {
   // If there is no previous call to SetSavePoint(), behaves the same as
   // Clear().
   virtual Status RollbackToSavePoint() = 0;
+
+  // Sets the maximum size of the write batch in bytes. 0 means no limit.
+  virtual void SetMaxBytes(size_t max_bytes) = 0;
 };
 
 }  // namespace rocksdb

--- a/util/status_message.cc
+++ b/util/status_message.cc
@@ -14,7 +14,8 @@ const char* Status::msgs[] = {
     "Failed to acquire lock due to max_num_locks limit",  // kLockLimit
     "No space left on device",                            // kNoSpace
     "Deadlock",                                           // kDeadlock
-    "Stale file handle"                                   // kStaleFile
+    "Stale file handle",                                  // kStaleFile
+    "Memory limit reached"                                // kMemoryLimit
 };
 
 }  // namespace rocksdb

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -23,7 +23,7 @@ TransactionBaseImpl::TransactionBaseImpl(DB* db,
       write_options_(write_options),
       cmp_(GetColumnFamilyUserComparator(db->DefaultColumnFamily())),
       start_time_(db_->GetEnv()->NowMicros()),
-      write_batch_(cmp_, 0, true),
+      write_batch_(cmp_, 0, true, 0),
       indexing_enabled_(true) {
   assert(dynamic_cast<DBImpl*>(db_) != nullptr);
   log_number_ = 0;
@@ -262,8 +262,10 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Put(column_family, key, value);
-    num_puts_++;
+    s = GetBatchForWrite()->Put(column_family, key, value);
+    if (s.ok()) {
+      num_puts_++;
+    }
   }
 
   return s;
@@ -276,8 +278,10 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Put(column_family, key, value);
-    num_puts_++;
+    s = GetBatchForWrite()->Put(column_family, key, value);
+    if (s.ok()) {
+      num_puts_++;
+    }
   }
 
   return s;
@@ -289,8 +293,10 @@ Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Merge(column_family, key, value);
-    num_merges_++;
+    s = GetBatchForWrite()->Merge(column_family, key, value);
+    if (s.ok()) {
+      num_merges_++;
+    }
   }
 
   return s;
@@ -302,8 +308,10 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Delete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->Delete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;
@@ -315,8 +323,10 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Delete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->Delete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;
@@ -328,8 +338,10 @@ Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->SingleDelete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->SingleDelete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;
@@ -341,8 +353,10 @@ Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
       TryLock(column_family, key, false /* read_only */, true /* exclusive */);
 
   if (s.ok()) {
-    GetBatchForWrite()->SingleDelete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->SingleDelete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;
@@ -354,8 +368,10 @@ Status TransactionBaseImpl::PutUntracked(ColumnFamilyHandle* column_family,
                      true /* exclusive */, true /* untracked */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Put(column_family, key, value);
-    num_puts_++;
+    s = GetBatchForWrite()->Put(column_family, key, value);
+    if (s.ok()) {
+      num_puts_++;
+    }
   }
 
   return s;
@@ -368,8 +384,10 @@ Status TransactionBaseImpl::PutUntracked(ColumnFamilyHandle* column_family,
                      true /* exclusive */, true /* untracked */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Put(column_family, key, value);
-    num_puts_++;
+    s = GetBatchForWrite()->Put(column_family, key, value);
+    if (s.ok()) {
+      num_puts_++;
+    }
   }
 
   return s;
@@ -382,8 +400,10 @@ Status TransactionBaseImpl::MergeUntracked(ColumnFamilyHandle* column_family,
                      true /* exclusive */, true /* untracked */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Merge(column_family, key, value);
-    num_merges_++;
+    s = GetBatchForWrite()->Merge(column_family, key, value);
+    if (s.ok()) {
+      num_merges_++;
+    }
   }
 
   return s;
@@ -395,8 +415,10 @@ Status TransactionBaseImpl::DeleteUntracked(ColumnFamilyHandle* column_family,
                      true /* exclusive */, true /* untracked */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Delete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->Delete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;
@@ -408,8 +430,10 @@ Status TransactionBaseImpl::DeleteUntracked(ColumnFamilyHandle* column_family,
                      true /* exclusive */, true /* untracked */);
 
   if (s.ok()) {
-    GetBatchForWrite()->Delete(column_family, key);
-    num_deletes_++;
+    s = GetBatchForWrite()->Delete(column_family, key);
+    if (s.ok()) {
+      num_deletes_++;
+    }
   }
 
   return s;

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -284,10 +284,10 @@ class TransactionBaseImpl : public Transaction {
           num_merges_(num_merges) {}
   };
 
- private:
   // Records writes pending in this transaction
   WriteBatchWithIndex write_batch_;
 
+ private:
   // batch to be written at commit time
   WriteBatch commit_time_batch_;
 

--- a/utilities/transactions/transaction_impl.cc
+++ b/utilities/transactions/transaction_impl.cc
@@ -60,6 +60,7 @@ void TransactionImpl::Initialize(const TransactionOptions& txn_options) {
 
   deadlock_detect_ = txn_options.deadlock_detect;
   deadlock_detect_depth_ = txn_options.deadlock_detect_depth;
+  write_batch_.SetMaxBytes(txn_options.max_write_batch_size);
 
   lock_timeout_ = txn_options.lock_timeout * 1000;
   if (lock_timeout_ < 0) {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -54,8 +54,8 @@ struct WriteBatchIndexEntry {
 
 class ReadableWriteBatch : public WriteBatch {
  public:
-  explicit ReadableWriteBatch(size_t reserved_bytes = 0)
-      : WriteBatch(reserved_bytes) {}
+  explicit ReadableWriteBatch(size_t reserved_bytes = 0, size_t max_bytes = 0)
+      : WriteBatch(reserved_bytes, max_bytes) {}
   // Retrieve some information from a write entry in the write batch, given
   // the start offset of the write entry.
   Status GetEntryFromDataOffset(size_t data_offset, WriteType* type, Slice* Key,


### PR DESCRIPTION
Extend TransactionOptions to include max_write_batch_size which determines the maximum size of the writebatch representation. If memory limit is exceeded, the operation will abort with subcode kMemoryLimit.
