### PR TITLE
WritePrepared Txn: Test sequence number 0 is visible

### DIFF
--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -589,6 +589,11 @@ bool WritePreparedTxnDB::IsInSnapshot(uint64_t prep_seq,
   // TODO(myabandeh): read your own writes
   // TODO(myabandeh): optimize this. This sequence of checks must be correct but
   // not necessary efficient
+  if (prep_seq == 0) {
+    // Compaction will output keys to bottom-level with sequence number 0 if
+    // it is visible to the earliest snapshot.
+    return true;
+  }
   if (snapshot_seq < prep_seq) {
     // snapshot_seq < prep_seq <= commit_seq => snapshot_seq < commit_seq
     return false;


### PR DESCRIPTION
Summary:
Compaction will output keys with sequence number 0, if it is visible to
earliest snapshot. Adding a test to make sure IsInSnapshot() report sequence number 0 is
visible to any snapshot.

Test Plan:
The new test itself.