### PR TITLE
Fix statistics in RocksJava sample

### DIFF
--- a/java/samples/src/main/java/RocksDBSample.java
+++ b/java/samples/src/main/java/RocksDBSample.java
@@ -31,6 +31,7 @@ public class RocksDBSample {
          final Filter bloomFilter = new BloomFilter(10);
          final ReadOptions readOptions = new ReadOptions()
              .setFillCache(false);
+         final Statistics stats = new Statistics();
          final RateLimiter rateLimiter = new RateLimiter(10000000,10000, 10)) {
 
       try (final RocksDB db = RocksDB.open(options, db_path_not_found)) {
@@ -41,7 +42,7 @@ public class RocksDBSample {
 
       try {
         options.setCreateIfMissing(true)
-            .createStatistics()
+            .setStatistics(stats)
             .setWriteBufferSize(8 * SizeUnit.KB)
             .setMaxWriteBufferNumber(3)
             .setMaxBackgroundCompactions(10)
@@ -50,8 +51,6 @@ public class RocksDBSample {
       } catch (final IllegalArgumentException e) {
         assert (false);
       }
-
-      final Statistics stats = options.statisticsPtr();
 
       assert (options.createIfMissing() == true);
       assert (options.writeBufferSize() == 8 * SizeUnit.KB);
@@ -221,7 +220,9 @@ public class RocksDBSample {
 
         try {
           for (final TickerType statsType : TickerType.values()) {
-            stats.getTickerCount(statsType);
+            if (statsType != TickerType.TICKER_ENUM_MAX) {
+              stats.getTickerCount(statsType);
+            }
           }
           System.out.println("getTickerCount() passed.");
         } catch (final Exception e) {
@@ -231,7 +232,9 @@ public class RocksDBSample {
 
         try {
           for (final HistogramType histogramType : HistogramType.values()) {
-            HistogramData data = stats.getHistogramData(histogramType);
+            if (histogramType != HistogramType.HISTOGRAM_ENUM_MAX) {
+              HistogramData data = stats.getHistogramData(histogramType);
+            }
           }
           System.out.println("getHistogramData() passed.");
         } catch (final Exception e) {


### PR DESCRIPTION
I observed while doing a `make jtest` that the java sample was broken, due to the changes in #2551 . 

Test Plan:
Before the fix:
```
cd rocksdb/java
make sample
javac -Xlint:deprecation -Xlint:unchecked -cp target/classes -d samples/target/classes samples/src/main/java/RocksDBSample.java
samples/src/main/java/RocksDBSample.java:44: error: cannot find symbol
            .createStatistics()
            ^
  symbol:   method createStatistics()
  location: class Options
samples/src/main/java/RocksDBSample.java:54: error: cannot find symbol
      final Statistics stats = options.statisticsPtr();
                                      ^
  symbol:   method statisticsPtr()
  location: variable options of type Options
samples/src/main/java/RocksDBSample.java:207: warning: [deprecation] remove(byte[]) in RocksDB has been deprecated
        db.remove(testKey);
          ^
2 errors
1 warning
make[1]: *** [sample] Error 1
```

After the fix:
No errors on doing a `make jtest` or `make sample`

