### PR TITLE
Fix a leak in FilterBlockBuilder when adding prefix

### DIFF
--- a/table/block_based_filter_block.cc
+++ b/table/block_based_filter_block.cc
@@ -108,9 +108,9 @@ inline void BlockBasedFilterBlockBuilder::AddPrefix(const Slice& key) {
   Slice prefix = prefix_extractor_->Transform(key);
   // insert prefix only when it's different from the previous prefix.
   if (prev.size() == 0 || prefix != prev) {
-    AddKey(prefix);
     prev_prefix_start_ = entries_.size();
     prev_prefix_size_ = prefix.size();
+    AddKey(prefix);
   }
 }
 


### PR DESCRIPTION
Our valgrind continuous test found an interesting leak which got introduced in #3614. We were adding the prefix key before saving the previous prefix start offset, due to which previous prefix offset is always incorrect. Fixed it by saving the the previous sate before adding the key. 

Test Plan:
`make valgrind_check`

Before the fix:
```
svemuri@devbig187 ~/rocksdb (fix-valgrind-issues) $ TEST_TMPDIR=/dev/shm /mnt/gvfs/third-party2/valgrind/423431d61786b20bcc3bde8972901130cb29e6b3/3.11.0/gcc-5-glibc-2.23/9bc6787/bin/valgrind --error-exitcode=2 --leak-check=full --track-origins=yes ./db_bloom_filter_test --gtest_filter=DBBloomFilterTest.PrefixScan
==738918== Memcheck, a memory error detector
==738918== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==738918== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==738918== Command: ./db_bloom_filter_test --gtest_filter=DBBloomFilterTest.PrefixScan
==738918==
Note: Google Test filter = DBBloomFilterTest.PrefixScan
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBBloomFilterTest
[ RUN      ] DBBloomFilterTest.PrefixScan
==738918== Thread 3:
==738918== Conditional jump or move depends on uninitialised value(s)
==738918==    at 0x4C3910E: __memcmp_sse4_1 (vg_replace_strmem.c:1099)
==738918==    by 0x6FCEEA: operator== (slice.h:213)
==738918==    by 0x6FCEEA: operator!= (slice.h:217)
==738918==    by 0x6FCEEA: AddPrefix (block_based_filter_block.cc:110)
==738918==    by 0x6FCEEA: rocksdb::BlockBasedFilterBlockBuilder::Add(rocksdb::Slice const&) (block_based_filter_block.cc:85)
==738918==    by 0x6FF4C4: rocksdb::BlockBasedTableBuilder::Add(rocksdb::Slice const&, rocksdb::Slice const&) (block_based_table_builder.cc:421)
==738918==    by 0x550BD6: rocksdb::BuildTable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::Env*, rocksdb::ImmutableCFOptions const&, rocksdb::MutableCFOptions const&, rocksdb::EnvOptions const&, rocksdb::TableCache*, rocksdb::InternalIterator*, std::unique_ptr<rocksdb::InternalIterator, std::default_delete<rocksdb::InternalIterator> >, rocksdb::FileMetaDat
a*, rocksdb::InternalKeyComparator const&, std::vector<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> >, std::allocator<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> > > > const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, st
d::vector<unsigned long, std::allocator<unsigned long> >, unsigned long, rocksdb::SnapshotChecker*, rocksdb::CompressionType, rocksdb::CompressionOptions const&, bool, rocksdb::InternalStats*, rocksdb::TableFileCreationReason, rocksdb::EventLogger*, int, rocksdb::Env::IOPriority, rocksdb::TableProperties*, int, unsigned long, unsigned long, rocksdb::Env::WriteLifeTimeHint) (builder.cc:145)
==738918==    by 0x611CF5: rocksdb::FlushJob::WriteLevel0Table() (flush_job.cc:349)
==738918==    by 0x61353F: rocksdb::FlushJob::Run(rocksdb::FileMetaData*) (flush_job.cc:215)
==738918==    by 0x5BBF16: rocksdb::DBImpl::FlushMemTableToOutputFile(rocksdb::ColumnFamilyData*, rocksdb::MutableCFOptions const&, bool*, rocksdb::JobContext*, rocksdb::LogBuffer*) (db_impl_compaction_flush.cc:132)
==738918==    by 0x5BCB52: rocksdb::DBImpl::BackgroundFlush(bool*, rocksdb::JobContext*, rocksdb::LogBuffer*) (db_impl_compaction_flush.cc:1350)
==738918==    by 0x5C29C0: rocksdb::DBImpl::BackgroundCallFlush() (db_impl_compaction_flush.cc:1375)
==738918==    by 0x5C2F8A: rocksdb::DBImpl::BGWorkFlush(void*) (db_impl_compaction_flush.cc:1260)
==738918==    by 0x77CD84: operator() (functional:2267)
==738918==    by 0x77CD84: rocksdb::ThreadPoolImpl::Impl::BGThread(unsigned long) (threadpool_imp.cc:240)
==738918==    by 0x77CF7A: rocksdb::ThreadPoolImpl::Impl::BGThreadWrapper(void*) (threadpool_imp.cc:278)
==738918==  Uninitialised value was created by a heap allocation
==738918==    at 0x4C2D1CF: operator new(unsigned long) (vg_replace_malloc.c:334)
==738918==    by 0x701545: CreateFilterBlockBuilder (block_based_table_builder.cc:72)
==738918==    by 0x701545: Rep (block_based_table_builder.cc:329)
==738918==    by 0x701545: rocksdb::BlockBasedTableBuilder::BlockBasedTableBuilder(rocksdb::ImmutableCFOptions const&, rocksdb::BlockBasedTableOptions const&, rocksdb::InternalKeyComparator const&, std::vector<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> >, std::allocator<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<
rocksdb::IntTblPropCollectorFactory> > > > const*, unsigned int, rocksdb::WritableFileWriter*, rocksdb::CompressionType, rocksdb::CompressionOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const*, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, unsigned long) (block_based_table_builder.cc:372)
==738918==    by 0x703EEF: rocksdb::BlockBasedTableFactory::NewTableBuilder(rocksdb::TableBuilderOptions const&, unsigned int, rocksdb::WritableFileWriter*) const (block_based_table_factory.cc:89)
==738918==    by 0x550091: rocksdb::NewTableBuilder(rocksdb::ImmutableCFOptions const&, rocksdb::InternalKeyComparator const&, std::vector<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> >, std::allocator<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> > > > const*, unsigned int, std::_
_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::WritableFileWriter*, rocksdb::CompressionType, rocksdb::CompressionOptions const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const*, bool, unsigned long, unsigned long) (builder.cc:59)
==738918==    by 0x550A56: rocksdb::BuildTable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::Env*, rocksdb::ImmutableCFOptions const&, rocksdb::MutableCFOptions const&, rocksdb::EnvOptions const&, rocksdb::TableCache*, rocksdb::InternalIterator*, std::unique_ptr<rocksdb::InternalIterator, std::default_delete<rocksdb::InternalIterator> >, rocksdb::FileMetaDat
a*, rocksdb::InternalKeyComparator const&, std::vector<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> >, std::allocator<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> > > > const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, st
d::vector<unsigned long, std::allocator<unsigned long> >, unsigned long, rocksdb::SnapshotChecker*, rocksdb::CompressionType, rocksdb::CompressionOptions const&, bool, rocksdb::InternalStats*, rocksdb::TableFileCreationReason, rocksdb::EventLogger*, int, rocksdb::Env::IOPriority, rocksdb::TableProperties*, int, unsigned long, unsigned long, rocksdb::Env::WriteLifeTimeHint) (builder.cc:128)
==738918==    by 0x611CF5: rocksdb::FlushJob::WriteLevel0Table() (flush_job.cc:349)
==738918==    by 0x61353F: rocksdb::FlushJob::Run(rocksdb::FileMetaData*) (flush_job.cc:215)
==738918==    by 0x5BBF16: rocksdb::DBImpl::FlushMemTableToOutputFile(rocksdb::ColumnFamilyData*, rocksdb::MutableCFOptions const&, bool*, rocksdb::JobContext*, rocksdb::LogBuffer*) (db_impl_compaction_flush.cc:132)
==738918==    by 0x5BCB52: rocksdb::DBImpl::BackgroundFlush(bool*, rocksdb::JobContext*, rocksdb::LogBuffer*) (db_impl_compaction_flush.cc:1350)
==738918==    by 0x5C29C0: rocksdb::DBImpl::BackgroundCallFlush() (db_impl_compaction_flush.cc:1375)
==738918==    by 0x5C2F8A: rocksdb::DBImpl::BGWorkFlush(void*) (db_impl_compaction_flush.cc:1260)
==738918==    by 0x77CD84: operator() (functional:2267)
==738918==    by 0x77CD84: rocksdb::ThreadPoolImpl::Impl::BGThread(unsigned long) (threadpool_imp.cc:240)
==738918==
[       OK ] DBBloomFilterTest.PrefixScan (2622 ms)
[----------] 1 test from DBBloomFilterTest (2630 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2670 ms total)
[  PASSED  ] 1 test.
==738918==
==738918== HEAP SUMMARY:
==738918==     in use at exit: 73,280 bytes in 7 blocks
==738918==   total heap usage: 192,160 allocs, 192,153 frees, 21,186,570 bytes allocated
==738918==
==738918== LEAK SUMMARY:
==738918==    definitely lost: 0 bytes in 0 blocks
==738918==    indirectly lost: 0 bytes in 0 blocks
==738918==      possibly lost: 0 bytes in 0 blocks
==738918==    still reachable: 73,280 bytes in 7 blocks
==738918==         suppressed: 0 bytes in 0 blocks
==738918== Reachable blocks (those to which a pointer was found) are not shown.
==738918== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==738918==
==738918== For counts of detected and suppressed errors, rerun with: -v
==738918== ERROR SUMMARY: 33 errors from 1 contexts (suppressed: 0 from 0)
```
No leaks after the fix. 
```
svemuri@devbig187 ~/rocksdb (fix-valgrind-issues) (fix-valgrind-issues) $ TEST_TMPDIR=/dev/shm /mnt/gvfs/third-party2/valgrind/423431d61786b20bcc3bde8972901130cb29e6b3/3.11.0/gcc-5-glibc-2.23/9bc6787/bin/valgrind --error-exitcode=2 --leak-check=full --track-origins=yes ./db_bloom_filter_test --gtest_filter=DBBloomFilterTest.PrefixScan
==982687== Memcheck, a memory error detector
==982687== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==982687== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==982687== Command: ./db_bloom_filter_test --gtest_filter=DBBloomFilterTest.PrefixScan
==982687==
Note: Google Test filter = DBBloomFilterTest.PrefixScan
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBBloomFilterTest
[ RUN      ] DBBloomFilterTest.PrefixScan
[       OK ] DBBloomFilterTest.PrefixScan (2556 ms)
[----------] 1 test from DBBloomFilterTest (2564 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2602 ms total)
[  PASSED  ] 1 test.
==982687==
==982687== HEAP SUMMARY:
==982687==     in use at exit: 73,280 bytes in 7 blocks
==982687==   total heap usage: 192,170 allocs, 192,163 frees, 21,186,836 bytes allocated
==982687==
==982687== LEAK SUMMARY:
==982687==    definitely lost: 0 bytes in 0 blocks
==982687==    indirectly lost: 0 bytes in 0 blocks
==982687==      possibly lost: 0 bytes in 0 blocks
==982687==    still reachable: 73,280 bytes in 7 blocks
==982687==         suppressed: 0 bytes in 0 blocks
==982687== Reachable blocks (those to which a pointer was found) are not shown.
==982687== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==982687==
==982687== For counts of detected and suppressed errors, rerun with: -v
==982687== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```