### PR TITLE
Fixed buffer overrun in BackupEngineImpl::BackupMeta::StoreToFile 

### DIFF
--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1733,26 +1733,44 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
   if (!app_metadata_.empty()) {
     std::string hex_encoded_metadata =
         Slice(app_metadata_).ToString(/* hex */ true);
+
+	// +1 to accomodate newline character
+	size_t hex_meta_strlen = kMetaDataPrefix.ToString().length() + hex_encoded_metadata.length() + 1;
+	if (hex_meta_strlen >= buf_size) {
+		return Status::Corruption("Buffer too small to fit backup metadata");
+	}
+	else if (len + hex_meta_strlen >= buf_size) {
+		backup_meta_file->Append(Slice(buf.get(), len));
+		buf.release();
+		unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
+		buf.swap(new_reset_buf);
+		len = 0;
+	}
     len += snprintf(buf.get() + len, buf_size - len, "%s%s\n",
                     kMetaDataPrefix.ToString().c_str(),
                     hex_encoded_metadata.c_str());
-    if (len >= buf_size) {
-      return Status::Corruption("Buffer too small to fit backup metadata");
-    }
+  }
+
+  char writelen_temp[18];
+  if (len + sprintf(writelen_temp, "%" ROCKSDB_PRIszt "\n") >= buf_size) {
+	  backup_meta_file->Append(Slice(buf.get(), len));
+	  buf.release();
+	  unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
+	  buf.swap(new_reset_buf);
+	  len = 0;
   }
   len += snprintf(buf.get() + len, buf_size - len, "%" ROCKSDB_PRIszt "\n",
                   files_.size());
-  if (len >= buf_size) {
-    return Status::Corruption("Buffer too small to fit backup metadata");
-  }
-  char tempbuf[18];
+
   for (const auto& file : files_) {
     // use crc32 for now, switch to something else if needed
 
-	size_t newlen = len + file->filename.length() + sprintf(tempbuf, " crc32 %u\n", file->checksum_value);
+	size_t newlen = len + file->filename.length() + sprintf(writelen_temp, " crc32 %u\n", file->checksum_value);
 	if (newlen >= buf_size) {
-		s = backup_meta_file->Append(Slice(buf.get(), len));
-		buf.reset();
+		backup_meta_file->Append(Slice(buf.get(), len));
+		buf.release();
+		unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
+		buf.swap(new_reset_buf);
 		len = 0;
 	}
     len += snprintf(buf.get() + len, buf_size - len, "%s crc32 %u\n",

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1751,7 +1751,7 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
                     hex_encoded_metadata.c_str());
   }
 
-  char writelen_temp[18];
+  char writelen_temp[19];
   if (len + sprintf(writelen_temp, "%" ROCKSDB_PRIszt "\n", files_.size()) >= buf_size) {
 	  backup_meta_file->Append(Slice(buf.get(), len));
 	  buf.release();

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1741,7 +1741,7 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
     }
     else if (len + hex_meta_strlen >= buf_size) {
       backup_meta_file->Append(Slice(buf.get(), len));
-      buf.release();
+      buf.reset();
       unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
       buf.swap(new_reset_buf);
       len = 0;
@@ -1754,7 +1754,7 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
   char writelen_temp[19];
   if (len + sprintf(writelen_temp, "%" ROCKSDB_PRIszt "\n", files_.size()) >= buf_size) {
     backup_meta_file->Append(Slice(buf.get(), len));
-    buf.release();
+    buf.reset();
     unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
     buf.swap(new_reset_buf);
     len = 0;
@@ -1771,7 +1771,7 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
     const char *const_write = writelen_temp;
     if (newlen >= buf_size) {
       backup_meta_file->Append(Slice(buf.get(), len));
-      buf.release();
+      buf.reset();
       unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);
       buf.swap(new_reset_buf);
       len = 0;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1752,7 +1752,7 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
   }
 
   char writelen_temp[18];
-  if (len + sprintf(writelen_temp, "%" ROCKSDB_PRIszt "\n") >= buf_size) {
+  if (len + sprintf(writelen_temp, "%" ROCKSDB_PRIszt "\n", files_.size()) >= buf_size) {
 	  backup_meta_file->Append(Slice(buf.get(), len));
 	  buf.release();
 	  unique_ptr<char[]> new_reset_buf(new char[max_backup_meta_file_size_]);


### PR DESCRIPTION
The 10MB buffer in BackupEngineImpl::BackupMeta::StoreToFile can be corrupted with a large number of files. Added a check to determine current buffer length and append data to file if buffer becomes full.

Resolves https://github.com/facebook/rocksdb/issues/3228