### PR TITLE
db_bench randomtransaction print throughput

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4944,6 +4944,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     if (FLAGS_perf_level > rocksdb::PerfLevel::kDisable) {
       thread->stats.AddMessage(get_perf_context()->ToString());
     }
+    thread->stats.AddBytes(static_cast<int64_t>(inserter.GetBytesInserted()));
   }
 
   // Verifies consistency of data after RandomTransaction() has been run.

--- a/util/transaction_test_util.cc
+++ b/util/transaction_test_util.cc
@@ -132,6 +132,7 @@ bool RandomTransactionInserter::DoInsert(DB* db, Transaction* txn,
       } else {
         batch.Put(key, sum);
       }
+      bytes_inserted_ += key.size() + sum.size();
     }
   }
 

--- a/util/transaction_test_util.h
+++ b/util/transaction_test_util.h
@@ -83,6 +83,9 @@ class RandomTransactionInserter {
   // write any data.
   uint64_t GetFailureCount() { return failure_count_; }
 
+  // Returns the sum of user keys/values Put() to the DB.
+  size_t GetBytesInserted() { return bytes_inserted_; }
+
  private:
   // Input options
   Random64* rand_;
@@ -96,6 +99,8 @@ class RandomTransactionInserter {
 
   // Number of failed insert batches attempted
   uint64_t failure_count_ = 0;
+
+  size_t bytes_inserted_ = 0;
 
   // Status returned by most recent insert operation
   Status last_status_;


### PR DESCRIPTION
print throughput in MB/s upon finishing randomtransaction benchmark

Test Plan:

```
$ ./db_bench -num=100000 -benchmarks=randomtransaction -max_background_jobs=12 -write_buffer_size=1048576 -transaction_db=true -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -compression_type=none
...
randomtransaction :      16.858 micros/op 59318 ops/sec;    1.3 MB/s ( transactions:100000 aborts:0)
```