### PR TITLE
Avoid unnecessary big for-loop when reporting ticker stats stored in GetContext

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1212,9 +1212,10 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
     // report the counters before returning
     if (get_context.State() != GetContext::kNotFound &&
-        get_context.State() != GetContext::kMerge) {
-      for (auto ticker_pair : get_context.tickers_pairs) {
-        if (ticker_pair.second > 0) {
+        get_context.State() != GetContext::kMerge &&
+        db_statistics_ != nullptr) {
+      for (auto ticker_pair : get_context.ticker_pairs_) {
+        if (ticker_pair.second != 0) {
           RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
         }
       }
@@ -1251,9 +1252,11 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     f = fp.GetNextFile();
   }
 
-  for (auto ticker_pair : get_context.tickers_pairs) {
-    if (ticker_pair.second > 0) {
-      RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
+  if (db_statistics_ != nullptr) {
+    for (auto ticker_pair : get_context.ticker_pairs_) {
+      if (ticker_pair.second != 0) {
+        RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
+      }
     }
   }
   if (GetContext::kMerge == get_context.State()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1213,9 +1213,9 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     // report the counters before returning
     if (get_context.State() != GetContext::kNotFound &&
         get_context.State() != GetContext::kMerge) {
-      for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
-        if (get_context.tickers_value[t] > 0) {
-          RecordTick(db_statistics_, t, get_context.tickers_value[t]);
+      for (auto ticker_pair : get_context.tickers_pairs) {
+        if (ticker_pair.second > 0) {
+          RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
         }
       }
     }
@@ -1251,9 +1251,9 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     f = fp.GetNextFile();
   }
 
-  for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
-    if (get_context.tickers_value[t] > 0) {
-      RecordTick(db_statistics_, t, get_context.tickers_value[t]);
+  for (auto ticker_pair : get_context.tickers_pairs) {
+    if (ticker_pair.second > 0) {
+      RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
     }
   }
   if (GetContext::kMerge == get_context.State()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1214,7 +1214,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     if (get_context.State() != GetContext::kNotFound &&
         get_context.State() != GetContext::kMerge &&
         db_statistics_ != nullptr) {
-          get_context.ReportCounters();
+      get_context.ReportCounters();
     }
     switch (get_context.State()) {
       case GetContext::kNotFound:

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1214,11 +1214,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     if (get_context.State() != GetContext::kNotFound &&
         get_context.State() != GetContext::kMerge &&
         db_statistics_ != nullptr) {
-      for (auto ticker_pair : get_context.ticker_pairs_) {
-        if (ticker_pair.second != 0) {
-          RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
-        }
-      }
+          get_context.ReportCounters();
     }
     switch (get_context.State()) {
       case GetContext::kNotFound:
@@ -1253,11 +1249,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
   }
 
   if (db_statistics_ != nullptr) {
-    for (auto ticker_pair : get_context.ticker_pairs_) {
-      if (ticker_pair.second != 0) {
-        RecordTick(db_statistics_, ticker_pair.first, ticker_pair.second);
-      }
-    }
+    get_context.ReportCounters();
   }
   if (GetContext::kMerge == get_context.State()) {
     if (!merge_operator_) {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -92,10 +92,14 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
 }
 
 void GetContext::RecordCounters(Tickers ticker, size_t val) {
-  if (ticker == Tickers::TICKER_ENUM_MAX) {
-    return;
+  for (auto ticker_pair : tickers_pairs) {
+    if (ticker_pair.first == ticker) {
+      ticker_pair.second += static_cast<uint64_t>(val);
+      return;
+    }
   }
-  tickers_value[ticker] += static_cast<uint64_t>(val);
+  tickers_pairs.emplace_back(
+      std::make_pair(ticker, static_cast<uint64_t>(val)));
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -96,52 +96,67 @@ void GetContext::ReportCounters() {
     RecordTick(statistics_, BLOCK_CACHE_HIT, get_context_stats_.num_cache_hit);
   }
   if (get_context_stats_.num_cache_index_hit > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_INDEX_HIT, get_context_stats_.num_cache_index_hit);
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_HIT,
+               get_context_stats_.num_cache_index_hit);
   }
   if (get_context_stats_.num_cache_data_hit > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_DATA_HIT, get_context_stats_.num_cache_data_hit);
+    RecordTick(statistics_, BLOCK_CACHE_DATA_HIT,
+               get_context_stats_.num_cache_data_hit);
   }
   if (get_context_stats_.num_cache_filter_hit > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_FILTER_HIT, get_context_stats_.num_cache_filter_hit);
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_HIT,
+               get_context_stats_.num_cache_filter_hit);
   }
   if (get_context_stats_.num_cache_index_miss > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_INDEX_MISS, get_context_stats_.num_cache_index_miss);
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_MISS,
+               get_context_stats_.num_cache_index_miss);
   }
   if (get_context_stats_.num_cache_filter_miss > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_FILTER_MISS, get_context_stats_.num_cache_filter_miss);
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_MISS,
+               get_context_stats_.num_cache_filter_miss);
   }
   if (get_context_stats_.num_cache_data_miss > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_DATA_MISS, get_context_stats_.num_cache_data_miss);
+    RecordTick(statistics_, BLOCK_CACHE_DATA_MISS,
+               get_context_stats_.num_cache_data_miss);
   }
   if (get_context_stats_.num_cache_bytes_read > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_BYTES_READ, get_context_stats_.num_cache_bytes_read);
+    RecordTick(statistics_, BLOCK_CACHE_BYTES_READ,
+               get_context_stats_.num_cache_bytes_read);
   }
   if (get_context_stats_.num_cache_miss > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_MISS, get_context_stats_.num_cache_miss);
