### PR TITLE
Java: Add copy constructors for various option classes

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -66,9 +66,8 @@ jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* env, jclass jcls,
  */
 jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* env, jclass jcls,
     jlong jhandle) {
-  auto old_opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto new_opt = new rocksdb::Options();
-  *new_opt = *old_opt;
+  auto new_opt = new rocksdb::Options(
+      *(reinterpret_cast<rocksdb::Options*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
 }
 
@@ -2868,9 +2867,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
     JNIEnv* env, jclass jcls, jlong jhandle) {
-  auto old_opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
-  auto new_opt = new rocksdb::ColumnFamilyOptions();
-  *new_opt = *old_opt;
+  auto new_opt = new rocksdb::ColumnFamilyOptions(
+      *(reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
 }
 
@@ -4194,9 +4192,8 @@ jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env,
  */
 jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
     jlong jhandle) {
-  auto old_opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  auto new_opt = new rocksdb::DBOptions();
-  *new_opt = *old_opt;
+  auto new_opt = new rocksdb::DBOptions(
+      *(reinterpret_cast<rocksdb::DBOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
 }
 
@@ -5731,6 +5728,18 @@ jlong Java_org_rocksdb_WriteOptions_newWriteOptions(
 
 /*
  * Class:     org_rocksdb_WriteOptions
+ * Method:    copyWriteOptions
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(
+    JNIEnv* env, jclass jcls, jlong jhandle) {
+  auto new_opt = new rocksdb::WriteOptions(
+      *(reinterpret_cast<rocksdb::WriteOptions*>(jhandle)));
+  return reinterpret_cast<jlong>(new_opt);
+}
+
+/*
+ * Class:     org_rocksdb_WriteOptions
  * Method:    disposeInternal
  * Signature: ()V
  */
@@ -5847,10 +5856,9 @@ jlong Java_org_rocksdb_ReadOptions_newReadOptions(
  */
 jlong Java_org_rocksdb_ReadOptions_copyReadOptions(
     JNIEnv* env, jclass jcls, jlong jhandle) {
-  auto old_read_opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
-  auto new_read_opt = new rocksdb::ReadOptions();
-  *new_read_opt = *old_read_opt;
-  return reinterpret_cast<jlong>(new_read_opt);
+  auto new_opt = new rocksdb::ReadOptions(
+      *(reinterpret_cast<rocksdb::ReadOptions*>(jhandle)));
+  return reinterpret_cast<jlong>(new_opt);
 }
 
 /*

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -61,6 +61,19 @@ jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* env, jclass jcls,
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    copyOptions
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* env, jclass jcls,
+    jlong jhandle) {
+  auto old_opt = reinterpret_cast<rocksdb::Options*>(jhandle);
+  auto new_opt = new rocksdb::Options();
+  *new_opt = *old_opt;
+  return reinterpret_cast<jlong>(new_opt);
+}
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    disposeInternal
  * Signature: (J)V
  */
@@ -2850,6 +2863,19 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
 
 /*
  * Class:     org_rocksdb_ColumnFamilyOptions
+ * Method:    copyColumnFamilyOptions
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
+    JNIEnv* env, jclass jcls, jlong jhandle) {
+  auto old_opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
+  auto new_opt = new rocksdb::ColumnFamilyOptions();
+  *new_opt = *old_opt;
+  return reinterpret_cast<jlong>(new_opt);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyOptions
  * Method:    getColumnFamilyOptionsFromProps
  * Signature: (Ljava/util/String;)J
  */
@@ -4159,6 +4185,19 @@ jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env,
     jclass jcls) {
   auto* dbop = new rocksdb::DBOptions();
   return reinterpret_cast<jlong>(dbop);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    copyDBOptions
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
+    jlong jhandle) {
+  auto old_opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
+  auto new_opt = new rocksdb::DBOptions();
+  *new_opt = *old_opt;
+  return reinterpret_cast<jlong>(new_opt);
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -27,10 +27,30 @@ public class ColumnFamilyOptions extends RocksObject
    * Construct ColumnFamilyOptions.
    *
    * This constructor will create (by allocating a block of memory)
-   * an {@code rocksdb::DBOptions} in the c++ side.
+   * an {@code rocksdb::ColumnFamilyOptions} in the c++ side.
    */
   public ColumnFamilyOptions() {
     super(newColumnFamilyOptions());
+  }
+
+  /**
+   * Copy constructor for ColumnFamilyOptions.
+   *
+   * NOTE: This does a shallow copy, which means comparator, merge_operator, compaction_filter,
+   * compaction_filter_factory and other pointers will be cloned!
+   *
+   * @param other The ColumnFamilyOptions to copy.
+   */
+  public ColumnFamilyOptions(ColumnFamilyOptions other) {
+    super(copyColumnFamilyOptions(other.nativeHandle_));
+    this.memTableConfig_ = other.memTableConfig_;
+    this.tableFormatConfig_ = other.tableFormatConfig_;
+    this.comparator_ = other.comparator_;
+    this.compactionFilter_ = other.compactionFilter_;
+    this.compactionFilterFactory_ = other.compactionFilterFactory_;
+    this.compactionOptionsUniversal_ = other.compactionOptionsUniversal_;
+    this.compactionOptionsFIFO_ = other.compactionOptionsFIFO_;
+    this.compressionOptions_ = other.compressionOptions_;
   }
 
   /**
@@ -783,6 +803,7 @@ public class ColumnFamilyOptions extends RocksObject
       String optString);
 
   private static native long newColumnFamilyOptions();
+  private static native long copyColumnFamilyOptions(long handle);
   @Override protected final native void disposeInternal(final long handle);
 
   private native void optimizeForSmallDb(final long handle);
@@ -934,6 +955,7 @@ public class ColumnFamilyOptions extends RocksObject
   private native boolean forceConsistencyChecks(final long handle);
 
   // instance variables
+  // NOTE: If you add new member variables, please update the copy constructor above!
   private MemTableConfig memTableConfig_;
   private TableFormatConfig tableFormatConfig_;
   private AbstractComparator<? extends AbstractSlice<?>> comparator_;

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -33,6 +33,22 @@ public class DBOptions
   }
 
   /**
+   * Copy constructor for DBOptions.
+   *
+   * NOTE: This does a shallow copy, which means env, rate_limiter, sst_file_manager,
+   * info_log and other pointers will be cloned!
+   *
+   * @param other The DBOptions to copy.
+   */
+  public DBOptions(DBOptions other) {
+    super(copyDBOptions(other.nativeHandle_));
+    this.env_ = other.env_;
+    this.numShardBits_ = other.numShardBits_;
+    this.rateLimiter_ = other.rateLimiter_;
+    this.rowCache_ = other.rowCache_;
+  }
+
+  /**
    * <p>Method to get a options instance by using pre-configured
    * property values. If one or many values are undefined in
    * the context of RocksDB the method will return a null
@@ -954,6 +970,7 @@ public class DBOptions
       String optString);
 
   private native static long newDBOptions();
+  private native static long copyDBOptions(long handle);
   @Override protected final native void disposeInternal(final long handle);
 
   private native void optimizeForSmallDb(final long handle);
@@ -1127,6 +1144,7 @@ public class DBOptions
   private native boolean avoidFlushDuringShutdown(final long handle);
 
   // instance variables
+  // NOTE: If you add new member variables, please update the copy constructor above!
   private Env env_;
   private int numShardBits_;
   private RateLimiter rateLimiter_;

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -51,6 +51,27 @@ public class Options extends RocksObject
     env_ = Env.getDefault();
   }
 
+  /**
+   * Copy constructor for ColumnFamilyOptions.
+   *
+   * NOTE: This does a shallow copy, which means comparator, merge_operator
+   * and other pointers will be cloned!
+   *
+   * @param other The Options to copy.
+   */
+  public Options(Options other) {
+    super(copyOptions(other.nativeHandle_));
+    this.env_ = other.env_;
+    this.memTableConfig_ = other.memTableConfig_;
+    this.tableFormatConfig_ = other.tableFormatConfig_;
+    this.rateLimiter_ = other.rateLimiter_;
+    this.comparator_ = other.comparator_;
+    this.compactionOptionsUniversal_ = other.compactionOptionsUniversal_;
+    this.compactionOptionsFIFO_ = other.compactionOptionsFIFO_;
+    this.compressionOptions_ = other.compressionOptions_;
+    this.rowCache_ = other.rowCache_;
+  }
+
   @Override
   public Options setIncreaseParallelism(final int totalThreads) {
     assert(isOwningHandle());
@@ -1548,6 +1569,7 @@ public class Options extends RocksObject
   private native static long newOptions();
   private native static long newOptions(long dbOptHandle,
       long cfOptHandle);
+  private native static long copyOptions(long handle);
   @Override protected final native void disposeInternal(final long handle);
   private native void setEnv(long optHandle, long envHandle);
   private native void prepareForBulkLoad(long handle);
@@ -1868,6 +1890,7 @@ public class Options extends RocksObject
   private native boolean forceConsistencyChecks(final long handle);
 
   // instance variables
+  // NOTE: If you add new member variables, please update the copy constructor above!
   private Env env_;
   private MemTableConfig memTableConfig_;
   private TableFormatConfig tableFormatConfig_;

--- a/java/src/main/java/org/rocksdb/ReadOptions.java
+++ b/java/src/main/java/org/rocksdb/ReadOptions.java
@@ -423,6 +423,9 @@ public class ReadOptions extends RocksObject {
     return null;
   }
 
+  // instance variables
+  // NOTE: If you add new member variables, please update the copy constructor above!
+  //
   // Hold a reference to any iterate upper bound that was set on this object
   // until we're destroyed or it's overwritten.  That way the caller can freely
   // leave scope without us losing the Java Slice object, which during close()

--- a/java/src/main/java/org/rocksdb/WriteOptions.java
+++ b/java/src/main/java/org/rocksdb/WriteOptions.java
@@ -21,6 +21,19 @@ public class WriteOptions extends RocksObject {
   }
 
   /**
+   * Copy constructor for WriteOptions.
+   *
+   * NOTE: This does a shallow copy, which means comparator, merge_operator, compaction_filter,
+   * compaction_filter_factory and other pointers will be cloned!
+   *
+   * @param other The ColumnFamilyOptions to copy.
+   */
+  public WriteOptions(WriteOptions other) {
+    super(copyWriteOptions(other.nativeHandle_));
+  }
+
+
+  /**
    * If true, the write will be flushed from the operating system
    * buffer cache (by calling WritableFile::Sync()) before the write
    * is considered complete.  If this flag is true, writes will be
@@ -145,6 +158,7 @@ public class WriteOptions extends RocksObject {
   }
 
   private native static long newWriteOptions();
+  private native static long copyWriteOptions(long handle);
   private native void setSync(long handle, boolean flag);
   private native boolean sync(long handle);
   private native void setDisableWAL(long handle, boolean flag);

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -25,6 +25,18 @@ public class ColumnFamilyOptionsTest {
       getPlatformSpecificRandomFactory();
 
   @Test
+  public void copyConstructor() {
+    ColumnFamilyOptions origOpts = new ColumnFamilyOptions();
+    origOpts.setNumLevels(rand.nextInt(8));
+    origOpts.setTargetFileSizeMultiplier(rand.nextInt(100));
+    origOpts.setLevel0StopWritesTrigger(rand.nextInt(50));
+    ColumnFamilyOptions copyOpts = new ColumnFamilyOptions(origOpts);
+    assertThat(origOpts.numLevels() == copyOpts.numLevels());
+    assertThat(origOpts.targetFileSizeMultiplier() == copyOpts.targetFileSizeMultiplier());
+    assertThat(origOpts.level0StopWritesTrigger() == copyOpts.level0StopWritesTrigger());
+  }
+
+  @Test
   public void getColumnFamilyOptionsFromProps() {
     Properties properties = new Properties();
     properties.put("write_buffer_size", "112");

--- a/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyOptionsTest.java
@@ -31,9 +31,9 @@ public class ColumnFamilyOptionsTest {
     origOpts.setTargetFileSizeMultiplier(rand.nextInt(100));
     origOpts.setLevel0StopWritesTrigger(rand.nextInt(50));
     ColumnFamilyOptions copyOpts = new ColumnFamilyOptions(origOpts);
-    assertThat(origOpts.numLevels() == copyOpts.numLevels());
-    assertThat(origOpts.targetFileSizeMultiplier() == copyOpts.targetFileSizeMultiplier());
-    assertThat(origOpts.level0StopWritesTrigger() == copyOpts.level0StopWritesTrigger());
+    assertThat(origOpts.numLevels()).isEqualTo(copyOpts.numLevels());
+    assertThat(origOpts.targetFileSizeMultiplier()).isEqualTo(copyOpts.targetFileSizeMultiplier());
+    assertThat(origOpts.level0StopWritesTrigger()).isEqualTo(copyOpts.level0StopWritesTrigger());
   }
 
   @Test

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -29,9 +29,10 @@ public class DBOptionsTest {
     origOpts.setAllow2pc(rand.nextBoolean());
     origOpts.setBaseBackgroundCompactions(rand.nextInt(10));
     DBOptions copyOpts = new DBOptions(origOpts);
-    assertThat(origOpts.createIfMissing() == copyOpts.createIfMissing());
-    assertThat(origOpts.allow2pc() == copyOpts.allow2pc());
-    assertThat(origOpts.baseBackgroundCompactions() == copyOpts.baseBackgroundCompactions());
+    assertThat(origOpts.createIfMissing()).isEqualTo(copyOpts.createIfMissing());
+    assertThat(origOpts.allow2pc()).isEqualTo(copyOpts.allow2pc());
+    assertThat(origOpts.baseBackgroundCompactions()).isEqualTo(
+            copyOpts.baseBackgroundCompactions());
   }
 
   @Test

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -23,6 +23,18 @@ public class DBOptionsTest {
       getPlatformSpecificRandomFactory();
 
   @Test
+  public void copyConstructor() {
+    DBOptions origOpts = new DBOptions();
+    origOpts.setCreateIfMissing(rand.nextBoolean());
+    origOpts.setAllow2pc(rand.nextBoolean());
+    origOpts.setBaseBackgroundCompactions(rand.nextInt(10));
+    DBOptions copyOpts = new DBOptions(origOpts);
+    assertThat(origOpts.createIfMissing() == copyOpts.createIfMissing());
+    assertThat(origOpts.allow2pc() == copyOpts.allow2pc());
+    assertThat(origOpts.baseBackgroundCompactions() == copyOpts.baseBackgroundCompactions());
+  }
+
+  @Test
   public void getDBOptionsFromProps() {
     // setup sample properties
     final Properties properties = new Properties();

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -27,6 +27,18 @@ public class OptionsTest {
       getPlatformSpecificRandomFactory();
 
   @Test
+  public void copyConstructor() {
+    Options origOpts = new Options();
+    origOpts.setNumLevels(rand.nextInt(8));
+    origOpts.setTargetFileSizeMultiplier(rand.nextInt(100));
+    origOpts.setLevel0StopWritesTrigger(rand.nextInt(50));
+    Options copyOpts = new Options(origOpts);
+    assertThat(origOpts.numLevels() == copyOpts.numLevels());
+    assertThat(origOpts.targetFileSizeMultiplier() == copyOpts.targetFileSizeMultiplier());
+    assertThat(origOpts.level0StopWritesTrigger() == copyOpts.level0StopWritesTrigger());
+  }
+
+  @Test
   public void setIncreaseParallelism() {
     try (final Options opt = new Options()) {
       final int threads = Runtime.getRuntime().availableProcessors() * 2;

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -33,9 +33,9 @@ public class OptionsTest {
     origOpts.setTargetFileSizeMultiplier(rand.nextInt(100));
     origOpts.setLevel0StopWritesTrigger(rand.nextInt(50));
     Options copyOpts = new Options(origOpts);
-    assertThat(origOpts.numLevels() == copyOpts.numLevels());
-    assertThat(origOpts.targetFileSizeMultiplier() == copyOpts.targetFileSizeMultiplier());
-    assertThat(origOpts.level0StopWritesTrigger() == copyOpts.level0StopWritesTrigger());
+    assertThat(origOpts.numLevels()).isEqualTo(copyOpts.numLevels());
+    assertThat(origOpts.targetFileSizeMultiplier()).isEqualTo(copyOpts.targetFileSizeMultiplier());
+    assertThat(origOpts.level0StopWritesTrigger()).isEqualTo(copyOpts.level0StopWritesTrigger());
   }
 
   @Test

--- a/java/src/test/java/org/rocksdb/WriteOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/WriteOptionsTest.java
@@ -8,6 +8,8 @@ package org.rocksdb;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.Random;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WriteOptionsTest {
@@ -15,6 +17,9 @@ public class WriteOptionsTest {
   @ClassRule
   public static final RocksMemoryResource rocksMemoryResource =
       new RocksMemoryResource();
+
+  public static final Random rand = PlatformRandomHelper.
+          getPlatformSpecificRandomFactory();
 
   @Test
   public void writeOptions() {
@@ -42,4 +47,18 @@ public class WriteOptionsTest {
       assertThat(writeOptions.noSlowdown()).isFalse();
     }
   }
+
+  @Test
+  public void copyConstructor() {
+    WriteOptions origOpts = new WriteOptions();
+    origOpts.setDisableWAL(rand.nextBoolean());
+    origOpts.setIgnoreMissingColumnFamilies(rand.nextBoolean());
+    origOpts.setSync(rand.nextBoolean());
+    WriteOptions copyOpts = new WriteOptions(origOpts);
+    assertThat(origOpts.disableWAL()).isEqualTo(copyOpts.disableWAL());
+    assertThat(origOpts.ignoreMissingColumnFamilies()).isEqualTo(
+            copyOpts.ignoreMissingColumnFamilies());
+    assertThat(origOpts.sync()).isEqualTo(copyOpts.sync());
+  }
+
 }


### PR DESCRIPTION
Add Java-side copy constructors for:
- Options
- DBOptions
- ColumnFamilyOptions
- WriteOptions

along with unit tests to assert the copy worked.

NOTE: Unit tests are failing in travis but it looks like a global timeout issue. These tests pass.