### PR TITLE
Add user stats Reset API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### New Features
 * DB::ResetStats() to reset internal stats.
+* Statistics::Reset() to reset user stats.
 * ldb add option --try_load_options, which will open DB with its own option file.
 
 ## 5.4.0 (04/11/2017)

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <vector>
 
+#include "rocksdb/status.h"
+
 namespace rocksdb {
 
 /**
@@ -442,6 +444,11 @@ class Statistics {
   virtual void setTickerCount(uint32_t tickerType, uint64_t count) = 0;
   virtual uint64_t getAndResetTickerCount(uint32_t tickerType) = 0;
   virtual void measureTime(uint32_t histogramType, uint64_t time) = 0;
+
+  // Resets all ticker and histogram stats
+  virtual Status Reset() {
+    return Status::NotSupported("Not implemented");
+  }
 
   // String representation of the statistic object.
   virtual std::string ToString() const {


### PR DESCRIPTION
It resets all the ticker and histogram stats to zero. Needed to change the locking a bit since Reset() is the only operation that manipulates multiple tickers/histograms together, and that operation should be seen as atomic by other operations that access tickers/histograms.

Test Plan: have a unit test but need to commit #2211 first.