### PR TITLE
Allow ignoring unknown options when loading options from a file

### DIFF
--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -161,12 +161,15 @@ namespace rocksdb {
 // @param input_strings_escaped when set to true, each escaped characters
 //     prefixed by '\' in the values of the opts_map will be further converted
 //     back to the raw string before assigning to the associated options.
+// @param ignore_unknown_options when set to true, unknown options are ignored
+//     instead of resulting in an unknown-option error.
 // @return Status::OK() on success.  Otherwise, a non-ok status indicating
 //     error will be returned, and "new_options" will be set to "base_options".
 Status GetColumnFamilyOptionsFromMap(
     const ColumnFamilyOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
-    ColumnFamilyOptions* new_options, bool input_strings_escaped = false);
+    ColumnFamilyOptions* new_options, bool input_strings_escaped = false,
+    bool ignore_unknown_options = false);
 
 // Take a default DBOptions "base_options" in addition to a
 // map "opts_map" of option name to option value to construct the new
@@ -189,12 +192,15 @@ Status GetColumnFamilyOptionsFromMap(
 // @param input_strings_escaped when set to true, each escaped characters
 //     prefixed by '\' in the values of the opts_map will be further converted
 //     back to the raw string before assigning to the associated options.
+// @param ignore_unknown_options when set to true, unknown options are ignored
+//     instead of resulting in an unknown-option error.
 // @return Status::OK() on success.  Otherwise, a non-ok status indicating
 //     error will be returned, and "new_options" will be set to "base_options".
 Status GetDBOptionsFromMap(
     const DBOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
-    DBOptions* new_options, bool input_strings_escaped = false);
+    DBOptions* new_options, bool input_strings_escaped = false,
+    bool ignore_unknown_options = false);
 
 // Take a default BlockBasedTableOptions "table_options" in addition to a
 // map "opts_map" of option name to option value to construct the new
@@ -229,6 +235,8 @@ Status GetDBOptionsFromMap(
 // @param input_strings_escaped when set to true, each escaped characters
 //     prefixed by '\' in the values of the opts_map will be further converted
 //     back to the raw string before assigning to the associated options.
+// @param ignore_unknown_options when set to true, unknown options are ignored
+//     instead of resulting in an unknown-option error.
 // @return Status::OK() on success.  Otherwise, a non-ok status indicating
 //     error will be returned, and "new_table_options" will be set to
 //     "table_options".
@@ -236,7 +244,7 @@ Status GetBlockBasedTableOptionsFromMap(
     const BlockBasedTableOptions& table_options,
     const std::unordered_map<std::string, std::string>& opts_map,
     BlockBasedTableOptions* new_table_options,
-    bool input_strings_escaped = false);
+    bool input_strings_escaped = false, bool ignore_unknown_options = false);
 
 // Take a default PlainTableOptions "table_options" in addition to a
 // map "opts_map" of option name to option value to construct the new
