### PR TITLE
Exclude DBTest.DynamicFIFOCompactionOptions test under RocksDB Lite

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4290,7 +4290,6 @@ TEST_F(DBTest, DynamicCompactionOptions) {
   dbfull()->TEST_WaitForCompact();
   ASSERT_LT(NumTableFilesAtLevel(0), 4);
 }
-#endif  // ROCKSDB_LITE
 
 // Test dynamic FIFO copmaction options.
 // This test covers just option parsing and makes sure that the options are
@@ -4357,6 +4356,7 @@ TEST_F(DBTest, DynamicFIFOCompactionOptions) {
   ASSERT_EQ(dbfull()->GetOptions().compaction_options_fifo.allow_compaction,
             true);
 }
+#endif  // ROCKSDB_LITE
 
 TEST_F(DBTest, FileCreationRandomFailure) {
   Options options;


### PR DESCRIPTION
This test shouldn't be enabled under the lite version; and this fixes the failing contrun test due to #3006.

Test: 
`OPT="-DROCKSDB_LITE" make check -j100`