### PR TITLE
Fix BlockFetcher ASAN error

### DIFF
--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -45,7 +45,7 @@ class BlockFetcher {
   RandomAccessFileReader* file_;
   FilePrefetchBuffer* prefetch_buffer_;
   const Footer& footer_;
-  const ReadOptions& read_options_;
+  const ReadOptions read_options_;
   const BlockHandle& handle_;
   BlockContents* contents_;
   const ImmutableCFOptions& ioptions_;


### PR DESCRIPTION
Summary:
Some call sites of BlockFetcher create temporary ReadOptions and pass to BlockFetcher. The temporary object will be gone after BlockFetcher construction but BlockFetcher keep its reference, causing stack-use-after-scope. Fixing it.

Test Plan:
Run `buck test @mode/dev-asan` on internal repo.