### PR TITLE
Fix PinnableSlice move assignment

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -150,8 +150,10 @@ class PinnableSlice : public Slice, public Cleanable {
       } else {
         buf_ = other.buf_;
       }
-      other.pinned_ = false;
+      // Re-initialize the other PinnablaeSlice.
+      other.self_space_.clear();
       other.buf_ = &other.self_space_;
+      other.pinned_ = false;
     }
     return *this;
   }

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -150,6 +150,8 @@ class PinnableSlice : public Slice, public Cleanable {
       } else {
         buf_ = other.buf_;
       }
+      other.pinned_ = false;
+      other.buf_ = &other.self_space_;
     }
     return *this;
   }

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -47,6 +47,7 @@ TEST_F(SliceTest, PinnableSliceMoveConstruct) {
     ASSERT_EQ("bar", s2->ToString());
     s2->RegisterCleanup(BumpCounter, &orig_cleanup, nullptr);
     *s2 = std::move(*s1);
+    ASSERT_FALSE(s1->IsPinned());
     ASSERT_EQ("foo", s2->ToString());
     ASSERT_EQ(1, orig_cleanup);
     ASSERT_EQ(0, moved_cleanup);


### PR DESCRIPTION
Summary:
After move assignment, we need to re-initialized the moved PinnableSlice.

Also update blob_db_impl.cc to not reuse the moved PinnableSlice since it is supposed to be in an undefined state after move.

Test Plan:
updated slice_test