### PR TITLE
Disable need_log_sync on bg err

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -697,8 +697,7 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
   }
 
   if (UNLIKELY(status.ok() && !bg_error_.ok())) {
-    *need_log_sync = false;
-    return bg_error_;
+    status = bg_error_;
   }
 
   if (UNLIKELY(status.ok() && !flush_scheduler_.Empty())) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -697,6 +697,7 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
   }
 
   if (UNLIKELY(status.ok() && !bg_error_.ok())) {
+    *need_log_sync = false;
     return bg_error_;
   }
 


### PR DESCRIPTION
When there is a background error PreprocessWrite returns without marking the logs synced. If we keep need_log_sync to true, it would try to sync them at the end, which would break the logic. The patch would unset need_log_sync if the logs end up not being marked for sync in PreprocessWrite.