### PR TITLE
Customized BlockBasedTableIterator and LevelIterator

### DIFF
--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -383,14 +383,13 @@ void ForwardIterator::SeekInternal(const Slice& internal_key,
 
       if (!l0_iters_[i]->status().ok()) {
         immutable_status_ = l0_iters_[i]->status();
-      } else if (l0_iters_[i]->Valid()) {
-        if (!IsOverUpperBound(l0_iters_[i]->key())) {
-          immutable_min_heap_.push(l0_iters_[i]);
-        } else {
-          has_iter_trimmed_for_upper_bound_ = true;
-          DeleteIterator(l0_iters_[i]);
-          l0_iters_[i] = nullptr;
-        }
+      } else if (l0_iters_[i]->Valid() &&
+                 !IsOverUpperBound(l0_iters_[i]->key())) {
+        immutable_min_heap_.push(l0_iters_[i]);
+      } else {
+        has_iter_trimmed_for_upper_bound_ = true;
+        DeleteIterator(l0_iters_[i]);
+        l0_iters_[i] = nullptr;
       }
     }
 
@@ -417,15 +416,14 @@ void ForwardIterator::SeekInternal(const Slice& internal_key,
 
         if (!level_iters_[level - 1]->status().ok()) {
           immutable_status_ = level_iters_[level - 1]->status();
-        } else if (level_iters_[level - 1]->Valid()) {
-          if (!IsOverUpperBound(level_iters_[level - 1]->key())) {
-            immutable_min_heap_.push(level_iters_[level - 1]);
-          } else {
-            // Nothing in this level is interesting. Remove.
-            has_iter_trimmed_for_upper_bound_ = true;
-            DeleteIterator(level_iters_[level - 1]);
-            level_iters_[level - 1] = nullptr;
-          }
+        } else if (level_iters_[level - 1]->Valid() &&
+                   !IsOverUpperBound(level_iters_[level - 1]->key())) {
+          immutable_min_heap_.push(level_iters_[level - 1]);
+        } else {
+          // Nothing in this level is interesting. Remove.
+          has_iter_trimmed_for_upper_bound_ = true;
+          DeleteIterator(level_iters_[level - 1]);
+          level_iters_[level - 1] = nullptr;
         }
       }
     }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -212,11 +212,17 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     // Filters are already checked before seeking the index
     const bool skip_filters = true;
     const bool is_index = true;
-    return NewTwoLevelIterator(
-        new BlockBasedTable::BlockEntryIteratorState(
-            table_, ReadOptions(), icomparator_, skip_filters, is_index,
-            partition_map_.size() ? &partition_map_ : nullptr),
-        index_block_->NewIterator(icomparator_, nullptr, true));
+    if (!partition_map_.empty()) {
+      return NewTwoLevelIterator(
+          new BlockBasedTable::PartitionedIndexIteratorState(
+              table_, ReadOptions(), icomparator_, skip_filters, is_index,
+              partition_map_.size() ? &partition_map_ : nullptr),
+          index_block_->NewIterator(icomparator_, nullptr, true));
+    } else {
+      return new BlockBasedTableIterator(
+          table_, ReadOptions(), *icomparator_,
+          index_block_->NewIterator(icomparator_, nullptr, true), false);
+    }
     // TODO(myabandeh): Update TwoLevelIterator to be able to make use of
     // on-stack BlockIter while the state is on heap. Currentlly it assumes
     // the first level iter is always on heap and will attempt to delete it
@@ -1632,91 +1638,37 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
   return s;
 }
 