+    RecordTick(statistics_, BLOCK_CACHE_MISS,
+               get_context_stats_.num_cache_miss);
   }
   if (get_context_stats_.num_cache_add > 0) {
     RecordTick(statistics_, BLOCK_CACHE_ADD, get_context_stats_.num_cache_add);
   }
   if (get_context_stats_.num_cache_bytes_write > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_BYTES_WRITE, get_context_stats_.num_cache_bytes_write);
+    RecordTick(statistics_, BLOCK_CACHE_BYTES_WRITE,
+               get_context_stats_.num_cache_bytes_write);
   }
   if (get_context_stats_.num_cache_index_add > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_INDEX_ADD, get_context_stats_.num_cache_index_add);
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_ADD,
+               get_context_stats_.num_cache_index_add);
   }
   if (get_context_stats_.num_cache_index_bytes_insert > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_INDEX_BYTES_INSERT, get_context_stats_.num_cache_index_bytes_insert);
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_BYTES_INSERT,
+               get_context_stats_.num_cache_index_bytes_insert);
   }
   if (get_context_stats_.num_cache_data_add > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_DATA_ADD, get_context_stats_.num_cache_data_add);
+    RecordTick(statistics_, BLOCK_CACHE_DATA_ADD,
+               get_context_stats_.num_cache_data_add);
   }
   if (get_context_stats_.num_cache_data_bytes_insert > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_DATA_BYTES_INSERT, get_context_stats_.num_cache_data_bytes_insert);
+    RecordTick(statistics_, BLOCK_CACHE_DATA_BYTES_INSERT,
+               get_context_stats_.num_cache_data_bytes_insert);
   }
   if (get_context_stats_.num_cache_filter_add > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_FILTER_ADD, get_context_stats_.num_cache_filter_add);
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_ADD,
+               get_context_stats_.num_cache_filter_add);
   }
   if (get_context_stats_.num_cache_filter_bytes_insert > 0) {
-    RecordTick(statistics_, BLOCK_CACHE_FILTER_BYTES_INSERT, get_context_stats_.num_cache_filter_bytes_insert);
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_BYTES_INSERT,
+               get_context_stats_.num_cache_filter_bytes_insert);
   }
 }
 

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -67,6 +67,7 @@ GetContext::GetContext(const Comparator* ucmp,
     *seq_ = kMaxSequenceNumber;
   }
   sample_ = should_sample_file_read();
