### PR TITLE
Store digested dictionary in BlockBasedTableBuilder

### DIFF
--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -104,7 +104,7 @@ bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
 Slice CompressBlock(const Slice& raw,
                     const CompressionOptions& compression_options,
                     CompressionType* type, uint32_t format_version,
-                    const Slice& compression_dict,
+                    const DictContext& dict_context,
                     std::string* compressed_output) {
   if (*type == kNoCompression) {
     return raw;
@@ -124,7 +124,8 @@ Slice CompressBlock(const Slice& raw,
       if (Zlib_Compress(
               compression_options,
               GetCompressFormatForVersion(kZlibCompression, format_version),
-              raw.data(), raw.size(), compressed_output, compression_dict) &&
+              raw.data(), raw.size(), compressed_output,
+              dict_context.raw_dict_bytes) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
       }
@@ -142,7 +143,8 @@ Slice CompressBlock(const Slice& raw,
       if (LZ4_Compress(
               compression_options,
               GetCompressFormatForVersion(kLZ4Compression, format_version),
-              raw.data(), raw.size(), compressed_output, compression_dict) &&
+              raw.data(), raw.size(), compressed_output,
+              dict_context.raw_dict_bytes) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
       }
@@ -151,7 +153,8 @@ Slice CompressBlock(const Slice& raw,
       if (LZ4HC_Compress(
               compression_options,
               GetCompressFormatForVersion(kLZ4HCCompression, format_version),
-              raw.data(), raw.size(), compressed_output, compression_dict) &&
+              raw.data(), raw.size(), compressed_output,
+              dict_context.raw_dict_bytes) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
       }
@@ -166,7 +169,7 @@ Slice CompressBlock(const Slice& raw,
     case kZSTD:
     case kZSTDNotFinalCompression:
       if (ZSTD_Compress(compression_options, raw.data(), raw.size(),
-                        compressed_output, compression_dict) &&
+                        compressed_output, dict_context) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
       }
@@ -259,8 +262,8 @@ struct BlockBasedTableBuilder::Rep {
   std::string last_key;
   const CompressionType compression_type;
   const CompressionOptions compression_opts;
-  // Data for presetting the compression library's dictionary, or nullptr.
-  const std::string* compression_dict;
+  // Data for presetting the compression library's dictionary
+  DictContext dict_context;
   TableProperties props;
 
   bool closed = false;  // Either Finish() or Abandon() has been called.
@@ -286,10 +289,9 @@ struct BlockBasedTableBuilder::Rep {
           int_tbl_prop_collector_factories,
       uint32_t _column_family_id, WritableFileWriter* f,
       const CompressionType _compression_type,
-      const CompressionOptions& _compression_opts,
-      const std::string* _compression_dict, const bool skip_filters,
-      const std::string& _column_family_name, const uint64_t _creation_time,
-      const uint64_t _oldest_key_time)
+      const CompressionOptions& _compression_opts, DictContext _dict_context,
+      const bool skip_filters, const std::string& _column_family_name,
+      const uint64_t _creation_time, const uint64_t _oldest_key_time)
       : ioptions(_ioptions),
         table_options(table_opt),
         internal_comparator(icomparator),
@@ -300,7 +302,7 @@ struct BlockBasedTableBuilder::Rep {
         internal_prefix_transform(_ioptions.prefix_extractor),
         compression_type(_compression_type),
         compression_opts(_compression_opts),
-        compression_dict(_compression_dict),
+        dict_context(std::move(_dict_context)),
         compressed_cache_key_prefix_size(0),
         flush_block_policy(
             table_options.flush_block_policy_factory->NewFlushBlockPolicy(
@@ -361,11 +363,18 @@ BlockBasedTableBuilder::BlockBasedTableBuilder(
     sanitized_table_options.format_version = 1;
   }
 
-  rep_ = new Rep(ioptions, sanitized_table_options, internal_comparator,
-                 int_tbl_prop_collector_factories, column_family_id, file,
-                 compression_type, compression_opts, compression_dict,
-                 skip_filters, column_family_name, creation_time,
-                 oldest_key_time);
+  DictContext dict_context;
+  Status status =
+      dict_context.Init(compression_type, compression_opts, compression_dict);
+  if (!status.ok()) {
+    ROCKS_LOG_WARN(ioptions.info_log, "%s", status.ToString().c_str());
+  }
+
+  rep_ =
+      new Rep(ioptions, sanitized_table_options, internal_comparator,
+              int_tbl_prop_collector_factories, column_family_id, file,
+              compression_type, compression_opts, std::move(dict_context),
+              skip_filters, column_family_name, creation_time, oldest_key_time);
 
   if (rep_->filter_builder != nullptr) {
     rep_->filter_builder->StartBlock(0);
@@ -480,14 +489,15 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     ShouldReportDetailedTime(r->ioptions.env, r->ioptions.statistics));
 
   if (raw_block_contents.size() < kCompressionSizeLimit) {
-    Slice compression_dict;
-    if (is_data_block && r->compression_dict && r->compression_dict->size()) {
-      compression_dict = *r->compression_dict;
+    if (is_data_block) {
+      block_contents = CompressBlock(raw_block_contents, r->compression_opts,
+                                     &type, r->table_options.format_version,
+                                     r->dict_context, &r->compressed_output);
+    } else {
+      block_contents = CompressBlock(raw_block_contents, r->compression_opts,
+                                     &type, r->table_options.format_version,
+                                     DictContext(), &r->compressed_output);
     }
-
-    block_contents = CompressBlock(raw_block_contents, r->compression_opts,
-                                   &type, r->table_options.format_version,
-                                   compression_dict, &r->compressed_output);
 
     // Some of the compression algorithms are known to be unreliable. If
     // the verify_compression flag is set then try to de-compress the
@@ -497,7 +507,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
       BlockContents contents;
       Status stat = UncompressBlockContentsForCompressionType(
           block_contents.data(), block_contents.size(), &contents,
-          r->table_options.format_version, compression_dict, type,
+          r->table_options.format_version, r->dict_context.raw_dict_bytes, type,
           r->ioptions);
 
       if (stat.ok()) {
@@ -761,8 +771,8 @@ Status BlockBasedTableBuilder::Finish() {
       meta_index_builder.Add(kPropertiesBlock, properties_block_handle);
 
       // Write compression dictionary block
-      if (r->compression_dict && r->compression_dict->size()) {
-        WriteRawBlock(*r->compression_dict, kNoCompression,
+      if (r->dict_context.raw_dict_bytes.size() > 0) {
+        WriteRawBlock(r->dict_context.raw_dict_bytes, kNoCompression,
                       &compression_dict_block_handle);
         meta_index_builder.Add(kCompressionDictBlock,
                                compression_dict_block_handle);

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -364,10 +364,10 @@ BlockBasedTableBuilder::BlockBasedTableBuilder(
   }
 
   DictContext dict_context;
-  Status status =
+  Status st =
       dict_context.Init(compression_type, compression_opts, compression_dict);
-  if (!status.ok()) {
-    ROCKS_LOG_WARN(ioptions.info_log, "%s", status.ToString().c_str());
+  if (!st.ok()) {
+    ROCKS_LOG_WARN(ioptions.info_log, "%s", st.ToString().c_str());
   }
 
   rep_ =

--- a/table/block_based_table_builder.h
+++ b/table/block_based_table_builder.h
@@ -123,7 +123,7 @@ class BlockBasedTableBuilder : public TableBuilder {
 Slice CompressBlock(const Slice& raw,
                     const CompressionOptions& compression_options,
                     CompressionType* type, uint32_t format_version,
-                    const Slice& compression_dict,
+                    const DictContext& dict_context,
                     std::string* compressed_output);
 
 }  // namespace rocksdb

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1959,7 +1959,7 @@ class Benchmark {
         break;
       case rocksdb::kZSTD:
         ok = ZSTD_Compress(Options().compression_opts, input.data(),
-                           input.size(), compressed);
+                           input.size(), compressed, DictContext());
         break;
       default:
         ok = false;

--- a/util/compression.h
+++ b/util/compression.h
@@ -53,13 +53,13 @@ struct DictContext {
   // we cannot use unique_ptr as ZSTD_CDict is an incomplete type so its
   // destructor is unknown. That's unfortunate because it means we have to
   // implement move semantics ourselves.
-  ZSTD_CDict* zstd_cdict;
+  ZSTD_CDict* zstd_cdict = nullptr;
 #endif
   Slice raw_dict_bytes;
 
-  DictContext() : zstd_cdict(nullptr) {}
+  DictContext() {}
 
-  DictContext(DictContext&& other) : zstd_cdict(nullptr) {
+  DictContext(DictContext&& other) {
     *this = std::move(other);
   }
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -738,7 +738,7 @@ Slice BlobDBImpl::GetCompressedSlice(const Slice& raw,
   CompressionType ct = bdb_options_.compression;
   CompressionOptions compression_opts;
   CompressBlock(raw, compression_opts, &ct, kBlockBasedTableVersionFormat,
-                Slice(), compression_output);
+                DictContext(), compression_output);
   return *compression_output;
 }
 

--- a/utilities/column_aware_encoding_util.cc
+++ b/utilities/column_aware_encoding_util.cc
@@ -244,10 +244,9 @@ void CompressDataBlock(const std::string& output_content, Slice* slice_final,
                        CompressionType* type, std::string* compressed_output) {
   CompressionOptions compression_opts;
   uint32_t format_version = 2;  // hard-coded version
-  Slice compression_dict;
   *slice_final =
       CompressBlock(output_content, compression_opts, type, format_version,
-                    compression_dict, compressed_output);
+                    DictContext(), compressed_output);
 }
 
 }  // namespace


### PR DESCRIPTION
We use the same compression dictionary to compress every data block in a given SST file. Previously, compressing each data block involved some repetitive work to convert the raw compression dictionary bytes into a usable form.

ZSTD's bulk processing API lets us avoid this repetitive work by providing APIs that create a "digested dictionary" (`ZSTD_createCDict`) and a compression function that operates on digested dictionaries (`ZSTD_compress_usingCDict`). This PR changes `BlockBasedTableBuilder` to create a single digested dictionary that is reused for compressing every data block. It is supported for zstd v0.7.0 and later.

Test Plan: verified it's faster; `make check -j64`; will do zstd version compatibility testing 

- Populate DB command:

```
TEST_TMPDIR=/dev/shm ./db_bench -benchmarks=filluniquerandom,compact -num=20000000 -compression_type=zstd -max_background_jobs=24 -memtablerep=vector -allow_concurrent_memtable_write=false -disable_wal=true -max_write_buffer_number=8
```

- Benchmark command:

```
TEST_TMPDIR=/dev/shm /usr/bin/time ./db_bench -use_existing_db=true -benchmarks=compact -compression_type=zstd -block_size=4096 -compression_max_dict_bytes=$dict_bytes
```

- Results before this PR:
```
dict_bytes  cpu_seconds
0           32.17
4096        41.41
16384       84.3
```

- Results after this PR:
```
dict_bytes  cpu_seconds
0           32.09
4096        38.51
16384       50.36
```