### PR TITLE
fix gflags namespace

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -227,23 +227,11 @@ EOF
     # check if the namespace is gflags
     $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null << EOF
       #include <gflags/gflags.h>
-      using namespace gflags;
       int main() {}
 EOF
     if [ "$?" = 0 ]; then
-        COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=gflags"
+        COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=1"
         PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lgflags"
-    else
-      # check if namespace is google
-      $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null << EOF
-        #include <gflags/gflags.h>
-        using namespace google;
-        int main() {}
-EOF
-      if [ "$?" = 0 ]; then
-          COMMON_FLAGS="$COMMON_FLAGS -DGFLAGS=google"
-          PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lgflags"
-      fi
     fi
 
     # Test whether zlib library is installed

--- a/cache/cache_bench.cc
+++ b/cache/cache_bench.cc
@@ -17,16 +17,16 @@ int main() {
 #include <inttypes.h>
 #include <sys/types.h>
 #include <stdio.h>
-#include <gflags/gflags.h>
 
-#include "rocksdb/db.h"
-#include "rocksdb/cache.h"
-#include "rocksdb/env.h"
 #include "port/port.h"
+#include "rocksdb/cache.h"
+#include "rocksdb/db.h"
+#include "rocksdb/env.h"
+#include "util/gflags_compat.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
 
-using GFLAGS::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 
 static const uint32_t KB = 1024;
 

--- a/db/forward_iterator_bench.cc
+++ b/db/forward_iterator_bench.cc
@@ -17,7 +17,6 @@ int main() {
 // Block forward_iterator_bench under MAC and Windows
 int main() { return 0; }
 #else
-#include <gflags/gflags.h>
 #include <semaphore.h>
 #include <atomic>
 #include <bitset>
@@ -30,11 +29,12 @@ int main() { return 0; }
 #include <random>
 #include <thread>
 
+#include "port/port.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/db.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
-#include "port/port.h"
+#include "util/gflags_compat.h"
 #include "util/testharness.h"
 
 const int MAX_SHARDS = 100000;
@@ -319,7 +319,7 @@ struct StatsThread {
 };
 
 int main(int argc, char** argv) {
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
   std::mt19937 rng{std::random_device()()};
   rocksdb::Status status;

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -17,7 +17,6 @@ int main() {
 #include <iostream>
 #include <vector>
 
-#include <gflags/gflags.h>
 #include "db/db_impl.h"
 #include "monitoring/histogram.h"
 #include "rocksdb/comparator.h"
@@ -27,14 +26,15 @@ int main() {
 #include "rocksdb/perf_context.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/table.h"
+#include "util/coding.h"
+#include "util/gflags_compat.h"
 #include "util/random.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 #include "util/testharness.h"
 #include "utilities/merge_operators.h"
-#include "util/coding.h"
 
-using GFLAGS::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 
 DEFINE_bool(trigger_deadlock, false,
             "issue delete in range scan to trigger PrefixHashMap deadlock");

--- a/memtable/memtablerep_bench.cc
+++ b/memtable/memtablerep_bench.cc
@@ -19,8 +19,6 @@ int main() {
 }
 #else
 
-#include <gflags/gflags.h>
-
 #include <atomic>
 #include <iostream>
 #include <memory>
@@ -38,13 +36,14 @@ int main() {
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/write_buffer_manager.h"
 #include "util/arena.h"
+#include "util/gflags_compat.h"
 #include "util/mutexlock.h"
 #include "util/stop_watch.h"
 #include "util/testutil.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::RegisterFlagValidator;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(benchmarks, "fillrandom",
               "Comma-separated list of benchmarks to run. Options:\n"

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -20,8 +20,8 @@
 #ifndef GFLAGS
 bool FLAGS_enable_print = false;
 #else
-#include <gflags/gflags.h>
-using GFLAGS::ParseCommandLineFlags;
+#include "util/gflags_compat.h"
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 DEFINE_bool(enable_print, false, "Print options generated to console.");
 #endif  // GFLAGS
 

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -34,8 +34,8 @@
 #ifndef GFLAGS
 bool FLAGS_enable_print = false;
 #else
-#include <gflags/gflags.h>
-using GFLAGS::ParseCommandLineFlags;
+#include "util/gflags_compat.h"
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 DEFINE_bool(enable_print, false, "Print options generated to console.");
 #endif  // GFLAGS
 

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -18,24 +18,24 @@ int main() {
 #endif
 
 #include <inttypes.h>
-#include <gflags/gflags.h>
 #include <vector>
 #include <string>
 #include <map>
 
-#include "table/meta_blocks.h"
 #include "table/cuckoo_table_builder.h"
-#include "table/cuckoo_table_reader.h"
 #include "table/cuckoo_table_factory.h"
+#include "table/cuckoo_table_reader.h"
 #include "table/get_context.h"
+#include "table/meta_blocks.h"
 #include "util/arena.h"
+#include "util/gflags_compat.h"
 #include "util/random.h"
 #include "util/string_util.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(file_dir, "", "Directory where the files will be created"
     " for benchmark. Added for using tmpfs.");

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -11,8 +11,6 @@ int main() {
 }
 #else
 
-#include <gflags/gflags.h>
-
 #include "db/db_impl.h"
 #include "db/dbformat.h"
 #include "monitoring/histogram.h"
@@ -25,11 +23,12 @@ int main() {
 #include "table/plain_table_factory.h"
 #include "table/table_builder.h"
 #include "util/file_reader_writer.h"
+#include "util/gflags_compat.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 namespace rocksdb {
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -20,7 +20,6 @@
 #include <unistd.h>
 #endif
 #include <fcntl.h>
-#include <gflags/gflags.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -61,6 +60,7 @@
 #include "util/cast_util.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
+#include "util/gflags_compat.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
 #include "util/stderr_logger.h"
@@ -76,9 +76,9 @@
 #include <io.h>  // open/close
 #endif
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::RegisterFlagValidator;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(
     benchmarks,

--- a/tools/db_bench_tool_test.cc
+++ b/tools/db_bench_tool_test.cc
@@ -15,7 +15,7 @@
 #include "util/testutil.h"
 
 #ifdef GFLAGS
-#include <gflags/gflags.h>
+#include "util/gflags_compat.h"
 
 namespace rocksdb {
 namespace {

--- a/tools/db_repl_stress.cc
+++ b/tools/db_repl_stress.cc
@@ -15,11 +15,10 @@ int main() {
 #include <cstdio>
 #include <atomic>
 
-#include <gflags/gflags.h>
-
 #include "db/write_batch_internal.h"
 #include "rocksdb/db.h"
 #include "rocksdb/types.h"
+#include "util/gflags_compat.h"
 #include "util/testutil.h"
 
 // Run a thread to perform Put's.
@@ -30,8 +29,8 @@ int main() {
 
 using namespace rocksdb;
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 struct DataPumpThread {
   size_t no_records;

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -39,7 +39,6 @@ int main() {
 #include <exception>
 #include <thread>
 
-#include <gflags/gflags.h>
 #include "db/db_impl.h"
 #include "db/version_set.h"
 #include "hdfs/env_hdfs.h"
@@ -56,6 +55,7 @@ int main() {
 #include "util/coding.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
+#include "util/gflags_compat.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
@@ -68,9 +68,9 @@ int main() {
 
 #include "utilities/merge_operators.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::RegisterFlagValidator;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 static const long KB = 1024;
 static const int kRandomValueMaxFactor = 3;

--- a/tools/dump/rocksdb_dump.cc
+++ b/tools/dump/rocksdb_dump.cc
@@ -18,9 +18,9 @@ int main() {
 
 #else
 
-#include <gflags/gflags.h>
 #include "rocksdb/convenience.h"
 #include "rocksdb/db_dump_tool.h"
+#include "util/gflags_compat.h"
 
 DEFINE_string(db_path, "", "Path to the db that will be dumped");
 DEFINE_string(dump_location, "", "Path to where the dump file location");
@@ -30,7 +30,7 @@ DEFINE_string(db_options, "",
               "Options string used to open the database that will be dumped");
 
 int main(int argc, char** argv) {
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
   if (FLAGS_db_path == "" || FLAGS_dump_location == "") {
     fprintf(stderr, "Please set --db_path and --dump_location\n");

--- a/tools/dump/rocksdb_undump.cc
+++ b/tools/dump/rocksdb_undump.cc
@@ -18,9 +18,9 @@ int main() {
 
 #else
 
-#include <gflags/gflags.h>
 #include "rocksdb/convenience.h"
 #include "rocksdb/db_dump_tool.h"
+#include "util/gflags_compat.h"
 
 DEFINE_string(dump_location, "", "Path to the dump file that will be loaded");
 DEFINE_string(db_path, "", "Path to the db that we will undump the file into");
@@ -29,7 +29,7 @@ DEFINE_string(db_options, "",
               "Options string used to open the database that will be loaded");
 
 int main(int argc, char **argv) {
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
   if (FLAGS_db_path == "" || FLAGS_dump_location == "") {
     fprintf(stderr, "Please set --db_path and --dump_location\n");

--- a/tools/write_stress.cc
+++ b/tools/write_stress.cc
@@ -56,8 +56,6 @@ int main() {
 }
 #else
 
-#include <gflags/gflags.h>
-
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <atomic>
@@ -72,10 +70,11 @@ int main() {
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "util/filename.h"
+#include "util/gflags_compat.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::RegisterFlagValidator;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_int32(key_size, 10, "Key size");
 DEFINE_int32(value_size, 100, "Value size");

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -15,17 +15,17 @@ int main() {
 }
 #else
 
-#include <gflags/gflags.h>
 #include <vector>
 
 #include "rocksdb/filter_policy.h"
 #include "table/full_filter_bits_builder.h"
 #include "util/arena.h"
+#include "util/gflags_compat.h"
 #include "util/logging.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
 
-using GFLAGS::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 
 DEFINE_int32(bits_per_key, 10, "");
 

--- a/util/dynamic_bloom_test.cc
+++ b/util/dynamic_bloom_test.cc
@@ -15,7 +15,6 @@ int main() {
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include <gflags/gflags.h>
 #include <inttypes.h>
 #include <algorithm>
 #include <atomic>
@@ -27,12 +26,13 @@ int main() {
 #include "dynamic_bloom.h"
 #include "port/port.h"
 #include "util/arena.h"
+#include "util/gflags_compat.h"
 #include "util/logging.h"
+#include "util/stop_watch.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
-#include "util/stop_watch.h"
 
-using GFLAGS::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 
 DEFINE_int32(bits_per_key, 10, "");
 DEFINE_int32(num_probes, 6, "");

--- a/util/gflags_compat.h
+++ b/util/gflags_compat.h
@@ -1,0 +1,12 @@
+//  Copyright (c) 2017-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <gflags/gflags.h>
+
+#ifndef GFLAGS_NAMESPACE
+// in case it's not defined in old versions, that's probably because it was
+// still google by default.
+#define GFLAGS_NAMESPACE google
+#endif

--- a/util/heap_test.cc
+++ b/util/heap_test.cc
@@ -16,7 +16,7 @@
 #ifndef GFLAGS
 const int64_t FLAGS_iters = 100000;
 #else
-#include <gflags/gflags.h>
+#include "util/gflags_compat.h"
 DEFINE_int64(iters, 100000, "number of pseudo-random operations in each test");
 #endif  // GFLAGS
 
@@ -133,7 +133,7 @@ INSTANTIATE_TEST_CASE_P(
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 #ifdef GFLAGS
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 #endif  // GFLAGS
   return RUN_ALL_TESTS();
 }

--- a/util/log_write_bench.cc
+++ b/util/log_write_bench.cc
@@ -11,16 +11,15 @@ int main() {
 }
 #else
 
-#include <gflags/gflags.h>
-
 #include "monitoring/histogram.h"
 #include "rocksdb/env.h"
 #include "util/file_reader_writer.h"
+#include "util/gflags_compat.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
 
-using GFLAGS::ParseCommandLineFlags;
-using GFLAGS::SetUsageMessage;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::SetUsageMessage;
 
 // A simple benchmark to simulate transactional logs
 

--- a/utilities/column_aware_encoding_exp.cc
+++ b/utilities/column_aware_encoding_exp.cc
@@ -13,7 +13,6 @@
 #ifndef ROCKSDB_LITE
 #ifdef GFLAGS
 
-#include <gflags/gflags.h>
 #include <inttypes.h>
 #include <vector>
 #include "rocksdb/env.h"
@@ -23,11 +22,12 @@
 #include "table/format.h"
 #include "tools/sst_dump_tool_imp.h"
 #include "util/compression.h"
+#include "util/gflags_compat.h"
 #include "util/stop_watch.h"
 #include "utilities/col_buf_encoder.h"
 #include "utilities/column_aware_encoding_util.h"
 
-using GFLAGS::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 DEFINE_string(encoded_file, "", "file to store encoded data blocks");
 DEFINE_string(decoded_file, "",
               "file to store decoded data blocks after encoding");

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -24,8 +24,8 @@
 #ifndef GFLAGS
 bool FLAGS_enable_print = false;
 #else
-#include <gflags/gflags.h>
-using GFLAGS::ParseCommandLineFlags;
+#include "util/gflags_compat.h"
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 DEFINE_bool(enable_print, false, "Print options generated to console.");
 #endif  // GFLAGS
 

--- a/utilities/persistent_cache/hash_table_bench.cc
+++ b/utilities/persistent_cache/hash_table_bench.cc
@@ -10,7 +10,6 @@
 #include <cstdio>
 int main() { fprintf(stderr, "Please install gflags to run tools\n"); }
 #else
-#include <gflags/gflags.h>
 
 #include <atomic>
 #include <functional>
@@ -19,6 +18,7 @@ int main() { fprintf(stderr, "Please install gflags to run tools\n"); }
 
 #include "port/port_posix.h"
 #include "rocksdb/env.h"
+#include "util/gflags_compat.h"
 #include "util/mutexlock.h"
 #include "utilities/persistent_cache/hash_table.h"
 
@@ -272,9 +272,9 @@ class GranularLockImpl : public HashTableImpl<size_t, string> {
 // main
 //
 int main(int argc, char** argv) {
-  GFLAGS::SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
-                          " [OPTIONS]...");
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, false);
+  GFLAGS_NAMESPACE::SetUsageMessage(std::string("\nUSAGE:\n") +
+                                    std::string(argv[0]) + " [OPTIONS]...");
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, false);
 
   //
   // Micro benchmark unordered_map

--- a/utilities/persistent_cache/persistent_cache_bench.cc
+++ b/utilities/persistent_cache/persistent_cache_bench.cc
@@ -9,7 +9,6 @@
 #include <cstdio>
 int main() { fprintf(stderr, "Please install gflags to run tools\n"); }
 #else
-#include <gflags/gflags.h>
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -25,6 +24,7 @@ int main() { fprintf(stderr, "Please install gflags to run tools\n"); }
 #include "monitoring/histogram.h"
 #include "port/port.h"
 #include "table/block_builder.h"
+#include "util/gflags_compat.h"
 #include "util/mutexlock.h"
 #include "util/stop_watch.h"
 
@@ -307,9 +307,9 @@ class CacheTierBenchmark {
 // main
 //
 int main(int argc, char** argv) {
-  GFLAGS::SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
-                          " [OPTIONS]...");
-  GFLAGS::ParseCommandLineFlags(&argc, &argv, false);
+  GFLAGS_NAMESPACE::SetUsageMessage(std::string("\nUSAGE:\n") +
+                                    std::string(argv[0]) + " [OPTIONS]...");
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, false);
 
   std::ostringstream msg;
   msg << "Config" << std::endl


### PR DESCRIPTION
I started adding gflags support for cmake on linux and got frustrated that I'd need to duplicate the build_detect_platform logic, which determines namespace based on attempting compilation. We can do it differently -- use the GFLAGS_NAMESPACE macro if available, and if not, that indicates it's an old gflags version without configurable namespace so we can simply hardcode "google".

Test Plan: compiled and ran db_bench against versions of gflags with different namespaces. Examined preprocessor output to verify the difference.