### PR TITLE
fix clang bug in block-based table reader

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1430,6 +1430,7 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
     FilePrefetchBuffer* prefetch_buffer, Rep* rep, const ReadOptions& ro,
     const BlockHandle& handle, Slice compression_dict,
     CachableEntry<Block>* block_entry, bool is_index) {
+  assert(block_entry != nullptr);
   const bool no_io = (ro.read_tier == kBlockCacheTier);
   Cache* block_cache = rep->table_options.block_cache.get();
   Cache* block_cache_compressed =
@@ -1486,6 +1487,7 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
       }
     }
   }
+  assert(s.ok() || block_entry->value == nullptr);
   return s;
 }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -257,6 +257,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
                                             handle, compression_dict, &block,
                                             is_index);
 
+      assert(s.ok() || block.value == nullptr);
       if (s.ok() && block.value != nullptr) {
         assert(block.cache_handle != nullptr);
         if (pin) {


### PR DESCRIPTION
This is the warning that clang considers a bug and has been causing it to fail:

```
table/block_based_table_reader.cc:240:27: warning: Potential leak of memory pointed to by 'block.value'
    for (; biter.Valid(); biter.Next()) {
                          ^~~~~
```

Actually clang just doesn't have enough knowledge to statically determine it's safe. We can teach it using an assert.

Test Plan:

- clang_analyze this file:
```
rm -f table/block_based_table_reader.o && /mnt/gvfs/third-party2/llvm-fb/a5fea028cb7ba43498976e1f8054b0b2e790c295/stable/centos6-native/6aaf4de/../../src/llvm/tools/clang/tools/scan-build/bin/scan-build --use-analyzer=/mnt/gvfs/third-party2/llvm-fb/a5fea028cb7ba43498976e1f8054b0b2e790c295/stable/centos6-native/6aaf4de/bin/clang++         --use-c++=/mnt/gvfs/third-party2/llvm-fb/a5fea028cb7ba43498976e1f8054b0b2e790c295/stable/centos6-native/6aaf4de/bin/clang++ --use-cc=/mnt/gvfs/third-party2/llvm-fb/a5fea028cb7ba43498976e1f8054b0b2e790c295/stable/centos6-native/6aaf4de/bin/clang --status-bugs         -o /data/users/andrewkr/rocksdb/scan_build_report         make table/block_based_table_reader.o
```
- make check