### PR TITLE
resolve glibc warning for major define

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -22,6 +22,9 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(__GNUC__) && __GNUC__ > 6 || (__GNUC__ == 6 && __GNUC_MINOR__ >= 3)
+#include <sys/sysmacros.h>
+#endif
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
The warning:

    rocksdb/env/io_posix.cc:57:13: error: In the GNU C Library, "major" is defined
     by <sys/sysmacros.h>. For historical compatibility, it is
     currently defined by <sys/types.h> as well, but we plan to
     remove this soon. To use "major", include <sys/sysmacros.h>
     directly. If you did not intend to use a system-defined macro
     "major", you should undefine it after including <sys/types.h>. [-Werror]
       if (major(buf.st_dev) == 0) {
                 ^~~~~~~~~~~~~~~~~~~
    /home/pdonnell/ceph/src/rocksdb/env/io_posix.cc:67:13: error: In the GNU C Library, "major" is defined
     by <sys/sysmacros.h>. For historical compatibility, it is
     currently defined by <sys/types.h> as well, but we plan to
     remove this soon. To use "major", include <sys/sysmacros.h>
     directly. If you did not intend to use a system-defined macro
     "major", you should undefine it after including <sys/types.h>. [-Werror]
       snprintf(path, kBufferSize, "/sys/dev/block/%u:%u", major(buf.st_dev),
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/pdonnell/ceph/src/rocksdb/env/io_posix.cc:68:13: error: In the GNU C Library, "minor" is defined
     by <sys/sysmacros.h>. For historical compatibility, it is
     currently defined by <sys/types.h> as well, but we plan to
     remove this soon. To use "minor", include <sys/sysmacros.h>
     directly. If you did not intend to use a system-defined macro
     "minor", you should undefine it after including <sys/types.h>. [-Werror]
                minor(buf.st_dev));
                 ^~~~~~~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>