### PR TITLE
Remove -pie in TSAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ endif
 # TSAN doesn't work well with jemalloc. If we're compiling with TSAN, we should use regular malloc.
 ifdef COMPILE_WITH_TSAN
 	DISABLE_JEMALLOC=1
-	EXEC_LDFLAGS += -fsanitize=thread -pie
+	EXEC_LDFLAGS += -fsanitize=thread
 	PLATFORM_CCFLAGS += -fsanitize=thread -fPIC -DROCKSDB_TSAN_RUN
 	PLATFORM_CXXFLAGS += -fsanitize=thread -fPIC -DROCKSDB_TSAN_RUN
         # Turn off -pg when enabling TSAN testing, because that induces


### PR DESCRIPTION
Summary: -pie seems to be not working in gcc-5 and it is currently broken. Remove it to fix the build.

Test Plan: Run TSAN build and manually introduce a data race bug and make sure TSAN can catch it.