### PR TITLE
Expose max_background_jobs option in RocksJava

### DIFF
--- a/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
+++ b/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
@@ -543,6 +543,7 @@ public class DbBenchmark {
         (Integer)flags_.get(Flag.max_background_compactions));
     options.setMaxBackgroundFlushes(
         (Integer)flags_.get(Flag.max_background_flushes));
+    options.setMaxBackgroundJobs((Integer) flags_.get(Flag.max_background_jobs));
     options.setMaxOpenFiles(
         (Integer)flags_.get(Flag.open_files));
     options.setUseFsync(
@@ -1113,6 +1114,14 @@ public class DbBenchmark {
         "The maximum number of concurrent background flushes\n" +
         "\tthat can occur in parallel.") {
       @Override public Object parseValue(String value) {
+        return Integer.parseInt(value);
+      }
+    },
+    max_background_jobs(defaultOptions_.maxBackgroundJobs(),
+        "The maximum number of concurrent background jobs\n"
+            + "\tthat can occur in parallel.") {
+      @Override
+      public Object parseValue(String value) {
         return Integer.parseInt(value);
       }
     },

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -670,6 +670,28 @@ void Java_org_rocksdb_Options_setMaxBackgroundFlushes(
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    maxBackgroundJobs
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv* env, jobject jobj,
+                                                jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_jobs;
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setMaxBackgroundJobs
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jint max_background_jobs) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_jobs =
+      static_cast<int>(max_background_jobs);
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
@@ -4698,6 +4720,28 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
       max_background_flushes;
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setMaxBackgroundJobs
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle,
+                                                     jint max_background_jobs) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_jobs =
+      static_cast<int>(max_background_jobs);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    maxBackgroundJobs
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_jobs;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -390,8 +390,20 @@ public class DBOptions
   }
 
   @Override
-  public DBOptions setMaxLogFileSize(
-      final long maxLogFileSize) {
+  public DBOptions setMaxBackgroundJobs(final int maxBackgroundJobs) {
+    assert(isOwningHandle());
+    setMaxBackgroundJobs(nativeHandle_, maxBackgroundJobs);
+    return this;
+  }
+
+  @Override
+  public int maxBackgroundJobs() {
+    assert(isOwningHandle());
+    return maxBackgroundJobs(nativeHandle_);
+  }
+
+  @Override
+  public DBOptions setMaxLogFileSize(final long maxLogFileSize) {
     assert(isOwningHandle());
     setMaxLogFileSize(nativeHandle_, maxLogFileSize);
     return this;
@@ -998,6 +1010,8 @@ public class DBOptions
   private native void setMaxBackgroundFlushes(
       long handle, int maxBackgroundFlushes);
   private native int maxBackgroundFlushes(long handle);
+  private native void setMaxBackgroundJobs(long handle, int maxBackgroundJobs);
+  private native int maxBackgroundJobs(long handle);
   private native void setMaxLogFileSize(long handle, long maxLogFileSize)
       throws IllegalArgumentException;
   private native long maxLogFileSize(long handle);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -446,6 +446,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    *
    * @param baseBackgroundCompactions Suggested number of background compaction
    *     jobs
+   *
+   * @deprecated Use {@link #setMaxBackgroundJobs(int)}
    */
   void setBaseBackgroundCompactions(int baseBackgroundCompactions);
 
@@ -485,6 +487,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    * @return the maximum number of concurrent background compaction jobs.
    * @see RocksEnv#setBackgroundThreads(int)
    * @see RocksEnv#setBackgroundThreads(int, int)
+   *
+   * @deprecated Use {@link #setMaxBackgroundJobs(int)}
    */
   int maxBackgroundCompactions();
 
@@ -522,6 +526,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    * @see RocksEnv#setBackgroundThreads(int)
    * @see RocksEnv#setBackgroundThreads(int, int)
    * @see #maxBackgroundCompactions()
+   *
+   * @deprecated Use {@link #setMaxBackgroundJobs(int)}
    */
   T setMaxBackgroundFlushes(int maxBackgroundFlushes);
 
@@ -536,6 +542,25 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    * @see RocksEnv#setBackgroundThreads(int, int)
    */
   int maxBackgroundFlushes();
+
+  /**
+   * Specifies the maximum number of concurrent background jobs (both flushes
+   * and compactions combined).
+   * Default: 2
+   *
+   * @param maxBackgroundJobs number of max concurrent background jobs
+   * @return the instance of the current object.
+   */
+  T setMaxBackgroundJobs(int maxBackgroundJobs);
+
+  /**
+   * Returns the maximum number of concurrent background jobs (both flushes
+   * and compactions combined).
+   * Default: 2
+   *
+   * @return the maximum number of concurrent background jobs.
+   */
+  int maxBackgroundJobs();
 
   /**
    * Specifies the maximum size of a info log file. If the current log file

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -444,6 +444,19 @@ public class Options extends RocksObject
   }
 
   @Override
+  public int maxBackgroundJobs() {
+    assert(isOwningHandle());
+    return maxBackgroundJobs(nativeHandle_);
+  }
+
+  @Override
+  public Options setMaxBackgroundJobs(final int maxBackgroundJobs) {
+    assert(isOwningHandle());
+    setMaxBackgroundJobs(nativeHandle_, maxBackgroundJobs);
+    return this;
+  }
+
+  @Override
   public long maxLogFileSize() {
     assert(isOwningHandle());
     return maxLogFileSize(nativeHandle_);
@@ -1591,6 +1604,8 @@ public class Options extends RocksObject
   private native void setMaxBackgroundFlushes(
       long handle, int maxBackgroundFlushes);
   private native int maxBackgroundFlushes(long handle);
+  private native void setMaxBackgroundJobs(long handle, int maxMaxBackgroundJobs);
+  private native int maxBackgroundJobs(long handle);
   private native void setMaxLogFileSize(long handle, long maxLogFileSize)
       throws IllegalArgumentException;
   private native long maxLogFileSize(long handle);

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -241,6 +241,15 @@ public class DBOptionsTest {
   }
 
   @Test
+  public void maxBackgroundJobs() {
+    try (final DBOptions opt = new DBOptions()) {
+      final int intValue = rand.nextInt();
+      opt.setMaxBackgroundJobs(intValue);
+      assertThat(opt.maxBackgroundJobs()).isEqualTo(intValue);
+    }
+  }
+
+  @Test
   public void maxLogFileSize() throws RocksDBException {
     try(final DBOptions opt = new DBOptions()) {
       final long longValue = rand.nextLong();

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -459,6 +459,15 @@ public class OptionsTest {
   }
 
   @Test
+  public void maxBackgroundJobs() {
+    try (final Options opt = new Options()) {
+      final int intValue = rand.nextInt();
+      opt.setMaxBackgroundJobs(intValue);
+      assertThat(opt.maxBackgroundJobs()).isEqualTo(intValue);
+    }
+  }
+
+  @Test
   public void maxLogFileSize() throws RocksDBException {
     try (final Options opt = new Options()) {
       final long longValue = rand.nextLong();


### PR DESCRIPTION
This option was introduced in the C++ API in RocksDB 5.6 in bb01c1880c0c89a6cf338e22fd54e7e25b7d12ba . Now, exposing it through RocksJava API.

Test Plan:
Added new unit tests. 