### PR TITLE
block_cache_tier: fix gcc-7 warnings

### DIFF
--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -136,7 +136,7 @@ Status BlockCacheTier::Close() {
 template<class T>
 void Add(std::map<std::string, double>* stats, const std::string& key,
          const T& t) {
-  stats->insert({key, static_cast<const double>(t)});
+  stats->insert({key, static_cast<double>(t)});
 }
 
 PersistentCache::StatsType BlockCacheTier::Stats() {


### PR DESCRIPTION
Error was:

utilities/persistent_cache/block_cache_tier.cc: In instantiation of ‘void rocksdb::Add(std::map<std::__cxx11::basic_string<char>, double>*, const string&, const T&) [with T = double; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
utilities/persistent_cache/block_cache_tier.cc:147:40:   required from here
utilities/persistent_cache/block_cache_tier.cc:141:23: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]

   stats->insert({key, static_cast<const double>(t)});

fixing like #2562