### PR TITLE
Fix memory leak in OptionsTest::OptionsComposeDecompose

### DIFF
--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -676,6 +676,7 @@ TEST_F(OptionsTest, OptionsComposeDecompose) {
 
   ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(base_db_opts, new_db_opts));
   ASSERT_OK(RocksDBOptionsParser::VerifyCFOptions(base_cf_opts, new_cf_opts));
+  delete new_cf_opts.compaction_filter;
 }
 
 TEST_F(OptionsTest, ColumnFamilyOptionsSerialization) {


### PR DESCRIPTION
Summary:
Fixing asan error.

Test Plan:
```
COMPILE_WITH_ASAN=1 make options_test && ./options_test
```