### PR TITLE
Fix BYTES_WRITTEN accounting

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -163,10 +163,8 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
           parallel = parallel && !writer->batch->HasMerge();
         }
 
-        if (writer->ShouldWriteToWAL()) {
-          total_byte_size = WriteBatchInternal::AppendedByteSize(
-              total_byte_size, WriteBatchInternal::ByteSize(writer->batch));
-        }
+        total_byte_size = WriteBatchInternal::AppendedByteSize(
+            total_byte_size, WriteBatchInternal::ByteSize(writer->batch));
       }
     }
 


### PR DESCRIPTION
BYTES_WRITTEN accounting doesn't work with disabled WAL. For example, this is what we
get in the LOG:

```
Cumulative writes: 9794K writes, 228M keys, 9794K commit groups, 1.0
writes per commit group, ingest: 0.00 GB, 0.00 MB/s
```

WAL bytes are tracked in a different statistic:
https://github.com/facebook/rocksdb/blob/master/db/internal_stats.h#L105.
BYTES_WRITTEN should count all the writes.