### PR TITLE
Callback bridge for Java-based CompactionFilter

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -9,6 +9,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/compaction_filter.cc
         rocksjni/compaction_filter_factory.cc
         rocksjni/compaction_filter_factory_jnicallback.cc
+        rocksjni/compaction_filter_jnicallback.cc
         rocksjni/compaction_options_fifo.cc
         rocksjni/compaction_options_universal.cc
         rocksjni/comparator.cc
@@ -52,6 +53,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.AbstractCompactionFilter
         org.rocksdb.AbstractCompactionFilterFactory
         org.rocksdb.AbstractImmutableNativeReference
+        org.rocksdb.AbstractJavaCompactionFilter.java
         org.rocksdb.AbstractNativeReference
         org.rocksdb.AbstractRocksIterator
         org.rocksdb.AbstractSlice
@@ -147,6 +149,7 @@ add_jar(
   src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
   src/main/java/org/rocksdb/AbstractComparator.java
   src/main/java/org/rocksdb/AbstractImmutableNativeReference.java
+  src/main/java/org/rocksdb/AbstractJavaCompactionFilter.java
   src/main/java/org/rocksdb/AbstractNativeReference.java
   src/main/java/org/rocksdb/AbstractRocksIterator.java
   src/main/java/org/rocksdb/AbstractSlice.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,6 +1,6 @@
 NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.AbstractCompactionFilterFactory\
-    org.rocksdb.AbstractJavaCompactionFilter\
+	org.rocksdb.AbstractJavaCompactionFilter\
 	org.rocksdb.AbstractSlice\
 	org.rocksdb.BackupEngine\
 	org.rocksdb.BackupableDBOptions\

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,5 +1,6 @@
 NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.AbstractCompactionFilterFactory\
+    org.rocksdb.AbstractJavaCompactionFilter\
 	org.rocksdb.AbstractSlice\
 	org.rocksdb.BackupEngine\
 	org.rocksdb.BackupableDBOptions\
@@ -97,6 +98,7 @@ JAVA_TESTS = org.rocksdb.BackupableDBOptionsTest\
 	org.rocksdb.FilterTest\
 	org.rocksdb.FlushTest\
 	org.rocksdb.InfoLogLevelTest\
+	org.rocksdb.JavaCompactionFilterTest\
 	org.rocksdb.KeyMayExistTest\
 	org.rocksdb.LoggerTest\
 	org.rocksdb.LRUCacheTest\

--- a/java/rocksjni/compaction_filter.cc
+++ b/java/rocksjni/compaction_filter.cc
@@ -9,7 +9,9 @@
 #include <jni.h>
 
 #include "include/org_rocksdb_AbstractCompactionFilter.h"
+#include "include/org_rocksdb_AbstractJavaCompactionFilter.h"
 #include "rocksdb/compaction_filter.h"
+#include "rocksjni/compaction_filter_jnicallback.h"
 
 // <editor-fold desc="org.rocksdb.AbstractCompactionFilter">
 
@@ -24,4 +26,26 @@ void Java_org_rocksdb_AbstractCompactionFilter_disposeInternal(
   assert(cf != nullptr);
   delete cf;
 }
+
+/*
+ * Class:     org_rocksdb_AbstractJavaCompactionFilter
+ * Method:    newCompactionFilter
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_AbstractJavaCompactionFilter_newCompactionFilter(JNIEnv* env, jclass jcls) {
+  auto* compaction_filter = new rocksdb::CompactionFilterJniCallback();
+  return reinterpret_cast<jlong>(compaction_filter);
+}
+
+/*
+ * Class:     org_rocksdb_AbstractJavaCompactionFilter
+ * Method:    initializeFilter
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_AbstractJavaCompactionFilter_initializeFilter(
+    JNIEnv* env, jobject jobj, jlong handle) {
+  auto* compaction_filter = reinterpret_cast<rocksdb::CompactionFilterJniCallback*>(handle);
+  return compaction_filter->Initialize(env, jobj);
+}
+
 // </editor-fold>

--- a/java/rocksjni/compaction_filter_jnicallback.cc
+++ b/java/rocksjni/compaction_filter_jnicallback.cc
@@ -1,3 +1,10 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the callback "bridge" between Java and C++ for
+// rocksdb::CompactionFilter.
 
 #include <iostream>
 

--- a/java/rocksjni/compaction_filter_jnicallback.cc
+++ b/java/rocksjni/compaction_filter_jnicallback.cc
@@ -1,0 +1,223 @@
+
+#include <iostream>
+
+#include "rocksjni/compaction_filter_jnicallback.h"
+#include "rocksjni/portal.h"
+
+namespace rocksdb {
+
+/**
+ * Main initialization function. Caches a bunch of class and method references to speed up access later.
+ *
+ * @param env                    JNI environment
+ * @param jCompactionFilter      Reference to the CompactionFilter Java object that is being initialized.
+ * @return                       Success (true) or failure (false)
+ */
+bool CompactionFilterJniCallback::Initialize(JNIEnv *env, jobject jCompactionFilterLocalRef) {
+
+  // Cache a reference to the JVM. We can then use it to safely spawn JNIEnv references from multiple threads while in
+  // the FilterV2 method, which in turn will let us call back into Java.
+  const jint rs = env->GetJavaVM(&javaVM_);
+  if(rs != JNI_OK) {
+    // exception thrown
+    return false;
+  }
+
+  // Cache the CompactionFilter instance reference
+  assert(jCompactionFilterLocalRef != nullptr);
+  jCompactionFilter_ = env->NewGlobalRef(jCompactionFilterLocalRef);
+  if(jCompactionFilter_ == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return false;
+  }
+
+  // The name of a CompactionFilter will not change during its lifetime,
+  // so we call and cache it in a global var
+  jmethodID jNameMethodId = AbstractJavaCompactionFilterJni::getNameMethodId(env);
+  if(jNameMethodId == nullptr) {
+    // exception thrown: NoSuchMethodException or OutOfMemoryError
+    return false;
+  }
+  jstring jsName = (jstring)env->CallObjectMethod(jCompactionFilter_, jNameMethodId);
+  if(env->ExceptionCheck()) {
+    // exception thrown
+    return false;
+  }
+  jboolean has_exception = JNI_FALSE;
+  name_ = JniUtil::copyStdString(env, jsName,
+                                 &has_exception);  // also releases jsName
+  if (has_exception == JNI_TRUE) {
+    // exception thrown
+    return false;
+  }
+
+  // Cache the CompactionFilter#FilterV2Internal method reference
+  jCompactionFilterFilterV2InternalMethodId_ = AbstractJavaCompactionFilterJni::getFilterV2InternalMethodId(env);
+  if(jCompactionFilterFilterV2InternalMethodId_ == nullptr) {
+    // exception thrown: NoSuchMethodException or OutOfMemoryError
+    return false;
+  }
+
+  // Cache the CompactionOutput class reference
+  jCompactionOutputClass_ = CompactionOutputJni::getJClass(env);
+  if(jCompactionOutputClass_ == nullptr) {
+    // exception thrown: ClassNotFoundException or OutOfMemoryError
+    return false;
+  }
+
+  // Cache the CompactionOutput#decisionValue field reference
+  jCompactionOutputDecisionValueFieldId_ = CompactionOutputJni::getDecisionValueFieldId(env);
+  if(jCompactionOutputDecisionValueFieldId_ == nullptr) {
+    // exception thrown: NoSuchFieldException or OutOfMemoryError
+    return false;
+  }
+
+  // Cache the CompactionOutput#newValue field reference
+  jCompactionOutputNewValueFieldId_ = CompactionOutputJni::getNewValueFieldId(env);
+  if(jCompactionOutputNewValueFieldId_ == nullptr) {
+    // exception thrown: NoSuchFieldException or OutOfMemoryError
+    return false;
+  }
+
+  // Cache the CompactionOutput#skipUntil field reference
+  jCompactionOutputSkipUntilFieldId_ = CompactionOutputJni::getSkipUntilFieldId(env);
+  if(jCompactionOutputSkipUntilFieldId_ == nullptr) {
+    // exception thrown: NoSuchFieldException or OutOfMemoryError
+    return false;
+  }
+
+  // Success
+  return true;
+
+}
+
+/**
+ * Destructor. Releases all the global references.
+ */
+CompactionFilterJniCallback::~CompactionFilterJniCallback() {
+  jboolean attached_thread = JNI_FALSE;
+  JNIEnv* env = JniUtil::getJniEnv(javaVM_, &attached_thread);
+  assert(env != nullptr);
+  if(jCompactionFilter_ != nullptr) {
+    env->DeleteGlobalRef(jCompactionFilter_);
+  }
+  // This MUST be last!
+  if(javaVM_ != nullptr) {
+    JniUtil::releaseJniEnv(javaVM_, attached_thread);
+  }
+}
+
+/**
+ * Accessor for the name of this CompactionFilter, which was cached from the Java side in Initialize()
+ *
+ * @return  Name string
+ */
+const char* CompactionFilterJniCallback::Name() const {
+  return name_.c_str();
+}
+
+/**
+ * Main filtering method. Translates from C++'s CompactionFilter::FilterV2() signature:
+ *      FilterV2(int level, Slice &key, ValueType value_type, Slice &existing_value, string *new_value, string *skip_until)
+ * to Java's AbstractJavaCompactionFilter.FilterV2() signature:
+ *      CompactionOutput FilterV2(int level, Slice key, ValueType valueType, DirectSlice existingValue)
+ * and then massages return types appropriately.
+ *
+ * See CompactionFilter::FilterV2() for parameter description.
+ */
+CompactionFilter::Decision CompactionFilterJniCallback::FilterV2(
+    int level, const Slice &key, CompactionFilter::ValueType value_type,
+    const Slice &existing_value, std::string *new_value,
+    std::string *skip_until) const {
+
+  // Grab a fresh JNI env by attaching the current thread to the Java VM. This is a no-op if we're already attached.
+  // NOTE: In the current implementation we never detach, because we assume the threads are long-lived.
+  //
+  // TODO(benclay): We need a lifecycle hook on thread death in order to safely detach without the huge performance
+  //                impact of detaching on every call.
+  jboolean attached_thread = JNI_FALSE;
+  JNIEnv* env = JniUtil::getJniEnv(javaVM_, &attached_thread);
+  assert(env != nullptr);
+
+  // Wrap with a try / catch for handling errors coming out of Java calls
+  CompactionFilter::Decision decision = CompactionFilter::Decision::kKeep;
+  try {
+
+    // Push a local frame to make sure all the thread-local JNI handles that are allocated during this method are
+    // eventually reclaimed.
+    if(env->PushLocalFrame(1) < 0) {
+      throw CompactionFilterJniCallbackException("Pushing local frame failed");
+    }
+
+    // Issue the CompactionFilter#FilterV2Internal call over to Java
+    jlong jKeyHandle = reinterpret_cast<jlong>(&key);
+    jlong jExistingValueHandle = reinterpret_cast<jlong>(&existing_value);
+    jobject jCompactionOutput =
+        env->CallObjectMethod(jCompactionFilter_, jCompactionFilterFilterV2InternalMethodId_, level, jKeyHandle,
+                              value_type, jExistingValueHandle);
+    if (env->ExceptionCheck()) {
+      throw CompactionFilterJniCallbackException("Exception encountered in Java FilterV2Internal method");
+    }
+    if(jCompactionOutput == nullptr) {
+      throw CompactionFilterJniCallbackException("Java FilterV2Internal method returned null");
+    }
+
+    // Extract decision value from the result object
+    jbyte jDecisionValue = env->GetByteField(jCompactionOutput, jCompactionOutputDecisionValueFieldId_);
+    decision = static_cast<CompactionFilter::Decision>(jDecisionValue);
+
+    // Extract new_value from the result object if we have one
+    if(decision == CompactionFilter::Decision::kChangeValue) {
+      jstring jNewValue = (jstring) env->GetObjectField(jCompactionOutput, jCompactionOutputNewValueFieldId_);
+      if (env->ExceptionCheck()) {
+        throw CompactionFilterJniCallbackException("Exception accessing CompactionOutput#newValue");
+      }
+      if (jNewValue != nullptr) {
+        jboolean has_exception = JNI_FALSE;
+        std::string incoming_new_value = JniUtil::copyStdString(env, jNewValue,
+                                                                &has_exception);  // also releases jsName
+        if (has_exception == JNI_TRUE) {
+          throw CompactionFilterJniCallbackException(
+              "Java exception encountered when copying new_value string from Java -> native");
+        }
+        new_value->assign(incoming_new_value);
+      }
+    }
+
+      // Extract skip_until from the result object
+    else if(decision == CompactionFilter::Decision::kRemoveAndSkipUntil) {
+      jstring jSkipUntil = (jstring) env->GetObjectField(jCompactionOutput, jCompactionOutputSkipUntilFieldId_);
+      if (env->ExceptionCheck()) {
+        throw CompactionFilterJniCallbackException("Exception accessing CompactionOutput#skipUntil");
+      }
+      if (jSkipUntil != nullptr) {
+        jboolean has_exception = JNI_FALSE;
+        std::string incoming_skip_until = JniUtil::copyStdString(env, jSkipUntil,
+                                                                 &has_exception);  // also releases jsName
+        if (has_exception == JNI_TRUE) {
+          throw CompactionFilterJniCallbackException(
+              "Java exception encountered when copying skip_until string from Java -> native");
+        }
+        skip_until->assign(incoming_skip_until);
+      }
+    }
+
+  } catch (CompactionFilterJniCallbackException e) {
+    // Print a warning to stderr
+    std::cerr << "Error condition encountered in CompactionFilterJniCallback::FilterV2: " << e.what() << std::endl;
+    // Print any Java exception to stderr
+    if(env->ExceptionCheck()) {
+      env->ExceptionDescribe();
+    }
+  }
+
+  // Pop the frame to make sure all the thread-local JNI handles that are allocated during this method are
+  // eventually reclaimed.
+  env->PopLocalFrame(NULL);
+
+  // Return
+  return decision;
+
+}
+
+}  // namespace rocksdb

