### PR TITLE
Fix mock_env.cc uninitialized variable

### DIFF
--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -378,7 +378,7 @@ class TestMemLogger : public Logger {
       struct timeval now_tv;
       gettimeofday(&now_tv, nullptr);
       const time_t seconds = now_tv.tv_sec;
-      struct tm t;
+      struct tm t{0, 0, 0, 0, 0, 0, 0, 0, 0};
       auto ret __attribute__((__unused__)) = localtime_r(&seconds, &t);
       assert(ret);
       p += snprintf(p, limit - p,


### PR DESCRIPTION
Summary:
Mingw is complaining about uninitialized variable in mock_env.cc. e.g. https://travis-ci.org/facebook/rocksdb/jobs/240132276
The fix is to initialize the variable.

Test Plan:
wait for travis job of this PR.