### PR TITLE
fix HistogramWindowingImpl copy-{assignment,constructor}

### DIFF
--- a/monitoring/histogram_windowing.h
+++ b/monitoring/histogram_windowing.h
@@ -22,8 +22,8 @@ public:
                          uint64_t micros_per_window,
                          uint64_t min_num_per_window);
 
-  HistogramWindowingImpl(const HistogramImpl&) = delete;
-  HistogramWindowingImpl& operator=(const HistogramImpl&) = delete;
+  HistogramWindowingImpl(const HistogramWindowingImpl&) = delete;
+  HistogramWindowingImpl& operator=(const HistogramWindowingImpl&) = delete;
 
   ~HistogramWindowingImpl();
 


### PR DESCRIPTION
their arguments had a typo.

Test Plan:
- `make check -j64`