### PR TITLE
Disable alignment check in UBSAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ endif
 # USAN doesn't work well with jemalloc. If we're compiling with USAN, we should use regular malloc.
 ifdef COMPILE_WITH_UBSAN
 	DISABLE_JEMALLOC=1
+	# Suppress alignment warning because murmurhash relies on casting unaligned
+	# memory to integer. Fixing it may cause performance regression. 3-way crc32
+	# relies on it too, although it can be rewritten to eliminate with minimal
+	# performance regression.
 	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment
 	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN
 	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN

--- a/Makefile
+++ b/Makefile
@@ -232,9 +232,9 @@ endif
 # USAN doesn't work well with jemalloc. If we're compiling with USAN, we should use regular malloc.
 ifdef COMPILE_WITH_UBSAN
 	DISABLE_JEMALLOC=1
-	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover
-	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover -DROCKSDB_UBSAN_RUN
-	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover -DROCKSDB_UBSAN_RUN
+	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment
+	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN
+	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN
 endif
 
 ifdef ROCKSDB_VALGRIND_RUN


### PR DESCRIPTION
Disable alignment check in UBSAN for now. Now we can't get signals to meaningful failures. We can reenable it after we figure out how we can suppress failures in finer grain manner.