### PR TITLE
Change L0 compaction score using level size

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1314,9 +1314,9 @@ void VersionStorageInfo::ComputeCompactionScore(
           // Level-based involves L0->L0 compactions that can lead to oversized
           // L0 files. Take into account size as well to avoid later giant
           // compactions to the base level.
-          uint64_t base_level_max_bytes = MaxBytesForLevel(base_level());
           score = std::max(
-              score, static_cast<double>(total_size) / base_level_max_bytes);
+              score, static_cast<double>(total_size) /
+                     mutable_cf_options.max_bytes_for_level_base);
         }
       }
     } else {


### PR DESCRIPTION
The goal is to avoid the problem of small number of L0 files triggering compaction to base level (which increased write-amp), while still allowing L0 compaction-by-size (so intra-L0 compactions cause score to increase).

Test Plan:
benchmark command:
```
TEST_TMPDIR=/data/rate_limit_bench/  ./db_bench -benchmarks=fillrandom -options_file=/home/andrewkr/myrocks-options-modified -statistics -stats_per_interval=1 -stats_interval=10000000 -num=500000000
```

- master 
  - Throughput: 19.9 MB/s
  - W-Amp: 10.0
  - rocksdb.stall.micros: 21486605
- after this diff
  - Throughput: 20.9 MB/s
  - W-Amp: 9.7
  - rocksdb.stall.micros: 0