### PR TITLE
WritePrepared Txn: optimizations for sysbench update_noindex

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -404,7 +404,8 @@ Status WriteBatch::Iterate(Handler* handler) const {
   Status s;
   char tag = 0;
   uint32_t column_family = 0;  // default
-  while ((s.ok() || UNLIKELY(s.IsTryAgain())) && !input.empty() && handler->Continue()) {
+  while ((s.ok() || UNLIKELY(s.IsTryAgain())) && !input.empty() &&
+         handler->Continue()) {
     if (LIKELY(!s.IsTryAgain())) {
       tag = 0;
       column_family = 0;  // default

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -175,30 +175,6 @@ TransactionDBOptions PessimisticTransactionDB::ValidateTxnDBOptions(
   return validated;
 }
 
-void PessimisticTransactionDB::UpdateCFComparatorMap(
-    const std::vector<ColumnFamilyHandle*>& handles) {
-  auto cf_map = new std::map<uint32_t, const Comparator*>();
-  for (auto h : handles) {
-    auto id = h->GetID();
-    const Comparator* comparator = h->GetComparator();
-    (*cf_map)[id] = comparator;
-  }
-  cf_map_.store(cf_map);
-  cf_map_gc_.reset(cf_map);
-}
-
-void PessimisticTransactionDB::UpdateCFComparatorMap(
-    const ColumnFamilyHandle* h) {
-  auto old_cf_map_ptr = cf_map_.load();
-  assert(old_cf_map_ptr);
-  auto cf_map = new std::map<uint32_t, const Comparator*>(*old_cf_map_ptr);
-  auto id = h->GetID();
-  const Comparator* comparator = h->GetComparator();
-  (*cf_map)[id] = comparator;
-  cf_map_.store(cf_map);
-  cf_map_gc_.reset(cf_map);
-}
-
 Status TransactionDB::Open(const Options& options,
                            const TransactionDBOptions& txn_db_options,
                            const std::string& dbname, TransactionDB** dbptr) {

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -228,7 +228,7 @@ Status TransactionDB::Open(
   Status s;
   DB* db;
 
-  ROCKS_LOG_WARN(db_options.info_log, "Transaction write_policy is " PRId32,
+  ROCKS_LOG_WARN(db_options.info_log, "Transaction write_policy is %" PRId32,
                  static_cast<int>(txn_db_options.write_policy));
   std::vector<ColumnFamilyDescriptor> column_families_copy = column_families;
   std::vector<size_t> compaction_enabled_cf_indices;

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -117,9 +117,8 @@ class PessimisticTransactionDB : public TransactionDB {
   // to the child classes that actually need this information. This was due to
   // an odd performance drop we observed when the added std::atomic member to
   // the base class even when the subclass do not read it in the fast path.
-  virtual void UpdateCFComparatorMap(
-      const std::vector<ColumnFamilyHandle*>& handles) {}
-  virtual void UpdateCFComparatorMap(const ColumnFamilyHandle* handle) {}
+  virtual void UpdateCFComparatorMap(const std::vector<ColumnFamilyHandle*>&) {}
+  virtual void UpdateCFComparatorMap(const ColumnFamilyHandle*) {}
 
  protected:
   DBImpl* db_impl_;

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -113,20 +113,18 @@ class PessimisticTransactionDB : public TransactionDB {
   std::vector<DeadlockPath> GetDeadlockInfoBuffer() override;
   void SetDeadlockInfoBufferSize(uint32_t target_size) override;
 
-  void UpdateCFComparatorMap(const std::vector<ColumnFamilyHandle*>& handles);
-  void UpdateCFComparatorMap(const ColumnFamilyHandle* handle);
-  std::map<uint32_t, const Comparator*>* GetCFComparatorMap() {
-    return cf_map_.load();
-  }
+  // The default implementation does nothing. The actual implementation is moved
+  // to the child classes that actually need this information. This was due to
+  // an odd performance drop we observed when the added std::atomic member to
+  // the base class even when the subclass do not read it in the fast path.
+  virtual void UpdateCFComparatorMap(
+      const std::vector<ColumnFamilyHandle*>& handles) {}
+  virtual void UpdateCFComparatorMap(const ColumnFamilyHandle* handle) {}
 
  protected:
   DBImpl* db_impl_;
   std::shared_ptr<Logger> info_log_;
   const TransactionDBOptions txn_db_options_;
-  // A cache of the cf comparators
-  std::atomic<std::map<uint32_t, const Comparator*>*> cf_map_;
-  // GC of the object above
-  std::unique_ptr<std::map<uint32_t, const Comparator*>> cf_map_gc_;
 
   void ReinitializeTransaction(
       Transaction* txn, const WriteOptions& write_options,

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -73,6 +73,8 @@ Status WritePreparedTxn::PrepareInternal() {
   // For each duplicate key we account for a new sub-batch
   prepare_batch_cnt_ = 1;
   if (GetWriteBatch()->HasDuplicateKeys()) {
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());
     auto s = GetWriteBatch()->GetWriteBatch()->Iterate(&counter);
     assert(s.ok());
@@ -130,6 +132,8 @@ Status WritePreparedTxn::CommitInternal() {
   assert(prepare_batch_cnt_);
   size_t commit_batch_cnt = 0;
   if (includes_data) {
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());
     auto s = working_batch->Iterate(&counter);
     assert(s.ok());
@@ -321,6 +325,8 @@ Status WritePreparedTxn::RebuildFromWriteBatch(WriteBatch* src_batch) {
   auto ret = PessimisticTransaction::RebuildFromWriteBatch(src_batch);
   prepare_batch_cnt_ = 1;
   if (GetWriteBatch()->HasDuplicateKeys()) {
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());
     auto s = GetWriteBatch()->GetWriteBatch()->Iterate(&counter);
     assert(s.ok());

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -72,7 +72,7 @@ Status WritePreparedTxn::PrepareInternal() {
   uint64_t seq_used = kMaxSequenceNumber;
   // For each duplicate key we account for a new sub-batch
   prepare_batch_cnt_ = 1;
-  if (GetWriteBatch()->HasDuplicateKeys()) {
+  if (UNLIKELY(GetWriteBatch()->HasDuplicateKeys())) {
     ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
                    "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());
@@ -99,7 +99,7 @@ Status WritePreparedTxn::PrepareInternal() {
 Status WritePreparedTxn::CommitWithoutPrepareInternal() {
   // For each duplicate key we account for a new sub-batch
   size_t batch_cnt = 1;
-  if (GetWriteBatch()->HasDuplicateKeys()) {
+  if (UNLIKELY(GetWriteBatch()->HasDuplicateKeys())) {
     batch_cnt = 0;  // this will trigger a batch cnt compute
   }
   return CommitBatchInternal(GetWriteBatch()->GetWriteBatch(), batch_cnt);
@@ -131,7 +131,7 @@ Status WritePreparedTxn::CommitInternal() {
   const bool includes_data = !empty && !for_recovery;
   assert(prepare_batch_cnt_);
   size_t commit_batch_cnt = 0;
-  if (includes_data) {
+  if (UNLIKELY(includes_data)) {
     ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
                    "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());
@@ -147,7 +147,7 @@ Status WritePreparedTxn::CommitInternal() {
   // a connection between the memtable and its WAL, so there is no need to
   // redundantly reference the log that contains the prepared data.
   const uint64_t zero_log_number = 0ull;
-  size_t batch_cnt = commit_batch_cnt ? commit_batch_cnt : 1;
+  size_t batch_cnt = UNLIKELY(commit_batch_cnt) ? commit_batch_cnt : 1;
   auto s = db_impl_->WriteImpl(write_options_, working_batch, nullptr, nullptr,
                                zero_log_number, disable_memtable, &seq_used,
                                batch_cnt, &update_commit_map);
@@ -324,7 +324,7 @@ Status WritePreparedTxn::ValidateSnapshot(ColumnFamilyHandle* column_family,
 Status WritePreparedTxn::RebuildFromWriteBatch(WriteBatch* src_batch) {
   auto ret = PessimisticTransaction::RebuildFromWriteBatch(src_batch);
   prepare_batch_cnt_ = 1;
-  if (GetWriteBatch()->HasDuplicateKeys()) {
+  if (UNLIKELY(GetWriteBatch()->HasDuplicateKeys())) {
     ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
                    "Duplicate key overhead");
     SubBatchCounter counter(*wpt_db_->GetCFComparatorMap());

--- a/utilities/transactions/write_prepared_txn.h
+++ b/utilities/transactions/write_prepared_txn.h
@@ -62,7 +62,7 @@ class WritePreparedTxn : public PessimisticTransaction {
                                 ColumnFamilyHandle* column_family) override;
 
  protected:
-  // Override the protected SetId to make it visible to the firend class
+  // Override the protected SetId to make it visible to the friend class
   // WritePreparedTxnDB
   inline void SetId(uint64_t id) override { Transaction::SetId(id); }
 

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -147,16 +147,15 @@ Status WritePreparedTxnDB::WriteInternal(const WriteOptions& write_options_orig,
   ROCKS_LOG_DETAILS(db_impl_->immutable_db_options().info_log,
                     "CommitBatchInternal 2nd write prepare_seq: %" PRIu64,
                     prepare_seq);
-  // TODO(myabandeh): Note: we skip AddPrepared here. This could be further
-  // optimized by skip erasing prepare_seq from prepared_txn_ in the following
-  // callback.
   // TODO(myabandeh): What if max advances the prepare_seq_ in the meanwhile and
   // readers assume the prepared data as committed? Almost zero probability.
 
   // Commit the batch by writing an empty batch to the 2nd queue that will
   // release the commit sequence number to readers.
+  const size_t ZERO_COMMITS = 0;
+  const bool PREP_HEAP_SKIPPED = true;
   WritePreparedCommitEntryPreReleaseCallback update_commit_map_with_prepare(
-      this, db_impl_, prepare_seq, batch_cnt);
+      this, db_impl_, prepare_seq, batch_cnt, ZERO_COMMITS, PREP_HEAP_SKIPPED);
   WriteBatch empty_batch;
   empty_batch.PutLogData(Slice());
   const size_t ONE_BATCH = 1;

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -104,6 +104,8 @@ Status WritePreparedTxnDB::WriteInternal(const WriteOptions& write_options_orig,
   }
   if (batch_cnt == 0) {  // not provided, then compute it
     // TODO(myabandeh): add an option to allow user skipping this cost
+    ROCKS_LOG_WARN(db_impl_->immutable_db_options().info_log,
+                   "Duplicate key overhead");
     SubBatchCounter counter(*GetCFComparatorMap());
     auto s = batch->Iterate(&counter);
     assert(s.ok());

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -216,6 +216,13 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   // Struct to hold ownership of snapshot and read callback for cleanup.
   struct IteratorState;
 
+  std::map<uint32_t, const Comparator*>* GetCFComparatorMap() {
+    return cf_map_.load();
+  }
+  void UpdateCFComparatorMap(
+      const std::vector<ColumnFamilyHandle*>& handles) override;
+  void UpdateCFComparatorMap(const ColumnFamilyHandle* handle) override;
+
  protected:
   virtual Status VerifyCFOptions(
       const ColumnFamilyOptions& cf_options) override;
@@ -394,6 +401,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   mutable port::RWMutex old_commit_map_mutex_;
   mutable port::RWMutex commit_cache_mutex_;
   mutable port::RWMutex snapshots_mutex_;
+  // A cache of the cf comparators
+  std::atomic<std::map<uint32_t, const Comparator*>*> cf_map_;
+  // GC of the object above
+  std::unique_ptr<std::map<uint32_t, const Comparator*>> cf_map_gc_;
 };
 
 class WritePreparedTxnReadCallback : public ReadCallback {


### PR DESCRIPTION
These are optimization that we applied to improve sysbech's update_noindex performance.
1. Make use of LIKELY compiler hint
2. Move std::atomic so the subclass
3. Make use of skip_prepared in non-2pc transactions.