### PR TITLE
Have a different function when ROCKSDB_JEMALLOC=0

### DIFF
--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -41,8 +41,8 @@ static void GetJemallocStatus(void* mstat_arg, const char* status) {
 }
 #endif  // ROCKSDB_JEMALLOC
 
-void DumpMallocStats(std::string* stats) {
 #ifdef ROCKSDB_JEMALLOC
+void DumpMallocStats(std::string* stats) {
   MallocStatus mstat;
   const unsigned int kMallocStatusLen = 1000000;
   std::unique_ptr<char[]> buf{new char[kMallocStatusLen + 1]};
@@ -50,8 +50,10 @@ void DumpMallocStats(std::string* stats) {
   mstat.end = buf.get() + kMallocStatusLen;
   je_malloc_stats_print(GetJemallocStatus, &mstat, "");
   stats->append(buf.get());
-#endif  // ROCKSDB_JEMALLOC
 }
+#else
+void DumpMallocStats(std::string*) {}
+#endif  // ROCKSDB_JEMALLOC
 
 }
 #endif  // !ROCKSDB_LITE


### PR DESCRIPTION
Summary: Some sanitizer is not happy with parameter name with ROCKSDB_JEMALLOC not set. Use another function instead.