### PR TITLE
Mark files as trash by using .trash extension

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * `BackupableDBOptions::max_valid_backups_to_open == 0` now means no backups will be opened during BackupEngine initialization. Previously this condition disabled limiting backups opened.
+* Deprecate trash_dir param in NewSstFileManager, right now we will rename deleted files to <name>.trash instead of moving them to trash directory
 
 ### New Features
 * `DBOptions::bytes_per_sync` and `DBOptions::wal_bytes_per_sync` can now be changed dynamically, `DBOptions::wal_bytes_per_sync` will flush all memtables and switch to a new WAL file.

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -127,12 +127,11 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
 #ifndef ROCKSDB_LITE
   // When the DB is stopped, it's possible that there are some .trash files that
   // were not deleted yet, when we open the DB we will find these .trash files
-  // and schedule them to be deleted
+  // and schedule them to be deleted (or delete immediately if SstFileManager
+  // was not used)
   auto sfm = static_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
-  if (sfm) {
-    for (size_t i = 0; i < result.db_paths.size(); i++) {
-      sfm->delete_scheduler()->CleanupDirectory(result.db_paths[i].path);
-    }
+  for (size_t i = 0; i < result.db_paths.size(); i++) {
+    DeleteScheduler::CleanupDirectory(result.env, sfm, result.db_paths[i].path);
   }
 #endif
 

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -124,6 +124,16 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.avoid_flush_during_recovery = false;
   }
 
+  // When the DB is stopped, it's possible that there are some .trash files that
+  // were not deleted yet, when we open the DB we will find these .trash files
+  // and schedule them to be deleted
+  if (result.sst_file_manager) {
+    auto sfm = static_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
+    for (size_t i = 0; i < result.db_paths.size(); i++) {
+      sfm->delete_scheduler()->CleanupDirectory(result.db_paths[i].path);
+    }
+  }
+
   return result;
 }
 

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -124,15 +124,17 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.avoid_flush_during_recovery = false;
   }
 
+#ifndef ROCKSDB_LITE
   // When the DB is stopped, it's possible that there are some .trash files that
   // were not deleted yet, when we open the DB we will find these .trash files
   // and schedule them to be deleted
-  if (result.sst_file_manager) {
-    auto sfm = static_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
+  auto sfm = static_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
+  if (sfm) {
     for (size_t i = 0; i < result.db_paths.size(); i++) {
       sfm->delete_scheduler()->CleanupDirectory(result.db_paths[i].path);
     }
   }
+#endif
 
   return result;
 }

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -327,11 +327,10 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
   options.disable_auto_compactions = true;
   options.env = env_;
 
-  std::string trash_dir = test::TmpDir(env_) + "/trash";
   int64_t rate_bytes_per_sec = 1024 * 10;  // 10 Kbs / Sec
   Status s;
   options.sst_file_manager.reset(
-      NewSstFileManager(env_, nullptr, trash_dir, 0, false, &s));
+      NewSstFileManager(env_, nullptr, "", 0, false, &s));
   ASSERT_OK(s);
   options.sst_file_manager->SetDeleteRateBytesPerSecond(rate_bytes_per_sec);
   auto sfm = static_cast<SstFileManagerImpl*>(options.sst_file_manager.get());
