### PR TITLE
Fix DBTest::SoftLimit TSAN failure

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5355,12 +5355,15 @@ class WriteStallListener : public EventListener {
  public:
   WriteStallListener() : condition_(WriteStallCondition::kNormal) {}
   void OnStallConditionsChanged(const WriteStallInfo& info) override {
+    MutexLock l(&mutex_);
     condition_ = info.condition.cur;
   }
   bool CheckCondition(WriteStallCondition expected) {
+    MutexLock l(&mutex_);
     return expected == condition_;
   }
  private:
+  port::Mutex mutex_;
   WriteStallCondition condition_;
 };
 


### PR DESCRIPTION
Summary:
Fix data race found by TSAN around WriteStallListener: https://gist.github.com/yiwu-arbug/027d2448b903648f2f0f40b05258d80f

Test Plan:
local run the test several times with TSAN