### PR TITLE
Suppress clang-analyzer false positive

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -933,7 +933,12 @@ void DBIter::FindPrevUserKey() {
     return;
   }
   size_t num_skipped = 0;
+// Suppress false positive clang analyzer warnings.
+#ifdef __clang_analyzer__
+  ParsedInternalKey ikey(Slice(), 0, 0);
+#else
   ParsedInternalKey ikey;
+#endif  // __clang_analyzer__
   FindParseableKey(&ikey, kReverse);
   int cmp;
   while (iter_->Valid() &&

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -258,13 +258,15 @@ __attribute__((__no_sanitize_undefined__))
 
   void CloseDB() {
     delete db_;
-    db_ = NULL;
+    db_ = nullptr;
   }
 
   Status OpenDB() {
     CloseDB();
     env_->ResetState();
-    return DB::Open(options_, dbname_, &db_);
+    Status s = DB::Open(options_, dbname_, &db_);
+    assert(db_ != nullptr);
+    return s;
   }
 
   void DeleteAllData() {

--- a/utilities/spatialdb/spatial_db_test.cc
+++ b/utilities/spatialdb/spatial_db_test.cc
@@ -115,8 +115,10 @@ TEST_F(SpatialDBTest, TestNextID) {
   ASSERT_OK(db_->Insert(WriteOptions(), BoundingBox<double>(10, 10, 15, 15),
                         "two", FeatureSet(), {"simple"}));
   delete db_;
+  db_ = nullptr;
 
   ASSERT_OK(SpatialDB::Open(SpatialDBOptions(), dbname_, &db_));
+  assert(db_ != nullptr);
   ASSERT_OK(db_->Insert(WriteOptions(), BoundingBox<double>(55, 55, 65, 65),
                         "three", FeatureSet(), {"simple"}));
   delete db_;
@@ -177,6 +179,7 @@ TEST_F(SpatialDBTest, SimpleTest) {
         {SpatialIndexOptions("index", BoundingBox<double>(0, 0, 128, 128),
                              3)}));
     ASSERT_OK(SpatialDB::Open(SpatialDBOptions(), dbname_, &db_));
+    assert(db_ != nullptr);
 
     ASSERT_OK(db_->Insert(WriteOptions(), BoundingBox<double>(33, 17, 63, 79),
                           "one", FeatureSet(), {"index"}));
@@ -193,6 +196,7 @@ TEST_F(SpatialDBTest, SimpleTest) {
 
     if (iter == 1) {
       delete db_;
+      db_ = nullptr;
       ASSERT_OK(SpatialDB::Open(SpatialDBOptions(), dbname_, &db_, true));
     }
 
@@ -214,6 +218,7 @@ TEST_F(SpatialDBTest, SimpleTest) {
                         {"three", "five"});
 
     delete db_;
+    db_ = nullptr;
   }
 }
 

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -47,6 +47,7 @@ class OptimisticTransactionTest : public testing::Test {
 
   void Reopen() {
     delete txn_db;
+    txn_db = nullptr;
     Open();
   }
 
@@ -54,6 +55,7 @@ private:
   void Open() {
     Status s = OptimisticTransactionDB::Open(options, dbname, &txn_db);
     assert(s.ok());
+    assert(txn_db != nullptr);
     db = txn_db->GetBaseDB();
   }
 };
@@ -465,6 +467,7 @@ TEST_F(OptimisticTransactionTest, ColumnFamiliesTest) {
   delete cfa;
   delete cfb;
   delete txn_db;
+  txn_db = nullptr;
 
   // open DB with three column families
   std::vector<ColumnFamilyDescriptor> column_families;
@@ -480,6 +483,7 @@ TEST_F(OptimisticTransactionTest, ColumnFamiliesTest) {
   s = OptimisticTransactionDB::Open(options, dbname, column_families, &handles,
                                     &txn_db);
   ASSERT_OK(s);
+  assert(txn_db != nullptr);
   db = txn_db->GetBaseDB();
 
   Transaction* txn = txn_db->BeginTransaction(write_options);

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -2113,6 +2113,7 @@ TEST_P(TransactionTest, ColumnFamiliesTest) {
   delete cfa;
   delete cfb;
   delete db;
+  db = nullptr;
 
   // open DB with three column families
   std::vector<ColumnFamilyDescriptor> column_families;
@@ -2129,6 +2130,7 @@ TEST_P(TransactionTest, ColumnFamiliesTest) {
 
   s = TransactionDB::Open(options, txn_db_options, dbname, column_families,
                           &handles, &db);
+  assert(db != nullptr);
   ASSERT_OK(s);
 
   Transaction* txn = db->BeginTransaction(write_options);
@@ -2810,10 +2812,12 @@ TEST_P(TransactionTest, LockLimitTest) {
   Status s;
 
   delete db;
+  db = nullptr;
 
   // Open DB with a lock limit of 3
   txn_db_options.max_num_locks = 3;
   s = TransactionDB::Open(options, txn_db_options, dbname, &db);
+  assert(db != nullptr);
   ASSERT_OK(s);
 
   // Create a txn and verify we can only lock up to 3 keys
@@ -3736,6 +3740,7 @@ TEST_P(TransactionTest, TimeoutTest) {
   Status s;
 
   delete db;
+  db = nullptr;
 
   // transaction writes have an infinite timeout,
   // but we will override this when we start a txn
@@ -3744,6 +3749,7 @@ TEST_P(TransactionTest, TimeoutTest) {
   txn_db_options.default_lock_timeout = -1;
 
   s = TransactionDB::Open(options, txn_db_options, dbname, &db);
+  assert(db != nullptr);
   ASSERT_OK(s);
 
   s = db->Put(write_options, "aaa", "aaa");


### PR DESCRIPTION
Fixing two types of clang-analyzer false positives:
* db is deleted and then reopen, and clang-analyzer thinks we are reusing the pointer after it has been deleted. Adding asserts to hint clang-analyzer the pointer is recreated.
* ParsedInternalKey is (intentionally) uninitialized. Initialize the struct only when clang-analyzer is running.

Test Plan:
run `make analyze` locally and see it succeed.