### PR TITLE
Introduce OnBackgroundError callback

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -751,7 +751,7 @@ class DBImpl : public DB {
                     bool need_log_dir_sync, SequenceNumber sequence);
 
   // Used by WriteImpl to update bg_error_ if paranoid check is enabled.
-  void ParanoidCheck(const Status& status);
+  void WriteCallbackStatusCheck(const Status& status);
 
   // Used by WriteImpl to update bg_error_ in case of memtable insert error.
   void MemTableInsertStatusCheck(const Status& memtable_insert_status);

--- a/db/event_helpers.h
+++ b/db/event_helpers.h
@@ -27,6 +27,10 @@ class EventHelpers {
       const std::string& db_name, const std::string& cf_name,
       const std::string& file_path, int job_id, TableFileCreationReason reason);
 #endif  // !ROCKSDB_LITE
+  static void NotifyOnBackgroundError(
+      const std::vector<std::shared_ptr<EventListener>>& listeners,
+      BackgroundErrorReason reason, Status* bg_error,
+      InstrumentedMutex* db_mutex);
   static void LogAndNotifyTableFileCreationFinished(
       EventLogger* event_logger,
       const std::vector<std::shared_ptr<EventListener>>& listeners,

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -77,6 +77,13 @@ enum class CompactionReason {
   kFilesMarkedForCompaction,
 };
 
+enum class BackgroundErrorReason {
+  kFlush,
+  kCompaction,
+  kWriteCallback,
+  kMemTable,
+};
+
 #ifndef ROCKSDB_LITE
 
 struct TableFileDeletionInfo {
@@ -347,6 +354,18 @@ class EventListener {
   // will be blocked from finishing.
   virtual void OnExternalFileIngested(
       DB* /*db*/, const ExternalFileIngestionInfo& /*info*/) {}
+
+  // A call-back function for RocksDB which will be called before setting the
+  // background error status to a non-OK value. The new background error status
+  // is provided in `bg_error` and can be modified by the callback. E.g., a
+  // callback can suppress errors by resetting it to Status::OK(), thus
+  // preventing the database from entering read-only mode.
+  //
+  // Note that this function can run on the same threads as flush, compaction,
+  // and user writes. So, it is extremely important not to perform heavy
+  // computations or blocking calls in this function.
+  virtual void OnBackgroundError(BackgroundErrorReason /* reason */,
+                                 Status* /* bg_error */) {}
 
   // Factory method to return CompactionEventListener. If multiple listeners
   // provides CompactionEventListner, only the first one will be used.

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -359,7 +359,9 @@ class EventListener {
   // background error status to a non-OK value. The new background error status
   // is provided in `bg_error` and can be modified by the callback. E.g., a
   // callback can suppress errors by resetting it to Status::OK(), thus
-  // preventing the database from entering read-only mode.
+  // preventing the database from entering read-only mode. We do not provide any
+  // guarantee when failed flushes/compactions will be rescheduled if the user
+  // suppresses an error.
   //
   // Note that this function can run on the same threads as flush, compaction,
   // and user writes. So, it is extremely important not to perform heavy


### PR DESCRIPTION
Some users want to prevent rocksdb from entering read-only mode in certain error cases. This diff gives them a callback, `OnBackgroundError`, that they can use to achieve it.

- call `OnBackgroundError` every time we consider setting `bg_error_`. Use its result to assign `bg_error_` but not to change the function's return status.
- classified calls using `BackgroundErrorReason` to give the callback some info about where the error happened
- renamed `ParanoidCheck` to something more specific so we can provide a clear `BackgroundErrorReason`
- unit tests for the most common cases: flush or compaction errors