### PR TITLE
Remove `import` use from TARGETS

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -1,8 +1,4 @@
-import os
-
-TARGETS_PATH = os.path.dirname(__file__)
-
-REPO_PATH = TARGETS_PATH[(TARGETS_PATH.find('fbcode/') + len('fbcode/')):] + "/"
+REPO_PATH = package_name() + "/"
 
 BUCK_BINS = "buck-out/gen/" + REPO_PATH
 
@@ -1033,7 +1029,7 @@ if not is_opt_mode:
         test_cc = test_cfg[1]
         ttype = "gtest" if test_cfg[2] == "parallel" else "simple"
         test_bin = test_name + "_bin"
-    
+
         cpp_binary (
           name = test_bin,
           srcs = [test_cc],
@@ -1043,7 +1039,7 @@ if not is_opt_mode:
           compiler_flags = rocksdb_compiler_flags,
           external_deps = rocksdb_external_deps,
         )
-    
+
         custom_unittest(
           name = test_name,
           type = ttype,

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -2,11 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-rocksdb_target_header = """import os
-
-TARGETS_PATH = os.path.dirname(__file__)
-
-REPO_PATH = TARGETS_PATH[(TARGETS_PATH.find('fbcode/') + len('fbcode/')):] + "/"
+rocksdb_target_header = """REPO_PATH = package_name() + "/"
 
 BUCK_BINS = "buck-out/gen/" + REPO_PATH
 


### PR DESCRIPTION
We're moving away from `import`. The equivalent internal construct that
gets the directory from `fbcode/` is `package_name()`. This is a
Skylark friendly wrapper around [`get_base_path`].

The additional whitespace change is from running `python ./buckifier/buckify_rocksdb.py`.

[`get_base_path`]: https://buckbuild.com/function/get_base_path.html