### PR TITLE
fix backup meta-file buffer overrun

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1722,16 +1722,9 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
   if (!app_metadata_.empty()) {
     std::string hex_encoded_metadata =
         Slice(app_metadata_).ToString(/* hex */ true);
-    if (hex_encoded_metadata.size() + kMetaDataPrefix.size() + 1 >
-        buf_size - len) {
-      return Status::Corruption("Buffer too small to fit backup metadata");
-    }
-    memcpy(buf.get() + len, kMetaDataPrefix.data(), kMetaDataPrefix.size());
-    len += kMetaDataPrefix.size();
-    memcpy(buf.get() + len, hex_encoded_metadata.data(),
-           hex_encoded_metadata.size());
-    len += hex_encoded_metadata.size();
-    buf[len++] = '\n';
+    len += snprintf(buf.get() + len, buf_size - len, "%s%s\n",
+                    kMetaDataPrefix.ToString().c_str(),
+                    hex_encoded_metadata.c_str());
   }
   len += snprintf(buf.get() + len, buf_size - len, "%" ROCKSDB_PRIszt "\n",
                   files_.size());
@@ -1739,6 +1732,12 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
     // use crc32 for now, switch to something else if needed
     len += snprintf(buf.get() + len, buf_size - len, "%s crc32 %u\n",
                     file->filename.c_str(), file->checksum_value);
+  }
+
+  if (len >= max_backup_meta_file_size_) {
+    // len is index of null-terminator, so exactly max_backup_meta_file_size_
+    // means the buffer was too small
+    return Status::Corruption("Buffer too small to fit backup metadata");
   }
 
   s = backup_meta_file->Append(Slice(buf.get(), len));


### PR DESCRIPTION
- check most times after calling snprintf that the buffer didn't fill up. Previously we'd proceed and use `buf_size - len` as the length in subsequent calls, which underflowed as those are unsigned size_t.
- replace some memcpys with snprintf for consistency

Test Plan:

before this PR:
```
$ sudo sh -c "ulimit -n 655350 && ./ldb backup --backup_dir=/dev/shm/dbbench_backup/ --db=/dev/shm/dbbench/ --num_threads 64"
open db OK
open backup engine OK
sh: line 1: 708494 Segmentation fault      (core dumped) ./ldb backup --backup_dir=/dev/shm/dbbench_backup/ --db=/dev/shm/dbbench/ --num_threads 64
```

after this PR:
```
$ sudo sh -c "ulimit -n 655350 && ./ldb backup --backup_dir=/dev/shm/dbbench_backup/ --db=/dev/shm/dbbench/ --num_threads 64"                                                                                                                                                                                                                                                                 
open db OK
open backup engine OK
Failed: Corruption: Buffer too small to fit backup metadata
```