### PR TITLE
Sanitize partitioning options

### DIFF
--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -47,6 +47,16 @@ BlockBasedTableFactory::BlockBasedTableFactory(
   if (table_options_.index_block_restart_interval < 1) {
     table_options_.index_block_restart_interval = 1;
   }
+  if (table_options_.partition_filters &&
+      table_options_.index_type !=
+          BlockBasedTableOptions::kTwoLevelIndexSearch) {
+    table_options_.partition_filters = false;
+    // We do not support partitioned filters without partitioning indexes
+    // TODO(myabandeh): make info_log avaialble tlroughout the code base
+    fprintf(stderr,
+            "partition_filters is reset to false since kTwoLevelIndexSearch is "
+            "not enabled.");
+  }
 }
 
 Status BlockBasedTableFactory::NewTableReader(

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -50,12 +50,8 @@ BlockBasedTableFactory::BlockBasedTableFactory(
   if (table_options_.partition_filters &&
       table_options_.index_type !=
           BlockBasedTableOptions::kTwoLevelIndexSearch) {
-    table_options_.partition_filters = false;
     // We do not support partitioned filters without partitioning indexes
-    // TODO(myabandeh): make info_log avaialble tlroughout the code base
-    fprintf(stderr,
-            "partition_filters is reset to false since kTwoLevelIndexSearch is "
-            "not enabled.");
+    table_options_.partition_filters = false;
   }
 }
 


### PR DESCRIPTION
We currently do not support partitioning filters if indexes are not partitioned. The patch makes sure that these two are consistent.