### PR TITLE
Shared block cache in RocksJava

### DIFF
--- a/java/rocksjni/table.cc
+++ b/java/rocksjni/table.cc
@@ -38,13 +38,14 @@ jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
 /*
  * Class:     org_rocksdb_BlockBasedTableConfig
  * Method:    newTableFactoryHandle
- * Signature: (ZJIJIIZIZZZJIBBI)J
+ * Signature: (ZJIJJIIZIZZZJIBBI)J
  */
 jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
-    JNIEnv* env, jobject jobj, jboolean no_block_cache, jlong block_cache_size,
-    jint block_cache_num_shardbits, jlong block_size, jint block_size_deviation,
-    jint block_restart_interval, jboolean whole_key_filtering,
-    jlong jfilterPolicy, jboolean cache_index_and_filter_blocks,
+    JNIEnv *env, jobject jobj, jboolean no_block_cache, jlong block_cache_size,
+    jint block_cache_num_shardbits, jlong jblockCache, jlong block_size,
+    jint block_size_deviation, jint block_restart_interval,
+    jboolean whole_key_filtering, jlong jfilterPolicy,
+    jboolean cache_index_and_filter_blocks,
     jboolean pin_l0_filter_and_index_blocks_in_cache,
     jboolean hash_index_allow_collision, jlong block_cache_compressed_size,
     jint block_cache_compressd_num_shard_bits, jbyte jchecksum_type,
@@ -52,7 +53,11 @@ jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
   rocksdb::BlockBasedTableOptions options;
   options.no_block_cache = no_block_cache;
 