@@ -377,6 +376,45 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
+TEST_F(DBSSTTest, SstFileManagerClearTrash) {
+  std::vector<std::string> directories;
+  std::vector<std::pair<std::string, bool>> all_files;
+
+  for (int i = 0; i < 10; i++) {
+    std::string dir = test::TmpDir(env_);
+
+    directories.push_back(dir);
+    all_files.emplace_back(dir + "/file.sst", false);
+    all_files.emplace_back(dir + "/file.trash", true);
+    all_files.emplace_back(dir + "/file.log", false);
+    all_files.emplace_back(dir + "/file.trash.trash", true);
+    all_files.emplace_back(dir + "/file.sst.trash", true);
+    all_files.emplace_back(dir + "/file.sst.tras", false);
+    all_files.emplace_back(dir + "/file.log.trash", true);
+    all_files.emplace_back(dir + "/file.log.trash.sst", false);
+  }
+
+  for (auto& f : all_files) {
+    ASSERT_OK(WriteStringToFile(env_, "anc", f.first));
+  }
+
+  Status s;
+  SstFileManager* sfm =
+      NewSstFileManager(env_, nullptr, "", 0, true, &s, directories);
+  delete sfm;
+  ASSERT_OK(s);
+
+  for (auto& f : all_files) {
+    std::string file_path = f.first;
+    bool is_trash = f.second;
+    s = env_->FileExists(file_path);
+    if (is_trash) {
+      ASSERT_NOK(s);
+    } else {
+      ASSERT_OK(s);
+    }
+  }
+}
 // Create a DB with 2 db_paths, and generate multiple files in the 2
 // db_paths using CompactRangeOptions, make sure that files that were
 // deleted from first db_path were deleted using DeleteScheduler and
@@ -394,11 +432,10 @@ TEST_F(DBSSTTest, DeleteSchedulerMultipleDBPaths) {
   options.db_paths.emplace_back(dbname_ + "_2", 1024 * 100);
   options.env = env_;
 
-  std::string trash_dir = test::TmpDir(env_) + "/trash";
   int64_t rate_bytes_per_sec = 1024 * 1024;  // 1 Mb / Sec
   Status s;
-  options.sst_file_manager.reset(NewSstFileManager(
-      env_, nullptr, trash_dir, rate_bytes_per_sec, false, &s));
+  options.sst_file_manager.reset(
+      NewSstFileManager(env_, nullptr, "", rate_bytes_per_sec, false, &s));
   ASSERT_OK(s);
   auto sfm = static_cast<SstFileManagerImpl*>(options.sst_file_manager.get());
   sfm->delete_scheduler()->TEST_SetMaxTrashDBRatio(1.1);
@@ -460,9 +497,8 @@ TEST_F(DBSSTTest, DestroyDBWithRateLimitedDelete) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.env = env_;
-  std::string trash_dir = test::TmpDir(env_) + "/trash";
   options.sst_file_manager.reset(
-      NewSstFileManager(env_, nullptr, trash_dir, 0, false, &s));
+      NewSstFileManager(env_, nullptr, "", 0, false, &s));
   ASSERT_OK(s);
   DestroyAndReopen(options);
 

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -20,6 +20,7 @@ class Logger;
 // SstFileManager is used to track SST files in the DB and control there
 // deletion rate.
 // All SstFileManager public functions are thread-safe.
