### PR TITLE
Fix ASAN: avoid arena mode with range deletions

### DIFF
--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -169,9 +169,13 @@ Status MemTableListVersion::AddRangeTombstoneIterators(
 }
 
 Status MemTableListVersion::AddRangeTombstoneIterators(
-    const ReadOptions& read_opts, MergeIteratorBuilder* merge_iter_builder) {
+    const ReadOptions& read_opts,
+    std::vector<InternalIterator*>* range_del_iters) {
   for (auto& m : memlist_) {
-    merge_iter_builder->AddIterator(m->NewRangeTombstoneIterator(read_opts));
+    auto* range_del_iter = m->NewRangeTombstoneIterator(read_opts);
+    if (range_del_iter != nullptr) {
+      range_del_iters->push_back(range_del_iter);
+    }
   }
   return Status::OK();
 }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -84,8 +84,9 @@ class MemTableListVersion {
 
   Status AddRangeTombstoneIterators(const ReadOptions& read_opts, Arena* arena,
                                     RangeDelAggregator* range_del_agg);
-  Status AddRangeTombstoneIterators(const ReadOptions& read_opts,
-                                    MergeIteratorBuilder* merge_iter_builder);
+  Status AddRangeTombstoneIterators(
+      const ReadOptions& read_opts,
+      std::vector<InternalIterator*>* range_del_iters);
 
   void AddIterators(const ReadOptions& options,
                     std::vector<InternalIterator*>* iterator_list,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -866,15 +866,18 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
 }
 
 void Version::AddRangeDelIteratorsForLevel(
-    const ReadOptions& read_options, const EnvOptions& soptions,
-    MergeIteratorBuilder* merge_iter_builder, int level) {
+    const ReadOptions& read_options, const EnvOptions& soptions, int level,
+    std::vector<InternalIterator*>* range_del_iters) {
+  range_del_iters->clear();
   for (size_t i = 0; i < storage_info_.LevelFilesBrief(level).num_files; i++) {
     const auto& file = storage_info_.LevelFilesBrief(level).files[i];
-    merge_iter_builder->AddIterator(
-        cfd_->table_cache()->NewRangeTombstoneIterator(
-            read_options, soptions, cfd_->internal_comparator(), file.fd,
-            cfd_->internal_stats()->GetFileReadHist(level),
-            false /* skip_filters */, level));
+    auto* range_del_iter = cfd_->table_cache()->NewRangeTombstoneIterator(
+        read_options, soptions, cfd_->internal_comparator(), file.fd,
+        cfd_->internal_stats()->GetFileReadHist(level),
+        false /* skip_filters */, level);
+    if (range_del_iter != nullptr) {
+      range_del_iters->push_back(range_del_iter);
+    }
   }
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -463,10 +463,9 @@ class Version {
                             MergeIteratorBuilder* merger_iter_builder,
                             int level, RangeDelAggregator* range_del_agg);
 
-  void AddRangeDelIteratorsForLevel(const ReadOptions& read_options,
-                                    const EnvOptions& soptions,
-                                    MergeIteratorBuilder* merge_iter_builder,
-                                    int level);
+  void AddRangeDelIteratorsForLevel(
+      const ReadOptions& read_options, const EnvOptions& soptions, int level,
+      std::vector<InternalIterator*>* range_del_iters);
 
   // Lookup the value for key.  If found, store it in *val and
   // return OK.  Else return a non-OK status.


### PR DESCRIPTION
The range deletion meta-block iterators weren't getting cleaned up properly since they don't support arena allocation. I didn't implement arena support since, in the general case, each iterator is used only once and separately from all other iterators, so there should be no benefit to data locality.

Anyways, this diff fixes up #2370 by treating range deletion iterators as non-arena-allocated.
