### PR TITLE
Implement ReopenWritibaleFile on Windows and other fixes

### DIFF
--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -60,7 +60,7 @@ TEST_P(DBWriteTest, ReturnSeuqneceNumberMultiThreaded) {
       ASSERT_FALSE(flags[sequence].test_and_set());
     }
   };
-  std::vector<std::thread> threads;
+  std::vector<port::Thread> threads;
   for (size_t i = 0; i < kThreads; i++) {
     threads.emplace_back(writer, i);
   }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -173,8 +173,7 @@ class Env {
   virtual Status ReopenWritableFile(const std::string& fname,
                                     unique_ptr<WritableFile>* result,
                                     const EnvOptions& options) {
-    Status s;
-    return s;
+    return Status::NotSupported();
   }
 
   // Reuse an existing file by renaming it and opening it as writable.

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -95,13 +95,15 @@ public:
     std::unique_ptr<SequentialFile>* result,
     const EnvOptions& options);
 
+  // Helper for NewWritable and ReopenWritableFile
+  virtual Status OpenWritableFile(const std::string& fname,
+    std::unique_ptr<WritableFile>* result,
+    const EnvOptions& options,
+    bool reopen);
+
   virtual Status NewRandomAccessFile(const std::string& fname,
     std::unique_ptr<RandomAccessFile>* result,
     const EnvOptions& options);
-
-  virtual Status NewWritableFile(const std::string& fname,
-                                 std::unique_ptr<WritableFile>* result,
-                                 const EnvOptions& options);
 
   // The returned file will only be accessed by one thread at a time.
   virtual Status NewRandomRWFile(const std::string& fname,
@@ -203,6 +205,17 @@ public:
   Status NewWritableFile(const std::string& fname,
                          std::unique_ptr<WritableFile>* result,
                          const EnvOptions& options) override;
+
+  // Create an object that writes to a new file with the specified
+  // name.  Deletes any existing file with the same name and creates a
+  // new file.  On success, stores a pointer to the new file in
+  // *result and returns OK.  On failure stores nullptr in *result and
+  // returns non-OK.
+  //
+  // The returned file will only be accessed by one thread at a time.
+  Status ReopenWritableFile(const std::string& fname,
+    std::unique_ptr<WritableFile>* result,
+    const EnvOptions& options) override;
 
   // The returned file will only be accessed by one thread at a time.
   Status NewRandomRWFile(const std::string& fname,

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -301,7 +301,7 @@ class WinWritableImpl {
  protected:
   WinFileData* file_data_;
   const uint64_t alignment_;
-  uint64_t filesize_;      // How much data is actually written disk
+  uint64_t next_write_offset_; // Needed because Windows does not support O_APPEND
   uint64_t reservedsize_;  // how far we have reserved space
 
   virtual Status PreallocateInternal(uint64_t spaceToReserve);
@@ -324,14 +324,14 @@ class WinWritableImpl {
 
   Status SyncImpl();
 
-  uint64_t GetFileSizeImpl() {
+  uint64_t GetFileNextWriteOffset() {
     // Double accounting now here with WritableFileWriter
     // and this size will be wrong when unbuffered access is used
     // but tests implement their own writable files and do not use
     // WritableFileWrapper
     // so we need to squeeze a square peg through
     // a round hole here.
-    return filesize_;
+    return next_write_offset_;
   }
 
   Status AllocateImpl(uint64_t offset, uint64_t len);

--- a/util/timer_queue.h
+++ b/util/timer_queue.h
@@ -21,6 +21,9 @@
 // work, even for commercial purposes, all without asking permission.
 
 #pragma once
+
+#include "port/port.h"
+
 #include <assert.h>
 #include <chrono>
 #include <condition_variable>
@@ -213,5 +216,5 @@ class TimerQueue {
    public:
     std::vector<WorkItem>& getContainer() { return this->c; }
   } m_items;
-  std::thread m_th;
+  rocksdb::port::Thread m_th;
 };

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -230,11 +230,11 @@ TEST_F(BlobDBTest, Compression) {
 TEST_F(BlobDBTest, DISABLED_MultipleWriters) {
   Open();
 
-  std::vector<std::thread> workers;
+  std::vector<port::Thread> workers;
   for (size_t ii = 0; ii < 10; ii++)
-    workers.push_back(std::thread(&BlobDBTest::InsertBlobs, this));
+    workers.push_back(port::Thread(&BlobDBTest::InsertBlobs, this));
 
-  for (std::thread &t : workers) {
+  for (auto& t : workers) {
     if (t.joinable()) {
       t.join();
     }


### PR DESCRIPTION
  Make default impl return NoSupported so the db_blob
  tests exist in a meaningful manner.
  Replace std::thread to port::Thread