### PR TITLE
fix corruption_test valgrind

### DIFF
--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -332,6 +332,7 @@ TEST_F(CorruptionTest, TableFileIndexData) {
   // corrupt an index block of an entire file
   Corrupt(kTableFile, -2000, 500);
   Reopen();
+  dbi = reinterpret_cast<DBImpl*>(db_);
   // one full file should be readable, since only one was corrupted
   // the other file should be fully non-readable, since index was corrupted
   Check(5000, 5000);


### PR DESCRIPTION
Test Plan:

```
/mnt/gvfs/third-party2/valgrind/d7f4d4d86674a57668e3a96f76f0e17dd0eb8765/3.11.0/gcc-5-glibc-2.23/9bc6787/bin/valgrind --error-exitcode=2 --leak-check=full ./corruption_test
```