--- a/java/rocksjni/compaction_filter_jnicallback.h
+++ b/java/rocksjni/compaction_filter_jnicallback.h
@@ -1,4 +1,10 @@
-// Stub compaction filter that hands off to Java
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the callback "bridge" between Java and C++ for
+// rocksdb::CompactionFilter.
 
 #ifndef JAVA_ROCKSJNI_COMPACTION_FILTER_JNICALLBACK_H_
 #define JAVA_ROCKSJNI_COMPACTION_FILTER_JNICALLBACK_H_

--- a/java/rocksjni/compaction_filter_jnicallback.h
+++ b/java/rocksjni/compaction_filter_jnicallback.h
@@ -1,0 +1,63 @@
+// Stub compaction filter that hands off to Java
+
+#ifndef JAVA_ROCKSJNI_COMPACTION_FILTER_JNICALLBACK_H_
+#define JAVA_ROCKSJNI_COMPACTION_FILTER_JNICALLBACK_H_
+
+#include <jni.h>
+
+#include "rocksdb/compaction_filter.h"
+#include "rocksjni/jnicallback.h"
+
+namespace rocksdb {
+
+/**
+ * A JNI shim rocksdb::CompactionFilter that calls back into Java upon invocation of FilterV2.
+ *
+ * Heavily inspired by BaseComparatorJniCallback
+ */
+// TODO(benclay): Inherit from public JniCallback here if we can come up with an inheritance story on the Java side.
+class CompactionFilterJniCallback : public CompactionFilter {
+
+public:
+  CompactionFilterJniCallback() {}
+  ~CompactionFilterJniCallback();
+  bool Initialize(JNIEnv *env, jobject jCompactionFilter);
+  const char* Name() const override;
+  rocksdb::CompactionFilter::Decision FilterV2(
+      int level, const rocksdb::Slice &key, rocksdb::CompactionFilter::ValueType value_type,
+      const rocksdb::Slice &existing_value, std::string *new_value,
+      std::string *skip_until) const override;
+
+private:
+  // Cached name of the CompactionFilter
+  std::string name_;
+  // Reference to the JVM, which is necessary given multithreaded access (not using a factory)
+  JavaVM* javaVM_;
+  // Reference to our CompactionFilter object
+  jobject jCompactionFilter_;
+  // CompactionFilter#FilterV2 Java method reference
+  jmethodID jCompactionFilterFilterV2InternalMethodId_;
+  // CompactionOutput Java class reference
+  jclass jCompactionOutputClass_;
+  // CompactionOutput#decisionValue Java field reference
+  jfieldID jCompactionOutputDecisionValueFieldId_;
+  // CompactionOutput#newValue Java field reference
+  jfieldID jCompactionOutputNewValueFieldId_;
+  // CompactionOutput#skipUntil Java field reference
+  jfieldID jCompactionOutputSkipUntilFieldId_;
+};
+
+/**
+ * Exception class used in CompactionFilterJniCallback
+ */
+
+class CompactionFilterJniCallbackException : public std::runtime_error {
+public:
+  CompactionFilterJniCallbackException(const char * message) throw()
+      : std::runtime_error(message) {}
+
+};
+
+}  // namespace rocksdb
+
+#endif // JAVA_ROCKSJNI_COMPACTION_FILTER_JNICALLBACK_H_

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -1193,6 +1193,69 @@ class AbstractComparatorJni : public RocksDBNativeClass<
   }
 };
 
