### PR TITLE
Blob DB: Evict oldest blob file when close to blob db size limit

### DIFF
--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -424,7 +424,9 @@ class BlobDBImpl : public BlobDB {
   bool FindFileAndEvictABlob(uint64_t file_number, uint64_t key_size,
                              uint64_t blob_offset, uint64_t blob_size);
 
-  void CopyBlobFiles(std::vector<std::shared_ptr<BlobFile>>* bfiles_copy);
+  void CopyBlobFiles(
+      std::vector<std::shared_ptr<BlobFile>>* bfiles_copy,
+      std::function<bool(const std::shared_ptr<BlobFile>&)> predicate = {});
 
   void FilterSubsetOfFiles(
       const std::vector<std::shared_ptr<BlobFile>>& blob_files,
@@ -432,6 +434,8 @@ class BlobDBImpl : public BlobDB {
       size_t files_to_collect);
 
   uint64_t EpochNow() { return env_->NowMicros() / 1000000; }
+
+  Status CheckSize(size_t blob_size);
 
   std::shared_ptr<BlobFile> GetOldestBlobFile();
 
@@ -543,6 +547,8 @@ class BlobDBImpl : public BlobDB {
   bool open_p1_done_;
 
   uint32_t debug_level_;
+
+  std::atomic<bool> oldest_file_evicted_;
 };
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -205,6 +205,10 @@ class BlobDBImpl : public BlobDB {
   // how often to schedule check seq files period
   static constexpr uint32_t kCheckSeqFilesPeriodMillisecs = 10 * 1000;
 
+  // when should oldest file be evicted:
+  // on reaching 90% of blob_dir_size
+  static constexpr double kEvictOldestFileAtSize = 0.9;
+
   using BlobDB::Put;
   Status Put(const WriteOptions& options, const Slice& key,
              const Slice& value) override;
@@ -428,6 +432,10 @@ class BlobDBImpl : public BlobDB {
       size_t files_to_collect);
 
   uint64_t EpochNow() { return env_->NowMicros() / 1000000; }
+
+  std::shared_ptr<BlobFile> GetOldestBlobFile();
+
+  bool EvictOldestBlobFile();
 
   // the base DB
   DBImpl* db_impl_;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -701,41 +701,44 @@ TEST_F(BlobDBTest, GCExpiredKeyWhileOverwriting) {
   VerifyDB({{"foo", "v2"}});
 }
 
-// TEST_F(BlobDBTest, GCOldestSimpleBlobFileWhenOutOfSpace) {
-//   // Use mock env to stop wall clock.
-//   Options options;
-//   options.env = mock_env_.get();
-//   BlobDBOptions bdb_options;
-//   // bdb_options.is_fifo = true;
-//   bdb_options.blob_dir_size = 100;
-//   bdb_options.blob_file_size = 100;
-//   bdb_options.min_blob_size = 0;
-//   bdb_options.disable_background_tasks = true;
-//   Open(bdb_options);
-//   std::string value(100, 'v');
-//   ASSERT_OK(blob_db_->PutWithTTL(WriteOptions(), "key_with_ttl", value, 60));
-//   for (int i = 0; i < 10; i++) {
-//     ASSERT_OK(blob_db_->Put(WriteOptions(), "key" + ToString(i), value));
-//   }
-//   BlobDBImpl *blob_db_impl =
-//       static_cast_with_check<BlobDBImpl, BlobDB>(blob_db_);
-//   auto blob_files = blob_db_impl->TEST_GetBlobFiles();
-//   ASSERT_EQ(11, blob_files.size());
-//   ASSERT_TRUE(blob_files[0]->HasTTL());
-//   ASSERT_TRUE(blob_files[0]->Immutable());
-//   for (int i = 1; i <= 10; i++) {
-//     ASSERT_FALSE(blob_files[i]->HasTTL());
-//     if (i < 10) {
-//       ASSERT_TRUE(blob_files[i]->Immutable());
-//     }
-//   }
-//   blob_db_impl->TEST_RunGC();
-//   // The oldest simple blob file (i.e. blob_files[1]) has been selected for GC.
-//   auto obsolete_files = blob_db_impl->TEST_GetObsoleteFiles();
-//   ASSERT_EQ(1, obsolete_files.size());
-//   ASSERT_EQ(blob_files[1]->BlobFileNumber(),
-//             obsolete_files[0]->BlobFileNumber());
-// }
+// This test is no longer valid since we now return an error when we go
+// over the configured blob_dir_size.
+// The test needs to be re-written later in such a way that writes continue
+// after a GC happens.
+TEST_F(BlobDBTest, DISABLED_GCOldestSimpleBlobFileWhenOutOfSpace) {
+  // Use mock env to stop wall clock.
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptions bdb_options;
+  bdb_options.blob_dir_size = 100;
+  bdb_options.blob_file_size = 100;
+  bdb_options.min_blob_size = 0;
+  bdb_options.disable_background_tasks = true;
+  Open(bdb_options);
+  std::string value(100, 'v');
+  ASSERT_OK(blob_db_->PutWithTTL(WriteOptions(), "key_with_ttl", value, 60));
+  for (int i = 0; i < 10; i++) {
+    ASSERT_OK(blob_db_->Put(WriteOptions(), "key" + ToString(i), value));
+  }
+  BlobDBImpl *blob_db_impl =
+      static_cast_with_check<BlobDBImpl, BlobDB>(blob_db_);
+  auto blob_files = blob_db_impl->TEST_GetBlobFiles();
+  ASSERT_EQ(11, blob_files.size());
+  ASSERT_TRUE(blob_files[0]->HasTTL());
+  ASSERT_TRUE(blob_files[0]->Immutable());
+  for (int i = 1; i <= 10; i++) {
+    ASSERT_FALSE(blob_files[i]->HasTTL());
+    if (i < 10) {
+      ASSERT_TRUE(blob_files[i]->Immutable());
+    }
+  }
+  blob_db_impl->TEST_RunGC();
+  // The oldest simple blob file (i.e. blob_files[1]) has been selected for GC.
+  auto obsolete_files = blob_db_impl->TEST_GetObsoleteFiles();
+  ASSERT_EQ(1, obsolete_files.size());
+  ASSERT_EQ(blob_files[1]->BlobFileNumber(),
+            obsolete_files[0]->BlobFileNumber());
+}
 
 TEST_F(BlobDBTest, ReadWhileGC) {
   // run the same test for Get(), MultiGet() and Iterator each.
@@ -950,19 +953,18 @@ TEST_F(BlobDBTest, OutOfSpace) {
   ASSERT_TRUE(s.IsNoSpace());
 }
 
-TEST_F(BlobDBTest, EvictOldestFileWhenCloseSpaceLimit) {
+TEST_F(BlobDBTest, EvictOldestFileWhenCloseToSpaceLimit) {
   // Use mock env to stop wall clock.
   Options options;
-  options.env = mock_env_.get();
   BlobDBOptions bdb_options;
-  bdb_options.blob_dir_size = 300;
+  bdb_options.blob_dir_size = 270;
   bdb_options.blob_file_size = 100;
   bdb_options.disable_background_tasks = true;
   bdb_options.is_fifo = true;
   Open(bdb_options);
 
-  // Each stored blob has an overhead of about 42 bytes currently.
-  // So a small key + a 100 byte blob should take up ~150 bytes in the db.
+  // Each stored blob has an overhead of about 32 bytes currently.
+  // So a 100 byte blob should take up 132 bytes.
   std::string value(100, 'v');
   ASSERT_OK(blob_db_->PutWithTTL(WriteOptions(), "key1", value, 10));
 
@@ -970,14 +972,16 @@ TEST_F(BlobDBTest, EvictOldestFileWhenCloseSpaceLimit) {
   auto blob_files = bdb_impl->TEST_GetBlobFiles();
   ASSERT_EQ(1, blob_files.size());
 
-  // Adding another 100 byte blob would take the total size to 284 bytes (2*142), which is
-  // more than 90% of blob_dir_size. So, the oldest file should be evicted and put in
-  // obsolete files list.
+  // Adding another 100 byte blob would take the total size to 264 bytes
+  // (2*132), which is more than 90% of blob_dir_size. So, the oldest file
+  // should be evicted and put in obsolete files list.
   ASSERT_OK(blob_db_->PutWithTTL(WriteOptions(), "key2", value, 60));
 
   auto obsolete_files = bdb_impl->TEST_GetObsoleteFiles();
   ASSERT_EQ(1, obsolete_files.size());
-  ASSERT_EQ(blob_files[0]->BlobFileNumber(), obsolete_files[0]->BlobFileNumber());
+  ASSERT_TRUE(obsolete_files[0]->Immutable());
+  ASSERT_EQ(blob_files[0]->BlobFileNumber(),
+            obsolete_files[0]->BlobFileNumber());
 
   bdb_impl->TEST_DeleteObsoleteFiles();
   obsolete_files = bdb_impl->TEST_GetObsoleteFiles();


### PR DESCRIPTION
Evict oldest blob file and put it in obsolete_files list when close to blob db size limit. The file will be delete when the `DeleteObsoleteFiles` background job runs next time. 
For now I set `kEvictOldestFileAtSize` constant, which controls when to evict the oldest file, at 90%. It could be tweaked or made into an option if really needed; I didn't want to expose it as an option pre-maturely as there are already too many :) . 

Test Plan:
Added a new unit test.
Commented out one test which doesn't make sense any more (left it out as a comment, to discuss further).