### PR TITLE
fix advance reservation of arena block addresses

### DIFF
--- a/util/arena.cc
+++ b/util/arena.cc
@@ -79,6 +79,9 @@ Arena::~Arena() {
 
 #ifdef MAP_HUGETLB
   for (const auto& mmap_info : huge_blocks_) {
+    if (mmap_info.addr_ == nullptr) {
+      continue;
+    }
     auto ret = munmap(mmap_info.addr_, mmap_info.length_);
     if (ret != 0) {
       // TODO(sdong): Better handling


### PR DESCRIPTION
Calling `std::vector::reserve()` causes memory to be reallocated and then data to be moved. It was called prior to adding every block. This reallocation could be done a huge amount of times, e.g., for users with large index blocks.

Instead, we can simply use `std::vector::emplace_back()` in such a way that preserves the no-memory-leak guarantee, while letting the vector decide when to reallocate space. Now I see reallocation/moving happen O(logN) times, rather than O(N) times, where N is the final size of vector.

Test Plan:

- `make check -j64`