### PR TITLE
Fix blob db compression bug

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -897,14 +897,17 @@ Status BlobDBImpl::Write(const WriteOptions& opts, WriteBatch* updates) {
       last_file_ = bfile;
       has_put_ = true;
 
-      Slice value = value_unc;
+      Slice value;
       std::string compression_output;
-      if (impl_->bdb_options_.compression != kNoCompression) {
+      if (impl_->bdb_options_.compression == kNoCompression) {
+        value = value_unc;
+      } else {
         CompressionType ct = impl_->bdb_options_.compression;
         CompressionOptions compression_opts;
-        value = CompressBlock(value_unc, compression_opts, &ct,
+        CompressBlock(value_unc, compression_opts, &ct,
                               kBlockBasedTableVersionFormat, Slice(),
                               &compression_output);
+        value = Slice(compression_output);
       }
 
       std::string headerbuf;
@@ -1028,14 +1031,17 @@ Status BlobDBImpl::PutUntil(const WriteOptions& options,
 
   if (!bfile) return Status::NotFound("Blob file not found");
 
-  Slice value = value_unc;
+  Slice value;
   std::string compression_output;
-  if (bdb_options_.compression != kNoCompression) {
+  if (bdb_options_.compression == kNoCompression) {
+    value = value_unc;
+  } else {
     CompressionType ct = bdb_options_.compression;
     CompressionOptions compression_opts;
-    value = CompressBlock(value_unc, compression_opts, &ct,
+    CompressBlock(value_unc, compression_opts, &ct,
                           kBlockBasedTableVersionFormat, Slice(),
                           &compression_output);
+    value = Slice(compression_output);
   }
 
   std::string headerbuf;

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -897,9 +897,8 @@ Status BlobDBImpl::Write(const WriteOptions& opts, WriteBatch* updates) {
       last_file_ = bfile;
       has_put_ = true;
 
-      Slice value;
       std::string compression_output;
-      Slice value = GetCompressedSlice(value_unc, &compression_output);
+      Slice value = impl_->GetCompressedSlice(value_unc, &compression_output);
 
       std::string headerbuf;
       Writer::ConstructBlobHeader(&headerbuf, key, value, expiration, -1);
@@ -1019,8 +1018,8 @@ Slice BlobDBImpl::GetCompressedSlice(const Slice& raw,
   }
   CompressionType ct = bdb_options_.compression;
   CompressionOptions compression_opts;
-  CompressBlock(value_unc, compression_opts, &ct, kBlockBasedTableVersionFormat,
-                Slice(), &compression_output);
+  CompressBlock(raw, compression_opts, &ct, kBlockBasedTableVersionFormat,
+                Slice(), compression_output);
   return *compression_output;
 }
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -212,7 +212,8 @@ class BlobDBImpl : public BlobDB {
                    const std::string& index_entry, std::string* value,
                    SequenceNumber* sequence = nullptr);
 
-  Slice GetCompressedSlice(const Slice& raw) const;
+  Slice GetCompressedSlice(const Slice& raw,
+                           std::string* compression_output) const;
 
   // Just before flush starts acting on memtable files,
   // this handler is called.

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -212,6 +212,8 @@ class BlobDBImpl : public BlobDB {
                    const std::string& index_entry, std::string* value,
                    SequenceNumber* sequence = nullptr);
 
+  Slice GetCompressedSlice(const Slice& raw) const;
+
   // Just before flush starts acting on memtable files,
   // this handler is called.
   void OnFlushBeginHandler(DB* db, const FlushJobInfo& info);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -205,7 +205,7 @@ TEST_F(BlobDBTest, Override) {
 }
 
 #ifdef SNAPPY
-TEST_F(BlobDBTest, DISABLED_Compression) {
+TEST_F(BlobDBTest, Compression) {
   Random rnd(301);
   BlobDBOptionsImpl bdb_options;
   bdb_options.disable_background_tasks = true;


### PR DESCRIPTION
Summary:
`CompressBlock()` will return the uncompressed slice (i.e. `Slice(value_unc)`) if compression ratio is not good enough. This is undesired. We need to always assign the compressed slice to `value`.

Test Plan:
Test with `BlobDBTest::Compression` test which can be found in #2446 