+// The portal class for org.rocksdb.CompactionFilter
+class AbstractJavaCompactionFilterJni : public RocksDBNativeClass<
+    const CompactionFilter *, AbstractJavaCompactionFilterJni> {
+public:
+
+  /**
+   * Get the Java Class org.rocksdb.AbstractJavaCompactionFilter
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The Java Class or nullptr if one of the
+   *     ClassFormatError, ClassCircularityError, NoClassDefFoundError,
+   *     OutOfMemoryError or ExceptionInInitializerError exceptions is thrown
+   */
+  static jclass getJClass(JNIEnv *env) {
+    return RocksDBNativeClass::getJClass(
+        env, "org/rocksdb/AbstractJavaCompactionFilter");
+  }
+
+  /**
+   * Get the Java Method: AbstractJavaCompactionFilterJni#name
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The Java Method ID or nullptr if the class or method id could not
+   *     be retieved
+   */
+  static jmethodID getNameMethodId(JNIEnv *env) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    static jmethodID mid =
+        env->GetMethodID(jclazz, "Name", "()Ljava/lang/String;");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+  /**
+   * Get the Java Method: AbstractJavaCompactionFilterJni#FilterV2Internal
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The Java Method ID or nullptr if the class or method id could not
+   *     be retieved
+   */
+  static jmethodID getFilterV2InternalMethodId(JNIEnv *env) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    static jmethodID mid =
+        env->GetMethodID(jclazz, "FilterV2Internal", "(IJBJ)Lorg/rocksdb/CompactionOutput;");
+    assert(mid != nullptr);
+    return mid;
+  }
+
+};
+
 // The portal class for org.rocksdb.AbstractSlice
 class AbstractSliceJni : public NativeRocksMutableObject<
     const rocksdb::Slice*, AbstractSliceJni> {
@@ -2113,6 +2176,83 @@ class BatchResultJni : public JavaClass {
     batch_result.writeBatchPtr.release();
     return jbatch_result;
   }
+};
+
+// The portal class for org.rocksdb.compaction.CompactionOutput
+class CompactionOutputJni : public rocksdb::JavaClass {
+public:
+
+  /**
+   * Get the Java Class org.rocksdb.compaction.CompactionOutput
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The Java Class or nullptr if one of the
+   *     ClassFormatError, ClassCircularityError, NoClassDefFoundError,
+   *     OutOfMemoryError or ExceptionInInitializerError exceptions is thrown
+   */
+  static jclass getJClass(JNIEnv *env) {
+    return JavaClass::getJClass(
+        env, "org/rocksdb/CompactionOutput");
+  }
+
+  /**
+   * Get the ID of the Java field: CompactionOutput#decisionValue
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The field ID or nullptr if the class could not be retrieved
+   */
+  static jfieldID getDecisionValueFieldId(JNIEnv *env) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    jfieldID fieldId = env->GetFieldID(jclazz, "decisionValue", "B");
+    assert(fieldId != nullptr);
+    return fieldId;
+  }
+
+  /**
+   * Get the ID of the Java field: CompactionOutput#newValue
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The field ID or nullptr if the class could not be retrieved
+   */
+  static jfieldID getNewValueFieldId(JNIEnv *env) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    jfieldID fieldId = env->GetFieldID(jclazz, "newValue", "Ljava/lang/String;");
+    assert(fieldId != nullptr);
+    return fieldId;
+  }
+
+  /**
+   * Get the ID of the Java field: CompactionOutput#skipUntil
+   *
+   * @param env A pointer to the Java environment
+   *
+   * @return The field ID or nullptr if the class could not be retrieved
+   */
+  static jfieldID getSkipUntilFieldId(JNIEnv *env) {
+    jclass jclazz = getJClass(env);
+    if (jclazz == nullptr) {
+      // exception occurred accessing class
+      return nullptr;
+    }
+
+    jfieldID fieldId = env->GetFieldID(jclazz, "skipUntil", "Ljava/lang/String;");
+    assert(fieldId != nullptr);
+    return fieldId;
+  }
+
 };
 
 // The portal class for org.rocksdb.CompactionStopStyle

