### PR TITLE
gcc-7/i386: markup intentional fallthroughs

### DIFF
--- a/util/murmurhash.cc
+++ b/util/murmurhash.cc
@@ -113,8 +113,8 @@ unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed )
 
     switch(len)
     {
-    case 3: h ^= data[2] << 16;
-    case 2: h ^= data[1] << 8;
+    case 3: h ^= data[2] << 16; // fallthrough
+    case 2: h ^= data[1] << 8; // fallthrough
     case 1: h ^= data[0];
         h *= m;
     };


### PR DESCRIPTION
Markup i386 code paths resolving compilation
failure under i386 with gcc-7.

Signed-off-by: James Page <james.page@ubuntu.com>