### PR TITLE
Fix build with USE_RTTI=0

### DIFF
--- a/utilities/column_aware_encoding_util.cc
+++ b/utilities/column_aware_encoding_util.cc
@@ -25,6 +25,7 @@
 #include "table/block_based_table_factory.h"
 #include "table/format.h"
 #include "table/table_reader.h"
+#include "util/cast_util.h"
 #include "util/coding.h"
 #include "utilities/col_buf_decoder.h"
 #include "utilities/col_buf_encoder.h"
@@ -58,7 +59,7 @@ void ColumnAwareEncodingReader::InitTableReader(const std::string& file_path) {
                          /*skip_filters=*/false),
       std::move(file_), file_size, &table_reader, /*enable_prefetch=*/false);
 
-  table_reader_.reset(dynamic_cast<BlockBasedTable*>(table_reader.release()));
+  table_reader_.reset(static_cast_with_check<BlockBasedTable, TableReader>(table_reader.release()));
 }
 
 void ColumnAwareEncodingReader::GetKVPairsFromDataBlocks(


### PR DESCRIPTION
utilities/column_aware_encoding_util.cc:61:23: error: cannot use dynamic_cast with -fno-rtti
  table_reader_.reset(dynamic_cast<BlockBasedTable*>(table_reader.release()));
                      ^
1 error generated.

It was added as a [local patch](https://svnweb.freebsd.org/ports/head/databases/rocksdb/files/patch-utilities-column_aware_encoding_util.cc) on FreeBSD since RocksDB 5.8.
It also fixes #2707.