### PR TITLE
Move ~Comparator define to comparator.h

### DIFF
--- a/include/rocksdb/comparator.h
+++ b/include/rocksdb/comparator.h
@@ -21,7 +21,7 @@ class Slice;
 // from multiple threads.
 class Comparator {
  public:
-  virtual ~Comparator();
+  virtual ~Comparator() {}
 
   // Three-way comparison.  Returns value:
   //   < 0 iff "a" < "b",

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -17,8 +17,6 @@
 
 namespace rocksdb {
 
-Comparator::~Comparator() { }
-
 namespace {
 class BytewiseComparatorImpl : public Comparator {
  public:


### PR DESCRIPTION
When I impl my own comparator, and build in release mode.
The following compile error occurs.
undefined reference to `typeinfo for rocksdb::Comparator'

This fix allows users build with RTTI off when has their own comparator.