### PR TITLE
Fix leak report by asan on DuplicateKeys test

### DIFF
--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5255,6 +5255,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     txn0->SetSavePoint();
     txn0->RollbackToSavePoint();
     ASSERT_OK(txn0->Commit());
+    delete txn0;
   }
 }
 


### PR DESCRIPTION
Deletes the transaction object at the end of the test.
Verified by:
- COMPILE_WITH_ASAN=1 make -j32 transaction_test
- ./transaction_test --gtest_filter="DBA**Duplicate*"