### PR TITLE
Blob DB: Initialize all fields in Blob Header, Footer and Record structs

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -552,6 +552,8 @@ std::shared_ptr<BlobFile> BlobDBImpl::SelectBlobFile() {
   bfile->file_size_ = BlobLogHeader::kSize;
   bfile->header_.compression = bdb_options_.compression;
   bfile->header_.has_ttl = false;
+  bfile->header_.column_family_id =
+      reinterpret_cast<ColumnFamilyHandleImpl*>(DefaultColumnFamily())->GetID();
   bfile->header_valid_ = true;
   bfile->SetHasTTL(false);
 
@@ -615,6 +617,9 @@ std::shared_ptr<BlobFile> BlobDBImpl::SelectBlobFileTTL(uint64_t expiration) {
   bfile->header_.expiration_range = expiration_range;
   bfile->header_.compression = bdb_options_.compression;
   bfile->header_.has_ttl = true;
+  bfile->header_.column_family_id =
+      reinterpret_cast<ColumnFamilyHandleImpl*>(DefaultColumnFamily())->GetID();
+  ;
   bfile->header_valid_ = true;
   bfile->SetHasTTL(true);
   bfile->file_size_ = BlobLogHeader::kSize;

--- a/utilities/blob_db/blob_log_format.h
+++ b/utilities/blob_db/blob_log_format.h
@@ -43,10 +43,10 @@ struct BlobLogHeader {
   static constexpr size_t kSize = 30;
 
   uint32_t version = kVersion1;
-  uint32_t column_family_id;
-  CompressionType compression;
-  bool has_ttl;
-  ExpirationRange expiration_range;
+  uint32_t column_family_id = 0;
+  CompressionType compression = kNoCompression;
+  bool has_ttl = false;
+  ExpirationRange expiration_range = std::make_pair(0, 0);
 
   void EncodeTo(std::string* dst);
 
@@ -68,10 +68,10 @@ struct BlobLogHeader {
 struct BlobLogFooter {
   static constexpr size_t kSize = 48;
 
-  uint64_t blob_count;
-  ExpirationRange expiration_range;
-  SequenceRange sequence_range;
-  uint32_t crc;
+  uint64_t blob_count = 0;
+  ExpirationRange expiration_range = std::make_pair(0, 0);
+  SequenceRange sequence_range = std::make_pair(0, 0);
+  uint32_t crc = 0;
 
   void EncodeTo(std::string* dst);
 

--- a/utilities/blob_db/blob_log_format.h
+++ b/utilities/blob_db/blob_log_format.h
@@ -101,11 +101,11 @@ struct BlobLogRecord {
   // header include fields up to blob CRC
   static constexpr size_t kHeaderSize = 32;
 
-  uint64_t key_size;
-  uint64_t value_size;
-  uint64_t expiration;
-  uint32_t header_crc;
-  uint32_t blob_crc;
+  uint64_t key_size = 0;
+  uint64_t value_size = 0;
+  uint64_t expiration = 0;
+  uint32_t header_crc = 0;
+  uint32_t blob_crc = 0;
   Slice key;
   Slice value;
   std::string key_buf;


### PR DESCRIPTION
Fixing un-itializations caught by valgrind.

Test Plan: 
make check
Monitor valgrind CI tests, as I couldn't repro myself. 