### PR TITLE
 cache line alignment of LRUcache to avoid false cache sharing

### DIFF
--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -151,7 +151,9 @@ class LRUHandleTable {
   // The table consists of an array of buckets where each bucket is
   // a linked list of cache entries that hash into the bucket.
   uint32_t length_;
-  uint32_t elems_;
+
+  // cache line alignment to avoid false sharing.
+  uint32_t elems_ __attribute__((aligned(128)));
   LRUHandle** list_;
 };
 


### PR DESCRIPTION
elems_ is "false sharing" with length_ and list_; any elems_ change will invalidate the cache line. So cache-align elems_. 