### PR TITLE
Add a Close() method to DB to return status when closing a db

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -856,7 +856,7 @@ class TestEnv : public EnvWrapper {
         using Logger::Logv;
         virtual void Logv(const char *format, va_list ap) override { };
       private:
-        virtual Status CloseImpl() {
+        virtual Status CloseImpl() override {
           return Status::NotSupported();
         }
     };

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -870,7 +870,7 @@ class TestEnv : public EnvWrapper {
 
 TEST_F(DBBasicTest, DBClose) {
   Options options = GetDefaultOptions();
-  std::string dbname = test::TmpDir(env_) + "/db_options_test";
+  std::string dbname = test::TmpDir(env_) + "/db_close_test";
   ASSERT_OK(DestroyDB(dbname, options));
 
   DB* db = nullptr;

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -847,6 +847,55 @@ TEST_F(DBBasicTest, MmapAndBufferOptions) {
 }
 #endif
 
+class TestEnv : public EnvWrapper {
+  public:
+    explicit TestEnv(Env* base) : EnvWrapper(base) { };
+
+    class TestLogger : public Logger {
+      public:
+        using Logger::Logv;
+        virtual void Logv(const char *format, va_list ap) override { };
+      private:
+        virtual Status CloseImpl() {
+          return Status::NotSupported();
+        }
+    };
+
+    virtual Status NewLogger(const std::string& fname,
+                             shared_ptr<Logger>* result) {
+      result->reset(new TestLogger());
+      return Status::OK();
+    }
+};
+
+TEST_F(DBBasicTest, DBClose) {
+  Options options = GetDefaultOptions();
+  std::string dbname = test::TmpDir(env_) + "/db_options_test";
+  ASSERT_OK(DestroyDB(dbname, options));
+
+  DB* db = nullptr;
+  options.create_if_missing = true;
+  options.env = new TestEnv(Env::Default());
+  Status s = DB::Open(options, dbname, &db);
+  ASSERT_OK(s);
+  ASSERT_TRUE(db != nullptr);
+
+  s = db->Close();
+  ASSERT_EQ(s, Status::NotSupported());
+
+  delete db;
+
+  // Provide our own logger and ensure DB::Close() does not close it
+  options.info_log.reset(new TestEnv::TestLogger());
+  options.create_if_missing = false;
+  s = DB::Open(options, dbname, &db);
+  ASSERT_OK(s);
+  ASSERT_TRUE(db != nullptr);
+
+  s = db->Close();
+  ASSERT_EQ(s, Status::OK());
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -141,6 +141,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
                const bool seq_per_batch)
     : env_(options.env),
       dbname_(dbname),
+      own_info_log_(options.info_log == nullptr),
       initial_db_options_(SanitizeOptions(dbname, options)),
       immutable_db_options_(initial_db_options_),
       mutable_db_options_(initial_db_options_),
@@ -381,8 +382,7 @@ Status DBImpl::CloseImpl() {
   LogFlush(immutable_db_options_.info_log);
 
   Status s = Status::OK();
-  if (immutable_db_options_.info_log &&
-      immutable_db_options_.info_log->GetOwner() == InfoLogOwner::ROCKSDB) {
+  if (immutable_db_options_.info_log && own_info_log_) {
     s = immutable_db_options_.info_log->Close();
   }
   return s;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -611,6 +611,8 @@ class DBImpl : public DB {
                      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
                      const bool seq_per_batch);
 
+  virtual Status Close() override;
+
  protected:
   Env* const env_;
   const std::string dbname_;
@@ -911,6 +913,9 @@ class DBImpl : public DB {
   const Snapshot* GetSnapshotImpl(bool is_write_conflict_boundary);
 
   uint64_t GetMaxTotalWalSize() const;
+
+  // Actual implementation of Close()
+  virtual Status CloseImpl();
 
   // table_cache_ provides its own synchronization
   std::shared_ptr<Cache> table_cache_;
@@ -1359,6 +1364,9 @@ class DBImpl : public DB {
   // is set to false.
   std::atomic<SequenceNumber> preserve_deletes_seqnum_;
   const bool preserve_deletes_;
+
+  // Flag to check whether Close() has been called on this DB
+  bool closed_;
 };
 
 extern Options SanitizeOptions(const std::string& db,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -617,6 +617,8 @@ class DBImpl : public DB {
   Env* const env_;
   const std::string dbname_;
   unique_ptr<VersionSet> versions_;
+  // Flag to check whether we allocated and own the info log file
+  bool own_info_log_;
   const DBOptions initial_db_options_;
   const ImmutableDBOptions immutable_db_options_;
   MutableDBOptions mutable_db_options_;

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -48,11 +48,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     if (!s.ok()) {
       // No place suitable for logging
       result.info_log = nullptr;
-    } else {
-      result.info_log->SetOwner(InfoLogOwner::ROCKSDB);
     }
-  } else {
-    result.info_log->SetOwner(InfoLogOwner::CLIENT);
   }
 
   if (!result.write_buffer_manager) {

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -48,7 +48,11 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     if (!s.ok()) {
       // No place suitable for logging
       result.info_log = nullptr;
+    } else {
+      result.info_log->SetOwner(InfoLogOwner::ROCKSDB);
     }
+  } else {
+    result.info_log->SetOwner(InfoLogOwner::CLIENT);
   }
 
   if (!result.write_buffer_manager) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2191,6 +2191,8 @@ class ModelDB : public DB {
     batch.Put(cf, k, v);
     return Write(o, &batch);
   }
+  using DB::Close;
+  virtual Status Close() { return Status::OK(); }
   using DB::Delete;
   virtual Status Delete(const WriteOptions& o, ColumnFamilyHandle* cf,
                         const Slice& key) override {

--- a/env/env.cc
+++ b/env/env.cc
@@ -73,8 +73,17 @@ RandomAccessFile::~RandomAccessFile() {
 WritableFile::~WritableFile() {
 }
 
-Logger::~Logger() {
+Logger::~Logger() { Close(); }
+
+Status Logger::Close() {
+  if (!closed_) {
+    closed_ = true;
+    return CloseImpl();
+  }
+  return Status::OK();
 }
+
+Status Logger::CloseImpl() { return Status::OK(); }
 
 FileLock::~FileLock() {
 }

--- a/env/env_hdfs.cc
+++ b/env/env_hdfs.cc
@@ -277,6 +277,16 @@ class HdfsLogger : public Logger {
   HdfsWritableFile* file_;
   uint64_t (*gettid_)();  // Return the thread id for the current thread
 
+  virtual Status CloseImpl() {
+    ROCKS_LOG_DEBUG(mylog, "[hdfs] HdfsLogger closed %s\n",
+                    file_->getName().c_str());
+    Status s = file_->Close();
+    if (mylog != nullptr && mylog == this) {
+      mylog = nullptr;
+    }
+    return s;
+  }
+
  public:
   HdfsLogger(HdfsWritableFile* f, uint64_t (*gettid)())
       : file_(f), gettid_(gettid) {
@@ -285,12 +295,6 @@ class HdfsLogger : public Logger {
   }
 
   virtual ~HdfsLogger() {
-    ROCKS_LOG_DEBUG(mylog, "[hdfs] HdfsLogger closed %s\n",
-                    file_->getName().c_str());
-    delete file_;
-    if (mylog != nullptr && mylog == this) {
-      mylog = nullptr;
-    }
   }
 
   virtual void Logv(const char* format, va_list ap) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -167,7 +167,7 @@ class DB {
   // called before calling the desctructor so that the caller can get back a
   // status in case there are any errors. Regardless of the return status, the
   // DB must be freed
-  virtual Status Close() = 0;
+  virtual Status Close() { return Status::OK(); }
 
   // ListColumnFamilies will open the DB specified by argument name
   // and return the list of all column families in that DB

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -163,6 +163,12 @@ class DB {
                      const std::vector<ColumnFamilyDescriptor>& column_families,
                      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr);
 
+  // Close the DB by releasing resources, closing files etc. This should be
+  // called before calling the desctructor so that the caller can get back a
+  // status in case there are any errors. Regardless of the return status, the
+  // DB must be freed
+  virtual Status Close() = 0;
+
   // ListColumnFamilies will open the DB specified by argument name
   // and return the list of all column families in that DB
   // through column_families argument. The ordering of

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -813,18 +813,13 @@ enum InfoLogLevel : unsigned char {
   NUM_INFO_LOG_LEVELS,
 };
 
-enum InfoLogOwner : unsigned char {
-  CLIENT = 0,
-  ROCKSDB,
-};
-
 // An interface for writing log messages.
 class Logger {
  public:
   size_t kDoNotSupportGetLogFileSize = (std::numeric_limits<size_t>::max)();
 
   explicit Logger(const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
-      : closed_(false), log_level_(log_level), owner_(InfoLogOwner::CLIENT) {}
+      : closed_(false), log_level_(log_level) {}
   virtual ~Logger();
 
   // Close the log file. Must be called before destructor
@@ -855,8 +850,6 @@ class Logger {
   virtual void SetInfoLogLevel(const InfoLogLevel log_level) {
     log_level_ = log_level;
   }
-  virtual void SetOwner(const InfoLogOwner owner) { owner_ = owner; }
-  virtual InfoLogOwner GetOwner() const { return owner_; }
 
  private:
   // No copying allowed
@@ -865,7 +858,6 @@ class Logger {
   virtual Status CloseImpl();
   bool closed_;
   InfoLogLevel log_level_;
-  InfoLogOwner owner_;
 };
 
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -25,6 +25,8 @@ class StackableDB : public DB {
     delete db_;
   }
 
+  virtual Status Close() override { return db_->Close(); }
+
   virtual DB* GetBaseDB() {
     return db_;
   }

--- a/util/auto_roll_logger.h
+++ b/util/auto_roll_logger.h
@@ -103,6 +103,14 @@ class AutoRollLogger : public Logger {
   std::string ValistToString(const char* format, va_list args) const;
   // Write the logs marked as headers to the new log file
   void WriteHeaderInfo();
+  // Implementation of Close()
+  virtual Status CloseImpl() override {
+    if (logger_) {
+      return logger_->Close();
+    } else {
+      return Status::OK();
+    }
+  }
 
   std::string log_fname_; // Current active info log's file name.
   std::string dbname_;

--- a/util/auto_roll_logger_test.cc
+++ b/util/auto_roll_logger_test.cc
@@ -354,6 +354,45 @@ TEST_F(AutoRollLoggerTest, InfoLogLevel) {
   inFile.close();
 }
 
+TEST_F(AutoRollLoggerTest, Close) {
+  InitTestDb();
+
+  size_t log_size = 8192;
+  size_t log_lines = 0;
+  AutoRollLogger logger(Env::Default(), kTestDir, "", log_size, 0);
+  for (int log_level = InfoLogLevel::HEADER_LEVEL;
+       log_level >= InfoLogLevel::DEBUG_LEVEL; log_level--) {
+    logger.SetInfoLogLevel((InfoLogLevel)log_level);
+    for (int log_type = InfoLogLevel::DEBUG_LEVEL;
+         log_type <= InfoLogLevel::HEADER_LEVEL; log_type++) {
+      // log messages with log level smaller than log_level will not be
+      // logged.
+      LogMessage((InfoLogLevel)log_type, &logger, kSampleMessage.c_str());
+    }
+    log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
+  }
+  for (int log_level = InfoLogLevel::HEADER_LEVEL;
+       log_level >= InfoLogLevel::DEBUG_LEVEL; log_level--) {
+    logger.SetInfoLogLevel((InfoLogLevel)log_level);
+
+    // again, messages with level smaller than log_level will not be logged.
+    ROCKS_LOG_HEADER(&logger, "%s", kSampleMessage.c_str());
+    ROCKS_LOG_DEBUG(&logger, "%s", kSampleMessage.c_str());
+    ROCKS_LOG_INFO(&logger, "%s", kSampleMessage.c_str());
+    ROCKS_LOG_WARN(&logger, "%s", kSampleMessage.c_str());
+    ROCKS_LOG_ERROR(&logger, "%s", kSampleMessage.c_str());
+    ROCKS_LOG_FATAL(&logger, "%s", kSampleMessage.c_str());
+    log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
+  }
+  ASSERT_EQ(logger.Close(), Status::OK());
+
+  std::ifstream inFile(AutoRollLoggerTest::kLogFile.c_str());
+  size_t lines = std::count(std::istreambuf_iterator<char>(inFile),
+                         std::istreambuf_iterator<char>(), '\n');
+  ASSERT_EQ(log_lines, lines);
+  inFile.close();
+}
+
 // Test the logger Header function for roll over logs
 // We expect the new logs creates as roll over to carry the headers specified
 static std::vector<std::string> GetOldFileNames(const std::string& path) {


### PR DESCRIPTION
Summary:
Currently, the only way to close an open DB is to destroy the DB
object. There is no way for the caller to know the status. In one
instance, the destructor encountered an error due to failure to
close a log file on HDFS. In order to prevent silent failures, we add
DB::Close() that calls CloseImpl() which must be implemented by its
descendants.
The main failure point in the destructor is closing the log file. This
patch also adds a Close() entry point to Logger in order to get status.
When DBOptions::info_log is allocated and owned by the DBImpl, it is
explicitly closed by DBImpl::CloseImpl().

Test Plan:
Added unit tests in env_test and db_basic_test.