### PR TITLE
Fix DeleteScheduler::MarkAsTrash() handling existing trash

### DIFF
--- a/util/delete_scheduler.cc
+++ b/util/delete_scheduler.cc
@@ -151,6 +151,7 @@ Status DeleteScheduler::MarkAsTrash(const std::string& file_path,
   Status s;
   if (DeleteScheduler::IsTrashFile(file_path)) {
     // This is already a trash file
+    *trash_file = file_path;
     return s;
   }
 


### PR DESCRIPTION
DeleteScheduler::MarkAsTrash() don't handle existing .trash files correctly
This cause rocksdb to not being able to delete existing .trash files on restart