### PR TITLE
Fix errors in clang-analyzer builds

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -933,12 +933,7 @@ void DBIter::FindPrevUserKey() {
     return;
   }
   size_t num_skipped = 0;
-// Suppress false positive clang analyzer warnings.
-#ifdef __clang_analyzer__
-  ParsedInternalKey ikey(Slice(), 0, 0);
-#else
   ParsedInternalKey ikey;
-#endif  // __clang_analyzer__
   FindParseableKey(&ikey, kReverse);
   int cmp;
   while (iter_->Valid() &&


### PR DESCRIPTION
Fix build error in db_iter.cc when running clang-analyzer.
```
  CC       db/db_iter.o
db/db_iter.cc:938:21: error: no matching constructor for initialization of 'rocksdb::ParsedInternalKey'
  ParsedInternalKey ikey(Slice(), 0, 0);
                    ^    ~~~~~~~~~~~~~
./db/dbformat.h:84:3: note: candidate constructor not viable: no known conversion from 'int' to 'rocksdb::ValueType' for 3rd argument
  ParsedInternalKey(const Slice& u, const SequenceNumber& seq, ValueType t)
  ^
./db/dbformat.h:78:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
struct ParsedInternalKey {
       ^
./db/dbformat.h:78:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 3 were provided
./db/dbformat.h:83:3: note: candidate constructor not viable: requires 0 arguments, but 3 were provided
  ParsedInternalKey() { }  // Intentionally left uninitialized (for speed)
  ^
1 error generated.
```

Test plan:
`USE_CLANG=1 make analyze`