### PR TITLE
save redundant key lookup in map of locked keys

### DIFF
--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -531,9 +531,10 @@ Status TransactionLockMgr::AcquireLocked(LockMap* lock_map,
 
   Status result;
   // Check if this key is already locked
-  if (stripe->keys.find(key) != stripe->keys.end()) {
+  auto stripe_iter = stripe->keys.find(key);
+  if (stripe_iter != stripe->keys.end()) {
     // Lock already held
-    LockInfo& lock_info = stripe->keys.at(key);
+    LockInfo& lock_info = stripe_iter->second;
     assert(lock_info.txn_ids.size() == 1 || !lock_info.exclusive);
 
     if (lock_info.exclusive || txn_lock_info.exclusive) {


### PR DESCRIPTION
In case it is found that a key is already marked as locked in a
stripe's map of locked keys, it is not necessary to look it up
again using `std::unordered_map<std::string, ...>::at(size_t)`.

Instead, we can use the already found position using the iterator
produced by the previous `find` operation. Reusing the iterator
will avoid having to hash the key again and do additional "random"
memory lookups in the map of keys (though the data will very
likely sit available in caches here already due to the previous
find operation)