### PR TITLE
Fix for when block.cache_handle is nullptr

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -259,12 +259,16 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
 
       assert(s.ok() || block.value == nullptr);
       if (s.ok() && block.value != nullptr) {
-        assert(block.cache_handle != nullptr);
-        if (pin) {
-          partition_map_[handle.offset()] = block;
-          RegisterCleanup(&ReleaseCachedEntry, block_cache, block.cache_handle);
+        if (block.cache_handle != nullptr) {
+          if (pin) {
+            partition_map_[handle.offset()] = block;
+            RegisterCleanup(&ReleaseCachedEntry, block_cache,
+                            block.cache_handle);
+          } else {
+            block_cache->Release(block.cache_handle);
+          }
         } else {
-          block_cache->Release(block.cache_handle);
+          delete block.value;
         }
       }
     }


### PR DESCRIPTION
When using with compressed cache it is possible that the status is ok but the block is not actually added to the block cache. The patch takes this case into account.