### PR TITLE
Problems with extending the Comparator with the other classes

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -21,7 +21,7 @@ class Slice;
 // from multiple threads.
 class Comparator {
  public:
-  virtual ~Comparator();
+  virtual ~Comparator() = 0;
 
   // Three-way comparison.  Returns value:
   //   < 0 iff "a" < "b",

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -17,7 +17,7 @@
 
 namespace rocksdb {
 
-Comparator::~Comparator() { }
+Comparator::~Comparator() {}
 
 namespace {
 class BytewiseComparatorImpl : public Comparator {


### PR DESCRIPTION
The way the virtual destructor is defined is not correct. It should be written as in the provided code. After this correction, the extension of all the subclasses defined outside the library work perfectly.