### PR TITLE
Blob DB: Fix GC handling for inlined blob

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1738,7 +1738,8 @@ Status BlobDBImpl::GCFileAndUpdateLSM(const std::shared_ptr<BlobFile>& bfptr,
                       s.ToString().c_str());
       break;
     }
-    if (blob_index.file_number() != bfptr->BlobFileNumber() ||
+    if (blob_index.IsInlined() ||
+        blob_index.file_number() != bfptr->BlobFileNumber() ||
         blob_index.offset() != blob_offset) {
       // Key has been overwritten. Drop the blob record.
       continue;


### PR DESCRIPTION
Summary:
Garbage collection checks if the offset in blob index matches the offset of the blob value in the file. If it is a mismatch, the value is the current version. However it failed to check if the blob index is an inlined type, which don't even have an offset. Fixing it.

Test Plan:
run custom db_bench with inlined value and trigger GC, see if the assert of https://github.com/facebook/rocksdb/blob/5a2a6483dc23a8854e02984ece3b8d88b783959d/utilities/blob_db/blob_index.h#L70 will be triggered.