### PR TITLE
Suppress UBSAN error in finer guanularity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,9 +236,9 @@ ifdef COMPILE_WITH_UBSAN
 	# memory to integer. Fixing it may cause performance regression. 3-way crc32
 	# relies on it too, although it can be rewritten to eliminate with minimal
 	# performance regression.
-	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment
-	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN
-	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover -fno-sanitize=alignment -DROCKSDB_UBSAN_RUN
+	EXEC_LDFLAGS += -fsanitize=undefined -fno-sanitize-recover=all
+	PLATFORM_CCFLAGS += -fsanitize=undefined -fno-sanitize-recover=all -DROCKSDB_UBSAN_RUN
+	PLATFORM_CXXFLAGS += -fsanitize=undefined -fno-sanitize-recover=all -DROCKSDB_UBSAN_RUN
 endif
 
 ifdef ROCKSDB_VALGRIND_RUN

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -605,6 +605,13 @@ const uint64_t clmul_constants[] = {
 };
 
 // Compute the crc32c value for buffer smaller than 8
+#ifdef ROCKSDB_UBSAN_RUN
+#if defined(__clang__)
+__attribute__((__no_sanitize__("alignment")))
+#elif defined(__GNUC__)
+__attribute__((__no_sanitize_undefined__))
+#endif
+#endif
 inline void align_to_8(
     size_t len,
     uint64_t& crc0, // crc so far, updated on return
@@ -649,6 +656,13 @@ inline uint64_t CombineCRC(
 }
 
 // Compute CRC-32C using the Intel hardware instruction.
+#ifdef ROCKSDB_UBSAN_RUN
+#if defined(__clang__)
+__attribute__((__no_sanitize__("alignment")))
+#elif defined(__GNUC__)
+__attribute__((__no_sanitize_undefined__))
+#endif
+#endif
 uint32_t crc32c_3way(uint32_t crc, const char* buf, size_t len) {
   const unsigned char* next = (const unsigned char*)buf;
   uint64_t count;

--- a/util/murmurhash.cc
+++ b/util/murmurhash.cc
@@ -20,6 +20,13 @@
 //
 // 64-bit hash for 64-bit platforms
 
+#ifdef ROCKSDB_UBSAN_RUN
+#if defined(__clang__)
+__attribute__((__no_sanitize__("alignment")))
+#elif defined(__GNUC__)
+__attribute__((__no_sanitize_undefined__))
+#endif
+#endif
 uint64_t MurmurHash64A ( const void * key, int len, unsigned int seed )
 {
     const uint64_t m = 0xc6a4a7935bd1e995;


### PR DESCRIPTION
Summary: Now we suppress alignment UBSAN error as a whole. Suppressing 3-way CRC and murmurhash feels a better idea than turning off alignment check as a whole.

Test Plan: run UBSAN with error or without error, with USE_CLANG=0 and without it. Make sure the results are all correct.