### PR TITLE
Iterator changes when skipping internal keys

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 * Iterator::SeekForPrev is now a pure virtual method. This is to prevent user who implement the Iterator interface fail to implement SeekForPrev by mistake.
 * Add `include_end` option to make the range end exclusive when `include_end == false` in `DeleteFilesInRange()`.
 * Add `CompactRangeOptions::allow_write_stall`, which makes `CompactRange` start working immediately, even if it causes user writes to stall. The default value is false, meaning we add delay to `CompactRange` calls until stalling can be avoided when possible. Note this delay is not present in previous RocksDB versions.
+* Fail only Iterator::Next and Prev with Incomplete status on encountering internal keys more than `ReadOptions.max_skippable_internal_keys`. The Seek family of operations (Seek, SeekForPrev, SeekToFirst and SeekToLast) do not fail anymore.
+* Add `rocksdb.iterator.internal-key` iterator property to return the key at which the iterator currently stopped.
 
 ### New Features
 * Improve the performance of iterators doing long range scans by using readahead.

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -225,6 +225,9 @@ class DBIter final: public Iterator {
         *prop = "Iterator is not valid.";
       }
       return Status::OK();
+    } else if (prop_name == "rocksdb.iterator.internal-key") {
+      *prop = saved_key_.GetUserKey().ToString();
+      return Status::OK();
     }
     return Status::InvalidArgument("Undentified property.");
   }

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1142,11 +1142,7 @@ void DBIter::FindPrevUserKey() {
 
 bool DBIter::TooManyInternalKeysSkipped(bool increment) {
   // Don't constrain during Seek operations (Seek, SeekForPrev, SeekToFirst, SeekToLast)
-  if (op_ == kSeek) {
-    return false;
-  }
-
-  if ((max_skippable_internal_keys_ > 0) &&
+  if ((op_ != Operation::kSeek) && (max_skippable_internal_keys_ > 0) &&
       (num_internal_keys_skipped_ > max_skippable_internal_keys_)) {
     valid_ = false;
     status_ = Status::Incomplete("Too many internal keys skipped.");

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -64,7 +64,7 @@ class DBIter final: public Iterator {
   enum Operation {
     kNext,
     kPrev,
-    kSeek, // Covers: Seek, SeekForPrev, SeekToFirst, SeekToLast
+    kSeek,  // Covers: Seek, SeekForPrev, SeekToFirst, SeekToLast
     KNone,
   };
 
@@ -1141,7 +1141,8 @@ void DBIter::FindPrevUserKey() {
 }
 
 bool DBIter::TooManyInternalKeysSkipped(bool increment) {
-  // Don't constrain during Seek operations (Seek, SeekForPrev, SeekToFirst, SeekToLast)
+  // Don't constrain during Seek operations (Seek, SeekForPrev, SeekToFirst,
+  // SeekToLast)
   if ((op_ != Operation::kSeek) && (max_skippable_internal_keys_ > 0) &&
       (num_internal_keys_skipped_ > max_skippable_internal_keys_)) {
     valid_ = false;

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -1277,7 +1277,8 @@ TEST_F(DBIteratorTest, SeekAfterSkippingManyInternalKeys) {
   ASSERT_EQ(db_iter->key().ToString(), "a");
   ASSERT_EQ(db_iter->value().ToString(), "val_a");
 
-  // This should fail as incomplete due to too many non-visible internal keys on the way to the next valid user key.
+  // This should fail as incomplete due to too many non-visible internal keys on
+  // the way to the next valid user key.
   db_iter->Next();
   ASSERT_TRUE(!db_iter->Valid());
   ASSERT_TRUE(db_iter->status().IsIncomplete());
@@ -1287,7 +1288,8 @@ TEST_F(DBIteratorTest, SeekAfterSkippingManyInternalKeys) {
   ASSERT_OK(db_iter->GetProperty("rocksdb.iterator.internal-key", &prop_value));
   ASSERT_EQ("b", prop_value);
 
-  // Explcitly Seek'ing to a valid key should work even though there are many skipped internal-keys.
+  // Explcitly Seek'ing to a valid key should work even though there are many
+  // skipped internal-keys.
   db_iter->Seek(prop_value);
   ASSERT_TRUE(db_iter->Valid());
   ASSERT_OK(db_iter->status());

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -97,6 +97,9 @@ class Iterator : public Cleanable {
   // Property "rocksdb.iterator.super-version-number":
   //   LSM version used by the iterator. The same format as DB Property
   //   kCurrentSuperVersionNumber. See its comment for more information.
+  // Property "rocksdb.iterator.internal-key":
+  //   Get the internal key (e.g. tombstone) at which the iteration stopped.
+  //   This key can be used to re-seek to next valid key to continue iteration.
   virtual Status GetProperty(std::string prop_name, std::string* prop);
 
  private:


### PR DESCRIPTION
User-Visible changes:
1. Do not fail a Seek-family operation (`Seek`, `SeekForPrev`, `SeekToFirst`, `SeekToLast`) as Incomplete when RocksDB encounters many internal keys to get to a valid user-visible key, on setting `ReadOptions.max_skippable_internal_keys`. Fail only `Next` and `Prev` operations. This change will enable users to re-seek on a failed Next/Prev op. 
2. Added a property `rocksdb.iterator.internal-key` to return the internal key at which the iterator stopped. 
3. Allow the same iterator to be re-used even after Next/Prev return Incomplete status. Note that an iterator returns Incomplete status only on encountering too many internal keys (say, tombstones). The user can then seek to the next valid key. This wasn't possible previously, as the user had to create a new iterator on encountering a non-ok status. Creating a new iterator is costly as compared to re-using the same one ... so this change was done to reduce iterator-creation cost.

Non-user visible changes:
- Added a new enum `Operation` in DBIter to keep track of what is the current operation that is being performed. This helps in making decisions based on the operation in the functions down the call stack. For example: `TooManyInternalKeys` method is called in both Seek and Next call-stack. We can make better decision in these functions if we know what top-level API calls it. 

Test Plan:
New tests added. 