### PR TITLE
Add a histogram stat for memtable flush

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -244,6 +244,7 @@ Status FlushJob::WriteLevel0Table() {
       ThreadStatus::STAGE_FLUSH_WRITE_L0);
   db_mutex_->AssertHeld();
   const uint64_t start_micros = db_options_.env->NowMicros();
+  StopWatch sw(db_options_.env, stats_, FLUSH_TIME);
   Status s;
   {
     auto write_hint = cfd_->CalculateSSTWriteHint(0);

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -510,6 +510,8 @@ enum Histograms : uint32_t {
   BLOB_DB_COMPRESSION_MICROS,
   // BlobDB decompression time.
   BLOB_DB_DECOMPRESSION_MICROS,
+  // Time spent flushing memtable to disk
+  FLUSH_TIME,
 
   HISTOGRAM_ENUM_MAX,  // TODO(ldemailly): enforce HistogramsNameMap match
 };
@@ -560,6 +562,7 @@ const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {
     {BLOB_DB_GC_MICROS, "rocksdb.blobdb.gc.micros"},
     {BLOB_DB_COMPRESSION_MICROS, "rocksdb.blobdb.compression.micros"},
     {BLOB_DB_DECOMPRESSION_MICROS, "rocksdb.blobdb.decompression.micros"},
+    {FLUSH_TIME, "rocksdb.db.flush.micros"},
 };
 
 struct HistogramData {

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2806,8 +2806,10 @@ class HistogramTypeJni {
         return 0x1D;
       case rocksdb::Histograms::READ_NUM_MERGE_OPERANDS:
         return 0x1E;
-      case rocksdb::Histograms::HISTOGRAM_ENUM_MAX:
+      case rocksdb::Histograms::FLUSH_TIME:
         return 0x1F;
+      case rocksdb::Histograms::HISTOGRAM_ENUM_MAX:
+        return 0x20;
 
       default:
         // undefined/default
@@ -2882,6 +2884,8 @@ class HistogramTypeJni {
       case 0x1E:
         return rocksdb::Histograms::READ_NUM_MERGE_OPERANDS;
       case 0x1F:
+        return rocksdb::Histograms::FLUSH_TIME;
+      case 0x20:
         return rocksdb::Histograms::HISTOGRAM_ENUM_MAX;
 
       default:


### PR DESCRIPTION
Summary:
Add a new histogram stat called rocksdb.db.flush.micros for memtable
flush

Test Plan:
1. Unit tests in flush_job_test.cc
2. ./db_bench --benchmarks="fillseq,stats" --statistics
-write_buffer_size 1048576
  rocksdb.db.flush.micros statistics Percentiles :=> 50 : 5748.695652 95
  : 9318.913043 99 : 13159.500000 100 : 14918.000000