### PR TITLE
Object lifetime in cache

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -187,6 +187,8 @@ class Cache {
 
   virtual std::string GetPrintableOptions() const { return ""; }
 
+  // Mark the last inserted object as being a raw data block. This will be used
+  // in tests. The default implementation does nothing.
   virtual void TEST_mark_as_data_block(const Slice& key, size_t charge) {}
 
  private:

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -187,6 +187,8 @@ class Cache {
 
   virtual std::string GetPrintableOptions() const { return ""; }
 
+  virtual void TEST_mark_as_data_block(const Slice& key, size_t charge) {}
+
  private:
   // No copying allowed
   Cache(const Cache&);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -909,6 +909,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
       s = block_cache->Insert(
           block_cache_key, block->value, block->value->usable_size(),
           &DeleteCachedEntry<Block>, &(block->cache_handle));
+      block_cache->TEST_mark_as_data_block(block_cache_key,
+                                           block->value->usable_size());
       if (s.ok()) {
         RecordTick(statistics, BLOCK_CACHE_ADD);
         if (is_index) {
@@ -990,6 +992,8 @@ Status BlockBasedTable::PutDataBlockToCache(
     s = block_cache->Insert(
         block_cache_key, block->value, block->value->usable_size(),
         &DeleteCachedEntry<Block>, &(block->cache_handle), priority);
+    block_cache->TEST_mark_as_data_block(block_cache_key,
+                                         block->value->usable_size());
     if (s.ok()) {
       assert(block->cache_handle != nullptr);
       RecordTick(statistics, BLOCK_CACHE_ADD);
@@ -2071,7 +2075,7 @@ void BlockBasedTable::Close() {
     char cache_key[kMaxCacheKeyPrefixSize + kMaxVarint64Length];
     // Get the filter block key
     auto key = GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
-                           rep_->footer.metaindex_handle(), cache_key);
+                           rep_->filter_handle, cache_key);
     rep_->table_options.block_cache.get()->Erase(key);
     // Get the index block key
     key = GetCacheKeyFromOffset(rep_->cache_key_prefix,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -370,9 +370,9 @@ struct BlockBasedTable::CachableEntry {
   CachableEntry(TValue* _value, Cache::Handle* _cache_handle)
       : value(_value), cache_handle(_cache_handle) {}
   CachableEntry() : CachableEntry(nullptr, nullptr) {}
-  void Release(Cache* cache) {
+  void Release(Cache* cache, bool force_erase = false) {
     if (cache_handle) {
-      cache->Release(cache_handle);
+      cache->Release(cache_handle, force_erase);
       value = nullptr;
       cache_handle = nullptr;
     }

--- a/table/partitioned_filter_block.h
+++ b/table/partitioned_filter_block.h
@@ -87,7 +87,12 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   const BlockBasedTable* table_;
   std::unordered_map<uint64_t, FilterBlockReader*> filter_cache_;
   autovector<Cache::Handle*> handle_list_;
-  autovector<BlockHandle> filter_block_list_;
+  struct BlockHandleCmp {
+    bool operator()(const BlockHandle& lhs, const BlockHandle& rhs) const {
+      return lhs.offset() < rhs.offset();
+    }
+  };
+  std::set<BlockHandle, BlockHandleCmp> filter_block_set_;
   port::RWMutex mu_;
 };
 

--- a/table/partitioned_filter_block.h
+++ b/table/partitioned_filter_block.h
@@ -87,6 +87,7 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   const BlockBasedTable* table_;
   std::unordered_map<uint64_t, FilterBlockReader*> filter_cache_;
   autovector<Cache::Handle*> handle_list_;
+  autovector<BlockHandle> filter_block_list_;
   port::RWMutex mu_;
 };
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2128,6 +2128,9 @@ TEST_F(BlockBasedTableTest, BlockReadCountTest) {
   }
 }
 
+// A wrapper around LRICache that also keeps track of data blocks (in contrast
+// with the objects) in the cache. The class is very simple and can be used only
+// for trivial tests.
 class MockCache : public LRUCache {
  public:
   MockCache(size_t capacity, int num_shard_bits, bool strict_capacity_limit,
@@ -2138,95 +2141,121 @@ class MockCache : public LRUCache {
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle = nullptr,
                         Priority priority = Priority::LOW) {
-    deleters[key.ToString()] = deleter;
+    // Replace the deleter with our own so that we keep track of data blocks
+    // erased from the cache
+    deleters_[key.ToString()] = deleter;
     return ShardedCache::Insert(key, value, charge, &MockDeleter, handle,
                                 priority);
   }
+  // This is called by the application right after inserting a data block
   virtual void TEST_mark_as_data_block(const Slice& key, size_t charge) {
     marked_data_in_cache_[key.ToString()] = charge;
     marked_size_ += charge;
   }
-  struct CmpBySlice {
-    bool operator()(const Slice& a, const Slice& b) const {
-      return a.compare(b) < 0;
-    }
-  };
   typedef void (*DeleterFunc)(const Slice& key, void* value);
-  static std::map<std::string, DeleterFunc> deleters;
+  static std::map<std::string, DeleterFunc> deleters_;
   static std::map<std::string, size_t> marked_data_in_cache_;
   static size_t marked_size_;
   static void MockDeleter(const Slice& key, void* value) {
+    // If the item was marked for being data block, decrease its usage from  the
+    // total data block usage of the cache
     if (marked_data_in_cache_.find(key.ToString()) !=
         marked_data_in_cache_.end()) {
       marked_size_ -= marked_data_in_cache_[key.ToString()];
     }
-    assert(deleters.find(key.ToString()) != deleters.end());
-    auto deleter = deleters[key.ToString()];
+    // Then call the origianl deleter
+    assert(deleters_.find(key.ToString()) != deleters_.end());
+    auto deleter = deleters_[key.ToString()];
     deleter(key, value);
   }
 };
 
 size_t MockCache::marked_size_ = 0;
-std::map<std::string, MockCache::DeleterFunc> MockCache::deleters;
+std::map<std::string, MockCache::DeleterFunc> MockCache::deleters_;
 std::map<std::string, size_t> MockCache::marked_data_in_cache_;
 
-TEST_F(BlockBasedTableTest, XXX) {
-  Options opt;
-  unique_ptr<InternalKeyComparator> ikc;
-  ikc.reset(new test::PlainInternalKeyComparator(opt.comparator));
-  opt.compression = kNoCompression;
-  BlockBasedTableOptions table_options;
-  table_options.block_size = 1024;
-  table_options.index_type =
-      BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
-  table_options.partition_filters = true;
-  table_options.cache_index_and_filter_blocks = true;
-  // big enough so we don't ever lose cached values.
-  table_options.block_cache = std::shared_ptr<rocksdb::Cache>(
-      new MockCache(16 * 1024 * 1024, 4, false, 0.0));
-  table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
-  opt.table_factory.reset(NewBlockBasedTableFactory(table_options));
+// Block cache can contain raw data blocks as well as general objects. If an
+// object depends on the table to be live, it then must be destructed before the
+// table is closed. This test makese sure that the only items remains in the
+// cache after the table is closed are raw data blocks.
+TEST_F(BlockBasedTableTest, NoObjectInCacheAfterTableClose) {
+  for (auto index_type :
+       {BlockBasedTableOptions::IndexType::kBinarySearch,
+        BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch}) {
+    for (bool block_based_filter : {true, false}) {
+      for (bool partition_filter : {true, false}) {
+        if (partition_filter &&
+            (block_based_filter ||
+             index_type !=
+                 BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch)) {
+          continue;
+        }
+        for (bool index_and_filter_in_cache : {true, false}) {
+          for (bool pin_l0 : {true, false}) {
+            if (pin_l0 && !index_and_filter_in_cache) {
+              continue;
+            }
+            // Create a table
+            Options opt;
+            unique_ptr<InternalKeyComparator> ikc;
+            ikc.reset(new test::PlainInternalKeyComparator(opt.comparator));
+            opt.compression = kNoCompression;
+            BlockBasedTableOptions table_options;
+            table_options.block_size = 1024;
+            table_options.index_type =
+                BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+            table_options.pin_l0_filter_and_index_blocks_in_cache = pin_l0;
+            table_options.partition_filters = partition_filter;
+            table_options.cache_index_and_filter_blocks =
+                index_and_filter_in_cache;
+            // big enough so we don't ever lose cached values.
+            table_options.block_cache = std::shared_ptr<rocksdb::Cache>(
+                new MockCache(16 * 1024 * 1024, 4, false, 0.0));
+            table_options.filter_policy.reset(
+                rocksdb::NewBloomFilterPolicy(10, block_based_filter));
+            opt.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
-  TableConstructor c(BytewiseComparator());
-  std::string user_key = "k01";
-  InternalKey internal_key(user_key, 0, kTypeValue);
-  c.Add(internal_key.Encode().ToString(), "hello");
-  std::vector<std::string> keys;
-  stl_wrappers::KVMap kvmap;
-  const ImmutableCFOptions ioptions(opt);
-  c.Finish(opt, ioptions, table_options, *ikc, &keys, &kvmap);
+            TableConstructor c(BytewiseComparator());
+            std::string user_key = "k01";
+            std::string key =
+                InternalKey(user_key, 0, kTypeValue).Encode().ToString();
+            c.Add(key, "hello");
+            std::vector<std::string> keys;
+            stl_wrappers::KVMap kvmap;
+            const ImmutableCFOptions ioptions(opt);
+            c.Finish(opt, ioptions, table_options, *ikc, &keys, &kvmap);
 
-  auto u = table_options.block_cache->GetUsage();
-  auto pu = table_options.block_cache->GetPinnedUsage();
-  printf("usage %zu pusage %zu marked_size %zu\n", u, pu,
-         MockCache::marked_size_);
+            // Doing a read to make index/filter loaded into the cache
+            auto table_reader =
+                dynamic_cast<BlockBasedTable*>(c.GetTableReader());
+            PinnableSlice value;
+            GetContext get_context(opt.comparator, nullptr, nullptr, nullptr,
+                                   GetContext::kNotFound, user_key, &value,
+                                   nullptr, nullptr, nullptr, nullptr);
+            InternalKey ikey(user_key, 0, kTypeValue);
+            auto s = table_reader->Get(ReadOptions(), key, &get_context);
+            ASSERT_EQ(get_context.State(), GetContext::kFound);
+            ASSERT_STREQ(value.data(), "hello");
 
-  auto table_reader = dynamic_cast<BlockBasedTable*>(c.GetTableReader());
-  PinnableSlice value;
-  GetContext get_context(opt.comparator, nullptr, nullptr, nullptr,
-                         GetContext::kNotFound, user_key, &value, nullptr,
-                         nullptr, nullptr, nullptr);
-  InternalKey ikey(user_key, 0, kTypeValue);
-  auto s = table_reader->Get(ReadOptions(), internal_key.Encode().ToString(),
-                             &get_context);
-  ASSERT_EQ(get_context.State(), GetContext::kFound);
-  ASSERT_STREQ(value.data(), "hello");
+            // Close the table
+            c.ResetTableReader();
 
-  u = table_options.block_cache->GetUsage();
-  pu = table_options.block_cache->GetPinnedUsage();
-  printf("usage %zu pusage %zu marked_size %zu\n", u, pu,
-         MockCache::marked_size_);
-
-  c.ResetTableReader();
-  u = table_options.block_cache->GetUsage();
-  pu = table_options.block_cache->GetPinnedUsage();
-  printf("usage %zu pusage %zu marked_size %zu\n", u, pu,
-         MockCache::marked_size_);
-  ASSERT_EQ(u, MockCache::marked_size_);
-  ASSERT_GT(pu, 0);
-  value.Reset();
-  pu = table_options.block_cache->GetPinnedUsage();
-  ASSERT_EQ(pu, 0);
+            auto usage = table_options.block_cache->GetUsage();
+            auto pinned_usage = table_options.block_cache->GetPinnedUsage();
+            // The only usage must be for marked data blocks
+            ASSERT_EQ(usage, MockCache::marked_size_);
+            // There must be some pinned data since PinnableSlice has not
+            // released them yet
+            ASSERT_GT(pinned_usage, 0);
+            // Release pinnable slice reousrces
+            value.Reset();
+            pinned_usage = table_options.block_cache->GetPinnedUsage();
+            ASSERT_EQ(pinned_usage, 0);
+          }
+        }
+      }
+    }
+  }
 }
 
 TEST_F(BlockBasedTableTest, BlockCacheLeak) {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -9,7 +9,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <inttypes.h>
 #include <stdio.h>
 
 #include <algorithm>
@@ -2140,7 +2139,7 @@ class MockCache : public LRUCache {
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle = nullptr,
-                        Priority priority = Priority::LOW) {
+                        Priority priority = Priority::LOW) override {
     // Replace the deleter with our own so that we keep track of data blocks
     // erased from the cache
     deleters_[key.ToString()] = deleter;
@@ -2148,11 +2147,12 @@ class MockCache : public LRUCache {
                                 priority);
   }
   // This is called by the application right after inserting a data block
-  virtual void TEST_mark_as_data_block(const Slice& key, size_t charge) {
+  virtual void TEST_mark_as_data_block(const Slice& key,
+                                       size_t charge) override {
     marked_data_in_cache_[key.ToString()] = charge;
     marked_size_ += charge;
   }
-  typedef void (*DeleterFunc)(const Slice& key, void* value);
+  using DeleterFunc = void (*)(const Slice& key, void* value);
   static std::map<std::string, DeleterFunc> deleters_;
   static std::map<std::string, size_t> marked_data_in_cache_;
   static size_t marked_size_;


### PR DESCRIPTION
    Any non-raw-data dependent object must be destructed before the table
    closes. There was a bug of not doing that for filter object. This patch
    fixes the bug and adds a unit test to prevent such bugs in future.