### PR TITLE
Fix MergingIterator::AddIterator bug

### DIFF
--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -62,11 +62,13 @@ class MergingIterator : public InternalIterator {
     if (pinned_iters_mgr_) {
       iter->SetPinnedItersMgr(pinned_iters_mgr_);
     }
-    auto new_wrapper = children_.back();
-    if (new_wrapper.Valid()) {
-      minHeap_.push(&new_wrapper);
-      current_ = CurrentForward();
+    minHeap_.clear();
+    for (auto& child : children_) {
+      if (child.Valid()) {
+        minHeap_.push(&child);
+      }
     }
+    current_ = CurrentForward();
   }
 
   virtual ~MergingIterator() {


### PR DESCRIPTION
fix isuues:
  1.  ``` children_.emplace_back(iter); ```, elements in ``` minHeap_ ``` will be invalid after ```children_```'s capacity changed.
  2.  ``` new_wrapper ``` is a stack object , add its address to ``` minHeap_ ``` will produce undefined behavior.

this fix is not graceful enough, but it should work...