### PR TITLE
parse CompressionOptions::zstd_max_train_bytes in options string

### DIFF
--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -918,6 +918,17 @@ Status ParseColumnFamilyOption(const std::string& name,
         }
         new_options->compression_opts.max_dict_bytes =
             ParseInt(value.substr(start, value.size() - start));
+        end = value.find(':', start);
+      }
+      // zstd_max_train_bytes is optional for backwards compatibility
+      if (end != std::string::npos) {
+        start = end + 1;
+        if (start >= value.size()) {
+          return Status::InvalidArgument(
+              "unable to parse the specified CF option " + name);
+        }
+        new_options->compression_opts.zstd_max_train_bytes =
+            ParseInt(value.substr(start, value.size() - start));
       }
     } else {
       auto iter = cf_options_type_info.find(name);


### PR DESCRIPTION
Test Plan: ran and verified logs

`2018/03/08-17:59:27.796158 7f3fa67d9240         Options.compression_opts.zstd_max_train_bytes: 1048576
`