### PR TITLE
trace/replay feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,8 @@ set(SOURCES
         util/testutil.cc
         util/thread_local.cc
         util/threadpool_imp.cc
+        util/trace_reader_writer_impl.cc
+        util/tracer_replayer.cc
         util/transaction_test_util.cc
         util/xxhash.cc
         utilities/backupable/backupable_db.cc

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2748,21 +2748,6 @@ Status DBImpl::StartTrace(std::unique_ptr<TraceWriter>&& writer) {
   return Status::OK();
 }
 
-Status DBImpl::StartTrace(const std::string& trace_filename) {
-  Status s;
-  unique_ptr<WritableFile> tfile;
-  s = env_->NewWritableFile(trace_filename, &tfile, env_options_);
-  if (s.ok()) {
-    unique_ptr<WritableFileWriter> trace_file_writer;
-    trace_file_writer.reset(
-      new WritableFileWriter(std::move(tfile), env_options_));
-    unique_ptr<TraceWriter> trace_writer;
-    trace_writer.reset(new TraceWriterImpl(std::move(trace_file_writer)));
-    s = StartTrace(std::move(trace_writer));
-  }
-  return s;
-}
-
 Status DBImpl::EndTrace() {
   std::lock_guard<std::mutex> lock(trace_mutex_);
   tracer_.reset();
@@ -2779,6 +2764,7 @@ Status DBImpl::StartReplay(std::vector<ColumnFamilyHandle*>& handles,
   return Status::OK();
 }
 
+<<<<<<< 51f5132e1f4ff3d6f7c38e52562601427288a817
 Status DBImpl::StartReplay(std::vector<ColumnFamilyHandle*>& handles,
                            const std::string& trace_filename, bool no_wait) {
   unique_ptr<RandomAccessFile> tfile;
@@ -2799,6 +2785,8 @@ Status DBImpl::StartReplay(std::vector<ColumnFamilyHandle*>& handles,
   return s;
 }
 
+=======
+>>>>>>> change api
 void DBImpl::NotifyOnExternalFileIngested(
     ColumnFamilyData* cfd, const ExternalSstFileIngestionJob& ingestion_job) {
 #ifndef ROCKSDB_LITE

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2764,29 +2764,6 @@ Status DBImpl::StartReplay(std::vector<ColumnFamilyHandle*>& handles,
   return Status::OK();
 }
 
-<<<<<<< 51f5132e1f4ff3d6f7c38e52562601427288a817
-Status DBImpl::StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                           const std::string& trace_filename, bool no_wait) {
-  unique_ptr<RandomAccessFile> tfile;
-  Status s = env_->NewRandomAccessFile(trace_filename, &tfile, env_options_);
-  uint64_t file_size = 0;
-  if (s.ok()) {
-    s = env_->GetFileSize(trace_filename, &file_size);
-  }
-  if (s.ok()) {
-    unique_ptr<RandomAccessFileReader> trace_file_reader;
-    trace_file_reader.reset(
-        new RandomAccessFileReader(std::move(tfile), trace_filename));
-    unique_ptr<TraceReader> trace_reader;
-    trace_reader.reset(
-        new TraceReaderImpl(std::move(trace_file_reader), file_size));
-    s = StartReplay(handles, std::move(trace_reader));
-  }
-  return s;
-}
-
-=======
->>>>>>> change api
 void DBImpl::NotifyOnExternalFileIngested(
     ColumnFamilyData* cfd, const ExternalSstFileIngestionJob& ingestion_job) {
 #ifndef ROCKSDB_LITE

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -147,10 +147,9 @@ class DBImpl : public DB {
   virtual bool GetAggregatedIntProperty(const Slice& property,
                                         uint64_t* aggregated_value) override;
   using DB::GetApproximateSizes;
-  virtual void GetApproximateSizes(ColumnFamilyHandle* column_family,
-                                   const Range* range, int n, uint64_t* sizes,
-                                   uint8_t include_flags
-                                   = INCLUDE_FILES) override;
+  virtual void GetApproximateSizes(
+      ColumnFamilyHandle* column_family, const Range* range, int n,
+      uint64_t* sizes, uint8_t include_flags = INCLUDE_FILES) override;
   using DB::GetApproximateMemTableStats;
   virtual void GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
                                            const Range& range,
@@ -219,8 +218,8 @@ class DBImpl : public DB {
 
   virtual Status GetUpdatesSince(
       SequenceNumber seq_number, unique_ptr<TransactionLogIterator>* iter,
-      const TransactionLogIterator::ReadOptions&
-          read_options = TransactionLogIterator::ReadOptions()) override;
+      const TransactionLogIterator::ReadOptions& read_options =
+          TransactionLogIterator::ReadOptions()) override;
   virtual Status DeleteFile(std::string name) override;
   Status DeleteFilesInRange(ColumnFamilyHandle* column_family,
                             const Slice* begin, const Slice* end);
@@ -232,9 +231,8 @@ class DBImpl : public DB {
   // Status::NotFound() will be returned if the current DB does not have
   // any column family match the specified name.
   // TODO(yhchiang): output parameter is placed in the end in this codebase.
-  virtual void GetColumnFamilyMetaData(
-      ColumnFamilyHandle* column_family,
-      ColumnFamilyMetaData* metadata) override;
+  virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* column_family,
+                                       ColumnFamilyMetaData* metadata) override;
 
   Status SuggestCompactRange(ColumnFamilyHandle* column_family,
                              const Slice* begin, const Slice* end) override;
@@ -294,18 +292,13 @@ class DBImpl : public DB {
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
 
-  virtual Status StartTrace(
-    std::unique_ptr<TraceWriter>&& trace_writer) override;
-  virtual Status StartTrace(const std::string& trace_filename) override;
-  virtual Status EndTrace() override;
+  virtual Status StartTrace(std::unique_ptr<TraceWriter>&& trace_writer);
+  virtual Status EndTrace();
 
   // StartReplay will replay the trace to the DB opened by trace_reader
   virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
                              std::unique_ptr<TraceReader>&& trace_reader,
-                             bool no_wait = false) override;
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             const std::string& trace_filename,
-                             bool no_wait = false) override;
+                             bool no_wait);
 #endif  // ROCKSDB_LITE
 
   // Similar to GetSnapshot(), but also lets the db know that this snapshot

--- a/db/db_impl_files.cc
+++ b/db/db_impl_files.cc
@@ -457,6 +457,7 @@ void DBImpl::PurgeObsoleteFiles(const JobContext& state, bool schedule_only) {
       case kMetaDatabase:
       case kOptionsFile:
       case kBlobFile:
+      case kTraceFile:
         keep = true;
         break;
     }

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -446,6 +446,12 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
   }
 
   assert(w.state == WriteThread::STATE_COMPLETED);
+  if (w.FinalStatus().ok()) {
+    std::lock_guard<std::mutex> lock(trace_mutex_);
+    if (tracer_ != nullptr) {
+      tracer_->Write(my_batch);
+    }
+  }
   return w.FinalStatus();
 }
 

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -318,6 +318,10 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
 
   if (status.ok()) {
     status = w.FinalStatus();
+    std::lock_guard<std::mutex> lock(trace_mutex_);
+    if (tracer_ != nullptr) {
+      tracer_->Write(my_batch);
+    }
   }
   return status;
 }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2447,6 +2447,27 @@ class ModelDB : public DB {
   virtual void GetColumnFamilyMetaData(
       ColumnFamilyHandle* column_family,
       ColumnFamilyMetaData* metadata) override {}
+
+  virtual Status StartTrace(
+      std::unique_ptr<TraceWriter>&& trace_writer) override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
+  virtual Status StartTrace(const std::string& trace_filename) override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
+  virtual Status EndTrace() override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             std::unique_ptr<TraceReader>&& trace_reader,
+                             bool no_wait) override {
+    return Status::NotSupported("Not supported in Model DB");
+  };
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             const std::string& trace_filename,
+                             bool no_wait) override {
+    return Status::NotSupported("Not supported in Model DB");
+  };
 #endif  // ROCKSDB_LITE
 
   virtual Status GetDbIdentity(std::string& identity) const override {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2448,26 +2448,6 @@ class ModelDB : public DB {
       ColumnFamilyHandle* column_family,
       ColumnFamilyMetaData* metadata) override {}
 
-  virtual Status StartTrace(
-      std::unique_ptr<TraceWriter>&& trace_writer) override {
-    return Status::NotSupported("Not supported in Model DB");
-  }
-  virtual Status StartTrace(const std::string& trace_filename) override {
-    return Status::NotSupported("Not supported in Model DB");
-  }
-  virtual Status EndTrace() override {
-    return Status::NotSupported("Not supported in Model DB");
-  }
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             std::unique_ptr<TraceReader>&& trace_reader,
-                             bool no_wait) override {
-    return Status::NotSupported("Not supported in Model DB");
-  };
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             const std::string& trace_filename,
-                             bool no_wait) override {
-    return Status::NotSupported("Not supported in Model DB");
-  };
 #endif  // ROCKSDB_LITE
 
   virtual Status GetDbIdentity(std::string& identity) const override {

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2307,18 +2307,18 @@ TEST_F(DBTest2, TraceAndReplay) {
   options.merge_operator.reset(new TestPutOperator());
   uint64_t num_ops = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-    "Tracer::~Tracer", [&num_ops](void* arg) {
-      ASSERT_TRUE(arg != nullptr);
-      num_ops = *(static_cast<uint64_t*>(arg));
-    });
+      "Tracer::~Tracer", [&num_ops](void* arg) {
+        ASSERT_TRUE(arg != nullptr);
+        num_ops = *(static_cast<uint64_t*>(arg));
+      });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-    "Replay::BackgroundReplay", [&num_ops](void* arg) {
-      ASSERT_TRUE(arg != nullptr);
-      num_ops = *(static_cast<uint64_t*>(arg));
-    });
+      "Replay::BackgroundReplay", [&num_ops](void* arg) {
+        ASSERT_TRUE(arg != nullptr);
+        num_ops = *(static_cast<uint64_t*>(arg));
+      });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   CreateAndReopenWithCF({"pikachu"}, options);
-  db_->StartTrace(dbname_ + "/test.tr");
+  StartTrace(db_, dbname_ + "/test.tr");
   Random rnd(301);
   for (int i = 0; i < 1000; i++) {
     ASSERT_OK(Put(0, Key(i), RandomString(&rnd, 10)));
@@ -2336,7 +2336,7 @@ TEST_F(DBTest2, TraceAndReplay) {
   ASSERT_EQ(num_ops, 8000);
   num_ops = 0;
   ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
-  db_->StartReplay(handles_, dbname_ + "/test.tr", false);
+  StartReplay(db_, handles_, dbname_ + "/test.tr", false);
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   Close();
   ASSERT_EQ(num_ops, 8000);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2320,7 +2320,7 @@ TEST_F(DBTest2, TraceAndReplay) {
   CreateAndReopenWithCF({"pikachu"}, options);
   db_->StartTrace(dbname_ + "/test.tr");
   Random rnd(301);
-  for (size_t i = 0; i < 1000; i++) {
+  for (int i = 0; i < 1000; i++) {
     ASSERT_OK(Put(0, Key(i), RandomString(&rnd, 10)));
     ASSERT_OK(Merge(0, Key(i), RandomString(&rnd, 10)));
     // Found

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2301,6 +2301,47 @@ TEST_F(DBTest2, RateLimitedCompactionReads) {
   }
 }
 #endif  // ROCKSDB_LITE
+
+TEST_F(DBTest2, TraceAndReplay) {
+  Options options = CurrentOptions();
+  options.merge_operator.reset(new TestPutOperator());
+  uint64_t num_ops = 0;
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+    "Tracer::~Tracer", [&num_ops](void* arg) {
+      ASSERT_TRUE(arg != nullptr);
+      num_ops = *(static_cast<uint64_t*>(arg));
+    });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+    "Replay::BackgroundReplay", [&num_ops](void* arg) {
+      ASSERT_TRUE(arg != nullptr);
+      num_ops = *(static_cast<uint64_t*>(arg));
+    });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+  CreateAndReopenWithCF({"pikachu"}, options);
+  db_->StartTrace(dbname_ + "/test.tr");
+  Random rnd(301);
+  for (size_t i = 0; i < 1000; i++) {
+    ASSERT_OK(Put(0, Key(i), RandomString(&rnd, 10)));
+    ASSERT_OK(Merge(0, Key(i), RandomString(&rnd, 10)));
+    // Found
+    Get(0, Key(i));
+    ASSERT_OK(Delete(0, Key(i)));
+    ASSERT_OK(Put(1, Key(i), RandomString(&rnd, 10)));
+    ASSERT_OK(Merge(1, Key(i), RandomString(&rnd, 10)));
+    ASSERT_OK(Delete(1, Key(i)));
+    // Not Found
+    Get(1, Key(i));
+  }
+  Close();
+  ASSERT_EQ(num_ops, 8000);
+  num_ops = 0;
+  ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
+  db_->StartReplay(handles_, dbname_ + "/test.tr", false);
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  Close();
+  ASSERT_EQ(num_ops, 8000);
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -792,14 +792,8 @@ class PosixEnv : public Env {
     dummy.resize(maxsize);
     char* p = &dummy[0];
     localtime_r(&seconds, &t);
-    snprintf(p, maxsize,
-             "%04d-%02d-%02d-%02d:%02d:%02d ",
-             t.tm_year + 1900,
-             t.tm_mon + 1,
-             t.tm_mday,
-             t.tm_hour,
-             t.tm_min,
-             t.tm_sec);
+    snprintf(p, maxsize, "%04d/%02d/%02d-%02d:%02d:%02d ", t.tm_year + 1900,
+             t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
     return dummy;
   }
 

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -793,7 +793,7 @@ class PosixEnv : public Env {
     char* p = &dummy[0];
     localtime_r(&seconds, &t);
     snprintf(p, maxsize,
-             "%04d/%02d/%02d-%02d:%02d:%02d ",
+             "%04d-%02d-%02d-%02d:%02d:%02d ",
              t.tm_year + 1900,
              t.tm_mon + 1,
              t.tm_mday,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -23,6 +23,7 @@
 #include "rocksdb/snapshot.h"
 #include "rocksdb/sst_file_writer.h"
 #include "rocksdb/thread_status.h"
+#include "rocksdb/trace_reader_writer.h"
 #include "rocksdb/transaction_log.h"
 #include "rocksdb/types.h"
 #include "rocksdb/version.h"
@@ -975,6 +976,20 @@ class DB {
       const IngestExternalFileOptions& options) {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
+
+  // StartTrace/EndTrace the major workload of the DB
+  virtual Status  StartTrace(
+      std::unique_ptr<TraceWriter>&& trace_writer) = 0;
+  virtual Status StartTrace(const std::string& trace_filename) = 0;
+  virtual Status EndTrace() = 0;
+
+  // StartReplay will replay the trace to the DB opened by trace_reader
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             std::unique_ptr<TraceReader>&& trace_reader,
+                             bool no_wait = false) = 0;
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             const std::string& trace_filename,
+                             bool no_wait = false) = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -977,20 +977,6 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
-  // StartTrace/EndTrace the major workload of the DB
-  virtual Status  StartTrace(
-      std::unique_ptr<TraceWriter>&& trace_writer) = 0;
-  virtual Status StartTrace(const std::string& trace_filename) = 0;
-  virtual Status EndTrace() = 0;
-
-  // StartReplay will replay the trace to the DB opened by trace_reader
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             std::unique_ptr<TraceReader>&& trace_reader,
-                             bool no_wait = false) = 0;
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             const std::string& trace_filename,
-                             bool no_wait = false) = 0;
-
   // AddFile() is deprecated, please use IngestExternalFile()
   ROCKSDB_DEPRECATED_FUNC virtual Status AddFile(
       ColumnFamilyHandle* column_family,

--- a/include/rocksdb/trace_reader_writer.h
+++ b/include/rocksdb/trace_reader_writer.h
@@ -2,6 +2,8 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 
 #pragma once
 #include <string>
@@ -12,17 +14,18 @@ namespace rocksdb {
 class TraceWriter {
  public:
   TraceWriter() {}
-  virtual ~TraceWriter() {};
+  virtual ~TraceWriter(){};
 
-  virtual Status AddRecord(const std::string& key, const std::string& value) = 0;
+  virtual Status AddRecord(const std::string& key,
+                           const std::string& value) = 0;
 
-  virtual void Close() {};
+  virtual void Close(){};
 };
 
 class TraceReader {
  public:
   TraceReader() {}
-  virtual ~TraceReader() {};
+  virtual ~TraceReader(){};
 
   virtual Status ReadRecord(std::string* key, std::string* value) = 0;
 
@@ -30,7 +33,6 @@ class TraceReader {
     return Status::NotSupported("ReadLastRecord is not supported");
   };
 
-  virtual void Close() {};
+  virtual void Close(){};
 };
-
 }

--- a/include/rocksdb/trace_reader_writer.h
+++ b/include/rocksdb/trace_reader_writer.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+#include <string>
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+
+class TraceWriter {
+ public:
+  TraceWriter() {}
+  virtual ~TraceWriter() {};
+
+  virtual Status AddRecord(const std::string& key, const std::string& value) = 0;
+
+  virtual void Close() {};
+};
+
+class TraceReader {
+ public:
+  TraceReader() {}
+  virtual ~TraceReader() {};
+
+  virtual Status ReadRecord(std::string* key, std::string* value) = 0;
+
+  virtual Status ReadLastRecord(std::string* key, std::string* value) {
+    return Status::NotSupported("ReadLastRecord is not supported");
+  };
+
+  virtual void Close() {};
+};
+
+}

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -291,31 +291,6 @@ class StackableDB : public DB {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);
   }
 
-  virtual Status StartTrace(
-      std::unique_ptr<TraceWriter>&& trace_writer) override {
-    return db_->StartTrace(std::move(trace_writer));
-  }
-
-  virtual Status StartTrace(const std::string& trace_filename) override {
-    return db_->StartTrace(trace_filename);
-  }
-
-  virtual Status EndTrace() override {
-    return db_->EndTrace();
-  }
-
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             std::unique_ptr<TraceReader>&& trace_reader,
-                             bool no_wait = false) override {
-    return db_->StartReplay(handles, std::move(trace_reader), no_wait);
-  }
-
-  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
-                             const std::string& trace_filename,
-                             bool no_wait = false) override {
-    return db_->StartReplay(handles, trace_filename, no_wait);
-  }
-
 #endif  // ROCKSDB_LITE
 
   virtual Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -291,6 +291,31 @@ class StackableDB : public DB {
     db_->GetColumnFamilyMetaData(column_family, cf_meta);
   }
 
