### PR TITLE
db_crashtest.py: remove need for shell

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -165,12 +165,12 @@ def gen_cmd_params(args):
 
 
 def gen_cmd(params):
-    cmd = './db_stress ' + ' '.join(
+    cmd = ['./db_stress'] + [
         '--{0}={1}'.format(k, v)
         for k, v in finalize_and_sanitize(params).items()
         if k not in set(['test_type', 'simple', 'duration', 'interval',
                          'random_kill_odd'])
-        and v is not None)
+        and v is not None]
     return cmd
 
 
@@ -195,10 +195,9 @@ def blackbox_crash_main(args):
 
         cmd = gen_cmd(dict(cmd_params.items() + {'db': dbname}.items()))
 
-        child = subprocess.Popen([cmd],
-                                 stderr=subprocess.PIPE, shell=True)
+        child = subprocess.Popen(cmd, stderr=subprocess.PIPE)
         print("Running db_stress with pid=%d: %s\n\n"
-              % (child.pid, cmd))
+              % (child.pid, ' '.join(cmd)))
 
         stop_early = False
         while time.time() < killtime:
@@ -315,11 +314,10 @@ def whitebox_crash_main(args):
         cmd = gen_cmd(dict(cmd_params.items() + additional_opts.items()
                            + {'db': dbname}.items()))
 
-        print "Running:" + cmd + "\n"
+        print "Running:" + ' '.join(cmd) + "\n"
 
-        popen = subprocess.Popen([cmd], stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT,
-                                 shell=True)
+        popen = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT)
         stdoutdata, stderrdata = popen.communicate()
         retncode = popen.returncode
         msg = ("check_mode={0}, kill option={1}, exitcode={2}\n".format(


### PR DESCRIPTION
Before:
$ ps -ef

build     1713    16  0 Jul11 ?        00:00:00 make crash_test
build     3437  1713  0 Jul11 ?        00:00:00 python -u tools/db_crashtest.py --simple blackbox
build     3438  3437  0 Jul11 ?        00:00:00 [sh] <defunct>
build     3440     1 99 Jul11 ?        5-03:01:25 ./db_stress --max_background_compactions=1 --max_write_buffer_number=3 --sync=0 --reopen=20 --write_buffer_size=33554432 --delpercent=5 --block_size=16384 --allow_concurrent_me

After:

build      1706     16  0 02:52 ?        00:00:01 make crash_test
build      3432   1706  0 02:55 ?        00:00:00 python -u tools/db_crashtest.py --simple blackbox
build      4452   3432 99 04:35 ?        00:01:42 ./db_stress --max_background_compactions=1 --max_write_buffer_number=3 --sync=0 --reopen=20 --write_buffer_size=33554432 --delpercent=5 --block_size=16384 --allow_concurr