### PR TITLE
Fix a block pinning regression introduced in b555ed30a4a93b80a3ac4781c6721ab988e03b5b

### DIFF
--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -545,9 +545,10 @@ class BlockBasedTableIterator : public InternalIterator {
   }
   bool IsKeyPinned() const override {
     return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
-           block_iter_points_to_real_block_;
+           block_iter_points_to_real_block_ && data_block_iter_.IsKeyPinned();
   }
   bool IsValuePinned() const override {
+    // BlockIter::IsValuePinned() is always true. No need to check
     return pinned_iters_mgr_ && pinned_iters_mgr_->PinningEnabled() &&
            block_iter_points_to_real_block_;
   }
@@ -566,7 +567,7 @@ class BlockBasedTableIterator : public InternalIterator {
 
   void ResetDataIter() {
     if (block_iter_points_to_real_block_) {
-      if (pinned_iters_mgr_ != nullptr) {
+      if (pinned_iters_mgr_ != nullptr && pinned_iters_mgr_->PinningEnabled()) {
         data_block_iter_.DelegateCleanupsTo(pinned_iters_mgr_);
       }
       data_block_iter_.~BlockIter();


### PR DESCRIPTION
Summary: b555ed30a4a93b80a3ac4781c6721ab988e03b5b introduces a regression, which causes blocks always to be pinned in block based iterators. Fix it.

Test Plan: Run all existing unit tests.