--- a/java/src/main/java/org/rocksdb/AbstractJavaCompactionFilter.java
+++ b/java/src/main/java/org/rocksdb/AbstractJavaCompactionFilter.java
@@ -1,0 +1,129 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Base class for compaction filters implemented in Java
+ */
+// TODO(benclay): Ideally this should extend RocksCallbackObject, I didn't see a clean way though
+// without converting the basic primitive for compaction filters to an interface.
+public abstract class AbstractJavaCompactionFilter extends AbstractCompactionFilter<Slice> {
+
+  // Static outputs representing the two immutable choices, avoiding object churn
+  protected static final CompactionOutput KEEP_OUTPUT = new CompactionOutput(
+          CompactionDecision.kKeep);
+  protected static final CompactionOutput REMOVE_OUTPUT = new CompactionOutput(
+          CompactionDecision.kRemove);
+
+  // We use threadlocal caches for DirectSlice to avoid finalization on each compaction call.
+  // Long-term we can get rid of this if AbstractNativeReference removes its finalize() method.
+  private static ThreadLocal<DirectSlice> keyCache =
+      new ThreadLocal<DirectSlice>() {
+        @Override
+        protected DirectSlice initialValue() {
+          return new DirectSlice();
+        }
+      };
+  private static ThreadLocal<DirectSlice> existingValueCache =
+      new ThreadLocal<DirectSlice>() {
+        @Override
+        protected DirectSlice initialValue() {
+          return new DirectSlice();
+        }
+      };
+
+  public AbstractJavaCompactionFilter() {
+    super(newCompactionFilter());
+    //
+    // Ideally we would construct the native-side CompactionFilter AND initialize it with all
+    // the caching of Java method + field IDs in a single native call.  We cannot for the
+    // following reasons:
+    //
+    // 1. CompactionFilter inherits from AbstractCompactionFilter, which way up the chain has
+    //    a constructor that will take a native handle. We need to provide this super() a new
+    //    native handle which we generate ourselves - when Java constructor calls, we jump into
+    //    native and generate a native-side handle representing the native compaction filter
+    //    (in this case, an instance of CompactionFilterJniCallback).
+    // 2. Native constructor counterparts are denoted private native static because the Java
+    //    object doesn't exist yet - we are constructing it when they're called, and hence
+    //    they're represented as static. Therefore they have the signature (JNIEnv *, jclass)
+    //    instead of an object method's (JNIEnv *, jobject)
+    // 3. We need to cache two sets of things on native side around the time of Java object
+    //    construction: a bunch of method and field IDs (just require the jclass references)
+    //    AND a jobject reference to our Java-side CompactionFilter. The former are for
+    //    performance reasons, but the latter is so that we call the Name() and FilterV2()
+    //    methods on our CompactionFilter object - these are non-static methods on Java side
+    //    and hence require an object. We could conceivably represent Name() as a static
+    //    method, but not FilterV2().
+    // 4. Java requires super() to be the very first call within a constructor, so that's when
+    //    we need to generate the native-side handle. That in turn requires us to call the
+    //    static newCompactionFilter().
+    // 5. We then follow it with a call to the non-static initializeFilter() to cache our Java
+    //    method and field IDs for speed.
+    //
+    if (!initializeFilter(nativeHandle_)) {
+      throw new RuntimeException("Unable to cache field IDs in AbstractJavaCompactionFilter");
+    }
+  }
+
+  /**
+   * Native handle accessor. We can think about making it package-private later.
+   *
+   * @return
+   */
+  public long nativeHandle() {
+    return nativeHandle_;
+  }
+
+  /**
+   * Java interface for rocksdb::CompactionFilter::FilterV2.
+   *
+   * See compaction_filter.h for a description of parameters. We have Java-side representations of
+   * the enums but their meaning is the same.
+   *
+   * @return  CompactionOutput struct type, which lets us avoid the native FilterV2() method's usage
+   *          of output parameters.
+   *          NOTE: If you return null from this method it will be treated as Decision.kKeep!
+   */
+  public abstract CompactionOutput FilterV2(
+          int level, DirectSlice key, CompactionValueType valueType, DirectSlice existingValue);
+
+  /**
+   * Internal callback function that is directly called from the native side. We perform input marshalling within the JVM instead of requiring native to do it.
+   *
+   * @param level                     Level
+   * @param keyHandle                 Handle of the key Slice
+   * @param valueTypeValue            Byte representing the CompactionValueType enum value
+   * @param existingValueHandle       Handle of the existingValue DirectSlice
+   * @return                          CompactionOutput object
+   */
+  @SuppressWarnings("unused")
+  private CompactionOutput FilterV2Internal(
+          int level, long keyHandle, byte valueTypeValue, long existingValueHandle) {
+    try {
+      DirectSlice key = keyCache.get();
+      key.setNativeHandle(keyHandle, false);
+      CompactionValueType valueType = CompactionValueType.getCompactionValueType(valueTypeValue);
+      DirectSlice existingValue = existingValueCache.get();
+      existingValue.setNativeHandle(existingValueHandle, false);
+      return this.FilterV2(level, key, valueType, existingValue);
+    } catch (Exception e) {
+      // We'd rather not let this thread die due to bugs in Java, so catch + return a default
+      // decision.
+      return KEEP_OUTPUT;
+    }
+  }
+
+  /**
+   * Unique name of this compaction filter
+   */
+  public abstract String Name();
+
+  /* Native method references below */
+  private native static long newCompactionFilter();
+  private native boolean initializeFilter(long handle);
+
+}

