### PR TITLE
Make kTolerateCorruptedTailRecords behave the same as kPointInTimeRec…

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * Introduce `EventListener::OnStallConditionsChanged()` callback. Users can implement it to be notified when user writes are stalled, stopped, or resumed.
 * Add a new db property "rocksdb.estimate-oldest-key-time" to return oldest data timestamp. The property is available only for FIFO compaction with compaction_options_fifo.allow_compaction = false.
 * Upon snapshot release, recompact bottommost files containing deleted/overwritten keys that previously could not be dropped due to the snapshot. This alleviates space-amp caused by long-held snapshots.
+* `kTolerateCorruptedTailRecords` used to fail `DB:Open` upon detecting a single corrupted record, while `kPointInTimeRecovery` tolerates the corruption and return success. `kPointInTimeRecovery` also probes the next log file's first sequence number to see if it matches the corrupted record's sequence number. `kTolerateCorruptedTailRecords` now behaves the same as `kPointInTimeRecovery`.
 
 ### Bug Fixes
 * Fix a potential data inconsistency issue during point-in-time recovery. `DB:Open()` will abort if column family inconsistency is found during PIT recovery.

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -270,6 +270,7 @@ TEST_F(CorruptionTest, Recovery) {
 #endif
   Corrupt(kLogFile, 19, 1);      // WriteBatch tag for first record
   Corrupt(kLogFile, log::kBlockSize + 1000, 1);  // Somewhere in second block
+  options_.wal_recovery_mode = WALRecoveryMode::kAbsoluteConsistency;
   ASSERT_TRUE(!TryReopen().ok());
   options_.paranoid_checks = false;
   Reopen(&options_);

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -575,7 +575,9 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       SequenceNumber sequence = WriteBatchInternal::Sequence(&batch);
 
       if (immutable_db_options_.wal_recovery_mode ==
-          WALRecoveryMode::kPointInTimeRecovery) {
+          WALRecoveryMode::kPointInTimeRecovery ||
+          immutable_db_options_.wal_recovery_mode ==
+          WALRecoveryMode::kTolerateCorruptedTailRecords ) {
         // In point-in-time recovery mode, if sequence id of log files are
         // consecutive, we continue recovery despite corruption. This could
         // happen when we open and write to a corrupted DB, where sequence id
@@ -721,6 +723,8 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
         // We should ignore all errors unconditionally
         status = Status::OK();
       } else if (immutable_db_options_.wal_recovery_mode ==
+                 WALRecoveryMode::kTolerateCorruptedTailRecords ||
+                 immutable_db_options_.wal_recovery_mode ==
                  WALRecoveryMode::kPointInTimeRecovery) {
         // We should ignore the error but not continue replaying
         status = Status::OK();
@@ -732,8 +736,6 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
                        log_number, *next_sequence);
       } else {
         assert(immutable_db_options_.wal_recovery_mode ==
-                   WALRecoveryMode::kTolerateCorruptedTailRecords ||
-               immutable_db_options_.wal_recovery_mode ==
                    WALRecoveryMode::kAbsoluteConsistency);
         return status;
       }

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -561,6 +561,7 @@ TEST_F(DBTest2, WalFilterTest) {
     // Reopen database with option to use WAL filter
     options = OptionsForLogIterTest();
     options.wal_filter = &test_wal_filter;
+    options.wal_recovery_mode = WALRecoveryMode::kAbsoluteConsistency;
     Status status =
       TryReopenWithColumnFamilies({ "default", "pikachu" }, options);
     if (wal_processing_option ==

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -833,7 +833,7 @@ TEST_F(DBWALTest, kTolerateCorruptedTailRecords) {
         } else {
           options.wal_recovery_mode =
               WALRecoveryMode::kTolerateCorruptedTailRecords;
-          ASSERT_NOK(TryReopen(options));
+          ASSERT_OK(TryReopen(options));
         }
       }
     }

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -275,7 +275,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
 enum class WALRecoveryMode : char {
   // Original levelDB recovery
   // We tolerate incomplete record in trailing data on all logs
-  // Use case : This is legacy behavior (default)
+  // Use case : This is now equivalent to PointInTimeRecovery (default)
   kTolerateCorruptedTailRecords = 0x00,
   // Recover from clean shutdown
   // We don't expect to find any corruption in the WAL


### PR DESCRIPTION
…overy

Right now the difference between the two is that when corruption is found:
- kTolerateCorruptedTailRecords stops immediately and returns failure, and this is the default recovery mode
- kPointInTimeRecovery tries to check if the corrupted record's seqnum matches the next log file's first record's seqnum.

This PR will keep both modes but make TCTR behave the same as PITR