### PR TITLE
support multiple db_paths in SstFileManager

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -461,13 +461,15 @@ TEST_F(DBSSTTest, DeleteSchedulerMultipleDBPaths) {
   sfm->WaitForEmptyTrash();
   ASSERT_EQ(bg_delete_file, 8);
 
+  // Compaction will delete and regenerate a file from L1 in second db path. It
+  // should still be cleaned up via delete scheduler.
   compact_options.bottommost_level_compaction =
       BottommostLevelCompaction::kForce;
   ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
   ASSERT_EQ("0,1", FilesPerLevel(0));
 
   sfm->WaitForEmptyTrash();
-  ASSERT_EQ(bg_delete_file, 8);
+  ASSERT_EQ(bg_delete_file, 9);
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }

--- a/util/file_util.cc
+++ b/util/file_util.cc
@@ -84,11 +84,10 @@ Status CreateFile(Env* env, const std::string& destination,
 
 Status DeleteSSTFile(const ImmutableDBOptions* db_options,
                      const std::string& fname, uint32_t path_id) {
-  // TODO(tec): support sst_file_manager for multiple path_ids
 #ifndef ROCKSDB_LITE
   auto sfm =
       static_cast<SstFileManagerImpl*>(db_options->sst_file_manager.get());
-  if (sfm && path_id == 0) {
+  if (sfm) {
     return sfm->ScheduleFileDeletion(fname);
   } else {
     return db_options->env->DeleteFile(fname);


### PR DESCRIPTION
Now that files scheduled for deletion are kept in the same directory, we don't need to constrain deletion scheduler to `db_paths[0]`. Previously this was done because there was a separate trash directory, and this constraint prevented files from being accidentally copied to another filesystem when they're scheduled for deletion.

Test Plan:

- new unit test, verified the files get ".trash" appended to them and stay in the same directory when scheduled for deletion. Also verified they are properly cleaned up.