### PR TITLE
stop calling memcmp with nullptrs

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -213,18 +213,17 @@ inline bool operator!=(const Slice& x, const Slice& y) {
   return !(x == y);
 }
 
-// UBSAN complain that we pass nullptr to memcmp that's fine since
-// we always do that for a string of len = 0
-#ifdef ROCKSDB_UBSAN_RUN
-#if defined(__clang__)
-__attribute__((__no_sanitize__("undefined")))
-#elif defined(__GNUC__)
-__attribute__((__no_sanitize_undefined__))
-#endif
-#endif
 inline int Slice::compare(const Slice& b) const {
   const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
-  assert((data_ != nullptr && b.data_ != nullptr) || min_len == 0);
+  if (min_len == 0) {
+    if (size_ > 0) {
+      return 1;
+    } else if (b.size_ > 0) {
+      return -1;
+    }
+    return 0;
+  }
+  assert(data_ != nullptr && b.data_ != nullptr);
   int r = memcmp(data_, b.data_, min_len);
   if (r == 0) {
     if (size_ < b.size_) r = -1;


### PR DESCRIPTION
it doesn't take nullptr according to its declaration in glibc, and calling it in this way causes our sanitizers (ubsan, clang analyze) to fail.

Test Plan:

- sanitizer: `USE_CLANG=1 make -j64 analyze`. the output is quite beautiful compared to before when it barfed on compiling every file that included "slice.h" even indirectly.

- perf command:
```
TEST_TMPDIR=/dev/shm perf record -g ./db_bench -num=1000000 -benchmarks=readwhilewriting -statistics -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -compression_type=none -max_background_compactions=8 -max_background_flushes=4
```

- perf before:
```
readwhilewriting :      20.741 micros/op 48214 ops/sec;    4.4 MB/s (819398 of 1000000 found)
+    9.62%     3.80%  db_bench     db_bench             [.] rocksdb::InternalKeyComparator::Compare
```

- perf after:
```
readwhilewriting :      19.963 micros/op 50092 ops/sec;    4.4 MB/s (795228 of 1000000 found)
+    9.83%     3.74%  db_bench     db_bench             [.] rocksdb::InternalKeyComparator::Compare
```