### PR TITLE
Revert how check_format_compatible.sh checkout release branches.

### DIFF
--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -76,7 +76,7 @@ https_proxy="fwdproxy:8080" git fetch github_origin
 for checkout_obj in "${checkout_objs[@]}"
 do
    echo == Generating DB from "$checkout_obj" ...
-   git checkout origin/$checkout_obj
+   git checkout $checkout_obj
    make clean
    make ldb -j32
    generate_db $input_data_path $test_dir/$checkout_obj
@@ -101,7 +101,7 @@ done
 for checkout_obj in "${forward_compatible_checkout_objs[@]}"
 do
    echo == Build "$checkout_obj" and try to open DB generated using $checkout_flag...
-   git checkout origin/$checkout_obj
+   git checkout $checkout_obj
    make clean
    make ldb -j32
    compare_db $test_dir/$checkout_obj $compare_base_db_dir forward_${checkout_obj}_dump.txt


### PR DESCRIPTION
Summary: In a previous commit, I changed the way to checkout release branches from "git checkout <branch_name>" to "git checkout origin/<branch_name>". However, this doesn't seem to work in our CI environment. Revert it.