### PR TITLE
Fix column_family_test with LITE build

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -521,6 +521,7 @@ TEST_F(ColumnFamilyTest, DontReuseColumnFamilyID) {
   }
 }
 
+#ifndef ROCKSDB_LITE
 TEST_F(ColumnFamilyTest, CreateCFRaceWithGetAggProperty) {
   Open();
 
@@ -542,6 +543,7 @@ TEST_F(ColumnFamilyTest, CreateCFRaceWithGetAggProperty) {
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
+#endif  // !ROCKSDB_LITE
 
 class FlushEmptyCFTestWithParam : public ColumnFamilyTest,
                                   public testing::WithParamInterface<bool> {


### PR DESCRIPTION
Summary:
Fix column_family_test with LITE build. I need this patch to fix 5.6 branch.

Test Plan:
OPT=-DROCKSDB_LITE make column_family_test