### PR TITLE
set PORTABLE explicitly for fbcode builds

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
+* When running `make` with environment variable `USE_SSE` set and `PORTABLE` unset, will use all machine features available locally. Previously this combination only compiled SSE-related features.
+
 ### New Features
 * Provide lifetime hints when writing files on Linux. This reduces hardware write-amp on storage devices supporting multiple streams.
 * Add a DB stat, `NUMBER_ITER_SKIP`, which returns how many internal keys were skipped during iterations (e.g., due to being tombstones or duplicate versions of a key).

--- a/build_tools/fbcode_config.sh
+++ b/build_tools/fbcode_config.sh
@@ -83,6 +83,7 @@ CFLAGS+=" -DTBB"
 
 # use Intel SSE support for checksum calculations
 export USE_SSE=1
+export PORTABLE=1
 
 BINUTILS="$BINUTILS_BASE/bin"
 AR="$BINUTILS/ar"

--- a/build_tools/fbcode_config4.8.1.sh
+++ b/build_tools/fbcode_config4.8.1.sh
@@ -54,6 +54,7 @@ TBB_LIBS="$TBB_BASE/lib/libtbb.a"
 
 # use Intel SSE support for checksum calculations
 export USE_SSE=1
+export PORTABLE=1
 
 BINUTILS="$BINUTILS_BASE/bin"
 AR="$BINUTILS/ar"


### PR DESCRIPTION
#3156 fixed a bug where specifying `USE_SSE=1` turned off all other machine features. To preserve the old behavior in fbcode (specify `-msse4.2` and turn off all other machine features), we now need to specify `PORTABLE=1` along with `USE_SSE=1`. Also updated the HISTORY file to reflect this.

Test Plan:

```
$ DEBUG_LEVEL=0 make -n -j64 util/crc32c.o | tr ' ' '\n' | grep '^-m'
-msse4.2
-momit-leaf-frame-pointer
```