### PR TITLE
revert perf_context and io_stats to __thread

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -154,7 +154,6 @@ struct PerfContext {
 // if defined(NPERF_CONTEXT), then the pointer is not thread-local
 PerfContext* get_perf_context();
 
-
 }
 
 #endif

--- a/monitoring/iostats_context.cc
+++ b/monitoring/iostats_context.cc
@@ -15,7 +15,11 @@ __thread IOStatsContext iostats_context;
 #endif
 
 IOStatsContext* get_iostats_context() {
+#ifdef ROCKSDB_SUPPORT_THREAD_LOCAL
   return &iostats_context;
+#else
+  return nullptr;
+#endif
 }
 
 void IOStatsContext::Reset() {

--- a/monitoring/iostats_context.cc
+++ b/monitoring/iostats_context.cc
@@ -10,16 +10,12 @@
 
 namespace rocksdb {
 
-ThreadLocalPtr iostats_context([](void* ptr) {
-    auto* p = static_cast<IOStatsContext*>(ptr);
-    delete p;
-  });
+#ifdef ROCKSDB_SUPPORT_THREAD_LOCAL
+__thread IOStatsContext iostats_context;
+#endif
 
 IOStatsContext* get_iostats_context() {
-  if (iostats_context.Get() == nullptr) {
-    iostats_context.Reset(static_cast<void*>(new IOStatsContext()));
-  }
-  return static_cast<IOStatsContext*>(iostats_context.Get());
+  return &iostats_context;
 }
 
 void IOStatsContext::Reset() {

--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -44,7 +44,10 @@ namespace rocksdb {
 #define PERF_TIMER_MEASURE(metric) perf_step_timer_##metric.Measure();
 
 // Increase metric value
-#define PERF_COUNTER_ADD(metric, value) get_perf_context()->metric += value;
+#define PERF_COUNTER_ADD(metric, value)        \
+  if (perf_level >= PerfLevel::kEnableCount) { \
+    get_perf_context()->metric += value;       \
+  }
 
 #endif
 


### PR DESCRIPTION
https://github.com/facebook/rocksdb/pull/2380 introduces a regression by replacing __thread with ThreadLocalPtr. Revert the thread local implementation back.