### PR TITLE
Fix unused var warnings in Release mode

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -465,6 +465,7 @@ ColumnFamilyData::~ColumnFamilyData() {
     assert(dummy_versions_->TEST_Next() == dummy_versions_);
     bool deleted __attribute__((unused)) = dummy_versions_->Unref();
     assert(deleted);
+    (deleted);
   }
 
   if (mem_ != nullptr) {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -463,9 +463,9 @@ ColumnFamilyData::~ColumnFamilyData() {
   if (dummy_versions_ != nullptr) {
     // List must be empty
     assert(dummy_versions_->TEST_Next() == dummy_versions_);
-    bool deleted __attribute__((unused)) = dummy_versions_->Unref();
+    bool deleted __attribute__((unused));
+    deleted = dummy_versions_->Unref();
     assert(deleted);
-    (deleted);
   }
 
   if (mem_ != nullptr) {

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -137,13 +137,11 @@ void CompactionIterator::Next() {
     if (merge_out_iter_.Valid()) {
       key_ = merge_out_iter_.key();
       value_ = merge_out_iter_.value();
-      bool valid_key __attribute__((__unused__)) =
-          ParseInternalKey(key_, &ikey_);
+      bool valid_key __attribute__((__unused__));
+      valid_key =  ParseInternalKey(key_, &ikey_);
       // MergeUntil stops when it encounters a corrupt key and does not
       // include them in the result, so we expect the keys here to be valid.
       assert(valid_key);
-      // Stop compiler from complaining
-      (valid_key);
       // Keep current_key_ in sync.
       current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
       key_ = current_key_.GetInternalKey();
@@ -336,9 +334,8 @@ void CompactionIterator::NextFromInput() {
     // If there are no snapshots, then this kv affect visibility at tip.
     // Otherwise, search though all existing snapshots to find the earliest
     // snapshot that is affected by this kv.
-    SequenceNumber last_sequence __attribute__((__unused__)) =
-        current_user_key_sequence_;
-    (last_sequence);
+    SequenceNumber last_sequence __attribute__((__unused__));
+    last_sequence = current_user_key_sequence_;
     current_user_key_sequence_ = ikey_.sequence;
     SequenceNumber last_snapshot = current_user_key_snapshot_;
     SequenceNumber prev_snapshot = 0;  // 0 means no previous snapshot
@@ -541,12 +538,11 @@ void CompactionIterator::NextFromInput() {
         //       These will be correctly set below.
         key_ = merge_out_iter_.key();
         value_ = merge_out_iter_.value();
-        bool valid_key __attribute__((__unused__)) =
-            ParseInternalKey(key_, &ikey_);
+        bool valid_key __attribute__((__unused__));
+        valid_key = ParseInternalKey(key_, &ikey_);
         // MergeUntil stops when it encounters a corrupt key and does not
         // include them in the result, so we expect the keys here to valid.
         assert(valid_key);
-        (valid_key);
         // Keep current_key_ in sync.
         current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
         key_ = current_key_.GetInternalKey();

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -142,6 +142,8 @@ void CompactionIterator::Next() {
       // MergeUntil stops when it encounters a corrupt key and does not
       // include them in the result, so we expect the keys here to be valid.
       assert(valid_key);
+      // Stop compiler from complaining
+      (valid_key);
       // Keep current_key_ in sync.
       current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
       key_ = current_key_.GetInternalKey();
@@ -336,6 +338,7 @@ void CompactionIterator::NextFromInput() {
     // snapshot that is affected by this kv.
     SequenceNumber last_sequence __attribute__((__unused__)) =
         current_user_key_sequence_;
+    (last_sequence);
     current_user_key_sequence_ = ikey_.sequence;
     SequenceNumber last_snapshot = current_user_key_snapshot_;
     SequenceNumber prev_snapshot = 0;  // 0 means no previous snapshot
@@ -543,6 +546,7 @@ void CompactionIterator::NextFromInput() {
         // MergeUntil stops when it encounters a corrupt key and does not
         // include them in the result, so we expect the keys here to valid.
         assert(valid_key);
+        (valid_key);
         // Keep current_key_ in sync.
         current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
         key_ = current_key_.GetInternalKey();

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1681,7 +1681,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     int output_level  __attribute__((unused)) = c->output_level();
     TEST_SYNC_POINT_CALLBACK("DBImpl::BackgroundCompaction:NonTrivial",
                              &output_level);
-
+    (output_level);
     SequenceNumber earliest_write_conflict_snapshot;
     std::vector<SequenceNumber> snapshot_seqs =
         snapshots_.GetAll(&earliest_write_conflict_snapshot);

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1678,10 +1678,10 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     env_->Schedule(&DBImpl::BGWorkBottomCompaction, ca, Env::Priority::BOTTOM,
                    this, &DBImpl::UnscheduleCallback);
   } else {
-    int output_level  __attribute__((unused)) = c->output_level();
+    int output_level  __attribute__((unused));
+    output_level = c->output_level();
     TEST_SYNC_POINT_CALLBACK("DBImpl::BackgroundCompaction:NonTrivial",
                              &output_level);
-    (output_level);
     SequenceNumber earliest_write_conflict_snapshot;
     std::vector<SequenceNumber> snapshot_seqs =
         snapshots_.GetAll(&earliest_write_conflict_snapshot);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1921,6 +1921,7 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
     if (user_cmp->Compare(file_limit, user_begin) >= 0) {
       *start_index = i;
       assert((count++, true));
+      (count);
     } else {
       break;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1912,7 +1912,8 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
 #endif
   *start_index = mid_index + 1;
   *end_index = mid_index;
-  int count __attribute__((unused)) = 0;
+  int count __attribute__((unused));
+  count = 0;
 
   // check backwards from 'mid' to lower indices
   for (int i = mid_index; i >= 0 ; i--) {
@@ -1921,7 +1922,6 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
     if (user_cmp->Compare(file_limit, user_begin) >= 0) {
       *start_index = i;
       assert((count++, true));
-      (count);
     } else {
       break;
     }

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -379,9 +379,9 @@ class TestMemLogger : public Logger {
       const time_t seconds = now_tv.tv_sec;
       struct tm t;
       memset(&t, 0, sizeof(t));
-      auto ret __attribute__((__unused__)) = localtime_r(&seconds, &t);
+      struct tm* ret __attribute__((__unused__));
+      ret = localtime_r(&seconds, &t);
       assert(ret);
-      (ret);
       p += snprintf(p, limit - p,
                     "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
                     t.tm_year + 1900,

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -381,6 +381,7 @@ class TestMemLogger : public Logger {
       memset(&t, 0, sizeof(t));
       auto ret __attribute__((__unused__)) = localtime_r(&seconds, &t);
       assert(ret);
+      (ret);
       p += snprintf(p, limit - p,
                     "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
                     t.tm_year + 1900,

--- a/monitoring/thread_status_updater.cc
+++ b/monitoring/thread_status_updater.cc
@@ -252,9 +252,9 @@ void ThreadStatusUpdater::EraseColumnFamilyInfo(const void* cf_key) {
     ConstantColumnFamilyInfo& cf_info = cf_pair->second;
     auto db_pair = db_key_map_.find(cf_info.db_key);
     assert(db_pair != db_key_map_.end());
-    size_t result __attribute__((unused)) = db_pair->second.erase(cf_key);
+    size_t result __attribute__((unused));
+    result = db_pair->second.erase(cf_key);
     assert(result);
-    (result);
     cf_info_map_.erase(cf_pair);
   }
 }

--- a/monitoring/thread_status_updater.cc
+++ b/monitoring/thread_status_updater.cc
@@ -254,6 +254,7 @@ void ThreadStatusUpdater::EraseColumnFamilyInfo(const void* cf_key) {
     assert(db_pair != db_key_map_.end());
     size_t result __attribute__((unused)) = db_pair->second.erase(cf_key);
     assert(result);
+    (result);
     cf_info_map_.erase(cf_pair);
   }
 }

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -76,6 +76,7 @@ WinEnvIO::WinEnvIO(Env* hosted_env)
     LARGE_INTEGER qpf;
     BOOL ret = QueryPerformanceFrequency(&qpf);
     assert(ret == TRUE);
+    (ret);
     perf_counter_frequency_ = qpf.QuadPart;
   }
 

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -74,9 +74,10 @@ WinEnvIO::WinEnvIO(Env* hosted_env)
 
   {
     LARGE_INTEGER qpf;
-    BOOL ret = QueryPerformanceFrequency(&qpf);
+    // No init as the compiler complains about unused var
+    BOOL ret;
+    ret = QueryPerformanceFrequency(&qpf);
     assert(ret == TRUE);
-    (ret);
     perf_counter_frequency_ = qpf.QuadPart;
   }
 

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -279,9 +279,9 @@ Status WinMmapFile::MapNewRegion() {
 
     if (hMap_ != NULL) {
       // Unmap the previous one
-      BOOL ret = ::CloseHandle(hMap_);
+      BOOL ret;
+      ret = ::CloseHandle(hMap_);
       assert(ret);
-      (ret);
       hMap_ = NULL;
     }
 
@@ -1021,9 +1021,9 @@ Status WinDirectory::Fsync() { return Status::OK(); }
 /// WinFileLock
 
 WinFileLock::~WinFileLock() {
-  BOOL ret = ::CloseHandle(hFile_);
+  BOOL ret;
+  ret = ::CloseHandle(hFile_);
   assert(ret);
-  (ret);
 }
 
 }

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -281,6 +281,7 @@ Status WinMmapFile::MapNewRegion() {
       // Unmap the previous one
       BOOL ret = ::CloseHandle(hMap_);
       assert(ret);
+      (ret);
       hMap_ = NULL;
     }
 
@@ -1022,6 +1023,7 @@ Status WinDirectory::Fsync() { return Status::OK(); }
 WinFileLock::~WinFileLock() {
   BOOL ret = ::CloseHandle(hFile_);
   assert(ret);
+  (ret);
 }
 
 }

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1314,6 +1314,7 @@ Status BlobDBImpl::CloseBlobFile(std::shared_ptr<BlobFile> bfile) {
     if (bfile->HasTTL()) {
       size_t erased __attribute__((__unused__)) = open_blob_files_.erase(bfile);
       assert(erased == 1);
+      (erased);
     } else {
       auto iter = std::find(open_simple_files_.begin(),
                             open_simple_files_.end(), bfile);

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1312,9 +1312,9 @@ Status BlobDBImpl::CloseBlobFile(std::shared_ptr<BlobFile> bfile) {
     WriteLock wl(&mutex_);
 
     if (bfile->HasTTL()) {
-      size_t erased __attribute__((__unused__)) = open_blob_files_.erase(bfile);
+      size_t erased __attribute__((__unused__));
+      erased = open_blob_files_.erase(bfile);
       assert(erased == 1);
-      (erased);
     } else {
       auto iter = std::find(open_simple_files_.begin(),
                             open_simple_files_.end(), bfile);

--- a/utilities/document/json_document.cc
+++ b/utilities/document/json_document.cc
@@ -48,9 +48,9 @@ void InitJSONDocument(std::unique_ptr<char[]>* data,
   fbson::FbsonWriter writer;
   bool res __attribute__((unused)) = writer.writeStartArray();
   assert(res);
-  uint32_t bytesWritten __attribute__((unused)) = f(writer);
+  uint32_t bytesWritten __attribute__((unused));
+  bytesWritten = f(writer);
   assert(bytesWritten != 0);
-  (bytesWritten);
   res = writer.writeEndArray();
   assert(res);
   char* buf = new char[writer.getOutput()->getSize()];

--- a/utilities/document/json_document.cc
+++ b/utilities/document/json_document.cc
@@ -50,6 +50,7 @@ void InitJSONDocument(std::unique_ptr<char[]>* data,
   assert(res);
   uint32_t bytesWritten __attribute__((unused)) = f(writer);
   assert(bytesWritten != 0);
+  (bytesWritten);
   res = writer.writeEndArray();
   assert(res);
   char* buf = new char[writer.getOutput()->getSize()];

--- a/utilities/persistent_cache/block_cache_tier_metadata.cc
+++ b/utilities/persistent_cache/block_cache_tier_metadata.cc
@@ -65,6 +65,7 @@ BlockInfo* BlockCacheTierMetadata::Remove(const Slice& key) {
   BlockInfo* binfo = nullptr;
   bool ok __attribute__((__unused__)) = block_index_.Erase(&lookup_key, &binfo);
   assert(ok);
+  (ok);
   return binfo;
 }
 

--- a/utilities/persistent_cache/block_cache_tier_metadata.cc
+++ b/utilities/persistent_cache/block_cache_tier_metadata.cc
@@ -63,9 +63,9 @@ bool BlockCacheTierMetadata::Lookup(const Slice& key, LBA* lba) {
 BlockInfo* BlockCacheTierMetadata::Remove(const Slice& key) {
   BlockInfo lookup_key(key);
   BlockInfo* binfo = nullptr;
-  bool ok __attribute__((__unused__)) = block_index_.Erase(&lookup_key, &binfo);
+  bool ok __attribute__((__unused__));
+  ok = block_index_.Erase(&lookup_key, &binfo);
   assert(ok);
-  (ok);
   return binfo;
 }
 

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -483,6 +483,7 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
   bool success __attribute__((__unused__)) =
       ReadKeyFromWriteBatchEntry(&entry_ptr, &key, column_family_id != 0);
   assert(success);
+  (success);
 
     auto* mem = arena.Allocate(sizeof(WriteBatchIndexEntry));
     auto* index_entry =

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -480,10 +480,10 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
                           wb_data.size() - last_entry_offset);
   // Extract key
   Slice key;
-  bool success __attribute__((__unused__)) =
+  bool success __attribute__((__unused__));
+  success =
       ReadKeyFromWriteBatchEntry(&entry_ptr, &key, column_family_id != 0);
   assert(success);
-  (success);
 
     auto* mem = arena.Allocate(sizeof(WriteBatchIndexEntry));
     auto* index_entry =


### PR DESCRIPTION
  MSVC does not support unused attribute at this time. A separate assignment line fixes the issue probably by being counted as usage for MSVC and it no longer complains about unused var.