### PR TITLE
Fix unstable floating point exception

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -100,7 +100,7 @@ void LRUHandleTable::Resize() {
 }
 
 LRUCacheShard::LRUCacheShard()
-    : high_pri_pool_usage_(0), usage_(0), lru_usage_(0) {
+    : high_pri_pool_usage_(0), high_pri_pool_ratio_(0), usage_(0), lru_usage_(0) {
   // Make empty circular linked list
   lru_.next = &lru_;
   lru_.prev = &lru_;


### PR DESCRIPTION
Fix unstable floating point exception, tested on Windows, 64-bit build.
The problem appeared in `SetCapacity()` method at line

`high_pri_pool_capacity_ = capacity_ * high_pri_pool_ratio_;`

`high_pri_pool_ratio_` was not initialized at that moment, because
`SetHighPriorityPoolRatio()` is called after `SetCapacity()`. So,
`high_pri_pool_ratio_` contained garbage, which caused "Floating point
exception" sometimes.