### PR TITLE
Update version

### DIFF
--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define ROCKSDB_MAJOR 5
-#define ROCKSDB_MINOR 10
+#define ROCKSDB_MINOR 12
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with


### PR DESCRIPTION
We missed updating version.h on master when cutting 5.11.fb and 5.12.fb branches. It should be the same as the version in the latest release branch. 

I noticed this when trying to run some upgrade/downgrade tests from 5.11 to a new piece of code on master. 