### PR TITLE
Blob DB: Store blob index as kTypeBlobIndex in base db

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -303,7 +303,8 @@ class DBImpl : public DB {
   // TODO(andrewkr): this API need to be aware of range deletion operations
   Status GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
                                  bool cache_only, SequenceNumber* seq,
-                                 bool* found_record_for_key);
+                                 bool* found_record_for_key,
+                                 bool* is_blob_index = nullptr);
 
   using DB::IngestExternalFile;
   virtual Status IngestExternalFile(

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -96,6 +96,14 @@ class DBImpl : public DB {
   virtual Status Get(const ReadOptions& options,
                      ColumnFamilyHandle* column_family, const Slice& key,
                      PinnableSlice* value) override;
+
+  // Function that Get and KeyMayExist call with no_io true or false
+  // Note: 'value_found' from KeyMayExist propagates here
+  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
+                 const Slice& key, PinnableSlice* value,
+                 bool* value_found = nullptr, ReadCallback* callback = nullptr,
+                 bool* is_blob_index = nullptr);
+
   using DB::MultiGet;
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
@@ -1271,13 +1279,6 @@ class DBImpl : public DB {
       TablePropertiesCollection* props) override;
 
 #endif  // ROCKSDB_LITE
-
-  // Function that Get and KeyMayExist call with no_io true or false
-  // Note: 'value_found' from KeyMayExist propagates here
-  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* column_family,
-                 const Slice& key, PinnableSlice* value,
-                 bool* value_found = nullptr, ReadCallback* callback = nullptr,
-                 bool* is_blob_index = nullptr);
 
   bool GetIntPropertyInternal(ColumnFamilyData* cfd,
                               const DBPropertyInfo& property_info,

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -109,14 +109,13 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                      seq, read_opts, callback, is_blob_index);
 }
 
