### PR TITLE
port: updated PhysicalCoreID()

### DIFF
--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -140,11 +140,18 @@ int PhysicalCoreID() {
   // if you ever find that this function is hot on Linux, you can go from
   // ~200 nanos to ~20 nanos by adding the machinery to use __vdso_getcpu
   unsigned eax, ebx = 0, ecx, edx;
-  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+  if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+    return -1;
+  }
   return ebx >> 24;
 #else
-  // getcpu or sched_getcpu could work here
-  return -1;
+  int cpuno = sched_getcpu();
+  if (cpuno < 0) {
+    return -1;
+  }
+  else {
+    return cpuno;
+  }
 #endif
 }
 


### PR DESCRIPTION
Summary:
Checked the return value of __get_cpuid(). Implemented the else case where the arch is different from i386 and x86_64.
    
Pulled By: joscollin
    
Signed-off-by: Jos Collin <jcollin@redhat.com>