### PR TITLE
Preload l0 index partitions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+
+## 5.7.8 (08/14/2017)
 ### New Features
 * Add Iterator::Refresh(), which allows users to update the iterator state so that they can avoid some initialization costs of recreating iterators.
 * Replace dynamic_cast<> (except unit test) so people can choose to build with RTTI off. With make, release mode is by default built with -fno-rtti and debug mode is built without it. Users can override it by setting USE_RTTI=0 or 1.

--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define ROCKSDB_MAJOR 5
-#define ROCKSDB_MINOR 7
+#define ROCKSDB_MINOR 8
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -205,6 +205,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     index_block_->NewIterator(icomparator_, &biter, true);
     // Index partitions are assumed to be consecuitive. Prefetch them all.
     // Read the first block offset
+    biter.SeekToFirst();
     Slice input = biter.value();
     Status s = handle.DecodeFrom(&input);
     assert(s.ok());
@@ -261,7 +262,6 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
                                             handle, compression_dict, &block,
                                             is_index);
 
-      // Didn't get any data from block caches.
       if (s.ok() && block.value != nullptr) {
         assert(block.cache_handle != nullptr);
         if (pin) {
@@ -271,8 +271,6 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
           block_cache->Release(block.cache_handle);
         }
       }
-      assert(block.value == nullptr);
-      assert(block.cache_handle == nullptr);
     }
   }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1502,13 +1502,8 @@ BlockBasedTable::BlockEntryIteratorState::NewSecondaryIterator(
   if (block_map_) {
     auto block = block_map_->find(handle.offset());
     assert(block != block_map_->end());
-    if (LIKELY(block != block_map_->end())) {
-      return block->second.value->NewIterator(
-          &rep->internal_comparator, nullptr, true, rep->ioptions.statistics);
-    }
-    ROCKS_LOG_ERROR(rep->ioptions.info_log,
-                    "The block is not found in the provided block map; moving "
-                    "on to search from the block cache");
+    return block->second.value->NewIterator(&rep->internal_comparator, nullptr,
+                                            true, rep->ioptions.statistics);
   }
   return NewDataBlockIterator(rep, read_options_, handle, nullptr, is_index_,
                               s);

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -181,7 +181,7 @@ class BlockBasedTable : public TableReader {
     // that was allocated in block cache.
     virtual size_t ApproximateMemoryUsage() const = 0;
 
-    virtual void CacheDependencies(bool pin){};
+    virtual void CacheDependencies(bool /* unused */){};
 
    protected:
     const InternalKeyComparator* icomparator_;

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -229,7 +229,8 @@ class BlockBasedTable : public TableReader {
   // @param block_entry value is set to the uncompressed block if found. If
   //    in uncompressed block cache, also sets cache_handle to reference that
   //    block.
-  static Status MaybeLoadDataBlockToCache(Rep* rep, const ReadOptions& ro,
+  static Status MaybeLoadDataBlockToCache(FilePrefetchBuffer* prefetch_buffer,
+                                          Rep* rep, const ReadOptions& ro,
                                           const BlockHandle& handle,
                                           Slice compression_dict,
                                           CachableEntry<Block>* block_entry,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -181,7 +181,7 @@ class BlockBasedTable : public TableReader {
     // that was allocated in block cache.
     virtual size_t ApproximateMemoryUsage() const = 0;
 
-    virtual void CacheDependencies(bool /* unused */){};
+    virtual void CacheDependencies(bool /* unused */) {}
 
    protected:
     const InternalKeyComparator* icomparator_;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2174,7 +2174,7 @@ std::map<std::string, size_t> MockCache::marked_data_in_cache_;
 
 // Block cache can contain raw data blocks as well as general objects. If an
 // object depends on the table to be live, it then must be destructed before the
-// table is closed. This test makese sure that the only items remains in the
+// table is closed. This test makes sure that the only items remains in the
 // cache after the table is closed are raw data blocks.
 TEST_F(BlockBasedTableTest, NoObjectInCacheAfterTableClose) {
   for (auto index_type :


### PR DESCRIPTION
This fixes the existing logic for pinning l0 index partitions. The patch preloads the partitions into block cache and pin them if they belong to level 0 and pin_l0 is set.

The drawback is that it does many small IOs when preloading all the partitions into the cache is direct io is enabled. Working for a solution for that.