-  if (!no_block_cache && block_cache_size > 0) {
+  if (jblockCache > 0) {
+    std::shared_ptr<rocksdb::Cache> *pCache =
+        reinterpret_cast<std::shared_ptr<rocksdb::Cache> *>(jblockCache);
+    options.block_cache = *pCache;
+  } else if (!no_block_cache && block_cache_size > 0) {
     if (block_cache_num_shardbits > 0) {
       options.block_cache =
           rocksdb::NewLRUCache(block_cache_size, block_cache_num_shardbits);

--- a/java/rocksjni/table.cc
+++ b/java/rocksjni/table.cc
@@ -42,9 +42,9 @@ jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
  */
 jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
     JNIEnv *env, jobject jobj, jboolean no_block_cache, jlong block_cache_size,
-    jint block_cache_num_shardbits, jlong jblockCache, jlong block_size,
+    jint block_cache_num_shardbits, jlong jblock_cache, jlong block_size,
     jint block_size_deviation, jint block_restart_interval,
-    jboolean whole_key_filtering, jlong jfilterPolicy,
+    jboolean whole_key_filtering, jlong jfilter_policy,
     jboolean cache_index_and_filter_blocks,
     jboolean pin_l0_filter_and_index_blocks_in_cache,
     jboolean hash_index_allow_collision, jlong block_cache_compressed_size,
@@ -53,26 +53,28 @@ jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
   rocksdb::BlockBasedTableOptions options;
   options.no_block_cache = no_block_cache;
 
-  if (jblockCache > 0) {
-    std::shared_ptr<rocksdb::Cache> *pCache =
-        reinterpret_cast<std::shared_ptr<rocksdb::Cache> *>(jblockCache);
-    options.block_cache = *pCache;
-  } else if (!no_block_cache && block_cache_size > 0) {
-    if (block_cache_num_shardbits > 0) {
-      options.block_cache =
-          rocksdb::NewLRUCache(block_cache_size, block_cache_num_shardbits);
-    } else {
-      options.block_cache = rocksdb::NewLRUCache(block_cache_size);
+  if (!no_block_cache) {
+    if (jblock_cache > 0) {
+      std::shared_ptr<rocksdb::Cache> *pCache =
+          reinterpret_cast<std::shared_ptr<rocksdb::Cache> *>(jblock_cache);
+      options.block_cache = *pCache;
+    } else if (block_cache_size > 0) {
+      if (block_cache_num_shardbits > 0) {
+        options.block_cache =
+            rocksdb::NewLRUCache(block_cache_size, block_cache_num_shardbits);
+      } else {
+        options.block_cache = rocksdb::NewLRUCache(block_cache_size);
+      }
     }
   }
   options.block_size = block_size;
   options.block_size_deviation = block_size_deviation;
   options.block_restart_interval = block_restart_interval;
   options.whole_key_filtering = whole_key_filtering;
-  if (jfilterPolicy > 0) {
+  if (jfilter_policy > 0) {
     std::shared_ptr<rocksdb::FilterPolicy> *pFilterPolicy =
         reinterpret_cast<std::shared_ptr<rocksdb::FilterPolicy> *>(
-            jfilterPolicy);
+            jfilter_policy);
     options.filter_policy = *pFilterPolicy;
   }
   options.cache_index_and_filter_blocks = cache_index_and_filter_blocks;

--- a/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
+++ b/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
@@ -15,6 +15,7 @@ public class BlockBasedTableConfig extends TableFormatConfig {
     noBlockCache_ = false;
     blockCacheSize_ = 8 * 1024 * 1024;
     blockCacheNumShardBits_ = 0;
+    blockCache_ = null;
     blockSize_ = 4 * 1024;
     blockSizeDeviation_ = 10;
     blockRestartInterval_ = 16;
@@ -69,6 +70,24 @@ public class BlockBasedTableConfig extends TableFormatConfig {
    */
   public long blockCacheSize() {
     return blockCacheSize_;
+  }
+
+  /**
+   * Use the specified cache for blocks.
+   * When not null this take precedence even if the user sets a block cache size.
+   *
+   * {@link org.rocksdb.Cache} should not be disposed before options instances
+   * using this cache is disposed.
+   *
+   * {@link org.rocksdb.Cache} instance can be re-used in multiple options
+   * instances.
+   *
+   * @param cache {@link org.rocksdb.Cache} Cache java instance (e.g. LRUCache).
+   * @return the reference to the current config.
+   */
+  public BlockBasedTableConfig setBlockCache(final Cache cache) {
+    blockCache_ = cache;
+    return this;
   }
 
   /**
@@ -413,25 +432,25 @@ public class BlockBasedTableConfig extends TableFormatConfig {
       filterHandle = filter_.nativeHandle_;
     }
 
-    return newTableFactoryHandle(noBlockCache_, blockCacheSize_,
-        blockCacheNumShardBits_, blockSize_, blockSizeDeviation_,
-        blockRestartInterval_, wholeKeyFiltering_,
-        filterHandle, cacheIndexAndFilterBlocks_,
-        pinL0FilterAndIndexBlocksInCache_,
-        hashIndexAllowCollision_, blockCacheCompressedSize_,
-        blockCacheCompressedNumShardBits_,
-        checksumType_.getValue(), indexType_.getValue(),
+    long blockCacheHandle = 0;
+    if (blockCache_ != null) {
+      blockCacheHandle = blockCache_.nativeHandle_;
+    }
+
+    return newTableFactoryHandle(noBlockCache_, blockCacheSize_, blockCacheNumShardBits_,
+        blockCacheHandle, blockSize_, blockSizeDeviation_, blockRestartInterval_,
+        wholeKeyFiltering_, filterHandle, cacheIndexAndFilterBlocks_,
+        pinL0FilterAndIndexBlocksInCache_, hashIndexAllowCollision_, blockCacheCompressedSize_,
+        blockCacheCompressedNumShardBits_, checksumType_.getValue(), indexType_.getValue(),
         formatVersion_);
   }
 
-  private native long newTableFactoryHandle(
-      boolean noBlockCache, long blockCacheSize, int blockCacheNumShardBits,
-      long blockSize, int blockSizeDeviation, int blockRestartInterval,
-      boolean wholeKeyFiltering, long filterPolicyHandle,
+  private native long newTableFactoryHandle(boolean noBlockCache, long blockCacheSize,
+      int blockCacheNumShardBits, long blockCacheHandle, long blockSize, int blockSizeDeviation,
+      int blockRestartInterval, boolean wholeKeyFiltering, long filterPolicyHandle,
       boolean cacheIndexAndFilterBlocks, boolean pinL0FilterAndIndexBlocksInCache,
       boolean hashIndexAllowCollision, long blockCacheCompressedSize,
-      int blockCacheCompressedNumShardBits, byte checkSumType,
-      byte indexType, int formatVersion);
+      int blockCacheCompressedNumShardBits, byte checkSumType, byte indexType, int formatVersion);
 
   private boolean cacheIndexAndFilterBlocks_;
   private boolean pinL0FilterAndIndexBlocksInCache_;
@@ -442,6 +461,7 @@ public class BlockBasedTableConfig extends TableFormatConfig {
   private long blockSize_;
   private long blockCacheSize_;
   private int blockCacheNumShardBits_;
+  private Cache blockCache_;
   private long blockCacheCompressedSize_;
   private int blockCacheCompressedNumShardBits_;
   private int blockSizeDeviation_;

--- a/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
+++ b/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
@@ -6,7 +6,11 @@
 package org.rocksdb;
 
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,6 +19,8 @@ public class BlockBasedTableConfigTest {
   @ClassRule
   public static final RocksMemoryResource rocksMemoryResource =
       new RocksMemoryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
 
   @Test
   public void noBlockCache() {
@@ -32,12 +38,27 @@ public class BlockBasedTableConfigTest {
   }
 
   @Test
-  public void blockBasedTableWithBlockCache() {
-    try(final Options options = new Options()
-        .setTableFormatConfig(new BlockBasedTableConfig()
-        .setBlockCache(new LRUCache(17 * 1024 * 1024)))) {
-      assertThat(options.tableFactoryName()).
-          isEqualTo("BlockBasedTable");
+  public void sharedBlockCache() throws RocksDBException {
+    try (final Cache cache = new LRUCache(8 * 1024 * 1024);
+         final Statistics statistics = new Statistics()) {
+      for (int shard = 0; shard < 8; shard++) {
+        try (final Options options =
+                 new Options()
+                     .setCreateIfMissing(true)
+                     .setStatistics(statistics)
+                     .setTableFormatConfig(new BlockBasedTableConfig().setBlockCache(cache));
+             final RocksDB db =
+                 RocksDB.open(options, dbFolder.getRoot().getAbsolutePath() + "/" + shard)) {
+          final byte[] key = "some-key".getBytes(StandardCharsets.UTF_8);
+          final byte[] value = "some-value".getBytes(StandardCharsets.UTF_8);
+
+          db.put(key, value);
+          db.flush(new FlushOptions());
+          db.get(key);
+
+          assertThat(statistics.getTickerCount(TickerType.BLOCK_CACHE_ADD)).isEqualTo(shard + 1);
+        }
+      }
     }
   }
 
@@ -155,6 +176,14 @@ public class BlockBasedTableConfigTest {
         new BlockBasedTableConfig().setFilter(null))) {
       assertThat(options.tableFactoryName()).
           isEqualTo("BlockBasedTable");
+    }
+  }
+
+  @Test
+  public void blockBasedTableWithBlockCache() {
+    try (final Options options = new Options().setTableFormatConfig(
+             new BlockBasedTableConfig().setBlockCache(new LRUCache(17 * 1024 * 1024)))) {
+      assertThat(options.tableFactoryName()).isEqualTo("BlockBasedTable");
     }
   }
 

--- a/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
+++ b/java/src/test/java/org/rocksdb/BlockBasedTableConfigTest.java
@@ -32,6 +32,16 @@ public class BlockBasedTableConfigTest {
   }
 
   @Test
+  public void blockBasedTableWithBlockCache() {
+    try(final Options options = new Options()
+        .setTableFormatConfig(new BlockBasedTableConfig()
+        .setBlockCache(new LRUCache(17 * 1024 * 1024)))) {
+      assertThat(options.tableFactoryName()).
+          isEqualTo("BlockBasedTable");
+    }
+  }
+
+  @Test
   public void blockSizeDeviation() {
     BlockBasedTableConfig blockBasedTableConfig = new BlockBasedTableConfig();
     blockBasedTableConfig.setBlockSizeDeviation(12);


### PR DESCRIPTION
Changes to support sharing block cache using the Java API. 

Previously DB instances could share the block cache only when the same Options instance is passed to all the DB instances. But now, with this change, it is possible to explicitly create a cache and pass it to multiple options instances, to share the block cache. 

Implementing this for [Rocksandra](https://github.com/instagram/cassandra/tree/rocks_3.0), but this feature has been requested by many java api users over the years.

Test Plan:
- Added a unit test to make sure shared block cache is working.
- Added another simple test to make sure that setBlockCache() is working. 

Sample code  to show how it works: 
```
import java.lang.IllegalArgumentException;

import org.rocksdb.*;
import org.rocksdb.util.SizeUnit;

public class SharedCacheSample
{
  static {
    RocksDB.loadLibrary();
  }

  public static void main( String[] args ) throws Exception {
    if (args.length < 2) {
      System.out.println("usage: SharedCacheSample db_path num_shards");
      System.exit(-1);
    }

    String baseDBPath = args[0];
    int numShards = 0;
    try {
      numShards = Integer.parseInt(args[1]);
    } catch (NumberFormatException e) {
      System.out.println("Enter a good value for num_shards");
      throw e;
    }

    try {
      Statistics stats = new Statistics();
      Cache cache = new LRUCache(64 * SizeUnit.MB);
      for (int shard = 0; shard < numShards; shard++) {
        BlockBasedTableConfig table_options = new BlockBasedTableConfig();
        table_options.setBlockCache(cache);
        Options options = new Options();
        options.setCreateIfMissing(true)
               .setStatistics(stats)
               .setTableFormatConfig(table_options);

        String db_path = baseDBPath + "/" + shard;
        RocksDB db = null;
        db = RocksDB.open(options, db_path);
        db.put("hello".getBytes(), "world".getBytes());

        FlushOptions flushOptions = new FlushOptions();
        db.flush(flushOptions);

        byte[] value = db.get("hello".getBytes());
        assert ("world".equals(new String(value)));

        System.out.println(stats.getTickerCount(TickerType.BLOCK_CACHE_ADD));
      }
    } catch (IllegalArgumentException e) {
      assert (false);
    } catch (RocksDBException e) {
      System.out.format("[ERROR] caught an unexpected RocksDB exception -- %s\n", e);
      throw e;
      // assert (false);
    } catch (Exception e) {
      assert (false);
    }
  }
}
```

Build and Run:
```
javac -g -verbose -cp ~/rocksdb/java/target/rocksdbjni-5.12.0-linux64.jar SharedCacheSample.java
java -cp ~/rocksdb/java/target/rocksdbjni-5.12.0-linux64.jar:. SharedCacheSample /tmp/rocksjavabc 8
1
2
3
4
5
6
7
8  
```
In the above output, you can see the counter for the block cache is increasing even though they are different DB instances.

Note that all the block caches have the same memory address below:
```
svemuri@devbig187 ~ $ ls -l /tmp/rocksjavabc
total 32
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 0
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 1
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 2
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 3
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 4
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 5
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 6
drwxr-xr-x. 2 svemuri users 4096 Mar 16 09:54 7

svemuri@devbig187 ~ $ cat /tmp/rocksjavabc/*/LOG | egrep "\sblock_cache:"
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8
  block_cache: 0x7f214c50a2a8

svemuri@devbig187 ~ $ cat /tmp/rocksjavabc/*/LOG | egrep -A5 "\sblock_cache:"
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
--
  block_cache: 0x7f214c50a2a8
  block_cache_name: LRUCache
  block_cache_options:
    capacity : 67108864
    num_shard_bits : 6
    strict_capacity_limit : 0
```
