### PR TITLE
Rounddown in FilePrefetchBuffer::Prefetch

### DIFF
--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -23,6 +23,8 @@ inline size_t Roundup(size_t x, size_t y) {
   return ((x + y - 1) / y) * y;
 }
 
+inline size_t Rounddown(size_t x, size_t y) { return (x / y) * y; }
+
 // This class is to manage an aligned user
 // allocated buffer for direct I/O purposes
 // though can be used for any purpose.

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -606,16 +606,19 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
 Status FilePrefetchBuffer::Prefetch(RandomAccessFileReader* reader,
                                     uint64_t offset, size_t n) {
   size_t alignment = reader->file()->GetRequiredBufferAlignment();
-  uint64_t roundup_offset = Roundup(offset, alignment);
-  uint64_t roundup_len = Roundup(n, alignment);
+  uint64_t rounddown_offset = Rounddown(offset, alignment);
+  uint64_t roundup_end = Roundup(offset + n, alignment);
+  uint64_t roundup_len = roundup_end - rounddown_offset;
+  assert(roundup_len >= alignment);
+  assert(roundup_len % alignment == 0);
   buffer_.Alignment(alignment);
   buffer_.AllocateNewBuffer(roundup_len);
 
   Slice result;
-  Status s =
-      reader->Read(roundup_offset, roundup_len, &result, buffer_.BufferStart());
+  Status s = reader->Read(rounddown_offset, roundup_len, &result,
+                          buffer_.BufferStart());
   if (s.ok()) {
-    buffer_offset_ = roundup_offset;
+    buffer_offset_ = rounddown_offset;
     buffer_len_ = result.size();
   }
   return s;


### PR DESCRIPTION
FilePrefetchBuffer::Prefetch is currently rounds the offset up which does not fit its new use cases in prefetching index/filter blocks, as it would skips over some the offsets that were requested to be prefetched. This patch rounds down instead.

Fixes #3180 