### PR TITLE
Add test kPointInTimeRecoveryCFConsistency

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 
 ### New Features
 ### Bug Fixes
+* Fix a potential data inconsistency issue during point-in-time recovery. `DB:Open()` will abort if column family inconsistency is found during PIT recovery.
 
 ## 5.8.0 (08/30/2017)
 ### Public API Change

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -493,6 +493,9 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
   bool stop_replay_by_wal_filter = false;
   bool stop_replay_for_corruption = false;
   bool flushed = false;
+  // record the maximum sequence number seen among all log files
+  // (excluding skipped content)
+  SequenceNumber max_sequence_all_WALs(0);
   for (auto log_number : log_numbers) {
     // The previous incarnation may not have written any MANIFEST
     // records after allocating this log number.  So we manually
@@ -572,6 +575,8 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       }
       WriteBatchInternal::SetContents(&batch, record);
       SequenceNumber sequence = WriteBatchInternal::Sequence(&batch);
+      if (sequence > max_sequence_all_WALs)
+        max_sequence_all_WALs = sequence;
 
       if (immutable_db_options_.wal_recovery_mode ==
           WALRecoveryMode::kPointInTimeRecovery) {
@@ -739,6 +744,25 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         (versions_->LastSequence() <= last_sequence)) {
       versions_->SetLastToBeWrittenSequence(last_sequence);
       versions_->SetLastSequence(last_sequence);
+    }
+  }
+  // Compare the largest sequence number in all SST files with
+  // the largest sequence number seen in all WALs. Abort Open() if SN from
+  // SST is larger than SN from WAL. This could happen when WAL is corrupted
+  // and some (but not all) CFs are flushed
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    auto* vstorage = cfd->current()->storage_info();
+    if (vstorage->num_levels() <= 0 || vstorage->NumLevelFiles(0) <= 0)
+      continue;
+    SequenceNumber latest_sequence_number_SST =
+        vstorage->LevelFiles(0)[0]->largest_seqno;
+    if (latest_sequence_number_SST > max_sequence_all_WALs) {
+      ROCKS_LOG_FATAL(immutable_db_options_.info_log,
+                    "SST file is ahead of WAL:"
+                    " max sequence of all WALs: #%" PRIu64
+                    " SequenceNumber in SST: #%" PRIu64,
+                    max_sequence_all_WALs, latest_sequence_number_SST);
+      return Status::Corruption("SST file is ahead of WALs");
     }
   }
 

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -37,7 +37,9 @@ TEST_F(DBWALTest, WAL) {
     writeOpt.disableWAL = true;
     ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v2"));
 
-    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
+    Options options = CurrentOptions();
+    options.wal_recovery_mode = WALRecoveryMode::kSkipAnyCorruptedRecords;
+    ReopenWithColumnFamilies({"default", "pikachu"}, options);
     // Both value's should be present.
     ASSERT_EQ("v2", Get(1, "bar"));
     ASSERT_EQ("v2", Get(1, "foo"));

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -37,9 +37,7 @@ TEST_F(DBWALTest, WAL) {
     writeOpt.disableWAL = true;
     ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v2"));
 
-    Options options = CurrentOptions();
-    options.wal_recovery_mode = WALRecoveryMode::kSkipAnyCorruptedRecords;
-    ReopenWithColumnFamilies({"default", "pikachu"}, options);
+    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
     // Both value's should be present.
     ASSERT_EQ("v2", Get(1, "bar"));
     ASSERT_EQ("v2", Get(1, "foo"));

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -898,8 +898,8 @@ TEST_F(DBWALTest, kPointInTimeRecoveryCFConsistency) {
 
   ASSERT_OK(Put(1, "key3", "val3"));
   // Corrupt WAL at location of key3
-  RecoveryTestHelper::InduceCorruption(fname, static_cast<size_t>(offset_to_corrupt),
-                   static_cast<size_t>(4));
+  RecoveryTestHelper::InduceCorruption(
+      fname, static_cast<size_t>(offset_to_corrupt), static_cast<size_t>(4));
   ASSERT_OK(Put(2, "key4", "val4"));
   ASSERT_OK(Put(1, "key5", "val5"));
   Flush(2);

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -877,6 +877,39 @@ TEST_F(DBWALTest, kAbsoluteConsistency) {
 }
 
 // Test scope:
+// We don't expect the data store to be opened if there is any inconsistency
+// between WAL and SST files
+TEST_F(DBWALTest, kPointInTimeRecoveryCFConsistency) {
+  Options options = CurrentOptions();
+  options.avoid_flush_during_recovery = true;
+
+  // Create DB with multiple column families.
+  CreateAndReopenWithCF({"one", "two"}, options);
+  ASSERT_OK(Put(1, "key1", "val1"));
+  ASSERT_OK(Put(2, "key2", "val2"));
+
+  // Record the offset at this point
+  Env* env = options.env;
+  int wal_file_id = RecoveryTestHelper::kWALFileOffset + 1;
+  std::string fname = LogFileName(dbname_, wal_file_id);
+  uint64_t offset_to_corrupt;
+  ASSERT_OK(env->GetFileSize(fname, &offset_to_corrupt));
+  ASSERT_GT(offset_to_corrupt, 0);
+
+  ASSERT_OK(Put(1, "key3", "val3"));
+  // Corrupt WAL at location of key3
+  RecoveryTestHelper::InduceCorruption(fname, static_cast<size_t>(offset_to_corrupt),
+                   static_cast<size_t>(4));
+  ASSERT_OK(Put(2, "key4", "val4"));
+  ASSERT_OK(Put(1, "key5", "val5"));
+  Flush(2);
+
+  // PIT recovery & verify
+  options.wal_recovery_mode = WALRecoveryMode::kPointInTimeRecovery;
+  ASSERT_NOK(TryReopenWithColumnFamilies({"default", "one", "two"}, options));
+}
+
+// Test scope:
 // - We expect to open data store under all circumstances
 // - We expect only data upto the point where the first error was encountered
 TEST_F(DBWALTest, kPointInTimeRecovery) {


### PR DESCRIPTION
Context/problem:

- CFs may be flushed at different times
- A WAL can only be deleted after all CFs have flushed beyond end of that WAL.
- Point-in-time recovery might stop upon reaching the first corruption.
- Some CFs may have already flushed beyond that point, while others haven't. We should fail the Open() instead of proceeding with inconsistent CFs.
