### PR TITLE
Fix TransactionTest::SeqAdvanceTest ASAN failure

### DIFF
--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -4703,6 +4703,7 @@ TEST_P(TransactionTest, SeqAdvanceTest) {
   ASSERT_OK(s);
   seq = db_impl->GetLatestSequenceNumber();
   ASSERT_EQ(exp_seq, seq);
+  delete txn;
 
   // Commit without prepare. It shoudl write to DB without a commit marker.
   txn = db->BeginTransaction(write_options, txn_options);


### PR DESCRIPTION
Summary:
The test didn't delete txn before creating a new one.

Test Plan:
```
COMPILE_WITH_ASAN=1 make transaction_test && ./transaction_test
```