### PR TITLE
[fb] Update buckifier and TARGETS

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -25,6 +25,10 @@ rocksdb_compiler_flags = [
     "-DTBB",
     # Needed to compile in fbcode
     "-Wno-expansion-to-defined",
+    # Added missing flags from output of build_detect_platform
+    "-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX",
+    "-DROCKSDB_BACKTRACE",
+    "-Wshorten-64-to-32",
 ]
 
 rocksdb_external_deps = [

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -29,6 +29,10 @@ rocksdb_compiler_flags = [
     "-DTBB",
     # Needed to compile in fbcode
     "-Wno-expansion-to-defined",
+    # Added missing flags from output of build_detect_platform
+    "-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX",
+    "-DROCKSDB_BACKTRACE",
+    "-Wshorten-64-to-32",
 ]
 
 rocksdb_external_deps = [


### PR DESCRIPTION
Some flags used via make were not applied in the buckifier/targets file, causing some failures to be missed by testing infra ( ie the one fixed by #3434 )