### PR TITLE
support db_bench compact benchmark on bottommost files

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5183,7 +5183,9 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 
   void Compact(ThreadState* thread) {
     DB* db = SelectDB(thread);
-    db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+    CompactRangeOptions cro;
+    cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+    db->CompactRange(cro, nullptr, nullptr);
   }
 
   void CompactAll() {


### PR DESCRIPTION
Without this option, running the compact benchmark on a DB containing only bottommost files simply returned immediately.

Test Plan: ran it on such a DB; verified it compacts all the files.