### PR TITLE
expose set_skip_stats_update_on_db_open to C bindings

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2102,6 +2102,10 @@ void rocksdb_options_enable_statistics(rocksdb_options_t* opt) {
   opt->rep.statistics = rocksdb::CreateDBStatistics();
 }
 
+void rocksdb_options_set_skip_stats_update_on_db_open(rocksdb_options_t* opt, unsigned char val) {
+	opt->rep.skip_stats_update_on_db_open = val;
+}
+
 void rocksdb_options_set_num_levels(rocksdb_options_t* opt, int n) {
   opt->rep.num_levels = n;
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -2103,7 +2103,7 @@ void rocksdb_options_enable_statistics(rocksdb_options_t* opt) {
 }
 
 void rocksdb_options_set_skip_stats_update_on_db_open(rocksdb_options_t* opt, unsigned char val) {
-	opt->rep.skip_stats_update_on_db_open = val;
+  opt->rep.skip_stats_update_on_db_open = val;
 }
 
 void rocksdb_options_set_num_levels(rocksdb_options_t* opt, int n) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -762,7 +762,9 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_max_bytes_for_level_multiplier_additional(
     rocksdb_options_t*, int* level_values, size_t num_levels);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_enable_statistics(
-    rocksdb_options_t*);
+    rocksdb_options_t*);	
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_skip_stats_update_on_db_open(
+	rocksdb_options_t* opt, unsigned char val);
 
 /* returns a pointer to a malloc()-ed, null terminated string */
 extern ROCKSDB_LIBRARY_API char* rocksdb_options_statistics_get_string(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -762,7 +762,7 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_max_bytes_for_level_multiplier_additional(
     rocksdb_options_t*, int* level_values, size_t num_levels);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_enable_statistics(
-    rocksdb_options_t*);	
+    rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_skip_stats_update_on_db_open(
     rocksdb_options_t* opt, unsigned char val);
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -764,7 +764,7 @@ rocksdb_options_set_max_bytes_for_level_multiplier_additional(
 extern ROCKSDB_LIBRARY_API void rocksdb_options_enable_statistics(
     rocksdb_options_t*);	
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_skip_stats_update_on_db_open(
-	rocksdb_options_t* opt, unsigned char val);
+    rocksdb_options_t* opt, unsigned char val);
 
 /* returns a pointer to a malloc()-ed, null terminated string */
 extern ROCKSDB_LIBRARY_API char* rocksdb_options_statistics_get_string(


### PR DESCRIPTION
It would be super helpful to not have to recompile rocksdb to get this performance tweak for mechanical disks.

I have signed the CLA.