### PR TITLE
fix coredump for release nullptr

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -286,7 +286,9 @@ InternalIterator* TableCache::NewRangeTombstoneIterator(
   if (s.ok()) {
     result = table_reader->NewRangeTombstoneIterator(options);
     if (result != nullptr) {
-      result->RegisterCleanup(&UnrefEntry, cache_, handle);
+      if (handle != nullptr) {
+        result->RegisterCleanup(&UnrefEntry, cache_, handle);
+      }
     }
   }
   if (result == nullptr && handle != nullptr) {


### PR DESCRIPTION
Coredump will be triggered when ingest external sst file after delete range. 
ref https://github.com/facebook/rocksdb/issues/2398