### PR TITLE
Fix Get does not return super version on error

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -968,6 +968,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       RecordTick(stats_, MEMTABLE_HIT);
     }
     if (!done && !s.ok() && !s.IsMergeInProgress()) {
+      ReturnAndCleanupSuperVersion(cfd, sv);
       return s;
     }
   }


### PR DESCRIPTION
Summary:
This is caught when I was testing #2886.

Test Plan:
```
make all check
```
plus the new tests that will add with #2886.