### PR TITLE
Fix assert in GetOverlappingInputsRangeBinarySearch

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1837,8 +1837,8 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
   } else {
     ExtendFileRangeOverlappingInterval(level, user_begin, user_end, mid,
                                        &start_index, &end_index);
+    assert(end_index >= start_index);
   }
-  assert(end_index >= start_index);
   // insert overlapping files into vector
   for (int i = start_index; i <= end_index; i++) {
     inputs->push_back(files_[level][i]);


### PR DESCRIPTION
ExtendFileRangeWithinInterval is not ensure start_index <= end_index