### PR TITLE
[WIP] Delete duplicated key/value pairs recursively

### DIFF
--- a/db/builder.h
+++ b/db/builder.h
@@ -79,6 +79,7 @@ extern Status BuildTable(
     InternalStats* internal_stats, TableFileCreationReason reason,
     EventLogger* event_logger = nullptr, int job_id = 0,
     const Env::IOPriority io_priority = Env::IO_HIGH,
-    TableProperties* table_properties = nullptr, int level = -1);
+    TableProperties* table_properties = nullptr, int level = -1,
+    InternalIterator* compare_iter = nullptr);
 
 }  // namespace rocksdb

--- a/db/c.cc
+++ b/db/c.cc
@@ -2263,6 +2263,14 @@ void rocksdb_options_set_max_write_buffer_number(rocksdb_options_t* opt, int n) 
   opt->rep.max_write_buffer_number = n;
 }
 
+void rocksdb_options_set_flush_style(rocksdb_options_t* opt, int style) {
+  opt->rep.flush_style = static_cast<rocksdb::FlushStyle>(style);
+}
+
+void rocksdb_options_set_write_buffer_number_to_flush(rocksdb_options_t* opt, int n) {
+  opt->rep.write_buffer_number_to_flush = n;
+}
+
 void rocksdb_options_set_min_write_buffer_number_to_merge(rocksdb_options_t* opt, int n) {
   opt->rep.min_write_buffer_number_to_merge = n;
 }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -236,6 +236,9 @@ class ColumnFamilyData {
   MemTable* mem() { return mem_; }
   Version* current() { return current_; }
   Version* dummy_versions() { return dummy_versions_; }
+  void set_stop() { stop = true; }
+  bool is_stop() { return stop; }
+  bool is_flush_recursive_dedup() { return (ioptions_.flush_style == kFlushStyleDedup); }
   void SetCurrent(Version* _current);
   uint64_t GetNumLiveVersions() const;  // REQUIRE: DB mutex held
   uint64_t GetTotalSstFilesSize() const;  // REQUIRE: DB mutex held
@@ -371,6 +374,7 @@ class ColumnFamilyData {
 
   MemTable* mem_;
   MemTableList imm_;
+  bool stop;
   SuperVersion* super_version_;
 
   // An ordinal representing the current SuperVersion. Updated by

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -1027,6 +1027,7 @@ TEST_F(ColumnFamilyTest, DifferentWriteBufferSizes) {
   default_cf.arena_block_size = 4 * 4096;
   default_cf.max_write_buffer_number = 10;
   default_cf.min_write_buffer_number_to_merge = 1;
+  default_cf.write_buffer_number_to_flush = 0;
   default_cf.max_write_buffer_number_to_maintain = 0;
   one.write_buffer_size = 200000;
   one.arena_block_size = 4 * 4096;

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -70,7 +70,7 @@ class CompactionPickerTest : public testing::Test {
     DeleteVersionStorage();
     options_.num_levels = num_levels;
     vstorage_.reset(new VersionStorageInfo(&icmp_, ucmp_, options_.num_levels,
-                                           style, nullptr, false));
+                                           kFlushStyleMerge, style, nullptr, false));
     vstorage_->CalculateBaseBytes(ioptions_, mutable_cf_options_);
   }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -226,6 +226,7 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       if (!cfd->IsDropped() && !cfd->mem()->IsEmpty()) {
         cfd->Ref();
+        cfd->set_stop();
         mutex_.Unlock();
         FlushMemTable(cfd, FlushOptions());
         mutex_.Lock();

--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -45,7 +45,7 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
     const std::string& db_name, const std::string& cf_name,
     const std::string& file_path, int job_id, const FileDescriptor& fd,
     const TableProperties& table_properties, TableFileCreationReason reason,
-    const Status& s) {
+    const Status& s, bool show_num, int total_num, int dup_num) {
   if (s.ok() && event_logger) {
     JSONWriter jwriter;
     AppendCurrentTime(&jwriter);
@@ -73,6 +73,9 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
               << "num_data_blocks" << table_properties.num_data_blocks
               << "num_entries" << table_properties.num_entries
               << "filter_policy_name" << table_properties.filter_policy_name;
+      if (show_num) {
+        jwriter << "total_paris" << total_num << "duplicated_pairs" << dup_num;
+      }
 
       // user collected properties
       for (const auto& prop : table_properties.readable_properties) {

--- a/db/event_helpers.h
+++ b/db/event_helpers.h
@@ -33,7 +33,7 @@ class EventHelpers {
       const std::string& db_name, const std::string& cf_name,
       const std::string& file_path, int job_id, const FileDescriptor& fd,
       const TableProperties& table_properties, TableFileCreationReason reason,
-      const Status& s);
+      const Status& s, bool show_num = false, int total_num = 0, int duplicated_num = 0);
   static void LogAndNotifyTableFileDeletion(
       EventLogger* event_logger, int job_id,
       uint64_t file_number, const std::string& file_path,

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -104,6 +104,7 @@ class FlushJob {
   // Variables below are set by PickMemTable():
   FileMetaData meta_;
   autovector<MemTable*> mems_;
+  autovector<MemTable*> compare_mems_;
   VersionEdit* edit_;
   Version* base_;
   bool pick_memtable_called;

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -158,9 +158,11 @@ class MemTableList {
  public:
   // A list of memtables.
   explicit MemTableList(int min_write_buffer_number_to_merge,
-                        int max_write_buffer_number_to_maintain)
+                        int max_write_buffer_number_to_maintain,
+                        int write_buffer_number_to_flush = 1)
       : imm_flush_needed(false),
         min_write_buffer_number_to_merge_(min_write_buffer_number_to_merge),
+        write_buffer_number_to_flush_(write_buffer_number_to_flush),
         current_(new MemTableListVersion(&current_memory_usage_,
                                          max_write_buffer_number_to_maintain)),
         num_flush_not_started_(0),
@@ -194,6 +196,7 @@ class MemTableList {
 
   // Returns the earliest memtables that needs to be flushed. The returned
   // memtables are guaranteed to be in the ascending order of created time.
+  void PickMemtablesToFlush(autovector<MemTable*>* mems, autovector<MemTable*>* compare_mems);
   void PickMemtablesToFlush(autovector<MemTable*>* mems);
 
   // Reset status of the given memtable list back to pending state so that
@@ -241,6 +244,8 @@ class MemTableList {
   void InstallNewVersion();
 
   const int min_write_buffer_number_to_merge_;
+
+  const unsigned int write_buffer_number_to_flush_;
 
   MemTableListVersion* current_;
 

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -32,7 +32,8 @@ class VersionBuilderTest : public testing::Test {
         icmp_(ucmp_),
         ioptions_(options_),
         mutable_cf_options_(options_),
-        vstorage_(&icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
+        vstorage_(&icmp_, ucmp_, options_.num_levels,
+                  kFlushStyleMerge, kCompactionStyleLevel,
                   nullptr, false),
         file_num_(1) {
     mutable_cf_options_.RefreshDerivedOptions(ioptions_);
@@ -125,7 +126,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   VersionBuilder version_builder(env_options, nullptr, &vstorage_);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                  kCompactionStyleLevel, nullptr, false);
+                                  kFlushStyleMerge, kCompactionStyleLevel,
+                                  nullptr, false);
   version_builder.Apply(&version_edit);
   version_builder.SaveTo(&new_vstorage);
 
@@ -160,7 +162,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   VersionBuilder version_builder(env_options, nullptr, &vstorage_);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                  kCompactionStyleLevel, nullptr, false);
+                                  kFlushStyleMerge, kCompactionStyleLevel,
+                                  nullptr, false);
   version_builder.Apply(&version_edit);
   version_builder.SaveTo(&new_vstorage);
 
@@ -200,7 +203,8 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
   VersionBuilder version_builder(env_options, nullptr, &vstorage_);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                  kCompactionStyleLevel, nullptr, false);
+                                  kFlushStyleMerge, kCompactionStyleLevel,
+                                  nullptr, false);
   version_builder.Apply(&version_edit);
   version_builder.SaveTo(&new_vstorage);
 
@@ -231,7 +235,7 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
   VersionBuilder version_builder(env_options, nullptr, &vstorage_);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                  kCompactionStyleLevel, nullptr, false);
+                                  kFlushStyleMerge, kCompactionStyleLevel, nullptr, false);
   version_builder.Apply(&version_edit);
   version_builder.SaveTo(&new_vstorage);
 
@@ -246,7 +250,7 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   EnvOptions env_options;
   VersionBuilder version_builder(env_options, nullptr, &vstorage_);
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                  kCompactionStyleLevel, nullptr, false);
+                                  kFlushStyleMerge, kCompactionStyleLevel, nullptr, false);
 
   VersionEdit version_edit;
   version_edit.AddFile(2, 666, 0, 100U, GetInternalKey("301"),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -884,7 +884,9 @@ void Version::AddRangeDelIteratorsForLevel(
 VersionStorageInfo::VersionStorageInfo(
     const InternalKeyComparator* internal_comparator,
     const Comparator* user_comparator, int levels,
-    CompactionStyle compaction_style, VersionStorageInfo* ref_vstorage,
+    FlushStyle flush_style,
+    CompactionStyle compaction_style,
+    VersionStorageInfo* ref_vstorage,
     bool _force_consistency_checks)
     : internal_comparator_(internal_comparator),
       user_comparator_(user_comparator),
@@ -892,6 +894,7 @@ VersionStorageInfo::VersionStorageInfo(
       num_levels_(levels),
       num_non_empty_levels_(0),
       file_indexer_(user_comparator),
+      flush_style_(flush_style),
       compaction_style_(compaction_style),
       files_(new std::vector<FileMetaData*>[num_levels_]),
       base_level_(num_levels_ == 1 ? -1 : 1),
@@ -939,6 +942,8 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
           (cfd_ == nullptr) ? nullptr : &cfd_->internal_comparator(),
           (cfd_ == nullptr) ? nullptr : cfd_->user_comparator(),
           cfd_ == nullptr ? 0 : cfd_->NumberLevels(),
+          cfd_ == nullptr ? kFlushStyleMerge
+                          : cfd_->ioptions()->flush_style,
           cfd_ == nullptr ? kCompactionStyleLevel
                           : cfd_->ioptions()->compaction_style,
           (cfd_ == nullptr || cfd_->current() == nullptr)

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -95,6 +95,7 @@ class VersionStorageInfo {
  public:
   VersionStorageInfo(const InternalKeyComparator* internal_comparator,
                      const Comparator* user_comparator, int num_levels,
+                     FlushStyle flush_style,
                      CompactionStyle compaction_style,
                      VersionStorageInfo* src_vstorage,
                      bool _force_consistency_checks);
@@ -371,6 +372,7 @@ class VersionStorageInfo {
   FileIndexer file_indexer_;
   Arena arena_;  // Used to allocate space for file_levels_
 
+  FlushStyle flush_style_;
   CompactionStyle compaction_style_;
 
   // List of files per level, files in each level are arranged

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -112,7 +112,8 @@ class VersionStorageInfoTest : public testing::Test {
         options_(GetOptionsWithNumLevels(6, logger_)),
         ioptions_(options_),
         mutable_cf_options_(options_),
-        vstorage_(&icmp_, ucmp_, 6, kCompactionStyleLevel, nullptr, false) {}
+        vstorage_(&icmp_, ucmp_, 6, kFlushStyleMerge,
+                  kCompactionStyleLevel, nullptr, false) {}
 
   ~VersionStorageInfoTest() {
     for (int i = 0; i < vstorage_.num_levels(); i++) {

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -56,6 +56,15 @@ enum CompactionPri : char {
   kMinOverlappingRatio = 0x3,
 };
 
+// Indicate the way when flushing memtables.
+enum FlushStyle : unsigned char {
+  // Current style.
+  kFlushStyleMerge = 0x0,
+  // Recursively delete duplicated/invalid key/value pairs compared to later
+  // memtables when flushing.
+  kFlushStyleDedup = 0x1,
+};
+
 struct CompactionOptionsFIFO {
   // once the total sum of table files reaches this, we will delete the oldest
   // table file
@@ -131,6 +140,11 @@ struct AdvancedColumnFamilyOptions {
   // individual write buffers.  Default: 1
   int min_write_buffer_number_to_merge = 1;
 
+  // When flush style is dedup, every time when it begins to flush, it flushes
+  // write_buffer_number_to_flush memtables to l0 while deduping with
+  // (min_write_buffer_number_to_merge - write_buffer_number_to_flush) later
+  // memtables.
+  int write_buffer_number_to_flush = 1;
   // The total maximum number of write buffers to maintain in memory including
   // copies of buffers that have already been flushed.  Unlike
   // max_write_buffer_number, this parameter does not affect flushing.
@@ -441,6 +455,8 @@ struct AdvancedColumnFamilyOptions {
   //
   // Default: 256GB
   uint64_t hard_pending_compaction_bytes_limit = 256 * 1073741824ull;
+
+  FlushStyle flush_style = kFlushStyleMerge;
 
   // The compaction style. Default: kCompactionStyleLevel
   CompactionStyle compaction_style = kCompactionStyleLevel;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -766,7 +766,11 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_options_statistics_get_string(
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_write_buffer_number(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_write_buffer_number_to_flush(rocksdb_options_t*, int);
+extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_min_write_buffer_number_to_merge(rocksdb_options_t*, int);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_flush_style(rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_max_write_buffer_number_to_maintain(rocksdb_options_t*,
                                                         int);

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -173,8 +173,8 @@ std::string StatisticsImpl::ToString() const {
       getHistogramImplLocked(h.first)->Data(&hData);
       snprintf(
           buffer, kTmpStrBufferSize,
-          "%s statistics Percentiles :=> 50 : %f 95 : %f 99 : %f 100 : %f\n",
-          h.second.c_str(), hData.median, hData.percentile95,
+          "%s statistics Percentiles :=> average: %f 50 : %f 95 : %f 99 : %f 100 : %f\n",
+          h.second.c_str(), hData.average, hData.median, hData.percentile95,
           hData.percentile99, hData.max);
       res.append(buffer);
     }

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -27,7 +27,8 @@ ImmutableCFOptions::ImmutableCFOptions(const Options& options)
 
 ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
                                        const ColumnFamilyOptions& cf_options)
-    : compaction_style(cf_options.compaction_style),
+    : flush_style(cf_options.flush_style),
+      compaction_style(cf_options.compaction_style),
       compaction_pri(cf_options.compaction_pri),
       compaction_options_universal(cf_options.compaction_options_universal),
       compaction_options_fifo(cf_options.compaction_options_fifo),
@@ -39,6 +40,8 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       compaction_filter_factory(cf_options.compaction_filter_factory.get()),
       min_write_buffer_number_to_merge(
           cf_options.min_write_buffer_number_to_merge),
+      write_buffer_number_to_flush(
+          cf_options.write_buffer_number_to_flush),
       max_write_buffer_number_to_maintain(
           cf_options.max_write_buffer_number_to_maintain),
       inplace_update_support(cf_options.inplace_update_support),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -26,6 +26,8 @@ struct ImmutableCFOptions {
   ImmutableCFOptions(const ImmutableDBOptions& db_options,
                      const ColumnFamilyOptions& cf_options);
 
+  FlushStyle flush_style;
+
   CompactionStyle compaction_style;
 
   CompactionPri compaction_pri;
@@ -46,6 +48,7 @@ struct ImmutableCFOptions {
 
   int min_write_buffer_number_to_merge;
 
+  int write_buffer_number_to_flush;
   int max_write_buffer_number_to_maintain;
 
   bool inplace_update_support;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -336,6 +336,10 @@ bool ParseOptionHelper(char* opt_address, const OptionType& opt_type,
     case OptionType::kDouble:
       *reinterpret_cast<double*>(opt_address) = ParseDouble(value);
       break;
+    case OptionType::kFlushStyle:
+      return ParseEnum<FlushStyle>(
+          flush_style_string_map, value,
+          reinterpret_cast<FlushStyle*>(opt_address));
     case OptionType::kCompactionStyle:
       return ParseEnum<CompactionStyle>(
           compaction_style_string_map, value,
@@ -429,6 +433,10 @@ bool SerializeSingleOptionHelper(const char* opt_address,
       *value = EscapeOptionString(
           *(reinterpret_cast<const std::string*>(opt_address)));
       break;
+    case OptionType::kFlushStyle:
+      return SerializeEnum<FlushStyle>(
+          flush_style_string_map,
+          *(reinterpret_cast<const FlushStyle*>(opt_address)), value);
     case OptionType::kCompactionStyle:
       return SerializeEnum<CompactionStyle>(
           compaction_style_string_map,

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -31,6 +31,10 @@ static std::map<CompactionStyle, std::string> compaction_style_to_string = {
     {kCompactionStyleFIFO, "kCompactionStyleFIFO"},
     {kCompactionStyleNone, "kCompactionStyleNone"}};
 
+static std::map<FlushStyle, std::string> flush_style_to_string = {
+    {kFlushStyleMerge, "kFlushStyleMerge"},
+    {kFlushStyleDedup, "kFlushStyleDedup"}};
+
 static std::map<CompactionPri, std::string> compaction_pri_to_string = {
     {kByCompensatedSize, "kByCompensatedSize"},
     {kOldestLargestSeqFirst, "kOldestLargestSeqFirst"},
@@ -72,6 +76,7 @@ enum class OptionType {
   kSizeT,
   kString,
   kDouble,
+  kFlushStyle,
   kCompactionStyle,
   kCompactionPri,
   kSliceTransform,
@@ -453,6 +458,9 @@ static std::unordered_map<std::string, OptionTypeInfo> cf_options_type_info = {
     {"min_write_buffer_number_to_merge",
      {offset_of(&ColumnFamilyOptions::min_write_buffer_number_to_merge),
       OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
+    {"write_buffer_number_to_flush",
+     {offset_of(&ColumnFamilyOptions::write_buffer_number_to_flush),
+      OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
     {"num_levels",
      {offset_of(&ColumnFamilyOptions::num_levels), OptionType::kInt,
       OptionVerificationType::kNormal, false, 0}},
@@ -565,6 +573,9 @@ static std::unordered_map<std::string, OptionTypeInfo> cf_options_type_info = {
     {"compaction_style",
      {offset_of(&ColumnFamilyOptions::compaction_style),
       OptionType::kCompactionStyle, OptionVerificationType::kNormal, false, 0}},
+    {"flush_style",
+     {offset_of(&ColumnFamilyOptions::flush_style),
+      OptionType::kFlushStyle, OptionVerificationType::kNormal, false, 0}},
     {"compaction_pri",
      {offset_of(&ColumnFamilyOptions::compaction_pri),
       OptionType::kCompactionPri, OptionVerificationType::kNormal, false, 0}}};
@@ -704,6 +715,11 @@ static std::unordered_map<std::string, CompactionStyle>
         {"kCompactionStyleUniversal", kCompactionStyleUniversal},
         {"kCompactionStyleFIFO", kCompactionStyleFIFO},
         {"kCompactionStyleNone", kCompactionStyleNone}};
+
+static std::unordered_map<std::string, FlushStyle>
+    flush_style_string_map = {
+        {"kFlushStyleMerge", kFlushStyleMerge},
+        {"kFlushStyleDedup", kFlushStyleDedup}};
 
 static std::unordered_map<std::string, CompactionPri>
     compaction_pri_string_map = {

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -547,6 +547,9 @@ bool AreEqualOptions(
     case OptionType::kDouble:
       return AreEqualDoubles(*reinterpret_cast<const double*>(offset1),
                              *reinterpret_cast<const double*>(offset2));
+    case OptionType::kFlushStyle:
+      return (*reinterpret_cast<const FlushStyle*>(offset1) ==
+              *reinterpret_cast<const FlushStyle*>(offset2));
     case OptionType::kCompactionStyle:
       return (*reinterpret_cast<const CompactionStyle*>(offset1) ==
               *reinterpret_cast<const CompactionStyle*>(offset2));


### PR DESCRIPTION
This is to implement the idea: http://pad.ceph.com/p/rocksdb-wal-improvement
Add a new flush style called kFlushStyleDedup which users can config by setting
flush_style=kFlushStyleDedup and write_buffer_number_to_flush. Flush
is triggered while number of non-flushed memtables is >= min_write_buffer_number_to_merge.
When flushing memtables to L0, it merges write_buffer_number_to_flush memtables
and deduping against other non-flushed memtables.

In Ceph Bluestore, it uses rocksdb to store metadata and WAL logs. For small write IOs(default < 16k), it at first writes the data to Rocksdb, secondly writes the data to disk, and then deletes the data in Rocksdb. With the merge style, it makes the data written to sst files as little as possible.

With bluestore fio plugin to do 4k random write test, I compared the two stats
db.get.micros and db.write.micros from rocksdb every ten minutes. db.get.micros
is the average of get operations, and db.write.micros is the average time of put/delete
functions. From the result, rocksdb read performance can be improved up to 38%,
and write performance can be improved to 15%. More detailed info please see the excel:
https://drive.google.com/drive/folders/0B6jqFc7e2yxVdUQ2aEpCR3ItbG8

Signed-off-by: Xiaoyan Li xiaoyan.li@intel.com