### PR TITLE
WritePrepared Txn: Fix bug with duplicate keys during recovery

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1466,8 +1466,10 @@ class MemTableInserter : public WriteBatch::Handler {
 
     if (recovering_log_number_ != 0) {
       assert(db_->allow_2pc());
+      size_t batch_cnt = static_cast<size_t>(sequence_ - rebuilding_trx_seq_);
       db_->InsertRecoveredTransaction(recovering_log_number_, name.ToString(),
-                                      rebuilding_trx_, rebuilding_trx_seq_);
+                                      rebuilding_trx_, rebuilding_trx_seq_,
+                                      batch_cnt);
       rebuilding_trx_ = nullptr;
     } else {
       assert(rebuilding_trx_ == nullptr);

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1516,7 +1516,9 @@ class MemTableInserter : public WriteBatch::Handler {
     if (recovering_log_number_ != 0) {
       assert(db_->allow_2pc());
       size_t batch_cnt =
-          static_cast<size_t>(sequence_ - rebuilding_trx_seq_ + 1);
+          write_after_commit_
+              ? 0  // 0 will disable further checks
+              : static_cast<size_t>(sequence_ - rebuilding_trx_seq_ + 1);
       db_->InsertRecoveredTransaction(recovering_log_number_, name.ToString(),
                                       rebuilding_trx_, rebuilding_trx_seq_,
                                       batch_cnt);

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1197,12 +1197,13 @@ class MemTableInserter : public WriteBatch::Handler {
 
     Status seek_status;
     if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+      bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
         WriteBatchInternal::Put(rebuilding_trx_, column_family_id, key, value);
+        batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
+            column_family_id, key, sequence_);
       }
-      const bool batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
-          column_family_id, key, sequence_);
       MaybeAdvanceSeq(batch_boundry);
       return seek_status;
     }
@@ -1320,12 +1321,13 @@ class MemTableInserter : public WriteBatch::Handler {
 
     Status seek_status;
     if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+      bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
         WriteBatchInternal::Delete(rebuilding_trx_, column_family_id, key);
-      }
-      const bool batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
+      batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
           column_family_id, key, sequence_);
+      }
       MaybeAdvanceSeq(batch_boundry);
       return seek_status;
     }
@@ -1350,13 +1352,14 @@ class MemTableInserter : public WriteBatch::Handler {
 
     Status seek_status;
     if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+      bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
         WriteBatchInternal::SingleDelete(rebuilding_trx_, column_family_id,
                                          key);
-      }
-      const bool batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
+      batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
           column_family_id, key, sequence_);
+      }
       MaybeAdvanceSeq(batch_boundry);
       return seek_status;
     }
@@ -1384,15 +1387,16 @@ class MemTableInserter : public WriteBatch::Handler {
 
     Status seek_status;
     if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+      bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
         WriteBatchInternal::DeleteRange(rebuilding_trx_, column_family_id,
                                         begin_key, end_key);
-      }
       // TODO(myabandeh): when transctional DeleteRange support is added, check
       // if end_key must also be added.
-      const bool batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
+      batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
           column_family_id, begin_key, sequence_);
+      }
       MaybeAdvanceSeq(batch_boundry);
       return seek_status;
     }
@@ -1433,13 +1437,14 @@ class MemTableInserter : public WriteBatch::Handler {
 
     Status seek_status;
     if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+      bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
         WriteBatchInternal::Merge(rebuilding_trx_, column_family_id, key,
                                   value);
-      }
-      const bool batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
+      batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
           column_family_id, key, sequence_);
+      }
       MaybeAdvanceSeq(batch_boundry);
       return seek_status;
     }

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -978,6 +978,7 @@ Status WriteBatch::PopSavePoint() {
   return Status::OK();
 }
 
