### PR TITLE
Add missing files of blob_db to CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,8 @@ set(SOURCES
         utilities/backupable/backupable_db.cc
         utilities/blob_db/blob_db.cc
         utilities/blob_db/blob_db_impl.cc
+        utilities/blob_db/blob_db_options_impl.cc
+        utilities/blob_db/blob_file.cc
         utilities/blob_db/blob_log_reader.cc
         utilities/blob_db/blob_log_writer.cc
         utilities/blob_db/blob_log_format.cc


### PR DESCRIPTION
Summary:
Some of the file from #2269 didn't add to CMake file. Adding them to fix window build.

Test Plan:
check AppVeyor build result.