### PR TITLE
fix db_bench filluniquerandom key count assertion

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3495,7 +3495,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         case RANDOM:
           return rand_->Next() % num_;
         case UNIQUE_RANDOM:
-          assert(next_ + 1 < num_);
+          assert(next_ < num_);
           return values_[next_++];
       }
       assert(false);


### PR DESCRIPTION
It failed every time. I guess people usually ran with assertions disabled.

Test Plan:

- verified "filluniquerandom" now works with assertions enabled:
`$ TEST_TMPDIR=/data/compaction_bench ./db_bench -benchmarks=filluniquerandom -compression_type=none -num=1000000 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -max_background_jobs=12`