### PR TITLE
Reduce heavy hitter for Get operation

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -980,7 +980,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
       storage_info_.num_non_empty_levels_, &storage_info_.file_indexer_,
       user_comparator(), internal_comparator());
   FdWithKeyRange* f = fp.GetNextFile();
-  uint32_t tickers_before[Tickers::TICKER_ENUM_MAX];
+  uint32_t tickers_before[Tickers::TICKER_ENUM_MAX] = {0};
   std::copy(std::begin(get_context.tickers_value),
             std::end(get_context.tickers_value), std::begin(tickers_before));
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -981,7 +981,8 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
       user_comparator(), internal_comparator());
   FdWithKeyRange* f = fp.GetNextFile();
   uint32_t tickers_before[Tickers::TICKER_ENUM_MAX];
-  std::copy(std::begin(get_context.tickers_value), std::end(get_context.tickers_value), std::begin(tickers_before));
+  std::copy(std::begin(get_context.tickers_value),
+            std::end(get_context.tickers_value), std::begin(tickers_before));
 
   while (f != nullptr) {
     if (get_context.sample()) {
@@ -1001,11 +1002,12 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
     if (get_context.State() != GetContext::kNotFound &&
         get_context.State() != GetContext::kMerge) {
-        for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
-          if (get_context.tickers_value[t] > tickers_before[t]) {
-            RecordTick(db_statistics_, t, get_context.tickers_value[t] - tickers_before[t]);
-          }
+      for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
+        if (get_context.tickers_value[t] > tickers_before[t]) {
+          RecordTick(db_statistics_, t,
+                     get_context.tickers_value[t] - tickers_before[t]);
         }
+      }
     }
     switch (get_context.State()) {
       case GetContext::kNotFound:
@@ -1041,7 +1043,8 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
   for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
     if (get_context.tickers_value[t] > tickers_before[t]) {
-      RecordTick(db_statistics_, t, get_context.tickers_value[t] - tickers_before[t]);
+      RecordTick(db_statistics_, t,
+                 get_context.tickers_value[t] - tickers_before[t]);
     }
   }
   if (GetContext::kMerge == get_context.State()) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -143,14 +143,14 @@ Cache::Handle* GetEntryFromCache(Cache* block_cache, const Slice& key,
   } else {
     // overall cache miss
     if (get_context != nullptr) {
-      get_context->BLOCK_CACHE_MISS_ticker++;
+      get_context->update_counter(0, 1);
     }
     else {
       RecordTick(statistics, BLOCK_CACHE_MISS);
     }
     // block-type specific cache miss
     if (block_cache_miss_ticker == BLOCK_CACHE_DATA_MISS && get_context != nullptr) {
-      get_context->BLOCK_CACHE_DATA_MISS_ticker++;
+      get_context->update_counter(3, 1);
     }
     else
       RecordTick(statistics, block_cache_miss_ticker);
@@ -1037,8 +1037,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
       if (s.ok()) {
         if (get_context != nullptr)
         {
-          get_context->BLOCK_CACHE_ADD_ticker++;
-          get_context->BLOCK_CACHE_BYTES_WRITE_ticker += block->value->usable_size();
+          get_context->update_counter(2, 1);
+          get_context->update_counter(1, block->value->usable_size());
         }
         else {
           RecordTick(statistics, BLOCK_CACHE_ADD);
@@ -1051,8 +1051,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
                      block->value->usable_size());
         } else {
           if (get_context != nullptr) {
-            get_context->BLOCK_CACHE_DATA_ADD_ticker++;
-            get_context->BLOCK_CACHE_DATA_BYTES_INSERT_ticker += block->value->usable_size();
+            get_context->update_counter(5, 1);
+            get_context->update_counter(4, block->value->usable_size());
           }
           else {
             RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
@@ -1133,8 +1133,8 @@ Status BlockBasedTable::PutDataBlockToCache(
     if (s.ok()) {
       assert(block->cache_handle != nullptr);
       if (get_context != nullptr) {
-        get_context->BLOCK_CACHE_ADD_ticker++;
-        get_context->BLOCK_CACHE_BYTES_WRITE_ticker+=block->value->usable_size();
+        get_context->update_counter(2, 1);
+        get_context->update_counter(1, block->value->usable_size());
       }
       else {
         RecordTick(statistics, BLOCK_CACHE_ADD);
@@ -1147,8 +1147,8 @@ Status BlockBasedTable::PutDataBlockToCache(
                    block->value->usable_size());
       } else {
         if (get_context != nullptr) {
-          get_context->BLOCK_CACHE_DATA_ADD_ticker++;
-          get_context->BLOCK_CACHE_DATA_BYTES_INSERT_ticker+=block->value->usable_size();
+          get_context->update_counter(5, 1);
+          get_context->update_counter(4, block->value->usable_size());
         }
         else {
         RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
@@ -1293,8 +1293,8 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
               : Cache::Priority::LOW);
       if (s.ok()) {
         if (get_context != nullptr) {
-          get_context->BLOCK_CACHE_ADD_ticker++;
-          get_context->BLOCK_CACHE_BYTES_WRITE_ticker+=filter->size();
+          get_context->update_counter(2, 1);
+          get_context->update_counter(1, filter->size());
           RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
           RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
         }
@@ -1376,8 +1376,8 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
     if (s.ok()) {
       size_t usable_size = index_reader->usable_size();
       if (get_context!= nullptr) {
-        get_context->BLOCK_CACHE_ADD_ticker++;
-        get_context->BLOCK_CACHE_BYTES_WRITE_ticker += usable_size;
+        get_context->update_counter(2, 1);
+        get_context->update_counter(1, usable_size);
       }
       else {
         RecordTick(statistics, BLOCK_CACHE_ADD);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -137,36 +137,34 @@ Cache::Handle* GetEntryFromCache(Cache* block_cache, const Slice& key,
       // overall cache hit
       get_context->record_counters(BLOCK_CACHE_HIT, 1);
       // total bytes read from cache
-      get_context->record_counters(BLOCK_CACHE_BYTES_READ, block_cache->GetUsage(cache_handle));
+      get_context->record_counters(BLOCK_CACHE_BYTES_READ,
+                                   block_cache->GetUsage(cache_handle));
       // block-type specific cache hit
       if (block_cache_hit_ticker == BLOCK_CACHE_DATA_HIT) {
         get_context->record_counters(BLOCK_CACHE_DATA_HIT, 1);
-      }
-      else {
+      } else {
         RecordTick(statistics, block_cache_hit_ticker);
       }
-    }
-    else {
+    } else {
       // overall cache hit
       RecordTick(statistics, BLOCK_CACHE_HIT);
       // total bytes read from cache
       RecordTick(statistics, BLOCK_CACHE_BYTES_READ,
-                block_cache->GetUsage(cache_handle));
+                 block_cache->GetUsage(cache_handle));
       RecordTick(statistics, block_cache_hit_ticker);
     }
   } else {
     // overall cache miss
     if (get_context != nullptr) {
       get_context->record_counters(BLOCK_CACHE_MISS, 1);
-    }
-    else {
+    } else {
       RecordTick(statistics, BLOCK_CACHE_MISS);
     }
     // block-type specific cache miss
-    if (block_cache_miss_ticker == BLOCK_CACHE_DATA_MISS && get_context != nullptr) {
+    if (block_cache_miss_ticker == BLOCK_CACHE_DATA_MISS &&
+        get_context != nullptr) {
       get_context->record_counters(BLOCK_CACHE_DATA_MISS, 1);
-    }
-    else
+    } else
       RecordTick(statistics, block_cache_miss_ticker);
   }
 
@@ -806,9 +804,10 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   } else {
     if (found_range_del_block && !rep->range_del_handle.IsNull()) {
       ReadOptions read_options;
-      s = MaybeLoadDataBlockToCache(
-          prefetch_buffer.get(), rep, read_options, rep->range_del_handle,
-          Slice() /* compression_dict */, &rep->range_del_entry, false, nullptr);
+      s = MaybeLoadDataBlockToCache(prefetch_buffer.get(), rep, read_options,
+                                    rep->range_del_handle,
+                                    Slice() /* compression_dict */,
+                                    &rep->range_del_entry, false, nullptr);
       if (!s.ok()) {
         ROCKS_LOG_WARN(
             rep->ioptions.info_log,
@@ -984,8 +983,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
     Cache* block_cache, Cache* block_cache_compressed,
     const ImmutableCFOptions& ioptions, const ReadOptions& read_options,
     BlockBasedTable::CachableEntry<Block>* block, uint32_t format_version,
-    const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-    bool is_index, GetContext* get_context) {
+    const Slice& compression_dict, size_t read_amp_bytes_per_bit, bool is_index,
+    GetContext* get_context) {
   Status s;
   Block* compressed_block = nullptr;
   Cache::Handle* block_cache_compressed_handle = nullptr;
@@ -996,7 +995,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
     block->cache_handle = GetEntryFromCache(
         block_cache, block_cache_key,
         is_index ? BLOCK_CACHE_INDEX_MISS : BLOCK_CACHE_DATA_MISS,
-        is_index ? BLOCK_CACHE_INDEX_HIT : BLOCK_CACHE_DATA_HIT, statistics, get_context);
+        is_index ? BLOCK_CACHE_INDEX_HIT : BLOCK_CACHE_DATA_HIT, statistics,
+        get_context);
     if (block->cache_handle != nullptr) {
       block->value =
           reinterpret_cast<Block*>(block_cache->Value(block->cache_handle));
@@ -1049,12 +1049,11 @@ Status BlockBasedTable::GetDataBlockFromCache(
       block_cache->TEST_mark_as_data_block(block_cache_key,
                                            block->value->usable_size());
       if (s.ok()) {
-        if (get_context != nullptr)
-        {
+        if (get_context != nullptr) {
           get_context->record_counters(BLOCK_CACHE_ADD, 1);
-          get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, block->value->usable_size());
-        }
-        else {
+          get_context->record_counters(BLOCK_CACHE_BYTES_WRITE,
+                                       block->value->usable_size());
+        } else {
           RecordTick(statistics, BLOCK_CACHE_ADD);
           RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
                      block->value->usable_size());
@@ -1066,13 +1065,13 @@ Status BlockBasedTable::GetDataBlockFromCache(
         } else {
           if (get_context != nullptr) {
             get_context->record_counters(BLOCK_CACHE_DATA_ADD, 1);
-            get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT, block->value->usable_size());
-          }
-          else {
+            get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT,
+                                         block->value->usable_size());
+          } else {
             RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
             RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
                        block->value->usable_size());
-           }
+          }
         }
       } else {
         RecordTick(statistics, BLOCK_CACHE_ADD_FAILURES);
@@ -1148,9 +1147,9 @@ Status BlockBasedTable::PutDataBlockToCache(
       assert(block->cache_handle != nullptr);
       if (get_context != nullptr) {
         get_context->record_counters(BLOCK_CACHE_ADD, 1);
-        get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, block->value->usable_size());
-      }
-      else {
+        get_context->record_counters(BLOCK_CACHE_BYTES_WRITE,
+                                     block->value->usable_size());
+      } else {
         RecordTick(statistics, BLOCK_CACHE_ADD);
         RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
                    block->value->usable_size());
@@ -1162,12 +1161,12 @@ Status BlockBasedTable::PutDataBlockToCache(
       } else {
         if (get_context != nullptr) {
           get_context->record_counters(BLOCK_CACHE_DATA_ADD, 1);
-          get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT, block->value->usable_size());
-        }
-        else {
-        RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
-        RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
-                   block->value->usable_size());
+          get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT,
+                                       block->value->usable_size());
+        } else {
+          RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
+          RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
+                     block->value->usable_size());
         }
       }
       assert(reinterpret_cast<Block*>(
@@ -1247,7 +1246,8 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
 }
 
 BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
-    FilePrefetchBuffer* prefetch_buffer, bool no_io, GetContext* get_context) const {
+    FilePrefetchBuffer* prefetch_buffer, bool no_io,
+    GetContext* get_context) const {
   const BlockHandle& filter_blk_handle = rep_->filter_handle;
   const bool is_a_filter_partition = true;
   return GetFilter(prefetch_buffer, filter_blk_handle, !is_a_filter_partition,
@@ -1256,7 +1256,8 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
 BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
-    const bool is_a_filter_partition, bool no_io, GetContext* get_context) const {
+    const bool is_a_filter_partition, bool no_io,
+    GetContext* get_context) const {
   // If cache_index_and_filter_blocks is false, filter should be pre-populated.
   // We will return rep_->filter anyway. rep_->filter can be nullptr if filter
   // read fails at Open() time. We don't want to reload again since it will
@@ -1310,12 +1311,13 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
           get_context->record_counters(BLOCK_CACHE_ADD, 1);
           get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, filter->size());
           RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
-          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
-        }
-        else {
+          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT,
+                     filter->size());
+        } else {
           RecordTick(statistics, BLOCK_CACHE_ADD);
           RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
-          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
+          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT,
+                     filter->size());
           RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, filter->size());
         }
       } else {
@@ -1389,11 +1391,10 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
 
     if (s.ok()) {
       size_t usable_size = index_reader->usable_size();
-      if (get_context!= nullptr) {
+      if (get_context != nullptr) {
         get_context->record_counters(BLOCK_CACHE_ADD, 1);
         get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, usable_size);
-      }
-      else {
+      } else {
         RecordTick(statistics, BLOCK_CACHE_ADD);
         RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, usable_size);
       }
@@ -1438,7 +1439,8 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
   // We intentionally allow extra stuff in index_value so that we
   // can add more features in the future.
   Status s = handle.DecodeFrom(&input);
-  return NewDataBlockIterator(rep, ro, handle, input_iter, is_index, get_context, s);
+  return NewDataBlockIterator(rep, ro, handle, input_iter, is_index,
+                              get_context, s);
 }
 
 // Convert an index iterator value (i.e., an encoded BlockHandle)
@@ -1459,7 +1461,8 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
       compression_dict = rep->compression_dict_block->data;
     }
     s = MaybeLoadDataBlockToCache(nullptr /*prefetch_buffer*/, rep, ro, handle,
-                                  compression_dict, &block, is_index, get_context);
+                                  compression_dict, &block, is_index,
+                                  get_context);
   }
 
   // Didn't get any data from block caches.
