### PR TITLE
use less time and space in MultiThreadedDBTest.MultiThreaded test

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1927,7 +1927,7 @@ namespace {
 
 static const int kColumnFamilies = 10;
 static const int kNumThreads = 10;
-static const int kTestSeconds = 10;
+static const int kTestSeconds = 1;
 static const int kNumKeys = 1000;
 
 struct MTState {
@@ -2052,6 +2052,9 @@ TEST_P(MultiThreadedDBTest, MultiThreaded) {
   anon::OptionsOverride options_override;
   options_override.skip_policy = kSkipNoSnapshot;
   Options options = CurrentOptions(options_override);
+  options.max_bytes_for_level_base = 4 << 20;
+  options.target_file_size_base = 1 << 20;
+  options.write_buffer_size = 1 << 20;
   std::vector<std::string> cfs;
   for (int i = 1; i < kColumnFamilies; ++i) {
     cfs.push_back(ToString(i));


### PR DESCRIPTION
Previously it consumed 250MB space and took 5 minutes when run serially. Now it consumes ~10MB and takes 30 seconds. The number of files/compactions is more now, too. In the longer term we should get rid of this test and just rely on `db_stress`.