### PR TITLE
Add -DPORTABLE=1 to MSVC CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2015
 before_build:
 - md %APPVEYOR_BUILD_FOLDER%\build
 - cd %APPVEYOR_BUILD_FOLDER%\build
-- cmake -G "Visual Studio 15 2017 Win64" -DOPTDBG=1 -DXPRESS=1 ..
+- cmake -G "Visual Studio 14 2015 Win64" -DOPTDBG=1 -DXPRESS=1 -DPORTABLE=1 ..
 - cd ..
 build:
   project: build\rocksdb.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 1.0.{build}
-image: Visual Studio 2015
+image: Visual Studio 2017
 before_build:
 - md %APPVEYOR_BUILD_FOLDER%\build
 - cd %APPVEYOR_BUILD_FOLDER%\build
-- cmake -G "Visual Studio 14 2015 Win64" -DOPTDBG=1 -DXPRESS=1 ..
+- cmake -G "Visual Studio 15 2017 Win64" -DOPTDBG=1 -DXPRESS=1 ..
 - cd ..
 build:
   project: build\rocksdb.sln

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -465,14 +465,7 @@ LRUCache::LRUCache(size_t capacity, int num_shard_bits,
                    bool strict_capacity_limit, double high_pri_pool_ratio)
     : ShardedCache(capacity, num_shard_bits, strict_capacity_limit) {
   num_shards_ = 1 << num_shard_bits;
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable: 4316) // We've validated the alignment with the new operators
-#endif
   shards_ = new LRUCacheShard[num_shards_];
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
   SetCapacity(capacity);
   SetStrictCapacityLimit(strict_capacity_limit);
   for (int i = 0; i < num_shards_; i++) {

--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -242,7 +242,7 @@ extern void InitOnce(OnceType* once, void (*initializer)());
 
 
 inline void *cacheline_aligned_alloc(size_t size) {
-  return _aligned_malloc(CACHE_LINE_SIZE, size);
+  return _aligned_malloc(size, CACHE_LINE_SIZE);
 }
 
 inline void cacheline_aligned_free(void *memblock) {

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -339,7 +339,7 @@ TEST_P(WritePreparedTransactionTest, CheckAgainstSnapshotsTest) {
 }
 
 // Return true if the ith bit is set in combination represented by comb
-bool IsInCombination(size_t i, size_t comb) { return comb & (1 << i); }
+bool IsInCombination(size_t i, size_t comb) { return comb & (size_t(1) << i); }
 
 // Test that CheckAgainstSnapshots will not miss a live snapshot if it is run in
 // parallel with UpdateSnapshots.
@@ -367,7 +367,7 @@ TEST_P(WritePreparedTransactionTest, SnapshotConcurrentAccessTest) {
 
     // Each member of old snapshot might or might not appear in the new list. We
     // create a common_snapshots for each combination.
-    size_t new_comb_cnt = static_cast<size_t>(1 << old_size);
+    size_t new_comb_cnt = size_t(1) << old_size;
     for (size_t new_comb = 0; new_comb < new_comb_cnt; new_comb++) {
       std::vector<SequenceNumber> common_snapshots;
       for (size_t i = 0; i < old_snapshots.size(); i++) {


### PR DESCRIPTION
  Add -DPORTABLE=1
  port::cacheline_aligned_alloc() has arguments swapped which prevents every single test from running.