### PR TITLE
Remove duplicated functionality

### DIFF
--- a/table/plain_table_builder.h
+++ b/table/plain_table_builder.h
@@ -104,15 +104,11 @@ class PlainTableBuilder: public TableBuilder {
 
   Slice GetPrefix(const Slice& target) const {
     assert(target.size() >= 8);  // target is internal key
-    return GetPrefixFromUserKey(GetUserKey(target));
+    return GetPrefixFromUserKey(ExtractUserKey(target));
   }
 
   Slice GetPrefix(const ParsedInternalKey& target) const {
     return GetPrefixFromUserKey(target.user_key);
-  }
-
-  Slice GetUserKey(const Slice& key) const {
-    return Slice(key.data(), key.size() - 8);
   }
 
   Slice GetPrefixFromUserKey(const Slice& user_key) const {

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -548,7 +548,7 @@ Status PlainTableReader::Get(const ReadOptions& ro, const Slice& target,
           Status::InvalidArgument("Get() is not allowed in full scan mode.");
     }
     // Match whole user key for bloom filter check.
-    if (!MatchBloom(GetSliceHash(GetUserKey(target)))) {
+    if (!MatchBloom(GetSliceHash(ExtractUserKey(target)))) {
       return Status::OK();
     }
     // in total order mode, there is only one bucket 0, and we always use empty

--- a/table/plain_table_reader.h
+++ b/table/plain_table_reader.h
@@ -167,15 +167,11 @@ class PlainTableReader: public TableReader {
 
   Slice GetPrefix(const Slice& target) const {
     assert(target.size() >= 8);  // target is internal key
-    return GetPrefixFromUserKey(GetUserKey(target));
+    return GetPrefixFromUserKey(ExtractUserKey(target));
   }
 
   Slice GetPrefix(const ParsedInternalKey& target) const {
     return GetPrefixFromUserKey(target.user_key);
-  }
-
-  Slice GetUserKey(const Slice& key) const {
-    return Slice(key.data(), key.size() - 8);
   }
 
   Slice GetPrefixFromUserKey(const Slice& user_key) const {


### PR DESCRIPTION
The `GetUserKey()` function of the Plain Table Builder/Reader does the
same as `ExtractUserKey()` from `db/dbformat.h`. Hence remove
`GetUserKey()` and use `ExtractUserKey()` instead.