### PR TITLE
Disable partitioning for l0

### DIFF
--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -71,9 +71,10 @@ Status BlockBasedTableFactory::NewTableReader(
   }
   return BlockBasedTable::Open(
       table_reader_options.ioptions, table_reader_options.env_options,
-      new_table_options, table_reader_options.internal_comparator, std::move(file),
-      file_size, table_reader, prefetch_index_and_filter_in_cache,
-      table_reader_options.skip_filters, table_reader_options.level);
+      new_table_options, table_reader_options.internal_comparator,
+      std::move(file), file_size, table_reader,
+      prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
+      table_reader_options.level);
 }
 
 TableBuilder* BlockBasedTableFactory::NewTableBuilder(
@@ -81,7 +82,9 @@ TableBuilder* BlockBasedTableFactory::NewTableBuilder(
     WritableFileWriter* file) const {
   auto new_table_options = table_options_;
   // Disable partitioning for l0 since they are accessed very often
-  if (table_builder_options.level < 1) {
+  if (table_builder_options.level < 1 &&
+      table_builder_options.ioptions.compaction_style ==
+          kCompactionStyleLevel) {
     if (new_table_options.partition_filters) {
       new_table_options.partition_filters = false;
     }

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -404,7 +404,9 @@ struct BlockBasedTable::Rep {
 
   const ImmutableCFOptions& ioptions;
   const EnvOptions& env_options;
-  const BlockBasedTableOptions& table_options;
+  // Use a copy of original table options since it the original could be on
+  // stack
+  const BlockBasedTableOptions table_options;
   const FilterPolicy* const filter_policy;
   const InternalKeyComparator& internal_comparator;
   Status status;


### PR DESCRIPTION
l0 files are accesses very often and using partitioning on index/filters could result to
i) higher cache misses
ii) contention on lock-based data structures in 2nd level index

This patch disables partitioning for l0 files.