### PR TITLE
Sample number of reads per SST file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,12 +5,14 @@
 * Replace `Options::max_background_flushes`, `Options::max_background_compactions`, and `Options::base_background_compactions` all with `Options::max_background_jobs`, which automatically decides how many threads to allocate towards flush/compaction.
 * options.delayed_write_rate by default take the value of options.rate_limiter rate.
 * Replace global variable `IOStatsContext iostats_context` with `IOStatsContext* get_iostats_context()`; replace global variable `PerfContext perf_context` with `PerfContext* get_perf_context()`.
+* DB property "rocksdb.sstables" now prints keys in hex form.
 
 ### New Features
 * Change ticker/histogram statistics implementations to use core-local storage. This improves aggregation speed compared to our previous thread-local approach, particularly for applications with many threads.
 * Users can pass a cache object to write buffer manager, so that they can cap memory usage for memtable and block cache using one single limit.
 * Flush will be triggered when 7/8 of the limit introduced by write_buffer_manager or db_write_buffer_size is triggered, so that the hard threshold is hard to hit.
 * Introduce WriteOptions.low_pri. If it is true, low priority writes will be throttled if the compaction is behind.
+* Measure estimated number of reads per file. The information can be accessed through DB::GetColumnFamilyMetaData or "rocksdb.sstables" DB property.
 
 ## 5.5.0 (05/17/2017)
 ### New Features

