### PR TITLE
Fix DeleteFilesInRange so keys never reappear

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1439,6 +1439,92 @@ TEST_F(DBCompactionTest, DeleteFileRange) {
   ASSERT_GT(old_num_files, new_num_files);
 }
 
+TEST_F(DBCompactionTest, DeleteFilesInRangeFixReappearanceBug) {
+  Options options = CurrentOptions();
+  options.write_buffer_size = 10 * 1024 * 1024;
+  options.max_bytes_for_level_multiplier = 2;
+  options.num_levels = 4;
+  options.level0_file_num_compaction_trigger = 3;
+  options.max_background_compactions = 3;
+
+  DestroyAndReopen(options);
+  int32_t value_size = 10 * 1024;  // 10 KB
+
+  /*
+    Test scenario:
+    L1: {1 2 3} {4 5 6 7 8 9} {10 11 12 13}
+    L2: {1 2 3 4 5 6 7 8} {9 10 11 12 13 14}
+
+    DeleteRange [5,7) then DeleteFilesInRange [2, 12]
+    Then make sure indices 5 and 6 are gone.
+  */
+
+  Random rnd(301);
+  std::map<int32_t, std::string> values;
+
+  for (int32_t i = 0; i <= 14; i++) {
+    values[i] = RandomString(&rnd, value_size);
+    ASSERT_OK(Put(Key(i), values[i]));
+    if (i == 8 || i == 14) {
+      ASSERT_OK(Flush());
+    }
+  }
+  dbfull()->TEST_WaitForFlushMemTable();
+  ASSERT_OK(dbfull()->TEST_CompactRange(0, nullptr, nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_CompactRange(1, nullptr, nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ("0,0,2", FilesPerLevel(0));
+
+  for (int32_t i = 1; i <= 13; i++) {
+    values[i] = RandomString(&rnd, value_size);
+    ASSERT_OK(Put(Key(i), values[i]));
+    if (i == 3 || i == 9 || i == 13) {
+      ASSERT_OK(Flush());
+      dbfull()->TEST_WaitForFlushMemTable();
+      ASSERT_OK(dbfull()->TEST_CompactRange(0, nullptr, nullptr, nullptr));
+      ASSERT_OK(dbfull()->TEST_WaitForCompact());
+    }
+  }
+  ASSERT_EQ("0,3,2", FilesPerLevel(0));
+
+  // Delete slots 5 and 6.
+  db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(5), Key(7));
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ("1,3,2", FilesPerLevel(0));
+  // Put the deletion flag into the SST file in level 1.
+  ASSERT_OK(dbfull()->TEST_CompactRange(0, nullptr, nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
+  ASSERT_EQ("0,3,2", FilesPerLevel(0));
+
+  {
+    std::string begin_string = Key(2);
+    std::string end_string = Key(12);
+    Slice begin_slice(begin_string);
+    Slice end_slice(end_string);
+    ASSERT_OK(
+        DeleteFilesInRange(db_, db_->DefaultColumnFamily(), &begin_slice,
+                           &end_slice));
+    ASSERT_OK(Flush());
+    dbfull()->TEST_WaitForFlushMemTable();
+  }
+  // Should not have deleted the level 1 SST file [4,9]
+  // because it touches undeleted files in level 2.
+  ASSERT_EQ("0,3,2", FilesPerLevel(0));
+
+  // Check that all values still exist except for keys 5 and 6.
+  for (int32_t i = 0; i <= 14; i++) {
+    if (i <= 4 || i >= 7) {
+      ASSERT_EQ(Get(Key(i)), values[i]);
+    } else {
+      ReadOptions roptions;
+      std::string result;
+      Status s = db_->Get(roptions, Key(i), &result);
+      ASSERT_TRUE(s.IsNotFound() || s.ok());
+    }
+  }
+}
+
 TEST_P(DBCompactionTestWithParam, TrivialMoveToLastLevelWithFiles) {
   int32_t trivial_move = 0;
   int32_t non_trivial_move = 0;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2072,7 +2072,8 @@ Status DBImpl::DeleteFile(std::string name) {
 }
 
 Status DBImpl::DeleteFilesInRange(ColumnFamilyHandle* column_family,
-                                  const Slice* begin, const Slice* end) {
+                                  const Slice* begin_userkey,
+                                  const Slice* end_userkey) {
   Status status;
   auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
   ColumnFamilyData* cfd = cfh->cfd();
@@ -2084,45 +2085,69 @@ Status DBImpl::DeleteFilesInRange(ColumnFamilyHandle* column_family,
     Version* input_version = cfd->current();
 
     auto* vstorage = input_version->storage_info();
-    for (int i = 1; i < cfd->NumberLevels(); i++) {
+    Slice begin_userkey_storage, end_userkey_storage;
+    if (begin_userkey != nullptr) {
+      begin_userkey_storage = *begin_userkey;
+      begin_userkey = &begin_userkey_storage;
+    }
+    if (end_userkey != nullptr) {
+      end_userkey_storage = *end_userkey;
+      end_userkey = &end_userkey_storage;
+    }
+    for (int i = cfd->NumberLevels() - 1; i >= 1; i--) {
       if (vstorage->LevelFiles(i).empty() ||
-          !vstorage->OverlapInLevel(i, begin, end)) {
+          !vstorage->OverlapInLevel(i, begin_userkey, end_userkey)) {
         continue;
       }
       std::vector<FileMetaData*> level_files;
-      InternalKey begin_storage, end_storage, *begin_key, *end_key;
-      if (begin == nullptr) {
-        begin_key = nullptr;
+      InternalKey begin_internalkey_storage, end_internalkey_storage,
+          *begin_internalkey, *end_internalkey;
+      if (begin_userkey == nullptr) {
+        begin_internalkey = nullptr;
       } else {
-        begin_storage.SetMinPossibleForUserKey(*begin);
-        begin_key = &begin_storage;
+        begin_internalkey_storage.SetMinPossibleForUserKey(*begin_userkey);
+        begin_internalkey = &begin_internalkey_storage;
       }
-      if (end == nullptr) {
-        end_key = nullptr;
+      if (end_userkey == nullptr) {
+        end_internalkey = nullptr;
       } else {
-        end_storage.SetMaxPossibleForUserKey(*end);
-        end_key = &end_storage;
+        end_internalkey_storage.SetMaxPossibleForUserKey(*end_userkey);
+        end_internalkey = &end_internalkey_storage;
       }
 
-      vstorage->GetOverlappingInputs(i, begin_key, end_key, &level_files, -1,
-                                     nullptr, false);
-      FileMetaData* level_file;
-      for (uint32_t j = 0; j < level_files.size(); j++) {
-        level_file = level_files[j];
-        if (((begin == nullptr) ||
-             (cfd->internal_comparator().user_comparator()->Compare(
-                  level_file->smallest.user_key(), *begin) >= 0)) &&
-            ((end == nullptr) ||
-             (cfd->internal_comparator().user_comparator()->Compare(
-                  level_file->largest.user_key(), *end) <= 0))) {
-          if (level_file->being_compacted) {
-            continue;
-          }
-          edit.SetColumnFamily(cfd->GetID());
-          edit.DeleteFile(i, level_file->fd.GetNumber());
-          deleted_files.push_back(level_file);
-          level_file->being_compacted = true;
+      vstorage->GetCleanInputsWithinInterval(
+          i, begin_internalkey, end_internalkey, &level_files, -1, nullptr);
+      if (level_files.empty()) {
+        // Nothing to do in this level, so there's nothing to do in the higher
+        // levels either.
+        break;
+      }
+      // Update the endpoints so that the range deleted at higher levels is a
+      // subset of the range deleted at this level.
+      if (begin_userkey != nullptr) {
+        begin_userkey_storage = level_files.front()->smallest.user_key();
+      }
+      if (end_userkey != nullptr) {
+        end_userkey_storage = level_files.front()->largest.user_key();
+      }
+      for (auto* level_file : level_files) {
+        Slice begin_userkey_compare = level_file->smallest.user_key();
+        if (cfd->internal_comparator().user_comparator()->Compare(
+                begin_userkey_storage, begin_userkey_compare) >= 0) {
+          begin_userkey_storage = begin_userkey_compare;
         }
+        Slice end_userkey_compare = level_file->largest.user_key();
+        if (cfd->internal_comparator().user_comparator()->Compare(
+                end_userkey_storage, end_userkey_compare) <= 0) {
+          end_userkey_storage = end_userkey_compare;
+        }
+        if (level_file->being_compacted) {
+          continue;
+        }
+        edit.SetColumnFamily(cfd->GetID());
+        edit.DeleteFile(i, level_file->fd.GetNumber());
+        deleted_files.push_back(level_file);
+        level_file->being_compacted = true;
       }
     }
     if (edit.GetDeletedFiles().empty()) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -245,7 +245,8 @@ class DBImpl : public DB {
           read_options = TransactionLogIterator::ReadOptions()) override;
   virtual Status DeleteFile(std::string name) override;
   Status DeleteFilesInRange(ColumnFamilyHandle* column_family,
-                            const Slice* begin, const Slice* end);
+                            const Slice* begin_userkey,
+                            const Slice* end_userkey);
 
   virtual void GetLiveFilesMetaData(
       std::vector<LiveFileMetaData>* metadata) override;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -175,8 +175,8 @@ class VersionStorageInfo {
 
   void GetOverlappingInputsRangeBinarySearch(
       int level,           // level > 0
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
+      const Slice* begin,  // nullptr means before all keys
+      const Slice* end,    // nullptr means after all keys
       std::vector<FileMetaData*>* inputs,
       int hint_index,                // index of overlap file
       int* file_index,               // return index of overlap file
@@ -185,8 +185,8 @@ class VersionStorageInfo {
 
   void ExtendFileRangeOverlappingInterval(
       int level,
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
+      const Slice* begin,  // nullptr means before all keys
+      const Slice* end,    // nullptr means after all keys
       unsigned int index,  // start extending from this index
       int* startIndex,     // return the startIndex of input range
       int* endIndex)       // return the endIndex of input range
@@ -194,8 +194,8 @@ class VersionStorageInfo {
 
   void ExtendFileRangeWithinInterval(
       int level,
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
+      const Slice* begin,  // nullptr means before all keys
+      const Slice* end,    // nullptr means after all keys
       unsigned int index,  // start extending from this index
       int* startIndex,     // return the startIndex of input range
       int* endIndex)       // return the endIndex of input range


### PR DESCRIPTION
In the previous implementation of DeleteFilesInRange, keys could reappear if we drop a wider range at a higher level, making the tombstone in the upper level disappear while the key it covered in the lower level doesn't. The second commit in this pull request reimplements DeleteFilesInRange to use the following strategy:
1) Initialize the deletion range to the lower and upper bounds specified by the user.
2) Start from the bottom level and iterate upward. At each level:
    i) pick the widest clean-cut set of files that fall entirely in the range.
    ii) Reset the deletion range to the min and max userkeys of the clean-cut set of files from step (i).

To support this, the first commit in this pull request modifies several functions VersionStorageInfo to accept ranges with no lower and/or upper bound. This is a "fix" in the sense that the functions' comments already promised the new behaviour.

I've added a new unit test in db_compaction_test which passes now but fails when using the old implementation.