### PR TITLE
Update rocksdb.read.block.get.micros when block cache disabled

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1499,11 +1499,15 @@ BlockIter* BlockBasedTable::NewDataBlockIterator(
       return iter;
     }
     std::unique_ptr<Block> block_value;
-    s = ReadBlockFromFile(rep->file.get(), nullptr /* prefetch_buffer */,
-                          rep->footer, ro, handle, &block_value, rep->ioptions,
-                          true /* compress */, compression_dict,
-                          rep->persistent_cache_options, rep->global_seqno,
-                          rep->table_options.read_amp_bytes_per_bit);
+    {
+      StopWatch sw(rep->ioptions.env, rep->ioptions.statistics,
+                   READ_BLOCK_GET_MICROS);
+      s = ReadBlockFromFile(
+          rep->file.get(), nullptr /* prefetch_buffer */, rep->footer, ro,
+          handle, &block_value, rep->ioptions, true /* compress */,
+          compression_dict, rep->persistent_cache_options, rep->global_seqno,
+          rep->table_options.read_amp_bytes_per_bit);
+    }
     if (s.ok()) {
       block.value = block_value.release();
     }


### PR DESCRIPTION
Previously `ReadBlockFromFile` for data blocks was only measured when reading a block to populate block cache. This PR adds the corresponding measurements for users who disabled block cache.

Test Plan: 

- `make check -j64`
- verify stat updated in db_bench:

```
$ TEST_TMPDIR=/dev/shm ./db_bench -benchmarks=readwhilewriting -cache_size=0 -statistics -num=1000000 -write_buffer_size=1048576
...
rocksdb.read.block.get.micros statistics Percentiles :=> 50 : 2.155096 95 : 2.953091 99 : 5.765839 100 : 398.000000
...
```