### PR TITLE
distinguish kZSTDNotFinalCompression in compression string

### DIFF
--- a/util/compression.h
+++ b/util/compression.h
@@ -145,8 +145,9 @@ inline std::string CompressionTypeToString(CompressionType compression_type) {
     case kXpressCompression:
       return "Xpress";
     case kZSTD:
-    case kZSTDNotFinalCompression:
       return "ZSTD";
+    case kZSTDNotFinalCompression:
+      return "ZSTDNotFinal";
     default:
       assert(false);
       return "";


### PR DESCRIPTION
This confused some users who were getting compression type from the logs.

Test Plan:

- log when using kZSTD
```
2017/11/09-18:43:27.793007 7f14ff98f200          Options.compression: ZSTD
```

- log when using kZSTDNotFinalCompression
```
2017/11/09-18:49:28.642191 7fd2f24d6200          Options.compression: ZSTDNotFinal
```