### PR TITLE
Make direct I/O write use incremental buffer

### DIFF
--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -97,11 +97,17 @@ public:
   }
 
   // Allocates a new buffer and sets bufstart_ to the aligned first byte
-  void AllocateNewBuffer(size_t requestedCapacity, bool copy_data = false) {
+  void AllocateNewBuffer(size_t requested_capacity, bool copy_data = false) {
     assert(alignment_ > 0);
     assert((alignment_ & (alignment_ - 1)) == 0);
 
-    size_t new_capacity = Roundup(requestedCapacity, alignment_);
+    if (copy_data && requested_capacity < cursize_) {
+      // If we are downsizing to a capacity that is smaller than the current
+      // data in the buffer. Ignore the request.
+      return;
+    }
+
+    size_t new_capacity = Roundup(requested_capacity, alignment_);
     char* new_buf = new char[new_capacity + alignment_];
     char* new_bufstart = reinterpret_cast<char*>(
         (reinterpret_cast<uintptr_t>(new_buf) + (alignment_ - 1)) &

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -97,20 +97,25 @@ public:
   }
 
   // Allocates a new buffer and sets bufstart_ to the aligned first byte
-  void AllocateNewBuffer(size_t requestedCapacity) {
-
+  void AllocateNewBuffer(size_t requestedCapacity, bool copy_data = false) {
     assert(alignment_ > 0);
     assert((alignment_ & (alignment_ - 1)) == 0);
 
-    size_t size = Roundup(requestedCapacity, alignment_);
-    buf_.reset(new char[size + alignment_]);
+    size_t new_capacity = Roundup(requestedCapacity, alignment_);
+    char* new_buf = new char[new_capacity + alignment_];
+    char* new_bufstart = reinterpret_cast<char*>(
+        (reinterpret_cast<uintptr_t>(new_buf) + (alignment_ - 1)) &
+        ~static_cast<uintptr_t>(alignment_ - 1));
 
-    char* p = buf_.get();
-    bufstart_ = reinterpret_cast<char*>(
-      (reinterpret_cast<uintptr_t>(p)+(alignment_ - 1)) &
-      ~static_cast<uintptr_t>(alignment_ - 1));
-    capacity_ = size;
-    cursize_ = 0;
+    if (copy_data) {
+      memcpy(new_bufstart, bufstart_, cursize_);
+    } else {
+      cursize_ = 0;
+    }
+
+    bufstart_ = new_bufstart;
+    capacity_ = new_capacity;
+    buf_.reset(new_buf);
   }
   // Used for write
   // Returns the number of bytes appended

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -126,8 +126,12 @@ Status WritableFileWriter::Append(const Slice& data) {
 
   // See whether we need to enlarge the buffer to avoid the flush
   if (buf_.Capacity() - buf_.CurrentSize() < left) {
-    for (size_t desired_capacity = buf_.Capacity();
-         desired_capacity < max_buffer_size_; desired_capacity *= 2) {
+    for (size_t cap = buf_.Capacity();
+         cap < max_buffer_size_;  // There is still room to increase
+         cap *= 2) {
+      // See whether the next available size is large enough.
+      // Buffer will never be increased to more than max_buffer_size_.
+      size_t desired_capacity = std::min(cap * 2, max_buffer_size_);
       if (desired_capacity - buf_.CurrentSize() >= left) {
         buf_.AllocateNewBuffer(desired_capacity, true);
         break;

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -132,7 +132,8 @@ Status WritableFileWriter::Append(const Slice& data) {
       // See whether the next available size is large enough.
       // Buffer will never be increased to more than max_buffer_size_.
       size_t desired_capacity = std::min(cap * 2, max_buffer_size_);
-      if (desired_capacity - buf_.CurrentSize() >= left) {
+      if (desired_capacity - buf_.CurrentSize() >= left ||
+          (use_direct_io() && desired_capacity == max_buffer_size_)) {
         buf_.AllocateNewBuffer(desired_capacity, true);
         break;
       }

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -142,9 +142,7 @@ class WritableFileWriter {
         rate_limiter_(options.rate_limiter),
         stats_(stats) {
     buf_.Alignment(writable_file_->GetRequiredBufferAlignment());
-    buf_.AllocateNewBuffer(use_direct_io()
-                               ? max_buffer_size_
-                               : std::min((size_t)65536, max_buffer_size_));
+    buf_.AllocateNewBuffer(std::min((size_t)65536, max_buffer_size_));
   }
 
   WritableFileWriter(const WritableFileWriter&) = delete;


### PR DESCRIPTION
Summary: Currently for direct I/O, the large maximum buffer is always allocated. This will be wasteful if users flush the data in much smaller chunks. This diff fix this by changing the behavior of incremental buffer works. When we enlarge buffer, we try to copy the existing data in the buffer to the enlarged buffer, rather than flush the buffer first. This can make sure that no extra I/O is introduced because of buffer enlargement.

Test Plan:Run existing tests.