### PR TITLE
unbiase readamp bitmap

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1701,9 +1701,11 @@ TEST_F(DBTest2, ReadAmpBitmap) {
   }
   delete iter;
 
-  // Read amp is 100% since we read all what we loaded in memory
-  ASSERT_EQ(options.statistics->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES),
-            options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES));
+  // Read amp is on average 100% since we read all what we loaded in memory
+  ASSERT_GE(options.statistics->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES) *
+                1.0f /
+                options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES),
+            0.99);
 }
 
 #ifndef OS_SOLARIS // GetUniqueIdFromFile is not implemented

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1644,68 +1644,80 @@ size_t GetEncodedEntrySize(size_t key_size, size_t value_size) {
 TEST_F(DBTest2, ReadAmpBitmap) {
   Options options = CurrentOptions();
   BlockBasedTableOptions bbto;
-  // Disable delta encoding to make it easier to calculate read amplification
-  bbto.use_delta_encoding = false;
-  // Huge block cache to make it easier to calculate read amplification
-  bbto.block_cache = NewLRUCache(1024 * 1024 * 1024);
-  bbto.read_amp_bytes_per_bit = 16;
-  options.table_factory.reset(NewBlockBasedTableFactory(bbto));
-  options.statistics = rocksdb::CreateDBStatistics();
-  DestroyAndReopen(options);
+  size_t bytes_per_bit[2] = {1, 16};
+  for (size_t k = 0; k < 2; k++) {
+    // Disable delta encoding to make it easier to calculate read amplification
+    bbto.use_delta_encoding = false;
+    // Huge block cache to make it easier to calculate read amplification
+    bbto.block_cache = NewLRUCache(1024 * 1024 * 1024);
+    bbto.read_amp_bytes_per_bit = bytes_per_bit[k];
+    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    options.statistics = rocksdb::CreateDBStatistics();
+    DestroyAndReopen(options);
 
-  const size_t kNumEntries = 10000;
+    const size_t kNumEntries = 10000;
 
-  Random rnd(301);
-  for (size_t i = 0; i < kNumEntries; i++) {
-    ASSERT_OK(Put(Key(static_cast<int>(i)), RandomString(&rnd, 100)));
-  }
-  ASSERT_OK(Flush());
+    Random rnd(301);
+    for (size_t i = 0; i < kNumEntries; i++) {
+      ASSERT_OK(Put(Key(static_cast<int>(i)), RandomString(&rnd, 100)));
+    }
+    ASSERT_OK(Flush());
 
-  Close();
-  Reopen(options);
+    Close();
+    Reopen(options);
 
-  // Read keys/values randomly and verify that reported read amp error
-  // is less than 2%
-  uint64_t total_useful_bytes = 0;
-  std::set<int> read_keys;
-  std::string value;
-  for (size_t i = 0; i < kNumEntries * 5; i++) {
-    int key_idx = rnd.Next() % kNumEntries;
-    std::string k = Key(key_idx);
-    ASSERT_OK(db_->Get(ReadOptions(), k, &value));
+    // Read keys/values randomly and verify that reported read amp error
+    // is less than 2%
+    uint64_t total_useful_bytes = 0;
+    std::set<int> read_keys;
+    std::string value;
+    for (size_t i = 0; i < kNumEntries * 5; i++) {
+      int key_idx = rnd.Next() % kNumEntries;
+      std::string key = Key(key_idx);
+      ASSERT_OK(db_->Get(ReadOptions(), key, &value));
 
-    if (read_keys.find(key_idx) == read_keys.end()) {
-      auto ik = InternalKey(k, 0, ValueType::kTypeValue);
-      total_useful_bytes += GetEncodedEntrySize(ik.size(), value.size());
-      read_keys.insert(key_idx);
+      if (read_keys.find(key_idx) == read_keys.end()) {
+        auto internal_key = InternalKey(key, 0, ValueType::kTypeValue);
+        total_useful_bytes +=
+            GetEncodedEntrySize(internal_key.size(), value.size());
+        read_keys.insert(key_idx);
+      }
+
+      double expected_read_amp =
+          static_cast<double>(total_useful_bytes) /
+          options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES);
+
+      double read_amp =
+          static_cast<double>(options.statistics->getTickerCount(
+              READ_AMP_ESTIMATE_USEFUL_BYTES)) /
+          options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES);
+
+      double error_pct = fabs(expected_read_amp - read_amp) * 100;
+      // Error between reported read amp and real read amp should be less than
+      // 2%
+      EXPECT_LE(error_pct, 2);
     }
 
-    double expected_read_amp =
-        static_cast<double>(total_useful_bytes) /
-        options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES);
+    // Make sure we read every thing in the DB (which is smaller than our cache)
+    Iterator* iter = db_->NewIterator(ReadOptions());
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      ASSERT_EQ(iter->value().ToString(), Get(iter->key().ToString()));
+    }
+    delete iter;
 
-    double read_amp =
-        static_cast<double>(options.statistics->getTickerCount(
-            READ_AMP_ESTIMATE_USEFUL_BYTES)) /
-        options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES);
-
-    double error_pct = fabs(expected_read_amp - read_amp) * 100;
-    // Error between reported read amp and real read amp should be less than 2%
-    EXPECT_LE(error_pct, 2);
+    // Read amp is on average 100% since we read all what we loaded in memory
+    if (k == 0) {
+      ASSERT_EQ(
+          options.statistics->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES),
+          options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES));
+    } else {
+      ASSERT_NEAR(
+          options.statistics->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES) *
+              1.0f /
+              options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES),
+          1, .01);
+    }
   }
