### PR TITLE
Blob DB: dump blob_db_options.min_blob_size

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -73,6 +73,8 @@ void BlobDBOptions::Dump(Logger* log) const {
                    blob_dir_size);
   ROCKS_LOG_HEADER(log, "           blob_db_options.ttl_range_secs: %" PRIu32,
                    ttl_range_secs);
+  ROCKS_LOG_HEADER(log, "            blob_db_options.min_blob_size: %" PRIu64,
+                   min_blob_size);
   ROCKS_LOG_HEADER(log, "           blob_db_options.bytes_per_sync: %" PRIu64,
                    bytes_per_sync);
   ROCKS_LOG_HEADER(log, "           blob_db_options.blob_file_size: %" PRIu64,


### PR DESCRIPTION
Summary:
min_blob_size was missing from BlobDBOptions::Dump.

Test Plan:
Run db_bench with --use_blob_db --blob_db_min_blob_size=42. Sample output:
https://gist.github.com/yiwu-arbug/3d10894100c8c3757e9a070de29ee974