### PR TITLE
cache-align read-write locks for in-place memtable updates

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -420,7 +420,7 @@ InternalIterator* MemTable::NewRangeTombstoneIterator(
 
 port::RWMutex* MemTable::GetLock(const Slice& key) {
   static murmur_hash hash;
-  return &locks_[hash(key) % locks_.size()];
+  return &locks_[hash(key) % locks_.size()].rw_mutex;
 }
 
 MemTable::MemTableStats MemTable::ApproximateStats(const Slice& start_ikey,

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -423,8 +423,13 @@ class MemTable {
   // which has been inserted into this memtable.
   std::atomic<uint64_t> min_prep_log_referenced_;
 
+  struct AlignedRWMutex {
+    port::RWMutex rw_mutex;
+    char padding[CACHE_LINE_SIZE - sizeof(port::RWMutex) % CACHE_LINE_SIZE];
+  };
+  static_assert(sizeof(AlignedRWMutex) % 64 == 0, "Expected 64-byte aligned");
   // rw locks for inplace updates
-  std::vector<port::RWMutex> locks_;
+  std::vector<AlignedRWMutex> locks_;
 
   const SliceTransform* const prefix_extractor_;
   std::unique_ptr<DynamicBloom> prefix_bloom_;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -425,7 +425,8 @@ class MemTable {
 
   struct AlignedRWMutex {
     port::RWMutex rw_mutex;
-    char padding[CACHE_LINE_SIZE - sizeof(port::RWMutex) % CACHE_LINE_SIZE];
+    char padding[(CACHE_LINE_SIZE - sizeof(port::RWMutex) % CACHE_LINE_SIZE) %
+                 CACHE_LINE_SIZE];
   };
   static_assert(sizeof(AlignedRWMutex) % 64 == 0, "Expected 64-byte aligned");
   // rw locks for inplace updates


### PR DESCRIPTION
These read-write locks are a contention point for one of our users. `pthread_rwlock_t` is 56 bytes so it's tempting to pad it to 64 bytes and avoid cache-line bouncing. It looks particularly beneficial for benchmarks when `inplace_update_num_locks` is really low. I didn't see benefit in the default case (`inplace_update_num_locks=10000`).

Benchmark command:

```
$ ./db_bench.opt -benchmarks=readwhilewriting -disable_wal=true -duration=60 -num=100000 -write_buffer_size=104857600 -threads=64 -inplace_update_support=true -allow_concurrent_memtable_write=false -inplace_update_num_locks=100 -benchmark_read_rate_limit=10000000 -memtablerep=hash_linkedlist -prefix_size=8
```

Results before this PR:

```
bg writer    :       0.840 micros/op 1190598 ops/sec;  131.7 MB/s
readwhilewriting :       0.100 micros/op 9994217 ops/sec;  152.1 MB/s (9388272 of 9399999 found)
```

Results after this PR:

```
bg writer    :       0.721 micros/op 1387023 ops/sec;  153.4 MB/s
readwhilewriting :       0.100 micros/op 9992979 ops/sec;  152.1 MB/s (9382064 of 9407999 found)
```

Test Plan:

- `make check -j64`