### PR TITLE
Add OptionsUtil class to java/CMakeLists.txt

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -22,6 +22,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/memtablejni.cc
         rocksjni/merge_operator.cc
         rocksjni/options.cc
+        rocksjni/options_util.cc
         rocksjni/ratelimiterjni.cc
         rocksjni/remove_emptyvalue_compactionfilterjni.cc
         rocksjni/cassandra_compactionfilterjni.cc
@@ -85,6 +86,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.MergeOperator
         org.rocksdb.NativeLibraryLoader
         org.rocksdb.Options
+        org.rocksdb.OptionsUtil
         org.rocksdb.PlainTableConfig
         org.rocksdb.RateLimiter
         org.rocksdb.ReadOptions


### PR DESCRIPTION
Adding OptionsUtil java class and options_util.cc to java/CMakeLists.txt, which were missed accidentally when they were introduced in #2898. 

Test Plan:
make rocksdbjava
Monitor Travis and Appveyor builds. 