### PR TITLE
Squash indirection layers on the key comparison path

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -106,67 +106,6 @@ const char* InternalKeyComparator::Name() const {
   return name_.c_str();
 }
 
-int InternalKeyComparator::Compare(const Slice& akey, const Slice& bkey) const {
-  // Order by:
-  //    increasing user key (according to user-supplied comparator)
-  //    decreasing sequence number
-  //    decreasing type (though sequence# should be enough to disambiguate)
-  int r = user_comparator_->Compare(ExtractUserKey(akey), ExtractUserKey(bkey));
-  PERF_COUNTER_ADD(user_key_comparison_count, 1);
-  if (r == 0) {
-    const uint64_t anum = DecodeFixed64(akey.data() + akey.size() - 8);
-    const uint64_t bnum = DecodeFixed64(bkey.data() + bkey.size() - 8);
-    if (anum > bnum) {
-      r = -1;
-    } else if (anum < bnum) {
-      r = +1;
-    }
-  }
-  return r;
-}
-
-int InternalKeyComparator::CompareKeySeq(const Slice& akey,
-                                         const Slice& bkey) const {
-  // Order by:
-  //    increasing user key (according to user-supplied comparator)
-  //    decreasing sequence number
-  int r = user_comparator_->Compare(ExtractUserKey(akey), ExtractUserKey(bkey));
-  PERF_COUNTER_ADD(user_key_comparison_count, 1);
-  if (r == 0) {
-    // Shift the number to exclude the last byte which contains the value type
-    const uint64_t anum = DecodeFixed64(akey.data() + akey.size() - 8) >> 8;
-    const uint64_t bnum = DecodeFixed64(bkey.data() + bkey.size() - 8) >> 8;
-    if (anum > bnum) {
-      r = -1;
-    } else if (anum < bnum) {
-      r = +1;
-    }
-  }
-  return r;
-}
-
-int InternalKeyComparator::Compare(const ParsedInternalKey& a,
-                                   const ParsedInternalKey& b) const {
-  // Order by:
-  //    increasing user key (according to user-supplied comparator)
-  //    decreasing sequence number
-  //    decreasing type (though sequence# should be enough to disambiguate)
-  int r = user_comparator_->Compare(a.user_key, b.user_key);
-  PERF_COUNTER_ADD(user_key_comparison_count, 1);
-  if (r == 0) {
-    if (a.sequence > b.sequence) {
-      r = -1;
-    } else if (a.sequence < b.sequence) {
-      r = +1;
-    } else if (a.type > b.type) {
-      r = -1;
-    } else if (a.type < b.type) {
-      r = +1;
-    }
-  }
-  return r;
-}
-
 void InternalKeyComparator::FindShortestSeparator(
       std::string* start,
       const Slice& limit) const {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -220,22 +220,6 @@ void MemTable::UpdateOldestKeyTime() {
   }
 }
 
