### PR TITLE
remove unused code

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -576,8 +576,6 @@ Status DBImpl::SetDBOptions(
                                             immutable_db_options_);
       env_options_for_compaction_.bytes_per_sync
                                     = mutable_db_options_.bytes_per_sync;
-      env_->OptimizeForCompactionTableWrite(env_options_for_compaction_,
-                                            immutable_db_options_);
       write_thread_.EnterUnbatched(&w, &mutex_);
       if (total_log_size_ > GetMaxTotalWalSize() || wal_changed) {
         Status purge_wal_status = SwitchWAL(&write_context);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -574,8 +574,6 @@ Status DBImpl::SetDBOptions(
       env_options_for_compaction_ = env_->OptimizeForCompactionTableWrite(
                                             env_options_for_compaction_,
                                             immutable_db_options_);
-      env_options_for_compaction_.bytes_per_sync
-                                    = mutable_db_options_.bytes_per_sync;
       write_thread_.EnterUnbatched(&w, &mutex_);
       if (total_log_size_ > GetMaxTotalWalSize() || wal_changed) {
         Status purge_wal_status = SwitchWAL(&write_context);


### PR DESCRIPTION
fixup 6a541afcc4d1e5b6e6d78e288b9bee3bb2a933b5. This code didn't do anything because (1) `bytes_per_sync` is assigned in `EnvOptions`'s constructor; and (2) `OptimizeForCompactionTableWrite`'s return value was ignored, even though its only purpose is to return something.

Test Plan: `make check -j64`