### PR TITLE
options.delayed_write_rate use the rate of rate_limiter by default.

### DIFF
--- a/DEFAULT_OPTIONS_HISTORY.md
+++ b/DEFAULT_OPTIONS_HISTORY.md
@@ -1,5 +1,8 @@
 # RocksDB default options change log
 ## Unreleased
+* delayed_write_rate takes the rate given by rate_limiter if not specified.
+
+## 5.2
 * Change the default of delayed slowdown value to 16MB/s and further increase the L0 stop condition to 36 files.
 
 ## 5.0 (11/17/2016)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,8 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
-*Scheduling flushes and compactions in the same thread pool is no longer supported by setting `max_background_flushes=0`. Instead, users can achieve this by configuring their high-pri thread pool to have zero threads.
+* Scheduling flushes and compactions in the same thread pool is no longer supported by setting `max_background_flushes=0`. Instead, users can achieve this by configuring their high-pri thread pool to have zero threads.
+* options.delayed_write_rate by default take the value of options.rate_limiter rate.
 
 ### New Features
 * Change ticker/histogram statistics implementations to use core-local storage. This improves aggregation speed compared to our previous thread-local approach, particularly for applications with many threads.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -746,10 +746,15 @@ struct DBOptions {
   // calculated using size of user write requests before compression.
   // RocksDB may decide to slow down more if the compaction still
   // gets behind further.
+  // If the value is 0, we will infer a value from `rater_limiter` value
+  // if it is not empty, or 16MB if `rater_limiter` is empty. Note that
+  // if users change the rate in `rate_limiter` after DB is opened,
+  // `delayed_write_rate` won't be adjusted.
+  //
   // Unit: byte per second.
   //
-  // Default: 16MB/s
-  uint64_t delayed_write_rate = 16 * 1024U * 1024U;
+  // Default: 0
+  uint64_t delayed_write_rate = 0;
 
   // By default, a single write thread queue is maintained. The thread gets
   // to the head of the queue becomes write batch group leader and responsible

--- a/include/rocksdb/rate_limiter.h
+++ b/include/rocksdb/rate_limiter.h
@@ -53,6 +53,8 @@ class RateLimiter {
   // Total # of requests that go though rate limiter
   virtual int64_t GetTotalRequests(
       const Env::IOPriority pri = Env::IO_TOTAL) const = 0;
+
+  virtual int64_t GetBytesPerSecond() const = 0;
 };
 
 // Create a RateLimiter object, which can be shared among RocksDB instances to

--- a/options/options.cc
+++ b/options/options.cc
@@ -486,8 +486,10 @@ DBOptions* DBOptions::OldDefaults(int rocksdb_major_version,
   if (rocksdb_major_version < 5 ||
       (rocksdb_major_version == 5 && rocksdb_minor_version < 2)) {
     delayed_write_rate = 2 * 1024U * 1024U;
+  } else if (rocksdb_major_version < 5 ||
+             (rocksdb_major_version == 5 && rocksdb_minor_version < 6)) {
+    delayed_write_rate = 16 * 1024U * 1024U;
   }
-
   max_open_files = 5000;
   base_background_compactions = -1;
   wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;

--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -32,6 +32,7 @@ GenericRateLimiter::GenericRateLimiter(int64_t rate_bytes_per_sec,
                                        int64_t refill_period_us,
                                        int32_t fairness)
     : refill_period_us_(refill_period_us),
+      rate_bytes_per_sec_(rate_bytes_per_sec),
       refill_bytes_per_period_(
           CalculateRefillBytesPerPeriod(rate_bytes_per_sec)),
       env_(Env::Default()),
@@ -68,6 +69,7 @@ GenericRateLimiter::~GenericRateLimiter() {
 // This API allows user to dynamically change rate limiter's bytes per second.
 void GenericRateLimiter::SetBytesPerSecond(int64_t bytes_per_second) {
   assert(bytes_per_second > 0);
+  rate_bytes_per_sec_ = bytes_per_second;
   refill_bytes_per_period_.store(
       CalculateRefillBytesPerPeriod(bytes_per_second),
       std::memory_order_relaxed);

--- a/util/rate_limiter.h
+++ b/util/rate_limiter.h
@@ -62,6 +62,10 @@ class GenericRateLimiter : public RateLimiter {
     return total_requests_[pri];
   }
 
+  virtual int64_t GetBytesPerSecond() const override {
+    return rate_bytes_per_sec_;
+  }
+
  private:
   void Refill();
   int64_t CalculateRefillBytesPerPeriod(int64_t rate_bytes_per_sec);
@@ -75,6 +79,8 @@ class GenericRateLimiter : public RateLimiter {
   const int64_t kMinRefillBytesPerPeriod = 100;
 
   const int64_t refill_period_us_;
+
+  int64_t rate_bytes_per_sec_;
   // This variable can be changed dynamically.
   std::atomic<int64_t> refill_bytes_per_period_;
   Env* const env_;


### PR DESCRIPTION
Summary: It's hard for RocksDB to come up with a good default of delayed write rate. Use rate given by rate limiter if it is availalbe. This provides the I/O order of magnitude.

Test Plan: Add a unit test.