### PR TITLE
Update DBOptions::IncreaseParallelism to use newer background settings

### DIFF
--- a/options/options.cc
+++ b/options/options.cc
@@ -503,8 +503,7 @@ ColumnFamilyOptions* ColumnFamilyOptions::OptimizeUniversalStyleCompaction(
 }
 
 DBOptions* DBOptions::IncreaseParallelism(int total_threads) {
-  max_background_compactions = total_threads - 1;
-  max_background_flushes = 1;
+  max_background_jobs = total_threads;
   env->SetBackgroundThreads(total_threads, Env::LOW);
   env->SetBackgroundThreads(1, Env::HIGH);
   return this;


### PR DESCRIPTION
The Options header file recommends using max_background_jobs rather than
directly setting max_background_compactions or max_background_flushes.

I've personally seen a performance problem where stalls were happening
because the one background flushing thread was blocked that was fixed
by this change -
https://github.com/cockroachdb/cockroach/issues/19699#issuecomment-347672485