### PR TITLE
add <sys/sysmacros.h> to avoid warning with glibc 2.25

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -22,6 +22,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -21,11 +21,11 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #endif
 #include "env/posix_logger.h"
 #include "monitoring/iostats_context_imp.h"

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -21,8 +21,8 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <sys/sysmacros.h>
+#include <sys/types.h>
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
https://github.com/facebook/rocksdb/issues/2152