@@ -1560,11 +1563,11 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
             block_entry, raw_block.release(), rep->table_options.format_version,
             compression_dict, rep->table_options.read_amp_bytes_per_bit,
             is_index,
-            is_index &&
-                    rep->table_options
-                        .cache_index_and_filter_blocks_with_high_priority
+            is_index && rep->table_options
+                            .cache_index_and_filter_blocks_with_high_priority
                 ? Cache::Priority::HIGH
-                : Cache::Priority::LOW, get_context);
+                : Cache::Priority::LOW,
+            get_context);
       }
     }
   }
@@ -1608,8 +1611,8 @@ BlockBasedTable::BlockEntryIteratorState::NewSecondaryIterator(
           &rep->internal_comparator, nullptr, true, rep->ioptions.statistics);
     }
   }
-  return NewDataBlockIterator(rep, read_options_, handle, nullptr, is_index_, nullptr,
-                              s);
+  return NewDataBlockIterator(rep, read_options_, handle, nullptr, is_index_,
+                              nullptr, s);
 }
 
 bool BlockBasedTable::BlockEntryIteratorState::PrefixMayMatch(
@@ -1803,8 +1806,9 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   const bool no_io = read_options.read_tier == kBlockCacheTier;
   CachableEntry<FilterBlockReader> filter_entry;
   if (!skip_filters) {
-    filter_entry = GetFilter(/*prefetch_buffer*/ nullptr,
-                             read_options.read_tier == kBlockCacheTier, get_context);
+    filter_entry =
+        GetFilter(/*prefetch_buffer*/ nullptr,
+                  read_options.read_tier == kBlockCacheTier, get_context);
   }
   FilterBlockReader* filter = filter_entry.value;
 
@@ -1814,7 +1818,8 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
     RecordTick(rep_->ioptions.statistics, BLOOM_FILTER_USEFUL);
   } else {
     BlockIter iiter_on_stack;
-    auto iiter = NewIndexIterator(read_options, &iiter_on_stack, nullptr, get_context);
+    auto iiter =
+        NewIndexIterator(read_options, &iiter_on_stack, nullptr, get_context);
     std::unique_ptr<InternalIterator> iiter_unique_ptr;
     if (iiter != &iiter_on_stack) {
       iiter_unique_ptr.reset(iiter);
@@ -1838,7 +1843,8 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         break;
       } else {
         BlockIter biter;
-        NewDataBlockIterator(rep_, read_options, iiter->value(), &biter, false, get_context);
+        NewDataBlockIterator(rep_, read_options, iiter->value(), &biter, false,
+                             get_context);
 
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -133,24 +133,38 @@ Cache::Handle* GetEntryFromCache(Cache* block_cache, const Slice& key,
   auto cache_handle = block_cache->Lookup(key, statistics);
   if (cache_handle != nullptr) {
     PERF_COUNTER_ADD(block_cache_hit_count, 1);
-    // overall cache hit
-    RecordTick(statistics, BLOCK_CACHE_HIT);
-    // total bytes read from cache
-    RecordTick(statistics, BLOCK_CACHE_BYTES_READ,
-               block_cache->GetUsage(cache_handle));
-    // block-type specific cache hit
-    RecordTick(statistics, block_cache_hit_ticker);
+    if (get_context != nullptr) {
+      // overall cache hit
+      get_context->record_counters(BLOCK_CACHE_HIT, 1);
+      // total bytes read from cache
+      get_context->record_counters(BLOCK_CACHE_BYTES_READ, block_cache->GetUsage(cache_handle));
+      // block-type specific cache hit
+      if (block_cache_hit_ticker == BLOCK_CACHE_DATA_HIT) {
+        get_context->record_counters(BLOCK_CACHE_DATA_HIT, 1);
+      }
+      else {
+        RecordTick(statistics, block_cache_hit_ticker);
+      }
+    }
+    else {
+      // overall cache hit
+      RecordTick(statistics, BLOCK_CACHE_HIT);
+      // total bytes read from cache
+      RecordTick(statistics, BLOCK_CACHE_BYTES_READ,
+                block_cache->GetUsage(cache_handle));
+      RecordTick(statistics, block_cache_hit_ticker);
+    }
   } else {
     // overall cache miss
     if (get_context != nullptr) {
-      get_context->update_counter(0, 1);
+      get_context->record_counters(BLOCK_CACHE_MISS, 1);
     }
     else {
       RecordTick(statistics, BLOCK_CACHE_MISS);
     }
     // block-type specific cache miss
     if (block_cache_miss_ticker == BLOCK_CACHE_DATA_MISS && get_context != nullptr) {
-      get_context->update_counter(3, 1);
+      get_context->record_counters(BLOCK_CACHE_DATA_MISS, 1);
     }
     else
       RecordTick(statistics, block_cache_miss_ticker);
@@ -1037,8 +1051,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
       if (s.ok()) {
         if (get_context != nullptr)
         {
-          get_context->update_counter(2, 1);
-          get_context->update_counter(1, block->value->usable_size());
+          get_context->record_counters(BLOCK_CACHE_ADD, 1);
+          get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, block->value->usable_size());
         }
         else {
           RecordTick(statistics, BLOCK_CACHE_ADD);
@@ -1051,8 +1065,8 @@ Status BlockBasedTable::GetDataBlockFromCache(
                      block->value->usable_size());
         } else {
           if (get_context != nullptr) {
-            get_context->update_counter(5, 1);
-            get_context->update_counter(4, block->value->usable_size());
+            get_context->record_counters(BLOCK_CACHE_DATA_ADD, 1);
+            get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT, block->value->usable_size());
           }
           else {
             RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
@@ -1133,8 +1147,8 @@ Status BlockBasedTable::PutDataBlockToCache(
     if (s.ok()) {
       assert(block->cache_handle != nullptr);
       if (get_context != nullptr) {
-        get_context->update_counter(2, 1);
-        get_context->update_counter(1, block->value->usable_size());
+        get_context->record_counters(BLOCK_CACHE_ADD, 1);
+        get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, block->value->usable_size());
       }
       else {
         RecordTick(statistics, BLOCK_CACHE_ADD);
@@ -1147,8 +1161,8 @@ Status BlockBasedTable::PutDataBlockToCache(
                    block->value->usable_size());
       } else {
         if (get_context != nullptr) {
-          get_context->update_counter(5, 1);
-          get_context->update_counter(4, block->value->usable_size());
+          get_context->record_counters(BLOCK_CACHE_DATA_ADD, 1);
+          get_context->record_counters(BLOCK_CACHE_DATA_BYTES_INSERT, block->value->usable_size());
         }
         else {
         RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
@@ -1293,8 +1307,8 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
               : Cache::Priority::LOW);
       if (s.ok()) {
         if (get_context != nullptr) {
-          get_context->update_counter(2, 1);
-          get_context->update_counter(1, filter->size());
+          get_context->record_counters(BLOCK_CACHE_ADD, 1);
+          get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, filter->size());
           RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
           RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
         }
@@ -1376,8 +1390,8 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
     if (s.ok()) {
       size_t usable_size = index_reader->usable_size();
       if (get_context!= nullptr) {
-        get_context->update_counter(2, 1);
-        get_context->update_counter(1, usable_size);
+        get_context->record_counters(BLOCK_CACHE_ADD, 1);
+        get_context->record_counters(BLOCK_CACHE_BYTES_WRITE, usable_size);
       }
       else {
         RecordTick(statistics, BLOCK_CACHE_ADD);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -128,7 +128,8 @@ Slice GetCacheKeyFromOffset(const char* cache_key_prefix,
 Cache::Handle* GetEntryFromCache(Cache* block_cache, const Slice& key,
                                  Tickers block_cache_miss_ticker,
                                  Tickers block_cache_hit_ticker,
-                                 Statistics* statistics) {
+                                 Statistics* statistics,
+                                 GetContext* get_context) {
   auto cache_handle = block_cache->Lookup(key, statistics);
   if (cache_handle != nullptr) {
     PERF_COUNTER_ADD(block_cache_hit_count, 1);
@@ -141,9 +142,18 @@ Cache::Handle* GetEntryFromCache(Cache* block_cache, const Slice& key,
     RecordTick(statistics, block_cache_hit_ticker);
   } else {
     // overall cache miss
-    RecordTick(statistics, BLOCK_CACHE_MISS);
+    if (get_context != nullptr) {
+      get_context->BLOCK_CACHE_MISS_ticker++;
+    }
+    else {
+      RecordTick(statistics, BLOCK_CACHE_MISS);
+    }
     // block-type specific cache miss
-    RecordTick(statistics, block_cache_miss_ticker);
+    if (block_cache_miss_ticker == BLOCK_CACHE_DATA_MISS && get_context != nullptr) {
+      get_context->BLOCK_CACHE_DATA_MISS_ticker++;
+    }
+    else
+      RecordTick(statistics, block_cache_miss_ticker);
   }
 
   return cache_handle;
@@ -257,7 +267,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
       const bool is_index = true;
       s = table_->MaybeLoadDataBlockToCache(prefetch_buffer.get(), rep, ro,
                                             handle, compression_dict, &block,
-                                            is_index);
+                                            is_index, nullptr);
 
       assert(s.ok() || block.value == nullptr);
       if (s.ok() && block.value != nullptr) {
@@ -784,7 +794,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
       ReadOptions read_options;
       s = MaybeLoadDataBlockToCache(
           prefetch_buffer.get(), rep, read_options, rep->range_del_handle,
-          Slice() /* compression_dict */, &rep->range_del_entry);
+          Slice() /* compression_dict */, &rep->range_del_entry, false, nullptr);
       if (!s.ok()) {
         ROCKS_LOG_WARN(
             rep->ioptions.info_log,
@@ -961,7 +971,7 @@ Status BlockBasedTable::GetDataBlockFromCache(
     const ImmutableCFOptions& ioptions, const ReadOptions& read_options,
     BlockBasedTable::CachableEntry<Block>* block, uint32_t format_version,
     const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-    bool is_index) {
+    bool is_index, GetContext* get_context) {
   Status s;
   Block* compressed_block = nullptr;
   Cache::Handle* block_cache_compressed_handle = nullptr;
@@ -972,7 +982,7 @@ Status BlockBasedTable::GetDataBlockFromCache(
     block->cache_handle = GetEntryFromCache(
         block_cache, block_cache_key,
         is_index ? BLOCK_CACHE_INDEX_MISS : BLOCK_CACHE_DATA_MISS,
-        is_index ? BLOCK_CACHE_INDEX_HIT : BLOCK_CACHE_DATA_HIT, statistics);
+        is_index ? BLOCK_CACHE_INDEX_HIT : BLOCK_CACHE_DATA_HIT, statistics, get_context);
     if (block->cache_handle != nullptr) {
       block->value =
           reinterpret_cast<Block*>(block_cache->Value(block->cache_handle));
@@ -1025,18 +1035,31 @@ Status BlockBasedTable::GetDataBlockFromCache(
       block_cache->TEST_mark_as_data_block(block_cache_key,
                                            block->value->usable_size());
       if (s.ok()) {
-        RecordTick(statistics, BLOCK_CACHE_ADD);
+        if (get_context != nullptr)
+        {
+          get_context->BLOCK_CACHE_ADD_ticker++;
+          get_context->BLOCK_CACHE_BYTES_WRITE_ticker += block->value->usable_size();
+        }
+        else {
+          RecordTick(statistics, BLOCK_CACHE_ADD);
+          RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
+                     block->value->usable_size());
+        }
         if (is_index) {
           RecordTick(statistics, BLOCK_CACHE_INDEX_ADD);
           RecordTick(statistics, BLOCK_CACHE_INDEX_BYTES_INSERT,
                      block->value->usable_size());
         } else {
-          RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
-          RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
-                     block->value->usable_size());
+          if (get_context != nullptr) {
+            get_context->BLOCK_CACHE_DATA_ADD_ticker++;
+            get_context->BLOCK_CACHE_DATA_BYTES_INSERT_ticker += block->value->usable_size();
+          }
+          else {
+            RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
+            RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
+                       block->value->usable_size());
+           }
         }
-        RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
-                   block->value->usable_size());
       } else {
         RecordTick(statistics, BLOCK_CACHE_ADD_FAILURES);
         delete block->value;
@@ -1056,7 +1079,7 @@ Status BlockBasedTable::PutDataBlockToCache(
     const ReadOptions& read_options, const ImmutableCFOptions& ioptions,
     CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
     const Slice& compression_dict, size_t read_amp_bytes_per_bit, bool is_index,
-    Cache::Priority priority) {
+    Cache::Priority priority, GetContext* get_context) {
   assert(raw_block->compression_type() == kNoCompression ||
          block_cache_compressed != nullptr);
 
@@ -1109,18 +1132,30 @@ Status BlockBasedTable::PutDataBlockToCache(
                                          block->value->usable_size());
     if (s.ok()) {
       assert(block->cache_handle != nullptr);
-      RecordTick(statistics, BLOCK_CACHE_ADD);
+      if (get_context != nullptr) {
+        get_context->BLOCK_CACHE_ADD_ticker++;
+        get_context->BLOCK_CACHE_BYTES_WRITE_ticker+=block->value->usable_size();
+      }
+      else {
+        RecordTick(statistics, BLOCK_CACHE_ADD);
+        RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
+                   block->value->usable_size());
+      }
       if (is_index) {
         RecordTick(statistics, BLOCK_CACHE_INDEX_ADD);
         RecordTick(statistics, BLOCK_CACHE_INDEX_BYTES_INSERT,
                    block->value->usable_size());
       } else {
+        if (get_context != nullptr) {
+          get_context->BLOCK_CACHE_DATA_ADD_ticker++;
+          get_context->BLOCK_CACHE_DATA_BYTES_INSERT_ticker+=block->value->usable_size();
+        }
+        else {
         RecordTick(statistics, BLOCK_CACHE_DATA_ADD);
         RecordTick(statistics, BLOCK_CACHE_DATA_BYTES_INSERT,
                    block->value->usable_size());
+        }
       }
-      RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE,
-                 block->value->usable_size());
       assert(reinterpret_cast<Block*>(
                  block_cache->Value(block->cache_handle)) == block->value);
     } else {
@@ -1198,16 +1233,16 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
 }
 
 BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
-    FilePrefetchBuffer* prefetch_buffer, bool no_io) const {
+    FilePrefetchBuffer* prefetch_buffer, bool no_io, GetContext* get_context) const {
   const BlockHandle& filter_blk_handle = rep_->filter_handle;
   const bool is_a_filter_partition = true;
   return GetFilter(prefetch_buffer, filter_blk_handle, !is_a_filter_partition,
-                   no_io);
+                   no_io, get_context);
 }
 
 BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
-    const bool is_a_filter_partition, bool no_io) const {
+    const bool is_a_filter_partition, bool no_io, GetContext* get_context) const {
   // If cache_index_and_filter_blocks is false, filter should be pre-populated.
   // We will return rep_->filter anyway. rep_->filter can be nullptr if filter
   // read fails at Open() time. We don't want to reload again since it will
@@ -1237,7 +1272,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   Statistics* statistics = rep_->ioptions.statistics;
   auto cache_handle =
       GetEntryFromCache(block_cache, key, BLOCK_CACHE_FILTER_MISS,
-                        BLOCK_CACHE_FILTER_HIT, statistics);
+                        BLOCK_CACHE_FILTER_HIT, statistics, get_context);
 
   FilterBlockReader* filter = nullptr;
   if (cache_handle != nullptr) {
@@ -1257,10 +1292,18 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
               ? Cache::Priority::HIGH
               : Cache::Priority::LOW);
       if (s.ok()) {
-        RecordTick(statistics, BLOCK_CACHE_ADD);
-        RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
-        RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
-        RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, filter->size());
+        if (get_context != nullptr) {
+          get_context->BLOCK_CACHE_ADD_ticker++;
+          get_context->BLOCK_CACHE_BYTES_WRITE_ticker+=filter->size();
+          RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
+          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
+        }
+        else {
+          RecordTick(statistics, BLOCK_CACHE_ADD);
+          RecordTick(statistics, BLOCK_CACHE_FILTER_ADD);
+          RecordTick(statistics, BLOCK_CACHE_FILTER_BYTES_INSERT, filter->size());
+          RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, filter->size());
+        }
       } else {
         RecordTick(statistics, BLOCK_CACHE_ADD_FAILURES);
         delete filter;
@@ -1274,7 +1317,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
 InternalIterator* BlockBasedTable::NewIndexIterator(
     const ReadOptions& read_options, BlockIter* input_iter,
-    CachableEntry<IndexReader>* index_entry) {
+    CachableEntry<IndexReader>* index_entry, GetContext* get_context) {
   // index reader has already been pre-populated.
   if (rep_->index_reader) {
     return rep_->index_reader->NewIterator(
@@ -1297,7 +1340,7 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
   Statistics* statistics = rep_->ioptions.statistics;
   auto cache_handle =
       GetEntryFromCache(block_cache, key, BLOCK_CACHE_INDEX_MISS,
-                        BLOCK_CACHE_INDEX_HIT, statistics);
+                        BLOCK_CACHE_INDEX_HIT, statistics, get_context);
 
   if (cache_handle == nullptr && no_io) {
     if (input_iter != nullptr) {
@@ -1332,10 +1375,16 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
 
     if (s.ok()) {
       size_t usable_size = index_reader->usable_size();
-      RecordTick(statistics, BLOCK_CACHE_ADD);
+      if (get_context!= nullptr) {
+        get_context->BLOCK_CACHE_ADD_ticker++;
+        get_context->BLOCK_CACHE_BYTES_WRITE_ticker += usable_size;
+      }
+      else {
+        RecordTick(statistics, BLOCK_CACHE_ADD);
+        RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, usable_size);
+      }
       RecordTick(statistics, BLOCK_CACHE_INDEX_ADD);
       RecordTick(statistics, BLOCK_CACHE_INDEX_BYTES_INSERT, usable_size);
-      RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, usable_size);
     } else {
       if (index_reader != nullptr) {
         delete index_reader;
@@ -1369,13 +1418,13 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
 
 InternalIterator* BlockBasedTable::NewDataBlockIterator(
     Rep* rep, const ReadOptions& ro, const Slice& index_value,
-    BlockIter* input_iter, bool is_index) {
+    BlockIter* input_iter, bool is_index, GetContext* get_context) {
   BlockHandle handle;
   Slice input = index_value;
   // We intentionally allow extra stuff in index_value so that we
   // can add more features in the future.
   Status s = handle.DecodeFrom(&input);
-  return NewDataBlockIterator(rep, ro, handle, input_iter, is_index, s);
+  return NewDataBlockIterator(rep, ro, handle, input_iter, is_index, get_context, s);
 }
 
 // Convert an index iterator value (i.e., an encoded BlockHandle)
@@ -1384,7 +1433,7 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
 // If input_iter is not null, update this iter and return it
 InternalIterator* BlockBasedTable::NewDataBlockIterator(
     Rep* rep, const ReadOptions& ro, const BlockHandle& handle,
-    BlockIter* input_iter, bool is_index, Status s) {
+    BlockIter* input_iter, bool is_index, GetContext* get_context, Status s) {
   PERF_TIMER_GUARD(new_table_block_iter_nanos);
 
   const bool no_io = (ro.read_tier == kBlockCacheTier);
@@ -1396,7 +1445,7 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
       compression_dict = rep->compression_dict_block->data;
     }
     s = MaybeLoadDataBlockToCache(nullptr /*prefetch_buffer*/, rep, ro, handle,
-                                  compression_dict, &block, is_index);
+                                  compression_dict, &block, is_index, get_context);
   }
 
   // Didn't get any data from block caches.
@@ -1447,7 +1496,7 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
 Status BlockBasedTable::MaybeLoadDataBlockToCache(
     FilePrefetchBuffer* prefetch_buffer, Rep* rep, const ReadOptions& ro,
     const BlockHandle& handle, Slice compression_dict,
-    CachableEntry<Block>* block_entry, bool is_index) {
+    CachableEntry<Block>* block_entry, bool is_index, GetContext* get_context) {
   assert(block_entry != nullptr);
   const bool no_io = (ro.read_tier == kBlockCacheTier);
   Cache* block_cache = rep->table_options.block_cache.get();
@@ -1478,7 +1527,7 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
     s = GetDataBlockFromCache(
         key, ckey, block_cache, block_cache_compressed, rep->ioptions, ro,
         block_entry, rep->table_options.format_version, compression_dict,
-        rep->table_options.read_amp_bytes_per_bit, is_index);
+        rep->table_options.read_amp_bytes_per_bit, is_index, get_context);
 
     if (block_entry->value == nullptr && !no_io && ro.fill_cache) {
       std::unique_ptr<Block> raw_block;
@@ -1501,7 +1550,7 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
                     rep->table_options
                         .cache_index_and_filter_blocks_with_high_priority
                 ? Cache::Priority::HIGH
-                : Cache::Priority::LOW);
+                : Cache::Priority::LOW, get_context);
       }
     }
   }
@@ -1545,7 +1594,7 @@ BlockBasedTable::BlockEntryIteratorState::NewSecondaryIterator(
           &rep->internal_comparator, nullptr, true, rep->ioptions.statistics);
     }
   }
-  return NewDataBlockIterator(rep, read_options_, handle, nullptr, is_index_,
+  return NewDataBlockIterator(rep, read_options_, handle, nullptr, is_index_, nullptr,
                               s);
 }
 
@@ -1741,7 +1790,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   CachableEntry<FilterBlockReader> filter_entry;
   if (!skip_filters) {
     filter_entry = GetFilter(/*prefetch_buffer*/ nullptr,
-                             read_options.read_tier == kBlockCacheTier);
+                             read_options.read_tier == kBlockCacheTier, get_context);
   }
   FilterBlockReader* filter = filter_entry.value;
 
@@ -1751,7 +1800,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
     RecordTick(rep_->ioptions.statistics, BLOOM_FILTER_USEFUL);
   } else {
     BlockIter iiter_on_stack;
-    auto iiter = NewIndexIterator(read_options, &iiter_on_stack);
+    auto iiter = NewIndexIterator(read_options, &iiter_on_stack, nullptr, get_context);
     std::unique_ptr<InternalIterator> iiter_unique_ptr;
     if (iiter != &iiter_on_stack) {
       iiter_unique_ptr.reset(iiter);
@@ -1775,7 +1824,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         break;
       } else {
         BlockIter biter;
-        NewDataBlockIterator(rep_, read_options, iiter->value(), &biter);
+        NewDataBlockIterator(rep_, read_options, iiter->value(), &biter, false, get_context);
 
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -218,11 +218,13 @@ class BlockBasedTable : public TableReader {
   static InternalIterator* NewDataBlockIterator(Rep* rep, const ReadOptions& ro,
                                                 const Slice& index_value,
                                                 BlockIter* input_iter = nullptr,
-                                                bool is_index = false);
+                                                bool is_index = false,
+                                                GetContext* get_context = nullptr);
   static InternalIterator* NewDataBlockIterator(Rep* rep, const ReadOptions& ro,
                                                 const BlockHandle& block_hanlde,
                                                 BlockIter* input_iter = nullptr,
                                                 bool is_index = false,
+                                                GetContext* get_context = nullptr,
                                                 Status s = Status());
   // If block cache enabled (compressed or uncompressed), looks for the block
   // identified by handle in (1) uncompressed cache, (2) compressed cache, and
@@ -238,16 +240,16 @@ class BlockBasedTable : public TableReader {
                                           const BlockHandle& handle,
                                           Slice compression_dict,
                                           CachableEntry<Block>* block_entry,
-                                          bool is_index = false);
+                                          bool is_index = false, GetContext* get_context = nullptr);
 
   // For the following two functions:
   // if `no_io == true`, we will not try to read filter/index from sst file
   // were they not present in cache yet.
   CachableEntry<FilterBlockReader> GetFilter(
-      FilePrefetchBuffer* prefetch_buffer = nullptr, bool no_io = false) const;
+      FilePrefetchBuffer* prefetch_buffer = nullptr, bool no_io = false, GetContext* get_context = nullptr) const;
   virtual CachableEntry<FilterBlockReader> GetFilter(
       FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
-      const bool is_a_filter_partition, bool no_io) const;
+      const bool is_a_filter_partition, bool no_io, GetContext* get_context) const;
 
   // Get the iterator from the index reader.
   // If input_iter is not set, return new Iterator
@@ -261,7 +263,7 @@ class BlockBasedTable : public TableReader {
   //     kBlockCacheTier
   InternalIterator* NewIndexIterator(
       const ReadOptions& read_options, BlockIter* input_iter = nullptr,
-      CachableEntry<IndexReader>* index_entry = nullptr);
+      CachableEntry<IndexReader>* index_entry = nullptr, GetContext* get_context = nullptr);
 
   // Read block cache from block caches (if set): block_cache and
   // block_cache_compressed.
@@ -275,7 +277,7 @@ class BlockBasedTable : public TableReader {
       const ImmutableCFOptions& ioptions, const ReadOptions& read_options,
       BlockBasedTable::CachableEntry<Block>* block, uint32_t format_version,
       const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-      bool is_index = false);
+      bool is_index = false, GetContext* get_context = nullptr);
 
   // Put a raw block (maybe compressed) to the corresponding block caches.
   // This method will perform decompression against raw_block if needed and then
