### PR TITLE
Make iterator invalid on Merge error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 ### New Features
 ### Bug Fixes
 * Fix IOError on WAL write doesn't propagate to write group follower
-* Fix iterator not become invalid on merge error
+* Make iterator invalid on merge error.
 
 ## 5.9.0 (11/1/2017)
 ### Public API Change

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 ### New Features
 ### Bug Fixes
 * Fix IOError on WAL write doesn't propagate to write group follower
+* Fix iterator not become invalid on merge error
 
 ## 5.9.0 (11/1/2017)
 ### Public API Change

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -640,6 +640,7 @@ void DBIter::MergeValuesNewToOld() {
           merge_operator_, ikey.user_key, &val, merge_context_.GetOperands(),
           &saved_value_, logger_, statistics_, env_, &pinned_value_, true);
       if (!s.ok()) {
+        valid_ = false;
         status_ = s;
       }
       // iter_ is positioned after put
@@ -677,6 +678,7 @@ void DBIter::MergeValuesNewToOld() {
                                   &saved_value_, logger_, statistics_, env_,
                                   &pinned_value_, true);
   if (!s.ok()) {
+    valid_ = false;
     status_ = s;
   }
 }
@@ -946,8 +948,10 @@ bool DBIter::FindValueForCurrentKey() {
       assert(false);
       break;
   }
-  valid_ = true;
-  if (!s.ok()) {
+  if (s.ok()) {
+    valid_ = true;
+  } else {
+    valid_ = false;
     status_ = s;
   }
   return true;
@@ -1023,8 +1027,10 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
       iter_->Seek(last_key);
       RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
     }
-    valid_ = true;
-    if (!s.ok()) {
+    if (s.ok()) {
+      valid_ = true;
+    } else {
+      valid_ = false;
       status_ = s;
     }
     return true;
@@ -1035,8 +1041,10 @@ bool DBIter::FindValueForCurrentKeyUsingSeek() {
                                   &val, merge_context_.GetOperands(),
                                   &saved_value_, logger_, statistics_, env_,
                                   &pinned_value_, true);
-  valid_ = true;
-  if (!s.ok()) {
+  if (s.ok()) {
+    valid_ = true;
+  } else {
+    valid_ = false;
     status_ = s;
   }
   return true;


### PR DESCRIPTION
Summary:
Since #1665, on merge error, iterator will be set to corrupted status, but it doesn't invalidate the iterator. Fixing it.

Test Plan:
Updated db_merge_operator_test