+  virtual Status StartTrace(
+      std::unique_ptr<TraceWriter>&& trace_writer) override {
+    return db_->StartTrace(std::move(trace_writer));
+  }
+
+  virtual Status StartTrace(const std::string& trace_filename) override {
+    return db_->StartTrace(trace_filename);
+  }
+
+  virtual Status EndTrace() override {
+    return db_->EndTrace();
+  }
+
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             std::unique_ptr<TraceReader>&& trace_reader,
+                             bool no_wait = false) override {
+    return db_->StartReplay(handles, std::move(trace_reader), no_wait);
+  }
+
+  virtual Status StartReplay(std::vector<ColumnFamilyHandle*>& handles,
+                             const std::string& trace_filename,
+                             bool no_wait = false) override {
+    return db_->StartReplay(handles, trace_filename, no_wait);
+  }
+
 #endif  // ROCKSDB_LITE
 
   virtual Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,

--- a/src.mk
+++ b/src.mk
@@ -151,7 +151,7 @@ LIB_SOURCES =                                                   \
   util/thread_local.cc                                          \
   util/threadpool_imp.cc                                        \
   util/trace_reader_writer_impl.cc                              \
-  util/tracer_replayer.cc                                        \
+  util/tracer_replayer.cc                                       \
   util/transaction_test_util.cc                                 \
   util/xxhash.cc                                                \
   utilities/backupable/backupable_db.cc                         \