-
-  // Make sure we read every thing in the DB (which is smaller than our cache)
-  Iterator* iter = db_->NewIterator(ReadOptions());
-  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-    ASSERT_EQ(iter->value().ToString(), Get(iter->key().ToString()));
-  }
-  delete iter;
-
-  // Read amp is on average 100% since we read all what we loaded in memory
-  ASSERT_GE(options.statistics->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES) *
-                1.0f /
-                options.statistics->getTickerCount(READ_AMP_TOTAL_READ_BYTES),
-            0.99);
 }
 
 #ifndef OS_SOLARIS // GetUniqueIdFromFile is not implemented

--- a/table/block.h
+++ b/table/block.h
@@ -50,9 +50,12 @@ class BlockReadAmpBitmap {
       : bitmap_(nullptr),
         bytes_per_bit_pow_(0),
         statistics_(statistics),
-        rnd_(Random::GetTLSInstance()->Uniform(
-            static_cast<int>(bytes_per_bit))) {
-    TEST_SYNC_POINT_CALLBACK("BlockReadAmpBitmap", &rnd_);
+        rnd_(
+            Random::GetTLSInstance()->Uniform(static_cast<int>(bytes_per_bit))),
+        last_rnd_(rnd_ * ((block_size - 1) % bytes_per_bit + 1) /
+                  bytes_per_bit) {
+    TEST_SYNC_POINT_CALLBACK("BlockReadAmpBitmap:rnd", &rnd_);
+    TEST_SYNC_POINT_CALLBACK("BlockReadAmpBitmap:last_rnd", &last_rnd_);
     assert(block_size > 0 && bytes_per_bit > 0);
 
     // convert bytes_per_bit to be a power of 2
@@ -62,16 +65,12 @@ class BlockReadAmpBitmap {
 
     // num_bits_needed = ceil(block_size / bytes_per_bit)
     size_t num_bits_needed =
-        (block_size >> static_cast<size_t>(bytes_per_bit_pow_)) +
-        (block_size % (static_cast<size_t>(1)
-                       << static_cast<size_t>(bytes_per_bit_pow_)) !=
-         0);
+      ((block_size - 1) >> bytes_per_bit_pow_) + 1;
     assert(num_bits_needed > 0);
     last_bit_ = static_cast<int>(num_bits_needed - 1);
 
     // bitmap_size = ceil(num_bits_needed / kBitsPerEntry)
-    size_t bitmap_size = (num_bits_needed / kBitsPerEntry) +
-                         (num_bits_needed % kBitsPerEntry != 0);
+    size_t bitmap_size = (num_bits_needed - 1) / kBitsPerEntry + 1;
 
     // Create bitmap and set all the bits to 0
     bitmap_ = new std::atomic<uint32_t>[bitmap_size];
@@ -85,56 +84,29 @@ class BlockReadAmpBitmap {
 
   void Mark(uint32_t start_offset, uint32_t end_offset) {
     assert(end_offset >= start_offset);
-
-    // Every new bit we set will bump this counter
-    uint32_t new_useful_bytes = 0;
     // Index of first bit in mask
     uint32_t start_bit =
-      (start_offset >> bytes_per_bit_pow_ == last_bit_
-             ? last_bit_
-             : (start_offset + (1 << bytes_per_bit_pow_) - rnd_ - 1) >>
-                   bytes_per_bit_pow_);
+        (start_offset + (1 << bytes_per_bit_pow_) -
+         (start_offset >> bytes_per_bit_pow_ == last_bit_ ? last_rnd_ : rnd_) -
+         1) >>
+        bytes_per_bit_pow_;
     // Index of last bit in mask + 1
     uint32_t exclusive_end_bit =
-      (end_offset >> bytes_per_bit_pow_ == last_bit_
-             ? last_bit_ + 1
-             : (end_offset + (1 << bytes_per_bit_pow_) - rnd_) >>
-                   bytes_per_bit_pow_);
+        (end_offset + (1 << bytes_per_bit_pow_) -
+         (end_offset >> bytes_per_bit_pow_ == last_bit_ ? last_rnd_ : rnd_)) >>
+        bytes_per_bit_pow_;
     if (start_bit >= exclusive_end_bit) {
       return;
     }
     assert(exclusive_end_bit > 0);
-    uint32_t end_bit = exclusive_end_bit - 1;
-    // Index of middle bit (unique to this range)
-    uint32_t mid_bit = start_bit + 1;
-
-    // It's guaranteed that ranges sent to Mark() wont overlap, this mean that
-    // we dont need to set the middle bits, we can simply set only one bit of
-    // the middle bits, and check this bit if we want to know if the whole
-    // range is set or not.
-    if (mid_bit < end_bit) {
-      if (GetAndSet(mid_bit) == 0) {
-        new_useful_bytes += (end_bit - mid_bit) << bytes_per_bit_pow_;
-      } else {
-        // If the middle bit is set, it's guaranteed that start and end bits
-        // are also set
-        return;
-      }
-    } else {
-      // This range dont have a middle bit, the whole range fall in 1 or 2 bits
-    }
 
     if (GetAndSet(start_bit) == 0) {
-      new_useful_bytes += (1 << bytes_per_bit_pow_);
-    }
-
-    if (GetAndSet(end_bit) == 0) {
-      new_useful_bytes += (1 << bytes_per_bit_pow_);
-    }
-
-    if (new_useful_bytes > 0) {
-      RecordTick(GetStatistics(), READ_AMP_ESTIMATE_USEFUL_BYTES,
-                 new_useful_bytes);
+      uint32_t new_useful_bytes = (exclusive_end_bit - start_bit)
+                                  << bytes_per_bit_pow_;
+      if (new_useful_bytes > 0) {
+        RecordTick(GetStatistics(), READ_AMP_ESTIMATE_USEFUL_BYTES,
+                   new_useful_bytes);
+      }
     }
   }
 
@@ -171,6 +143,7 @@ class BlockReadAmpBitmap {
   // by using SetStatistics() before calling Mark()
   std::atomic<Statistics*> statistics_;
   uint32_t rnd_;
+  uint32_t last_rnd_;
 };
 
 class Block {

--- a/table/block.h
+++ b/table/block.h
@@ -47,8 +47,11 @@ class BlockReadAmpBitmap {
  public:
   explicit BlockReadAmpBitmap(size_t block_size, size_t bytes_per_bit,
                               Statistics* statistics)
-      : bitmap_(nullptr), bytes_per_bit_pow_(0), statistics_(statistics),
-        rnd_(Random::GetTLSInstance()->Uniform(bytes_per_bit)){
+      : bitmap_(nullptr),
+        bytes_per_bit_pow_(0),
+        statistics_(statistics),
+        rnd_(Random::GetTLSInstance()->Uniform(
+            static_cast<int>(bytes_per_bit))) {
     TEST_SYNC_POINT_CALLBACK("BlockReadAmpBitmap", &rnd_);
     assert(block_size > 0 && bytes_per_bit > 0);
 
@@ -63,7 +66,8 @@ class BlockReadAmpBitmap {
         (block_size % (static_cast<size_t>(1)
                        << static_cast<size_t>(bytes_per_bit_pow_)) !=
          0);
-    last_bit_ = num_bits_needed - 1;
+    assert(num_bits_needed > 0);
+    last_bit_ = static_cast<int>(num_bits_needed - 1);
 
     // bitmap_size = ceil(num_bits_needed / kBitsPerEntry)
     size_t bitmap_size = (num_bits_needed / kBitsPerEntry) +

--- a/table/block.h
+++ b/table/block.h
@@ -94,10 +94,8 @@ class BlockReadAmpBitmap {
     if (GetAndSet(start_bit) == 0) {
       uint32_t new_useful_bytes = (exclusive_end_bit - start_bit)
                                   << bytes_per_bit_pow_;
-      if (new_useful_bytes > 0) {
-        RecordTick(GetStatistics(), READ_AMP_ESTIMATE_USEFUL_BYTES,
-                   new_useful_bytes);
-      }
+      RecordTick(GetStatistics(), READ_AMP_ESTIMATE_USEFUL_BYTES,
+                 new_useful_bytes);
     }
   }
 
@@ -125,7 +123,6 @@ class BlockReadAmpBitmap {
   // Bitmap used to record the bytes that we read, use atomic to protect
   // against multiple threads updating the same bit
   std::atomic<uint32_t>* bitmap_;
-  uint32_t last_bit_;
   // (1 << bytes_per_bit_pow_) is bytes_per_bit. Use power of 2 to optimize
   // muliplication and division
   uint8_t bytes_per_bit_pow_;
@@ -134,7 +131,6 @@ class BlockReadAmpBitmap {
   // by using SetStatistics() before calling Mark()
   std::atomic<Statistics*> statistics_;
   uint32_t rnd_;
-  uint32_t last_rnd_;
 };
 
 class Block {

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -228,18 +228,27 @@ class BlockReadAmpBitmapSlowAndAccurate {
  public:
   void Mark(size_t start_offset, size_t end_offset) {
     assert(end_offset >= start_offset);
-
     marked_ranges_.emplace(end_offset, start_offset);
   }
-
   // Return true if any byte in this range was Marked
   bool IsAnyInRangeMarked(size_t start_offset, size_t end_offset) {
-    auto it = marked_ranges_.lower_bound(
-        std::make_pair(start_offset, static_cast<size_t>(0)));
+  auto it = marked_ranges_.lower_bound(
+      std::make_pair(start_offset, static_cast<size_t>(0)));
     if (it == marked_ranges_.end()) {
       return false;
     }
+    fprintf(stderr, "hhh %lu %lu\n", it->first, it->second);
     return start_offset <= it->first && end_offset >= it->second;
+  }
+
+  // Return true if any byte in this range was Marked
+  bool IsPinMarked(size_t offset) {
+    auto it = marked_ranges_.lower_bound(
+        std::make_pair(offset, static_cast<size_t>(0)));
+    if (it == marked_ranges_.end()) {
+      return false;
+    }
+    return offset <= it->first && offset >= it->second;
   }
 
  private:
@@ -247,6 +256,12 @@ class BlockReadAmpBitmapSlowAndAccurate {
 };
 
 TEST_F(BlockTest, BlockReadAmpBitmap) {
+  uint32_t pin_offset = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+    "BlockReadAmpBitmap", [&pin_offset](void* arg) {
+      pin_offset = *(static_cast<uint32_t*>(arg));
+    });
+  SyncPoint::GetInstance()->EnableProcessing();
   std::vector<size_t> block_sizes = {
       1,                 // 1 byte
       32,                // 32 bytes
@@ -279,7 +294,6 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
     if (needed_bits % 32 != 0) {
       bitmap_size++;
     }
-    size_t bits_in_bitmap = bitmap_size * 32;
 
     ASSERT_EQ(stats->getTickerCount(READ_AMP_TOTAL_READ_BYTES),
               needed_bits * kBytesPerBit);
@@ -316,20 +330,23 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
                                       current_entry.second);
 
       size_t total_bits = 0;
-      for (size_t bit_idx = 0; bit_idx < bits_in_bitmap; bit_idx++) {
-        size_t start_rng = bit_idx * kBytesPerBit;
-        size_t end_rng = (start_rng + kBytesPerBit) - 1;
-
-        total_bits +=
-            read_amp_slow_and_accurate.IsAnyInRangeMarked(start_rng, end_rng);
+      for (size_t bit_idx = 0; bit_idx < needed_bits; bit_idx++) {
+        if (bit_idx + 1 == needed_bits) {
+          total_bits += read_amp_slow_and_accurate.IsAnyInRangeMarked(
+            bit_idx * kBytesPerBit, (bit_idx + 1) * kBytesPerBit - 1);
+        } else {
+          total_bits += read_amp_slow_and_accurate.IsPinMarked(
+              bit_idx * kBytesPerBit + pin_offset);
+        }
       }
       size_t expected_estimate_useful = total_bits * kBytesPerBit;
       size_t got_estimate_useful =
-          stats->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES);
-
+        stats->getTickerCount(READ_AMP_ESTIMATE_USEFUL_BYTES);
       ASSERT_EQ(expected_estimate_useful, got_estimate_useful);
     }
   }
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_F(BlockTest, BlockWithReadAmpBitmap) {

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -246,15 +246,11 @@ class BlockReadAmpBitmapSlowAndAccurate {
 };
 
 TEST_F(BlockTest, BlockReadAmpBitmap) {
-  uint32_t pin_offset = 0, last_pin_offset = 0;
+  uint32_t pin_offset = 0;
   SyncPoint::GetInstance()->SetCallBack(
     "BlockReadAmpBitmap:rnd", [&pin_offset](void* arg) {
       pin_offset = *(static_cast<uint32_t*>(arg));
     });
-  SyncPoint::GetInstance()->SetCallBack(
-      "BlockReadAmpBitmap:last_rnd", [&last_pin_offset](void* arg) {
-        last_pin_offset = *(static_cast<uint32_t*>(arg));
-      });
   SyncPoint::GetInstance()->EnableProcessing();
   std::vector<size_t> block_sizes = {
       1,                 // 1 byte
@@ -289,8 +285,7 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
       bitmap_size++;
     }
 
-    ASSERT_EQ(stats->getTickerCount(READ_AMP_TOTAL_READ_BYTES),
-              needed_bits * kBytesPerBit);
+    ASSERT_EQ(stats->getTickerCount(READ_AMP_TOTAL_READ_BYTES), block_size);
 
     // Generate some random entries
     std::vector<size_t> random_entry_offsets;
@@ -326,8 +321,7 @@ TEST_F(BlockTest, BlockReadAmpBitmap) {
       size_t total_bits = 0;
       for (size_t bit_idx = 0; bit_idx < needed_bits; bit_idx++) {
         total_bits += read_amp_slow_and_accurate.IsPinMarked(
-            bit_idx * kBytesPerBit +
-            (bit_idx + 1 == needed_bits ? last_pin_offset : pin_offset));
+          bit_idx * kBytesPerBit + pin_offset);
       }
       size_t expected_estimate_useful = total_bits * kBytesPerBit;
       size_t got_estimate_useful =


### PR DESCRIPTION
Consider BlockReadAmpBitmap with bytes_per_bit = 32. Suppose bytes [a, b) were used, while bytes [a-32, a)
 and [b+1, b+33) weren't used; more formally, the union of ranges passed to BlockReadAmpBitmap::Mark() contains [a, b) and doesn't intersect with [a-32, a) and [b+1, b+33). Then bits [floor(a/32), ceil(b/32)] will be set, and so the number of useful bytes will be estimated as (ceil(b/32) - floor(a/32)) * 32, which is on average equal to b-a+31.

An extreme example: if we use 1 byte from each block, it'll be counted as 32 bytes from each block.

It's easy to remove this bias by slightly changing the semantics of the bitmap. Currently each bit represents a byte range [i*32, (i+1)*32). 

This diff makes each bit represent a single byte: i*32 + X, where X is a random number in [0, 31] generated when bitmap is created. So, e.g., if you read a single byte at random, with probability 31/32 it won't be counted at all, and with probability 1/32 it will be counted as 32 bytes; so, on average it's counted as 1 byte. 

*But there is one exception: the last bit will always set with the old way.*

(*) - assuming read_amp_bytes_per_bit = 32.