### PR TITLE
[ubsan] add -fno-sanitize-recover option to force exit on errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,9 +232,9 @@ endif
 # USAN doesn't work well with jemalloc. If we're compiling with USAN, we should use regular malloc.
 ifdef COMPILE_WITH_UBSAN
 	DISABLE_JEMALLOC=1
-	EXEC_LDFLAGS += -fsanitize=undefined
-	PLATFORM_CCFLAGS += -fsanitize=undefined -DROCKSDB_UBSAN_RUN
-	PLATFORM_CXXFLAGS += -fsanitize=undefined -DROCKSDB_UBSAN_RUN
+	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover
+	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover -DROCKSDB_UBSAN_RUN
+	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover -DROCKSDB_UBSAN_RUN
 endif
 
 ifdef ROCKSDB_VALGRIND_RUN


### PR DESCRIPTION
By default if ubsan detects any problem, it outputs a “runtime error:” message, and in most cases continues executing the program. 
In order to make test abort on errors, option `-fno-sanitize-recover` is needed. [link](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)

Test plan: run ubsan and make sure test aborts with non-zero return code.