### PR TITLE
Perf  shouldnt' get time except enabled

### DIFF
--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -39,11 +39,13 @@ extern __thread PerfContext perf_context;
 // Declare and set start time of the timer
 #define PERF_TIMER_GUARD(metric)                                  \
   PerfStepTimer perf_step_timer_##metric(&(perf_context.metric)); \
-  perf_step_timer_##metric.Start();
+  if (perf_level >= PerfLevel::kEnableTime) {                     \
+    perf_step_timer_##metric.Start();                             \
+  }
 
 #define PERF_CONDITIONAL_TIMER_FOR_MUTEX_GUARD(metric, condition)       \
   PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), true); \
-  if ((condition)) {                                                    \
+  if (perf_level >= PerfLevel::kEnableTime && (condition)) {            \
     perf_step_timer_##metric.Start();                                   \
   }
 


### PR DESCRIPTION
Summary: Right now, by mistake, timer is always started even if the counter isn't reported. Fix it.

Test Plan: Manually set perf levels in db_bench and see the timer function is called or not called.