### PR TITLE
Revert the mistake in version update

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,6 @@
 # Rocksdb Change Log
 ## Unreleased
 
-## 5.7.8 (08/14/2017)
 ### New Features
 * Add Iterator::Refresh(), which allows users to update the iterator state so that they can avoid some initialization costs of recreating iterators.
 * Replace dynamic_cast<> (except unit test) so people can choose to build with RTTI off. With make, release mode is by default built with -fno-rtti and debug mode is built without it. Users can override it by setting USE_RTTI=0 or 1.

--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define ROCKSDB_MAJOR 5
-#define ROCKSDB_MINOR 8
+#define ROCKSDB_MINOR 7
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with


### PR DESCRIPTION
https://github.com/facebook/rocksdb/pull/2661 mistakenly updates the version. This patch reverts it.