### PR TITLE
utilities: Fix coverity issues

### DIFF
--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -62,7 +62,8 @@ Status BlockCacheFile::Delete(uint64_t* size) {
 // <-- 4 --><-- 4  --><-- 4   --><-- 4     --><-- key size  --><-- v-size -->
 //
 struct CacheRecordHeader {
-  CacheRecordHeader() {}
+  CacheRecordHeader()
+    : magic_(0), crc_(0), key_size_(0), val_size_(0) {}
   CacheRecordHeader(const uint32_t magic, const uint32_t key_size,
                     const uint32_t val_size)
       : magic_(magic), crc_(0), key_size_(key_size), val_size_(val_size) {}

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -155,7 +155,8 @@ class SimCacheImpl : public SimCache {
       : cache_(cache),
         key_only_cache_(NewLRUCache(sim_capacity, num_shard_bits)),
         miss_times_(0),
-        hit_times_(0) {}
+        hit_times_(0),
+        stats_(nullptr) {}
 
   virtual ~SimCacheImpl() {}
   virtual void SetCapacity(size_t capacity) override {


### PR DESCRIPTION
Summary:
```
utilities/persistent_cache/block_cache_tier_file.cc
64struct CacheRecordHeader {
   	2. uninit_member: Non-static class member magic_ is not initialized in this constructor nor in any functions that it calls.
   	4. uninit_member: Non-static class member crc_ is not initialized in this constructor nor in any functions that it calls.
   	6. uninit_member: Non-static class member key_size_ is not initialized in this constructor nor in any functions that it calls.

CID 1396161 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
8. uninit_member: Non-static class member val_size_ is not initialized in this constructor nor in any functions that it calls.
 65  CacheRecordHeader() {}
 66  CacheRecordHeader(const uint32_t magic, const uint32_t key_size,
 67                    const uint32_t val_size)
 68      : magic_(magic), crc_(0), key_size_(key_size), val_size_(val_size) {}
 69
   	1. member_decl: Class member declaration for magic_.
 70  uint32_t magic_;
   	3. member_decl: Class member declaration for crc_.
 71  uint32_t crc_;
   	5. member_decl: Class member declaration for key_size_.
 72  uint32_t key_size_;
   	7. member_decl: Class member declaration for val_size_.
 73  uint32_t val_size_;
 74};

utilities/simulator_cache/sim_cache.cc:
157        miss_times_(0),

CID 1396124 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member stats_ is not initialized in this constructor nor in any functions that it calls.
158        hit_times_(0) {}
159
```