### PR TITLE
Remoe unused BlockBasedTable::compaction_optimized_

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -797,7 +797,6 @@ void BlockBasedTable::SetupForCompaction() {
     default:
       assert(false);
   }
-  compaction_optimized_ = true;
 }
 
 std::shared_ptr<const TableProperties> BlockBasedTable::GetTableProperties()

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -206,12 +206,9 @@ class BlockBasedTable : public TableReader {
   struct CachableEntry;
   struct Rep;
   Rep* rep_;
-  explicit BlockBasedTable(Rep* rep)
-      : rep_(rep), compaction_optimized_(false) {}
+  explicit BlockBasedTable(Rep* rep) : rep_(rep) {}
 
  private:
-  bool compaction_optimized_;
-
   // input_iter: if it is not null, update this one and return it as Iterator
   static InternalIterator* NewDataBlockIterator(Rep* rep, const ReadOptions& ro,
                                                 const Slice& index_value,


### PR DESCRIPTION
Summary: BlockBasedTable::compaction_optimized_ is never used but can cause TSAN warning. Remove it.

Test Plan: Run all tests.