### PR TITLE
Make WithParamInterface virtual in transaction_test

### DIFF
--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -400,7 +400,7 @@ class TransactionTestBase : public ::testing::Test {
 };
 
 class TransactionTest : public TransactionTestBase,
-                        public ::testing::WithParamInterface<
+                        virtual public ::testing::WithParamInterface<
                             std::tuple<bool, bool, TxnDBWritePolicy>> {
  public:
   TransactionTest()

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -360,7 +360,7 @@ class WritePreparedTransactionTest
 
 class SnapshotConcurrentAccessTest
     : public WritePreparedTransactionTestBase,
-      public ::testing::WithParamInterface<
+      virtual public ::testing::WithParamInterface<
           std::tuple<bool, bool, TxnDBWritePolicy, size_t, size_t>> {
  public:
   SnapshotConcurrentAccessTest()


### PR DESCRIPTION
Without this patch, ubsan_check is currently failing with this error:
```
utilities/transactions/write_prepared_transaction_test.cc:369:63: runtime error: member call on address 0x0000051649f8 which does not point to an object of type 'WithParamInterface'
0x0000051649f8: note: object has invalid vptr
```
Tested by `COMPILE_WITH_UBSAN=1 make -j32 transaction_test` and running `./write_prepared_transaction_test --gtest_filter=TwoWriteQueues/SnapshotConcurrentAccessTest.SnapshotConcurrentAccessTest1/0`