### PR TITLE
Fix ColumnFamilyTest:BulkAddDrop

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -692,6 +692,9 @@ TEST_F(ColumnFamilyTest, BulkAddDrop) {
   }
   ASSERT_OK(db_->DropColumnFamilies(cf_handles));
   std::vector<ColumnFamilyDescriptor> cf_descriptors;
+  for (auto* handle : cf_handles) {
+    delete handle;
+  }
   cf_handles.clear();
   for (int i = 1; i <= kNumCF; i++) {
     cf_descriptors.emplace_back("cf2-" + ToString(i), ColumnFamilyOptions());
@@ -701,6 +704,9 @@ TEST_F(ColumnFamilyTest, BulkAddDrop) {
     ASSERT_OK(db_->Put(write_options, cf_handles[i - 1], "foo", "bar"));
   }
   ASSERT_OK(db_->DropColumnFamilies(cf_handles));
+  for (auto* handle : cf_handles) {
+    delete handle;
+  }
   Close();
   std::vector<std::string> families;
   ASSERT_OK(DB::ListColumnFamilies(db_options_, dbname_, &families));


### PR DESCRIPTION
Summary:
Fix ColumnFamilyTest:BulkAddDrop not deleted CF handles at the end, causing ASAN failure.

Test Plan:
COMPILE_WITH_ASAN=1 make column_family_test
./column_family_test --gtest_filter=*BulkAddDrop