### PR TITLE
db_stress support long-held snapshots

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -17,6 +17,7 @@ import argparse
 #       simple_default_params < blackbox|whitebox_simple_default_params < args
 
 default_params = {
+    "acquire_snapshot_one_in": 10000,
     "block_size": 16384,
     "cache_size": 1048576,
     "use_clock_cache": "false",
@@ -37,6 +38,7 @@ default_params = {
     "progress_reports": 0,
     "readpercent": 45,
     "reopen": 20,
+    "snapshot_hold_ops": 100000,
     "sync": 0,
     "target_file_size_base": 2097152,
     "target_file_size_multiplier": 2,


### PR DESCRIPTION
Add options to `db_stress` (correctness testing tool) to randomly acquire snapshot and release it after some period of time. It's useful for correctness testing of #3009, as well as other parts of compaction that behave differently depending on which snapshots are held.

Test Plan:

```
TEST_TMPDIR=/dev/shm ./db_stress -column_families=2 -clear_column_family_one_in=0 -reopen=0 -threads=1 -ops_per_thread=10000000 -max_key=10000000 -max_background_compactions=8 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -value_size_mult=32 -acquire_snapshot_one_in=10000 -snapshot_hold_ops=1000000
...
2017/10/17-20:44:39  Verification successful
```