### PR TITLE
Add dual-license info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ rely on the details of any other header files in this package.  Those
 internal APIs may be changed without warning.
 
 Design discussions are conducted in https://www.facebook.com/groups/rocksdb.dev/
+
+## License
+
+RocksDB is dual-licensed under both the GPLv2 (found in the COPYING file in the root directory) and Apache 2.0 License (found in the LICENSE.Apache file in the root directory).  You may select, at your option, one of the above-listed licenses.


### PR DESCRIPTION
From #3417 and after talking to both GitHub and our open source legal team, the recommended approach was to explicitly state the dual-license in the readme.

Changing the license files to accommodate the auto-detection is too much of a pain, would involve editing every code file header.