### PR TITLE
db_stress snapshot compatibility with reopens

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1782,9 +1782,11 @@ class StressTest {
             std::min(FLAGS_ops_per_thread - 1, i + FLAGS_snapshot_hold_ops),
             db_->GetSnapshot());
       }
-      if (!snapshot_queue_.empty() && i == snapshot_queue_.front().first) {
-        db_->ReleaseSnapshot(snapshot_queue_.front().second);
-        snapshot_queue_.pop();
+      if (!snapshot_queue_.empty()) {
+        while (i == snapshot_queue_.front().first) {
+          db_->ReleaseSnapshot(snapshot_queue_.front().second);
+          snapshot_queue_.pop();
+        }
       }
 
       const double completed_ratio =


### PR DESCRIPTION
- Release all snapshots before crashing and reopening the DB. Without this, we may attempt to release snapshots from an old DB using a new DB. That tripped an assertion.
- Release multiple snapshots in the same operation if needed. Without this, we would sometimes leak snapshots.

Test Plan: verified it fixes the asan crash test

```
$ COMPILE_WITH_ASAN=1 make -j64 db_stress
$ ./db_stress --max_background_compactions=20 --use_merge=0 --max_write_buffer_number=3 --sync=0 --reopen=1 --acquire_snapshot_one_in=10000 --delpercent=5 --log2_keys_per_lock=10 --block_size=16384 --allow_concurrent_memtable_write=0 --target_file_size_multiplier=2 --use_full_merge_v1=0 --target_file_size_base=2097152
 --mmap_read=1 --writepercent=35 --readpercent=45 --subcompactions=3 --ops_per_thread=200000 --memtablerep=prefix_hash --prefix_size=7 --test_batches_snapshots=1 --db=/dev/shm/rocksdb/rocksdb_crashtest_whitebox --max_bytes_for_level_base=10485760 --threads=32 --disable_wal=0 --open_files=500000 --destroy_db_initially=0 --progress_reports=0 --snapshot_hold_ops=
100000 --nooverwritepercent=1 --iterpercent=10 --max_key=100000000 --prefixpercent=5 --use_clock_cache=false --cache_size=1048576 --compaction_style=1 --verify_checksum=1 --write_buffer_size=4194304
```