### PR TITLE
[rocksdb] fix shift UBSAN error in col_buf_encoder.cc

### DIFF
--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -228,16 +228,9 @@ class FaultInjectionTest : public testing::Test,
     return Status::OK();
   }
 
-#ifdef ROCKSDB_UBSAN_RUN
-#if defined(__clang__)
-__attribute__((__no_sanitize__("shift"), no_sanitize("signed-integer-overflow")))
-#elif defined(__GNUC__)
-__attribute__((__no_sanitize_undefined__))
-#endif
-#endif
   // Return the ith key
   Slice Key(int i, std::string* storage) const {
-    int num = i;
+    unsigned long long num = i;
     if (!sequential_order_) {
       // random transfer
       const int m = 0x5bd1e995;
@@ -245,7 +238,7 @@ __attribute__((__no_sanitize_undefined__))
       num ^= num << 24;
     }
     char buf[100];
-    snprintf(buf, sizeof(buf), "%016d", num);
+    snprintf(buf, sizeof(buf), "%016d", static_cast<int>(num));
     storage->assign(buf, strlen(buf));
     return Slice(*storage);
   }

--- a/utilities/col_buf_encoder.cc
+++ b/utilities/col_buf_encoder.cc
@@ -46,13 +46,6 @@ ColBufEncoder *ColBufEncoder::NewColBufEncoder(
   return nullptr;
 }
 
-#ifdef ROCKSDB_UBSAN_RUN
-#if defined(__clang__)
-__attribute__((__no_sanitize__("shift")))
-#elif defined(__GNUC__)
-__attribute__((__no_sanitize_undefined__))
-#endif
-#endif
 size_t FixedLengthColBufEncoder::Append(const char *buf) {
   if (nullable_) {
     if (buf == nullptr) {
@@ -72,7 +65,7 @@ size_t FixedLengthColBufEncoder::Append(const char *buf) {
       col_compression_type_ == kColRleDeltaVarint) {
     int64_t delta = read_val - last_val_;
     // Encode signed delta value
-    delta = (delta << 1) ^ (delta >> 63);
+    delta = (static_cast<uint64_t>(delta) << 1) ^ (delta >> 63);
     write_val = delta;
     last_val_ = read_val;
   } else if (col_compression_type_ == kColDict ||


### PR DESCRIPTION
Add a static cast to perform the left shift as with an unsigned type.

make ubsan_check