--- a/src.mk
+++ b/src.mk
@@ -141,6 +141,7 @@ LIB_SOURCES =                                                   \
   util/murmurhash.cc                                            \
   util/random.cc                                                \
   util/rate_limiter.cc                                          \
+  util/read_batch.cc                                            \
   util/slice.cc                                                 \
   util/sst_file_manager_impl.cc                                 \
   util/status.cc                                                \
@@ -149,6 +150,8 @@ LIB_SOURCES =                                                   \
   util/sync_point.cc                                            \
   util/thread_local.cc                                          \
   util/threadpool_imp.cc                                        \
+  util/trace_reader_writer_impl.cc                              \
+  util/tracer_replayer.cc                                        \
   util/transaction_test_util.cc                                 \
   util/xxhash.cc                                                \
   utilities/backupable/backupable_db.cc                         \

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2401,7 +2401,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       } else if (name == "replay") {
         method = &Benchmark::Replay;
         if (FLAGS_replay_file == "") {
-          fprintf(stderr, "Please set --replay_file to the trace file"
+          fprintf(stderr,
+                  "Please set --replay_file to the trace file"
                   "path you want to replay from\n");
           exit(1);
         }
@@ -2550,7 +2551,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 
       if (method != nullptr) {
         if (FLAGS_trace_file != "") {
-          Status s = db_.db->StartTrace(FLAGS_trace_file);
+          Status s = StartTrace(db_.db, FLAGS_trace_file);
           if (!s.ok()) {
             fprintf(stderr, "Error in starting trace, %s\n",
                     s.ToString().c_str());
@@ -2587,7 +2588,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       }
 
       if (FLAGS_trace_file != "") {
-        db_.db->EndTrace();
+        EndTrace(db_.db);
       }
     }
     if (FLAGS_statistics) {
@@ -3919,8 +3920,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
   }
 
   void Replay(ThreadState* thread, DBWithColumnFamilies* db_with_cfh) {
-    Status s = db_with_cfh->db->StartReplay(db_with_cfh->cfh, FLAGS_replay_file,
-                                            false);
+    Status s = StartReplay(db_with_cfh->db, db_with_cfh->cfh, FLAGS_replay_file,
+                           false);
   }
 
   void ReadSequential(ThreadState* thread) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2556,7 +2556,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
                     s.ToString().c_str());
             exit(1);
           }
-          fprintf(stdout, "[Trace] Start tracing the workload to [%s] in DB Path\n",
+          fprintf(stdout, "[Trace] Start tracing the workload to [%s]\n",
                   FLAGS_trace_file.c_str());
         }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -87,6 +87,7 @@ DEFINE_string(
     "fillsync,"
     "fillrandom,"
     "filluniquerandomdeterministic,"
+    "replay,"
     "overwrite,"
     "readrandom,"
     "newiterator,"
@@ -129,6 +130,7 @@ DEFINE_string(
     " mode\n"
     "\tfilluniquerandomdeterministic       -- write N values in a random"
     " key order and keep the shape of the LSM tree\n"
+    "\treplay        -- replay the trace file specified with replay_file"
     "\toverwrite     -- overwrite N values in random key order in"
     " async mode\n"
     "\tfillsync      -- write N/100 values in random key order in "
@@ -234,6 +236,17 @@ DEFINE_bool(reverse_iterator, false,
             "Seek and then Next");
 
 DEFINE_bool(use_uint64_comparator, false, "use Uint64 user comparator");
+
+DEFINE_bool(pin_slice, true, "use pinnable slice for point lookup");
+
+DEFINE_string(trace_file, "",
+              "If not empty string, use default tracer to trace the"
+              "workload with this as filename");
+
+DEFINE_string(replay_file, "",
+              "If not empty string, use default replayer to replay the"
+              "workload with this as file path, must be specified when"
+              "benchmarks includes 'replay'");
 
 DEFINE_int64(batch_size, 1, "Batch size");
 
@@ -2366,7 +2379,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         fresh_db = true;
         if (num_threads > 1) {
           fprintf(stderr,
-                  "filluniquerandom multithreaded not supported"
+                  "Multi-threading filluniquerandom is not supported"
                   ", use 1 thread");
           num_threads = 1;
         }
@@ -2385,6 +2398,20 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         method = &Benchmark::WriteRandom;
       } else if (name == "readseq") {
         method = &Benchmark::ReadSequential;
+      } else if (name == "replay") {
+        method = &Benchmark::Replay;
+        if (FLAGS_replay_file == "") {
+          fprintf(stderr, "Please set --replay_file to the trace file"
+                  "path you want to replay from\n");
+          exit(1);
+        }
+        if (num_threads > 1) {
+          fprintf(stderr,
+                  "Multi-threading replay is not supported"
+                  ", use 1 thread");
+          num_threads = 1;
+        }
+        method = &Benchmark::Replay;
       } else if (name == "readtocache") {
         method = &Benchmark::ReadSequential;
         num_threads = 1;
@@ -2522,6 +2549,17 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       }
 
       if (method != nullptr) {
+        if (FLAGS_trace_file != "") {
+          Status s = db_.db->StartTrace(FLAGS_trace_file);
+          if (!s.ok()) {
+            fprintf(stderr, "Error in starting trace, %s\n",
+                    s.ToString().c_str());
+            exit(1);
+          }
+          fprintf(stdout, "[Trace] Start tracing the workload to [%s] in DB Path\n",
+                  FLAGS_trace_file.c_str());
+        }
+
         fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
         if (num_warmup > 0) {
           printf("Warming up benchmark by running %d times\n", num_warmup);
@@ -2546,6 +2584,10 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       }
       if (post_process_method != nullptr) {
         (this->*post_process_method)();
+      }
+
+      if (FLAGS_trace_file != "") {
+        db_.db->EndTrace();
       }
     }
     if (FLAGS_statistics) {
@@ -3864,6 +3906,21 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     return Status::NotSupported(
         "Rocksdb Lite doesn't support filldeterministic");
 #endif  // ROCKSDB_LITE
+  }
+
+  void Replay(ThreadState* thread) {
+    if (db_.db != nullptr) {
+      Replay(thread, &db_);
+    } else {
+      for (auto& db_with_cfh : multi_dbs_) {
+        Replay(thread, &db_with_cfh);
+      }
+    }
+  }
+
+  void Replay(ThreadState* thread, DBWithColumnFamilies* db_with_cfh) {
+    Status s = db_with_cfh->db->StartReplay(db_with_cfh->cfh, FLAGS_replay_file,
+                                            false);
   }
 
   void ReadSequential(ThreadState* thread) {

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -104,7 +104,7 @@ int FullFilterBitsBuilder::CalculateNumEntry(const uint32_t space) {
   assert(bits_per_key_);
   assert(space > 0);
   uint32_t dont_care1, dont_care2;
-  int high = (int) (space * 8 / bits_per_key_ + 1);
+  int high = (int)(space * 8 / bits_per_key_ + 1);
   int low = 1;
   int n = high;
   for (; n >= low; n--) {

--- a/util/filename.cc
+++ b/util/filename.cc
@@ -136,6 +136,12 @@ void FormatFileNumber(uint64_t number, uint32_t path_id, char* out_buf,
   }
 }
 
+std::string TraceFileName(const std::string& dbname, const std::string& time) {
+  char buf[100];
+  snprintf(buf, sizeof(buf), "/%s", time.c_str());
+  return dbname + buf;
+}
+
 std::string DescriptorFileName(const std::string& dbname, uint64_t number) {
   assert(number > 0);
   char buf[100];

--- a/util/filename.h
+++ b/util/filename.h
@@ -39,7 +39,8 @@ enum FileType {
   kMetaDatabase,
   kIdentityFile,
   kOptionsFile,
-  kBlobFile
+  kBlobFile,
+  kTraceFile
 };
 
 // Return the name of the log file with the specified number
@@ -79,6 +80,12 @@ const size_t kFormatFileNumberBufSize = 38;
 
 extern void FormatFileNumber(uint64_t number, uint32_t path_id, char* out_buf,
                              size_t out_buf_size);
+
+// Return the name of the trace file for the db named by
+// "dbname" and the specified time filename.  The result will be
+// prefixed with "dbname".
+extern std::string TraceFileName(const std::string& dbname,
+                                 const std::string& time);
 
 // Return the name of the descriptor file for the db named by
 // "dbname" and the specified incarnation number.  The result will be

--- a/util/read_batch.cc
+++ b/util/read_batch.cc
@@ -2,6 +2,8 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 //
 // IteratorBatch::rep_ :=
 //     count: fixed32
@@ -66,20 +68,15 @@ enum IteratorOpType : unsigned char {
 
 // ReadBatchBase
 ReadBatchBase::ReadBatchBase(size_t reserved_bytes) {
-  rep_.reserve((reserved_bytes > kHeader) ?
-               reserved_bytes : kHeader);
+  rep_.reserve((reserved_bytes > kHeader) ? reserved_bytes : kHeader);
   rep_.resize(kHeader);
 }
 
-ReadBatchBase::~ReadBatchBase() { }
+ReadBatchBase::~ReadBatchBase() {}
 
-int ReadBatchBase::Count() {
-  return DecodeFixed32(rep_.data());
-}
+int ReadBatchBase::Count() { return DecodeFixed32(rep_.data()); }
 
-void ReadBatchBase::SetCount(int n) {
-  EncodeFixed32(&rep_[0], n);
-}
+void ReadBatchBase::SetCount(int n) { EncodeFixed32(&rep_[0], n); }
 
 // ReadBatch
 void ReadBatch::Get(uint32_t column_family_id, const Slice& key) {
@@ -111,8 +108,7 @@ Status ReadBatch::Execute(
     char tag = input[0];
     input.remove_prefix(1);
     switch (tag) {
-      case kGet:
-      {
+      case kGet: {
         if (!GetVarint32(&input, &column_family_id) ||
             !GetLengthPrefixedSlice(&input, &key)) {
           return Status::Corruption("bad ReadBatch Get");
@@ -123,8 +119,7 @@ Status ReadBatch::Execute(
         s = db->Get(ReadOptions(), handle_map[column_family_id], key, &value);
         break;
       }
-      case kNewIterator:
-      {
+      case kNewIterator: {
         if (!GetVarint32(&input, &column_family_id) ||
             !GetVarint32(&input, &iter_id)) {
           return Status::Corruption("bad ReadBatch Get");
@@ -211,4 +206,4 @@ void IteratorBatch::GetProperty(uint64_t timestamp) {
   rep_.push_back(static_cast<unsigned char>(kIteratorGetProperty));
 }
 
-} // namespace rocksdb
+}  // namespace rocksdb

--- a/util/read_batch.cc
+++ b/util/read_batch.cc
@@ -1,0 +1,214 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+// IteratorBatch::rep_ :=
+//     count: fixed32
+//     data: record[count]
+// record :=
+//     timestamp:fixed64 kIteratorValid       varint32
+//     timestamp:fixed64 kIteratorSeekToFirst varint32
+//     timestamp:fixed64 kIteratorSeekToLast  varint32
+//     timestamp:fixed64 kIteratorSeek        varint32
+//     timestamp:fixed64 kIteratorSeekForPrev varint32
+//     timestamp:fixed64 kIteratorNext        varint32
+//     timestamp:fixed64 kIteratorPrev        varint32
+//     timestamp:fixed64 kIteratorKey         varint32
+//     timestamp:fixed64 kIteratorValue       varint32
+//     timestamp:fixed64 kIteratorStatus      varint32
+//     timestamp:fixed64 kIteratorGetProperty varint32
+//
+// ReadBatch holds a collection of reads to apply sequentially to a DB.
+// Similar to write_batch
+//
+// ReadBatch::rep_ :=
+//     count: fixed32 (always 1 for now)
+//     data: record[count]
+// record :=
+//     timestamp:fixed64 kIteratorValid  varint32 varstring
+//     timestamp:fixed64 kNewIterator varint32 varint32
+//
+// TraceableOp is an operation applied to db
+//
+// TraceableOp::rep_ :=
+//     timestamp:fixed64 varint32
+
+#include "util/read_batch.h"
+
+#include "db/db_impl.h"
+#include "util/coding.h"
+
+namespace rocksdb {
+
+namespace {
+
+enum ReadOpType : unsigned char {
+  kGet = 0,
+  kNewIterator,
+};
+
+enum IteratorOpType : unsigned char {
+  kIteratorValid,
+  kIteratorSeekToFirst,
+  kIteratorSeekToLast,
+  kIteratorSeek,
+  kIteratorSeekForPrev,
+  kIteratorNext,
+  kIteratorPrev,
+  kIteratorKey,
+  kIteratorValue,
+  kIteratorStatus,
+  kIteratorGetProperty,
+};
+
+}  // end anonymous namespace
+
+// ReadBatchBase
+ReadBatchBase::ReadBatchBase(size_t reserved_bytes) {
+  rep_.reserve((reserved_bytes > kHeader) ?
+               reserved_bytes : kHeader);
+  rep_.resize(kHeader);
+}
+
+ReadBatchBase::~ReadBatchBase() { }
+
+int ReadBatchBase::Count() {
+  return DecodeFixed32(rep_.data());
+}
+
+void ReadBatchBase::SetCount(int n) {
+  EncodeFixed32(&rep_[0], n);
+}
+
+// ReadBatch
+void ReadBatch::Get(uint32_t column_family_id, const Slice& key) {
+  SetCount(Count() + 1);
+  rep_.push_back(static_cast<unsigned char>(kGet));
+  PutVarint32(&rep_, column_family_id);
+  PutLengthPrefixedSlice(&rep_, key);
+}
+
+void ReadBatch::NewIterator(uint32_t column_family_id, uint32_t iter_id) {
+  SetCount(Count() + 1);
+  rep_.push_back(static_cast<unsigned char>(kNewIterator));
+  PutVarint32(&rep_, column_family_id);
+  PutVarint32(&rep_, iter_id);
+}
+
+Status ReadBatch::Execute(
+    DBImpl* db,
+    std::unordered_map<uint32_t, ColumnFamilyHandle*>& handle_map) const {
+  Slice input(rep_);
+  if (input.size() < ReadBatch::kHeader) {
+    return Status::Corruption("malformed ReadBatch (too small)");
+  }
+  Status s;
+  uint32_t column_family_id, iter_id;
+  Slice key;
+  PinnableSlice value;
+  while (s.ok() && !input.empty()) {
+    char tag = input[0];
+    input.remove_prefix(1);
+    switch (tag) {
+      case kGet:
+      {
+        if (!GetVarint32(&input, &column_family_id) ||
+            !GetLengthPrefixedSlice(&input, &key)) {
+          return Status::Corruption("bad ReadBatch Get");
+        }
+        if (handle_map.find(column_family_id) == handle_map.end()) {
+          return Status::Corruption("bad ReadBatch Column Family ID");
+        }
+        s = db->Get(ReadOptions(), handle_map[column_family_id], key, &value);
+        break;
+      }
+      case kNewIterator:
+      {
+        if (!GetVarint32(&input, &column_family_id) ||
+            !GetVarint32(&input, &iter_id)) {
+          return Status::Corruption("bad ReadBatch Get");
+        }
+        if (handle_map.find(column_family_id) == handle_map.end()) {
+          return Status::Corruption("bad ReadBatch Column Family ID");
+        }
+        auto iter =
+            db->NewIterator(ReadOptions(), handle_map[column_family_id]);
+        delete iter;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return s;
+}
+
+// IteraterBatch
+void IteratorBatch::Valid(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorValid));
+}
+
+void IteratorBatch::SeekToFirst(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorSeekToFirst));
+}
+
+void IteratorBatch::SeekToLast(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorSeekToLast));
+}
+
+void IteratorBatch::Seek(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorSeek));
+}
+
+void IteratorBatch::SeekForPrev(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorSeekForPrev));
+}
+
+void IteratorBatch::Next(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorNext));
+}
+
+void IteratorBatch::Prev(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorPrev));
+}
+
+void IteratorBatch::Key(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorKey));
+}
+
+void IteratorBatch::Value(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorValue));
+}
+
+void IteratorBatch::Status(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorStatus));
+}
+
+void IteratorBatch::GetProperty(uint64_t timestamp) {
+  SetCount(Count() + 1);
+  PutFixed64(&rep_, timestamp);
+  rep_.push_back(static_cast<unsigned char>(kIteratorGetProperty));
+}
+
+} // namespace rocksdb

