### PR TITLE
set min file count on L0->base compactions

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1310,7 +1310,8 @@ void VersionStorageInfo::ComputeCompactionScore(
       } else {
         score = static_cast<double>(num_sorted_runs) /
                 mutable_cf_options.level0_file_num_compaction_trigger;
-        if (compaction_style_ == kCompactionStyleLevel && num_levels() > 1) {
+        if (score >= 1.0 && compaction_style_ == kCompactionStyleLevel &&
+            num_levels() > 1) {
           // Level-based involves L0->L0 compactions that can lead to oversized
           // L0 files. Take into account size as well to avoid later giant
           // compactions to the base level.


### PR DESCRIPTION
With the L0 scoring change in #2027, individual L0 files may trigger compaction when dynamic level sizing is enabled. This behavior increases write-amp.

This diff is a temporary fix to prevent such single-file compactions until #2123 gets reviewed. We need one of these fixes for the next release.

Test Plan:

command: 
```
TEST_TMPDIR=/data/rate_limit_bench/  ./db_bench -benchmarks=fillrandom -options_file=/home/andrewkr/myrocks-options-modified -statistics -stats_per_interval=1 -stats_interval=10000000 -num=500000000
```

- master 
  - Throughput: 19.9 MB/s
  - W-Amp: 10.0
  - rocksdb.stall.micros: 21486605
- after this diff
  - Throughput: 19.8 MB/s
  - W-Amp: 9.8
  - rocksdb.stall.micros: 0