### PR TITLE
fix memory alignment with logical sector size

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -118,18 +118,13 @@ size_t GetLogicalBufferSize(int __attribute__((__unused__)) fd) {
  */
 #ifndef NDEBUG
 namespace {
-#ifdef OS_LINUX
-const size_t kPageSize = sysconf(_SC_PAGESIZE);
-#else
-const size_t kPageSize = 4 * 1024;
-#endif
 
 bool IsSectorAligned(const size_t off, size_t sector_size) {
   return off % sector_size == 0;
 }
 
-static bool IsPageAligned(const void* ptr) {
-  return uintptr_t(ptr) % (kPageSize) == 0;
+static bool IsPageAligned(const void* ptr, size_t sector_size) {
+  return uintptr_t(ptr) % sector_size == 0;
 }
 
 }
@@ -185,6 +180,10 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
 
 Status PosixSequentialFile::PositionedRead(uint64_t offset, size_t n,
                                            Slice* result, char* scratch) {
+  assert(!use_direct_io() ||
+         (IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
+          IsSectorAligned(n, GetRequiredBufferAlignment()) &&
+          IsPageAligned(scratch, GetRequiredBufferAlignment())));
   Status s;
   ssize_t r = -1;
   size_t left = n;
@@ -309,6 +308,10 @@ PosixRandomAccessFile::~PosixRandomAccessFile() { close(fd_); }
 
 Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
                                    char* scratch) const {
+  assert(!use_direct_io() ||
+         (IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
+          IsSectorAligned(n, GetRequiredBufferAlignment()) &&
+          IsPageAligned(scratch, GetRequiredBufferAlignment())));
   Status s;
   ssize_t r = -1;
   size_t left = n;
@@ -709,7 +712,7 @@ PosixWritableFile::~PosixWritableFile() {
 Status PosixWritableFile::Append(const Slice& data) {
   assert(!use_direct_io() ||
          (IsSectorAligned(data.size(), GetRequiredBufferAlignment()) &&
-          IsPageAligned(data.data())));
+          IsPageAligned(data.data(), GetRequiredBufferAlignment())));
   const char* src = data.data();
   size_t left = data.size();
   while (left != 0) {
@@ -731,7 +734,7 @@ Status PosixWritableFile::PositionedAppend(const Slice& data, uint64_t offset) {
   assert(use_direct_io() &&
          IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
          IsSectorAligned(data.size(), GetRequiredBufferAlignment()) &&
-         IsPageAligned(data.data()));
+         IsPageAligned(data.data(), GetRequiredBufferAlignment()));
   assert(offset <= std::numeric_limits<off_t>::max());
   const char* src = data.data();
   size_t left = data.size();

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -123,7 +123,7 @@ bool IsSectorAligned(const size_t off, size_t sector_size) {
   return off % sector_size == 0;
 }
 
-static bool IsPageAligned(const void* ptr, size_t sector_size) {
+bool IsSectorAligned(const void* ptr, size_t sector_size) {
   return uintptr_t(ptr) % sector_size == 0;
 }
 
@@ -180,10 +180,11 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
 
 Status PosixSequentialFile::PositionedRead(uint64_t offset, size_t n,
                                            Slice* result, char* scratch) {
-  assert(!use_direct_io() ||
-         (IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
-          IsSectorAligned(n, GetRequiredBufferAlignment()) &&
-          IsPageAligned(scratch, GetRequiredBufferAlignment())));
+  if (use_direct_io()) {
+    assert(IsSectorAligned(offset, GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(n, GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(scratch, GetRequiredBufferAlignment()));
+  }
   Status s;
   ssize_t r = -1;
   size_t left = n;
@@ -308,10 +309,11 @@ PosixRandomAccessFile::~PosixRandomAccessFile() { close(fd_); }
 
 Status PosixRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
                                    char* scratch) const {
-  assert(!use_direct_io() ||
-         (IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
-          IsSectorAligned(n, GetRequiredBufferAlignment()) &&
-          IsPageAligned(scratch, GetRequiredBufferAlignment())));
+  if (use_direct_io()) {
+    assert(IsSectorAligned(offset, GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(n, GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(scratch, GetRequiredBufferAlignment()));
+  }
   Status s;
   ssize_t r = -1;
   size_t left = n;
@@ -710,9 +712,10 @@ PosixWritableFile::~PosixWritableFile() {
 }
 
 Status PosixWritableFile::Append(const Slice& data) {
-  assert(!use_direct_io() ||
-         (IsSectorAligned(data.size(), GetRequiredBufferAlignment()) &&
-          IsPageAligned(data.data(), GetRequiredBufferAlignment())));
+  if (use_direct_io()) {
+    assert(IsSectorAligned(data.size(), GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(data.data(), GetRequiredBufferAlignment()));
+  }
   const char* src = data.data();
   size_t left = data.size();
   while (left != 0) {
@@ -731,10 +734,11 @@ Status PosixWritableFile::Append(const Slice& data) {
 }
 
 Status PosixWritableFile::PositionedAppend(const Slice& data, uint64_t offset) {
-  assert(use_direct_io() &&
-         IsSectorAligned(offset, GetRequiredBufferAlignment()) &&
-         IsSectorAligned(data.size(), GetRequiredBufferAlignment()) &&
-         IsPageAligned(data.data(), GetRequiredBufferAlignment()));
+  if (use_direct_io()) {
+    assert(IsSectorAligned(offset, GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(data.size(), GetRequiredBufferAlignment()));
+    assert(IsSectorAligned(data.data(), GetRequiredBufferAlignment()));
+  }
   assert(offset <= std::numeric_limits<off_t>::max());
   const char* src = data.data();
   size_t left = data.size();


### PR DESCRIPTION
we align the buffer with logical sector size and should not test it with page size, which is usually 4k.