### PR TITLE
Add Memtable Read Tier to RocksJava

### DIFF
--- a/java/src/main/java/org/rocksdb/ReadTier.java
+++ b/java/src/main/java/org/rocksdb/ReadTier.java
@@ -11,7 +11,8 @@ package org.rocksdb;
 public enum ReadTier {
   READ_ALL_TIER((byte)0),
   BLOCK_CACHE_TIER((byte)1),
-  PERSISTED_TIER((byte)2);
+  PERSISTED_TIER((byte)2),
+  MEMTABLE_TIER((byte)3);
 
   private final byte value;
 


### PR DESCRIPTION
This options was introduced in the C++ API in #1953 .

Test Plan:
`ROCKSDB_NO_FBCODE=1 make jtest -j64`