### PR TITLE
Blob DB: Remove some redundant log lines

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1295,8 +1295,9 @@ std::pair<bool, int64_t> BlobDBImpl::SanityCheck(bool aborted) {
 Status BlobDBImpl::CloseBlobFile(std::shared_ptr<BlobFile> bfile) {
   assert(bfile != nullptr);
   Status s;
-  ROCKS_LOG_INFO(db_options_.info_log, "Close blob file %" PRIu64,
-                 bfile->BlobFileNumber());
+  ROCKS_LOG_INFO(db_options_.info_log,
+                 "Closing blob file %" PRIu64 ". Path: %s",
+                 bfile->BlobFileNumber(), bfile->PathName().c_str());
   {
     WriteLock wl(&mutex_);
 

--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -147,10 +147,6 @@ Status BlobFile::WriteFooterAndCloseLocked() {
   if (s.ok()) {
     closed_ = true;
     file_size_ += BlobLogFooter::kSize;
-  } else {
-    ROCKS_LOG_ERROR(parent_->db_options_.info_log,
-                    "Failure to append footer to blob-file %s",
-                    PathName().c_str());
   }
   // delete the sequential writer
   log_writer_.reset();

--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -134,9 +134,6 @@ bool BlobFile::NeedsFsync(bool hard, uint64_t bytes_per_sync) const {
 }
 
 Status BlobFile::WriteFooterAndCloseLocked() {
-  ROCKS_LOG_INFO(parent_->db_options_.info_log,
-                 "File is being closed after footer %s", PathName().c_str());
-
   BlobLogFooter footer;
   footer.blob_count = blob_count_;
   if (HasTTL()) {
@@ -152,7 +149,7 @@ Status BlobFile::WriteFooterAndCloseLocked() {
     file_size_ += BlobLogFooter::kSize;
   } else {
     ROCKS_LOG_ERROR(parent_->db_options_.info_log,
-                    "Failure to read Header for blob-file %s",
+                    "Failure to append footer to blob-file %s",
                     PathName().c_str());
   }
   // delete the sequential writer


### PR DESCRIPTION
Saw some redundant log lines when trying to benchmark blob db. So, removed the lines from blob_file.cc, and let the lines in blob_db_impl.cc take the lead.

Test Plan: 
- `make check`
- `TEST_TMPDIR=benchmarks/blob ./db_bench --benchmarks="fillrandom,readrandom" --value_size=8192 --use_blob_db` and observed that there are a fewer log lines without redundancy. 