### PR TITLE
Blob DB: update blob file format

### DIFF
--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -128,9 +128,6 @@ class BlobDBTest : public testing::Test {
     Iterator *iter = db->NewIterator(ReadOptions());
     iter->SeekToFirst();
     for (auto &p : data) {
-      if (!iter->Valid()) {
-        printf("s = %s\n", iter->status().ToString().c_str());
-      }
       ASSERT_TRUE(iter->Valid());
       ASSERT_EQ(p.first, iter->key().ToString());
       ASSERT_EQ(p.second, iter->value().ToString());
@@ -259,7 +256,6 @@ TEST_F(BlobDBTest, PutUntil) {
   ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
   ASSERT_EQ(data.size(), gc_stats.num_relocate);
   VerifyDB(data);
-  ASSERT_FALSE(true);
 }
 
 TEST_F(BlobDBTest, TTLExtrator_NoTTL) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -128,6 +128,9 @@ class BlobDBTest : public testing::Test {
     Iterator *iter = db->NewIterator(ReadOptions());
     iter->SeekToFirst();
     for (auto &p : data) {
+      if (!iter->Valid()) {
+        printf("s = %s\n", iter->status().ToString().c_str());
+      }
       ASSERT_TRUE(iter->Valid());
       ASSERT_EQ(p.first, iter->key().ToString());
       ASSERT_EQ(p.second, iter->value().ToString());
@@ -256,6 +259,7 @@ TEST_F(BlobDBTest, PutUntil) {
   ASSERT_EQ(100 - data.size(), gc_stats.num_deletes);
   ASSERT_EQ(data.size(), gc_stats.num_relocate);
   VerifyDB(data);
+  ASSERT_FALSE(true);
 }
 
 TEST_F(BlobDBTest, TTLExtrator_NoTTL) {
@@ -1012,11 +1016,11 @@ TEST_F(BlobDBTest, InlineSmallValues) {
     ttl_file = blob_files[1];
   }
   ASSERT_FALSE(non_ttl_file->HasTTL());
-  ASSERT_EQ(first_non_ttl_seq, non_ttl_file->GetSNRange().first);
-  ASSERT_EQ(last_non_ttl_seq, non_ttl_file->GetSNRange().second);
+  ASSERT_EQ(first_non_ttl_seq, non_ttl_file->GetSequenceRange().first);
+  ASSERT_EQ(last_non_ttl_seq, non_ttl_file->GetSequenceRange().second);
   ASSERT_TRUE(ttl_file->HasTTL());
-  ASSERT_EQ(first_ttl_seq, ttl_file->GetSNRange().first);
-  ASSERT_EQ(last_ttl_seq, ttl_file->GetSNRange().second);
+  ASSERT_EQ(first_ttl_seq, ttl_file->GetSequenceRange().first);
+  ASSERT_EQ(last_ttl_seq, ttl_file->GetSequenceRange().second);
 }
 
 }  //  namespace blob_db

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -92,7 +92,7 @@ Status BlobDumpTool::Read(uint64_t offset, size_t size, Slice* result) {
 
 Status BlobDumpTool::DumpBlobLogHeader(uint64_t* offset) {
   Slice slice;
-  Status s = Read(0, BlobLogHeader::kHeaderSize, &slice);
+  Status s = Read(0, BlobLogHeader::kSize, &slice);
   if (!s.ok()) {
     return s;
   }
@@ -102,20 +102,19 @@ Status BlobDumpTool::DumpBlobLogHeader(uint64_t* offset) {
     return s;
   }
   fprintf(stdout, "Blob log header:\n");
-  fprintf(stdout, "  Magic Number   : %" PRIu32 "\n", header.magic_number());
-  fprintf(stdout, "  Version        : %" PRIu32 "\n", header.version());
-  CompressionType compression = header.compression();
+  fprintf(stdout, "  Version          : %" PRIu32 "\n", header.version);
+  fprintf(stdout, "  Column Family ID : %" PRIu32 "\n",
+          header.column_family_id);
   std::string compression_str;
-  if (!GetStringFromCompressionType(&compression_str, compression).ok()) {
+  if (!GetStringFromCompressionType(&compression_str, header.compression)
+           .ok()) {
     compression_str = "Unrecongnized compression type (" +
-                      ToString((int)header.compression()) + ")";
+                      ToString((int)header.compression) + ")";
   }
-  fprintf(stdout, "  Compression    : %s\n", compression_str.c_str());
-  fprintf(stdout, "  TTL Range      : %s\n",
-          GetString(header.ttl_range()).c_str());
-  fprintf(stdout, "  Timestamp Range: %s\n",
-          GetString(header.ts_range()).c_str());
-  *offset = BlobLogHeader::kHeaderSize;
+  fprintf(stdout, "  Compression      : %s\n", compression_str.c_str());
+  fprintf(stdout, "  Expiration range : %s\n",
+          GetString(header.expiration_range).c_str());
+  *offset = BlobLogHeader::kSize;
   return s;
 }
 
@@ -126,20 +125,12 @@ Status BlobDumpTool::DumpBlobLogFooter(uint64_t file_size,
     fprintf(stdout, "No blob log footer.\n");
     return Status::OK();
   };
-  if (file_size < BlobLogHeader::kHeaderSize + BlobLogFooter::kFooterSize) {
+  if (file_size < BlobLogHeader::kSize + BlobLogFooter::kSize) {
     return no_footer();
   }
   Slice slice;
-  Status s = Read(file_size - 4, 4, &slice);
-  if (!s.ok()) {
-    return s;
-  }
-  uint32_t magic_number = DecodeFixed32(slice.data());
-  if (magic_number != kMagicNumber) {
-    return no_footer();
-  }
-  *footer_offset = file_size - BlobLogFooter::kFooterSize;
-  s = Read(*footer_offset, BlobLogFooter::kFooterSize, &slice);
+  *footer_offset = file_size - BlobLogFooter::kSize;
+  Status s = Read(*footer_offset, BlobLogFooter::kSize, &slice);
   if (!s.ok()) {
     return s;
   }
@@ -149,13 +140,11 @@ Status BlobDumpTool::DumpBlobLogFooter(uint64_t file_size,
     return s;
   }
   fprintf(stdout, "Blob log footer:\n");
-  fprintf(stdout, "  Blob count     : %" PRIu64 "\n", footer.GetBlobCount());
-  fprintf(stdout, "  TTL Range      : %s\n",
-          GetString(footer.GetTTLRange()).c_str());
-  fprintf(stdout, "  Time Range     : %s\n",
-          GetString(footer.GetTimeRange()).c_str());
-  fprintf(stdout, "  Sequence Range : %s\n",
-          GetString(footer.GetSNRange()).c_str());
+  fprintf(stdout, "  Blob count       : %" PRIu64 "\n", footer.blob_count);
+  fprintf(stdout, "  Expiration Range : %s\n",
+          GetString(footer.expiration_range).c_str());
+  fprintf(stdout, "  Sequence Range   : %s\n",
+          GetString(footer.sequence_range).c_str());
   return s;
 }
 
@@ -173,41 +162,25 @@ Status BlobDumpTool::DumpRecord(DisplayType show_key, DisplayType show_blob,
   if (!s.ok()) {
     return s;
   }
-  uint32_t key_size = record.GetKeySize();
-  uint64_t blob_size = record.GetBlobSize();
-  fprintf(stdout, "  key size   : %" PRIu32 "\n", key_size);
-  fprintf(stdout, "  blob size  : %" PRIu64 "\n", record.GetBlobSize());
-  fprintf(stdout, "  TTL        : %" PRIu64 "\n", record.GetTTL());
-  fprintf(stdout, "  time       : %" PRIu64 "\n", record.GetTimeVal());
-  fprintf(stdout, "  type       : %d, %d\n", record.type(), record.subtype());
-  fprintf(stdout, "  header CRC : %" PRIu32 "\n", record.header_checksum());
-  fprintf(stdout, "  CRC        : %" PRIu32 "\n", record.checksum());
-  uint32_t header_crc =
-      crc32c::Extend(0, slice.data(), slice.size() - 2 * sizeof(uint32_t));
+  uint64_t key_size = record.key_size;
+  uint64_t value_size = record.value_size;
+  fprintf(stdout, "  key size   : %" PRIu64 "\n", key_size);
+  fprintf(stdout, "  value size : %" PRIu64 "\n", value_size);
+  fprintf(stdout, "  expiration : %" PRIu64 "\n", record.expiration);
   *offset += BlobLogRecord::kHeaderSize;
-  s = Read(*offset, key_size + blob_size, &slice);
+  s = Read(*offset, key_size + value_size, &slice);
   if (!s.ok()) {
     return s;
-  }
-  header_crc = crc32c::Extend(header_crc, slice.data(), key_size);
-  header_crc = crc32c::Mask(header_crc);
-  if (header_crc != record.header_checksum()) {
-    return Status::Corruption("Record header checksum mismatch.");
-  }
-  uint32_t blob_crc = crc32c::Extend(0, slice.data() + key_size, blob_size);
-  blob_crc = crc32c::Mask(blob_crc);
-  if (blob_crc != record.checksum()) {
-    return Status::Corruption("Blob checksum mismatch.");
   }
   if (show_key != DisplayType::kNone) {
     fprintf(stdout, "  key        : ");
     DumpSlice(Slice(slice.data(), key_size), show_key);
     if (show_blob != DisplayType::kNone) {
       fprintf(stdout, "  blob       : ");
-      DumpSlice(Slice(slice.data() + key_size, blob_size), show_blob);
+      DumpSlice(Slice(slice.data() + key_size, value_size), show_blob);
     }
   }
-  *offset += key_size + blob_size;
+  *offset += key_size + value_size;
   return s;
 }
 

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -18,7 +18,6 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "util/coding.h"
-#include "util/crc32c.h"
 #include "util/string_util.h"
 
 namespace rocksdb {

--- a/utilities/blob_db/blob_log_format.cc
+++ b/utilities/blob_db/blob_log_format.cc
@@ -6,284 +6,145 @@
 #ifndef ROCKSDB_LITE
 
 #include "utilities/blob_db/blob_log_format.h"
+
 #include "util/coding.h"
 #include "util/crc32c.h"
 
 namespace rocksdb {
 namespace blob_db {
 
-const uint32_t kMagicNumber = 2395959;
-const uint32_t kVersion1 = 1;
-const size_t kBlockSize = 32768;
-
-BlobLogHeader::BlobLogHeader()
-    : magic_number_(kMagicNumber), compression_(kNoCompression) {}
-
-BlobLogHeader& BlobLogHeader::operator=(BlobLogHeader&& in) noexcept {
-  if (this != &in) {
-    magic_number_ = in.magic_number_;
-    version_ = in.version_;
-    ttl_guess_ = std::move(in.ttl_guess_);
-    ts_guess_ = std::move(in.ts_guess_);
-    compression_ = in.compression_;
-  }
-  return *this;
+void BlobLogHeader::EncodeTo(std::string* dst) {
+  assert(dst != nullptr);
+  dst->clear();
+  dst->reserve(BlobLogHeader::kSize);
+  PutFixed32(dst, kMagicNumber);
+  PutFixed32(dst, version);
+  PutFixed32(dst, column_family_id);
+  unsigned char flags = (has_ttl ? 1 : 0);
+  dst->push_back(flags);
+  dst->push_back(compression);
+  PutFixed64(dst, expiration_range.first);
+  PutFixed64(dst, expiration_range.second);
 }
 
-BlobLogFooter::BlobLogFooter() : magic_number_(kMagicNumber), blob_count_(0) {}
-
-Status BlobLogFooter::DecodeFrom(const Slice& input) {
-  Slice slice(input);
-  uint32_t val;
-  if (!GetFixed32(&slice, &val)) {
-    return Status::Corruption("Invalid Blob Footer: flags");
+Status BlobLogHeader::DecodeFrom(Slice src) {
+  static const std::string kErrorMessage =
+      "Error while decoding blob log header";
+  if (src.size() != BlobLogHeader::kSize) {
+    return Status::Corruption(kErrorMessage,
+                              "Unexpected blob file header size");
   }
-
-  bool has_ttl = false;
-  bool has_ts = false;
-  val >>= 8;
-  RecordSubType st = static_cast<RecordSubType>(val);
-  switch (st) {
-    case kRegularType:
-      break;
-    case kTTLType:
-      has_ttl = true;
-      break;
-    case kTimestampType:
-      has_ts = true;
-      break;
-    default:
-      return Status::Corruption("Invalid Blob Footer: flags_val");
+  uint32_t magic_number;
+  unsigned char flags;
+  if (!GetFixed32(&src, &magic_number) || !GetFixed32(&src, &version) ||
+      !GetFixed32(&src, &column_family_id)) {
+    return Status::Corruption(
+        kErrorMessage,
+        "Error decoding magic number, version and column family id");
   }
-
-  if (!GetFixed64(&slice, &blob_count_)) {
-    return Status::Corruption("Invalid Blob Footer: blob_count");
+  if (magic_number != kMagicNumber) {
+    return Status::Corruption(kErrorMessage, "Magic number mismatch");
   }
-
-  ttlrange_t temp_ttl;
-  if (!GetFixed64(&slice, &temp_ttl.first) ||
-      !GetFixed64(&slice, &temp_ttl.second)) {
-    return Status::Corruption("Invalid Blob Footer: ttl_range");
+  if (version != kVersion1) {
+    return Status::Corruption(kErrorMessage, "Unknown header version");
   }
-  if (has_ttl) {
-    ttl_range_.reset(new ttlrange_t(temp_ttl));
+  flags = src.data()[0];
+  compression = static_cast<CompressionType>(src.data()[1]);
+  has_ttl = (flags & 1) == 1;
+  src.remove_prefix(2);
+  if (!GetFixed64(&src, &expiration_range.first) ||
+      !GetFixed64(&src, &expiration_range.second)) {
+    return Status::Corruption(kErrorMessage, "Error decoding expiration range");
   }
-
-  if (!GetFixed64(&slice, &sn_range_.first) ||
-      !GetFixed64(&slice, &sn_range_.second)) {
-    return Status::Corruption("Invalid Blob Footer: sn_range");
-  }
-
-  tsrange_t temp_ts;
-  if (!GetFixed64(&slice, &temp_ts.first) ||
-      !GetFixed64(&slice, &temp_ts.second)) {
-    return Status::Corruption("Invalid Blob Footer: ts_range");
-  }
-  if (has_ts) {
-    ts_range_.reset(new tsrange_t(temp_ts));
-  }
-
-  if (!GetFixed32(&slice, &magic_number_) || magic_number_ != kMagicNumber) {
-    return Status::Corruption("Invalid Blob Footer: magic");
-  }
-
   return Status::OK();
 }
 
-void BlobLogFooter::EncodeTo(std::string* dst) const {
-  dst->reserve(kFooterSize);
-
-  RecordType rt = kFullType;
-  RecordSubType st = kRegularType;
-  if (HasTTL()) {
-    st = kTTLType;
-  } else if (HasTimestamp()) {
-    st = kTimestampType;
-  }
-  uint32_t val = static_cast<uint32_t>(rt) | (static_cast<uint32_t>(st) << 8);
-  PutFixed32(dst, val);
-
-  PutFixed64(dst, blob_count_);
-  bool has_ttl = HasTTL();
-  bool has_ts = HasTimestamp();
-
-  if (has_ttl) {
-    PutFixed64(dst, ttl_range_.get()->first);
-    PutFixed64(dst, ttl_range_.get()->second);
-  } else {
-    PutFixed64(dst, 0);
-    PutFixed64(dst, 0);
-  }
-  PutFixed64(dst, sn_range_.first);
-  PutFixed64(dst, sn_range_.second);
-
-  if (has_ts) {
-    PutFixed64(dst, ts_range_.get()->first);
-    PutFixed64(dst, ts_range_.get()->second);
-  } else {
-    PutFixed64(dst, 0);
-    PutFixed64(dst, 0);
-  }
-
-  PutFixed32(dst, magic_number_);
+void BlobLogFooter::EncodeTo(std::string* dst) {
+  assert(dst != nullptr);
+  dst->clear();
+  dst->reserve(BlobLogFooter::kSize);
+  PutFixed32(dst, kMagicNumber);
+  PutFixed64(dst, blob_count);
+  PutFixed64(dst, expiration_range.first);
+  PutFixed64(dst, expiration_range.second);
+  PutFixed64(dst, sequence_range.first);
+  PutFixed64(dst, sequence_range.second);
+  crc = crc32c::Value(dst->c_str(), dst->size());
+  crc = crc32c::Mask(crc);
+  PutFixed32(dst, crc);
 }
 
-void BlobLogHeader::EncodeTo(std::string* dst) const {
-  dst->reserve(kHeaderSize);
-
-  PutFixed32(dst, magic_number_);
-
-  PutFixed32(dst, version_);
-
-  RecordSubType st = kRegularType;
-  bool has_ttl = HasTTL();
-  bool has_ts = HasTimestamp();
-
-  if (has_ttl) {
-    st = kTTLType;
-  } else if (has_ts) {
-    st = kTimestampType;
+Status BlobLogFooter::DecodeFrom(Slice src) {
+  static const std::string kErrorMessage =
+      "Error while decoding blob log footer";
+  if (src.size() != BlobLogFooter::kSize) {
+    return Status::Corruption(kErrorMessage,
+                              "Unexpected blob file footer size");
   }
-  uint32_t val =
-      static_cast<uint32_t>(st) | (static_cast<uint32_t>(compression_) << 8);
-  PutFixed32(dst, val);
-
-  if (has_ttl) {
-    PutFixed64(dst, ttl_guess_.get()->first);
-    PutFixed64(dst, ttl_guess_.get()->second);
-  } else {
-    PutFixed64(dst, 0);
-    PutFixed64(dst, 0);
+  uint32_t src_crc = 0;
+  src_crc = crc32c::Value(src.data(), BlobLogFooter::kSize - 4);
+  src_crc = crc32c::Mask(src_crc);
+  uint32_t magic_number;
+  if (!GetFixed32(&src, &magic_number) || !GetFixed64(&src, &blob_count) ||
+      !GetFixed64(&src, &expiration_range.first) ||
+      !GetFixed64(&src, &expiration_range.second) ||
+      !GetFixed64(&src, &sequence_range.first) ||
+      !GetFixed64(&src, &sequence_range.second) || !GetFixed32(&src, &crc)) {
+    return Status::Corruption(kErrorMessage, "Error decoding content");
   }
-
-  if (has_ts) {
-    PutFixed64(dst, ts_guess_.get()->first);
-    PutFixed64(dst, ts_guess_.get()->second);
-  } else {
-    PutFixed64(dst, 0);
-    PutFixed64(dst, 0);
+  if (magic_number != kMagicNumber) {
+    return Status::Corruption(kErrorMessage, "Magic number mismatch");
   }
-}
-
-Status BlobLogHeader::DecodeFrom(const Slice& input) {
-  Slice slice(input);
-  if (!GetFixed32(&slice, &magic_number_) || magic_number_ != kMagicNumber) {
-    return Status::Corruption("Invalid Blob Log Header: magic");
+  if (src_crc != crc) {
+    return Status::Corruption(kErrorMessage, "CRC mismatch");
   }
-
-  // as of today, we only support 1 version
-  if (!GetFixed32(&slice, &version_) || version_ != kVersion1) {
-    return Status::Corruption("Invalid Blob Log Header: version");
-  }
-
-  uint32_t val;
-  if (!GetFixed32(&slice, &val)) {
-    return Status::Corruption("Invalid Blob Log Header: subtype");
-  }
-
-  bool has_ttl = false;
-  bool has_ts = false;
-  RecordSubType st = static_cast<RecordSubType>(val & 0xff);
-  compression_ = static_cast<CompressionType>((val >> 8) & 0xff);
-  switch (st) {
-    case kRegularType:
-      break;
-    case kTTLType:
-      has_ttl = true;
-      break;
-    case kTimestampType:
-      has_ts = true;
-      break;
-    default:
-      return Status::Corruption("Invalid Blob Log Header: subtype_2");
-  }
-
-  ttlrange_t temp_ttl;
-  if (!GetFixed64(&slice, &temp_ttl.first) ||
-      !GetFixed64(&slice, &temp_ttl.second)) {
-    return Status::Corruption("Invalid Blob Log Header: ttl");
-  }
-  if (has_ttl) {
-    set_ttl_guess(temp_ttl);
-  }
-
-  tsrange_t temp_ts;
-  if (!GetFixed64(&slice, &temp_ts.first) ||
-      !GetFixed64(&slice, &temp_ts.second)) {
-    return Status::Corruption("Invalid Blob Log Header: timestamp");
-  }
-  if (has_ts) set_ts_guess(temp_ts);
-
   return Status::OK();
 }
 
-BlobLogRecord::BlobLogRecord()
-    : checksum_(0),
-      header_cksum_(0),
-      key_size_(0),
-      blob_size_(0),
-      time_val_(0),
-      ttl_val_(0),
-      type_(0),
-      subtype_(0) {}
-
-BlobLogRecord::~BlobLogRecord() {}
-
-void BlobLogRecord::ResizeKeyBuffer(size_t kbs) {
-  if (kbs > key_buffer_.size()) {
-    key_buffer_.resize(kbs);
-  }
+void BlobLogRecord::EncodeHeaderTo(std::string* dst) {
+  assert(dst != nullptr);
+  dst->clear();
+  dst->reserve(BlobLogRecord::kHeaderSize + key.size() + value.size());
+  PutFixed64(dst, key.size());
+  PutFixed64(dst, value.size());
+  PutFixed64(dst, expiration);
+  header_crc = crc32c::Value(dst->c_str(), dst->size());
+  header_crc = crc32c::Mask(header_crc);
+  PutFixed32(dst, header_crc);
+  blob_crc = crc32c::Value(key.data(), key.size());
+  blob_crc = crc32c::Extend(blob_crc, value.data(), value.size());
+  blob_crc = crc32c::Mask(blob_crc);
+  PutFixed32(dst, blob_crc);
 }
 
-void BlobLogRecord::ResizeBlobBuffer(size_t bbs) {
-  if (bbs > blob_buffer_.size()) {
-    blob_buffer_.resize(bbs);
+Status BlobLogRecord::DecodeHeaderFrom(Slice src) {
+  static const std::string kErrorMessage = "Error while decoding blob record";
+  if (src.size() != BlobLogRecord::kHeaderSize) {
+    return Status::Corruption(kErrorMessage,
+                              "Unexpected blob record header size");
   }
+  uint32_t src_crc = 0;
+  src_crc = crc32c::Value(src.data(), BlobLogRecord::kHeaderSize - 8);
+  src_crc = crc32c::Mask(src_crc);
+  if (!GetFixed64(&src, &key_size) || !GetFixed64(&src, &value_size) ||
+      !GetFixed64(&src, &expiration) || !GetFixed32(&src, &header_crc) ||
+      !GetFixed32(&src, &blob_crc)) {
+    return Status::Corruption(kErrorMessage, "Error decoding content");
+  }
+  if (src_crc != header_crc) {
+    return Status::Corruption(kErrorMessage, "Header CRC mismatch");
+  }
+  return Status::OK();
 }
 
-void BlobLogRecord::Clear() {
-  checksum_ = 0;
-  header_cksum_ = 0;
-  key_size_ = 0;
-  blob_size_ = 0;
-  time_val_ = 0;
-  ttl_val_ = 0;
-  type_ = subtype_ = 0;
-  key_.clear();
-  blob_.clear();
-}
-
-Status BlobLogRecord::DecodeHeaderFrom(const Slice& hdrslice) {
-  Slice input = hdrslice;
-  if (input.size() < kHeaderSize) {
-    return Status::Corruption("Invalid Blob Record Header: size");
+Status BlobLogRecord::CheckBlobCRC() const {
+  uint32_t expected_crc = 0;
+  expected_crc = crc32c::Value(key.data(), key.size());
+  expected_crc = crc32c::Extend(expected_crc, value.data(), value.size());
+  expected_crc = crc32c::Mask(expected_crc);
+  if (expected_crc != blob_crc) {
+    return Status::Corruption("Blob CRC mismatch");
   }
-
-  if (!GetFixed32(&input, &key_size_)) {
-    return Status::Corruption("Invalid Blob Record Header: key_size");
-  }
-  if (!GetFixed64(&input, &blob_size_)) {
-    return Status::Corruption("Invalid Blob Record Header: blob_size");
-  }
-  if (!GetFixed64(&input, &ttl_val_)) {
-    return Status::Corruption("Invalid Blob Record Header: ttl_val");
-  }
-  if (!GetFixed64(&input, &time_val_)) {
-    return Status::Corruption("Invalid Blob Record Header: time_val");
-  }
-
-  type_ = *(input.data());
-  input.remove_prefix(1);
-  subtype_ = *(input.data());
-  input.remove_prefix(1);
-
-  if (!GetFixed32(&input, &header_cksum_)) {
-    return Status::Corruption("Invalid Blob Record Header: header_cksum");
-  }
-  if (!GetFixed32(&input, &checksum_)) {
-    return Status::Corruption("Invalid Blob Record Header: checksum");
-  }
-
   return Status::OK();
 }
 

--- a/utilities/blob_db/blob_log_format.h
+++ b/utilities/blob_db/blob_log_format.h
@@ -9,243 +9,113 @@
 
 #ifndef ROCKSDB_LITE
 
-#include <cstddef>
-#include <cstdint>
 #include <limits>
-#include <memory>
-#include <string>
 #include <utility>
 #include "rocksdb/options.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/types.h"
 
 namespace rocksdb {
-
 namespace blob_db {
-class BlobFile;
-class BlobDBImpl;
 
+constexpr uint32_t kMagicNumber = 2395959;  // 0x00248f37
+constexpr uint32_t kVersion1 = 1;
 constexpr uint64_t kNoExpiration = std::numeric_limits<uint64_t>::max();
 
-enum RecordType : uint8_t {
-  // Zero is reserved for preallocated files
-  kFullType = 0,
+using ExpirationRange = std::pair<uint64_t, uint64_t>;
+using SequenceRange = std::pair<uint64_t, uint64_t>;
 
-  // For fragments
-  kFirstType = 1,
-  kMiddleType = 2,
-  kLastType = 3,
-  kMaxRecordType = kLastType
+// Format of blob log file header (30 bytes):
+//
+//    +--------------+---------+---------+-------+-------------+-------------------+
+//    | magic number | version |  cf id  | flags | compression | expiration range  |
+//    +--------------+---------+---------+-------+-------------+-------------------+
+//    |   Fixed32    | Fixed32 | Fixed32 | char  |    char     | Fixed64   Fixed64 |
+//    +--------------+---------+---------+-------+-------------+-------------------+
+//
+// List of flags:
+//   has_ttl: Whether the file contain TTL data.
+//
+// Expiration range in the header is a rough range based on
+// blob_db_options.ttl_range_secs.
+struct BlobLogHeader {
+  static constexpr size_t kSize = 30;
+
+  uint32_t version = kVersion1;
+  uint32_t column_family_id;
+  CompressionType compression;
+  bool has_ttl;
+  ExpirationRange expiration_range;
+
+  void EncodeTo(std::string* dst);
+
+  Status DecodeFrom(Slice slice);
 };
 
-enum RecordSubType : uint8_t {
-  kRegularType = 0,
-  kTTLType = 1,
-  kTimestampType = 2,
+// Format of blob log file footer (44 bytes):
+//
+//    +--------------+------------+-------------------+-------------------+------------+
+//    | magic number | blob count | expiration range  |  sequence range   | footer CRC |
+//    +--------------+------------+-------------------+-------------------+------------+
+//    |   Fixed32    |  Fixed64   | Fixed64 + Fixed64 | Fixed64 + Fixed64 |   Fixed32  |
+//    +--------------+------------+-------------------+-------------------+------------+
+//
+// The footer will be presented only when the blob file is properly closed.
+//
+// Unlike the same field in file header, expiration range in the footer is the
+// range of smallest and largest expiration of the data in this file.
+struct BlobLogFooter {
+  static constexpr size_t kSize = 48;
+
+  uint64_t blob_count;
+  ExpirationRange expiration_range;
+  SequenceRange sequence_range;
+  uint32_t crc;
+
+  void EncodeTo(std::string* dst);
+
+  Status DecodeFrom(Slice slice);
 };
 
-extern const uint32_t kMagicNumber;
+// Blob record format (32 bytes header + key + value):
+//
+//    +------------+--------------+------------+------------+----------+---------+-----------+
+//    | key length | value length | expiration | header CRC | blob CRC |   key   |   value   |
+//    +------------+--------------+------------+------------+----------+---------+-----------+
+//    |   Fixed64  |   Fixed64    |  Fixed64   |  Fixed32   | Fixed32  | key len | value len |
+//    +------------+--------------+------------+------------+----------+---------+-----------+
+//
+// If file has has_ttl = false, expiration field is always 0, and the blob
+// doesn't has expiration.
+//
+// Also note that if compression is used, value is compressed value and value
+// length is compressed value length.
+//
+// Header CRC is the checksum of (key_len + val_len + expiration), while
+// blob CRC is the checksum of (key + value).
+//
+// We could use variable length encoding (Varint64) to save more space, but it
+// make reader more complicated.
+struct BlobLogRecord {
+  // header include fields up to blob CRC
+  static constexpr size_t kHeaderSize = 32;
 
-class Reader;
+  uint64_t key_size;
+  uint64_t value_size;
+  uint64_t expiration;
+  uint32_t header_crc;
+  uint32_t blob_crc;
+  Slice key;
+  Slice value;
+  std::string key_buf;
+  std::string value_buf;
 
-using ttlrange_t = std::pair<uint64_t, uint64_t>;
-using tsrange_t = std::pair<uint64_t, uint64_t>;
-using snrange_t = std::pair<rocksdb::SequenceNumber, rocksdb::SequenceNumber>;
+  void EncodeHeaderTo(std::string* dst);
 
-class BlobLogHeader {
-  friend class BlobFile;
-  friend class BlobDBImpl;
+  Status DecodeHeaderFrom(Slice src);
 
- private:
-  uint32_t magic_number_ = 0;
-  uint32_t version_ = 1;
-  CompressionType compression_;
-  std::unique_ptr<ttlrange_t> ttl_guess_;
-  std::unique_ptr<tsrange_t> ts_guess_;
-
- private:
-  void set_ttl_guess(const ttlrange_t& ttl) {
-    ttl_guess_.reset(new ttlrange_t(ttl));
-  }
-
-  void set_version(uint32_t v) { version_ = v; }
-
-  void set_ts_guess(const tsrange_t& ts) { ts_guess_.reset(new tsrange_t(ts)); }
-
- public:
-  // magic number + version + flags + ttl guess + timestamp range = 44
-  static const size_t kHeaderSize = 4 + 4 + 4 + 8 * 2 + 8 * 2;
-
-  void EncodeTo(std::string* dst) const;
-
-  Status DecodeFrom(const Slice& input);
-
-  BlobLogHeader();
-
-  uint32_t magic_number() const { return magic_number_; }
-
-  uint32_t version() const { return version_; }
-
-  CompressionType compression() const { return compression_; }
-
-  ttlrange_t ttl_range() const {
-    if (!ttl_guess_) {
-      return {0, 0};
-    }
-    return *ttl_guess_;
-  }
-
-  tsrange_t ts_range() const {
-    if (!ts_guess_) {
-      return {0, 0};
-    }
-    return *ts_guess_;
-  }
-
-  bool HasTTL() const { return ttl_guess_ != nullptr; }
-
-  bool HasTimestamp() const { return ts_guess_ != nullptr; }
-
-  BlobLogHeader& operator=(BlobLogHeader&& in) noexcept;
-};
-
-// Footer encapsulates the fixed information stored at the tail
-// end of every blob log file.
-class BlobLogFooter {
-  friend class BlobFile;
-
- public:
-  // Use this constructor when you plan to write out the footer using
-  // EncodeTo(). Never use this constructor with DecodeFrom().
-  BlobLogFooter();
-
-  uint32_t magic_number() const { return magic_number_; }
-
-  void EncodeTo(std::string* dst) const;
-
-  Status DecodeFrom(const Slice& input);
-
-  // convert this object to a human readable form
-  std::string ToString() const;
-
-  // footer size = 4 byte magic number
-  // 8 bytes count
-  // 8, 8 - ttl range
-  // 8, 8 - sn range
-  // 8, 8 - ts range
-  // = 64
-  static const size_t kFooterSize = 4 + 4 + 8 + (8 * 2) + (8 * 2) + (8 * 2);
-
-  bool HasTTL() const { return !!ttl_range_; }
-
-  bool HasTimestamp() const { return !!ts_range_; }
-
-  uint64_t GetBlobCount() const { return blob_count_; }
-
-  ttlrange_t GetTTLRange() const {
-    if (ttl_range_) {
-      *ttl_range_;
-    }
-    return {0, 0};
-  }
-
-  tsrange_t GetTimeRange() const {
-    if (ts_range_) {
-      return *ts_range_;
-    }
-    return {0, 0};
-  }
-
-  const snrange_t& GetSNRange() const { return sn_range_; }
-
- private:
-  uint32_t magic_number_ = 0;
-  uint64_t blob_count_ = 0;
-
-  std::unique_ptr<ttlrange_t> ttl_range_;
-  std::unique_ptr<tsrange_t> ts_range_;
-  snrange_t sn_range_;
-
- private:
-  void set_ttl_range(const ttlrange_t& ttl) {
-    ttl_range_.reset(new ttlrange_t(ttl));
-  }
-  void set_time_range(const tsrange_t& ts) {
-    ts_range_.reset(new tsrange_t(ts));
-  }
-};
-
-extern const size_t kBlockSize;
-
-class BlobLogRecord {
-  friend class Reader;
-
- private:
-  // this might not be set.
-  uint32_t checksum_;
-  uint32_t header_cksum_;
-  uint32_t key_size_;
-  uint64_t blob_size_;
-  uint64_t time_val_;
-  uint64_t ttl_val_;
-  char type_;
-  char subtype_;
-  Slice key_;
-  Slice blob_;
-  std::string key_buffer_;
-  std::string blob_buffer_;
-
- private:
-  void Clear();
-
-  char* GetKeyBuffer() { return &(key_buffer_[0]); }
-
-  char* GetBlobBuffer() { return &(blob_buffer_[0]); }
-
-  void ResizeKeyBuffer(size_t kbs);
-
-  void ResizeBlobBuffer(size_t bbs);
-
- public:
-  // Header is
-  // Key Length ( 4 bytes ),
-  // Blob Length ( 8 bytes),
-  // ttl (8 bytes), timestamp (8 bytes),
-  // type (1 byte), subtype (1 byte)
-  // header checksum (4 bytes), blob checksum (4 bytes),
-  // = 42
-  static const size_t kHeaderSize = 4 + 4 + 8 + 8 + 4 + 8 + 1 + 1;
-
- public:
-  BlobLogRecord();
-
-  ~BlobLogRecord();
-
-  const Slice& Key() const { return key_; }
-
-  const Slice& Blob() const { return blob_; }
-
-  uint32_t GetKeySize() const { return key_size_; }
-
-  uint64_t GetBlobSize() const { return blob_size_; }
-
-  bool HasTTL() const {
-    return ttl_val_ != std::numeric_limits<uint32_t>::max();
-  }
-
-  uint64_t GetTTL() const { return ttl_val_; }
-
-  uint64_t GetTimeVal() const { return time_val_; }
-
-  char type() const { return type_; }
-
-  char subtype() const { return subtype_; }
-
-  uint32_t header_checksum() const { return header_cksum_; }
-
-  uint32_t checksum() const { return checksum_; }
-
-  Status DecodeHeaderFrom(const Slice& hdrslice);
+  Status CheckBlobCRC() const;
 };
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_log_format.h
+++ b/utilities/blob_db/blob_log_format.h
@@ -53,7 +53,7 @@ struct BlobLogHeader {
   Status DecodeFrom(Slice slice);
 };
 
-// Format of blob log file footer (44 bytes):
+// Format of blob log file footer (48 bytes):
 //
 //    +--------------+------------+-------------------+-------------------+------------+
 //    | magic number | blob count | expiration range  |  sequence range   | footer CRC |

--- a/utilities/blob_db/blob_log_reader.h
+++ b/utilities/blob_db/blob_log_reader.h
@@ -7,11 +7,9 @@
 
 #ifndef ROCKSDB_LITE
 
-#include <cstdint>
 #include <memory>
 #include <string>
 
-#include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "utilities/blob_db/blob_log_format.h"
@@ -51,7 +49,11 @@ class Reader {
   Reader(std::shared_ptr<Logger> info_log,
          std::unique_ptr<SequentialFileReader>&& file);
 
-  ~Reader();
+  ~Reader() = default;
+
+  // No copying allowed
+  Reader(const Reader&) = delete;
+  Reader& operator=(const Reader&) = delete;
 
   Status ReadHeader(BlobLogHeader* header);
 
@@ -64,6 +66,8 @@ class Reader {
   Status ReadRecord(BlobLogRecord* record, ReadLevel level = kReadHeader,
                     uint64_t* blob_offset = nullptr);
 
+  Status ReadSlice(uint64_t size, Slice* slice, std::string* buf);
+
   SequentialFileReader* file() { return file_.get(); }
 
   void ResetNextByte() { next_byte_ = 0; }
@@ -71,9 +75,6 @@ class Reader {
   uint64_t GetNextByte() const { return next_byte_; }
 
   const SequentialFileReader* file_reader() const { return file_.get(); }
-
- private:
-  char* GetReadBuffer() { return &(backing_store_[0]); }
 
  private:
   std::shared_ptr<Logger> info_log_;
@@ -84,10 +85,6 @@ class Reader {
 
   // which byte to read next. For asserting proper usage
   uint64_t next_byte_;
-
-  // No copying allowed
-  Reader(const Reader&) = delete;
-  Reader& operator=(const Reader&) = delete;
 };
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_log_writer.cc
+++ b/utilities/blob_db/blob_log_writer.cc
@@ -12,6 +12,7 @@
 #include "util/coding.h"
 #include "util/crc32c.h"
 #include "util/file_reader_writer.h"
+#include "utilities/blob_db/blob_log_format.h"
 
 namespace rocksdb {
 namespace blob_db {
@@ -24,18 +25,11 @@ Writer::Writer(unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
       bytes_per_sync_(bpsync),
       next_sync_offset_(0),
       use_fsync_(use_fs),
-      last_elem_type_(kEtNone) {
-  for (int i = 0; i <= kMaxRecordType; i++) {
-    char t = static_cast<char>(i);
-    type_crc_[i] = crc32c::Value(&t, 1);
-  }
-}
-
-Writer::~Writer() {}
+      last_elem_type_(kEtNone) {}
 
 void Writer::Sync() { dest_->Sync(use_fsync_); }
 
-Status Writer::WriteHeader(const BlobLogHeader& header) {
+Status Writer::WriteHeader(BlobLogHeader& header) {
   assert(block_offset_ == 0);
   assert(last_elem_type_ == kEtNone);
   std::string str;
@@ -50,7 +44,7 @@ Status Writer::WriteHeader(const BlobLogHeader& header) {
   return s;
 }
 
-Status Writer::AppendFooter(const BlobLogFooter& footer) {
+Status Writer::AppendFooter(BlobLogFooter& footer) {
   assert(block_offset_ != 0);
   assert(last_elem_type_ == kEtFileHdr || last_elem_type_ == kEtRecord);
 
@@ -69,13 +63,13 @@ Status Writer::AppendFooter(const BlobLogFooter& footer) {
 }
 
 Status Writer::AddRecord(const Slice& key, const Slice& val,
-                         uint64_t* key_offset, uint64_t* blob_offset,
-                         uint64_t ttl) {
+                         uint64_t expiration, uint64_t* key_offset,
+                         uint64_t* blob_offset) {
   assert(block_offset_ != 0);
   assert(last_elem_type_ == kEtFileHdr || last_elem_type_ == kEtRecord);
 
   std::string buf;
-  ConstructBlobHeader(&buf, key, val, ttl, -1);
+  ConstructBlobHeader(&buf, key, val, expiration);
 
   Status s = EmitPhysicalRecord(buf, key, val, key_offset, blob_offset);
   return s;
@@ -87,44 +81,19 @@ Status Writer::AddRecord(const Slice& key, const Slice& val,
   assert(last_elem_type_ == kEtFileHdr || last_elem_type_ == kEtRecord);
 
   std::string buf;
-  ConstructBlobHeader(&buf, key, val, 0, -1);
+  ConstructBlobHeader(&buf, key, val, 0);
 
   Status s = EmitPhysicalRecord(buf, key, val, key_offset, blob_offset);
   return s;
 }
 
-void Writer::ConstructBlobHeader(std::string* headerbuf, const Slice& key,
-                                 const Slice& val, uint64_t ttl, int64_t ts) {
-  headerbuf->reserve(BlobLogRecord::kHeaderSize);
-
-  uint32_t key_size = static_cast<uint32_t>(key.size());
-  PutFixed32(headerbuf, key_size);
-  PutFixed64(headerbuf, val.size());
-
-  PutFixed64(headerbuf, ttl);
-  PutFixed64(headerbuf, ts);
-
-  RecordType t = kFullType;
-  headerbuf->push_back(static_cast<char>(t));
-
-  RecordSubType st = kRegularType;
-  if (ttl != kNoExpiration) {
-    st = kTTLType;
-  }
-  headerbuf->push_back(static_cast<char>(st));
-
-  uint32_t header_crc = 0;
-  header_crc =
-      crc32c::Extend(header_crc, headerbuf->c_str(), headerbuf->size());
-  header_crc = crc32c::Extend(header_crc, key.data(), key.size());
-  header_crc = crc32c::Mask(header_crc);
-  PutFixed32(headerbuf, header_crc);
-
-  uint32_t crc = 0;
-  // Compute the crc of the record type and the payload.
-  crc = crc32c::Extend(crc, val.data(), val.size());
-  crc = crc32c::Mask(crc);  // Adjust for storage
-  PutFixed32(headerbuf, crc);
+void Writer::ConstructBlobHeader(std::string* buf, const Slice& key,
+                                 const Slice& val, uint64_t expiration) {
+  BlobLogRecord record;
+  record.key = key;
+  record.value = val;
+  record.expiration = expiration;
+  record.EncodeHeaderTo(buf);
 }
 
 Status Writer::EmitPhysicalRecord(const std::string& headerbuf,

--- a/utilities/blob_db/blob_log_writer.cc
+++ b/utilities/blob_db/blob_log_writer.cc
@@ -10,7 +10,6 @@
 #include <string>
 #include "rocksdb/env.h"
 #include "util/coding.h"
-#include "util/crc32c.h"
 #include "util/file_reader_writer.h"
 #include "utilities/blob_db/blob_log_format.h"
 


### PR DESCRIPTION
Summary:
Changing blob file format and some code cleanup around the change. The change with blob log format are:
* Remove timestamp field in blob file header, blob file footer and blob records. The field is not being use and often confuse with expiration field.
* Blob file header now come with column family id, which always equal to default column family id. It leaves room for future support of column family.
* Compression field in blob file header now is a standalone byte (instead of compact encode with flags field)
* Blob file footer now come with its own crc.
* Key length now being uint64_t instead of uint32_t
* Blob CRC now checksum both key and value (instead of value only).
* Some reordering of the fields.

The list of cleanups:
* Better inline comments in blob_log_format.h
* rename ttlrange_t and snrange_t to ExpirationRange and SequenceRange respectively.
* simplify blob_db::Reader
* Move crc checking logic to inside blob_log_format.cc

Test Plan:
Existing tests
