### PR TITLE
fix ThreadStatus for bottom-pri compaction threads

### DIFF
--- a/include/rocksdb/thread_status.h
+++ b/include/rocksdb/thread_status.h
@@ -164,7 +164,7 @@ struct ThreadStatus {
   // The followings are a set of utility functions for interpreting
   // the information of ThreadStatus
 
-  static const std::string& GetThreadTypeName(ThreadType thread_type);
+  static std::string GetThreadTypeName(ThreadType thread_type);
 
   // Obtain the name of an operation given its type.
   static const std::string& GetOperationName(OperationType op_type);

--- a/include/rocksdb/thread_status.h
+++ b/include/rocksdb/thread_status.h
@@ -45,6 +45,7 @@ struct ThreadStatus {
     HIGH_PRIORITY = 0,  // RocksDB BG thread in high-pri thread pool
     LOW_PRIORITY,  // RocksDB BG thread in low-pri thread pool
     USER,  // User thread (Non-RocksDB BG thread)
+    BOTTOM_PRIORITY,  // RocksDB BG thread in bottom-pri thread pool
     NUM_THREAD_TYPES
   };
 

--- a/monitoring/thread_status_impl.cc
+++ b/monitoring/thread_status_impl.cc
@@ -127,7 +127,7 @@ std::map<std::string, uint64_t>
 
 #else
 
-const std::string& ThreadStatus::GetThreadTypeName(
+std::string ThreadStatus::GetThreadTypeName(
     ThreadStatus::ThreadType thread_type) {
   static std::string dummy_str = "";
   return dummy_str;

--- a/monitoring/thread_status_impl.cc
+++ b/monitoring/thread_status_impl.cc
@@ -14,14 +14,21 @@
 namespace rocksdb {
 
 #ifdef ROCKSDB_USING_THREAD_STATUS
-const std::string& ThreadStatus::GetThreadTypeName(
+std::string ThreadStatus::GetThreadTypeName(
     ThreadStatus::ThreadType thread_type) {
-  static std::string thread_type_names[NUM_THREAD_TYPES + 1] = {
-      "High Pri", "Low Pri", "User", "Unknown"};
-  if (thread_type < 0 || thread_type >= NUM_THREAD_TYPES) {
-    return thread_type_names[NUM_THREAD_TYPES];  // "Unknown"
+  switch (thread_type) {
+    case ThreadStatus::ThreadType::HIGH_PRIORITY:
+      return "High Pri";
+    case ThreadStatus::ThreadType::LOW_PRIORITY:
+      return "Low Pri";
+    case ThreadStatus::ThreadType::USER:
+      return "User";
+    case ThreadStatus::ThreadType::BOTTOM_PRIORITY:
+      return "Bottom Pri";
+    case ThreadStatus::ThreadType::NUM_THREAD_TYPES:
+      assert(false);
   }
-  return thread_type_names[thread_type];
+  return "Unknown";
 }
 
 const std::string& ThreadStatus::GetOperationName(


### PR DESCRIPTION
added `ThreadType::BOTTOM_PRIORITY` which is used in the `ThreadStatus` object to indicate the thread is used for bottom-pri compactions. Previously there was a bug where we mislabeled such threads as `ThreadType::LOW_PRIORITY`.

Test Plan: 

- updated existing unit test; ran `make check -j64`
- ran db_bench to print thread status strings:

```
./db_bench -benchmarks=fillrandom -thread_status_per_interval=1 -stats_interval=100000 -num=1000000 -num_bottom_pri_threads=1
...
          ThreadID ThreadType       cfName            Operation   ElapsedTime                                         Stage        State OperationProperties
   140275253901056   High Pri      default                Flush    295.589 ms                                                            BytesMemtables 65013912 | BytesWritten 0 | JobID 3 |
   140275262293760    Low Pri                                                                                                           
   140275283273472 Bottom Pri                                                                                                           
```