### PR TITLE
log decimal TID on linux

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -686,12 +686,17 @@ class PosixEnv : public Env {
   }
 
   static uint64_t gettid() {
+#if defined(OS_LINUX) && defined(__NR_gettid)
+    pid_t tid = syscall(__NR_gettid);
+    return static_cast<uint64_t>(tid);
+#else
     pthread_t tid = pthread_self();
     return gettid(tid);
+#endif  // defined(OS_LINUX) && defined(__NR_gettid)
   }
 
   virtual uint64_t GetThreadID() const override {
-    return gettid(pthread_self());
+    return gettid();
   }
 
   virtual Status NewLogger(const std::string& fname,

--- a/env/posix_logger.h
+++ b/env/posix_logger.h
@@ -92,7 +92,7 @@ class PosixLogger : public Logger {
       struct tm t;
       localtime_r(&seconds, &t);
       p += snprintf(p, limit - p,
-                    "%04d/%02d/%02d-%02d:%02d:%02d.%06d %llx ",
+                    "%04d/%02d/%02d-%02d:%02d:%02d.%06d %llu ",
                     t.tm_year + 1900,
                     t.tm_mon + 1,
                     t.tm_mday,


### PR DESCRIPTION
identify the thread using the output of `gettid()` syscall on Linux, which is a system-wide unique ID, unlike `pthread_self()`. Also changed from hex to decimal to be compatible with tools like `top`.

Test Plan:

- make check -j64
- run db_bench and correlate `top` entries with log entries

```
$ top -H
...
782508 andrewkr  20   0  319272  47864   8884 R 99.7  0.0   0:04.18  4 db_bench
...
```

```
$ grep '782508' /dev/shm/dbbench/LOG | head -1
2017/10/05-13:23:17.517942 782508 [db/db_impl_write.cc:1162] [default] New memtable created with log file: #6. Immutable memtables: 0.
```