### PR TITLE
add emacs tags file - etags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ package/
 .phutil_module_cache
 unity.a
 tags
+etags
 rocksdb_dump
 rocksdb_undump
 db_test2

--- a/Makefile
+++ b/Makefile
@@ -881,6 +881,7 @@ clean:
 tags:
 	ctags * -R
 	cscope -b `find . -name '*.cc'` `find . -name '*.h'` `find . -name '*.c'`
+	ctags -e -R -o etags *
 
 format:
 	build_tools/format-diff.sh


### PR DESCRIPTION
added ctags -e to the tags target in the makefile. It creates an etags file suitable for emacs.