### PR TITLE
Circumvent ASAN false positive

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -234,19 +234,35 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 }
 
 void* LRUCacheShard::operator new(size_t size) {
+#if __SANITIZE_ADDRESS__
+  return malloc(size);
+#else
   return port::cacheline_aligned_alloc(size);
+#endif
 }
 
 void* LRUCacheShard::operator new[](size_t size) {
+#if __SANITIZE_ADDRESS__
+  return malloc(size);
+#else
   return port::cacheline_aligned_alloc(size);
+#endif
 }
 
 void LRUCacheShard::operator delete(void *memblock) {
+#if __SANITIZE_ADDRESS__
+  free(memblock);
+#else
   port::cacheline_aligned_free(memblock);
+#endif
 }
 
 void LRUCacheShard::operator delete[](void* memblock) {
+#if __SANITIZE_ADDRESS__
+  free(memblock);
+#else
   port::cacheline_aligned_free(memblock);
+#endif
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {


### PR DESCRIPTION
Changes:
* checks if ASAN mode is on, and uses malloc and free in the constructor and destructor