### PR TITLE
Fix a memory leak in WindowsThread

### DIFF
--- a/port/win/win_thread.cc
+++ b/port/win/win_thread.cc
@@ -166,7 +166,6 @@ unsigned int __stdcall  WindowsThread::Data::ThreadProc(void* arg) {
   auto ptr = reinterpret_cast<std::shared_ptr<Data>*>(arg);
   std::unique_ptr<std::shared_ptr<Data>> data(ptr);
   (*data)->func_();
-  _endthreadex(0);
   return 0;
 }
 } // namespace port


### PR DESCRIPTION
_endthreadex does not return and thus objects
  for stack destructors do not run. This creates a memory leak.
  We remove the calls since _enthreadex called automatically after the
  threadproc returns i.e. thread exits.