### PR TITLE
Fix license headers in Cassandra related files

### DIFF
--- a/include/rocksdb/utilities/debug.h
+++ b/include/rocksdb/utilities/debug.h
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 #pragma once
 

--- a/java/rocksjni/cassandra_value_operator.cc
+++ b/java/rocksjni/cassandra_value_operator.cc
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/CassandraCompactionFilter.java
@@ -1,7 +1,7 @@
-// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
-// This source code is licensed under the BSD-style license found in the
-// LICENSE file in the root directory of this source tree. An additional grant
-// of patent rights can be found in the PATENTS file in the same directory.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 
 package org.rocksdb;
 

--- a/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
+++ b/java/src/main/java/org/rocksdb/CassandraValueMergeOperator.java
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 package org.rocksdb;
 

--- a/utilities/cassandra/merge_operator.cc
+++ b/utilities/cassandra/merge_operator.cc
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 #include "merge_operator.h"
 

--- a/utilities/cassandra/merge_operator.h
+++ b/utilities/cassandra/merge_operator.h
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 #pragma once
 #include "rocksdb/merge_operator.h"

--- a/utilities/cassandra/serialize.h
+++ b/utilities/cassandra/serialize.h
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 /**
  * Helper functions which serialize and deserialize integers

--- a/utilities/cassandra/test_utils.cc
+++ b/utilities/cassandra/test_utils.cc
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
-// This source code is licensed under the BSD-style license found in the
-// LICENSE file in the root directory of this source tree. An additional grant
-// of patent rights can be found in the PATENTS file in the same directory.
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
 
 #include "test_utils.h"
 

--- a/utilities/cassandra/test_utils.h
+++ b/utilities/cassandra/test_utils.h
@@ -1,9 +1,7 @@
-// Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-// This source code is also licensed under the GPLv2 license found in the
-// COPYING file in the root directory of this source tree.
 
 #pragma once
 #include <memory>


### PR DESCRIPTION
I might have missed these while doing some recent cassandra code reviews. 

Test Plan:
Make sure that there are no other files returned with:
grep -R PATENT *
grep -R "under the GPLv2" *