### PR TITLE
remove unnecessary fadvise

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -172,9 +172,6 @@ Status PosixSequentialFile::Read(size_t n, Slice* result, char* scratch) {
       s = IOError("While reading file sequentially", filename_, errno);
     }
   }
-  // we need to fadvise away the entire range of pages because
-  // we do not want readahead pages to be cached under buffered io
-  Fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);  // free OS pages
   return s;
 }
 


### PR DESCRIPTION
We has to remove this line because previously it is only called when use_os_buffer = false. But now we have direct io to replace it.