### PR TITLE
Demonstrate async IO with coroutines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ make_config.mk
 CMakeCache.txt
 CMakeFiles/
 build/
+build17/
 
 ldb
 manifest_dump

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,15 @@ target_include_directories(build_version PRIVATE
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W4 /wd4127 /wd4800 /wd4996 /wd4351 /wd4100 /wd4204 /wd4324")
+
+   # Co-routines support
+   option(WITH_COROUTINES "build with coroutines support" OFF)
+   if(WITH_COROUTINES)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /await")
+    add_definitions(-DROCKSDB_COROUTINES)
+    message(STATUS "Coroutines enabled")
+   endif()
+
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wextra -Wall")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare -Wshadow -Wno-unused-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-strict-aliasing")
@@ -620,6 +629,8 @@ endif()
 
 if(WIN32)
   list(APPEND SOURCES
+    port/win/asyncthreadpoolimpl.cc
+    port/win/iocompletion.cc
     port/win/io_win.cc
     port/win/env_win.cc
     port/win/env_default.cc
@@ -936,6 +947,11 @@ if(WITH_TESTS)
         EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
         EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
         )
+
+   if(WITH_COROUTINES)
+    list(APPEND TESTS async/coroutine_random_access_test.cc)
+   endif()
+
 
   # Tests are excluded from Release builds
   set(TEST_EXES ${TESTS})

