### PR TITLE
Gcc 7 ParsedInternalKey replace memset with clear function.

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -84,6 +84,12 @@ struct ParsedInternalKey {
   ParsedInternalKey(const Slice& u, const SequenceNumber& seq, ValueType t)
       : user_key(u), sequence(seq), type(t) { }
   std::string DebugString(bool hex = false) const;
+
+  void clear() {
+    user_key.clear();
+    sequence = 0;
+    type = kTypeDeletion;
+  }
 };
 
 // Return the length of the encoding of "key".

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -60,7 +60,7 @@ static std::string PrintContents(WriteBatch* b) {
     }
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
       ParsedInternalKey ikey;
-      memset((void*)&ikey, 0, sizeof(ikey));
+      ikey.clear();
       EXPECT_TRUE(ParseInternalKey(iter->key(), &ikey));
       switch (ikey.type) {
         case kTypeValue:

--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -59,7 +59,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
       rocksdb::ReadOptions(), &arena));
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     rocksdb::ParsedInternalKey ikey;
-    memset(reinterpret_cast<void*>(&ikey), 0, sizeof(ikey));
+    ikey.clear();
     bool parsed = rocksdb::ParseInternalKey(iter->key(), &ikey);
     if (!parsed) {
       assert(parsed);


### PR DESCRIPTION
I haven't looked to see if a class variable inside a loop like this is always initialised.