### PR TITLE
Fix PinnableSlice move assignment (again)

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -143,16 +143,13 @@ class PinnableSlice : public Slice, public Cleanable {
       Slice::operator=(other);
       Cleanable::operator=(std::move(other));
       pinned_ = other.pinned_;
-      if (!pinned_ && other.buf_ == &other.self_space_) {
-        self_space_ = std::move(other.self_space_);
-        buf_ = &self_space_;
+      if (!pinned_) {
+        *buf_ = std::move(*other.buf_);
         data_ = buf_->data();
-      } else {
-        buf_ = other.buf_;
       }
       // Re-initialize the other PinnablaeSlice.
-      other.self_space_.clear();
-      other.buf_ = &other.self_space_;
+      assert(buf_ != other.buf_);
+      other.buf_->clear();
       other.pinned_ = false;
     }
     return *this;

--- a/util/slice_test.cc
+++ b/util/slice_test.cc
@@ -62,6 +62,16 @@ TEST_F(SliceTest, PinnableSliceMoveConstruct) {
   }
 }
 
+TEST_F(SliceTest, PinnableSliceMoveWithNonDefaultStorage) {
+  std::string storage;
+  PinnableSlice s1(&storage);
+  PinnableSlice s2;
+  s2.PinSelf("foo");
+  s1 = std::move(s2);
+  ASSERT_EQ("foo", s1.ToString());
+  ASSERT_EQ("foo", storage);
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -150,6 +150,18 @@ class BlobDBTest : public testing::Test {
   }
 
   void VerifyDB(DB *db, const std::map<std::string, std::string> &data) {
+    // Verify normal Get
+    auto* cfh = db->DefaultColumnFamily();
+    for (auto &p : data) {
+      PinnableSlice value_slice;
+      ASSERT_OK(db->Get(ReadOptions(), cfh, p.first, &value_slice));
+      ASSERT_EQ(p.second, value_slice.ToString());
+      std::string value;
+      ASSERT_OK(db->Get(ReadOptions(), cfh, p.first, &value));
+      ASSERT_EQ(p.second, value);
+    }
+
+    // Verify iterators
     Iterator *iter = db->NewIterator(ReadOptions());
     iter->SeekToFirst();
     for (auto &p : data) {


### PR DESCRIPTION
Summary:
If a PinnableSlice is initialize with a given back storage, and being the target to move into, the move assignment will override the back storage with `self_space_`, which caller expect the given back storage will contain the data of the slice. This is the case with the default implementation of `DB::Get(ReadOptions, Slice, std::string*)`. Fixing it.

Test Plan:
Add new test. Also update blob_db_test to catch the issue.