### PR TITLE
Add a template for issues

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,7 @@
+> Note: Please use Issues only for bug reports. For questions, discussions, feature requests, etc. post to dev group: https://www.facebook.com/groups/rocksdb.dev
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior


### PR DESCRIPTION
This template reminds the users to use issues only for bug reports. The template is written according to the github guidelines at https://help.github.com/articles/creating-an-issue-template-for-your-repository/