### PR TITLE
Dump non-final ZSTD compression type support

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -130,6 +130,8 @@ void DumpSupportInfo(Logger* logger) {
   ROCKS_LOG_HEADER(logger, "\tZlib supported: %d", Zlib_Supported());
   ROCKS_LOG_HEADER(logger, "\tBzip supported: %d", BZip2_Supported());
   ROCKS_LOG_HEADER(logger, "\tLZ4 supported: %d", LZ4_Supported());
+  ROCKS_LOG_HEADER(logger, "\tZSTDNotFinal supported: %d",
+                   ZSTDNotFinal_Supported());
   ROCKS_LOG_HEADER(logger, "\tZSTD supported: %d", ZSTD_Supported());
   ROCKS_LOG_HEADER(logger, "Fast CRC32 supported: %d",
                    crc32c::IsFastCrc32Supported());


### PR DESCRIPTION
Test Plan:

- install zstd v0.7.5 (a version with non-finalized format) and observe the output when db_bench runs:

```
2017/08/30-14:12:45.466609 7fb5f3cdea00 Compression algorithms supported:
2017/08/30-14:12:45.466610 7fb5f3cdea00         Snappy supported: 0
2017/08/30-14:12:45.466610 7fb5f3cdea00         Zlib supported: 1
2017/08/30-14:12:45.466611 7fb5f3cdea00         Bzip supported: 0
2017/08/30-14:12:45.466612 7fb5f3cdea00         LZ4 supported: 0
2017/08/30-14:12:45.466613 7fb5f3cdea00         ZSTDNotFinal supported: 1
2017/08/30-14:12:45.466614 7fb5f3cdea00         ZSTD supported: 0
2017/08/30-14:12:45.466615 7fb5f3cdea00 Fast CRC32 supported: 1
```