### PR TITLE
fix duplicate definition of GetEntryType()

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -106,6 +106,8 @@ extern uint64_t PackSequenceAndType(uint64_t seq, ValueType t);
 // and the ValueType in *t.
 extern void UnPackSequenceAndType(uint64_t packed, uint64_t* seq, ValueType* t);
 
+EntryType GetEntryType(ValueType value_type);
+
 // Append the serialization of "key" to *result.
 extern void AppendInternalKey(std::string* result,
                               const ParsedInternalKey& key);

--- a/db/table_properties_collector.cc
+++ b/db/table_properties_collector.cc
@@ -59,21 +59,6 @@ InternalKeyPropertiesCollector::GetReadableProperties() const {
 
 namespace {
 
-EntryType GetEntryType(ValueType value_type) {
-  switch (value_type) {
-    case kTypeValue:
-      return kEntryPut;
-    case kTypeDeletion:
-      return kEntryDelete;
-    case kTypeSingleDeletion:
-      return kEntrySingleDelete;
-    case kTypeMerge:
-      return kEntryMerge;
-    default:
-      return kEntryOther;
-  }
-}
-
 uint64_t GetUint64Property(const UserCollectedProperties& props,
                            const std::string property_name,
                            bool* property_present) {


### PR DESCRIPTION
It's also defined in db/dbformat.cc per 7fe3b32896ecbb21d67ec52fccb713cb9bc6a644

Test Plan:
- `make -j64 unity_test`
- `make -j64 check`