### PR TITLE
Align persistent cache blocks with device pages

### DIFF
--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -332,7 +332,8 @@ Status BlockCacheTier::NewCacheFile() {
                            GetCachePath(), writer_cache_id_,
                            opt_.cache_file_size, opt_.log));
 
-  bool status = f->Create(opt_.enable_direct_writes, opt_.enable_direct_reads, opt_.page_alignment);
+  bool status = f->Create(opt_.enable_direct_writes, opt_.enable_direct_reads,
+                          opt_.page_alignment);
   if (!status) {
     return Status::IOError("Error creating file");
   }

--- a/utilities/persistent_cache/block_cache_tier.cc
+++ b/utilities/persistent_cache/block_cache_tier.cc
@@ -332,7 +332,7 @@ Status BlockCacheTier::NewCacheFile() {
                            GetCachePath(), writer_cache_id_,
                            opt_.cache_file_size, opt_.log));
 
-  bool status = f->Create(opt_.enable_direct_writes, opt_.enable_direct_reads);
+  bool status = f->Create(opt_.enable_direct_writes, opt_.enable_direct_reads, opt_.page_alignment);
   if (!status) {
     return Status::IOError("Error creating file");
   }

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -279,7 +279,7 @@ WriteableCacheFile::~WriteableCacheFile() {
 
 bool WriteableCacheFile::Create(const bool enable_direct_writes,
                                 const bool enable_direct_reads,
-                                const size_t page_alignment) {
+                                const uint32_t page_alignment) {
   WriteLock _(&rwlock_);
 
   page_alignment_ = page_alignment;
@@ -321,15 +321,15 @@ bool WriteableCacheFile::Append(const Slice& key, const Slice& val, LBA* lba) {
   if (page_alignment_ > 0) {
     assert(page_alignment_ % 2 == 0);
 
-    size_t min_extra_pages = (rec_size-1) / page_alignment_;
-    size_t start_page = disk_woff_ / page_alignment_;
-    size_t end_page = (disk_woff_ + rec_size) / page_alignment_;
+    uint32_t min_extra_pages = (rec_size-1) / page_alignment_;
+    uint32_t start_page = disk_woff_ / page_alignment_;
+    uint32_t end_page = (disk_woff_ + rec_size) / page_alignment_;
 
     if (end_page - start_page != min_extra_pages) {
       assert(end_page - start_page > min_extra_pages);
 
-      size_t new_woff_ = (start_page + 1) * page_alignment_;
-      size_t zeros_size = new_woff_ - disk_woff_;
+      uint32_t new_woff_ = (start_page + 1) * page_alignment_;
+      uint32_t zeros_size = new_woff_ - disk_woff_;
 
       if (PadZeros(zeros_size)) {
         disk_woff_ += zeros_size;
@@ -365,7 +365,7 @@ bool WriteableCacheFile::Append(const Slice& key, const Slice& val, LBA* lba) {
   return true;
 }
 
-bool WriteableCacheFile::PadZeros(const size_t size) {
+bool WriteableCacheFile::PadZeros(const uint32_t size) {
   if (!ExpandBuffer(size)) {
     // unable to expand the buffer
     ROCKS_LOG_DEBUG(log_, "Error expanding buffers. size=%d", size);

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -372,12 +372,12 @@ bool WriteableCacheFile::PadZeros(const uint32_t size) {
     return false;
   }
 
-  char zeros_[size];
-  memset(zeros_, '0', size);
-  Slice zeros(zeros_, size);
-  CacheRecord zeros_rec(zeros,zeros);
+  unique_ptr<char[]> zeros(new char[size]);
+  memset(zeros.get(), '0', size);
+  Slice zeros_slice(zeros.get(), size);
+  CacheRecord zeros_rec(zeros_slice,zeros_slice);
   return zeros_rec.Append(&bufs_, &buf_woff_,
-                          reinterpret_cast<const char*>(zeros_), size);
+                          reinterpret_cast<const char*>(zeros.get()), size);
 }
 
 

--- a/utilities/persistent_cache/block_cache_tier_file.h
+++ b/utilities/persistent_cache/block_cache_tier_file.h
@@ -187,7 +187,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
 
   // create file on disk
   bool Create(const bool enable_direct_writes, const bool enable_direct_reads,
-              const size_t page_alignment);
+              const uint32_t page_alignment);
 
   // read data from logical file
   bool Read(const LBA& lba, Slice* key, Slice* block, char* scratch) override {
@@ -213,7 +213,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
 
   bool ReadBuffer(const LBA& lba, Slice* key, Slice* block, char* scratch);
   bool ReadBuffer(const LBA& lba, char* data);
-  bool PadZeros(const size_t size);
+  bool PadZeros(const uint32_t size);
   bool ExpandBuffer(const size_t size);
   void DispatchBuffer();
   void BufferWriteDone();
@@ -247,7 +247,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
   size_t pending_ios_ = 0;               // Number of ios to disk in-progress
   bool enable_direct_reads_ = false;     // Should we enable direct reads
                                          // when reading from disk
-  size_t page_alignment_ = 0;            // Align writes with this page size
+  uint32_t page_alignment_ = 0;          // Align writes with this page size
                                          // (disabled if 0)
 };
 

--- a/utilities/persistent_cache/block_cache_tier_file.h
+++ b/utilities/persistent_cache/block_cache_tier_file.h
@@ -186,7 +186,8 @@ class WriteableCacheFile : public RandomAccessCacheFile {
   virtual ~WriteableCacheFile();
 
   // create file on disk
-  bool Create(const bool enable_direct_writes, const bool enable_direct_reads);
+  bool Create(const bool enable_direct_writes, const bool enable_direct_reads,
+              const size_t page_alignment);
 
   // read data from logical file
   bool Read(const LBA& lba, Slice* key, Slice* block, char* scratch) override {
@@ -212,6 +213,7 @@ class WriteableCacheFile : public RandomAccessCacheFile {
 
   bool ReadBuffer(const LBA& lba, Slice* key, Slice* block, char* scratch);
   bool ReadBuffer(const LBA& lba, char* data);
+  bool PadZeros(const size_t size);
   bool ExpandBuffer(const size_t size);
   void DispatchBuffer();
   void BufferWriteDone();
@@ -245,6 +247,8 @@ class WriteableCacheFile : public RandomAccessCacheFile {
   size_t pending_ios_ = 0;               // Number of ios to disk in-progress
   bool enable_direct_reads_ = false;     // Should we enable direct reads
                                          // when reading from disk
+  size_t page_alignment_ = 0;            // Align writes with this page size
+                                         // (disabled if 0)
 };
 
 //

--- a/utilities/persistent_cache/persistent_cache_tier.cc
+++ b/utilities/persistent_cache/persistent_cache_tier.cc
@@ -54,7 +54,8 @@ std::string PersistentCacheConfig::ToString() const {
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "    is_compressed: %d\n", is_compressed);
   ret.append(buffer);
-  snprintf(buffer, kBufferSize, "    page_alignment: %zu\n", page_alignment);
+  snprintf(buffer, kBufferSize, "    page_alignment:  %" PRIu32 "\n",
+           page_alignment);
   ret.append(buffer);
 
   return ret;

--- a/utilities/persistent_cache/persistent_cache_tier.cc
+++ b/utilities/persistent_cache/persistent_cache_tier.cc
@@ -54,6 +54,8 @@ std::string PersistentCacheConfig::ToString() const {
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "    is_compressed: %d\n", is_compressed);
   ret.append(buffer);
+  snprintf(buffer, kBufferSize, "    page_alignment: %zu\n", page_alignment);
+  ret.append(buffer);
 
   return ret;
 }

--- a/utilities/persistent_cache/persistent_cache_tier.h
+++ b/utilities/persistent_cache/persistent_cache_tier.h
@@ -222,7 +222,7 @@ struct PersistentCacheConfig {
   // This option aligns cache blocks with the specified page size in order to
   // reduce the number of page splits (and thus, reduce read bandwidth). This
   // option is disabled if set to 0
-  size_t page_alignment = 0;
+  uint32_t page_alignment = 0;
 
   PersistentCacheConfig MakePersistentCacheConfig(
       const std::string& path, const uint64_t size,

--- a/utilities/persistent_cache/persistent_cache_tier.h
+++ b/utilities/persistent_cache/persistent_cache_tier.h
@@ -217,6 +217,13 @@ struct PersistentCacheConfig {
   // uncompressed mode
   bool is_compressed = true;
 
+  // page_alignment
+  //
+  // This option aligns cache blocks with the specified page size in order to
+  // reduce the number of page splits (and thus, reduce read bandwidth). This
+  // option is disabled if set to 0
+  size_t page_alignment = 0;
+
   PersistentCacheConfig MakePersistentCacheConfig(
       const std::string& path, const uint64_t size,
       const std::shared_ptr<Logger>& log);


### PR DESCRIPTION
When persistent cache appends blocks to a file, these blocks may spread over several device pages. In order to read these blocks, the cache has to read their corresponding pages entirely, potentially creating significant read amplification. For example, to read a 4K block that does not start at the beginning of a page (and thus, spreads over two pages), the cache will actually have to read 8K.
To reduce read bandwidth from the persistent cache device, this diff introduces an option to align blocks with pages, such that each block will spread over the minimal number of pages possible. When needed, a page will be padded with zeros in order to align a block with the beginning of next page.