### PR TITLE
pin L0 filters/indexes for compaction outputs

### DIFF
--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1122,7 +1122,8 @@ Status CompactionJob::FinishCompactionOutputFile(
         nullptr /* range_del_agg */, nullptr,
         cfd->internal_stats()->GetFileReadHist(
             compact_->compaction->output_level()),
-        false);
+        false, nullptr /* arena */, false /* skip_filters */,
+        compact_->compaction->output_level());
     s = iter->status();
 
     if (s.ok() && paranoid_file_checks_) {


### PR DESCRIPTION
We need to tell the iterator the compaction output file's level so it can apply proper optimizations, like pinning filter and index blocks when user enables `pin_l0_filter_and_index_blocks_in_cache` and the output file's level is zero.

Test Plan:

- make check
- verified Sumeet isn't concerned about perf impact