### PR TITLE
always drop tombstones compacted to bottommost level

### DIFF
--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -295,9 +295,8 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
       }
     }
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 // Mark (or clear) each file that is being compacted

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -272,7 +272,10 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
   assert(input_version_ != nullptr);
   assert(level_ptrs != nullptr);
   assert(level_ptrs->size() == static_cast<size_t>(number_levels_));
-  if (cfd_->ioptions()->compaction_style == kCompactionStyleLevel) {
+  if (bottommost_level_) {
+    return true;
+  } else if (output_level_ != 0 &&
+             cfd_->ioptions()->compaction_style == kCompactionStyleLevel) {
     if (output_level_ == 0) {
       return false;
     }
@@ -296,7 +299,7 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
     }
     return true;
   } else {
-    return bottommost_level_;
+    return false;
   }
 }
 

--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -276,9 +276,6 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
     return true;
   } else if (output_level_ != 0 &&
              cfd_->ioptions()->compaction_style == kCompactionStyleLevel) {
-    if (output_level_ == 0) {
-      return false;
-    }
     // Maybe use binary search to find right entry instead of linear search?
     const Comparator* user_cmp = cfd_->user_comparator();
     for (int lvl = output_level_ + 1; lvl < number_levels_; lvl++) {


### PR DESCRIPTION
Problem was in bottommost compaction, when an L0->L0 compaction happened and L0 was bottommost. Then we'd preserve tombstones according to `Compaction::KeyNotExistsBeyondOutputLevel`, while zeroing seqnum according to `CompactionIterator::PrepareOutput`, thus triggering the assertion in `PrepareOutput`. To fix, we can just drop tombstones in L0->L0 when the output is "bottommost", i.e., the compaction includes the oldest L0 file and there's nothing at lower levels.

Test Plan:

- `make check -j64`
- MyRocks test that used to fail consistently: `../tools/mysqltest.sh --clean --jenkins --testset=RocksDBBig --async-client --workers=16 --copybuild=/tmp/mysql_sandcastle rocksdb.rqg_transactions`