### PR TITLE
Add a BlockBasedTableOption to turn off index block compression.

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -218,9 +218,10 @@ struct BlockBasedTableOptions {
   // the information about version is read from the footer.
   uint32_t format_version = 2;
 
-  // Store index blocks on disk in uncompressed format. This will avoid the
-  // overhead if index blocks are evicted
-  bool index_uncompressed = false;
+  // Store index blocks on disk in compressed format. Changing this option to
+  // false  will avoid the overhead of decompression if index blocks are evicted
+  // and read back
+  bool enable_index_compression = true;
 };
 
 // Table Properties that are specific to block-based table properties.

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -217,6 +217,10 @@ struct BlockBasedTableOptions {
   // This option only affects newly written tables. When reading exising tables,
   // the information about version is read from the footer.
   uint32_t format_version = 2;
+
+  // Store index blocks on disk in uncompressed format. This will avoid the
+  // overhead if index blocks are evicted
+  bool index_uncompressed = false;
 };
 
 // Table Properties that are specific to block-based table properties.

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -151,7 +151,7 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "format_version=1;"
       "hash_index_allow_collision=false;"
       "verify_compression=true;read_amp_bytes_per_bit=0;"
-      "index_uncompressed=true",
+      "enable_index_compression=false",
       new_bbto));
 
   ASSERT_EQ(unset_bytes_base,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -150,7 +150,8 @@ TEST_F(OptionsSettableTest, BlockBasedTableOptionsAllFieldsSettable) {
       "filter_policy=bloomfilter:4:true;whole_key_filtering=1;"
       "format_version=1;"
       "hash_index_allow_collision=false;"
-      "verify_compression=true;read_amp_bytes_per_bit=0",
+      "verify_compression=true;read_amp_bytes_per_bit=0;"
+      "index_uncompressed=true",
       new_bbto));
 
   ASSERT_EQ(unset_bytes_base,

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -783,10 +783,8 @@ Status BlockBasedTableBuilder::Finish() {
     WriteRawBlock(meta_index_builder.Finish(), kNoCompression,
                   &metaindex_block_handle);
 
-    const bool is_data_block = true;
-    if (!r->table_options.index_uncompressed) {
-      WriteBlock(index_blocks.index_block_contents, &index_block_handle,
-                 !is_data_block);
+    if (r->table_options.enable_index_compression) {
+      WriteBlock(index_blocks.index_block_contents, &index_block_handle, false);
     } else {
       WriteRawBlock(index_blocks.index_block_contents, kNoCompression,
                     &index_block_handle);
@@ -798,9 +796,9 @@ Status BlockBasedTableBuilder::Finish() {
       if (!s.ok() && !s.IsIncomplete()) {
         return s;
       }
-      if (!r->table_options.index_uncompressed) {
+      if (r->table_options.enable_index_compression) {
         WriteBlock(index_blocks.index_block_contents, &index_block_handle,
-                   !is_data_block);
+                   false);
       } else {
         WriteRawBlock(index_blocks.index_block_contents, kNoCompression,
                       &index_block_handle);

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -784,8 +784,13 @@ Status BlockBasedTableBuilder::Finish() {
                   &metaindex_block_handle);
 
     const bool is_data_block = true;
-    WriteBlock(index_blocks.index_block_contents, &index_block_handle,
-               !is_data_block);
+    if (!r->table_options.index_uncompressed) {
+      WriteBlock(index_blocks.index_block_contents, &index_block_handle,
+                 !is_data_block);
+    } else {
+      WriteRawBlock(index_blocks.index_block_contents, kNoCompression,
+                    &index_block_handle);
+    }
     // If there are more index partitions, finish them and write them out
     Status& s = index_builder_status;
     while (s.IsIncomplete()) {
@@ -793,8 +798,13 @@ Status BlockBasedTableBuilder::Finish() {
       if (!s.ok() && !s.IsIncomplete()) {
         return s;
       }
-      WriteBlock(index_blocks.index_block_contents, &index_block_handle,
-                 !is_data_block);
+      if (!r->table_options.index_uncompressed) {
+        WriteBlock(index_blocks.index_block_contents, &index_block_handle,
+                   !is_data_block);
+      } else {
+        WriteRawBlock(index_blocks.index_block_contents, kNoCompression,
+                      &index_block_handle);
+      }
       // The last index_block_handle will be for the partition index block
     }
   }

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -223,6 +223,9 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
   snprintf(buffer, kBufferSize, "  format_version: %d\n",
            table_options_.format_version);
   ret.append(buffer);
+  snprintf(buffer, kBufferSize, "  index_uncompressed: %d\n",
+           table_options_.index_uncompressed);
+  ret.append(buffer);
   return ret;
 }
 

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -223,8 +223,8 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
   snprintf(buffer, kBufferSize, "  format_version: %d\n",
            table_options_.format_version);
   ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  index_uncompressed: %d\n",
-           table_options_.index_uncompressed);
+  snprintf(buffer, kBufferSize, "  enable_index_compression: %d\n",
+           table_options_.enable_index_compression);
   ret.append(buffer);
   return ret;
 }

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -153,8 +153,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"read_amp_bytes_per_bit",
          {offsetof(struct BlockBasedTableOptions, read_amp_bytes_per_bit),
           OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-        {"index_uncompressed",
-         {offsetof(struct BlockBasedTableOptions, index_uncompressed),
+        {"enable_index_compression",
+         {offsetof(struct BlockBasedTableOptions, enable_index_compression),
           OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 #endif  // !ROCKSDB_LITE
 }  // namespace rocksdb

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -152,6 +152,9 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
         {"read_amp_bytes_per_bit",
          {offsetof(struct BlockBasedTableOptions, read_amp_bytes_per_bit),
-          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}}};
+          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
+        {"index_uncompressed",
+         {offsetof(struct BlockBasedTableOptions, index_uncompressed),
+          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 #endif  // !ROCKSDB_LITE
 }  // namespace rocksdb

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1101,7 +1101,7 @@ TEST_F(BlockBasedTableTest, BasicBlockBasedTableProperties) {
   c.ResetTableReader();
 }
 
-uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool uncompressed) {
+uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool compressed) {
   TableConstructor c(BytewiseComparator(), true /* convert_to_internal_key_ */);
   constexpr size_t kNumKeys = 10000;
 
@@ -1117,7 +1117,7 @@ uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool uncompressed) {
   options.statistics->stats_level_ = StatsLevel::kAll;
   BlockBasedTableOptions table_options;
   table_options.block_restart_interval = 1;
-  table_options.index_uncompressed = uncompressed;
+  table_options.enable_index_compression = compressed;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
   ImmutableCFOptions ioptions(options);
@@ -1128,8 +1128,8 @@ uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool uncompressed) {
   return options.statistics->getTickerCount(NUMBER_BLOCK_COMPRESSED);
 }
 TEST_F(BlockBasedTableTest, IndexUncompressed) {
-  uint64_t tbl1_compressed_cnt = IndexUncompressedHelper(false);
-  uint64_t tbl2_compressed_cnt = IndexUncompressedHelper(true);
+  uint64_t tbl1_compressed_cnt = IndexUncompressedHelper(true);
+  uint64_t tbl2_compressed_cnt = IndexUncompressedHelper(false);
   // tbl1_compressed_cnt should include 1 index block
   EXPECT_EQ(tbl2_compressed_cnt + 1, tbl1_compressed_cnt);
 }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1003,7 +1003,10 @@ class TableTest : public testing::Test {
 };
 
 class GeneralTableTest : public TableTest {};
-class BlockBasedTableTest : public TableTest {};
+class BlockBasedTableTest : public TableTest {
+ protected:
+  uint64_t IndexUncompressedHelper(bool indexCompress);
+};
 class PlainTableTest : public TableTest {};
 class TablePropertyTest : public testing::Test {};
 
@@ -1064,13 +1067,17 @@ TEST_F(BlockBasedTableTest, BasicBlockBasedTableProperties) {
   stl_wrappers::KVMap kvmap;
   Options options;
   options.compression = kNoCompression;
+  options.statistics = CreateDBStatistics();
+  options.statistics->stats_level_ = StatsLevel::kAll;
   BlockBasedTableOptions table_options;
   table_options.block_restart_interval = 1;
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
-  const ImmutableCFOptions ioptions(options);
+  ImmutableCFOptions ioptions(options);
+  ioptions.statistics = options.statistics.get();
   c.Finish(options, ioptions, table_options,
            GetPlainInternalComparator(options.comparator), &keys, &kvmap);
+  ASSERT_EQ(options.statistics->getTickerCount(NUMBER_BLOCK_NOT_COMPRESSED), 0);
 
   auto& props = *c.GetTableReader()->GetTableProperties();
   ASSERT_EQ(kvmap.size(), props.num_entries);
@@ -1092,6 +1099,39 @@ TEST_F(BlockBasedTableTest, BasicBlockBasedTableProperties) {
   ASSERT_EQ(content.size() + kBlockTrailerSize + diff_internal_user_bytes,
             props.data_size);
   c.ResetTableReader();
+}
+
+uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool uncompressed) {
+  TableConstructor c(BytewiseComparator(), true /* convert_to_internal_key_ */);
+  constexpr size_t kNumKeys = 10000;
+
+  for (size_t k = 0; k < kNumKeys; ++k) {
+    c.Add("key" + ToString(k), "val" + ToString(k));
+  }
+
+  std::vector<std::string> keys;
+  stl_wrappers::KVMap kvmap;
+  Options options;
+  options.compression = kSnappyCompression;
+  options.statistics = CreateDBStatistics();
+  options.statistics->stats_level_ = StatsLevel::kAll;
+  BlockBasedTableOptions table_options;
+  table_options.block_restart_interval = 1;
+  table_options.index_uncompressed = uncompressed;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  ImmutableCFOptions ioptions(options);
+  ioptions.statistics = options.statistics.get();
+  c.Finish(options, ioptions, table_options,
+           GetPlainInternalComparator(options.comparator), &keys, &kvmap);
+  c.ResetTableReader();
+  return options.statistics->getTickerCount(NUMBER_BLOCK_COMPRESSED);
+}
+TEST_F(BlockBasedTableTest, IndexUncompressed) {
+  uint64_t tbl1_compressed_cnt = IndexUncompressedHelper(false);
+  uint64_t tbl2_compressed_cnt = IndexUncompressedHelper(true);
+  // tbl1_compressed_cnt should include 1 index block
+  EXPECT_EQ(tbl2_compressed_cnt + 1, tbl1_compressed_cnt);
 }
 
 TEST_F(BlockBasedTableTest, BlockBasedTableProperties2) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -442,6 +442,10 @@ DEFINE_int32(read_amp_bytes_per_bit,
              rocksdb::BlockBasedTableOptions().read_amp_bytes_per_bit,
              "Number of bytes per bit to be used in block read-amp bitmap");
 
+DEFINE_bool(index_uncompressed,
+            rocksdb::BlockBasedTableOptions().index_uncompressed,
+            "Do not compress the index block");
+
 DEFINE_int64(compressed_cache_size, -1,
              "Number of bytes to use as a cache of compressed data.");
 
@@ -3110,6 +3114,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       block_based_options.filter_policy = filter_policy_;
       block_based_options.format_version = 2;
       block_based_options.read_amp_bytes_per_bit = FLAGS_read_amp_bytes_per_bit;
+      block_based_options.index_uncompressed = FLAGS_index_uncompressed;
       if (FLAGS_read_cache_path != "") {
 #ifndef ROCKSDB_LITE
         Status rc_status;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -442,9 +442,9 @@ DEFINE_int32(read_amp_bytes_per_bit,
              rocksdb::BlockBasedTableOptions().read_amp_bytes_per_bit,
              "Number of bytes per bit to be used in block read-amp bitmap");
 
-DEFINE_bool(index_uncompressed,
-            rocksdb::BlockBasedTableOptions().index_uncompressed,
-            "Do not compress the index block");
+DEFINE_bool(enable_index_compression,
+            rocksdb::BlockBasedTableOptions().enable_index_compression,
+            "Compress the index block");
 
 DEFINE_int64(compressed_cache_size, -1,
              "Number of bytes to use as a cache of compressed data.");
@@ -3114,7 +3114,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       block_based_options.filter_policy = filter_policy_;
       block_based_options.format_version = 2;
       block_based_options.read_amp_bytes_per_bit = FLAGS_read_amp_bytes_per_bit;
-      block_based_options.index_uncompressed = FLAGS_index_uncompressed;
+      block_based_options.enable_index_compression =
+          FLAGS_enable_index_compression;
       if (FLAGS_read_cache_path != "") {
 #ifndef ROCKSDB_LITE
         Status rc_status;


### PR DESCRIPTION
Summary:
Add a new bool option index_uncompressed in BlockBasedTableOptions.

Test Plan:
1. New unit test in table_test.cc
2. dbbench to check size w/wo index compression -

  ./db_bench --benchmarks="fillseq,stats" -enable_index_compression=true
  ls -l /tmp/rocksdbtest-142225/dbbench/*.sst
    -rw-r--r--. 1 anand76 users 30287419 Dec 20 21:46
    /tmp/rocksdbtest-142225/dbbench/000007.sst

  ./db_bench --benchmarks="fillseq,stats" -enable_index_compression=false
  ls -l /tmp/rocksdbtest-142225/dbbench/*.sst
    -rw-r--r--. 1 anand76 users 30470586 Dec 20 21:49
    /tmp/rocksdbtest-142225/dbbench/000007.sst