### PR TITLE
remove duplicated utilities/merge_operators/cassandra/test_utils.cc in src.mk

### DIFF
--- a/src.mk
+++ b/src.mk
@@ -340,7 +340,6 @@ MAIN_SOURCES =                                                    \
   utilities/memory/memory_test.cc                                       \
   utilities/merge_operators/string_append/stringappend_test.cc          \
   utilities/merge_operators/cassandra/cassandra_merge_test.cc           \
-  utilities/merge_operators/cassandra/test_utils.cc                     \
   utilities/merge_operators/cassandra/cassandra_format_test.cc          \
   utilities/merge_operators/cassandra/cassandra_row_merge_test.cc       \
   utilities/merge_operators/cassandra/cassandra_serialize_test.cc       \


### PR DESCRIPTION
target `utilities/merge_operators/cassandra/test_utils.d' given more than once in the same rule
remove the duplicate one