### PR TITLE
implement GetFilterBitsBuilder/GetFilterBitsReader for c bloom

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -98,6 +98,8 @@ using rocksdb::TransactionDB;
 using rocksdb::TransactionOptions;
 using rocksdb::Transaction;
 using rocksdb::Checkpoint;
+using rocksdb::FilterBitsBuilder;
+using rocksdb::FilterBitsReader;
 
 using std::shared_ptr;
 
@@ -2606,6 +2608,13 @@ rocksdb_filterpolicy_t* rocksdb_filterpolicy_create_bloom_format(int bits_per_ke
     }
     bool KeyMayMatch(const Slice& key, const Slice& filter) const override {
       return rep_->KeyMayMatch(key, filter);
+    }
+    virtual FilterBitsBuilder* GetFilterBitsBuilder() const override {
+      return rep_->GetFilterBitsBuilder();
+    }
+    virtual FilterBitsReader* GetFilterBitsReader(
+        const Slice& contents) const override {
+      return rep_->GetFilterBitsReader(contents);
     }
     static void DoNothing(void*) { }
   };


### PR DESCRIPTION
If we don't implement these two functions, `CreateFilterBlockBuilder` always create  `BlockBasedFilterBlockBuilder`.
https://github.com/facebook/rocksdb/blob/master/table/block_based_table_builder.cc#L74