### PR TITLE
Remove residual arcanist_util directory

### DIFF
--- a/arcanist_util/INTERNAL_ONLY_DIR
+++ b/arcanist_util/INTERNAL_ONLY_DIR
@@ -1,2 +1,0 @@
-arcanist_util are only used internaly, If you want to change it please check
-<internal_rocksdb_repo>/arcanist_util


### PR DESCRIPTION
Summary:
The only file under the directory RocksDBCommonHelper.php have been moved to build_tools/. Removing the directory.

Test Plan:
N/A