### PR TITLE
Fix db_write_test clang/windows build failure

### DIFF
--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -47,7 +47,7 @@ TEST_P(DBWriteTest, ReturnSeuqneceNumberMultiThreaded) {
     flags[i].clear();
   }
   auto writer = [&](size_t id) {
-    Random rnd(4422 + (uint32_t)id);
+    Random rnd(4422 + static_cast<uint32_t>(id));
     for (size_t k = 0; k < kNumKeys; k++) {
       WriteBatch batch;
       batch.Put("key" + ToString(id) + "-" + ToString(k),

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -47,7 +47,7 @@ TEST_P(DBWriteTest, ReturnSeuqneceNumberMultiThreaded) {
     flags[i].clear();
   }
   auto writer = [&](size_t id) {
-    Random rnd(4422 + id);
+    Random rnd(4422 + (uint32_t)id);
     for (size_t k = 0; k < kNumKeys; k++) {
       WriteBatch batch;
       batch.Put("key" + ToString(id) + "-" + ToString(k),


### PR DESCRIPTION
Summary:
Fix db_write_test clang/windows build failure. Explicitly cast size_t (unsigned long) to uint32_t (unsigned int).

Test Plan:
USE_CLANG=1 make db_write_test