### PR TITLE
fix missing manual_wal_flush for DBOptions ctor

### DIFF
--- a/options/options.cc
+++ b/options/options.cc
@@ -191,7 +191,9 @@ DBOptions::DBOptions(const Options& options)
       dump_malloc_stats(options.dump_malloc_stats),
       avoid_flush_during_recovery(options.avoid_flush_during_recovery),
       avoid_flush_during_shutdown(options.avoid_flush_during_shutdown),
-      allow_ingest_behind(options.allow_ingest_behind) {
+      allow_ingest_behind(options.allow_ingest_behind),
+      concurrent_prepare(options.concurrent_prepare),
+      manual_wal_flush(options.manual_wal_flush) {
 }
 
 void DBOptions::Dump(Logger* log) const {


### PR DESCRIPTION
currently `ImmutableDBOptions::Dump` use default value for `concurrent_prepare` and `manual_wal_flush`, because DBOptions ctor does not init those member variables.

so in LOG file,  it will be
```
             Options.concurrent_prepare: 0
             Options.manual_wal_flush: 0
```
