### PR TITLE
Fix coverity issue for MutableDBOptions default constructor

### DIFF
--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -234,7 +234,9 @@ MutableDBOptions::MutableDBOptions()
       max_total_wal_size(0),
       delete_obsolete_files_period_micros(6ULL * 60 * 60 * 1000000),
       stats_dump_period_sec(600),
-      max_open_files(-1) {}
+      max_open_files(-1),
+      bytes_per_sync(0),
+      wal_bytes_per_sync(0) {}
 
 MutableDBOptions::MutableDBOptions(const DBOptions& options)
     : max_background_jobs(options.max_background_jobs),


### PR DESCRIPTION
228MutableDBOptions::MutableDBOptions()
229    : max_background_jobs(2),
230      base_background_compactions(-1),
231      max_background_compactions(-1),
232      avoid_flush_during_shutdown(false),
233      delayed_write_rate(2 * 1024U * 1024U),
234      max_total_wal_size(0),
235      delete_obsolete_files_period_micros(6ULL * 60 * 60 * 1000000),
236      stats_dump_period_sec(600),
   	2. uninit_member: Non-static class member bytes_per_sync is not initialized in this constructor nor in any functions that it calls.
   	
CID 1419857 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
4. uninit_member: Non-static class member wal_bytes_per_sync is not initialized in this constructor nor in any functions that it calls.
237      max_open_files(-1) {}