### PR TITLE
GNU C library for struct tm has 2 additional fields.

### DIFF
--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -378,7 +378,8 @@ class TestMemLogger : public Logger {
       struct timeval now_tv;
       gettimeofday(&now_tv, nullptr);
       const time_t seconds = now_tv.tv_sec;
-      struct tm t{0, 0, 0, 0, 0, 0, 0, 0, 0};
+      struct tm t;
+      memset(&t, 0, sizeof(t));
       auto ret __attribute__((__unused__)) = localtime_r(&seconds, &t);
       assert(ret);
       p += snprintf(p, limit - p,


### PR DESCRIPTION
Summary: initialize 2 additional fields tm_gmtoff and tm_zone,
otherwise under strict warnings for initialization, we get errors
in myrocks.