### PR TITLE
Improve L0->L0 compaction

### DIFF
--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -106,7 +106,7 @@ int FullFilterBitsBuilder::CalculateNumEntry(const uint32_t space) {
   assert(bits_per_key_);
   assert(space > 0);
   uint32_t dont_care1, dont_care2;
-  int high = (int) (space * 8 / bits_per_key_ + 1);
+  int high = (int)(space * 8 / bits_per_key_ + 1);
   int low = 1;
   int n = high;
   for (; n >= low; n--) {


### PR DESCRIPTION
In my opinion, L0->L0 compaction is used to reduce small sst files count in L0 that making unreasonable stall harder to reach. But current L0->L0 compaction mechanism:
1) May generate a [big sst file](https://github.com/facebook/rocksdb/issues/2530). This will cause a very big L0->L1 compaction job which need a long time to finish.
2) Simply compact [0,n) sst files of L0.

This pr:
1) Only compact small sst files;
2) Add a size limitation for L0->L0 compaction;
3) Can compact [n, m) sst files of L0.

@ajkr PTAL
