### PR TITLE
[RocksJava] Allow iterators to be refreshed with new data

### DIFF
--- a/java/rocksjni/iterator.cc
+++ b/java/rocksjni/iterator.cc
@@ -141,6 +141,24 @@ void Java_org_rocksdb_RocksIterator_status0(
 
 /*
  * Class:     org_rocksdb_RocksIterator
+ * Method:    refresh0
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_RocksIterator_refresh0(
+    JNIEnv* env, jobject jobj, jlong handle) {
+  auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
+  rocksdb::Status s = it->Refresh();
+
+  if (s.ok()) {
+    return;
+  }
+
+  rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+}
+
+
+/*
+ * Class:     org_rocksdb_RocksIterator
  * Method:    key0
  * Signature: (J)[B
  */

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -541,6 +541,23 @@ void Java_org_rocksdb_WBWIRocksIterator_status0(
 
 /*
  * Class:     org_rocksdb_WBWIRocksIterator
+ * Method:    refresh0
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_WBWIRocksIterator_refresh0(
+    JNIEnv* env, jobject jobj, jlong handle) {
+  auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
+  rocksdb::Status s = it->Refresh();
+
+  if (s.ok()) {
+    return;
+  }
+
+  rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+}
+
+/*
+ * Class:     org_rocksdb_WBWIRocksIterator
  * Method:    entry1
  * Signature: (J)[J
  */

--- a/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
+++ b/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
@@ -82,6 +82,12 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
     status0(nativeHandle_);
   }
 
+  @Override
+  public void refresh() throws RocksDBException {
+    assert(isOwningHandle());
+    refresh0(nativeHandle_);
+  }
+
   /**
    * <p>Deletes underlying C++ iterator pointer.</p>
    *
@@ -105,4 +111,5 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
   abstract void seek0(long handle, byte[] target, int targetLen);
   abstract void seekForPrev0(long handle, byte[] target, int targetLen);
   abstract void status0(long handle) throws RocksDBException;
+  abstract void refresh0(long handle) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -59,6 +59,7 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
   @Override final native void seek0(long handle, byte[] target, int targetLen);
   @Override final native void seekForPrev0(long handle, byte[] target, int targetLen);
   @Override final native void status0(long handle) throws RocksDBException;
+  @Override final native void refresh0(long handle) throws RocksDBException;
 
   private native byte[] key0(long handle);
   private native byte[] value0(long handle);

--- a/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
+++ b/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
@@ -90,5 +90,13 @@ public interface RocksIteratorInterface {
    */
   void status() throws RocksDBException;
 
+  /**
+   * <p>If supported, renew the iterator to represent the latest state. The
+   * iterator will be invalidated after the call. Not supported if
+   * ReadOptions.snapshot is given when creating the iterator.</p>
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *                          native library.
+   */
   void refresh() throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
+++ b/java/src/main/java/org/rocksdb/RocksIteratorInterface.java
@@ -89,4 +89,6 @@ public interface RocksIteratorInterface {
    *                          native library.
    */
   void status() throws RocksDBException;
+
+  void refresh() throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/WBWIRocksIterator.java
+++ b/java/src/main/java/org/rocksdb/WBWIRocksIterator.java
@@ -47,6 +47,7 @@ public class WBWIRocksIterator
   @Override final native void seek0(long handle, byte[] target, int targetLen);
   @Override final native void seekForPrev0(long handle, byte[] target, int targetLen);
   @Override final native void status0(long handle) throws RocksDBException;
+  @Override final native void refresh0(long handle) throws RocksDBException;
 
   private native long[] entry1(final long handle);
 

--- a/java/src/test/java/org/rocksdb/RocksIteratorTest.java
+++ b/java/src/test/java/org/rocksdb/RocksIteratorTest.java
@@ -51,7 +51,6 @@ public class RocksIteratorTest {
         assertThat(iterator.isValid()).isTrue();
         assertThat(iterator.key()).isEqualTo("key2".getBytes());
         assertThat(iterator.value()).isEqualTo("value2".getBytes());
-        iterator.status();
       }
 
       try (final RocksIterator iterator = db.newIterator()) {
@@ -94,6 +93,33 @@ public class RocksIteratorTest {
         iterator.seekForPrev("key3".getBytes());
         assertThat(iterator.isValid()).isTrue();
         assertThat(iterator.key()).isEqualTo("key2".getBytes());
+      }
+
+      try (final RocksIterator iterator = db.newIterator()) {
+        iterator.seek("key1.5".getBytes());
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key2".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
+
+        db.put("key3".getBytes(), "value3".getBytes());
+
+        iterator.seek("key1.5".getBytes());
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key2".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
+
+        iterator.refresh();
+
+        iterator.seek("key1.5".getBytes());
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key2".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isTrue();
+        assertThat(iterator.key()).isEqualTo("key3".getBytes());
+        iterator.next();
+        assertThat(iterator.isValid()).isFalse();
       }
     }
   }

--- a/java/src/test/java/org/rocksdb/util/BytewiseComparatorTest.java
+++ b/java/src/test/java/org/rocksdb/util/BytewiseComparatorTest.java
@@ -249,7 +249,7 @@ public class BytewiseComparatorTest {
       for (int i = 0; i < num_iter_ops; i++) {
         // Random walk and make sure iter and result_iter returns the
         // same key and value
-        final int type = rnd.nextInt(7);
+        final int type = rnd.nextInt(8);
         iter.status();
         switch (type) {
           case 0:
@@ -296,8 +296,15 @@ public class BytewiseComparatorTest {
               continue;
             }
             break;
+          case 6:
+            // Refresh
+            iter.refresh();
+            result_iter.refresh();
+            iter.seekToFirst();
+            result_iter.seekToFirst();
+            break;
           default: {
-            assert (type == 6);
+            assert (type == 7);
             final int key_idx = rnd.nextInt(source_strings.size());
             final String key = source_strings.get(key_idx);
             final byte[] result = db.get(new ReadOptions(), bytes(key));
@@ -404,9 +411,6 @@ public class BytewiseComparatorTest {
     private final java.util.Comparator<? super K> comparator;
     private int offset = -1;
 
-    private int lastPrefixMatchIdx = -1;
-    private int lastPrefixMatch = 0;
-
     public KVIter(final TreeMap<K, V> map) {
       this.entries = new ArrayList<>();
       final Iterator<Map.Entry<K, V>> iterator = map.entrySet().iterator();
@@ -490,6 +494,11 @@ public class BytewiseComparatorTest {
         throw new RocksDBException("Index out of bounds. Size is: " +
             entries.size() + ", offset is: " + offset);
       }
+    }
+
+    @Override
+    public void refresh() throws RocksDBException {
+      offset = -1;
     }
 
     public K key() {


### PR DESCRIPTION
Ported Iterator::Refresh functionality to RocksJava. This was originally introduced in the C++ API by @siying in #2621. 

This should reduce GC pressure particularly in use-cases that frequently create and destroy large number of iterators just to get to the latest snapshot of data.

The API can be invoked by calling `RocksIterator::refresh()`.
`WBWIRocksIterator::refresh()` is not implemented and would throw a not-supported exception for now. 

Test Plan:
Added Unit tests. 