### PR TITLE
add WriteBatch::WriteBatch(std::string&&)

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -144,6 +144,12 @@ WriteBatch::WriteBatch(const std::string& rep)
       max_bytes_(0),
       rep_(rep) {}
 
+WriteBatch::WriteBatch(std::string&& rep)
+    : save_points_(nullptr),
+      content_flags_(ContentFlags::DEFERRED),
+      max_bytes_(0),
+      rep_(std::move(rep)) {}
+
 WriteBatch::WriteBatch(const WriteBatch& src)
     : save_points_(src.save_points_),
       wal_term_point_(src.wal_term_point_),

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -315,6 +315,7 @@ class WriteBatch : public WriteBatchBase {
 
   // Constructor with a serialized string object
   explicit WriteBatch(const std::string& rep);
+  explicit WriteBatch(std::string&& rep);
 
   WriteBatch(const WriteBatch& src);
   WriteBatch(WriteBatch&& src) noexcept;


### PR DESCRIPTION
to save a string copy for some use cases.

The change is pretty straightforward, please feel free to let me know if you want to suggest any tests for it.