-BlockBasedTable::BlockEntryIteratorState::BlockEntryIteratorState(
-    BlockBasedTable* table, const ReadOptions& read_options,
-    const InternalKeyComparator* icomparator, bool skip_filters, bool is_index,
+BlockBasedTable::PartitionedIndexIteratorState::PartitionedIndexIteratorState(
+    BlockBasedTable* table,
     std::unordered_map<uint64_t, CachableEntry<Block>>* block_map)
-    : TwoLevelIteratorState(table->rep_->ioptions.prefix_extractor != nullptr),
-      table_(table),
-      read_options_(read_options),
-      icomparator_(icomparator),
-      skip_filters_(skip_filters),
-      is_index_(is_index),
-      block_map_(block_map) {}
+    : table_(table), block_map_(block_map) {}
 
-const size_t BlockBasedTable::BlockEntryIteratorState::kMaxReadaheadSize =
-    256 * 1024;
+const size_t BlockBasedTableIterator::kMaxReadaheadSize = 256 * 1024;
 
 InternalIterator*
-BlockBasedTable::BlockEntryIteratorState::NewSecondaryIterator(
+BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
     const Slice& index_value) {
   // Return a block iterator on the index partition
   BlockHandle handle;
   Slice input = index_value;
   Status s = handle.DecodeFrom(&input);
-  auto rep = table_->rep_;
-  if (block_map_) {
-    auto block = block_map_->find(handle.offset());
-    // This is a possible scenario since block cache might not have had space
-    // for the partition
-    if (block != block_map_->end()) {
-      PERF_COUNTER_ADD(block_cache_hit_count, 1);
-      RecordTick(rep->ioptions.statistics, BLOCK_CACHE_INDEX_HIT);
-      RecordTick(rep->ioptions.statistics, BLOCK_CACHE_HIT);
-      Cache* block_cache = rep->table_options.block_cache.get();
-      assert(block_cache);
-      RecordTick(rep->ioptions.statistics, BLOCK_CACHE_BYTES_READ,
-                 block_cache->GetUsage(block->second.cache_handle));
-      return block->second.value->NewIterator(
-          &rep->internal_comparator, nullptr, true, rep->ioptions.statistics);
-    }
+  auto rep = table_->get_rep();
+  auto block = block_map_->find(handle.offset());
+  // This is a possible scenario since block cache might not have had space
+  // for the partition
+  if (block != block_map_->end()) {
+    PERF_COUNTER_ADD(block_cache_hit_count, 1);
+    RecordTick(rep->ioptions.statistics, BLOCK_CACHE_INDEX_HIT);
+    RecordTick(rep->ioptions.statistics, BLOCK_CACHE_HIT);
+    Cache* block_cache = rep->table_options.block_cache.get();
+    assert(block_cache);
+    RecordTick(rep->ioptions.statistics, BLOCK_CACHE_BYTES_READ,
+               block_cache->GetUsage(block->second.cache_handle));
+    return block->second.value->NewIterator(&rep->internal_comparator, nullptr,
+                                            true, rep->ioptions.statistics);
   }
-
-  // Automatically prefetch additional data when a range scan (iterator) does
-  // more than 2 sequential IOs. This is enabled only when
-  // ReadOptions.readahead_size is 0.
-  if (read_options_.readahead_size == 0) {
-    if (num_file_reads_ < 2) {
-      num_file_reads_++;
-    } else if (handle.offset() + static_cast<size_t>(handle.size()) +
-                   kBlockTrailerSize >
-               readahead_limit_) {
-      num_file_reads_++;
-      // Do not readahead more than kMaxReadaheadSize.
-      readahead_size_ =
-          std::min(BlockBasedTable::BlockEntryIteratorState::kMaxReadaheadSize,
-                   readahead_size_);
-      table_->rep_->file->Prefetch(handle.offset(), readahead_size_);
-      readahead_limit_ = handle.offset() + readahead_size_;
-      // Keep exponentially increasing readahead size until kMaxReadaheadSize.
-      readahead_size_ *= 2;
-    }
-  }
-
-  return NewDataBlockIterator(rep, read_options_, handle,
-                              /* input_iter */ nullptr, is_index_,
-                              /* get_context */ nullptr, s);
-}
-
-bool BlockBasedTable::BlockEntryIteratorState::PrefixMayMatch(
-    const Slice& internal_key) {
-  if (read_options_.total_order_seek || skip_filters_) {
-    return true;
-  }
-  return table_->PrefixMayMatch(internal_key);
-}
-
-bool BlockBasedTable::BlockEntryIteratorState::KeyReachedUpperBound(
-    const Slice& internal_key) {
-  bool reached_upper_bound = read_options_.iterate_upper_bound != nullptr &&
-                             icomparator_ != nullptr &&
-                             icomparator_->user_comparator()->Compare(
-                                 ExtractUserKey(internal_key),
-                                 *read_options_.iterate_upper_bound) >= 0;
-  TEST_SYNC_POINT_CALLBACK(
-      "BlockBasedTable::BlockEntryIteratorState::KeyReachedUpperBound",
-      &reached_upper_bound);
-  return reached_upper_bound;
+  // Create an empty iterator
+  return new BlockIter();
 }
 
 // This will be broken if the user specifies an unusual implementation
@@ -1820,13 +1772,224 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key) {
   return may_match;
 }
 
+void BlockBasedTableIterator::Seek(const Slice& target) {
+  if (!CheckPrefixMayMatch(target)) {
+    ResetDataIter();
+    return;
+  }
+
+  SavePrevIndexValue();
+
+  index_iter_->Seek(target);
+
+  if (!index_iter_->Valid()) {
+    ResetDataIter();
+    return;
+  }
+
+  InitDataBlock();
+
+  data_block_iter_.Seek(target);
+
+  FindKeyForward();
+  assert(!data_block_iter_.Valid() ||
+         icomp_.Compare(target, data_block_iter_.key()) <= 0);
+}
+
+void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
+  if (!CheckPrefixMayMatch(target)) {
+    ResetDataIter();
+    return;
+  }
+
+  SavePrevIndexValue();
+
+  // Call Seek() rather than SeekForPrev() in the index block, because the
+  // target data block will likely to contain the position for `target`, the
+  // same as Seek(), rather than than before.
+  // For example, if we have three data blocks, each containing two keys:
+  //   [2, 4]  [6, 8] [10, 12]
+  //  (the keys in the index block would be [4, 8, 12])
+  // and the user calls SeekForPrev(7), we need to go to the second block,
+  // just like if they call Seek(7).
+  // The only case where the block is difference is when they seek to a position
+  // in the boundary. For example, if they SeekForPrev(5), we should go to the
+  // first block, rather than the second. However, we don't have the information
+  // to distinguish the two unless we read the second block. In this case, we'll
+  // end up with reading two blocks.
+  index_iter_->Seek(target);
+
+  if (!index_iter_->Valid()) {
+    index_iter_->SeekToLast();
+    if (!index_iter_->Valid()) {
+      ResetDataIter();
+      block_iter_points_to_real_block_ = false;
+      return;
+    }
+  }
+
+  InitDataBlock();
+
+  data_block_iter_.SeekForPrev(target);
+
+  FindKeyBackward();
+  assert(!data_block_iter_.Valid() ||
+         icomp_.Compare(target, data_block_iter_.key()) >= 0);
+}
+
+void BlockBasedTableIterator::SeekToFirst() {
+  SavePrevIndexValue();
+  index_iter_->SeekToFirst();
+  if (!index_iter_->Valid()) {
+    ResetDataIter();
+    return;
+  }
+  InitDataBlock();
+  data_block_iter_.SeekToFirst();
+  FindKeyForward();
+}
+
+void BlockBasedTableIterator::SeekToLast() {
+  SavePrevIndexValue();
+  index_iter_->SeekToLast();
+  if (!index_iter_->Valid()) {
+    ResetDataIter();
+    return;
+  }
+  InitDataBlock();
+  data_block_iter_.SeekToLast();
+  FindKeyBackward();
+}
+
+void BlockBasedTableIterator::Next() {
+  assert(block_iter_points_to_real_block_);
+  data_block_iter_.Next();
+  FindKeyForward();
+}
+
+void BlockBasedTableIterator::Prev() {
+  assert(block_iter_points_to_real_block_);
+  data_block_iter_.Prev();
+  FindKeyBackward();
+}
+
+void BlockBasedTableIterator::InitDataBlock() {
+  BlockHandle data_block_handle;
+  Slice handle_slice = index_iter_->value();
+  if (!block_iter_points_to_real_block_ ||
+      handle_slice.compare(prev_index_value_) != 0) {
+    if (block_iter_points_to_real_block_) {
+      ResetDataIter();
+    }
+    Status s = data_block_handle.DecodeFrom(&handle_slice);
+    auto* rep = table_->get_rep();
+
+    // Automatically prefetch additional data when a range scan (iterator) does
+    // more than 2 sequential IOs. This is enabled only when
+    // ReadOptions.readahead_size is 0.
+    if (read_options_.readahead_size == 0) {
+      if (num_file_reads_ < 2) {
+        num_file_reads_++;
+      } else if (data_block_handle.offset() +
+                     static_cast<size_t>(data_block_handle.size()) +
+                     kBlockTrailerSize >
+                 readahead_limit_) {
+        num_file_reads_++;
+        // Do not readahead more than kMaxReadaheadSize.
+        readahead_size_ = std::min(kMaxReadaheadSize, readahead_size_);
+        table_->get_rep()->file->Prefetch(data_block_handle.offset(),
+                                          readahead_size_);
+        readahead_limit_ = data_block_handle.offset() + readahead_size_;
+        // Keep exponentially increasing readahead size until kMaxReadaheadSize.
+        readahead_size_ *= 2;
+      }
+    }
+
+    BlockBasedTable::NewDataBlockIterator(rep, read_options_, data_block_handle,
+                                          &data_block_iter_, false,
+                                          /* get_context */ nullptr, s);
+    block_iter_points_to_real_block_ = true;
+  }
+}
+
+void BlockBasedTableIterator::FindKeyForward() {
+  is_out_of_bound_ = false;
+  // TODO the while loop inherits from two-level-iterator. We don't know
+  // whether a block can be empty so it can be replaced by an "if".
+  while (!data_block_iter_.Valid()) {
+    if (!data_block_iter_.status().ok()) {
+      return;
+    }
+    ResetDataIter();
+    // We used to check the current index key for upperbound.
+    // It will only save a data reading for a small percentage of use cases,
+    // so for code simplicity, we removed it. We can add it back if there is a
+    // significnat performance regression.
+    index_iter_->Next();
+
+    if (index_iter_->Valid()) {
+      InitDataBlock();
+      data_block_iter_.SeekToFirst();
+    } else {
+      return;
+    }
+  }
+
+  // Check upper bound on the current key
+  bool reached_upper_bound =
+      (read_options_.iterate_upper_bound != nullptr &&
+       block_iter_points_to_real_block_ && data_block_iter_.Valid() &&
+       icomp_.user_comparator()->Compare(ExtractUserKey(data_block_iter_.key()),
+                                         *read_options_.iterate_upper_bound) >=
+           0);
+  TEST_SYNC_POINT_CALLBACK(
+      "BlockBasedTable::BlockEntryIteratorState::KeyReachedUpperBound",
+      &reached_upper_bound);
+  if (reached_upper_bound) {
+    is_out_of_bound_ = true;
+    ResetDataIter();
+    return;
+  }
+}
+
+void BlockBasedTableIterator::FindKeyBackward() {
+  while (!data_block_iter_.Valid()) {
+    if (!data_block_iter_.status().ok()) {
+      return;
+    }
+
+    ResetDataIter();
+    index_iter_->Prev();
+
+    if (index_iter_->Valid()) {
+      InitDataBlock();
+      data_block_iter_.SeekToLast();
+    } else {
+      return;
+    }
+  }
+
+  // We could have check lower bound here too, but we opt not to do it for
+  // code simplicity.
+}
+
 InternalIterator* BlockBasedTable::NewIterator(const ReadOptions& read_options,
                                                Arena* arena,
                                                bool skip_filters) {
-  return NewTwoLevelIterator(
-      new BlockEntryIteratorState(this, read_options,
-                                  &rep_->internal_comparator, skip_filters),
-      NewIndexIterator(read_options), arena);
+  if (arena == nullptr) {
+    return new BlockBasedTableIterator(
+        this, read_options, rep_->internal_comparator,
+        NewIndexIterator(read_options),
+        !skip_filters && !read_options.total_order_seek &&
+            rep_->ioptions.prefix_extractor != nullptr);
+  } else {
+    auto* mem = arena->AllocateAligned(sizeof(BlockBasedTableIterator));
+    return new (mem) BlockBasedTableIterator(
+        this, read_options, rep_->internal_comparator,
+        NewIndexIterator(read_options),
+        !skip_filters && !read_options.total_order_seek &&
+            rep_->ioptions.prefix_extractor != nullptr);
+  }
 }
 
 InternalIterator* BlockBasedTable::NewRangeTombstoneIterator(
@@ -1854,8 +2017,8 @@ InternalIterator* BlockBasedTable::NewRangeTombstoneIterator(
   }
   std::string str;
   rep_->range_del_handle.EncodeTo(&str);
-  // The meta-block exists but isn't in uncompressed block cache (maybe because
-  // it is disabled), so go through the full lookup process.
+  // The meta-block exists but isn't in uncompressed block cache (maybe
+  // because it is disabled), so go through the full lookup process.
   return NewDataBlockIterator(rep_, read_options, Slice(str));
 }
 