@@ -293,7 +295,7 @@ class BlockBasedTable : public TableReader {
       const ReadOptions& read_options, const ImmutableCFOptions& ioptions,
       CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
       const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW);
+      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW, GetContext* get_context = nullptr);
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found
   // after a call to Seek(key), until handle_result returns false.

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -215,17 +215,14 @@ class BlockBasedTable : public TableReader {
  private:
   friend class MockedBlockBasedTable;
   // input_iter: if it is not null, update this one and return it as Iterator
-  static InternalIterator* NewDataBlockIterator(Rep* rep, const ReadOptions& ro,
-                                                const Slice& index_value,
-                                                BlockIter* input_iter = nullptr,
-                                                bool is_index = false,
-                                                GetContext* get_context = nullptr);
-  static InternalIterator* NewDataBlockIterator(Rep* rep, const ReadOptions& ro,
-                                                const BlockHandle& block_hanlde,
-                                                BlockIter* input_iter = nullptr,
-                                                bool is_index = false,
-                                                GetContext* get_context = nullptr,
-                                                Status s = Status());
+  static InternalIterator* NewDataBlockIterator(
+      Rep* rep, const ReadOptions& ro, const Slice& index_value,
+      BlockIter* input_iter = nullptr, bool is_index = false,
+      GetContext* get_context = nullptr);
+  static InternalIterator* NewDataBlockIterator(
+      Rep* rep, const ReadOptions& ro, const BlockHandle& block_hanlde,
+      BlockIter* input_iter = nullptr, bool is_index = false,
+      GetContext* get_context = nullptr, Status s = Status());
   // If block cache enabled (compressed or uncompressed), looks for the block
   // identified by handle in (1) uncompressed cache, (2) compressed cache, and
   // then (3) file. If found, inserts into the cache(s) that were searched
@@ -240,16 +237,19 @@ class BlockBasedTable : public TableReader {
                                           const BlockHandle& handle,
                                           Slice compression_dict,
                                           CachableEntry<Block>* block_entry,
-                                          bool is_index = false, GetContext* get_context = nullptr);
+                                          bool is_index = false,
+                                          GetContext* get_context = nullptr);
 
   // For the following two functions:
   // if `no_io == true`, we will not try to read filter/index from sst file
   // were they not present in cache yet.
   CachableEntry<FilterBlockReader> GetFilter(
-      FilePrefetchBuffer* prefetch_buffer = nullptr, bool no_io = false, GetContext* get_context = nullptr) const;
+      FilePrefetchBuffer* prefetch_buffer = nullptr, bool no_io = false,
+      GetContext* get_context = nullptr) const;
   virtual CachableEntry<FilterBlockReader> GetFilter(
       FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
-      const bool is_a_filter_partition, bool no_io, GetContext* get_context) const;
+      const bool is_a_filter_partition, bool no_io,
+      GetContext* get_context) const;
 
   // Get the iterator from the index reader.
   // If input_iter is not set, return new Iterator
