### PR TITLE
Use jemalloc in rocksdbjni library built via vagrant

### DIFF
--- a/java/crossbuild/build-linux-centos.sh
+++ b/java/crossbuild/build-linux-centos.sh
@@ -9,7 +9,7 @@ sudo rm -f /etc/yum/vars/releasever
 sudo yum -y install epel-release
 
 # install all required packages for rocksdb that are available through yum
-sudo yum -y install openssl java-1.7.0-openjdk-devel zlib-devel bzip2-devel lz4-devel snappy-devel libzstd-devel
+sudo yum -y install openssl java-1.7.0-openjdk-devel zlib-devel bzip2-devel lz4-devel snappy-devel libzstd-devel jemalloc-devel
 
 # install gcc/g++ 4.8.2 from tru/devtools-2
 sudo wget -O /etc/yum.repos.d/devtools-2.repo https://people.centos.org/tru/devtools-2/devtools-2.repo
@@ -29,4 +29,3 @@ scl enable devtoolset-2 'make jclean clean'
 scl enable devtoolset-2 'PORTABLE=1 make rocksdbjavastatic'
 cp /rocksdb/java/target/librocksdbjni-* /rocksdb-build
 cp /rocksdb/java/target/rocksdbjni-* /rocksdb-build
-


### PR DESCRIPTION
Problem:
During RocksJava performance testing we found that the rocksdb jni library is not built with jemalloc; instead it was getting built with the default glibc malloc. We saw quite a bit of memory bloat due to this.

Addressed this by installing jemalloc-devel package in the vm that we use to build release jars. 

Test plan:
- Built db_bench on the vagrant vm with this fix, and confirmed with the below command that jemalloc is used and its stats are printed:
`MALLOC_CONF=stats_print:true ./db_bench --benchmarks="fillseq" --num=1`
```
[vagrant@vagrant-centos6 rocksdb]$ MALLOC_CONF=stats_print:true ./db_bench --benchmarks="fillseq" --num=1
...
...
___ Begin jemalloc statistics ___
Version: 3.6.0-0-g46c0af68bd248b04df75e4f92d5fb804c3d75340
Assertions disabled
Run-time option settings:
  opt.abort: false
  opt.lg_chunk: 22
  opt.dss: "secondary"
  opt.narenas: 16
  opt.lg_dirty_mult: 3
  opt.stats_print: true
  opt.junk: false
  opt.quarantine: 0
  opt.redzone: false
  opt.zero: false
  opt.tcache: true
  opt.lg_tcache_max: 15
CPUs: 4
Arenas: 16
Pointer size: 8
Quantum size: 16
Page size: 4096
Min active:dirty page ratio per arena: 8:1
Maximum thread-cached size class: 32768
Chunk size: 4194304 (2^22)
Allocated: 395392, active: 888832, mapped: 20971520
Current active ceiling: 54525952
...
...
```
- Confirmed that the build now uses `-DROCKSDB_JEMALLOC` flag and shows `JEMALLOC=1` and `WITH_JEMALLOC_FLAG=1` in make_config.mk  on the vm. 
```
[vagrant@vagrant-centos6 rocksdb]$ grep -i jemalloc make_config.mk
JEMALLOC_INCLUDE=
JEMALLOC_LIB=
JEMALLOC=1
WITH_JEMALLOC_FLAG=1
```
- Also, `malloc_stats_print` symbol (which is enabled only if jemalloc is linked) is now in the jni, whereas it wasn't in it before:
```
[vagrant@vagrant-centos6 target]$ strings librocksdbjni-linux64.so | grep -i malloc
...
malloc_stats_print
...
```
