### PR TITLE
Windows.h macro call fix

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -793,7 +793,7 @@ enum InfoLogLevel : unsigned char {
 // An interface for writing log messages.
 class Logger {
  public:
-  size_t kDoNotSupportGetLogFileSize = std::numeric_limits<size_t>::max();
+  size_t kDoNotSupportGetLogFileSize = (std::numeric_limits<size_t>::max)();
 
   explicit Logger(const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
       : log_level_(log_level) {}


### PR DESCRIPTION
- moved the max call for numeric limits into paranthesis so that max wont be called as macro when including <Windows.h>