### PR TITLE
Portable aligned alloc implementation for heap allocated LRUCacheShard

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -233,6 +233,14 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
   }
 }
 
+void* LRUCacheShard::operator new(size_t size) {
+  return rocksdb::port::cacheline_aligned_alloc(size);
+}
+
+void LRUCacheShard::operator delete(void *memblock) {
+  rocksdb::port::cacheline_aligned_free(memblock);
+}
+
 void LRUCacheShard::SetCapacity(size_t capacity) {
   autovector<LRUHandle*> last_reference_list;
   {

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -202,6 +202,11 @@ class LRUCacheShard : public CacheShard {
   //  not threadsafe
   size_t TEST_GetLRUSize();
 
+  // Overloading to aligned it to cache line size
+  void* operator new(size_t);
+
+  void operator delete(void *);
+
  private:
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -184,5 +184,22 @@ int GetMaxOpenFiles() {
   return -1;
 }
 
+void *cacheline_aligned_alloc(size_t size) {
+#if defined (_ISOC11_SOURCE)
+  return aligned_alloc(CACHE_LINE_SIZE, size);
+#elif ( _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__))
+  void *m;
+  errno = posix_memalign(&m, CACHE_LINE_SIZE, size);
+  return errno ? NULL : m;
+#else
+  return malloc(size);
+#endif
+}
+
+void cacheline_aligned_free(void *memblock) {
+  free(memblock);
+}
+
+
 }  // namespace port
 }  // namespace rocksdb

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -193,6 +193,10 @@ extern void InitOnce(OnceType* once, void (*initializer)());
   #endif
 #endif
 
+extern void *cacheline_aligned_alloc(size_t size);
+
+extern void cacheline_aligned_free(void *memblock);
+
 #define PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
 
 extern void Crash(const std::string& srcfile, int srcline);

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <limits>
 #include <condition_variable>
+#include <malloc.h>
 
 #include <stdint.h>
 
@@ -238,6 +239,14 @@ extern void InitOnce(OnceType* once, void (*initializer)());
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64U
 #endif
+
+inline void *cacheline_aligned_alloc(size_t size) {
+  return _aligned_malloc(CACHE_LINE_SIZE, size);
+}
+
+inline void cacheline_aligned_free(void *memblock) {
+  _aligned_free(memblock);
+}
 
 static inline void AsmVolatilePause() {
 #if defined(_M_IX86) || defined(_M_X64)


### PR DESCRIPTION
Initial proof of concept solution to part of #2568 

Checking of defines for posix bits currently emits a warning on OSX causing failure so I removed the warning.

This is the first time tested on Windows so we'll see.