### PR TITLE
Fix missing stdlib include required for abort()

### DIFF
--- a/include/rocksdb/filter_policy.h
+++ b/include/rocksdb/filter_policy.h
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <stdlib.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
If ROCKSDB_LITE is defined, a call to abort() is introduced. This call requires stdlib.h.

Build log of unpatched 5.7.1:

http://beefy9.nyi.freebsd.org/data/110amd64-default/447974/logs/rocksdb-lite-5.7.1.log

Closes #2731 