### PR TITLE
Log GetCurrentTime failures during Flush and Compaction

### DIFF
--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1325,7 +1325,12 @@ Status CompactionJob::OpenCompactionOutputFile(
       sub_compact->compaction->MaxInputFileCreationTime();
   if (output_file_creation_time == 0) {
     int64_t _current_time = 0;
-    db_options_.env->GetCurrentTime(&_current_time);  // ignore error
+    auto status = db_options_.env->GetCurrentTime(&_current_time);
+    // Safe to proceed even if GetCurrentTime fails. So, log and proceed.
+    if (!status.ok()) {
+      ROCKS_LOG_DEBUG(db_options_.info_log,
+          "Failed to get current time. Status: %s", status.ToString().c_str());
+    }
     output_file_creation_time = static_cast<uint64_t>(_current_time);
   }
 

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1328,8 +1328,11 @@ Status CompactionJob::OpenCompactionOutputFile(
     auto status = db_options_.env->GetCurrentTime(&_current_time);
     // Safe to proceed even if GetCurrentTime fails. So, log and proceed.
     if (!status.ok()) {
-      ROCKS_LOG_DEBUG(db_options_.info_log,
-          "Failed to get current time. Status: %s", status.ToString().c_str());
+      ROCKS_LOG_WARN(
+          db_options_.info_log,
+          "Failed to get current time to populate creation_time property. "
+          "Status: %s",
+          status.ToString().c_str());
     }
     output_file_creation_time = static_cast<uint64_t>(_current_time);
   }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -302,8 +302,11 @@ Status FlushJob::WriteLevel0Table() {
       auto status = db_options_.env->GetCurrentTime(&_current_time);
       // Safe to proceed even if GetCurrentTime fails. So, log and proceed.
       if (!status.ok()) {
-        ROCKS_LOG_DEBUG(db_options_.info_log,
-            "Failed to get current time. Status: %s", status.ToString().c_str());
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
+            "Failed to get current time to populate creation_time property. "
+            "Status: %s",
+            status.ToString().c_str());
       }
       const uint64_t current_time = static_cast<uint64_t>(_current_time);
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -299,7 +299,12 @@ Status FlushJob::WriteLevel0Table() {
       TEST_SYNC_POINT_CALLBACK("FlushJob::WriteLevel0Table:output_compression",
                                &output_compression_);
       int64_t _current_time = 0;
-      db_options_.env->GetCurrentTime(&_current_time);  // ignore error
+      auto status = db_options_.env->GetCurrentTime(&_current_time);
+      // Safe to proceed even if GetCurrentTime fails. So, log and proceed.
+      if (!status.ok()) {
+        ROCKS_LOG_DEBUG(db_options_.info_log,
+            "Failed to get current time. Status: %s", status.ToString().c_str());
+      }
       const uint64_t current_time = static_cast<uint64_t>(_current_time);
 
       uint64_t oldest_key_time =


### PR DESCRIPTION
`GetCurrentTime()` is used to populate `creation_time` table property during flushes and compactions. It is safe to ignore `GetCurrentTime()` failures here but they should be logged. 

(Note that `creation_time` property was introduced as part of TTL-based FIFO compaction in #2480.)

Tes Plan:
`make check`