+// SstFileManager is not extensible.
 class SstFileManager {
  public:
   virtual ~SstFileManager() {}
@@ -70,7 +71,8 @@ class SstFileManager {
 //    this value is set to 1024 (1 Kb / sec) and we deleted a file of size 4 Kb
 //    in 1 second, we will wait for another 3 seconds before we delete other
 //    files, Set to 0 to disable deletion rate limiting.
-// @param delete_existing_trash: Deprecated, this argument have no effect
+// @param delete_existing_trash: Deprecated, this argument have no effect, but
+//    if user provide trash_dir we will schedule deletes for files in the dir
 // @param status: If not nullptr, status will contain any errors that happened
 //    during creating the missing trash_dir or deleting existing files in trash.
 extern SstFileManager* NewSstFileManager(

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -70,18 +70,12 @@ class SstFileManager {
 //    this value is set to 1024 (1 Kb / sec) and we deleted a file of size 4 Kb
 //    in 1 second, we will wait for another 3 seconds before we delete other
 //    files, Set to 0 to disable deletion rate limiting.
-// @param delete_existing_trash: If set to true, the newly created
-//    SstFileManager will delete files that already marked as trash in db_path.
+// @param delete_existing_trash: Deprecated, this argument have no effect
 // @param status: If not nullptr, status will contain any errors that happened
 //    during creating the missing trash_dir or deleting existing files in trash.
-// @param paths: If passed, we will check if there are any files that are marked
-//    as trash in the passed paths so that they will schedule there deletes.
-//    This argument is used to clean up if the DB was shutdown without deleting
-//    all trash files.
 extern SstFileManager* NewSstFileManager(
     Env* env, std::shared_ptr<Logger> info_log = nullptr,
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
-    bool delete_existing_trash = true, Status* status = nullptr,
-    std::vector<std::string> paths = {});
+    bool delete_existing_trash = true, Status* status = nullptr);
 
 }  // namespace rocksdb

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -64,22 +64,21 @@ class SstFileManager {
 // @param info_log: If not nullptr, info_log will be used to log errors.
 //
 // == Deletion rate limiting specific arguments ==
-// @param trash_dir: Path to the directory where deleted files will be moved
-//    to be deleted in a background thread while applying rate limiting. If this
-//    directory doesn't exist, it will be created. This directory should not be
-//    used by any other process or any other SstFileManager, Set to "" to
-//    disable deletion rate limiting.
+// @param trash_dir: Deprecated, this argument have no effect
 // @param rate_bytes_per_sec: How many bytes should be deleted per second, If
 //    this value is set to 1024 (1 Kb / sec) and we deleted a file of size 4 Kb
 //    in 1 second, we will wait for another 3 seconds before we delete other
 //    files, Set to 0 to disable deletion rate limiting.
 // @param delete_existing_trash: If set to true, the newly created
-//    SstFileManager will delete files that already exist in trash_dir.
+//    SstFileManager will delete files that already marked as trash in db_path.
 // @param status: If not nullptr, status will contain any errors that happened
 //    during creating the missing trash_dir or deleting existing files in trash.
+// @param db_path: If delete_existing_trash is passed as true, SstFileManager
+//    will get all files marked as trash in db_path to delete them.
 extern SstFileManager* NewSstFileManager(
     Env* env, std::shared_ptr<Logger> info_log = nullptr,
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
-    bool delete_existing_trash = true, Status* status = nullptr);
+    bool delete_existing_trash = true, Status* status = nullptr,
+    std::string db_path = "");
 
 }  // namespace rocksdb

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "rocksdb/status.h"
 
@@ -73,12 +74,14 @@ class SstFileManager {
 //    SstFileManager will delete files that already marked as trash in db_path.
 // @param status: If not nullptr, status will contain any errors that happened
 //    during creating the missing trash_dir or deleting existing files in trash.
-// @param db_path: If delete_existing_trash is passed as true, SstFileManager
-//    will get all files marked as trash in db_path to delete them.
+// @param paths: If passed, we will check if there are any files that are marked
+//    as trash in the passed paths so that they will schedule there deletes.
+//    This argument is used to clean up if the DB was shutdown without deleting
+//    all trash files.
 extern SstFileManager* NewSstFileManager(
     Env* env, std::shared_ptr<Logger> info_log = nullptr,
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
     bool delete_existing_trash = true, Status* status = nullptr,
-    std::string db_path = "");
+    std::vector<std::string> paths = {});
 
 }  // namespace rocksdb

