### PR TITLE
Fix DBFlushTest::ManualFlushWithMinWriteBufferNumberToMerge dead lock

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -137,7 +137,7 @@ TEST_F(DBFlushTest, ManualFlushWithMinWriteBufferNumberToMerge) {
       {{"DBImpl::BGWorkFlush",
         "DBFlushTest::ManualFlushWithMinWriteBufferNumberToMerge:1"},
        {"DBFlushTest::ManualFlushWithMinWriteBufferNumberToMerge:2",
-        "DBImpl::FlushMemTableToOutputFile:BeforeInstallSV"}});
+        "FlushJob::WriteLevel0Table"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
   ASSERT_OK(Put("key1", "value1"));

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -134,7 +134,6 @@ Status DBImpl::FlushMemTableToOutputFile(
   }
 
   if (s.ok()) {
-    TEST_SYNC_POINT("DBImpl::FlushMemTableToOutputFile:BeforeInstallSV");
     InstallSuperVersionAndScheduleWork(cfd, &job_context->superversion_context,
                                        mutable_cf_options);
     if (made_progress) {


### PR DESCRIPTION
Summary:
In the test, there can be a dead lock between background flush thread and foreground main thread as following:
* background flush thread:
  - holding db mutex, while
  - waiting on "DBImpl::FlushMemTableToOutputFile:BeforeInstallSV" sync point.
* foreground thread: 
  - waiting for db mutex to write "key2"

Fixing by let background flush thread wait without holding db mutex.

Test Plan:
run `make test` 10 times locally and don't see db_flush_test hang.
