### PR TITLE
Fix write_callback_test compile error

### DIFF
--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -294,7 +294,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                 if (seq_per_batch && two_queues) {
                   class PublishSeqCallback : public PreReleaseCallback {
                    public:
-                    PublishSeqCallback(DBImpl* db_impl) : db_impl_(db_impl) {}
+                    PublishSeqCallback(DBImpl* db_impl_in) : db_impl_(db_impl_in) {}
                     virtual Status Callback(SequenceNumber last_seq) {
                       db_impl_->SetLastPublishedSequence(last_seq);
                       return Status::OK();

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -294,7 +294,8 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                 if (seq_per_batch && two_queues) {
                   class PublishSeqCallback : public PreReleaseCallback {
                    public:
-                    PublishSeqCallback(DBImpl* db_impl_in) : db_impl_(db_impl_in) {}
+                    PublishSeqCallback(DBImpl* db_impl_in)
+                        : db_impl_(db_impl_in) {}
                     virtual Status Callback(SequenceNumber last_seq) {
                       db_impl_->SetLastPublishedSequence(last_seq);
                       return Status::OK();


### PR DESCRIPTION
Summary:
Rename shadow variable name db_impl.

Fixing #3227

Test Plan:
Compile and run the test on Mac.