--- a/db/compaction.h
+++ b/db/compaction.h
@@ -101,7 +101,8 @@ class Compaction {
   // input level.
   // REQUIREMENT: "compaction_input_level" must be >= 0 and
   //              < "input_levels()"
-  const std::vector<FileMetaData*>* inputs(size_t compaction_input_level) {
+  const std::vector<FileMetaData*>* inputs(
+      size_t compaction_input_level) const {
     assert(compaction_input_level < inputs_.size());
     return &inputs_[compaction_input_level].files;
   }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -544,7 +544,7 @@ bool InternalStats::HandleDBStats(std::string* value, Slice suffix) {
 
 bool InternalStats::HandleSsTables(std::string* value, Slice suffix) {
   auto* current = cfd_->current();
-  *value = current->DebugString();
+  *value = current->DebugString(true, true);
   return true;
 }
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -63,17 +63,29 @@ struct FileDescriptor {
   uint64_t GetFileSize() const { return file_size; }
 };
 
+struct FileSampledStats {
+  FileSampledStats() : num_reads_sampled(0) {}
+  FileSampledStats(const FileSampledStats& other) { *this = other; }
+  FileSampledStats& operator=(const FileSampledStats& other) {
+    num_reads_sampled = other.num_reads_sampled.load();
+    return *this;
+  }
+
+  // number of user reads to this file.
+  mutable std::atomic<uint64_t> num_reads_sampled;
+};
+
 struct FileMetaData {
-  int refs;
   FileDescriptor fd;
   InternalKey smallest;            // Smallest internal key served by table
   InternalKey largest;             // Largest internal key served by table
-  bool being_compacted;            // Is this file undergoing compaction?
   SequenceNumber smallest_seqno;   // The smallest seqno in this file
   SequenceNumber largest_seqno;    // The largest seqno in this file
 
   // Needs to be disposed when refs becomes 0.
   Cache::Handle* table_reader_handle;
+
+  FileSampledStats stats;
 
   // Stats for compensating deletion entries during compaction
 
@@ -87,6 +99,10 @@ struct FileMetaData {
   uint64_t num_deletions;          // the number of deletion entries.
   uint64_t raw_key_size;           // total uncompressed key size.
   uint64_t raw_value_size;         // total uncompressed value size.
+
+  int refs;  // Reference count
+
+  bool being_compacted;        // Is this file undergoing compaction?
   bool init_stats_from_file;   // true if the data-entry stats of this file
                                // has initialized from file.
 
@@ -94,9 +110,7 @@ struct FileMetaData {
                                // file.
 
   FileMetaData()
-      : refs(0),
-        being_compacted(false),
-        smallest_seqno(kMaxSequenceNumber),
+      : smallest_seqno(kMaxSequenceNumber),
         largest_seqno(0),
         table_reader_handle(nullptr),
         compensated_file_size(0),
@@ -104,6 +118,8 @@ struct FileMetaData {
         num_deletions(0),
         raw_key_size(0),
         raw_value_size(0),
+        refs(0),
+        being_compacted(false),
         init_stats_from_file(false),
         marked_for_compaction(false) {}
 
@@ -119,10 +135,12 @@ struct FileMetaData {
   }
 };
 
-// A compressed copy of file meta data that just contain
-// smallest and largest key's slice
+// A compressed copy of file meta data that just contain minimum data needed
+// to server read operations, while still keeping the pointer to full metadata
+// of the file in case it is needed.
 struct FdWithKeyRange {
   FileDescriptor fd;
+  FileMetaData* file_metadata;  // Point to all metadata
   Slice smallest_key;    // slice that contain smallest key
   Slice largest_key;     // slice that contain largest key
 
@@ -132,8 +150,12 @@ struct FdWithKeyRange {
         largest_key() {
   }
 
-  FdWithKeyRange(FileDescriptor _fd, Slice _smallest_key, Slice _largest_key)
-      : fd(_fd), smallest_key(_smallest_key), largest_key(_largest_key) {}
+  FdWithKeyRange(FileDescriptor _fd, Slice _smallest_key, Slice _largest_key,
+                 FileMetaData* _file_metadata)
+      : fd(_fd),
+        file_metadata(_file_metadata),
+        smallest_key(_smallest_key),
+        largest_key(_largest_key) {}
 };
 
 // Data structure to store an array of FdWithKeyRange in one level

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -504,7 +504,7 @@ class Version {
   void AddLiveFiles(std::vector<FileDescriptor>* live);
 
   // Return a human readable string that describes this version's contents.
-  std::string DebugString(bool hex = false) const;
+  std::string DebugString(bool hex = false, bool print_stats = false) const;
 
   // Returns the version nuber of this version
   uint64_t GetVersionNumber() const { return version_number_; }

--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -55,17 +55,21 @@ struct LevelMetaData {
 // The metadata that describes a SST file.
 struct SstFileMetaData {
   SstFileMetaData() {}
-  SstFileMetaData(const std::string& _file_name,
-                  const std::string& _path, uint64_t _size,
-                  SequenceNumber _smallest_seqno,
+  SstFileMetaData(const std::string& _file_name, const std::string& _path,
+                  uint64_t _size, SequenceNumber _smallest_seqno,
                   SequenceNumber _largest_seqno,
                   const std::string& _smallestkey,
-                  const std::string& _largestkey,
-                  bool _being_compacted) :
-    size(_size), name(_file_name),
-    db_path(_path), smallest_seqno(_smallest_seqno), largest_seqno(_largest_seqno),
-    smallestkey(_smallestkey), largestkey(_largestkey),
-    being_compacted(_being_compacted) {}
+                  const std::string& _largestkey, uint64_t _num_reads_sampled,
+                  bool _being_compacted)
+      : size(_size),
+        name(_file_name),
+        db_path(_path),
+        smallest_seqno(_smallest_seqno),
+        largest_seqno(_largest_seqno),
+        smallestkey(_smallestkey),
+        largestkey(_largestkey),
+        num_reads_sampled(_num_reads_sampled),
+        being_compacted(_being_compacted) {}
 
   // File size in bytes.
   uint64_t size;
@@ -78,6 +82,7 @@ struct SstFileMetaData {
   SequenceNumber largest_seqno;   // Largest sequence number in file.
   std::string smallestkey;     // Smallest user defined key in the file.
   std::string largestkey;      // Largest user defined key in the file.
+  uint64_t num_reads_sampled;  // How many times the file is read.
   bool being_compacted;  // true if the file is currently being compacted.
 };
 
@@ -86,7 +91,4 @@ struct LiveFileMetaData : SstFileMetaData {
   std::string column_family_name;  // Name of the column family
   int level;               // Level at which this file resides.
 };
-
-
-
 }  // namespace rocksdb

--- a/monitoring/file_read_sample.h
+++ b/monitoring/file_read_sample.h
@@ -1,0 +1,25 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
+//
+#pragma once
+#include "db/version_edit.h"
+#include "util/random.h"
+
+namespace rocksdb {
+static const uint32_t kFileReadSampleRate = 1024;
+extern bool should_sample_file_read();
+extern void sample_file_read_inc(FileMetaData*);
+
+inline bool should_sample_file_read() {
+  return (Random::GetTLSInstance()->Next() % kFileReadSampleRate == 307);
+}
+
+inline void sample_file_read_inc(FileMetaData* meta) {
+  meta->stats.num_reads_sampled.fetch_add(kFileReadSampleRate,
+                                          std::memory_order_relaxed);
+}
+}

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -8,6 +8,7 @@
 #include "table/get_context.h"
 #include "db/merge_helper.h"
 #include "db/pinned_iterators_manager.h"
+#include "monitoring/file_read_sample.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
 #include "rocksdb/env.h"
@@ -59,6 +60,7 @@ GetContext::GetContext(const Comparator* ucmp,
   if (seq_) {
     *seq_ = kMaxSequenceNumber;
   }
+  sample_ = should_sample_file_read();
 }
 
 // Called from TableCache::Get and Table::Get when file/block in which

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -62,6 +62,8 @@ class GetContext {
   // Do we need to fetch the SequenceNumber for this key?
   bool NeedToReadSequence() const { return (seq_ != nullptr); }
 
+  bool sample() const { return sample_; }
+
  private:
   const Comparator* ucmp_;
   const MergeOperator* merge_operator_;
@@ -82,6 +84,7 @@ class GetContext {
   std::string* replay_log_;
   // Used to temporarily pin blocks when state_ == GetContext::kMerge
   PinnedIteratorsManager* pinned_iters_mgr_;
+  bool sample_;
 };
 
 void replayGetContextLog(const Slice& replay_log, const Slice& user_key,


### PR DESCRIPTION
Summary:We estimate number of reads per SST files, by updating the counter per file in sampled read requests. This information can later be used to trigger compactions to improve read performacne.

Test Plan:
Load the DB with
./db_bench --benchmarks=fillrandom,sstables --write_buffer_size=2000000 --num=3000000

And then observe stats in outputs of:

./db_bench --benchmarks=readrandom,sstables --write_buffer_size=2000000 --num=3000000 --threads=8

and

./db_bench --benchmarks=seekrandom,sstables --write_buffer_size=2000000 --num=3000000 --threads=8