### PR TITLE
BlobDB: update blob_db_options.bytes_per_sync behavior

### DIFF
--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -59,7 +59,7 @@ struct BlobDBOptions {
   // Allows OS to incrementally sync blob files to disk for every
   // bytes_per_sync bytes written. Users shouldn't rely on it for
   // persistency guarantee.
-  uint64_t bytes_per_sync = 512;
+  uint64_t bytes_per_sync = 512 * 1024;
 
   // the target size of each blob file. File will become immutable
   // after it exceeds that size

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -56,8 +56,10 @@ struct BlobDBOptions {
   // will be inlined in base DB together with the key.
   uint64_t min_blob_size = 0;
 
-  // at what bytes will the blob files be synced to blob log.
-  uint64_t bytes_per_sync = 0;
+  // Allows OS to incrementally sync blob files to disk for every
+  // bytes_per_sync bytes written. Users shouldn't rely on it for
+  // persistency guarantee.
+  uint64_t bytes_per_sync = 512;
 
   // the target size of each blob file. File will become immutable
   // after it exceeds that size
@@ -202,6 +204,8 @@ class BlobDB : public StackableDB {
                      BlobDB** blob_db);
 
   virtual BlobDBOptions GetBlobDBOptions() const = 0;
+
+  virtual Status SyncBlobFiles() = 0;
 
   virtual ~BlobDB() {}
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -158,9 +158,6 @@ class BlobDBImpl : public BlobDB {
   // if 50% of the space of a blob file has been deleted/expired,
   static constexpr uint32_t kPartialExpirationPercentage = 75;
 
-  // how often should we schedule a job to fsync open files
-  static constexpr uint32_t kFSyncFilesPeriodMillisecs = 10 * 1000;
-
   // how often to schedule reclaim open files.
   static constexpr uint32_t kReclaimOpenFilesPeriodMillisecs = 1 * 1000;
 
@@ -228,7 +225,7 @@ class BlobDBImpl : public BlobDB {
 
   Status Open(std::vector<ColumnFamilyHandle*>* handles);
 
-  Status SyncBlobFiles();
+  Status SyncBlobFiles() override;
 
 #ifndef NDEBUG
   Status TEST_GetBlobValue(const Slice& key, const Slice& index_entry,
@@ -312,9 +309,6 @@ class BlobDBImpl : public BlobDB {
 
   // Major task to garbage collect expired and deleted blobs
   std::pair<bool, int64_t> RunGC(bool aborted);
-
-  // asynchronous task to fsync/fdatasync the open blob files
-  std::pair<bool, int64_t> FsyncFiles(bool aborted);
 
   // periodically check if open blob files and their TTL's has expired
   // if expired, close the sequential writer and make the file immutable
@@ -419,8 +413,6 @@ class BlobDBImpl : public BlobDB {
 
   // pointer to directory
   std::unique_ptr<Directory> dir_ent_;
-
-  std::atomic<bool> dir_change_;
 
   // Read Write Mutex, which protects all the data structures
   // HEAVILY TRAFFICKED


### PR DESCRIPTION
Summary:
Previously, if blob_db_options.bytes_per_sync, there is a background job to call fsync() for every bytes_per_sync bytes written to a blob file. With the change we simply pass bytes_per_sync as env_options_ to blob files so that sync_file_range() will be used instead.

Test Plan:
Existing blob_db_test.