### PR TITLE
FIFO Compaction with TTL

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ### New Features
 * Measure estimated number of reads per file. The information can be accessed through DB::GetColumnFamilyMetaData or "rocksdb.sstables" DB property.
 * RateLimiter support for throttling background reads, or throttling the sum of background reads and writes. This can give more predictable I/O usage when compaction reads more data than it writes, e.g., due to lots of deletions.
+* [Experimental] FIFO compaction with TTL support. It can be enabled by setting CompactionOptionsFIFO.ttl > 0.
 
 ## 5.6.0 (06/06/2017)
 ### Public API Change

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -47,9 +47,9 @@ TableBuilder* NewTableBuilder(
         int_tbl_prop_collector_factories,
     uint32_t column_family_id, const std::string& column_family_name,
     WritableFileWriter* file, const CompressionType compression_type,
-    const CompressionOptions& compression_opts,
-    int level,
-    const std::string* compression_dict, const bool skip_filters) {
+    const CompressionOptions& compression_opts, int level,
+    const std::string* compression_dict, const bool skip_filters,
+    const uint64_t creation_time) {
   assert((column_family_id ==
           TablePropertiesCollectorFactory::Context::kUnknownColumnFamily) ==
          column_family_name.empty());
@@ -57,7 +57,7 @@ TableBuilder* NewTableBuilder(
       TableBuilderOptions(ioptions, internal_comparator,
                           int_tbl_prop_collector_factories, compression_type,
                           compression_opts, compression_dict, skip_filters,
-                          column_family_name, level),
+                          column_family_name, level, creation_time),
       column_family_id, file);
 }
 
@@ -76,7 +76,8 @@ Status BuildTable(
     const CompressionOptions& compression_opts, bool paranoid_file_checks,
     InternalStats* internal_stats, TableFileCreationReason reason,
     EventLogger* event_logger, int job_id, const Env::IOPriority io_priority,
-    TableProperties* table_properties, int level) {
+    TableProperties* table_properties, int level,
+    const uint64_t creation_time) {
   assert((column_family_id ==
           TablePropertiesCollectorFactory::Context::kUnknownColumnFamily) ==
          column_family_name.empty());

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -126,7 +126,8 @@ Status BuildTable(
       builder = NewTableBuilder(
           ioptions, internal_comparator, int_tbl_prop_collector_factories,
           column_family_id, column_family_name, file_writer.get(), compression,
-          compression_opts, level);
+          compression_opts, level, nullptr /* compression_dict */,
+          false /* skip_filters */, creation_time);
     }
 
     MergeHelper merge(env, internal_comparator.user_comparator(),

--- a/db/builder.h
+++ b/db/builder.h
@@ -50,10 +50,9 @@ TableBuilder* NewTableBuilder(
         int_tbl_prop_collector_factories,
     uint32_t column_family_id, const std::string& column_family_name,
     WritableFileWriter* file, const CompressionType compression_type,
-    const CompressionOptions& compression_opts,
-    int level,
+    const CompressionOptions& compression_opts, int level,
     const std::string* compression_dict = nullptr,
-    const bool skip_filters = false);
+    const bool skip_filters = false, const uint64_t creation_time = 0);
 
 // Build a Table file from the contents of *iter.  The generated file
 // will be named according to number specified in meta. On success, the rest of
