### PR TITLE
Supports universal compaction with bulk loading

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -433,8 +433,8 @@ void CompactionIterator::NextFromInput() {
         at_next_ = true;
       }
     } else if (last_snapshot == current_user_key_snapshot_) {
-      // If the earliest snapshot is which this key is visible in
-      // is the same as the visibility of a previous instance of the
+      // If the earliest snapshot in which this key is visible is
+      // the same as the visibility of a previous instance of the
       // same key, then this kv is not visible in any snapshot.
       // Hidden by an newer entry for same user key
       // TODO(noetzli): why not > ?

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -182,92 +182,125 @@ TEST_F(ExternalSSTFileBasicTest, NoCopy) {
 }
 
 TEST_F(ExternalSSTFileBasicTest, IngestFileWithGlobalSeqnoPickedSeqno) {
-  Options options = CurrentOptions();
-  DestroyAndReopen(options);
-  std::map<std::string, std::string> true_data;
+  do {
+    Options options = CurrentOptions();
+    DestroyAndReopen(options);
+    std::map<std::string, std::string> true_data;
 
-  int file_id = 1;
+    int file_id = 1;
 
-  ASSERT_OK(GenerateAndAddExternalFile(options, {1, 2, 3, 4, 5, 6}, file_id++,
-                                       &true_data));
-  // File dont overwrite any keys, No seqno needed
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {1, 2, 3, 4, 5, 6}, file_id++,
+                                         &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
-  ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13}, file_id++,
-                                       &true_data));
-  // File dont overwrite any keys, No seqno needed
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13}, file_id++,
+                                         &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {1, 4, 6}, file_id++, &true_data));
-  // File overwrite some keys, a seqno will be assigned
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 1);
+    ASSERT_OK(
+        GenerateAndAddExternalFile(options, {1, 4, 6}, file_id++, &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 1);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {11, 15, 19}, file_id++, &true_data));
-  // File overwrite some keys, a seqno will be assigned
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {11, 15, 19}, file_id++,
+                                         &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {120, 130}, file_id++, &true_data));
-  // File dont overwrite any keys, No seqno needed
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
+    ASSERT_OK(
+        GenerateAndAddExternalFile(options, {120, 130}, file_id++, &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {1, 130}, file_id++, &true_data));
-  // File overwrite some keys, a seqno will be assigned
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
+    ASSERT_OK(
+        GenerateAndAddExternalFile(options, {1, 130}, file_id++, &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
-  // Write some keys through normal write path
-  for (int i = 0; i < 50; i++) {
-    ASSERT_OK(Put(Key(i), "memtable"));
-    true_data[Key(i)] = "memtable";
-  }
-  SequenceNumber last_seqno = dbfull()->GetLatestSequenceNumber();
+    // Write some keys through normal write path
+    for (int i = 0; i < 50; i++) {
+      ASSERT_OK(Put(Key(i), "memtable"));
+      true_data[Key(i)] = "memtable";
+    }
+    SequenceNumber last_seqno = dbfull()->GetLatestSequenceNumber();
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {60, 61, 62}, file_id++, &true_data));
-  // File dont overwrite any keys, No seqno needed
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {60, 61, 62}, file_id++,
+                                         &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {40, 41, 42}, file_id++, &true_data));
-  // File overwrite some keys, a seqno will be assigned
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {40, 41, 42}, file_id++,
+                                         &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {20, 30, 40}, file_id++, &true_data));
-  // File overwrite some keys, a seqno will be assigned
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 2);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {20, 30, 40}, file_id++,
+                                         &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 2);
 
-  const Snapshot* snapshot = db_->GetSnapshot();
+    const Snapshot* snapshot = db_->GetSnapshot();
 
-  // We will need a seqno for the file regardless if the file overwrite
-  // keys in the DB or not because we have a snapshot
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {1000, 1002}, file_id++, &true_data));
-  // A global seqno will be assigned anyway because of the snapshot
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 3);
+    // We will need a seqno for the file regardless if the file overwrite
+    // keys in the DB or not because we have a snapshot
+    ASSERT_OK(GenerateAndAddExternalFile(options, {1000, 1002}, file_id++,
+                                         &true_data));
+    // A global seqno will be assigned anyway because of the snapshot
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 3);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {2000, 3002}, file_id++, &true_data));
-  // A global seqno will be assigned anyway because of the snapshot
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 4);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {2000, 3002}, file_id++,
+                                         &true_data));
+    // A global seqno will be assigned anyway because of the snapshot
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 4);
 
-  ASSERT_OK(GenerateAndAddExternalFile(options, {1, 20, 40, 100, 150},
-                                       file_id++, &true_data));
-  // A global seqno will be assigned anyway because of the snapshot
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 5);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {1, 20, 40, 100, 150},
+                                         file_id++, &true_data));
+    // A global seqno will be assigned anyway because of the snapshot
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 5);
 
