### PR TITLE
gflags in cmake on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 
 find_package(gflags)
 if(gflags_FOUND)
-  add_definitions(-DGFLAGS=gflags)
+  add_definitions(-DGFLAGS=1)
   include_directories(${gflags_INCLUDE_DIR})
   list(APPEND THIRDPARTY_LIBS ${gflags_LIBRARIES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,13 @@ if(WITH_UBSAN)
   endif()
 endif()
 
+find_package(gflags)
+if(gflags_FOUND)
+  add_definitions(-DGFLAGS=gflags)
+  include_directories(${gflags_INCLUDE_DIR})
+  list(APPEND THIRDPARTY_LIBS ${gflags_LIBRARIES})
+endif()
+
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize
 


### PR DESCRIPTION
We should use it if available otherwise the tools builds never work. Thanks to #3212, we can set -DGFLAGS=1 and it'll be independent of the namespace with which gflags was compiled.

Test Plan:

- compile and run a tool that requires gflags:
```
$ cmake . && make clean && make db_bench -j64
$ ./db_bench -benchmarks=fillrandom -compression_type=none
```