--- a/util/read_batch.h
+++ b/util/read_batch.h
@@ -2,8 +2,10 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 //
-// IteratorBatch holds a collection of readss to apply sequentially to a DB.
+// IteratorBatch holds a collection of reads to apply sequentially to a DB.
 // Similar to write_batch
 
 #pragma once
@@ -70,4 +72,4 @@ class ReadBatch : public ReadBatchBase {
       std::unordered_map<uint32_t, ColumnFamilyHandle*>& handle_map) const;
 };
 
-} // namespace rocksdb
+}  // namespace rocksdb

--- a/util/read_batch.h
+++ b/util/read_batch.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+// IteratorBatch holds a collection of readss to apply sequentially to a DB.
+// Similar to write_batch
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+
+class DBImpl;
+class ColumnFamilyHandle;
+
+class ReadBatchBase {
+ public:
+  static const size_t kHeader = 4;
+  explicit ReadBatchBase(size_t reserved_bytes);
+  explicit ReadBatchBase(const std::string& rep) : rep_(rep) {}
+  virtual ~ReadBatchBase() = 0;
+
+ protected:
+  virtual int Count();
+  virtual void SetCount(int n);
+  std::string rep_;
+};
+
+class IteratorBatch : public ReadBatchBase {
+ public:
+  explicit IteratorBatch(size_t reserved_bytes = 0)
+      : ReadBatchBase(reserved_bytes) {}
+  explicit IteratorBatch(const std::string& rep) : ReadBatchBase(rep) {}
+  ~IteratorBatch();
+  virtual void Valid(uint64_t timestamp);
+  virtual void SeekToFirst(uint64_t timestamp);
+  virtual void SeekToLast(uint64_t timestamp);
+  virtual void Seek(uint64_t timestamp);
+  virtual void SeekForPrev(uint64_t timestamp);
+  virtual void Next(uint64_t timestamp);
+  virtual void Prev(uint64_t timestamp);
+  virtual void Key(uint64_t timestamp);
+  virtual void Value(uint64_t timestamp);
+  virtual void Status(uint64_t timestamp);
+  virtual void GetProperty(uint64_t timestamp);
+};
+
+class ReadBatch : public ReadBatchBase {
+ public:
+  explicit ReadBatch(size_t reserved_bytes = 0)
+      : ReadBatchBase(reserved_bytes) {}
+  explicit ReadBatch(const std::string& rep) : ReadBatchBase(rep) {}
+  ~ReadBatch() {}
+
+  virtual void Get(uint32_t column_family_id, const Slice& key);
+
+  virtual void NewIterator(uint32_t column_family_id, uint32_t iter_id);
+
+  // Retrieve the serialized version of this batch.
+  const std::string& Data() const { return rep_; }
+
+  Status Execute(
+      DBImpl* db,
+      std::unordered_map<uint32_t, ColumnFamilyHandle*>& handle_map) const;
+};
+
+} // namespace rocksdb

