### PR TITLE
Windows cumulative patch

### DIFF
--- a/build_tools/run_ci_db_test.ps1
+++ b/build_tools/run_ci_db_test.ps1
@@ -336,7 +336,7 @@ $InvokeTestAsync = {
 # Test limiting factor here
 [int]$count = 0
 # Overall status
-[bool]$success = $true;
+[bool]$script:success = $true;
 
 function RunJobs($Suites, $TestCmds, [int]$ConcurrencyVal)
 {
@@ -425,7 +425,7 @@ function RunJobs($Suites, $TestCmds, [int]$ConcurrencyVal)
         $log_content = @(Get-Content $log)
 
         if($completed.State -ne "Completed") {
-            $success = $false
+            $script:success = $false
             Write-Warning $message
             $log_content | Write-Warning
         } else {
@@ -449,7 +449,7 @@ function RunJobs($Suites, $TestCmds, [int]$ConcurrencyVal)
             }
 
             if(!$pass_found) {
-                $success = $false;
+                $script:success = $false;
                 Write-Warning $message
                 $log_content | Write-Warning
             } else {
@@ -473,7 +473,7 @@ New-TimeSpan -Start $StartDate -End $EndDate |
   }
 
 
-if(!$success) {
+if(!$script:success) {
 # This does not succeed killing off jobs quick
 # So we simply exit
 #    Remove-Job -Job $jobs -Force

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2389,10 +2389,13 @@ Snapshot::~Snapshot() {
 }
 
 Status DestroyDB(const std::string& dbname, const Options& options) {
-  const ImmutableDBOptions soptions(SanitizeOptions(dbname, options));
+  ImmutableDBOptions soptions(SanitizeOptions(dbname, options));
   Env* env = soptions.env;
   std::vector<std::string> filenames;
 
+  // Reset the logger because it holds a handle to the
+  // log file and prevents cleanup and directory removal
+  soptions.info_log.reset();
   // Ignore error in case directory does not exist
   env->GetChildren(dbname, &filenames);
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5394,7 +5394,10 @@ TEST_F(DBTest, HardLimit) {
 class WriteStallListener : public EventListener {
  public:
   WriteStallListener() : cond_(&mutex_), 
-    condition_(WriteStallCondition::kNormal) {}
+    condition_(WriteStallCondition::kNormal),
+    expected_(WriteStallCondition::kNormal),
+    expected_set_(false) 
+  {}
   void OnStallConditionsChanged(const WriteStallInfo& info) override {
     MutexLock l(&mutex_);
     condition_ = info.condition.cur;
@@ -5415,6 +5418,7 @@ class WriteStallListener : public EventListener {
           expected_set_ = false;
           return false;
         }
+        expected_set_ = false;
       }
     }
     return true;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5404,6 +5404,7 @@ class WriteStallListener : public EventListener {
     if (expected_set_ && 
       condition_ == expected_) {
         cond_.Signal();
+        expected_set_ = false;
     }
   }
   bool CheckCondition(WriteStallCondition expected) {
@@ -5418,7 +5419,6 @@ class WriteStallListener : public EventListener {
           expected_set_ = false;
           return false;
         }
-        expected_set_ = false;
       }
     }
     return true;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5153,7 +5153,7 @@ TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
     }
     ASSERT_OK(Flush());
   }
-  std::thread manual_compaction_thread([this]() {
+  port::Thread manual_compaction_thread([this]() {
     CompactRangeOptions croptions;
     croptions.exclusive_manual_compaction = true;
     ASSERT_OK(db_->CompactRange(croptions, nullptr, nullptr));
@@ -5743,7 +5743,7 @@ TEST_F(DBTest, ThreadLocalPtrDeadlock) {
     return flushes_done.load() > 10;
   };
 
-  std::thread flushing_thread([&] {
+  port::Thread flushing_thread([&] {
     for (int i = 0; !done(); ++i) {
       ASSERT_OK(db_->Put(WriteOptions(), Slice("hi"),
                          Slice(std::to_string(i).c_str())));
@@ -5753,12 +5753,12 @@ TEST_F(DBTest, ThreadLocalPtrDeadlock) {
     }
   });
 
-  std::vector<std::thread> thread_spawning_threads(10);
+  std::vector<port::Thread> thread_spawning_threads(10);
   for (auto& t: thread_spawning_threads) {
-    t = std::thread([&] {
+    t = port::Thread([&] {
       while (!done()) {
         {
-          std::thread tmp_thread([&] {
+          port::Thread tmp_thread([&] {
             auto it = db_->NewIterator(ReadOptions());
             delete it;
           });

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -164,7 +164,7 @@ TEST_F(EnvPosixTest, AreFilesSame) {
   ASSERT_OK(env->AreFilesSame(same_file_name, same_file_link_name, &result));
   ASSERT_TRUE(result);
 }
-#endif OS_WIN
+#endif
 
 TEST_P(EnvPosixTestWithParam, UnSchedule) {
   std::atomic<bool> called(false);

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -135,6 +135,37 @@ TEST_F(EnvPosixTest, RunImmediately) {
   }
 }
 
+#ifdef OS_WIN
+TEST_F(EnvPosixTest, AreFilesSame) {
+  {
+    bool tmp;
+    if (env_->AreFilesSame("", "", &tmp).IsNotSupported()) {
+      fprintf(stderr,
+              "skipping EnvBasicTestWithParam.AreFilesSame due to "
+              "unsupported Env::AreFilesSame\n");
+      return;
+    }
+  }
+
+  const EnvOptions soptions;
+  auto* env = Env::Default();
+  std::string same_file_name = test::TmpDir(env) + "/same_file";
+  std::string same_file_link_name = same_file_name + "_link";
+
+  std::unique_ptr<WritableFile> same_file;
+  ASSERT_OK(env->NewWritableFile(same_file_name,
+    &same_file, soptions));
+  same_file->Append("random_data");
+  ASSERT_OK(same_file->Flush());
+  same_file.reset();
+
+  ASSERT_OK(env->LinkFile(same_file_name, same_file_link_name));
+  bool result = false;
+  ASSERT_OK(env->AreFilesSame(same_file_name, same_file_link_name, &result));
+  ASSERT_TRUE(result);
+}
+#endif OS_WIN
+
 TEST_P(EnvPosixTestWithParam, UnSchedule) {
   std::atomic<bool> called(false);
   env_->SetBackgroundThreads(1, Env::LOW);

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -802,6 +802,10 @@ class Directory {
   virtual ~Directory() {}
   // Fsync directory. Can be called concurrently from multiple threads.
   virtual Status Fsync() = 0;
+
+  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+    return 0;
+  }
 };
 
 enum InfoLogLevel : unsigned char {

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -606,7 +606,10 @@ Status WinEnvIO::LinkFile(const std::string& src,
 
 Status WinEnvIO::AreFilesSame(const std::string& first,
   const std::string& second, bool* res) {
-
+// For MinGW builds
+#if (_WIN32_WINNT == _WIN32_WINNT_VISTA)
+  Status s = Status::NotSupported();
+#else
   assert(res != nullptr);
   Status s;
   if (res == nullptr) {
@@ -672,7 +675,7 @@ Status WinEnvIO::AreFilesSame(const std::string& first,
   } else {
     *res = false;
   }
-
+#endif
   return s;
 }
 

--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -35,6 +35,10 @@
 
 #include <rpc.h>  // for uuid generation
 #include <windows.h>
+#include <shlwapi.h>
+#include "strsafe.h"
+
+#include <algorithm>
 
 namespace rocksdb {
 
@@ -47,6 +51,9 @@ namespace {
 // RAII helpers for HANDLEs
 const auto CloseHandleFunc = [](HANDLE h) { ::CloseHandle(h); };
 typedef std::unique_ptr<void, decltype(CloseHandleFunc)> UniqueCloseHandlePtr;
+
+const auto FindCloseFunc = [](HANDLE h) { ::FindClose(h); };
+typedef std::unique_ptr<void, decltype(FindCloseFunc)> UniqueFindClosePtr;
 
 void WinthreadCall(const char* label, std::error_code result) {
   if (0 != result.value()) {
@@ -61,7 +68,7 @@ namespace port {
 
 WinEnvIO::WinEnvIO(Env* hosted_env)
   :   hosted_env_(hosted_env),
-      page_size_(4 * 1012),
+      page_size_(4 * 1024),
       allocation_granularity_(page_size_),
       perf_counter_frequency_(0),
       GetSystemTimePreciseAsFileTime_(NULL) {
@@ -93,8 +100,11 @@ WinEnvIO::~WinEnvIO() {
 Status WinEnvIO::DeleteFile(const std::string& fname) {
   Status result;
 
-  if (_unlink(fname.c_str())) {
-    result = IOError("Failed to delete: " + fname, errno);
+  BOOL ret = DeleteFileA(fname.c_str());
+  if(!ret) {
+    auto lastError = GetLastError();
+    result = IOErrorFromWindowsError("Failed to delete: " + fname,
+      lastError);
   }
 
   return result;
@@ -265,8 +275,7 @@ Status WinEnvIO::OpenWritableFile(const std::string& fname,
 
   if (local_options.use_mmap_writes) {
     desired_access |= GENERIC_READ;
-  }
-  else {
+  } else {
     // Adding this solely for tests to pass (fault_injection_test,
     // wal_manager_test).
     shared_mode |= (FILE_SHARE_WRITE | FILE_SHARE_DELETE);
@@ -383,56 +392,96 @@ Status WinEnvIO::NewDirectory(const std::string& name,
 }
 
 Status WinEnvIO::FileExists(const std::string& fname) {
-  // F_OK == 0
-  const int F_OK_ = 0;
-  return _access(fname.c_str(), F_OK_) == 0 ? Status::OK()
-    : Status::NotFound();
+  Status s;
+  // TODO: This does not follow symbolic links at this point
+  // which is consistent with _access() impl on windows
+  // but can be added
+  WIN32_FILE_ATTRIBUTE_DATA attrs;
+  if (FALSE == GetFileAttributesExA(fname.c_str(), GetFileExInfoStandard,
+    &attrs)) {
+    auto lastError = GetLastError();
+    switch (lastError) {
+    case ERROR_ACCESS_DENIED:
+    case ERROR_NOT_FOUND:
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+      s = Status::NotFound();
+      break;
+    default:
+      s = IOErrorFromWindowsError("Unexpected error for: " + fname,
+        lastError);
+      break;
+    }
+  }
+  return s;
 }
 
 Status WinEnvIO::GetChildren(const std::string& dir,
   std::vector<std::string>* result) {
 
+  Status status;
   result->clear();
   std::vector<std::string> output;
 
-  Status status;
+  WIN32_FIND_DATA data;
+  std::string pattern(dir);
+  pattern.append("\\").append("*");
 
-  auto CloseDir = [](DIR* p) { closedir(p); };
-  std::unique_ptr<DIR, decltype(CloseDir)> dirp(opendir(dir.c_str()),
-    CloseDir);
+  HANDLE handle = ::FindFirstFileExA(pattern.c_str(),
+    FindExInfoBasic, // Do not want alternative name
+    &data,
+    FindExSearchNameMatch,
+    NULL, // lpSearchFilter
+    0);
 
-  if (!dirp) {
-    switch (errno) {
-      case EACCES:
-      case ENOENT:
-      case ENOTDIR:
-        return Status::NotFound();
-      default:
-        return IOError(dir, errno);
+  if (handle == INVALID_HANDLE_VALUE) {
+    auto lastError = GetLastError();
+    switch (lastError) {
+    case ERROR_NOT_FOUND:
+    case ERROR_ACCESS_DENIED:
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+      status = Status::NotFound();
+      break;
+    default:
+      status = IOErrorFromWindowsError(
+        "Failed to GetChhildren for: " + dir, lastError);
     }
-  } else {
-    if (result->capacity() > 0) {
-      output.reserve(result->capacity());
-    }
-
-    struct dirent* ent = readdir(dirp.get());
-    while (ent) {
-      output.push_back(ent->d_name);
-      ent = readdir(dirp.get());
-    }
+    return status;
   }
 
-  output.swap(*result);
+  UniqueFindClosePtr fc(handle, FindCloseFunc);
 
+  if (result->capacity() > 0) {
+    output.reserve(result->capacity());
+  }
+
+  // For safety
+  data.cFileName[MAX_PATH - 1] = 0;
+
+  while (true) {
+    output.emplace_back(data.cFileName);
+    BOOL ret =- ::FindNextFileA(handle, &data);
+    // If the function fails the return value is zero
+    // and non-zero otherwise. Not TRUE or FALSE.
+    if (ret == FALSE) {
+      // Posix does not care why we stopped
+      break;
+    }
+    data.cFileName[MAX_PATH - 1] = 0;
+  }
+  output.swap(*result);
   return status;
 }
 
 Status WinEnvIO::CreateDir(const std::string& name) {
   Status result;
 
-  if (_mkdir(name.c_str()) != 0) {
-    auto code = errno;
-    result = IOError("Failed to create dir: " + name, code);
+  BOOL ret = CreateDirectoryA(name.c_str(), NULL);
+  if (!ret) {
+    auto lastError = GetLastError();
+    result = IOErrorFromWindowsError(
+        "Failed to create a directory: " + name, lastError);
   }
 
   return result;
@@ -441,28 +490,26 @@ Status WinEnvIO::CreateDir(const std::string& name) {
 Status  WinEnvIO::CreateDirIfMissing(const std::string& name) {
   Status result;
 
-  if (DirExists(name)) {
-    return result;
-  }
-
-  if (_mkdir(name.c_str()) != 0) {
-    if (errno == EEXIST) {
+  BOOL ret = CreateDirectoryA(name.c_str(), NULL);
+  if (!ret) {
+    auto lastError = GetLastError();
+    if (lastError != ERROR_ALREADY_EXISTS) {
+      result = IOErrorFromWindowsError(
+        "Failed to create a directory: " + name, lastError);
+    } else if (!DirExists(name)) {
       result =
         Status::IOError("`" + name + "' exists but is not a directory");
-    } else {
-      auto code = errno;
-      result = IOError("Failed to create dir: " + name, code);
     }
   }
-
   return result;
 }
 
 Status WinEnvIO::DeleteDir(const std::string& name) {
   Status result;
-  if (_rmdir(name.c_str()) != 0) {
-    auto code = errno;
-    result = IOError("Failed to remove dir: " + name, code);
+  BOOL ret = RemoveDirectoryA(name.c_str());
+  if (!ret) {
+    auto lastError = GetLastError();
+    result = IOErrorFromWindowsError("Failed to remove dir: " + name, lastError);
   }
   return result;
 }
@@ -553,6 +600,78 @@ Status WinEnvIO::LinkFile(const std::string& src,
   return result;
 }
 
+Status WinEnvIO::AreFilesSame(const std::string& first,
+  const std::string& second, bool* res) {
+
+  assert(res != nullptr);
+  Status s;
+  if (res == nullptr) {
+    s = Status::InvalidArgument("res");
+    return s;
+  }
+
+  // 0 - for access means read metadata
+  HANDLE file_1 = ::CreateFileA(first.c_str(), 0, 
+                      FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                      NULL, 
+                      OPEN_EXISTING,
+                      FILE_FLAG_BACKUP_SEMANTICS, // make opening folders possible
+                      NULL);
+
+  if (INVALID_HANDLE_VALUE == file_1) {
+    auto lastError = GetLastError();
+    s = IOErrorFromWindowsError(
+      "open file: " + first, lastError);
+    return s;
+  }
+  UniqueCloseHandlePtr g_1(file_1, CloseHandleFunc);
+
+  HANDLE file_2 = ::CreateFileA(second.c_str(), 0,
+                     FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                     NULL, OPEN_EXISTING,
+                     FILE_FLAG_BACKUP_SEMANTICS, // make opening folders possible
+                     NULL);
+
+  if (INVALID_HANDLE_VALUE == file_2) {
+    auto lastError = GetLastError();
+    s = IOErrorFromWindowsError(
+      "open file: " + second, lastError);
+    return s;
+  }
+  UniqueCloseHandlePtr g_2(file_2, CloseHandleFunc);
+
+  FILE_ID_INFO FileInfo_1;
+  BOOL result = GetFileInformationByHandleEx(file_1, FileIdInfo, &FileInfo_1,
+    sizeof(FileInfo_1));
+
+  if (!result) {
+    auto lastError = GetLastError();
+    s = IOErrorFromWindowsError(
+      "stat file: " + first, lastError);
+    return s;
+  }
+
+   FILE_ID_INFO FileInfo_2;
+   result = GetFileInformationByHandleEx(file_2, FileIdInfo, &FileInfo_2,
+    sizeof(FileInfo_2));
+
+  if (!result) {
+    auto lastError = GetLastError();
+    s = IOErrorFromWindowsError(
+      "stat file: " + second, lastError);
+    return s;
+  }
+
+  if (FileInfo_1.VolumeSerialNumber == FileInfo_2.VolumeSerialNumber) {
+    *res = (0 == memcmp(FileInfo_1.FileId.Identifier, FileInfo_2.FileId.Identifier, 
+      sizeof(FileInfo_1.FileId.Identifier)));
+  } else {
+    *res = false;
+  }
+
+  return s;
+}
+
 Status  WinEnvIO::LockFile(const std::string& lockFname,
   FileLock** lock) {
   assert(lock != nullptr);
@@ -596,12 +715,12 @@ Status WinEnvIO::UnlockFile(FileLock* lock) {
 }
 
 Status WinEnvIO::GetTestDirectory(std::string* result) {
+
   std::string output;
 
   const char* env = getenv("TEST_TMPDIR");
   if (env && env[0] != '\0') {
     output = env;
-    CreateDir(output);
   } else {
     env = getenv("TMP");
 
@@ -610,9 +729,8 @@ Status WinEnvIO::GetTestDirectory(std::string* result) {
     } else {
       output = "c:\\tmp";
     }
-
-    CreateDir(output);
   }
+  CreateDir(output);
 
   output.append("\\testrocksdb-");
   output.append(std::to_string(_getpid()));
@@ -722,26 +840,29 @@ Status WinEnvIO::GetHostName(char* name, uint64_t len) {
 
 Status WinEnvIO::GetAbsolutePath(const std::string& db_path,
   std::string* output_path) {
+
   // Check if we already have an absolute path
-  // that starts with non dot and has a semicolon in it
-  if ((!db_path.empty() && (db_path[0] == '/' || db_path[0] == '\\')) ||
-    (db_path.size() > 2 && db_path[0] != '.' &&
-    ((db_path[1] == ':' && db_path[2] == '\\') ||
-    (db_path[1] == ':' && db_path[2] == '/')))) {
+  // For test compatibility we will consider starting slash as an
+  // absolute path
+  if ((!db_path.empty() && (db_path[0] == '\\' || db_path[0] == '/')) ||
+    !PathIsRelativeA(db_path.c_str())) {
     *output_path = db_path;
     return Status::OK();
   }
 
   std::string result;
-  result.resize(_MAX_PATH);
+  result.resize(MAX_PATH);
 
-  char* ret = _getcwd(&result[0], _MAX_PATH);
-  if (ret == nullptr) {
-    return Status::IOError("Failed to get current working directory",
-      strerror(errno));
+  // Hopefully no changes the current directory while we do this
+  // however _getcwd also suffers from the same limitation
+  DWORD len = GetCurrentDirectoryA(MAX_PATH, &result[0]);
+  if (len == 0) {
+    auto lastError = GetLastError();
+    return IOErrorFromWindowsError("Failed to get current working directory",
+      lastError);
   }
 
-  result.resize(strlen(result.data()));
+  result.resize(len);
 
   result.swap(*output_path);
   return Status::OK();
@@ -1012,6 +1133,11 @@ Status WinEnv::RenameFile(const std::string& src,
 Status WinEnv::LinkFile(const std::string& src,
   const std::string& target) {
   return winenv_io_.LinkFile(src, target);
+}
+
+Status WinEnv::AreFilesSame(const std::string& first,
+  const std::string& second, bool* res) {
+  return winenv_io_.AreFilesSame(first, second, res);
 }
 
 Status WinEnv::LockFile(const std::string& lockFname,

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -138,6 +138,9 @@ public:
   virtual Status LinkFile(const std::string& src,
     const std::string& target);
 
+  virtual Status AreFilesSame(const std::string& first,
+    const std::string& second, bool* res);
+
   virtual Status LockFile(const std::string& lockFname,
     FileLock** lock);
 
@@ -247,6 +250,9 @@ public:
 
   Status LinkFile(const std::string& src,
     const std::string& target) override;
+
+  Status AreFilesSame(const std::string& first,
+    const std::string& second, bool* res) override;
 
   Status LockFile(const std::string& lockFname,
     FileLock** lock) override;

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -174,6 +174,8 @@ public:
 
   uint64_t GetPerfCounterFrequency() const { return perf_counter_frequency_; }
 
+  static size_t GetSectorSize(const std::string& fname);
+
 private:
   // Returns true iff the named directory exists and is a directory.
   virtual bool DirExists(const std::string& dname);

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -164,7 +164,7 @@ size_t GetUniqueIdFromFile(HANDLE hFile, char* id, size_t max_size) {
 
   TEST_SYNC_POINT_CALLBACK("GetUniqueIdFromFile:FS_IOC_GETVERSION", &result);
 
-  if (result != TRUE) {
+  if (!result) {
     return 0;
   }
 

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -1046,6 +1046,9 @@ Status WinRandomRWFile::Close() {
 
 Status WinDirectory::Fsync() { return Status::OK(); }
 
+size_t WinDirectory::GetUniqueId(char* id, size_t max_size) const {
+  return GetUniqueIdFromFile(handle_, id, max_size);
+}
 //////////////////////////////////////////////////////////////////////////
 /// WinFileLock
 

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -788,8 +788,7 @@ Status WinWritableImpl::AppendImpl(const Slice& data) {
       auto lastError = GetLastError();
       s = IOErrorFromWindowsError(
         "Failed to pwrite for: " + file_data_->GetName(), lastError);
-    }
-    else {
+    } else {
       written = ret;
     }
 
@@ -834,8 +833,7 @@ Status WinWritableImpl::PositionedAppendImpl(const Slice& data, uint64_t offset)
     auto lastError = GetLastError();
     s = IOErrorFromWindowsError(
       "Failed to pwrite for: " + file_data_->GetName(), lastError);
-  }
-  else {
+  } else {
     assert(size_t(ret) == data.size());
     // For sequential write this would be simple
     // size extension by data.size()

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -421,10 +421,19 @@ class WinRandomRWFile : private WinFileData,
 };
 
 class WinDirectory : public Directory {
+  HANDLE handle_;
  public:
-  WinDirectory() {}
-
+  explicit
+  WinDirectory(HANDLE h) noexcept : 
+    handle_(h) {
+    assert(handle_ != INVALID_HANDLE_VALUE);
+  }
+  ~WinDirectory() {
+    ::CloseHandle(handle_);
+  }
   virtual Status Fsync() override;
+
+  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinFileLock : public FileLock {

--- a/port/win/win_logger.h
+++ b/port/win/win_logger.h
@@ -36,8 +36,6 @@ class WinLogger : public rocksdb::Logger {
 
   WinLogger& operator=(const WinLogger&) = delete;
 
-  void close();
-
   void Flush() override;
 
   using rocksdb::Logger::Logv;
@@ -47,6 +45,10 @@ class WinLogger : public rocksdb::Logger {
 
   void DebugWriter(const char* str, int len);
 
+protected:
+
+    Status CloseImpl() override;
+
  private:
   HANDLE file_;
   uint64_t (*gettid_)();  // Return the thread id for the current thread
@@ -54,6 +56,8 @@ class WinLogger : public rocksdb::Logger {
   std::atomic_uint_fast64_t last_flush_micros_;
   Env* env_;
   bool flush_pending_;
+
+  Status CloseInternal();
 
   const static uint64_t flush_every_seconds_ = 5;
 };

--- a/util/transaction_test_util.cc
+++ b/util/transaction_test_util.cc
@@ -175,7 +175,7 @@ bool RandomTransactionInserter::DoInsert(DB* db, Transaction* txn,
     if (txn != nullptr) {
       std::hash<std::thread::id> hasher;
       char name[64];
-      snprintf(name, 64, "txn%zu-%d", hasher(std::this_thread::get_id()),
+      snprintf(name, 64, "txn%" ROCKSDB_PRIszt "-%d", hasher(std::this_thread::get_id()),
                txn_id_++);
       assert(strlen(name) < 64 - 1);
       if (!is_optimistic && !rand_->OneIn(10)) {

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -278,7 +278,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
         if (heap_.top() == erased_heap_.top()) {
           heap_.pop();
         }
-        auto erased __attribute__((__unused__)) = erased_heap_.top();
+        uint64_t erased __attribute__((__unused__));
+        erased = erased_heap_.top();
         erased_heap_.pop();
         // No duplicate prepare sequence numbers
         assert(erased_heap_.empty() || erased_heap_.top() != erased);


### PR DESCRIPTION
This patch addressed several issues.
  Portability including db_test std::thread -> port::Thread Cc: @
  and %z to ROCKSDB portable macro. Cc: @maysamyabandeh

  Implement Env::AreFilesSame

  Make the implementation of file unique number more robust

  Get rid of C-runtime and go directly to Windows API when dealing
  with file primitives.
  
  Implement GetSectorSize() and aling unbuffered read on the value if
  available.

  Adjust Windows Logger for the new interface, implement CloseImpl() Cc: @anand1976

  Fix test running script issue where $status var was of incorrect scope
  so the failures were swallowed and not reported.

  DestroyDB() creates a logger and opens a LOG file in the directory
  being cleaned up. This holds a lock on the folder and the cleanup is
  prevented. This fails one of the checkpoin tests. We observe the same in production.
  We close the log file in this change.

 Fix DBTest2.ReadAmpBitmapLiveInCacheAfterDBClose failure where the test
 attempts to open a directory with NewRandomAccessFile which does not
 work on Windows.
  Fix DBTest.SoftLimit as it is dependent on thread timing. CC: @yiwu-arbug