### PR TITLE
Define CACHE_LINE_SIZE only when it's not defined

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -185,7 +185,9 @@ typedef pthread_once_t OnceType;
 #define LEVELDB_ONCE_INIT PTHREAD_ONCE_INIT
 extern void InitOnce(OnceType* once, void (*initializer)());
 
+#ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64U
+#endif
 
 #define PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
 

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -237,7 +237,9 @@ struct OnceType {
 #define LEVELDB_ONCE_INIT port::OnceType::Init()
 extern void InitOnce(OnceType* once, void (*initializer)());
 
+#ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64U
+#endif
 
 static inline void AsmVolatilePause() {
 #if defined(_M_IX86) || defined(_M_X64)


### PR DESCRIPTION
RocksDB is compiled as part of MyRocks (MySQL storage engine) build.
MySQL already defines `CACHE_LINE_SIZE` and therefore we're getting a
conflict. Change RocksDB definition to be more cognizant of this.