### PR TITLE
db_bench support for memtable in-place update

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -845,6 +845,13 @@ DEFINE_bool(enable_pipelined_write, true,
 DEFINE_bool(allow_concurrent_memtable_write, true,
             "Allow multi-writers to update mem tables in parallel.");
 
+DEFINE_bool(inplace_update_support, rocksdb::Options().inplace_update_support,
+            "Support in-place memtable update for smaller or same-size values");
+
+DEFINE_uint64(inplace_update_num_locks,
+              rocksdb::Options().inplace_update_num_locks,
+              "Number of RW locks to protect in-place memtable updates");
+
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");
 
@@ -3198,6 +3205,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     options.delayed_write_rate = FLAGS_delayed_write_rate;
     options.allow_concurrent_memtable_write =
         FLAGS_allow_concurrent_memtable_write;
+    options.inplace_update_support = FLAGS_inplace_update_support;
+    options.inplace_update_num_locks = FLAGS_inplace_update_num_locks;
     options.enable_write_thread_adaptive_yield =
         FLAGS_enable_write_thread_adaptive_yield;
     options.enable_pipelined_write = FLAGS_enable_pipelined_write;


### PR DESCRIPTION
Test Plan:

tried it out:

```
$ ./db_bench -benchmarks=fillrandom -num=100000 -duration=30 -write_buffer_size=1048576000 -disable_wal=true -threads=64 -inplace_update_support=true -allow_concurrent_memtable_write=false
...
$ grep "inplace_update" /tmp/rocksdbtest-9383/dbbench/LOG
2018/01/25-20:49:45.862628 7faae4ef6200                   Options.inplace_update_support: 1
2018/01/25-20:49:45.862629 7faae4ef6200                 Options.inplace_update_num_locks: 10000
```