### PR TITLE
Blob DB TTL extractor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,7 @@ set(SOURCES
         utilities/blob_db/blob_log_reader.cc
         utilities/blob_db/blob_log_writer.cc
         utilities/blob_db/blob_log_format.cc
+        utilities/blob_db/ttl_extractor.cc
         utilities/cassandra/cassandra_compaction_filter.cc
         utilities/cassandra/format.cc
         utilities/cassandra/merge_operator.cc

--- a/TARGETS
+++ b/TARGETS
@@ -211,6 +211,7 @@ cpp_library(
       "utilities/blob_db/blob_log_reader.cc",
       "utilities/blob_db/blob_log_writer.cc",
       "utilities/blob_db/blob_log_format.cc",
+      "utilities/blob_db/ttl_extractor.cc",
       "utilities/cassandra/cassandra_compaction_filter.cc",
       "utilities/cassandra/format.cc",
       "utilities/cassandra/merge_operator.cc",

--- a/src.mk
+++ b/src.mk
@@ -159,6 +159,7 @@ LIB_SOURCES =                                                   \
   utilities/blob_db/blob_log_reader.cc                          \
   utilities/blob_db/blob_log_writer.cc                          \
   utilities/blob_db/blob_log_format.cc                          \
+  utilities/blob_db/ttl_extractor.cc                            \
   utilities/cassandra/cassandra_compaction_filter.cc            \
   utilities/cassandra/format.cc                                 \
   utilities/cassandra/merge_operator.cc                         \

--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -163,7 +163,6 @@ BlobDBOptions::BlobDBOptions()
       bytes_per_sync(0),
       blob_file_size(256 * 1024 * 1024),
       num_concurrent_simple_blobs(4),
-      default_ttl_extractor(false),
       compression(kNoCompression) {}
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -17,7 +17,6 @@
 #include "table/block.h"
 #include "table/block_based_table_builder.h"
 #include "table/block_builder.h"
-#include "util/crc32c.h"
 #include "util/file_reader_writer.h"
 #include "util/filename.h"
 #include "utilities/blob_db/blob_db_impl.h"

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -306,7 +306,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractExpiration) {
     explicit TestTTLExtractor(Random *r) : rnd(r) {}
 
     virtual bool ExtractExpiration(const Slice &key, const Slice &value,
-                                   uint64_t now, uint64_t *expiration,
+                                   uint64_t /*now*/, uint64_t *expiration,
                                    std::string * /*new_value*/,
                                    bool * /*value_changed*/) override {
       *expiration = rnd->Next() % 100 + 50;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -259,7 +259,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractTTL) {
    public:
     explicit TestTTLExtractor(Random *r) : rnd(r) {}
 
-    virtual bool ExtractTTL(const Slice &key, const Slice &value, uint32_t *ttl,
+    virtual bool ExtractTTL(const Slice &key, const Slice &value, uint64_t *ttl,
                             std::string * /*new_value*/,
                             bool * /*value_changed*/) override {
       *ttl = rnd->Next() % 100;
@@ -362,9 +362,9 @@ TEST_F(BlobDBTest, TTLExtractor_DefaultTTLExtractor) {
     int len = rnd.Next() % kMaxBlobSize + 1;
     std::string key = "key" + ToString(i);
     std::string value = test::RandomHumanReadableString(&rnd, len);
-    uint32_t ttl = rnd.Next() % 100;
+    uint64_t ttl = rnd.Next() % 100;
     std::string value_ttl = value + "ttl:";
-    PutFixed32(&value_ttl, ttl);
+    PutFixed64(&value_ttl, ttl);
     ASSERT_OK(blob_db_->Put(WriteOptions(), Slice(key), Slice(value_ttl)));
     if (ttl >= 50) {
       data[key] = value;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -206,7 +206,7 @@ TEST_F(BlobDBTest, PutUntil) {
   for (size_t i = 0; i < 100; i++) {
     int32_t expiration = rnd.Next() % 100 + 50;
     PutRandomUntil("key" + ToString(i), expiration, &rnd,
-                     (expiration < 100 ? nullptr : &data));
+                   (expiration < 100 ? nullptr : &data));
   }
   mock_env_->set_now_micros(100 * 1000000);
   auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
@@ -293,7 +293,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractTTL) {
   bdb_impl->TEST_CloseBlobFile(blob_files[0]);
   GCStats gc_stats;
   ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
-  auto& data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
+  auto &data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
   ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
   ASSERT_EQ(data.size(), gc_stats.num_relocs);
   VerifyDB(data);
@@ -340,7 +340,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractExpiration) {
   bdb_impl->TEST_CloseBlobFile(blob_files[0]);
   GCStats gc_stats;
   ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
-  auto& data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
+  auto &data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
   ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
   ASSERT_EQ(data.size(), gc_stats.num_relocs);
   VerifyDB(data);
@@ -350,13 +350,13 @@ TEST_F(BlobDBTest, TTLExtractor_ChangeValue) {
   class TestTTLExtractor : public TTLExtractor {
    public:
     const Slice kTTLSuffix = Slice("ttl:");
-  
-    bool ExtractTTL(const Slice& /*key*/, const Slice& value, uint64_t* ttl,
-                    std::string* new_value, bool* value_changed) override {
+
+    bool ExtractTTL(const Slice & /*key*/, const Slice &value, uint64_t *ttl,
+                    std::string *new_value, bool *value_changed) override {
       if (value.size() < 12) {
         return false;
       }
-      const char* p = value.data() + value.size() - 12;
+      const char *p = value.data() + value.size() - 12;
       if (kTTLSuffix != Slice(p, 4)) {
         return false;
       }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -164,7 +164,7 @@ TEST_F(BlobDBTest, PutWithTTL) {
   options.env = mock_env_.get();
   BlobDBOptionsImpl bdb_options;
   bdb_options.ttl_range_secs = 1000;
-  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.blob_file_size = 256 * 1000 * 1000;
   bdb_options.disable_background_tasks = true;
   Open(bdb_options, options);
   std::map<std::string, std::string> data;
@@ -193,7 +193,7 @@ TEST_F(BlobDBTest, PutUntil) {
   options.env = mock_env_.get();
   BlobDBOptionsImpl bdb_options;
   bdb_options.ttl_range_secs = 1000;
-  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.blob_file_size = 256 * 1000 * 1000;
   bdb_options.disable_background_tasks = true;
   Open(bdb_options, options);
   std::map<std::string, std::string> data;
@@ -224,7 +224,7 @@ TEST_F(BlobDBTest, TTLExtrator_NoTTL) {
   options.env = mock_env_.get();
   BlobDBOptionsImpl bdb_options;
   bdb_options.ttl_range_secs = 1000;
-  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.blob_file_size = 256 * 1000 * 1000;
   bdb_options.num_concurrent_simple_blobs = 1;
   bdb_options.ttl_extractor = ttl_extractor_;
   bdb_options.disable_background_tasks = true;
@@ -252,11 +252,11 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractTTL) {
   Random rnd(301);
   class TestTTLExtractor : public TTLExtractor {
    public:
-    TestTTLExtractor(Random *r) : rnd(r) {}
+    explicit TestTTLExtractor(Random *r) : rnd(r) {}
 
     virtual bool ExtractTTL(const Slice &key, const Slice &value, uint32_t *ttl,
-                            std::string *new_value,
-                            bool *value_changed) override {
+                            std::string* /*new_value*/,
+                            bool* /*value_changed*/) override {
       *ttl = rnd->Next() % 100;
       if (*ttl >= 50) {
         data[key.ToString()] = value.ToString();
@@ -272,7 +272,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractTTL) {
   options.env = mock_env_.get();
   BlobDBOptionsImpl bdb_options;
   bdb_options.ttl_range_secs = 1000;
-  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.blob_file_size = 256 * 1000 * 1000;
   bdb_options.disable_background_tasks = true;
   Open(bdb_options, options);
   mock_env_->set_now_micros(50 * 1000000);
@@ -297,12 +297,12 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractExpiration) {
   Random rnd(301);
   class TestTTLExtractor : public TTLExtractor {
    public:
-    TestTTLExtractor(Random *r) : rnd(r) {}
+    explicit TestTTLExtractor(Random *r) : rnd(r) {}
 
     virtual bool ExtractExpiration(const Slice &key, const Slice &value,
                                    uint64_t now, uint64_t *expiration,
-                                   std::string *new_value,
-                                   bool *value_changed) override {
+                                   std::string* /*new_value*/,
+                                   bool* /*value_changed*/) override {
       *expiration = rnd->Next() % 100 + 50;
       if (*expiration >= 100) {
         data[key.ToString()] = value.ToString();
@@ -318,7 +318,7 @@ TEST_F(BlobDBTest, TTLExtractor_ExtractExpiration) {
   options.env = mock_env_.get();
   BlobDBOptionsImpl bdb_options;
   bdb_options.ttl_range_secs = 1000;
-  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.blob_file_size = 256 * 1000 * 1000;
   bdb_options.disable_background_tasks = true;
   Open(bdb_options, options);
   mock_env_->set_now_micros(50 * 1000000);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -25,7 +25,22 @@ class BlobDBTest : public testing::Test {
  public:
   const int kMaxBlobSize = 1 << 14;
 
-  BlobDBTest() : dbname_(test::TmpDir() + "/blob_db_test"), blob_db_(nullptr) {
+  class MockEnv : public EnvWrapper {
+   public:
+    MockEnv() : EnvWrapper(Env::Default()) {}
+
+    void set_now_micros(uint64_t now_micros) { now_micros_ = now_micros; }
+
+    uint64_t NowMicros() override { return now_micros_; }
+
+   private:
+    uint64_t now_micros_ = 0;
+  };
+
+  BlobDBTest()
+      : dbname_(test::TmpDir() + "/blob_db_test"),
+        mock_env_(new MockEnv()),
+        blob_db_(nullptr) {
     Status s = DestroyBlobDB(dbname_, Options(), BlobDBOptions());
     assert(s.ok());
   }
@@ -54,6 +69,17 @@ class BlobDBTest : public testing::Test {
     std::string value = test::RandomHumanReadableString(rnd, len);
     ASSERT_OK(
         blob_db_->PutWithTTL(WriteOptions(), Slice(key), Slice(value), ttl));
+    if (data != nullptr) {
+      (*data)[key] = value;
+    }
+  }
+
+  void PutRandomUntil(const std::string &key, int32_t expiration, Random *rnd,
+                      std::map<std::string, std::string> *data = nullptr) {
+    int len = rnd->Next() % kMaxBlobSize + 1;
+    std::string value = test::RandomHumanReadableString(rnd, len);
+    ASSERT_OK(blob_db_->PutUntil(WriteOptions(), Slice(key), Slice(value),
+                                 expiration));
     if (data != nullptr) {
       (*data)[key] = value;
     }
@@ -115,6 +141,8 @@ class BlobDBTest : public testing::Test {
   }
 
   const std::string dbname_;
+  std::unique_ptr<MockEnv> mock_env_;
+  std::shared_ptr<TTLExtractor> ttl_extractor_;
   BlobDB *blob_db_;
 };  // class BlobDBTest
 
@@ -127,6 +155,187 @@ TEST_F(BlobDBTest, Put) {
   for (size_t i = 0; i < 100; i++) {
     PutRandom("key" + ToString(i), &rnd, &data);
   }
+  VerifyDB(data);
+}
+
+TEST_F(BlobDBTest, PutWithTTL) {
+  Random rnd(301);
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptionsImpl bdb_options;
+  bdb_options.ttl_range_secs = 1000;
+  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options, options);
+  std::map<std::string, std::string> data;
+  mock_env_->set_now_micros(50 * 1000000);
+  for (size_t i = 0; i < 100; i++) {
+    int32_t ttl = rnd.Next() % 100;
+    PutRandomWithTTL("key" + ToString(i), ttl, &rnd,
+                     (ttl < 50 ? nullptr : &data));
+  }
+  mock_env_->set_now_micros(100 * 1000000);
+  auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
+  auto blob_files = bdb_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  ASSERT_TRUE(blob_files[0]->HasTTL());
+  bdb_impl->TEST_CloseBlobFile(blob_files[0]);
+  GCStats gc_stats;
+  ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
+  ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
+  ASSERT_EQ(data.size(), gc_stats.num_relocs);
+  VerifyDB(data);
+}
+
+TEST_F(BlobDBTest, PutUntil) {
+  Random rnd(301);
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptionsImpl bdb_options;
+  bdb_options.ttl_range_secs = 1000;
+  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options, options);
+  std::map<std::string, std::string> data;
+  mock_env_->set_now_micros(50 * 1000000);
+  for (size_t i = 0; i < 100; i++) {
+    int32_t expiration = rnd.Next() % 100 + 50;
+    PutRandomUntil("key" + ToString(i), expiration, &rnd,
+                     (expiration < 100 ? nullptr : &data));
+  }
+  mock_env_->set_now_micros(100 * 1000000);
+  auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
+  auto blob_files = bdb_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  ASSERT_TRUE(blob_files[0]->HasTTL());
+  bdb_impl->TEST_CloseBlobFile(blob_files[0]);
+  GCStats gc_stats;
+  ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
+  ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
+  ASSERT_EQ(data.size(), gc_stats.num_relocs);
+  VerifyDB(data);
+}
+
+TEST_F(BlobDBTest, TTLExtrator_NoTTL) {
+  // The default ttl extractor return no ttl for every key.
+  ttl_extractor_.reset(new TTLExtractor());
+  Random rnd(301);
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptionsImpl bdb_options;
+  bdb_options.ttl_range_secs = 1000;
+  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.num_concurrent_simple_blobs = 1;
+  bdb_options.ttl_extractor = ttl_extractor_;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options, options);
+  std::map<std::string, std::string> data;
+  mock_env_->set_now_micros(0);
+  for (size_t i = 0; i < 100; i++) {
+    PutRandom("key" + ToString(i), &rnd, &data);
+  }
+  // very far in the future..
+  mock_env_->set_now_micros(std::numeric_limits<uint64_t>::max() - 10);
+  auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
+  auto blob_files = bdb_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  ASSERT_FALSE(blob_files[0]->HasTTL());
+  bdb_impl->TEST_CloseBlobFile(blob_files[0]);
+  GCStats gc_stats;
+  ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
+  ASSERT_EQ(0, gc_stats.num_deletes);
+  ASSERT_EQ(100, gc_stats.num_relocs);
+  VerifyDB(data);
+}
+
+TEST_F(BlobDBTest, TTLExtractor_ExtractTTL) {
+  Random rnd(301);
+  class TestTTLExtractor : public TTLExtractor {
+   public:
+    TestTTLExtractor(Random *r) : rnd(r) {}
+
+    virtual bool ExtractTTL(const Slice &key, const Slice &value, uint32_t *ttl,
+                            std::string *new_value,
+                            bool *value_changed) override {
+      *ttl = rnd->Next() % 100;
+      if (*ttl >= 50) {
+        data[key.ToString()] = value.ToString();
+      }
+      return true;
+    }
+
+    Random *rnd;
+    std::map<std::string, std::string> data;
+  };
+  ttl_extractor_.reset(new TestTTLExtractor(&rnd));
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptionsImpl bdb_options;
+  bdb_options.ttl_range_secs = 1000;
+  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options, options);
+  mock_env_->set_now_micros(50 * 1000000);
+  for (size_t i = 0; i < 100; i++) {
+    PutRandom("key" + ToString(i), &rnd);
+  }
+  mock_env_->set_now_micros(100 * 1000000);
+  auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
+  auto blob_files = bdb_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  ASSERT_TRUE(blob_files[0]->HasTTL());
+  bdb_impl->TEST_CloseBlobFile(blob_files[0]);
+  GCStats gc_stats;
+  ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
+  auto& data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
+  ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
+  ASSERT_EQ(data.size(), gc_stats.num_relocs);
+  VerifyDB(data);
+}
+
+TEST_F(BlobDBTest, TTLExtractor_ExtractExpiration) {
+  Random rnd(301);
+  class TestTTLExtractor : public TTLExtractor {
+   public:
+    TestTTLExtractor(Random *r) : rnd(r) {}
+
+    virtual bool ExtractExpiration(const Slice &key, const Slice &value,
+                                   uint64_t now, uint64_t *expiration,
+                                   std::string *new_value,
+                                   bool *value_changed) override {
+      *expiration = rnd->Next() % 100 + 50;
+      if (*expiration >= 100) {
+        data[key.ToString()] = value.ToString();
+      }
+      return true;
+    }
+
+    Random *rnd;
+    std::map<std::string, std::string> data;
+  };
+  ttl_extractor_.reset(new TestTTLExtractor(&rnd));
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptionsImpl bdb_options;
+  bdb_options.ttl_range_secs = 1000;
+  bdb_options.blob_file_size = 1 << 28;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options, options);
+  mock_env_->set_now_micros(50 * 1000000);
+  for (size_t i = 0; i < 100; i++) {
+    PutRandom("key" + ToString(i), &rnd);
+  }
+  mock_env_->set_now_micros(100 * 1000000);
+  auto *bdb_impl = static_cast<BlobDBImpl *>(blob_db_);
+  auto blob_files = bdb_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  ASSERT_TRUE(blob_files[0]->HasTTL());
+  bdb_impl->TEST_CloseBlobFile(blob_files[0]);
+  GCStats gc_stats;
+  ASSERT_OK(bdb_impl->TEST_GCFileAndUpdateLSM(blob_files[0], &gc_stats));
+  auto& data = static_cast<TestTTLExtractor *>(ttl_extractor_.get())->data;
+  ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
+  ASSERT_EQ(data.size(), gc_stats.num_relocs);
   VerifyDB(data);
 }
 

--- a/utilities/blob_db/blob_log_format.h
+++ b/utilities/blob_db/blob_log_format.h
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -228,6 +229,10 @@ class BlobLogRecord {
   uint32_t GetKeySize() const { return key_size_; }
 
   uint64_t GetBlobSize() const { return blob_size_; }
+
+  bool HasTTL() const {
+    return ttl_val_ != std::numeric_limits<uint32_t>::max();
+  }
 
   uint32_t GetTTL() const { return ttl_val_; }
 

--- a/utilities/blob_db/ttl_extractor.cc
+++ b/utilities/blob_db/ttl_extractor.cc
@@ -27,6 +27,7 @@ bool TTLExtractor::ExtractExpiration(const Slice& key, const Slice& value,
   return has_ttl;
 }
 
+namespace {
 class DefaultTTLExtractor : public TTLExtractor {
  public:
   const Slice kTTLSuffix = Slice("ttl:");
@@ -46,6 +47,7 @@ class DefaultTTLExtractor : public TTLExtractor {
     return true;
   }
 };
+}  // anonymous namespace
 
 std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor() {
   return std::make_shared<DefaultTTLExtractor>();

--- a/utilities/blob_db/ttl_extractor.cc
+++ b/utilities/blob_db/ttl_extractor.cc
@@ -1,0 +1,55 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#include "ttl_extractor.h"
+
+#include "util/coding.h"
+
+namespace rocksdb {
+namespace blob_db {
+
+bool TTLExtractor::ExtractTTL(const Slice& /*key*/, const Slice& /*value*/,
+                              uint32_t* /*ttl*/, std::string* /*new_value*/,
+                              bool* /*value_changed*/) {
+  return false;
+}
+
+bool TTLExtractor::ExtractExpiration(const Slice& key, const Slice& value,
+                                     uint64_t now, uint64_t* expiration,
+                                     std::string* new_value,
+                                     bool* value_changed) {
+  uint32_t ttl;
+  bool has_ttl = ExtractTTL(key, value, &ttl, new_value, value_changed);
+  if (has_ttl) {
+    *expiration = now + ttl;
+  }
+  return true;
+}
+
+class DefaultTTLExtractor : public TTLExtractor {
+ public:
+  const Slice kTTLSuffix = Slice("ttl:");
+
+  bool ExtractTTL(const Slice& /*key*/, const Slice& value, uint32_t* ttl,
+                  std::string* new_value, bool* value_changed) override {
+    if (value.size() < 8) {
+      return false;
+    }
+    const char* p = value.data() + value.size() - 8;
+    if (kTTLSuffix != Slice(p, 4)) {
+      return false;
+    }
+    *ttl = DecodeFixed32(p + 4);
+    *new_value = Slice(value.data(), value.size() - 8).ToString();
+    *value_changed = true;
+    return true;
+  }
+};
+
+std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor() {
+  return std::make_shared<DefaultTTLExtractor>();
+}
+
+}  // namespace blob_db
+}  // namespace rocksdb

--- a/utilities/blob_db/ttl_extractor.cc
+++ b/utilities/blob_db/ttl_extractor.cc
@@ -27,31 +27,5 @@ bool TTLExtractor::ExtractExpiration(const Slice& key, const Slice& value,
   return has_ttl;
 }
 
-namespace {
-class DefaultTTLExtractor : public TTLExtractor {
- public:
-  const Slice kTTLSuffix = Slice("ttl:");
-
-  bool ExtractTTL(const Slice& /*key*/, const Slice& value, uint64_t* ttl,
-                  std::string* new_value, bool* value_changed) override {
-    if (value.size() < 12) {
-      return false;
-    }
-    const char* p = value.data() + value.size() - 12;
-    if (kTTLSuffix != Slice(p, 4)) {
-      return false;
-    }
-    *ttl = DecodeFixed64(p + 4);
-    *new_value = Slice(value.data(), value.size() - 12).ToString();
-    *value_changed = true;
-    return true;
-  }
-};
-}  // anonymous namespace
-
-std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor() {
-  return std::make_shared<DefaultTTLExtractor>();
-}
-
 }  // namespace blob_db
 }  // namespace rocksdb

--- a/utilities/blob_db/ttl_extractor.cc
+++ b/utilities/blob_db/ttl_extractor.cc
@@ -10,7 +10,7 @@ namespace rocksdb {
 namespace blob_db {
 
 bool TTLExtractor::ExtractTTL(const Slice& /*key*/, const Slice& /*value*/,
-                              uint32_t* /*ttl*/, std::string* /*new_value*/,
+                              uint64_t* /*ttl*/, std::string* /*new_value*/,
                               bool* /*value_changed*/) {
   return false;
 }
@@ -19,7 +19,7 @@ bool TTLExtractor::ExtractExpiration(const Slice& key, const Slice& value,
                                      uint64_t now, uint64_t* expiration,
                                      std::string* new_value,
                                      bool* value_changed) {
-  uint32_t ttl;
+  uint64_t ttl;
   bool has_ttl = ExtractTTL(key, value, &ttl, new_value, value_changed);
   if (has_ttl) {
     *expiration = now + ttl;
@@ -31,17 +31,17 @@ class DefaultTTLExtractor : public TTLExtractor {
  public:
   const Slice kTTLSuffix = Slice("ttl:");
 
-  bool ExtractTTL(const Slice& /*key*/, const Slice& value, uint32_t* ttl,
+  bool ExtractTTL(const Slice& /*key*/, const Slice& value, uint64_t* ttl,
                   std::string* new_value, bool* value_changed) override {
-    if (value.size() < 8) {
+    if (value.size() < 12) {
       return false;
     }
-    const char* p = value.data() + value.size() - 8;
+    const char* p = value.data() + value.size() - 12;
     if (kTTLSuffix != Slice(p, 4)) {
       return false;
     }
-    *ttl = DecodeFixed32(p + 4);
-    *new_value = Slice(value.data(), value.size() - 8).ToString();
+    *ttl = DecodeFixed64(p + 4);
+    *new_value = Slice(value.data(), value.size() - 12).ToString();
     *value_changed = true;
     return true;
   }

--- a/utilities/blob_db/ttl_extractor.cc
+++ b/utilities/blob_db/ttl_extractor.cc
@@ -24,7 +24,7 @@ bool TTLExtractor::ExtractExpiration(const Slice& key, const Slice& value,
   if (has_ttl) {
     *expiration = now + ttl;
   }
-  return true;
+  return has_ttl;
 }
 
 class DefaultTTLExtractor : public TTLExtractor {

--- a/utilities/blob_db/ttl_extractor.h
+++ b/utilities/blob_db/ttl_extractor.h
@@ -39,9 +39,5 @@ class TTLExtractor {
   virtual ~TTLExtractor() = default;
 };
 
-// Create a default TTLExtractor which extract TTL from value with suffix of
-// the form "ttl:" + <8 bytes ttl>.
-extern std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor();
-
 }  // namespace blob_db
 }  // namespace rocksdb

--- a/utilities/blob_db/ttl_extractor.h
+++ b/utilities/blob_db/ttl_extractor.h
@@ -1,0 +1,47 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "rocksdb/slice.h"
+
+namespace rocksdb {
+namespace blob_db {
+
+// TTLExtractor allow applications to extract TTL from key-value pairs.
+// This useful for applications using Put or WriteBatch to write keys and
+// don't intend to migrate to PutWithTTL or PutUntil.
+//
+// Applications can implement either ExtractTTL or ExtractExpiration. If both
+// are implemented, ExtractExpiration will take precedence.
+class TTLExtractor {
+ public:
+  // Extract TTL from key-value pair.
+  // Return true if the key has TTL, false otherwise. If key has TTL,
+  // TTL is pass back through ttl. The method can optionally modify the value,
+  // pass the result back through new_value, and also set value_changed to true.
+  virtual bool ExtractTTL(const Slice& key, const Slice& value, uint32_t* ttl,
+                          std::string* new_value, bool* value_changed);
+
+  // Extract expiration time from key-value pair.
+  // Return true if the key has expiration time, false otherwise. If key has
+  // expiration time, it is pass back through expiration. The method can
+  // optionally modify the value, pass the result back through new_value,
+  // and also set value_changed to true.
+  virtual bool ExtractExpiration(const Slice& key, const Slice& value,
+                                 uint64_t now, uint64_t* expiration,
+                                 std::string* new_value, bool* value_changed);
+
+  virtual ~TTLExtractor() = default;
+};
+
+// Create a default TTLExtractor which extract TTL from value with suffix of
+// the form "ttl:" + <4 bytes ttl>.
+extern std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor();
+
+}  // namespace blob_db
+}  // namespace rocksdb

--- a/utilities/blob_db/ttl_extractor.h
+++ b/utilities/blob_db/ttl_extractor.h
@@ -24,7 +24,7 @@ class TTLExtractor {
   // Return true if the key has TTL, false otherwise. If key has TTL,
   // TTL is pass back through ttl. The method can optionally modify the value,
   // pass the result back through new_value, and also set value_changed to true.
-  virtual bool ExtractTTL(const Slice& key, const Slice& value, uint32_t* ttl,
+  virtual bool ExtractTTL(const Slice& key, const Slice& value, uint64_t* ttl,
                           std::string* new_value, bool* value_changed);
 
   // Extract expiration time from key-value pair.
@@ -40,7 +40,7 @@ class TTLExtractor {
 };
 
 // Create a default TTLExtractor which extract TTL from value with suffix of
-// the form "ttl:" + <4 bytes ttl>.
+// the form "ttl:" + <8 bytes ttl>.
 extern std::shared_ptr<TTLExtractor> NewDefaultTTLExtractor();
 
 }  // namespace blob_db


### PR DESCRIPTION
Summary:
Introducing blob_db::TTLExtractor to replace extract_ttl_fn. The TTL
extractor can be use to extract TTL from keys insert with Put or
WriteBatch. Change over existing extract_ttl_fn are:
* If value is changed, it will be return via std::string* (rather than Slice*). With Slice* the new value has to be part of the existing value. With std::string* the limitation is removed.
* It can optionally return TTL or expiration.

Other changes in this PR:
* replace `std::chrono::system_clock` with `Env::NowMicros` so that I can mock time in tests.
* add several TTL tests.
* other minor naming change.

Test Plan:
The new tests.