### PR TITLE
cache line alignment of LRUcache to avoid false cache sharing

### DIFF
--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -151,8 +151,11 @@ class LRUHandleTable {
   // The table consists of an array of buckets where each bucket is
   // a linked list of cache entries that hash into the bucket.
   uint32_t length_;
-  uint32_t elems_;
-  LRUHandle** list_;
+
+  // cache line alignment to avoid false sharing.
+  uint32_t length_ __attribute__((aligned(64)));
+  uint32_t elems_ __attribute__((aligned(64)));
+  LRUHandle** list_ __attribute__((aligned(64)));
 };
 
 // A single shard of sharded cache.

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -150,8 +150,6 @@ class LRUHandleTable {
 
   // The table consists of an array of buckets where each bucket is
   // a linked list of cache entries that hash into the bucket.
-  uint32_t length_;
-
   // cache line alignment to avoid false sharing.
   uint32_t length_ __attribute__((aligned(64)));
   uint32_t elems_ __attribute__((aligned(64)));


### PR DESCRIPTION
a lot of false cache sharing around these variables. So cacheline align them. 