### PR TITLE
Fix universal compaction bug

### DIFF
--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -169,6 +169,7 @@ Compaction::Compaction(VersionStorageInfo* vstorage,
       bottommost_level_(IsBottommostLevel(output_level_, vstorage, inputs_)),
       is_full_compaction_(IsFullCompaction(vstorage, inputs_)),
       is_manual_compaction_(_manual_compaction),
+      is_trivial_move_(false),
       compaction_reason_(_compaction_reason) {
   MarkFilesBeingCompacted(true);
   if (is_manual_compaction_) {


### PR DESCRIPTION
this value ``` Compaction::is_trivial_move_ ``` uninitialized .
under universal compaction , we enable ```  CompactionOptionsUniversal::allow_trivial_move  ``` ,
https://github.com/facebook/rocksdb/blob/9b11d4345a0f01fc3de756e01460bf1b0446f326/db/compaction.cc#L245
here is a disastrous bug , some sst trivial move to target level without overlap check ...
THEN , DATABASE DAMAGED , WE GOT A LEVEL WITH OVERLAP !