-int MemTable::KeyComparator::operator()(const char* prefix_len_key1,
-                                        const char* prefix_len_key2) const {
-  // Internal keys are encoded as length-prefixed strings.
-  Slice k1 = GetLengthPrefixedSlice(prefix_len_key1);
-  Slice k2 = GetLengthPrefixedSlice(prefix_len_key2);
-  return comparator.CompareKeySeq(k1, k2);
-}
-
-int MemTable::KeyComparator::operator()(const char* prefix_len_key,
-                                        const Slice& key)
-    const {
-  // Internal keys are encoded as length-prefixed strings.
-  Slice a = GetLengthPrefixedSlice(prefix_len_key);
-  return comparator.CompareKeySeq(a, key);
-}
-
 void MemTableRep::InsertConcurrently(KeyHandle handle) {
 #ifndef ROCKSDB_LITE
   throw std::runtime_error("concurrent insert not supported");

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -24,6 +24,7 @@
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
 #include "rocksdb/memtablerep.h"
+#include "rocksdb/keycomparator.h"
 #include "util/allocator.h"
 #include "util/concurrent_arena.h"
 #include "util/dynamic_bloom.h"
@@ -31,6 +32,7 @@
 
 namespace rocksdb {
 
+class KeyComparator;
 class Mutex;
 class MemTableIterator;
 class MergeContext;
@@ -78,14 +80,7 @@ struct MemTablePostProcessInfo {
 // written to (aka the 'immutable memtables').
 class MemTable {
  public:
-  struct KeyComparator : public MemTableRep::KeyComparator {
-    const InternalKeyComparator comparator;
-    explicit KeyComparator(const InternalKeyComparator& c) : comparator(c) { }
-    virtual int operator()(const char* prefix_len_key1,
-                           const char* prefix_len_key2) const override;
-    virtual int operator()(const char* prefix_len_key,
-                           const Slice& key) const override;
-  };
+  typedef class rocksdb::KeyComparator KeyComparator;
 
   // MemTables are reference counted.  The initial reference count
   // is zero and the caller must call Ref() at least once.

--- a/include/rocksdb/keycomparator.h
+++ b/include/rocksdb/keycomparator.h
@@ -1,0 +1,56 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "db/dbformat.h"
+#include "util/coding.h"
+
+namespace rocksdb {
+
+class KeyComparator {
+public:
+  const InternalKeyComparator comparator;
+  explicit KeyComparator(const InternalKeyComparator& c) : comparator(c) { }
+
+  // Compare a and b. Return a negative value if a is less than b, 0 if they
+  // are equal, and a positive value if a is greater than b
+  int operator()(const char* prefix_len_key1,
+                 const char* prefix_len_key2) const;
+  int operator()(const char* prefix_len_key,
+                 const Slice& key) const;
+  // TODO(rzarzynski): introduce a variant for the typical use case:
+  // comparing ONE key with MANY others keys. We could squeeze a lot
+  // of work spent on transforming the same data here and in Internal
+  // KeyComparator.
+};
+
+
+inline int KeyComparator::operator()(const char* prefix_len_key1,
+                                     const char* prefix_len_key2) const {
+  // Internal keys are encoded as length-prefixed strings.
+  Slice k1 = GetLengthPrefixedSlice(prefix_len_key1);
+  Slice k2 = GetLengthPrefixedSlice(prefix_len_key2);
+  return comparator.CompareKeySeq(k1, k2);
+}
+
+inline int KeyComparator::operator()(const char* prefix_len_key,
+                                     const Slice& key)
+    const {
+  // Internal keys are encoded as length-prefixed strings.
+  Slice a = GetLengthPrefixedSlice(prefix_len_key);
+  return comparator.CompareKeySeq(a, key);
+}
+
+}  // namespace rocksdb

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -48,6 +48,7 @@ class LookupKey;
 class Slice;
 class SliceTransform;
 class Logger;
+class KeyComparator;
 
 typedef void* KeyHandle;
 
@@ -55,18 +56,7 @@ class MemTableRep {
  public:
   // KeyComparator provides a means to compare keys, which are internal keys
   // concatenated with values.
-  class KeyComparator {
-   public:
-    // Compare a and b. Return a negative value if a is less than b, 0 if they
-    // are equal, and a positive value if a is greater than b
-    virtual int operator()(const char* prefix_len_key1,
-                           const char* prefix_len_key2) const = 0;
-
-    virtual int operator()(const char* prefix_len_key,
-                           const Slice& key) const = 0;
-
-    virtual ~KeyComparator() { }
-  };
+  typedef class rocksdb::KeyComparator KeyComparator;
 
   explicit MemTableRep(Allocator* allocator) : allocator_(allocator) {}
 

--- a/memtable/stl_wrappers.h
+++ b/memtable/stl_wrappers.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "rocksdb/comparator.h"
+#include "rocksdb/keycomparator.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/slice.h"
 #include "util/coding.h"
@@ -18,13 +19,13 @@ namespace stl_wrappers {
 
 class Base {
  protected:
-  const MemTableRep::KeyComparator& compare_;
+  const rocksdb::KeyComparator& compare_;
   explicit Base(const MemTableRep::KeyComparator& compare)
       : compare_(compare) {}
 };
 
 struct Compare : private Base {
-  explicit Compare(const MemTableRep::KeyComparator& compare) : Base(compare) {}
+  explicit Compare(const rocksdb::KeyComparator& compare) : Base(compare) {}
   inline bool operator()(const char* a, const char* b) const {
     return compare_(a, b) < 0;
   }


### PR DESCRIPTION
Summary
========
`rocksdb` has multi-level abstraction over key comparison. Quick view on burnt cycles distribution with `perf` sampling from PMU:

```
-   26,91%     0,02%  db_bench     db_bench             [.] rocksdb::MemTableInserter::PutCF
     26,89% rocksdb::MemTableInserter::PutCF
      - rocksdb::MemTableInserter::PutCFImpl
         - 26,26% rocksdb::MemTable::Add
            - 24,96% rocksdb::InlineSkipList<rocksdb::MemTableRep::KeyComparator const&>::Insert<false>
               - 23,46% rocksdb::InlineSkipList<rocksdb::MemTableRep::KeyComparator const&>::RecomputeSpliceLevels
                  - rocksdb::InlineSkipList<rocksdb::MemTableRep::KeyComparator const&>::KeyIsAfterNode
                     - 9,10% rocksdb::MemTable::KeyComparator::operator()
                        - 4,60% rocksdb::InternalKeyComparator::Compare
                           - rocksdb::(anonymous namespace)::BytewiseComparatorImpl::Compare
                                __memcmp_sse4_1
                          1,80% rocksdb::GetVarint32PtrFallback
               + 1,10% rocksdb::InlineSkipList<rocksdb::MemTableRep::KeyComparator const&>::KeyIsAfterNode
              0,56% rocksdb::(anonymous namespace)::SkipListRep::Allocate
```

The indirection might be costly because of prohibiting compiler from inlining the code while imposing unnecessary memory dereferences. The changeset tries to deal with that through:
* just shuffling the `rocksdb::InternalKeyComparator::Compare` family from `.cc` to header,
* unifying `rocksdb::MemTableRep::KeyComparator` and `rocksdb::MemTable::KeyComparator` via common `rocksdb::KeyComparator`.

With the patches applied:
```
-   27,94%     0,06%  db_bench     db_bench             [.] rocksdb::MemTableInserter::PutCF
     27,88% rocksdb::MemTableInserter::PutCF
      - rocksdb::MemTableInserter::PutCFImpl
         - 27,07% rocksdb::MemTable::Add
            - 25,55% rocksdb::InlineSkipList<rocksdb::KeyComparator const&>::Insert<false>
               - 24,44% rocksdb::InlineSkipList<rocksdb::KeyComparator const&>::RecomputeSpliceLevels
                  - rocksdb::InlineSkipList<rocksdb::KeyComparator const&>::KeyIsAfterNode
                     - 2,94% rocksdb::(anonymous namespace)::BytewiseComparatorImpl::Compare
                          __memcmp_sse4_1
                       1,93% rocksdb::GetVarint32PtrFallback
                 0,74% rocksdb::InlineSkipList<rocksdb::KeyComparator const&>::KeyIsAfterNode
            + 0,70% rocksdb::(anonymous namespace)::SkipListRep::Allocate
```

Very rough performance comparison
==================

Before the rebase
----------------------
The branch started from pretty old `master` that is used in the Ceph project. It's still available as [wip-inlineable-KeyComparator-ceph](https://github.com/rzarzynski/rocksdb/tree/wip-inlineable-KeyComparator-ceph). Run under profiler, huge keys.

#### Reference point: 8dd0a7e11abad6bc32e59a5cba8769961e085312.

```
$ perf record -e cycles:pp --call-graph dwarf ./db_bench --writes 1000000 --benchmarks="fillrandom" --compression_type none -key_size 256

(...)

Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 5.8
Date:       Thu Feb 15 22:09:31 2018
CPU:        8 * Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
CPUCache:   8192 KB
Keys:       256 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    339.5 MB (estimated)
FileSize:   291.8 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Memtablerep: skip_list
Perf Level: 1
------------------------------------------------
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
DB path: [/tmp/rocksdbtest-1000/dbbench]
fillrandom   :       3.787 micros/op 264046 ops/sec;   89.6 MB/s

(...)

[ perf record: Captured and wrote 165.024 MB perf.data (20480 samples) ]
```

#### Changed: 5faa1dc9aa53d909bcfdee05be588803784f831f:
```
$ perf record -e cycles:pp --call-graph dwarf ./db_bench --writes 1000000 --benchmarks="fillrandom" --compression_type none -key_size 256

(...)

Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 5.8
Date:       Fri Feb 16 00:12:59 2018
CPU:        8 * Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
CPUCache:   8192 KB
Keys:       256 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    339.5 MB (estimated)
FileSize:   291.8 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Memtablerep: skip_list
Perf Level: 1
------------------------------------------------
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
DB path: [/tmp/rocksdbtest-1000/dbbench]
fillrandom   :       3.327 micros/op 300584 ops/sec;  102.1 MB/s

(...)

[ perf record: Captured and wrote 143.288 MB perf.data (17815 samples) ]
```

The rebased branch
--------------------------
Slightly longer runs without `perf record`.

#### Reference point: c88c57cde10a820b21d9fab0ca3f059da3852057.
```
$ ./db_bench --writes 20000000 --benchmarks="fillrandom" --compression_type none -key_size 256
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 5.10
Date:       Fri Feb 16 02:56:54 2018
CPU:        8 * Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
CPUCache:   8192 KB
Keys:       256 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    339.5 MB (estimated)
FileSize:   291.8 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Memtablerep: skip_list
Perf Level: 1
------------------------------------------------
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
DB path: [/tmp/rocksdbtest-1000/dbbench]
fillrandom   :       3.779 micros/op 264615 ops/sec;   89.8 MB/s
```

#### Changed: 7a7f60a24c7007adc9a4af995cb722c1e16d7875
```
$ ./db_bench --writes 20000000 --benchmarks="fillrandom" --compression_type none -key_size 256
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
RocksDB:    version 5.10
Date:       Fri Feb 16 02:41:39 2018
CPU:        8 * Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
CPUCache:   8192 KB
Keys:       256 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
Prefix:    0 bytes
Keys per prefix:    0
RawSize:    339.5 MB (estimated)
FileSize:   291.8 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Memtablerep: skip_list
Perf Level: 1
------------------------------------------------
Initializing RocksDB Options from the specified file
Initializing RocksDB Options from command-line flags
DB path: [/tmp/rocksdbtest-1000/dbbench]
fillrandom   :       3.447 micros/op 290073 ops/sec;   98.5 MB/s
```