### PR TITLE
cmake: pass "-msse4.2" to when building crc32c.cc if HAVE_SSE42

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,8 +179,10 @@ else()
   endif()
 endif()
 
-set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS})
 include(CheckCXXSourceCompiles)
+if(NOT MSVC)
+  set(CMAKE_REQUIRED_FLAGS "-msse4.2")
+endif()
 CHECK_CXX_SOURCE_COMPILES("
 #include <cstdint>
 #include <nmmintrin.h>
@@ -188,6 +190,7 @@ int main() {
   volatile uint32_t x = _mm_crc32_u32(0, 0);
 }
 " HAVE_SSE42)
+unset(CMAKE_REQUIRED_FLAGS)
 if(HAVE_SSE42)
   add_definitions(-DHAVE_SSE42)
 elseif(FORCE_SSE42)
@@ -554,6 +557,12 @@ set(SOURCES
         utilities/write_batch_with_index/write_batch_with_index.cc
         utilities/write_batch_with_index/write_batch_with_index_internal.cc
         $<TARGET_OBJECTS:build_version>)
+
+if(HAVE_SSE42 AND NOT FORCE_SSE42)
+set_source_files_properties(
+  util/crc32c.cc
+  PROPERTIES COMPILE_FLAGS "-msse4.2")
+endif()
 
 if(WIN32)
   list(APPEND SOURCES

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -336,15 +336,6 @@ static inline void Slow_CRC32(uint64_t* l, uint8_t const **p) {
   table0_[c >> 24];
 }
 
-#if defined(HAVE_SSE42) && defined(__GNUC__)
-#if defined(__clang__)
-#if __has_cpp_attribute(gnu::target)
-__attribute__ ((target ("sse4.2")))
-#endif
-#else  // gcc supports this since 4.4
-__attribute__ ((target ("sse4.2")))
-#endif
-#endif
 static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
 #ifndef HAVE_SSE42
   Slow_CRC32(l, p);


### PR DESCRIPTION
it turns out that, with older GCC shipped from centos7, the SSE42
intrinsics are not available even with "target" specified. so we
need to pass "-msse42" for checking compiler's sse4.2 support and
for building crc32c.cc which uses sse4.2 intrinsics for crc32.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>