### PR TITLE
WritePrepared Txn: duplicate keys

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -233,6 +233,9 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // remove the duplicate keys. The index will not be updated after this.
   // Returns false if collapse was not necessary
   bool Collapse();
+  void DisableDuplicateMergeKeys() { allow_dup_merge = false; }
+  bool allow_dup_merge = true;
+
   Status GetFromBatchAndDB(DB* db, const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,
                            PinnableSlice* value, ReadCallback* callback);

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -233,8 +233,8 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // remove the duplicate keys. The index will not be updated after this.
   // Returns false if collapse was not necessary
   bool Collapse();
-  void DisableDuplicateMergeKeys() { allow_dup_merge = false; }
-  bool allow_dup_merge = true;
+  void DisableDuplicateMergeKeys() { allow_dup_merge_ = false; }
+  bool allow_dup_merge_ = true;
 
   Status GetFromBatchAndDB(DB* db, const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -134,6 +134,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
   using WriteBatchBase::GetWriteBatch;
   WriteBatch* GetWriteBatch() override;
+  WriteBatch* GetWriteBatchCollapsed(RawWriteBatch* collapsed_buf);
 
   // Create an iterator of a column family. User can call iterator.Seek() to
   // search to the next entry of or after a key. Keys will be iterated in the

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -228,8 +228,9 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
  private:
   friend class WritePreparedTxn;
-  // TODO(myabandeh): this is hackish, non-efficient solution to enable the e2e unit tests. Replace it with a proper solution.
-  // Collapse the WriteBatch to remove the duplicate keys. The index will not be updated after this.
+  // TODO(myabandeh): this is hackish, non-efficient solution to enable the e2e
+  // unit tests. Replace it with a proper solution. Collapse the WriteBatch to
+  // remove the duplicate keys. The index will not be updated after this.
   // Returns false if collapse was not necessary
   bool Collapse();
   Status GetFromBatchAndDB(DB* db, const ReadOptions& read_options,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -134,7 +134,6 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
   using WriteBatchBase::GetWriteBatch;
   WriteBatch* GetWriteBatch() override;
-  WriteBatch* GetWriteBatchCollapsed(RawWriteBatch* collapsed_buf);
 
   // Create an iterator of a column family. User can call iterator.Seek() to
   // search to the next entry of or after a key. Keys will be iterated in the
@@ -229,6 +228,10 @@ class WriteBatchWithIndex : public WriteBatchBase {
 
  private:
   friend class WritePreparedTxn;
+  // TODO(myabandeh): this is hackish, non-efficient solution to enable the e2e unit tests. Replace it with a proper solution.
+  // Collapse the WriteBatch to remove the duplicate keys. The index will not be updated after this.
+  // Returns false if collapse was not necessary
+  bool Collapse();
   Status GetFromBatchAndDB(DB* db, const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,
                            PinnableSlice* value, ReadCallback* callback);

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -327,7 +327,9 @@ class WriteBatch : public WriteBatchBase {
  private:
   friend class WriteBatchInternal;
   friend class LocalSavePoint;
-  //TODO(myabandeh): this is needed for a hack to collapse the write batch and remove duplicate keys. Remove it when the hack is replaced with a propper solution.
+  // TODO(myabandeh): this is needed for a hack to collapse the write batch and
+  // remove duplicate keys. Remove it when the hack is replaced with a propper
+  // solution.
   friend class WriteBatchWithIndex;
   SavePoints* save_points_;
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -327,6 +327,7 @@ class WriteBatch : public WriteBatchBase {
  private:
   friend class WriteBatchInternal;
   friend class LocalSavePoint;
+  friend class WriteBatchWithIndex;
   SavePoints* save_points_;
 
   // When sending a WriteBatch through WriteImpl we might want to
@@ -348,15 +349,6 @@ class WriteBatch : public WriteBatchBase {
 
   // Intentionally copyable
 };
-    class RawWriteBatch: public WriteBatch {
-      private:
-        RawWriteBatch() : WriteBatch() {}
-        friend class WritePreparedTxn;
-      public :
-        void Append(Slice slice) {
-          rep_.append(slice.data(), slice.size());
-        }
-    };
 
 }  // namespace rocksdb
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -327,6 +327,7 @@ class WriteBatch : public WriteBatchBase {
  private:
   friend class WriteBatchInternal;
   friend class LocalSavePoint;
+  //TODO(myabandeh): this is needed for a hack to collapse the write batch and remove duplicate keys. Remove it when the hack is replaced with a propper solution.
   friend class WriteBatchWithIndex;
   SavePoints* save_points_;
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -348,6 +348,15 @@ class WriteBatch : public WriteBatchBase {
 
   // Intentionally copyable
 };
+    class RawWriteBatch: public WriteBatch {
+      private:
+        RawWriteBatch() : WriteBatch() {}
+        friend class WritePreparedTxn;
+      public :
+        void Append(Slice slice) {
+          rep_.append(slice.data(), slice.size());
+        }
+    };
 
 }  // namespace rocksdb
 

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -465,6 +465,7 @@ Status PessimisticTransactionDB::Write(const WriteOptions& opts,
   // concurrent transactions.
   Transaction* txn = BeginInternalTransaction(opts);
   txn->DisableIndexing();
+  //TODO(myabandeh): indexing being disabled we need another machanism to detect duplicattes in the input patch
 
   auto txn_impl =
       static_cast_with_check<PessimisticTransaction, Transaction>(txn);

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -465,7 +465,8 @@ Status PessimisticTransactionDB::Write(const WriteOptions& opts,
   // concurrent transactions.
   Transaction* txn = BeginInternalTransaction(opts);
   txn->DisableIndexing();
-  //TODO(myabandeh): indexing being disabled we need another machanism to detect duplicattes in the input patch
+  // TODO(myabandeh): indexing being disabled we need another machanism to
+  // detect duplicattes in the input patch
 
   auto txn_impl =
       static_cast_with_check<PessimisticTransaction, Transaction>(txn);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1238,6 +1238,72 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
   }
 }
 
+// TODO(myabandeh): move it to transaction_test when it is extended to
+// WROTE_PREPARED.
+
+// Test that the transactional db can handle duplicate keys in the write batch
+TEST_P(WritePreparedTransactionTest, DuplicateKeyTest) {
+  for (bool do_prepare: {true, false}) {
+  TransactionOptions txn_options;
+  WriteOptions write_options;
+  Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
+  auto s = txn0->SetName("xid");
+  ASSERT_OK(s);
+  s = txn0->Put(Slice("foo0"), Slice("bar0a"));
+  ASSERT_OK(s);
+  s = txn0->Put(Slice("foo0"), Slice("bar0b"));
+  ASSERT_OK(s);
+  s = txn0->Put(Slice("foo1"), Slice("bar1"));
+  ASSERT_OK(s);
+  s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
+  ASSERT_OK(s);
+  //TODO(myabandeh): enable this after duplicatae merge keys are supported
+  //s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
+  //ASSERT_OK(s);
+  s = txn0->Put(Slice("foo2"), Slice("bar2b"));
+  ASSERT_OK(s);
+  s = txn0->Put(Slice("foo3"), Slice("bar3"));
+  ASSERT_OK(s);
+  //TODO(myabandeh): enable this after duplicatae merge keys are supported
+  //s = txn0->Merge(Slice("foo3"), Slice("bar3"));
+  //ASSERT_OK(s);
+  s = txn0->Put(Slice("foo4"), Slice("bar4"));
+  ASSERT_OK(s);
+  s = txn0->Delete(Slice("foo4"));
+  ASSERT_OK(s);
+  s = txn0->SingleDelete(Slice("foo4"));
+  ASSERT_OK(s);
+  if (do_prepare) {
+  s = txn0->Prepare();
+  ASSERT_OK(s);
+  }
+  s = txn0->Commit();
+  ASSERT_OK(s);
+  if (!do_prepare) {
+  auto pdb = reinterpret_cast<PessimisticTransactionDB*>(db);
+  pdb->UnregisterTransaction(txn0);
+  }
+  delete txn0;
+  ReadOptions ropt;
+  PinnableSlice pinnable_val;
+
+  s = db->Get(ropt, db->DefaultColumnFamily(), "foo0", &pinnable_val);
+  ASSERT_OK(s);
+  ASSERT_TRUE(pinnable_val == ("bar0b"));
+  s = db->Get(ropt, db->DefaultColumnFamily(), "foo1", &pinnable_val);
+  ASSERT_OK(s);
+  ASSERT_TRUE(pinnable_val == ("bar1"));
+  s = db->Get(ropt, db->DefaultColumnFamily(), "foo2", &pinnable_val);
+  ASSERT_OK(s);
+  ASSERT_TRUE(pinnable_val == ("bar2b"));
+  s = db->Get(ropt, db->DefaultColumnFamily(), "foo3", &pinnable_val);
+  ASSERT_OK(s);
+  ASSERT_TRUE(pinnable_val == ("bar3"));
+  s = db->Get(ropt, db->DefaultColumnFamily(), "foo4", &pinnable_val);
+  ASSERT_TRUE(s.IsNotFound());
+  }
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1243,64 +1243,64 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
 
 // Test that the transactional db can handle duplicate keys in the write batch
 TEST_P(WritePreparedTransactionTest, DuplicateKeyTest) {
-  for (bool do_prepare: {true, false}) {
-  TransactionOptions txn_options;
-  WriteOptions write_options;
-  Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
-  auto s = txn0->SetName("xid");
-  ASSERT_OK(s);
-  s = txn0->Put(Slice("foo0"), Slice("bar0a"));
-  ASSERT_OK(s);
-  s = txn0->Put(Slice("foo0"), Slice("bar0b"));
-  ASSERT_OK(s);
-  s = txn0->Put(Slice("foo1"), Slice("bar1"));
-  ASSERT_OK(s);
-  s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
-  ASSERT_OK(s);
-  //TODO(myabandeh): enable this after duplicatae merge keys are supported
-  //s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
-  //ASSERT_OK(s);
-  s = txn0->Put(Slice("foo2"), Slice("bar2b"));
-  ASSERT_OK(s);
-  s = txn0->Put(Slice("foo3"), Slice("bar3"));
-  ASSERT_OK(s);
-  //TODO(myabandeh): enable this after duplicatae merge keys are supported
-  //s = txn0->Merge(Slice("foo3"), Slice("bar3"));
-  //ASSERT_OK(s);
-  s = txn0->Put(Slice("foo4"), Slice("bar4"));
-  ASSERT_OK(s);
-  s = txn0->Delete(Slice("foo4"));
-  ASSERT_OK(s);
-  s = txn0->SingleDelete(Slice("foo4"));
-  ASSERT_OK(s);
-  if (do_prepare) {
-  s = txn0->Prepare();
-  ASSERT_OK(s);
-  }
-  s = txn0->Commit();
-  ASSERT_OK(s);
-  if (!do_prepare) {
-  auto pdb = reinterpret_cast<PessimisticTransactionDB*>(db);
-  pdb->UnregisterTransaction(txn0);
-  }
-  delete txn0;
-  ReadOptions ropt;
-  PinnableSlice pinnable_val;
+  for (bool do_prepare : {true, false}) {
+    TransactionOptions txn_options;
+    WriteOptions write_options;
+    Transaction* txn0 = db->BeginTransaction(write_options, txn_options);
+    auto s = txn0->SetName("xid");
+    ASSERT_OK(s);
+    s = txn0->Put(Slice("foo0"), Slice("bar0a"));
+    ASSERT_OK(s);
+    s = txn0->Put(Slice("foo0"), Slice("bar0b"));
+    ASSERT_OK(s);
+    s = txn0->Put(Slice("foo1"), Slice("bar1"));
+    ASSERT_OK(s);
+    s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
+    ASSERT_OK(s);
+    // TODO(myabandeh): enable this after duplicatae merge keys are supported
+    // s = txn0->Merge(Slice("foo2"), Slice("bar2a"));
+    // ASSERT_OK(s);
+    s = txn0->Put(Slice("foo2"), Slice("bar2b"));
+    ASSERT_OK(s);
+    s = txn0->Put(Slice("foo3"), Slice("bar3"));
+    ASSERT_OK(s);
+    // TODO(myabandeh): enable this after duplicatae merge keys are supported
+    // s = txn0->Merge(Slice("foo3"), Slice("bar3"));
+    // ASSERT_OK(s);
+    s = txn0->Put(Slice("foo4"), Slice("bar4"));
+    ASSERT_OK(s);
+    s = txn0->Delete(Slice("foo4"));
+    ASSERT_OK(s);
+    s = txn0->SingleDelete(Slice("foo4"));
+    ASSERT_OK(s);
+    if (do_prepare) {
+      s = txn0->Prepare();
+      ASSERT_OK(s);
+    }
+    s = txn0->Commit();
+    ASSERT_OK(s);
+    if (!do_prepare) {
+      auto pdb = reinterpret_cast<PessimisticTransactionDB*>(db);
+      pdb->UnregisterTransaction(txn0);
+    }
+    delete txn0;
+    ReadOptions ropt;
+    PinnableSlice pinnable_val;
 
-  s = db->Get(ropt, db->DefaultColumnFamily(), "foo0", &pinnable_val);
-  ASSERT_OK(s);
-  ASSERT_TRUE(pinnable_val == ("bar0b"));
-  s = db->Get(ropt, db->DefaultColumnFamily(), "foo1", &pinnable_val);
-  ASSERT_OK(s);
-  ASSERT_TRUE(pinnable_val == ("bar1"));
-  s = db->Get(ropt, db->DefaultColumnFamily(), "foo2", &pinnable_val);
-  ASSERT_OK(s);
-  ASSERT_TRUE(pinnable_val == ("bar2b"));
-  s = db->Get(ropt, db->DefaultColumnFamily(), "foo3", &pinnable_val);
-  ASSERT_OK(s);
-  ASSERT_TRUE(pinnable_val == ("bar3"));
-  s = db->Get(ropt, db->DefaultColumnFamily(), "foo4", &pinnable_val);
-  ASSERT_TRUE(s.IsNotFound());
+    s = db->Get(ropt, db->DefaultColumnFamily(), "foo0", &pinnable_val);
+    ASSERT_OK(s);
+    ASSERT_TRUE(pinnable_val == ("bar0b"));
+    s = db->Get(ropt, db->DefaultColumnFamily(), "foo1", &pinnable_val);
+    ASSERT_OK(s);
+    ASSERT_TRUE(pinnable_val == ("bar1"));
+    s = db->Get(ropt, db->DefaultColumnFamily(), "foo2", &pinnable_val);
+    ASSERT_OK(s);
+    ASSERT_TRUE(pinnable_val == ("bar2b"));
+    s = db->Get(ropt, db->DefaultColumnFamily(), "foo3", &pinnable_val);
+    ASSERT_OK(s);
+    ASSERT_TRUE(pinnable_val == ("bar3"));
+    s = db->Get(ropt, db->DefaultColumnFamily(), "foo4", &pinnable_val);
+    ASSERT_TRUE(s.IsNotFound());
   }
 }
 

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -27,6 +27,7 @@ WritePreparedTxn::WritePreparedTxn(WritePreparedTxnDB* txn_db,
     : PessimisticTransaction(txn_db, write_options, txn_options),
       wpt_db_(txn_db) {
   PessimisticTransaction::Initialize(txn_options);
+  GetWriteBatch()->DisableDuplicateMergeKeys();
 }
 
 Status WritePreparedTxn::Get(const ReadOptions& read_options,

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -49,8 +49,8 @@ Status WritePreparedTxn::PrepareInternal() {
   uint64_t seq_used = kMaxSequenceNumber;
   bool collapsed = GetWriteBatch()->Collapse();
   if (collapsed) {
-      ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
-                     "Collapse overhead due to duplicate keys");
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Collapse overhead due to duplicate keys");
   }
   Status s =
       db_impl_->WriteImpl(write_options, GetWriteBatch()->GetWriteBatch(),
@@ -66,8 +66,8 @@ Status WritePreparedTxn::PrepareInternal() {
 Status WritePreparedTxn::CommitWithoutPrepareInternal() {
   bool collapsed = GetWriteBatch()->Collapse();
   if (collapsed) {
-      ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
-                     "Collapse overhead due to duplicate keys");
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Collapse overhead due to duplicate keys");
   }
   return CommitBatchInternal(GetWriteBatch()->GetWriteBatch());
 }

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -47,6 +47,7 @@ Status WritePreparedTxn::PrepareInternal() {
   WriteBatchInternal::MarkEndPrepare(GetWriteBatch()->GetWriteBatch(), name_);
   const bool disable_memtable = true;
   uint64_t seq_used = kMaxSequenceNumber;
+  GetWriteBatch()->Collapse();
   Status s =
       db_impl_->WriteImpl(write_options, GetWriteBatch()->GetWriteBatch(),
                           /*callback*/ nullptr, &log_number_, /*log ref*/ 0,
@@ -59,11 +60,13 @@ Status WritePreparedTxn::PrepareInternal() {
 }
 
 Status WritePreparedTxn::CommitWithoutPrepareInternal() {
+  GetWriteBatch()->Collapse();
   return CommitBatchInternal(GetWriteBatch()->GetWriteBatch());
 }
 
 Status WritePreparedTxn::CommitBatchInternal(WriteBatch* batch) {
-  // In the absense of Prepare markers, use Noop as a batch separator
+  // TODO(myabandeh): handle the duplicate keys in the batch
+  // In the absence of Prepare markers, use Noop as a batch separator
   WriteBatchInternal::InsertNoop(batch);
   const bool disable_memtable = true;
   const uint64_t no_log_ref = 0;
@@ -112,7 +115,7 @@ Status WritePreparedTxn::RollbackInternal() {
   WriteBatch rollback_batch;
   assert(GetId() != kMaxSequenceNumber);
   assert(GetId() > 0);
-  // In the absense of Prepare markers, use Noop as a batch separator
+  // In the absence of Prepare markers, use Noop as a batch separator
   WriteBatchInternal::InsertNoop(&rollback_batch);
   // In WritePrepared, the txn is is the same as prepare seq
   auto last_visible_txn = GetId() - 1;

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -7,7 +7,6 @@
 
 #include "rocksdb/utilities/write_batch_with_index.h"
 
-#include <limits>
 #include <memory>
 #include <vector>
 
@@ -635,7 +634,7 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
       collapsed_buf.append(entry_ptr.data(), entry_ptr.size());
     }
     write_batch.rep_ = std::move(collapsed_buf);
-    WriteBatchInternal::SetCount(&write_batch, count);
+    WriteBatchInternal::SetCount(&write_batch, static_cast<int>(count));
     return true;
   }
 
@@ -756,7 +755,7 @@ Status WriteBatchWithIndex::Merge(ColumnFamilyHandle* column_family,
     rep->AddOrUpdateIndex(column_family, key);
     auto size_after = rep->obsolete_offsets.size();
     bool duplicate_key = size_before != size_after;
-    if (!allow_dup_merge && duplicate_key) {
+    if (!allow_dup_merge_ && duplicate_key) {
       assert(0);
       return Status::NotSupported(
           "Duplicate key with merge value is not supported yet");
@@ -773,7 +772,7 @@ Status WriteBatchWithIndex::Merge(const Slice& key, const Slice& value) {
     rep->AddOrUpdateIndex(key);
     auto size_after = rep->obsolete_offsets.size();
     bool duplicate_key = size_before != size_after;
-    if (!allow_dup_merge && duplicate_key) {
+    if (!allow_dup_merge_ && duplicate_key) {
       assert(0);
       return Status::NotSupported(
           "Duplicate key with merge value is not supported yet");

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -756,7 +756,7 @@ Status WriteBatchWithIndex::Merge(ColumnFamilyHandle* column_family,
     rep->AddOrUpdateIndex(column_family, key);
     auto size_after = rep->obsolete_offsets.size();
     bool duplicate_key = size_before != size_after;
-    if (duplicate_key) {
+    if (!allow_dup_merge && duplicate_key) {
       assert(0);
       return Status::NotSupported(
           "Duplicate key with merge value is not supported yet");
@@ -773,7 +773,7 @@ Status WriteBatchWithIndex::Merge(const Slice& key, const Slice& value) {
     rep->AddOrUpdateIndex(key);
     auto size_after = rep->obsolete_offsets.size();
     bool duplicate_key = size_before != size_after;
-    if (duplicate_key) {
+    if (!allow_dup_merge && duplicate_key) {
       assert(0);
       return Status::NotSupported(
           "Duplicate key with merge value is not supported yet");

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -616,7 +616,7 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
         case kTypeSingleDeletion:
         case kTypeColumnFamilyMerge:
         case kTypeMerge:
-      count++;
+          count++;
           break;
         case kTypeLogData:
         case kTypeBeginPrepareXID:
@@ -635,8 +635,8 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
       collapsed_buf.append(entry_ptr.data(), entry_ptr.size());
     }
     write_batch.rep_ = std::move(collapsed_buf);
-  WriteBatchInternal::SetCount(&write_batch, count);
-  return true;
+    WriteBatchInternal::SetCount(&write_batch, count);
+    return true;
   }
 
   WBWIIterator* WriteBatchWithIndex::NewIterator() {
@@ -758,7 +758,8 @@ Status WriteBatchWithIndex::Merge(ColumnFamilyHandle* column_family,
     bool duplicate_key = size_before != size_after;
     if (duplicate_key) {
       assert(0);
-      return Status::NotSupported("Duplicate key with merge value is not supported yet");
+      return Status::NotSupported(
+          "Duplicate key with merge value is not supported yet");
     }
   }
   return s;
@@ -774,7 +775,8 @@ Status WriteBatchWithIndex::Merge(const Slice& key, const Slice& value) {
     bool duplicate_key = size_before != size_after;
     if (duplicate_key) {
       assert(0);
-      return Status::NotSupported("Duplicate key with merge value is not supported yet");
+      return Status::NotSupported(
+          "Duplicate key with merge value is not supported yet");
     }
   }
   return s;


### PR DESCRIPTION
With WriteCommitted, when the write batch has duplicate keys, the txn db simply inserts them to the db with different seq numbers and let the db ignore/merge the duplicate values at the read time. With WritePrepared all the entries of the batch are inserted with the same seq number which prevents us from benefiting from this simple solution.

This patch applies a hackish solution to unblock the end-to-end testing. The hack is to be replaced with a proper solution soon. The patch simply detects the duplicate key insertions, and mark the previous one as obsolete. Then before writing to the db it rewrites the batch eliminating the obsolete keys. This would incur a memcpy cost. Furthermore handing duplicate merge would require to do FullMerge instead of simply ignoring the previous value, which is not handled by this patch.