### PR TITLE
Fix UBSAN Error in WritePreparedTransactionTest

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -349,7 +349,7 @@ class WritePreparedTransactionTestBase : public TransactionTestBase {
 
 class WritePreparedTransactionTest
     : public WritePreparedTransactionTestBase,
-      public ::testing::WithParamInterface<
+      virtual public ::testing::WithParamInterface<
           std::tuple<bool, bool, TxnDBWritePolicy>> {
  public:
   WritePreparedTransactionTest()


### PR DESCRIPTION
Summary: WritePreparedTransactionTest has the UBSAN error because the wrong order of its parent class construction. Fix it.

Test Plan: Run ubsan against those tests. It used to fail but now can pass.