### PR TITLE
Fix UBSAN issue of passing nullptr to memcmp

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -222,8 +222,8 @@ __attribute__((__no_sanitize_undefined__))
 #endif
 inline int Slice::compare(const Slice& b) const {
   const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
-  int r = memcmp(data_, b.data_, min_len);
   assert((data_ != nullptr && b.data_ != nullptr) || min_len == 0);
+  int r = memcmp(data_, b.data_, min_len);
   if (r == 0) {
     if (size_ < b.size_) r = -1;
     else if (size_ > b.size_) r = +1;

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -213,9 +213,19 @@ inline bool operator!=(const Slice& x, const Slice& y) {
   return !(x == y);
 }
 
+// UBSAN complain that we pass nullptr to memcmp that's fine since
+// we always do that for a string of len = 0
+#ifdef ROCKSDB_UBSAN_RUN
+#if defined(__clang__)
+__attribute__((__no_sanitize__("undefined")))
+#elif defined(__GNUC__)
+__attribute__((__no_sanitize_undefined__))
+#endif
+#endif
 inline int Slice::compare(const Slice& b) const {
   const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
   int r = memcmp(data_, b.data_, min_len);
+  assert((data_ != nullptr && b.data_ != nullptr) || min_len == 0);
   if (r == 0) {
     if (size_ < b.size_) r = -1;
     else if (size_ > b.size_) r = +1;

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -215,10 +215,12 @@ inline bool operator!=(const Slice& x, const Slice& y) {
 
 // UBSAN complain that we pass nullptr to memcmp that's fine since
 // we always do that for a string of len = 0
+#ifdef ROCKSDB_UBSAN_RUN
 #if defined(__clang__)
 __attribute__((__no_sanitize__("undefined")))
 #elif defined(__GNUC__)
 __attribute__((__no_sanitize_undefined__))
+#endif
 #endif
 inline int Slice::compare(const Slice& b) const {
   const size_t min_len = (size_ < b.size_) ? size_ : b.size_;

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -215,12 +215,10 @@ inline bool operator!=(const Slice& x, const Slice& y) {
 
 // UBSAN complain that we pass nullptr to memcmp that's fine since
 // we always do that for a string of len = 0
-#ifdef ROCKSDB_UBSAN_RUN
 #if defined(__clang__)
 __attribute__((__no_sanitize__("undefined")))
 #elif defined(__GNUC__)
 __attribute__((__no_sanitize_undefined__))
-#endif
 #endif
 inline int Slice::compare(const Slice& b) const {
   const size_t min_len = (size_ < b.size_) ? size_ : b.size_;


### PR DESCRIPTION
As explained in the comments, Sometimes we create Slice(nullptr, 0) in our code base which cause us to do calls like
```
memcmp(nullptr, "abc", 0);
```
That's fine since the len is equal 0, but UBSAN is not happy about it
so disable UBSAN for this function and add an assert instead