### PR TITLE
Fix .gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ rocksdb.h
 unity.cc
 java/crossbuild/.vagrant
 .vagrant/
-java/**.asc
+java/**/*.asc
 java/javadoc
 
 scan_build_report/


### PR DESCRIPTION
`java/**.asc` is not a correct gitignore pattern
See https://git-scm.com/docs/gitignore for the list of allowed `**` patterns

It seems reasonable to assume that intention is `java/**/*.asc`

The reason why it bothers me is the fact that ripgrep parses .gitignore files
and complains about invalid pattern
https://github.com/BurntSushi/ripgrep