### PR TITLE
Fix clang errors by asserting the precondition

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -589,6 +589,7 @@ Status PosixMmapFile::Append(const Slice& data) {
     }
 
     size_t n = (left <= avail) ? left : avail;
+    assert(dst_);
     memcpy(dst_, src, n);
     dst_ += n;
     src += n;

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1200,6 +1200,7 @@ std::vector<Status> BlobDBImpl::MultiGet(
 Status BlobDBImpl::CommonGet(const ColumnFamilyData* cfd, const Slice& key,
                              const std::string& index_entry, std::string* value,
                              SequenceNumber* sequence) {
+  assert(value);
   Slice index_entry_slice(index_entry);
   BlobHandle handle;
   Status s = handle.DecodeFrom(&index_entry_slice);


### PR DESCRIPTION
USE_CLANG=1 make -j32 analyze
The two errors would disappear after the assertion.