### PR TITLE
Properly destruct rebuilding_trx_

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -980,6 +980,7 @@ class MemTableInserter : public WriteBatch::Handler {
       reinterpret_cast<MemPostInfoMap*>
         (&mem_post_info_map_)->~MemPostInfoMap();
     }
+    delete rebuilding_trx_;
   }
 
   MemTableInserter(const MemTableInserter&) = delete;


### PR DESCRIPTION
When testing rebuilding_trx_ in MemTableInserter might still be set before the tests finishes which would cause ASAN alarms for leaks. This patch deletes the pointers in MemTableInserter destructor.