### PR TITLE
avoid use-after-move error

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -357,7 +357,8 @@ Status RangeDelAggregator::AddTombstone(RangeTombstone tombstone) {
       ++new_range_dels_iter;
     }
   } else {
-    tombstone_map.emplace(tombstone.start_key_, std::move(tombstone));
+    auto start_key = tombstone.start_key_;
+    tombstone_map.emplace(start_key, std::move(tombstone));
   }
   return Status::OK();
 }


### PR DESCRIPTION
* db/range_del_aggregator.cc (AddTombstone): Avoid a potential
use-after-move bug. The original code would both use and move
`tombstone` in a context where the order of those operations is
not specified.  The fix is to perform the use on a new, preceding
statement.

Author: @meyering 