--- a/java/src/main/java/org/rocksdb/CompactionDecision.java
+++ b/java/src/main/java/org/rocksdb/CompactionDecision.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Parallel for compaction_filter.h's Decision enum.
+ */
+public enum CompactionDecision {
+
+  // Enum values
+  kKeep((byte) 0x0),
+  kRemove((byte) 0x1),
+  kChangeValue((byte) 0x2),
+  kRemoveAndSkipUntil((byte) 0x3);
+
+  // We use our own value field so we can ensure a tight binding to C++ enum values
+  private final byte value_;
+
+  /**
+   * Private constructor
+   *
+   * @param value     Byte value we want to bind to this enum value
+   */
+  CompactionDecision(final byte value) {
+    value_ = value;
+  }
+
+  /**
+   * <p>Returns the byte value of the enumerations value.</p>
+   *
+   * @return byte representation
+   */
+  public byte getValue() {
+    return value_;
+  }
+
+  /**
+   * <p>Get the CompactionDecision enumeration value by
+   * passing the byte identifier to this method.</p>
+   *
+   * @param byteIdentifier of CompactionDecision.
+   *
+   * @return CompactionDecision instance.
+   *
+   * @throws IllegalArgumentException If CompactionDecision cannot be found for the
+   *   provided byteIdentifier
+   */
+  public static CompactionDecision getCompactionDecision(byte byteIdentifier) {
+    for (final CompactionDecision decision : CompactionDecision.values()) {
+      if (decision.getValue() == byteIdentifier) {
+        return decision;
+      }
+    }
+    throw new IllegalArgumentException("Illegal value provided for CompactionDecision.");
+  }
+
+}

