### PR TITLE
Support a suboptimal but faster ingestion

### DIFF
--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -149,6 +149,11 @@ class ExternalSstFileIngestionJob {
   bool IngestedFileFitInLevel(const IngestedFileInfo* file_to_ingest,
                               int level);
 
+  // Check if `file_to_ingest` overlap with files in level `level`
+  // REQUIRES: Mutex held
+  bool IngestedFileOverlapWithFiles(const IngestedFileInfo* file_to_ingest,
+                                    int level);
+
   Env* env_;
   VersionSet* versions_;
   ColumnFamilyData* cfd_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1231,6 +1231,13 @@ struct IngestExternalFileOptions {
   // with allow_ingest_behind=true since the dawn of time.
   // All files will be ingested at the bottommost level with seqno=0.
   bool ingest_behind = false;
+  // Aggressive overlap checking needs to seek the existing files to check if an
+  // ingested file really overlaps with the existing data. This is generally
+  // desirable because it can put the ingested file to the under level if
+  // possible. However, aggressive overlap checking may be slow especially when
+  // a lot of files are overlapped. Set this to false if you just want to check
+  // overlap with file endpoints, which is suboptimal but more lightweight.
+  bool allow_aggressive_overlap_checking = true;
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
Add an option to support a suboptimal but faster overlap checking for file ingestion.
Check https://github.com/facebook/rocksdb/issues/3540 to see why we want to do this.