### PR TITLE
Fix PowerPC dynamic java build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1750,7 +1750,7 @@ JAVA_C_LIBOBJECTS = $(patsubst %.c.o,jl/%.c.o,$(JAVA_C_OBJECTS))
 JAVA_ASM_LIBOBJECTS = $(patsubst %.S.o,jl/%.S.o,$(JAVA_ASM_OBJECTS))
 endif
 
-java_libobjects = $(patsubst %,jl/%,$(LIBOBJECTS))
+java_libobjects = $(patsubst %,jl/%,$(LIB_CC_OBJECTS))
 CLEAN_FILES += jl
 java_all_libobjects = $(java_libobjects)
 


### PR DESCRIPTION
Java build on PPC64le has been broken since a few months, due to #2716. Fixing it with the least amount of changes. 
(We should cleanup a little around this code when time permits). 

This should fix the build failures seen in http://140.211.168.68:8080/job/Rocksdb/ . 

Test Plan:
make rocksdbjava
Verified on a ppc64le machine. 