### PR TITLE
added missing subcodes and improved error message for missing enum values

### DIFF
--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -290,8 +290,14 @@ class StatusJni : public RocksDBNativeClass<rocksdb::Status*, StatusJni> {
         return 0x2;
       case rocksdb::Status::SubCode::kLockLimit:
         return 0x3;
-      case rocksdb::Status::SubCode::kMaxSubCode:
-        return 0x7E;
+      case rocksdb::Status::SubCode::kNoSpace:
+        return 0x4;
+      case rocksdb::Status::SubCode::kDeadlock:
+        return 0x5;
+      case rocksdb::Status::SubCode::kStaleFile:
+        return 0x6;
+      case rocksdb::Status::SubCode::kMemoryLimit:
+        return 0x7;
       default:
         return 0x7F;  // undefined
     }

--- a/java/src/main/java/org/rocksdb/Status.java
+++ b/java/src/main/java/org/rocksdb/Status.java
@@ -54,6 +54,7 @@ public class Status {
     return builder.toString();
   }
 
+  // should stay in sync with /include/rocksdb/status.h:Code and /java/rocksjni/portal.h:toJavaStatusCode
   public enum Code {
     Ok(                 (byte)0x0),
     NotFound(           (byte)0x1),
@@ -68,7 +69,8 @@ public class Status {
     Aborted(            (byte)0xA),
     Busy(               (byte)0xB),
     Expired(            (byte)0xC),
-    TryAgain(           (byte)0xD);
+    TryAgain(           (byte)0xD),
+    Undefined(          (byte)0x7F);
 
     private final byte value;
 
@@ -83,16 +85,21 @@ public class Status {
         }
       }
       throw new IllegalArgumentException(
-          "Illegal value provided for Code.");
+          "Illegal value provided for Code (" + value + ").");
     }
   }
 
+  // should stay in sync with /include/rocksdb/status.h:SubCode and /java/rocksjni/portal.h:toJavaStatusSubCode
   public enum SubCode {
     None(         (byte)0x0),
     MutexTimeout( (byte)0x1),
     LockTimeout(  (byte)0x2),
     LockLimit(    (byte)0x3),
-    MaxSubCode(   (byte)0x7E);
+    NoSpace(      (byte)0x4),
+    Deadlock(     (byte)0x5),
+    StaleFile(    (byte)0x6),
+    MemoryLimit(  (byte)0x7),
+    Undefined(    (byte)0x7F);
 
     private final byte value;
 
@@ -107,7 +114,7 @@ public class Status {
         }
       }
       throw new IllegalArgumentException(
-          "Illegal value provided for SubCode.");
+          "Illegal value provided for SubCode (" + value + ").");
     }
   }
 }


### PR DESCRIPTION
Java's `Status.SubCode` was out of sync with `include/rocksdb/status.h:SubCode`.

When running out of disc space this led to an `IllegalArgumentException` because of an invalid status code, rather than just returning the corresponding status code without an exception.

I added the missing status codes.

By this, we keep the behaviour of throwing an `IllegalArgumentException` in case of newly added status codes that are defined in C but not in Java.

We could think of an alternative strategy: add in Java another code "UnknownCode" which acts as a catch-all for all those status codes that are not yet mirrored from C to Java. This approach would never throw an exception but simply return a non-OK status-code.

I think the current approach of throwing an Exception in case of a C/Java inconsistency is fine, but if you have some opinion on the alternative strategy, then feel free to comment here.