--- a/java/src/main/java/org/rocksdb/CompactionOutput.java
+++ b/java/src/main/java/org/rocksdb/CompactionOutput.java
@@ -1,0 +1,50 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Struct class representing the output of a compaction operation
+ */
+public class CompactionOutput {
+
+  public final CompactionDecision decision;
+  public final String newValue;
+  public final String skipUntil;
+
+  // We cache this to avoid an extra Java lookup from native side
+  private final byte decisionValue;
+
+  /**
+   * Constructor for a Keep or Remove decision.
+   */
+  public CompactionOutput(CompactionDecision decision) {
+    assert(decision.equals(CompactionDecision.kKeep) || decision.equals(CompactionDecision.kRemove));
+    this.decision = decision;
+    this.decisionValue = decision.getValue();
+    this.newValue = null;
+    this.skipUntil = null;
+  }
+
+  /**
+   * Constructor for a ChangeValue or RemoveAndSkipUntil decision.
+   *
+   * @param decision      The decision
+   * @param param         Will be treated as either the new value or skip until parameter depending on {@code decision}
+   */
+  public CompactionOutput(CompactionDecision decision, String param) {
+    assert(decision.equals(CompactionDecision.kChangeValue) || decision.equals(CompactionDecision.kRemoveAndSkipUntil));
+    this.decision = decision;
+    this.decisionValue = decision.getValue();
+    if(this.decision.equals(CompactionDecision.kChangeValue)) {
+      this.newValue = param;
+      this.skipUntil = null;
+    } else {
+      this.newValue = null;
+      this.skipUntil = param;
+    }
+  }
+
+}