+  InitTickers();
 }
 
 // Called from TableCache::Get and Table::Get when file/block in which
@@ -92,14 +93,33 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
 }
 
 void GetContext::RecordCounters(Tickers ticker, size_t val) {
-  for (auto ticker_pair : tickers_pairs) {
-    if (ticker_pair.first == ticker) {
-      ticker_pair.second += static_cast<uint64_t>(val);
+  for (auto it = ticker_pairs_.begin(); it != ticker_pairs_.end(); ++it) {
+    if (it->first == ticker) {
+      it->second += static_cast<uint64_t>(val);
       return;
     }
   }
-  tickers_pairs.emplace_back(
-      std::make_pair(ticker, static_cast<uint64_t>(val)));
+  ticker_pairs_.push_back(std::make_pair(ticker, static_cast<uint64_t>(val)));
+}
+
+void GetContext::InitTickers() {
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_HIT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_HIT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_HIT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_HIT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_MISS, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_MISS, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_MISS, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_BYTES_READ, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_MISS, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_ADD, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_BYTES_WRITE, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_ADD, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_BYTES_INSERT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_ADD, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_BYTES_INSERT, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_ADD, 0));
+  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_BYTES_INSERT, 0));
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -67,7 +67,6 @@ GetContext::GetContext(const Comparator* ucmp,
     *seq_ = kMaxSequenceNumber;
   }
   sample_ = should_sample_file_read();
-  InitTickers();
 }
 
 // Called from TableCache::Get and Table::Get when file/block in which
@@ -92,34 +91,58 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
   }
 }
 
-void GetContext::RecordCounters(Tickers ticker, size_t val) {
-  for (auto it = ticker_pairs_.begin(); it != ticker_pairs_.end(); ++it) {
-    if (it->first == ticker) {
-      it->second += static_cast<uint64_t>(val);
-      return;
-    }
+void GetContext::ReportCounters() {
+  if (get_context_stats_.num_cache_hit > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_HIT, get_context_stats_.num_cache_hit);
   }
-  ticker_pairs_.push_back(std::make_pair(ticker, static_cast<uint64_t>(val)));
-}
-
-void GetContext::InitTickers() {
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_HIT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_HIT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_HIT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_HIT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_MISS, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_MISS, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_MISS, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_BYTES_READ, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_MISS, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_ADD, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_BYTES_WRITE, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_ADD, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_INDEX_BYTES_INSERT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_ADD, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_DATA_BYTES_INSERT, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_ADD, 0));
-  ticker_pairs_.push_back(std::make_pair<Tickers, uint64_t>(BLOCK_CACHE_FILTER_BYTES_INSERT, 0));
+  if (get_context_stats_.num_cache_index_hit > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_HIT, get_context_stats_.num_cache_index_hit);
+  }
+  if (get_context_stats_.num_cache_data_hit > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_DATA_HIT, get_context_stats_.num_cache_data_hit);
+  }
+  if (get_context_stats_.num_cache_filter_hit > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_HIT, get_context_stats_.num_cache_filter_hit);
+  }
+  if (get_context_stats_.num_cache_index_miss > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_MISS, get_context_stats_.num_cache_index_miss);
+  }
+  if (get_context_stats_.num_cache_filter_miss > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_MISS, get_context_stats_.num_cache_filter_miss);
+  }
+  if (get_context_stats_.num_cache_data_miss > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_DATA_MISS, get_context_stats_.num_cache_data_miss);
+  }
+  if (get_context_stats_.num_cache_bytes_read > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_BYTES_READ, get_context_stats_.num_cache_bytes_read);
+  }
+  if (get_context_stats_.num_cache_miss > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_MISS, get_context_stats_.num_cache_miss);
+  }
+  if (get_context_stats_.num_cache_add > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_ADD, get_context_stats_.num_cache_add);
+  }
+  if (get_context_stats_.num_cache_bytes_write > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_BYTES_WRITE, get_context_stats_.num_cache_bytes_write);
+  }
+  if (get_context_stats_.num_cache_index_add > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_ADD, get_context_stats_.num_cache_index_add);
+  }
+  if (get_context_stats_.num_cache_index_bytes_insert > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_INDEX_BYTES_INSERT, get_context_stats_.num_cache_index_bytes_insert);
+  }
+  if (get_context_stats_.num_cache_data_add > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_DATA_ADD, get_context_stats_.num_cache_data_add);
+  }
+  if (get_context_stats_.num_cache_data_bytes_insert > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_DATA_BYTES_INSERT, get_context_stats_.num_cache_data_bytes_insert);
+  }
+  if (get_context_stats_.num_cache_filter_add > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_ADD, get_context_stats_.num_cache_filter_add);
+  }
+  if (get_context_stats_.num_cache_filter_bytes_insert > 0) {
+    RecordTick(statistics_, BLOCK_CACHE_FILTER_BYTES_INSERT, get_context_stats_.num_cache_filter_bytes_insert);
+  }
 }
 
 bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -27,7 +27,7 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
