### PR TITLE
Persist corruption detected during compaction

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * DB property "rocksdb.sstables" now prints keys in hex form.
+* Persist corruptions detected by compactions, so they can be remembered across database restarts. The corruption state can be queried via DB property: "rocksdb.is-corrupted".
 
 ### New Features
 * Measure estimated number of reads per file. The information can be accessed through DB::GetColumnFamilyMetaData or "rocksdb.sstables" DB property.

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -350,6 +350,7 @@ ColumnFamilyData::ColumnFamilyData(
       current_(nullptr),
       refs_(0),
       dropped_(false),
+      corrupted_(false),
       internal_comparator_(cf_options.comparator),
       initial_cf_options_(SanitizeOptions(db_options, cf_options)),
       ioptions_(db_options, initial_cf_options_),

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -196,6 +196,9 @@ class ColumnFamilyData {
   void SetDropped();
   bool IsDropped() const { return dropped_; }
 
+  void SetCorrupted() { corrupted_ = true; }
+  bool IsCorrupted() const { return corrupted_; }
+
   // thread-safe
   int NumberLevels() const { return ioptions_.num_levels; }
 
@@ -352,6 +355,7 @@ class ColumnFamilyData {
 
   std::atomic<int> refs_;      // outstanding references to ColumnFamilyData
   bool dropped_;               // true if client dropped it
+  bool corrupted_;             // true if data corruption detected
 
   const InternalKeyComparator internal_comparator_;
   std::vector<std::unique_ptr<IntTblPropCollectorFactory>>

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -589,7 +589,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
 
   if (status.ok()) {
     status = InstallCompactionResults(mutable_cf_options);
-  } else if (status.IsCorruption()) {
+  } else if (status.IsCorruption() && !cfd->IsCorrupted()) {
     VersionEdit edit;
     edit.SetColumnFamily(cfd->GetID());
     edit.CorruptColumnFamily();

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -589,6 +589,17 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
 
   if (status.ok()) {
     status = InstallCompactionResults(mutable_cf_options);
+  } else if (status.IsCorruption()) {
+    VersionEdit edit;
+    edit.SetColumnFamily(cfd->GetID());
+    edit.CorruptColumnFamily();
+    Status s = versions_->LogAndApply(cfd, mutable_cf_options, &edit, db_mutex_,
+                                      db_directory_);
+    if (!s.ok()) {
+      ROCKS_LOG_WARN(
+          db_options_.info_log, "[%s] Persisting corruption state failed",
+          cfd->GetName().c_str());
+    }
   }
   VersionStorageInfo::LevelSummaryStorage tmp;
   auto vstorage = cfd->current()->storage_info();

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -245,6 +245,7 @@ static const std::string num_running_flushes = "num-running-flushes";
 static const std::string actual_delayed_write_rate =
     "actual-delayed-write-rate";
 static const std::string is_write_stopped = "is-write-stopped";
+static const std::string is_corrupted = "is-corrupted";
 
 const std::string DB::Properties::kNumFilesAtLevelPrefix =
                       rocksdb_prefix + num_files_at_level_prefix;
@@ -318,6 +319,8 @@ const std::string DB::Properties::kActualDelayedWriteRate =
     rocksdb_prefix + actual_delayed_write_rate;
 const std::string DB::Properties::kIsWriteStopped =
     rocksdb_prefix + is_write_stopped;
+const std::string DB::Properties::kIsCorrupted =
+    rocksdb_prefix + is_corrupted;
 
 const std::unordered_map<std::string, DBPropertyInfo>
     InternalStats::ppt_name_to_info = {
@@ -416,6 +419,8 @@ const std::unordered_map<std::string, DBPropertyInfo>
           nullptr}},
         {DB::Properties::kIsWriteStopped,
          {false, nullptr, &InternalStats::HandleIsWriteStopped, nullptr}},
+        {DB::Properties::kIsCorrupted,
+         {false, nullptr, &InternalStats::HandleIsCorrupted, nullptr}},
 };
 
 const DBPropertyInfo* GetPropertyInfo(const Slice& property) {
@@ -774,6 +779,12 @@ bool InternalStats::HandleActualDelayedWriteRate(uint64_t* value, DBImpl* db,
 bool InternalStats::HandleIsWriteStopped(uint64_t* value, DBImpl* db,
                                          Version* version) {
   *value = db->write_controller().IsStopped() ? 1 : 0;
+  return true;
+}
+
+bool InternalStats::HandleIsCorrupted(uint64_t* value, DBImpl* /* db */,
+                                      Version* /* version */) {
+  *value = cfd_->IsCorrupted() ? 1 : 0;
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -472,6 +472,7 @@ class InternalStats {
   bool HandleActualDelayedWriteRate(uint64_t* value, DBImpl* db,
                                     Version* version);
   bool HandleIsWriteStopped(uint64_t* value, DBImpl* db, Version* version);
+  bool HandleIsCorrupted(uint64_t* value, DBImpl* db, Version* version);
 
   // Total number of background errors encountered. Every time a flush task
   // or compaction task fails, this counter is incremented. The failure can

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -41,6 +41,7 @@ enum Tag {
   kColumnFamilyAdd = 201,
   kColumnFamilyDrop = 202,
   kMaxColumnFamily = 203,
+  kColumnFamilyCorrupt = 204,
 };
 
 enum CustomTag {
@@ -76,6 +77,7 @@ void VersionEdit::Clear() {
   column_family_ = 0;
   is_column_family_add_ = 0;
   is_column_family_drop_ = 0;
+  is_column_family_corrupt_ = 0;
   column_family_name_.clear();
 }
 
@@ -186,6 +188,10 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
 
   if (is_column_family_drop_) {
     PutVarint32(dst, kColumnFamilyDrop);
+  }
+
+  if (is_column_family_corrupt_) {
+    PutVarint32(dst, kColumnFamilyCorrupt);
   }
   return true;
 }
@@ -441,6 +447,10 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         is_column_family_drop_ = true;
         break;
 
+      case kColumnFamilyCorrupt:
+        is_column_family_corrupt_ = true;
+        break;
+
       default:
         msg = "unknown tag";
         break;
@@ -511,6 +521,9 @@ std::string VersionEdit::DebugString(bool hex_key) const {
   if (is_column_family_drop_) {
     r.append("\n  ColumnFamilyDrop");
   }
+  if (is_column_family_corrupt_) {
+    r.append("\n  ColumnFamilyCorrupt");
+  }
   if (has_max_column_family_) {
     r.append("\n  MaxColumnFamily: ");
     AppendNumberTo(&r, max_column_family_);
@@ -580,6 +593,9 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
   }
   if (is_column_family_drop_) {
     jw << "ColumnFamilyDrop" << column_family_name_;
+  }
+  if (is_column_family_corrupt_) {
+    jw << "ColumnFamilyCorrupt" << column_family_name_;
   }
   if (has_max_column_family_) {
     jw << "MaxColumnFamily" << max_column_family_;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -234,7 +234,8 @@ class VersionEdit {
   size_t NumEntries() { return new_files_.size() + deleted_files_.size(); }
 
   bool IsColumnFamilyManipulation() {
-    return is_column_family_add_ || is_column_family_drop_;
+    return is_column_family_add_ || is_column_family_drop_ ||
+           is_column_family_corrupt_;
   }
 
   void SetColumnFamily(uint32_t column_family_id) {
@@ -245,6 +246,7 @@ class VersionEdit {
   void AddColumnFamily(const std::string& name) {
     assert(!is_column_family_drop_);
     assert(!is_column_family_add_);
+    assert(!is_column_family_corrupt_);
     assert(NumEntries() == 0);
     is_column_family_add_ = true;
     column_family_name_ = name;
@@ -254,8 +256,18 @@ class VersionEdit {
   void DropColumnFamily() {
     assert(!is_column_family_drop_);
     assert(!is_column_family_add_);
+    assert(!is_column_family_corrupt_);
     assert(NumEntries() == 0);
     is_column_family_drop_ = true;
+  }
+
+  // set column family ID by calling SetColumnFamily()
+  void CorruptColumnFamily() {
+    assert(!is_column_family_drop_);
+    assert(!is_column_family_add_);
+    assert(!is_column_family_corrupt_);
+    assert(NumEntries() == 0);
+    is_column_family_corrupt_ = true;
   }
 
   // return true on success.
@@ -301,10 +313,11 @@ class VersionEdit {
   // If it's not set, it is default (0)
   uint32_t column_family_;
   // a version edit can be either column_family add or
-  // column_family drop. If it's column family add,
+  // column_family drop or corruption marker. If it's column family add,
   // it also includes column family name.
   bool is_column_family_drop_;
   bool is_column_family_add_;
+  bool is_column_family_corrupt_;
   std::string column_family_name_;
 };
 

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -181,6 +181,11 @@ TEST_F(VersionEditTest, ColumnFamilyTest) {
   edit.SetColumnFamily(3);
   edit.DropColumnFamily();
   TestEncodeDecode(edit);
+
+  edit.Clear();
+  edit.SetColumnFamily(4);
+  edit.CorruptColumnFamily();
+  TestEncodeDecode(edit);
 }
 
 }  // namespace rocksdb

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -582,6 +582,10 @@ class DB {
 
     //  "rocksdb.is-write-stopped" - Return 1 if write has been stopped.
     static const std::string kIsWriteStopped;
+
+    //  "rocksdb.is-corrupted" - returns 1 if a compaction operation has
+    //      encountered any corruption; otherwise, returns 0.
+    static const std::string kIsCorrupted;
   };
 #endif /* ROCKSDB_LITE */
 
@@ -632,6 +636,7 @@ class DB {
   //  "rocksdb.num-running-flushes"
   //  "rocksdb.actual-delayed-write-rate"
   //  "rocksdb.is-write-stopped"
+  //  "rocksdb.is-corrupted"
   virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
                               const Slice& property, uint64_t* value) = 0;
   virtual bool GetIntProperty(const Slice& property, uint64_t* value) {


### PR DESCRIPTION
A customer wants a non-perf-impacting (i.e., without scanning everything), best-effort way to check whether a database is corrupted. One way we can do this is persist corruptions across database restarts. This is very useful to them as their application crashes immediately on detecting corruption, and currently can't find out about it after restarting.

- Persist per-CF corruption state as a "column family manipulation" entry in manifest
- Currently only compaction records corruption entries to manifest; if needed in the future, we can add others as well
- Expose property, "rocksdb.is-corrupted", to query per-CF corruption state

Test Plan:

- unit tests
- used `ldb manifest_dump` on manifests with and without corruption entries