### PR TITLE
Add prefetch buffer to RandomAccessFileReader

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -536,6 +536,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   Footer footer;
 
   // Before read footer, readahead backwards to prefetch data
+  file->MarkForMutualAccess();
   Status s =
       file->Prefetch((file_size < 512 * 1024 ? 0 : file_size - 512 * 1024),
                      512 * 1024 /* 512 KB prefetching */);
@@ -579,6 +580,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   std::unique_ptr<InternalIterator> meta_iter;
   s = ReadMetaBlock(rep, &meta, &meta_iter);
   if (!s.ok()) {
+    rep->file->MarkForConcurrentAccess();
     return s;
   }
 
@@ -776,6 +778,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
     *table_reader = std::move(new_table);
   }
 
+  rep->file->MarkForConcurrentAccess();
   return s;
 }
 

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -145,6 +145,7 @@ class RandomAccessFileReader {
     mutual_access_ = true;
     prefetch_buffer_ =
         std::move(unique_ptr<AlignedBuffer>(new AlignedBuffer()));
+    prefetch_buffer_->Alignment(alignment_);
   }
 
   // This is to be used right before the pointer is shared for concurrent

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -64,11 +64,22 @@ class RandomAccessFileReader {
   HistogramImpl*  file_read_hist_;
   RateLimiter* rate_limiter_;
   bool for_compaction_;
+  size_t alignment_;
+  // Whether the pointer is accessed by only one thread.
+  bool mutual_access_;
+  // The buffer to be used for prefetch when direct_io is set. The buffer is not
+  // thread safe and thus has to be disabled when mutual_access_ is unset.
+  mutable unique_ptr<AlignedBuffer> prefetch_buffer_;
+  mutable uint64_t buffer_offset_;
+  mutable size_t buffer_len_;
+
+  Status ReadIntoPrefetchBuffer(uint64_t offset, size_t n) const;
+  bool TryReadFromPrefetchBuffer(uint64_t offset, size_t n,
+                                 char* scratch) const;
 
  public:
   explicit RandomAccessFileReader(std::unique_ptr<RandomAccessFile>&& raf,
-                                  std::string _file_name,
-                                  Env* env = nullptr,
+                                  std::string _file_name, Env* env = nullptr,
                                   Statistics* stats = nullptr,
                                   uint32_t hist_type = 0,
                                   HistogramImpl* file_read_hist = nullptr,
@@ -81,7 +92,11 @@ class RandomAccessFileReader {
         hist_type_(hist_type),
         file_read_hist_(file_read_hist),
         rate_limiter_(rate_limiter),
-        for_compaction_(for_compaction) {}
+        for_compaction_(for_compaction),
+        alignment_(file_->GetRequiredBufferAlignment()),
+        mutual_access_(false),
+        buffer_offset_(0),
+        buffer_len_(0) {}
 
   RandomAccessFileReader(RandomAccessFileReader&& o) ROCKSDB_NOEXCEPT {
     *this = std::move(o);
@@ -96,6 +111,11 @@ class RandomAccessFileReader {
     file_read_hist_ = std::move(o.file_read_hist_);
     rate_limiter_ = std::move(o.rate_limiter_);
     for_compaction_ = std::move(o.for_compaction_);
+    alignment_ = std::move(o.alignment_);
+    mutual_access_ = std::move(o.mutual_access_);
+    prefetch_buffer_ = std::move(o.prefetch_buffer_);
+    buffer_offset_ = std::move(o.buffer_offset_);
+    buffer_len_ = std::move(o.buffer_len_);
     return *this;
   }
 
@@ -105,7 +125,34 @@ class RandomAccessFileReader {
   Status Read(uint64_t offset, size_t n, Slice* result, char* scratch) const;
 
   Status Prefetch(uint64_t offset, size_t n) const {
-    return file_->Prefetch(offset, n);
+    if (mutual_access_ && use_direct_io()) {
+      size_t prefetch_offset = TruncateToPageBoundary(alignment_, offset);
+      if (offset >= buffer_offset_ &&
+          offset + n <= buffer_offset_ + buffer_len_) {
+        return Status::OK();
+      }
+      return ReadIntoPrefetchBuffer(
+          prefetch_offset, Roundup(offset + n, alignment_) - prefetch_offset);
+    } else {
+      return file_->Prefetch(offset, n);
+    }
+  }
+
+  // This is to be used when the pointer is not yet shared for concurrent
+  // access. In mutual access mode certain optimizations are feasible, which
+  // will be disabled when concurrent mode is active.
+  void MarkForMutualAccess() {
+    mutual_access_ = true;
+    prefetch_buffer_ =
+        std::move(unique_ptr<AlignedBuffer>(new AlignedBuffer()));
+  }
+
+  // This is to be used right before the pointer is shared for concurrent
+  // access. In concurrent access mode certain optimizations that are not safe
+  // will be disabled.
+  void MarkForConcurrentAccess() {
+    mutual_access_ = false;
+    prefetch_buffer_.reset();
   }
 
   RandomAccessFile* file() { return file_.get(); }

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -311,6 +311,133 @@ INSTANTIATE_TEST_CASE_P(
     NExceedReadaheadTest, ReadaheadRandomAccessFileTest,
     ::testing::ValuesIn(ReadaheadRandomAccessFileTest::GetReadaheadSizeList()));
 
+class RandomAccessFileReaderTest
+    : public testing::Test,
+      public testing::WithParamInterface<std::tuple<size_t, bool, bool, bool>> {
+ public:
+  static std::vector<size_t> GetFileSizeList() {
+    auto alignment = kDefaultPageSize;
+    return {100, 100 + alignment, 100 + 2 * alignment};
+  }
+  virtual void SetUp() override {
+    file_size_ = std::get<0>(GetParam());
+    scratch_.reset(new char[file_size_]);
+    auto direct_io = std::get<3>(GetParam());
+    ResetSourceStr(direct_io);
+    bool mutual_before = std::get<1>(GetParam());
+    if (mutual_before) {
+      reader_->MarkForMutualAccess();
+    }
+    parallel_after_ = std::get<2>(GetParam());
+  }
+  RandomAccessFileReaderTest() : control_contents_() {}
+  std::string Read(uint64_t offset, size_t n) {
+    Slice result;
+    reader_->Read(offset, n, &result, scratch_.get());
+    return std::string(result.data(), result.size());
+  }
+  void Prefetch(uint64_t offset, size_t n) { reader_->Prefetch(offset, n); }
+  size_t GetFileSize() const { return file_size_; }
+  const std::string& GetSrcStr() const { return src_str_; }
+  bool parallel_after_;
+  std::unique_ptr<RandomAccessFileReader> reader_;
+
+ private:
+  void ResetSourceStr(bool direct_io) {
+    Random rng(file_size_);
+    src_str_ =
+        test::RandomHumanReadableString(&rng, static_cast<int>(file_size_));
+    auto write_holder = std::unique_ptr<WritableFileWriter>(
+        test::GetWritableFileWriter(new test::StringSink(&control_contents_)));
+    write_holder->Append(Slice(src_str_));
+    write_holder->Flush();
+    auto file = new test::StringSource(control_contents_, 0, false, direct_io);
+    reader_ = std::unique_ptr<RandomAccessFileReader>(
+        GetRandomAccessFileReader(file));
+  }
+
+  size_t file_size_;
+  Slice control_contents_;
+  std::unique_ptr<char[]> scratch_;
+  std::string src_str_;
+};
+
+TEST_P(RandomAccessFileReaderTest, ReadTest) {
+  if (parallel_after_) {
+    reader_->MarkForConcurrentAccess();
+  }
+  const std::string& src = GetSrcStr();
+  int fsize = GetFileSize();
+  for (int p : {0, 10, fsize / 2, fsize / 2 + 10, fsize - 10}) {
+    for (int l : {10, fsize}) {
+      ASSERT_EQ(src.substr(p, l), Read(p, l));
+    }
+  }
+}
+
+TEST_P(RandomAccessFileReaderTest, ReadWithinPrefetchTest) {
+  const std::string& src = GetSrcStr();
+  int fsize = GetFileSize();
+  for (int p : {0, 10, fsize / 2, fsize / 2 + 10, fsize - 10}) {
+    for (int l : {10, fsize}) {
+      Prefetch(p, l);
+      if (parallel_after_) {
+        reader_->MarkForConcurrentAccess();
+      }
+      ASSERT_EQ(src.substr(p, l), Read(p, l));
+      ASSERT_EQ(src.substr(p + 1, l - 2), Read(p + 1, l - 2));
+    }
+  }
+}
+
+TEST_P(RandomAccessFileReaderTest, ReadOutsidePrefetchTest) {
+  const std::string& src = GetSrcStr();
+  int fsize = GetFileSize();
+  for (int p : {0, 10, fsize / 2, fsize / 2 + 10, fsize - 10}) {
+    for (int l : {10, fsize}) {
+      Prefetch(p, l);
+      if (parallel_after_) {
+        reader_->MarkForConcurrentAccess();
+      }
+      if (p + l + 1 < fsize) {
+        ASSERT_EQ(src.substr(p + l + 1, 1), Read(p + l + 1, 1));
+      }
+      if (p - 2 >= 0) {
+        ASSERT_EQ(src.substr(p - 2, 1), Read(p - 2, 1));
+      }
+    }
+  }
+}
+
+static const bool ps = kDefaultPageSize;
+static const bool dio = true;
+INSTANTIATE_TEST_CASE_P(
+    RandomAccessFileReaderTest, RandomAccessFileReaderTest,
+    ::testing::Values(std::make_tuple(100, false, false, dio),
+                      std::make_tuple(100 + ps, false, false, dio),
+                      std::make_tuple(100 + 2 * ps, false, false, dio),
+                      std::make_tuple(100, false, true, dio),
+                      std::make_tuple(100 + ps, false, true, dio),
+                      std::make_tuple(100 + 2 * ps, false, true, dio),
+                      std::make_tuple(100, true, true, dio),
+                      std::make_tuple(100 + ps, true, true, dio),
+                      std::make_tuple(100 + 2 * ps, true, true, dio),
+                      std::make_tuple(100, true, false, dio),
+                      std::make_tuple(100 + ps, true, false, dio),
+                      std::make_tuple(100 + 2 * ps, true, false, dio),
+                      std::make_tuple(100, false, false, !dio),
+                      std::make_tuple(100 + ps, false, false, !dio),
+                      std::make_tuple(100 + 2 * ps, false, false, !dio),
+                      std::make_tuple(100, false, true, !dio),
+                      std::make_tuple(100 + ps, false, true, !dio),
+                      std::make_tuple(100 + 2 * ps, false, true, !dio),
+                      std::make_tuple(100, true, true, !dio),
+                      std::make_tuple(100 + ps, true, true, !dio),
+                      std::make_tuple(100 + 2 * ps, true, true, !dio),
+                      std::make_tuple(100, true, false, !dio),
+                      std::make_tuple(100 + ps, true, false, !dio),
+                      std::make_tuple(100 + 2 * ps, true, false, !dio)));
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -323,13 +323,16 @@ class OverwritingStringSink : public WritableFile {
 class StringSource: public RandomAccessFile {
  public:
   explicit StringSource(const Slice& contents, uint64_t uniq_id = 0,
-                        bool mmap = false)
+                        bool mmap = false, bool direct_io = false)
       : contents_(contents.data(), contents.size()),
         uniq_id_(uniq_id),
         mmap_(mmap),
-        total_reads_(0) {}
+        total_reads_(0),
+        direct_io_(direct_io) {}
 
   virtual ~StringSource() { }
+
+  virtual bool use_direct_io() const { return direct_io_; }
 
   uint64_t Size() const { return contents_.size(); }
 
@@ -371,6 +374,7 @@ class StringSource: public RandomAccessFile {
   uint64_t uniq_id_;
   bool mmap_;
   mutable int total_reads_;
+  const bool direct_io_;
 };
 
 class NullLogger : public Logger {


### PR DESCRIPTION
The prefetch buffer will be used with direct io so that reading sequential metadata does not cause many small IOs. Currently prefetch is disabled with direct io. It is enabled in ReadaheadRandomAccessFile but due to thread safety concerns, this augmented RandomAccessFile is not in table cache to be used for normal file reads.

The prefetch buffer is not thread-safe and meant to be only be used during initialization phase when only one thread is reading some metadata. It is created explicitly upon request and must be deleted explicitly before the pointer is shared with other threads.

The current impl is very simple, limiting the buffer to only prefetched data. and not that of normal reads. This simple impl is sufficient for metadata reads. If this buffer meant to replace ReadaheadRandomAccessFile, we can improve it to also cache the reads.

The current impl has the problem of double buffering if the underlying RandomAccessFile also caches the read data, like in ReadaheadRandomAccessFile. However this problem should not cause much trouble since the prefetch buffer is only used during the short time of initialization. We can still avoid double buffering by adding an API for RandomAccessFile that tells whether its impl does any kind of buffering.