-  autovector<std::pair<Tickers, uint64_t>> tickers_pairs;
+  autovector<std::pair<Tickers, uint64_t>> ticker_pairs_;
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
@@ -78,6 +78,7 @@ class GetContext {
   }
 
   void RecordCounters(Tickers ticker, size_t val);
+  void InitTickers();
 
  private:
   const Comparator* ucmp_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -17,6 +17,27 @@ namespace rocksdb {
 class MergeContext;
 class PinnedIteratorsManager;
 
+struct GetContextStats {
+  uint64_t num_cache_hit = 0;
+  uint64_t num_cache_index_hit = 0;
+  uint64_t num_cache_data_hit = 0;
+  uint64_t num_cache_filter_hit = 0;
+  uint64_t num_cache_index_miss = 0;
+  uint64_t num_cache_filter_miss = 0;
+  uint64_t num_cache_data_miss = 0;
+  uint64_t num_cache_bytes_read = 0;
+  uint64_t num_cache_miss = 0;
+  uint64_t num_cache_add = 0;
+  uint64_t num_cache_bytes_write = 0;
+  uint64_t num_cache_index_add = 0;
+  uint64_t num_cache_index_bytes_insert = 0;
+  uint64_t num_cache_data_add = 0;
+  uint64_t num_cache_data_bytes_insert = 0;
+  uint64_t num_cache_filter_add = 0;
+  uint64_t num_cache_filter_bytes_insert = 0;
+};
+
+
 class GetContext {
  public:
   enum GetState {
@@ -27,7 +48,7 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
-  autovector<std::pair<Tickers, uint64_t>> ticker_pairs_;
+  GetContextStats get_context_stats_;
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
@@ -77,8 +98,7 @@ class GetContext {
     return true;
   }
 
-  void RecordCounters(Tickers ticker, size_t val);
-  void InitTickers();
+  void ReportCounters();
 
  private:
   const Comparator* ucmp_;

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -37,7 +37,6 @@ struct GetContextStats {
   uint64_t num_cache_filter_bytes_insert = 0;
 };
 
-
 class GetContext {
  public:
   enum GetState {

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -27,7 +27,7 @@ class GetContext {
     kMerge,  // saver contains the current merge result (the operands)
     kBlobIndex,
   };
-  uint64_t tickers_value[Tickers::TICKER_ENUM_MAX] = {0};
+  autovector<std::pair<Tickers, uint64_t>> tickers_pairs;
 
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,


### PR DESCRIPTION
Currently in `Version::Get` when reporting ticker stats stored in `GetContext`, there is a big for-loop through all `Ticker` which adds unnecessary cost to overall CPU usage. We can optimize by storing only ticker values that are used in `Get()` calls in a new struct `GetContextStats` since only a small fraction of all tickers are used in `Get()` calls. For comparison, with the new approach we only need to visit 17 values while old approach will require visiting 100+ `Ticker`