### PR TITLE
Fix removed structurally dead return statement

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -428,8 +428,6 @@ class PosixEnv : public Env {
       result->reset(new PosixWritableFile(fname, fd, no_mmap_writes_options));
     }
     return s;
-
-    return s;
   }
 
   virtual Status NewRandomRWFile(const std::string& fname,


### PR DESCRIPTION
There seems to be a typo mistake in env ReuseWritableFile func
where status is being returned twice.