--- a/util/delete_scheduler.h
+++ b/util/delete_scheduler.h
@@ -66,7 +66,7 @@ class DeleteScheduler {
   static const std::string kTrashExtension;
   static bool IsTrashFile(const std::string& file_path);
 
-  // Check if there are any .trash filse in path, and schedule there deletion
+  // Check if there are any .trash filse in path, and schedule their deletion
   // Or delete immediately if sst_file_manager is nullptr
   static Status CleanupDirectory(Env* env, SstFileManagerImpl* sfm,
                                  const std::string& path);

--- a/util/delete_scheduler.h
+++ b/util/delete_scheduler.h
@@ -58,6 +58,9 @@ class DeleteScheduler {
 
   uint64_t GetTotalTrashSize() { return total_trash_size_.load(); }
 
+  // Check if there are any .trash filse in path, and schedule there deletion
+  Status CleanupDirectory(const std::string& path);
+
   void TEST_SetMaxTrashDBRatio(double r) {
     assert(r >= 0);
     max_trash_db_ratio_ = r;

--- a/util/delete_scheduler.h
+++ b/util/delete_scheduler.h
@@ -58,9 +58,6 @@ class DeleteScheduler {
 
   uint64_t GetTotalTrashSize() { return total_trash_size_.load(); }
 
-  // Check if there are any .trash filse in path, and schedule there deletion
-  Status CleanupDirectory(const std::string& path);
-
   void TEST_SetMaxTrashDBRatio(double r) {
     assert(r >= 0);
     max_trash_db_ratio_ = r;
@@ -68,6 +65,11 @@ class DeleteScheduler {
 
   static const std::string kTrashExtension;
   static bool IsTrashFile(const std::string& file_path);
+
+  // Check if there are any .trash filse in path, and schedule there deletion
+  // Or delete immediately if sst_file_manager is nullptr
+  static Status CleanupDirectory(Env* env, SstFileManagerImpl* sfm,
+                                 const std::string& path);
 
  private:
   Status MarkAsTrash(const std::string& file_path, std::string* path_in_trash);

--- a/util/delete_scheduler.h
+++ b/util/delete_scheduler.h
@@ -24,7 +24,7 @@ class Logger;
 class SstFileManagerImpl;
 
 // DeleteScheduler allows the DB to enforce a rate limit on file deletion,
-// Instead of deleteing files immediately, files are moved to trash_dir
+// Instead of deleteing files immediately, files are marked as trash
 // and deleted in a background thread that apply sleep penlty between deletes
 // if they are happening in a rate faster than rate_bytes_per_sec,
 //
@@ -32,8 +32,7 @@ class SstFileManagerImpl;
 // case DeleteScheduler will delete files immediately.
 class DeleteScheduler {
  public:
-  DeleteScheduler(Env* env, const std::string& trash_dir,
-                  int64_t rate_bytes_per_sec, Logger* info_log,
+  DeleteScheduler(Env* env, int64_t rate_bytes_per_sec, Logger* info_log,
                   SstFileManagerImpl* sst_file_manager);
 
   ~DeleteScheduler();
@@ -46,7 +45,7 @@ class DeleteScheduler {
     return rate_bytes_per_sec_.store(bytes_per_sec);
   }
 
-  // Move file to trash directory and schedule it's deletion
+  // Mark file as trash directory and schedule it's deletion
   Status DeleteFile(const std::string& fname);
 
   // Wait for all files being deleteing in the background to finish or for
@@ -64,8 +63,11 @@ class DeleteScheduler {
     max_trash_db_ratio_ = r;
   }
 
+  static const std::string kTrashExtension;
+  static bool IsTrashFile(const std::string& file_path);
+
  private:
-  Status MoveToTrash(const std::string& file_path, std::string* path_in_trash);
+  Status MarkAsTrash(const std::string& file_path, std::string* path_in_trash);
 
   Status DeleteTrashFile(const std::string& path_in_trash,
                          uint64_t* deleted_bytes);
@@ -73,17 +75,15 @@ class DeleteScheduler {
   void BackgroundEmptyTrash();
 
   Env* env_;
-  // Path to the trash directory
-  std::string trash_dir_;
-  // total size of trash directory
+  // total size of trash files
   std::atomic<uint64_t> total_trash_size_;
   // Maximum number of bytes that should be deleted per second
   std::atomic<int64_t> rate_bytes_per_sec_;
   // Mutex to protect queue_, pending_files_, bg_errors_, closing_
   InstrumentedMutex mu_;
-  // Queue of files in trash that need to be deleted
+  // Queue of trash files that need to be deleted
   std::queue<std::string> queue_;
-  // Number of files in trash that are waiting to be deleted
+  // Number of trash files that are waiting to be deleted
   int32_t pending_files_;
   // Errors that happened in BackgroundEmptyTrash (file_path => error)
   std::map<std::string, Status> bg_errors_;

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -536,6 +536,27 @@ TEST_F(DeleteSchedulerTest, ImmediateDeleteOn25PercDBSize) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
+TEST_F(DeleteSchedulerTest, IsTrashCheck) {
+  // Trash files
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("x.trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile(".trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("abc.sst.trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("/a/b/c/abc..sst.trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("log.trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("^^^^^.log.trash"));
+  ASSERT_TRUE(DeleteScheduler::IsTrashFile("abc.t.trash"));
+
+  // Not trash files
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("abc.sst"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("abc.txt"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("/a/b/c/abc.sst"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("/a/b/c/abc.sstrash"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("^^^^^.trashh"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("abc.ttrash"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile(".ttrash"));
+  ASSERT_FALSE(DeleteScheduler::IsTrashFile("abc.trashx"));
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -30,8 +30,6 @@ class DeleteSchedulerTest : public testing::Test {
   DeleteSchedulerTest() : env_(Env::Default()) {
     dummy_files_dir_ = test::TmpDir(env_) + "/delete_scheduler_dummy_data_dir";
     DestroyAndCreateDir(dummy_files_dir_);
-    trash_dir_ = test::TmpDir(env_) + "/delete_scheduler_trash";
-    DestroyAndCreateDir(trash_dir_);
   }
 
   ~DeleteSchedulerTest() {
@@ -46,11 +44,31 @@ class DeleteSchedulerTest : public testing::Test {
     EXPECT_OK(env_->CreateDir(dir));
   }
 
-  int CountFilesInDir(const std::string& dir) {
+  int CountNormalFiles() {
     std::vector<std::string> files_in_dir;
-    EXPECT_OK(env_->GetChildren(dir, &files_in_dir));
-    // Ignore "." and ".."
-    return static_cast<int>(files_in_dir.size()) - 2;
+    EXPECT_OK(env_->GetChildren(dummy_files_dir_, &files_in_dir));
+
+    int normal_cnt = 0;
+    for (auto& f : files_in_dir) {
+      if (!DeleteScheduler::IsTrashFile(f) && f != "." && f != "..") {
+        printf("%s\n", f.c_str());
+        normal_cnt++;
+      }
+    }
+    return normal_cnt;
+  }
+
+  int CountTrashFiles() {
+    std::vector<std::string> files_in_dir;
+    EXPECT_OK(env_->GetChildren(dummy_files_dir_, &files_in_dir));
+
+    int trash_cnt = 0;
+    for (auto& f : files_in_dir) {
+      if (DeleteScheduler::IsTrashFile(f)) {
+        trash_cnt++;
+      }
+    }
+    return trash_cnt;
   }
 
   std::string NewDummyFile(const std::string& file_name, uint64_t size = 1024) {
@@ -65,9 +83,8 @@ class DeleteSchedulerTest : public testing::Test {
   }
 
   void NewDeleteScheduler() {
-    ASSERT_OK(env_->CreateDirIfMissing(trash_dir_));
     sst_file_mgr_.reset(
-        new SstFileManagerImpl(env_, nullptr, trash_dir_, rate_bytes_per_sec_));
+        new SstFileManagerImpl(env_, nullptr, rate_bytes_per_sec_));
     delete_scheduler_ = sst_file_mgr_->delete_scheduler();
     // Tests in this file are for DeleteScheduler component and dont create any
     // DBs, so we need to use set this value to 100% (instead of default 25%)
@@ -76,7 +93,6 @@ class DeleteSchedulerTest : public testing::Test {
 
   Env* env_;
   std::string dummy_files_dir_;
-  std::string trash_dir_;
   int64_t rate_bytes_per_sec_;
   DeleteScheduler* delete_scheduler_;
   std::unique_ptr<SstFileManagerImpl> sst_file_mgr_;
@@ -124,7 +140,7 @@ TEST_F(DeleteSchedulerTest, BasicRateLimiting) {
     for (int i = 0; i < num_files; i++) {
       ASSERT_OK(delete_scheduler_->DeleteFile(generated_files[i]));
     }
-    ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
+    ASSERT_EQ(CountNormalFiles(), 0);
 
     uint64_t delete_start_time = env_->NowMicros();
     TEST_SYNC_POINT("DeleteSchedulerTest::BasicRateLimiting:1");
@@ -144,7 +160,7 @@ TEST_F(DeleteSchedulerTest, BasicRateLimiting) {
     }
     ASSERT_GT(time_spent_deleting, expected_penlty * 0.9);
 
-    ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+    ASSERT_EQ(CountTrashFiles(), 0);
     rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   }
 }
@@ -226,8 +242,8 @@ TEST_F(DeleteSchedulerTest, RateLimitingMultiThreaded) {
     }
     ASSERT_GT(time_spent_deleting, expected_penlty * 0.9);
 
-    ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
-    ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+    ASSERT_EQ(CountNormalFiles(), 0);
+    ASSERT_EQ(CountTrashFiles(), 0);
     rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   }
 }
@@ -251,8 +267,8 @@ TEST_F(DeleteSchedulerTest, DisableRateLimiting) {
     std::string dummy_file = NewDummyFile("dummy.data");
     ASSERT_OK(delete_scheduler_->DeleteFile(dummy_file));
     ASSERT_TRUE(env_->FileExists(dummy_file).IsNotFound());
-    ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
-    ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+    ASSERT_EQ(CountNormalFiles(), 0);
+    ASSERT_EQ(CountTrashFiles(), 0);
   }
 
   ASSERT_EQ(bg_delete_file, 0);
@@ -281,14 +297,14 @@ TEST_F(DeleteSchedulerTest, ConflictNames) {
     std::string dummy_file = NewDummyFile("conflict.data");
     ASSERT_OK(delete_scheduler_->DeleteFile(dummy_file));
   }
-  ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
+  ASSERT_EQ(CountNormalFiles(), 0);
   // 10 files ("conflict.data" x 10) in trash
-  ASSERT_EQ(CountFilesInDir(trash_dir_), 10);
+  ASSERT_EQ(CountTrashFiles(), 10);
 
   // Hold BackgroundEmptyTrash
   TEST_SYNC_POINT("DeleteSchedulerTest::ConflictNames:1");
   delete_scheduler_->WaitForEmptyTrash();
-  ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+  ASSERT_EQ(CountTrashFiles(), 0);
 
   auto bg_errors = delete_scheduler_->GetBackgroundErrors();
   ASSERT_EQ(bg_errors.size(), 0);
@@ -317,15 +333,15 @@ TEST_F(DeleteSchedulerTest, BackgroundError) {
     std::string file_name = "data_" + ToString(i) + ".data";
     ASSERT_OK(delete_scheduler_->DeleteFile(NewDummyFile(file_name)));
   }
-  ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
-  ASSERT_EQ(CountFilesInDir(trash_dir_), 10);
+  ASSERT_EQ(CountNormalFiles(), 0);
+  ASSERT_EQ(CountTrashFiles(), 10);
 
   // Delete 10 files from trash, this will cause background errors in
   // BackgroundEmptyTrash since we already deleted the files it was
   // goind to delete
   for (int i = 0; i < 10; i++) {
-    std::string file_name = "data_" + ToString(i) + ".data";
-    ASSERT_OK(env_->DeleteFile(trash_dir_ + "/" + file_name));
+    std::string file_name = "data_" + ToString(i) + ".data.trash";
+    ASSERT_OK(env_->DeleteFile(dummy_files_dir_ + "/" + file_name));
   }
 
   // Hold BackgroundEmptyTrash
@@ -359,10 +375,10 @@ TEST_F(DeleteSchedulerTest, StartBGEmptyTrashMultipleTimes) {
       std::string file_name = "data_" + ToString(i) + ".data";
       ASSERT_OK(delete_scheduler_->DeleteFile(NewDummyFile(file_name)));
     }
-    ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
+    ASSERT_EQ(CountNormalFiles(), 0);
     delete_scheduler_->WaitForEmptyTrash();
     ASSERT_EQ(bg_delete_file, 10 * run);
-    ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+    ASSERT_EQ(CountTrashFiles(), 0);
 
     auto bg_errors = delete_scheduler_->GetBackgroundErrors();
     ASSERT_EQ(bg_errors.size(), 0);
@@ -397,35 +413,7 @@ TEST_F(DeleteSchedulerTest, DestructorWithNonEmptyQueue) {
   sst_file_mgr_.reset();
 
   ASSERT_LT(bg_delete_file, 100);
-  ASSERT_GT(CountFilesInDir(trash_dir_), 0);
-
-  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
-}
-
-// 1- Delete the trash directory
-// 2- Delete 10 files using DeleteScheduler
-// 3- Make sure that the 10 files were deleted immediately since DeleteScheduler
-//    failed to move them to trash directory
-TEST_F(DeleteSchedulerTest, MoveToTrashError) {
-  int bg_delete_file = 0;
-  rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
-  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
-
-  rate_bytes_per_sec_ = 1024;  // 1 Kb / sec
-  NewDeleteScheduler();
-
-  // We will delete the trash directory, that mean that DeleteScheduler wont
-  // be able to move files to trash and will delete files them immediately.
-  ASSERT_OK(test::DestroyDir(env_, trash_dir_));
-  for (int i = 0; i < 10; i++) {
-    std::string file_name = "data_" + ToString(i) + ".data";
-    ASSERT_OK(delete_scheduler_->DeleteFile(NewDummyFile(file_name)));
-  }
-
-  ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
-  ASSERT_EQ(bg_delete_file, 0);
+  ASSERT_GT(CountTrashFiles(), 0);
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -480,7 +468,7 @@ TEST_F(DeleteSchedulerTest, DISABLED_DynamicRateLimiting1) {
     for (int i = 0; i < num_files; i++) {
       ASSERT_OK(delete_scheduler_->DeleteFile(generated_files[i]));
     }
-    ASSERT_EQ(CountFilesInDir(dummy_files_dir_), 0);
+    ASSERT_EQ(CountNormalFiles(), 0);
 
     if (rate_bytes_per_sec_ > 0) {
       uint64_t delete_start_time = env_->NowMicros();
@@ -508,7 +496,7 @@ TEST_F(DeleteSchedulerTest, DISABLED_DynamicRateLimiting1) {
       ASSERT_EQ(fg_delete_file, num_files);
     }
 
-    ASSERT_EQ(CountFilesInDir(trash_dir_), 0);
+    ASSERT_EQ(CountTrashFiles(), 0);
     rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   }
 }

--- a/util/sst_file_manager_impl.h
+++ b/util/sst_file_manager_impl.h
@@ -25,7 +25,6 @@ class Logger;
 class SstFileManagerImpl : public SstFileManager {
  public:
   explicit SstFileManagerImpl(Env* env, std::shared_ptr<Logger> logger,
-                              const std::string& trash_dir,
                               int64_t rate_bytes_per_sec);
 
   ~SstFileManagerImpl();
@@ -68,7 +67,7 @@ class SstFileManagerImpl : public SstFileManager {
   // Update the delete rate limit in bytes per second.
   virtual void SetDeleteRateBytesPerSecond(int64_t delete_rate) override;
 
-  // Move file to trash directory and schedule it's deletion.
+  // Mark file as trash and schedule it's deletion.
   virtual Status ScheduleFileDeletion(const std::string& file_path);
 
   // Wait for all files being deleteing in the background to finish or for
@@ -94,9 +93,7 @@ class SstFileManagerImpl : public SstFileManager {
   std::unordered_map<std::string, uint64_t> tracked_files_;
   // The maximum allowed space (in bytes) for sst files.
   uint64_t max_allowed_space_;
-  // DeleteScheduler used to throttle file deletition, if SstFileManagerImpl was
-  // created with rate_bytes_per_sec == 0 or trash_dir == "", delete_scheduler_
-  // rate limiting will be disabled and will simply delete the files.
+  // DeleteScheduler used to throttle file deletition.
   DeleteScheduler delete_scheduler_;
 };
 


### PR DESCRIPTION
SstFileManager move files that need to be deleted into a trash directory.
Deprecate this behaviour and instead add ".trash" extension to files that need to be deleted