### PR TITLE
Eliminate some redundant block reads.

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -759,23 +759,25 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
 
   // Read the compression dictionary meta block
   bool found_compression_dict;
-  s = SeekToCompressionDictBlock(meta_iter.get(), &found_compression_dict);
+  BlockHandle compression_dict_handle;
+  s = SeekToCompressionDictBlock(meta_iter.get(), &found_compression_dict, 
+    &compression_dict_handle);
   if (!s.ok()) {
     ROCKS_LOG_WARN(
         rep->ioptions.info_log,
         "Error when seeking to compression dictionary block from file: %s",
         s.ToString().c_str());
-  } else if (found_compression_dict) {
+  } else if (found_compression_dict && !compression_dict_handle.IsNull()) {
     // TODO(andrewkr): Add to block cache if cache_index_and_filter_blocks is
     // true.
-    unique_ptr<BlockContents> compression_dict_block{new BlockContents()};
-    // TODO(andrewkr): ReadMetaBlock repeats SeekToCompressionDictBlock().
-    // maybe decode a handle from meta_iter
-    // and do ReadBlockContents(handle) instead
-    s = rocksdb::ReadMetaBlock(rep->file.get(), prefetch_buffer.get(),
-                               file_size, kBlockBasedTableMagicNumber,
-                               rep->ioptions, rocksdb::kCompressionDictBlock,
-                               compression_dict_block.get());
+    std::unique_ptr<BlockContents> compression_dict_cont{new BlockContents()};
+    PersistentCacheOptions cache_options;
+    BlockFetcher compression_block_fetcher(
+      rep->file.get(), prefetch_buffer.get(), rep->footer, ReadOptions(),
+      compression_dict_handle, compression_dict_cont.get(), rep->ioptions, false /* decompress */,
+      Slice() /*compression dict*/, cache_options);
+    s = compression_block_fetcher.ReadBlockContents();
+
     if (!s.ok()) {
       ROCKS_LOG_WARN(
           rep->ioptions.info_log,
@@ -783,7 +785,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
           "block %s",
           s.ToString().c_str());
     } else {
-      rep->compression_dict_block = std::move(compression_dict_block);
+      rep->compression_dict_block = std::move(compression_dict_cont);
     }
   }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -772,8 +772,10 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
     // true.
     std::unique_ptr<BlockContents> compression_dict_cont{new BlockContents()};
     PersistentCacheOptions cache_options;
+    ReadOptions read_options;
+    read_options.verify_checksums = false;
     BlockFetcher compression_block_fetcher(
-      rep->file.get(), prefetch_buffer.get(), rep->footer, ReadOptions(),
+      rep->file.get(), prefetch_buffer.get(), rep->footer, read_options,
       compression_dict_handle, compression_dict_cont.get(), rep->ioptions, false /* decompress */,
       Slice() /*compression dict*/, cache_options);
     s = compression_block_fetcher.ReadBlockContents();

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -215,8 +215,9 @@ Status SeekToPropertiesBlock(InternalIterator* meta_iter, bool* is_found) {
 
 // Seek to the compression dictionary block.
 // Return true if it successfully seeks to that block.
-Status SeekToCompressionDictBlock(InternalIterator* meta_iter, bool* is_found) {
-  return SeekToMetaBlock(meta_iter, kCompressionDictBlock, is_found);
+Status SeekToCompressionDictBlock(InternalIterator* meta_iter, bool* is_found,
+                                  BlockHandle* block_handle) {
+  return SeekToMetaBlock(meta_iter, kCompressionDictBlock, is_found, block_handle);
 }
 
 Status SeekToRangeDelBlock(InternalIterator* meta_iter, bool* is_found,

--- a/table/table_properties_internal.h
+++ b/table/table_properties_internal.h
@@ -21,7 +21,8 @@ Status SeekToPropertiesBlock(InternalIterator* meta_iter, bool* is_found);
 // Seek to the compression dictionary block.
 // If it successfully seeks to the properties block, "is_found" will be
 // set to true.
-Status SeekToCompressionDictBlock(InternalIterator* meta_iter, bool* is_found);
+Status SeekToCompressionDictBlock(InternalIterator* meta_iter, bool* is_found,
+                          BlockHandle* block_handle);
 
 // TODO(andrewkr) should not put all meta block in table_properties.h/cc
 Status SeekToRangeDelBlock(InternalIterator* meta_iter, bool* is_found,


### PR DESCRIPTION
  Re-use metadata for reading Compression Dictionary on BlockBased
  table open, this saves two reads from disk.
  This helps to our 999 percentile in 5.6.1 where prefetch buffer is  not present.