### PR TITLE
Fix flaky write_callback_test

### DIFF
--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -152,7 +152,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
               std::atomic<uint64_t> threads_joined(0);
               // Writers that have linked to the queue
               std::atomic<uint64_t> threads_linked(0);
-              // Writers that passes WriteThread::JoinBatchGroup:Wait sync-point.
+              // Writers that pass WriteThread::JoinBatchGroup:Wait sync-point.
               std::atomic<uint64_t> threads_waiting(0);
 
               std::atomic<uint64_t> seq(db_impl->GetLatestSequenceNumber());

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -147,7 +147,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
 
               db_impl = dynamic_cast<DBImpl*>(db);
               ASSERT_TRUE(db_impl);
-              
+
               // Writers that have called JoinBatchGroup.
               std::atomic<uint64_t> threads_joining(0);
               // Writers that have linked to the queue

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -16,7 +16,6 @@
 #include "rocksdb/db.h"
 #include "rocksdb/write_batch.h"
 #include "port/port.h"
-#include "util/logging.h"
 #include "util/random.h"
 #include "util/sync_point.h"
 #include "util/testharness.h"
@@ -160,7 +159,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
               ASSERT_EQ(db_impl->GetLatestSequenceNumber(), 0);
 
               rocksdb::SyncPoint::GetInstance()->SetCallBack(
-                  "WriteThread::JoinBatchGroup:Start", [&](void* arg) {
+                  "WriteThread::JoinBatchGroup:Start", [&](void*) {
                     uint64_t cur_threads_joined = threads_joined.fetch_add(1);
                     // Wait for other writers linking to the queue. In this way
                     // we will know whether the writer is a leader by checking
@@ -201,7 +200,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                       ASSERT_TRUE(writer->callback->Callback(nullptr).ok() ==
                                   !write_group.back().callback_.should_fail_);
                     }
-                    
+
                     threads_waiting.fetch_add(1);
                     // Wait here until all verification in this sync-point
                     // callback finish for all writers.

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -271,7 +271,7 @@ static WriteThread::AdaptationContext jbg_ctx("JoinBatchGroup");
 void WriteThread::JoinBatchGroup(Writer* w) {
   TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Start", w);
   assert(w->batch != nullptr);
-  
+
   bool linked_as_leader = LinkOne(w, &newest_writer_);
   if (linked_as_leader) {
     SetState(w, STATE_GROUP_LEADER);

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -269,8 +269,9 @@ void WriteThread::CompleteFollower(Writer* w, WriteGroup& write_group) {
 
 static WriteThread::AdaptationContext jbg_ctx("JoinBatchGroup");
 void WriteThread::JoinBatchGroup(Writer* w) {
-
+  TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:Start", w);
   assert(w->batch != nullptr);
+  
   bool linked_as_leader = LinkOne(w, &newest_writer_);
   if (linked_as_leader) {
     SetState(w, STATE_GROUP_LEADER);


### PR DESCRIPTION
Summary:
The test is failing occasionally on the assert: `ASSERT_TRUE(writer->state == WriteThread::State::STATE_INIT)`. This is because the test don't make the leader wait for long enough before updating state for its followers. The patch move the update to `threads_waiting` to the end of `WriteThread::JoinBatchGroup:Wait` callback to avoid this happening.

Also adding `WriteThread::JoinBatchGroup:Start` and have each thread wait there while another thread is linking to the linked-list. This is to make the check of `is_leader` more deterministic.

Also changing two while-loops of `compare_exchange_strong` to plain `fetch_add`, to make it look cleaner.

Test Plan:
run the test 10k times (before the fix it fails around 0.1% of the time on my devserver)