### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -16,8 +16,13 @@
 namespace rocksdb {
 
 #ifdef ROCKSDB_JEMALLOC
+#ifdef __FreeBSD__
+#include <malloc_np.h>
+#define je_malloc_stats_print malloc_stats_print
+#else
 #include "jemalloc/jemalloc.h"
-
+#endif
+  
 typedef struct {
   char* cur;
   char* end;


### PR DESCRIPTION
FreeBSD uses jemalloc as the base malloc implementation.
The patch has been functional on FreeBSD as of the MariaDB 10.2 port.