### PR TITLE
Regression test build binaries with PORTABLE=1

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -376,7 +376,7 @@ function build_db_bench_and_ldb {
   make clean
   exit_on_error $?
 
-  DEBUG_LEVEL=0 make db_bench ldb -j32
+  DEBUG_LEVEL=0 PORTABLE=1 make db_bench ldb -j32
   exit_on_error $?
 }
 

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -376,7 +376,7 @@ function build_db_bench_and_ldb {
   make clean
   exit_on_error $?
 
-  DEBUG_LEVEL=0 PORTABLE=1 make db_bench ldb -j32
+  DEBUG_LEVEL=0 PORTABLE=1 USE_SSE=1 make db_bench ldb -j32
   exit_on_error $?
 }
 

--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -376,7 +376,7 @@ function build_db_bench_and_ldb {
   make clean
   exit_on_error $?
 
-  DEBUG_LEVEL=0 PORTABLE=1 USE_SSE=1 make db_bench ldb -j32
+  DEBUG_LEVEL=0 PORTABLE=1 make db_bench ldb -j32
   exit_on_error $?
 }
 


### PR DESCRIPTION
Summary:
We hit "Illegal instruction" error in regression test with "shlx" instruction. Setting PORTABLE=1 to resolve it.

Test Plan:
land and see.