### PR TITLE
log value of CompressionOptions::zstd_max_train_bytes

### DIFF
--- a/options/options.cc
+++ b/options/options.cc
@@ -168,6 +168,10 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
         log,
         "        Options.compression_opts.max_dict_bytes: %" ROCKSDB_PRIszt,
         compression_opts.max_dict_bytes);
+    ROCKS_LOG_HEADER(log,
+                     "        Options.compression_opts.zstd_max_train_bytes: "
+                     "%" ROCKSDB_PRIszt,
+                     compression_opts.zstd_max_train_bytes);
     ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",
                      level0_file_num_compaction_trigger);
     ROCKS_LOG_HEADER(log, "         Options.level0_slowdown_writes_trigger: %d",


### PR DESCRIPTION
Test Plan: ran db_bench, verified it shows up:

`2018/03/08-17:38:41.333096 7f8a35d9e200         Options.compression_opts.zstd_max_train_bytes: 1048576`