@@ -1932,8 +2095,8 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {
           // couldn't get block from block_cache
-          // Update Saver.state to Found because we are only looking for whether
-          // we can guarantee the key is not there when "no_io" is set
+          // Update Saver.state to Found because we are only looking for
+          // whether we can guarantee the key is not there when "no_io" is set
           get_context->MarkKeyMayExist();
           break;
         }
@@ -2098,8 +2261,8 @@ bool BlockBasedTable::TEST_KeyInCache(const ReadOptions& options,
 
   char cache_key_storage[kMaxCacheKeyPrefixSize + kMaxVarint64Length];
   Slice cache_key =
-      GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
-                  handle, cache_key_storage);
+      GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size, handle,
+                  cache_key_storage);
   Slice ckey;
 
   s = GetDataBlockFromCache(

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -210,13 +210,10 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
   virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
                                         bool dont_care = true) override {
     // Filters are already checked before seeking the index
-    const bool skip_filters = true;
-    const bool is_index = true;
     if (!partition_map_.empty()) {
       return NewTwoLevelIterator(
           new BlockBasedTable::PartitionedIndexIteratorState(
-              table_, ReadOptions(), icomparator_, skip_filters, is_index,
-              partition_map_.size() ? &partition_map_ : nullptr),
+              table_, partition_map_.size() ? &partition_map_ : nullptr),
           index_block_->NewIterator(icomparator_, nullptr, true));
     } else {
       return new BlockBasedTableIterator(

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -69,6 +69,10 @@ class InternalIterator : public Cleanable {
   // satisfied without doing some IO, then this returns Status::Incomplete().
   virtual Status status() const = 0;
 
+  // True if the iterator is invalidated because it is out of the iterator
+  // upper bound
+  virtual bool IsOutOfBound() { return false; }
+
   // Pass the PinnedIteratorsManager to the Iterator, most Iterators dont
   // communicate with PinnedIteratorsManager so default implementation is no-op
   // but for Iterators that need to communicate with PinnedIteratorsManager

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -22,22 +22,9 @@ namespace {
 class TwoLevelIterator : public InternalIterator {
  public:
   explicit TwoLevelIterator(TwoLevelIteratorState* state,
-                            InternalIterator* first_level_iter,
-                            bool need_free_iter_and_state);
+                            InternalIterator* first_level_iter);
 
-  virtual ~TwoLevelIterator() {
-    // Assert that the TwoLevelIterator is never deleted while Pinning is
-    // Enabled.
-    assert(!pinned_iters_mgr_ ||
-           (pinned_iters_mgr_ && !pinned_iters_mgr_->PinningEnabled()));
-    first_level_iter_.DeleteIter(!need_free_iter_and_state_);
-    second_level_iter_.DeleteIter(false);
-    if (need_free_iter_and_state_) {
-      delete state_;
-    } else {
-      state_->~TwoLevelIteratorState();
-    }
-  }
+  virtual ~TwoLevelIterator() { delete state_; }
 
   virtual void Seek(const Slice& target) override;
   virtual void SeekForPrev(const Slice& target) override;
@@ -68,20 +55,9 @@ class TwoLevelIterator : public InternalIterator {
   }
   virtual void SetPinnedItersMgr(
       PinnedIteratorsManager* pinned_iters_mgr) override {
-    pinned_iters_mgr_ = pinned_iters_mgr;
-    first_level_iter_.SetPinnedItersMgr(pinned_iters_mgr);
-    if (second_level_iter_.iter()) {
-      second_level_iter_.SetPinnedItersMgr(pinned_iters_mgr);
-    }
   }
-  virtual bool IsKeyPinned() const override {
-    return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
-           second_level_iter_.iter() && second_level_iter_.IsKeyPinned();
-  }
-  virtual bool IsValuePinned() const override {
-    return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
-           second_level_iter_.iter() && second_level_iter_.IsValuePinned();
-  }
+  virtual bool IsKeyPinned() const override { return false; }
+  virtual bool IsValuePinned() const override { return false; }
 
  private:
   void SaveError(const Status& s) {
@@ -95,8 +71,6 @@ class TwoLevelIterator : public InternalIterator {
   TwoLevelIteratorState* state_;
   IteratorWrapper first_level_iter_;
   IteratorWrapper second_level_iter_;  // May be nullptr
-  bool need_free_iter_and_state_;
-  PinnedIteratorsManager* pinned_iters_mgr_;
   Status status_;
   // If second_level_iter is non-nullptr, then "data_block_handle_" holds the
   // "index_value" passed to block_function_ to create the second_level_iter.
@@ -104,19 +78,10 @@ class TwoLevelIterator : public InternalIterator {
 };
 
 TwoLevelIterator::TwoLevelIterator(TwoLevelIteratorState* state,
-                                   InternalIterator* first_level_iter,
-                                   bool need_free_iter_and_state)
-    : state_(state),
-      first_level_iter_(first_level_iter),
-      need_free_iter_and_state_(need_free_iter_and_state),
-      pinned_iters_mgr_(nullptr) {}
+                                   InternalIterator* first_level_iter)
+    : state_(state), first_level_iter_(first_level_iter) {}
 
 void TwoLevelIterator::Seek(const Slice& target) {
-  if (state_->check_prefix_may_match &&
-      !state_->PrefixMayMatch(target)) {
-    SetSecondLevelIterator(nullptr);
-    return;
-  }
   first_level_iter_.Seek(target);
 
   InitDataBlock();
@@ -127,10 +92,6 @@ void TwoLevelIterator::Seek(const Slice& target) {
 }
 
 void TwoLevelIterator::SeekForPrev(const Slice& target) {
-  if (state_->check_prefix_may_match && !state_->PrefixMayMatch(target)) {
-    SetSecondLevelIterator(nullptr);
-    return;
-  }
   first_level_iter_.Seek(target);
   InitDataBlock();
   if (second_level_iter_.iter() != nullptr) {
@@ -183,8 +144,7 @@ void TwoLevelIterator::SkipEmptyDataBlocksForward() {
          (!second_level_iter_.Valid() &&
           !second_level_iter_.status().IsIncomplete())) {
     // Move to next block
-    if (!first_level_iter_.Valid() ||
-        state_->KeyReachedUpperBound(first_level_iter_.key())) {
+    if (!first_level_iter_.Valid()) {
       SetSecondLevelIterator(nullptr);
       return;
     }
@@ -217,17 +177,8 @@ void TwoLevelIterator::SetSecondLevelIterator(InternalIterator* iter) {
   if (second_level_iter_.iter() != nullptr) {
     SaveError(second_level_iter_.status());
   }
-
-  if (pinned_iters_mgr_ && iter) {
-    iter->SetPinnedItersMgr(pinned_iters_mgr_);
-  }
-
   InternalIterator* old_iter = second_level_iter_.Set(iter);
-  if (pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled()) {
-    pinned_iters_mgr_->PinIterator(old_iter);
-  } else {
-    delete old_iter;
-  }
+  delete old_iter;
 }
 
 void TwoLevelIterator::InitDataBlock() {
@@ -251,17 +202,7 @@ void TwoLevelIterator::InitDataBlock() {
 }  // namespace
 
 InternalIterator* NewTwoLevelIterator(TwoLevelIteratorState* state,
-                                      InternalIterator* first_level_iter,
-                                      Arena* arena,
-                                      bool need_free_iter_and_state) {
-  if (arena == nullptr) {
-    return new TwoLevelIterator(state, first_level_iter,
-                                need_free_iter_and_state);
-  } else {
-    auto mem = arena->AllocateAligned(sizeof(TwoLevelIterator));
-    return new (mem)
-        TwoLevelIterator(state, first_level_iter, need_free_iter_and_state);
-  }
+                                      InternalIterator* first_level_iter) {
+  return new TwoLevelIterator(state, first_level_iter);
 }
-
 }  // namespace rocksdb

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -19,16 +19,10 @@ class InternalKeyComparator;
 class Arena;
 
 struct TwoLevelIteratorState {
-  explicit TwoLevelIteratorState(bool _check_prefix_may_match)
-      : check_prefix_may_match(_check_prefix_may_match) {}
+  TwoLevelIteratorState() {}
 
   virtual ~TwoLevelIteratorState() {}
   virtual InternalIterator* NewSecondaryIterator(const Slice& handle) = 0;
-  virtual bool PrefixMayMatch(const Slice& internal_key) = 0;
-  virtual bool KeyReachedUpperBound(const Slice& internal_key) = 0;
-
-  // If call PrefixMayMatch()
-  bool check_prefix_may_match;
 };
 
 
@@ -47,7 +41,6 @@ struct TwoLevelIteratorState {
 // need_free_iter_and_state: free `state` and `first_level_iter` if
 //                           true. Otherwise, just call destructor.
 extern InternalIterator* NewTwoLevelIterator(
-    TwoLevelIteratorState* state, InternalIterator* first_level_iter,
-    Arena* arena = nullptr, bool need_free_iter_and_state = true);
+    TwoLevelIteratorState* state, InternalIterator* first_level_iter);
 
 }  // namespace rocksdb


### PR DESCRIPTION
Summary:
Use a customzied BlockBasedTableIterator and LevelIterator to replace current implementations leveraging two-level-iterator. Hope the customized logic will make code easier to understand. As a side effect, BlockBasedTableIterator reduces the allocation for the data block iterator object, and avoid the virtual function call to it, because we can directly reference BlockIter, a final class. Similarly, LevelIterator reduces virtual function call to the dummy iterator iterating the file metadata. It also enabled further optimization.

The upper bound check is also moved from index block to data block. This implementation fits this iterator better. After the change, forwared iterator is slightly optimized to ensure we trim those iterators.

The two-level-iterator now is only used by partitioned index, so it is simplified.

Test Plan: Run all existing tests using ASAN.