### PR TITLE
Handle error return from WriteBuffer()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 * Fix `DisableFileDeletions()` followed by `GetSortedWalFiles()` to not return obsolete WAL files that `PurgeObsoleteFiles()` is going to delete.
 * Fix DB::Flush() keep waiting after flush finish under certain condition.
+* Fix Handle error return from WriteBuffer() during WAL file close and DB close
 
 ## 5.10.0 (12/11/2017)
 ### Public API Change

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -904,10 +904,15 @@ TEST_F(DBBasicTest, DBCloseFlushError) {
       new FaultInjectionTestEnv(Env::Default()));
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
+  options.manual_wal_flush = true;
+  options.write_buffer_size=100;
   options.env = fault_injection_env.get();
 
   Reopen(options);
   ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Put("key2", "value2"));
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+  ASSERT_OK(Put("key3", "value3"));
   fault_injection_env->SetFilesystemActive(false);
   Status s = dbfull()->Close();
   fault_injection_env->SetFilesystemActive(true);

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -9,6 +9,7 @@
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
+#include "util/fault_injection_test_env.h"
 #if !defined(ROCKSDB_LITE)
 #include "util/sync_point.h"
 #endif
@@ -896,6 +897,23 @@ TEST_F(DBBasicTest, DBClose) {
   ASSERT_EQ(s, Status::OK());
   delete db;
   delete options.env;
+}
+
+TEST_F(DBBasicTest, DBCloseFlushError) {
+  std::unique_ptr<FaultInjectionTestEnv> fault_injection_env(
+      new FaultInjectionTestEnv(Env::Default()));
+  Options options = GetDefaultOptions();
+  options.create_if_missing = true;
+  options.env = fault_injection_env.get();
+
+  Reopen(options);
+  ASSERT_OK(Put("key1", "value1"));
+  fault_injection_env->SetFilesystemActive(false);
+  Status s = dbfull()->Close();
+  fault_injection_env->SetFilesystemActive(true);
+  ASSERT_NE(s, Status::OK());
+
+  Destroy(options);
 }
 
 }  // namespace rocksdb

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -185,6 +185,26 @@ TEST_P(DBFlushDirectIOTest, DirectIO) {
   delete options.env;
 }
 
+TEST_F(DBFlushTest, FlushError) {
+  Options options;
+  std::unique_ptr<FaultInjectionTestEnv> fault_injection_env(
+      new FaultInjectionTestEnv(env_));
+  options.write_buffer_size = 100;
+  options.max_write_buffer_number = 4;
+  options.min_write_buffer_number_to_merge = 3;
+  options.disable_auto_compactions = true;
+  options.env = fault_injection_env.get();
+  Reopen(options);
+
+  ASSERT_OK(Put("key1", "value1"));
+  ASSERT_OK(Put("key2", "value2"));
+  fault_injection_env->SetFilesystemActive(false);
+  Status s = dbfull()->TEST_SwitchMemtable();
+  fault_injection_env->SetFilesystemActive(true);
+  Destroy(options);
+  ASSERT_NE(s, Status::OK());
+}
+
 INSTANTIATE_TEST_CASE_P(DBFlushDirectIOTest, DBFlushDirectIOTest,
                         testing::Bool());
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -351,7 +351,7 @@ Status DBImpl::CloseImpl() {
   }
   for (auto& log : logs_) {
     uint64_t log_number = log.writer->get_log_number();
-    Status s = log.ClearWriter(immutable_db_options_.use_fsync);
+    Status s = log.ClearWriter();
     if (!s.ok()) {
       ROCKS_LOG_WARN(immutable_db_options_.info_log,
                      "Unable to Sync WAL file %s with error -- %s",

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -351,7 +351,7 @@ Status DBImpl::CloseImpl() {
   }
   for (auto& log : logs_) {
     uint64_t log_number = log.writer->get_log_number();
-    Status s = log.ClearWriter();
+    Status s = log.ClearWriter(immutable_db_options_.use_fsync);
     if (!s.ok()) {
       ROCKS_LOG_WARN(immutable_db_options_.info_log,
                      "Unable to Sync WAL file %s with error -- %s",

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -993,9 +993,11 @@ class DBImpl : public DB {
       writer = nullptr;
       return w;
     }
-    void ClearWriter() {
+    Status ClearWriter() {
+      Status s = writer->file()->Sync(true);
       delete writer;
       writer = nullptr;
+      return s;
     }
 
     uint64_t number;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -993,8 +993,8 @@ class DBImpl : public DB {
       writer = nullptr;
       return w;
     }
-    Status ClearWriter() {
-      Status s = writer->file()->Sync(true);
+    Status ClearWriter(bool use_fsync) {
+      Status s = writer->file()->Sync(use_fsync);
       delete writer;
       writer = nullptr;
       return s;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -993,8 +993,8 @@ class DBImpl : public DB {
       writer = nullptr;
       return w;
     }
-    Status ClearWriter(bool use_fsync) {
-      Status s = writer->file()->Sync(use_fsync);
+    Status ClearWriter() {
+      Status s = writer->WriteBuffer();
       delete writer;
       writer = nullptr;
       return s;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -173,8 +173,9 @@ class DB {
 
   // Close the DB by releasing resources, closing files etc. This should be
   // called before calling the desctructor so that the caller can get back a
-  // status in case there are any errors. Regardless of the return status, the
-  // DB must be freed
+  // status in case there are any errors. This will not fsync the WAL files.
+  // If syncing is required, the caller must first call SyncWAL.
+  // Regardless of the return status, the DB must be freed
   virtual Status Close() { return Status::OK(); }
 
   // ListColumnFamilies will open the DB specified by argument name


### PR DESCRIPTION
Summary:
There are a couple of places where we swallow any error from
WriteBuffer() - in SwitchMemtable() and DBImpl::CloseImpl(). Propagate
the error up in those cases rather than ignoring it.

Test Plan:
1. Added unit tests
2. make check