### PR TITLE
Revert "Makefile: correct faligned-new test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,17 @@ default: all
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
   -Wno-unused-parameter
 
-CCFALIGNED := $(shell $(CXX) --version | awk 'NR==1 { split($$3, ver, "."); if (($$1 == "clang" && ver[1] >= 4) || ($$2 == "(GCC)" && ver[1] >= 7)) { print "yes" } }')
+CCVERSION = $(shell $(CXX) -dumpversion)
+CCNAME = $(shell $(CXX) --version | awk 'NR==1' | cut -f1 -d " ")
 
-ifeq ($(CCFALIGNED), yes)
+ifeq ($(CCNAME), clang)
+ifeq ($(CCVERSION), 4*)
 	CXXFLAGS += -faligned-new
+endif
+else
+ifeq ($(CCVERSION), 7)
+	CXXFLAGS += -faligned-new
+endif
 endif
 
 ifndef DISABLE_WARNING_AS_ERROR


### PR DESCRIPTION
Summary:
This reverting #2699 to fix clang build.

Test Plan:
build with clang 4.0.