### PR TITLE
Add DeleteRange interface without Column Family

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -49,6 +49,10 @@ TEST_F(DBRangeDelTest, FlushOutputHasOnlyRangeTombstones) {
   ASSERT_EQ(1, NumTableFilesAtLevel(0));
 }
 
+TEST_F(DBRangeDelTest, BasicCallDeleteRangeWithoutCF) {
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), "dr1", "dr2"));
+}
+
 TEST_F(DBRangeDelTest, CompactionOutputHasOnlyRangeTombstone) {
   Options opts = CurrentOptions();
   opts.disable_auto_compactions = true;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -280,6 +280,10 @@ class DB {
   virtual Status DeleteRange(const WriteOptions& options,
                              ColumnFamilyHandle* column_family,
                              const Slice& begin_key, const Slice& end_key);
+  virtual Status DeleteRange(const WriteOptions& options,
+                             const Slice& begin_key, const Slice& end_key) {
+    return DeleteRange(options, DefaultColumnFamily(), begin_key, end_key);
+  }
 
   // Merge the database entry for "key" with "value".  Returns OK on success,
   // and a non-OK status on error. The semantics of this operation is


### PR DESCRIPTION
So that the interface can be called without specifying CF.