### PR TITLE
Direct I/O writable file should do fsync in Close()

### DIFF
--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -239,6 +239,9 @@ Status WritableFileWriter::Close() {
   // we need to let the file know where data ends.
   if (use_direct_io()) {
     interim = writable_file_->Truncate(filesize_);
+    if (interim.ok()) {
+      interim = writable_file_->Fsync();
+    }
     if (!interim.ok() && s.ok()) {
       s = interim;
     }


### PR DESCRIPTION
Summary: We don't do fsync() after truncate in direct I/O writeable file (in fact we don't do any fsync ever). This can cause metadata not persistent to disk after the file is generated. We call it instead.

Test Plan: run all tests