### PR TITLE
max_align_t -> std::max_align_t

### DIFF
--- a/util/arena.cc
+++ b/util/arena.cc
@@ -33,7 +33,7 @@ const size_t Arena::kInlineSize;
 
 const size_t Arena::kMinBlockSize = 4096;
 const size_t Arena::kMaxBlockSize = 2u << 30;
-static const int kAlignUnit = alignof(max_align_t);
+static const int kAlignUnit = alignof(std::max_align_t);
 
 size_t OptimizeBlockSize(size_t block_size) {
   // Make sure block_size is in optimal range

--- a/util/arena.h
+++ b/util/arena.h
@@ -82,7 +82,7 @@ class Arena : public Allocator {
   }
 
  private:
-  char inline_block_[kInlineSize] __attribute__((__aligned__(alignof(max_align_t))));
+  char inline_block_[kInlineSize] __attribute__((__aligned__(alignof(std::max_align_t))));
   // Number of bytes allocated in one block
   const size_t kBlockSize;
   // Array of new[] allocated memory blocks


### PR DESCRIPTION
This fixes the build for -lite on FreeBSD 10.3.

https://lists.freebsd.org/pipermail/freebsd-pkg-fallout/Week-of-Mon-20180205/654346.html