### PR TITLE
WritePrepare Txn: Cancel flush/compaction before destruction

### DIFF
--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -954,5 +954,12 @@ bool WritePreparedTxnDB::MaybeUpdateOldCommitMap(
   return next_is_larger;
 }
 
+WritePreparedTxnDB::~WritePreparedTxnDB() {
+  // At this point there could be running compaction/flush holding a
+  // SnapshotChecker, which holds a pointer back to WritePreparedTxnDB.
+  // Make sure those jobs finished before destructing WritePreparedTxnDB.
+  db_impl_->CancelAllBackgroundWork(true/*wait*/);
+}
+
 }  //  namespace rocksdb
 #endif  // ROCKSDB_LITE

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -191,7 +191,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     Init(txn_db_options);
   }
 
-  virtual ~WritePreparedTxnDB() {}
+  virtual ~WritePreparedTxnDB();
 
   virtual Status Initialize(
       const std::vector<size_t>& compaction_enabled_cf_indices,


### PR DESCRIPTION
Summary:
On WritePreparedTxnDB destruct there could be running compaction/flush holding a SnapshotChecker, which holds a pointer back to WritePreparedTxnDB. Make sure those jobs finished before destructing WritePreparedTxnDB.

This is caught by TransactionTest::SeqAdvanceTest.

Test Plan:
`make all check` and see TransactionTest::SeqAdvanceTest is passing.