-bool MemTableListVersion::GetFromHistory(const LookupKey& key,
-                                         std::string* value, Status* s,
-                                         MergeContext* merge_context,
-                                         RangeDelAggregator* range_del_agg,
-                                         SequenceNumber* seq,
-                                         const ReadOptions& read_opts) {
+bool MemTableListVersion::GetFromHistory(
+    const LookupKey& key, std::string* value, Status* s,
+    MergeContext* merge_context, RangeDelAggregator* range_del_agg,
+    SequenceNumber* seq, const ReadOptions& read_opts, bool* is_blob_index) {
   return GetFromList(&memlist_history_, key, value, s, merge_context,
-                     range_del_agg, seq, read_opts);
+                     range_del_agg, seq, read_opts, nullptr /*read_callback*/,
+                     is_blob_index);
 }
 
 bool MemTableListVersion::GetFromList(

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -73,14 +73,16 @@ class MemTableListVersion {
   bool GetFromHistory(const LookupKey& key, std::string* value, Status* s,
                       MergeContext* merge_context,
                       RangeDelAggregator* range_del_agg, SequenceNumber* seq,
-                      const ReadOptions& read_opts);
+                      const ReadOptions& read_opts,
+                      bool* is_blob_index = nullptr);
   bool GetFromHistory(const LookupKey& key, std::string* value, Status* s,
                       MergeContext* merge_context,
                       RangeDelAggregator* range_del_agg,
-                      const ReadOptions& read_opts) {
+                      const ReadOptions& read_opts,
+                      bool* is_blob_index = nullptr) {
     SequenceNumber seq;
     return GetFromHistory(key, value, s, merge_context, range_del_agg, &seq,
-                          read_opts);
+                          read_opts, is_blob_index);
   }
 
   Status AddRangeTombstoneIterators(const ReadOptions& read_opts, Arena* arena,

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1025,6 +1025,8 @@ Status BlobDBImpl::PutUntil(const WriteOptions& options, const Slice& key,
     if (expiration != kNoExpiration) {
       extendTTL(&(bfile->ttl_range_), expiration);
     }
+
+    s = CloseBlobFileIfNeeded(bfile);
   }
 
   TEST_SYNC_POINT("BlobDBImpl::PutUntil:Finish");

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -994,18 +994,6 @@ Status BlobDBImpl::PutUntil(const WriteOptions& options, const Slice& key,
   std::string headerbuf;
   Writer::ConstructBlobHeader(&headerbuf, key, value, expiration, -1);
 
-  // this is another more safer way to do it, where you keep the writeLock
-  // for the entire write path. this will increase latency and reduce
-  // throughput
-  // WriteLock lockbfile_w(&bfile->mutex_);
-  // std::shared_ptr<Writer> writer =
-  // CheckOrCreateWriterLocked(bfile);
-
-  if (debug_level_ >= 3)
-    ROCKS_LOG_DEBUG(
-        db_options_.info_log, ">Adding KEY FILE: %s: KEY: %s VALSZ: %d",
-        bfile->PathName().c_str(), key.ToString().c_str(), value.size());
-
   std::string index_entry;
   Status s = AppendBlob(bfile, headerbuf, key, value, &index_entry);
   if (!s.ok()) {

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "db/db_iter.h"
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/db.h"
 #include "rocksdb/listener.h"
@@ -215,8 +216,19 @@ class BlobDBImpl : public BlobDB {
   Status Get(const ReadOptions& read_options, ColumnFamilyHandle* column_family,
              const Slice& key, PinnableSlice* value) override;
 
+  Status GetBlobValue(const Slice& key, const Slice& index_entry,
+                      PinnableSlice* value);
+
   using BlobDB::NewIterator;
   virtual Iterator* NewIterator(const ReadOptions& read_options) override;
+
+  using BlobDB::NewIterators;
+  virtual Status NewIterators(
+      const ReadOptions& read_options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<Iterator*>* iterators) override {
+    return Status::NotSupported("Not implemented");
+  }
 
   using BlobDB::MultiGet;
   virtual std::vector<Status> MultiGet(
@@ -274,9 +286,6 @@ class BlobDBImpl : public BlobDB {
   // Create a snapshot if there isn't one in read options.
   // Return true if a snapshot is created.
   bool SetSnapshotIfNeeded(ReadOptions* read_options);
-
-  Status CommonGet(const Slice& key, const std::string& index_entry,
-                   std::string* value);
 
   Slice GetCompressedSlice(const Slice& raw,
                            std::string* compression_output) const;
@@ -525,55 +534,6 @@ class BlobDBImpl : public BlobDB {
   bool open_p1_done_;
 
   uint32_t debug_level_;
-};
-
-class BlobDBIterator : public Iterator {
- public:
-  explicit BlobDBIterator(Iterator* iter, BlobDBImpl* impl, bool own_snapshot,
-                          const Snapshot* snapshot)
-      : iter_(iter),
-        db_impl_(impl),
-        own_snapshot_(own_snapshot),
-        snapshot_(snapshot) {
-    assert(iter != nullptr);
-    assert(snapshot != nullptr);
-  }
-
-  ~BlobDBIterator() {
-    if (own_snapshot_) {
-      db_impl_->ReleaseSnapshot(snapshot_);
-    }
-    delete iter_;
-  }
-
-  bool Valid() const override { return iter_->Valid(); }
-
-  void SeekToFirst() override { iter_->SeekToFirst(); }
-
-  void SeekToLast() override { iter_->SeekToLast(); }
-
-  void Seek(const Slice& target) override { iter_->Seek(target); }
-
-  void SeekForPrev(const Slice& target) override { iter_->SeekForPrev(target); }
-
-  void Next() override { iter_->Next(); }
-
-  void Prev() override { iter_->Prev(); }
-
-  Slice key() const override { return iter_->key(); }
-
-  Slice value() const override;
-
-  Status status() const override { return iter_->status(); }
-
-  // Iterator::Refresh() not supported.
-
- private:
-  Iterator* iter_;
-  BlobDBImpl* db_impl_;
-  bool own_snapshot_;
-  const Snapshot* snapshot_;
-  mutable std::string vpart_;
 };
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -281,6 +281,8 @@ class BlobDBImpl : public BlobDB {
 #endif  //  !NDEBUG
 
  private:
+  class GarbageCollectionWriteCallback;
+
   Status OpenPhase1();
 
   // Create a snapshot if there isn't one in read options.
@@ -424,10 +426,6 @@ class BlobDBImpl : public BlobDB {
   DBImpl* db_impl_;
   Env* env_;
   TTLExtractor* ttl_extractor_;
-
-  // Optimistic Transaction DB used during Garbage collection
-  // for atomicity
-  std::unique_ptr<OptimisticTransactionDBImpl> opt_db_;
 
   // a boolean to capture whether write_options has been set
   std::atomic<bool> wo_set_;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -38,7 +38,6 @@ namespace rocksdb {
 class DBImpl;
 class ColumnFamilyHandle;
 class ColumnFamilyData;
-class OptimisticTransactionDBImpl;
 struct FlushJobInfo;
 
 namespace blob_db {

--- a/utilities/blob_db/blob_db_iterator.h
+++ b/utilities/blob_db/blob_db_iterator.h
@@ -1,0 +1,108 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#ifndef ROCKSDB_LITE
+
+#include "rocksdb/iterator.h"
+#include "utilities/blob_db/blob_db_impl.h"
+
+namespace rocksdb {
+namespace blob_db {
+
+using rocksdb::ManagedSnapshot;
+
+class BlobDBIterator : public Iterator {
+ public:
+  BlobDBIterator(ManagedSnapshot* snapshot, ArenaWrappedDBIter* iter,
+                 BlobDBImpl* blob_db)
+      : snapshot_(snapshot), iter_(iter), blob_db_(blob_db) {}
+
+  virtual ~BlobDBIterator() = default;
+
+  bool Valid() const override {
+    if (!iter_->Valid()) {
+      return false;
+    }
+    return status_.ok();
+  }
+
+  Status status() const override {
+    if (!iter_->status().ok()) {
+      return iter_->status();
+    }
+    return status_;
+  }
+
+  void SeekToFirst() override {
+    assert(Valid());
+    iter_->SeekToFirst();
+    UpdateBlobValue();
+  }
+
+  void SeekToLast() override {
+    assert(Valid());
+    iter_->SeekToLast();
+    UpdateBlobValue();
+  }
+
+  void Seek(const Slice& target) override {
+    assert(Valid());
+    iter_->Seek(target);
+    UpdateBlobValue();
+  }
+
+  void SeekForPrev(const Slice& target) override {
+    assert(Valid());
+    iter_->SeekForPrev(target);
+    UpdateBlobValue();
+  }
+
+  void Next() override {
+    assert(Valid());
+    iter_->Next();
+    UpdateBlobValue();
+  }
+
+  void Prev() override {
+    assert(Valid());
+    iter_->Prev();
+    UpdateBlobValue();
+  }
+
+  Slice key() const override {
+    assert(Valid());
+    return iter_->key();
+  }
+
+  Slice value() const override {
+    assert(Valid());
+    if (!iter_->IsBlob()) {
+      return iter_->value();
+    }
+    return value_;
+  }
+
+  // Iterator::Refresh() not supported.
+
+ private:
+  void UpdateBlobValue() {
+    TEST_SYNC_POINT("BlobDBIterator::UpdateBlobValue:Start:1");
+    TEST_SYNC_POINT("BlobDBIterator::UpdateBlobValue:Start:2");
+    value_.Reset();
+    if (iter_->Valid() && iter_->IsBlob()) {
+      status_ = blob_db_->GetBlobValue(iter_->key(), iter_->value(), &value_);
+    }
+  }
+
+  std::unique_ptr<ManagedSnapshot> snapshot_;
+  std::unique_ptr<ArenaWrappedDBIter> iter_;
+  BlobDBImpl* blob_db_;
+  Status status_;
+  PinnableSlice value_;
+};
+}  // namespace blob_db
+}  // namespace rocksdb
+#endif  // !ROCKSDB_LITE

--- a/utilities/blob_db/blob_db_iterator.h
+++ b/utilities/blob_db/blob_db_iterator.h
@@ -37,25 +37,21 @@ class BlobDBIterator : public Iterator {
   }
 
   void SeekToFirst() override {
-    assert(Valid());
     iter_->SeekToFirst();
     UpdateBlobValue();
   }
 
   void SeekToLast() override {
-    assert(Valid());
     iter_->SeekToLast();
     UpdateBlobValue();
   }
 
   void Seek(const Slice& target) override {
-    assert(Valid());
     iter_->Seek(target);
     UpdateBlobValue();
   }
 
   void SeekForPrev(const Slice& target) override {
-    assert(Valid());
     iter_->SeekForPrev(target);
     UpdateBlobValue();
   }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -86,12 +86,12 @@ class BlobDBTest : public testing::Test {
     }
   }
 
-  void PutRandom(const std::string& key, Random* rnd,
+  void PutRandom(const std::string &key, Random *rnd,
                  std::map<std::string, std::string> *data = nullptr) {
     PutRandom(blob_db_, key, rnd, data);
   }
 
-  void PutRandom(DB* db, const std::string &key, Random *rnd,
+  void PutRandom(DB *db, const std::string &key, Random *rnd,
                  std::map<std::string, std::string> *data = nullptr) {
     int len = rnd->Next() % kMaxBlobSize + 1;
     std::string value = test::RandomHumanReadableString(rnd, len);
@@ -125,7 +125,7 @@ class BlobDBTest : public testing::Test {
     VerifyDB(blob_db_, data);
   }
 
-  void VerifyDB(DB* db, const std::map<std::string, std::string> &data) {
+  void VerifyDB(DB *db, const std::map<std::string, std::string> &data) {
     Iterator *iter = db->NewIterator(ReadOptions());
     iter->SeekToFirst();
     for (auto &p : data) {
@@ -839,7 +839,7 @@ TEST_F(BlobDBTest, MigrateFromPlainRocksDB) {
   // Write to plain rocksdb.
   Options options;
   options.create_if_missing = true;
-  DB* db = nullptr;
+  DB *db = nullptr;
   ASSERT_OK(DB::Open(options, dbname_, &db));
   for (size_t i = 0; i < kNumIteration; i++) {
     auto key_index = rnd.Next() % kNumKey;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -593,7 +593,7 @@ TEST_F(BlobDBTest, GCRelocateKeyWhileOverwriting) {
   ASSERT_OK(blob_db_impl->TEST_CloseBlobFile(blob_files[0]));
 
   SyncPoint::GetInstance()->LoadDependency(
-      {{"BlobDBImpl::GCFileAndUpdateLSM:AfterGetForUpdate",
+      {{"BlobDBImpl::GCFileAndUpdateLSM:AfterGetFromBaseDB",
         "BlobDBImpl::PutUntil:Start"},
        {"BlobDBImpl::PutUntil:Finish",
         "BlobDBImpl::GCFileAndUpdateLSM:BeforeRelocate"}});
@@ -630,7 +630,7 @@ TEST_F(BlobDBTest, GCExpiredKeyWhileOverwriting) {
   mock_env_->set_now_micros(300 * 1000000);
 
   SyncPoint::GetInstance()->LoadDependency(
-      {{"BlobDBImpl::GCFileAndUpdateLSM:AfterGetForUpdate",
+      {{"BlobDBImpl::GCFileAndUpdateLSM:AfterGetFromBaseDB",
         "BlobDBImpl::PutUntil:Start"},
        {"BlobDBImpl::PutUntil:Finish",
         "BlobDBImpl::GCFileAndUpdateLSM:BeforeDelete"}});


### PR DESCRIPTION
Summary:
Blob db insert blob index to base db as kTypeBlobIndex type, to tell apart values written by plain rocksdb or blob db. This is to make it possible to migrate from existing rocksdb to blob db.

Also with the patch blob db garbage collection get away from OptimisticTransaction. Instead it use a custom write callback to achieve similar behavior as OptimisticTransaction. This is because we need to pass the is_blob_index flag to DBImpl::Get but OptimisticTransaction don't support it.

Test Plan:
existing test + will add a new test for migrating from existing rocksdb to blob db.