### PR TITLE
Delete filter before closing the table

### DIFF
--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -101,6 +101,11 @@ Status BlockBasedTableFactory::SanitizeOptions(
         "Unsupported BlockBasedTable format_version. Please check "
         "include/rocksdb/table.h for more info");
   }
+  if (table_options_.block_cache &&
+      table_options_.no_block_cache) {
+    return Status::InvalidArgument("Block cache is initialized"
+        ", but it is disabled");
+  }
   return Status::OK();
 }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2069,8 +2069,7 @@ void BlockBasedTable::Close() {
   // be deleted before the table is closed
   rep_->filter_entry.Release(block_cache, force_erase);
   rep_->index_entry.Release(block_cache, force_erase);
-  // range_del_entry's lifetime does not need to be longer than table's
-  rep_->range_del_entry.Release(block_cache, force_erase);
+  rep_->range_del_entry.Release(block_cache);
 }
 
 Status BlockBasedTable::DumpIndexBlock(WritableFile* out_file) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2063,7 +2063,11 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file) {
 }
 
 void BlockBasedTable::Close() {
-  rep_->filter_entry.Release(rep_->table_options.block_cache.get());
+  const bool force_erase = true;
+  // The filter_entry could have a pointer to the table and must be deleted
+  // before the table is closed
+  rep_->filter_entry.Release(rep_->table_options.block_cache.get(),
+                             force_erase);
   rep_->index_entry.Release(rep_->table_options.block_cache.get());
   rep_->range_del_entry.Release(rep_->table_options.block_cache.get());
   // cleanup index and filter blocks to avoid accessing dangling pointer

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -370,9 +370,10 @@ struct BlockBasedTable::CachableEntry {
   CachableEntry(TValue* _value, Cache::Handle* _cache_handle)
       : value(_value), cache_handle(_cache_handle) {}
   CachableEntry() : CachableEntry(nullptr, nullptr) {}
-  void Release(Cache* cache) {
+  void Release(Cache* cache, bool force_erase = false) {
     if (cache_handle) {
-      cache->Release(cache_handle);
+      bool erased = cache->Release(cache_handle, force_erase);
+      assert(!force_erase || erased);
       value = nullptr;
       cache_handle = nullptr;
     }

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -92,9 +92,11 @@ PartitionedFilterBlockReader::PartitionedFilterBlockReader(
 PartitionedFilterBlockReader::~PartitionedFilterBlockReader() {
   // The destructor migh be called via cache evict after the table is deleted.
   // We should avoid using table_ pointer in destructor then.
-  ReadLock rl(&mu_);
-  for (auto it = handle_list_.begin(); it != handle_list_.end(); ++it) {
-    block_cache_->Release(*it);
+  if (block_cache_) {
+    ReadLock rl(&mu_);
+    for (auto it = handle_list_.begin(); it != handle_list_.end(); ++it) {
+      block_cache_->Release(*it);
+    }
   }
 }
 
@@ -125,7 +127,7 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
     return res;
   }
   if (LIKELY(filter_partition.IsSet())) {
-    filter_partition.Release(table_->rep_->table_options.block_cache.get());
+    filter_partition.Release(block_cache_);
   } else {
     delete filter_partition.value;
   }
@@ -157,7 +159,7 @@ bool PartitionedFilterBlockReader::PrefixMayMatch(
     return res;
   }
   if (LIKELY(filter_partition.IsSet())) {
-    filter_partition.Release(table_->rep_->table_options.block_cache.get());
+    filter_partition.Release(block_cache_);
   } else {
     delete filter_partition.value;
   }
@@ -185,8 +187,7 @@ PartitionedFilterBlockReader::GetFilterPartition(Slice* handle_value,
   auto s = fltr_blk_handle.DecodeFrom(handle_value);
   assert(s.ok());
   const bool is_a_filter_partition = true;
-  auto block_cache = table_->rep_->table_options.block_cache.get();
-  if (LIKELY(block_cache != nullptr)) {
+  if (LIKELY(block_cache_ != nullptr)) {
     bool pin_cached_filters =
         GetLevel() == 0 &&
         table_->rep_->table_options.pin_l0_filter_and_index_blocks_in_cache;

--- a/table/partitioned_filter_block.h
+++ b/table/partitioned_filter_block.h
@@ -85,6 +85,7 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   std::unique_ptr<Block> idx_on_fltr_blk_;
   const Comparator& comparator_;
   const BlockBasedTable* table_;
+  Cache* block_cache_;
   std::unordered_map<uint64_t, FilterBlockReader*> filter_cache_;
   autovector<Cache::Handle*> handle_list_;
   port::RWMutex mu_;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1930,7 +1930,7 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
   }
   // release the iterator so that the block cache can reset correctly.
   iter.reset();
-
+  table_options.block_cache->EraseUnRefEntries();
   c.ResetTableReader();
 
   // -- PART 2: Open with very small block cache
@@ -1973,6 +1973,7 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
     ASSERT_EQ(props.GetCacheBytesRead(), 0);
   }
   iter.reset();
+  table_options.block_cache->EraseUnRefEntries();
   c.ResetTableReader();
 
   // -- PART 3: Open table with bloom filter enabled but not in SST file
@@ -1988,6 +1989,7 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
   // Generate table without filter policy
   c3.Finish(options, ioptions3, table_options,
             GetPlainInternalComparator(options.comparator), &keys, &kvmap);
+  table_options.block_cache->EraseUnRefEntries();
   c3.ResetTableReader();
 
   // Open table with filter policy
@@ -2006,6 +2008,7 @@ TEST_F(BlockBasedTableTest, FilterBlockInBlockCache) {
   ASSERT_STREQ(value.data(), "hello");
   BlockCachePropertiesSnapshot props(options.statistics.get());
   props.AssertFilterBlockStat(0, 0);
+  table_options.block_cache->EraseUnRefEntries();
   c3.ResetTableReader();
 }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -9,7 +9,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <inttypes.h>
 #include <stdio.h>
 
 #include <algorithm>


### PR DESCRIPTION
Some filters such as partitioned filter have pointers to the table for which they are created. Therefore is they are stored in the block cache, the should be forcibly erased from block cache before closing the  table, which would result into deleting the object. Otherwise the destructor will be called later when the cache is lazily erasing the object, which having the parent table no longer existent it could result into undefined behavior.

Update: there will be still cases the filter is not removed from the cache since the table has not kept a pointer to the cache handle to be able to forcibly release it later. We make sure that the filter destructor does not access the table pointer to get around such cases.