### PR TITLE
Fix multiple build failures

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -894,6 +894,8 @@ TEST_F(DBBasicTest, DBClose) {
 
   s = db->Close();
   ASSERT_EQ(s, Status::OK());
+  delete db;
+  delete options.env;
 }
 
 }  // namespace rocksdb

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -503,7 +503,9 @@ TEST_F(DBTest, DISABLED_VeryLargeValue) {
   ASSERT_OK(Put(key2, raw));
   dbfull()->TEST_WaitForFlushMemTable();
 
+#ifndef ROCKSDB_LITE
   ASSERT_EQ(1, NumTableFilesAtLevel(0));
+#endif  // !ROCKSDB_LITE
 
   std::string value;
   Status s = db_->Get(ReadOptions(), key1, &value);
@@ -2192,7 +2194,7 @@ class ModelDB : public DB {
     return Write(o, &batch);
   }
   using DB::Close;
-  virtual Status Close() { return Status::OK(); }
+  virtual Status Close() override { return Status::OK(); }
   using DB::Delete;
   virtual Status Delete(const WriteOptions& o, ColumnFamilyHandle* cf,
                         const Slice& key) override {
@@ -5056,7 +5058,6 @@ TEST_F(DBTest, PromoteL0Failure) {
   status = experimental::PromoteL0(db_, db_->DefaultColumnFamily());
   ASSERT_TRUE(status.IsInvalidArgument());
 }
-#endif  // ROCKSDB_LITE
 
 // Github issue #596
 TEST_F(DBTest, CompactRangeWithEmptyBottomLevel) {
@@ -5079,6 +5080,7 @@ TEST_F(DBTest, CompactRangeWithEmptyBottomLevel) {
   ASSERT_EQ(NumTableFilesAtLevel(0), 0);
   ASSERT_EQ(NumTableFilesAtLevel(1), kNumL0Files);
 }
+#endif  // ROCKSDB_LITE
 
 TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
   Options options = CurrentOptions();
@@ -5101,7 +5103,7 @@ TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
       [&](void* arg) { callback_count.fetch_add(1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   CompactRangeOptions croptions;
-  croptions.exclusive_manual_compaction = false;
+  croptions.exclusive_manual_compaction = true;
   ASSERT_OK(db_->CompactRange(croptions, nullptr, nullptr));
   ASSERT_GE(callback_count.load(), 1);
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -867,7 +867,6 @@ size_t DBTestBase::CountLiveFiles() {
   db_->GetLiveFilesMetaData(&metadata);
   return metadata.size();
 }
-#endif  // ROCKSDB_LITE
 
 int DBTestBase::NumTableFilesAtLevel(int level, int cf) {
   std::string property;
@@ -928,6 +927,7 @@ std::string DBTestBase::FilesPerLevel(int cf) {
   result.resize(last_non_zero_offset);
   return result;
 }
+#endif  // !ROCKSDB_LITE
 
 size_t DBTestBase::CountFiles() {
   std::vector<std::string> files;
@@ -997,6 +997,7 @@ void DBTestBase::MoveFilesToLevel(int level, int cf) {
   }
 }
 
+#ifndef ROCKSDB_LITE
 void DBTestBase::DumpFileCounts(const char* label) {
   fprintf(stderr, "---\n%s:\n", label);
   fprintf(stderr, "maxoverlap: %" PRIu64 "\n",
@@ -1008,6 +1009,7 @@ void DBTestBase::DumpFileCounts(const char* label) {
     }
   }
 }
+#endif  // !ROCKSDB_LITE
 
 std::string DBTestBase::DumpSSTableList() {
   std::string property;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -863,13 +863,13 @@ class DBTestBase : public testing::Test {
   size_t TotalLiveFiles(int cf = 0);
 
   size_t CountLiveFiles();
-#endif  // ROCKSDB_LITE
 
   int NumTableFilesAtLevel(int level, int cf = 0);
 
   double CompressionRatioAtLevel(int level, int cf = 0);
 
   int TotalTableFiles(int cf = 0, int levels = -1);
+#endif  // ROCKSDB_LITE
 
   // Return spread of files per level
   std::string FilesPerLevel(int cf = 0);
@@ -897,7 +897,9 @@ class DBTestBase : public testing::Test {
 
   void MoveFilesToLevel(int level, int cf = 0);
 
+#ifndef ROCKSDB_LITE
   void DumpFileCounts(const char* label);
+#endif  // ROCKSDB_LITE
 
   std::string DumpSSTableList();
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1101,6 +1101,7 @@ TEST_F(BlockBasedTableTest, BasicBlockBasedTableProperties) {
   c.ResetTableReader();
 }
 
+#ifdef SNAPPY
 uint64_t BlockBasedTableTest::IndexUncompressedHelper(bool compressed) {
   TableConstructor c(BytewiseComparator(), true /* convert_to_internal_key_ */);
   constexpr size_t kNumKeys = 10000;
@@ -1133,6 +1134,7 @@ TEST_F(BlockBasedTableTest, IndexUncompressed) {
   // tbl1_compressed_cnt should include 1 index block
   EXPECT_EQ(tbl2_compressed_cnt + 1, tbl1_compressed_cnt);
 }
+#endif  // SNAPPY
 
 TEST_F(BlockBasedTableTest, BlockBasedTableProperties2) {
   TableConstructor c(&reverse_key_comparator);


### PR DESCRIPTION
Summary:
* Fix DBTest.CompactRangeWithEmptyBottomLevel lite build failure
* Fix DBTest.AutomaticConflictsWithManualCompaction failure introduce by #3366 
* Fix BlockBasedTableTest::IndexUncompressed should be disabled if snappy is disabled
* Fix ASAN failure with DBBasicTest::DBClose test

Test Plan:
local run these tests under particular test modes.