### PR TITLE
WritePrepared Txn: Rollback

### DIFF
--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -54,7 +54,7 @@ class PessimisticTransaction : public TransactionBaseImpl {
   // transactions writes to an internal write batch.
   Status CommitBatch(WriteBatch* batch);
 
-  Status Rollback() override = 0;
+  Status Rollback() override;
 
   Status RollbackToSavePoint() override;
 
@@ -120,6 +120,8 @@ class PessimisticTransaction : public TransactionBaseImpl {
   virtual Status CommitBatchInternal(WriteBatch* batch) = 0;
 
   virtual Status CommitInternal() = 0;
+
+  virtual Status RollbackInternal() = 0;
 
   void Initialize(const TransactionOptions& txn_options);
 
@@ -191,8 +193,6 @@ class WriteCommittedTxn : public PessimisticTransaction {
 
   virtual ~WriteCommittedTxn() {}
 
-  Status Rollback() override;
-
  private:
   Status PrepareInternal() override;
 
@@ -201,6 +201,8 @@ class WriteCommittedTxn : public PessimisticTransaction {
   Status CommitBatchInternal(WriteBatch* batch) override;
 
   Status CommitInternal() override;
+
+  Status RollbackInternal() override;
 
   Status ValidateSnapshot(ColumnFamilyHandle* column_family, const Slice& key,
                           SequenceNumber prev_seqno, SequenceNumber* new_seqno);

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -673,6 +673,14 @@ void WritePreparedTxnDB::RollbackPrepared(uint64_t prep_seq,
   }
   WriteLock wl(&prepared_mutex_);
   prepared_txns_.erase(prep_seq);
+  bool was_empty = delayed_prepared_.empty();
+  if (!was_empty) {
+    delayed_prepared_.erase(prep_seq);
+    bool is_empty = delayed_prepared_.empty();
+    if (was_empty != is_empty) {
+      delayed_prepared_empty_.store(is_empty, std::memory_order_release);
+    }
+  }
 }
 
 void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq,

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -655,6 +655,26 @@ void WritePreparedTxnDB::AddPrepared(uint64_t seq) {
   prepared_txns_.push(seq);
 }
 
+void WritePreparedTxnDB::RollbackPrepared(uint64_t prep_seq,
+                                          uint64_t rollback_seq) {
+  ROCKS_LOG_DEBUG(
+      info_log_, "Txn %" PRIu64 " rolling back with rollback seq of " PRIu64 "",
+      prep_seq, rollback_seq);
+  std::vector<SequenceNumber> snapshots =
+      GetSnapshotListFromDB(kMaxSequenceNumber);
+  // TODO(myabandeh): currently we are assuming that there is no snapshot taken
+  // when a transaciton is rolled back. This is the case the way MySQL does
+  // rollback which is after recovery. We should extend it to be able to
+  // rollback txns that overlap with exsiting snapshots.
+  assert(snapshots.size() == 0);
+  if (snapshots.size()) {
+    throw std::runtime_error(
+        "Rollback reqeust while there are live snapshots.");
+  }
+  WriteLock wl(&prepared_mutex_);
+  prepared_txns_.erase(prep_seq);
+}
+
 void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq,
                                       uint64_t commit_seq) {
   ROCKS_LOG_DEBUG(info_log_, "Txn %" PRIu64 " Committing with %" PRIu64,

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -210,6 +210,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   bool IsInSnapshot(uint64_t seq, uint64_t snapshot_seq);
   // Add the trasnaction with prepare sequence seq to the prepared list
   void AddPrepared(uint64_t seq);
+  // Rollback a prepared txn identified with prep_seq. rollback_seq is the seq
+  // with which the additional data is written to cancel the txn effect. It can
+  // be used to idenitfy the snapshots that overlap with the rolled back txn.
+  void RollbackPrepared(uint64_t prep_seq, uint64_t rollback_seq);
   // Add the transaction with prepare sequence prepare_seq and commit sequence
   // commit_seq to the commit map
   void AddCommitted(uint64_t prepare_seq, uint64_t commit_seq);
@@ -306,6 +310,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   friend class WritePreparedTransactionTest_AdvanceMaxEvictedSeqBasicTest_Test;
   friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
+  friend class WritePreparedTransactionTest_RollbackTest_Test;
 
   void init(const TransactionDBOptions& /* unused */) {
     // Adcance max_evicted_seq_ no more than 100 times before the cache wraps

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1130,8 +1130,7 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
   const size_t num_values = 5;
   for (size_t ikey = 1; ikey <= num_keys; ikey++) {
     for (size_t ivalue = 0; ivalue < num_values; ivalue++) {
-      // TODO(myabandeh): check rollback after recovery
-      for (bool crash : {false}) {
+      for (bool crash : {false, true}) {
         ReOpen();
         WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
         std::string key_str = "key" + ToString(ikey);
@@ -1181,8 +1180,7 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
         ASSERT_OK(s);
 
         ASSERT_FALSE(wp_db->prepared_txns_.empty());
-        // TODO(myabandeh): uncomment it after rebase
-        // ASSERT_EQ(txn->GetId(), wp_db->prepared_txns_.top());
+        ASSERT_EQ(txn->GetId(), wp_db->prepared_txns_.top());
 
         ASSERT_SAME(db, s1, v1, "key1");
         ASSERT_SAME(db, s2, v2, "key2");
@@ -1197,8 +1195,7 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
           wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
           txn = db->GetTransactionByName("xid0");
           ASSERT_FALSE(wp_db->prepared_txns_.empty());
-          // TODO(myabandeh): uncomment it after rebase
-          // ASSERT_EQ(txn->GetId(), wp_db->prepared_txns_.top());
+          ASSERT_EQ(txn->GetId(), wp_db->prepared_txns_.top());
         }
 
         ASSERT_SAME(db, s1, v1, "key1");

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -110,12 +110,13 @@ Status WritePreparedTxn::CommitInternal() {
 
 Status WritePreparedTxn::RollbackInternal() {
   WriteBatch rollback_batch;
-  assert(prepare_seq_ != kMaxSequenceNumber);
-  assert(prepare_seq_ > 0);
+  assert(GetId() != kMaxSequenceNumber);
+  assert(GetId() > 0);
   // In the absense of Prepare markers, use Noop as a batch separator
   WriteBatchInternal::InsertNoop(&rollback_batch);
   PinnableSlice pinnable_val;
-  auto snap_seq = prepare_seq_ - 1;
+  // In WritePrepared, the txn is is the same as prepare seq
+  auto snap_seq = GetId() - 1;
   struct RollbackWriteBatchBuilder : public WriteBatch::Handler {
     DBImpl* db_;
     ReadOptions roptions;
@@ -183,7 +184,7 @@ Status WritePreparedTxn::RollbackInternal() {
   wpt_db_->AddPrepared(prepare_seq);
   wpt_db_->AddCommitted(prepare_seq, commit_seq);
   // Mark the txn as rolled back
-  wpt_db_->RollbackPrepared(prepare_seq_, commit_seq);
+  wpt_db_->RollbackPrepared(GetId(), commit_seq);
 
   return s;
 }

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -63,7 +63,7 @@ Status WritePreparedTxn::CommitWithoutPrepareInternal() {
 }
 
 Status WritePreparedTxn::CommitBatchInternal(WriteBatch* batch) {
-  // In the absenese of Prepare markers, use Noop as a batch separator
+  // In the absense of Prepare markers, use Noop as a batch separator
   WriteBatchInternal::InsertNoop(batch);
   const bool disable_memtable = true;
   const uint64_t no_log_ref = 0;
@@ -108,10 +108,83 @@ Status WritePreparedTxn::CommitInternal() {
   return s;
 }
 
-Status WritePreparedTxn::Rollback() {
-  // TODO(myabandeh) Implement this
-  throw std::runtime_error("Rollback not Implemented");
-  return Status::OK();
+Status WritePreparedTxn::RollbackInternal() {
+  WriteBatch rollback_batch;
+  assert(prepare_seq_ != kMaxSequenceNumber);
+  assert(prepare_seq_ > 0);
+  // In the absense of Prepare markers, use Noop as a batch separator
+  WriteBatchInternal::InsertNoop(&rollback_batch);
+  PinnableSlice pinnable_val;
+  auto snap_seq = prepare_seq_ - 1;
+  struct RollbackWriteBatchBuilder : public WriteBatch::Handler {
+    DBImpl* db_;
+    ReadOptions roptions;
+    WriteOptions woptions;
+    WritePreparedTxnReadCallback callback;
+    RollbackWriteBatchBuilder(DBImpl* db, WritePreparedTxnDB* wpt_db,
+                              SequenceNumber snap_seq)
+        : db_(db), callback(wpt_db, snap_seq) {}
+
+    Status Rollback(uint32_t cf, const Slice& key) {
+      PinnableSlice pinnable_val;
+      bool found;
+      auto cf_handle = db_->GetColumnFamilyHandle(cf);
+      auto s = db_->GetImpl(roptions, cf_handle, key, &pinnable_val, &found,
+                            &callback);
+      assert(s.ok());
+      if (found) {
+        s = db_->Put(woptions, cf_handle, key, pinnable_val);
+        assert(s.ok());
+      } else {
+        // There has been no readable value before txn. By adding a delete we
+        // make sure that there will be none afterwards either.
+        s = db_->Delete(woptions, cf_handle, key);
+        assert(s.ok());
+      }
+      return s;
+    }
+
+    Status PutCF(uint32_t cf, const Slice& key, const Slice& val) override {
+      return Rollback(cf, key);
+    }
+
+    Status DeleteCF(uint32_t cf, const Slice& key) override {
+      return Rollback(cf, key);
+    }
+
+    Status SingleDeleteCF(uint32_t cf, const Slice& key) override {
+      return Rollback(cf, key);
+    }
+
+    Status MergeCF(uint32_t cf, const Slice& key, const Slice& val) override {
+      return Rollback(cf, key);
+    }
+
+    Status MarkNoop(bool) override { return Status::OK(); }
+    Status MarkBeginPrepare() override { return Status::OK(); }
+    Status MarkEndPrepare(const Slice&) override { return Status::OK(); }
+    Status MarkCommit(const Slice&) override { return Status::OK(); }
+    Status MarkRollback(const Slice&) override {
+      return Status::InvalidArgument();
+    }
+  } rollback_handler(db_impl_, wpt_db_, snap_seq);
+  auto s = rollback_batch.Iterate(&rollback_handler);
+  assert(s.ok());
+  WriteBatchInternal::MarkRollback(&rollback_batch, name_);
+  const bool disable_memtable = true;
+  const uint64_t no_log_ref = 0;
+  uint64_t seq_used = kMaxSequenceNumber;
+  s = db_impl_->WriteImpl(write_options_, &rollback_batch, nullptr, nullptr,
+                          no_log_ref, !disable_memtable, &seq_used);
+  assert(seq_used != kMaxSequenceNumber);
+  uint64_t& prepare_seq = seq_used;
+  uint64_t& commit_seq = seq_used;
+  // TODO(myabandeh): skip AddPrepared
+  wpt_db_->AddPrepared(prepare_seq);
+  wpt_db_->AddCommitted(prepare_seq, commit_seq);
+  // TODO(myabandeh): after rollback remove txn from prepared list
+
+  return s;
 }
 
 }  // namespace rocksdb

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -182,7 +182,8 @@ Status WritePreparedTxn::RollbackInternal() {
   // TODO(myabandeh): skip AddPrepared
   wpt_db_->AddPrepared(prepare_seq);
   wpt_db_->AddCommitted(prepare_seq, commit_seq);
-  // TODO(myabandeh): after rollback remove txn from prepared list
+  // Mark the txn as rolled back
+  wpt_db_->RollbackPrepared(prepare_seq_, commit_seq);
 
   return s;
 }

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -50,8 +50,6 @@ class WritePreparedTxn : public PessimisticTransaction {
                      ColumnFamilyHandle* column_family, const Slice& key,
                      PinnableSlice* value) override;
 
-  Status Rollback() override;
-
  private:
   friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;
 
@@ -62,6 +60,8 @@ class WritePreparedTxn : public PessimisticTransaction {
   Status CommitBatchInternal(WriteBatch* batch) override;
 
   Status CommitInternal() override;
+
+  Status RollbackInternal() override;
 
   // TODO(myabandeh): verify that the current impl work with values being
   // written with prepare sequence number too.


### PR DESCRIPTION
Implement the rollback of WritePrepared txns. For each modified value, it reads the value before the txn and write it back. This would cancel out the effect of transaction. It also remove the rolled back txn from prepared heap.