### PR TITLE
Fix db_bench write being disabled in lite build

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3661,9 +3661,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         }
       }
       if (!use_blob_db_) {
-#ifndef ROCKSDB_LITE
         s = db_with_cfh->db->Write(write_options_, &batch);
-#endif  //  ROCKSDB_LITE
       }
       thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db,
                                 entries_per_batch_, kWrite);


### PR DESCRIPTION
Summary:
The macro was added by mistake in #2372 

Test Plan:
Build db_bench in lite mode and run fillrandom benchmark.