### PR TITLE
move TableCache::EraseHandle outside of db mutex

### DIFF
--- a/db/db_impl_files.cc
+++ b/db/db_impl_files.cc
@@ -368,6 +368,9 @@ void DBImpl::PurgeObsoleteFiles(const JobContext& state, bool schedule_only) {
     candidate_files.emplace_back(
         MakeTableFileName(kDumbDbName, file->fd.GetNumber()),
         file->fd.GetPathId());
+    if (file->table_reader_handle) {
+      table_cache_->Release(file->table_reader_handle);
+    }
     delete file;
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -328,10 +328,6 @@ Version::~Version() {
       assert(f->refs > 0);
       f->refs--;
       if (f->refs <= 0) {
-        if (f->table_reader_handle) {
-          cfd_->table_cache()->EraseHandle(f->fd, f->table_reader_handle);
-          f->table_reader_handle = nullptr;
-        }
         vset_->obsolete_files_.push_back(f);
       }
     }


### PR DESCRIPTION
Post-compaction work holds onto db mutex for the longest time (found by tracing lock acquires/releases with LTTng and correlating timestamps with our info log). Further experimentation showed `TableCache::EraseHandle` is responsible for ~86% of time mutex is held. We can just release the handle outside the db mutex.

Test Plan:

- Command: `TEST_TMPDIR=/data/compaction_bench/ ./db_bench -compression_type=none -benchmarks=fillrandom -statistics -write_buffer_size=655360 -target_file_size_base=655360 -max_bytes_for_level_base=2623440 -max_background_jobs=12 -num=10000000 -max_write_buffer_number=12 -enable_pipelined_write=false`
- before: max mutex held time in a compaction thread is 5ms
- after: max mutex held time in a compaction thread is 0.7ms