### PR TITLE
fix release order in validateNumberOfEntries

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -1157,11 +1157,13 @@ UpdateStatus DBTestBase::updateInPlaceNoAction(char* prevValue,
 
 // Utility method to test InplaceUpdate
 void DBTestBase::validateNumberOfEntries(int numValues, int cf) {
-  ScopedArenaIterator iter;
   Arena arena;
   auto options = CurrentOptions();
   InternalKeyComparator icmp(options.comparator);
   RangeDelAggregator range_del_agg(icmp, {} /* snapshots */);
+  // This should be defined after range_del_agg so that it destructs the
+  // assigned iterator before it range_del_agg is already destructed.
+  ScopedArenaIterator iter;
   if (cf != 0) {
     iter.set(
         dbfull()->NewInternalIterator(&arena, &range_del_agg, handles_[cf]));


### PR DESCRIPTION
ScopedArenaIterator should be defined after range_del_agg so that it destructs the assigned iterator, which depends on range_del_agg, before it range_del_agg is already destructed.

Test: buck test @mode/dev rocksdb/src:db_inplace_update_test