### PR TITLE
Fix Flaky DeleteSchedulerTest::ImmediateDeleteOn25PercDBSize

### DIFF
--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -541,7 +541,7 @@ TEST_F(DeleteSchedulerTest, ImmediateDeleteOn25PercDBSize) {
     delete_scheduler_->DeleteFile(file_name);
   }
 
-  // When we end up with 24 files in trash we will start
+  // When we end up with 26 files in trash we will start
   // deleting new files immediately
   ASSERT_EQ(fg_delete_file, 74);
 

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -544,7 +544,6 @@ TEST_F(DeleteSchedulerTest, ImmediateDeleteOn25PercDBSize) {
   // When we end up with 24 files in trash we will start
   // deleting new files immediately
   ASSERT_EQ(fg_delete_file, 74);
-  ASSERT_EQ(CountFilesInDir(trash_dir_), 25);
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }


### PR DESCRIPTION
In this test we are deleting 100 files, and we are expecting DeleteScheduler to delete 26 files in the background and 74 files immediately in the foreground 

The main purpose of the test is to make sure that we delete files in foreground thread, which is verified in line 546

But sometimes we may end up with 26 files or 25 files in the trash directory because the background thread may be slow and not be able to delete the first file fast enough, so sometimes this test fail.

Remove
```
ASSERT_EQ(CountFilesInDir(trash_dir_), 25);
```
Since it does not have any benefit any way