### PR TITLE
 Add rocksdb.iterator.internal-key property

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -217,6 +217,9 @@ class DBIter final: public Iterator {
         *prop = "Iterator is not valid.";
       }
       return Status::OK();
+    } else if (prop_name == "rocksdb.iterator.internal-key") {
+      *prop = saved_key_.GetUserKey().ToString();
+      return Status::OK();
     }
     return Status::InvalidArgument("Undentified property.");
   }

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -81,6 +81,7 @@ TEST_P(DBIteratorTest, IteratorProperty) {
   Options options = CurrentOptions();
   CreateAndReopenWithCF({"pikachu"}, options);
   Put(1, "1", "2");
+  Delete(1, "2");
   ReadOptions ropt;
   ropt.pin_data = false;
   {
@@ -90,9 +91,15 @@ TEST_P(DBIteratorTest, IteratorProperty) {
     ASSERT_NOK(iter->GetProperty("non_existing.value", &prop_value));
     ASSERT_OK(iter->GetProperty("rocksdb.iterator.is-key-pinned", &prop_value));
     ASSERT_EQ("0", prop_value);
+    ASSERT_OK(iter->GetProperty("rocksdb.iterator.internal-key", &prop_value));
+    ASSERT_EQ("1", prop_value);
     iter->Next();
     ASSERT_OK(iter->GetProperty("rocksdb.iterator.is-key-pinned", &prop_value));
     ASSERT_EQ("Iterator is not valid.", prop_value);
+
+    // Get internal key at which the iteration stopped (tombstone in this case).
+    ASSERT_OK(iter->GetProperty("rocksdb.iterator.internal-key", &prop_value));
+    ASSERT_EQ("2", prop_value);
   }
   Close();
 }

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -97,6 +97,8 @@ class Iterator : public Cleanable {
   // Property "rocksdb.iterator.super-version-number":
   //   LSM version used by the iterator. The same format as DB Property
   //   kCurrentSuperVersionNumber. See its comment for more information.
+  // Property "rocksdb.iterator.internal-key":
+  //   Get the internal key (e.g. tombstone) at which the iteration stopped.
   virtual Status GetProperty(std::string prop_name, std::string* prop);
 
  private:

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -98,7 +98,8 @@ class Iterator : public Cleanable {
   //   LSM version used by the iterator. The same format as DB Property
   //   kCurrentSuperVersionNumber. See its comment for more information.
   // Property "rocksdb.iterator.internal-key":
-  //   Get the internal key (e.g. tombstone) at which the iteration stopped.
+  //   Get the user-key portion of the internal key at which the iteration
+  //   stopped.
   virtual Status GetProperty(std::string prop_name, std::string* prop);
 
  private:


### PR DESCRIPTION
Added a new iterator property: `rocksdb.iterator.internal-key` to get the internal-key (converted to user key) at which the iterator stopped. 

Test Plan:
Added a new unit-test and modified an existing one.
`make check -j64`