### PR TITLE
Enable Cassandra merge operator to be called with a single merge operand

### DIFF
--- a/utilities/cassandra/merge_operator.h
+++ b/utilities/cassandra/merge_operator.h
@@ -26,6 +26,8 @@ public:
                                  Logger* logger) const override;
 
   virtual const char* Name() const override;
+
+  virtual bool AllowSingleOperand() const override { return true; }
 };
 } // namespace cassandra
 } // namespace rocksdb


### PR DESCRIPTION
Updating Cassandra merge operator to make use of a single merge operand when needed. Single merge operand support has been introduced in #2721.

Test Plan:
`make check`