### PR TITLE
Eliminate a memcpy for uncompressed blocks

### DIFF
--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -224,6 +224,7 @@ class BlockBasedTable : public TableReader {
       Rep* rep, const ReadOptions& ro, const BlockHandle& block_hanlde,
       BlockIter* input_iter = nullptr, bool is_index = false,
       GetContext* get_context = nullptr, Status s = Status());
+
   // If block cache enabled (compressed or uncompressed), looks for the block
   // identified by handle in (1) uncompressed cache, (2) compressed cache, and
   // then (3) file. If found, inserts into the cache(s) that were searched
@@ -495,6 +496,11 @@ struct BlockBasedTable::Rep {
   // A value of kDisableGlobalSequenceNumber means that this feature is disabled
   // and every key have it's own seqno.
   SequenceNumber global_seqno;
+
+  // If false, blocks in this file are definitely all uncompressed. Knowing this
+  // before reading individual blocks enables certain optimizations.
+  bool blocks_maybe_compressed = true;
+
   bool closed = false;
 };
 


### PR DESCRIPTION
`ReadBlockFromFile` uses a stack buffer to hold small data blocks before passing them to the compression library, which outputs uncompressed data in a heap buffer. In the case of `kNoCompression` there is a `memcpy` to copy from stack buffer to heap buffer.

This PR optimizes `ReadBlockFromFile` to skip the stack buffer for files whose blocks are known to be uncompressed. We determine this using the SST file property, "compression_name", if it's available.

Test Plan:

- `make check -j64`
- benchmark showed slightly improved CPU util (between 3-5% saving over a few runs), and no change in latency/throughput:

setup:

```
$ TEST_TMPDIR=/data/compaction_bench ./db_bench -benchmarks=fillrandom,compact -compression_type=none -write_buffer_size=1048576000 -block_size=4096
```

benchmark command:

```
$ TEST_TMPDIR=/data/compaction_bench /usr/bin/time ./db_bench -num=1000000 -threads=32 -benchmarks=readrandom -use_existing_db=true -use_direct_reads=true -cache_size=0 -compression_type=none -histogram=true
```

benchmark output before this PR:

```
...
readrandom   :       4.710 micros/op 212329 ops/sec;   15.1 MB/s (1000000 of 1000000 found)
...
138.56user 118.51system 2:30.73elapsed 170%CPU (0avgtext+0avgdata 16512maxresident)k
506159656inputs+80outputs (0major+3676minor)pagefaults 0swaps
```

benchmark output after this PR:

```
...
readrandom   :       4.712 micros/op 212224 ops/sec;   15.1 MB/s (1000000 of 1000000 found)
...
129.59user 115.69system 2:30.80elapsed 162%CPU (0avgtext+0avgdata 16360maxresident)k
506159656inputs+80outputs (0major+3674minor)pagefaults 0swaps
```