### PR TITLE
release build treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,9 @@ CFLAGS +=  -DHAVE_POWER8
 HAVE_POWER8=1
 endif
 
-# if we're compiling for release, compile without debug code (-DNDEBUG) and
-# don't treat warnings as errors
+# if we're compiling for release, compile without debug code (-DNDEBUG)
 ifeq ($(DEBUG_LEVEL),0)
 OPT += -DNDEBUG
-DISABLE_WARNING_AS_ERROR=1
 
 ifneq ($(USE_RTTI), 1)
 	CXXFLAGS += -fno-rtti


### PR DESCRIPTION
fixing warnings is important, especially for release code.

Test Plan:

- on master branch, `make -j64 release` succeeds
- when I introduced an unused variable, it failed like this:
```
db/compaction_job.cc: In member function ‘rocksdb::Status rocksdb::CompactionJob::OpenCompactionOutputFile(rocksdb::CompactionJob::SubcompactionState*)’:
db/compaction_job.cc:1264:8: error: unused variable ‘syncpoint_arg’ [-Werror=unused-variable]
   bool syncpoint_arg = env_options_.use_direct_writes;
...
cc1plus: all warnings being treated as errors
make[1]: *** [db/compaction_job.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory `/data/users/andrewkr/rocksdb'
make: *** [release] Error 2
```

