### PR TITLE
Downgrade option sanitiy check level for prefix_extractor

### DIFF
--- a/options/options_sanity_check.h
+++ b/options/options_sanity_check.h
@@ -29,7 +29,6 @@ static const std::unordered_map<std::string, OptionsSanityCheckLevel>
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
     sanity_level_cf_options = {
         {"comparator", kSanityLevelLooselyCompatible},
-        {"prefix_extractor", kSanityLevelLooselyCompatible},
         {"table_factory", kSanityLevelLooselyCompatible},
         {"merge_operator", kSanityLevelLooselyCompatible}};
 

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1462,13 +1462,15 @@ TEST_F(OptionsSanityCheckTest, SanityCheck) {
 
     // use same prefix extractor but with different parameter
     opts.prefix_extractor.reset(NewCappedPrefixTransform(15));
-    // expect pass only in kSanityLevelNone
-    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
+    // expect pass only in kSanityLevelLooselyCompatible
+    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelExactMatch));
+    ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
     ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelNone));
 
     // repeat the test with FixedPrefixTransform
     opts.prefix_extractor.reset(NewFixedPrefixTransform(10));
-    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
+    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelExactMatch));
+    ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
     ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelNone));
 
     // persist the change of prefix_extractor
@@ -1477,8 +1479,9 @@ TEST_F(OptionsSanityCheckTest, SanityCheck) {
 
     // use same prefix extractor but with different parameter
     opts.prefix_extractor.reset(NewFixedPrefixTransform(15));
-    // expect pass only in kSanityLevelNone
-    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
+    // expect pass only in kSanityLevelLooselyCompatible
+    ASSERT_NOK(SanityCheckCFOptions(opts, kSanityLevelExactMatch));
+    ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelLooselyCompatible));
     ASSERT_OK(SanityCheckCFOptions(opts, kSanityLevelNone));
 
     // Change prefix extractor from non-nullptr to nullptr

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -234,7 +234,7 @@ TEST_F(OptionsUtilTest, SanityCheck) {
         CheckOptionsCompatibility(dbname_, Env::Default(), db_opt, cf_descs));
 
     cf_descs[1].options.prefix_extractor.reset(new DummySliceTransform());
-    ASSERT_NOK(
+    ASSERT_OK(
         CheckOptionsCompatibility(dbname_, Env::Default(), db_opt, cf_descs));
 
     cf_descs[1].options.prefix_extractor = prefix_extractor;


### PR DESCRIPTION
Summary: With c7004840d2f4ad5fc1bdce042902b822492f3a0e, it's safe to open a DB with different prefix extractor. So it's safe to skip prefix extractor check.

Test Plan: N/A