### PR TITLE
silence warning with clang-3.9+ (TablePropertiesCollector::AddUserKey)

### DIFF
--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -89,7 +89,7 @@ class TablePropertiesCollector {
   // @params value  the value that is inserted into the table.
   virtual Status AddUserKey(const Slice& key, const Slice& value,
                             EntryType /*type*/, SequenceNumber /*seq*/,
-                            uint64_t /*file_size*/) {
+                            uint64_t /*file_size*/) override {
     // For backwards-compatibility.
     return Add(key, value);
   }


### PR DESCRIPTION
Also shows up in AppleClang 8.1.0.8020042

Warning:

/Users/travis/build/MariaDB/server/storage/rocksdb/./properties_collector.h:84:27: warning: 'AddUserKey' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual rocksdb::Status AddUserKey(const rocksdb::Slice &key,
                          ^

/Users/travis/build/MariaDB/server/storage/rocksdb/rocksdb/include/rocksdb/table_properties.h:87:18: note: overridden virtual function is here
  virtual Status AddUserKey(const Slice& key, const Slice& value,
                 ^