### PR TITLE
Fixing Solaris Sparc crash due to cached TLS

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -155,7 +155,12 @@ extern PerfContext perf_context;
 #elif defined(_MSC_VER)
 extern __declspec(thread) PerfContext perf_context;
 #else
-extern __thread PerfContext perf_context;
+  #if defined(OS_SOLARIS)
+    PerfContext *getPerfContext();
+    #define perf_context (*getPerfContext())
+  #else
+    extern __thread PerfContext perf_context;
+  #endif
 #endif
 
 }

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -14,7 +14,11 @@ namespace rocksdb {
 #elif defined(_MSC_VER)
   __declspec(thread) PerfContext perf_context;
 #else
-  __thread PerfContext perf_context;
+  #if defined(OS_SOLARIS)
+    __thread PerfContext perf_context_;
+  #else
+    __thread PerfContext perf_context;
+  #endif
 #endif
 
 void PerfContext::Reset() {
@@ -161,5 +165,11 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   return ss.str();
 #endif
 }
+
+#if defined(OS_SOLARIS)
+PerfContext *getPerfContext() {
+  return &perf_context_;
+}
+#endif
 
 }


### PR DESCRIPTION
Workaround for Solaris gcc binary. Program is crashing, because when TLS of perf context that is used twice on same frame, it is damaged thus Segmentation fault.

Issue: #2153