### PR TITLE
Level Compaction with TTL

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * Add a BlockBasedTableOption to align uncompressed data blocks on the smaller of block size or page size boundary, to reduce flash reads by avoiding reads spanning 4K pages.
 
 ### New Features
+* * Introduce TTL for level compaction so that all files older than ttl go through the compaction process to get rid of old data.
 
 ### Bug Fixes
 * Fsync after writing global seq number to the ingestion file in ExternalSstFileIngestionJob.

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1099,8 +1099,9 @@ void LevelCompactionBuilder::PickExpiredTtlFiles() {
     output_level_ =
         (start_level_ == 0) ? vstorage_->base_level() : start_level_ + 1;
 
-    if (start_level_ == 0 &&
-        !compaction_picker_->level0_compactions_in_progress()->empty()) {
+
+    if ((start_level_ == vstorage_->num_non_empty_levels() - 1) ||
+        (start_level_ == 0 && !compaction_picker_->level0_compactions_in_progress()->empty())) {
       return false;
     }
 

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1099,9 +1099,9 @@ void LevelCompactionBuilder::PickExpiredTtlFiles() {
     output_level_ =
         (start_level_ == 0) ? vstorage_->base_level() : start_level_ + 1;
 
-
     if ((start_level_ == vstorage_->num_non_empty_levels() - 1) ||
-        (start_level_ == 0 && !compaction_picker_->level0_compactions_in_progress()->empty())) {
+        (start_level_ == 0 &&
+         !compaction_picker_->level0_compactions_in_progress()->empty())) {
       return false;
     }
 
@@ -1120,8 +1120,6 @@ void LevelCompactionBuilder::PickExpiredTtlFiles() {
 
   start_level_inputs_.files.clear();
 }
-
-
 
 void LevelCompactionBuilder::SetupInitialFiles() {
   // Find the compactions by size on all levels.
@@ -1186,8 +1184,7 @@ void LevelCompactionBuilder::SetupInitialFiles() {
     size_t i;
     for (i = 0; i < vstorage_->BottommostFilesMarkedForCompaction().size();
          ++i) {
-      auto& level_and_file =
-          vstorage_->BottommostFilesMarkedForCompaction()[i];
+      auto& level_and_file = vstorage_->BottommostFilesMarkedForCompaction()[i];
       assert(!level_and_file.second->being_compacted);
       start_level_inputs_.level = output_level_ = start_level_ =
           level_and_file.first;

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -941,6 +941,9 @@ void CompactionPicker::UnregisterCompaction(Compaction* c) {
 
 bool LevelCompactionPicker::NeedsCompaction(
     const VersionStorageInfo* vstorage) const {
+  if (!vstorage->ExpiredTtlFiles().empty()) {
+    return true;
+  }
   if (!vstorage->BottommostFilesMarkedForCompaction().empty()) {
     return true;
   }

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1010,6 +1010,8 @@ class LevelCompactionBuilder {
   // If there is any file marked for compaction, put put it into inputs.
   void PickFilesMarkedForCompaction();
 
+  void PickExpiredTtlFiles();
+
   const std::string& cf_name_;
   VersionStorageInfo* vstorage_;
   CompactionPicker* compaction_picker_;
@@ -1080,6 +1082,43 @@ void LevelCompactionBuilder::PickFilesMarkedForCompaction() {
   start_level_inputs_.files.clear();
 }
 
+void LevelCompactionBuilder::PickExpiredTtlFiles() {
+  if (vstorage_->ExpiredTtlFiles().empty()) {
+    return;
+  }
+
+  auto continuation = [&](std::pair<int, FileMetaData*> level_file) {
+    // If it's being compacted it has nothing to do here.
+    // If this assert() fails that means that some function marked some
+    // files as being_compacted, but didn't call ComputeCompactionScore()
+    assert(!level_file.second->being_compacted);
+    start_level_ = level_file.first;
+    output_level_ =
+        (start_level_ == 0) ? vstorage_->base_level() : start_level_ + 1;
+
+    if (start_level_ == 0 &&
+        !compaction_picker_->level0_compactions_in_progress()->empty()) {
+      return false;
+    }
+
+    start_level_inputs_.files = {level_file.second};
+    start_level_inputs_.level = start_level_;
+    return compaction_picker_->ExpandInputsToCleanCut(cf_name_, vstorage_,
+                                                      &start_level_inputs_);
+  };
+
+  for (auto& level_file : vstorage_->ExpiredTtlFiles()) {
+    if (continuation(level_file)) {
+      // found the compaction!
+      return;
+    }
+  }
+
+  start_level_inputs_.files.clear();
+}
+
+
+
 void LevelCompactionBuilder::SetupInitialFiles() {
   // Find the compactions by size on all levels.
   bool skipped_l0_to_base = false;
@@ -1133,30 +1172,39 @@ void LevelCompactionBuilder::SetupInitialFiles() {
   if (start_level_inputs_.empty()) {
     is_manual_ = true;
     parent_index_ = base_index_ = -1;
+
     PickFilesMarkedForCompaction();
-    if (start_level_inputs_.empty()) {
-      size_t i;
-      for (i = 0; i < vstorage_->BottommostFilesMarkedForCompaction().size();
-           ++i) {
-        auto& level_and_file =
-            vstorage_->BottommostFilesMarkedForCompaction()[i];
-        assert(!level_and_file.second->being_compacted);
-        start_level_inputs_.level = output_level_ = start_level_ =
-            level_and_file.first;
-        start_level_inputs_.files = {level_and_file.second};
-        if (compaction_picker_->ExpandInputsToCleanCut(cf_name_, vstorage_,
-                                                       &start_level_inputs_)) {
-          break;
-        }
-      }
-      if (i == vstorage_->BottommostFilesMarkedForCompaction().size()) {
-        start_level_inputs_.clear();
-      } else {
-        assert(!start_level_inputs_.empty());
-        compaction_reason_ = CompactionReason::kBottommostFiles;
-      }
-    } else {
+    if (!start_level_inputs_.empty()) {
       compaction_reason_ = CompactionReason::kFilesMarkedForCompaction;
+      return;
+    }
+
+    size_t i;
+    for (i = 0; i < vstorage_->BottommostFilesMarkedForCompaction().size();
+         ++i) {
+      auto& level_and_file =
+          vstorage_->BottommostFilesMarkedForCompaction()[i];
+      assert(!level_and_file.second->being_compacted);
+      start_level_inputs_.level = output_level_ = start_level_ =
+          level_and_file.first;
+      start_level_inputs_.files = {level_and_file.second};
+      if (compaction_picker_->ExpandInputsToCleanCut(cf_name_, vstorage_,
+                                                     &start_level_inputs_)) {
+        break;
+      }
+    }
+    if (i == vstorage_->BottommostFilesMarkedForCompaction().size()) {
+      start_level_inputs_.clear();
+    } else {
+      assert(!start_level_inputs_.empty());
+      compaction_reason_ = CompactionReason::kBottommostFiles;
+      return;
+    }
+
+    assert(start_level_inputs_.empty());
+    PickExpiredTtlFiles();
+    if (!start_level_inputs_.empty()) {
+      compaction_reason_ = CompactionReason::kTtl;
     }
   }
 }

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include "db/compaction.h"
 #include "db/compaction_picker_universal.h"
-// #include "db/db_test_util.h"
 
 #include "util/logging.h"
 #include "util/string_util.h"
@@ -1443,26 +1442,6 @@ TEST_F(CompactionPickerTest, CacheNextCompactionIndex) {
       cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
   ASSERT_TRUE(compaction.get() == nullptr);
   ASSERT_EQ(4, vstorage_->NextCompactionIndex(1 /* level */));
-}
-
-TEST_F(CompactionPickerTest, CompactExpiredTTLFiles) {
-
-  // SpecialEnv env(Env::Default());
-  // env.time_elapse_only_sleep_ = false;
-  // options_.env = &env;
-  ioptions_.level_compaction_untouched_files_ttl = 2;
-
-  NewVersionStorage(6, kCompactionStyleLevel);
-  Add(2, 1U, "150", "200");
-  Add(3, 2U, "160", "180");
-  Add(3, 3U, "181", "230");
-  UpdateVersionStorageInfo();
-
-  //env.addon_time_.fetch_add(2 * 60 * 60);
-  options_.env->SleepForMicroseconds(5 * 1000 * 1000);
-  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
-      cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
-  ASSERT_TRUE(compaction.get() != nullptr);
 }
 
 }  // namespace rocksdb

--- a/db/compaction_picker_test.cc
+++ b/db/compaction_picker_test.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include "db/compaction.h"
 #include "db/compaction_picker_universal.h"
+// #include "db/db_test_util.h"
 
 #include "util/logging.h"
 #include "util/string_util.h"
@@ -1442,6 +1443,26 @@ TEST_F(CompactionPickerTest, CacheNextCompactionIndex) {
       cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
   ASSERT_TRUE(compaction.get() == nullptr);
   ASSERT_EQ(4, vstorage_->NextCompactionIndex(1 /* level */));
+}
+
+TEST_F(CompactionPickerTest, CompactExpiredTTLFiles) {
+
+  // SpecialEnv env(Env::Default());
+  // env.time_elapse_only_sleep_ = false;
+  // options_.env = &env;
+  ioptions_.level_compaction_untouched_files_ttl = 2;
+
+  NewVersionStorage(6, kCompactionStyleLevel);
+  Add(2, 1U, "150", "200");
+  Add(3, 2U, "160", "180");
+  Add(3, 3U, "181", "230");
+  UpdateVersionStorageInfo();
+
+  //env.addon_time_.fetch_add(2 * 60 * 60);
+  options_.env->SleepForMicroseconds(5 * 1000 * 1000);
+  std::unique_ptr<Compaction> compaction(level_compaction_picker.PickCompaction(
+      cf_name_, mutable_cf_options_, vstorage_.get(), &log_buffer_));
+  ASSERT_TRUE(compaction.get() != nullptr);
 }
 
 }  // namespace rocksdb

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3106,6 +3106,69 @@ TEST_F(DBCompactionTest, CompactBottomLevelFilesWithDeletions) {
   }
 }
 
+TEST_F(DBCompactionTest, CompactExpiredFiles) {
+  const int kNumKeysPerFile = 32;
+  const int kNumLevelFiles = 2;
+  const int kValueSize = 1024;
+
+  Options options = CurrentOptions();
+  // options.num_levels = 4;
+  options.compression = kNoCompression;
+  options.level_compaction_untouched_files_ttl = 5;
+  options.max_open_files = -1;
+  env_->time_elapse_only_sleep_ = false;
+  options.env = env_;
+
+  env_->addon_time_.store(0);
+  Reopen(options);
+
+  Random rnd(301);
+  for (int i = 0; i < kNumLevelFiles; ++i) {
+    for (int j = 0; j < kNumKeysPerFile; ++j) {
+      ASSERT_OK(Put(Key(i * kNumKeysPerFile + j), RandomString(&rnd, kValueSize)));
+    }
+    Flush();
+  }
+
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(2));
+
+  for (int i = 0; i < kNumLevelFiles; ++i) {
+    for (int j = 0; j < kNumKeysPerFile; ++j) {
+      ASSERT_OK(Put(Key(i * kNumKeysPerFile + j), ""));
+    }
+    Flush();
+  }
+
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
+  MoveFilesToLevel(1);
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(1));
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(2));
+
+  env_->addon_time_.fetch_add(2 * 60 * 60);
+
+  for (int i = 0; i < 1; ++i) {
+    for (int j = 0; j < kNumKeysPerFile; ++j) {
+      ASSERT_OK(Put(Key(10 * kNumKeysPerFile + j), ""));
+    }
+    Flush();
+  }
+  dbfull()->TEST_WaitForCompact();
+
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+  ASSERT_EQ(0, NumTableFilesAtLevel(4));
+  ASSERT_EQ(0, NumTableFilesAtLevel(5));
+  ASSERT_EQ(2, NumTableFilesAtLevel(6));
+}
+
 TEST_F(DBCompactionTest, CompactRangeDelayedByL0FileCount) {
   // Verify that, when `CompactRangeOptions::allow_write_stall == false`, manual
   // compaction only triggers flush after it's sure stall won't be triggered for

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3113,7 +3113,7 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
 
   Options options = CurrentOptions();
   options.compression = kNoCompression;
-  options.ttl = 1 * 24 * 60 * 60;  // 1 day
+  options.ttl = 24 * 60 * 60;  // 24 hours
   options.max_open_files = -1;
   env_->time_elapse_only_sleep_ = false;
   options.env = env_;
@@ -3146,7 +3146,7 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
   MoveFilesToLevel(1);
   ASSERT_EQ("0,2,0,2", FilesPerLevel());
 
-  env_->addon_time_.fetch_add(1.5 * 24 * 60 * 60);  // 1.5 days
+  env_->addon_time_.fetch_add(36 * 60 * 60);  // 36 hours
   ASSERT_EQ("0,2,0,2", FilesPerLevel());
 
   // Just do a siimple write + flush so that the Ttl expired files get

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3124,7 +3124,8 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
   Random rnd(301);
   for (int i = 0; i < kNumLevelFiles; ++i) {
     for (int j = 0; j < kNumKeysPerFile; ++j) {
-      ASSERT_OK(Put(Key(i * kNumKeysPerFile + j), RandomString(&rnd, kValueSize)));
+      ASSERT_OK(
+          Put(Key(i * kNumKeysPerFile + j), RandomString(&rnd, kValueSize)));
     }
     Flush();
   }
@@ -3148,7 +3149,8 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
   env_->addon_time_.fetch_add(1.5 * 24 * 60 * 60);  // 1.5 days
   ASSERT_EQ("0,2,0,2", FilesPerLevel());
 
-  // Just do a siimple write + flush so that the Ttl expired files get compacted.
+  // Just do a siimple write + flush so that the Ttl expired files get
+  // compacted.
   ASSERT_OK(Put("a", "1"));
   Flush();
   dbfull()->TEST_WaitForCompact();

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3106,15 +3106,15 @@ TEST_F(DBCompactionTest, CompactBottomLevelFilesWithDeletions) {
   }
 }
 
-TEST_F(DBCompactionTest, CompactExpiredFiles) {
+TEST_F(DBCompactionTest, CompactExpiredFilesTrivialMove) {
   const int kNumKeysPerFile = 32;
-  const int kNumLevelFiles = 2;
+  const int kNumLevelFiles = 1;
   const int kValueSize = 1024;
 
   Options options = CurrentOptions();
-  // options.num_levels = 4;
+  options.num_levels = 4;
   options.compression = kNoCompression;
-  options.level_compaction_untouched_files_ttl = 5;
+  options.level_compaction_untouched_files_ttl = 1 * 24 * 60 * 60;  // 1 day
   options.max_open_files = -1;
   env_->time_elapse_only_sleep_ = false;
   options.env = env_;
@@ -3130,43 +3130,121 @@ TEST_F(DBCompactionTest, CompactExpiredFiles) {
     Flush();
   }
 
-  dbfull()->TEST_WaitForCompact();
   ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
-  MoveFilesToLevel(2);
-  ASSERT_EQ(0, NumTableFilesAtLevel(0));
-  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  dbfull()->TEST_WaitForCompact();
+
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  env_->addon_time_.fetch_add(1.5 * 24 * 60 * 60);  // 1.5 days
+
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
 
   for (int i = 0; i < kNumLevelFiles; ++i) {
-    for (int j = 0; j < kNumKeysPerFile; ++j) {
-      ASSERT_OK(Put(Key(i * kNumKeysPerFile + j), ""));
-    }
-    Flush();
-  }
-
-  dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
-  MoveFilesToLevel(1);
-  ASSERT_EQ(0, NumTableFilesAtLevel(0));
-  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(1));
-  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(2));
-
-  env_->addon_time_.fetch_add(2 * 60 * 60);
-
-  for (int i = 0; i < 1; ++i) {
     for (int j = 0; j < kNumKeysPerFile; ++j) {
       ASSERT_OK(Put(Key(10 * kNumKeysPerFile + j), ""));
     }
     Flush();
   }
+  ASSERT_EQ(2 * kNumLevelFiles, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
   dbfull()->TEST_WaitForCompact();
 
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(kNumLevelFiles, NumTableFilesAtLevel(3));
+}
+
+TEST_F(DBCompactionTest, CompactExpiredFilesNoTrivialMove) {
+  // const int kNumKeysPerFile = 32;
+  // const int kNumLevelFiles = 1;
+  // const int kValueSize = 1024;
+
+  Options options = CurrentOptions();
+  options.num_levels = 4;
+  options.compression = kNoCompression;
+  options.level_compaction_untouched_files_ttl = 1 * 24 * 60 * 60;  // 1 day
+  options.max_open_files = -1;
+  env_->time_elapse_only_sleep_ = false;
+  options.env = env_;
+
+  env_->addon_time_.store(0);
+  Reopen(options);
+
+  Random rnd(301);
+  ASSERT_OK(Put("1", "1"));
+  ASSERT_OK(Put("2", "2"));
+
+  Flush();
   ASSERT_EQ(1, NumTableFilesAtLevel(0));
   ASSERT_EQ(0, NumTableFilesAtLevel(1));
   ASSERT_EQ(0, NumTableFilesAtLevel(2));
   ASSERT_EQ(0, NumTableFilesAtLevel(3));
-  ASSERT_EQ(0, NumTableFilesAtLevel(4));
-  ASSERT_EQ(0, NumTableFilesAtLevel(5));
-  ASSERT_EQ(2, NumTableFilesAtLevel(6));
+
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(0, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  MoveFilesToLevel(2);
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  ASSERT_OK(Put("2", "new2"));
+  ASSERT_OK(Put("3", "new3"));
+
+  Flush();
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  MoveFilesToLevel(1);
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  env_->addon_time_.fetch_add(1.5 * 24 * 60 * 60);  // 1.5 days
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(0, NumTableFilesAtLevel(0));
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  ASSERT_OK(Put("7", "7"));
+  ASSERT_OK(Put("8", "8"));
+  Flush();
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(1, NumTableFilesAtLevel(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  ASSERT_EQ(0, NumTableFilesAtLevel(3));
+
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+  ASSERT_EQ(0, NumTableFilesAtLevel(1));
+
+  // These fail at the moment ... but should pass
+  // ASSERT_EQ(1, NumTableFilesAtLevel(2));
+  // ASSERT_EQ(0, NumTableFilesAtLevel(3));
 }
 
 TEST_F(DBCompactionTest, CompactRangeDelayedByL0FileCount) {

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3113,7 +3113,7 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
 
   Options options = CurrentOptions();
   options.compression = kNoCompression;
-  options.level_compaction_untouched_files_ttl = 1 * 24 * 60 * 60;  // 1 day
+  options.ttl = 1 * 24 * 60 * 60;  // 1 day
   options.max_open_files = -1;
   env_->time_elapse_only_sleep_ = false;
   options.env = env_;

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -174,17 +174,16 @@ static Status ValidateOptions(
             "universal and level compaction styles. ");
       }
     }
-    if (cfd.options.compaction_options_fifo.ttl > 0) {
+    if (cfd.options.ttl > 0 || cfd.options.compaction_options_fifo.ttl > 0) {
       if (db_options.max_open_files != -1) {
         return Status::NotSupported(
-            "FIFO Compaction with TTL is only supported when files are always "
+            "TTL is only supported when files are always "
             "kept open (set max_open_files = -1). ");
       }
       if (cfd.options.table_factory->Name() !=
           BlockBasedTableFactory().Name()) {
         return Status::NotSupported(
-            "FIFO Compaction with TTL is only supported in "
-            "Block-Based Table format. ");
+            "TTL is only supported in Block-Based Table format. ");
       }
     }
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1667,7 +1667,7 @@ void VersionStorageInfo::ComputeCompactionScore(
   }
   ComputeFilesMarkedForCompaction();
   ComputeBottommostFilesMarkedForCompaction();
-  if (immutable_cf_options.level_compaction_untouched_files_ttl > 0) {
+  if (immutable_cf_options.ttl > 0) {
     ComputeExpiredTtlFiles(immutable_cf_options);
   }
   EstimateCompactionBytesNeeded(mutable_cf_options);
@@ -1698,7 +1698,7 @@ void VersionStorageInfo::ComputeFilesMarkedForCompaction() {
 
 void VersionStorageInfo::ComputeExpiredTtlFiles(
     const ImmutableCFOptions& ioptions) {
-  assert(ioptions.level_compaction_untouched_files_ttl > 0);
+  assert(ioptions.ttl > 0);
 
   expired_ttl_files_.clear();
 
@@ -1717,7 +1717,7 @@ void VersionStorageInfo::ComputeExpiredTtlFiles(
             f->fd.table_reader->GetTableProperties()->creation_time;
         if (creation_time > 0 &&
             creation_time < (current_time -
-                             ioptions.level_compaction_untouched_files_ttl)) {
+                             ioptions.ttl)) {
           expired_ttl_files_.emplace_back(level, f);
         }
       }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1667,6 +1667,7 @@ void VersionStorageInfo::ComputeCompactionScore(
   }
   ComputeFilesMarkedForCompaction();
   ComputeBottommostFilesMarkedForCompaction();
+  ComputeExpiredTtlFiles(immutable_cf_options);
   EstimateCompactionBytesNeeded(mutable_cf_options);
 }
 
@@ -1692,6 +1693,34 @@ void VersionStorageInfo::ComputeFilesMarkedForCompaction() {
     }
   }
 }
+
+void VersionStorageInfo::ComputeExpiredTtlFiles(
+    const ImmutableCFOptions& ioptions) {
+  expired_ttl_files_.clear();
+
+  int64_t _current_time;
+  auto status = ioptions.env->GetCurrentTime(&_current_time);
+  if (!status.ok()) {
+    return;
+  }
+  const uint64_t current_time = static_cast<uint64_t>(_current_time);
+
+  for (int level = 0; level < num_levels() - 1; level++) {
+    for (auto f : files_[level]) {
+      if (!f->being_compacted && f->fd.table_reader != nullptr &&
+          f->fd.table_reader->GetTableProperties() != nullptr) {
+        auto creation_time =
+            f->fd.table_reader->GetTableProperties()->creation_time;
+        if (creation_time > 0 &&
+            creation_time < (current_time -
+                             ioptions.level_compaction_untouched_files_ttl)) {
+          expired_ttl_files_.emplace_back(level, f);
+        }
+      }
+    }
+  }
+}
+
 
 namespace {
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1716,15 +1716,13 @@ void VersionStorageInfo::ComputeExpiredTtlFiles(
         auto creation_time =
             f->fd.table_reader->GetTableProperties()->creation_time;
         if (creation_time > 0 &&
-            creation_time < (current_time -
-                             ioptions.ttl)) {
+            creation_time < (current_time - ioptions.ttl)) {
           expired_ttl_files_.emplace_back(level, f);
         }
       }
     }
   }
 }
-
 
 namespace {
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1667,7 +1667,9 @@ void VersionStorageInfo::ComputeCompactionScore(
   }
   ComputeFilesMarkedForCompaction();
   ComputeBottommostFilesMarkedForCompaction();
-  ComputeExpiredTtlFiles(immutable_cf_options);
+  if (immutable_cf_options.level_compaction_untouched_files_ttl > 0) {
+    ComputeExpiredTtlFiles(immutable_cf_options);
+  }
   EstimateCompactionBytesNeeded(mutable_cf_options);
 }
 
@@ -1696,6 +1698,8 @@ void VersionStorageInfo::ComputeFilesMarkedForCompaction() {
 
 void VersionStorageInfo::ComputeExpiredTtlFiles(
     const ImmutableCFOptions& ioptions) {
+  assert(ioptions.level_compaction_untouched_files_ttl > 0);
+
   expired_ttl_files_.clear();
 
   int64_t _current_time;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -292,8 +292,7 @@ class VersionStorageInfo {
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   // REQUIRES: DB mutex held during access
-  const autovector<std::pair<int, FileMetaData*>>& ExpiredTtlFiles()
-      const {
+  const autovector<std::pair<int, FileMetaData*>>& ExpiredTtlFiles() const {
     assert(finalized_);
     return expired_ttl_files_;
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -135,6 +135,10 @@ class VersionStorageInfo {
   // ComputeCompactionScore()
   void ComputeFilesMarkedForCompaction();
 
+  // This computes ttl_expired_files_ and is called by
+  // ComputeCompactionScore()
+  void ComputeExpiredTtlFiles(const ImmutableCFOptions& ioptions);
+
   // This computes bottommost_files_marked_for_compaction_ and is called by
   // ComputeCompactionScore() or UpdateOldestSnapshot().
   //
@@ -284,6 +288,14 @@ class VersionStorageInfo {
       const {
     assert(finalized_);
     return files_marked_for_compaction_;
+  }
+
+  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  // REQUIRES: DB mutex held during access
+  const autovector<std::pair<int, FileMetaData*>>& ExpiredTtlFiles()
+      const {
+    assert(finalized_);
+    return expired_ttl_files_;
   }
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
@@ -445,6 +457,8 @@ class VersionStorageInfo {
   // currently being compacted. It is protected by DB mutex. It is calculated in
   // ComputeCompactionScore()
   autovector<std::pair<int, FileMetaData*>> files_marked_for_compaction_;
+
+  autovector<std::pair<int, FileMetaData*>> expired_ttl_files_;
 
   // These files are considered bottommost because none of their keys can exist
   // at lower levels. They are not necessarily all in the same level. The marked

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -570,7 +570,11 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool report_bg_io_stats = false;
 
-  uint64_t level_compaction_untouched_files_ttl = 0;
+  // Files older than TTL will go through the compaction process.
+  // Enabled only for level compaction for now.
+  // 
+  // Default: 0 (disabled)
+  uint64_t ttl = 0;
 
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -572,7 +572,7 @@ struct AdvancedColumnFamilyOptions {
 
   // Files older than TTL will go through the compaction process.
   // Enabled only for level compaction for now.
-  // 
+  //
   // Default: 0 (disabled)
   uint64_t ttl = 0;
 

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -570,7 +570,8 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool report_bg_io_stats = false;
 
-  // Files older than TTL will go through the compaction process.
+  // Non-bottom-level files older than TTL will go through the compaction
+  // process. This needs max_open_files to be set to -1.
   // Enabled only for level compaction for now.
   //
   // Default: 0 (disabled)

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -570,6 +570,8 @@ struct AdvancedColumnFamilyOptions {
   // Default: false
   bool report_bg_io_stats = false;
 
+  uint64_t level_compaction_untouched_files_ttl = 0;
+
   // Create ColumnFamilyOptions with default values for all fields
   AdvancedColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -80,6 +80,7 @@ enum class CompactionReason {
   // [Level] Automatic compaction within bottommost level to cleanup duplicate
   // versions of same user key, usually due to a released snapshot.
   kBottommostFiles,
+  kTtl,
 };
 
 enum class FlushReason : int {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -74,7 +74,9 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       row_cache(db_options.row_cache),
       max_subcompactions(db_options.max_subcompactions),
       memtable_insert_with_hint_prefix_extractor(
-          cf_options.memtable_insert_with_hint_prefix_extractor.get()) {}
+          cf_options.memtable_insert_with_hint_prefix_extractor.get()),
+      level_compaction_untouched_files_ttl(
+          cf_options.level_compaction_untouched_files_ttl) {}
 
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -75,8 +75,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       max_subcompactions(db_options.max_subcompactions),
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor.get()),
-      level_compaction_untouched_files_ttl(
-          cf_options.level_compaction_untouched_files_ttl) {}
+      ttl(cf_options.ttl) {}
 
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -118,6 +118,8 @@ struct ImmutableCFOptions {
   uint32_t max_subcompactions;
 
   const SliceTransform* memtable_insert_with_hint_prefix_extractor;
+
+  uint64_t level_compaction_untouched_files_ttl;
 };
 
 struct MutableCFOptions {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -119,7 +119,7 @@ struct ImmutableCFOptions {
 
   const SliceTransform* memtable_insert_with_hint_prefix_extractor;
 
-  uint64_t level_compaction_untouched_files_ttl;
+  uint64_t ttl;
 };
 
 struct MutableCFOptions {

--- a/options/options.cc
+++ b/options/options.cc
@@ -85,7 +85,9 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       optimize_filters_for_hits(options.optimize_filters_for_hits),
       paranoid_file_checks(options.paranoid_file_checks),
       force_consistency_checks(options.force_consistency_checks),
-      report_bg_io_stats(options.report_bg_io_stats) {
+      report_bg_io_stats(options.report_bg_io_stats),
+      level_compaction_untouched_files_ttl(
+          options.level_compaction_untouched_files_ttl) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -321,6 +323,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      force_consistency_checks);
     ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                      report_bg_io_stats);
+    ROCKS_LOG_HEADER(log, "   Options.level_compaction_untouched_files_ttl: %d",
+                     level_compaction_untouched_files_ttl);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options.cc
+++ b/options/options.cc
@@ -322,8 +322,7 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      force_consistency_checks);
     ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                      report_bg_io_stats);
-    ROCKS_LOG_HEADER(log, "                              Options.ttl: %d",
-                     ttl);
+    ROCKS_LOG_HEADER(log, "                              Options.ttl: %d", ttl);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options.cc
+++ b/options/options.cc
@@ -86,8 +86,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       paranoid_file_checks(options.paranoid_file_checks),
       force_consistency_checks(options.force_consistency_checks),
       report_bg_io_stats(options.report_bg_io_stats),
-      level_compaction_untouched_files_ttl(
-          options.level_compaction_untouched_files_ttl) {
+      ttl(options.ttl) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -323,8 +322,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      force_consistency_checks);
     ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                      report_bg_io_stats);
-    ROCKS_LOG_HEADER(log, "   Options.level_compaction_untouched_files_ttl: %d",
-                     level_compaction_untouched_files_ttl);
+    ROCKS_LOG_HEADER(log, "                              Options.ttl: %d",
+                     ttl);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1820,8 +1820,8 @@ std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kCompactionOptionsUniversal,
           OptionVerificationType::kNormal, true,
           offsetof(struct MutableCFOptions, compaction_options_universal)}},
-        {"level_compaction_untouched_files_ttl",
-         {offset_of(&ColumnFamilyOptions::level_compaction_untouched_files_ttl),
+        {"ttl",
+         {offset_of(&ColumnFamilyOptions::ttl),
           OptionType::kUInt64T, OptionVerificationType::kNormal, false, 0}}};
 
 std::unordered_map<std::string, OptionTypeInfo>

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1821,8 +1821,8 @@ std::unordered_map<std::string, OptionTypeInfo>
           OptionVerificationType::kNormal, true,
           offsetof(struct MutableCFOptions, compaction_options_universal)}},
         {"ttl",
-         {offset_of(&ColumnFamilyOptions::ttl),
-          OptionType::kUInt64T, OptionVerificationType::kNormal, false, 0}}};
+         {offset_of(&ColumnFamilyOptions::ttl), OptionType::kUInt64T,
+          OptionVerificationType::kNormal, false, 0}}};
 
 std::unordered_map<std::string, OptionTypeInfo>
     OptionsHelper::fifo_compaction_options_type_info = {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1819,7 +1819,10 @@ std::unordered_map<std::string, OptionTypeInfo>
          {offset_of(&ColumnFamilyOptions::compaction_options_universal),
           OptionType::kCompactionOptionsUniversal,
           OptionVerificationType::kNormal, true,
-          offsetof(struct MutableCFOptions, compaction_options_universal)}}};
+          offsetof(struct MutableCFOptions, compaction_options_universal)}},
+        {"level_compaction_untouched_files_ttl",
+         {offset_of(&ColumnFamilyOptions::level_compaction_untouched_files_ttl),
+          OptionType::kUInt64T, OptionVerificationType::kNormal, false, 0}}};
 
 std::unordered_map<std::string, OptionTypeInfo>
     OptionsHelper::fifo_compaction_options_type_info = {

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -437,6 +437,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "hard_pending_compaction_bytes_limit=0;"
       "disable_auto_compactions=false;"
       "report_bg_io_stats=true;"
+      "level_compaction_untouched_files_ttl=60;"
       "compaction_options_fifo={max_table_files_size=3;ttl=100;allow_"
       "compaction=false;};",
       new_options));

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -437,7 +437,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "hard_pending_compaction_bytes_limit=0;"
       "disable_auto_compactions=false;"
       "report_bg_io_stats=true;"
