### PR TITLE
Adding stat to count cancelled compactions

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1668,6 +1668,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
           // Don't need to sleep here, because BackgroundCallCompaction
           // will sleep if !s.ok()
           status = Status::CompactionTooLarge();
+          RecordTick(stats_, COMPACTION_CANCELLED, 1);
         } else {
           // update statistics
           MeasureTime(stats_, NUM_FILES_IN_SINGLE_COMPACTION,

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -550,11 +550,9 @@ TEST_F(DBSSTTest, CancellingCompactionsWorks) {
   options.statistics = CreateDBStatistics();
   DestroyAndReopen(options);
 
-  int cancelled_compaction = 0;
   int completed_compactions = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction():CancelledCompaction", [&](void* arg) {
-        cancelled_compaction++;
         sfm->SetMaxAllowedSpaceUsage(0);
       });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
@@ -581,7 +579,6 @@ TEST_F(DBSSTTest, CancellingCompactionsWorks) {
   ASSERT_OK(Flush());
   dbfull()->TEST_WaitForCompact(true);
 
-  ASSERT_GT(cancelled_compaction, 0);
   ASSERT_GT(completed_compactions, 0);
   ASSERT_EQ(sfm->GetCompactionsReservedSize(), 0);
   // Make sure the stat is bumped

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -547,6 +547,7 @@ TEST_F(DBSSTTest, CancellingCompactionsWorks) {
   Options options = CurrentOptions();
   options.sst_file_manager = sst_file_manager;
   options.level0_file_num_compaction_trigger = 2;
+  options.statistics = CreateDBStatistics();
   DestroyAndReopen(options);
 
   int cancelled_compaction = 0;
@@ -583,6 +584,8 @@ TEST_F(DBSSTTest, CancellingCompactionsWorks) {
   ASSERT_GT(cancelled_compaction, 0);
   ASSERT_GT(completed_compactions, 0);
   ASSERT_EQ(sfm->GetCompactionsReservedSize(), 0);
+  // Make sure the stat is bumped
+  ASSERT_GT(dbfull()->immutable_db_options().statistics.get()->getTickerCount(COMPACTION_CANCELLED), 0);
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -108,6 +108,8 @@ enum Tickers : uint32_t {
   COMPACTION_RANGE_DEL_DROP_OBSOLETE,  // all keys in range were deleted.
   // Deletions obsoleted before bottom level due to file gap optimization.
   COMPACTION_OPTIMIZED_DEL_DROP_OBSOLETE,
+  // If a compaction was cancelled in sfm to prevent ENOSPC
+  COMPACTION_CANCELLED,
 
   // Number of keys written to the database via the Put and Write call's
   NUMBER_KEYS_WRITTEN,
@@ -347,6 +349,8 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.compaction.range_del.drop.obsolete"},
     {COMPACTION_OPTIMIZED_DEL_DROP_OBSOLETE,
      "rocksdb.compaction.optimized.del.drop.obsolete"},
+    {COMPACTION_CANCELLED,
+     "rocksdb.compaction.cancelled"},
     {NUMBER_KEYS_WRITTEN, "rocksdb.number.keys.written"},
     {NUMBER_KEYS_READ, "rocksdb.number.keys.read"},
     {NUMBER_KEYS_UPDATED, "rocksdb.number.keys.updated"},


### PR DESCRIPTION
Summary: Added a stat that counts the number of cancelled compactions.

Test Plan: Simple test in db_sst_test to make sure stat is bumped on a cancelled compaction due to max space reached in sfm

Reviewers:

Subscribers:

Tasks:

Tags: