### PR TITLE
readahead backwards from sst end

### DIFF
--- a/env/env.cc
+++ b/env/env.cc
@@ -70,8 +70,6 @@ SequentialFile::~SequentialFile() {
 RandomAccessFile::~RandomAccessFile() {
 }
 
-size_t RandomAccessFile::prefetch_bytes = 512 * 1024;
-
 WritableFile::~WritableFile() {
 }
 

--- a/env/env.cc
+++ b/env/env.cc
@@ -70,6 +70,8 @@ SequentialFile::~SequentialFile() {
 RandomAccessFile::~RandomAccessFile() {
 }
 
+size_t RandomAccessFile::prefetch_bytes = 512 * 1024;
+
 WritableFile::~WritableFile() {
 }
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -457,8 +457,6 @@ class SequentialFile {
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
  public:
-  // Read prefetch_bytes backwards from the offset of ReadaheadBackwards()
-  static size_t prefetch_bytes;
 
   RandomAccessFile() { }
   virtual ~RandomAccessFile();
@@ -476,9 +474,9 @@ class RandomAccessFile {
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const = 0;
 
-  // Readahead from the file ending at offset - 1 by several bytes for caching.
+  // Readahead from the file backwards from offset - 1 by n bytes for caching.
   // Implementation details are up to subclasses
-  virtual Status ReadaheadBackwards(uint64_t offset) {
+  virtual Status Prefetch(uint64_t offset, size_t n) {
     return Status::OK();
   }
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -457,6 +457,9 @@ class SequentialFile {
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
  public:
+  // Read prefetch_bytes backwards from the offset of ReadaheadBackwards()
+  static size_t prefetch_bytes;
+
   RandomAccessFile() { }
   virtual ~RandomAccessFile();
 
@@ -472,6 +475,12 @@ class RandomAccessFile {
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const = 0;
+
+  // Readahead from the file ending at offset - 1 by several bytes for caching.
+  // Implementation details are up to subclasses
+  virtual Status ReadaheadBackwards(uint64_t offset) {
+    return Status::OK();
+  }
 
   // Used by the file_reader_writer to decide if the ReadAhead wrapper
   // should simply forward the call and do not enact buffering or locking.

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -474,8 +474,7 @@ class RandomAccessFile {
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const = 0;
 
-  // Readahead from the file backwards from offset - 1 by n bytes for caching.
-  // Implementation details are up to subclasses
+  // Readahead the file starting from offset by n bytes for caching.
   virtual Status Prefetch(uint64_t offset, size_t n) {
     return Status::OK();
   }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -535,10 +535,6 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   Status s =
       file->Prefetch((file_size < 512 * 1024 ? 0 : file_size - 512 * 1024),
                      512 * 1024 /* 512 KB prefetching */);
-  if (!s.ok()) {
-    return s;
-  }
-
   s = ReadFooterFromFile(file.get(), file_size, &footer,
                               kBlockBasedTableMagicNumber);
   if (!s.ok()) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -532,7 +532,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   Footer footer;
 
   // Before read footer, readahead backwards to prefetch data
-  Status s = file->ReadaheadBackwards(file_size);
+  Status s = file->Prefetch(file_size, 512 * 1024 /* 512 KB prefetching */);
   if (!s.ok()) {
     return s;
   }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -532,7 +532,9 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   Footer footer;
 
   // Before read footer, readahead backwards to prefetch data
-  Status s = file->Prefetch(file_size, 512 * 1024 /* 512 KB prefetching */);
+  Status s =
+      file->Prefetch((file_size < 512 * 1024 ? 0 : file_size - 512 * 1024),
+                     512 * 1024 /* 512 KB prefetching */);
   if (!s.ok()) {
     return s;
   }

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -506,7 +506,7 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     return s;
   }
 
-  virtual Status Prefetch(uint64_t offset, size_t n) {
+  virtual Status Prefetch(uint64_t offset, size_t n) override {
     size_t prefetch_offset = TruncateToPageBoundary(alignment_, offset);
     if (prefetch_offset == buffer_offset_) {
       return Status::OK();

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -553,9 +553,6 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     }
     Slice result;
     Status s = file_->Read(offset, n, &result, buffer_.BufferStart());
-    if (result.data() != buffer_.BufferStart()) {
-      fprintf(stderr, "hahha\n");
-    }
     if (s.ok()) {
       buffer_offset_ = offset;
       buffer_len_ = result.size();

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -507,16 +507,11 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
   }
 
   virtual Status Prefetch(uint64_t offset, size_t n) {
-    size_t prefetch_offset = Roundup(offset, alignment_);
-    if (prefetch_offset < n) {
-      prefetch_offset = 0;
-    } else {
-      prefetch_offset -= n;
-    }
+    size_t prefetch_offset = TruncateToPageBoundary(alignment_, offset);
     if (prefetch_offset == buffer_offset_) {
       return Status::OK();
     }
-    return ReadIntoBuffer(prefetch_offset, n);
+    return ReadIntoBuffer(prefetch_offset, offset - prefetch_offset + n);
   }
 
   virtual size_t GetUniqueId(char* id, size_t max_size) const override {

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -472,7 +472,7 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     // complitely or partially in the buffer
     // If it's completely cached, including end of file case when offset + n is
     // greater than EOF, return
-    if (TryReadFromCache_(offset, n, &cached_len, scratch) &&
+    if (TryReadFromCache(offset, n, &cached_len, scratch) &&
         (cached_len == n ||
          // End of file
          buffer_len_ < readahead_size_)) {
@@ -484,59 +484,39 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     // chunk_offset equals to advanced_offset
     size_t chunk_offset = TruncateToPageBoundary(alignment_, advanced_offset);
     Slice readahead_result;
-    Status s = file_->Read(chunk_offset, readahead_size_, &readahead_result,
-                           buffer_.BufferStart());
-    if (!s.ok()) {
-      return s;
-    }
-    // In the case of cache miss, i.e. when cached_len equals 0, an offset can
-    // exceed the file end position, so the following check is required
-    if (advanced_offset < chunk_offset + readahead_result.size()) {
-      // In the case of cache miss, the first chunk_padding bytes in buffer_ are
-      // stored for alignment only and must be skipped
-      size_t chunk_padding = advanced_offset - chunk_offset;
-      auto remaining_len =
-          std::min(readahead_result.size() - chunk_padding, n - cached_len);
-      memcpy(scratch + cached_len, readahead_result.data() + chunk_padding,
-             remaining_len);
-      *result = Slice(scratch, cached_len + remaining_len);
-    } else {
-      *result = Slice(scratch, cached_len);
-    }
 
-    if (readahead_result.data() == buffer_.BufferStart()) {
-      buffer_offset_ = chunk_offset;
-      buffer_len_ = readahead_result.size();
-    } else {
-      buffer_len_ = 0;
-    }
-
-    return Status::OK();
-  }
-
-  virtual Status ReadaheadBackwards(uint64_t offset) {
-    Status s;
-    size_t prefetch_offset = Roundup(offset, alignment_);
-    if (prefetch_offset < prefetch_bytes) {
-      prefetch_offset = 0;
-    } else {
-      prefetch_offset -= prefetch_bytes;
-    }
-    if (prefetch_offset == buffer_offset_) {
-      return s;
-    }
-    Slice readahead_result;
-    s = file_->Read(prefetch_offset, prefetch_bytes, &readahead_result,
-                    buffer_.BufferStart());
+    Status s = ReadIntoBuffer(chunk_offset, readahead_size_);
     if (s.ok()) {
-      if (readahead_result.data() == buffer_.BufferStart()) {
-        buffer_offset_ = prefetch_offset;
-        buffer_len_ = readahead_result.size();
+      // In the case of cache miss, i.e. when cached_len equals 0, an offset can
+      // exceed the file end position, so the following check is required
+      if (advanced_offset < chunk_offset + buffer_len_) {
+        // In the case of cache miss, the first chunk_padding bytes in buffer_
+        // are
+        // stored for alignment only and must be skipped
+        size_t chunk_padding = advanced_offset - chunk_offset;
+        auto remaining_len =
+            std::min(buffer_len_ - chunk_padding, n - cached_len);
+        memcpy(scratch + cached_len, buffer_.BufferStart() + chunk_padding,
+               remaining_len);
+        *result = Slice(scratch, cached_len + remaining_len);
       } else {
-        buffer_len_ = 0;
+        *result = Slice(scratch, cached_len);
       }
     }
     return s;
+  }
+
+  virtual Status Prefetch(uint64_t offset, size_t n) {
+    size_t prefetch_offset = Roundup(offset, alignment_);
+    if (prefetch_offset < n) {
+      prefetch_offset = 0;
+    } else {
+      prefetch_offset -= n;
+    }
+    if (prefetch_offset == buffer_offset_) {
+      return Status::OK();
+    }
+    return ReadIntoBuffer(prefetch_offset, n);
   }
 
   virtual size_t GetUniqueId(char* id, size_t max_size) const override {
@@ -554,7 +534,7 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
   }
 
  private:
-  bool TryReadFromCache_(uint64_t offset, size_t n, size_t* cached_len,
+  bool TryReadFromCache(uint64_t offset, size_t n, size_t* cached_len,
                          char* scratch) const {
     if (offset < buffer_offset_ || offset >= buffer_offset_ + buffer_len_) {
       *cached_len = 0;
@@ -567,15 +547,31 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     return true;
   }
 
+  Status ReadIntoBuffer(uint64_t offset, size_t n) const {
+    if (n > buffer_.Capacity()) {
+      n = buffer_.Capacity();
+    }
+    Slice result;
+    Status s = file_->Read(offset, n, &result, buffer_.BufferStart());
+    if (result.data() != buffer_.BufferStart()) {
+      fprintf(stderr, "hahha\n");
+    }
+    if (s.ok()) {
+      buffer_offset_ = offset;
+      buffer_len_ = result.size();
+    }
+    return s;
+  }
+
   std::unique_ptr<RandomAccessFile> file_;
   const size_t alignment_;
   size_t               readahead_size_;
   const bool           forward_calls_;
 
-  mutable std::mutex   lock_;
+  mutable std::mutex lock_;
   mutable AlignedBuffer buffer_;
-  mutable uint64_t     buffer_offset_;
-  mutable size_t       buffer_len_;
+  mutable uint64_t buffer_offset_;
+  mutable size_t buffer_len_;
 };
 }  // namespace
 

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -92,6 +92,10 @@ class RandomAccessFileReader {
 
   Status Read(uint64_t offset, size_t n, Slice* result, char* scratch) const;
 
+  Status ReadaheadBackwards(uint64_t offset) const {
+    return file_->ReadaheadBackwards(offset);
+  }
+
   RandomAccessFile* file() { return file_.get(); }
 
   bool use_direct_io() const { return file_->use_direct_io(); }

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -92,8 +92,8 @@ class RandomAccessFileReader {
 
   Status Read(uint64_t offset, size_t n, Slice* result, char* scratch) const;
 
-  Status ReadaheadBackwards(uint64_t offset) const {
-    return file_->ReadaheadBackwards(offset);
+  Status Prefetch(uint64_t offset, size_t n) const {
+    return file_->Prefetch(offset, n);
   }
 
   RandomAccessFile* file() { return file_.get(); }


### PR DESCRIPTION
prefetch some data from the end of the file for each compaction to reduce IO.