### PR TITLE
enable UBSAN macro in TARGETS

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -18,6 +18,7 @@ rocksdb_compiler_flags = [
   "-DROCKSDB_SUPPORT_THREAD_LOCAL",
   "-DHAVE_SSE42",
   "-DOS_LINUX",
+  "-DROCKSDB_UBSAN_RUN",
   # Flags to enable libs we include
   "-DSNAPPY",
   "-DZLIB",

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -22,6 +22,7 @@ rocksdb_compiler_flags = [
   "-DROCKSDB_SUPPORT_THREAD_LOCAL",
   "-DHAVE_SSE42",
   "-DOS_LINUX",
+  "-DROCKSDB_UBSAN_RUN",
   # Flags to enable libs we include
   "-DSNAPPY",
   "-DZLIB",


### PR DESCRIPTION
simply enable the macro in internal build, it wont hurt other sanitizers and will fix UBSAN issues