### PR TITLE
Overload new[] to properly align LRUCacheShard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,19 +259,6 @@ default: all
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
   -Wno-unused-parameter
 
-CCVERSION = $(shell $(CXX) -dumpversion)
-CCNAME = $(shell $(CXX) --version | awk 'NR==1' | cut -f1 -d " ")
-
-ifeq ($(CCNAME), clang)
-ifeq ($(CCVERSION), 4*)
-	CXXFLAGS += -faligned-new
-endif
-else
-ifeq ($(CCVERSION), 7)
-	CXXFLAGS += -faligned-new
-endif
-endif
-
 ifndef DISABLE_WARNING_AS_ERROR
 	WARNING_FLAGS += -Werror
 endif

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -234,11 +234,19 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 }
 
 void* LRUCacheShard::operator new(size_t size) {
-  return rocksdb::port::cacheline_aligned_alloc(size);
+  return port::cacheline_aligned_alloc(size);
+}
+
+void* LRUCacheShard::operator new[](size_t size) {
+  return port::cacheline_aligned_alloc(size);
 }
 
 void LRUCacheShard::operator delete(void *memblock) {
-  rocksdb::port::cacheline_aligned_free(memblock);
+  port::cacheline_aligned_free(memblock);
+}
+
+void LRUCacheShard::operator delete[](void* memblock) {
+  port::cacheline_aligned_free(memblock);
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -205,7 +205,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   // Overloading to aligned it to cache line size
   void* operator new(size_t);
 
+  void* operator new[](size_t);
+
   void operator delete(void *);
+
+  void operator delete[](void*);
 
  private:
   void LRU_Remove(LRUHandle* e);


### PR DESCRIPTION
Summary:
#2620 add the facility to align LRUCacheShard to cache line size, but it failed to overload new[] and delete[] to make array allocation aligned. On initialize of LRUCache we use new[] to allocate an array of 2^num_shard_bits LRUCacheShard, which make the cache not aligned. Fixing it.

Also verify it fixes gcc7 compile failure #2672 (see also #2699)

Test Plan:
COMPILE_WITH_UBSAN=1 make db_block_cache_test && ./db_block_cache_test
See the following error disappears: "runtime error: member call on misaligned address 0x000004290f60 for type 'rocksdb::LRUCacheShard', which requires 64 byte alignment"

Verified gcc7 can compile.