--- a/util/trace_reader_writer_impl.cc
+++ b/util/trace_reader_writer_impl.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include "util/trace_reader_writer_impl.h"
+#include "util/coding.h"
+#include "util/tracer_replayer.h"
+
+namespace rocksdb {
+
+/*
+ * TraceWriterImpl
+ */
+TraceWriterImpl::TraceWriterImpl(unique_ptr<WritableFileWriter>&& dest)
+    : writer_(std::move(dest)) {}
+
+Status TraceWriterImpl::AddRecord(const std::string& key,
+                                  const std::string& value) {
+  Status s = writer_->Append(Slice(key));
+  std::string payload_length;
+  PutFixed32(&payload_length, value.size());
+  if (s.ok()) {
+    s = writer_->Append(Slice(payload_length));
+  }
+  if (s.ok()) {
+    writer_->Append(Slice(value));
+  }
+  return s;
+}
+
+void TraceWriterImpl::Close() {
+  return writer_.reset();
+}
+
+/*
+ * TraceReaderImpl
+ */
+
+const unsigned int TraceReaderImpl::kBufferSize = 32 * 1024; // 32KB
+const unsigned int TraceReaderImpl::kHeaderSize = Tracer::kKeySize + 4;
+const unsigned int TraceReaderImpl::kLastRecordSize =
+    TraceReaderImpl::kHeaderSize + 8;
+
+TraceReaderImpl::TraceReaderImpl(unique_ptr<RandomAccessFileReader>&& dest,
+                                 uint64_t file_size)
+    : reader_(std::move(dest)),
+      file_size_(file_size),
+      offset_(0),
+      header_buffer_(new char[kHeaderSize]),
+      buffer_(new char[kBufferSize]) {
+  assert(file_size_ >= kLastRecordSize);
+}
+
+Status TraceReaderImpl::ReadRecord(std::string* key, std::string* value) {
+  Status s = reader_->Read(offset_, kHeaderSize, &result_, header_buffer_);
+  if (!s.ok()) {
+    return s;
+  }
+  offset_ += result_.size();
+  if (result_.size() < kHeaderSize) {
+    if (result_.size() < Tracer::kKeySize) {
+      return Status::Corruption("The trace file is corrupted");
+    }
+  }
+  key->clear();
+  value->clear();
+  key->append(header_buffer_, Tracer::kKeySize);
+  uint32_t len = DecodeFixed32(header_buffer_ + Tracer::kKeySize);
+  while (len > 0) {
+    s = reader_->Read(offset_, std::min(len, kBufferSize), &result_, buffer_);
+    if (!s.ok()) {
+      break;
+    }
+    offset_ += result_.size();
+    value->append(result_.data(), result_.size());
+    len -= result_.size();
+  }
+  return s;
+}
+
+Status TraceReaderImpl::ReadLastRecord(std::string* key, std::string* value) {
+  size_t last_record_offset = file_size_ - kLastRecordSize;
+  char buffer[kLastRecordSize];
+  Slice record;
+  Status s =
+      reader_->Read(last_record_offset, kLastRecordSize, &record, buffer);
+  if (s.ok()) {
+    if (record.size() < kLastRecordSize) {
+      return Status::Corruption("File is too short to be an Trace file");
+    }
+    key->clear();
+    value->clear();
+    key->append(buffer, Tracer::kKeySize);
+    assert(DecodeFixed32(buffer + Tracer::kKeySize) == 8);
+    value->append(buffer + kLastRecordSize - 8, 8);
+  }
+  return s;
+}
+
+void TraceReaderImpl::Close() {
+  return reader_.reset();
+}
+
+
+} // namespace rocksdb

