### PR TITLE
dont skip IO for filter blocks

### DIFF
--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -796,36 +796,19 @@ TEST_P(BloomStatsTestWithParam, BloomStatsTestWithIter) {
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ(value1, iter->value().ToString());
-  if (partition_filters_) {
-    ASSERT_EQ(0, perf_context.bloom_sst_hit_count);   // no_io
-    ASSERT_EQ(0, perf_context.bloom_sst_miss_count);  // no_io
-  } else {
-    ASSERT_EQ(1, perf_context.bloom_sst_hit_count);
-  }
+  ASSERT_EQ(1, perf_context.bloom_sst_hit_count);
 
   iter->Seek(key3);
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ(value3, iter->value().ToString());
-  if (partition_filters_) {
-    ASSERT_EQ(0, perf_context.bloom_sst_hit_count);   // no_io
-    ASSERT_EQ(0, perf_context.bloom_sst_miss_count);  // no_io
-  } else {
-    ASSERT_EQ(2, perf_context.bloom_sst_hit_count);
-  }
+  ASSERT_EQ(2, perf_context.bloom_sst_hit_count);
 
   iter->Seek(key2);
   ASSERT_OK(iter->status());
-  if (partition_filters_) {
-    // iter is still valid since filter did not reject the key2
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ(0, perf_context.bloom_sst_hit_count);   // no_io
-    ASSERT_EQ(0, perf_context.bloom_sst_miss_count);  // no_io
-  } else {
-    ASSERT_TRUE(!iter->Valid());
-    ASSERT_EQ(1, perf_context.bloom_sst_miss_count);
-    ASSERT_EQ(2, perf_context.bloom_sst_hit_count);
-  }
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_EQ(1, perf_context.bloom_sst_miss_count);
+  ASSERT_EQ(2, perf_context.bloom_sst_hit_count);
 }
 
 INSTANTIATE_TEST_CASE_P(BloomStatsTestWithParam, BloomStatsTestWithParam,

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1448,14 +1448,13 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key) {
   Status s;
 
   // First, try check with full filter
-  const bool no_io = true;
-  auto filter_entry = GetFilter(no_io);
+  auto filter_entry = GetFilter();
   FilterBlockReader* filter = filter_entry.value;
   if (filter != nullptr) {
     if (!filter->IsBlockBased()) {
       const Slice* const const_ikey_ptr = &internal_key;
       may_match =
-          filter->PrefixMayMatch(prefix, kNotValid, no_io, const_ikey_ptr);
+          filter->PrefixMayMatch(prefix, kNotValid, false, const_ikey_ptr);
     } else {
       InternalKey internal_key_prefix(prefix, kMaxSequenceNumber, kTypeValue);
       auto internal_prefix = internal_key_prefix.Encode();


### PR DESCRIPTION
Based on my experience with linkbench, We should not skip loading bloom filter blocks when they are not available in block cache when using Iterator::Seek

Actually I am not sure why this behavior existed in the first place