### PR TITLE
Not using aligned_alloc with gcc4 + asan

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -234,35 +234,19 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
 }
 
 void* LRUCacheShard::operator new(size_t size) {
-#if __SANITIZE_ADDRESS__
-  return malloc(size);
-#else
   return port::cacheline_aligned_alloc(size);
-#endif
 }
 
 void* LRUCacheShard::operator new[](size_t size) {
-#if __SANITIZE_ADDRESS__
-  return malloc(size);
-#else
   return port::cacheline_aligned_alloc(size);
-#endif
 }
 
 void LRUCacheShard::operator delete(void *memblock) {
-#if __SANITIZE_ADDRESS__
-  free(memblock);
-#else
   port::cacheline_aligned_free(memblock);
-#endif
 }
 
 void LRUCacheShard::operator delete[](void* memblock) {
-#if __SANITIZE_ADDRESS__
-  free(memblock);
-#else
   port::cacheline_aligned_free(memblock);
-#endif
 }
 
 void LRUCacheShard::SetCapacity(size_t capacity) {
@@ -518,7 +502,12 @@ uint32_t LRUCache::GetHash(Handle* handle) const {
   return reinterpret_cast<const LRUHandle*>(handle)->hash;
 }
 
-void LRUCache::DisownData() { shards_ = nullptr; }
+void LRUCache::DisownData() {
+// Do not drop data if compile with ASAN to suppress leak warning.
+#ifndef __SANITIZE_ADDRESS__
+  shards_ = nullptr;
+#endif  // !__SANITIZE_ADDRESS__
+}
 
 size_t LRUCache::TEST_GetLRUSize() {
   size_t lru_size_of_all_shards = 0;

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -185,7 +185,9 @@ int GetMaxOpenFiles() {
 }
 
 void *cacheline_aligned_alloc(size_t size) {
-#if defined (_ISOC11_SOURCE)
+#if __GNUC__ < 5 && defined(__SANITIZE_ADDRESS__)
+  return malloc(size);
+#elif defined(_ISOC11_SOURCE)
   return aligned_alloc(CACHE_LINE_SIZE, size);
 #elif ( _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__))
   void *m;


### PR DESCRIPTION
Summary:
GCC < 5 + ASAN does not instrument aligned_alloc, which can make ASAN
report false-positive with "free on address which was not malloc" error.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61693

Also suppress leak warning with LRUCache::DisownData().

Test Plan:
Run myrocks test which will trigger the false-positive prior to #2767
```
./tools/mysqltest.sh --jenkins --testset=Serial --asandebug --workers=16
rocksdb.deadlock_stats
```