### PR TITLE
WritePrepared Txn: sort indexes before batch collapse

### DIFF
--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -954,6 +954,7 @@ Status WriteBatchWithIndex::RollbackToSavePoint() {
 
   if (s.ok()) {
     s = rep->ReBuildIndex();
+    rep->obsolete_offsets.clear();
   }
 
   return s;

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -583,6 +583,7 @@ void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
     if (rep->obsolete_offsets.size() == 0) {
       return false;
     }
+    std::sort(rep->obsolete_offsets.begin(), rep->obsolete_offsets.end());
     WriteBatch& write_batch = rep->write_batch;
     assert(write_batch.Count() != 0);
     size_t offset = WriteBatchInternal::GetFirstOffset(&write_batch);


### PR DESCRIPTION
The collapse of duplicate keys in write batch needs to sort the indexes of duplicate keys since it only checks the index in the batch with the head of the list of duplicate keys.