### PR TITLE
add VerifyChecksum() to db.h

### DIFF
--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -27,14 +27,14 @@ Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
       ->DeleteFilesInRange(column_family, begin, end);
 }
 
-Status VerifyChecksum(const std::string& file_path) {
+Status VerifySstFileChecksum(const Options& options,
+                             const EnvOptions& env_options,
+                             const std::string& file_path,
+                             const Comparator* comp) {
   unique_ptr<RandomAccessFile> file;
   uint64_t file_size;
-
-  Options options;
+  InternalKeyComparator internal_comparator(comp);
   ImmutableCFOptions ioptions(options);
-  EnvOptions env_options;
-  InternalKeyComparator internal_comparator(BytewiseComparator());
 
   Status s = ioptions.env->NewRandomAccessFile(file_path, &file, env_options);
   if (s.ok()) {

--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -29,11 +29,10 @@ Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
 
 Status VerifySstFileChecksum(const Options& options,
                              const EnvOptions& env_options,
-                             const std::string& file_path,
-                             const Comparator* comp) {
+                             const std::string& file_path) {
   unique_ptr<RandomAccessFile> file;
   uint64_t file_size;
-  InternalKeyComparator internal_comparator(comp);
+  InternalKeyComparator internal_comparator(options.comparator);
   ImmutableCFOptions ioptions(options);
 
   Status s = ioptions.env->NewRandomAccessFile(file_path, &file, env_options);

--- a/db/convenience.cc
+++ b/db/convenience.cc
@@ -27,6 +27,36 @@ Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
       ->DeleteFilesInRange(column_family, begin, end);
 }
 
+Status VerifyChecksum(const std::string& file_path) {
+  unique_ptr<RandomAccessFile> file;
+  uint64_t file_size;
+
+  Options options;
+  ImmutableCFOptions ioptions(options);
+  EnvOptions env_options;
+  InternalKeyComparator internal_comparator(BytewiseComparator());
+
+  Status s = ioptions.env->NewRandomAccessFile(file_path, &file, env_options);
+  if (s.ok()) {
+    s = ioptions.env->GetFileSize(file_path, &file_size);
+  } else {
+    return s;
+  }
+  unique_ptr<TableReader> table_reader;
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(std::move(file), file_path));
+  s = ioptions.table_factory->NewTableReader(
+      TableReaderOptions(ioptions, env_options, internal_comparator,
+                         false /* skip_filters */, -1 /* level */),
+      std::move(file_reader), file_size, &table_reader,
+      false /* prefetch_index_and_filter_in_cache */);
+  if (!s.ok()) {
+    return s;
+  }
+  s = table_reader->VerifyChecksum();
+  return s;
+}
+
 }  // namespace rocksdb
 
 #endif  // ROCKSDB_LITE

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -184,8 +184,7 @@ class CorruptionTest : public testing::Test {
     ASSERT_TRUE(s.ok()) << s.ToString();
     Options options;
     EnvOptions env_options;
-    ASSERT_NOK(VerifySstFileChecksum(options, env_options, fname,
-                                     BytewiseComparator()));
+    ASSERT_NOK(VerifySstFileChecksum(options, env_options, fname));
   }
 
   void Corrupt(FileType filetype, int offset, int bytes_to_corrupt) {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -314,7 +314,7 @@ TEST_F(CorruptionTest, TableFile) {
 
   Corrupt(kTableFile, 100, 1);
   Check(99, 99);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 }
 
 TEST_F(CorruptionTest, TableFileIndexData) {
@@ -333,7 +333,7 @@ TEST_F(CorruptionTest, TableFileIndexData) {
   // one full file should be readable, since only one was corrupted
   // the other file should be fully non-readable, since index was corrupted
   Check(5000, 5000);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 }
 
 TEST_F(CorruptionTest, MissingDescriptor) {
@@ -393,12 +393,12 @@ TEST_F(CorruptionTest, CompactionInputError) {
 
   Corrupt(kTableFile, 100, 1);
   Check(9, 9);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 
   // Force compactions by writing lots of values
   Build(10000);
   Check(10000, 10000);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 }
 
 TEST_F(CorruptionTest, CompactionInputErrorParanoid) {
@@ -430,7 +430,7 @@ TEST_F(CorruptionTest, CompactionInputErrorParanoid) {
 
   CorruptTableFileAtLevel(0, 100, 1);
   Check(9, 9);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 
   // Write must eventually fail because of corrupted table
   Status s;
@@ -452,7 +452,7 @@ TEST_F(CorruptionTest, UnrelatedKeys) {
   DBImpl* dbi = reinterpret_cast<DBImpl*>(db_);
   dbi->TEST_FlushMemTable();
   Corrupt(kTableFile, 100, 1);
-  ASSERT_NOK(dbi->CheckCorruption());
+  ASSERT_NOK(dbi->VerifyChecksum());
 
   std::string tmp1, tmp2;
   ASSERT_OK(db_->Put(WriteOptions(), Key(1000, &tmp1), Value(1000, &tmp2)));

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -314,6 +314,7 @@ TEST_F(CorruptionTest, TableFile) {
 
   Corrupt(kTableFile, 100, 1);
   Check(99, 99);
+  ASSERT_NOK(dbi->CheckCorruption());
 }
 
 TEST_F(CorruptionTest, TableFileIndexData) {
@@ -332,6 +333,7 @@ TEST_F(CorruptionTest, TableFileIndexData) {
   // one full file should be readable, since only one was corrupted
   // the other file should be fully non-readable, since index was corrupted
   Check(5000, 5000);
+  ASSERT_NOK(dbi->CheckCorruption());
 }
 
 TEST_F(CorruptionTest, MissingDescriptor) {
@@ -391,10 +393,12 @@ TEST_F(CorruptionTest, CompactionInputError) {
 
   Corrupt(kTableFile, 100, 1);
   Check(9, 9);
+  ASSERT_NOK(dbi->CheckCorruption());
 
   // Force compactions by writing lots of values
   Build(10000);
   Check(10000, 10000);
+  ASSERT_NOK(dbi->CheckCorruption());
 }
 
 TEST_F(CorruptionTest, CompactionInputErrorParanoid) {
@@ -426,6 +430,7 @@ TEST_F(CorruptionTest, CompactionInputErrorParanoid) {
 
   CorruptTableFileAtLevel(0, 100, 1);
   Check(9, 9);
+  ASSERT_NOK(dbi->CheckCorruption());
 
   // Write must eventually fail because of corrupted table
   Status s;
@@ -447,6 +452,7 @@ TEST_F(CorruptionTest, UnrelatedKeys) {
   DBImpl* dbi = reinterpret_cast<DBImpl*>(db_);
   dbi->TEST_FlushMemTable();
   Corrupt(kTableFile, 100, 1);
+  ASSERT_NOK(dbi->CheckCorruption());
 
   std::string tmp1, tmp2;
   ASSERT_OK(db_->Put(WriteOptions(), Key(1000, &tmp1), Value(1000, &tmp2)));

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -181,6 +181,7 @@ class CorruptionTest : public testing::Test {
     }
     s = WriteStringToFile(Env::Default(), contents, fname);
     ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_NOK(db_->VerifyChecksum(fname));
   }
 
   void Corrupt(FileType filetype, int offset, int bytes_to_corrupt) {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -182,7 +182,10 @@ class CorruptionTest : public testing::Test {
     }
     s = WriteStringToFile(Env::Default(), contents, fname);
     ASSERT_TRUE(s.ok()) << s.ToString();
-    ASSERT_NOK(VerifyChecksum(fname));
+    Options options;
+    EnvOptions env_options;
+    ASSERT_NOK(VerifySstFileChecksum(options, env_options, fname,
+                                     BytewiseComparator()));
   }
 
   void Corrupt(FileType filetype, int offset, int bytes_to_corrupt) {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -22,6 +22,7 @@
 #include "db/log_format.h"
 #include "db/version_set.h"
 #include "rocksdb/cache.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "rocksdb/table.h"
 #include "rocksdb/write_batch.h"
@@ -181,7 +182,7 @@ class CorruptionTest : public testing::Test {
     }
     s = WriteStringToFile(Env::Default(), contents, fname);
     ASSERT_TRUE(s.ok()) << s.ToString();
-    ASSERT_NOK(db_->VerifyChecksum(fname));
+    ASSERT_NOK(VerifyChecksum(fname));
   }
 
   void Corrupt(FileType filetype, int offset, int bytes_to_corrupt) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2776,7 +2776,7 @@ Status DBImpl::VerifyChecksumImpl(ColumnFamilyData* cfd,
   }
   unique_ptr<TableReader> table_reader;
   std::unique_ptr<RandomAccessFileReader> file_reader(
-      new RandomAccessFileReader(std::move(file)));
+    new RandomAccessFileReader(std::move(file), file_path));
   s = cfd->ioptions()->table_factory->NewTableReader(
       TableReaderOptions(*cfd->ioptions(), env_options_,
                          cfd->internal_comparator(), false /* skip_filters */,

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2765,8 +2765,7 @@ Status DBImpl::VerifyChecksum() {
         const auto& fd = vstorage->LevelFilesBrief(i).files[j].fd;
         std::string fname = TableFileName(immutable_db_options_.db_paths,
                                           fd.GetNumber(), fd.GetPathId());
-        s = rocksdb::VerifySstFileChecksum(options, env_options, fname,
-                                           BytewiseComparator());
+        s = rocksdb::VerifySstFileChecksum(options, env_options, fname); 
       }
     }
     if (!s.ok()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2740,7 +2740,6 @@ Status DBImpl::IngestExternalFile(
 Status DBImpl::VerifyChecksum() {
   InstrumentedMutexLock l(&mutex_);
   Status s;
-  EnvOptions env_options;
   for (auto cfd: *versions_->GetColumnFamilySet()) {
     VersionStorageInfo* vstorage = cfd->current()->storage_info();
     for (int i = 0; i < vstorage->num_non_empty_levels(); i++) {
@@ -2768,7 +2767,8 @@ Status DBImpl::VerifyChecksumImpl(ColumnFamilyData* cfd,
                                   const std::string& file_path) {
   unique_ptr<RandomAccessFile> file;
   uint64_t file_size;
-  Status s = env_->NewRandomAccessFile(file_path, &file, env_options_);
+  EnvOptions env_options;
+  Status s = env_->NewRandomAccessFile(file_path, &file, env_options);
   if (s.ok()) {
     s = env_->GetFileSize(file_path, &file_size);
   } else {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2737,7 +2737,7 @@ Status DBImpl::IngestExternalFile(
   return status;
 }
 
-Status DBImpl::CheckCorruption() {
+Status DBImpl::VerifyChecksum() {
   InstrumentedMutexLock l(&mutex_);
   Status s;
   EnvOptions env_options;
@@ -2766,7 +2766,7 @@ Status DBImpl::CheckCorruption() {
         if (!s.ok()) {
           return s;
         }
-        s = table_reader->CheckCorruption();
+        s = table_reader->VerifyChecksum();
         if (!s.ok()) {
           return s;
         }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -296,6 +296,8 @@ class DBImpl : public DB {
       const IngestExternalFileOptions& ingestion_options) override;
 
   virtual Status VerifyChecksum() override;
+  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
+                                const std::string& file_path) override;
 
 #endif  // ROCKSDB_LITE
 
@@ -773,6 +775,9 @@ class DBImpl : public DB {
 
   // Used by WriteImpl to update bg_error_ in case of memtable insert error.
   void MemTableInsertStatusCheck(const Status& memtable_insert_status);
+
+  Status VerifyChecksumImpl(ColumnFamilyData* cfd,
+                            const std::string& file_path);
 
 #ifndef ROCKSDB_LITE
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -296,8 +296,7 @@ class DBImpl : public DB {
       const IngestExternalFileOptions& ingestion_options) override;
 
   virtual Status VerifyChecksum() override;
-  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
-                                const std::string& file_path) override;
+  virtual Status VerifyChecksum(const std::string& file_path) override;
 
 #endif  // ROCKSDB_LITE
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -295,7 +295,7 @@ class DBImpl : public DB {
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
 
-  virtual Status CheckCorruption() override;
+  virtual Status VerifyChecksum() override;
 
 #endif  // ROCKSDB_LITE
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -295,6 +295,8 @@ class DBImpl : public DB {
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
 
+  virtual Status CheckCorruption() override;
+
 #endif  // ROCKSDB_LITE
 
   // Similar to GetSnapshot(), but also lets the db know that this snapshot

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -296,7 +296,6 @@ class DBImpl : public DB {
       const IngestExternalFileOptions& ingestion_options) override;
 
   virtual Status VerifyChecksum() override;
-  virtual Status VerifyChecksum(const std::string& file_path) override;
 
 #endif  // ROCKSDB_LITE
 
@@ -774,9 +773,6 @@ class DBImpl : public DB {
 
   // Used by WriteImpl to update bg_error_ in case of memtable insert error.
   void MemTableInsertStatusCheck(const Status& memtable_insert_status);
-
-  Status VerifyChecksumImpl(ColumnFamilyData* cfd,
-                            const std::string& file_path);
 
 #ifndef ROCKSDB_LITE
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2236,6 +2236,10 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
+  virtual Status CheckCorruption() {
+    return Status::NotSupported("Not implemented.");
+  }
+
   using DB::GetPropertiesOfAllTables;
   virtual Status GetPropertiesOfAllTables(
       ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2240,6 +2240,11 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
+  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
+                                const std::string& file_path) override {
+    return Status::NotSupported("Not implemented.");
+  }
+
   using DB::GetPropertiesOfAllTables;
   virtual Status GetPropertiesOfAllTables(
       ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2240,10 +2240,6 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
-  virtual Status VerifyChecksum(const std::string& file_path) override {
-    return Status::NotSupported("Not implemented.");
-  }
-
   using DB::GetPropertiesOfAllTables;
   virtual Status GetPropertiesOfAllTables(
       ColumnFamilyHandle* column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2236,7 +2236,7 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
-  virtual Status CheckCorruption() {
+  virtual Status VerifyChecksum() override {
     return Status::NotSupported("Not implemented.");
   }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2240,8 +2240,7 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
-  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
-                                const std::string& file_path) override {
+  virtual Status VerifyChecksum(const std::string& file_path) override {
     return Status::NotSupported("Not implemented.");
   }
 

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -333,8 +333,7 @@ Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
 // Verify the checksum of file
 Status VerifySstFileChecksum(const Options& options,
                              const EnvOptions& env_options,
-                             const std::string& file_path,
-                             const Comparator* comp);
+                             const std::string& file_path);
 #endif  // ROCKSDB_LITE
 
 }  // namespace rocksdb

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -329,6 +329,10 @@ void CancelAllBackgroundWork(DB* db, bool wait = false);
 // Snapshots before the delete might not see the data in the given range.
 Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
                           const Slice* begin, const Slice* end);
+
+// Verify the checksum of file
+Status VerifyChecksum(const std::string& file_path);
+
 #endif  // ROCKSDB_LITE
 
 }  // namespace rocksdb

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -331,8 +331,10 @@ Status DeleteFilesInRange(DB* db, ColumnFamilyHandle* column_family,
                           const Slice* begin, const Slice* end);
 
 // Verify the checksum of file
-Status VerifyChecksum(const std::string& file_path);
-
+Status VerifySstFileChecksum(const Options& options,
+                             const EnvOptions& env_options,
+                             const std::string& file_path,
+                             const Comparator* comp);
 #endif  // ROCKSDB_LITE
 
 }  // namespace rocksdb

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -977,8 +977,7 @@ class DB {
   }
 
   virtual Status VerifyChecksum() = 0;
-  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
-                                const std::string& file_path) = 0;
+  virtual Status VerifyChecksum(const std::string& file_path) = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -976,6 +976,8 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
+  virtual Status CheckCorruption() = 0;
+
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(
       ColumnFamilyHandle* column_family,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -977,6 +977,8 @@ class DB {
   }
 
   virtual Status VerifyChecksum() = 0;
+  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
+                                const std::string& file_path) = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -977,7 +977,6 @@ class DB {
   }
 
   virtual Status VerifyChecksum() = 0;
-  virtual Status VerifyChecksum(const std::string& file_path) = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -976,7 +976,7 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
-  virtual Status CheckCorruption() = 0;
+  virtual Status VerifyChecksum() = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,8 +95,8 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
-  virtual Status CheckCorruption() {
-    return db_->CheckCorruption();
+  virtual Status VerifyChecksum() override {
+    return db_->VerifyChecksum();
   }
 
   using DB::KeyMayExist;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,6 +95,10 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
+  virtual Status CheckCorruption() {
+    return db_->CheckCorruption();
+  }
+
   using DB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,10 +95,8 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
-  virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
-
-  virtual Status VerifyChecksum(const std::string& file_path) override {
-    return db_->VerifyChecksum(file_path);
+  virtual Status VerifyChecksum() override {
+    return db_->VerifyChecksum();
   }
 
   using DB::KeyMayExist;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -99,6 +99,11 @@ class StackableDB : public DB {
     return db_->VerifyChecksum();
   }
 
+  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
+                                const std::string& file_path) override {
+    return db_->VerifyChecksum(column_family, file_path);
+  }
+
   using DB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,
                            ColumnFamilyHandle* column_family, const Slice& key,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,13 +95,10 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
-  virtual Status VerifyChecksum() override {
-    return db_->VerifyChecksum();
-  }
+  virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
-  virtual Status VerifyChecksum(ColumnFamilyHandle* column_family,
-                                const std::string& file_path) override {
-    return db_->VerifyChecksum(column_family, file_path);
+  virtual Status VerifyChecksum(const std::string& file_path) override {
+    return db_->VerifyChecksum(file_path);
   }
 
   using DB::KeyMayExist;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,9 +95,7 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
-  virtual Status VerifyChecksum() override {
-    return db_->VerifyChecksum();
-  }
+  virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
   using DB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1746,14 +1746,14 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
   return Status::OK();
 }
 
-Status BlockBasedTable::CheckCorruption() {
+Status BlockBasedTable::VerifyChecksum() {
   Status s;
   // Check Meta blocks
   std::unique_ptr<Block> meta;
   std::unique_ptr<InternalIterator> meta_iter;
   s = ReadMetaBlock(rep_, &meta, &meta_iter);
   if (s.ok()) {
-    s = CheckCorruptionInBlocks(meta_iter.get());
+    s = VerifyChecksumInBlocks(meta_iter.get());
     if (!s.ok()) {
       return s;
     }
@@ -1771,11 +1771,11 @@ Status BlockBasedTable::CheckCorruption() {
     // error opening index iterator
     return iiter->status();
   }
-  s = CheckCorruptionInBlocks(iiter);
+  s = VerifyChecksumInBlocks(iiter);
   return s;
 }
 
-Status BlockBasedTable::CheckCorruptionInBlocks(InternalIterator* index_iter) {
+Status BlockBasedTable::VerifyChecksumInBlocks(InternalIterator* index_iter) {
   Status s;
   for (index_iter->SeekToFirst(); index_iter->Valid(); index_iter->Next()) {
     s = index_iter->status();

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -142,7 +142,7 @@ class BlockBasedTable : public TableReader {
   // convert SST file to a human readable form
   Status DumpTable(WritableFile* out_file) override;
 
-  Status CheckCorruption() override;
+  Status VerifyChecksum() override;
 
   void Close() override;
 
@@ -315,7 +315,7 @@ class BlockBasedTable : public TableReader {
   static Status ReadMetaBlock(Rep* rep, std::unique_ptr<Block>* meta_block,
                               std::unique_ptr<InternalIterator>* iter);
 
-  Status CheckCorruptionInBlocks(InternalIterator* index_iter);
+  Status VerifyChecksumInBlocks(InternalIterator* index_iter);
 
   // Create the filter from the filter block.
   FilterBlockReader* ReadFilter(const BlockHandle& filter_handle,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -142,6 +142,8 @@ class BlockBasedTable : public TableReader {
   // convert SST file to a human readable form
   Status DumpTable(WritableFile* out_file) override;
 
+  Status CheckCorruption() override;
+
   void Close() override;
 
   ~BlockBasedTable();
@@ -312,6 +314,8 @@ class BlockBasedTable : public TableReader {
   // Read the meta block from sst.
   static Status ReadMetaBlock(Rep* rep, std::unique_ptr<Block>* meta_block,
                               std::unique_ptr<InternalIterator>* iter);
+
+  Status CheckCorruptionInBlocks(InternalIterator* index_iter);
 
   // Create the filter from the filter block.
   FilterBlockReader* ReadFilter(const BlockHandle& filter_handle,

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -101,6 +101,11 @@ class TableReader {
     return Status::NotSupported("DumpTable() not supported");
   }
 
+  // check whether there is corruption in this db file
+  virtual Status CheckCorruption() {
+    return Status::NotSupported("CheckCorruption() not supported");
+  }
+
   virtual void Close() {}
 };
 

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -102,8 +102,8 @@ class TableReader {
   }
 
   // check whether there is corruption in this db file
-  virtual Status CheckCorruption() {
-    return Status::NotSupported("CheckCorruption() not supported");
+  virtual Status VerifyChecksum() {
+    return Status::NotSupported("VerifyChecksum() not supported");
   }
 
   virtual void Close() {}

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -135,6 +135,10 @@ Status SstFileReader::NewTableReader(
       std::move(file_), file_size, &table_reader_);
 }
 
+Status SstFileReader::VerifyChecksum() {
+  return table_reader_->VerifyChecksum();
+}
+
 Status SstFileReader::DumpTable(const std::string& out_filename) {
   unique_ptr<WritableFile> out_file;
   Env* env = Env::Default();
@@ -357,10 +361,11 @@ void print_help() {
     --file=<data_dir_OR_sst_file>
       Path to SST file or directory containing SST files
 
-    --command=check|scan|raw
+    --command=check|scan|raw|verify
         check: Iterate over entries in files but dont print anything except if an error is encounterd (default command)
         scan: Iterate over entries in files and print them to screen
         raw: Dump all the table contents to <file_name>_dump.txt
+        verify: Iterate all the blocks in files verifying checksum to detect possible coruption but dont print anything except if a corruption is encountered
 
     --output_hex
       Can be combined with scan command to print the keys and values in Hex
@@ -586,6 +591,17 @@ int SSTDumpTool::Run(int argc, char** argv) {
       if (read_num > 0 && total_read > read_num) {
         break;
       }
+    }
+
+    if (command == "verify") {
+      st = reader.VerifyChecksum();
+      if (!st.ok()) {
+        fprintf(stderr, "%s is corrupted: %s\n", filename.c_str(),
+                st.ToString().c_str());
+      } else {
+        fprintf(stdout, "The file is ok\n");
+      }
+      continue;
     }
 
     if (show_properties || show_summary) {

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -30,6 +30,7 @@ class SstFileReader {
   uint64_t GetReadNumber() { return read_num_; }
   TableProperties* GetInitTableProperties() { return table_properties_.get(); }
 
+  Status VerifyChecksum();
   Status DumpTable(const std::string& out_filename);
   Status getStatus() { return init_result_; }
 


### PR DESCRIPTION
We need a tool to check any sst file corruption in the db.
It will check all the sst files in current version and read all the blocks (data, meta, index) with checksum verification. If any verification fails, the function will return non-OK status.

test plan:
add an additional line in corruption test cases.