### PR TITLE
fix tracking oldest snapshot for bottom-level compaction

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1618,7 +1618,9 @@ void DBImpl::ReleaseSnapshot(const Snapshot* s) {
     snapshots_.Delete(casted_s);
     uint64_t oldest_snapshot;
     if (snapshots_.empty()) {
-      oldest_snapshot = versions_->LastSequence();
+      oldest_snapshot = concurrent_prepare_ && seq_per_batch_
+                              ? versions_->LastToBeWrittenSequence()
+                              : versions_->LastSequence();
     } else {
       oldest_snapshot = snapshots_.oldest()->number_;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1726,9 +1726,7 @@ void VersionStorageInfo::GenerateBottommostFiles() {
 }
 
 void VersionStorageInfo::UpdateOldestSnapshot(SequenceNumber seqnum) {
-  if (seqnum <= oldest_snapshot_seqnum_) {
-    return;
-  }
+  assert(seqnum >= oldest_snapshot_seqnum_);
   oldest_snapshot_seqnum_ = seqnum;
   if (oldest_snapshot_seqnum_ > bottommost_files_mark_threshold_) {
     ComputeBottommostFilesMarkedForCompaction();

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1726,7 +1726,9 @@ void VersionStorageInfo::GenerateBottommostFiles() {
 }
 
 void VersionStorageInfo::UpdateOldestSnapshot(SequenceNumber seqnum) {
-  assert(seqnum >= oldest_snapshot_seqnum_);
+  if (seqnum <= oldest_snapshot_seqnum_) {
+    return;
+  }
   oldest_snapshot_seqnum_ = seqnum;
   if (oldest_snapshot_seqnum_ > bottommost_files_mark_threshold_) {
     ComputeBottommostFilesMarkedForCompaction();


### PR DESCRIPTION
The assertion was caught by `MySQLStyleTransactionTest/MySQLStyleTransactionTest.TransactionStressTest/5` when run in a loop. The caller doesn't track whether the released snapshot is oldest, so let this function handle that case.

Test Plan: ran `make check -j64` and ran `MySQLStyleTransactionTest/MySQLStyleTransactionTest.TransactionStressTest/5` in a loop for a while