### PR TITLE
[WIP] Skip obsolete files during recovery

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -41,6 +41,7 @@ SpecialEnv::SpecialEnv(Env* base)
   new_writable_count_ = 0;
   non_writable_count_ = 0;
   table_write_callback_ = nullptr;
+  drop_file_delete_ = false;
 }
 #ifndef ROCKSDB_LITE
 ROT13BlockCipher rot13Cipher_(16);

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -509,7 +509,11 @@ class SpecialEnv : public EnvWrapper {
 
   virtual Status DeleteFile(const std::string& fname) override {
     delete_count_.fetch_add(1);
-    return target()->DeleteFile(fname);
+    if (!drop_file_delete_) {
+      return target()->DeleteFile(fname);
+    } else {
+      return Status::OK();
+    }
   }
 
   Random rnd_;
@@ -575,6 +579,9 @@ class SpecialEnv : public EnvWrapper {
   std::atomic<bool> is_wal_sync_thread_safe_{true};
 
   std::atomic<size_t> compaction_readahead_size_;
+
+  // Drop file deletes on the floor if this flag is set
+  bool drop_file_delete_;
 };
 
 class MockTimeEnv : public EnvWrapper {


### PR DESCRIPTION
Right now during crash recovery Rocksdb replays all logs found in order of log number and relies on `recovering_log_number_` to ignore duplicate replays. This PR simplifies the process by first collecting the smallest log number(`min_log_num`) among all column families from the manifest, and skipping all obsolete WAL logs whose log number is strictly smaller than `min_log_num`.

This change might cause some regression in txn related tests and will be updated soon.