### PR TITLE
refactor universal size-amp picking

### DIFF
--- a/db/compaction_picker_universal.cc
+++ b/db/compaction_picker_universal.cc
@@ -619,11 +619,12 @@ Compaction* UniversalCompactionPicker::PickCompactionToReduceSizeAmp(
     const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
     VersionStorageInfo* vstorage, double score,
     const std::vector<SortedRun>& sorted_runs, LogBuffer* log_buffer) {
+  assert(!sorted_runs.empty());
   // percentage flexibility while reducing size amplification
   uint64_t ratio =
       ioptions_.compaction_options_universal.max_size_amplification_percent;
   uint64_t candidate_size = 0;
-  uint64_t estimated_total_size = 0;
+  uint64_t estimated_total_size = sorted_runs.back().size;
   size_t start_index = sorted_runs.size() - 1;
   // Get longest span of available sorted runs ending at last
   while (start_index > 0) {


### PR DESCRIPTION
There were three loops over `sorted_runs` where only one is needed. We just need to iterate backwards over the vector instead of forwards since we're looking for a span of sorted runs including the final element.

Also I am experimenting with some changes to size-amp compaction that depend on this change.

Test Plan: unit tests