### PR TITLE
Update comments about MergeOperator::AllowSingleOperand

### DIFF
--- a/include/rocksdb/merge_operator.h
+++ b/include/rocksdb/merge_operator.h
@@ -185,9 +185,9 @@ class MergeOperator {
 
   // Determines whether the MergeOperator can be called with just a single
   // merge operand.
-  // Override and return true for allowing a single operand. FullMergeV2 and
-  // PartialMerge/PartialMergeMulti should be implemented accordingly to handle
-  // a single operand.
+  // Override and return true for allowing a single operand. Both FullMergeV2
+  // and PartialMerge/PartialMergeMulti should be overridden and implemented
+  // correctly to handle a single operand.
   virtual bool AllowSingleOperand() const { return false; }
 
   // Allows to control when to invoke a full merge during Get.


### PR DESCRIPTION
Updated comments around AllowSingleOperand. 
Reason: A couple of users were confused and encountered issues due to no overriding PartialMerge with AllowSingleOperand=true. 

I'll also look into modifying the default merge operator implementation so that overriding PartialMerge is not mandatory when AllowSingleOp=true.
