### PR TITLE
Prevent empty memtables from using a lot of memory

### DIFF
--- a/util/arena.h
+++ b/util/arena.h
@@ -77,6 +77,10 @@ class Arena : public Allocator {
 
   size_t BlockSize() const override { return kBlockSize; }
 
+  bool IsInInlineBlock() const {
+    return blocks_.empty();
+  }
+
  private:
   char inline_block_[kInlineSize] __attribute__((__aligned__(sizeof(void*))));
   // Number of bytes allocated in one block

--- a/util/arena_test.cc
+++ b/util/arena_test.cc
@@ -91,9 +91,13 @@ static void ApproximateMemoryUsageTest(size_t huge_page_size) {
   ASSERT_EQ(kZero, arena.ApproximateMemoryUsage());
 
   // allocate inline bytes
+  EXPECT_TRUE(arena.IsInInlineBlock());
   arena.AllocateAligned(8);
+  EXPECT_TRUE(arena.IsInInlineBlock());
   arena.AllocateAligned(Arena::kInlineSize / 2 - 16);
+  EXPECT_TRUE(arena.IsInInlineBlock());
   arena.AllocateAligned(Arena::kInlineSize / 2);
+  EXPECT_TRUE(arena.IsInInlineBlock());
   ASSERT_EQ(arena.ApproximateMemoryUsage(), Arena::kInlineSize - 8);
   ASSERT_PRED2(CheckMemoryAllocated, arena.MemoryAllocatedBytes(),
                Arena::kInlineSize);
@@ -102,6 +106,7 @@ static void ApproximateMemoryUsageTest(size_t huge_page_size) {
 
   // first allocation
   arena.AllocateAligned(kEntrySize);
+  EXPECT_FALSE(arena.IsInInlineBlock());
   auto mem_usage = arena.MemoryAllocatedBytes();
   if (huge_page_size) {
     ASSERT_TRUE(
@@ -117,6 +122,7 @@ static void ApproximateMemoryUsageTest(size_t huge_page_size) {
     arena.AllocateAligned(kEntrySize);
     ASSERT_EQ(mem_usage, arena.MemoryAllocatedBytes());
     ASSERT_EQ(arena.ApproximateMemoryUsage(), usage + kEntrySize);
+    EXPECT_FALSE(arena.IsInInlineBlock());
     usage = arena.ApproximateMemoryUsage();
   }
   if (huge_page_size) {


### PR DESCRIPTION
This fixes OOMs that we (logdevice) are currently having in production.

SkipListRep constructor does a couple small allocations from ConcurrentArena (see InlineSkipList constructor). ConcurrentArena would sometimes allocate an entire block for that, which is a few megabytes (we use Options::arena_block_size = 4 MB). So an empty memtable can take take 4 MB of memory. We have ~40k column families (spread across 15 DB instances), so 4 MB per empty memtable easily OOMs a machine for us.

This PR makes ConcurrentArena always allocate from Arena's inline block when possible. So as long as InlineSkipList's initial allocations are below 2 KB there would be no blocks allocated for empty memtables.