### PR TITLE
Make InternalKeyComparator final and directly use it in merging iterator

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -136,7 +136,11 @@ inline ValueType ExtractValueType(const Slice& internal_key) {
 
 // A comparator for internal keys that uses a specified comparator for
 // the user key portion and breaks ties by decreasing sequence number.
-class InternalKeyComparator : public Comparator {
+class InternalKeyComparator
+#ifdef NDEBUG
+    final
+#endif
+    : public Comparator {
  private:
   const Comparator* user_comparator_;
   std::string name_;

--- a/table/iter_heap.h
+++ b/table/iter_heap.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "rocksdb/comparator.h"
+#include "db/dbformat.h"
 #include "table/iterator_wrapper.h"
 
 namespace rocksdb {
@@ -15,28 +15,28 @@ namespace rocksdb {
 // iterator with the max/largest key on top.
 class MaxIteratorComparator {
  public:
-  MaxIteratorComparator(const Comparator* comparator) :
-    comparator_(comparator) {}
+  MaxIteratorComparator(const InternalKeyComparator* comparator)
+      : comparator_(comparator) {}
 
   bool operator()(IteratorWrapper* a, IteratorWrapper* b) const {
     return comparator_->Compare(a->key(), b->key()) < 0;
   }
  private:
-  const Comparator* comparator_;
+  const InternalKeyComparator* comparator_;
 };
 
 // When used with std::priority_queue, this comparison functor puts the
 // iterator with the min/smallest key on top.
 class MinIteratorComparator {
  public:
-  MinIteratorComparator(const Comparator* comparator) :
-    comparator_(comparator) {}
+  MinIteratorComparator(const InternalKeyComparator* comparator)
+      : comparator_(comparator) {}
 
   bool operator()(IteratorWrapper* a, IteratorWrapper* b) const {
     return comparator_->Compare(a->key(), b->key()) > 0;
   }
  private:
-  const Comparator* comparator_;
+  const InternalKeyComparator* comparator_;
 };
 
 }  // namespace rocksdb

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "db/dbformat.h"
 #include "rocksdb/types.h"
 
 namespace rocksdb {
@@ -26,10 +27,9 @@ class Arena;
 // key is present in K child iterators, it will be yielded K times.
 //
 // REQUIRES: n >= 0
-extern InternalIterator* NewMergingIterator(const Comparator* comparator,
-                                            InternalIterator** children, int n,
-                                            Arena* arena = nullptr,
-                                            bool prefix_seek_mode = false);
+extern InternalIterator* NewMergingIterator(
+    const InternalKeyComparator* comparator, InternalIterator** children, int n,
+    Arena* arena = nullptr, bool prefix_seek_mode = false);
 
 class MergingIterator;
 
@@ -38,8 +38,8 @@ class MergeIteratorBuilder {
  public:
   // comparator: the comparator used in merging comparator
   // arena: where the merging iterator needs to be allocated from.
-  explicit MergeIteratorBuilder(const Comparator* comparator, Arena* arena,
-                                bool prefix_seek_mode = false);
+  explicit MergeIteratorBuilder(const InternalKeyComparator* comparator,
+                                Arena* arena, bool prefix_seek_mode = false);
   ~MergeIteratorBuilder() {}
 
   // Add iter to the merging iterator.

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -72,6 +72,7 @@ class ErrorEnv : public EnvWrapper {
   }
 };
 
+#ifndef NDEBUG
 // An internal comparator that just forward comparing results from the
 // user comparator in it. Can be used to test entities that have no dependency
 // on internal key structure but consumes InternalKeyComparator, like
@@ -94,6 +95,7 @@ class PlainInternalKeyComparator : public InternalKeyComparator {
     user_comparator()->FindShortSuccessor(key);
   }
 };
+#endif
 
 // A test comparator which compare two strings in this way:
 // (1) first compare prefix of 8 bytes in alphabet order,

--- a/utilities/date_tiered/date_tiered_db_impl.cc
+++ b/utilities/date_tiered/date_tiered_db_impl.cc
@@ -32,6 +32,7 @@ DateTieredDBImpl::DateTieredDBImpl(
     : db_(db),
       cf_options_(ColumnFamilyOptions(options)),
       ioptions_(ImmutableCFOptions(options)),
+      icomp_(cf_options_.comparator),
       ttl_(ttl),
       column_family_interval_(column_family_interval),
       mutex_(options.statistics.get(), db->GetEnv(), DB_MUTEX_WAIT_MICROS,
@@ -382,7 +383,7 @@ Iterator* DateTieredDBImpl::NewIterator(const ReadOptions& opts) {
       cf_options_.max_sequential_skip_in_iterations, 0);
 
   auto arena = db_iter->GetArena();
-  MergeIteratorBuilder builder(cf_options_.comparator, arena);
+  MergeIteratorBuilder builder(&icomp_, arena);
   for (auto& item : handle_map_) {
     auto handle = item.second;
     builder.AddIterator(db_impl->NewInternalIterator(

--- a/utilities/date_tiered/date_tiered_db_impl.h
+++ b/utilities/date_tiered/date_tiered_db_impl.h
@@ -56,6 +56,8 @@ class DateTieredDBImpl : public DateTieredDB {
 
   const ImmutableCFOptions ioptions_;
 
+  const InternalKeyComparator icomp_;
+
   // Storing all column family handles for time series data.
   std::vector<ColumnFamilyHandle*> handles_;
 


### PR DESCRIPTION
Summary:
Merging iterator invokes InternalKeyComparator.Compare() frequently to heap merge. By making InternalKeyComparator final and merging iterator to directly use InternalKeyComparator rather than through Iterator interface, we can give compiler a choice to avoid one more virtual function call if possible. I ran readseq benchmark in memory-only use case to make sure the performance at least doesn't regress.

I have to disable the final key word in debug build, as a hack test class depends on overriding the class.

Test Plan:run all existing tests