### PR TITLE
Fix data races caught by tsan

### DIFF
--- a/utilities/persistent_cache/block_cache_tier.h
+++ b/utilities/persistent_cache/block_cache_tier.h
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #endif // ! OS_WIN
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <set>
@@ -123,10 +124,10 @@ class BlockCacheTier : public PersistentCacheTier {
     HistogramImpl read_hit_latency_;
     HistogramImpl read_miss_latency_;
     HistogramImpl write_latency_;
-    uint64_t cache_hits_ = 0;
-    uint64_t cache_misses_ = 0;
-    uint64_t cache_errors_ = 0;
-    uint64_t insert_dropped_ = 0;
+    std::atomic<uint64_t> cache_hits_{0};
+    std::atomic<uint64_t> cache_misses_{0};
+    std::atomic<uint64_t> cache_errors_{0};
+    std::atomic<uint64_t> insert_dropped_{0};
 
     double CacheHitPct() const {
       const auto lookups = cache_hits_ + cache_misses_;

--- a/utilities/persistent_cache/volatile_tier_impl.h
+++ b/utilities/persistent_cache/volatile_tier_impl.h
@@ -110,10 +110,10 @@ class VolatileCacheTier : public PersistentCacheTier {
   };
 
   struct Statistics {
-    uint64_t cache_misses_ = 0;
-    uint64_t cache_hits_ = 0;
-    uint64_t cache_inserts_ = 0;
-    uint64_t cache_evicts_ = 0;
+    std::atomic<uint64_t> cache_misses_{0};
+    std::atomic<uint64_t> cache_hits_{0};
+    std::atomic<uint64_t> cache_inserts_{0};
+    std::atomic<uint64_t> cache_evicts_{0};
 
     double CacheHitPct() const {
       auto lookups = cache_hits_ + cache_misses_;


### PR DESCRIPTION
This fixes the tsan build failures in:
- write_callback_test
- persistent_cache_test.*

Test plan:
`COMPILE_WITH_TSAN=1 make check`