### PR TITLE
allowing CompactFiles to return new file names

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -185,7 +185,8 @@ class DBImpl : public DB {
                               ColumnFamilyHandle* column_family,
                               const std::vector<std::string>& input_file_names,
                               const int output_level,
-                              const int output_path_id = -1) override;
+                              const int output_path_id = -1,
+                              std::vector<std::string>* const output_file_names = NULL) override;
 
   virtual Status PauseBackgroundWork() override;
   virtual Status ContinueBackgroundWork() override;
@@ -881,6 +882,7 @@ class DBImpl : public DB {
   Status CompactFilesImpl(const CompactionOptions& compact_options,
                           ColumnFamilyData* cfd, Version* version,
                           const std::vector<std::string>& input_file_names,
+                          std::vector<std::string>* const output_file_names,
                           const int output_level, int output_path_id,
                           JobContext* job_context, LogBuffer* log_buffer);
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -186,7 +186,8 @@ class DBImpl : public DB {
                               const std::vector<std::string>& input_file_names,
                               const int output_level,
                               const int output_path_id = -1,
-                              std::vector<std::string>* const output_file_names = NULL) override;
+                              std::vector<std::string>* const output_file_names
+                              = nullptr) override;
 
   virtual Status PauseBackgroundWork() override;
   virtual Status ContinueBackgroundWork() override;

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -682,9 +682,11 @@ Status DBImpl::CompactFilesImpl(
     }
   }
 
-  if (output_file_names != NULL) {
+  if (output_file_names != nullptr) {
     for (const auto newf : c->edit()->GetNewFiles()) {
-      (*output_file_names).push_back(TableFileName(immutable_db_options_.db_paths, newf.second.fd.GetNumber(), newf.second.fd.GetPathId()) );
+      (*output_file_names).push_back(TableFileName(
+              immutable_db_options_.db_paths, newf.second.fd.GetNumber(),
+              newf.second.fd.GetPathId()) );
     }
   }
 

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -461,7 +461,8 @@ Status DBImpl::CompactFiles(
     const CompactionOptions& compact_options,
     ColumnFamilyHandle* column_family,
     const std::vector<std::string>& input_file_names,
-    const int output_level, const int output_path_id) {
+    const int output_level, const int output_path_id,
+    std::vector<std::string>* const output_file_names) {
 #ifdef ROCKSDB_LITE
     // not supported in lite version
   return Status::NotSupported("Not supported in ROCKSDB LITE");
@@ -488,7 +489,7 @@ Status DBImpl::CompactFiles(
     WaitForIngestFile();
 
     s = CompactFilesImpl(compact_options, cfd, sv->current,
-                         input_file_names, output_level,
+                         input_file_names, output_file_names, output_level,
                          output_path_id, &job_context, &log_buffer);
   }
   if (sv->Unref()) {
@@ -532,6 +533,7 @@ Status DBImpl::CompactFiles(
 Status DBImpl::CompactFilesImpl(
     const CompactionOptions& compact_options, ColumnFamilyData* cfd,
     Version* version, const std::vector<std::string>& input_file_names,
+    std::vector<std::string>* const output_file_names,
     const int output_level, int output_path_id, JobContext* job_context,
     LogBuffer* log_buffer) {
   mutex_.AssertHeld();
@@ -677,6 +679,12 @@ Status DBImpl::CompactFilesImpl(
       if (!new_bg_error.ok()) {
         bg_error_ = new_bg_error;
       }
+    }
+  }
+
+  if (output_file_names != NULL) {
+    for (const auto newf : c->edit()->GetNewFiles()) {
+      (*output_file_names).push_back(TableFileName(immutable_db_options_.db_paths, newf.second.fd.GetNumber(), newf.second.fd.GetPathId()) );
     }
   }
 

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -76,7 +76,8 @@ class DBImplReadOnly : public DBImpl {
       const CompactionOptions& /*compact_options*/,
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
-      const int /*output_level*/, const int /*output_path_id*/ = -1) override {
+      const int /*output_level*/, const int /*output_path_id*/ = -1,
+      std::vector<std::string>* const /*output_file_names*/ = NULL) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -77,7 +77,8 @@ class DBImplReadOnly : public DBImpl {
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
       const int /*output_level*/, const int /*output_path_id*/ = -1,
-      std::vector<std::string>* const /*output_file_names*/ = NULL) override {
+      std::vector<std::string>* const /*output_file_names*/ = nullptr
+      ) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2412,7 +2412,8 @@ class ModelDB : public DB {
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
       const int /*output_level*/, const int /*output_path_id*/ = -1,
-      std::vector<std::string>* const /*output_file_names*/ = NULL) override {
+      std::vector<std::string>* const /*output_file_names*/ = nullptr
+      ) override {
     return Status::NotSupported("Not supported operation.");
   }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2411,7 +2411,8 @@ class ModelDB : public DB {
       const CompactionOptions& /*compact_options*/,
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
-      const int /*output_level*/, const int /*output_path_id*/ = -1) override {
+      const int /*output_level*/, const int /*output_path_id*/ = -1,
+      std::vector<std::string>* const /*output_file_names*/ = NULL) override {
     return Status::NotSupported("Not supported operation.");
   }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -815,13 +815,13 @@ class DB {
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = NULL) = 0;
+      std::vector<std::string>* const output_file_names = nullptr) = 0;
 
   virtual Status CompactFiles(
       const CompactionOptions& compact_options,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = NULL) {
+      std::vector<std::string>* const output_file_names = nullptr) {
     return CompactFiles(compact_options, DefaultColumnFamily(),
                         input_file_names, output_level, output_path_id,
                         output_file_names);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -814,14 +814,17 @@ class DB {
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
-      const int output_level, const int output_path_id = -1) = 0;
+      const int output_level, const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = NULL) = 0;
 
   virtual Status CompactFiles(
       const CompactionOptions& compact_options,
       const std::vector<std::string>& input_file_names,
-      const int output_level, const int output_path_id = -1) {
+      const int output_level, const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = NULL) {
     return CompactFiles(compact_options, DefaultColumnFamily(),
-                        input_file_names, output_level, output_path_id);
+                        input_file_names, output_level, output_path_id,
+                        output_file_names);
   }
 
   // This function will wait until all currently running background processes

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -219,10 +219,11 @@ class StackableDB : public DB {
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
-      const int output_level, const int output_path_id = -1) override {
+      const int output_level, const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = NULL) override {
     return db_->CompactFiles(
         compact_options, column_family, input_file_names,
-        output_level, output_path_id);
+        output_level, output_path_id, output_file_names);
   }
 
   virtual Status PauseBackgroundWork() override {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -220,7 +220,7 @@ class StackableDB : public DB {
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = NULL) override {
+      std::vector<std::string>* const output_file_names = nullptr) override {
     return db_->CompactFiles(
         compact_options, column_family, input_file_names,
         output_level, output_path_id, output_file_names);


### PR DESCRIPTION
This is a small API extension to allow the CompactFiles method to return the names of files that were created during the compaction.  