### PR TITLE
BlockBasedTable::NewDataBlockIterator to always return BlockIter

### DIFF
--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -22,7 +22,7 @@ namespace rocksdb {
 #else
 #include "jemalloc/jemalloc.h"
 #endif
-  
+
 typedef struct {
   char* cur;
   char* end;

--- a/table/block.cc
+++ b/table/block.cc
@@ -421,36 +421,28 @@ Block::Block(BlockContents&& contents, SequenceNumber _global_seqno,
   }
 }
 
-InternalIterator* Block::NewIterator(const Comparator* cmp, BlockIter* iter,
-                                     bool total_order_seek, Statistics* stats) {
+BlockIter* Block::NewIterator(const Comparator* cmp, BlockIter* iter,
+                              bool total_order_seek, Statistics* stats) {
+  BlockIter* ret_iter;
+  if (iter != nullptr) {
+    ret_iter = iter;
+  } else {
+    ret_iter = new BlockIter;
+  }
   if (size_ < 2*sizeof(uint32_t)) {
-    if (iter != nullptr) {
-      iter->SetStatus(Status::Corruption("bad block contents"));
-      return iter;
-    } else {
-      return NewErrorInternalIterator(Status::Corruption("bad block contents"));
-    }
+    ret_iter->SetStatus(Status::Corruption("bad block contents"));
+    return ret_iter;
   }
   const uint32_t num_restarts = NumRestarts();
   if (num_restarts == 0) {
-    if (iter != nullptr) {
-      iter->SetStatus(Status::OK());
-      return iter;
-    } else {
-      return NewEmptyInternalIterator();
-    }
+    ret_iter->SetStatus(Status::OK());
+    return ret_iter;
   } else {
     BlockPrefixIndex* prefix_index_ptr =
         total_order_seek ? nullptr : prefix_index_.get();
-
-    if (iter != nullptr) {
-      iter->Initialize(cmp, data_, restart_offset_, num_restarts,
-                       prefix_index_ptr, global_seqno_, read_amp_bitmap_.get());
-    } else {
-      iter = new BlockIter(cmp, data_, restart_offset_, num_restarts,
-                           prefix_index_ptr, global_seqno_,
-                           read_amp_bitmap_.get());
-    }
+    ret_iter->Initialize(cmp, data_, restart_offset_, num_restarts,
+                         prefix_index_ptr, global_seqno_,
+                         read_amp_bitmap_.get());
 
     if (read_amp_bitmap_) {
       if (read_amp_bitmap_->GetStatistics() != stats) {
@@ -460,7 +452,7 @@ InternalIterator* Block::NewIterator(const Comparator* cmp, BlockIter* iter,
     }
   }
 
-  return iter;
+  return ret_iter;
 }
 
 void Block::SetBlockPrefixIndex(BlockPrefixIndex* prefix_index) {

--- a/table/block.h
+++ b/table/block.h
@@ -168,10 +168,10 @@ class Block {
   // If total_order_seek is true, hash_index_ and prefix_index_ are ignored.
   // This option only applies for index block. For data block, hash_index_
   // and prefix_index_ are null, so this option does not matter.
-  InternalIterator* NewIterator(const Comparator* comparator,
-                                BlockIter* iter = nullptr,
-                                bool total_order_seek = true,
-                                Statistics* stats = nullptr);
+  BlockIter* NewIterator(const Comparator* comparator,
+                         BlockIter* iter = nullptr,
+                         bool total_order_seek = true,
+                         Statistics* stats = nullptr);
   void SetBlockPrefixIndex(BlockPrefixIndex* prefix_index);
 
   // Report an approximation of how much memory has been used.
@@ -191,8 +191,8 @@ class Block {
   const SequenceNumber global_seqno_;
 
   // No copying allowed
-  Block(const Block&);
-  void operator=(const Block&);
+  Block(const Block&) = delete;
+  void operator=(const Block&) = delete;
 };
 
 class BlockIter : public InternalIterator {

--- a/table/block.h
+++ b/table/block.h
@@ -198,8 +198,8 @@ class Block {
 class BlockIter : public InternalIterator {
  public:
   // Object created using this constructor will behave like an iterator
-  // against an empty block. Valid()=false after the creation and status()
-  // is OK.
+  // against an empty block. The state after the creation: Valid()=false
+  // and status() is OK.
   BlockIter()
       : comparator_(nullptr),
         data_(nullptr),

--- a/table/block.h
+++ b/table/block.h
@@ -197,6 +197,9 @@ class Block {
 
 class BlockIter : public InternalIterator {
  public:
+  // Object created using this constructor will behave like an iterator
+  // against an empty block. Valid()=false after the creation and status()
+  // is OK.
   BlockIter()
       : comparator_(nullptr),
         data_(nullptr),

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -215,11 +215,11 @@ class BlockBasedTable : public TableReader {
  private:
   friend class MockedBlockBasedTable;
   // input_iter: if it is not null, update this one and return it as Iterator
-  static InternalIterator* NewDataBlockIterator(
+  static BlockIter* NewDataBlockIterator(
       Rep* rep, const ReadOptions& ro, const Slice& index_value,
       BlockIter* input_iter = nullptr, bool is_index = false,
       GetContext* get_context = nullptr);
-  static InternalIterator* NewDataBlockIterator(
+  static BlockIter* NewDataBlockIterator(
       Rep* rep, const ReadOptions& ro, const BlockHandle& block_hanlde,
       BlockIter* input_iter = nullptr, bool is_index = false,
       GetContext* get_context = nullptr, Status s = Status());


### PR DESCRIPTION
Summary: This is a pre-cleaning up before a major block based table iterator refactoring. BlockBasedTable::NewDataBlockIterator() will always return BlockIter. This simplifies the logic and code and enable further refactoring and optimization.

Test Plan: Run all existing tests