### PR TITLE
Pass in remote as a param to branch creation script

### DIFF
--- a/build_tools/make_new_version.sh
+++ b/build_tools/make_new_version.sh
@@ -17,7 +17,9 @@ function title() {
 }
 
 usage="Create new RocksDB version and prepare it for the release process\n"
-usage+="USAGE: ./make_new_version.sh <version>"
+usage+="USAGE: ./make_new_version.sh <version> [<remote>]\n"
+usage+="  version: specify a version without '.fb' suffix (e.g. 5.4).\n"
+usage+="  remote: name of the remote to push the branch to (default: origin)."
 
 # -- Pre-check
 if [[ $# < 1 ]]; then
@@ -26,6 +28,11 @@ if [[ $# < 1 ]]; then
 fi
 
 ROCKSDB_VERSION=$1
+
+REMOTE="origin"
+if [[ $# > 1 ]]; then
+  REMOTE=$2
+fi
 
 GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 echo $GIT_BRANCH
@@ -41,6 +48,6 @@ $GIT checkout -b $BRANCH
 
 # Setting up the proxy for remote repo access
 title "Pushing new branch to remote repo ..."
-git push origin --set-upstream $BRANCH
+git push $REMOTE --set-upstream $BRANCH
 
 title "Branch $BRANCH is pushed to github;"


### PR DESCRIPTION
When people are working off of a rocksdb fork, i.e. when their 'origin'
points to github.com/<username>/rocksdb, the script creates a new branch
and pushes to their origin. The new branch created by this script should
instead be pushed to github.com/facebook/rocksdb. Many people might
have named facebook/rocksdb remote as 'upstream' (or something else).
This fix provides an option to specify the remote to push the branch to.
The default is still 'origin'

More context:
When I created 5.4 branch using this script, it got pushed to sagar0/rocksdb instead of facebook/rocksdb, as I was working off of a fork. My 'origin' was pointing to sagar0/rocksdb. My 'upstream' was set to 'facebook/rocksdb'. So, I had to manually push the branch to my 'upstream'. 