### PR TITLE
update cmake version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,22 @@ matrix:
 
 # https://docs.travis-ci.com/user/caching/#ccache-cache
 install:
-  - if [ "${TRAVIS_OS_NAME}" == osx ]; then
-      brew install ccache;
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - pwd
+  - echo ${DEPS_DIR}
+  - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+  - echo "${TRAVIS_OS_NAME}"
+  - |
+    if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      CMAKE_URL="https://cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.tar.gz"
+      mkdir cmake && travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake || travis_terminate 1;
+      export "PATH=${DEPS_DIR}/cmake/bin:${PATH}";
+    elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      #brew install cmake boost python gcc || travis_terminate 1; # 3.8 already availalbe
+      brew install ccache || travis_terminate 1;
       PATH=$PATH:/usr/local/opt/ccache/libexec;
     fi
+  - cd ${TRAVIS_BUILD_DIR}
 
 before_script:
   # Increase the maximum number of open file descriptors, since some tests use
@@ -56,15 +68,16 @@ before_script:
   - ulimit -n 8192
 
 script:
-  - ${CXX} --version
-  - if [ "${TEST_GROUP}" == 'platform_dependent' ]; then OPT=-DTRAVIS V=1 make -j4 all; OPT=-DTRAVIS V=1 ROCKSDBTESTS_END=db_block_cache_test make -j4 check_some; fi
-  - if [ "${TEST_GROUP}" == '1' ]; then OPT=-DTRAVIS V=1 ROCKSDBTESTS_START=db_block_cache_test ROCKSDBTESTS_END=comparator_db_test make -j4 check_some; fi
-  - if [ "${TEST_GROUP}" == '2' ]; then OPT=-DTRAVIS V=1 ROCKSDBTESTS_START=comparator_db_test make -j4 check_some; fi
-  - if [ "${JOB_NAME}" == 'java_test' ]; then OPT=-DTRAVIS V=1 make clean jclean && make rocksdbjava jtest; fi
-  - if [ "${JOB_NAME}" == 'lite_build' ]; then OPT="-DTRAVIS -DROCKSDB_LITE" V=1 make -j4 static_lib; fi
-  - if [ "${JOB_NAME}" == 'examples' ]; then OPT=-DTRAVIS V=1 make -j4 static_lib; cd examples; make -j4; fi
-  - if [ "${JOB_NAME}" == 'cmake' ]; then mkdir build && cd build && cmake .. && make -j4 rocksdb; fi
-  - if [ "${JOB_NAME}" == 'cmake-mingw' ]; then mkdir build && cd build && cmake .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb; fi
+  - echo "test group - ${TEST_GROUP}"; echo "job name - ${JOB_NAME}"; echo "--- compiler ---"; ${CXX} --version; echo "--- CMake ---"; cmake --version; export MAKE="make -j4"; 
+  - if [ "${TEST_GROUP}" == 'platform_dependent' ]; then OPT=-DTRAVIS V=1 make all && OPT=-DTRAVIS V=1 ROCKSDBTESTS_END=db_block_cache_test $MAKE check_some;
+    elif [ "${TEST_GROUP}" == '1' ]; then OPT=-DTRAVIS V=1 ROCKSDBTESTS_START=db_block_cache_test ROCKSDBTESTS_END=comparator_db_test $MAKE check_some;
+    elif [ "${TEST_GROUP}" == '2' ]; then OPT=-DTRAVIS V=1 ROCKSDBTESTS_START=comparator_db_test $MAKE check_some;
+    elif [ "${JOB_NAME}" == 'java_test' ]; then OPT=-DTRAVIS V=1 $MAKE clean jclean &&  $MAKE rocksdbjava jtest;
+    elif [ "${JOB_NAME}" == 'lite_build' ]; then OPT="-DTRAVIS -DROCKSDB_LITE" V=1 make -j4 static_lib;
+    elif [ "${JOB_NAME}" == 'examples' ]; then OPT=-DTRAVIS V=1 $MAKE static_lib && cd examples && $MAKE;
+    elif [ "${JOB_NAME}" == 'cmake' ]; then mkdir build && cd build && cmake .. && $MAKE rocksdb;
+    elif [ "${JOB_NAME}" == 'cmake-mingw' ]; then mkdir build && cd build && cmake .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && $MAKE rocksdb;
+    fi
 notifications:
     email:
       - leveldb@fb.com

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@
 # 3. cmake ..
 # 4. make -j
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.2)
 project(rocksdb)
 
 if(POLICY CMP0042)


### PR DESCRIPTION
Newer CMake versions support the the cmake target system. CMake targets allow easier composition of CMake projects. They also allow finer configuration of include paths and compile definitions.

Please take a look at: http://doc.qt.io/qt-5/cmake-manual.html
The use of target_link_libraries that will not require any extra call of include_directories is just
one of the advantages.