### PR TITLE
allow nullptr Slice only as sentinel

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * Users of `Statistics::getHistogramString()` will see fewer histogram buckets and different bucket endpoints.
+* `Slice::compare` and BytewiseComparator `Compare` no longer accept `Slice`s containing nullptr.
 
 ### New Features
 * Add Iterator::Refresh(), which allows users to update the iterator state so that they can avoid some initialization costs of recreating iterators.

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -214,16 +214,8 @@ inline bool operator!=(const Slice& x, const Slice& y) {
 }
 
 inline int Slice::compare(const Slice& b) const {
-  const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
-  if (min_len == 0) {
-    if (size_ > 0) {
-      return 1;
-    } else if (b.size_ > 0) {
-      return -1;
-    }
-    return 0;
-  }
   assert(data_ != nullptr && b.data_ != nullptr);
+  const size_t min_len = (size_ < b.size_) ? size_ : b.size_;
   int r = memcmp(data_, b.data_, min_len);
   if (r == 0) {
     if (size_ < b.size_) r = -1;

--- a/table/cuckoo_table_builder_test.cc
+++ b/table/cuckoo_table_builder_test.cc
@@ -109,7 +109,11 @@ class CuckooBuilderTest : public testing::Test {
           expected_locations.begin();
       if (key_idx == keys.size()) {
         // i is not one of the expected locations. Empty bucket.
-        ASSERT_EQ(read_slice.compare(expected_unused_bucket), 0);
+        if (read_slice.data() == nullptr) {
+          ASSERT_EQ(0, expected_unused_bucket.size());
+        } else {
+          ASSERT_EQ(read_slice.compare(expected_unused_bucket), 0);
+        }
       } else {
         keys_found[key_idx] = true;
         ASSERT_EQ(read_slice.compare(keys[key_idx] + values[key_idx]), 0);

--- a/utilities/merge_operators/max.cc
+++ b/utilities/merge_operators/max.cc
@@ -25,6 +25,8 @@ class MaxOperator : public MergeOperator {
     if (merge_in.existing_value) {
       max = Slice(merge_in.existing_value->data(),
                   merge_in.existing_value->size());
+    } else if (max.data() == nullptr) {
+      max = Slice();
     }
 
     for (const auto& op : merge_in.operand_list) {


### PR DESCRIPTION
Allow `Slice` holding nullptr as a sentinel value but not in comparisons. This new restriction eliminates the need for the manual checks in 39ef900551a4d88c8546ca086baaba76730e6162, while still conforming to glibc's `memcmp` API. Thanks @siying for the idea. Users may need to migrate, so mentioned it in HISTORY.md.

Test Plan:

- make check

- perf command:
```
TEST_TMPDIR=/dev/shm perf record -g ./db_bench -num=1000000 -benchmarks=readwhilewriting -statistics -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -compression_type=none -max_background_compactions=8 -max_background_flushes=4
```

- perf before 39ef900551a4d88c8546ca086baaba76730e6162:
```
+    9.62%     3.80%  db_bench     db_bench             [.] rocksdb::InternalKeyComparator::Compare
```

- perf after this PR:
```
+    9.61%     3.80%  db_bench     db_bench             [.] rocksdb::InternalKeyComparator::Compare
```