### PR TITLE
Remove the orphan assert on !need_log_sync

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -236,16 +236,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         // wal_write_mutex_ to ensure ordered events in WAL
         status = ConcurrentWriteToWAL(write_group, log_used, &last_sequence,
                                       total_count);
-        if (status.ok() && need_log_sync) {
-          // Requesting sync with concurrent_prepare_ is expected to be very
-          // rare. We hance provide a simple implementation that is not
-          // necessarily efficient.
-          if (manual_wal_flush_) {
-            status = FlushWAL(true);
-          } else {
-            status = SyncWAL();
-          }
-        }
       } else {
         // Otherwise we inc seq number for memtable writes
         last_sequence = versions_->FetchAddLastToBeWrittenSequence(total_count);

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -230,13 +230,22 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
                             need_log_dir_sync, last_sequence + 1);
       }
     } else {
-      assert(!need_log_sync && !need_log_dir_sync);
       if (status.ok() && !write_options.disableWAL) {
         PERF_TIMER_GUARD(write_wal_time);
         // LastToBeWrittenSequence is increased inside WriteToWAL under
         // wal_write_mutex_ to ensure ordered events in WAL
         status = ConcurrentWriteToWAL(write_group, log_used, &last_sequence,
                                       total_count);
+        if (status.ok() && need_log_sync) {
+          // Requesting sync with concurrent_prepare_ is expected to be very
+          // rare. We hance provide a simple implementation that is not
+          // necessarily efficient.
+          if (manual_wal_flush_) {
+            status = FlushWAL(true);
+          } else {
+            status = SyncWAL();
+          }
+        }
       } else {
         // Otherwise we inc seq number for memtable writes
         last_sequence = versions_->FetchAddLastToBeWrittenSequence(total_count);


### PR DESCRIPTION
We initially had disabled support for write_options.sync when concurrent_prepare_ is set. We later added this support but the statement that asserts this combination is not used was left there. This patch cleans it up.