### PR TITLE
Do not run RateLimiterTest.Rate test on Travis+Mac OSX.

### DIFF
--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -59,6 +59,7 @@ TEST_F(RateLimiterTest, Modes) {
   }
 }
 
+#if !(defined(TRAVIS) && defined(OS_MACOSX))
 TEST_F(RateLimiterTest, Rate) {
   auto* env = Env::Default();
   struct Arg {
@@ -121,6 +122,7 @@ TEST_F(RateLimiterTest, Rate) {
     }
   }
 }
+#endif
 
 TEST_F(RateLimiterTest, LimitChangeTest) {
   // starvation test when limit changes to a smaller value


### PR DESCRIPTION
RateLimiterTest.Rate test has been failing continuously since many days on travis in Mac OSX PLATFORM_DEPENDENT test suite. 
Check https://travis-ci.org/facebook/rocksdb/pull_requests. 

Disabling this test for now, so that we can investigate more in depth. 

Test plan:
Verified that the test runs on linux and my mac locally. I'll wait and verify to make sure that PLATFORM_DEPENDENT OSX test suite is green on travis.