### PR TITLE
Fix bug that flush doesn't respond to fsync result

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,8 +21,8 @@
 * Introduce WriteOptions.low_pri. If it is true, low priority writes will be throttled if the compaction is behind.
 * `DB::IngestExternalFile()` now supports ingesting files into a database containing range deletions.
 
-### Big Fixes
-* Shouldn't skip return value of fsync() in flush.
+### Bu Fixes
+* Shouldn't ignore return value of fsync() in flush.
 
 ## 5.5.0 (05/17/2017)
 ### New Features

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,9 @@
 * Introduce WriteOptions.low_pri. If it is true, low priority writes will be throttled if the compaction is behind.
 * `DB::IngestExternalFile()` now supports ingesting files into a database containing range deletions.
 
+### Big Fixes
+* Shouldn't skip return value of fsync() in flush.
+
 ## 5.5.0 (05/17/2017)
 ### New Features
 * FIFO compaction to support Intra L0 compaction too with CompactionOptionsFIFO.allow_compaction=true.

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -179,7 +179,7 @@ Status BuildTable(
     // Finish and check for file errors
     if (s.ok() && !empty) {
       StopWatch sw(env, ioptions.statistics, TABLE_SYNC_MICROS);
-      file_writer->Sync(ioptions.use_fsync);
+      s = file_writer->Sync(ioptions.use_fsync);
     }
     if (s.ok() && !empty) {
       s = file_writer->Close();


### PR DESCRIPTION
Summary: With a regression bug was introduced two years ago, by https://github.com/facebook/rocksdb/commit/6e9fbeb27c38329f33ae541302c44c8db8374f8c , we fail to check return status of fsync call. This can cause we miss the information from the file system and can potentially cause corrupted data which we could have been detected.

Test Plan: Unit test provided in https://github.com/facebook/rocksdb/pull/2454 verifies that it fixes the problem.