### PR TITLE
keep util/build_version.cc when make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,9 +304,6 @@ util/build_version.cc: FORCE
 	  cmp -s $@-t $@ && rm -f $@-t || mv -f $@-t $@;		\
 	else mv -f $@-t $@; fi
 endif
-ifndef KEEP_BUILD_VERSION
-CLEAN_FILES += util/build_version.cc
-endif
 
 LIBOBJECTS = $(LIB_SOURCES:.cc=.o)
 LIBOBJECTS += $(TOOL_LIB_SOURCES:.cc=.o)

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,9 @@ util/build_version.cc: FORCE
 	  cmp -s $@-t $@ && rm -f $@-t || mv -f $@-t $@;		\
 	else mv -f $@-t $@; fi
 endif
+ifndef KEEP_BUILD_VERSION
 CLEAN_FILES += util/build_version.cc
+endif
 
 LIBOBJECTS = $(LIB_SOURCES:.cc=.o)
 LIBOBJECTS += $(TOOL_LIB_SOURCES:.cc=.o)


### PR DESCRIPTION
https://github.com/facebook/rocksdb/pull/2264
adding build_version.cc into clean list which breaks fbcode release.
we need to keep it when `make clean`