### PR TITLE
fix travis error with init time in mockenv

### DIFF
--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -379,8 +379,7 @@ class TestMemLogger : public Logger {
       gettimeofday(&now_tv, nullptr);
       const time_t seconds = now_tv.tv_sec;
       struct tm t;
-      auto ret = localtime_r(&seconds, &t);
-      assert(ret != nullptr);
+      assert(localtime_r(&seconds, &t));
       p += snprintf(p, limit - p,
                     "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
                     t.tm_year + 1900,

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -379,7 +379,8 @@ class TestMemLogger : public Logger {
       gettimeofday(&now_tv, nullptr);
       const time_t seconds = now_tv.tv_sec;
       struct tm t;
-      localtime_r(&seconds, &t);
+      auto ret = localtime_r(&seconds, &t);
+      assert(ret != nullptr);
       p += snprintf(p, limit - p,
                     "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
                     t.tm_year + 1900,

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -379,7 +379,8 @@ class TestMemLogger : public Logger {
       gettimeofday(&now_tv, nullptr);
       const time_t seconds = now_tv.tv_sec;
       struct tm t;
-      assert(localtime_r(&seconds, &t));
+      auto ret __attribute__((__unused__)) = localtime_r(&seconds, &t);
+      assert(ret);
       p += snprintf(p, limit - p,
                     "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
                     t.tm_year + 1900,


### PR DESCRIPTION
/home/travis/build/facebook/rocksdb/env/mock_env.cc: In member function ‘virtual void rocksdb::{anonymous}::TestMemLogger::Logv(const char*, va_list)’:
/home/travis/build/facebook/rocksdb/env/mock_env.cc:391:53: error: ‘t.tm::tm_year’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                     static_cast<int>(now_tv.tv_usec));