### PR TITLE
Add cpu usage to regression benchmarks (3rd attempt)

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -214,7 +214,7 @@ function run_db_bench {
   options_file_arg=$(setup_options_file)
   echo "$options_file_arg"
   # use `which time` to avoid using bash's internal time command
-  db_bench_cmd="("'`which time`'" -p $DB_BENCH_DIR/db_bench \
+  db_bench_cmd="("'$(which time)'" -p $DB_BENCH_DIR/db_bench \
       --benchmarks=$1 --db=$DB_PATH --wal_dir=$WAL_PATH \
       --use_existing_db=$USE_EXISTING_DB \
       --disable_auto_compactions \

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -214,7 +214,7 @@ function run_db_bench {
   options_file_arg=$(setup_options_file)
   echo "$options_file_arg"
   # use `which time` to avoid using bash's internal time command
-  db_bench_cmd="(`which time` -p $DB_BENCH_DIR/db_bench \
+  db_bench_cmd="("'`which time`'" -p $DB_BENCH_DIR/db_bench \
       --benchmarks=$1 --db=$DB_PATH --wal_dir=$WAL_PATH \
       --use_existing_db=$USE_EXISTING_DB \
       --disable_auto_compactions \

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -96,13 +96,15 @@
 TITLE_FORMAT="%40s,%25s,%30s,%7s,%9s,%8s,"
 TITLE_FORMAT+="%10s,%13s,%14s,%11s,%12s,"
 TITLE_FORMAT+="%7s,%11s,"
-TITLE_FORMAT+="%9s,%10s,%10s,%10s,%10s,%10s,%5s"
+TITLE_FORMAT+="%9s,%10s,%10s,%10s,%10s,%10s,%5s,"
+TITLE_FORMAT+="%5s,%5s,%5s" # time
 TITLE_FORMAT+="\n"
 
 DATA_FORMAT="%40s,%25s,%30s,%7s,%9s,%8s,"
 DATA_FORMAT+="%10s,%13.0f,%14s,%11s,%12s,"
 DATA_FORMAT+="%7s,%11s,"
-DATA_FORMAT+="%9.0f,%10.0f,%10.0f,%10.0f,%10.0f,%10.0f,%5.0f"
+DATA_FORMAT+="%9.0f,%10.0f,%10.0f,%10.0f,%10.0f,%10.0f,%5.0f,"
+DATA_FORMAT+="%5.0f,%5.0f,%5.0f" # time
 DATA_FORMAT+="\n"
 
 MAIN_PATTERN="$1""[[:blank:]]+:.*[[:blank:]]+([0-9\.]+)[[:blank:]]+ops/sec"
@@ -211,7 +213,8 @@ function run_db_bench {
   db_bench_error=0
   options_file_arg=$(setup_options_file)
   echo "$options_file_arg"
-  db_bench_cmd="$DB_BENCH_DIR/db_bench \
+  # use `which time` to avoid using bash's internal time command
+  db_bench_cmd="(`which time` -p $DB_BENCH_DIR/db_bench \
       --benchmarks=$1 --db=$DB_PATH --wal_dir=$WAL_PATH \
       --use_existing_db=$USE_EXISTING_DB \
       --disable_auto_compactions \
@@ -233,7 +236,7 @@ function run_db_bench {
       --max_background_flushes=$MAX_BACKGROUND_FLUSHES \
       --num_multi_db=$NUM_MULTI_DB \
       --max_background_compactions=$MAX_BACKGROUND_COMPACTIONS \
-      --seed=$SEED 2>&1"
+      --seed=$SEED) 2>&1"
   ps_cmd="ps aux"
   if ! [ -z "$REMOTE_USER_AT_HOST" ]; then
     echo "Running benchmark remotely on $REMOTE_USER_AT_HOST"
@@ -306,6 +309,11 @@ function update_report {
   perc[3]=${BASH_REMATCH[4]}  # p99.9
   perc[4]=${BASH_REMATCH[5]}  # p99.99
 
+  # parse the output of the time command
+  real_sec=`tail -3 $2 | grep real | awk '{print $2}'`
+  user_sec=`tail -3 $2 | grep user | awk '{print $2}'`
+  sec_sec=`tail -3 $2 | grep sys | awk '{print $2}'`
+
   (printf "$DATA_FORMAT" \
     $COMMIT_ID $1 $REMOTE_USER_AT_HOST $NUM_MULTI_DB $NUM_KEYS $KEY_SIZE $VALUE_SIZE \
        $(multiply $COMPRESSION_RATIO 100) \
@@ -318,6 +326,9 @@ function update_report {
        $(multiply ${perc[3]} 1000) \
        $(multiply ${perc[4]} 1000) \
        $DEBUG \
+       $real_sec \
+       $user_sec \
+       $sec_sec \
        >> $SUMMARY_FILE)
   exit_on_error $?
 }
@@ -416,6 +427,7 @@ function setup_test_directory {
       "value-size" "compress-rate" "ops-per-thread" "num-threads" "cache-size" \
       "flushes" "compactions" \
       "ops-per-s" "p50" "p75" "p99" "p99.9" "p99.99" "debug" \
+      "real" "user" "sys" \
       >> $SUMMARY_FILE)
   exit_on_error $?
 }

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -312,7 +312,7 @@ function update_report {
   # parse the output of the time command
   real_sec=`tail -3 $2 | grep real | awk '{print $2}'`
   user_sec=`tail -3 $2 | grep user | awk '{print $2}'`
-  sec_sec=`tail -3 $2 | grep sys | awk '{print $2}'`
+  sys_sec=`tail -3 $2 | grep sys | awk '{print $2}'`
 
   (printf "$DATA_FORMAT" \
     $COMMIT_ID $1 $REMOTE_USER_AT_HOST $NUM_MULTI_DB $NUM_KEYS $KEY_SIZE $VALUE_SIZE \
@@ -328,7 +328,7 @@ function update_report {
        $DEBUG \
        $real_sec \
        $user_sec \
-       $sec_sec \
+       $sys_sec \
        >> $SUMMARY_FILE)
   exit_on_error $?
 }
@@ -427,7 +427,7 @@ function setup_test_directory {
       "value-size" "compress-rate" "ops-per-thread" "num-threads" "cache-size" \
       "flushes" "compactions" \
       "ops-per-s" "p50" "p75" "p99" "p99.9" "p99.99" "debug" \
-      "real" "user" "sys" \
+      "real-sec" "user-sec" "sys-sec" \
       >> $SUMMARY_FILE)
   exit_on_error $?
 }

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -240,7 +240,7 @@ function run_db_bench {
   ps_cmd="ps aux"
   if ! [ -z "$REMOTE_USER_AT_HOST" ]; then
     echo "Running benchmark remotely on $REMOTE_USER_AT_HOST"
-    db_bench_cmd="$SSH $REMOTE_USER_AT_HOST $db_bench_cmd"
+    db_bench_cmd="$SSH $REMOTE_USER_AT_HOST \"$db_bench_cmd\""
     ps_cmd="$SSH $REMOTE_USER_AT_HOST $ps_cmd"
   fi
 

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -309,7 +309,7 @@ function update_report {
   perc[3]=${BASH_REMATCH[4]}  # p99.9
   perc[4]=${BASH_REMATCH[5]}  # p99.99
 
-  # parse the output of the time command
+  # Parse the output of the time command
   real_sec=`tail -3 $2 | grep real | awk '{print $2}'`
   user_sec=`tail -3 $2 | grep user | awk '{print $2}'`
   sys_sec=`tail -3 $2 | grep sys | awk '{print $2}'`


### PR DESCRIPTION
Tested by running rocks/tools/debug_regression_test.sh and verifying the local output:
```
 cat local/rocks_regression_tests/OPTIONS-viewstate-66-1262-5000/2017-04-13-11-34-51/SUMMARY.csv
                               commit id,                benchmark,                     user@host,num-dbs,key-range,key-size,value-size,compress-rate,ops-per-thread,num-threads,  cache-size,flushes,compactions,ops-per-s,       p50,       p75,       p99,     p99.9,    p99.99,debug,real-sec,user-sec,sys-sec
d2dce5611ab4b9a671ef518f648adf84d49e5356,               readrandom,                root@localhost,     12,     5000,      66,      1262,           50,           312,         16,  1073741824,      4,         16,   138458,      9380,     11530,     55200,  16803200,  32504000,    1,    0,    0,    0
d2dce5611ab4b9a671ef518f648adf84d49e5356,         readwhilewriting,                root@localhost,     12,     5000,      66,      1262,           50,           312,         16,  1073741824,      4,         16,   104511,      8900,     10130,    121600,  23346670,  40527000,    1,    0,    0,    0
d2dce5611ab4b9a671ef518f648adf84d49e5356,             deleterandom,                root@localhost,     12,     5000,      66,      1262,           50,            31,         16,  1073741824,      4,         16,     2937,      8670,     46250,  90133330, 124640000, 124640000,    1,    0,    0,    1
d2dce5611ab4b9a671ef518f648adf84d49e5356,               seekrandom,                root@localhost,     12,     5000,      66,      1262,           50,           312,         16,  1073741824,      4,         16,    43130,     31970,     36730,    204000,  67520000,  94229000,    1,    0,    0,    0
d2dce5611ab4b9a671ef518f648adf84d49e5356,   seekrandomwhilewriting,                root@localhost,     12,     5000,      66,      1262,           50,           312,         16,  1073741824,      4,         16,    62303,     45750,     57670,    130270,  39008000,  54698000,    1,    0,    0,    0
```