### PR TITLE
CMake cross platform Java support and add JNI to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ install:
       brew install ccache;
       PATH=$PATH:/usr/local/opt/ccache/libexec;
     fi
+  - if [[ "${JOB_NAME}" == cmake* ]] && [ "${TRAVIS_OS_NAME}" == linux ]; then
+      mkdir cmake-dist && curl -sfSL https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.tar.gz | tar --strip-components=1 -C cmake-dist -xz && export PATH=$PWD/cmake-dist/bin:$PATH;
+    fi
 
 before_script:
   # Increase the maximum number of open file descriptors, since some tests use
@@ -68,8 +71,8 @@ script:
   - if [ "${JOB_NAME}" == 'java_test' ]; then OPT=-DTRAVIS V=1 make clean jclean && make rocksdbjava jtest; fi
   - if [ "${JOB_NAME}" == 'lite_build' ]; then OPT="-DTRAVIS -DROCKSDB_LITE" V=1 make -j4 static_lib tools; fi
   - if [ "${JOB_NAME}" == 'examples' ]; then OPT=-DTRAVIS V=1 make -j4 static_lib; cd examples; make -j4; fi
-  - if [ "${JOB_NAME}" == 'cmake' ]; then mkdir build && cd build && cmake .. && make -j4 rocksdb; fi
-  - if [ "${JOB_NAME}" == 'cmake-mingw' ]; then mkdir build && cd build && cmake .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb; fi
+  - if [ "${JOB_NAME}" == 'cmake' ]; then mkdir build && cd build && cmake -DJNI=1 .. && make -j4 rocksdb rocksdbjni; fi
+  - if [ "${JOB_NAME}" == 'cmake-mingw' ]; then mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb rocksdbjni; fi
 notifications:
     email:
       - leveldb@fb.com

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.4)
 
 set(JNI_NATIVE_SOURCES
         rocksjni/backupablejni.cc
@@ -46,7 +46,7 @@ set(JNI_NATIVE_SOURCES
 
 set(NATIVE_JAVA_CLASSES
         org.rocksdb.AbstractCompactionFilter
-        org.rocksdb.AbstractComparator
+        org.rocksdb.AbstractCompactionFilterFactory
         org.rocksdb.AbstractImmutableNativeReference
         org.rocksdb.AbstractNativeReference
         org.rocksdb.AbstractRocksIterator
@@ -74,7 +74,6 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.DirectSlice
         org.rocksdb.Env
         org.rocksdb.EnvOptions
-        org.rocksdb.ExternalSstFileInfo
         org.rocksdb.Filter
         org.rocksdb.FlushOptions
         org.rocksdb.HashLinkedListMemTableConfig
@@ -92,6 +91,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.ReadOptions
         org.rocksdb.RemoveEmptyValueCompactionFilter
         org.rocksdb.RestoreOptions
+        org.rocksdb.RocksCallbackObject
         org.rocksdb.RocksDB
         org.rocksdb.RocksDBExceptionTest
         org.rocksdb.RocksEnv
@@ -120,8 +120,11 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.WriteOptions
 )
 
-include_directories($ENV{JAVA_HOME}/include)
-include_directories($ENV{JAVA_HOME}/include/win32)
+include(FindJava)
+include(UseJava)
+include(FindJNI)
+
+include_directories(${JNI_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/java)
 
 set(JAVA_TEST_LIBDIR ${PROJECT_SOURCE_DIR}/java/test-libs)
@@ -131,7 +134,118 @@ set(JAVA_HAMCR_JAR ${JAVA_TEST_LIBDIR}/hamcrest-core-1.3.jar)
 set(JAVA_MOCKITO_JAR ${JAVA_TEST_LIBDIR}/mockito-all-1.10.19.jar)
 set(JAVA_CGLIB_JAR ${JAVA_TEST_LIBDIR}/cglib-2.2.2.jar)
 set(JAVA_ASSERTJ_JAR ${JAVA_TEST_LIBDIR}/assertj-core-1.7.1.jar)
-set(JAVA_TESTCLASSPATH "${JAVA_JUNIT_JAR}\;${JAVA_HAMCR_JAR}\;${JAVA_MOCKITO_JAR}\;${JAVA_CGLIB_JAR}\;${JAVA_ASSERTJ_JAR}")
+set(JAVA_TESTCLASSPATH ${JAVA_JUNIT_JAR} ${JAVA_HAMCR_JAR} ${JAVA_MOCKITO_JAR} ${JAVA_CGLIB_JAR} ${JAVA_ASSERTJ_JAR})
+
+add_jar(
+  rocksdbjni_classes
+  SOURCES
+  src/main/java/org/rocksdb/AbstractCompactionFilter.java
+  src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
+  src/main/java/org/rocksdb/AbstractComparator.java
+  src/main/java/org/rocksdb/AbstractImmutableNativeReference.java
+  src/main/java/org/rocksdb/AbstractNativeReference.java
+  src/main/java/org/rocksdb/AbstractRocksIterator.java
+  src/main/java/org/rocksdb/AbstractSlice.java
+  src/main/java/org/rocksdb/AbstractWriteBatch.java
+  src/main/java/org/rocksdb/AccessHint.java
+  src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/AdvancedMutableColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/BackupableDBOptions.java
+  src/main/java/org/rocksdb/BackupEngine.java
+  src/main/java/org/rocksdb/BackupInfo.java
+  src/main/java/org/rocksdb/BlockBasedTableConfig.java
+  src/main/java/org/rocksdb/BloomFilter.java
+  src/main/java/org/rocksdb/BuiltinComparator.java
+  src/main/java/org/rocksdb/Cache.java
+  src/main/java/org/rocksdb/CassandraCompactionFilter.java
+  src/main/java/org/rocksdb/CassandraValueMergeOperator.java
+  src/main/java/org/rocksdb/Checkpoint.java
+  src/main/java/org/rocksdb/ChecksumType.java
+  src/main/java/org/rocksdb/ClockCache.java
+  src/main/java/org/rocksdb/ColumnFamilyDescriptor.java
+  src/main/java/org/rocksdb/ColumnFamilyHandle.java
+  src/main/java/org/rocksdb/ColumnFamilyOptions.java
+  src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/CompactionOptionsFIFO.java
+  src/main/java/org/rocksdb/CompactionOptionsUniversal.java
+  src/main/java/org/rocksdb/CompactionPriority.java
+  src/main/java/org/rocksdb/CompactionStopStyle.java
+  src/main/java/org/rocksdb/CompactionStyle.java
+  src/main/java/org/rocksdb/Comparator.java
+  src/main/java/org/rocksdb/ComparatorOptions.java
+  src/main/java/org/rocksdb/CompressionOptions.java
+  src/main/java/org/rocksdb/CompressionType.java
+  src/main/java/org/rocksdb/DBOptions.java
+  src/main/java/org/rocksdb/DBOptionsInterface.java
+  src/main/java/org/rocksdb/DbPath.java
+  src/main/java/org/rocksdb/DirectComparator.java
+  src/main/java/org/rocksdb/DirectSlice.java
+  src/main/java/org/rocksdb/EncodingType.java
+  src/main/java/org/rocksdb/Env.java
+  src/main/java/org/rocksdb/EnvOptions.java
+  src/main/java/org/rocksdb/Experimental.java
+  src/main/java/org/rocksdb/Filter.java
+  src/main/java/org/rocksdb/FlushOptions.java
+  src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java
+  src/main/java/org/rocksdb/HashSkipListMemTableConfig.java
+  src/main/java/org/rocksdb/HistogramData.java
+  src/main/java/org/rocksdb/HistogramType.java
+  src/main/java/org/rocksdb/IndexType.java
+  src/main/java/org/rocksdb/InfoLogLevel.java
+  src/main/java/org/rocksdb/IngestExternalFileOptions.java
+  src/main/java/org/rocksdb/Logger.java
+  src/main/java/org/rocksdb/LRUCache.java
+  src/main/java/org/rocksdb/MemTableConfig.java
+  src/main/java/org/rocksdb/MergeOperator.java
+  src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
+  src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/NativeLibraryLoader.java
+  src/main/java/org/rocksdb/Options.java
+  src/main/java/org/rocksdb/OptionsUtil.java
+  src/main/java/org/rocksdb/PlainTableConfig.java
+  src/main/java/org/rocksdb/RateLimiter.java
+  src/main/java/org/rocksdb/ReadOptions.java
+  src/main/java/org/rocksdb/ReadTier.java
+  src/main/java/org/rocksdb/RemoveEmptyValueCompactionFilter.java
+  src/main/java/org/rocksdb/RestoreOptions.java
+  src/main/java/org/rocksdb/RocksCallbackObject.java
+  src/main/java/org/rocksdb/RocksDB.java
+  src/main/java/org/rocksdb/RocksDBException.java
+  src/main/java/org/rocksdb/RocksEnv.java
+  src/main/java/org/rocksdb/RocksIterator.java
+  src/main/java/org/rocksdb/RocksIteratorInterface.java
+  src/main/java/org/rocksdb/RocksMemEnv.java
+  src/main/java/org/rocksdb/RocksMutableObject.java
+  src/main/java/org/rocksdb/RocksObject.java
+  src/main/java/org/rocksdb/SkipListMemTableConfig.java
+  src/main/java/org/rocksdb/Slice.java
+  src/main/java/org/rocksdb/Snapshot.java
+  src/main/java/org/rocksdb/SstFileWriter.java
+  src/main/java/org/rocksdb/Statistics.java
+  src/main/java/org/rocksdb/StatsLevel.java
+  src/main/java/org/rocksdb/Status.java
+  src/main/java/org/rocksdb/StringAppendOperator.java
+  src/main/java/org/rocksdb/TableFormatConfig.java
+  src/main/java/org/rocksdb/TickerType.java
+  src/main/java/org/rocksdb/TransactionLogIterator.java
+  src/main/java/org/rocksdb/TtlDB.java
+  src/main/java/org/rocksdb/util/Environment.java
+  src/main/java/org/rocksdb/VectorMemTableConfig.java
+  src/main/java/org/rocksdb/WALRecoveryMode.java
+  src/main/java/org/rocksdb/WBWIRocksIterator.java
+  src/main/java/org/rocksdb/WriteBatch.java
+  src/main/java/org/rocksdb/WriteBatchInterface.java
+  src/main/java/org/rocksdb/WriteBatchWithIndex.java
+  src/main/java/org/rocksdb/WriteOptions.java
+  src/test/java/org/rocksdb/BackupEngineTest.java
+  src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
+  src/test/java/org/rocksdb/PlatformRandomHelper.java
+  src/test/java/org/rocksdb/RocksDBExceptionTest.java
+  src/test/java/org/rocksdb/RocksMemoryResource.java
+  src/test/java/org/rocksdb/SnapshotTest.java
+  src/test/java/org/rocksdb/WriteBatchTest.java
+  INCLUDE_JARS ${JAVA_TESTCLASSPATH}
+)
 
 if(NOT EXISTS ${PROJECT_SOURCE_DIR}/java/classes)
   file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/java/classes)
@@ -195,16 +309,35 @@ if(NOT EXISTS ${JAVA_ASSERTJ_JAR})
   file(RENAME ${JAVA_TMP_JAR} ${JAVA_ASSERTJ_JAR})
 endif()
 
-if(WIN32)
-  set(JAVAC cmd /c javac)
-  set(JAVAH cmd /c javah)
-else()
-  set(JAVAC javac)
-  set(JAVAH javah)
+set(JNI_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/java/include)
+
+file(MAKE_DIRECTORY ${JNI_OUTPUT_DIR})
+create_javah(
+  TARGET rocksdbjni_headers
+  CLASSES ${NATIVE_JAVA_CLASSES}
+  CLASSPATH rocksdbjni_classes ${JAVA_TESTCLASSPATH}
+  OUTPUT_DIR ${JNI_OUTPUT_DIR}
+)
+
+if(NOT MSVC)
+  set_property(TARGET ${ROCKSDB_STATIC_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-execute_process(COMMAND ${JAVAC} ${JAVAC_ARGS} -cp ${JAVA_TESTCLASSPATH} -d ${PROJECT_SOURCE_DIR}/java/classes ${PROJECT_SOURCE_DIR}/java/src/main/java/org/rocksdb/util/*.java ${PROJECT_SOURCE_DIR}/java/src/main/java/org/rocksdb/*.java ${PROJECT_SOURCE_DIR}/java/src/test/java/org/rocksdb/*.java)
-execute_process(COMMAND ${JAVAH} -cp ${PROJECT_SOURCE_DIR}/java/classes -d ${PROJECT_SOURCE_DIR}/java/include -jni ${NATIVE_JAVA_CLASSES})
-add_library(rocksdbjni${ARTIFACT_SUFFIX} SHARED ${JNI_NATIVE_SOURCES})
-set_target_properties(rocksdbjni${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/rocksdbjni${ARTIFACT_SUFFIX}.pdb")
-target_link_libraries(rocksdbjni${ARTIFACT_SUFFIX} rocksdb${ARTIFACT_SUFFIX} ${LIBS})
+set(ROCKSDBJNI_STATIC_LIB rocksdbjni${ARTIFACT_SUFFIX})
+add_library(${ROCKSDBJNI_STATIC_LIB} ${JNI_NATIVE_SOURCES})
+add_dependencies(${ROCKSDBJNI_STATIC_LIB} rocksdbjni_headers)
+target_link_libraries(${ROCKSDBJNI_STATIC_LIB} ${ROCKSDB_STATIC_LIB} ${LIBS})
+
+if(NOT MINGW)
+  set(ROCKSDBJNI_SHARED_LIB rocksdbjni-shared${ARTIFACT_SUFFIX})
+  add_library(${ROCKSDBJNI_SHARED_LIB} SHARED ${JNI_NATIVE_SOURCES})
+  add_dependencies(${ROCKSDBJNI_SHARED_LIB} rocksdbjni_headers)
+  target_link_libraries(${ROCKSDBJNI_SHARED_LIB} ${ROCKSDB_STATIC_LIB} ${LIBS})
+
+  set_target_properties(
+    ${ROCKSDBJNI_SHARED_LIB}
+    PROPERTIES
+    COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_CFG_INTDIR}
+    COMPILE_PDB_NAME ${ROCKSDBJNI_STATIC_LIB}.pdb
+  )
+endif()

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -636,7 +636,7 @@ class ColumnFamilyOptionsJni
       return nullptr;
     }
 
-    jobject jcfd = env->NewObject(jclazz, mid, reinterpret_cast<long>(cfo));
+    jobject jcfd = env->NewObject(jclazz, mid, reinterpret_cast<jlong>(cfo));
     if (env->ExceptionCheck()) {
       return nullptr;
     }


### PR DESCRIPTION
Rewrite `java/CMakeLists.txt` to take advantage of CMake's cross platform
Java support.

@adamretter 