--- a/util/trace_reader_writer_impl.cc
+++ b/util/trace_reader_writer_impl.cc
@@ -2,6 +2,8 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 
 #include "util/trace_reader_writer_impl.h"
 #include "util/coding.h"
@@ -19,7 +21,7 @@ Status TraceWriterImpl::AddRecord(const std::string& key,
                                   const std::string& value) {
   Status s = writer_->Append(Slice(key));
   std::string payload_length;
-  PutFixed32(&payload_length,static_cast<uint32_t>(value.size()));
+  PutFixed32(&payload_length, static_cast<uint32_t>(value.size()));
   if (s.ok()) {
     s = writer_->Append(Slice(payload_length));
   }
@@ -29,15 +31,13 @@ Status TraceWriterImpl::AddRecord(const std::string& key,
   return s;
 }
 
-void TraceWriterImpl::Close() {
-  return writer_.reset();
-}
+void TraceWriterImpl::Close() { return writer_.reset(); }
 
 /*
  * TraceReaderImpl
  */
 
-const unsigned int TraceReaderImpl::kBufferSize = 32 * 1024; // 32KB
+const unsigned int TraceReaderImpl::kBufferSize = 32 * 1024;  // 32KB
 const unsigned int TraceReaderImpl::kHeaderSize = Tracer::kKeySize + 4;
 const unsigned int TraceReaderImpl::kLastRecordSize =
     TraceReaderImpl::kHeaderSize + 8;
@@ -74,7 +74,7 @@ Status TraceReaderImpl::ReadRecord(std::string* key, std::string* value) {
     }
     offset_ += result_.size();
     value->append(result_.data(), result_.size());
-    len -= result_.size();
+    len -= static_cast<uint32_t>(result_.size());
   }
   return s;
 }
@@ -98,9 +98,6 @@ Status TraceReaderImpl::ReadLastRecord(std::string* key, std::string* value) {
   return s;
 }
 
-void TraceReaderImpl::Close() {
-  return reader_.reset();
-}
+void TraceReaderImpl::Close() { return reader_.reset(); }
 
-
-} // namespace rocksdb
+}  // namespace rocksdb