@@ -263,7 +263,8 @@ class BlockBasedTable : public TableReader {
   //     kBlockCacheTier
   InternalIterator* NewIndexIterator(
       const ReadOptions& read_options, BlockIter* input_iter = nullptr,
-      CachableEntry<IndexReader>* index_entry = nullptr, GetContext* get_context = nullptr);
+      CachableEntry<IndexReader>* index_entry = nullptr,
+      GetContext* get_context = nullptr);
 
   // Read block cache from block caches (if set): block_cache and
   // block_cache_compressed.
@@ -295,7 +296,8 @@ class BlockBasedTable : public TableReader {
       const ReadOptions& read_options, const ImmutableCFOptions& ioptions,
       CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
       const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW, GetContext* get_context = nullptr);
+      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW,
+      GetContext* get_context = nullptr);
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found
   // after a call to Seek(key), until handle_result returns false.

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -87,6 +87,18 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber seq) {
   }
 }
 
+void GetContext::update_counter(int counter_ind, int val) {
+  if (counter_ind < 0 || counter_ind > 5) return;
+  switch (counter_ind) {
+    case 0: BLOCK_CACHE_MISS_ticker+=val;
+    case 1: BLOCK_CACHE_BYTES_WRITE_ticker+=val;
+    case 2: BLOCK_CACHE_ADD_ticker+=val;
+    case 3: BLOCK_CACHE_DATA_MISS_ticker+=val;
+    case 4: BLOCK_CACHE_DATA_BYTES_INSERT_ticker+=val;
+    case 5: BLOCK_CACHE_DATA_ADD_ticker+=val;
+  }
+}
+
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
                            const Slice& value, Cleanable* value_pinner) {
   assert((state_ != kMerge && parsed_key.type != kTypeMerge) ||

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -91,7 +91,7 @@ void GetContext::RecordCounters(Tickers ticker, size_t val) {
   if (ticker == Tickers::TICKER_ENUM_MAX) {
     return;
   }
-  tickers_value[ticker] += static_cast<uint32_t>(val);
+  tickers_value[ticker] += static_cast<uint64_t>(val);
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -88,8 +88,10 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber seq) {
 }
 
 void GetContext::RecordCounters(Tickers ticker, size_t val) {
-  if (ticker == Tickers::TICKER_ENUM_MAX) return;
-  tickers_value[ticker] += static_cast<uint32_t> (val);
+  if (ticker == Tickers::TICKER_ENUM_MAX) {
+    return;
+  }
+  tickers_value[ticker] += static_cast<uint32_t>(val);
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -87,16 +87,9 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber seq) {
   }
 }
 
-void GetContext::update_counter(int counter_ind, int val) {
-  if (counter_ind < 0 || counter_ind > 5) return;
-  switch (counter_ind) {
-    case 0: BLOCK_CACHE_MISS_ticker+=val;
-    case 1: BLOCK_CACHE_BYTES_WRITE_ticker+=val;
-    case 2: BLOCK_CACHE_ADD_ticker+=val;
-    case 3: BLOCK_CACHE_DATA_MISS_ticker+=val;
-    case 4: BLOCK_CACHE_DATA_BYTES_INSERT_ticker+=val;
-    case 5: BLOCK_CACHE_DATA_ADD_ticker+=val;
-  }
+void GetContext::record_counters(Tickers ticker, int val) {
+  if (ticker == Tickers::TICKER_ENUM_MAX) return;
+  tickers_value[ticker] += val;
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -87,7 +87,7 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber seq) {
   }
 }
 
-void GetContext::record_counters(Tickers ticker, size_t val) {
+void GetContext::RecordCounters(Tickers ticker, size_t val) {
   if (ticker == Tickers::TICKER_ENUM_MAX) return;
   tickers_value[ticker] += static_cast<uint32_t> (val);
 }

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -87,9 +87,9 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber seq) {
   }
 }
 
