### PR TITLE
add carryless multiplication flag to TARGETS

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -46,7 +46,7 @@ rocksdb_preprocessor_flags = [
 ]
 
 rocksdb_arch_preprocessor_flags = {
-    "x86_64": ["-DHAVE_SSE42"],
+    "x86_64": ["-DHAVE_SSE42", "-DHAVE_PCLMUL"],
 }
 
 build_mode = read_config("fbcode", "build_mode")


### PR DESCRIPTION
Test Plan:

```
$ buck build --verbose 8 rocksdb:rocksdb
```
verified it always passes `-DHAVE_PCLMUL` to the compiler.