### PR TITLE
Lower num of iterations in DeadlockCycle test

### DIFF
--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -543,7 +543,7 @@ TEST_P(TransactionTest, DeadlockCycle) {
 TEST_P(TransactionTest, DeadlockStress) {
   const uint32_t NUM_TXN_THREADS = 10;
   const uint32_t NUM_KEYS = 100;
-  const uint32_t NUM_ITERS = 100000;
+  const uint32_t NUM_ITERS = 10000;
 
   WriteOptions write_options;
   ReadOptions read_options;


### PR DESCRIPTION
Currently this test times out with tsan. This is likely due to decreased speed with tsan. By lowering the number of iterations we can still catch a bug as the test is run regularly and multiple runs of the test is equivalent with running the test with more iterations.