### PR TITLE
NUMBER_BLOCK_COMPRESSED, etc, shouldn't be treated as timer counter

### DIFF
--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -531,9 +531,9 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     if (ShouldReportDetailedTime(r->ioptions.env, r->ioptions.statistics)) {
       MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS,
                   timer.ElapsedNanos());
-      MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED,
-                  raw_block_contents.size());
     }
+    MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED,
+                raw_block_contents.size());
     RecordTick(r->ioptions.statistics, NUMBER_BLOCK_COMPRESSED);
   }
 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -527,13 +527,13 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     RecordTick(r->ioptions.statistics, NUMBER_BLOCK_NOT_COMPRESSED);
     type = kNoCompression;
     block_contents = raw_block_contents;
-  } else if (type != kNoCompression &&
-             ShouldReportDetailedTime(r->ioptions.env,
-                                      r->ioptions.statistics)) {
-    MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS,
-                timer.ElapsedNanos());
-    MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED,
-                raw_block_contents.size());
+  } else if (type != kNoCompression) {
+    if (ShouldReportDetailedTime(r->ioptions.env, r->ioptions.statistics)) {
+      MeasureTime(r->ioptions.statistics, COMPRESSION_TIMES_NANOS,
+                  timer.ElapsedNanos());
+      MeasureTime(r->ioptions.statistics, BYTES_COMPRESSED,
+                  raw_block_contents.size());
+    }
     RecordTick(r->ioptions.statistics, NUMBER_BLOCK_COMPRESSED);
   }
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -369,8 +369,8 @@ Status UncompressBlockContentsForCompressionType(
   if(ShouldReportDetailedTime(ioptions.env, ioptions.statistics)){
     MeasureTime(ioptions.statistics, DECOMPRESSION_TIMES_NANOS,
       timer.ElapsedNanos());
-    MeasureTime(ioptions.statistics, BYTES_DECOMPRESSED, contents->data.size());
   }
+  MeasureTime(ioptions.statistics, BYTES_DECOMPRESSED, contents->data.size());
   RecordTick(ioptions.statistics, NUMBER_BLOCK_DECOMPRESSED);
 
   return Status::OK();

--- a/table/format.cc
+++ b/table/format.cc
@@ -370,8 +370,8 @@ Status UncompressBlockContentsForCompressionType(
     MeasureTime(ioptions.statistics, DECOMPRESSION_TIMES_NANOS,
       timer.ElapsedNanos());
     MeasureTime(ioptions.statistics, BYTES_DECOMPRESSED, contents->data.size());
-    RecordTick(ioptions.statistics, NUMBER_BLOCK_DECOMPRESSED);
   }
+  RecordTick(ioptions.statistics, NUMBER_BLOCK_DECOMPRESSED);
 
   return Status::OK();
 }


### PR DESCRIPTION
Summary: NUMBER_BLOCK_DECOMPRESSED and NUMBER_BLOCK_COMPRESSED are not reported unless the stats level contain detailed timers, which is wrong. They are normal counters. Fix it.

Test Plan: Verify the counters are reported using db_bench.