### PR TITLE
ldb to allow db with --try_load_options and without an options file

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -315,7 +315,7 @@ void LDBCommand::OpenDB() {
   if (!create_if_missing_ && try_load_options_) {
     Status s = LoadLatestOptions(db_path_, Env::Default(), &options_,
                                  &column_families_, ignore_unknown_options_);
-    if (!s.ok()) {
+    if (!s.ok() && !s.IsNotFound()) {
       // Option file exists but load option file error.
       std::string msg = s.ToString();
       exec_state_ = LDBCommandExecuteResult::Failed(msg);


### PR DESCRIPTION
Summary:
This is to fix tools/check_format_compatible.sh. The tool try to open
old versions of rocksdb with the provided options file. When options
file is missing (e.g. rocksdb 2.2), it should still proceed with default
options.

Test Plan:
run tools/check_format_compatible.sh locally