### PR TITLE
adjust AUTHORS to avoid ugliness

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,6 @@ Sanjay Ghemawat <sanjay@google.com>
 # Partial list of contributors:
 Kevin Regan <kevin.d.regan@gmail.com>
 Johan Bilien <jobi@litl.com>
+
+# with acknowledgements to Basho Technologies
+## including https://github.com/matthewvon


### PR DESCRIPTION
Basho check-in:

https://github.com/basho/leveldb/commit/17875bb891ddf8690ec1d9be8b9269dfafcbff86#diff-84233aba85a47aac78d2e6e9be64e3c1

Facebook check-in a few months later:

https://github.com/facebook/rocksdb/commit/e5a7c8e58080cc2189bf52e11e6980e85328511c#diff-05c7e24700502a079cdd88012b5a76d3

My experience with the Facebook source code started recently, August 2017.  There are several things that seem "familiar".  This is the first item I researched, and is blatant.  How about we just nip this in the bud now?!