### PR TITLE
Avoid static global variable destruction order issue

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Bug Fixes
+* Fix static variable destruction order issue causing crash on shutdown.
 
 ## 5.10.0 (12/11/2017)
 ### Public API Change

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2430,6 +2430,24 @@ TEST_F(DBTest2, ReadCallbackTest) {
   }
 }
 
+namespace {
+std::unique_ptr<DB> static_db_ptr;
+}
+
+// Test to make sure static allocated DB can be destruct successfully
+// without suffer from static variable destruction order issue.
+TEST_F(DBTest2, StaticDBPointerTest) {
+  DB* db;
+  Options options;
+  options.create_if_missing = true;
+  std::string db_name =
+      test::TmpDir(Env::Default()) + "/static_db_pointer_test";
+  ASSERT_OK(DB::Open(options, db_name, &db));
+  static_db_ptr.reset(db);
+  // Exit the test and let static_db_ptr destruct. It should close DB
+  // without crash.
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
static global variable suffer from "initialization order fiasco", where since order of construct/destruct of static global variable is undefined. If static global variable depends on each other, it can cause construction/destruction order issue: https://isocpp.org/wiki/faq/ctors#static-init-order 

The test code here shows a destruction order issue that can cause rocksdb crash on shutdown: https://gist.github.com/yiwu-arbug/1bd9738e462de837b25f6603afcfd17a
Here db_ptr in a.cc can be destruct after some of the static global variable in env_posix.cc get destruct, and causing crash when the DB trying to access those static global variables on shutdown. Fixing it by making those variables a pointer and intentionally not deleting them on shutdown.

Test Plan:
test with master with the test code above and get crash.
test with the fix and there's no crash.
Run `asan_check` and see no test failure.