### PR TITLE
ConcurrentArena to use smaller local buffer if write buffer manager s…

### DIFF
--- a/util/concurrent_arena.h
+++ b/util/concurrent_arena.h
@@ -102,9 +102,10 @@ class ConcurrentArena : public Allocator {
 
   char padding0[56] ROCKSDB_FIELD_UNUSED;
 
+  CoreLocalArray<Shard> shards_;
+
   size_t shard_block_size_;
 
-  CoreLocalArray<Shard> shards_;
 
   Arena arena_;
   mutable SpinMutex arena_mutex_;


### PR DESCRIPTION
…hows up

Summary: WriteBufferManager will trigger flush as soon as allocated arena blocks reaches a limit. Currently, every CPU shard allocates 1/8 of the arena block size. If there are 32 processors with arena block size 8MB, very soon it accumulates to 64MB without much data inserted. If the budget per DB/DCF is around 32MB, then we'll keep trigger flushes all the time, even if the data is small. To work it around, if WriteBufferManager is given, concurrent arena will allocate smaller chunks.

Didn't change the case if WriteBufferManager is not given for the concern of performance regression.