### PR TITLE
fix db_compaction_test when compression disabled

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -2751,6 +2751,7 @@ TEST_P(DBCompactionTestWithParam, ForceBottommostLevelCompaction) {
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
+  options.target_file_size_base = 100000000;
   options.write_buffer_size = 100000000;
   options.max_subcompactions = max_subcompactions_;
   DestroyAndReopen(options);


### PR DESCRIPTION
Previously, the compaction in `DBCompactionTestWithParam.ForceBottommostLevelCompaction` generated multiple files in no-compression use case, andone file in compression use case. I increased `target_file_size_base` so it generates one file in both use cases.

Test Plan: `./build_tools/rocksdb-lego-determinator run_no_compression`