### PR TITLE
cache which requires allocation experiments

### DIFF
--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -56,8 +56,9 @@ WriteBufferManager::WriteBufferManager(size_t _buffer_size,
       memory_active_(0),
       cache_rep_(nullptr) {
 #ifndef ROCKSDB_LITE
-  if (cache) {
+  if (cache && !cache->need_allocate()) {
     // Construct the cache key using the pointer to this.
+    // TODO allow allocate from the cache.
     cache_rep_.reset(new CacheRep(cache));
   }
 #endif  // ROCKSDB_LITE

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -305,7 +305,7 @@ class BlockBasedTable : public TableReader {
       CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
       const Slice& compression_dict, size_t read_amp_bytes_per_bit,
       bool is_index = false, Cache::Priority pri = Cache::Priority::LOW,
-      GetContext* get_context = nullptr);
+      GetContext* get_context = nullptr, void* alloc_handle = nullptr);
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found
   // after a call to Seek(key), until handle_result returns false.

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -23,10 +23,11 @@ class BlockFetcher {
   BlockFetcher(RandomAccessFileReader* file,
                FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                const ReadOptions& read_options, const BlockHandle& handle,
-               BlockContents* contents,
-               const ImmutableCFOptions& ioptions,
+               BlockContents* contents, const ImmutableCFOptions& ioptions,
                bool do_uncompress, const Slice& compression_dict,
-               const PersistentCacheOptions& cache_options)
+               const PersistentCacheOptions& cache_options,
+               Cache* block_cache = nullptr, const Slice* cache_key = nullptr,
+               void** alloc_handle = nullptr)
       : file_(file),
         prefetch_buffer_(prefetch_buffer),
         footer_(footer),
@@ -36,7 +37,10 @@ class BlockFetcher {
         ioptions_(ioptions),
         do_uncompress_(do_uncompress),
         compression_dict_(compression_dict),
-        cache_options_(cache_options) {}
+        cache_options_(cache_options),
+        block_cache_(block_cache),
+        cache_key_(cache_key),
+        alloc_handle_(alloc_handle) {}
   Status ReadBlockContents();
 
  private:
@@ -50,13 +54,18 @@ class BlockFetcher {
   BlockContents* contents_;
   const ImmutableCFOptions& ioptions_;
   bool do_uncompress_;
+  Slice* block_cache_key_;
   const Slice& compression_dict_;
   const PersistentCacheOptions& cache_options_;
+  Cache* block_cache_;
+  const Slice* cache_key_;
+  void** alloc_handle_;
   Status status_;
   Slice slice_;
   char* used_buf_ = nullptr;
   size_t block_size_;
   std::unique_ptr<char[]> heap_buf_;
+  char* alloc_buf_from_cache_ = nullptr;
   char stack_buf_[kDefaultStackBufferSize];
   bool got_from_prefetch_buffer_ = false;
   rocksdb::CompressionType compression_type;
@@ -71,5 +80,6 @@ class BlockFetcher {
   void InsertCompressedBlockToPersistentCacheIfNeeded();
   void InsertUncompressedBlockToPersistentCacheIfNeeded();
   void CheckBlockChecksum();
+  char* AllocateBuf();
 };
 }  // namespace rocksdb


### PR DESCRIPTION
Summary: Some cache implementation controls memory allocation too. In here we provide a small implementation change enabling experiments to these caches in limited scenario: data blocks in SST files with compression disabled.

Test Plan: Add a unit test