### PR TITLE
Use default fs in DestroyDB

### DIFF
--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -72,6 +72,11 @@ class TransactionTest : public ::testing::TestWithParam<
 
   ~TransactionTest() {
     delete db;
+    // This is to skip the assert statement in FaultInjectionTestEnv. There
+    // seems to be a bug in btrfs that the makes readdir return recently
+    // unlink-ed files. By using the default fs we simply ignore errors resulted
+    // from attempting to delete such files in DestroyDB.
+    options.env = Env::Default();
     DestroyDB(dbname, options);
     delete env;
   }


### PR DESCRIPTION
There seems to be a bug in btrfs that the makes readdir return recently unlink-ed files. This problem showed up in transaction_test when we call DestroyDB right after deleting the DB. Closing the DB deleted all the absolute files but one of them still showed up in the GetChildren call inside DestroyDB, which resulted in "file does not exist" error when it tried to attempt it.

FaultInjectionTestEnv::DeleteFile asserts on DeleteFile return status. By using the default fs for DestroyDB we simply ignore errors resulted from attempting to delete such files in DestroyDB.