--- a/async/asynccallbacks_test.cc
+++ b/async/asynccallbacks_test.cc
@@ -1,0 +1,489 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <rocksdb/async/callables.h>
+#include <rocksdb/iterator.h>
+
+#include "ms_internal/ms_threadpool.h"
+#include "ms_internal/ms_taskpoolhandle.h"
+
+#include "util/random.h"
+#include "port/stack_trace.h"
+#include "port/win/io_win.h"
+#include "port/win/iocompletion.h"
+#include "util/testharness.h"
+#include "util/testutil.h"
+
+#include <algorithm>
+#include <fstream>
+
+namespace rocksdb {
+
+// This interface extends the standard Iterator
+// and introduces async versions of the API
+// which may incur IO and therefore complete async
+// on another thread
+class AsyncIterator : public Iterator {
+public:
+  AsyncIterator() {}
+
+  // Position at the first key in the source.  The iterator is Valid()
+  // after this call iff the source is not empty.
+  // bool - true is returned if the call has completed synchronously
+  // false - if an async operation was submitted. In this case,
+  // the current code path of iteration must exit the current
+  // thread and preserve its state on the heap. The execution will
+  // continue when IO completes and the callable is invoked
+  virtual bool SeekToFirst(const async::Callable<void,const Slice&>&) = 0;
+
+  // Position at the last key in the source.  The iterator is
+  // Valid() after this call iff the source is not empty.
+  virtual bool SeekToLast(const async::Callable<void,const Slice&>&) = 0;
+
+  // Position at the first key in the source that at or past target
+  // The iterator is Valid() after this call iff the source contains
+  // an entry that comes at or past target.
+  virtual bool Seek(const Slice& target,
+      const async::Callable<void,const Slice&>&) = 0;
+
+  // Position at the last key in the source that at or before target
+  // The iterator is Valid() after this call iff the source contains
+  // an entry that comes at or before target.
+  virtual bool SeekForPrev(const Slice& target, 
+       const async::Callable<void,const Slice&>&) {}
+
+  // Moves to the next entry in the source.  After this call, Valid() is
+  // true iff the iterator was not positioned at the last entry in the source.
+  // REQUIRES: Valid()
+  virtual bool Next(const async::Callable<void,const Slice&>&) = 0;
+
+};
+
+
+class AsyncTest : public testing::Test {};
+
+static
+void* test_ctx = reinterpret_cast<void*>(0x10000);
+
+void CallbackTest(void* ctx) {
+  ASSERT_EQ(test_ctx, ctx);
+}
+
+void CallbackTestWithArg(void* ctx, int) {
+  ASSERT_EQ(test_ctx, ctx);
+}
+
+int CallbackTestWithRet(void* ctx) {
+  return 10;
+}
+
+int CallbackWithRValue(void*, std::string&& s) {
+  std::string a(std::move(s));
+  return 0;
+}
+
+struct MethodCallbackTest {
+
+  bool invoked_;
+
+  MethodCallbackTest() : 
+    invoked_(false) {}
+
+  void TestMethod(int) {
+    invoked_ = true;
+  }
+
+  int TestMethodWithRet(int a) {
+    invoked_ = true;
+    return a;
+  }
+
+  int TestMethodWithRValue(std::string&&) {
+    invoked_ = true;
+    return 10;
+  }
+
+};
+
+// Compilation test only
+void Indirect(async::Callable<int, int>& cb, int arg) {
+  cb.Invoke(arg);
+}
+
+TEST_F(AsyncTest, SimleTest) {
+  {
+    // Simple callable direct use
+    // nothing to return and no arguments
+    async::Callable<void> simple(test_ctx, &CallbackTest);
+    simple.Invoke();
+  }
+
+  {
+    // Simple callable direct use
+    // nothing to return one int argument by value
+    async::Callable<void,int> simple(test_ctx, &CallbackTestWithArg);
+    simple.Invoke(10);
+  }
+
+  {
+    // Simple callable direct use
+    // no arguments and integer return type
+    async::Callable<int> simple(test_ctx, &CallbackTestWithRet);
+    int result = simple.Invoke();
+  }
+
+  {
+    // Simple callable direct use
+    // test rvalue parameter invocation
+    async::Callable<int,std::string&&> simple(test_ctx, &CallbackWithRValue);
+    std::string s("10");
+    int result = simple.Invoke(std::move(s));
+  }
+
+  {
+    MethodCallbackTest testObj;
+    async::CallableFactory<MethodCallbackTest,void,int> 
+      methodCallback(&testObj);
+
+    auto callable = methodCallback.GetCallable<
+      &MethodCallbackTest::TestMethod>();
+
+    ASSERT_FALSE(testObj.invoked_);
+    callable.Invoke(10);
+    ASSERT_TRUE(testObj.invoked_);
+
+    testObj.invoked_ = false;
+
+    async::CallableFactory<MethodCallbackTest, int, int> methodRet(&testObj);
+    auto callableWithRet = methodRet.GetCallable<&MethodCallbackTest::TestMethodWithRet>();
+
+    int result = callableWithRet.Invoke(30);
+    ASSERT_TRUE(testObj.invoked_);
+    ASSERT_EQ(result, 30);
+
+
+    testObj.invoked_ = false;
+    async::CallableFactory<MethodCallbackTest, int, std::string&&> methodRValue(&testObj);
+    auto callableRValue = methodRValue.GetCallable<&MethodCallbackTest::TestMethodWithRValue>();
+    std::string s("10");
+    callableRValue.Invoke(std::move(s));
+    ASSERT_TRUE(testObj.invoked_);
+  }
+}
+
+// Helper for quickly generating random data.
+class RandomGenerator {
+private:
+  std::string data_;
+  size_t      pos_;
+
+public:
+  RandomGenerator(size_t valsize, double compression_ratio) :
+    pos_(0) {
+    // We use a limited amount of data over and over again and ensure
+    // that it is larger than the compression window (32KB), and also
+    // large enough to serve all typical value sizes we want to write.
+    Random rnd(301);
+    std::string piece;
+    while (data_.size() < std::max<size_t>(1048576U, valsize)) {
+      // Add a short fragment that is as compressible as specified
+      // by FLAGS_compression_ratio.
+      test::CompressibleString(&rnd, compression_ratio, 100, &piece);
+      data_.append(piece);
+    }
+  }
+
+  Slice Generate(size_t len) {
+    assert(len <= data_.size());
+    if (pos_ + len > data_.size()) {
+      pos_ = 0;
+    }
+    pos_ += len;
+    return Slice(data_.data() + pos_ - len, len);
+  }
+};
+
+struct WinIOOverlapped : public OVERLAPPED {
+
+  using
+  RequestCallback = async::Callable<void, const Status&, const Slice&>;
+
+  port::MemoryArenaId arena_;
+  RequestCallback     cb_;
+  char*               buffer_;
+
+  WinIOOverlapped(const RequestCallback& cb, uint64_t offset,
+    char* buffer) :
+    cb_(cb),
+    buffer_(buffer) {
+
+    ZeroMemory(this, sizeof(OVERLAPPED));
+
+    ULARGE_INTEGER offsetUnion;
+    offsetUnion.QuadPart = offset;
+    Offset = offsetUnion.LowPart;
+    OffsetHigh = offsetUnion.HighPart;
+  }
+
+  ~WinIOOverlapped() {
+  }
+
+  Slice GetSlice(uint64_t len) {
+    return Slice(buffer_, len);
+  }
+
+  const port::MemoryArenaId& GetArenaId() const {
+    return arena_;
+  }
+};
+
+// Test callback here
+class TestIOCompletionCallback {
+  HANDLE                              hFile_;
+  std::unique_ptr<port::IOCompletion> io_compl_handle_;
+public:
+
+  TestIOCompletionCallback(const std::string& fileName,
+    port::TaskPoolHandle& tp) :
+    hFile_(NULL) {
+
+    DWORD fileFlags = FILE_ATTRIBUTE_READONLY | FILE_FLAG_RANDOM_ACCESS |
+      FILE_FLAG_OVERLAPPED;
+
+    HANDLE hFile =
+      CreateFileA(fileName.c_str(), GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL, OPEN_EXISTING, fileFlags, NULL);
+
+    hFile_ = hFile;
+    assert(hFile_ != INVALID_HANDLE_VALUE);
+
+    // Do not require setting an event since we are using a compl port
+    // and in case the operation completes sync we do not want
+    // a callback dispatch
+    SetFileCompletionNotificationModes(hFile, 
+      FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
+
+    io_compl_handle_ = tp.CreateIOCompletion(hFile_, OnIoCompletion);
+    assert(io_compl_handle_ != nullptr);
+  }
+
+  ~TestIOCompletionCallback() {
+    io_compl_handle_.reset();
+    CloseHandle(hFile_);
+  }
+
+  TestIOCompletionCallback(const TestIOCompletionCallback&) = delete;
+  TestIOCompletionCallback& operator-(const TestIOCompletionCallback&) = delete;
+
+  // A sketch of a async read API for random access
+  // Takes callback that returns nothing but accepts Status and Slice
+  // which would be the return values for such an API
+  // This API returns status either OK - meaning things completed inline
+  // OR - IOPending which means async operation is in progress, act accordingly
+  // vacate the thread
+  Status Read(const WinIOOverlapped::RequestCallback& cb,
+    uint64_t offset, size_t n, char* buffer, Slice* result) {
+
+    Status s;
+
+    std::unique_ptr<WinIOOverlapped> overlapped(new WinIOOverlapped(cb, offset,
+      buffer));
+
+    unsigned long bytesRead = 0;
+
+    // Let the TP know we are about to start
+    // Must do it on every IO
+    io_compl_handle_->Start();
+
+    BOOL ret = ReadFile(hFile_, buffer, static_cast<DWORD>(n), &bytesRead,
+      overlapped.get());
+
+    if (ret == TRUE) {
+      // Operation completed sync
+      io_compl_handle_->Cancel();
+      // We choose not to invoke callback and return in sync
+      *result = Slice(buffer, bytesRead);
+      return s;
+    }
+
+    DWORD lastError = GetLastError();
+    if (lastError == ERROR_IO_PENDING) {
+      // Async operation has been initiated
+      overlapped.release();
+      // We may want to mention file name here
+      return Status::IOPending();
+    }
+
+    // Operation completed sync
+    io_compl_handle_->Cancel();
+
+    // We handle EOF as a success with zero bytes read
+    if (lastError == ERROR_HANDLE_EOF) {
+      *result = Slice(buffer, 0);
+      return s;
+    }
+
+    // We have some other error
+    return port::IOErrorFromWindowsError("Failed to initiate async Read()",
+      lastError);
+  }
+
+  static
+  void CALLBACK OnIoCompletion(
+    PTP_CALLBACK_INSTANCE /* Instance */,
+    PVOID                 /* Context */,
+    PVOID                 Overlapped,
+    ULONG                 IoResult,
+    ULONG_PTR             NumberOfBytesTransferred,
+    PTP_IO                /* ptp_io */) {
+
+    std::unique_ptr<WinIOOverlapped> overlapped(
+      reinterpret_cast<WinIOOverlapped*>(Overlapped));
+
+    port::MemoryArenaSwitch arena(overlapped->GetArenaId());
+
+    Status status;
+    Slice slice;
+
+    if (IoResult == ERROR_HANDLE_EOF) {
+      slice = overlapped->GetSlice(0);
+    } else if (IoResult == NO_ERROR) {
+      slice = overlapped->GetSlice(NumberOfBytesTransferred);
+    } else {
+      slice = overlapped->GetSlice(0);
+      status = port::IOErrorFromWindowsError("Async read failed: ",
+        IoResult);
+    }
+
+    auto cb = overlapped->cb_;
+    // Free the structure here as no longer needed
+    // When pooling overlapped structures we we will want
+    // to release it asap
+    // Also release in this arena
+    overlapped.reset();
+
+    // Invoke callback and further processing continues on this thread
+    cb.Invoke(status, slice);
+  }
+};
+
+struct Customer {
+  HANDLE hEvent_;
+  Customer() {
+    hEvent_ = CreateEvent(NULL, TRUE, FALSE, NULL);
+    assert(NULL != hEvent_);
+  }
+
+  ~Customer() {
+    if (hEvent_ != NULL) {
+      CloseHandle(hEvent_);
+    }
+  }
+
+  void Wait() {
+    auto ret = WaitForSingleObject(hEvent_, INFINITE);
+    assert(ret == WAIT_OBJECT_0);
+  }
+
+  void Reset() {
+    ResetEvent(hEvent_);
+  }
+
+  async::Callable<void, const Status&, const Slice&>
+  GetCallback() {
+    async::CallableFactory<Customer,void, const Status&, const Slice&>
+      factory(this);
+    return factory.GetCallable<&Customer::OnIOCompletion>();
+  }
+
+  // IO COmpletion callback
+  void OnIOCompletion(const Status& status, const Slice& slice) {
+    std::cout << "Async Bytes read: " << slice.size() <<
+      " status: " << status.ToString() << std::endl;
+    SetEvent(hEvent_);
+  }
+};
+
+
+TEST_F(AsyncTest, IOCompletionTest) {
+
+  // Generate a file for reading
+  std::string fileName = test::TmpDir();
+  fileName += "/io_completion.bin";
+
+  {
+    std::ofstream os(fileName, std::ios::binary | std::ios::out);
+    ASSERT_TRUE(os.is_open());
+
+    RandomGenerator gen(32 * 1024U, 0.5);
+    uint64_t sizeWritten = 0;
+    while (sizeWritten < 1024 * 10U) {
+      Slice data = gen.Generate(4096);
+      os.write(data.data(), data.size());
+      sizeWritten += data.size();
+    }
+    os.flush();
+    ASSERT_FALSE(os.fail());
+    os.close();
+  }
+
+  using namespace port;
+  // Create 5 threads in the current arena
+  // We use task pools to submit IOs always on behalf of
+  // specific instances
+
+  VistaThreadPool threadPool(MemoryArenaId(), 5);
+
+  // Test creation and then destroy the taskpool first
+  // and cleaning all the instances
+  // TODO: After we removed the indirection from the
+  // callback context and zeroing out the handles that the
+  // task pool closes, we should always destroy the database
+  // first as it will wait for all the handles
+  {
+    TaskPoolHandle taskPool = threadPool.CreateTaskPool();
+    TestIOCompletionCallback dummy(fileName, taskPool);
+    taskPool.Destroy();
+  }
+
+  // Reverse the destruction. File object destroys first.
+  {
+    TaskPoolHandle taskPool = threadPool.CreateTaskPool();
+    TestIOCompletionCallback dummy(fileName, taskPool);
+  }
+
+  // Test the actual overlapped IO
+  {
+    TaskPoolHandle taskPool = threadPool.CreateTaskPool();
+    TestIOCompletionCallback fileIO(fileName, taskPool);
+    Customer customer;
+    char buffer[4096 * 2];
+    Slice result;
+    Status status = fileIO.Read(customer.GetCallback(),
+      4096U, sizeof(buffer), buffer, &result);
+
+    if (status.IsIOPending()) {
+      customer.Wait();
+    }  else if(status.ok()) {
+      std::cout << 
+        "Sync read bytes: " << result.size() << std::endl;
+    }     else {
+      std::cout << "Sync read failed: " << status.ToString() << std::endl;
+    }
+  }
+
+  remove(fileName.c_str());
+}
+} // namespace rocksdb
+
+int main(int argc, char** argv) {
+  rocksdb::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/async/coroutine_random_access_test.cc
+++ b/async/coroutine_random_access_test.cc
@@ -1,0 +1,198 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+
+#if !(defined ROCKSDB_COROUTINES)
+#error "Only for Coroutines support"
+#endif
+
+#include "rocksdb/status.h"
+
+#include "db/db_test_util.h"
+#include "rocksdb/env.h"
+#include "port/port.h"
+#include <algorithm>
+#include <fstream>
+#include <vector>
+#include <future>
+
+#include "util/aligned_buffer.h"
+#include "util/random.h"
+#include "util/testharness.h"
+#include "util/testutil.h"
+
+#include "port/win/io_win.h"
+
+namespace rocksdb {
+
+// Helper for quickly generating random data.
+class RandomGenerator {
+private:
+  std::string data_;
+  size_t      pos_;
+
+public:
+  RandomGenerator(size_t valsize, double compression_ratio) :
+    pos_(0) {
+    // We use a limited amount of data over and over again and ensure
+    // that it is larger than the compression window (32KB), and also
+    // large enough to serve all typical value sizes we want to write.
+    Random rnd(301);
+    std::string piece;
+    while (data_.size() < std::max<size_t>(1048576U, valsize)) {
+      // Add a short fragment that is as compressible as specified
+      // by FLAGS_compression_ratio.
+      test::CompressibleString(&rnd, compression_ratio, 100, &piece);
+      data_.append(piece);
+    }
+  }
+
+  Slice Generate(size_t len) {
+    assert(len <= data_.size());
+    if (pos_ + len > data_.size()) {
+      pos_ = 0;
+    }
+    pos_ += len;
+    return Slice(data_.data() + pos_ - len, len);
+  }
+};
+
+class RandomAccessCoroutineTest :
+  public testing::Test,
+  public testing::WithParamInterface<bool> {
+
+public:
+
+  PTP_POOL    tp_pool_;
+  bool        direct_io_;
+  std::string fileName_;
+
+  RandomAccessCoroutineTest() : tp_pool_(nullptr) {
+
+    tp_pool_ = CreateThreadpool(NULL);
+    BOOL ret = SetThreadpoolThreadMinimum(tp_pool_, 5);
+    assert(ret);
+    SetThreadpoolThreadMaximum(tp_pool_, 10);
+
+    direct_io_ = GetParam();
+
+    // Generate a file for reading
+    fileName_ = test::TmpDir();
+    fileName_ += "/io_completion.bin";
+
+    {
+      std::ofstream os(fileName_, std::ios::binary | std::ios::out);
+
+      // Writing 64 K so we can issue 8 reads 8K each
+      //
+      RandomGenerator gen(10 * 1024U, 0.5);
+      uint64_t sizeWritten = 0;
+      while (sizeWritten < 1024 * 64U) {
+        Slice data = gen.Generate(4096);
+        os.write(data.data(), data.size());
+        sizeWritten += data.size();
+      }
+      os.flush();
+      os.close();
+    }
+  }
+
+  ~RandomAccessCoroutineTest() {
+    unlink(fileName_.c_str());
+    if (tp_pool_ != nullptr) {
+      CloseThreadpool(tp_pool_);
+    }
+  }
+};
+
+// We use future here because we can wait on it
+// in the test but generally we do not have to wait
+// for anything since the code completes on another thread
+std::future<void> InitiateAsyncRead(Env* env, RandomAccessFileReader* reader,
+  uint64_t offset, size_t n) {
+
+  Slice result;
+  AlignedBuffer  buffer;
+  buffer.Alignment(reader->file()->GetRequiredBufferAlignment());
+  buffer.AllocateNewBuffer(n);
+
+  auto tid = env->GetThreadID();
+  Status s = co_await reader->RequestRead(offset, n, &result, buffer.BufferStart());
+
+  // The thread that calls back has no reference to the caller since the
+  // caller is NOT a coroutine so the thread goes away
+  std::cout << "Thread ID before co_await: " << tid << " after co_await: " << env->GetThreadID() << "\n";
+  std::cout << "Read:" << result.size() << " bytes, status: " << s.ToString() << "\n";
+  // This is just to signal the future
+  co_return;
+}
+
+TEST_P(RandomAccessCoroutineTest, TestAsyncRead) {
+
+  Env* env = Env::Default();
+  // This is where the io completions will run
+  auto io_tp(env->CreateAsyncThreadPool(tp_pool_));
+
+  EnvOptions options;
+  options.use_direct_reads = direct_io_;
+  options.use_async_reads = true;
+  options.async_threadpool = io_tp.get();
+
+  std::unique_ptr<RandomAccessFile> file;
+  Status s = env->NewRandomAccessFile(fileName_, &file, options);
+  ASSERT_OK(s);
+
+  std::unique_ptr<RandomAccessFileReader> f_reader(new RandomAccessFileReader(std::move(file), 
+    fileName_, env));
+
+  {
+    // Single wait
+    // Make sure that offsets and sizes are not factors of
+    // page size
+    std::future<void> f = InitiateAsyncRead(env, f_reader.get(), 815, 8 * 1024 - 256);
+    // Wait here for the callback to return
+    f.get();
+    std::cout << "Wait completed" << std::endl;
+  }
+
+  // Now several threads at once
+  {
+    const size_t tnum = 12;
+    std::vector<port::Thread> threads;
+    threads.reserve(tnum);
+
+    auto t = [env, &f_reader](size_t cust, size_t size)
+    {
+      uint64_t offset = 1024 * cust + 37;
+      std::future<void> f = InitiateAsyncRead(env, f_reader.get(), offset, size);
+      // Wait here for the callback to return
+      f.get();
+    };
+
+    for (size_t n = 0; n < tnum; ++n) {
+      threads.emplace_back(t, n, 8 * 1024 - 257);
+    }
+
+    for (auto& th : threads) {
+      th.join();
+    }
+  }
+
+  io_tp->CloseThreadPool();
+}
+
+INSTANTIATE_TEST_CASE_P(
+  TestAsyncRead, RandomAccessCoroutineTest,
+  ::testing::ValuesIn({ false, true }));
+
+} // rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/env/env.cc
+++ b/env/env.cc
@@ -316,12 +316,14 @@ void AssignEnvOptions(EnvOptions* env_options, const DBOptions& options) {
   env_options->use_mmap_reads = options.allow_mmap_reads;
   env_options->use_mmap_writes = options.allow_mmap_writes;
   env_options->use_direct_reads = options.use_direct_reads;
+  env_options->use_async_reads = options.use_async_reads;
   env_options->set_fd_cloexec = options.is_fd_close_on_exec;
   env_options->bytes_per_sync = options.bytes_per_sync;
   env_options->compaction_readahead_size = options.compaction_readahead_size;
   env_options->random_access_max_buffer_size =
       options.random_access_max_buffer_size;
   env_options->rate_limiter = options.rate_limiter.get();
+  env_options->async_threadpool = options.async_threadpool.get();
   env_options->writable_file_max_buffer_size =
       options.writable_file_max_buffer_size;
   env_options->allow_fallocate = options.allow_fallocate;

--- a/include/rocksdb/async/asyncthreadpool.h
+++ b/include/rocksdb/async/asyncthreadpool.h
@@ -1,0 +1,28 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+namespace rocksdb {
+namespace async {
+
+// Env depended implementation
+class AsyncThreadPool {
+protected:
+  AsyncThreadPool() {}
+public:
+  virtual ~AsyncThreadPool() {}
+  // Ensures that all outstanding items
+  // are closed. Any async callbacks in progress
+  // are waited on
+  virtual void CloseThreadPool() = 0;
+};
+
+}
+}

--- a/include/rocksdb/async/coro_promise.h
+++ b/include/rocksdb/async/coro_promise.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// Experimental coroutines support to explore async implementations.
+//
+// For detailed information see: 
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4649.pdf
+//
+// Quick cookbooks
+// https://youtu.be/ZTqHjjm86Bw
+// https://youtu.be/8C8NnE1Dg4A?t=2414
+// 
+
+#pragma once
+
+#ifndef STORAGE_ROCKSDB_INCLUDE_CORO_PROMISE_H_
+#define STORAGE_ROCKSDB_INCLUDE_CORO_PROMISE_H_
+
+#if !(defined ROCKSDB_COROUTINES)
+#error "Only for Coroutines support"
+#endif
+
+#if !(defined _MSC_VER)
+// also LLVM/Clang supports this but I have not tested
+#error "Currently support for MS compiler only"
+#endif
+
+#include <experimental/resumable>
+
+namespace rocksdb {
+// This promise enables few things:
+// - capture the callers coroutine handle so it can be resumed(called back)
+// - preserve the existing functions signature that usually (but not always)
+//      return Status
+// - deliver the actual return value via result_ (most of the time Status)
+// This lacks get_return_object that is to be implemented in the return type
+// specific manner
+template<typename Result>
+struct PromiseType
+{
+  using coroutine_handle = std::experimental::coroutine_handle<>;
+  // Caller coroutine handle. essentially a callback
+  coroutine_handle   cb_;
+  // Result delivered here
+  Result             result_;
+
+  PromiseType() : cb_(nullptr) {}
+
+  // Always suspend, return to the caller
+  // and capture the callers handle and then immediately resume
+  // AwaitableStatus in status.h where co_await is overloaded on Status
+  std::experimental::suspend_always initial_suspend() {
+    return{};
+  }
+  // Return the awaiter so we can resume the calling coroutine
+  // essentially invoking the callback that points the next statement
+  // of the caller
+  auto final_suspend() {
+    struct CallbackAwaiterInvoker {
+      PromiseType* me_;
+      explicit CallbackAwaiterInvoker(PromiseType* p) : me_(p) {}
+      bool await_ready() { return false; }
+      void await_suspend(coroutine_handle) {
+        me_->cb_.resume();
+      }
+      void await_resume() {}
+    };
+    return CallbackAwaiterInvoker{ this };
+  }
+  // Called automatically by co_return statement
+  template<typename U>
+  void return_value(U&& v) {
+    result_ = std::forward<U&&>(v);
+  }
+};
+} // rocksdb
+
+#endif // STORAGE_ROCKSDB_INCLUDE_CORO_PROMISE_H_
+

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "rocksdb/async/asyncthreadpool.h"
 #include "rocksdb/status.h"
 #include "rocksdb/thread_status.h"
 
@@ -76,6 +77,12 @@ struct EnvOptions {
   // If true, then use O_DIRECT for writing data
   bool use_direct_writes = false;
 
+  // If true, random reads will be performed
+  // in async manner. ReadOptions must also have
+  // async_reads = true set and a callback for
+  // the DB::Get()/DB::MultiGet
+  bool use_async_reads = false;
+
   // If false, fallocate() calls are bypassed
   bool allow_fallocate = true;
 
@@ -107,6 +114,10 @@ struct EnvOptions {
 
   // If not nullptr, write rate limiting is enabled for flush and compaction
   RateLimiter* rate_limiter = nullptr;
+
+  // If use_async_reads = true then this thread-pool
+  // will be used to issue async reads
+  async::AsyncThreadPool* async_threadpool = nullptr;
 };
 
 class Env {
@@ -446,6 +457,15 @@ class Env {
   // Returns the ID of the current thread.
   virtual uint64_t GetThreadID() const;
 
+  // This is a platform specific factory method that can instantiate
+  // platform dependent implementation of thread-pool that
+  // will run async callbacks.
+  // Context is also platform dependent
+  virtual std::unique_ptr<async::AsyncThreadPool> CreateAsyncThreadPool(
+    void* /* context */) {
+    return nullptr;
+  }
+
  protected:
   // The pointer to an internal structure that will update the
   // status of each thread.
@@ -513,7 +533,6 @@ class SequentialFile {
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
  public:
-
   RandomAccessFile() { }
   virtual ~RandomAccessFile();
 
@@ -529,6 +548,12 @@ class RandomAccessFile {
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const = 0;
+
+  // For coroutines only
+  virtual Status RequestRead(uint64_t offset, size_t n, Slice* result,
+    char* scratch) const {
+    return Status::NotSupported();
+  }
 
   // Readahead the file starting from offset by n bytes for caching.
   virtual Status Prefetch(uint64_t offset, size_t n) {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include "rocksdb/advanced_options.h"
+#include "rocksdb/async/asyncthreadpool.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/env.h"
 #include "rocksdb/listener.h"
@@ -354,6 +355,9 @@ struct DBOptions {
   // Default: nullptr
   std::shared_ptr<RateLimiter> rate_limiter = nullptr;
 
+  // A thread-pool that is capable of handling async IO operations
+  std::shared_ptr<async::AsyncThreadPool>  async_threadpool = nullptr;
+
   // Use to track SST files and control their file deletion rate.
   //
   // Features:
@@ -598,6 +602,12 @@ struct DBOptions {
   // Default: false
   // Not supported in ROCKSDB_LITE mode!
   bool use_direct_io_for_flush_and_compaction = false;
+
+  // If true, random reads will be performed
+  // in async manner. ReadOptions must also have
+  // async_reads = true set and a callback for
+  // the DB::Get()/DB::MultiGet
+  bool use_async_reads = false;
 
   // If false, fallocate() calls are bypassed
   bool allow_fallocate = true;

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -54,6 +54,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       use_direct_reads(options.use_direct_reads),
       use_direct_io_for_flush_and_compaction(
           options.use_direct_io_for_flush_and_compaction),
+      use_async_reads(options.use_async_reads),
       allow_fallocate(options.allow_fallocate),
       is_fd_close_on_exec(options.is_fd_close_on_exec),
       advise_random_on_open(options.advise_random_on_open),
@@ -132,6 +133,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    "                       "
                    "Options.use_direct_io_for_flush_and_compaction: %d",
                    use_direct_io_for_flush_and_compaction);
+  ROCKS_LOG_HEADER(log, "                       Options.use_async_reads: %d",
+                   use_async_reads);
   ROCKS_LOG_HEADER(log, "         Options.create_missing_column_families: %d",
                    create_missing_column_families);
   ROCKS_LOG_HEADER(log, "                             Options.db_log_dir: %s",
@@ -172,8 +175,10 @@ void ImmutableDBOptions::Dump(Logger* log) const {
       random_access_max_buffer_size);
   ROCKS_LOG_HEADER(log, "                     Options.use_adaptive_mutex: %d",
                    use_adaptive_mutex);
+  ROCKS_LOG_HEADER(log, "                           Options.async_threadpool: %p",
+                   async_threadpool.get());
   ROCKS_LOG_HEADER(log, "                           Options.rate_limiter: %p",
-                   rate_limiter.get());
+                 rate_limiter.get());
   Header(
       log, "    Options.sst_file_manager.rate_bytes_per_sec: %" PRIi64,
       sst_file_manager ? sst_file_manager->GetDeleteRateBytesPerSecond() : 0);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -24,6 +24,7 @@ struct ImmutableDBOptions {
   bool paranoid_checks;
   Env* env;
   std::shared_ptr<RateLimiter> rate_limiter;
+  std::shared_ptr<async::AsyncThreadPool> async_threadpool;
   std::shared_ptr<SstFileManager> sst_file_manager;
   std::shared_ptr<Logger> info_log;
   InfoLogLevel info_log_level;
@@ -48,6 +49,7 @@ struct ImmutableDBOptions {
   bool allow_mmap_writes;
   bool use_direct_reads;
   bool use_direct_io_for_flush_and_compaction;
+  bool use_async_reads;
   bool allow_fallocate;
   bool is_fd_close_on_exec;
   bool advise_random_on_open;

--- a/options/options.cc
+++ b/options/options.cc
@@ -102,6 +102,7 @@ ColumnFamilyOptions::ColumnFamilyOptions(const Options& options)
     : ColumnFamilyOptions(*static_cast<const ColumnFamilyOptions*>(&options)) {}
 
 DBOptions::DBOptions() {}
+
 DBOptions::DBOptions(const Options& options)
     : DBOptions(*static_cast<const DBOptions*>(&options)) {}
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -37,6 +37,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.paranoid_checks = immutable_db_options.paranoid_checks;
   options.env = immutable_db_options.env;
   options.rate_limiter = immutable_db_options.rate_limiter;
+  options.async_threadpool = immutable_db_options.async_threadpool;
   options.sst_file_manager = immutable_db_options.sst_file_manager;
   options.info_log = immutable_db_options.info_log;
   options.info_log_level = immutable_db_options.info_log_level;
@@ -76,6 +77,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.use_direct_reads = immutable_db_options.use_direct_reads;
   options.use_direct_io_for_flush_and_compaction =
       immutable_db_options.use_direct_io_for_flush_and_compaction;
+  options.use_async_reads = immutable_db_options.use_async_reads;
   options.allow_fallocate = immutable_db_options.allow_fallocate;
   options.is_fd_close_on_exec = immutable_db_options.is_fd_close_on_exec;
   options.stats_dump_period_sec = mutable_db_options.stats_dump_period_sec;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -181,6 +181,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, env), sizeof(Env*)},
       {offsetof(struct DBOptions, rate_limiter),
        sizeof(std::shared_ptr<RateLimiter>)},
+     { offsetof(struct DBOptions, async_threadpool),
+       sizeof(std::shared_ptr<async::AsyncThreadPool>) },
       {offsetof(struct DBOptions, sst_file_manager),
        sizeof(std::shared_ptr<SstFileManager>)},
       {offsetof(struct DBOptions, info_log), sizeof(std::shared_ptr<Logger>)},
@@ -265,6 +267,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "allow_mmap_reads=false;"
                              "use_direct_reads=false;"
                              "use_direct_io_for_flush_and_compaction=false;"
+                             "use_async_reads=false;"
                              "max_log_file_size=4607;"
                              "random_access_max_buffer_size=1048576;"
                              "advise_random_on_open=true;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -123,6 +123,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"allow_mmap_writes", "false"},
       {"use_direct_reads", "false"},
       {"use_direct_io_for_flush_and_compaction", "false"},
+      { "use_async_reads", "false" },
       {"is_fd_close_on_exec", "true"},
       {"skip_log_error_on_recovery", "false"},
       {"stats_dump_period_sec", "46"},
@@ -248,6 +249,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_db_opt.allow_mmap_writes, false);
   ASSERT_EQ(new_db_opt.use_direct_reads, false);
   ASSERT_EQ(new_db_opt.use_direct_io_for_flush_and_compaction, false);
+  ASSERT_EQ(new_db_opt.use_async_reads, false);
   ASSERT_EQ(new_db_opt.is_fd_close_on_exec, true);
   ASSERT_EQ(new_db_opt.skip_log_error_on_recovery, false);
   ASSERT_EQ(new_db_opt.stats_dump_period_sec, 46U);

--- a/port/win/asyncthreadpoolimpl.cc
+++ b/port/win/asyncthreadpoolimpl.cc
@@ -1,0 +1,114 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "port/win/asyncthreadpoolimpl.h"
+#include "port/win/iocompletion.h"
+#include "port/win/winasyncthreadpoolimpl.h"
+
+namespace rocksdb {
+namespace port {
+
+ThreadPoolTaskToken::ThreadPoolTaskToken() {
+}
+
+ThreadPoolTaskToken::~ThreadPoolTaskToken() {
+}
+
+// Default destruction
+void ThreadPoolTaskToken::Destroy() {
+  delete this;
+}
+
+void CALLBACK ThreadPoolTaskToken::Cleanup(void* context, void*) {
+  if (context != nullptr) {
+    reinterpret_cast<ThreadPoolTaskToken*>(context)->Destroy();
+  }
+}
+
+/////////////////////////////////////////////////////////////////////
+// WinIOCompletionThreadToken
+
+class WinIOCompletionThreadToken : public ThreadPoolTaskToken {
+  IOCompletion* io_compl_;
+public:
+  explicit
+    WinIOCompletionThreadToken(IOCompletion* io_compl) :
+    io_compl_(io_compl) {
+  }
+
+  WinIOCompletionThreadToken(const WinIOCompletionThreadToken&) = delete;
+  WinIOCompletionThreadToken& operator=(const WinIOCompletionThreadToken&) = delete;
+
+  // Called when thread-pool cleans up
+  // outstanding items on destruction
+  void Reset() {
+    io_compl_ = nullptr;
+  }
+
+  ~WinIOCompletionThreadToken() {
+    if (io_compl_ != nullptr) {
+      io_compl_->Reset();
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////
+/// WinAsyncThreadPool
+
+WinAsyncThreadPool::WinAsyncThreadPool(PTP_POOL ptp_pool) {
+
+  InitializeThreadpoolEnvironment(&env_);
+  SetThreadpoolCallbackPool(&env_, ptp_pool);
+
+  ptp_cgroup_ = CreateThreadpoolCleanupGroup();
+
+  SetThreadpoolCallbackCleanupGroup(&env_, 
+    ptp_cgroup_, &ThreadPoolTaskToken::Cleanup);
+}
+
+WinAsyncThreadPool::~WinAsyncThreadPool() {
+  CloseThreadPool();
+}
+
+std::unique_ptr<IOCompletion>
+WinAsyncThreadPool::MakeIOCompletion(HANDLE hDevice, 
+  IOCompletionCallback cb) {
+
+  std::unique_ptr<IOCompletion> iocompl(new IOCompletion);
+  auto tp_token = new port::WinIOCompletionThreadToken(iocompl.get());
+
+  auto ptp_io = CreateThreadpoolIo(hDevice, cb, tp_token, &env_);
+
+  if (ptp_io == nullptr) {
+    tp_token->Destroy();
+    return nullptr;
+  }
+
+  iocompl->SetWrapper(ptp_io, tp_token);
+  return iocompl;
+}
+
+void WinAsyncThreadPool::CloseThreadPool() {
+  // Wait for all of the IO to complete
+  // and clean it up
+  if (ptp_cgroup_ != nullptr) {
+
+    const BOOL c_CancelPendingCallbacksFalse = FALSE;
+
+    CloseThreadpoolCleanupGroupMembers(ptp_cgroup_, 
+      c_CancelPendingCallbacksFalse, nullptr);
+    CloseThreadpoolCleanupGroup(ptp_cgroup_);
+    ptp_cgroup_ = nullptr;
+
+    DestroyThreadpoolEnvironment(&env_);
+  }
+}
+
+} // namepsace port
+} // namespace rocksdb

--- a/port/win/asyncthreadpoolimpl.h
+++ b/port/win/asyncthreadpoolimpl.h
@@ -1,0 +1,56 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include "rocksdb/async/asyncthreadpool.h"
+
+#include <memory>
+
+#include <Windows.h>
+
+namespace rocksdb {
+namespace port {
+// This class is a sentinel
+// that can signal our user-defined
+// objects that the thread-pool has cleaned
+// up a TP item and thus operations on that
+// IO completion object or anything else
+// is no longer possible and no cleanup is
+// necessary.
+class ThreadPoolTaskToken {
+protected:
+  ThreadPoolTaskToken();
+  virtual ~ThreadPoolTaskToken();
+public:
+  // customize destruction as it may require
+  // some custom actions before the __dtor
+  // is invoked
+  virtual void Destroy();
+  // static TP callback that is
+  // called to cleanup items that are either
+  // in the queue or semi-permanent objects
+  // such as work items or io completion objects
+  static void CALLBACK Cleanup(void* context, void*);
+};
+
+// This is a callback that is to be submitted for I/O
+// completion
+using
+IOCompletionCallback = VOID(CALLBACK *)(
+  PTP_CALLBACK_INSTANCE Instance,
+  PVOID Context,
+  PVOID Overlapped,
+  ULONG ioResult,
+  ULONG_PTR bytesTransferred,
+  PTP_IO ptp_io);
+
+} // namespace async
+} //namespace rocksdb
+

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -27,6 +27,10 @@
 #include "port/dirent.h"
 #include "port/win/win_logger.h"
 #include "port/win/io_win.h"
+#include "port/win/iocompletion.h"
+#include "port/win/win_logger.h"
+#include "port/win/win_thread.h"
+#include "port/win/winasyncthreadpoolimpl.h"
 
 #include "monitoring/iostats_context_imp.h"
 
@@ -151,6 +155,7 @@ Status WinEnvIO::NewSequentialFile(const std::string& fname,
 Status WinEnvIO::NewRandomAccessFile(const std::string& fname,
   std::unique_ptr<RandomAccessFile>* result,
   const EnvOptions& options) {
+
   result->reset();
   Status s;
 
@@ -162,6 +167,18 @@ Status WinEnvIO::NewRandomAccessFile(const std::string& fname,
     fileFlags |= FILE_FLAG_NO_BUFFERING;
   } else {
     fileFlags |= FILE_FLAG_RANDOM_ACCESS;
+  }
+
+  // TODO: Need to disqualify async when doing things
+  // other than reading the tables. Disable it for compactions.
+  if (options.use_async_reads && !options.use_mmap_reads) {
+
+    fileFlags |= FILE_FLAG_OVERLAPPED;
+
+    if (options.async_threadpool == nullptr) {
+      return Status::InvalidArgument(
+        "WinEnvIO::NewRandomAccessFile async_threadpool not provided");
+    }
   }
 
   /// Shared access is necessary for corruption test to pass
@@ -232,7 +249,24 @@ Status WinEnvIO::NewRandomAccessFile(const std::string& fname,
       fileGuard.release();
     }
   } else {
-    result->reset(new WinRandomAccessFile(fname, hFile, page_size_, options));
+
+    std::unique_ptr<IOCompletion> iocompl;
+      auto tp = reinterpret_cast<WinAsyncThreadPool*>(
+        options.async_threadpool);
+      iocompl = tp->MakeIOCompletion(hFile, &WinRandomAccessImpl::OnAsyncReadCompletion);
+      if (!iocompl) {
+        auto lastError = GetLastError();
+        return IOErrorFromWindowsError(fname, lastError);
+      }
+
+      // Do not require setting an event since we are using a compl port
+      // and in case the operation completes sync we do not want
+      // a callback dispatch
+      SetFileCompletionNotificationModes(hFile,
+        FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
+
+    result->reset(new WinRandomAccessFile(fname, hFile, page_size_, options,
+      std::move(iocompl)));
     fileGuard.release();
   }
   return s;
@@ -1078,6 +1112,12 @@ unsigned int  WinEnv::GetThreadPoolQueueLen(Env::Priority pri) const {
 
 uint64_t WinEnv::GetThreadID() const {
   return winenv_threads_.GetThreadID();
+}
+
+std::unique_ptr<async::AsyncThreadPool> WinEnv::CreateAsyncThreadPool(void * context) {
+  std::unique_ptr<async::AsyncThreadPool> pool ( 
+    new WinAsyncThreadPool(reinterpret_cast<PTP_POOL>(context)));
+  return pool;
 }
 
 void WinEnv::SleepForMicroseconds(int micros) {

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -251,7 +251,8 @@ Status WinEnvIO::NewRandomAccessFile(const std::string& fname,
   } else {
 
     std::unique_ptr<IOCompletion> iocompl;
-      auto tp = reinterpret_cast<WinAsyncThreadPool*>(
+#ifdef ROCKSDB_COROUTINES
+    auto tp = reinterpret_cast<WinAsyncThreadPool*>(
         options.async_threadpool);
       iocompl = tp->MakeIOCompletion(hFile, &WinRandomAccessImpl::OnAsyncReadCompletion);
       if (!iocompl) {
@@ -264,7 +265,7 @@ Status WinEnvIO::NewRandomAccessFile(const std::string& fname,
       // a callback dispatch
       SetFileCompletionNotificationModes(hFile,
         FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
-
+#endif // ROCKSDB_COROUTINES
     result->reset(new WinRandomAccessFile(fname, hFile, page_size_, options,
       std::move(iocompl)));
     fileGuard.release();

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -286,6 +286,9 @@ public:
 
   uint64_t GetThreadID() const override;
 
+  std::unique_ptr<async::AsyncThreadPool> CreateAsyncThreadPool(void* 
+    context) override;
+
   void SleepForMicroseconds(int micros) override;
 
   // Allow increasing the number of worker threads.

--- a/port/win/iocompletion.cc
+++ b/port/win/iocompletion.cc
@@ -1,0 +1,47 @@
+
+#include "port/win/iocompletion.h"
+#include "port/win/asyncthreadpoolimpl.h"
+
+#include <Windows.h>
+
+namespace rocksdb {
+namespace port {
+
+//////////////////////////////////////////////////////////////////////////////
+// IOCompletion
+
+IOCompletion::~IOCompletion() {
+  Close();
+}
+
+inline
+PTP_IO GetHandle(void* h) {
+  return reinterpret_cast<PTP_IO>(h);
+}
+
+void IOCompletion::Start() const {
+  ::StartThreadpoolIo(GetHandle(io_compl_));
+}
+
+// Can only be called if Start()
+// was called
+void IOCompletion::Cancel() const {
+  ::CancelThreadpoolIo(GetHandle(io_compl_));
+}
+
+void IOCompletion::Close() {
+
+  if (io_compl_ != nullptr) {
+    // Wait for all of them to finish
+    ::WaitForThreadpoolIoCallbacks(GetHandle(io_compl_), FALSE);
+    ::CloseThreadpoolIo(GetHandle(io_compl_));
+    io_compl_ = nullptr;
+  }
+
+  if (tp_tasktoken_ != nullptr) {
+    reinterpret_cast<ThreadPoolTaskToken*>(tp_tasktoken_)->Destroy();
+    tp_tasktoken_ = nullptr;
+  }
+}
+} // namespace async
+} //namespace rocksdb

--- a/port/win/iocompletion.h
+++ b/port/win/iocompletion.h
@@ -1,0 +1,79 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <utility>
+
+namespace rocksdb {
+namespace port {
+
+class IOCompletion {
+public:
+
+  IOCompletion() noexcept :
+    io_compl_(nullptr),
+    tp_tasktoken_(nullptr) {
+  }
+
+  // On destruction do nothing as
+  // we either cancel this explicitly
+  // or it completes successfully and
+  // is taken care of
+  ~IOCompletion();
+
+  IOCompletion(const IOCompletion&) = delete;
+  IOCompletion& operator=(const IOCompletion&) = delete;
+
+  IOCompletion(IOCompletion&& o) noexcept :
+  IOCompletion() {
+    *this = std::move(o);
+  }
+
+  IOCompletion& operator=(IOCompletion&& o) noexcept {
+    std::swap(io_compl_, o.io_compl_);
+    std::swap(tp_tasktoken_, o.tp_tasktoken_);
+    return *this;
+  }
+
+  void Start() const;
+
+  // Can only be called if Start()
+  // was called
+  void Cancel() const;
+
+  bool Valid() const {
+    return io_compl_ != nullptr;
+  }
+
+  void SetWrapper(void *ptp_io, void* tp_wrapper) {
+    io_compl_ = ptp_io;
+    tp_tasktoken_ = tp_wrapper;
+  }
+
+  // Called out by a thread-pool that
+  // is cleaning this up and does not want
+  // us to do so
+  void Reset() {
+    io_compl_ = nullptr;
+    tp_tasktoken_ = nullptr;
+  }
+
+  // Associated file handle must be closed
+  // after this
+  void Close();
+
+private:
+  void*          io_compl_;
+  void*          tp_tasktoken_;
+};
+
+} // namespace async
+} //namespace rocksdb
+

--- a/port/win/winasyncthreadpoolimpl.h
+++ b/port/win/winasyncthreadpoolimpl.h
@@ -1,0 +1,49 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include "port/win/asyncthreadpoolimpl.h"
+
+#include <Windows.h>
+
+namespace rocksdb {
+namespace port {
+
+class IOCompletion;
+// This class is initialized by a Vista ThreadPool handle
+// Creates its own TP environment for easy cleanup
+// It issues IOCompletion instances used by files for async IO
+// This is not a general purpose threadpool, rather it is a
+// lightweight interface to issue IOCompletion instances
+// for files that facilitate async IO
+class WinAsyncThreadPool : public async::AsyncThreadPool {
+
+  TP_CALLBACK_ENVIRON       env_;
+  PTP_CLEANUP_GROUP         ptp_cgroup_;
+
+public:
+  explicit
+  WinAsyncThreadPool(PTP_POOL ptp_pool);
+
+  ~WinAsyncThreadPool();
+
+  WinAsyncThreadPool(const WinAsyncThreadPool&) = delete;
+  WinAsyncThreadPool& operator=(const WinAsyncThreadPool&) = delete;
+
+  std::unique_ptr<IOCompletion>
+  MakeIOCompletion(HANDLE hDevice, IOCompletionCallback cb);
+
+  void CloseThreadPool() override;
+};
+
+} // namespace port
+} //namespace rocksdb
+
+

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -105,6 +105,14 @@ class RandomAccessFileReader {
 
   Status Read(uint64_t offset, size_t n, Slice* result, char* scratch) const;
 
+// Separate entry point only for demonstration purposes so we donot break
+// the rest of the build as with coroutines
+// we do not really need to change code simply insert co_await/co_return macros
+// below is a copy of Read with those
+#ifdef ROCKSDB_COROUTINES
+  Status RequestRead(uint64_t offset, size_t n, Slice* result, char* scratch) const;
+#endif // ROCKSDB_COROUTINES
+
   Status Prefetch(uint64_t offset, size_t n) const {
     return file_->Prefetch(offset, n);
   }

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -24,9 +24,10 @@ namespace rocksdb {
 //
 Status NewWritableCacheFile(Env* const env, const std::string& filepath,
                             std::unique_ptr<WritableFile>* file,
-                            const bool use_direct_writes = false) {
+                            const bool use_direct_io_for_flush_and_compaction = false) {
   EnvOptions opt;
-  opt.use_direct_writes = use_direct_writes;
+  opt.use_direct_writes = 
+    use_direct_io_for_flush_and_compaction;
   Status s = env->NewWritableFile(filepath, file, opt);
   return s;
 }


### PR DESCRIPTION
  with async/coroutine_random_access_test.cc windows only test.
  RandomAccessFileReader::RequestRead() is a clone of Read() for test purposes.
  demonstrates minimal would be changes to Read() with the insertion of 3 keywords
  and keeping the source code intact.
  Some scaffolding is required but it is all on the side and does not affect the code flow.
  The downside that we would need to keep track that all functions on the way
  down to I/O become coroutines and make use of co_await and co_return if they returning
  anything (usually status). A separate AppVeyor build would be enough to make sure we are OK.
  Use VS 2017 to build. It might work on 2015, I have not tried yet.
  Use -DWITH_COROUTINES=1 to enable coroutines.
  The output on my box is:
  [==========] Running 2 tests from 1 test case.
  [----------] Global test environment set-up.
  [----------] 2 tests from TestAsyncRead/RandomAccessCoroutineTest
  [ RUN      ] TestAsyncRead/RandomAccessCoroutineTest.TestAsyncRead/0
  Thread ID before co_await: 240 after co_await: 27328
  Read:7936 bytes, status: OK
  Wait completed
  Thread ID before co_await: 2600 after co_await: 27328
  Thread ID before co_await: 17928 after co_await: 9420
  Read:7935 bytes, status: OK
  Thread ID before co_await: 28480 after co_await: 30912
  Thread ID before co_await: 25000 after co_await: 15280
  Thread ID before co_await: 14312 after co_await: 21532
  Read:7935 bytes, status: OK
  Thread ID before co_await: 19940 after co_await: 14912
  Thread ID before co_await: 7188 after co_await: 9420
  Thread ID before co_await: 360 after co_await: 7012
  Thread ID before co_await: 28892 after co_await: 27328
  Thread ID before co_await: 14744 after co_await: 26552
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Thread ID before co_await: 13904 after co_await: 12556
  Thread ID before co_await: 15712 after co_await: 28904
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  [       OK ] TestAsyncRead/RandomAccessCoroutineTest.TestAsyncRead/0 (235 ms)
  [ RUN      ] TestAsyncRead/RandomAccessCoroutineTest.TestAsyncRead/1
  Thread ID before co_await: 240 after co_await: 13428
  Read:7936 bytes, status: OK
  Wait completed
  Thread ID before co_await: 26040 after co_await: 13428
  Thread ID before co_await: 10276 after co_await: 14276
  Read:7935 bytes, status: OK
  Read:Thread ID before co_await: 7396Thread ID before co_await: 20800 after co_await: 18884
  Thread ID before co_await: 20684 after co_await: 26680
  Thread ID before co_await: 16728 after co_await: 18724
  Thread ID before co_await: 27968 after co_await: 7148
  after co_await: 13428
  Thread ID before co_await: 27496 after co_await: 22984
  Read:Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Thread ID before co_await: 21056 after co_await: 2012
  Read:7935 bytes, status: OK
  Thread ID before co_await: 29944 after co_await: 2896
  7935Read:7935 bytes, status: OK
  bytes, status: OK
  Thread ID before co_await: 10464 after co_await: 31984
  Read:7935 bytes, status: OK
  Thread ID before co_await: 15656 after co_await: 22984
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  Read:7935 bytes, status: OK
  [       OK ] TestAsyncRead/RandomAccessCoroutineTest.TestAsyncRead/1 (230 ms)
  [----------] 2 tests from TestAsyncRead/RandomAccessCoroutineTest (467 ms total)

  [----------] Global test environment tear-down
  [==========] 2 tests from 1 test case ran. (468 ms total)
  [  PASSED  ] 2 tests.