### PR TITLE
fix inclusive-exclusiveness of histogram ToString

### DIFF
--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -209,7 +209,8 @@ std::string HistogramStat::ToString() const {
     if (bucket_value <= 0.0) continue;
     cumulative_sum += bucket_value;
     snprintf(buf, sizeof(buf),
-             "[ %7" PRIu64 ", %7" PRIu64 " ) %8" PRIu64 " %7.3f%% %7.3f%% ",
+             "%c %7" PRIu64 ", %7" PRIu64 " ] %8" PRIu64 " %7.3f%% %7.3f%% ",
+             (b == 0) ? '[' : '(',
              (b == 0) ? 0 : bucketMapper.BucketLimit(b-1),  // left
               bucketMapper.BucketLimit(b),  // right
               bucket_value,                   // count

--- a/monitoring/histogram_test.cc
+++ b/monitoring/histogram_test.cc
@@ -87,7 +87,11 @@ TEST_F(HistogramTest, BasicOperation) {
 
 TEST_F(HistogramTest, BoundaryValue) {
   HistogramImpl histogram;
-  // both should be in [0, 1], never (1, 2].
+  // - both should be in [0, 1] bucket because we place values on bucket
+  //   boundaries in the lower bucket.
+  // - all points are in [0, 1] bucket, so p50 will be 0.5
+  // - the test cannot be written with a single point since histogram won't
+  //   report percentiles lower than the min or greater than the max.
   histogram.Add(0);
   histogram.Add(1);
 

--- a/monitoring/histogram_test.cc
+++ b/monitoring/histogram_test.cc
@@ -85,6 +85,15 @@ TEST_F(HistogramTest, BasicOperation) {
   BasicOperation(histogramWindowing);
 }
 
+TEST_F(HistogramTest, BoundaryValue) {
+  HistogramImpl histogram;
+  // both should be in [0, 1], never (1, 2].
+  histogram.Add(0);
+  histogram.Add(1);
+
+  ASSERT_LE(fabs(histogram.Percentile(50.0) - 0.5), kIota);
+}
+
 TEST_F(HistogramTest, MergeHistogram) {
   HistogramImpl histogram;
   HistogramImpl other;


### PR DESCRIPTION
I spent too much time thinking about histograms lately and realized boundary values fall into the lower bucket, not the upper bucket. It's because we're using `std::map::lower_bound` here: https://github.com/facebook/rocksdb/blob/867fe92e5e65ce501069aa22c538757acfaade34/monitoring/histogram.cc#L53.  Fixed histogram's `ToString()` to reflect this.

Test Plan:

- unit test to verify in which bucket boundary values are added
- verified db_bench histogram output:
```
[       0,       1 ]    81936   8.194%   8.194% ##
(       1,       2 ]   636865  63.687%  71.880% #############
(       2,       3 ]   237846  23.785%  95.665% #####
(       3,       4 ]    34207   3.421%  99.085% #
(       4,       6 ]     5712   0.571%  99.657% 
(       6,      10 ]      914   0.091%  99.748% 
(      10,      15 ]       50   0.005%  99.753% 
...
```