--- a/util/trace_reader_writer_impl.cc
+++ b/util/trace_reader_writer_impl.cc
@@ -19,7 +19,7 @@ Status TraceWriterImpl::AddRecord(const std::string& key,
                                   const std::string& value) {
   Status s = writer_->Append(Slice(key));
   std::string payload_length;
-  PutFixed32(&payload_length, value.size());
+  PutFixed32(&payload_length,static_cast<uint32_t>(value.size()));
   if (s.ok()) {
     s = writer_->Append(Slice(payload_length));
   }

--- a/util/trace_reader_writer_impl.h
+++ b/util/trace_reader_writer_impl.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+#include "rocksdb/trace_reader_writer.h"
+#include "util/file_reader_writer.h"
+#include "util/tracer_replayer.h"
+
+namespace rocksdb {
+
+class TraceWriterImpl : public TraceWriter {
+ public:
+  TraceWriterImpl(unique_ptr<WritableFileWriter>&& dest);
+  ~TraceWriterImpl() {}
+
+  virtual Status AddRecord(const std::string& key,
+                           const std::string& value) override;
+  virtual void Close() override;
+
+ private:
+  std::unique_ptr<WritableFileWriter> writer_;
+};
+
+class TraceReaderImpl : public TraceReader {
+ public:
+  static const unsigned int kBufferSize;
+  static const unsigned int kHeaderSize;
+  static const unsigned int kLastRecordSize;
+
+  TraceReaderImpl(unique_ptr<RandomAccessFileReader>&& dest,
+                  uint64_t file_size);
+  ~TraceReaderImpl() {}
+  virtual Status ReadRecord(std::string* key, std::string* value) override;
+
+  virtual Status ReadLastRecord(std::string* key, std::string* value) override;
+
+  virtual void Close() override;
+
+ private:
+  unique_ptr<RandomAccessFileReader> reader_;
+  uint64_t file_size_;
+  size_t offset_;
+  Slice result_;
+  char* const header_buffer_;
+  char* const buffer_;
+};
+
+}  // namespace rocksdb

--- a/util/trace_reader_writer_impl.h
+++ b/util/trace_reader_writer_impl.h
@@ -2,6 +2,8 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 
 #pragma once
 #include "rocksdb/trace_reader_writer.h"

--- a/util/tracer_replayer.cc
+++ b/util/tracer_replayer.cc
@@ -32,7 +32,7 @@ Tracer::~Tracer() {
     bg_thread_->join();
   }
   TEST_SYNC_POINT_CALLBACK("Tracer::~Tracer", &num_ops_);
-  fprintf(stdout, "[Trace] Finish tracing: %lu ops\n", num_ops_);
+  fprintf(stdout, "[Trace] Finish tracing: %llu ops\n", num_ops_);
   trace_writer_->Close();
 }
 

--- a/util/tracer_replayer.cc
+++ b/util/tracer_replayer.cc
@@ -1,0 +1,197 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <inttypes.h>
+#include <chrono>
+#include <thread>
+#include "db/db_impl.h"
+#include "util/read_batch.h"
+#include "util/sync_point.h"
+#include "util/tracer_replayer.h"
+
+namespace rocksdb {
+
+Tracer::Tracer(Env* env, std::unique_ptr<TraceWriter>&& writer)
+    : env_(env), stop_(false), num_ops_(0) {
+  assert(writer != nullptr);
+  trace_writer_ = std::move(writer);
+  Start();
+  bg_thread_.reset(new port::Thread(&Tracer::BackgroundTrace, this));
+}
+
+Tracer::~Tracer() {
+  {
+    Finish();
+    std::lock_guard<std::mutex> lock(mutex_);
+    stop_ = true;
+    cv_.notify_all();
+  }
+  if (bg_thread_) {
+    bg_thread_->join();
+  }
+  TEST_SYNC_POINT_CALLBACK("Tracer::~Tracer", &num_ops_);
+  fprintf(stdout, "[Trace] Finish tracing: %lu ops\n", num_ops_);
+  trace_writer_->Close();
+}
+
+void Tracer::Start() {
+  AppendTrace(env_->NowMicros(), kTraceStart, "");
+}
+
+void Tracer::Finish() {
+  std::string ops(8, '\0');
+  EncodeFixed64(&ops[0], num_ops_);
+  AppendTrace(env_->NowMicros(), kTraceEnd, std::move(ops));
+}
+
+void Tracer::Write(WriteBatch* batch) {
+  std::string payload(batch->Data());
+  AppendTrace(env_->NowMicros(), kTraceWrite, std::move(payload));
+}
+
+void Tracer::Get(ColumnFamilyHandle* column_family,
+                 const Slice& key) {
+  ReadBatch batch;
+  batch.Get(column_family->GetID(), key);
+  std::string payload(batch.Data());
+  AppendTrace(env_->NowMicros(), kTraceRead, std::move(payload));
+}
+
+void Tracer::AppendTrace(uint64_t timestamp, TraceType type,
+                         std::string&& value) {
+  if (type != kTraceStart && type != kTraceEnd) {
+    num_ops_++;
+  }
+  std::string key = EncodeKey(timestamp, type);
+  std::lock_guard<std::mutex> lock(mutex_);
+  user_queue_.emplace(key, value);
+  cv_.notify_all();
+}
+
+void Tracer::BackgroundTrace() {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  while (true) {
+    lock.lock();
+    while (user_queue_.empty() && !stop_) {
+      cv_.wait(lock);
+    }
+    if (!user_queue_.empty()) {
+      // Record the trace in the queue
+      swap(user_queue_, log_queue_);
+      lock.unlock();
+      while (!log_queue_.empty()) {
+        trace_writer_->AddRecord(log_queue_.front().first,
+                                 log_queue_.front().second);
+        log_queue_.pop();
+      }
+    }
+    if (stop_) {
+      break;
+    }
+  }
+}
+
+std::string Tracer::EncodeKey(uint64_t timestamp, TraceType type) {
+  std::string key(9, '\0');
+  EncodeFixed64(&key[0], timestamp);
+  key[kKeySize - 1] = static_cast<char>(type);
+  return key;
+}
+
+void Replayer::DecodeKey(const std::string& key, uint64_t* timestamp,
+                                TraceType* type) {
+  assert(key.length() == Tracer::kKeySize);
+  *timestamp = DecodeFixed64(key.data());
+  *type = static_cast<TraceType>(key[Tracer::kKeySize - 1]);
+}
+
+Replayer::Replayer(DBImpl* db, std::vector<ColumnFamilyHandle*>& handles,
+                   std::unique_ptr<TraceReader>&& reader)
+    : db_(db), stop_(false) {
+  for (ColumnFamilyHandle* cfh: handles) {
+    handle_map_[cfh->GetID()] = cfh;
+  }
+  trace_reader_ = std::move(reader);
+  bg_thread_.reset(new port::Thread(&Replayer::BackgroundReplay, this));
+}
+
+Replayer::~Replayer() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stop_ = true;
+    cv_.notify_all();
+  }
+  if (bg_thread_) {
+    bg_thread_->join();
+    bg_thread_.reset();
+  }
+}
+
+Status Replayer::WaitForReplay() {
+  Status s;
+  if (bg_thread_ != nullptr) {
+    bg_thread_->join();
+    bg_thread_.reset();
+  }
+  return s;
+}
+
+void Replayer::BackgroundReplay() {
+  std::string key, value;
+  uint64_t trace_epoch, timestamp;
+  TraceType type;
+  WriteOptions write_options;
+  uint64_t num_ops = 0;
+  uint64_t ops = 0;
+  // Read the last entry for num of ops
+  Status s = trace_reader_->ReadLastRecord(&key, &value);
+  if (s.ok()) {
+    DecodeKey(key, &timestamp, &type);
+    assert(type == kTraceEnd);
+    assert(value.size() == 8);
+    num_ops = DecodeFixed64(value.data());
+  }
+
+  s = trace_reader_->ReadRecord(&key, &value);
+  DecodeKey(key, &timestamp, &type);
+  assert(type == kTraceStart);
+  trace_epoch = timestamp;
+  std::chrono::system_clock::time_point replay_epoch =
+      std::chrono::system_clock::now();
+  do {
+    s = trace_reader_->ReadRecord(&key, &value);
+    DecodeKey(key, &timestamp, &type);
+    if (s.ok() && type != kTraceEnd) {
+      ops++;
+      std::this_thread::sleep_until(
+          replay_epoch + std::chrono::microseconds(timestamp - trace_epoch));
+      switch (type) {
+        case kTraceWrite: {
+          WriteBatch write_batch(value);
+          db_->Write(write_options, &write_batch);
+          break;
+        }
+        case kTraceRead: {
+          ReadBatch read_batch(value);
+          read_batch.Execute(db_, handle_map_);
+          break;
+        }
+        case kTraceIterator:
+        default:
+          break;
+      }
+      if (num_ops != 0) {
+        fprintf(stderr, "... finished %3.2f%%\r", ops * 1.0f / num_ops * 100);
+      }
+    } else {
+      break;
+    }
+  } while (!stop_);
+  assert(ops == num_ops);
+  TEST_SYNC_POINT_CALLBACK("Replay::BackgroundReplay", &ops);
+  fprintf(stderr, "[Replay] Finished %" PRIu64 " ops\n", ops);
+}
+
+}  // namespace rocksdb

