### PR TITLE
HistogramStat: Handle divide by zero situation

### DIFF
--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -202,9 +202,7 @@ std::string HistogramStat::ToString() const {
            Percentile(99.99));
   r.append(buf);
   r.append("------------------------------------------------------\n");
-  if (cur_num == 0) {
-	throw std::overflow_error("Divide by zero exception, as cur_num is 0");
-  }
+  if (cur_num == 0) return r;   // all buckets are empty
   const double mult = 100.0 / cur_num;
   uint64_t cumulative_sum = 0;
   for (unsigned int b = 0; b < num_buckets_; b++) {

--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -202,6 +202,9 @@ std::string HistogramStat::ToString() const {
            Percentile(99.99));
   r.append(buf);
   r.append("------------------------------------------------------\n");
+  if (cur_num == 0) {
+	throw std::overflow_error("Divide by zero exception, as cur_num is 0");
+  }
   const double mult = 100.0 / cur_num;
   uint64_t cumulative_sum = 0;
   for (unsigned int b = 0; b < num_buckets_; b++) {


### PR DESCRIPTION
Summary:
The num() might return cur_num as 0 and we are making sure that
cur_num will not be 0 down the path. The mult variable is being set to
100.0/cur_num which makes program crash when cur_num is 0.