### PR TITLE
BlobDB: dump blob db options on open

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -202,6 +202,7 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   }
 
   ROCKS_LOG_INFO(db_options_.info_log, "BlobDB pointer %p", this);
+  bdb_options_.Dump(db_options_.info_log.get());
   return s;
 }
 


### PR DESCRIPTION
Summary:
We dump blob db options on blob db open, but it was removed by mistake in #3246. Adding it back.

Test Plan:
Try open blob db and check the LOG.