--- a/util/tracer_replayer.cc
+++ b/util/tracer_replayer.cc
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <chrono>
 #include <thread>
 #include "db/db_impl.h"

--- a/util/tracer_replayer.cc
+++ b/util/tracer_replayer.cc
@@ -32,7 +32,8 @@ Tracer::~Tracer() {
     bg_thread_->join();
   }
   TEST_SYNC_POINT_CALLBACK("Tracer::~Tracer", &num_ops_);
-  fprintf(stdout, "[Trace] Finish tracing: %llu ops\n", num_ops_);
+  fprintf(stdout, "[Trace] Finish tracing: %llu ops\n",
+          static_cast<unsigned long long>(num_ops_));
   trace_writer_->Close();
 }
 

--- a/util/tracer_replayer.h
+++ b/util/tracer_replayer.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <unordered_map>
+#include <string>
+#include "rocksdb/trace_reader_writer.h"
+#include "db/column_family.h"
+#include "port/port.h"
+#include "util/coding.h"
+
+namespace rocksdb {
+
+class DBImpl;
+class Slice;
+
+enum TraceType : char {
+    kTraceStart = 0,
+    kTraceEnd,
+    kTraceWrite,
+    kTraceRead,
+    kTraceIterator,
+    };
+
+using TraceRecord = std::pair<std::string, std::string>;
+
+class Tracer {
+ public:
+  // 8-byte timestamp(ms) + 1-byte type
+  static const size_t kKeySize = 9;
+  Tracer(Env* env, std::unique_ptr<TraceWriter>&& writer);
+
+  ~Tracer();
+
+  void Write(WriteBatch* batch);
+
+  void Get(ColumnFamilyHandle* column_family,
+           const Slice& key);
+
+  void BackgroundTrace();
+
+ private:
+  inline void Start();
+  inline void Finish();
+  inline void AppendTrace(uint64_t timestamp, TraceType type, std::string&& value);
+  std::string EncodeKey(uint64_t timestamp, TraceType type);
+
+  Env* const env_;
+  bool stop_;
+  uint64_t num_ops_;
+  std::unique_ptr<port::Thread> bg_thread_;
+  std::unique_ptr<TraceWriter> trace_writer_;
+  std::queue<TraceRecord> log_queue_;
+  std::queue<TraceRecord> user_queue_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+};
+
+class Replayer {
+ public:
+  Replayer(DBImpl* db, std::vector<ColumnFamilyHandle*>& handles,
+           std::unique_ptr<TraceReader>&& reader);
+
+  ~Replayer();
+
+  Status WaitForReplay();
+
+  void BackgroundReplay();
+
+ private:
+  void DecodeKey(const std::string& key, uint64_t* timestamp, TraceType* type);
+
+  DBImpl* db_;
+  bool stop_;
+  std::unique_ptr<TraceReader> trace_reader_;
+  std::unique_ptr<port::Thread> bg_thread_;
+  std::unordered_map<uint32_t, ColumnFamilyHandle*> handle_map_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+};
+
+}  // namespace rocksdb

--- a/util/tracer_replayer.h
+++ b/util/tracer_replayer.h
@@ -2,31 +2,43 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
+//  This source code is also licensed under the GPLv2 license found in the
+//  COPYING file in the root directory of this source tree.
 
 #pragma once
 #include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <unordered_map>
 #include <string>
-#include "rocksdb/trace_reader_writer.h"
+#include <unordered_map>
 #include "db/column_family.h"
 #include "port/port.h"
+#include "rocksdb/trace_reader_writer.h"
 #include "util/coding.h"
 
 namespace rocksdb {
+
+Status StartTrace(DB* db, const std::string& trace_filename);
+Status StartTrace(DB* db, std::unique_ptr<TraceWriter>&& trace_writer);
+Status EndTrace(DB* db);
+
+Status StartReplay(DB* db, std::vector<ColumnFamilyHandle*>& handles,
+                   std::unique_ptr<TraceReader>&& trace_reader,
+                   bool no_wait = false);
+Status StartReplay(DB* db, std::vector<ColumnFamilyHandle*>& handles,
+                   const std::string& trace_filename, bool no_wait = false);
 
 class DBImpl;
 class Slice;
 
 enum TraceType : char {
-    kTraceStart = 0,
-    kTraceEnd,
-    kTraceWrite,
-    kTraceRead,
-    kTraceIterator,
-    };
+  kTraceStart = 0,
+  kTraceEnd,
+  kTraceWrite,
+  kTraceRead,
+  kTraceIterator,
+};
 
 using TraceRecord = std::pair<std::string, std::string>;
 
@@ -40,15 +52,15 @@ class Tracer {
 
   void Write(WriteBatch* batch);
 
-  void Get(ColumnFamilyHandle* column_family,
-           const Slice& key);
+  void Get(ColumnFamilyHandle* column_family, const Slice& key);
 
   void BackgroundTrace();
 
  private:
   inline void Start();
   inline void Finish();
-  inline void AppendTrace(uint64_t timestamp, TraceType type, std::string&& value);
+  inline void AppendTrace(uint64_t timestamp, TraceType type,
+                          std::string&& value);
   std::string EncodeKey(uint64_t timestamp, TraceType type);
 
   Env* const env_;


### PR DESCRIPTION
This diff finished the first implementation of trace and replay prototype.
Basically, we are trying to trace the workload of rocksdb including general writes, reads(get and iteration) for a specific range of time and can store the trace record. Later, we can replay the workload from the trace file to mimic the workload recorded in the trace record.

The use cases are primarily for benchmarking. For example, we may need the workload from production to setup our regression test since db_bench doesn't reflect the real workload so it may be not able to find bug which could only be triggered in specific workload. Another example would be converting upper-layer application workload to rocksdb workload. There are lots of applications that builds on top of rocksdb, such as myrocks. For now, there is no easy way to translate their workload (SQL insertion) into storage engine workload( key-value put). But trace/replay could achieve this goal as a optional utility. 

I built a extensible interface with a default implementation that uses a local file to trace and replay  Writebatch(put, merge, delete...) and Get, but not iterations. Customers could build their own trace/replay system following the interfaces defined in tracer_and_replayer.h.

Benchmarks:
1）DB on SSD
TEST_TMPDIR=/data/users/gzh/test ./db_bench --benchmarks=fillrandom -num=100000000
fillrandom   :       4.988 micros/op 200483 ops/sec;   22.2 MB/s
2）DB on SSD, trace on TMPFS
TEST_TMPDIR=/data/users/gzh/test ./db_bench --benchmarks=fillrandom -num=100000000 --trace_file=/dev/shm/trace
fillrandom   :       6.982 micros/op 143224 ops/sec;   15.8 MB/s
3) DB and trace are both on SSD
fillrandom   :       7.158 micros/op 139708 ops/sec;   15.5 MB/s