@@ -79,6 +78,7 @@ extern Status BuildTable(
     InternalStats* internal_stats, TableFileCreationReason reason,
     EventLogger* event_logger = nullptr, int job_id = 0,
     const Env::IOPriority io_priority = Env::IO_HIGH,
-    TableProperties* table_properties = nullptr, int level = -1);
+    TableProperties* table_properties = nullptr, int level = -1,
+    const uint64_t creation_time = 0);
 
 }  // namespace rocksdb

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -463,13 +463,11 @@ bool Compaction::ShouldFormSubcompactions() const {
 
 uint64_t Compaction::MaxInputFileCreationTime() const {
   uint64_t max_creation_time = 0;
-  if (cfd_->ioptions()->compaction_style == kCompactionStyleFIFO) {
-    for (const auto& file : inputs_[0].files) {
-      if (file->fd.table_reader != nullptr) {
-        uint64_t creation_time =
-            file->fd.table_reader->GetTableProperties()->creation_time;
-        max_creation_time = std::max(max_creation_time, creation_time);
-      }
+  for (const auto& file : inputs_[0].files) {
+    if (file->fd.table_reader != nullptr) {
+      uint64_t creation_time =
+          file->fd.table_reader->GetTableProperties()->creation_time;
+      max_creation_time = std::max(max_creation_time, creation_time);
     }
   }
   return max_creation_time;

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -465,10 +465,11 @@ uint64_t Compaction::MaxInputFileCreationTime() const {
   uint64_t max_creation_time = 0;
   if (cfd_->ioptions()->compaction_style == kCompactionStyleFIFO) {
     for (const auto& file : inputs_[0].files) {
-      uint64_t creation_time =
-          file->fd.table_reader->GetTableProperties()->creation_time;
-      max_creation_time =
-          creation_time > max_creation_time ? creation_time : max_creation_time;
+      if (file->fd.table_reader != nullptr) {
+        uint64_t creation_time =
+            file->fd.table_reader->GetTableProperties()->creation_time;
+        max_creation_time = std::max(max_creation_time, creation_time);
+      }
     }
   }
   return max_creation_time;

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -464,7 +464,8 @@ bool Compaction::ShouldFormSubcompactions() const {
 uint64_t Compaction::MaxInputFileCreationTime() const {
   uint64_t max_creation_time = 0;
   for (const auto& file : inputs_[0].files) {
-    if (file->fd.table_reader != nullptr) {
+    if (file->fd.table_reader != nullptr &&
+        file->fd.table_reader->GetTableProperties() != nullptr) {
       uint64_t creation_time =
           file->fd.table_reader->GetTableProperties()->creation_time;
       max_creation_time = std::max(max_creation_time, creation_time);

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -461,4 +461,17 @@ bool Compaction::ShouldFormSubcompactions() const {
   }
 }
 
+uint64_t Compaction::MaxInputFileCreationTime() const {
+  uint64_t max_creation_time = 0;
+  if (cfd_->ioptions()->compaction_style == kCompactionStyleFIFO) {
+    for (const auto& file : inputs_[0].files) {
+      uint64_t creation_time =
+          file->fd.table_reader->GetTableProperties()->creation_time;
+      max_creation_time =
+          creation_time > max_creation_time ? creation_time : max_creation_time;
+    }
+  }
+  return max_creation_time;
+}
+
 }  // namespace rocksdb

--- a/db/compaction.h
+++ b/db/compaction.h
@@ -243,6 +243,8 @@ class Compaction {
 
   uint64_t max_compaction_bytes() const { return max_compaction_bytes_; }
 
+  uint64_t MaxInputFileCreationTime() const;
+
  private:
   // mark (or clear) all files that are being compacted
   void MarkFilesBeingCompacted(bool mark_as_compacted);

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1263,13 +1263,24 @@ Status CompactionJob::OpenCompactionOutputFile(
   bool skip_filters =
       cfd->ioptions()->optimize_filters_for_hits && bottommost_level_;
 
+  uint64_t output_file_creation_time =
+      sub_compact->compaction->MaxInputFileCreationTime();
+  if (output_file_creation_time == 0) {
+    int64_t _current_time;
+    auto status = db_options_.env->GetCurrentTime(&_current_time);
+    if (!status.ok()) {
+      _current_time = 0;
+    }
+    output_file_creation_time = static_cast<uint64_t>(_current_time);
+  }
+
   sub_compact->builder.reset(NewTableBuilder(
       *cfd->ioptions(), cfd->internal_comparator(),
       cfd->int_tbl_prop_collector_factories(), cfd->GetID(), cfd->GetName(),
       sub_compact->outfile.get(), sub_compact->compaction->output_compression(),
       cfd->ioptions()->compression_opts,
       sub_compact->compaction->output_level(), &sub_compact->compression_dict,
-      skip_filters, sub_compact->compaction->MaxInputFileCreationTime()));
+      skip_filters, output_file_creation_time));
   LogFlush(db_options_.info_log);
   return s;
 }

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1025,7 +1025,6 @@ Status CompactionJob::FinishCompactionOutputFile(
   uint64_t output_number = sub_compact->current_output()->meta.fd.GetNumber();
   assert(output_number != 0);
 
-  TableProperties table_properties;
   // Check for iterator errors
   Status s = input_status;
   auto meta = &sub_compact->current_output()->meta;
@@ -1263,14 +1262,14 @@ Status CompactionJob::OpenCompactionOutputFile(
   // data is going to be found
   bool skip_filters =
       cfd->ioptions()->optimize_filters_for_hits && bottommost_level_;
+
   sub_compact->builder.reset(NewTableBuilder(
       *cfd->ioptions(), cfd->internal_comparator(),
       cfd->int_tbl_prop_collector_factories(), cfd->GetID(), cfd->GetName(),
       sub_compact->outfile.get(), sub_compact->compaction->output_compression(),
       cfd->ioptions()->compression_opts,
-      sub_compact->compaction->output_level(),
-      &sub_compact->compression_dict,
-      skip_filters));
+      sub_compact->compaction->output_level(), &sub_compact->compression_dict,
+      skip_filters, sub_compact->compaction->MaxInputFileCreationTime()));
   LogFlush(db_options_.info_log);
   return s;
 }

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1450,10 +1450,6 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
               (current_time - ioptions_.compaction_options_fifo.ttl)) {
         total_size -= f->compensated_file_size;
         inputs[0].files.push_back(f);
-        ROCKS_LOG_BUFFER(log_buffer,
-                         "[%s] FIFO compaction: picking file %" PRIu64
-                         " with creation time %" PRIu64 " for deletion",
-                         cf_name.c_str(), f->fd.GetNumber(), creation_time);
       }
     }
   }
@@ -1465,6 +1461,14 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
   if (inputs[0].files.empty() ||
       total_size > ioptions_.compaction_options_fifo.max_table_files_size) {
     return nullptr;
+  }
+
+  for (const auto& f : inputs[0].files) {
+    ROCKS_LOG_BUFFER(log_buffer,
+                     "[%s] FIFO compaction: picking file %" PRIu64
+                     " with creation time %" PRIu64 " for deletion",
+                     cf_name.c_str(), f->fd.GetNumber(),
+                     f->fd.table_reader->GetTableProperties()->creation_time);
   }
 
   Compaction* c = new Compaction(

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1405,7 +1405,8 @@ bool FIFOCompactionPicker::NeedsCompaction(
   return vstorage->CompactionScore(kLevel0) >= 1;
 }
 
-uint64_t FIFOCompactionPicker::GetTotalFilesSize(
+namespace {
+uint64_t GetTotalFilesSize(
     const std::vector<FileMetaData*>& files) {
   uint64_t total_size = 0;
   for (const auto& f : files) {
@@ -1413,6 +1414,7 @@ uint64_t FIFOCompactionPicker::GetTotalFilesSize(
   }
   return total_size;
 }
+}  // anonymous namespace
 
 Compaction* FIFOCompactionPicker::PickTTLCompaction(
     const std::string& cf_name, const MutableCFOptions& mutable_cf_options,

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1442,15 +1442,17 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
 
   for (auto ritr = level_files.rbegin(); ritr != level_files.rend(); ++ritr) {
     auto f = *ritr;
-    if (f->fd.table_reader != nullptr) {
+    if (f->fd.table_reader != nullptr &&
+        f->fd.table_reader->GetTableProperties() != nullptr) {
       auto creation_time =
           f->fd.table_reader->GetTableProperties()->creation_time;
-      if (creation_time > 0 &&
-          creation_time <
+      if (creation_time == 0 ||
+          creation_time >=
               (current_time - ioptions_.compaction_options_fifo.ttl)) {
-        total_size -= f->compensated_file_size;
-        inputs[0].files.push_back(f);
+        break;
       }
+      total_size -= f->compensated_file_size;
+      inputs[0].files.push_back(f);
     }
   }
 

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -255,8 +255,6 @@ class FIFOCompactionPicker : public CompactionPicker {
                                  const MutableCFOptions& mutable_cf_options,
                                  VersionStorageInfo* version,
                                  LogBuffer* log_buffer);
-
-  uint64_t GetTotalFilesSize(const std::vector<FileMetaData*>& files);
 };
 
 class NullCompactionPicker : public CompactionPicker {

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -244,6 +244,19 @@ class FIFOCompactionPicker : public CompactionPicker {
 
   virtual bool NeedsCompaction(
       const VersionStorageInfo* vstorage) const override;
+
+ private:
+  Compaction* PickTTLCompaction(const std::string& cf_name,
+                                const MutableCFOptions& mutable_cf_options,
+                                VersionStorageInfo* version,
+                                LogBuffer* log_buffer);
+
+  Compaction* PickSizeCompaction(const std::string& cf_name,
+                                 const MutableCFOptions& mutable_cf_options,
+                                 VersionStorageInfo* version,
+                                 LogBuffer* log_buffer);
+
+  uint64_t GetTotalFilesSize(const std::vector<FileMetaData*>& files);
 };
 
 class NullCompactionPicker : public CompactionPicker {

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -165,11 +165,18 @@ static Status ValidateOptions(
             "universal and level compaction styles. ");
       }
     }
-    if (cfd.options.compaction_options_fifo.ttl > 0 &&
-        cfd.options.table_factory->Name() != BlockBasedTableFactory().Name()) {
-      return Status::NotSupported(
-          "FIFO Compaction with TTL is only supported in "
-          "Block-Based Table format. ");
+    if (cfd.options.compaction_options_fifo.ttl > 0) {
+      if (db_options.max_open_files != -1) {
+        return Status::NotSupported(
+            "FIFO Compaction with TTL is only supported when files are always "
+            "kept open (set max_open_files = -1). ");
+      }
+      if (cfd.options.table_factory->Name() !=
+          BlockBasedTableFactory().Name()) {
+        return Status::NotSupported(
+            "FIFO Compaction with TTL is only supported in "
+            "Block-Based Table format. ");
+      }
     }
   }
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -243,7 +243,6 @@ Status FlushJob::WriteLevel0Table() {
       ThreadStatus::STAGE_FLUSH_WRITE_L0);
   db_mutex_->AssertHeld();
   const uint64_t start_micros = db_options_.env->NowMicros();
-
   Status s;
   {
     db_mutex_->Unlock();
@@ -301,7 +300,10 @@ Status FlushJob::WriteLevel0Table() {
           db_options_.env->OptimizeForCompactionTableWrite(env_options_, db_options_);
 
       int64_t _current_time;
-      db_options_.env->GetCurrentTime(&_current_time);
+      auto status = db_options_.env->GetCurrentTime(&_current_time);
+      if (!status.ok()) {
+        _current_time = 0;
+      }
       const uint64_t current_time = static_cast<uint64_t>(_current_time);
 
       s = BuildTable(

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -243,6 +243,7 @@ Status FlushJob::WriteLevel0Table() {
       ThreadStatus::STAGE_FLUSH_WRITE_L0);
   db_mutex_->AssertHeld();
   const uint64_t start_micros = db_options_.env->NowMicros();
+
   Status s;
   {
     db_mutex_->Unlock();
@@ -298,6 +299,11 @@ Status FlushJob::WriteLevel0Table() {
                                &output_compression_);
       EnvOptions optimized_env_options =
           db_options_.env->OptimizeForCompactionTableWrite(env_options_, db_options_);
+
+      int64_t _current_time;
+      db_options_.env->GetCurrentTime(&_current_time);
+      const uint64_t current_time = static_cast<uint64_t>(_current_time);
+
       s = BuildTable(
           dbname_, db_options_.env, *cfd_->ioptions(), mutable_cf_options_,
           optimized_env_options, cfd_->table_cache(), iter.get(),
@@ -308,7 +314,7 @@ Status FlushJob::WriteLevel0Table() {
           cfd_->ioptions()->compression_opts,
           mutable_cf_options_.paranoid_file_checks, cfd_->internal_stats(),
           TableFileCreationReason::kFlush, event_logger_, job_context_->job_id,
-          Env::IO_HIGH, &table_properties_, 0 /* level */);
+          Env::IO_HIGH, &table_properties_, 0 /* level */, current_time);
       LogFlush(db_options_.info_log);
     }
     ROCKS_LOG_INFO(db_options_.info_log,

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -70,7 +70,7 @@ class FlushJob {
   ~FlushJob();
 
   // Require db_mutex held.
-  // Once PickMemTable() is called, either Run() or Cancel() has to be call.
+  // Once PickMemTable() is called, either Run() or Cancel() has to be called.
   void PickMemTable();
   Status Run(FileMetaData* file_meta = nullptr);
   void Cancel();

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -382,6 +382,14 @@ class Repairer {
       ScopedArenaIterator iter(mem->NewIterator(ro, &arena));
       EnvOptions optimized_env_options =
           env_->OptimizeForCompactionTableWrite(env_options_, immutable_db_options_);
+
+      int64_t _current_time;
+      status = env_->GetCurrentTime(&_current_time);
+      if (!status.ok()) {
+        _current_time = 0;
+      }
+      const uint64_t current_time = static_cast<uint64_t>(_current_time);
+
       status = BuildTable(
           dbname_, env_, *cfd->ioptions(), *cfd->GetLatestMutableCFOptions(),
           optimized_env_options, table_cache_, iter.get(),
@@ -389,7 +397,9 @@ class Repairer {
           &meta, cfd->internal_comparator(),
           cfd->int_tbl_prop_collector_factories(), cfd->GetID(), cfd->GetName(),
           {}, kMaxSequenceNumber, kNoCompression, CompressionOptions(), false,
-          nullptr /* internal_stats */, TableFileCreationReason::kRecovery);
+          nullptr /* internal_stats */, TableFileCreationReason::kRecovery,
+          nullptr /* event_logger */, 0 /* job_id */, Env::IO_HIGH,
+          nullptr /* table_properties */, -1 /* level */, current_time);
       ROCKS_LOG_INFO(db_options_.info_log,
                      "Log #%" PRIu64 ": %d ops saved to Table #%" PRIu64 " %s",
                      log, counter, meta.fd.GetNumber(),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1318,6 +1318,31 @@ void VersionStorageInfo::EstimateCompactionBytesNeeded(
   }
 }
 
+namespace {
+uint32_t GetExpiredTtlFilesCount(const ImmutableCFOptions& ioptions,
+                                 const std::vector<FileMetaData*>& files) {
+  uint32_t ttl_expired_files_count = 0;
+
+  int64_t _current_time;
+  auto status = ioptions.env->GetCurrentTime(&_current_time);
+  if (status.ok()) {
+    const uint64_t current_time = static_cast<uint64_t>(_current_time);
+    for (auto f : files) {
+      if (!f->being_compacted && f->fd.table_reader != nullptr) {
+        auto creation_time =
+            f->fd.table_reader->GetTableProperties()->creation_time;
+        if (creation_time > 0 &&
+            creation_time <
+                (current_time - ioptions.compaction_options_fifo.ttl)) {
+          ttl_expired_files_count++;
+        }
+      }
+    }
+  }
+  return ttl_expired_files_count;
+}
+}  // anonymous namespace
+
 void VersionStorageInfo::ComputeCompactionScore(
     const ImmutableCFOptions& immutable_cf_options,
     const MutableCFOptions& mutable_cf_options) {
@@ -1363,6 +1388,11 @@ void VersionStorageInfo::ComputeCompactionScore(
               static_cast<double>(num_sorted_runs) /
                   mutable_cf_options.level0_file_num_compaction_trigger,
               score);
+        }
+        if (immutable_cf_options.compaction_options_fifo.ttl > 0) {
+          score = std::max(static_cast<double>(GetExpiredTtlFilesCount(
+                               immutable_cf_options, files_[level])),
+                           score);
         }
 
       } else {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1328,7 +1328,8 @@ uint32_t GetExpiredTtlFilesCount(const ImmutableCFOptions& ioptions,
   if (status.ok()) {
     const uint64_t current_time = static_cast<uint64_t>(_current_time);
     for (auto f : files) {
-      if (!f->being_compacted && f->fd.table_reader != nullptr) {
+      if (!f->being_compacted && f->fd.table_reader != nullptr &&
+          f->fd.table_reader->GetTableProperties() != nullptr) {
         auto creation_time =
             f->fd.table_reader->GetTableProperties()->creation_time;
         if (creation_time > 0 &&

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -62,6 +62,13 @@ struct CompactionOptionsFIFO {
   // Default: 1GB
   uint64_t max_table_files_size;
 
+  // Drop files older than TTL. TTL based deletion will take precedence over
+  // size based deletion if ttl > 0.
+  // delete if sst_file_creation_time < (current_time - ttl)
+  // unit: seconds. Ex: 1 day = 1 * 24 * 60 * 60
+  // Default: 0 (disabled)
+  uint64_t ttl = 0;
+
   // If true, try to do compaction to compact smaller files into larger ones.
   // Minimum files to compact follows options.level0_file_num_compaction_trigger
   // and compaction won't trigger if average compact bytes per del file is
@@ -71,9 +78,10 @@ struct CompactionOptionsFIFO {
   bool allow_compaction = false;
 
   CompactionOptionsFIFO() : max_table_files_size(1 * 1024 * 1024 * 1024) {}
-  CompactionOptionsFIFO(uint64_t _max_table_files_size,
+  CompactionOptionsFIFO(uint64_t _max_table_files_size, uint64_t _ttl,
                         bool _allow_compaction)
       : max_table_files_size(_max_table_files_size),
+        ttl(_ttl),
         allow_compaction(_allow_compaction) {}
 };
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -78,8 +78,8 @@ struct CompactionOptionsFIFO {
   bool allow_compaction = false;
 
   CompactionOptionsFIFO() : max_table_files_size(1 * 1024 * 1024 * 1024) {}
-  CompactionOptionsFIFO(uint64_t _max_table_files_size, uint64_t _ttl,
-                        bool _allow_compaction)
+  CompactionOptionsFIFO(uint64_t _max_table_files_size, bool _allow_compaction,
+                        uint64_t _ttl = 0)
       : max_table_files_size(_max_table_files_size),
         ttl(_ttl),
         allow_compaction(_allow_compaction) {}

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -27,8 +27,6 @@ enum class TableFileCreationReason {
   kFlush,
   kCompaction,
   kRecovery,
-  kBulkLoading,
-  kUnknown,
 };
 
 struct TableFileCreationBriefInfo {

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -27,6 +27,8 @@ enum class TableFileCreationReason {
   kFlush,
   kCompaction,
   kRecovery,
+  kBulkLoading,
+  kUnknown,
 };
 
 struct TableFileCreationBriefInfo {
@@ -71,6 +73,8 @@ enum class CompactionReason {
   kFIFOMaxSize,
   // [FIFO] reduce number of files.
   kFIFOReduceNumFiles,
+  // [FIFO] files with creation time < (current_time - interval)
+  kFIFOTtl,
   // Manual compaction
   kManualCompaction,
   // DB::SuggestCompactRange() marked files for compaction

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -48,6 +48,7 @@ struct TablePropertiesNames {
   static const std::string kPrefixExtractorName;
   static const std::string kPropertyCollectors;
   static const std::string kCompression;
+  static const std::string kCreationTime;
 };
 
 extern const std::string kPropertiesBlock;
@@ -158,6 +159,9 @@ struct TableProperties {
   // by column_family_name.
   uint64_t column_family_id =
       rocksdb::TablePropertiesCollectorFactory::Context::kUnknownColumnFamily;
+  // The time when the SST file was created.
+  // Since SST files are immutable, this is equivalent to last modified time.
+  uint64_t creation_time = 0;
 
   // Name of the column family with which this SST file is associated.
   // If column family is unknown, `column_family_name` will be an empty string.

--- a/options/options.cc
+++ b/options/options.cc
@@ -367,6 +367,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(log,
                      "Options.compaction_options_fifo.allow_compaction: %d",
                      compaction_options_fifo.allow_compaction);
+    ROCKS_LOG_HEADER(log, "Options.compaction_options_fifo.ttl: %" PRIu64,
+                     compaction_options_fifo.ttl);
     std::string collector_names;
     for (const auto& collector_factory : table_properties_collector_factories) {
       collector_names.append(collector_factory->Name());

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -269,6 +269,7 @@ struct BlockBasedTableBuilder::Rep {
   std::unique_ptr<FlushBlockPolicy> flush_block_policy;
   uint32_t column_family_id;
   const std::string& column_family_name;
+  uint64_t creation_time = 0;
 
   std::vector<std::unique_ptr<IntTblPropCollector>> table_properties_collectors;
 
@@ -281,7 +282,7 @@ struct BlockBasedTableBuilder::Rep {
       const CompressionType _compression_type,
       const CompressionOptions& _compression_opts,
       const std::string* _compression_dict, const bool skip_filters,
-      const std::string& _column_family_name)
+      const std::string& _column_family_name, const uint64_t _creation_time)
       : ioptions(_ioptions),
         table_options(table_opt),
         internal_comparator(icomparator),
@@ -297,7 +298,8 @@ struct BlockBasedTableBuilder::Rep {
             table_options.flush_block_policy_factory->NewFlushBlockPolicy(
                 table_options, data_block)),
         column_family_id(_column_family_id),
-        column_family_name(_column_family_name) {
+        column_family_name(_column_family_name),
+        creation_time(_creation_time) {
     if (table_options.index_type ==
         BlockBasedTableOptions::kTwoLevelIndexSearch) {
       p_index_builder_ = PartitionedIndexBuilder::CreateIndexBuilder(
@@ -336,7 +338,7 @@ BlockBasedTableBuilder::BlockBasedTableBuilder(
     const CompressionType compression_type,
     const CompressionOptions& compression_opts,
     const std::string* compression_dict, const bool skip_filters,
-    const std::string& column_family_name) {
+    const std::string& column_family_name, const uint64_t creation_time) {
   BlockBasedTableOptions sanitized_table_options(table_options);
   if (sanitized_table_options.format_version == 0 &&
       sanitized_table_options.checksum != kCRC32c) {
@@ -352,7 +354,7 @@ BlockBasedTableBuilder::BlockBasedTableBuilder(
   rep_ = new Rep(ioptions, sanitized_table_options, internal_comparator,
                  int_tbl_prop_collector_factories, column_family_id, file,
                  compression_type, compression_opts, compression_dict,
-                 skip_filters, column_family_name);
+                 skip_filters, column_family_name, creation_time);
 
   if (rep_->filter_builder != nullptr) {
     rep_->filter_builder->StartBlock(0);
@@ -728,6 +730,7 @@ Status BlockBasedTableBuilder::Finish() {
         r->props.top_level_index_size =
             r->p_index_builder_->EstimateTopLevelIndexSize(r->offset);
       }
+      r->props.creation_time = r->creation_time;
 
       // Add basic properties
       property_block_builder.AddTableProperty(r->props);

--- a/table/block_based_table_builder.h
+++ b/table/block_based_table_builder.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "rocksdb/flush_block_policy.h"
+#include "rocksdb/listener.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "table/table_builder.h"
@@ -48,7 +49,7 @@ class BlockBasedTableBuilder : public TableBuilder {
       const CompressionType compression_type,
       const CompressionOptions& compression_opts,
       const std::string* compression_dict, const bool skip_filters,
-      const std::string& column_family_name);
+      const std::string& column_family_name, const uint64_t creation_time = 0);
 
   // REQUIRES: Either Finish() or Abandon() has been called.
   ~BlockBasedTableBuilder();

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -72,7 +72,8 @@ TableBuilder* BlockBasedTableFactory::NewTableBuilder(
       table_builder_options.compression_opts,
       table_builder_options.compression_dict,
       table_builder_options.skip_filters,
-      table_builder_options.column_family_name);
+      table_builder_options.column_family_name,
+      table_builder_options.creation_time);
 
   return table_builder;
 }

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -77,6 +77,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   Add(TablePropertiesNames::kFormatVersion, props.format_version);
   Add(TablePropertiesNames::kFixedKeyLen, props.fixed_key_len);
   Add(TablePropertiesNames::kColumnFamilyId, props.column_family_id);
+  Add(TablePropertiesNames::kCreationTime, props.creation_time);
 
   if (!props.filter_policy_name.empty()) {
     Add(TablePropertiesNames::kFilterPolicy, props.filter_policy_name);
@@ -208,6 +209,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
        &new_table_properties->fixed_key_len},
       {TablePropertiesNames::kColumnFamilyId,
        &new_table_properties->column_family_id},
+      {TablePropertiesNames::kCreationTime,
+       &new_table_properties->creation_time},
   };
 
   std::string last_key;

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -56,7 +56,8 @@ struct TableBuilderOptions {
       CompressionType _compression_type,
       const CompressionOptions& _compression_opts,
       const std::string* _compression_dict, bool _skip_filters,
-      const std::string& _column_family_name, int _level)
+      const std::string& _column_family_name, int _level,
+      const uint64_t _creation_time = 0)
       : ioptions(_ioptions),
         internal_comparator(_internal_comparator),
         int_tbl_prop_collector_factories(_int_tbl_prop_collector_factories),
@@ -65,7 +66,8 @@ struct TableBuilderOptions {
         compression_dict(_compression_dict),
         skip_filters(_skip_filters),
         column_family_name(_column_family_name),
-        level(_level) {}
+        level(_level),
+        creation_time(_creation_time) {}
   const ImmutableCFOptions& ioptions;
   const InternalKeyComparator& internal_comparator;
   const std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
@@ -77,6 +79,7 @@ struct TableBuilderOptions {
   bool skip_filters;  // only used by BlockBasedTableBuilder
   const std::string& column_family_name;
   int level; // what level this table/file is on, -1 for "not set, don't know"
+  const uint64_t creation_time;
 };
 
 // TableBuilder provides the interface used to build a Table

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -139,6 +139,8 @@ std::string TableProperties::ToString(
       compression_name.empty() ? std::string("N/A") : compression_name,
       prop_delim, kv_delim);
 
+  AppendProperty(result, "creation time", creation_time, prop_delim, kv_delim);
+
   return result;
 }
 
@@ -190,6 +192,7 @@ const std::string TablePropertiesNames::kPrefixExtractorName =
 const std::string TablePropertiesNames::kPropertyCollectors =
     "rocksdb.property.collectors";
 const std::string TablePropertiesNames::kCompression = "rocksdb.compression";
+const std::string TablePropertiesNames::kCreationTime = "rocksdb.creation.time";
 
 extern const std::string kPropertiesBlock = "rocksdb.properties";
 // Old property block name for backward compatibility

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -638,6 +638,7 @@ DEFINE_uint64(fifo_compaction_max_table_files_size_mb, 0,
               "The limit of total table file sizes to trigger FIFO compaction");
 DEFINE_bool(fifo_compaction_allow_compaction, true,
             "Allow compaction in FIFO compaction.");
+DEFINE_uint64(fifo_compaction_ttl, 0, "TTL for the SST Files in seconds.");
 #endif  // ROCKSDB_LITE
 
 DEFINE_bool(report_bg_io_stats, false,
@@ -2864,7 +2865,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 #ifndef ROCKSDB_LITE
     options.compaction_options_fifo = CompactionOptionsFIFO(
         FLAGS_fifo_compaction_max_table_files_size_mb * 1024 * 1024,
-        FLAGS_fifo_compaction_allow_compaction);
+        FLAGS_fifo_compaction_ttl, FLAGS_fifo_compaction_allow_compaction);
 #endif  // ROCKSDB_LITE
     if (FLAGS_prefix_size != 0) {
       options.prefix_extractor.reset(

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2865,7 +2865,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 #ifndef ROCKSDB_LITE
     options.compaction_options_fifo = CompactionOptionsFIFO(
         FLAGS_fifo_compaction_max_table_files_size_mb * 1024 * 1024,
-        FLAGS_fifo_compaction_ttl, FLAGS_fifo_compaction_allow_compaction);
+        FLAGS_fifo_compaction_allow_compaction, FLAGS_fifo_compaction_ttl);
 #endif  // ROCKSDB_LITE
     if (FLAGS_prefix_size != 0) {
       options.prefix_extractor.reset(


### PR DESCRIPTION
Introducing FIFO compactions with TTL. 

FIFO compaction is based on size only which makes it tricky to enable in production as use cases can have organic growth. A user requested an option to drop files based on the time of their creation instead of the total size.

To address that request: 
- Added a new TTL option to FIFO compaction options.
- Updated FIFO compaction score to take TTL into consideration.
- Added a new table property, creation_time, to keep track of when the SST file is created.
- Creation_time is set as below:
  - On Flush: Set to the time of flush.
  - On Compaction: Set to the max creation_time of all the files involved in the compaction.
  - On Repair and Recovery: Set to the time of repair/recovery.
  - Old files created prior to this code change will have a creation_time of 0.
- FIFO compaction with TTL is enabled when ttl > 0. All files older than ttl will be deleted during compaction. i.e. `if (file.creation_time < (current_time - ttl)) then delete(file)`. This will enable cases where you might want to delete all files older than, say, 1 day. 
- FIFO compaction will fall back to the prior way of deleting files based on size if: 
  - the creation_time of all files involved in compaction is 0.
  - the total size (of all SST files combined) does not drop below `compaction_options_fifo.max_table_files_size` even if the files older than ttl are deleted.

This feature is not supported if max_open_files != -1 or with table formats other than Block-based.

**Test Plan:**
Added tests.

**Benchmark results:**
Base: FIFO with max size: 100MB ::
```
svemuri@dev15905 ~/rocksdb (fifo-compaction) $ TEST_TMPDIR=/dev/shm ./db_bench --benchmarks=readwhilewriting --num=5000000 --threads=16 --compaction_style=2 --fifo_compaction_max_table_files_size_mb=100

readwhilewriting :       1.924 micros/op 519858 ops/sec;   13.6 MB/s (1176277 of 5000000 found)
```

With TTL (a low one for testing) ::
```
svemuri@dev15905 ~/rocksdb (fifo-compaction) $ TEST_TMPDIR=/dev/shm ./db_bench --benchmarks=readwhilewriting --num=5000000 --threads=16 --compaction_style=2 --fifo_compaction_max_table_files_size_mb=100 --fifo_compaction_ttl=20

readwhilewriting :       1.902 micros/op 525817 ops/sec;   13.7 MB/s (1185057 of 5000000 found)
```
Example Log lines:
```
2017/06/26-15:17:24.609249 7fd5a45ff700 (Original Log Time 2017/06/26-15:17:24.609177) [db/compaction_picker.cc:1471] [default] FIFO compaction: picking file 40 with creation time 1498515423 for deletion
2017/06/26-15:17:24.609255 7fd5a45ff700 (Original Log Time 2017/06/26-15:17:24.609234) [db/db_impl_compaction_flush.cc:1541] [default] Deleted 1 files
...
2017/06/26-15:17:25.553185 7fd5a61a5800 [DEBUG] [db/db_impl_files.cc:309] [JOB 0] Delete /dev/shm/dbbench/000040.sst type=2 #40 -- OK
2017/06/26-15:17:25.553205 7fd5a61a5800 EVENT_LOG_v1 {"time_micros": 1498515445553199, "job": 0, "event": "table_file_deletion", "file_number": 40}
```

SST Files remaining in the dbbench dir, after db_bench execution completed:
```
svemuri@dev15905 ~/rocksdb (fifo-compaction)  $ ls -l /dev/shm//dbbench/*.sst
-rw-r--r--. 1 svemuri users 30749887 Jun 26 15:17 /dev/shm//dbbench/000042.sst
-rw-r--r--. 1 svemuri users 30768779 Jun 26 15:17 /dev/shm//dbbench/000044.sst
-rw-r--r--. 1 svemuri users 30757481 Jun 26 15:17 /dev/shm//dbbench/000046.sst
```