### PR TITLE
Fix Travis build failures in CMake RocksJava

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -208,6 +208,7 @@ add_jar(
   src/main/java/org/rocksdb/OptionsUtil.java
   src/main/java/org/rocksdb/PlainTableConfig.java
   src/main/java/org/rocksdb/RateLimiter.java
+  src/main/java/org/rocksdb/RateLimiterMode.java
   src/main/java/org/rocksdb/ReadOptions.java
   src/main/java/org/rocksdb/ReadTier.java
   src/main/java/org/rocksdb/RemoveEmptyValueCompactionFilter.java


### PR DESCRIPTION
Fixed RocksJava travis build failure due to a missing file in java/CMakeLists.txt. (from #3332). 

Test Plan:
- Tested on mac with cmake:
`mkdir build && cd build && cmake -DJNI=1 .. && make -j4 rocksdb rocksdbjni`
- Make sure that all travis builds are green.