### PR TITLE
Revert "Avoid too frequent MaybeScheduleFlushOrCompaction() call"

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1506,7 +1506,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
                : m->manual_end->DebugString().c_str()));
     }
   } else if (!is_prepicked && !compaction_queue_.empty()) {
-    if (HasExclusiveManualCompaction()) {
+    if (HaveManualCompaction(compaction_queue_.front())) {
       // Can't compact right now, but try again later
       TEST_SYNC_POINT("DBImpl::BackgroundCompaction()::Conflict");
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5103,7 +5103,7 @@ TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
       [&](void* arg) { callback_count.fetch_add(1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   CompactRangeOptions croptions;
-  croptions.exclusive_manual_compaction = true;
+  croptions.exclusive_manual_compaction = false;
   ASSERT_OK(db_->CompactRange(croptions, nullptr, nullptr));
   ASSERT_GE(callback_count.load(), 1);
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();


### PR DESCRIPTION
This reverts commit af92d4ad112f192693f6017f24f9ae1b00e1f053.

Also reverted part of dc360df81ec48e56a5d9cee4adb7f11ef0ca82ac that attempted to fix the test failure.

The manual compaction code is in worse shape than I imagined. It is difficult to fix the test for automatic/manual conflict as there are random checks everywhere that try to prevent conflict. I will revert now to fix the test and think if there's a way to save this part of the codebase.

Test Plan:

- `make check -j64`