@@ -250,14 +258,16 @@ Status GetBlockBasedTableOptionsFromMap(
 // @param input_strings_escaped when set to true, each escaped characters
 //     prefixed by '\' in the values of the opts_map will be further converted
 //     back to the raw string before assigning to the associated options.
+// @param ignore_unknown_options when set to true, unknown options are ignored
+//     instead of resulting in an unknown-option error.
 // @return Status::OK() on success.  Otherwise, a non-ok status indicating
 //     error will be returned, and "new_table_options" will be set to
 //     "table_options".
 Status GetPlainTableOptionsFromMap(
     const PlainTableOptions& table_options,
     const std::unordered_map<std::string, std::string>& opts_map,
-    PlainTableOptions* new_table_options,
-    bool input_strings_escaped = false);
+    PlainTableOptions* new_table_options, bool input_strings_escaped = false,
+    bool ignore_unknown_options = false);
 
 // Take a string representation of option names and  values, apply them into the
 // base_options, and return the new options as a result. The string has the

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -42,6 +42,7 @@ class LDBCommand {
   static const std::string ARG_TTL_END;
   static const std::string ARG_TIMESTAMP;
   static const std::string ARG_TRY_LOAD_OPTIONS;
+  static const std::string ARG_IGNORE_UNKNOWN_OPTIONS;
   static const std::string ARG_FROM;
   static const std::string ARG_TO;
   static const std::string ARG_MAX_KEYS;
@@ -148,6 +149,8 @@ class LDBCommand {
 
   // If true, try to construct options from DB's option files.
   bool try_load_options_;
+
+  bool ignore_unknown_options_;
 
   bool create_if_missing_;
 

--- a/include/rocksdb/utilities/options_util.h
+++ b/include/rocksdb/utilities/options_util.h
@@ -41,6 +41,10 @@ namespace rocksdb {
 // casting the return value of TableFactoroy::GetOptions() to
 // BlockBasedTableOptions and making necessary changes.
 //
+// ignore_unknown_options can be set to true if you want to ignore options
+// that are from a newer version of the db, esentially for forward
+// compatibility.
+//
 // examples/options_file_example.cc demonstrates how to use this function
 // to open a RocksDB instance.
 //
@@ -53,7 +57,8 @@ namespace rocksdb {
 // @see LoadOptionsFromFile
 Status LoadLatestOptions(const std::string& dbpath, Env* env,
                          DBOptions* db_options,
-                         std::vector<ColumnFamilyDescriptor>* cf_descs);
+                         std::vector<ColumnFamilyDescriptor>* cf_descs,
+                         bool ignore_unknown_options = false);
 
 // Similar to LoadLatestOptions, this function constructs the DBOptions
 // and ColumnFamilyDescriptors based on the specified RocksDB Options file.
@@ -61,7 +66,8 @@ Status LoadLatestOptions(const std::string& dbpath, Env* env,
 // @see LoadLatestOptions
 Status LoadOptionsFromFile(const std::string& options_file_name, Env* env,
                            DBOptions* db_options,
-                           std::vector<ColumnFamilyDescriptor>* cf_descs);
+                           std::vector<ColumnFamilyDescriptor>* cf_descs,
+                           bool ignore_unknown_options = false);
 
 // Returns the latest options file name under the specified db path.
 Status GetLatestOptionsFileName(const std::string& dbpath, Env* env,
@@ -80,7 +86,8 @@ Status GetLatestOptionsFileName(const std::string& dbpath, Env* env,
 // * merge_operator
 Status CheckOptionsCompatibility(
     const std::string& dbpath, Env* env, const DBOptions& db_options,
-    const std::vector<ColumnFamilyDescriptor>& cf_descs);
+    const std::vector<ColumnFamilyDescriptor>& cf_descs,
+    bool ignore_unknown_options = false);
 
 }  // namespace rocksdb
 #endif  // !ROCKSDB_LITE

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -57,7 +57,8 @@ Status GetMutableDBOptionsFromStrings(
 Status GetTableFactoryFromMap(
     const std::string& factory_name,
     const std::unordered_map<std::string, std::string>& opt_map,
-    std::shared_ptr<TableFactory>* table_factory);
+    std::shared_ptr<TableFactory>* table_factory,
+    bool ignore_unknown_options = false);
 
 Status GetStringFromTableFactory(std::string* opts_str, const TableFactory* tf,
                                  const std::string& delimiter = ";  ");
@@ -129,7 +130,8 @@ Status GetDBOptionsFromMapInternal(
     const DBOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
     DBOptions* new_options, bool input_strings_escaped,
-    std::vector<std::string>* unsupported_options_names = nullptr);
+    std::vector<std::string>* unsupported_options_names = nullptr,
+    bool ignore_unknown_options = false);
 
 // In addition to its public version defined in rocksdb/convenience.h,
 // this further takes an optional output vector "unsupported_options_names",
@@ -138,7 +140,8 @@ Status GetColumnFamilyOptionsFromMapInternal(
     const ColumnFamilyOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
     ColumnFamilyOptions* new_options, bool input_strings_escaped,
-    std::vector<std::string>* unsupported_options_names = nullptr);
+    std::vector<std::string>* unsupported_options_names = nullptr,
+    bool ignore_unknown_options = false);
 
 static std::unordered_map<std::string, OptionTypeInfo> db_options_type_info = {
     /*

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -44,7 +44,8 @@ class RocksDBOptionsParser {
   ~RocksDBOptionsParser() {}
   void Reset();
 
-  Status Parse(const std::string& file_name, Env* env);
+  Status Parse(const std::string& file_name, Env* env,
+               bool ignore_unknown_options = false);
   static std::string TrimAndRemoveComment(const std::string& line,
                                           const bool trim_only = false);
 
@@ -68,7 +69,8 @@ class RocksDBOptionsParser {
       const DBOptions& db_opt, const std::vector<std::string>& cf_names,
       const std::vector<ColumnFamilyOptions>& cf_opts,
       const std::string& file_name, Env* env,
-      OptionsSanityCheckLevel sanity_check_level = kSanityLevelExactMatch);
+      OptionsSanityCheckLevel sanity_check_level = kSanityLevelExactMatch,
+      bool ignore_unknown_options = false);
 
   static Status VerifyDBOptions(
       const DBOptions& base_opt, const DBOptions& new_opt,
@@ -103,10 +105,10 @@ class RocksDBOptionsParser {
   Status ParseStatement(std::string* name, std::string* value,
                         const std::string& line, const int line_num);
 
-  Status EndSection(
-      const OptionSection section, const std::string& title,
-      const std::string& section_arg,
-      const std::unordered_map<std::string, std::string>& opt_map);
+  Status EndSection(const OptionSection section, const std::string& title,
+                    const std::string& section_arg,
+                    const std::unordered_map<std::string, std::string>& opt_map,
+                    bool ignore_unknown_options);
 
   Status ValidityCheck();
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -60,6 +60,8 @@ const std::string LDBCommand::ARG_TTL_START = "start_time";
 const std::string LDBCommand::ARG_TTL_END = "end_time";
 const std::string LDBCommand::ARG_TIMESTAMP = "timestamp";
 const std::string LDBCommand::ARG_TRY_LOAD_OPTIONS = "try_load_options";
+const std::string LDBCommand::ARG_IGNORE_UNKNOWN_OPTIONS =
+    "ignore_unknown_options";
 const std::string LDBCommand::ARG_FROM = "from";
 const std::string LDBCommand::ARG_TO = "to";
 const std::string LDBCommand::ARG_MAX_KEYS = "max_keys";
@@ -284,6 +286,7 @@ LDBCommand::LDBCommand(const std::map<std::string, std::string>& options,
       is_db_ttl_(false),
       timestamp_(false),
       try_load_options_(false),
+      ignore_unknown_options_(false),
       create_if_missing_(false),
       option_map_(options),
       flags_(flags),
@@ -305,14 +308,15 @@ LDBCommand::LDBCommand(const std::map<std::string, std::string>& options,
   is_db_ttl_ = IsFlagPresent(flags, ARG_TTL);
   timestamp_ = IsFlagPresent(flags, ARG_TIMESTAMP);
   try_load_options_ = IsFlagPresent(flags, ARG_TRY_LOAD_OPTIONS);
+  ignore_unknown_options_ = IsFlagPresent(flags, ARG_IGNORE_UNKNOWN_OPTIONS);
 }
 
 void LDBCommand::OpenDB() {
   Options opt;
   bool opt_set = false;
   if (!create_if_missing_ && try_load_options_) {
-    Status s =
-        LoadLatestOptions(db_path_, Env::Default(), &opt, &column_families_);
+    Status s = LoadLatestOptions(db_path_, Env::Default(), &opt,
+                                 &column_families_, ignore_unknown_options_);
     if (s.ok()) {
       opt_set = true;
     } else if (!s.IsNotFound()) {
@@ -440,6 +444,7 @@ std::vector<std::string> LDBCommand::BuildCmdLineOptions(
                                   ARG_FILE_SIZE,
                                   ARG_FIX_PREFIX_LEN,
                                   ARG_TRY_LOAD_OPTIONS,
+                                  ARG_IGNORE_UNKNOWN_OPTIONS,
                                   ARG_CF_NAME};
   ret.insert(ret.end(), options.begin(), options.end());
   return ret;

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -46,6 +46,8 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
              " : DB supports ttl and value is internally timestamp-suffixed\n");
   ret.append("  --" + LDBCommand::ARG_TRY_LOAD_OPTIONS +
              " : Try to load option file from DB.\n");
+  ret.append("  --" + LDBCommand::ARG_IGNORE_UNKNOWN_OPTIONS +
+             " : Ignore unknown options when loading option file.\n");
   ret.append("  --" + LDBCommand::ARG_BLOOM_BITS + "=<int,e.g.:14>\n");
   ret.append("  --" + LDBCommand::ARG_FIX_PREFIX_LEN + "=<int,e.g.:14>\n");
   ret.append("  --" + LDBCommand::ARG_COMPRESSION_TYPE +

--- a/utilities/options/options_util.cc
+++ b/utilities/options/options_util.cc
@@ -14,9 +14,10 @@
 namespace rocksdb {
 Status LoadOptionsFromFile(const std::string& file_name, Env* env,
                            DBOptions* db_options,
-                           std::vector<ColumnFamilyDescriptor>* cf_descs) {
+                           std::vector<ColumnFamilyDescriptor>* cf_descs,
+                           bool ignore_unknown_options) {
   RocksDBOptionsParser parser;
-  Status s = parser.Parse(file_name, env);
+  Status s = parser.Parse(file_name, env, ignore_unknown_options);
   if (!s.ok()) {
     return s;
   }
@@ -61,20 +62,22 @@ Status GetLatestOptionsFileName(const std::string& dbpath,
 
 Status LoadLatestOptions(const std::string& dbpath, Env* env,
                          DBOptions* db_options,
-                         std::vector<ColumnFamilyDescriptor>* cf_descs) {
+                         std::vector<ColumnFamilyDescriptor>* cf_descs,
+                         bool ignore_unknown_options) {
   std::string options_file_name;
   Status s = GetLatestOptionsFileName(dbpath, env, &options_file_name);
   if (!s.ok()) {
     return s;
   }
 
-  return LoadOptionsFromFile(dbpath + "/" + options_file_name, env,
-                             db_options, cf_descs);
+  return LoadOptionsFromFile(dbpath + "/" + options_file_name, env, db_options,
+                             cf_descs, ignore_unknown_options);
 }
 
 Status CheckOptionsCompatibility(
     const std::string& dbpath, Env* env, const DBOptions& db_options,
-    const std::vector<ColumnFamilyDescriptor>& cf_descs) {
+    const std::vector<ColumnFamilyDescriptor>& cf_descs,
+    bool ignore_unknown_options) {
   std::string options_file_name;
   Status s = GetLatestOptionsFileName(dbpath, env, &options_file_name);
   if (!s.ok()) {
@@ -92,7 +95,7 @@ Status CheckOptionsCompatibility(
 
   return RocksDBOptionsParser::VerifyRocksDBOptionsFromFile(
       db_options, cf_names, cf_opts, dbpath + "/" + options_file_name, env,
-      kDefaultLevel);
+      kDefaultLevel, ignore_unknown_options);
 }
 
 }  // namespace rocksdb


### PR DESCRIPTION
Added a flag, `ignore_unknown_options`, to skip unknown options when loading an options file (using `LoadLatestOptions`/`LoadOptionsFromFile`) or while verifying options (using `CheckOptionsCompatibility`). This will help in downgrading the db to an older version. 

Also added `--ignore_unknown_options` flag to ldb

**Example Use case:**
In MyRocks, if copying from newer version to older version, it is often impossible to start because of new RocksDB options that don't exist in older version, even though data format is compatible. 
MyRocks uses these load and verify functions in [ha_rocksdb.cc::check_rocksdb_options_compatibility](https://github.com/facebook/mysql-5.6/blob/e004fd9f416821d043ccc8ad4a345c33ac9953f0/storage/rocksdb/ha_rocksdb.cc#L3348-L3401).

**Test Plan:**
Updated the unit tests.
`make check`

ldb:
$ ./ldb --db=/tmp/test_db --create_if_missing put a1 b1
OK

Now edit /tmp/test_db/<OPTIONS-file> and add an unknown option.

Try loading the options now, and it fails:
$ ./ldb --db=/tmp/test_db --try_load_options get a1
Failed: Invalid argument: Unrecognized option DBOptions:: abcd

Passes with the new --ignore_unknown_options flag
$ ./ldb --db=/tmp/test_db --try_load_options --ignore_unknown_options get a1
b1