### PR TITLE
Add NO_UPDATE_BUILD_VERSION option to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,9 @@ CXXFLAGS += $(WARNING_FLAGS) -I. -I./include $(PLATFORM_CXXFLAGS) $(OPT) -Woverl
 
 LDFLAGS += $(PLATFORM_LDFLAGS)
 
+# If NO_UPDATE_BUILD_VERSION is set we don't update util/build_version.cc, but
+# the file needs to already exist or else the build will fail
+ifndef NO_UPDATE_BUILD_VERSION
 date := $(shell date +%F)
 ifdef FORCE_GIT_SHA
 	git_sha := $(FORCE_GIT_SHA)
@@ -293,7 +296,6 @@ gen_build_version = sed -e s/@@GIT_SHA@@/$(git_sha)/ -e s/@@GIT_DATE_TIME@@/$(da
 # as a regular source file as part of the compilation process.
 # One can run "strings executable_filename | grep _build_" to find
 # the version of the source that we used to build the executable file.
-CLEAN_FILES += util/build_version.cc:
 FORCE:
 util/build_version.cc: FORCE
 	$(AM_V_GEN)rm -f $@-t
@@ -301,6 +303,8 @@ util/build_version.cc: FORCE
 	$(AM_V_at)if test -f $@; then					\
 	  cmp -s $@-t $@ && rm -f $@-t || mv -f $@-t $@;		\
 	else mv -f $@-t $@; fi
+endif
+CLEAN_FILES += util/build_version.cc
 
 LIBOBJECTS = $(LIB_SOURCES:.cc=.o)
 LIBOBJECTS += $(TOOL_LIB_SOURCES:.cc=.o)


### PR DESCRIPTION
Summary: When building rocksdb in fbcode using `make`, util/build_version.cc is always updated (gitignore/hgignore doesn't apply because the file is already checked into fbcode).  To use the rocksdb makefile from our own makefile, I would like an option to prevent the metadata update, which is of no value for us.

Test Plan: FORCE_GIT_SHA=1 make -j24 ; sha1sum util/build_version.cc
FORCE_GIT_SHA=2 NO_UPDATE_BUILD_VERSION=1 make -j24 ; sha1sum util/build_version.cc
FORCE_GIT_SHA=2 make -j24 ; sha1sum util/build_version.cc

The first and third builds update the file but the second doesn't.