### PR TITLE
column_family_test: EnvCounter::num_new_writable_file_ to be atomic

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -55,7 +55,7 @@ class EnvCounter : public EnvWrapper {
   }
 
  private:
-  int num_new_writable_file_;
+  std::atomic<int> num_new_writable_file_;
 };
 
 class ColumnFamilyTest : public testing::Test {


### PR DESCRIPTION
Summary: TSAN shows warning of data race of EnvCounter::num_new_writable_file_. Make it atomic.

Test Plan: Run all tests.