### PR TITLE
Makefile: correct faligned-new test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,17 +259,10 @@ default: all
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
   -Wno-unused-parameter
 
-CCVERSION = $(shell $(CXX) -dumpversion)
-CCNAME = $(shell $(CXX) --version | awk 'NR==1' | cut -f1 -d " ")
+CCFALIGNED := $(shell $(CXX) --version | awk 'NR==1 { split($$3, ver, "."); if (($$1 == "clang" && ver[1] >= 4) || ($$2 == "(GCC)" && ver[1] >= 7)) { print "yes" } }')
 
-ifeq ($(CCNAME), clang)
-ifeq ($(CCVERSION), 4*)
+ifeq ($(CCFALIGNED), yes)
 	CXXFLAGS += -faligned-new
-endif
-else
-ifeq ($(CCVERSION), 7)
-	CXXFLAGS += -faligned-new
-endif
 endif
 
 ifndef DISABLE_WARNING_AS_ERROR


### PR DESCRIPTION
Commit 4f81ab38bf18aacdc5f2e2f2a82cf577989ae39b has the test wrong.

clang doesn't support a -dumpversion option. By lucky coincidence
clang/gcc --version both place a version number at the same output location
when --verison is passed.

Example output (1st line only).

    $ clang --version
    clang version 3.9.1 (tags/RELEASE_391/final)

    $ gcc --version
    gcc (GCC) 6.4.1 20170727 (Red Hat 6.4.1-1)

During the test of the compiler we ensure that a minimum version is met
as Makefile doesn't support patterns.

Also xcode9 doesn't seem affected by https://github.com/facebook/rocksdb/issues/2672
and also doesn't have "clang" as the first part of its output so the
fix implemented here also is Apple clang friendly.

    $ clang --version
    Apple LLVM version 9.0.0 (clang-900.0.31)

Signed-off-by: Daniel Black <daniel.black@au.ibm.com>