### PR TITLE
Fix the command used to generate ctags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ clean:
 	cd java; $(MAKE) clean
 
 tags:
-	ctags * -R
+	ctags -R .
 	cscope -b `find . -name '*.cc'` `find . -name '*.h'` `find . -name '*.c'`
 	ctags -e -R -o etags *
 


### PR DESCRIPTION
In original $ROCKSDB_HOME/Makefile, the command used to generate ctags is
```
ctags * -R
```
However, this failed to generate tags for me.
I did some search on the usage of ctags command and found that it should be
```
ctags -R .
```
or
```
ctags -R *
```
After the change, I can find the tags in vim using `:ts <identifier>`.
