### PR TITLE
support set global seqno for external file

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -314,6 +314,14 @@ class DBImpl : public DB {
 
   virtual Status VerifyChecksum() override;
 
+  virtual Status GetExternalFileGlobalSeqnoInfo(
+      ColumnFamilyHandle* column_family, const std::string& external_file,
+      uint64_t* seqno, uint64_t* offset) override;
+
+  virtual Status SetExternalFileGlobalSeqno(ColumnFamilyHandle* column_family,
+                                            const std::string& external_file,
+                                            SequenceNumber seqno) override;
+
 #endif  // ROCKSDB_LITE
 
   // Similar to GetSnapshot(), but also lets the db know that this snapshot

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -976,6 +976,18 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
+  virtual Status GetExternalFileGlobalSeqnoInfo(
+      ColumnFamilyHandle* column_family, const std::string& external_file,
+      uint64_t* seqno, uint64_t* offset) {
+    return Status::OK();
+  }
+
+  virtual Status SetExternalFileGlobalSeqno(ColumnFamilyHandle* column_family,
+                                            const std::string& external_file,
+                                            SequenceNumber seqno) {
+    return Status::OK();
+  }
+
   virtual Status VerifyChecksum() = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()


### PR DESCRIPTION
Before ingesting external file, we usually need to verify the checksum of the external file to guarantee the file is not corrupted. 
When ingesting fail before version change has been added to MANIFEST, but after global_seqno has been set with `move_files = true and allow_global_seqno = true` mode(actually use hard link instead of move), if we restart the ingesting process, checksum verify will fail because of the global_seqno has been changed. So we need to reset the global sequence number to zero before verify.
