### PR TITLE
Fix WritePreparedTransactionTest::SeqAdvanceTest ASAN failure

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -621,6 +621,7 @@ TEST_P(WritePreparedTransactionTest, SeqAdvanceTest) {
   ASSERT_OK(s);
   seq = db_impl->GetLatestSequenceNumber();
   ASSERT_EQ(exp_seq, seq);
+  delete txn;
 
   // Commit without prepare. It shoudl write to DB without a commit marker.
   txn = db->BeginTransaction(write_options, txn_options);


### PR DESCRIPTION
Test Plan:
```
COMPILE_WITH_ASAN=1 make write_prepared_transaction_test && ./write_prepared_transaction_test --gtest_filter=*SeqAdvanceTest
```