### PR TITLE
Legocastle job to report lite build binary size to scuba

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -353,6 +353,22 @@ LITE_BUILD_COMMANDS="[
 ]"
 
 #
+# Report RocksDB lite binary size to scuba
+REPORT_LITE_BINARY_SIZE_COMMANDS="[
+    {
+        'name':'Rocksdb Lite Binary Size',
+        'oncall':'$ONCALL',
+        'steps': [
+            $CLEANUP_ENV,
+            {
+                'name':'Report RocksDB Lite binary size to scuba',
+                'shell':'tools/report_lite_binary_size.sh',
+                'user':'root',
+            },
+        ],
+]"
+
+#
 # RocksDB stress/crash test
 #
 STRESS_CRASH_TEST_COMMANDS="[
@@ -727,6 +743,9 @@ case $1 in
     ;;
   lite)
     echo $LITE_BUILD_COMMANDS
+    ;;
+  report_lite_binary_size)
+    echo $REPORT_LITE_BINARY_SIZE_COMMANDS
     ;;
   stress_crash)
     echo $STRESS_CRASH_TEST_COMMANDS

--- a/tools/report_lite_binary_size.sh
+++ b/tools/report_lite_binary_size.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Script to report lite build binary size for latest RocksDB commits.
+# Usage:
+#   ./report_lite_binary_size [num_recent_commits]
+
+num_recent_commits=${1:-10}
+
+echo "Computing RocksDB lite build binary size for the most recent $num_recent_commits commits."
+
+for ((i=0; i<$num_recent_commits; i++))
+do
+  git checkout master~$i
+  commit_hash=`git show -s --format=%H`
+  commit_time=`git show -s --format=%ct`
+
+  # It would be nice to check if scuba already have a record for the commit,
+  # but sandcastle don't seems to have scuba CLI installed.
+
+  make clean
+  make OPT=-DROCKSDB_LITE static_lib
+
+  if [ $? -eq 0 ]
+  then
+    build_succeeded='true'
+    strip librocksdb.a
+    binary_size=`ls -l librocksdb.a | cut -f5 -d" "`
+  else
+    build_succeeded='false'
+    binary_size=0
+  fi
+  
+  current_time=`date +%s`
+
+  current_time="\"time\": $current_time"
+  commit_hash="\"hash\": \"$commit_hash\""
+  commit_time="\"commit_time\": $commit_time"
+  build_succeeded="\"build_succeeded\": \"$build_succeeded\""
+  binary_size="\"binary_size\": $binary_size"
+
+  scribe_log="{\"int\":{$current_time, $commit_time, $binary_size}, \"normal\":{$commit_hash, $build_succeeded}}"
+  echo "Logging to scribe: $scribe_log"
+  scribe_cat perfpipe_rocksdb_lite_build "$scribe_log"
+done

--- a/tools/report_lite_binary_size.sh
+++ b/tools/report_lite_binary_size.sh
@@ -7,11 +7,11 @@ num_recent_commits=${1:-10}
 
 echo "Computing RocksDB lite build binary size for the most recent $num_recent_commits commits."
 
-for ((i=0; i<$num_recent_commits; i++))
+for ((i=0; i < num_recent_commits; i++))
 do
   git checkout master~$i
-  commit_hash=`git show -s --format=%H`
-  commit_time=`git show -s --format=%ct`
+  commit_hash=$(git show -s --format=%H)
+  commit_time=$(git show -s --format=%ct)
 
   # It would be nice to check if scuba already have a record for the commit,
   # but sandcastle don't seems to have scuba CLI installed.
@@ -19,19 +19,17 @@ do
   make clean
   make OPT=-DROCKSDB_LITE static_lib
 
-  if [ $? -eq 0 ]
+  if make OPT=-DROCKSDB_LITE static_lib
   then
     build_succeeded='true'
     strip librocksdb.a
-    binary_size=`ls -l librocksdb.a | cut -f5 -d" "`
+    binary_size=$(stat -c %s librocksdb.a)
   else
     build_succeeded='false'
     binary_size=0
   fi
-  
-  current_time=`date +%s`
 
-  current_time="\"time\": $current_time"
+  current_time="\"time\": $(date +%s)"
   commit_hash="\"hash\": \"$commit_hash\""
   commit_time="\"commit_time\": $commit_time"
   build_succeeded="\"build_succeeded\": \"$build_succeeded\""


### PR DESCRIPTION
Summary:
Add a legocastle job to continuously build the last 10 commits every 4 hours and report lite build binary size to scuba.

Test Plan:
local run the report_lite_binary_size.sh script.
To test the actual legocastle job it needs to wait till this PR being landed.