### PR TITLE
Fix Windows build broken by 5c97a7c0664d4071768113814e9ba71fe87e18cf

### DIFF
--- a/db/db_io_failure_test.cc
+++ b/db/db_io_failure_test.cc
@@ -283,7 +283,8 @@ TEST_F(DBIOFailureTest, FlushSstRangeSyncError) {
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Random rnd(301);
-  std::string rnd_str = RandomString(&rnd, options.bytes_per_sync / 2);
+  std::string rnd_str =
+      RandomString(&rnd, static_cast<int>(options.bytes_per_sync / 2));
   std::string rnd_str_512kb = RandomString(&rnd, 512 * 1024);
 
   ASSERT_OK(Put(1, "foo", "bar"));


### PR DESCRIPTION
Summary:A typo conversion fails Windows build. Fix it.

Test Plan:Wait for appveyor