### PR TITLE
WriteBufferManager will not trigger flush if much data is already being flushed

### DIFF
--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -53,6 +53,7 @@ struct WriteBufferManager::CacheRep {};
 WriteBufferManager::WriteBufferManager(size_t _buffer_size,
                                        std::shared_ptr<Cache> cache)
     : buffer_size_(_buffer_size),
+      mutable_limit_(buffer_size_ * 7 / 8),
       memory_used_(0),
       memory_active_(0),
       cache_rep_(nullptr) {


### PR DESCRIPTION
Summary: Even if hard limit hits, flushing more memtable may not help cap the memory usage if already more than half data is scheduled for flush. Not triggering flush instead.

Test Plan: Add a new unit test.