### PR TITLE
make compaction_readahead_size_ thread safe

### DIFF
--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -574,7 +574,7 @@ class SpecialEnv : public EnvWrapper {
 
   std::atomic<bool> is_wal_sync_thread_safe_{true};
 
-  size_t compaction_readahead_size_;
+  std::atomic<size_t> compaction_readahead_size_;
 };
 
 class MockTimeEnv : public EnvWrapper {


### PR DESCRIPTION
this should fix the failing tsan_check