### PR TITLE
Write path error handling cleanup

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -836,10 +836,7 @@ class DBImpl : public DB {
                               size_t seq_inc);
 
   // Used by WriteImpl to update bg_error_ if paranoid check is enabled.
-  void WriteCallbackStatusCheck(const Status& status);
-
-  // Used by WriteImpl to update bg_error_ in case of memtable insert error.
-  void MemTableInsertStatusCheck(const Status& memtable_insert_status);
+  void SetBackgroundErrorIfNeeded(const Status& status);
 
 #ifndef ROCKSDB_LITE
 

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -263,6 +263,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
         last_sequence = versions_->FetchAddLastAllocatedSequence(seq_inc);
       }
     }
+    TEST_SYNC_POINT("DBImpl::WriteImpl:FinishWriteToWAL");
     assert(last_sequence != kMaxSequenceNumber);
     const SequenceNumber current_sequence = last_sequence + 1;
     last_sequence += seq_inc;
@@ -348,7 +349,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       versions_->SetLastSequence(last_sequence);
     }
     MemTableInsertStatusCheck(w.status);
-    write_thread_.ExitAsBatchGroupLeader(write_group, w.status);
+    write_thread_.ExitAsBatchGroupLeader(write_group, status);
   }
 
   if (status.ok()) {

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -3,12 +3,18 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <atomic>
 #include <memory>
 #include <thread>
 #include <vector>
 #include "db/db_test_util.h"
+#include "db/write_thread.h"
 #include "db/write_batch_internal.h"
+#include "port/port.h"
 #include "port/stack_trace.h"
+#include "util/fault_injection_test_env.h"
+#include "util/string_util.h"
+#include "util/sync_point.h"
 
 namespace rocksdb {
 
@@ -17,7 +23,9 @@ class DBWriteTest : public DBTestBase, public testing::WithParamInterface<int> {
  public:
   DBWriteTest() : DBTestBase("/db_write_test") {}
 
-  void Open() { DBTestBase::Reopen(GetOptions(GetParam())); }
+  Options GetOptions() { return DBTestBase::GetOptions(GetParam()); }
+
+  void Open() { DBTestBase::Reopen(GetOptions()); }
 };
 
 // It is invalid to do sync write while disabling WAL.
@@ -75,6 +83,52 @@ TEST_P(DBWriteTest, ReturnSeuqneceNumberMultiThreaded) {
   for (size_t i = 0; i < kThreads; i++) {
     threads[i].join();
   }
+}
+
+TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
+  constexpr int kNumThreads = 5;
+  std::unique_ptr<FaultInjectionTestEnv> mock_env(
+      new FaultInjectionTestEnv(Env::Default()));
+  Options options = GetOptions();
+  options.env = mock_env.get();
+  Reopen(options);
+  std::atomic<int> ready_count{0};
+  std::atomic<int> leader_count{0};
+  std::vector<port::Thread> threads;
+  mock_env->SetFilesystemActive(false);
+  // Wait until all threads linked to write threads, to make sure
+  // all threads join the same batch group.
+  SyncPoint::GetInstance()->SetCallBack(
+      "WriteThread::JoinBatchGroup:Wait", [&](void* arg) {
+        ready_count++;
+        auto* w = reinterpret_cast<WriteThread::Writer*>(arg);
+        if (w->state == WriteThread::STATE_GROUP_LEADER) {
+          leader_count++;
+          while (ready_count < kNumThreads) {
+            // busy waiting
+          }
+        }
+      });
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::WriteImpl::FinishWriteToWAL", [&](void* /*arg*/) {
+        // Reactivate file system immediate after the first WAL write.
+        mock_env->SetFilesystemActive(true);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  for (int i = 0; i < kNumThreads; i++) {
+    threads.push_back(port::Thread(
+        [&](int i) {
+          // All threads should fail.
+          ASSERT_FALSE(Put("key" + ToString(i), "value").ok());
+        },
+        i));
+  }
+  for (int i = 0; i < kNumThreads; i++) {
+    threads[i].join();
+  }
+  ASSERT_EQ(1, leader_count);
+  // Close before mock_env destruct.
+  Close();
 }
 
 INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -112,9 +112,9 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
   SyncPoint::GetInstance()->EnableProcessing();
   for (int i = 0; i < kNumThreads; i++) {
     threads.push_back(port::Thread(
-        [&](int i) {
+        [&](int index) {
           // All threads should fail.
-          ASSERT_FALSE(Put("key" + ToString(i), "value").ok());
+          ASSERT_FALSE(Put("key" + ToString(index), "value").ok());
         },
         i));
   }

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -8,8 +8,8 @@
 #include <thread>
 #include <vector>
 #include "db/db_test_util.h"
-#include "db/write_thread.h"
 #include "db/write_batch_internal.h"
+#include "db/write_thread.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "util/fault_injection_test_env.h"
@@ -108,11 +108,6 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
             // busy waiting
           }
         }
-      });
-  SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::WriteImpl::FinishWriteToWAL", [&](void* /*arg*/) {
-        // Reactivate file system immediate after the first WAL write.
-        mock_env->SetFilesystemActive(true);
       });
   SyncPoint::GetInstance()->EnableProcessing();
   for (int i = 0; i < kNumThreads; i++) {


### PR DESCRIPTION
Summary:
Fixing the bug where concurrent writes may get Status::OK while it actually gets IOError on WAL write. This happens when multiple writes form a write batch group, and the leader get an IOError while writing to WAL. The leader failed to pass the error to followers in the group, and the followers end up return Status::OK() while actually writing nothing. The bug only affect writes in a batch group. Future writes after the batch group will correctly return immediately with the IOError.

Closes #3096 

Test Plan:
See the new test.