### PR TITLE
No need to seek to next file in the level if prefix bloom filters out…

### DIFF
--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -17,7 +17,7 @@ class PinnedIteratorsManager;
 
 class InternalIterator : public Cleanable {
  public:
-  InternalIterator() {}
+  InternalIterator() : filtered_out_(false) {}
   virtual ~InternalIterator() {}
 
   // An iterator is either positioned at a key/value pair, or
@@ -69,6 +69,8 @@ class InternalIterator : public Cleanable {
   // satisfied without doing some IO, then this returns Status::Incomplete().
   virtual Status status() const = 0;
 
+  bool filtered_out() const { return filtered_out_; }
+
   // Pass the PinnedIteratorsManager to the Iterator, most Iterators dont
   // communicate with PinnedIteratorsManager so default implementation is no-op
   // but for Iterators that need to communicate with PinnedIteratorsManager
@@ -105,6 +107,8 @@ class InternalIterator : public Cleanable {
       Prev();
     }
   }
+
+  bool filtered_out_;
 
  private:
   // No copying allowed

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -82,6 +82,8 @@ class IteratorWrapper {
     return iter_->IsValuePinned();
   }
 
+  bool filtered_out() const { return iter_->filtered_out(); }
+
  private:
   void Update() {
     valid_ = iter_->Valid();


### PR DESCRIPTION
… the key.

Summary: Right now, if the seek key is filterd out by one SST file in a level, we open the first block in the next file.

Test Plan: Run all unit tests
And run db_bench for prefix iterating case.
DB is populated using: ./db_bench --prefix_size=16 --benchmarks=fillrandom --num=10000000 --key_size=17 --bloom_bits=10
And is read using: ./db_bench --prefix_size=16 --benchmarks=seekrandom --num=10000000 --key_size=17 --use_existing_db -seek_nexts=0 --bloom_bits=10 --reads=1000000
With the single thread test, the new version is 5% faster.