### PR TITLE
Clean zstd files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -902,7 +902,7 @@ clean:
 	rm -rf $(CLEAN_FILES) ios-x86 ios-arm scan_build_report
 	find . -name "*.[oda]" -exec rm -f {} \;
 	find . -type f -regex ".*\.\(\(gcda\)\|\(gcno\)\)" -exec rm {} \;
-	rm -rf bzip2* snappy* zlib* lz4*
+	rm -rf bzip2* snappy* zlib* lz4* zstd*
 	cd java; $(MAKE) clean
 
 tags:


### PR DESCRIPTION
zstd files are downloaded and used as part of JNI build, but are left behind even after doing a `make clean`. This PR updates the `clean` target to remove these zstd files as well. 

Test plan:
Before:
```
/rocksdb (master) $ make clean
...
~/rocksdb (master) $ git st
On branch master
Your branch is ahead of 'origin/master' by 15 commits.
  (use "git push" to publish your local commits)
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	zstd-1.2.0.tar.gz
	zstd-1.2.0/

nothing added to commit but untracked files present (use "git add" to track)
```
After this fix:
zstd files also get removed.
