### PR TITLE
Add ROCKSDB_LIBRARY_API macro to a few C APIs, to fix windows build

### DIFF
--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1223,16 +1223,17 @@ extern ROCKSDB_LIBRARY_API void rocksdb_delete_file_in_range_cf(
 // to free memory that was malloc()ed
 extern ROCKSDB_LIBRARY_API void rocksdb_free(void* ptr);
 
-extern rocksdb_pinnableslice_t* rocksdb_get_pinned(
+extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t* rocksdb_get_pinned(
     rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key,
     size_t keylen, char** errptr);
-extern rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
+extern ROCKSDB_LIBRARY_API rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(
     rocksdb_t* db, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr);
-extern void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);
-extern const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t,
-                                               size_t* vlen);
+extern ROCKSDB_LIBRARY_API void rocksdb_pinnableslice_destroy(
+    rocksdb_pinnableslice_t* v);
+extern ROCKSDB_LIBRARY_API const char* rocksdb_pinnableslice_value(
+    const rocksdb_pinnableslice_t* t, size_t* vlen);
 
 #ifdef __cplusplus
 }  /* end extern "C" */


### PR DESCRIPTION
Windows build in AppVeyor is broken, I believe due to https://github.com/facebook/rocksdb/pull/2254.
Error messages:
```
c_test.obj : error LNK2019: unresolved external symbol rocksdb_get_pinned referenced in function CheckPinGet [C:\projects\rocksdb\build\c_test.vcxproj]
c_test.obj : error LNK2019: unresolved external symbol rocksdb_get_pinned_cf referenced in function CheckPinGetCF [C:\projects\rocksdb\build\c_test.vcxproj]
c_test.obj : error LNK2019: unresolved external symbol rocksdb_pinnableslice_destroy referenced in function CheckPinGet [C:\projects\rocksdb\build\c_test.vcxproj]
c_test.obj : error LNK2019: unresolved external symbol rocksdb_pinnableslice_value referenced in function CheckPinGet [C:\projects\rocksdb\build\c_test.vcxproj]
C:\projects\rocksdb\build\Debug\c_test.exe : fatal error LNK1120: 4 unresolved externals [C:\projects\rocksdb\build\c_test.vcxproj]
```
See, for example: https://ci.appveyor.com/project/Facebook/rocksdb/build/1.0.4420

Test Plan:
I don't have a local windows machine to make sure that this fixes the build; So I'll just depend on appveyor to see if this passes. 
`make check` on linux passes. 