-void GetContext::record_counters(Tickers ticker, int val) {
+void GetContext::record_counters(Tickers ticker, size_t val) {
   if (ticker == Tickers::TICKER_ENUM_MAX) return;
-  tickers_value[ticker] += val;
+  tickers_value[ticker] += static_cast<uint32_t> (val);
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -74,7 +74,7 @@ class GetContext {
     return true;
   }
 
-  void record_counters(Tickers ticker, size_t val);
+  void RecordCounters(Tickers ticker, size_t val);
 
  private:
   const Comparator* ucmp_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -9,10 +9,9 @@
 #include "db/range_del_aggregator.h"
 #include "db/read_callback.h"
 #include "rocksdb/env.h"
+#include "rocksdb/statistics.h"
 #include "rocksdb/types.h"
 #include "table/block.h"
-#include "rocksdb/statistics.h"
-
 
 namespace rocksdb {
 class MergeContext;
@@ -75,7 +74,7 @@ class GetContext {
     return true;
   }
 
-  void record_counters(Tickers ticker, int val);
+  void record_counters(Tickers ticker, size_t val);
 
  private:
   const Comparator* ucmp_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -28,12 +28,7 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
-  uint32_t BLOCK_CACHE_MISS_ticker;
-  uint32_t BLOCK_CACHE_BYTES_WRITE_ticker;
-  uint32_t BLOCK_CACHE_ADD_ticker;
-  uint32_t BLOCK_CACHE_DATA_MISS_ticker;
-  uint32_t BLOCK_CACHE_DATA_BYTES_INSERT_ticker;
-  uint32_t BLOCK_CACHE_DATA_ADD_ticker;
+  uint32_t tickers_value[Tickers::TICKER_ENUM_MAX];
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
@@ -80,7 +75,7 @@ class GetContext {
     return true;
   }
 
-  void update_counter(int counter_ind, int val);
+  void record_counters(Tickers ticker, int val);
 
  private:
   const Comparator* ucmp_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -80,6 +80,8 @@ class GetContext {
     return true;
   }
 
+  void update_counter(int counter_ind, int val);
+
  private:
   const Comparator* ucmp_;
   const MergeOperator* merge_operator_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -11,6 +11,8 @@
 #include "rocksdb/env.h"
 #include "rocksdb/types.h"
 #include "table/block.h"
+#include "rocksdb/statistics.h"
+
 
 namespace rocksdb {
 class MergeContext;
@@ -26,6 +28,12 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
+  uint32_t BLOCK_CACHE_MISS_ticker;
+  uint32_t BLOCK_CACHE_BYTES_WRITE_ticker;
+  uint32_t BLOCK_CACHE_ADD_ticker;
+  uint32_t BLOCK_CACHE_DATA_MISS_ticker;
+  uint32_t BLOCK_CACHE_DATA_BYTES_INSERT_ticker;
+  uint32_t BLOCK_CACHE_DATA_ADD_ticker;
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -27,7 +27,7 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
-  uint32_t tickers_value[Tickers::TICKER_ENUM_MAX];
+  uint64_t tickers_value[Tickers::TICKER_ENUM_MAX] = {0};
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -231,7 +231,7 @@ PartitionedFilterBlockReader::GetFilterPartition(
       }
     }
     return table_->GetFilter(/*prefetch_buffer*/ nullptr, fltr_blk_handle,
-                             is_a_filter_partition, no_io);
+                             is_a_filter_partition, no_io, nullptr);
   } else {
     auto filter = table_->ReadFilter(prefetch_buffer, fltr_blk_handle,
                                      is_a_filter_partition);
@@ -295,7 +295,7 @@ void PartitionedFilterBlockReader::CacheDependencies(bool pin) {
     const bool no_io = true;
     const bool is_a_filter_partition = true;
     auto filter = table_->GetFilter(prefetch_buffer.get(), handle,
-                                    is_a_filter_partition, !no_io);
+                                    is_a_filter_partition, !no_io, nullptr);
     if (LIKELY(filter.IsSet())) {
       if (pin) {
         filter_map_[handle.offset()] = std::move(filter);

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -231,7 +231,8 @@ PartitionedFilterBlockReader::GetFilterPartition(
       }
     }
     return table_->GetFilter(/*prefetch_buffer*/ nullptr, fltr_blk_handle,
-                             is_a_filter_partition, no_io, nullptr);
+                             is_a_filter_partition, no_io,
+                             /* get_context */ nullptr);
   } else {
     auto filter = table_->ReadFilter(prefetch_buffer, fltr_blk_handle,
                                      is_a_filter_partition);
@@ -295,7 +296,8 @@ void PartitionedFilterBlockReader::CacheDependencies(bool pin) {
     const bool no_io = true;
     const bool is_a_filter_partition = true;
     auto filter = table_->GetFilter(prefetch_buffer.get(), handle,
-                                    is_a_filter_partition, !no_io, nullptr);
+                                    is_a_filter_partition, !no_io,
+                                    /* get_context */ nullptr);
     if (LIKELY(filter.IsSet())) {
       if (pin) {
         filter_map_[handle.offset()] = std::move(filter);

--- a/table/partitioned_filter_block_test.cc
+++ b/table/partitioned_filter_block_test.cc
@@ -29,7 +29,7 @@ class MockedBlockBasedTable : public BlockBasedTable {
 
   virtual CachableEntry<FilterBlockReader> GetFilter(
       FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
-      const bool /* unused */, bool /* unused */) const override {
+      const bool /* unused */, bool /* unused */, GetContext*) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(
         nullptr, true, BlockContents(slice, false, kNoCompression),

--- a/table/partitioned_filter_block_test.cc
+++ b/table/partitioned_filter_block_test.cc
@@ -29,7 +29,8 @@ class MockedBlockBasedTable : public BlockBasedTable {
 
   virtual CachableEntry<FilterBlockReader> GetFilter(
       FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
-      const bool /* unused */, bool /* unused */, GetContext*) const override {
+      const bool /* unused */, bool /* unused */,
+      GetContext* /* unused */) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(
         nullptr, true, BlockContents(slice, false, kNoCompression),


### PR DESCRIPTION
This PR addresses the following heavy hitters in `Get` operation by moving calls to `StatisticsImpl::recordTick` from `BlockBasedTable` to `Version::Get`

- rocksdb.block.cache.bytes.write
- rocksdb.block.cache.add
- rocksdb.block.cache.data.miss
- rocksdb.block.cache.data.bytes.insert
- rocksdb.block.cache.data.add
- rocksdb.block.cache.hit
- rocksdb.block.cache.data.hit
- rocksdb.block.cache.bytes.read

The db_bench statistics before and after the change are:

|1GB block read|Children      |Self  |Command          |Shared Object        |Symbol|
|---|---|---|---|---|---|
|master:     |4.22%     |1.31%  |db_bench  |db_bench  |[.] rocksdb::StatisticsImpl::recordTick|
|updated:    |0.51%     |0.21%  |db_bench  |db_bench  |[.] rocksdb::StatisticsImpl::recordTick|
|     	     |0.14%     |0.14%  |db_bench  |db_bench  |[.] rocksdb::GetContext::record_counters|

|1MB block read|Children      |Self  |Command          |Shared Object        |Symbol|
|---|---|---|---|---|---|
|master:    |3.48%     |1.08%  |db_bench  |db_bench  |[.] rocksdb::StatisticsImpl::recordTick|
|updated:    |0.80%     |0.31%  |db_bench  |db_bench  |[.] rocksdb::StatisticsImpl::recordTick|
|    	     |0.35%     |0.35%  |db_bench  |db_bench  |[.] rocksdb::GetContext::record_counters|


