### PR TITLE
Fix build errors in blob_dump_tool with GCC 4.8

### DIFF
--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -5,6 +5,11 @@
 //  This source code is also licensed under the GPLv2 license found in the
 //  COPYING file in the root directory of this source tree.
 #ifndef ROCKSDB_LITE
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "utilities/blob_db/blob_dump_tool.h"
 #include <inttypes.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixing the build errors seen with GCC 4.8.1.
```
Makefile:105: Warning: Compiling in debug mode. Don't use the resulting binary in production
utilities/blob_db/blob_dump_tool.cc: In member function ‘rocksdb::Status rocksdb::blob_db::BlobDumpTool::DumpBlobLogFooter(uint64_t, uint64_t*)’:
utilities/blob_db/blob_dump_tool.cc:149:42: error: expected ‘)’ before ‘PRIu64’
   fprintf(stdout, "  Blob count     : %" PRIu64 "\n", footer.GetBlobCount());
                                          ^
utilities/blob_db/blob_dump_tool.cc:149:76: error: spurious trailing ‘%’ in format [-Werror=format=]
   fprintf(stdout, "  Blob count     : %" PRIu64 "\n", footer.GetBlobCount());
                                                                            ^
utilities/blob_db/blob_dump_tool.cc:149:76: error: too many arguments for format [-Werror=format-extra-args]
utilities/blob_db/blob_dump_tool.cc: In member function ‘rocksdb::Status rocksdb::blob_db::BlobDumpTool::DumpRecord(rocksdb::blob_db::BlobDumpTool::DisplayType, rocksdb::blob_db::BlobDumpTool::DisplayType, uint64_t*)’:
utilities/blob_db/blob_dump_tool.cc:161:49: error: expected ‘)’ before ‘PRIx64’
   fprintf(stdout, "Read record with offset 0x%" PRIx64 " (%" PRIu64 "):\n",
                                                 ^
utilities/blob_db/blob_dump_tool.cc:162:27: error: spurious trailing ‘%’ in format [-Werror=format=]
           *offset, *offset);
                           ^
utilities/blob_db/blob_dump_tool.cc:162:27: error: too many arguments for format [-Werror=format-extra-args]
utilities/blob_db/blob_dump_tool.cc:176:38: error: expected ‘)’ before ‘PRIu64’
   fprintf(stdout, "  blob size  : %" PRIu64 "\n", record.GetBlobSize());
                                      ^
utilities/blob_db/blob_dump_tool.cc:176:71: error: spurious trailing ‘%’ in format [-Werror=format=]
   fprintf(stdout, "  blob size  : %" PRIu64 "\n", record.GetBlobSize());
                                                                       ^
utilities/blob_db/blob_dump_tool.cc:176:71: error: too many arguments for format [-Werror=format-extra-args]
utilities/blob_db/blob_dump_tool.cc:178:38: error: expected ‘)’ before ‘PRIu64’
   fprintf(stdout, "  time       : %" PRIu64 "\n", record.GetTimeVal());
                                      ^
utilities/blob_db/blob_dump_tool.cc:178:70: error: spurious trailing ‘%’ in format [-Werror=format=]
   fprintf(stdout, "  time       : %" PRIu64 "\n", record.GetTimeVal());
                                                                      ^
utilities/blob_db/blob_dump_tool.cc:178:70: error: too many arguments for format [-Werror=format-extra-args]
utilities/blob_db/blob_dump_tool.cc:214:38: error: expected ‘)’ before ‘PRIu64’
   fprintf(stdout, "  sequence   : %" PRIu64 "\n", record.GetSN());
                                      ^
utilities/blob_db/blob_dump_tool.cc:214:65: error: spurious trailing ‘%’ in format [-Werror=format=]
   fprintf(stdout, "  sequence   : %" PRIu64 "\n", record.GetSN());
```

Test Plan:
`ROCKSDB_FBCODE_BUILD_WITH_481=1 make check`