### PR TITLE
Make Iterator::SeekForPrev pure virtual

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Public API Change
+* Iterator::SeekForPrev is now a pure virtual method. This is to prevent user who implement the Iterator interface fail to implement SeekForPrev by mistake.
 ### Bug Fixes
 * Fix `DisableFileDeletions()` followed by `GetSortedWalFiles()` to not return obsolete WAL files that `PurgeObsoleteFiles()` is going to delete.
 * Fix DB::Flush() keep waiting after flush finish under certain condition.

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -51,7 +51,7 @@ class Iterator : public Cleanable {
   // Position at the last key in the source that at or before target
   // The iterator is Valid() after this call iff the source contains
   // an entry that comes at or before target.
-  virtual void SeekForPrev(const Slice& target) {}
+  virtual void SeekForPrev(const Slice& target) = 0;
 
   // Moves to the next entry in the source.  After this call, Valid() is
   // true iff the iterator was not positioned at the last entry in the source.


### PR DESCRIPTION
Summary:
To prevent user who implement the Iterator interface fail to implement SeekForPrev by mistake.

Test Plan:
Existing tests.