### PR TITLE
Optimize range-delete aggregator call in merge helper.

### DIFF
--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -201,12 +201,11 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
           ikey.sequence <= latest_snapshot_
               ? CompactionFilter::Decision::kKeep
               : FilterMerge(orig_ikey.user_key, value_slice);
-      if (range_del_agg != nullptr &&
-
+      if (filter != CompactionFilter::Decision::kRemoveAndSkipUntil &&
+          range_del_agg != nullptr &&
           range_del_agg->ShouldDelete(
               iter->key(),
-              RangeDelAggregator::RangePositioningMode::kForwardTraversal) &&
-          filter != CompactionFilter::Decision::kRemoveAndSkipUntil) {
+              RangeDelAggregator::RangePositioningMode::kForwardTraversal)) {
         filter = CompactionFilter::Decision::kRemove;
       }
       if (filter == CompactionFilter::Decision::kKeep ||


### PR DESCRIPTION
In the condition:
```
if (range_del_agg != nullptr &&
    range_del_agg->ShouldDelete(
        iter->key(),
        RangeDelAggregator::RangePositioningMode::kForwardTraversal) &&
    filter != CompactionFilter::Decision::kRemoveAndSkipUntil) {
...
}
```
it could be possible that all the work done in `range_del_agg->ShouldDelete` is wasted due to not having the right `filter` value later on. 
Instead, check `filter` value before even calling `range_del_agg->ShouldDelete`, which is a much more involved function.

Test Plan:
`make check`.