### PR TITLE
speedup DBTest.EncodeDecompressedBlockSizeTest

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4503,7 +4503,7 @@ TEST_F(DBTest, EncodeDecompressedBlockSizeTest) {
       options.compression = comp;
       DestroyAndReopen(options);
 
-      int kNumKeysWritten = 100000;
+      int kNumKeysWritten = 1000;
 
       Random rnd(301);
       for (int i = 0; i < kNumKeysWritten; ++i) {


### PR DESCRIPTION
it sometimes takes more than 10 minutes (i.e., times out) on our internal CI. mainly because bzip is super slow. so I reduced the amount of  work it tries to do.

Test Plan:

- before:

```
$ ./db_test --gtest_filter=DBTest.EncodeDecompressedBlockSizeTest
...
[==========] 1 test from 1 test case ran. (24503 ms total)
[  PASSED  ] 1 test.
```

- after:

```
$ ./db_test --gtest_filter=DBTest.EncodeDecompressedBlockSizeTest
...
[==========] 1 test from 1 test case ran. (2960 ms total)
[  PASSED  ] 1 test.
```