### PR TITLE
Directly refernce perf_context internally.

### DIFF
--- a/monitoring/iostats_context.cc
+++ b/monitoring/iostats_context.cc
@@ -6,7 +6,6 @@
 #include <sstream>
 #include "monitoring/iostats_context_imp.h"
 #include "rocksdb/env.h"
-#include "util/thread_local.h"
 
 namespace rocksdb {
 

--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -8,35 +8,33 @@
 #include "rocksdb/iostats_context.h"
 
 #ifdef ROCKSDB_SUPPORT_THREAD_LOCAL
+namespace rocksdb {
+extern __thread IOStatsContext iostats_context;
+}  // namespace rocksdb
 
 // increment a specific counter by the specified value
-#define IOSTATS_ADD(metric, value)     \
-  (get_iostats_context()->metric += value)
+#define IOSTATS_ADD(metric, value) (iostats_context.metric += value)
 
 // Increase metric value only when it is positive
 #define IOSTATS_ADD_IF_POSITIVE(metric, value)   \
   if (value > 0) { IOSTATS_ADD(metric, value); }
 
 // reset a specific counter to zero
-#define IOSTATS_RESET(metric)          \
-  (get_iostats_context()->metric = 0)
+#define IOSTATS_RESET(metric) (iostats_context.metric = 0)
 
 // reset all counters to zero
-#define IOSTATS_RESET_ALL()                        \
-  (get_iostats_context()->Reset())
+#define IOSTATS_RESET_ALL() (iostats_context.Reset())
 
-#define IOSTATS_SET_THREAD_POOL_ID(value)      \
-  (get_iostats_context()->thread_pool_id = value)
+#define IOSTATS_SET_THREAD_POOL_ID(value) \
+  (iostats_context.thread_pool_id = value)
 
-#define IOSTATS_THREAD_POOL_ID()               \
-  (get_iostats_context()->thread_pool_id)
+#define IOSTATS_THREAD_POOL_ID() (iostats_context.thread_pool_id)
 
-#define IOSTATS(metric)                        \
-  (get_iostats_context()->metric)
+#define IOSTATS(metric) (iostats_context.metric)
 
 // Declare and set start time of the timer
-#define IOSTATS_TIMER_GUARD(metric)                                          \
-  PerfStepTimer iostats_step_timer_##metric(&(get_iostats_context()->metric)); \
+#define IOSTATS_TIMER_GUARD(metric)                                     \
+  PerfStepTimer iostats_step_timer_##metric(&(iostats_context.metric)); \
   iostats_step_timer_##metric.Start();
 
 #else  // ROCKSDB_SUPPORT_THREAD_LOCAL


### PR DESCRIPTION
Summary: After 7f6c02dda16471c2ed3318e9e7156f2b8d13bf46, the same get_perf_context() is called both of internally and externally. However, I found internally this is not got inlined. I don't know why this is the case, but directly referencing perf_context is the logical way to do.

Test Plan:Run all existing tests. Look at the binary and make sure the reference is inlined.