### PR TITLE
Fix warnings while generating RocksJava documentation

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -2135,6 +2135,9 @@ public class RocksDB extends RocksObject {
    *
    * @param filePathList The list of files to ingest
    * @param ingestExternalFileOptions the options for the ingestion
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *     native library.
    */
   public void ingestExternalFile(final List<String> filePathList,
       final IngestExternalFileOptions ingestExternalFileOptions)
@@ -2158,6 +2161,9 @@ public class RocksDB extends RocksObject {
    * @param columnFamilyHandle The column family for the ingested files
    * @param filePathList The list of files to ingest
    * @param ingestExternalFileOptions the options for the ingestion
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *     native library.
    */
   public void ingestExternalFile(final ColumnFamilyHandle columnFamilyHandle,
       final List<String> filePathList,


### PR DESCRIPTION
There are a couple of warnings while building RocksJava, coming from Javadoc generation. 
```
Generating target/apidocs/org/rocksdb/RocksDB.html...
src/main/java/org/rocksdb/RocksDB.java:2139: warning: no @throws for org.rocksdb.RocksDBException
  public void ingestExternalFile(final List<String> filePathList,
              ^
src/main/java/org/rocksdb/RocksDB.java:2162: warning: no @throws for org.rocksdb.RocksDBException
  public void ingestExternalFile(final ColumnFamilyHandle columnFamilyHandle,
              ^
```

Test Plan:
`cd java && make javadocs` or
`make rocksdbjava`