### PR TITLE
Fsync after writing global seq number in ExternalSstFileIngestionJob

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 ### New Features
 
 ### Bug Fixes
-
+* Fsync after writing global seq number to the ingestion file in ExternalSstFileIngestionJob.
 
 ## 5.13.0 (3/20/2018)
 ### Public API Change

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -511,6 +511,9 @@ Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
   PutFixed64(&seqno_val, seqno);
   status = rwfile->Write(file_to_ingest->global_seqno_offset, seqno_val);
   if (status.ok()) {
+    status = rwfile->Fsync();
+  }
+  if (status.ok()) {
     file_to_ingest->assigned_seqno = seqno;
   }
   return status;


### PR DESCRIPTION
Fsync after writing global sequence number to the ingestion file in ExternalSstFileIngestionJob. Otherwise the file metadata could be incorrect.

Test Plan:
Run existing unit tests