### PR TITLE
Fix TSAN test timeout in MergeOperatorPinningTest.Randomized/x

### DIFF
--- a/db/db_merge_operator_test.cc
+++ b/db/db_merge_operator_test.cc
@@ -284,7 +284,7 @@ TEST_P(MergeOperatorPinningTest, Randomized) {
     Random rnd(301);
     std::map<std::string, std::string> true_data;
 
-    const int kTotalMerges = 10000;
+    const int kTotalMerges = 5000;
     // Every key gets ~10 operands
     const int kKeyRange = kTotalMerges / 10;
     const int kOperandSize = 20;


### PR DESCRIPTION
[FB - Internal] 
MergeOperatorPinningTest.Randomized/x tests are frequently failing with timeouts when run with tsan, as they are exceeding 10 minute limit for tests. The tests are in turn getting disabled due to frequent failures. 
I halved the number of rounds to make the test complete sooner. This reduces the number of testing iterations a little, but it still is much better than totally letting the test be disabled. 

Test Plan:
```
buck test @mode/dev-tsan <internal repo>/repo:db_merge_operator_test -- 'MergeOperatorPinningTest\/MergeOperatorPinningTest\.Randomized\/0'
buck test @mode/dev-tsan <internal repo>/repo:db_merge_operator_test -- 'MergeOperatorPinningTest\/MergeOperatorPinningTest\.Randomized\/0'
```