--- a/java/src/main/java/org/rocksdb/CompactionValueType.java
+++ b/java/src/main/java/org/rocksdb/CompactionValueType.java
@@ -1,0 +1,57 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * Parallel for compaction_filter.h's ValueType enum.
+ */
+public enum CompactionValueType {
+
+  kValue((byte)0x0),
+  kMergeOperand((byte)0x1);
+
+  // We use our own value field so we can ensure a tight binding to C++ enum values
+  private final byte value_;
+
+  /**
+   * Private constructor
+   *
+   * @param value     Byte value we want to bind to this enum value
+   */
+  CompactionValueType(final byte value) {
+    value_ = value;
+  }
+
+  /**
+   * <p>Returns the byte value of the enumerations value.</p>
+   *
+   * @return byte representation
+   */
+  public byte getValue() {
+    return value_;
+  }
+
+  /**
+   * <p>Get the Decision enumeration value by
+   * passing the byte identifier to this method.</p>
+   *
+   * @param byteIdentifier of CompactionValueType.
+   *
+   * @return CompactionValueType instance.
+   *
+   * @throws IllegalArgumentException If CompactionValueType cannot be found for the
+   *   provided byteIdentifier
+   */
+  public static CompactionValueType getCompactionValueType(byte byteIdentifier) {
+    for (final CompactionValueType valueType : CompactionValueType.values()) {
+      if (valueType.getValue() == byteIdentifier) {
+        return valueType;
+      }
+    }
+    throw new IllegalArgumentException("Illegal value provided for CompactionValueType.");
+  }
+}
+

--- a/java/src/test/java/org/rocksdb/JavaCompactionFilterTest.java
+++ b/java/src/test/java/org/rocksdb/JavaCompactionFilterTest.java
@@ -1,0 +1,140 @@
+package org.rocksdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the JNI layer for AbstractJavaCompactionFilter
+ */
+public class JavaCompactionFilterTest {
+
+  /**
+   * Static test inputs
+   */
+  private final String originalValueStr = "foobar";
+  private final byte[] originalValueBytes = originalValueStr.getBytes();
+  private final String[] keys = {"key1", "key2", "key3", "key4"};
+
+  /**
+   * Dummy compaction filter that lets us control the decision reached in the FilterV2 method
+   */
+  private static class DummyCompactionFilter extends AbstractJavaCompactionFilter {
+
+    public static final String changedValue = "foobaz";
+    public static final String skipUntil = "key3";
+
+    private CompactionDecision decision = CompactionDecision.kKeep;
+
+    public void setDecision(CompactionDecision newDecision) {
+      this.decision = newDecision;
+    }
+
+    @Override
+    public CompactionOutput FilterV2(int level, DirectSlice key, CompactionValueType valueType, DirectSlice existingValue) {
+      if(this.decision.equals(CompactionDecision.kKeep) || this.decision.equals(CompactionDecision.kRemove)) {
+        return new CompactionOutput(this.decision);
+      } else if (this.decision.equals(CompactionDecision.kChangeValue)) {
+        return new CompactionOutput(this.decision, this.changedValue);
+      } else {
+        return new CompactionOutput(this.decision, this.skipUntil);
+      }
+    }
+
+    @Override
+    public String Name() {
+      return "DummyCompactionFilter";
+    }
+  }
+
+  private void putOriginalValues(RocksDB db) throws RocksDBException {
+    for(String key : this.keys) {
+      db.put(key.getBytes(), this.originalValueBytes);
+    }
+  }
+
+  @Rule
+  public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  /**
+   * Tests AbstractJavaCompactionFilter
+   */
+  @Test
+  public void testAbstractJavaCompactionFilter() throws IOException, RocksDBException {
+
+    // Create a compaction filter to use
+    final DummyCompactionFilter compactionFilter = new DummyCompactionFilter();
+
+    // Set up rocks options, wire in the compaction filter and disable auto-compaction
+    DBOptions dbOptions = new DBOptions()
+        .setCreateIfMissing(true);
+    final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions()
+        .setCompactionFilter(compactionFilter)
+        .setDisableAutoCompactions(true);
+    final List<ColumnFamilyDescriptor> columnFamilyDescriptors = Arrays.asList(
+        new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions));
+    final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
+
+    // Create a database with our one column family
+    RocksDB db = RocksDB.open(dbOptions, dbFolder.getRoot().getAbsolutePath(),
+        columnFamilyDescriptors, columnFamilyHandles);
+
+    // Put original values
+    putOriginalValues(db);
+
+    // Set the decision to keep and trigger a compaction
+    compactionFilter.setDecision(CompactionDecision.kKeep);
+    db.compactRange();
+
+    // Assert that we have all KV pairs we expected - all should've been kept
+    for(String key : this.keys) {
+      assertThat(db.get(key.getBytes())).isEqualTo(this.originalValueBytes);
+    }
+
+    // Set the decision to remove and trigger a compaction
+    compactionFilter.setDecision(CompactionDecision.kRemove);
+    db.compactRange();
+
+    // Assert that we have none of the KV pairs from earlier - all should've been removed
+    for(String key : this.keys) {
+      assertThat(db.get(key.getBytes())).isNull();
+    }
+
+    // Put original values
+    putOriginalValues(db);
+
+    // Set the decision to change values and trigger a compaction
+    compactionFilter.setDecision(CompactionDecision.kChangeValue);
+    db.compactRange();
+
+    // Assert that the values have all been changed
+    for(String key : this.keys) {
+      assertThat(db.get(key.getBytes())).isEqualTo(DummyCompactionFilter.changedValue.getBytes());
+    }
+
+    // Put original values
+    putOriginalValues(db);
+
+    // Set the decision to remove and skip until and trigger a compaction
+    compactionFilter.setDecision(CompactionDecision.kRemoveAndSkipUntil);
+    db.compactRange();
+
+    // Assert that we removed all keys until the skip marker
+    for(String key : this.keys) {
+      if(key.compareTo(DummyCompactionFilter.skipUntil) < 0) {
+        assertThat(db.get(key.getBytes())).isNull();
+      } else {
+        assertThat(db.get(key.getBytes())).isEqualTo(this.originalValueBytes);
+      }
+    }
+
+  }
+
+}