-      "level_compaction_untouched_files_ttl=60;"
+      "ttl=60;"
       "compaction_options_fifo={max_table_files_size=3;ttl=100;allow_"
       "compaction=false;};",
       new_options));

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -349,6 +349,7 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, Random* rnd) {
 
   // uint64_t options
   static const uint64_t uint_max = static_cast<uint64_t>(UINT_MAX);
+  cf_opt->ttl = uint_max + rnd->Uniform(10000);
   cf_opt->max_sequential_skip_in_iterations = uint_max + rnd->Uniform(10000);
   cf_opt->target_file_size_base = uint_max + rnd->Uniform(10000);
   cf_opt->max_compaction_bytes =
@@ -356,7 +357,6 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, Random* rnd) {
   cf_opt->compaction_options_fifo.max_table_files_size =
       uint_max + rnd->Uniform(10000);
   cf_opt->compaction_options_fifo.ttl = uint_max + rnd->Uniform(10000);
-  cf_opt->level_compaction_untouched_files_ttl = uint_max + rnd->Uniform(10000);
 
   // unsigned int options
   cf_opt->rate_limit_delay_max_milliseconds = rnd->Uniform(10000);

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -356,6 +356,7 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, Random* rnd) {
   cf_opt->compaction_options_fifo.max_table_files_size =
       uint_max + rnd->Uniform(10000);
   cf_opt->compaction_options_fifo.ttl = uint_max + rnd->Uniform(10000);
+  cf_opt->level_compaction_untouched_files_ttl = uint_max + rnd->Uniform(10000);
 
   // unsigned int options
   cf_opt->rate_limit_delay_max_milliseconds = rnd->Uniform(10000);


### PR DESCRIPTION
Level Compaction with TTL.

As of today, a file could exist in the LSM tree without going through the compaction process for a really long time if there are no updates to the data in the file's key range. For example, in certain use cases, the keys are not actually "deleted"; instead they are just set to empty values. There might not be any more writes to this "deleted" key range, and if so, such data could remain in the LSM for a really long time resulting in wasted space. 

Introducing a TTL could solve this problem. Files (and, in turn, data) older than TTL will be scheduled for compaction when there is no other background work. This will make the data go through the regular compaction process and get rid of old unwanted data. 
This also has the (good) side-effect of all the data in the non-bottommost level being newer than ttl, and all data in the bottommost level older than ttl. It could lead to more writes while reducing space. 

This functionality can be controlled by the newly introduced column family option -- ttl. 

TODO for later:
- Make ttl mutable
- Extend TTL to Universal compaction as well? (TTL is already supported in FIFO)
- Maybe deprecate CompactionOptionsFIFO.ttl in favor of this new ttl option.

Test Plan:
Added a new unit test.
```
KEEP_DB=1 TEST_TMPDIR=/dev/shm ./db_compaction_test --gtest_filter=DBCompactionTest.LevelCompactExpiredTtlFiles
```
LOG file from the unit test: https://gist.github.com/sagar0/93e86a41dab29a4f5d5f1ad511663a4f . 