### PR TITLE
Put lib files into suitable path in RPM package

### DIFF
--- a/build_tools/make_package.sh
+++ b/build_tools/make_package.sh
@@ -99,7 +99,18 @@ function main() {
 
   make static_lib
   make install INSTALL_PATH=package
+
   cd package
+
+  LIB_DIR=lib
+  if [[ -z "$ARCH" ]]; then
+      ARCH=$(getconf LONG_BIT)
+  fi
+  if [[ ("$FPM_OUTPUT" = "rpm") && ($ARCH -eq 64) ]]; then
+      mv lib lib64
+      LIB_DIR=lib64
+  fi
+
   fpm \
     -s dir \
     -t $FPM_OUTPUT \
@@ -111,7 +122,7 @@ function main() {
     --license BSD \
     --vendor Facebook \
     --description "RocksDB is an embeddable persistent key-value store for fast storage." \
-    include lib
+    include $LIB_DIR
 }
 
 main $@

--- a/build_tools/make_package.sh
+++ b/build_tools/make_package.sh
@@ -99,6 +99,7 @@ function main() {
 
   make static_lib
   make install INSTALL_PATH=package
+  cd package
   fpm \
     -s dir \
     -t $FPM_OUTPUT \
@@ -110,7 +111,7 @@ function main() {
     --license BSD \
     --vendor Facebook \
     --description "RocksDB is an embeddable persistent key-value store for fast storage." \
-    package
+    include lib
 }
 
 main $@


### PR DESCRIPTION
Currently, the RPM package will install the lib and header files into `/usr/package/lib` and `/usr/package/include` which is not in the default search paths. It is reasonable to install them under `/usr/lib` and `/usr/include` so that no extra configuration is required.