### PR TITLE
WritePrepared Txn: make buck tests parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,7 @@ PARALLEL_TEST = \
 	backupable_db_test \
 	db_compaction_filter_test \
 	db_compaction_test \
+	db_merge_operator_test \
 	db_sst_test \
 	db_test \
 	db_universal_compaction_test \
@@ -515,7 +516,7 @@ PARALLEL_TEST = \
 	persistent_cache_test \
 	table_test \
 	transaction_test \
-	write_prepared_transaction_test
+	write_prepared_transaction_test \
 
 SUBSET := $(TESTS)
 ifdef ROCKSDBTESTS_START

--- a/TARGETS
+++ b/TARGETS
@@ -1017,7 +1017,7 @@ ROCKS_TESTS = [
     [
         "write_prepared_transaction_test",
         "utilities/transactions/write_prepared_transaction_test.cc",
-        "serial",
+        "parallel",
     ],
 ]
 

--- a/TARGETS
+++ b/TARGETS
@@ -567,7 +567,7 @@ ROCKS_TESTS = [
     [
         "db_merge_operator_test",
         "db/db_merge_operator_test.cc",
-        "serial",
+        "parallel",
     ],
     [
         "db_options_test",


### PR DESCRIPTION
The TSAN version of tests could take quite long. Make the buck tests parallel to avoid timeouts.