### PR TITLE
Compile error clang+jemalloc - conflicts with malloc.h

### DIFF
--- a/table/block.h
+++ b/table/block.h
@@ -18,7 +18,11 @@
 #ifdef OS_FREEBSD
 #include <malloc_np.h>
 #else
+#ifdef ROCKSDB_JEMALLOC
+#include "jemalloc/jemalloc.h"
+#else
 #include <malloc.h>
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
make -j24 --output-sync=target V=1 'OPT=-DSNAPPY=1 -DLZ4=1 -DZLIB=1 -DJEMALLOC=1 -DZSTD=1 -DNUMA=1' static_lib caused the below compile error:

Fix:

Don't include malloc.h when ROCKSDB_JEMALLOC is defined
both define memalign and malloc_usable_size differently
enough for clang to complain.

Fixes compiler error:

clang++-3.9 -m64 -O3 -g -mtune=native -I /opt/ibm/java/include/ -std=c++11  -g -W -Wextra -Wall -Wsign-compare -Wshadow -Wno-unused-parameter -I. -I./include -std=c++11 -m64 -O3 -g -mtune=native -I /opt/ibm/java/include/ -std=c++11 -DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -m64 -O3 -g -mtune=native -I /opt/ibm/java/include/ -DOS_LINUX -fno-builtin-memcmp -DROCKSDB_FALLOCATE_PRESENT -DSNAPPY -DGFLAGS=gflags -DZLIB -DBZIP2 -DLZ4 -DZSTD -DNUMA -DTBB -DROCKSDB_MALLOC_USABLE_SIZE -DROCKSDB_PTHREAD_ADAPTIVE_MUTEX -DROCKSDB_BACKTRACE -Wshorten-64-to-32 -march=native  -DROCKSDB_JEMALLOC -DJEMALLOC_NO_DEMANGLE  -isystem ./third-party/gtest-1.7.0/fused-src -DSNAPPY=1 -DLZ4=1 -DZLIB=1 -DJEMALLOC=1 -DZSTD=1 -DNUMA=1 -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -c db/db_impl.cc -o db/db_impl.o
In file included from db/db_impl.cc:80:
In file included from ./table/block.h:19:
/usr/include/malloc.h:59:14: error: exception specification in declaration does not match previous declaration
extern void *memalign (size_t __alignment, size_t __size)
             ^
/usr/include/jemalloc/jemalloc.h:167:24: note: previous declaration is here
JEMALLOC_EXPORT void *  je_memalign(size_t alignment, size_t size)
                        ^
/usr/include/jemalloc/jemalloc.h:57:23: note: expanded from macro 'je_memalign'
                      ^