### PR TITLE
Include statistics pointer in ImmutableDBOptions::Dump

### DIFF
--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -104,6 +104,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    info_log.get());
   ROCKS_LOG_HEADER(log, "               Options.max_file_opening_threads: %d",
                    max_file_opening_threads);
+  ROCKS_LOG_HEADER(log, "                             Options.statistics: %p",
+                   statistics.get());
   ROCKS_LOG_HEADER(log, "                              Options.use_fsync: %d",
                    use_fsync);
   ROCKS_LOG_HEADER(


### PR DESCRIPTION
useful when debugging to tell whether a DB has stats enabled, and whether a stats object is shared across DBs.

Test Plan:
- look at db_bench logs:
```
2017/08/30-16:09:47.633658 7f399cfc8a80                              Options.statistics: 0x7f399b669610
```