### PR TITLE
Add DB:ResetStats()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### New Features
+* DB::ResetInternalStats() to reset internal stats.
 
 ## 5.4.0 (04/11/2017)
 ### Public API Change

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
 ### New Features
-* DB::ResetInternalStats() to reset internal stats.
+* DB::ResetStats() to reset internal stats.
 
 ## 5.4.0 (04/11/2017)
 ### Public API Change

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1667,7 +1667,7 @@ bool DBImpl::GetIntPropertyInternal(ColumnFamilyData* cfd,
 }
 
 #ifndef ROCKSDB_LITE
-Status DBImpl::ResetInternalStats() {
+Status DBImpl::ResetStats() {
   InstrumentedMutexLock l(&mutex_);
   for (auto* cfd : *versions_->GetColumnFamilySet()) {
     cfd->internal_stats()->Clear();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1666,6 +1666,16 @@ bool DBImpl::GetIntPropertyInternal(ColumnFamilyData* cfd,
   }
 }
 
+#ifndef ROCKSDB_LITE
+Status DBImpl::ResetInternalStats() {
+  InstrumentedMutexLock l(&mutex_);
+  for (auto* cfd : *versions_->GetColumnFamilySet()) {
+    cfd->internal_stats()->Clear();
+  }
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
 bool DBImpl::GetAggregatedIntProperty(const Slice& property,
                                       uint64_t* aggregated_value) {
   const DBPropertyInfo* property_info = GetPropertyInfo(property);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -193,8 +193,8 @@ class DBImpl : public DB {
   virtual SequenceNumber GetLatestSequenceNumber() const override;
 
 #ifndef ROCKSDB_LITE
-  using DB::ResetInternalStats;
-  virtual Status ResetInternalStats() override;
+  using DB::ResetStats;
+  virtual Status ResetStats() override;
   virtual Status DisableFileDeletions() override;
   virtual Status EnableFileDeletions(bool force) override;
   virtual int IsFileDeletionsEnabled() const;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -193,6 +193,8 @@ class DBImpl : public DB {
   virtual SequenceNumber GetLatestSequenceNumber() const override;
 
 #ifndef ROCKSDB_LITE
+  using DB::ResetInternalStats;
+  virtual Status ResetInternalStats() override;
   virtual Status DisableFileDeletions() override;
   virtual Status EnableFileDeletions(bool force) override;
   virtual int IsFileDeletionsEnabled() const;

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -427,7 +427,7 @@ TEST_F(DBPropertiesTest, ReadLatencyHistogramByLevel) {
   ASSERT_EQ(std::string::npos, prop.find("** Level 2 read latency histogram"));
 
   // Clear internal stats
-  dbfull()->ResetInternalStats();
+  dbfull()->ResetStats();
   ASSERT_TRUE(dbfull()->GetProperty("rocksdb.cfstats", &prop));
   ASSERT_EQ(std::string::npos, prop.find("** Level 0 read latency histogram"));
   ASSERT_EQ(std::string::npos, prop.find("** Level 1 read latency histogram"));

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -425,6 +425,13 @@ TEST_F(DBPropertiesTest, ReadLatencyHistogramByLevel) {
   ASSERT_NE(std::string::npos, prop.find("** Level 0 read latency histogram"));
   ASSERT_NE(std::string::npos, prop.find("** Level 1 read latency histogram"));
   ASSERT_EQ(std::string::npos, prop.find("** Level 2 read latency histogram"));
+
+  // Clear internal stats
+  dbfull()->ResetInternalStats();
+  ASSERT_TRUE(dbfull()->GetProperty("rocksdb.cfstats", &prop));
+  ASSERT_EQ(std::string::npos, prop.find("** Level 0 read latency histogram"));
+  ASSERT_EQ(std::string::npos, prop.find("** Level 1 read latency histogram"));
+  ASSERT_EQ(std::string::npos, prop.find("** Level 2 read latency histogram"));
 }
 
 TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -341,6 +341,19 @@ class InternalStats {
     uint64_t ingest_l0_files_addfile;  // Total number of files ingested to L0
     uint64_t ingest_keys_addfile;      // Total number of keys ingested
 
+    CFStatsSnapshot()
+        : comp_stats(0),
+          ingest_bytes_flush(0),
+          stall_count(0),
+          compact_bytes_write(0),
+          compact_bytes_read(0),
+          compact_micros(0),
+          seconds_up(0),
+          ingest_bytes_addfile(0),
+          ingest_files_addfile(0),
+          ingest_l0_files_addfile(0),
+          ingest_keys_addfile(0) {}
+
     void Clear() {
       comp_stats.Clear();
       ingest_bytes_flush = 0;
@@ -354,19 +367,6 @@ class InternalStats {
       ingest_l0_files_addfile = 0;
       ingest_keys_addfile = 0;
     }
-
-    CFStatsSnapshot()
-        : comp_stats(0),
-          ingest_bytes_flush(0),
-          stall_count(0),
-          compact_bytes_write(0),
-          compact_bytes_read(0),
-          compact_micros(0),
-          seconds_up(0),
-          ingest_bytes_addfile(0),
-          ingest_files_addfile(0),
-          ingest_l0_files_addfile(0),
-          ingest_keys_addfile(0) {}
   } cf_stats_snapshot_;
 
   struct DBStatsSnapshot {
@@ -388,6 +388,17 @@ class InternalStats {
     uint64_t write_stall_micros;
     double seconds_up;
 
+    DBStatsSnapshot()
+        : ingest_bytes(0),
+          wal_bytes(0),
+          wal_synced(0),
+          write_with_wal(0),
+          write_other(0),
+          write_self(0),
+          num_keys_written(0),
+          write_stall_micros(0),
+          seconds_up(0) {}
+
     void Clear() {
       ingest_bytes = 0;
       wal_bytes = 0;
@@ -399,17 +410,6 @@ class InternalStats {
       write_stall_micros = 0;
       seconds_up = 0;
     }
-
-    DBStatsSnapshot()
-        : ingest_bytes(0),
-          wal_bytes(0),
-          wal_synced(0),
-          write_with_wal(0),
-          write_other(0),
-          write_self(0),
-          num_keys_written(0),
-          write_stall_micros(0),
-          seconds_up(0) {}
   } db_stats_snapshot_;
 
   // Handler functions for getting property values. They use "value" as a value-

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -189,6 +189,20 @@ class InternalStats {
           num_dropped_records(c.num_dropped_records),
           count(c.count) {}
 
+    void Clear() {
+      this->micros = 0;
+      this->bytes_read_non_output_levels = 0;
+      this->bytes_read_output_level = 0;
+      this->bytes_written = 0;
+      this->bytes_moved = 0;
+      this->num_input_files_in_non_output_levels = 0;
+      this->num_input_files_in_output_level = 0;
+      this->num_output_files = 0;
+      this->num_input_records = 0;
+      this->num_dropped_records = 0;
+      this->count = 0;
+    }
+
     void Add(const CompactionStats& c) {
       this->micros += c.micros;
       this->bytes_read_non_output_levels += c.bytes_read_non_output_levels;
@@ -221,6 +235,26 @@ class InternalStats {
       this->count -= c.count;
     }
   };
+
+  void Clear() {
+    for (int i = 0; i < INTERNAL_DB_STATS_ENUM_MAX; i++) {
+      db_stats_[i].store(0);
+    }
+    for (int i = 0; i < INTERNAL_CF_STATS_ENUM_MAX; i++) {
+      cf_stats_count_[i] = 0;
+      cf_stats_value_[i] = 0;
+    }
+    for (auto& comp_stat : comp_stats_) {
+      comp_stat.Clear();
+    }
+    for (auto& h : file_read_latency_) {
+      h.Clear();
+    }
+    cf_stats_snapshot_.Clear();
+    db_stats_snapshot_.Clear();
+    bg_error_count_ = 0;
+    started_at_ = env_->NowMicros();
+  }
 
   void AddCompactionStats(int level, const CompactionStats& stats) {
     comp_stats_[level].Add(stats);
@@ -307,6 +341,20 @@ class InternalStats {
     uint64_t ingest_l0_files_addfile;  // Total number of files ingested to L0
     uint64_t ingest_keys_addfile;      // Total number of keys ingested
 
+    void Clear() {
+      comp_stats.Clear();
+      ingest_bytes_flush = 0;
+      stall_count = 0;
+      compact_bytes_write = 0;
+      compact_bytes_read = 0;
+      compact_micros = 0;
+      seconds_up = 0;
+      ingest_bytes_addfile = 0;
+      ingest_files_addfile = 0;
+      ingest_l0_files_addfile = 0;
+      ingest_keys_addfile = 0;
+    }
+
     CFStatsSnapshot()
         : comp_stats(0),
           ingest_bytes_flush(0),
@@ -339,6 +387,18 @@ class InternalStats {
     // Total time writes delayed by stalls.
     uint64_t write_stall_micros;
     double seconds_up;
+
+    void Clear() {
+      ingest_bytes = 0;
+      wal_bytes = 0;
+      wal_synced = 0;
+      write_with_wal = 0;
+      write_other = 0;
+      write_self = 0;
+      num_keys_written = 0;
+      write_stall_micros = 0;
+      seconds_up = 0;
+    }
 
     DBStatsSnapshot()
         : ingest_bytes(0),
@@ -420,7 +480,7 @@ class InternalStats {
   const int number_levels_;
   Env* env_;
   ColumnFamilyData* cfd_;
-  const uint64_t started_at_;
+  uint64_t started_at_;
 };
 
 #else

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -612,8 +612,9 @@ class DB {
   }
 
   // Reset internal stats for DB and all column families.
-  // Note this doesn't reset options.statistics.
-  virtual Status ResetInternalStats() {
+  // Note this doesn't reset options.statistics as it is not owned by
+  // DB.
+  virtual Status ResetStats() {
     return Status::NotSupported("Not implemented");
   }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -611,6 +611,12 @@ class DB {
     return GetIntProperty(DefaultColumnFamily(), property, value);
   }
 
+  // Reset internal stats for DB and all column families.
+  // Note this doesn't reset options.statistics.
+  virtual Status ResetInternalStats() {
+    return Status::NotSupported("Not implemented");
+  }
+
   // Same as GetIntProperty(), but this one returns the aggregated int
   // property from all column families.
   virtual bool GetAggregatedIntProperty(const Slice& property,

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -176,6 +176,7 @@ DEFINE_string(
     "Meta operations:\n"
     "\tcompact     -- Compact the entire DB\n"
     "\tstats       -- Print DB stats\n"
+    "\tresetstats  -- Reset DB stats\n"
     "\tlevelstats  -- Print the number of files and bytes per level\n"
     "\tsstables    -- Print sstable info\n"
     "\theapprofile -- Dump a heap profile (if supported by this"
@@ -2430,6 +2431,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         method = &Benchmark::TimeSeries;
       } else if (name == "stats") {
         PrintStats("rocksdb.stats");
+      } else if (name == "resetstats") {
+        ResetStats();
       } else if (name == "verify") {
         VerifyDBFromDB(FLAGS_truth_db);
       } else if (name == "levelstats") {
@@ -5010,6 +5013,15 @@ void VerifyDBFromDB(std::string& truth_db_name) {
   void Compact(ThreadState* thread) {
     DB* db = SelectDB(thread);
     db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  }
+
+  void ResetStats() {
+    if (db_.db != nullptr) {
+      db_.db->ResetInternalStats();
+    }
+    for (const auto& db_with_cfh : multi_dbs_) {
+      db_with_cfh.db->ResetInternalStats();
+    }
   }
 
   void PrintStats(const char* key) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5017,10 +5017,10 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 
   void ResetStats() {
     if (db_.db != nullptr) {
-      db_.db->ResetInternalStats();
+      db_.db->ResetStats();
     }
     for (const auto& db_with_cfh : multi_dbs_) {
-      db_with_cfh.db->ResetInternalStats();
+      db_with_cfh.db->ResetStats();
     }
   }
 


### PR DESCRIPTION
Summary: Add a function to allow users to reset internal stats without restarting the DB.

Test Plan: Reset stats in db_properties_test once to make sure some stats get cleared. Add resetstats "benchmark" in db_bench and run it with "--benchmarks=fillrandom,stats,resetstats,stats" to observe the outputs are expected.