+// TODO(myabandeh): move it to util
 namespace {
 // During recovery if the memtable is flushed we cannot rely on its help on
 // duplicate key detection and as key insert will not be attempted. This class
@@ -1202,6 +1203,8 @@ class MemTableInserter : public WriteBatch::Handler {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
+        // The CF is probabely flushed and hence no need for insert but we still
+        // need to keep track of the keys for upcoming rollback/commit.
         WriteBatchInternal::Put(rebuilding_trx_, column_family_id, key, value);
         batch_boundry = duplicate_detector_.IsDuplicateKeySeq(column_family_id,
                                                               key, sequence_);
@@ -1279,6 +1282,8 @@ class MemTableInserter : public WriteBatch::Handler {
     // optimize for non-recovery mode
     if (UNLIKELY(!ret_status.IsTryAgain() && rebuilding_trx_ != nullptr)) {
       assert(!write_after_commit_);
+      // If the ret_status is TryAgain then let the next try to add the ky to
+      // the the rebuilding transaction object.
       WriteBatchInternal::Put(rebuilding_trx_, column_family_id, key, value);
     }
     // Since all Puts are logged in trasaction logs (if enabled), always bump
@@ -1326,6 +1331,8 @@ class MemTableInserter : public WriteBatch::Handler {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
+        // The CF is probabely flushed and hence no need for insert but we still
+        // need to keep track of the keys for upcoming rollback/commit.
         WriteBatchInternal::Delete(rebuilding_trx_, column_family_id, key);
         batch_boundry = duplicate_detector_.IsDuplicateKeySeq(column_family_id,
                                                               key, sequence_);
@@ -1338,6 +1345,8 @@ class MemTableInserter : public WriteBatch::Handler {
     // optimize for non-recovery mode
     if (UNLIKELY(!ret_status.IsTryAgain() && rebuilding_trx_ != nullptr)) {
       assert(!write_after_commit_);
+      // If the ret_status is TryAgain then let the next try to add the ky to
+      // the the rebuilding transaction object.
       WriteBatchInternal::Delete(rebuilding_trx_, column_family_id, key);
     }
     return ret_status;
@@ -1357,6 +1366,8 @@ class MemTableInserter : public WriteBatch::Handler {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
+        // The CF is probabely flushed and hence no need for insert but we still
+        // need to keep track of the keys for upcoming rollback/commit.
         WriteBatchInternal::SingleDelete(rebuilding_trx_, column_family_id,
                                          key);
         batch_boundry = duplicate_detector_.IsDuplicateKeySeq(column_family_id,
@@ -1371,6 +1382,8 @@ class MemTableInserter : public WriteBatch::Handler {
     // optimize for non-recovery mode
     if (UNLIKELY(!ret_status.IsTryAgain() && rebuilding_trx_ != nullptr)) {
       assert(!write_after_commit_);
+      // If the ret_status is TryAgain then let the next try to add the ky to
+      // the the rebuilding transaction object.
       WriteBatchInternal::SingleDelete(rebuilding_trx_, column_family_id, key);
     }
     return ret_status;
@@ -1392,10 +1405,12 @@ class MemTableInserter : public WriteBatch::Handler {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
+        // The CF is probabely flushed and hence no need for insert but we still
+        // need to keep track of the keys for upcoming rollback/commit.
         WriteBatchInternal::DeleteRange(rebuilding_trx_, column_family_id,
                                         begin_key, end_key);
-      // TODO(myabandeh): when transctional DeleteRange support is added, check
-      // if end_key must also be added.
+        // TODO(myabandeh): when transctional DeleteRange support is added,
+        // check if end_key must also be added.
         batch_boundry = duplicate_detector_.IsDuplicateKeySeq(
             column_family_id, begin_key, sequence_);
       }
@@ -1421,6 +1436,8 @@ class MemTableInserter : public WriteBatch::Handler {
     // optimize for non-recovery mode
     if (UNLIKELY(!ret_status.IsTryAgain() && rebuilding_trx_ != nullptr)) {
       assert(!write_after_commit_);
+      // If the ret_status is TryAgain then let the next try to add the ky to
+      // the the rebuilding transaction object.
       WriteBatchInternal::DeleteRange(rebuilding_trx_, column_family_id,
                                       begin_key, end_key);
     }
@@ -1442,6 +1459,8 @@ class MemTableInserter : public WriteBatch::Handler {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);
+        // The CF is probabely flushed and hence no need for insert but we still
+        // need to keep track of the keys for upcoming rollback/commit.
         WriteBatchInternal::Merge(rebuilding_trx_, column_family_id, key,
                                   value);
         batch_boundry = duplicate_detector_.IsDuplicateKeySeq(column_family_id,
@@ -1531,6 +1550,8 @@ class MemTableInserter : public WriteBatch::Handler {
     // optimize for non-recovery mode
     if (UNLIKELY(!ret_status.IsTryAgain() && rebuilding_trx_ != nullptr)) {
       assert(!write_after_commit_);
+      // If the ret_status is TryAgain then let the next try to add the ky to
+      // the the rebuilding transaction object.
       WriteBatchInternal::Merge(rebuilding_trx_, column_family_id, key, value);
     }
     MaybeAdvanceSeq();

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -227,6 +227,7 @@ class WriteBatchWithIndex : public WriteBatchBase {
   void SetMaxBytes(size_t max_bytes) override;
 
  private:
+  friend class PessimisticTransactionDB;
   friend class WritePreparedTxn;
   friend class WriteBatchWithIndex_SubBatchCnt_Test;
   // Returns the number of sub-batches inside the write batch. A sub-batch

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -142,8 +142,8 @@ Status PessimisticTransactionDB::Initialize(
     }
 
     s = real_trx->RebuildFromWriteBatch(recovered_trx->batch_);
-    // WritePrepared txns do not insert empty prepare entries but WriteCommitted
-    // do
+    // WriteCommitted set this to to disable this check that is specific to
+    // WritePrepared txns
     assert(recovered_trx->batch_cnt_ == 0 ||
            real_trx->GetWriteBatch()->SubBatchCnt() ==
                recovered_trx->batch_cnt_);

--- a/utilities/transactions/pessimistic_transaction_db.cc
+++ b/utilities/transactions/pessimistic_transaction_db.cc
@@ -142,6 +142,11 @@ Status PessimisticTransactionDB::Initialize(
     }
 
     s = real_trx->RebuildFromWriteBatch(recovered_trx->batch_);
+    // WritePrepared txns do not insert empty prepare entries but WriteCommitted
+    // do
+    assert(recovered_trx->batch_cnt_ == 0 ||
+           real_trx->GetWriteBatch()->SubBatchCnt() ==
+               recovered_trx->batch_cnt_);
     real_trx->SetState(Transaction::PREPARED);
     if (!s.ok()) {
       break;

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -135,6 +135,7 @@ class PessimisticTransactionDB : public TransactionDB {
   friend class WritePreparedTxnDB;
   friend class WritePreparedTxnDBMock;
   friend class TransactionTest_DoubleEmptyWrite_Test;
+  friend class TransactionTest_DuplicateKeys_Test;
   friend class TransactionTest_PersistentTwoPhaseTransactionTest_Test;
   friend class TransactionTest_TwoPhaseLongPrepareTest_Test;
   friend class TransactionTest_TwoPhaseDoubleRecoveryTest_Test;

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5527,6 +5527,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     for (auto h : handles) {
       delete h;
     }
+    delete db;
   }
 }
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5365,6 +5365,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     txn0 = db->GetTransactionByName("xid");
     ASSERT_TRUE(txn0 != nullptr);
     ASSERT_OK(txn0->Commit());
+    delete txn0;
     s = db->Get(ropt, db->DefaultColumnFamily(), "foo0", &pinnable_val);
     ASSERT_OK(s);
     ASSERT_TRUE(pinnable_val == ("bar0a"));

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5129,6 +5129,8 @@ TEST_P(TransactionTest, DuplicateKeys) {
     batch.Put(cf_handle, Slice("key"), Slice("value"));
     // The first three bytes are the same, do it must be counted as duplicate
     batch.Put(cf_handle, Slice("key2"), Slice("value2"));
+    // check for 2nd duplicate key in cf with non-default comparator
+    batch.Put(cf_handle, Slice("key2b"), Slice("value2b"));
     ASSERT_OK(db->Write(write_options, &batch));
 
     // The value must be the most recent value for all the keys equal to "key",
@@ -5136,7 +5138,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     ReadOptions ropt;
     PinnableSlice pinnable_val;
     ASSERT_OK(db->Get(ropt, cf_handle, "key", &pinnable_val));
-    ASSERT_TRUE(pinnable_val == ("value2"));
+    ASSERT_TRUE(pinnable_val == ("value2b"));
 
     // Test duplicate keys with rollback
     TransactionOptions txn_options;
@@ -5146,7 +5148,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
     ASSERT_OK(txn0->Merge(cf_handle, Slice("key4"), Slice("value4")));
     ASSERT_OK(txn0->Rollback());
     ASSERT_OK(db->Get(ropt, cf_handle, "key5", &pinnable_val));
-    ASSERT_TRUE(pinnable_val == ("value2"));
+    ASSERT_TRUE(pinnable_val == ("value2b"));
     delete txn0;
 
     delete cf_handle;
@@ -5378,6 +5380,9 @@ TEST_P(TransactionTest, DuplicateKeys) {
     delete txn0;
     // This will check the asserts inside recovery code
     db->FlushWAL(true);
+    // Flush only cf 1
+    reinterpret_cast<DBImpl*>(db->GetRootDB())
+        ->TEST_FlushMemTable(true, handles[1]);
     reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
     ASSERT_OK(ReOpenNoDelete(cfds, &handles));
     txn0 = db->GetTransactionByName("xid");
@@ -5413,6 +5418,9 @@ TEST_P(TransactionTest, DuplicateKeys) {
     delete txn0;
     // This will check the asserts inside recovery code
     db->FlushWAL(true);
+    // Flush only cf 1
+    reinterpret_cast<DBImpl*>(db->GetRootDB())
+        ->TEST_FlushMemTable(true, handles[1]);
     reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
     ASSERT_OK(ReOpenNoDelete(cfds, &handles));
     txn0 = db->GetTransactionByName("xid");
@@ -5443,6 +5451,9 @@ TEST_P(TransactionTest, DuplicateKeys) {
     delete txn0;
     // This will check the asserts inside recovery code
     db->FlushWAL(true);
+    // Flush only cf 1
+    reinterpret_cast<DBImpl*>(db->GetRootDB())
+        ->TEST_FlushMemTable(true, handles[1]);
     reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
     ASSERT_OK(ReOpenNoDelete(cfds, &handles));
     txn0 = db->GetTransactionByName("xid");
@@ -5467,6 +5478,9 @@ TEST_P(TransactionTest, DuplicateKeys) {
     delete txn0;
     // This will check the asserts inside recovery code
     db->FlushWAL(true);
+    // Flush only cf 1
+    reinterpret_cast<DBImpl*>(db->GetRootDB())
+        ->TEST_FlushMemTable(true, handles[1]);
     reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
     ASSERT_OK(ReOpenNoDelete(cfds, &handles));
     txn0 = db->GetTransactionByName("xid");
@@ -5491,6 +5505,9 @@ TEST_P(TransactionTest, DuplicateKeys) {
     delete txn0;
     // This will check the asserts inside recovery code
     db->FlushWAL(true);
+    // Flush only cf 1
+    reinterpret_cast<DBImpl*>(db->GetRootDB())
+        ->TEST_FlushMemTable(true, handles[1]);
     reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
     ASSERT_OK(ReOpenNoDelete(cfds, &handles));
     txn0 = db->GetTransactionByName("xid");

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5528,6 +5528,7 @@ TEST_P(TransactionTest, DuplicateKeys) {
       delete h;
     }
     delete db;
+    db = nullptr;
   }
 }
 

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -101,6 +101,27 @@ class TransactionTestBase : public ::testing::Test {
     return s;
   }
 
+  Status ReOpenNoDelete(const std::vector<ColumnFamilyDescriptor>& cfs,
+                        std::vector<ColumnFamilyHandle*>* handles) {
+    for (auto h : *handles) {
+      delete h;
+    }
+    handles->clear();
+    delete db;
+    db = nullptr;
+    env->AssertNoOpenFile();
+    env->DropUnsyncedFileData();
+    env->ResetState();
+    Status s;
+    if (use_stackable_db_ == false) {
+      s = TransactionDB::Open(options, txn_db_options, dbname, cfs, handles,
+                              &db);
+    } else {
+      s = OpenWithStackableDB();
+    }
+    return s;
+  }
+
   Status ReOpen() {
     delete db;
     DestroyDB(dbname, options);

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -101,7 +101,7 @@ class TransactionTestBase : public ::testing::Test {
     return s;
   }
 
-  Status ReOpenNoDelete(const std::vector<ColumnFamilyDescriptor>& cfs,
+  Status ReOpenNoDelete(std::vector<ColumnFamilyDescriptor>& cfs,
                         std::vector<ColumnFamilyHandle*>* handles) {
     for (auto h : *handles) {
       delete h;
@@ -117,7 +117,7 @@ class TransactionTestBase : public ::testing::Test {
       s = TransactionDB::Open(options, txn_db_options, dbname, cfs, handles,
                               &db);
     } else {
-      s = OpenWithStackableDB();
+      s = OpenWithStackableDB(cfs, handles);
     }
     return s;
   }
@@ -130,6 +130,25 @@ class TransactionTestBase : public ::testing::Test {
       s = TransactionDB::Open(options, txn_db_options, dbname, &db);
     } else {
       s = OpenWithStackableDB();
+    }
+    return s;
+  }
+
+  Status OpenWithStackableDB(std::vector<ColumnFamilyDescriptor>& cfs,
+                             std::vector<ColumnFamilyHandle*>* handles) {
+    std::vector<size_t> compaction_enabled_cf_indices;
+    TransactionDB::PrepareWrap(&options, &cfs,
+                               &compaction_enabled_cf_indices);
+    DB* root_db;
+    Options options_copy(options);
+    const bool use_seq_per_batch =
+        txn_db_options.write_policy == WRITE_PREPARED;
+    Status s = DBImpl::Open(options_copy, dbname, cfs, handles,
+                            &root_db, use_seq_per_batch);
+    if (s.ok()) {
+      s = TransactionDB::WrapStackableDB(
+          new StackableDB(root_db), txn_db_options,
+          compaction_enabled_cf_indices, *handles, &db);
     }
     return s;
   }

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -137,14 +137,13 @@ class TransactionTestBase : public ::testing::Test {
   Status OpenWithStackableDB(std::vector<ColumnFamilyDescriptor>& cfs,
                              std::vector<ColumnFamilyHandle*>* handles) {
     std::vector<size_t> compaction_enabled_cf_indices;
-    TransactionDB::PrepareWrap(&options, &cfs,
-                               &compaction_enabled_cf_indices);
+    TransactionDB::PrepareWrap(&options, &cfs, &compaction_enabled_cf_indices);
     DB* root_db;
     Options options_copy(options);
     const bool use_seq_per_batch =
         txn_db_options.write_policy == WRITE_PREPARED;
-    Status s = DBImpl::Open(options_copy, dbname, cfs, handles,
-                            &root_db, use_seq_per_batch);
+    Status s = DBImpl::Open(options_copy, dbname, cfs, handles, &root_db,
+                            use_seq_per_batch);
     if (s.ok()) {
       s = TransactionDB::WrapStackableDB(
           new StackableDB(root_db), txn_db_options,

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -475,7 +475,8 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
   CommitEntry64b evicted_64b;
   CommitEntry evicted;
   bool to_be_evicted = GetCommitEntry(indexed_seq, &evicted_64b, &evicted);
-  if (to_be_evicted) {
+  if (LIKELY(to_be_evicted)) {
+    assert(evicted.prep_seq != prepare_seq);
     auto prev_max = max_evicted_seq_.load(std::memory_order_acquire);
     ROCKS_LOG_DETAILS(info_log_,
                       "Evicting %" PRIu64 ",%" PRIu64 " with max %" PRIu64,
@@ -491,7 +492,11 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
   }
   bool succ =
       ExchangeCommitEntry(indexed_seq, evicted_64b, {prepare_seq, commit_seq});
-  if (!succ) {
+  if (UNLIKELY(!succ)) {
+    ROCKS_LOG_ERROR(info_log_,
+                    "ExchangeCommitEntry failed on [%" PRIu64 "] %" PRIu64
+                    ",%" PRIu64 " retrying...",
+                    indexed_seq, prepare_seq, commit_seq);
     // A very rare event, in which the commit entry is updated before we do.
     // Here we apply a very simple solution of retrying.
     if (loop_cnt > 100) {

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -789,8 +789,8 @@ WritePreparedTxnDB::~WritePreparedTxnDB() {
 }
 
 void SubBatchCounter::InitWithComp(const uint32_t cf) {
-    auto cmp = comparators_[cf];
-    keys_[cf] = CFKeys(SetComparator(cmp));
+  auto cmp = comparators_[cf];
+  keys_[cf] = CFKeys(SetComparator(cmp));
 }
 
 void SubBatchCounter::AddKey(const uint32_t cf, const Slice& key) {

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -788,16 +788,21 @@ WritePreparedTxnDB::~WritePreparedTxnDB() {
   db_impl_->CancelAllBackgroundWork(true /*wait*/);
 }
 
+void SubBatchCounter::InitWithComp(const uint32_t cf) {
+    auto cmp = comparators_[cf];
+    keys_[cf] = CFKeys(SetComparator(cmp));
+}
+
 void SubBatchCounter::AddKey(const uint32_t cf, const Slice& key) {
   CFKeys& cf_keys = keys_[cf];
   if (cf_keys.size() == 0) {  // just inserted
-    auto cmp = comparators_[cf];
-    keys_[cf] = CFKeys(SetComparator(cmp));
+    InitWithComp(cf);
   }
   auto it = cf_keys.insert(key);
   if (it.second == false) {  // second is false if a element already existed.
     batches_++;
     keys_.clear();
+    InitWithComp(cf);
     keys_[cf].insert(key);
   }
 }

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -541,6 +541,7 @@ struct SubBatchCounter : public WriteBatch::Handler {
   size_t batches_;
   size_t BatchCount() { return batches_; }
   void AddKey(const uint32_t cf, const Slice& key);
+  void InitWithComp(const uint32_t cf);
   Status MarkNoop(bool) override { return Status::OK(); }
   Status MarkEndPrepare(const Slice&) override { return Status::OK(); }
   Status MarkCommit(const Slice&) override { return Status::OK(); }


### PR DESCRIPTION
Fix the following bugs:
- During recovery a duplicate key was inserted twice into the write batch of the recovery transaction, 
once when the memtable returns false (because it was duplicates) and once for the 2nd attempt. This would result into different SubBatch count measured when the recovered transactions is committing.
- If a cf is flushed during recovery the memtable is not available to assist in detecting the duplicate key. This could result into not advancing the sequence number when iterating over duplicate keys of a flushed cf and hence inserting the next key with the wrong sequence number.
- SubBacthCounter would reset the comparator to default comparator after the first duplicate key. The 2nd duplicate key hence would have gone through a wrong comparator and not being detected.