### PR TITLE
approximate histogram stats to save cpu

### DIFF
--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -105,7 +105,8 @@ void HistogramStat::Add(uint64_t value) {
   // by concurrent threads is tolerable.
   const size_t index = bucketMapper.IndexForValue(value);
   assert(index < num_buckets_);
-  buckets_[index].fetch_add(1, std::memory_order_relaxed);
+  buckets_[index].store(buckets_[index].load(std::memory_order_relaxed) + 1,
+                        std::memory_order_relaxed);
 
   uint64_t old_min = min();
   while (value < old_min && !min_.compare_exchange_weak(old_min, value)) {}
@@ -113,9 +114,13 @@ void HistogramStat::Add(uint64_t value) {
   uint64_t old_max = max();
   while (value > old_max && !max_.compare_exchange_weak(old_max, value)) {}
 
-  num_.fetch_add(1, std::memory_order_relaxed);
-  sum_.fetch_add(value, std::memory_order_relaxed);
-  sum_squares_.fetch_add(value * value, std::memory_order_relaxed);
+  num_.store(num_.load(std::memory_order_relaxed) + 1,
+             std::memory_order_relaxed);
+  sum_.store(sum_.load(std::memory_order_relaxed) + value,
+             std::memory_order_relaxed);
+  sum_squares_.store(
+      sum_squares_.load(std::memory_order_relaxed) + value * value,
+      std::memory_order_relaxed);
 }
 
 void HistogramStat::Merge(const HistogramStat& other) {

--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -109,10 +109,14 @@ void HistogramStat::Add(uint64_t value) {
                         std::memory_order_relaxed);
 
   uint64_t old_min = min();
-  while (value < old_min && !min_.compare_exchange_weak(old_min, value)) {}
+  if (value < old_min) {
+    min_.store(value, std::memory_order_relaxed);
+  }
 
   uint64_t old_max = max();
-  while (value > old_max && !max_.compare_exchange_weak(old_max, value)) {}
+  if (value > old_max) {
+    max_.store(value, std::memory_order_relaxed);
+  }
 
   num_.store(num_.load(std::memory_order_relaxed) + 1,
              std::memory_order_relaxed);


### PR DESCRIPTION
sounds like we're willing to tradeoff minor inaccuracy in stats for speed. start with histogram stats. ticker stats will be harder (and, IMO, we shouldn't change them in this manner) as many test cases rely on them being exactly correct.

Test Plan:

command:

```
TEST_TMPDIR=/dev/shm perf record -g ./db_bench -num=5000000 -benchmarks=readwhilewriting -threads=16 -statistics
```

before:

```
+    1.87%     1.86%  db_bench     db_bench             [.] rocksdb::HistogramStat::Add
```

after:

```
+    0.61%     0.61%  db_bench     db_bench             [.] rocksdb::HistogramStat::Add
```