### PR TITLE
Remove PartialMerge implementation from Cassandra merge operator

### DIFF
--- a/utilities/cassandra/merge_operator.cc
+++ b/utilities/cassandra/merge_operator.cc
@@ -47,27 +47,6 @@ bool CassandraValueMergeOperator::FullMergeV2(
   return true;
 }
 
-// Implementation for the merge operation (merges two Cassandra values)
-bool CassandraValueMergeOperator::PartialMerge(const Slice& key,
-                                               const Slice& left_operand,
-                                               const Slice& right_operand,
-                                               std::string* new_value,
-                                               Logger* logger) const {
-  // Clear the *new_value for writing.
-  assert(new_value);
-  new_value->clear();
-
-  std::vector<RowValue> row_values;
-  row_values.push_back(RowValue::Deserialize(left_operand.data(),
-                                             left_operand.size()));
-  row_values.push_back(RowValue::Deserialize(right_operand.data(),
-                                             right_operand.size()));
-  RowValue merged = RowValue::Merge(std::move(row_values));
-  new_value->reserve(merged.Size());
-  merged.Serialize(new_value);
-  return true;
-}
-
 bool CassandraValueMergeOperator::PartialMergeMulti(
     const Slice& key,
     const std::deque<Slice>& operand_list,

--- a/utilities/cassandra/merge_operator.h
+++ b/utilities/cassandra/merge_operator.h
@@ -20,12 +20,6 @@ public:
   virtual bool FullMergeV2(const MergeOperationInput& merge_in,
                            MergeOperationOutput* merge_out) const override;
 
-  virtual bool PartialMerge(const Slice& key,
-                            const Slice& left_operand,
-                            const Slice& right_operand,
-                            std::string* new_value,
-                            Logger* logger) const override;
-
   virtual bool PartialMergeMulti(const Slice& key,
                                  const std::deque<Slice>& operand_list,
                                  std::string* new_value,


### PR DESCRIPTION
`PartialMergeMulti` implementation is enough for Cassandra, and `PartialMerge` is not required. Implementing both will just duplicate the code. 
As per https://github.com/facebook/rocksdb/blob/master/include/rocksdb/merge_operator.h#L130-L135 :

```
  // The default implementation of PartialMergeMulti will use this function
  // as a helper, for backward compatibility.  Any successor class of
  // MergeOperator should either implement PartialMerge or PartialMergeMulti,
  // although implementing PartialMergeMulti is suggested as it is in general
  // more effective to merge multiple operands at a time instead of two
  // operands at a time.
```

Test Plan:
make check -- Run all unit tests. 