-  db_->ReleaseSnapshot(snapshot);
+    db_->ReleaseSnapshot(snapshot);
 
-  ASSERT_OK(
-      GenerateAndAddExternalFile(options, {5000, 5001}, file_id++, &true_data));
-  // No snapshot anymore, no need to assign a seqno
-  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 5);
+    ASSERT_OK(GenerateAndAddExternalFile(options, {5000, 5001}, file_id++,
+                                         &true_data));
+    // No snapshot anymore, no need to assign a seqno
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 5);
 
-  size_t kcnt = 0;
-  VerifyDBFromMap(true_data, &kcnt, false);
+    size_t kcnt = 0;
+    VerifyDBFromMap(true_data, &kcnt, false);
+  } while (ChangeCompactOptions());
+}
+
+TEST_F(ExternalSSTFileBasicTest, IngestFileCompactionWithGlobalSeqno) {
+  do {
+    Options options = CurrentOptions();
+    options.disable_auto_compactions = true;
+    DestroyAndReopen(options);
+    std::map<std::string, std::string> true_data;
+
+    int file_id = 1;
+
+    ASSERT_OK(GenerateAndAddExternalFile(
+        options, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, file_id++, &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
+
+    for (int i = 11; i < 20; i++) {
+      ASSERT_OK(Put(Key(i), "memtable"));
+      true_data[Key(i)] = "memtable";
+    }
+    ASSERT_OK(Flush());
+    SequenceNumber last_seqno = dbfull()->GetLatestSequenceNumber();
+    ASSERT_OK(GenerateAndAddExternalFile(options, {6, 7, 8}, file_id++,
+                                         &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
+    options.level0_file_num_compaction_trigger = 0;
+    options.disable_auto_compactions = false;
+    Reopen(options);
+    dbfull()->TEST_WaitForCompact();
+  } while (ChangeCompactOptions());
 }
 
 TEST_F(ExternalSSTFileBasicTest, FadviseTrigger) {

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -15,6 +15,7 @@
 #include "options/db_options.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/options.h"
 #include "rocksdb/sst_file_writer.h"
 #include "util/autovector.h"
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -732,7 +732,6 @@ TEST_F(ExternalSSTFileTest, MultiThreaded) {
 
   do {
     Options options = CurrentOptions();
-    fprintf(stderr, "%u  === \n", option_config_);
     std::atomic<int> thread_num(0);
     std::function<void()> write_file_func = [&]() {
       int file_idx = thread_num.fetch_add(1);

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -315,8 +315,7 @@ TEST_F(ExternalSSTFileTest, Basic) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipUniversalCompaction |
-                         kSkipFIFOCompaction));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 class SstFileWriterCollector : public TablePropertiesCollector {
  public:
@@ -368,7 +367,6 @@ class SstFileWriterCollectorFactory : public TablePropertiesCollectorFactory {
 TEST_F(ExternalSSTFileTest, AddList) {
   do {
     Options options = CurrentOptions();
-
     auto abc_collector = std::make_shared<SstFileWriterCollectorFactory>("abc");
     auto xyz_collector = std::make_shared<SstFileWriterCollectorFactory>("xyz");
 
@@ -556,8 +554,7 @@ TEST_F(ExternalSSTFileTest, AddList) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipUniversalCompaction |
-                         kSkipFIFOCompaction));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, AddListAtomicity) {
@@ -599,8 +596,7 @@ TEST_F(ExternalSSTFileTest, AddListAtomicity) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipUniversalCompaction |
-                         kSkipFIFOCompaction));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 // This test reporduce a bug that can happen in some cases if the DB started
 // purging obsolete files when we are adding an external sst file.
@@ -736,7 +732,7 @@ TEST_F(ExternalSSTFileTest, MultiThreaded) {
 
   do {
     Options options = CurrentOptions();
-
+    fprintf(stderr, "%u  === \n", option_config_);
     std::atomic<int> thread_num(0);
     std::function<void()> write_file_func = [&]() {
       int file_idx = thread_num.fetch_add(1);
@@ -831,8 +827,7 @@ TEST_F(ExternalSSTFileTest, MultiThreaded) {
 
     fprintf(stderr, "Verified %d values\n", num_files * keys_per_file);
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipUniversalCompaction |
-                         kSkipFIFOCompaction));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, OverlappingRanges) {
@@ -930,8 +925,7 @@ TEST_F(ExternalSSTFileTest, OverlappingRanges) {
     }
     printf("keys/values verified\n");
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipUniversalCompaction |
-                         kSkipFIFOCompaction));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, PickedLevel) {


### PR DESCRIPTION
I remove the assertion of seqno order in universal compaction picker and keep ingestion code untouched because the effort to keep the seqno order is not optimal in terms of performance and it brings a lot of difficult to keep this order.