### PR TITLE
Blob db create a snapshot before every read

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1081,7 +1081,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   SuperVersion* new_superversion = nullptr;
   const MutableCFOptions mutable_cf_options = *cfd->GetLatestMutableCFOptions();
 
-// Set memtable_info for memtable sealed callback
+  // Set memtable_info for memtable sealed callback
 #ifndef ROCKSDB_LITE
   MemTableInfo memtable_info;
   memtable_info.cf_name = cfd->GetName();

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1081,7 +1081,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   SuperVersion* new_superversion = nullptr;
   const MutableCFOptions mutable_cf_options = *cfd->GetLatestMutableCFOptions();
 
-  // Set memtable_info for memtable sealed callback
+// Set memtable_info for memtable sealed callback
 #ifndef ROCKSDB_LITE
   MemTableInfo memtable_info;
   memtable_info.cf_name = cfd->GetName();

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1123,11 +1123,7 @@ std::vector<Status> BlobDBImpl::MultiGet(
   // Get a snapshot to avoid blob file get deleted between we
   // fetch and index entry and reading from the file.
   ReadOptions ro(read_options);
-  const Snapshot* snapshot = nullptr;
-  if (ro.snapshot == nullptr) {
-    snapshot = db_->GetSnapshot();
-    ro.snapshot = snapshot;
-  }
+  bool snapshot_created = SetSnapshotIfNeeded(&ro);
   std::vector<std::string> values_lsm;
   values_lsm.resize(keys.size());
   auto statuses = db_->MultiGet(ro, column_family, keys, &values_lsm);
@@ -1146,10 +1142,19 @@ std::vector<Status> BlobDBImpl::MultiGet(
     Status s = CommonGet(cfd, keys[i], values_lsm[i], &((*values)[i]));
     statuses[i] = s;
   }
-  if (snapshot != nullptr) {
-    db_->ReleaseSnapshot(snapshot);
+  if (snapshot_created) {
+    db_->ReleaseSnapshot(ro.snapshot);
   }
   return statuses;
+}
+
+bool BlobDBImpl::SetSnapshotIfNeeded(ReadOptions* read_options) {
+  assert(read_options != nullptr);
+  if (read_options->snapshot != nullptr) {
+    return false;
+  }
+  read_options->snapshot = db_->GetSnapshot();
+  return true;
 }
 
 Status BlobDBImpl::CommonGet(const ColumnFamilyData* cfd, const Slice& key,
@@ -1295,11 +1300,7 @@ Status BlobDBImpl::Get(const ReadOptions& read_options,
   // fetch and index entry and reading from the file.
   // TODO(yiwu): For Get() retry if file not found would be a simpler strategy.
   ReadOptions ro(read_options);
-  const Snapshot* snapshot = nullptr;
-  if (ro.snapshot == nullptr) {
-    snapshot = db_->GetSnapshot();
-    ro.snapshot = snapshot;
-  }
+  bool snapshot_created = SetSnapshotIfNeeded(&ro);
 
   Status s;
   std::string index_entry;
@@ -1310,8 +1311,8 @@ Status BlobDBImpl::Get(const ReadOptions& read_options,
     s = CommonGet(cfd, key, index_entry, value->GetSelf());
     value->PinSelf();
   }
-  if (snapshot != nullptr) {
-    db_->ReleaseSnapshot(snapshot);
+  if (snapshot_created) {
+    db_->ReleaseSnapshot(ro.snapshot);
   }
   return s;
 }
@@ -2257,17 +2258,9 @@ Iterator* BlobDBImpl::NewIterator(const ReadOptions& read_options,
   // Get a snapshot to avoid blob file get deleted between we
   // fetch and index entry and reading from the file.
   ReadOptions ro(read_options);
-  bool own_snapshot = false;
-  const Snapshot* snapshot = nullptr;
-  if (ro.snapshot == nullptr) {
-    own_snapshot = true;
-    snapshot = db_->GetSnapshot();
-  } else {
-    snapshot = ro.snapshot;
-  }
-
+  bool snapshot_created = SetSnapshotIfNeeded(&ro);
   return new BlobDBIterator(db_->NewIterator(ro, column_family), column_family,
-                            this, own_snapshot, snapshot);
+                            this, snapshot_created, ro.snapshot);
 }
 
 Status DestroyBlobDB(const std::string& dbname, const Options& options,

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -2330,8 +2330,8 @@ std::vector<std::shared_ptr<BlobFile>> BlobDBImpl::TEST_GetObsoleteFiles()
   return obsolete_files;
 }
 
-void BlobDBImpl::TEST_DeleteObsoletedFiles() {
-  DeleteObsoletedFiles(false /*abort*/);
+void BlobDBImpl::TEST_DeleteObsoleteFiles() {
+  DeleteObsoleteFiles(false /*abort*/);
 }
 
 void BlobDBImpl::TEST_CloseBlobFile(std::shared_ptr<BlobFile>& bfile) {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -304,9 +304,9 @@ void BlobDBImpl::StartBackgroundTasks() {
   tqueue_.add(
       kDeleteCheckPeriodMillisecs,
       std::bind(&BlobDBImpl::EvictCompacted, this, std::placeholders::_1));
-  tqueue_.add(kDeleteObsoletedFilesPeriodMillisecs,
-              std::bind(&BlobDBImpl::DeleteObsoletedFiles, this,
-                        std::placeholders::_1));
+  tqueue_.add(
+      kDeleteObsoleteFilesPeriodMillisecs,
+      std::bind(&BlobDBImpl::DeleteObsoleteFiles, this, std::placeholders::_1));
   tqueue_.add(kSanityCheckPeriodMillisecs,
               std::bind(&BlobDBImpl::SanityCheck, this, std::placeholders::_1));
   tqueue_.add(kWriteAmplificationStatsPeriodMillisecs,
@@ -1131,6 +1131,7 @@ std::vector<Status> BlobDBImpl::MultiGet(
   TEST_SYNC_POINT("BlobDBImpl::MultiGet:AfterIndexEntryGet:2");
 
   values->resize(keys.size());
+  assert(statuses.size() == keys.size());
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
       continue;
@@ -2000,18 +2001,18 @@ bool BlobDBImpl::ShouldGCFile(std::shared_ptr<BlobFile> bfile, uint64_t now,
   return false;
 }
 
-std::pair<bool, int64_t> BlobDBImpl::DeleteObsoletedFiles(bool aborted) {
+std::pair<bool, int64_t> BlobDBImpl::DeleteObsoleteFiles(bool aborted) {
   if (aborted) return std::make_pair(false, -1);
 
   {
     ReadLock rl(&mutex_);
-    if (obsoleted_files_.empty()) return std::make_pair(true, -1);
+    if (obsolete_files_.empty()) return std::make_pair(true, -1);
   }
 
   std::list<std::shared_ptr<BlobFile>> tobsolete;
   {
     WriteLock wl(&mutex_);
-    tobsolete.swap(obsoleted_files_);
+    tobsolete.swap(obsolete_files_);
   }
 
   bool file_deleted = false;
@@ -2050,7 +2051,9 @@ std::pair<bool, int64_t> BlobDBImpl::DeleteObsoletedFiles(bool aborted) {
   // put files back into obsolete if for some reason, delete failed
   if (!tobsolete.empty()) {
     WriteLock wl(&mutex_);
-    for (auto bfile : tobsolete) obsoleted_files_.push_front(bfile);
+    for (auto bfile : tobsolete) {
+      obsolete_files_.push_front(bfile);
+    }
   }
 
   return std::make_pair(!aborted, -1);
@@ -2112,7 +2115,7 @@ std::pair<bool, int64_t> BlobDBImpl::CallbackEvicts(
 
   WriteLock wl(&mutex_);
   bfile->SetCanBeDeleted();
-  obsoleted_files_.push_front(bfile);
+  obsolete_files_.push_front(bfile);
   if (tq) {
     // all of the callbacks have been processed
     tqueue_.add(0, std::bind(&BlobDBImpl::RemoveTimerQ, this, tq,
@@ -2239,7 +2242,7 @@ std::pair<bool, int64_t> BlobDBImpl::RunGC(bool aborted) {
 
       if (!evict_cb) {
         bfile->SetCanBeDeleted();
-        obsoleted_files_.push_front(bfile);
+        obsolete_files_.push_front(bfile);
       } else {
         tq->add(0, std::bind(&BlobDBImpl::CallbackEvicts, this,
                              (last_file) ? tq.get() : nullptr, bfile,
@@ -2348,7 +2351,7 @@ void BlobDBImpl::TEST_ObsoleteFile(std::shared_ptr<BlobFile>& bfile) {
   bfile->SetCanBeDeleted();
   {
     WriteLock l(&mutex_);
-    obsoleted_files_.push_back(bfile);
+    obsolete_files_.push_back(bfile);
   }
 }
 #endif  //  !NDEBUG

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -200,7 +200,7 @@ class BlobDBImpl : public BlobDB {
   static constexpr uint32_t kReclaimOpenFilesPeriodMillisecs = 1 * 1000;
 
   // how often to schedule delete obs files periods
-  static constexpr uint32_t kDeleteObsoletedFilesPeriodMillisecs = 10 * 1000;
+  static constexpr uint32_t kDeleteObsoleteFilesPeriodMillisecs = 10 * 1000;
 
   // how often to schedule check seq files period
   static constexpr uint32_t kCheckSeqFilesPeriodMillisecs = 10 * 1000;
@@ -269,10 +269,10 @@ class BlobDBImpl : public BlobDB {
                                  GCStats* gc_stats);
 
   void TEST_RunGC();
-  
+
   void TEST_ObsoleteFile(std::shared_ptr<BlobFile>& bfile);
 
-  void TEST_DeleteObsoletedFiles();
+  void TEST_DeleteObsoleteFiles();
 #endif  //  !NDEBUG
 
  private:
@@ -340,7 +340,7 @@ class BlobDBImpl : public BlobDB {
   // delete files which have been garbage collected and marked
   // obsolete. Check whether any snapshots exist which refer to
   // the same
-  std::pair<bool, int64_t> DeleteObsoletedFiles(bool aborted);
+  std::pair<bool, int64_t> DeleteObsoleteFiles(bool aborted);
 
   // Major task to garbage collect expired and deleted blobs
   std::pair<bool, int64_t> RunGC(bool aborted);
@@ -534,7 +534,7 @@ class BlobDBImpl : public BlobDB {
 
   // total size of all blob files at a given time
   std::atomic<uint64_t> total_blob_space_;
-  std::list<std::shared_ptr<BlobFile>> obsoleted_files_;
+  std::list<std::shared_ptr<BlobFile>> obsolete_files_;
   bool open_p1_done_;
 
   uint32_t debug_level_;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -278,6 +278,10 @@ class BlobDBImpl : public BlobDB {
  private:
   Status OpenPhase1();
 
+  // Create a snapshot if there isn't one in read options.
+  // Return true if a snapshot is created.
+  bool SetSnapshotIfNeeded(ReadOptions* read_options);
+
   Status CommonGet(const ColumnFamilyData* cfd, const Slice& key,
                    const std::string& index_entry, std::string* value,
                    SequenceNumber* sequence = nullptr);

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -792,24 +792,24 @@ TEST_F(BlobDBTest, ReadWhileGC) {
     ASSERT_EQ(1, gc_stats.num_relocate);
     ASSERT_EQ(1, gc_stats.relocate_succeeded);
     blob_db_impl->TEST_ObsoleteFile(blob_files[0]);
-    blob_db_impl->TEST_DeleteObsoletedFiles();
+    blob_db_impl->TEST_DeleteObsoleteFiles();
     // The file shouln't be deleted
     blob_files = blob_db_impl->TEST_GetBlobFiles();
     ASSERT_EQ(2, blob_files.size());
     ASSERT_EQ(bfile_number, blob_files[0]->BlobFileNumber());
-    auto obsoleted_files = blob_db_impl->TEST_GetObsoletedFiles();
-    ASSERT_EQ(1, obsoleted_files.size());
-    ASSERT_EQ(bfile_number, obsoleted_files[0]->BlobFileNumber());
+    auto obsolete_files = blob_db_impl->TEST_GetObsoleteFiles();
+    ASSERT_EQ(1, obsolete_files.size());
+    ASSERT_EQ(bfile_number, obsolete_files[0]->BlobFileNumber());
     TEST_SYNC_POINT("BlobDBTest::ReadWhileGC:2");
     reader.join();
     SyncPoint::GetInstance()->DisableProcessing();
 
     // The file is deleted this time
-    blob_db_impl->TEST_DeleteObsoletedFiles();
+    blob_db_impl->TEST_DeleteObsoleteFiles();
     blob_files = blob_db_impl->TEST_GetBlobFiles();
     ASSERT_EQ(1, blob_files.size());
     ASSERT_NE(bfile_number, blob_files[0]->BlobFileNumber());
-    ASSERT_EQ(0, blob_db_impl->TEST_GetObsoletedFiles().size());
+    ASSERT_EQ(0, blob_db_impl->TEST_GetObsoleteFiles().size());
     VerifyDB({{"foo", "bar"}});
     Destroy();
   }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -723,6 +723,98 @@ TEST_F(BlobDBTest, GCOldestSimpleBlobFileWhenOutOfSpace) {
             obsolete_files[0]->BlobFileNumber());
 }
 
+TEST_F(BlobDBTest, ReadWhileGC) {
+  // run the same test for Get(), MultiGet() and Iterator each.
+  for (int i = 0; i < 3; i++) {
+    BlobDBOptions bdb_options;
+    bdb_options.disable_background_tasks = true;
+    Open(bdb_options);
+    blob_db_->Put(WriteOptions(), "foo", "bar");
+    BlobDBImpl *blob_db_impl =
+        static_cast_with_check<BlobDBImpl, BlobDB>(blob_db_);
+    auto blob_files = blob_db_impl->TEST_GetBlobFiles();
+    ASSERT_EQ(1, blob_files.size());
+    std::shared_ptr<BlobFile> bfile = blob_files[0];
+    uint64_t bfile_number = bfile->BlobFileNumber();
+    blob_db_impl->TEST_CloseBlobFile(bfile);
+
+    switch (i) {
+      case 0:
+        SyncPoint::GetInstance()->LoadDependency(
+            {{"BlobDBImpl::Get:AfterIndexEntryGet:1",
+              "BlobDBTest::ReadWhileGC:1"},
+             {"BlobDBTest::ReadWhileGC:2",
+              "BlobDBImpl::Get:AfterIndexEntryGet:2"}});
+        break;
+      case 1:
+        SyncPoint::GetInstance()->LoadDependency(
+            {{"BlobDBImpl::MultiGet:AfterIndexEntryGet:1",
+              "BlobDBTest::ReadWhileGC:1"},
+             {"BlobDBTest::ReadWhileGC:2",
+              "BlobDBImpl::MultiGet:AfterIndexEntryGet:2"}});
+        break;
+      case 2:
+        SyncPoint::GetInstance()->LoadDependency(
+            {{"BlobDBIterator::value:BeforeGetBlob:1",
+              "BlobDBTest::ReadWhileGC:1"},
+             {"BlobDBTest::ReadWhileGC:2",
+              "BlobDBIterator::value:BeforeGetBlob:2"}});
+        break;
+    }
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    auto reader = port::Thread([this, i]() {
+      std::string value;
+      std::vector<std::string> values;
+      std::vector<Status> statuses;
+      switch (i) {
+        case 0:
+          ASSERT_OK(blob_db_->Get(ReadOptions(), "foo", &value));
+          ASSERT_EQ("bar", value);
+          break;
+        case 1:
+          statuses = blob_db_->MultiGet(ReadOptions(), {"foo"}, &values);
+          ASSERT_EQ(1, statuses.size());
+          ASSERT_EQ(1, values.size());
+          ASSERT_EQ("bar", values[0]);
+          break;
+        case 2:
+          // VerifyDB use iterator to scan the DB.
+          VerifyDB({{"foo", "bar"}});
+          break;
+      }
+    });
+
+    TEST_SYNC_POINT("BlobDBTest::ReadWhileGC:1");
+    GCStats gc_stats;
+    ASSERT_OK(blob_db_impl->TEST_GCFileAndUpdateLSM(bfile, &gc_stats));
+    ASSERT_EQ(1, gc_stats.blob_count);
+    ASSERT_EQ(1, gc_stats.num_relocate);
+    ASSERT_EQ(1, gc_stats.relocate_succeeded);
+    blob_db_impl->TEST_ObsoleteFile(blob_files[0]);
+    blob_db_impl->TEST_DeleteObsoletedFiles();
+    // The file shouln't be deleted
+    blob_files = blob_db_impl->TEST_GetBlobFiles();
+    ASSERT_EQ(2, blob_files.size());
+    ASSERT_EQ(bfile_number, blob_files[0]->BlobFileNumber());
+    auto obsoleted_files = blob_db_impl->TEST_GetObsoletedFiles();
+    ASSERT_EQ(1, obsoleted_files.size());
+    ASSERT_EQ(bfile_number, obsoleted_files[0]->BlobFileNumber());
+    TEST_SYNC_POINT("BlobDBTest::ReadWhileGC:2");
+    reader.join();
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    // The file is deleted this time
+    blob_db_impl->TEST_DeleteObsoletedFiles();
+    blob_files = blob_db_impl->TEST_GetBlobFiles();
+    ASSERT_EQ(1, blob_files.size());
+    ASSERT_NE(bfile_number, blob_files[0]->BlobFileNumber());
+    ASSERT_EQ(0, blob_db_impl->TEST_GetObsoletedFiles().size());
+    VerifyDB({{"foo", "bar"}});
+    Destroy();
+  }
+}
+
 }  //  namespace blob_db
 }  //  namespace rocksdb
 


### PR DESCRIPTION
Summary:
If GC kicks in between

* A Get() reads index entry from base db.
* The Get() read from a blob file

The GC can delete the corresponding blob file, making the key not found. Fortunately we have existing logic to avoid deleting a blob file if it is referenced by a snapshot. So the fix is to explicitly create a snapshot before reading index entry from base db.

Test Plan:
See the new test.