### PR TITLE
Use block cache to track memory usage when ReadOptions.fill_cache=false

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1508,42 +1508,43 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
     assert(block.value != nullptr);
     iter = block.value->NewIterator(&rep->internal_comparator, input_iter, true,
                                     rep->ioptions.statistics);
-    if (!ro.fill_cache && rep->cache_key_prefix_size != 0) {
-      // insert a dummy record to block cache to track the memory usage
-      Cache::Handle* cache_handle;
-      // There are two other types of cache keys: 1) SST cache key added in
-      // `MaybeLoadDataBlockToCache` 2) dummy cache key added in
-      // `write_buffer_manager`. Use longer prefix (41 bytes) to differentiate
-      // from SST cache key(31 bytes), and use non-zero prefix to differentiate
-      // from `write_buffer_manager`
-      const size_t kExtraCacheKeyPrefix = kMaxVarint64Length * 4 + 1;
-      char cache_key[kExtraCacheKeyPrefix + kMaxVarint64Length];
-      // Prefix: use rep->cache_key_prefix padded by 0s
-      memset(cache_key, 0, kExtraCacheKeyPrefix + kMaxVarint64Length);
-      assert(rep->cache_key_prefix_size != 0);
-      assert(rep->cache_key_prefix_size <= kExtraCacheKeyPrefix);
-      memcpy(cache_key, rep->cache_key_prefix, rep->cache_key_prefix_size);
-      char* end = EncodeVarint64(cache_key + kExtraCacheKeyPrefix,
-                                 next_cache_key_id_++);
-      assert(end - cache_key <=
-             static_cast<int>(kExtraCacheKeyPrefix + kMaxVarint64Length));
-      Slice unique_key = Slice(cache_key, static_cast<size_t>(end - cache_key));
-      s = block_cache->Insert(unique_key, nullptr, block.value->usable_size(),
-                          nullptr, &cache_handle);
-      if (s.ok()) {
-        if (cache_handle != nullptr) {
-          iter->RegisterCleanup(&ForceReleaseCachedEntry, block_cache, cache_handle);
-        }
-      }
-      else {
-        delete block.value;
-        block.value = nullptr;
-      }
-    }
     if (block.cache_handle != nullptr) {
       iter->RegisterCleanup(&ReleaseCachedEntry, block_cache,
                             block.cache_handle);
     } else {
+      if (!ro.fill_cache && rep->cache_key_prefix_size != 0) {
+        // insert a dummy record to block cache to track the memory usage
+        Cache::Handle* cache_handle;
+        // There are two other types of cache keys: 1) SST cache key added in
+        // `MaybeLoadDataBlockToCache` 2) dummy cache key added in
+        // `write_buffer_manager`. Use longer prefix (41 bytes) to differentiate
+        // from SST cache key(31 bytes), and use non-zero prefix to
+        // differentiate from `write_buffer_manager`
+        const size_t kExtraCacheKeyPrefix = kMaxVarint64Length * 4 + 1;
+        char cache_key[kExtraCacheKeyPrefix + kMaxVarint64Length];
+        // Prefix: use rep->cache_key_prefix padded by 0s
+        memset(cache_key, 0, kExtraCacheKeyPrefix + kMaxVarint64Length);
+        assert(rep->cache_key_prefix_size != 0);
+        assert(rep->cache_key_prefix_size <= kExtraCacheKeyPrefix);
+        memcpy(cache_key, rep->cache_key_prefix, rep->cache_key_prefix_size);
+        char* end = EncodeVarint64(cache_key + kExtraCacheKeyPrefix,
+                                   next_cache_key_id_++);
+        assert(end - cache_key <=
+               static_cast<int>(kExtraCacheKeyPrefix + kMaxVarint64Length));
+        Slice unique_key =
+            Slice(cache_key, static_cast<size_t>(end - cache_key));
+        s = block_cache->Insert(unique_key, nullptr, block.value->usable_size(),
+                                nullptr, &cache_handle);
+        if (s.ok()) {
+          if (cache_handle != nullptr) {
+            iter->RegisterCleanup(&ForceReleaseCachedEntry, block_cache,
+                                  cache_handle);
+          }
+        } else {
+          delete block.value;
+          block.value = nullptr;
+        }
+      }
       iter->RegisterCleanup(&DeleteHeldResource<Block>, block.value, nullptr);
     }
   } else {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -116,6 +116,13 @@ void ReleaseCachedEntry(void* arg, void* h) {
   cache->Release(handle);
 }
 
+// Release the cached entry and decrement its ref count.
+void ForceReleaseCachedEntry(void* arg, void* h) {
+  Cache* cache = reinterpret_cast<Cache*>(arg);
+  Cache::Handle* handle = reinterpret_cast<Cache::Handle*>(h);
+  cache->Release(handle, true);
+}
+
 Slice GetCacheKeyFromOffset(const char* cache_key_prefix,
                             size_t cache_key_prefix_size, uint64_t offset,
                             char* cache_key) {
@@ -1518,11 +1525,12 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
       memcpy(cache_key, rep->cache_key_prefix, rep->cache_key_prefix_size);
       char* end = EncodeVarint64(cache_key + kExtraCacheKeyPrefix,
                                  next_cache_key_id_++);
-      assert(end - cache_key <= int(kExtraCacheKeyPrefix + kMaxVarint64Length));
+      assert(end - cache_key <=
+             static_cast<int>(kExtraCacheKeyPrefix + kMaxVarint64Length));
       Slice unique_key = Slice(cache_key, static_cast<size_t>(end - cache_key));
       block_cache->Insert(unique_key, nullptr, block.value->size(), nullptr,
                           &cache_handle);
-      iter->RegisterCleanup(&ReleaseCachedEntry, block_cache, cache_handle);
+      iter->RegisterCleanup(&ForceReleaseCachedEntry, block_cache, cache_handle);
     } else if (block.cache_handle != nullptr) {
       iter->RegisterCleanup(&ReleaseCachedEntry, block_cache,
                             block.cache_handle);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1516,15 +1516,14 @@ InternalIterator* BlockBasedTable::NewDataBlockIterator(
       assert(rep->cache_key_prefix_size != 0);
       assert(rep->cache_key_prefix_size <= kExtraCacheKeyPrefix);
       memcpy(cache_key, rep->cache_key_prefix, rep->cache_key_prefix_size);
-      char* end =
-          EncodeVarint64(cache_key + kExtraCacheKeyPrefix, next_cache_key_id_++);
-      assert(end - cache_key <= int (kExtraCacheKeyPrefix + kMaxVarint64Length));
+      char* end = EncodeVarint64(cache_key + kExtraCacheKeyPrefix,
+                                 next_cache_key_id_++);
+      assert(end - cache_key <= int(kExtraCacheKeyPrefix + kMaxVarint64Length));
       Slice unique_key = Slice(cache_key, static_cast<size_t>(end - cache_key));
-      block_cache->Insert(unique_key, nullptr, block.value->size(),
-                          nullptr, &cache_handle);
+      block_cache->Insert(unique_key, nullptr, block.value->size(), nullptr,
+                          &cache_handle);
       iter->RegisterCleanup(&ReleaseCachedEntry, block_cache, cache_handle);
-    }
-    else if (block.cache_handle != nullptr) {
+    } else if (block.cache_handle != nullptr) {
       iter->RegisterCleanup(&ReleaseCachedEntry, block_cache,
                             block.cache_handle);
     } else {

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -214,6 +214,7 @@ class BlockBasedTable : public TableReader {
 
  private:
   friend class MockedBlockBasedTable;
+  static std::atomic<uint64_t> next_cache_key_id_;
   // input_iter: if it is not null, update this one and return it as Iterator
   static InternalIterator* NewDataBlockIterator(
       Rep* rep, const ReadOptions& ro, const Slice& index_value,


### PR DESCRIPTION
ReadOptions.fill_cache is set in compaction inputs and can be set by users in their queries too. It tells RocksDB not to put a data block used to block cache.

The memory used by the data block is, however, not trackable by users.

To make the system more manageable, we can cost the block to block cache while using it, and then release it after using.
