### PR TITLE
s/std::snprintf/snprintf

### DIFF
--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -4,9 +4,9 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 #ifndef ROCKSDB_LITE
 
+#include <stdio.h>
 #include <chrono>
 #include <cinttypes>
-#include <cstdio>
 #include <memory>
 #include "utilities/blob_db/blob_db_impl.h"
 
@@ -89,17 +89,17 @@ std::shared_ptr<Reader> BlobFile::OpenSequentialReader(
 
 std::string BlobFile::DumpState() const {
   char str[1000];
-  std::snprintf(str, sizeof(str),
-                "path: %s fn: %" PRIu64 " blob_count: %" PRIu64
-                " gc_epoch: %" PRIu64 " file_size: %" PRIu64
-                " deleted_count: %" PRIu64 " deleted_size: %" PRIu64
-                " closed: %d can_be_deleted: %d ttl_range: (%d, %d)"
-                " sn_range: (%" PRIu64 " %" PRIu64 "), writer: %d reader: %d",
-                path_to_dir_.c_str(), file_number_, blob_count_.load(),
-                gc_epoch_.load(), file_size_.load(), deleted_count_,
-                deleted_size_, closed_.load(), can_be_deleted_.load(),
-                ttl_range_.first, ttl_range_.second, sn_range_.first,
-                sn_range_.second, (!!log_writer_), (!!ra_file_reader_));
+  snprintf(str, sizeof(str),
+           "path: %s fn: %" PRIu64 " blob_count: %" PRIu64 " gc_epoch: %" PRIu64
+           " file_size: %" PRIu64 " deleted_count: %" PRIu64
+           " deleted_size: %" PRIu64
+           " closed: %d can_be_deleted: %d ttl_range: (%d, %d)"
+           " sn_range: (%" PRIu64 " %" PRIu64 "), writer: %d reader: %d",
+           path_to_dir_.c_str(), file_number_, blob_count_.load(),
+           gc_epoch_.load(), file_size_.load(), deleted_count_, deleted_size_,
+           closed_.load(), can_be_deleted_.load(), ttl_range_.first,
+           ttl_range_.second, sn_range_.first, sn_range_.second,
+           (!!log_writer_), (!!ra_file_reader_));
   return str;
 }
 


### PR DESCRIPTION
Summary:
Looks like std::snprintf is not available on all platforms (e.g. MSVC 2010). Change it back to snprintf, for which we have a macro in port.h to workaround compatibility.

Test Plan:
CI builds.