--- a/java/src/test/java/org/rocksdb/JavaCompactionFilterTest.java
+++ b/java/src/test/java/org/rocksdb/JavaCompactionFilterTest.java
@@ -1,3 +1,8 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
 package org.rocksdb;
 
 import org.junit.Rule;

--- a/src.mk
+++ b/src.mk
@@ -381,6 +381,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/compaction_filter.cc                          \
   java/rocksjni/compaction_filter_factory.cc                  \
   java/rocksjni/compaction_filter_factory_jnicallback.cc      \
+  java/rocksjni/compaction_filter_jnicallback.cc              \
   java/rocksjni/compaction_options_fifo.cc                    \
   java/rocksjni/compaction_options_universal.cc               \
   java/rocksjni/comparator.cc                                 \


### PR DESCRIPTION
Similar to `AbstractCompactionFilterFactory` and `AbstractComparator`, this diff contains an abstract base class for `rocksdb::CompactionFilter` written in Java. It uses a similar set of techniques to cache relevant field / method IDs at startup, passes scalars back into Java and relies on threadlocals to avoid `DirectSlice` finalize churn.

Using this implementation we've been able to run a Java compaction filter under Manhattan production workloads with a ~10% performance reduction.  It's not free but is good enough for some usecases.

There are a few unresolved issues with this implementation that I wanted to discuss with the community. They're marked with `TODO(benclay)` below.

- Detaching compaction threads after every callback is extremely expensive. On our JDK8 JVM the `DetachCurrentThread` call internally serializes on a mutex while releasing monitors, causing compactions and thus writes to eventually stall.  As a result, in this diff **we are not detaching at all**.  However, I am concerned about upstreaming this as-is this because folks might explicitly take locks in their CompactionFilter implementations and need those monitors to be automatically released.  I am looking for feedback from the community on this problem.  There are a few solutions from Rocks side I can think of, but am open to more ideas:
  - Add a lifecycle hook (perhaps to CompactionFilterFactory?) when the compaction thread is shutting down. At that point we can detach the thread from the JVM.  This still risks the thread crashing and never detaching though.
  - Implement a batching interface to CompactionFilter so we aren't making so many roundtrips and the detach cost is amortized.  This would help performance more generally but is probably more invasive - I haven't looked into the implications on Rocks side.
  - Detach every Nth call - this seems very racy and doesn't guarantee that the thread detaches on the final call, so it seems like a non-starter.
- I couldn't take advantage of @adamretter 's `RocksCallbackObject` regime because Java disallows multiple inheritance and I needed to inherit from `AbstractCompactionFilter`.  Right now that class and its C++ companion `JniCallback` are fairly basic, but over time could export some useful performance enhancements.  I thought about shimming a new `ICompactionFilter` interface **below** `AbstractCompactionFilter` and have that be the primary unit for interacting with `ColumnFamilyOptions`. Upon further examination that will somewhat break the tradition of having abstract base classes with package-private `nativeHandle_` member variables, which is how `ColumnFamilyOptions` is binding the `CompactionFilter` handle on the C++ side.  Open to suggestions here as well.

@sagar0 @adamretter 