### PR TITLE
API extention to allow CompactFiles to return CompactionJobInfo

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -186,7 +186,7 @@ class DBImpl : public DB {
                               const std::vector<std::string>& input_file_names,
                               const int output_level,
                               const int output_path_id = -1,
-                              std::vector<std::string>* const output_file_names
+                              CompactionJobInfo* const job_info
                               = nullptr) override;
 
   virtual Status PauseBackgroundWork() override;
@@ -886,7 +886,7 @@ class DBImpl : public DB {
   Status CompactFilesImpl(const CompactionOptions& compact_options,
                           ColumnFamilyData* cfd, Version* version,
                           const std::vector<std::string>& input_file_names,
-                          std::vector<std::string>* const output_file_names,
+                          CompactionJobInfo* const jo_info,
                           const int output_level, int output_path_id,
                           JobContext* job_context, LogBuffer* log_buffer);
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -886,7 +886,7 @@ class DBImpl : public DB {
   Status CompactFilesImpl(const CompactionOptions& compact_options,
                           ColumnFamilyData* cfd, Version* version,
                           const std::vector<std::string>& input_file_names,
-                          CompactionJobInfo* const jo_info,
+                          CompactionJobInfo* const job_info,
                           const int output_level, int output_path_id,
                           JobContext* job_context, LogBuffer* log_buffer);
 

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -624,19 +624,7 @@ Status DBImpl::CompactFilesImpl(
       table_cache_, &event_logger_,
       c->mutable_cf_options()->paranoid_file_checks,
       c->mutable_cf_options()->report_bg_io_stats, dbname_,
-      &compaction_job_stats);  // Here we pass a nullptr for CompactionJobStats because
-                 // CompactFiles does not trigger OnCompactionCompleted(),
-                 // which is the only place where CompactionJobStats is
-                 // returned.  The idea of not triggering OnCompationCompleted()
-                 // is that CompactFiles runs in the caller thread, so the user
-                 // should always know when it completes.  As a result, it makes
-                 // less sense to notify the users something they should already
-                 // know.
-                 //
-                 // In the future, if we would like to add CompactionJobStats
-                 // support for CompactFiles, we should have CompactFiles API
-                 // pass a pointer of CompactionJobStats as the out-value
-                 // instead of using EventListener.
+      &compaction_job_stats);
 
   // Creating a compaction influences the compaction score because the score
   // takes running compactions into account (by skipping files that are already

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -712,7 +712,8 @@ Status DBImpl::CompactFilesImpl(
       }
     }
     for (const auto newf : c->edit()->GetNewFiles()) {
-      job_info->output_files.push_back(TableFileName(immutable_db_options_.db_paths,
+      job_info->output_files.push_back(TableFileName(
+          immutable_db_options_.db_paths,
           newf.second.fd.GetNumber(),
           newf.second.fd.GetPathId()));
     }

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -77,7 +77,7 @@ class DBImplReadOnly : public DBImpl {
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
       const int /*output_level*/, const int /*output_path_id*/ = -1,
-      std::vector<std::string>* const /*output_file_names*/ = nullptr
+      CompactionJobInfo* const /*job_info*/ = nullptr
       ) override {
     return Status::NotSupported("Not supported operation in read only mode.");
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2412,7 +2412,7 @@ class ModelDB : public DB {
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*input_file_names*/,
       const int /*output_level*/, const int /*output_path_id*/ = -1,
-      std::vector<std::string>* const /*output_file_names*/ = nullptr
+      CompactionJobInfo* const /*job_info*/ = nullptr
       ) override {
     return Status::NotSupported("Not supported operation.");
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -815,16 +815,16 @@ class DB {
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = nullptr) = 0;
+      CompactionJobInfo* const job_info = nullptr) = 0;
 
   virtual Status CompactFiles(
       const CompactionOptions& compact_options,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = nullptr) {
+      CompactionJobInfo* const job_info = nullptr) {
     return CompactFiles(compact_options, DefaultColumnFamily(),
                         input_file_names, output_level, output_path_id,
-                        output_file_names);
+                        job_info);
   }
 
   // This function will wait until all currently running background processes

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -220,10 +220,10 @@ class StackableDB : public DB {
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& input_file_names,
       const int output_level, const int output_path_id = -1,
-      std::vector<std::string>* const output_file_names = nullptr) override {
+      CompactionJobInfo* const job_info = nullptr) override {
     return db_->CompactFiles(
         compact_options, column_family, input_file_names,
-        output_level, output_path_id, output_file_names);
+        output_level, output_path_id, job_info);
   }
 
   virtual Status PauseBackgroundWork() override {


### PR DESCRIPTION
A simple API extention to allow CompactFiles to return a CompactionJobInfo struct 
This is the same metadata that already gets returned in the OnCompactionCompleted method
I am changing slightly the API of CompactFiles by replacing the output_file_names because this is included in the CompactionJobInfo struct. Since the output_file_names argument was added by me one week ago, this API change is extremely unlikely to break anyone's code at this stage, and it is now much more general and in line with the rest of the API. 