### PR TITLE
Fix a race condition in WindowsThread (port::Thread)

### DIFF
--- a/port/win/win_thread.h
+++ b/port/win/win_thread.h
@@ -28,7 +28,7 @@ class WindowsThread {
 
   struct Data;
 
-  std::unique_ptr<Data>  data_;
+  std::shared_ptr<Data>  data_;
   unsigned int           th_id_;
 
   void Init(std::function<void()>&&);


### PR DESCRIPTION
Fix a race condition when we create a thread and immediately destroy
 This case should be supported.
  What happens is that the thread function needs the Data instance
  to actually run but has no shared ownership and must rely on the
  WindowsThread instance to continue existing.
  To address this we change unique_ptr to shared_ptr and then
  acquire an additional refcount for the threadproc which destroys it
  just before the thread exit.
  We choose to allocate shared_ptr instance on the heap as this allows
  the original thread to continue w/o waiting for the new thread to start
  running.