### PR TITLE
Fix Clang release build broken by 5582123dee8426a5191dfd5e846cea8c676c793c 

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -228,7 +228,9 @@ class FilePicker {
   unsigned int hit_file_level_;
   int32_t search_left_bound_;
   int32_t search_right_bound_;
+#ifndef NDEBUG
   std::vector<FileMetaData*>* files_;
+#endif
   autovector<LevelFilesBrief>* level_files_brief_;
   bool search_ended_;
   bool is_hit_file_last_in_level_;


### PR DESCRIPTION
Summary: 5582123dee8426a5191dfd5e846cea8c676c793c broken CLANG release build because of an unexpected change. Fix it.