### PR TITLE
db: error: dereferencing type-punned pointer will break strict-aliasi…

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -847,7 +847,8 @@ class MemTableInserter : public WriteBatch::Handler {
       new (&mem_post_info_map_) MemPostInfoMap();
       post_info_created_ = true;
     }
-    return *reinterpret_cast<MemPostInfoMap*>(&mem_post_info_map_);
+    MemPostInfoMap* pmem_post_info_map = reinterpret_cast<MemPostInfoMap*>(&mem_post_info_map_);
+    return *pmem_post_info_map;
   }
 
 public:
@@ -874,8 +875,8 @@ public:
 
   ~MemTableInserter() {
     if (post_info_created_) {
-      reinterpret_cast<MemPostInfoMap*>
-        (&mem_post_info_map_)->~MemPostInfoMap();
+      MemPostInfoMap* pmem_post_info_map = reinterpret_cast<MemPostInfoMap*>(&mem_post_info_map_);
+      pmem_post_info_map->~MemPostInfoMap();
     }
   }
 

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -191,7 +191,8 @@ class WriteThread {
     // always last in the order
     std::mutex& StateMutex() {
       assert(made_waitable);
-      return *static_cast<std::mutex*>(static_cast<void*>(&state_mutex_bytes));
+      std::mutex* pstate_mutex_bytes = static_cast<std::mutex*>(static_cast<void*>(&state_mutex_bytes));
+      return *pstate_mutex_bytes;
     }
 
     std::condition_variable& StateCV() {


### PR DESCRIPTION
…ng rules

The following error appears during make:
```
./db/write_thread.h: In member function ‘std::mutex& rocksdb::WriteThread::Writer::StateMutex()’:
./db/write_thread.h:194:78: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
       return *static_cast<std::mutex*>(static_cast<void*>(&state_mutex_bytes));

db/write_batch.cc: In member function ‘rocksdb::MemTableInserter::MemPostInfoMap& rocksdb::MemTableInserter::GetPostMap()’:
db/write_batch.cc:850:66: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     return *reinterpret_cast<MemPostInfoMap*>(&mem_post_info_map_);

db/write_batch.cc: In destructor ‘virtual rocksdb::MemTableInserter::~MemTableInserter()’:
db/write_batch.cc:879:30: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         (&mem_post_info_map_)->~MemPostInfoMap();
```
Signed-off-by: Jos Collin <jcollin@redhat.com>