### PR TITLE
add prefetch to PosixRandomAccessFile in buffered io

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -339,7 +339,7 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
 Status PosixRandomAccessFile::Prefetch(uint64_t offset, size_t n) {
   Status s;
   if (!use_direct_io()) {
-    int r = 0;
+    ssize_t r = 0;
 #ifdef OS_LINUX
     r = readahead(fd_, offset, n);
 #endif
@@ -347,7 +347,7 @@ Status PosixRandomAccessFile::Prefetch(uint64_t offset, size_t n) {
     radvisory advice;
     advice.ra_offset = static_cast<off_t>(offset);
     advice.ra_count = static_cast<int>(n);
-    r = fcntl(fd, F_RDADVISE, &advice);
+    r = fcntl(fd_, F_RDADVISE, &advice);
 #endif
     if (r == -1) {
       s = IOError(filename_, errno);

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -30,7 +30,6 @@
 #include "monitoring/iostats_context_imp.h"
 #include "port/port.h"
 #include "rocksdb/slice.h"
-#include "util/aligned_buffer.h"
 #include "util/coding.h"
 #include "util/string_util.h"
 #include "util/sync_point.h"
@@ -340,9 +339,7 @@ Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
 Status PosixRandomAccessFile::Prefetch(uint64_t offset, size_t n) {
   Status s;
   if (!use_direct_io()) {
-    size_t prefetch_offset =
-        TruncateToPageBoundary(GetRequiredBufferAlignment(), offset);
-    if (readahead(fd_, prefetch_offset, offset - prefetch_offset + n) == -1) {
+    if (readahead(fd_, offset, n) == -1) {
       s = IOError(filename_, errno);
     }
   }

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -79,6 +79,9 @@ class PosixRandomAccessFile : public RandomAccessFile {
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override;
+
+  virtual Status Prefetch(uint64_t offset, size_t n) override;
+
 #if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
   virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif


### PR DESCRIPTION
Every time after a compaction/flush finish, we issue user reads to put the table into block cache which includes a couple of IO that read footer, index blocks, meta block, etc. So we implement Prefetch here to reduce IO.