### PR TITLE
Close info_log logger so DestroyDB can cleanup the directory

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2379,10 +2379,13 @@ Snapshot::~Snapshot() {
 }
 
 Status DestroyDB(const std::string& dbname, const Options& options) {
-  const ImmutableDBOptions soptions(SanitizeOptions(dbname, options));
+  ImmutableDBOptions soptions(SanitizeOptions(dbname, options));
   Env* env = soptions.env;
   std::vector<std::string> filenames;
 
+  // Reset the logger because it holds a handle to the
+  // log file and prevents cleanup and directory removal
+  soptions.info_log.reset();
   // Ignore error in case directory does not exist
   env->GetChildren(dbname, &filenames);
 


### PR DESCRIPTION
  Add asserts to win_logger along with the Buffer Flush on close().
The issue is reproduced on windows with:

WARNING: checkpoint_test_je::CheckpointTest.GetSnapshotLink State: Completed
WARNING: Note: Google Test filter = CheckpointTest.GetSnapshotLink
WARNING: [==========] Running 1 test from 1 test case.
WARNING: [----------] Global test environment set-up.
WARNING: [----------] 1 test from CheckpointTest
WARNING: [ RUN      ] CheckpointTest.GetSnapshotLink
WARNING: c:\dev\rocksdb\rocksdb\utilities\checkpoint\checkpoint_test.cc(248): error: checkpoint->CreateCheckpoint(snapshot_name_, log_size_for_flush)
WARNING: Invalid argument: Directory exists
WARNING: [  FAILED  ] CheckpointTest.GetSnapshotLink (1822 ms)
WARNING: [----------] 1 test from CheckpointTest (1822 ms total)
WARNING:
WARNING: [----------] Global test environment tear-down
WARNING: [==========] 1 test from 1 test case ran. (1823 ms total)
WARNING: [  PASSED  ] 0 tests.
WARNING: [  FAILED  ] 1 test, listed below:
WARNING: [  FAILED  ] CheckpointTest.GetSnapshotLink
WARNING:
WARNING:  1 FAILED TEST
