### PR TITLE
fix WritableFile buffer size in direct IO

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -691,7 +691,8 @@ struct DBOptions {
   // This is the maximum buffer size that is used by WritableFileWriter.
   // On Windows, we need to maintain an aligned buffer for writes.
   // We allow the buffer to grow until it's size hits the limit in buffered
-  // IO and fix the buffer size when using direct IO
+  // IO and fix the buffer size when using direct IO to ensure alignment of
+  // write requests if the logical sector size is unusual
   //
   // Default: 1024 * 1024 (1 MB)
   size_t writable_file_max_buffer_size = 1024 * 1024;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -690,7 +690,8 @@ struct DBOptions {
 
   // This is the maximum buffer size that is used by WritableFileWriter.
   // On Windows, we need to maintain an aligned buffer for writes.
-  // We allow the buffer to grow until it's size hits the limit.
+  // We allow the buffer to grow until it's size hits the limit in buffered
+  // IO and fix the buffer size when using direct IO
   //
   // Default: 1024 * 1024 (1 MB)
   size_t writable_file_max_buffer_size = 1024 * 1024;

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -138,7 +138,9 @@ class WritableFileWriter {
         rate_limiter_(options.rate_limiter),
         stats_(stats) {
     buf_.Alignment(writable_file_->GetRequiredBufferAlignment());
-    buf_.AllocateNewBuffer(std::min((size_t)65536, max_buffer_size_));
+    buf_.AllocateNewBuffer(use_direct_io()
+                               ? max_buffer_size_
+                               : std::min((size_t)65536, max_buffer_size_));
   }
 
   WritableFileWriter(const WritableFileWriter&) = delete;


### PR DESCRIPTION
fix the buffer size in case of ppl use buffer size as their block_size.