### PR TITLE
[codemod] comment unused parameters to turn on -Wunused-parameter flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ endif
 default: all
 
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
-	-Wunused-parameter
+  -Wunused-parameter
 
 ifeq ($(PLATFORM), OS_OPENBSD)
 	WARNING_FLAGS += -Wno-unused-lambda-capture

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ endif
 default: all
 
 WARNING_FLAGS = -W -Wextra -Wall -Wsign-compare -Wshadow \
-  -Wno-unused-parameter
+	-Wunused-parameter
 
 ifeq ($(PLATFORM), OS_OPENBSD)
 	WARNING_FLAGS += -Wno-unused-lambda-capture

--- a/cache/cache_bench.cc
+++ b/cache/cache_bench.cc
@@ -52,7 +52,7 @@ namespace rocksdb {
 
 class CacheBench;
 namespace {
-void deleter(const Slice& key, void* value) {
+void deleter(const Slice& /*key*/, void* value) {
     delete reinterpret_cast<char *>(value);
 }
 

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -13,8 +13,8 @@
 
 namespace rocksdb {
 
-std::shared_ptr<Cache> NewClockCache(size_t capacity, int num_shard_bits,
-                                     bool strict_capacity_limit) {
+std::shared_ptr<Cache> NewClockCache(size_t /*capacity*/, int /*num_shard_bits*/,
+                                     bool /*strict_capacity_limit*/) {
   // Clock cache not supported.
   return nullptr;
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -192,10 +192,11 @@ static void CheckDel(void* ptr, const char* k, size_t klen) {
   (*state)++;
 }
 
-static void CmpDestroy(void* arg) { }
+static void CmpDestroy(void* arg) { (void)arg; }
 
 static int CmpCompare(void* arg, const char* a, size_t alen,
                       const char* b, size_t blen) {
+  (void)arg;
   size_t n = (alen < blen) ? alen : blen;
   int r = memcmp(a, b, n);
   if (r == 0) {
@@ -206,13 +207,15 @@ static int CmpCompare(void* arg, const char* a, size_t alen,
 }
 
 static const char* CmpName(void* arg) {
+  (void)arg;
   return "foo";
 }
 
 // Custom filter policy
 static unsigned char fake_filter_result = 1;
-static void FilterDestroy(void* arg) { }
+static void FilterDestroy(void* arg) { (void)arg; }
 static const char* FilterName(void* arg) {
+  (void)arg;
   return "TestFilter";
 }
 static char* FilterCreate(
@@ -220,6 +223,10 @@ static char* FilterCreate(
     const char* const* key_array, const size_t* key_length_array,
     int num_keys,
     size_t* filter_length) {
+  (void)arg;
+  (void)key_array;
+  (void)key_length_array;
+  (void)num_keys;
   *filter_length = 4;
   char* result = malloc(4);
   memcpy(result, "fake", 4);
@@ -229,20 +236,30 @@ static unsigned char FilterKeyMatch(
     void* arg,
     const char* key, size_t length,
     const char* filter, size_t filter_length) {
+  (void)arg;
+  (void)key;
+  (void)length;
   CheckCondition(filter_length == 4);
   CheckCondition(memcmp(filter, "fake", 4) == 0);
   return fake_filter_result;
 }
 
 // Custom compaction filter
-static void CFilterDestroy(void* arg) {}
-static const char* CFilterName(void* arg) { return "foo"; }
+static void CFilterDestroy(void* arg) { (void)arg; }
+static const char* CFilterName(void* arg) {
+  (void)arg;
+  return "foo";
+}
 static unsigned char CFilterFilter(void* arg, int level, const char* key,
                                    size_t key_length,
                                    const char* existing_value,
                                    size_t value_length, char** new_value,
                                    size_t* new_value_length,
                                    unsigned char* value_changed) {
+  (void)arg;
+  (void)level;
+  (void)existing_value;
+  (void)value_length;
   if (key_length == 3) {
     if (memcmp(key, "bar", key_length) == 0) {
       return 1;
@@ -256,10 +273,15 @@ static unsigned char CFilterFilter(void* arg, int level, const char* key,
   return 0;
 }
 
-static void CFilterFactoryDestroy(void* arg) {}
-static const char* CFilterFactoryName(void* arg) { return "foo"; }
+static void CFilterFactoryDestroy(void* arg) { (void)arg; }
+static const char* CFilterFactoryName(void* arg) {
+  (void)arg;
+  return "foo";
+}
 static rocksdb_compactionfilter_t* CFilterCreate(
     void* arg, rocksdb_compactionfiltercontext_t* context) {
+  (void)arg;
+  (void)context;
   return rocksdb_compactionfilter_create(NULL, CFilterDestroy, CFilterFilter,
                                          CFilterName);
 }
@@ -290,8 +312,9 @@ static rocksdb_t* CheckCompaction(rocksdb_t* db, rocksdb_options_t* options,
 }
 
 // Custom merge operator
-static void MergeOperatorDestroy(void* arg) { }
+static void MergeOperatorDestroy(void* arg) { (void)arg; }
 static const char* MergeOperatorName(void* arg) {
+  (void)arg;
   return "TestMergeOperator";
 }
 static char* MergeOperatorFullMerge(
@@ -301,6 +324,14 @@ static char* MergeOperatorFullMerge(
     const char* const* operands_list, const size_t* operands_list_length,
     int num_operands,
     unsigned char* success, size_t* new_value_length) {
+  (void)arg;
+  (void)key;
+  (void)key_length;
+  (void)existing_value;
+  (void)existing_value_length;
+  (void)operands_list;
+  (void)operands_list_length;
+  (void)num_operands;
   *new_value_length = 4;
   *success = 1;
   char* result = malloc(4);
@@ -313,6 +344,12 @@ static char* MergeOperatorPartialMerge(
     const char* const* operands_list, const size_t* operands_list_length,
     int num_operands,
     unsigned char* success, size_t* new_value_length) {
+  (void)arg;
+  (void)key;
+  (void)key_length;
+  (void)operands_list;
+  (void)operands_list_length;
+  (void)num_operands;
   *new_value_length = 4;
   *success = 1;
   char* result = malloc(4);
@@ -377,6 +414,8 @@ static void CheckTxnDBGetCF(rocksdb_transactiondb_t* txn_db,
 }
 
 int main(int argc, char** argv) {
+  (void)argc;
+  (void)argv;
   rocksdb_t* db;
   rocksdb_comparator_t* cmp;
   rocksdb_cache_t* cache;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -85,6 +85,7 @@ Status ColumnFamilyHandleImpl::GetDescriptor(ColumnFamilyDescriptor* desc) {
   *desc = ColumnFamilyDescriptor(cfd()->GetName(), cfd()->GetLatestCFOptions());
   return Status::OK();
 #else
+  (void)desc;
   return Status::NotSupported();
 #endif  // !ROCKSDB_LITE
 }

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -1361,7 +1361,7 @@ TEST_F(ColumnFamilyTest, MultipleManualCompactions) {
        {"ColumnFamilyTest::MultiManual:2", "ColumnFamilyTest::MultiManual:5"},
        {"ColumnFamilyTest::MultiManual:2", "ColumnFamilyTest::MultiManual:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::MultiManual:4");
           cf_1_1 = false;
@@ -1454,7 +1454,7 @@ TEST_F(ColumnFamilyTest, AutomaticAndManualCompactions) {
        {"ColumnFamilyTest::AutoManual:2", "ColumnFamilyTest::AutoManual:5"},
        {"ColumnFamilyTest::AutoManual:2", "ColumnFamilyTest::AutoManual:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           cf_1_1 = false;
           TEST_SYNC_POINT("ColumnFamilyTest::AutoManual:4");
@@ -1555,7 +1555,7 @@ TEST_F(ColumnFamilyTest, ManualAndAutomaticCompactions) {
        {"ColumnFamilyTest::ManualAuto:5", "ColumnFamilyTest::ManualAuto:2"},
        {"ColumnFamilyTest::ManualAuto:2", "ColumnFamilyTest::ManualAuto:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::ManualAuto:4");
           cf_1_1 = false;
@@ -1648,7 +1648,7 @@ TEST_F(ColumnFamilyTest, SameCFManualManualCompactions) {
        {"ColumnFamilyTest::ManualManual:1",
         "ColumnFamilyTest::ManualManual:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::ManualManual:4");
           cf_1_1 = false;
@@ -1746,7 +1746,7 @@ TEST_F(ColumnFamilyTest, SameCFManualAutomaticCompactions) {
        {"ColumnFamilyTest::ManualAuto:1", "ColumnFamilyTest::ManualAuto:2"},
        {"ColumnFamilyTest::ManualAuto:1", "ColumnFamilyTest::ManualAuto:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::ManualAuto:4");
           cf_1_1 = false;
@@ -1838,7 +1838,7 @@ TEST_F(ColumnFamilyTest, SameCFManualAutomaticCompactionsLevel) {
         "ColumnFamilyTest::ManualAuto:3"},
        {"ColumnFamilyTest::ManualAuto:1", "ColumnFamilyTest::ManualAuto:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::ManualAuto:4");
           cf_1_1 = false;
@@ -1925,7 +1925,7 @@ TEST_F(ColumnFamilyTest, SameCFAutomaticManualCompactions) {
        {"CompactionPicker::CompactRange:Conflict",
         "ColumnFamilyTest::AutoManual:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (cf_1_1) {
           TEST_SYNC_POINT("ColumnFamilyTest::AutoManual:4");
           cf_1_1 = false;
@@ -2372,7 +2372,7 @@ TEST_F(ColumnFamilyTest, CreateAndDropRace) {
   auto main_thread_id = std::this_thread::get_id();
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack("PersistRocksDBOptions:start",
-                                                 [&](void* arg) {
+                                                 [&](void* /*arg*/) {
     auto current_thread_id = std::this_thread::get_id();
     // If it's the main thread hitting this sync-point, then it
     // will be blocked until some other thread update the test_stage.
@@ -2385,7 +2385,7 @@ TEST_F(ColumnFamilyTest, CreateAndDropRace) {
   });
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "WriteThread::EnterUnbatched:Wait", [&](void* arg) {
+      "WriteThread::EnterUnbatched:Wait", [&](void* /*arg*/) {
         // This means a thread doing DropColumnFamily() is waiting for
         // other thread to finish persisting options.
         // In such case, we update the test_stage to unblock the main thread.

--- a/db/compaction_job_stats_test.cc
+++ b/db/compaction_job_stats_test.cc
@@ -806,7 +806,7 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
     stats_checker->set_verify_next_comp_io_stats(true);
     std::atomic<bool> first_prepare_write(true);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
-        "WritableFileWriter::Append:BeforePrepareWrite", [&](void* arg) {
+        "WritableFileWriter::Append:BeforePrepareWrite", [&](void* /*arg*/) {
           if (first_prepare_write.load()) {
             options.env->SleepForMicroseconds(3);
             first_prepare_write.store(false);
@@ -815,7 +815,7 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
 
     std::atomic<bool> first_flush(true);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
-        "WritableFileWriter::Flush:BeforeAppend", [&](void* arg) {
+        "WritableFileWriter::Flush:BeforeAppend", [&](void* /*arg*/) {
           if (first_flush.load()) {
             options.env->SleepForMicroseconds(3);
             first_flush.store(false);
@@ -824,7 +824,7 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
 
     std::atomic<bool> first_sync(true);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
-        "WritableFileWriter::SyncInternal:0", [&](void* arg) {
+        "WritableFileWriter::SyncInternal:0", [&](void* /*arg*/) {
           if (first_sync.load()) {
             options.env->SleepForMicroseconds(3);
             first_sync.store(false);
@@ -833,7 +833,7 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
 
     std::atomic<bool> first_range_sync(true);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
-        "WritableFileWriter::RangeSync:0", [&](void* arg) {
+        "WritableFileWriter::RangeSync:0", [&](void* /*arg*/) {
           if (first_range_sync.load()) {
             options.env->SleepForMicroseconds(3);
             first_range_sync.store(false);

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1674,6 +1674,10 @@ Compaction* FIFOCompactionPicker::CompactRange(
     uint32_t /*output_path_id*/, const InternalKey* /*begin*/,
     const InternalKey* /*end*/, InternalKey** compaction_end,
     bool* /*manual_conflict*/) {
+#ifdef NDEBUG
+  (void)input_level;
+  (void)output_level;
+#endif
   assert(input_level == 0);
   assert(output_level == 0);
   *compaction_end = nullptr;

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -1057,10 +1057,10 @@ TEST_F(DBBloomFilterTest, OptimizeFiltersForHits) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   CompactRangeOptions compact_options;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -436,7 +436,7 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
       });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "TableCache::GetTableReader:0",
-      [&](void* arg) { num_new_table_reader++; });
+      [&](void* /*arg*/) { num_new_table_reader++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   for (int k = 0; k < options.level0_file_num_compaction_trigger; ++k) {
@@ -992,7 +992,7 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveOneFile) {
   int32_t trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -1049,10 +1049,10 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveNonOverlappingFiles) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -1148,10 +1148,10 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveTargetLevel) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -1207,10 +1207,10 @@ TEST_P(DBCompactionTestWithParam, ManualCompactionPartial) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   bool first = true;
   // Purpose of dependencies:
   // 4 -> 1: ensure the order of two non-trivial compactions
@@ -1221,7 +1221,7 @@ TEST_P(DBCompactionTestWithParam, ManualCompactionPartial) {
        {"DBCompaction::ManualPartial:5", "DBCompaction::ManualPartial:2"},
        {"DBCompaction::ManualPartial:5", "DBCompaction::ManualPartial:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (first) {
           first = false;
           TEST_SYNC_POINT("DBCompaction::ManualPartial:4");
@@ -1352,17 +1352,17 @@ TEST_F(DBCompactionTest, DISABLED_ManualPartialFill) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   bool first = true;
   bool second = true;
   rocksdb::SyncPoint::GetInstance()->LoadDependency(
       {{"DBCompaction::PartialFill:4", "DBCompaction::PartialFill:1"},
        {"DBCompaction::PartialFill:2", "DBCompaction::PartialFill:3"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:NonTrivial:AfterRun", [&](void* /*arg*/) {
         if (first) {
           TEST_SYNC_POINT("DBCompaction::PartialFill:4");
           first = false;
@@ -1768,10 +1768,10 @@ TEST_P(DBCompactionTestWithParam, TrivialMoveToLastLevelWithFiles) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -2768,16 +2768,16 @@ TEST_P(DBCompactionTestWithParam, CompressLevelCompaction) {
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "Compaction::InputCompressionMatchesOutput:Matches",
-      [&](void* arg) { matches++; });
+      [&](void* /*arg*/) { matches++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "Compaction::InputCompressionMatchesOutput:DidntMatch",
-      [&](void* arg) { didnt_match++; });
+      [&](void* /*arg*/) { didnt_match++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial++; });
+      [&](void* /*arg*/) { non_trivial++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Reopen(options);
@@ -2939,10 +2939,10 @@ TEST_P(DBCompactionTestWithParam, ForceBottommostLevelCompaction) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial_move++; });
+      [&](void* /*arg*/) { non_trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -3689,7 +3689,7 @@ TEST_P(DBCompactionDirectIOTest, DirectIO) {
       });
   if (options.use_direct_io_for_flush_and_compaction) {
     SyncPoint::GetInstance()->SetCallBack(
-        "SanitizeOptions:direct_io", [&](void* arg) {
+        "SanitizeOptions:direct_io", [&](void* /*arg*/) {
           readahead = true;
         });
   }

--- a/db/db_dynamic_level_test.cc
+++ b/db/db_dynamic_level_test.cc
@@ -194,7 +194,7 @@ TEST_F(DBTestDynamicLevel, DynamicLevelMaxBytesBase2) {
   // Hold compaction jobs to make sure
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "CompactionJob::Run():Start",
-      [&](void* arg) { env_->SleepForMicroseconds(100000); });
+      [&](void* /*arg*/) { env_->SleepForMicroseconds(100000); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(dbfull()->SetOptions({
       {"disable_auto_compactions", "true"},
@@ -378,7 +378,7 @@ TEST_F(DBTestDynamicLevel, DynamicLevelMaxBytesBaseInc) {
   int non_trivial = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial",
-      [&](void* arg) { non_trivial++; });
+      [&](void* /*arg*/) { non_trivial++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Random rnd(301);

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -105,7 +105,7 @@ TEST_F(DBFlushTest, FlushInLowPriThreadPool) {
   std::thread::id tid;
   int num_flushes = 0, num_compactions = 0;
   SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BGWorkFlush", [&](void* arg) {
+      "DBImpl::BGWorkFlush", [&](void* /*arg*/) {
         if (tid == std::thread::id()) {
           tid = std::this_thread::get_id();
         } else {
@@ -114,7 +114,7 @@ TEST_F(DBFlushTest, FlushInLowPriThreadPool) {
         ++num_flushes;
       });
   SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BGWorkCompaction", [&](void* arg) {
+      "DBImpl::BGWorkCompaction", [&](void* /*arg*/) {
         ASSERT_EQ(tid, std::this_thread::get_id());
         ++num_compactions;
       });

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -24,8 +24,7 @@ DBImplReadOnly::DBImplReadOnly(const DBOptions& db_options,
   LogFlush(immutable_db_options_.info_log);
 }
 
-DBImplReadOnly::~DBImplReadOnly() {
-}
+DBImplReadOnly::~DBImplReadOnly() {}
 
 // Implementations of the DB interface
 Status DBImplReadOnly::Get(const ReadOptions& read_options,
@@ -183,20 +182,21 @@ Status DB::OpenForReadOnly(
   return s;
 }
 
-#else  // !ROCKSDB_LITE
+#else   // !ROCKSDB_LITE
 
-Status DB::OpenForReadOnly(const Options& options, const std::string& dbname,
-                           DB** dbptr, bool error_if_log_file_exist) {
+Status DB::OpenForReadOnly(const Options& /*options*/,
+                           const std::string& /*dbname*/, DB** /*dbptr*/,
+                           bool /*error_if_log_file_exist*/) {
   return Status::NotSupported("Not supported in ROCKSDB_LITE.");
 }
 
 Status DB::OpenForReadOnly(
-    const DBOptions& db_options, const std::string& dbname,
-    const std::vector<ColumnFamilyDescriptor>& column_families,
-    std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
-    bool error_if_log_file_exist) {
+    const DBOptions& /*db_options*/, const std::string& /*dbname*/,
+    const std::vector<ColumnFamilyDescriptor>& /*column_families*/,
+    std::vector<ColumnFamilyHandle*>* /*handles*/, DB** /*dbptr*/,
+    bool /*error_if_log_file_exist*/) {
   return Status::NotSupported("Not supported in ROCKSDB_LITE.");
 }
 #endif  // !ROCKSDB_LITE
 
-}   // namespace rocksdb
+}  // namespace rocksdb

--- a/db/db_iter_test.cc
+++ b/db/db_iter_test.cc
@@ -2550,7 +2550,7 @@ TEST_F(DBIterWithMergeIterTest, InnerMergeIteratorDataRace1) {
   // and before an SeekToLast() is called.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "MergeIterator::Prev:BeforeSeekToLast",
-      [&](void* arg) { internal_iter2_->Add("z", kTypeValue, "7", 12u); });
+      [&](void* /*arg*/) { internal_iter2_->Add("z", kTypeValue, "7", 12u); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   db_iter_->Prev();
@@ -2585,7 +2585,7 @@ TEST_F(DBIterWithMergeIterTest, InnerMergeIteratorDataRace2) {
   // mem table after MergeIterator::Prev() realized the mem tableiterator is at
   // its end and before an SeekToLast() is called.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "MergeIterator::Prev:BeforeSeekToLast", [&](void* arg) {
+      "MergeIterator::Prev:BeforeSeekToLast", [&](void* /*arg*/) {
         internal_iter2_->Add("z", kTypeValue, "7", 12u);
         internal_iter2_->Add("z", kTypeValue, "7", 11u);
       });
@@ -2623,7 +2623,7 @@ TEST_F(DBIterWithMergeIterTest, InnerMergeIteratorDataRace3) {
   // mem table after MergeIterator::Prev() realized the mem table iterator is at
   // its end and before an SeekToLast() is called.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "MergeIterator::Prev:BeforeSeekToLast", [&](void* arg) {
+      "MergeIterator::Prev:BeforeSeekToLast", [&](void* /*arg*/) {
         internal_iter2_->Add("z", kTypeValue, "7", 16u, true);
         internal_iter2_->Add("z", kTypeValue, "7", 15u, true);
         internal_iter2_->Add("z", kTypeValue, "7", 14u, true);

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -134,7 +134,7 @@ TEST_F(DBOptionsTest, SetBytesPerSync) {
   const std::string kValue(kValueSize, 'v');
   ASSERT_EQ(options.bytes_per_sync, dbfull()->GetDBOptions().bytes_per_sync);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "WritableFileWriter::RangeSync:0", [&](void* arg) {
+      "WritableFileWriter::RangeSync:0", [&](void* /*arg*/) {
         counter++;
       });
 
@@ -183,7 +183,7 @@ TEST_F(DBOptionsTest, SetWalBytesPerSync) {
   int counter = 0;
   int low_bytes_per_sync = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "WritableFileWriter::RangeSync:0", [&](void* arg) {
+      "WritableFileWriter::RangeSync:0", [&](void* /*arg*/) {
         counter++;
       });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -685,7 +685,7 @@ TEST_F(DBSSTTest, CancellingManualCompactionsWorks) {
   sfm->SetMaxAllowedSpaceUsage(0);
   int completed_compactions = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "CompactFilesImpl:End", [&](void* arg) { completed_compactions++; });
+      "CompactFilesImpl:End", [&](void* /*arg*/) { completed_compactions++; });
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   dbfull()->CompactFiles(rocksdb::CompactionOptions(), l0_files, 0);

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -262,11 +262,11 @@ TEST_F(DBSSTTest, DBWithSstFileManager) {
   int files_deleted = 0;
   int files_moved = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "SstFileManagerImpl::OnAddFile", [&](void* arg) { files_added++; });
+      "SstFileManagerImpl::OnAddFile", [&](void* /*arg*/) { files_added++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "SstFileManagerImpl::OnDeleteFile", [&](void* arg) { files_deleted++; });
+      "SstFileManagerImpl::OnDeleteFile", [&](void* /*arg*/) { files_deleted++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "SstFileManagerImpl::OnMoveFile", [&](void* arg) { files_moved++; });
+      "SstFileManagerImpl::OnMoveFile", [&](void* /*arg*/) { files_moved++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -439,12 +439,12 @@ TEST_F(DBSSTTest, DeleteSchedulerMultipleDBPaths) {
   int bg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   // The deletion scheduler sometimes skips marking file as trash according to
   // a heuristic. In that case the deletion will go through the below SyncPoint.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Options options = CurrentOptions();
@@ -514,7 +514,7 @@ TEST_F(DBSSTTest, DestroyDBWithRateLimitedDelete) {
   int bg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Status s;
@@ -588,13 +588,13 @@ TEST_F(DBSSTTest, CancellingCompactionsWorks) {
 
   int completed_compactions = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction():CancelledCompaction", [&](void* arg) {
+      "DBImpl::BackgroundCompaction():CancelledCompaction", [&](void* /*arg*/) {
         sfm->SetMaxAllowedSpaceUsage(0);
         ASSERT_EQ(sfm->GetCompactionsReservedSize(), 0);
       });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial:AfterRun",
-      [&](void* arg) { completed_compactions++; });
+      [&](void* /*arg*/) { completed_compactions++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Random rnd(301);
@@ -733,7 +733,7 @@ TEST_F(DBSSTTest, DBWithMaxSpaceAllowedRandomized) {
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "CompactionJob::FinishCompactionOutputFile:MaxAllowedSpaceReached",
-      [&](void* arg) {
+      [&](void* /*arg*/) {
         bg_error_set = true;
         GetAllSSTFiles(&total_sst_files_size);
         reached_max_space_on_compaction++;

--- a/db/db_tailing_iter_test.cc
+++ b/db/db_tailing_iter_test.cc
@@ -157,10 +157,10 @@ TEST_F(DBTestTailingIterator, TailingIteratorTrimSeekToNext) {
       });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "ForwardIterator::RenewIterators:Null",
-      [&](void* arg) { file_iters_renewed_null = true; });
+      [&](void* /*arg*/) { file_iters_renewed_null = true; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "ForwardIterator::RenewIterators:Copy",
-      [&](void* arg) { file_iters_renewed_copy = true; });
+      [&](void* /*arg*/) { file_iters_renewed_copy = true; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   const int num_records = 1000;
   for (int i = 1; i < num_records; ++i) {
@@ -415,7 +415,7 @@ TEST_F(DBTestTailingIterator, TailingIteratorUpperBound) {
   int immutable_seeks = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "ForwardIterator::SeekInternal:Immutable",
-      [&](void* arg) { ++immutable_seeks; });
+      [&](void* /*arg*/) { ++immutable_seeks; });
 
   // Seek to 13. This should not require any immutable seeks.
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -234,11 +234,11 @@ TEST_F(DBTest, SkipDelay) {
       std::atomic<int> sleep_count(0);
       rocksdb::SyncPoint::GetInstance()->SetCallBack(
           "DBImpl::DelayWrite:Sleep",
-          [&](void* arg) { sleep_count.fetch_add(1); });
+          [&](void* /*arg*/) { sleep_count.fetch_add(1); });
       std::atomic<int> wait_count(0);
       rocksdb::SyncPoint::GetInstance()->SetCallBack(
           "DBImpl::DelayWrite:Wait",
-          [&](void* arg) { wait_count.fetch_add(1); });
+          [&](void* /*arg*/) { wait_count.fetch_add(1); });
       rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
       WriteOptions wo;
@@ -3491,7 +3491,7 @@ TEST_F(DBTest, DynamicMemtableOptions) {
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DelayWrite:Wait",
-      [&](void* arg) { sleeping_task_low.WakeUp(); });
+      [&](void* /*arg*/) { sleeping_task_low.WakeUp(); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   while (!sleeping_task_low.WokenUp() && count < 256) {
@@ -5194,7 +5194,7 @@ TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
   std::atomic<int> callback_count(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::MaybeScheduleFlushOrCompaction:Conflict",
-      [&](void* arg) { callback_count.fetch_add(1); });
+      [&](void* /*arg*/) { callback_count.fetch_add(1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Random rnd(301);
@@ -5417,7 +5417,7 @@ TEST_F(DBTest, HardLimit) {
 
   std::atomic<int> callback_count(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack("DBImpl::DelayWrite:Wait",
-                                                 [&](void* arg) {
+                                                 [&](void* /*arg*/) {
                                                    callback_count.fetch_add(1);
                                                    sleeping_task_low.WakeUp();
                                                  });
@@ -5554,7 +5554,7 @@ TEST_F(DBTest, SoftLimit) {
 
   // Only allow one compactin going through.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "BackgroundCallCompaction:0", [&](void* arg) {
+      "BackgroundCallCompaction:0", [&](void* /*arg*/) {
         // Schedule a sleeping task.
         sleeping_task_low.Reset();
         env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1691,7 +1691,7 @@ TEST_F(DBTest2, SyncPointMarker) {
   std::atomic<int> sync_point_called(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBTest2::MarkedPoint",
-      [&](void* arg) { sync_point_called.fetch_add(1); });
+      [&](void* /*arg*/) { sync_point_called.fetch_add(1); });
 
   // The first dependency enforces Marker can be loaded before MarkedPoint.
   // The second checks that thread 1's MarkedPoint should be disabled here.
@@ -1978,7 +1978,7 @@ TEST_F(DBTest2, AutomaticCompactionOverlapManualCompaction) {
   // can fit in L2, these 2 files will be moved to L2 and overlap with
   // the running compaction and break the LSM consistency.
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "CompactionJob::Run():Start", [&](void* arg) {
+      "CompactionJob::Run():Start", [&](void* /*arg*/) {
         ASSERT_OK(
             dbfull()->SetOptions({{"level0_file_num_compaction_trigger", "2"},
                                   {"max_bytes_for_level_base", "1"}}));
@@ -2044,7 +2044,7 @@ TEST_F(DBTest2, ManualCompactionOverlapManualCompaction) {
   // the running compaction and break the LSM consistency.
   std::atomic<bool> flag(false);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "CompactionJob::Run():Start", [&](void* arg) {
+      "CompactionJob::Run():Start", [&](void* /*arg*/) {
         if (flag.exchange(true)) {
           // We want to make sure to call this callback only once
           return;
@@ -2478,7 +2478,7 @@ TEST_F(DBTest2, LiveFilesOmitObsoleteFiles) {
   });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::PurgeObsoleteFiles:Begin",
-      [&](void* arg) { env_->SleepForMicroseconds(1000000); });
+      [&](void* /*arg*/) { env_->SleepForMicroseconds(1000000); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   Put("key", "val");

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -697,7 +697,7 @@ TEST_P(DBTestUniversalCompactionMultiLevels, UniversalCompactionTrivialMove) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial", [&](void* arg) {
         non_trivial_move++;
@@ -769,7 +769,7 @@ TEST_P(DBTestUniversalCompactionParallel, UniversalCompactionParallel) {
   std::atomic<int> num_compactions_running(0);
   std::atomic<bool> has_parallel(false);
   rocksdb::SyncPoint::GetInstance()->SetCallBack("CompactionJob::Run():Start",
-                                                 [&](void* arg) {
+                                                 [&](void* /*arg*/) {
     if (num_compactions_running.fetch_add(1) > 0) {
       has_parallel.store(true);
       return;
@@ -784,7 +784,7 @@ TEST_P(DBTestUniversalCompactionParallel, UniversalCompactionParallel) {
   });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "CompactionJob::Run():End",
-      [&](void* arg) { num_compactions_running.fetch_add(-1); });
+      [&](void* /*arg*/) { num_compactions_running.fetch_add(-1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   options = CurrentOptions(options);
@@ -1154,7 +1154,7 @@ TEST_P(DBTestUniversalCompaction, UniversalCompactionTrivialMoveTest1) {
   int32_t non_trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial", [&](void* arg) {
         non_trivial_move++;
@@ -1200,7 +1200,7 @@ TEST_P(DBTestUniversalCompaction, UniversalCompactionTrivialMoveTest2) {
   int32_t trivial_move = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:TrivialMove",
-      [&](void* arg) { trivial_move++; });
+      [&](void* /*arg*/) { trivial_move++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:NonTrivial", [&](void* arg) {
         ASSERT_TRUE(arg != nullptr);
@@ -1698,7 +1698,7 @@ TEST_P(DBTestUniversalCompaction, FullCompactionInBottomPriThreadPool) {
     int num_bottom_pri_compactions = 0;
     SyncPoint::GetInstance()->SetCallBack(
         "DBImpl::BGWorkBottomCompaction",
-        [&](void* arg) { ++num_bottom_pri_compactions; });
+        [&](void* /*arg*/) { ++num_bottom_pri_compactions; });
     SyncPoint::GetInstance()->EnableProcessing();
 
     Random rnd(301);
@@ -1796,7 +1796,7 @@ TEST_P(DBTestUniversalCompaction, RecalculateScoreAfterPicking) {
 
   std::atomic<int> num_compactions_attempted(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCompaction:Start", [&](void* arg) {
+      "DBImpl::BackgroundCompaction:Start", [&](void* /*arg*/) {
         ++num_compactions_attempted;
       });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();

--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -8,7 +8,7 @@
 namespace rocksdb {
 
 namespace {
-template<class T>
+template <class T>
 inline T SafeDivide(T a, T b) {
   return b == 0 ? 0 : a / b;
 }
@@ -17,7 +17,8 @@ inline T SafeDivide(T a, T b) {
 void EventHelpers::AppendCurrentTime(JSONWriter* jwriter) {
   *jwriter << "time_micros"
            << std::chrono::duration_cast<std::chrono::microseconds>(
-                  std::chrono::system_clock::now().time_since_epoch()).count();
+                  std::chrono::system_clock::now().time_since_epoch())
+                  .count();
 }
 
 #ifndef ROCKSDB_LITE
@@ -52,6 +53,11 @@ void EventHelpers::NotifyOnBackgroundError(
     listener->OnBackgroundError(reason, bg_error);
   }
   db_mutex->Lock();
+#else
+  (void)listeners;
+  (void)reason;
+  (void)bg_error;
+  (void)db_mutex;
 #endif  // ROCKSDB_LITE
 }
 
@@ -117,20 +123,25 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
   for (auto& listener : listeners) {
     listener->OnTableFileCreated(info);
   }
+#else
+  (void)listeners;
+  (void)db_name;
+  (void)cf_name;
+  (void)file_path;
+  (void)reason;
 #endif  // !ROCKSDB_LITE
 }
 
 void EventHelpers::LogAndNotifyTableFileDeletion(
-    EventLogger* event_logger, int job_id,
-    uint64_t file_number, const std::string& file_path,
-    const Status& status, const std::string& dbname,
+    EventLogger* event_logger, int job_id, uint64_t file_number,
+    const std::string& file_path, const Status& status,
+    const std::string& dbname,
     const std::vector<std::shared_ptr<EventListener>>& listeners) {
-
   JSONWriter jwriter;
   AppendCurrentTime(&jwriter);
 
-  jwriter << "job" << job_id
-          << "event" << "table_file_deletion"
+  jwriter << "job" << job_id << "event"
+          << "table_file_deletion"
           << "file_number" << file_number;
   if (!status.ok()) {
     jwriter << "status" << status.ToString();
@@ -149,6 +160,10 @@ void EventHelpers::LogAndNotifyTableFileDeletion(
   for (auto& listener : listeners) {
     listener->OnTableFileDeleted(info);
   }
+#else
+  (void)file_path;
+  (void)dbname;
+  (void)listeners;
 #endif  // !ROCKSDB_LITE
 }
 

--- a/db/experimental.cc
+++ b/db/experimental.cc
@@ -30,12 +30,13 @@ Status PromoteL0(DB* db, ColumnFamilyHandle* column_family, int target_level) {
 
 #else  // ROCKSDB_LITE
 
-Status SuggestCompactRange(DB* db, ColumnFamilyHandle* column_family,
-                           const Slice* begin, const Slice* end) {
+Status SuggestCompactRange(DB* /*db*/, ColumnFamilyHandle* /*column_family*/,
+                           const Slice* /*begin*/, const Slice* /*end*/) {
   return Status::NotSupported("Not supported in RocksDB LITE");
 }
 
-Status PromoteL0(DB* db, ColumnFamilyHandle* column_family, int target_level) {
+Status PromoteL0(DB* /*db*/, ColumnFamilyHandle* /*column_family*/,
+                 int /*target_level*/) {
   return Status::NotSupported("Not supported in RocksDB LITE");
 }
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -689,7 +689,7 @@ TEST_F(ExternalSSTFileTest, PurgeObsoleteFilesBug) {
   DestroyAndReopen(options);
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::AddFile:FileCopied", [&](void* arg) {
+      "DBImpl::AddFile:FileCopied", [&](void* /*arg*/) {
         ASSERT_OK(Put("aaa", "bbb"));
         ASSERT_OK(Flush());
         ASSERT_OK(Put("aaa", "xxx"));
@@ -1128,7 +1128,7 @@ TEST_F(ExternalSSTFileTest, PickedLevelBug) {
   std::atomic<bool> bg_compact_started(false);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BackgroundCompaction:Start",
-      [&](void* arg) { bg_compact_started.store(true); });
+      [&](void* /*arg*/) { bg_compact_started.store(true); });
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
@@ -1409,7 +1409,7 @@ TEST_F(ExternalSSTFileTest, AddFileTrivialMoveBug) {
   ASSERT_OK(GenerateAndAddExternalFile(options, {22, 23}, 6));  // L2
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "CompactionJob::Run():Start", [&](void* arg) {
+      "CompactionJob::Run():Start", [&](void* /*arg*/) {
         // fit in L3 but will overlap with compaction so will be added
         // to L2 but a compaction will trivially move it to L3
         // and break LSM consistency

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -456,10 +456,10 @@ TEST_P(FaultInjectionTest, UninstalledCompaction) {
 
   std::atomic<bool> opened(false);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::Open:Opened", [&](void* arg) { opened.store(true); });
+      "DBImpl::Open:Opened", [&](void* /*arg*/) { opened.store(true); });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::BGWorkCompaction",
-      [&](void* arg) { ASSERT_TRUE(opened.load()); });
+      [&](void* /*arg*/) { ASSERT_TRUE(opened.load()); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(OpenDB());
   ASSERT_OK(Verify(0, kNumKeys, FaultInjectionTest::kValExpectFound));

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -86,8 +86,7 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
                        const InternalStats::CompactionStats& stats) {
   uint64_t bytes_read =
       stats.bytes_read_non_output_levels + stats.bytes_read_output_level;
-  int64_t bytes_new =
-      stats.bytes_written - stats.bytes_read_output_level;
+  int64_t bytes_new = stats.bytes_written - stats.bytes_read_output_level;
   double elapsed = (stats.micros + 1) / kMicrosInSec;
 
   (*level_stats)[LevelStatType::NUM_FILES] = num_files;
@@ -117,50 +116,50 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
 
 void PrintLevelStats(char* buf, size_t len, const std::string& name,
                      const std::map<LevelStatType, double>& stat_value) {
-  snprintf(buf, len,
-           "%4s "      /*  Level */
-           "%6d/%-3d " /*  Files */
-           "%8s "      /*  Size */
-           "%5.1f "    /*  Score */
-           "%8.1f "    /*  Read(GB) */
-           "%7.1f "    /*  Rn(GB) */
-           "%8.1f "    /*  Rnp1(GB) */
-           "%9.1f "    /*  Write(GB) */
-           "%8.1f "    /*  Wnew(GB) */
-           "%9.1f "    /*  Moved(GB) */
-           "%5.1f "    /*  W-Amp */
-           "%8.1f "    /*  Rd(MB/s) */
-           "%8.1f "    /*  Wr(MB/s) */
-           "%9.0f "    /*  Comp(sec) */
-           "%9d "      /*  Comp(cnt) */
-           "%8.3f "    /*  Avg(sec) */
-           "%7s "      /*  KeyIn */
-           "%6s\n",    /*  KeyDrop */
-           name.c_str(),
-           static_cast<int>(stat_value.at(LevelStatType::NUM_FILES)),
-           static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES)),
-           BytesToHumanString(
-               static_cast<uint64_t>(stat_value.at(LevelStatType::SIZE_BYTES)))
-               .c_str(),
-           stat_value.at(LevelStatType::SCORE),
-           stat_value.at(LevelStatType::READ_GB),
-           stat_value.at(LevelStatType::RN_GB),
-           stat_value.at(LevelStatType::RNP1_GB),
-           stat_value.at(LevelStatType::WRITE_GB),
-           stat_value.at(LevelStatType::W_NEW_GB),
-           stat_value.at(LevelStatType::MOVED_GB),
-           stat_value.at(LevelStatType::WRITE_AMP),
-           stat_value.at(LevelStatType::READ_MBPS),
-           stat_value.at(LevelStatType::WRITE_MBPS),
-           stat_value.at(LevelStatType::COMP_SEC),
-           static_cast<int>(stat_value.at(LevelStatType::COMP_COUNT)),
-           stat_value.at(LevelStatType::AVG_SEC),
-           NumberToHumanString(
-               static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_IN)))
-               .c_str(),
-           NumberToHumanString(static_cast<std::int64_t>(
-                                   stat_value.at(LevelStatType::KEY_DROP)))
-               .c_str());
+  snprintf(
+      buf, len,
+      "%4s "      /*  Level */
+      "%6d/%-3d " /*  Files */
+      "%8s "      /*  Size */
+      "%5.1f "    /*  Score */
+      "%8.1f "    /*  Read(GB) */
+      "%7.1f "    /*  Rn(GB) */
+      "%8.1f "    /*  Rnp1(GB) */
+      "%9.1f "    /*  Write(GB) */
+      "%8.1f "    /*  Wnew(GB) */
+      "%9.1f "    /*  Moved(GB) */
+      "%5.1f "    /*  W-Amp */
+      "%8.1f "    /*  Rd(MB/s) */
+      "%8.1f "    /*  Wr(MB/s) */
+      "%9.0f "    /*  Comp(sec) */
+      "%9d "      /*  Comp(cnt) */
+      "%8.3f "    /*  Avg(sec) */
+      "%7s "      /*  KeyIn */
+      "%6s\n",    /*  KeyDrop */
+      name.c_str(), static_cast<int>(stat_value.at(LevelStatType::NUM_FILES)),
+      static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES)),
+      BytesToHumanString(
+          static_cast<uint64_t>(stat_value.at(LevelStatType::SIZE_BYTES)))
+          .c_str(),
+      stat_value.at(LevelStatType::SCORE),
+      stat_value.at(LevelStatType::READ_GB),
+      stat_value.at(LevelStatType::RN_GB),
+      stat_value.at(LevelStatType::RNP1_GB),
+      stat_value.at(LevelStatType::WRITE_GB),
+      stat_value.at(LevelStatType::W_NEW_GB),
+      stat_value.at(LevelStatType::MOVED_GB),
+      stat_value.at(LevelStatType::WRITE_AMP),
+      stat_value.at(LevelStatType::READ_MBPS),
+      stat_value.at(LevelStatType::WRITE_MBPS),
+      stat_value.at(LevelStatType::COMP_SEC),
+      static_cast<int>(stat_value.at(LevelStatType::COMP_COUNT)),
+      stat_value.at(LevelStatType::AVG_SEC),
+      NumberToHumanString(
+          static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_IN)))
+          .c_str(),
+      NumberToHumanString(
+          static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_DROP)))
+          .c_str());
 }
 
 void PrintLevelStats(char* buf, size_t len, const std::string& name,
@@ -208,22 +207,22 @@ static const std::string mem_table_flush_pending = "mem-table-flush-pending";
 static const std::string compaction_pending = "compaction-pending";
 static const std::string background_errors = "background-errors";
 static const std::string cur_size_active_mem_table =
-                          "cur-size-active-mem-table";
+    "cur-size-active-mem-table";
 static const std::string cur_size_all_mem_tables = "cur-size-all-mem-tables";
 static const std::string size_all_mem_tables = "size-all-mem-tables";
 static const std::string num_entries_active_mem_table =
-                          "num-entries-active-mem-table";
+    "num-entries-active-mem-table";
 static const std::string num_entries_imm_mem_tables =
-                          "num-entries-imm-mem-tables";
+    "num-entries-imm-mem-tables";
 static const std::string num_deletes_active_mem_table =
-                          "num-deletes-active-mem-table";
+    "num-deletes-active-mem-table";
 static const std::string num_deletes_imm_mem_tables =
-                          "num-deletes-imm-mem-tables";
+    "num-deletes-imm-mem-tables";
 static const std::string estimate_num_keys = "estimate-num-keys";
 static const std::string estimate_table_readers_mem =
-                          "estimate-table-readers-mem";
+    "estimate-table-readers-mem";
 static const std::string is_file_deletions_enabled =
-                          "is-file-deletions-enabled";
+    "is-file-deletions-enabled";
 static const std::string num_snapshots = "num-snapshots";
 static const std::string oldest_snapshot_time = "oldest-snapshot-time";
 static const std::string num_live_versions = "num-live-versions";
@@ -248,9 +247,9 @@ static const std::string is_write_stopped = "is-write-stopped";
 static const std::string estimate_oldest_key_time = "estimate-oldest-key-time";
 
 const std::string DB::Properties::kNumFilesAtLevelPrefix =
-                      rocksdb_prefix + num_files_at_level_prefix;
+    rocksdb_prefix + num_files_at_level_prefix;
 const std::string DB::Properties::kCompressionRatioAtLevelPrefix =
-                      rocksdb_prefix + compression_ratio_at_level_prefix;
+    rocksdb_prefix + compression_ratio_at_level_prefix;
 const std::string DB::Properties::kStats = rocksdb_prefix + allstats;
 const std::string DB::Properties::kSSTables = rocksdb_prefix + sstables;
 const std::string DB::Properties::kCFStats = rocksdb_prefix + cfstats;
@@ -261,53 +260,53 @@ const std::string DB::Properties::kCFFileHistogram =
 const std::string DB::Properties::kDBStats = rocksdb_prefix + dbstats;
 const std::string DB::Properties::kLevelStats = rocksdb_prefix + levelstats;
 const std::string DB::Properties::kNumImmutableMemTable =
-                      rocksdb_prefix + num_immutable_mem_table;
+    rocksdb_prefix + num_immutable_mem_table;
 const std::string DB::Properties::kNumImmutableMemTableFlushed =
     rocksdb_prefix + num_immutable_mem_table_flushed;
 const std::string DB::Properties::kMemTableFlushPending =
-                      rocksdb_prefix + mem_table_flush_pending;
+    rocksdb_prefix + mem_table_flush_pending;
 const std::string DB::Properties::kCompactionPending =
-                      rocksdb_prefix + compaction_pending;
+    rocksdb_prefix + compaction_pending;
 const std::string DB::Properties::kNumRunningCompactions =
     rocksdb_prefix + num_running_compactions;
 const std::string DB::Properties::kNumRunningFlushes =
     rocksdb_prefix + num_running_flushes;
 const std::string DB::Properties::kBackgroundErrors =
-                      rocksdb_prefix + background_errors;
+    rocksdb_prefix + background_errors;
 const std::string DB::Properties::kCurSizeActiveMemTable =
-                      rocksdb_prefix + cur_size_active_mem_table;
+    rocksdb_prefix + cur_size_active_mem_table;
 const std::string DB::Properties::kCurSizeAllMemTables =
     rocksdb_prefix + cur_size_all_mem_tables;
 const std::string DB::Properties::kSizeAllMemTables =
     rocksdb_prefix + size_all_mem_tables;
 const std::string DB::Properties::kNumEntriesActiveMemTable =
-                      rocksdb_prefix + num_entries_active_mem_table;
+    rocksdb_prefix + num_entries_active_mem_table;
 const std::string DB::Properties::kNumEntriesImmMemTables =
-                      rocksdb_prefix + num_entries_imm_mem_tables;
+    rocksdb_prefix + num_entries_imm_mem_tables;
 const std::string DB::Properties::kNumDeletesActiveMemTable =
-                      rocksdb_prefix + num_deletes_active_mem_table;
+    rocksdb_prefix + num_deletes_active_mem_table;
 const std::string DB::Properties::kNumDeletesImmMemTables =
-                      rocksdb_prefix + num_deletes_imm_mem_tables;
+    rocksdb_prefix + num_deletes_imm_mem_tables;
 const std::string DB::Properties::kEstimateNumKeys =
-                      rocksdb_prefix + estimate_num_keys;
+    rocksdb_prefix + estimate_num_keys;
 const std::string DB::Properties::kEstimateTableReadersMem =
-                      rocksdb_prefix + estimate_table_readers_mem;
+    rocksdb_prefix + estimate_table_readers_mem;
 const std::string DB::Properties::kIsFileDeletionsEnabled =
-                      rocksdb_prefix + is_file_deletions_enabled;
+    rocksdb_prefix + is_file_deletions_enabled;
 const std::string DB::Properties::kNumSnapshots =
-                      rocksdb_prefix + num_snapshots;
+    rocksdb_prefix + num_snapshots;
 const std::string DB::Properties::kOldestSnapshotTime =
-                      rocksdb_prefix + oldest_snapshot_time;
+    rocksdb_prefix + oldest_snapshot_time;
 const std::string DB::Properties::kNumLiveVersions =
-                      rocksdb_prefix + num_live_versions;
+    rocksdb_prefix + num_live_versions;
 const std::string DB::Properties::kCurrentSuperVersionNumber =
     rocksdb_prefix + current_version_number;
 const std::string DB::Properties::kEstimateLiveDataSize =
-                      rocksdb_prefix + estimate_live_data_size;
+    rocksdb_prefix + estimate_live_data_size;
 const std::string DB::Properties::kMinLogNumberToKeep =
     rocksdb_prefix + min_log_number_to_keep;
 const std::string DB::Properties::kTotalSstFilesSize =
-                      rocksdb_prefix + total_sst_files_size;
+    rocksdb_prefix + total_sst_files_size;
 const std::string DB::Properties::kLiveSstFilesSize =
     rocksdb_prefix + live_sst_files_size;
 const std::string DB::Properties::kBaseLevel = rocksdb_prefix + base_level;
@@ -882,8 +881,7 @@ void InternalStats::DumpDBStats(std::string* value) {
   value->append(buf);
   // Stall
   AppendHumanMicros(write_stall_micros, human_micros, kHumanMicrosLen, true);
-  snprintf(buf, sizeof(buf),
-           "Cumulative stall: %s, %.1f percent\n",
+  snprintf(buf, sizeof(buf), "Cumulative stall: %s, %.1f percent\n",
            human_micros,
            // 10000 = divide by 1M to get secs, then multiply by 100 for pct
            write_stall_micros / 10000.0 / std::max(seconds_up, 0.001));
@@ -894,43 +892,40 @@ void InternalStats::DumpDBStats(std::string* value) {
   uint64_t interval_write_self = write_self - db_stats_snapshot_.write_self;
   uint64_t interval_num_keys_written =
       num_keys_written - db_stats_snapshot_.num_keys_written;
-  snprintf(buf, sizeof(buf),
-           "Interval writes: %s writes, %s keys, %s commit groups, "
-           "%.1f writes per commit group, ingest: %.2f MB, %.2f MB/s\n",
-           NumberToHumanString(
-               interval_write_other + interval_write_self).c_str(),
-           NumberToHumanString(interval_num_keys_written).c_str(),
-           NumberToHumanString(interval_write_self).c_str(),
-           static_cast<double>(interval_write_other + interval_write_self) /
-               (interval_write_self + 1),
-           (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB,
-           (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB /
-               std::max(interval_seconds_up, 0.001)),
-  value->append(buf);
+  snprintf(
+      buf, sizeof(buf),
+      "Interval writes: %s writes, %s keys, %s commit groups, "
+      "%.1f writes per commit group, ingest: %.2f MB, %.2f MB/s\n",
+      NumberToHumanString(interval_write_other + interval_write_self).c_str(),
+      NumberToHumanString(interval_num_keys_written).c_str(),
+      NumberToHumanString(interval_write_self).c_str(),
+      static_cast<double>(interval_write_other + interval_write_self) /
+          (interval_write_self + 1),
+      (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB,
+      (user_bytes_written - db_stats_snapshot_.ingest_bytes) / kMB /
+          std::max(interval_seconds_up, 0.001)),
+      value->append(buf);
 
   uint64_t interval_write_with_wal =
       write_with_wal - db_stats_snapshot_.write_with_wal;
   uint64_t interval_wal_synced = wal_synced - db_stats_snapshot_.wal_synced;
   uint64_t interval_wal_bytes = wal_bytes - db_stats_snapshot_.wal_bytes;
 
-  snprintf(buf, sizeof(buf),
-           "Interval WAL: %s writes, %s syncs, "
-           "%.2f writes per sync, written: %.2f MB, %.2f MB/s\n",
-           NumberToHumanString(interval_write_with_wal).c_str(),
-           NumberToHumanString(interval_wal_synced).c_str(),
-           interval_write_with_wal /
-              static_cast<double>(interval_wal_synced + 1),
-           interval_wal_bytes / kGB,
-           interval_wal_bytes / kMB / std::max(interval_seconds_up, 0.001));
+  snprintf(
+      buf, sizeof(buf),
+      "Interval WAL: %s writes, %s syncs, "
+      "%.2f writes per sync, written: %.2f MB, %.2f MB/s\n",
+      NumberToHumanString(interval_write_with_wal).c_str(),
+      NumberToHumanString(interval_wal_synced).c_str(),
+      interval_write_with_wal / static_cast<double>(interval_wal_synced + 1),
+      interval_wal_bytes / kGB,
+      interval_wal_bytes / kMB / std::max(interval_seconds_up, 0.001));
   value->append(buf);
 
   // Stall
-  AppendHumanMicros(
-      write_stall_micros - db_stats_snapshot_.write_stall_micros,
-      human_micros, kHumanMicrosLen, true);
-  snprintf(buf, sizeof(buf),
-           "Interval stall: %s, %.1f percent\n",
-           human_micros,
+  AppendHumanMicros(write_stall_micros - db_stats_snapshot_.write_stall_micros,
+                    human_micros, kHumanMicrosLen, true);
+  snprintf(buf, sizeof(buf), "Interval stall: %s, %.1f percent\n", human_micros,
            // 10000 = divide by 1M to get secs, then multiply by 100 for pct
            (write_stall_micros - db_stats_snapshot_.write_stall_micros) /
                10000.0 / std::max(interval_seconds_up, 0.001));
@@ -956,7 +951,7 @@ void InternalStats::DumpDBStats(std::string* value) {
  * and values represent uint64 encoded as strings.
  */
 void InternalStats::DumpCFMapStats(
-        std::map<std::string, std::string>* cf_stats) {
+    std::map<std::string, std::string>* cf_stats) {
   CompactionStats compaction_stats_sum;
   std::map<int, std::map<LevelStatType, double>> levels_stats;
   DumpCFMapStats(&levels_stats, &compaction_stats_sum);
@@ -1143,8 +1138,9 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
 
   uint64_t interval_ingest_files_addfile =
       ingest_files_addfile - cf_stats_snapshot_.ingest_files_addfile;
-  snprintf(buf, sizeof(buf), "AddFile(Total Files): cumulative %" PRIu64
-                             ", interval %" PRIu64 "\n",
+  snprintf(buf, sizeof(buf),
+           "AddFile(Total Files): cumulative %" PRIu64 ", interval %" PRIu64
+           "\n",
            ingest_files_addfile, interval_ingest_files_addfile);
   value->append(buf);
 
@@ -1262,7 +1258,9 @@ void InternalStats::DumpCFFileHistogram(std::string* value) {
 
 #else
 
-const DBPropertyInfo* GetPropertyInfo(const Slice& property) { return nullptr; }
+const DBPropertyInfo* GetPropertyInfo(const Slice& /*property*/) {
+  return nullptr;
+}
 
 #endif  // !ROCKSDB_LITE
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -580,7 +580,7 @@ class InternalStats {
     INTERNAL_DB_STATS_ENUM_MAX,
   };
 
-  InternalStats(int num_levels, Env* env, ColumnFamilyData* cfd) {}
+  InternalStats(int /*num_levels*/, Env* /*env*/, ColumnFamilyData* /*cfd*/) {}
 
   struct CompactionStats {
     uint64_t micros;
@@ -597,48 +597,48 @@ class InternalStats {
 
     explicit CompactionStats() {}
 
-    explicit CompactionStats(CompactionReason reason, int c) {}
+    explicit CompactionStats(CompactionReason reason, int /*c*/) {}
 
-    explicit CompactionStats(const CompactionStats& c) {}
+    explicit CompactionStats(const CompactionStats& /*c*/) {}
 
-    void Add(const CompactionStats& c) {}
+    void Add(const CompactionStats& /*c*/) {}
 
-    void Subtract(const CompactionStats& c) {}
+    void Subtract(const CompactionStats& /*c*/) {}
   };
 
-  void AddCompactionStats(int level, const CompactionStats& stats) {}
+  void AddCompactionStats(int /*level*/, const CompactionStats& /*stats*/) {}
 
-  void IncBytesMoved(int level, uint64_t amount) {}
+  void IncBytesMoved(int /*level*/, uint64_t /*amount*/) {}
 
-  void AddCFStats(InternalCFStatsType type, uint64_t value) {}
+  void AddCFStats(InternalCFStatsType /*type*/, uint64_t /*value*/) {}
 
-  void AddDBStats(InternalDBStatsType type, uint64_t value,
-                  bool concurrent = false) {}
+  void AddDBStats(InternalDBStatsType /*type*/, uint64_t /*value*/,
+                  bool /*concurrent */ = false) {}
 
-  HistogramImpl* GetFileReadHist(int level) { return nullptr; }
+  HistogramImpl* GetFileReadHist(int /*level*/) { return nullptr; }
 
   uint64_t GetBackgroundErrorCount() const { return 0; }
 
   uint64_t BumpAndGetBackgroundErrorCount() { return 0; }
 
-  bool GetStringProperty(const DBPropertyInfo& property_info,
-                         const Slice& property, std::string* value) {
+  bool GetStringProperty(const DBPropertyInfo& /*property_info*/,
+                         const Slice& /*property*/, std::string* /*value*/) {
     return false;
   }
 
-  bool GetMapProperty(const DBPropertyInfo& property_info,
-                      const Slice& property,
-                      std::map<std::string, std::string>* value) {
+  bool GetMapProperty(const DBPropertyInfo& /*property_info*/,
+                      const Slice& /*property*/,
+                      std::map<std::string, std::string>* /*value*/) {
     return false;
   }
 
-  bool GetIntProperty(const DBPropertyInfo& property_info, uint64_t* value,
-                      DBImpl* db) const {
+  bool GetIntProperty(const DBPropertyInfo& /*property_info*/, uint64_t* /*value*/,
+                      DBImpl* /*db*/) const {
     return false;
   }
 
-  bool GetIntPropertyOutOfMutex(const DBPropertyInfo& property_info,
-                                Version* version, uint64_t* value) const {
+  bool GetIntPropertyOutOfMutex(const DBPropertyInfo& /*property_info*/,
+                                Version* /*version*/, uint64_t* /*value*/) const {
     return false;
   }
 };

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -597,7 +597,7 @@ class InternalStats {
 
     explicit CompactionStats() {}
 
-    explicit CompactionStats(CompactionReason reason, int /*c*/) {}
+    explicit CompactionStats(CompactionReason /*reason*/, int /*c*/) {}
 
     explicit CompactionStats(const CompactionStats& /*c*/) {}
 

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -52,6 +52,11 @@ struct SuperVersionContext {
     notif.write_stall_info.condition.cur = new_cond;
     notif.immutable_cf_options = ioptions;
     write_stall_notifications.push_back(notif);
+#else
+    (void)old_cond;
+    (void)new_cond;
+    (void)name;
+    (void)ioptions;
 #endif  // !ROCKSDB_LITE
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -135,6 +135,9 @@ class FilePicker {
         file_indexer_(file_indexer),
         user_comparator_(user_comparator),
         internal_comparator_(internal_comparator) {
+#ifdef NDEBUG
+    (void)files;
+#endif
     // Setup member variables to search first level.
     search_ended_ = !PrepareNextLevel();
     if (!search_ended_) {
@@ -1764,6 +1767,8 @@ void VersionStorageInfo::AddFile(int level, FileMetaData* f, Logger* info_log) {
     }
     assert(false);
   }
+#else
+  (void)info_log;
 #endif
   f->refs++;
   level_files->push_back(f);
@@ -3028,6 +3033,9 @@ void VersionSet::LogAndApplyCFHelper(VersionEdit* edit) {
 void VersionSet::LogAndApplyHelper(ColumnFamilyData* cfd,
                                    VersionBuilder* builder, Version* /*v*/,
                                    VersionEdit* edit, InstrumentedMutex* mu) {
+#ifdef NDEBUG
+  (void)cfd;
+#endif
   mu->AssertHeld();
   assert(!edit->IsColumnFamilyManipulation());
 
@@ -4070,6 +4078,8 @@ bool VersionSet::VerifyCompactionFileConsistency(Compaction* c) {
       }
     }
   }
+#else
+  (void)c;
 #endif
   return true;     // everything good
 }

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1716,6 +1716,9 @@ Status WriteBatchInternal::InsertInto(
     ColumnFamilyMemTables* memtables, FlushScheduler* flush_scheduler,
     bool ignore_missing_column_families, uint64_t log_number, DB* db,
     bool concurrent_memtable_writes, bool seq_per_batch, size_t batch_cnt) {
+#ifdef NDEBUG
+  (void)batch_cnt;
+#endif
   assert(writer->ShouldWriteToMemtable());
   MemTableInserter inserter(sequence, memtables, flush_scheduler,
                             ignore_missing_column_families, log_number, db,

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -799,6 +799,8 @@ class PosixEnv : public Env {
     assert(pool >= Priority::BOTTOM && pool <= Priority::HIGH);
 #ifdef OS_LINUX
     thread_pools_[pool].LowerIOPriority();
+#else
+    (void)pool;
 #endif
   }
 

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -876,6 +876,7 @@ class PosixEnv : public Env {
         return false;
     }
 #else
+    (void)path;
     return false;
 #endif
   }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1523,7 +1523,7 @@ class TestEnv : public EnvWrapper {
         CloseHelper();
       }
     }
-    virtual void Logv(const char* format, va_list ap) override{};
+    virtual void Logv(const char* /*format*/, va_list /*ap*/) override{};
 
    protected:
     virtual Status CloseImpl() override { return CloseHelper(); }
@@ -1540,7 +1540,7 @@ class TestEnv : public EnvWrapper {
 
   int GetCloseCount() { return close_count; }
 
-  virtual Status NewLogger(const std::string& fname,
+  virtual Status NewLogger(const std::string& /*fname*/,
                            shared_ptr<Logger>* result) {
     result->reset(new TestLogger(this));
     return Status::OK();

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -48,6 +48,10 @@ int Fadvise(int fd, off_t offset, size_t len, int advice) {
 #ifdef OS_LINUX
   return posix_fadvise(fd, offset, len, advice);
 #else
+  (void)fd;
+  (void)offset;
+  (void)len;
+  (void)advice;
   return 0;  // simply do nothing.
 #endif
 }
@@ -227,6 +231,8 @@ Status PosixSequentialFile::Skip(uint64_t n) {
 
 Status PosixSequentialFile::InvalidateCache(size_t offset, size_t length) {
 #ifndef OS_LINUX
+  (void)offset;
+  (void)length;
   return Status::OK();
 #else
   if (!use_direct_io()) {
@@ -410,6 +416,8 @@ Status PosixRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
     return Status::OK();
   }
 #ifndef OS_LINUX
+  (void)offset;
+  (void)length;
   return Status::OK();
 #else
   // free OS pages
@@ -464,6 +472,8 @@ Status PosixMmapReadableFile::Read(uint64_t offset, size_t n, Slice* result,
 
 Status PosixMmapReadableFile::InvalidateCache(size_t offset, size_t length) {
 #ifndef OS_LINUX
+  (void)offset;
+  (void)length;
   return Status::OK();
 #else
   // free OS pages
@@ -672,6 +682,8 @@ uint64_t PosixMmapFile::GetFileSize() {
 
 Status PosixMmapFile::InvalidateCache(size_t offset, size_t length) {
 #ifndef OS_LINUX
+  (void)offset;
+  (void)length;
   return Status::OK();
 #else
   // free OS pages
@@ -874,6 +886,8 @@ void PosixWritableFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) {
     write_hint_ = hint;
   }
 #endif
+#else
+  (void)hint;
 #endif
 }
 
@@ -882,6 +896,8 @@ Status PosixWritableFile::InvalidateCache(size_t offset, size_t length) {
     return Status::OK();
   }
 #ifndef OS_LINUX
+  (void)offset;
+  (void)length;
   return Status::OK();
 #else
   // free OS pages

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -442,6 +442,9 @@ PosixMmapReadableFile::PosixMmapReadableFile(const int fd,
                                              void* base, size_t length,
                                              const EnvOptions& options)
     : fd_(fd), filename_(fname), mmapped_region_(base), length_(length) {
+#ifdef NDEBUG
+  (void)options;
+#endif
   fd_ = fd_ + 0;  // suppress the warning for used variables
   assert(options.use_mmap_reads);
   assert(!options.use_direct_reads);
@@ -582,6 +585,8 @@ PosixMmapFile::PosixMmapFile(const std::string& fname, int fd, size_t page_size,
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   allow_fallocate_ = options.allow_fallocate;
   fallocate_with_keep_size_ = options.fallocate_with_keep_size;
+#else
+  (void)options;
 #endif
   assert((page_size & (page_size - 1)) == 0);
   assert(options.use_mmap_writes);

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -72,9 +72,7 @@ class MemFile {
     }
   }
 
-  uint64_t Size() const {
-    return size_;
-  }
+  uint64_t Size() const { return size_; }
 
   void Truncate(size_t size) {
     MutexLock lock(&mutex_);
@@ -143,9 +141,7 @@ class MemFile {
     return Status::OK();
   }
 
-  uint64_t ModifiedTime() const {
-    return modified_time_;
-  }
+  uint64_t ModifiedTime() const { return modified_time_; }
 
  private:
   uint64_t Now() {
@@ -156,9 +152,7 @@ class MemFile {
   }
 
   // Private since only Unref() should be used to delete it.
-  ~MemFile() {
-    assert(refs_ == 0);
-  }
+  ~MemFile() { assert(refs_ == 0); }
 
   // No copying allowed.
   MemFile(const MemFile&);
@@ -189,9 +183,7 @@ class MockSequentialFile : public SequentialFile {
     file_->Ref();
   }
 
-  ~MockSequentialFile() {
-    file_->Unref();
-  }
+  ~MockSequentialFile() { file_->Unref(); }
 
   virtual Status Read(size_t n, Slice* result, char* scratch) override {
     Status s = file_->Read(pos_, n, result, scratch);
@@ -220,13 +212,9 @@ class MockSequentialFile : public SequentialFile {
 
 class MockRandomAccessFile : public RandomAccessFile {
  public:
-  explicit MockRandomAccessFile(MemFile* file) : file_(file) {
-    file_->Ref();
-  }
+  explicit MockRandomAccessFile(MemFile* file) : file_(file) { file_->Ref(); }
 
-  ~MockRandomAccessFile() {
-    file_->Unref();
-  }
+  ~MockRandomAccessFile() { file_->Unref(); }
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override {
@@ -265,14 +253,11 @@ class MockRandomRWFile : public RandomRWFile {
 class MockWritableFile : public WritableFile {
  public:
   MockWritableFile(MemFile* file, RateLimiter* rate_limiter)
-    : file_(file),
-      rate_limiter_(rate_limiter) {
+      : file_(file), rate_limiter_(rate_limiter) {
     file_->Ref();
   }
 
-  ~MockWritableFile() {
-    file_->Unref();
-  }
+  ~MockWritableFile() { file_->Unref(); }
 
   virtual Status Append(const Slice& data) override {
     size_t bytes_written = 0;
@@ -301,8 +286,8 @@ class MockWritableFile : public WritableFile {
  private:
   inline size_t RequestToken(size_t bytes) {
     if (rate_limiter_ && io_priority_ < Env::IO_TOTAL) {
-      bytes = std::min(bytes,
-          static_cast<size_t>(rate_limiter_->GetSingleBurstBytes()));
+      bytes = std::min(
+          bytes, static_cast<size_t>(rate_limiter_->GetSingleBurstBytes()));
       rate_limiter_->Request(bytes, io_priority_);
     }
     return bytes;
@@ -319,12 +304,9 @@ class MockEnvDirectory : public Directory {
 
 class MockEnvFileLock : public FileLock {
  public:
-  explicit MockEnvFileLock(const std::string& fname)
-    : fname_(fname) {}
+  explicit MockEnvFileLock(const std::string& fname) : fname_(fname) {}
 
-  std::string FileName() const {
-    return fname_;
-  }
+  std::string FileName() const { return fname_; }
 
  private:
   const std::string fname_;
@@ -348,8 +330,7 @@ class TestMemLogger : public Logger {
         last_flush_micros_(0),
         env_(env),
         flush_pending_(false) {}
-  virtual ~TestMemLogger() {
-  }
+  virtual ~TestMemLogger() {}
 
   virtual void Flush() override {
     if (flush_pending_) {
@@ -384,15 +365,9 @@ class TestMemLogger : public Logger {
       struct tm* ret __attribute__((__unused__));
       ret = localtime_r(&seconds, &t);
       assert(ret);
-      p += snprintf(p, limit - p,
-                    "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
-                    t.tm_year + 1900,
-                    t.tm_mon + 1,
-                    t.tm_mday,
-                    t.tm_hour,
-                    t.tm_min,
-                    t.tm_sec,
-                    static_cast<int>(now_tv.tv_usec));
+      p += snprintf(p, limit - p, "%04d/%02d/%02d-%02d:%02d:%02d.%06d ",
+                    t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour,
+                    t.tm_min, t.tm_sec, static_cast<int>(now_tv.tv_usec));
 
       // Print the message
       if (p < limit) {
@@ -405,7 +380,7 @@ class TestMemLogger : public Logger {
       // Truncate to available space if necessary
       if (p >= limit) {
         if (iter == 0) {
-          continue;       // Try again with larger buffer
+          continue;  // Try again with larger buffer
         } else {
           p = limit - 1;
         }
@@ -422,8 +397,8 @@ class TestMemLogger : public Logger {
       file_->Append(Slice(base, write_size));
       flush_pending_ = true;
       log_size_ += write_size;
-      uint64_t now_micros = static_cast<uint64_t>(now_tv.tv_sec) * 1000000 +
-        now_tv.tv_usec;
+      uint64_t now_micros =
+          static_cast<uint64_t>(now_tv.tv_sec) * 1000000 + now_tv.tv_usec;
       if (now_micros - last_flush_micros_ >= flush_every_seconds_ * 1000000) {
         flush_pending_ = false;
         last_flush_micros_ = now_micros;
@@ -447,7 +422,7 @@ MockEnv::~MockEnv() {
   }
 }
 
-  // Partial implementation of the Env interface.
+// Partial implementation of the Env interface.
 Status MockEnv::NewSequentialFile(const std::string& fname,
                                   unique_ptr<SequentialFile>* result,
                                   const EnvOptions& /*soptions*/) {
@@ -543,8 +518,7 @@ Status MockEnv::FileExists(const std::string& fname) {
   // Now also check if fn exists as a dir
   for (const auto& iter : file_map_) {
     const std::string& filename = iter.first;
-    if (filename.size() >= fn.size() + 1 &&
-        filename[fn.size()] == '/' &&
+    if (filename.size() >= fn.size() + 1 && filename[fn.size()] == '/' &&
         Slice(filename).starts_with(Slice(fn))) {
       return Status::OK();
     }
@@ -553,7 +527,7 @@ Status MockEnv::FileExists(const std::string& fname) {
 }
 
 Status MockEnv::GetChildren(const std::string& dir,
-                               std::vector<std::string>* result) {
+                            std::vector<std::string>* result) {
   auto d = NormalizePath(dir);
   bool found_dir = false;
   {
@@ -569,8 +543,8 @@ Status MockEnv::GetChildren(const std::string& dir,
         found_dir = true;
         size_t next_slash = filename.find('/', d.size() + 1);
         if (next_slash != std::string::npos) {
-          result->push_back(filename.substr(
-                d.size() + 1, next_slash - d.size() - 1));
+          result->push_back(
+              filename.substr(d.size() + 1, next_slash - d.size() - 1));
         } else {
           result->push_back(filename.substr(d.size() + 1));
         }
@@ -635,7 +609,7 @@ Status MockEnv::GetFileSize(const std::string& fname, uint64_t* file_size) {
 }
 
 Status MockEnv::GetFileModificationTime(const std::string& fname,
-                                           uint64_t* time) {
+                                        uint64_t* time) {
   auto fn = NormalizePath(fname);
   MutexLock lock(&mutex_);
   auto iter = file_map_.find(fn);
@@ -675,7 +649,7 @@ Status MockEnv::LinkFile(const std::string& src, const std::string& dest) {
 }
 
 Status MockEnv::NewLogger(const std::string& fname,
-                             shared_ptr<Logger>* result) {
+                          shared_ptr<Logger>* result) {
   auto fn = NormalizePath(fname);
   MutexLock lock(&mutex_);
   auto iter = file_map_.find(fn);
@@ -795,7 +769,7 @@ Env* NewMemEnv(Env* base_env) { return new MockEnv(base_env); }
 
 #else  // ROCKSDB_LITE
 
-Env* NewMemEnv(Env* base_env) { return nullptr; }
+Env* NewMemEnv(Env* /*base_env*/) { return nullptr; }
 
 #endif  // !ROCKSDB_LITE
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -803,7 +803,7 @@ class Directory {
   // Fsync directory. Can be called concurrently from multiple threads.
   virtual Status Fsync() = 0;
 
-  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+  virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
     return 0;
   }
 };

--- a/include/rocksdb/utilities/lua/rocks_lua_compaction_filter.h
+++ b/include/rocksdb/utilities/lua/rocks_lua_compaction_filter.h
@@ -168,8 +168,8 @@ class RocksLuaCompactionFilter : public rocksdb::CompactionFilter {
                       std::string* new_value,
                       bool* value_changed) const override;
   // Not yet supported
-  virtual bool FilterMergeOperand(int level, const Slice& key,
-                                  const Slice& operand) const override {
+  virtual bool FilterMergeOperand(int /*level*/, const Slice& /*key*/,
+                                  const Slice& /*operand*/) const override {
     return false;
   }
   virtual bool IgnoreSnapshots() const override;

--- a/include/rocksdb/utilities/lua/rocks_lua_custom_library.h
+++ b/include/rocksdb/utilities/lua/rocks_lua_custom_library.h
@@ -36,7 +36,7 @@ class RocksLuaCustomLibrary {
   // and pushed on the top of the lua_State.  This custom setup function
   // allows developers to put additional table or constant values inside
   // the same table / namespace.
-  virtual void CustomSetup(lua_State* L) const {}
+  virtual void CustomSetup(lua_State* /*L*/) const {}
 };
 }  // namespace lua
 }  // namespace rocksdb

--- a/java/rocksjni/backupablejni.cc
+++ b/java/rocksjni/backupablejni.cc
@@ -7,15 +7,15 @@
 // calling c++ rocksdb::BackupEnginge and rocksdb::BackupableDBOptions methods
 // from Java side.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <string>
 #include <vector>
 
 #include "include/org_rocksdb_BackupableDBOptions.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/utilities/backupable_db.h"
+#include "rocksjni/portal.h"
 
 ///////////////////////////////////////////////////////////////////////////
 // BackupDBOptions
@@ -26,9 +26,9 @@
  * Signature: (Ljava/lang/String;)J
  */
 jlong Java_org_rocksdb_BackupableDBOptions_newBackupableDBOptions(
-    JNIEnv* env, jclass jcls, jstring jpath) {
+    JNIEnv* env, jclass /*jcls*/, jstring jpath) {
   const char* cpath = env->GetStringUTFChars(jpath, nullptr);
-  if(cpath == nullptr) {
+  if (cpath == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -42,8 +42,9 @@ jlong Java_org_rocksdb_BackupableDBOptions_newBackupableDBOptions(
  * Method:    backupDir
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_BackupableDBOptions_backupDir(
-    JNIEnv* env, jobject jopt, jlong jhandle) {
+jstring Java_org_rocksdb_BackupableDBOptions_backupDir(JNIEnv* env,
+                                                       jobject /*jopt*/,
+                                                       jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return env->NewStringUTF(bopt->backup_dir.c_str());
 }
@@ -54,7 +55,7 @@ jstring Java_org_rocksdb_BackupableDBOptions_backupDir(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setBackupEnv(
-    JNIEnv* env, jobject jopt, jlong jhandle, jlong jrocks_env_handle) {
+    JNIEnv* /*env*/, jobject /*jopt*/, jlong jhandle, jlong jrocks_env_handle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(jrocks_env_handle);
   bopt->backup_env = rocks_env;
@@ -65,8 +66,10 @@ void Java_org_rocksdb_BackupableDBOptions_setBackupEnv(
  * Method:    setShareTableFiles
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_BackupableDBOptions_setShareTableFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_BackupableDBOptions_setShareTableFiles(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
+                                                             jlong jhandle,
+                                                             jboolean flag) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->share_table_files = flag;
 }
@@ -76,8 +79,9 @@ void Java_org_rocksdb_BackupableDBOptions_setShareTableFiles(
  * Method:    shareTableFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_BackupableDBOptions_shareTableFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_BackupableDBOptions_shareTableFiles(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->share_table_files;
 }
@@ -87,11 +91,13 @@ jboolean Java_org_rocksdb_BackupableDBOptions_shareTableFiles(
  * Method:    setInfoLog
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_BackupableDBOptions_setInfoLog(
-  JNIEnv* env, jobject jobj, jlong jhandle, jlong jlogger_handle) {
+void Java_org_rocksdb_BackupableDBOptions_setInfoLog(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle,
+                                                     jlong /*jlogger_handle*/) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   auto* sptr_logger =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   bopt->info_log = sptr_logger->get();
 }
 
@@ -100,8 +106,10 @@ void Java_org_rocksdb_BackupableDBOptions_setInfoLog(
  * Method:    setSync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_BackupableDBOptions_setSync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_BackupableDBOptions_setSync(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle,
+                                                  jboolean flag) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->sync = flag;
 }
@@ -111,8 +119,9 @@ void Java_org_rocksdb_BackupableDBOptions_setSync(
  * Method:    sync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_BackupableDBOptions_sync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_BackupableDBOptions_sync(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->sync;
 }
@@ -122,8 +131,10 @@ jboolean Java_org_rocksdb_BackupableDBOptions_sync(
  * Method:    setDestroyOldData
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_BackupableDBOptions_setDestroyOldData(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_BackupableDBOptions_setDestroyOldData(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jhandle,
+                                                            jboolean flag) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->destroy_old_data = flag;
 }
@@ -133,8 +144,9 @@ void Java_org_rocksdb_BackupableDBOptions_setDestroyOldData(
  * Method:    destroyOldData
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_BackupableDBOptions_destroyOldData(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_BackupableDBOptions_destroyOldData(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
+                                                             jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->destroy_old_data;
 }
@@ -144,8 +156,10 @@ jboolean Java_org_rocksdb_BackupableDBOptions_destroyOldData(
  * Method:    setBackupLogFiles
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_BackupableDBOptions_setBackupLogFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_BackupableDBOptions_setBackupLogFiles(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jhandle,
+                                                            jboolean flag) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->backup_log_files = flag;
 }
@@ -155,8 +169,9 @@ void Java_org_rocksdb_BackupableDBOptions_setBackupLogFiles(
  * Method:    backupLogFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_BackupableDBOptions_backupLogFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_BackupableDBOptions_backupLogFiles(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
+                                                             jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->backup_log_files;
 }
@@ -167,7 +182,8 @@ jboolean Java_org_rocksdb_BackupableDBOptions_backupLogFiles(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setBackupRateLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jbackup_rate_limit) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jbackup_rate_limit) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->backup_rate_limit = jbackup_rate_limit;
 }
@@ -177,8 +193,9 @@ void Java_org_rocksdb_BackupableDBOptions_setBackupRateLimit(
  * Method:    backupRateLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_BackupableDBOptions_backupRateLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_BackupableDBOptions_backupRateLimit(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->backup_rate_limit;
 }
@@ -189,10 +206,12 @@ jlong Java_org_rocksdb_BackupableDBOptions_backupRateLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setBackupRateLimiter(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrate_limiter_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jrate_limiter_handle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   auto* sptr_rate_limiter =
-      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(jrate_limiter_handle);
+      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(
+          jrate_limiter_handle);
   bopt->backup_rate_limiter = *sptr_rate_limiter;
 }
 
@@ -202,7 +221,8 @@ void Java_org_rocksdb_BackupableDBOptions_setBackupRateLimiter(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setRestoreRateLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrestore_rate_limit) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jrestore_rate_limit) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->restore_rate_limit = jrestore_rate_limit;
 }
@@ -212,8 +232,9 @@ void Java_org_rocksdb_BackupableDBOptions_setRestoreRateLimit(
  * Method:    restoreRateLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_BackupableDBOptions_restoreRateLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_BackupableDBOptions_restoreRateLimit(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->restore_rate_limit;
 }
@@ -224,10 +245,12 @@ jlong Java_org_rocksdb_BackupableDBOptions_restoreRateLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setRestoreRateLimiter(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrate_limiter_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jrate_limiter_handle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   auto* sptr_rate_limiter =
-      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(jrate_limiter_handle);
+      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(
+          jrate_limiter_handle);
   bopt->restore_rate_limiter = *sptr_rate_limiter;
 }
 
@@ -237,7 +260,7 @@ void Java_org_rocksdb_BackupableDBOptions_setRestoreRateLimiter(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setShareFilesWithChecksum(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean flag) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->share_files_with_checksum = flag;
 }
@@ -248,7 +271,7 @@ void Java_org_rocksdb_BackupableDBOptions_setShareFilesWithChecksum(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_BackupableDBOptions_shareFilesWithChecksum(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return bopt->share_files_with_checksum;
 }
@@ -259,10 +282,10 @@ jboolean Java_org_rocksdb_BackupableDBOptions_shareFilesWithChecksum(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setMaxBackgroundOperations(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max_background_operations) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint max_background_operations) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
-  bopt->max_background_operations =
-      static_cast<int>(max_background_operations);
+  bopt->max_background_operations = static_cast<int>(max_background_operations);
 }
 
 /*
@@ -271,7 +294,7 @@ void Java_org_rocksdb_BackupableDBOptions_setMaxBackgroundOperations(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_BackupableDBOptions_maxBackgroundOperations(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return static_cast<jint>(bopt->max_background_operations);
 }
@@ -282,7 +305,7 @@ jint Java_org_rocksdb_BackupableDBOptions_maxBackgroundOperations(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_BackupableDBOptions_setCallbackTriggerIntervalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcallback_trigger_interval_size) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   bopt->callback_trigger_interval_size =
@@ -295,7 +318,7 @@ void Java_org_rocksdb_BackupableDBOptions_setCallbackTriggerIntervalSize(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_BackupableDBOptions_callbackTriggerIntervalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   return static_cast<jlong>(bopt->callback_trigger_interval_size);
 }
@@ -305,8 +328,9 @@ jlong Java_org_rocksdb_BackupableDBOptions_callbackTriggerIntervalSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupableDBOptions_disposeInternal(
-    JNIEnv* env, jobject jopt, jlong jhandle) {
+void Java_org_rocksdb_BackupableDBOptions_disposeInternal(JNIEnv* /*env*/,
+                                                          jobject /*jopt*/,
+                                                          jlong jhandle) {
   auto* bopt = reinterpret_cast<rocksdb::BackupableDBOptions*>(jhandle);
   assert(bopt != nullptr);
   delete bopt;

--- a/java/rocksjni/backupenginejni.cc
+++ b/java/rocksjni/backupenginejni.cc
@@ -18,16 +18,15 @@
  * Method:    open
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_BackupEngine_open(
-    JNIEnv* env, jclass jcls, jlong env_handle,
-    jlong backupable_db_options_handle) {
+jlong Java_org_rocksdb_BackupEngine_open(JNIEnv* env, jclass /*jcls*/,
+                                         jlong env_handle,
+                                         jlong backupable_db_options_handle) {
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(env_handle);
-  auto* backupable_db_options =
-      reinterpret_cast<rocksdb::BackupableDBOptions*>(
+  auto* backupable_db_options = reinterpret_cast<rocksdb::BackupableDBOptions*>(
       backupable_db_options_handle);
   rocksdb::BackupEngine* backup_engine;
-  auto status = rocksdb::BackupEngine::Open(rocks_env,
-      *backupable_db_options, &backup_engine);
+  auto status = rocksdb::BackupEngine::Open(rocks_env, *backupable_db_options,
+                                            &backup_engine);
 
   if (status.ok()) {
     return reinterpret_cast<jlong>(backup_engine);
@@ -43,12 +42,12 @@ jlong Java_org_rocksdb_BackupEngine_open(
  * Signature: (JJZ)V
  */
 void Java_org_rocksdb_BackupEngine_createNewBackup(
-    JNIEnv* env, jobject jbe, jlong jbe_handle, jlong db_handle,
+    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jlong db_handle,
     jboolean jflush_before_backup) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
-  auto status = backup_engine->CreateNewBackup(db,
-      static_cast<bool>(jflush_before_backup));
+  auto status = backup_engine->CreateNewBackup(
+      db, static_cast<bool>(jflush_before_backup));
 
   if (status.ok()) {
     return;
@@ -62,8 +61,9 @@ void Java_org_rocksdb_BackupEngine_createNewBackup(
  * Method:    getBackupInfo
  * Signature: (J)Ljava/util/List;
  */
-jobject Java_org_rocksdb_BackupEngine_getBackupInfo(
-    JNIEnv* env, jobject jbe, jlong jbe_handle) {
+jobject Java_org_rocksdb_BackupEngine_getBackupInfo(JNIEnv* env,
+                                                    jobject /*jbe*/,
+                                                    jlong jbe_handle) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   std::vector<rocksdb::BackupInfo> backup_infos;
   backup_engine->GetBackupInfo(&backup_infos);
@@ -75,24 +75,25 @@ jobject Java_org_rocksdb_BackupEngine_getBackupInfo(
  * Method:    getCorruptedBackups
  * Signature: (J)[I
  */
-jintArray Java_org_rocksdb_BackupEngine_getCorruptedBackups(
-    JNIEnv* env, jobject jbe, jlong jbe_handle) {
+jintArray Java_org_rocksdb_BackupEngine_getCorruptedBackups(JNIEnv* env,
+                                                            jobject /*jbe*/,
+                                                            jlong jbe_handle) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   std::vector<rocksdb::BackupID> backup_ids;
   backup_engine->GetCorruptedBackups(&backup_ids);
   // store backupids in int array
   std::vector<jint> int_backup_ids(backup_ids.begin(), backup_ids.end());
-  
+
   // Store ints in java array
   // Its ok to loose precision here (64->32)
   jsize ret_backup_ids_size = static_cast<jsize>(backup_ids.size());
   jintArray ret_backup_ids = env->NewIntArray(ret_backup_ids_size);
-  if(ret_backup_ids == nullptr) {
+  if (ret_backup_ids == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
   env->SetIntArrayRegion(ret_backup_ids, 0, ret_backup_ids_size,
-      int_backup_ids.data());
+                         int_backup_ids.data());
   return ret_backup_ids;
 }
 
@@ -101,8 +102,8 @@ jintArray Java_org_rocksdb_BackupEngine_getCorruptedBackups(
  * Method:    garbageCollect
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupEngine_garbageCollect(
-    JNIEnv* env, jobject jbe, jlong jbe_handle) {
+void Java_org_rocksdb_BackupEngine_garbageCollect(JNIEnv* env, jobject /*jbe*/,
+                                                  jlong jbe_handle) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   auto status = backup_engine->GarbageCollect();
 
@@ -118,12 +119,12 @@ void Java_org_rocksdb_BackupEngine_garbageCollect(
  * Method:    purgeOldBackups
  * Signature: (JI)V
  */
-void Java_org_rocksdb_BackupEngine_purgeOldBackups(
-    JNIEnv* env, jobject jbe, jlong jbe_handle, jint jnum_backups_to_keep) {
+void Java_org_rocksdb_BackupEngine_purgeOldBackups(JNIEnv* env, jobject /*jbe*/,
+                                                   jlong jbe_handle,
+                                                   jint jnum_backups_to_keep) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
-  auto status =
-      backup_engine->
-          PurgeOldBackups(static_cast<uint32_t>(jnum_backups_to_keep));
+  auto status = backup_engine->PurgeOldBackups(
+      static_cast<uint32_t>(jnum_backups_to_keep));
 
   if (status.ok()) {
     return;
@@ -137,8 +138,9 @@ void Java_org_rocksdb_BackupEngine_purgeOldBackups(
  * Method:    deleteBackup
  * Signature: (JI)V
  */
-void Java_org_rocksdb_BackupEngine_deleteBackup(
-    JNIEnv* env, jobject jbe, jlong jbe_handle, jint jbackup_id) {
+void Java_org_rocksdb_BackupEngine_deleteBackup(JNIEnv* env, jobject /*jbe*/,
+                                                jlong jbe_handle,
+                                                jint jbackup_id) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   auto status =
       backup_engine->DeleteBackup(static_cast<rocksdb::BackupID>(jbackup_id));
@@ -156,26 +158,25 @@ void Java_org_rocksdb_BackupEngine_deleteBackup(
  * Signature: (JILjava/lang/String;Ljava/lang/String;J)V
  */
 void Java_org_rocksdb_BackupEngine_restoreDbFromBackup(
-    JNIEnv* env, jobject jbe, jlong jbe_handle, jint jbackup_id,
+    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jint jbackup_id,
     jstring jdb_dir, jstring jwal_dir, jlong jrestore_options_handle) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   const char* db_dir = env->GetStringUTFChars(jdb_dir, nullptr);
-  if(db_dir == nullptr) {
+  if (db_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, nullptr);
-  if(wal_dir == nullptr) {
+  if (wal_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseStringUTFChars(jdb_dir, db_dir);
     return;
   }
   auto* restore_options =
       reinterpret_cast<rocksdb::RestoreOptions*>(jrestore_options_handle);
-  auto status =
-      backup_engine->RestoreDBFromBackup(
-          static_cast<rocksdb::BackupID>(jbackup_id), db_dir, wal_dir,
-          *restore_options);
+  auto status = backup_engine->RestoreDBFromBackup(
+      static_cast<rocksdb::BackupID>(jbackup_id), db_dir, wal_dir,
+      *restore_options);
 
   env->ReleaseStringUTFChars(jwal_dir, wal_dir);
   env->ReleaseStringUTFChars(jdb_dir, db_dir);
@@ -193,25 +194,24 @@ void Java_org_rocksdb_BackupEngine_restoreDbFromBackup(
  * Signature: (JLjava/lang/String;Ljava/lang/String;J)V
  */
 void Java_org_rocksdb_BackupEngine_restoreDbFromLatestBackup(
-    JNIEnv* env, jobject jbe, jlong jbe_handle, jstring jdb_dir,
+    JNIEnv* env, jobject /*jbe*/, jlong jbe_handle, jstring jdb_dir,
     jstring jwal_dir, jlong jrestore_options_handle) {
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   const char* db_dir = env->GetStringUTFChars(jdb_dir, nullptr);
-  if(db_dir == nullptr) {
+  if (db_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, nullptr);
-  if(wal_dir == nullptr) {
+  if (wal_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseStringUTFChars(jdb_dir, db_dir);
     return;
   }
   auto* restore_options =
       reinterpret_cast<rocksdb::RestoreOptions*>(jrestore_options_handle);
-  auto status =
-      backup_engine->RestoreDBFromLatestBackup(db_dir, wal_dir,
-          *restore_options);
+  auto status = backup_engine->RestoreDBFromLatestBackup(db_dir, wal_dir,
+                                                         *restore_options);
 
   env->ReleaseStringUTFChars(jwal_dir, wal_dir);
   env->ReleaseStringUTFChars(jdb_dir, db_dir);
@@ -228,8 +228,9 @@ void Java_org_rocksdb_BackupEngine_restoreDbFromLatestBackup(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_BackupEngine_disposeInternal(
-    JNIEnv* env, jobject jbe, jlong jbe_handle) {
+void Java_org_rocksdb_BackupEngine_disposeInternal(JNIEnv* /*env*/,
+                                                   jobject /*jbe*/,
+                                                   jlong jbe_handle) {
   auto* be = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
   assert(be != nullptr);
   delete be;

--- a/java/rocksjni/cassandra_compactionfilterjni.cc
+++ b/java/rocksjni/cassandra_compactionfilterjni.cc
@@ -14,8 +14,8 @@
  * Signature: (ZI)J
  */
 jlong Java_org_rocksdb_CassandraCompactionFilter_createNewCassandraCompactionFilter0(
-    JNIEnv* env, jclass jcls, jboolean purge_ttl_on_expiration,
-    jint gc_grace_period_in_seconds) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*purge_ttl_on_expiration*/,
+    jint /*gc_grace_period_in_seconds*/) {
   auto* compaction_filter = new rocksdb::cassandra::CassandraCompactionFilter(
       purge_ttl_on_expiration, gc_grace_period_in_seconds);
   // set the native handle to our native compaction filter

--- a/java/rocksjni/cassandra_compactionfilterjni.cc
+++ b/java/rocksjni/cassandra_compactionfilterjni.cc
@@ -14,8 +14,8 @@
  * Signature: (ZI)J
  */
 jlong Java_org_rocksdb_CassandraCompactionFilter_createNewCassandraCompactionFilter0(
-    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*purge_ttl_on_expiration*/,
-    jint /*gc_grace_period_in_seconds*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean purge_ttl_on_expiration,
+    jint gc_grace_period_in_seconds) {
   auto* compaction_filter = new rocksdb::cassandra::CassandraCompactionFilter(
       purge_ttl_on_expiration, gc_grace_period_in_seconds);
   // set the native handle to our native compaction filter

--- a/java/rocksjni/cassandra_value_operator.cc
+++ b/java/rocksjni/cassandra_value_operator.cc
@@ -3,21 +3,21 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "include/org_rocksdb_CassandraValueMergeOperator.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/db.h"
-#include "rocksdb/options.h"
-#include "rocksdb/statistics.h"
 #include "rocksdb/memtablerep.h"
-#include "rocksdb/table.h"
-#include "rocksdb/slice_transform.h"
 #include "rocksdb/merge_operator.h"
+#include "rocksdb/options.h"
+#include "rocksdb/slice_transform.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/table.h"
+#include "rocksjni/portal.h"
 #include "utilities/cassandra/merge_operator.h"
 
 /*
@@ -26,8 +26,8 @@
  * Signature: (II)J
  */
 jlong Java_org_rocksdb_CassandraValueMergeOperator_newSharedCassandraValueMergeOperator(
-    JNIEnv* env, jclass jclazz, jint gcGracePeriodInSeconds,
-    jint operands_limit) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jint /*gcGracePeriodInSeconds*/,
+    jint /*operands_limit*/) {
   auto* op = new std::shared_ptr<rocksdb::MergeOperator>(
       new rocksdb::cassandra::CassandraValueMergeOperator(
           gcGracePeriodInSeconds, operands_limit));
@@ -40,7 +40,7 @@ jlong Java_org_rocksdb_CassandraValueMergeOperator_newSharedCassandraValueMergeO
  * Signature: (J)V
  */
 void Java_org_rocksdb_CassandraValueMergeOperator_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* op =
       reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
   delete op;

--- a/java/rocksjni/cassandra_value_operator.cc
+++ b/java/rocksjni/cassandra_value_operator.cc
@@ -26,8 +26,8 @@
  * Signature: (II)J
  */
 jlong Java_org_rocksdb_CassandraValueMergeOperator_newSharedCassandraValueMergeOperator(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jint /*gcGracePeriodInSeconds*/,
-    jint /*operands_limit*/) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jint gcGracePeriodInSeconds,
+    jint operands_limit) {
   auto* op = new std::shared_ptr<rocksdb::MergeOperator>(
       new rocksdb::cassandra::CassandraValueMergeOperator(
           gcGracePeriodInSeconds, operands_limit));

--- a/java/rocksjni/checkpoint.cc
+++ b/java/rocksjni/checkpoint.cc
@@ -6,22 +6,23 @@
 // This file implements the "bridge" between Java and C++ and enables
 // calling c++ rocksdb::Checkpoint methods from Java side.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <string>
 
 #include "include/org_rocksdb_Checkpoint.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/db.h"
 #include "rocksdb/utilities/checkpoint.h"
+#include "rocksjni/portal.h"
 /*
  * Class:     org_rocksdb_Checkpoint
  * Method:    newCheckpoint
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Checkpoint_newCheckpoint(JNIEnv* env,
-    jclass jclazz, jlong jdb_handle) {
+jlong Java_org_rocksdb_Checkpoint_newCheckpoint(JNIEnv* /*env*/,
+                                                jclass /*jclazz*/,
+                                                jlong jdb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::Checkpoint* checkpoint;
   rocksdb::Checkpoint::Create(db, &checkpoint);
@@ -33,8 +34,9 @@ jlong Java_org_rocksdb_Checkpoint_newCheckpoint(JNIEnv* env,
  * Method:    dispose
  * Signature: (J)V
  */
-void Java_org_rocksdb_Checkpoint_disposeInternal(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Checkpoint_disposeInternal(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* checkpoint = reinterpret_cast<rocksdb::Checkpoint*>(jhandle);
   assert(checkpoint != nullptr);
   delete checkpoint;
@@ -45,24 +47,21 @@ void Java_org_rocksdb_Checkpoint_disposeInternal(JNIEnv* env, jobject jobj,
  * Method:    createCheckpoint
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_Checkpoint_createCheckpoint(
-    JNIEnv* env, jobject jobj, jlong jcheckpoint_handle,
-    jstring jcheckpoint_path) {
-  const char* checkpoint_path = env->GetStringUTFChars(
-      jcheckpoint_path, 0);
-  if(checkpoint_path == nullptr) {
+void Java_org_rocksdb_Checkpoint_createCheckpoint(JNIEnv* env, jobject /*jobj*/,
+                                                  jlong jcheckpoint_handle,
+                                                  jstring jcheckpoint_path) {
+  const char* checkpoint_path = env->GetStringUTFChars(jcheckpoint_path, 0);
+  if (checkpoint_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
-  auto* checkpoint = reinterpret_cast<rocksdb::Checkpoint*>(
-      jcheckpoint_handle);
-  rocksdb::Status s = checkpoint->CreateCheckpoint(
-      checkpoint_path);
-  
+  auto* checkpoint = reinterpret_cast<rocksdb::Checkpoint*>(jcheckpoint_handle);
+  rocksdb::Status s = checkpoint->CreateCheckpoint(checkpoint_path);
+
   env->ReleaseStringUTFChars(jcheckpoint_path, checkpoint_path);
-  
+
   if (!s.ok()) {
-      rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
 }

--- a/java/rocksjni/clock_cache.cc
+++ b/java/rocksjni/clock_cache.cc
@@ -17,8 +17,8 @@
  * Signature: (JIZ)J
  */
 jlong Java_org_rocksdb_ClockCache_newClockCache(
-    JNIEnv* /*env*/, jclass /*jcls*/, jlong /*jcapacity*/,
-    jint /*jnum_shard_bits*/, jboolean /*jstrict_capacity_limit*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jcapacity, jint jnum_shard_bits,
+    jboolean jstrict_capacity_limit) {
   auto* sptr_clock_cache =
       new std::shared_ptr<rocksdb::Cache>(rocksdb::NewClockCache(
           static_cast<size_t>(jcapacity), static_cast<int>(jnum_shard_bits),

--- a/java/rocksjni/clock_cache.cc
+++ b/java/rocksjni/clock_cache.cc
@@ -17,12 +17,11 @@
  * Signature: (JIZ)J
  */
 jlong Java_org_rocksdb_ClockCache_newClockCache(
-    JNIEnv* env, jclass jcls, jlong jcapacity, jint jnum_shard_bits,
-    jboolean jstrict_capacity_limit) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong /*jcapacity*/,
+    jint /*jnum_shard_bits*/, jboolean /*jstrict_capacity_limit*/) {
   auto* sptr_clock_cache =
       new std::shared_ptr<rocksdb::Cache>(rocksdb::NewClockCache(
-          static_cast<size_t>(jcapacity),
-          static_cast<int>(jnum_shard_bits),
+          static_cast<size_t>(jcapacity), static_cast<int>(jnum_shard_bits),
           static_cast<bool>(jstrict_capacity_limit)));
   return reinterpret_cast<jlong>(sptr_clock_cache);
 }
@@ -32,9 +31,10 @@ jlong Java_org_rocksdb_ClockCache_newClockCache(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ClockCache_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_ClockCache_disposeInternal(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* sptr_clock_cache =
-      reinterpret_cast<std::shared_ptr<rocksdb::Cache> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
   delete sptr_clock_cache;  // delete std::shared_ptr
 }

--- a/java/rocksjni/columnfamilyhandle.cc
+++ b/java/rocksjni/columnfamilyhandle.cc
@@ -6,9 +6,9 @@
 // This file implements the "bridge" between Java and C++ for
 // rocksdb::ColumnFamilyHandle.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 
 #include "include/org_rocksdb_ColumnFamilyHandle.h"
 #include "rocksjni/portal.h"
@@ -18,20 +18,22 @@
  * Method:    getName
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_ColumnFamilyHandle_getName(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyteArray Java_org_rocksdb_ColumnFamilyHandle_getName(JNIEnv* env,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
   auto* cfh = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jhandle);
   std::string cf_name = cfh->GetName();
   return rocksdb::JniUtil::copyBytes(env, cf_name);
 }
 
 /*
-* Class:     org_rocksdb_ColumnFamilyHandle
-* Method:    getID
-* Signature: (J)I
-*/
-jint Java_org_rocksdb_ColumnFamilyHandle_getID(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+ * Class:     org_rocksdb_ColumnFamilyHandle
+ * Method:    getID
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_ColumnFamilyHandle_getID(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* cfh = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jhandle);
   const int32_t id = cfh->GetID();
   return static_cast<jint>(id);
@@ -42,8 +44,9 @@ jint Java_org_rocksdb_ColumnFamilyHandle_getID(
  * Method:    getDescriptor
  * Signature: (J)Lorg/rocksdb/ColumnFamilyDescriptor;
  */
-jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(JNIEnv* env,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle) {
   auto* cfh = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jhandle);
   rocksdb::ColumnFamilyDescriptor desc;
   rocksdb::Status s = cfh->GetDescriptor(&desc);
@@ -60,8 +63,9 @@ jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyHandle_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_ColumnFamilyHandle_disposeInternal(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* cfh = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jhandle);
   assert(cfh != nullptr);
   delete cfh;

--- a/java/rocksjni/compaction_filter.cc
+++ b/java/rocksjni/compaction_filter.cc
@@ -18,8 +18,9 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_AbstractCompactionFilter_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_AbstractCompactionFilter_disposeInternal(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong handle) {
   auto* cf = reinterpret_cast<rocksdb::CompactionFilter*>(handle);
   assert(cf != nullptr);
   delete cf;

--- a/java/rocksjni/compaction_filter_factory.cc
+++ b/java/rocksjni/compaction_filter_factory.cc
@@ -18,7 +18,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_AbstractCompactionFilterFactory_createNewCompactionFilterFactory0(
-    JNIEnv* /*env*/, jobject /*jobj*/) {
+    JNIEnv* env, jobject jobj) {
   auto* cff = new rocksdb::CompactionFilterFactoryJniCallback(env, jobj);
   auto* ptr_sptr_cff =
       new std::shared_ptr<rocksdb::CompactionFilterFactoryJniCallback>(cff);

--- a/java/rocksjni/compaction_filter_factory.cc
+++ b/java/rocksjni/compaction_filter_factory.cc
@@ -18,9 +18,10 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_AbstractCompactionFilterFactory_createNewCompactionFilterFactory0(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* /*env*/, jobject /*jobj*/) {
   auto* cff = new rocksdb::CompactionFilterFactoryJniCallback(env, jobj);
-  auto* ptr_sptr_cff = new std::shared_ptr<rocksdb::CompactionFilterFactoryJniCallback>(cff);
+  auto* ptr_sptr_cff =
+      new std::shared_ptr<rocksdb::CompactionFilterFactoryJniCallback>(cff);
   return reinterpret_cast<jlong>(ptr_sptr_cff);
 }
 
@@ -30,9 +31,9 @@ jlong Java_org_rocksdb_AbstractCompactionFilterFactory_createNewCompactionFilter
  * Signature: (J)V
  */
 void Java_org_rocksdb_AbstractCompactionFilterFactory_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  auto* ptr_sptr_cff =
-      reinterpret_cast<std::shared_ptr<rocksdb::CompactionFilterFactoryJniCallback> *>(jhandle);
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* ptr_sptr_cff = reinterpret_cast<
+      std::shared_ptr<rocksdb::CompactionFilterFactoryJniCallback>*>(jhandle);
   delete ptr_sptr_cff;
-// @lint-ignore TXT4 T25377293 Grandfathered in
+  // @lint-ignore TXT4 T25377293 Grandfathered in
 }

--- a/java/rocksjni/compaction_options_fifo.cc
+++ b/java/rocksjni/compaction_options_fifo.cc
@@ -17,7 +17,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_CompactionOptionsFIFO_newCompactionOptionsFIFO(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   const auto* opt = new rocksdb::CompactionOptionsFIFO();
   return reinterpret_cast<jlong>(opt);
 }
@@ -28,7 +28,8 @@ jlong Java_org_rocksdb_CompactionOptionsFIFO_newCompactionOptionsFIFO(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_CompactionOptionsFIFO_setMaxTableFilesSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_table_files_size) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
   opt->max_table_files_size = static_cast<uint64_t>(jmax_table_files_size);
 }
@@ -38,8 +39,9 @@ void Java_org_rocksdb_CompactionOptionsFIFO_setMaxTableFilesSize(
  * Method:    maxTableFilesSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
   return static_cast<jlong>(opt->max_table_files_size);
 }
@@ -49,7 +51,8 @@ jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompactionOptionsFIFO_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_CompactionOptionsFIFO_disposeInternal(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jhandle) {
   delete reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
 }

--- a/java/rocksjni/compaction_options_universal.cc
+++ b/java/rocksjni/compaction_options_universal.cc
@@ -18,7 +18,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_CompactionOptionsUniversal_newCompactionOptionsUniversal(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   const auto* opt = new rocksdb::CompactionOptionsUniversal();
   return reinterpret_cast<jlong>(opt);
 }
@@ -29,7 +29,7 @@ jlong Java_org_rocksdb_CompactionOptionsUniversal_newCompactionOptionsUniversal(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setSizeRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jsize_ratio) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jsize_ratio) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->size_ratio = static_cast<unsigned int>(jsize_ratio);
 }
@@ -39,8 +39,9 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setSizeRatio(
  * Method:    sizeRatio
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->size_ratio);
 }
@@ -51,7 +52,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_sizeRatio(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMinMergeWidth(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmin_merge_width) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jmin_merge_width) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->min_merge_width = static_cast<unsigned int>(jmin_merge_width);
 }
@@ -61,8 +62,9 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMinMergeWidth(
  * Method:    minMergeWidth
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->min_merge_width);
 }
@@ -73,7 +75,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_minMergeWidth(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMaxMergeWidth(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_merge_width) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jmax_merge_width) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->max_merge_width = static_cast<unsigned int>(jmax_merge_width);
 }
@@ -83,8 +85,9 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMaxMergeWidth(
  * Method:    maxMergeWidth
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->max_merge_width);
 }
@@ -95,7 +98,7 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_maxMergeWidth(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setMaxSizeAmplificationPercent(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jmax_size_amplification_percent) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->max_size_amplification_percent =
@@ -108,7 +111,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setMaxSizeAmplificationPercent(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactionOptionsUniversal_maxSizeAmplificationPercent(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->max_size_amplification_percent);
 }
@@ -119,7 +122,8 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_maxSizeAmplificationPercent(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setCompressionSizePercent(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jcompression_size_percent) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jcompression_size_percent) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->compression_size_percent =
       static_cast<unsigned int>(jcompression_size_percent);
@@ -131,7 +135,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setCompressionSizePercent(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_CompactionOptionsUniversal_compressionSizePercent(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return static_cast<jint>(opt->compression_size_percent);
 }
@@ -142,11 +146,10 @@ jint Java_org_rocksdb_CompactionOptionsUniversal_compressionSizePercent(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setStopStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jstop_style_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jbyte jstop_style_value) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
-  opt->stop_style =
-      rocksdb::CompactionStopStyleJni::toCppCompactionStopStyle(
-          jstop_style_value); 
+  opt->stop_style = rocksdb::CompactionStopStyleJni::toCppCompactionStopStyle(
+      jstop_style_value);
 }
 
 /*
@@ -154,8 +157,9 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setStopStyle(
  * Method:    stopStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return rocksdb::CompactionStopStyleJni::toJavaCompactionStopStyle(
       opt->stop_style);
@@ -167,7 +171,8 @@ jbyte Java_org_rocksdb_CompactionOptionsUniversal_stopStyle(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_setAllowTrivialMove(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_trivial_move) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jallow_trivial_move) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   opt->allow_trivial_move = static_cast<bool>(jallow_trivial_move);
 }
@@ -178,7 +183,7 @@ void Java_org_rocksdb_CompactionOptionsUniversal_setAllowTrivialMove(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_CompactionOptionsUniversal_allowTrivialMove(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
   return opt->allow_trivial_move;
 }
@@ -189,6 +194,6 @@ jboolean Java_org_rocksdb_CompactionOptionsUniversal_allowTrivialMove(
  * Signature: (J)V
  */
 void Java_org_rocksdb_CompactionOptionsUniversal_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   delete reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(jhandle);
 }

--- a/java/rocksjni/comparator.cc
+++ b/java/rocksjni/comparator.cc
@@ -6,11 +6,11 @@
 // This file implements the "bridge" between Java and C++ for
 // rocksdb::Comparator.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
-#include <string>
 #include <functional>
+#include <string>
 
 #include "include/org_rocksdb_Comparator.h"
 #include "include/org_rocksdb_DirectComparator.h"
@@ -25,12 +25,12 @@
  * Method:    createNewComparator0
  * Signature: ()J
  */
-jlong Java_org_rocksdb_Comparator_createNewComparator0(
-    JNIEnv* env, jobject jobj, jlong copt_handle) {
+jlong Java_org_rocksdb_Comparator_createNewComparator0(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong copt_handle) {
   auto* copt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(copt_handle);
-  auto* c =
-      new rocksdb::ComparatorJniCallback(env, jobj, copt);
+  auto* c = new rocksdb::ComparatorJniCallback(env, jobj, copt);
   return reinterpret_cast<jlong>(c);
 }
 // </editor-fold>
@@ -43,11 +43,10 @@ jlong Java_org_rocksdb_Comparator_createNewComparator0(
  * Signature: ()J
  */
 jlong Java_org_rocksdb_DirectComparator_createNewDirectComparator0(
-    JNIEnv* env, jobject jobj, jlong copt_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong copt_handle) {
   auto* copt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(copt_handle);
-  auto* c =
-      new rocksdb::DirectComparatorJniCallback(env, jobj, copt);
+  auto* c = new rocksdb::DirectComparatorJniCallback(env, jobj, copt);
   return reinterpret_cast<jlong>(c);
 }
 
@@ -57,9 +56,8 @@ jlong Java_org_rocksdb_DirectComparator_createNewDirectComparator0(
  * Signature: (J)V
  */
 void Java_org_rocksdb_NativeComparatorWrapper_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jcomparator_handle) {
-  auto* comparator =
-      reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jcomparator_handle) {
+  auto* comparator = reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
   delete comparator;
 }
 // </editor-fold>

--- a/java/rocksjni/comparator.cc
+++ b/java/rocksjni/comparator.cc
@@ -25,8 +25,8 @@
  * Method:    createNewComparator0
  * Signature: ()J
  */
-jlong Java_org_rocksdb_Comparator_createNewComparator0(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
+jlong Java_org_rocksdb_Comparator_createNewComparator0(JNIEnv* env,
+                                                       jobject jobj,
                                                        jlong copt_handle) {
   auto* copt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(copt_handle);
@@ -43,7 +43,7 @@ jlong Java_org_rocksdb_Comparator_createNewComparator0(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_DirectComparator_createNewDirectComparator0(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong copt_handle) {
+    JNIEnv* env, jobject jobj, jlong copt_handle) {
   auto* copt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(copt_handle);
   auto* c = new rocksdb::DirectComparatorJniCallback(env, jobj, copt);

--- a/java/rocksjni/compression_options.cc
+++ b/java/rocksjni/compression_options.cc
@@ -17,7 +17,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_CompressionOptions_newCompressionOptions(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   const auto* opt = new rocksdb::CompressionOptions();
   return reinterpret_cast<jlong>(opt);
 }
@@ -27,8 +27,10 @@ jlong Java_org_rocksdb_CompressionOptions_newCompressionOptions(
  * Method:    setWindowBits
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setWindowBits(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jwindow_bits) {
+void Java_org_rocksdb_CompressionOptions_setWindowBits(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle,
+                                                       jint jwindow_bits) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   opt->window_bits = static_cast<int>(jwindow_bits);
 }
@@ -38,8 +40,9 @@ void Java_org_rocksdb_CompressionOptions_setWindowBits(
  * Method:    windowBits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_windowBits(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompressionOptions_windowBits(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->window_bits);
 }
@@ -49,8 +52,9 @@ jint Java_org_rocksdb_CompressionOptions_windowBits(
  * Method:    setLevel
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jlevel) {
+void Java_org_rocksdb_CompressionOptions_setLevel(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle, jint jlevel) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   opt->level = static_cast<int>(jlevel);
 }
@@ -60,8 +64,9 @@ void Java_org_rocksdb_CompressionOptions_setLevel(
  * Method:    level
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_level(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompressionOptions_level(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->level);
 }
@@ -71,8 +76,10 @@ jint Java_org_rocksdb_CompressionOptions_level(
  * Method:    setStrategy
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setStrategy(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jstrategy) {
+void Java_org_rocksdb_CompressionOptions_setStrategy(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle,
+                                                     jint jstrategy) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   opt->strategy = static_cast<int>(jstrategy);
 }
@@ -82,8 +89,9 @@ void Java_org_rocksdb_CompressionOptions_setStrategy(
  * Method:    strategy
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_strategy(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompressionOptions_strategy(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->strategy);
 }
@@ -93,8 +101,10 @@ jint Java_org_rocksdb_CompressionOptions_strategy(
  * Method:    setMaxDictBytes
  * Signature: (JI)V
  */
-void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_dict_bytes) {
+void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle,
+                                                         jint jmax_dict_bytes) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   opt->max_dict_bytes = static_cast<int>(jmax_dict_bytes);
 }
@@ -104,8 +114,9 @@ void Java_org_rocksdb_CompressionOptions_setMaxDictBytes(
  * Method:    maxDictBytes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_CompressionOptions_maxDictBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_CompressionOptions_maxDictBytes(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
   return static_cast<jint>(opt->max_dict_bytes);
 }
@@ -115,7 +126,8 @@ jint Java_org_rocksdb_CompressionOptions_maxDictBytes(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_CompressionOptions_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_CompressionOptions_disposeInternal(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   delete reinterpret_cast<rocksdb::CompressionOptions*>(jhandle);
 }

--- a/java/rocksjni/env.cc
+++ b/java/rocksjni/env.cc
@@ -6,18 +6,18 @@
 // This file implements the "bridge" between Java and C++ and enables
 // calling c++ rocksdb::Env methods from Java side.
 
+#include "rocksdb/env.h"
 #include "include/org_rocksdb_Env.h"
 #include "include/org_rocksdb_RocksEnv.h"
 #include "include/org_rocksdb_RocksMemEnv.h"
-#include "rocksdb/env.h"
 
 /*
  * Class:     org_rocksdb_Env
  * Method:    getDefaultEnvInternal
  * Signature: ()J
  */
-jlong Java_org_rocksdb_Env_getDefaultEnvInternal(
-    JNIEnv* env, jclass jclazz) {
+jlong Java_org_rocksdb_Env_getDefaultEnvInternal(JNIEnv* /*env*/,
+                                                 jclass /*jclazz*/) {
   return reinterpret_cast<jlong>(rocksdb::Env::Default());
 }
 
@@ -26,9 +26,10 @@ jlong Java_org_rocksdb_Env_getDefaultEnvInternal(
  * Method:    setBackgroundThreads
  * Signature: (JII)V
  */
-void Java_org_rocksdb_Env_setBackgroundThreads(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jint num, jint priority) {
+void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong /*jhandle*/, jint /*num*/,
+                                               jint /*priority*/) {
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(jhandle);
   switch (priority) {
     case org_rocksdb_Env_FLUSH_POOL:
@@ -45,8 +46,10 @@ void Java_org_rocksdb_Env_setBackgroundThreads(
  * Method:    getThreadPoolQueueLen
  * Signature: (JI)I
  */
-jint Java_org_rocksdb_Env_getThreadPoolQueueLen(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint pool_id) {
+jint Java_org_rocksdb_Env_getThreadPoolQueueLen(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong /*jhandle*/,
+                                                jint /*pool_id*/) {
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(jhandle);
   switch (pool_id) {
     case org_rocksdb_RocksEnv_FLUSH_POOL:
@@ -62,10 +65,9 @@ jint Java_org_rocksdb_Env_getThreadPoolQueueLen(
  * Method:    createMemEnv
  * Signature: ()J
  */
-jlong Java_org_rocksdb_RocksMemEnv_createMemEnv(
-    JNIEnv* env, jclass jclazz) {
-  return reinterpret_cast<jlong>(rocksdb::NewMemEnv(
-      rocksdb::Env::Default()));
+jlong Java_org_rocksdb_RocksMemEnv_createMemEnv(JNIEnv* /*env*/,
+                                                jclass /*jclazz*/) {
+  return reinterpret_cast<jlong>(rocksdb::NewMemEnv(rocksdb::Env::Default()));
 }
 
 /*
@@ -73,8 +75,9 @@ jlong Java_org_rocksdb_RocksMemEnv_createMemEnv(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksMemEnv_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_RocksMemEnv_disposeInternal(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong /*jhandle*/) {
   auto* e = reinterpret_cast<rocksdb::Env*>(jhandle);
   assert(e != nullptr);
   delete e;

--- a/java/rocksjni/env.cc
+++ b/java/rocksjni/env.cc
@@ -27,9 +27,8 @@ jlong Java_org_rocksdb_Env_getDefaultEnvInternal(JNIEnv* /*env*/,
  * Signature: (JII)V
  */
 void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
-                                               jlong /*jhandle*/, jint /*num*/,
-                                               jint /*priority*/) {
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jint num, jint priority) {
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(jhandle);
   switch (priority) {
     case org_rocksdb_Env_FLUSH_POOL:
@@ -47,9 +46,8 @@ void Java_org_rocksdb_Env_setBackgroundThreads(JNIEnv* /*env*/,
  * Signature: (JI)I
  */
 jint Java_org_rocksdb_Env_getThreadPoolQueueLen(JNIEnv* /*env*/,
-                                                jobject /*jobj*/,
-                                                jlong /*jhandle*/,
-                                                jint /*pool_id*/) {
+                                                jobject /*jobj*/, jlong jhandle,
+                                                jint pool_id) {
   auto* rocks_env = reinterpret_cast<rocksdb::Env*>(jhandle);
   switch (pool_id) {
     case org_rocksdb_RocksEnv_FLUSH_POOL:
@@ -77,7 +75,7 @@ jlong Java_org_rocksdb_RocksMemEnv_createMemEnv(JNIEnv* /*env*/,
  */
 void Java_org_rocksdb_RocksMemEnv_disposeInternal(JNIEnv* /*env*/,
                                                   jobject /*jobj*/,
-                                                  jlong /*jhandle*/) {
+                                                  jlong jhandle) {
   auto* e = reinterpret_cast<rocksdb::Env*>(jhandle);
   assert(e != nullptr);
   delete e;

--- a/java/rocksjni/env_options.cc
+++ b/java/rocksjni/env_options.cc
@@ -32,7 +32,8 @@
  * Method:    newEnvOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_EnvOptions_newEnvOptions(JNIEnv *env, jclass jcls) {
+jlong Java_org_rocksdb_EnvOptions_newEnvOptions(JNIEnv * /*env*/,
+                                                jclass /*jcls*/) {
   auto *env_opt = new rocksdb::EnvOptions();
   return reinterpret_cast<jlong>(env_opt);
 }
@@ -42,9 +43,10 @@ jlong Java_org_rocksdb_EnvOptions_newEnvOptions(JNIEnv *env, jclass jcls) {
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_EnvOptions_disposeInternal(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_disposeInternal(JNIEnv * /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
-  auto* eo = reinterpret_cast<rocksdb::EnvOptions *>(jhandle);
+  auto *eo = reinterpret_cast<rocksdb::EnvOptions *>(jhandle);
   assert(eo != nullptr);
   delete eo;
 }
@@ -54,7 +56,8 @@ void Java_org_rocksdb_EnvOptions_disposeInternal(JNIEnv *env, jobject jobj,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv * /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jboolean use_direct_reads) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_direct_reads);
@@ -65,7 +68,8 @@ void Java_org_rocksdb_EnvOptions_setUseDirectReads(JNIEnv *env, jobject jobj,
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv * /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_direct_reads);
 }
@@ -76,7 +80,8 @@ jboolean Java_org_rocksdb_EnvOptions_useDirectReads(JNIEnv *env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_EnvOptions_setUseDirectWrites(
-    JNIEnv *env, jobject jobj, jlong jhandle, jboolean use_direct_writes) {
+    JNIEnv * /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean use_direct_writes) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_direct_writes);
 }
 
@@ -85,7 +90,8 @@ void Java_org_rocksdb_EnvOptions_setUseDirectWrites(
  * Method:    useDirectWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv * /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_direct_writes);
 }
@@ -95,7 +101,8 @@ jboolean Java_org_rocksdb_EnvOptions_useDirectWrites(JNIEnv *env, jobject jobj,
  * Method:    setUseMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv * /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jboolean use_mmap_reads) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_mmap_reads);
@@ -106,7 +113,8 @@ void Java_org_rocksdb_EnvOptions_setUseMmapReads(JNIEnv *env, jobject jobj,
  * Method:    useMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv * /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_mmap_reads);
 }
@@ -116,7 +124,8 @@ jboolean Java_org_rocksdb_EnvOptions_useMmapReads(JNIEnv *env, jobject jobj,
  * Method:    setUseMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv * /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jboolean use_mmap_writes) {
   ENV_OPTIONS_SET_BOOL(jhandle, use_mmap_writes);
@@ -127,7 +136,8 @@ void Java_org_rocksdb_EnvOptions_setUseMmapWrites(JNIEnv *env, jobject jobj,
  * Method:    useMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv * /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, use_mmap_writes);
 }
@@ -137,7 +147,8 @@ jboolean Java_org_rocksdb_EnvOptions_useMmapWrites(JNIEnv *env, jobject jobj,
  * Method:    setAllowFallocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv * /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jboolean allow_fallocate) {
   ENV_OPTIONS_SET_BOOL(jhandle, allow_fallocate);
@@ -148,7 +159,8 @@ void Java_org_rocksdb_EnvOptions_setAllowFallocate(JNIEnv *env, jobject jobj,
  * Method:    allowFallocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv * /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, allow_fallocate);
 }
@@ -158,7 +170,8 @@ jboolean Java_org_rocksdb_EnvOptions_allowFallocate(JNIEnv *env, jobject jobj,
  * Method:    setSetFdCloexec
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv * /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jboolean set_fd_cloexec) {
   ENV_OPTIONS_SET_BOOL(jhandle, set_fd_cloexec);
@@ -169,7 +182,8 @@ void Java_org_rocksdb_EnvOptions_setSetFdCloexec(JNIEnv *env, jobject jobj,
  * Method:    setFdCloexec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv *env, jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv * /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, set_fd_cloexec);
 }
@@ -179,7 +193,8 @@ jboolean Java_org_rocksdb_EnvOptions_setFdCloexec(JNIEnv *env, jobject jobj,
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv * /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jlong bytes_per_sync) {
   ENV_OPTIONS_SET_UINT64_T(jhandle, bytes_per_sync);
@@ -190,7 +205,8 @@ void Java_org_rocksdb_EnvOptions_setBytesPerSync(JNIEnv *env, jobject jobj,
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv *env, jobject jobj,
+jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv * /*env*/,
+                                               jobject /*jobj*/,
                                                jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, bytes_per_sync);
 }
@@ -201,7 +217,7 @@ jlong Java_org_rocksdb_EnvOptions_bytesPerSync(JNIEnv *env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_EnvOptions_setFallocateWithKeepSize(
-    JNIEnv *env, jobject jobj, jlong jhandle,
+    JNIEnv * /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean fallocate_with_keep_size) {
   ENV_OPTIONS_SET_BOOL(jhandle, fallocate_with_keep_size);
 }
@@ -211,8 +227,8 @@ void Java_org_rocksdb_EnvOptions_setFallocateWithKeepSize(
  * Method:    fallocateWithKeepSize
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv *env,
-                                                           jobject jobj,
+jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv * /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, fallocate_with_keep_size);
 }
@@ -223,7 +239,8 @@ jboolean Java_org_rocksdb_EnvOptions_fallocateWithKeepSize(JNIEnv *env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setCompactionReadaheadSize(
-    JNIEnv *env, jobject jobj, jlong jhandle, jlong compaction_readahead_size) {
+    JNIEnv * /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong compaction_readahead_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, compaction_readahead_size);
 }
 
@@ -232,8 +249,8 @@ void Java_org_rocksdb_EnvOptions_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv *env,
-                                                          jobject jobj,
+jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv * /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, compaction_readahead_size);
 }
@@ -244,7 +261,7 @@ jlong Java_org_rocksdb_EnvOptions_compactionReadaheadSize(JNIEnv *env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setRandomAccessMaxBufferSize(
-    JNIEnv *env, jobject jobj, jlong jhandle,
+    JNIEnv * /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong random_access_max_buffer_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, random_access_max_buffer_size);
 }
@@ -254,8 +271,8 @@ void Java_org_rocksdb_EnvOptions_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv *env,
-                                                            jobject jobj,
+jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv * /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, random_access_max_buffer_size);
 }
@@ -266,7 +283,7 @@ jlong Java_org_rocksdb_EnvOptions_randomAccessMaxBufferSize(JNIEnv *env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_EnvOptions_setWritableFileMaxBufferSize(
-    JNIEnv *env, jobject jobj, jlong jhandle,
+    JNIEnv * /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong writable_file_max_buffer_size) {
   ENV_OPTIONS_SET_SIZE_T(jhandle, writable_file_max_buffer_size);
 }
@@ -276,8 +293,8 @@ void Java_org_rocksdb_EnvOptions_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv *env,
-                                                            jobject jobj,
+jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv * /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle) {
   return ENV_OPTIONS_GET(jhandle, writable_file_max_buffer_size);
 }
@@ -287,11 +304,11 @@ jlong Java_org_rocksdb_EnvOptions_writableFileMaxBufferSize(JNIEnv *env,
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_EnvOptions_setRateLimiter(JNIEnv *env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_EnvOptions_setRateLimiter(JNIEnv * /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jlong rl_handle) {
-  auto* sptr_rate_limiter =
+  auto *sptr_rate_limiter =
       reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(rl_handle);
-  auto* env_opt = reinterpret_cast<rocksdb::EnvOptions *>(jhandle);
+  auto *env_opt = reinterpret_cast<rocksdb::EnvOptions *>(jhandle);
   env_opt->rate_limiter = sptr_rate_limiter->get();
 }

--- a/java/rocksjni/filter.cc
+++ b/java/rocksjni/filter.cc
@@ -6,15 +6,15 @@
 // This file implements the "bridge" between Java and C++ for
 // rocksdb::FilterPolicy.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <string>
 
-#include "include/org_rocksdb_Filter.h"
 #include "include/org_rocksdb_BloomFilter.h"
-#include "rocksjni/portal.h"
+#include "include/org_rocksdb_Filter.h"
 #include "rocksdb/filter_policy.h"
+#include "rocksjni/portal.h"
 
 /*
  * Class:     org_rocksdb_BloomFilter
@@ -22,11 +22,10 @@
  * Signature: (IZ)J
  */
 jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(
-    JNIEnv* env, jclass jcls, jint bits_per_key,
-    jboolean use_block_base_builder) {
-  auto* sptr_filter =
-      new std::shared_ptr<const rocksdb::FilterPolicy>(
-          rocksdb::NewBloomFilterPolicy(bits_per_key, use_block_base_builder));
+    JNIEnv* /*env*/, jclass /*jcls*/, jint /*bits_per_key*/,
+    jboolean /*use_block_base_builder*/) {
+  auto* sptr_filter = new std::shared_ptr<const rocksdb::FilterPolicy>(
+      rocksdb::NewBloomFilterPolicy(bits_per_key, use_block_base_builder));
   return reinterpret_cast<jlong>(sptr_filter);
 }
 
@@ -35,9 +34,9 @@ jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Filter_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_Filter_disposeInternal(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong jhandle) {
   auto* handle =
-      reinterpret_cast<std::shared_ptr<const rocksdb::FilterPolicy> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<const rocksdb::FilterPolicy>*>(jhandle);
   delete handle;  // delete std::shared_ptr
 }

--- a/java/rocksjni/filter.cc
+++ b/java/rocksjni/filter.cc
@@ -22,8 +22,8 @@
  * Signature: (IZ)J
  */
 jlong Java_org_rocksdb_BloomFilter_createNewBloomFilter(
-    JNIEnv* /*env*/, jclass /*jcls*/, jint /*bits_per_key*/,
-    jboolean /*use_block_base_builder*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jint bits_per_key,
+    jboolean use_block_base_builder) {
   auto* sptr_filter = new std::shared_ptr<const rocksdb::FilterPolicy>(
       rocksdb::NewBloomFilterPolicy(bits_per_key, use_block_base_builder));
   return reinterpret_cast<jlong>(sptr_filter);

--- a/java/rocksjni/ingest_external_file_options.cc
+++ b/java/rocksjni/ingest_external_file_options.cc
@@ -17,7 +17,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_IngestExternalFileOptions_newIngestExternalFileOptions__(
-    JNIEnv* env, jclass jclazz) {
+    JNIEnv* /*env*/, jclass /*jclazz*/) {
   auto* options = new rocksdb::IngestExternalFileOptions();
   return reinterpret_cast<jlong>(options);
 }
@@ -28,7 +28,7 @@ jlong Java_org_rocksdb_IngestExternalFileOptions_newIngestExternalFileOptions__(
  * Signature: (ZZZZ)J
  */
 jlong Java_org_rocksdb_IngestExternalFileOptions_newIngestExternalFileOptions__ZZZZ(
-    JNIEnv* env, jclass jcls, jboolean jmove_files,
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean jmove_files,
     jboolean jsnapshot_consistency, jboolean jallow_global_seqno,
     jboolean jallow_blocking_flush) {
   auto* options = new rocksdb::IngestExternalFileOptions();
@@ -44,8 +44,9 @@ jlong Java_org_rocksdb_IngestExternalFileOptions_newIngestExternalFileOptions__Z
  * Method:    moveFiles
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->move_files);
@@ -57,7 +58,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_moveFiles(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setMoveFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jmove_files) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jmove_files) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   options->move_files = static_cast<bool>(jmove_files);
@@ -69,7 +70,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setMoveFiles(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_snapshotConsistency(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->snapshot_consistency);
@@ -81,7 +82,7 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_snapshotConsistency(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setSnapshotConsistency(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jsnapshot_consistency) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
@@ -94,7 +95,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setSnapshotConsistency(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_allowGlobalSeqNo(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->allow_global_seqno);
@@ -106,7 +107,8 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_allowGlobalSeqNo(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setAllowGlobalSeqNo(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_global_seqno) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jallow_global_seqno) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   options->allow_global_seqno = static_cast<bool>(jallow_global_seqno);
@@ -118,7 +120,7 @@ void Java_org_rocksdb_IngestExternalFileOptions_setAllowGlobalSeqNo(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_IngestExternalFileOptions_allowBlockingFlush(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   return static_cast<jboolean>(options->allow_blocking_flush);
@@ -130,7 +132,8 @@ jboolean Java_org_rocksdb_IngestExternalFileOptions_allowBlockingFlush(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_setAllowBlockingFlush(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_blocking_flush) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jallow_blocking_flush) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   options->allow_blocking_flush = static_cast<bool>(jallow_blocking_flush);
@@ -142,9 +145,9 @@ void Java_org_rocksdb_IngestExternalFileOptions_setAllowBlockingFlush(
  * Signature: (J)V
  */
 void Java_org_rocksdb_IngestExternalFileOptions_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* options =
       reinterpret_cast<rocksdb::IngestExternalFileOptions*>(jhandle);
   delete options;
-// @lint-ignore TXT4 T25377293 Grandfathered in
+  // @lint-ignore TXT4 T25377293 Grandfathered in
 }

--- a/java/rocksjni/iterator.cc
+++ b/java/rocksjni/iterator.cc
@@ -87,7 +87,7 @@ void Java_org_rocksdb_RocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
  */
 void Java_org_rocksdb_RocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
                                           jlong handle, jbyteArray jtarget,
-                                          jint /*jtarget_len*/) {
+                                          jint jtarget_len) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
   if (target == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -110,7 +110,7 @@ void Java_org_rocksdb_RocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
 void Java_org_rocksdb_RocksIterator_seekForPrev0(JNIEnv* env, jobject /*jobj*/,
                                                  jlong handle,
                                                  jbyteArray jtarget,
-                                                 jint /*jtarget_len*/) {
+                                                 jint jtarget_len) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
   if (target == nullptr) {
     // exception thrown: OutOfMemoryError

--- a/java/rocksjni/iterator.cc
+++ b/java/rocksjni/iterator.cc
@@ -6,21 +6,22 @@
 // This file implements the "bridge" between Java and C++ and enables
 // calling c++ rocksdb::Iterator methods from Java side.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 
 #include "include/org_rocksdb_RocksIterator.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/iterator.h"
+#include "rocksjni/portal.h"
 
 /*
  * Class:     org_rocksdb_RocksIterator
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_disposeInternal(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong handle) {
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   assert(it != nullptr);
   delete it;
@@ -31,8 +32,9 @@ void Java_org_rocksdb_RocksIterator_disposeInternal(
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_RocksIterator_isValid0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jboolean Java_org_rocksdb_RocksIterator_isValid0(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong handle) {
   return reinterpret_cast<rocksdb::Iterator*>(handle)->Valid();
 }
 
@@ -41,8 +43,9 @@ jboolean Java_org_rocksdb_RocksIterator_isValid0(
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_seekToFirst0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_seekToFirst0(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong handle) {
   reinterpret_cast<rocksdb::Iterator*>(handle)->SeekToFirst();
 }
 
@@ -51,8 +54,9 @@ void Java_org_rocksdb_RocksIterator_seekToFirst0(
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_seekToLast0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_seekToLast0(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong handle) {
   reinterpret_cast<rocksdb::Iterator*>(handle)->SeekToLast();
 }
 
@@ -61,8 +65,8 @@ void Java_org_rocksdb_RocksIterator_seekToLast0(
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_next0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong handle) {
   reinterpret_cast<rocksdb::Iterator*>(handle)->Next();
 }
 
@@ -71,8 +75,8 @@ void Java_org_rocksdb_RocksIterator_next0(
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_prev0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong handle) {
   reinterpret_cast<rocksdb::Iterator*>(handle)->Prev();
 }
 
@@ -81,17 +85,16 @@ void Java_org_rocksdb_RocksIterator_prev0(
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksIterator_seek0(
-    JNIEnv* env, jobject jobj, jlong handle,
-    jbyteArray jtarget, jint jtarget_len) {
+void Java_org_rocksdb_RocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
+                                          jlong handle, jbyteArray jtarget,
+                                          jint /*jtarget_len*/) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
-  if(target == nullptr) {
+  if (target == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
-  rocksdb::Slice target_slice(
-      reinterpret_cast<char*>(target), jtarget_len);
+  rocksdb::Slice target_slice(reinterpret_cast<char*>(target), jtarget_len);
 
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   it->Seek(target_slice);
@@ -104,17 +107,17 @@ void Java_org_rocksdb_RocksIterator_seek0(
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksIterator_seekForPrev0(
-    JNIEnv* env, jobject jobj, jlong handle,
-    jbyteArray jtarget, jint jtarget_len) {
+void Java_org_rocksdb_RocksIterator_seekForPrev0(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong handle,
+                                                 jbyteArray jtarget,
+                                                 jint /*jtarget_len*/) {
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
-  if(target == nullptr) {
+  if (target == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
-  rocksdb::Slice target_slice(
-      reinterpret_cast<char*>(target), jtarget_len);
+  rocksdb::Slice target_slice(reinterpret_cast<char*>(target), jtarget_len);
 
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   it->SeekForPrev(target_slice);
@@ -127,8 +130,8 @@ void Java_org_rocksdb_RocksIterator_seekForPrev0(
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksIterator_status0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_RocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
+                                            jlong handle) {
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   rocksdb::Status s = it->status();
 
@@ -144,18 +147,19 @@ void Java_org_rocksdb_RocksIterator_status0(
  * Method:    key0
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_RocksIterator_key0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jbyteArray Java_org_rocksdb_RocksIterator_key0(JNIEnv* env, jobject /*jobj*/,
+                                               jlong handle) {
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   rocksdb::Slice key_slice = it->key();
 
   jbyteArray jkey = env->NewByteArray(static_cast<jsize>(key_slice.size()));
-  if(jkey == nullptr) {
+  if (jkey == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
-  env->SetByteArrayRegion(jkey, 0, static_cast<jsize>(key_slice.size()),
-                          const_cast<jbyte*>(reinterpret_cast<const jbyte*>(key_slice.data())));
+  env->SetByteArrayRegion(
+      jkey, 0, static_cast<jsize>(key_slice.size()),
+      const_cast<jbyte*>(reinterpret_cast<const jbyte*>(key_slice.data())));
   return jkey;
 }
 
@@ -164,18 +168,19 @@ jbyteArray Java_org_rocksdb_RocksIterator_key0(
  * Method:    value0
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_RocksIterator_value0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jbyteArray Java_org_rocksdb_RocksIterator_value0(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong handle) {
   auto* it = reinterpret_cast<rocksdb::Iterator*>(handle);
   rocksdb::Slice value_slice = it->value();
 
   jbyteArray jkeyValue =
       env->NewByteArray(static_cast<jsize>(value_slice.size()));
-  if(jkeyValue == nullptr) {
+  if (jkeyValue == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
-  env->SetByteArrayRegion(jkeyValue, 0, static_cast<jsize>(value_slice.size()),
-                          const_cast<jbyte*>(reinterpret_cast<const jbyte*>(value_slice.data())));
+  env->SetByteArrayRegion(
+      jkeyValue, 0, static_cast<jsize>(value_slice.size()),
+      const_cast<jbyte*>(reinterpret_cast<const jbyte*>(value_slice.data())));
   return jkeyValue;
 }

--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -226,9 +226,8 @@ LoggerJniCallback::~LoggerJniCallback() {
  * Method:    createNewLoggerOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Logger_createNewLoggerOptions(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong /*joptions*/) {
+jlong Java_org_rocksdb_Logger_createNewLoggerOptions(JNIEnv* env, jobject jobj,
+                                                     jlong joptions) {
   auto* sptr_logger = new std::shared_ptr<rocksdb::LoggerJniCallback>(
       new rocksdb::LoggerJniCallback(env, jobj));
 
@@ -244,9 +243,9 @@ jlong Java_org_rocksdb_Logger_createNewLoggerOptions(JNIEnv* /*env*/,
  * Method:    createNewLoggerDbOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(JNIEnv* /*env*/,
-                                                       jobject /*jobj*/,
-                                                       jlong /*jdb_options*/) {
+jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jdb_options) {
   auto* sptr_logger = new std::shared_ptr<rocksdb::LoggerJniCallback>(
       new rocksdb::LoggerJniCallback(env, jobj));
 
@@ -263,8 +262,7 @@ jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(JNIEnv* /*env*/,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Logger_setInfoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
-                                             jlong /*jhandle*/,
-                                             jbyte /*jlog_level*/) {
+                                             jlong jhandle, jbyte jlog_level) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   handle->get()->SetInfoLogLevel(
@@ -277,7 +275,7 @@ void Java_org_rocksdb_Logger_setInfoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)B
  */
 jbyte Java_org_rocksdb_Logger_infoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
-                                           jlong /*jhandle*/) {
+                                           jlong jhandle) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   return static_cast<jbyte>(handle->get()->GetInfoLogLevel());
@@ -289,7 +287,7 @@ jbyte Java_org_rocksdb_Logger_infoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_Logger_disposeInternal(JNIEnv* /*env*/, jobject /*jobj*/,
-                                             jlong /*jhandle*/) {
+                                             jlong jhandle) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   delete handle;  // delete std::shared_ptr

--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -96,7 +96,7 @@ LoggerJniCallback::LoggerJniCallback(JNIEnv* env, jobject jlogger)
   }
 }
 
-void LoggerJniCallback::Logv(const char* format, va_list ap) {
+void LoggerJniCallback::Logv(const char* /*format*/, va_list /*ap*/) {
   // We implement this method because it is virtual but we don't
   // use it because we need to know about the log level.
 }

--- a/java/rocksjni/loggerjnicallback.cc
+++ b/java/rocksjni/loggerjnicallback.cc
@@ -8,90 +8,89 @@
 
 #include "include/org_rocksdb_Logger.h"
 
-#include "rocksjni/loggerjnicallback.h"
-#include "rocksjni/portal.h"
 #include <cstdarg>
 #include <cstdio>
+#include "rocksjni/loggerjnicallback.h"
+#include "rocksjni/portal.h"
 
 namespace rocksdb {
 
-LoggerJniCallback::LoggerJniCallback(
-    JNIEnv* env, jobject jlogger) : JniCallback(env, jlogger) {
-
+LoggerJniCallback::LoggerJniCallback(JNIEnv* env, jobject jlogger)
+    : JniCallback(env, jlogger) {
   m_jLogMethodId = LoggerJni::getLogMethodId(env);
-  if(m_jLogMethodId == nullptr) {
+  if (m_jLogMethodId == nullptr) {
     // exception thrown: NoSuchMethodException or OutOfMemoryError
     return;
   }
 
   jobject jdebug_level = InfoLogLevelJni::DEBUG_LEVEL(env);
-  if(jdebug_level == nullptr) {
+  if (jdebug_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jdebug_level = env->NewGlobalRef(jdebug_level);
-  if(m_jdebug_level == nullptr) {
+  if (m_jdebug_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   jobject jinfo_level = InfoLogLevelJni::INFO_LEVEL(env);
-  if(jinfo_level == nullptr) {
+  if (jinfo_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jinfo_level = env->NewGlobalRef(jinfo_level);
-  if(m_jinfo_level == nullptr) {
+  if (m_jinfo_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   jobject jwarn_level = InfoLogLevelJni::WARN_LEVEL(env);
-  if(jwarn_level == nullptr) {
+  if (jwarn_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jwarn_level = env->NewGlobalRef(jwarn_level);
-  if(m_jwarn_level == nullptr) {
+  if (m_jwarn_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   jobject jerror_level = InfoLogLevelJni::ERROR_LEVEL(env);
-  if(jerror_level == nullptr) {
+  if (jerror_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jerror_level = env->NewGlobalRef(jerror_level);
-  if(m_jerror_level == nullptr) {
+  if (m_jerror_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   jobject jfatal_level = InfoLogLevelJni::FATAL_LEVEL(env);
-  if(jfatal_level == nullptr) {
+  if (jfatal_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jfatal_level = env->NewGlobalRef(jfatal_level);
-  if(m_jfatal_level == nullptr) {
+  if (m_jfatal_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   jobject jheader_level = InfoLogLevelJni::HEADER_LEVEL(env);
-  if(jheader_level == nullptr) {
+  if (jheader_level == nullptr) {
     // exception thrown: NoSuchFieldError, ExceptionInInitializerError
     // or OutOfMemoryError
     return;
   }
   m_jheader_level = env->NewGlobalRef(jheader_level);
-  if(m_jheader_level == nullptr) {
+  if (m_jheader_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -102,10 +101,9 @@ void LoggerJniCallback::Logv(const char* format, va_list ap) {
   // use it because we need to know about the log level.
 }
 
-void LoggerJniCallback::Logv(const InfoLogLevel log_level,
-    const char* format, va_list ap) {
+void LoggerJniCallback::Logv(const InfoLogLevel log_level, const char* format,
+                             va_list ap) {
   if (GetInfoLogLevel() <= log_level) {
-
     // determine InfoLogLevel java enum instance
     jobject jlog_level;
     switch (log_level) {
@@ -142,26 +140,26 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level,
     assert(env != nullptr);
 
     jstring jmsg = env->NewStringUTF(msg.get());
-    if(jmsg == nullptr) {
+    if (jmsg == nullptr) {
       // unable to construct string
-      if(env->ExceptionCheck()) {
-        env->ExceptionDescribe(); // print out exception to stderr
+      if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();  // print out exception to stderr
       }
       releaseJniEnv(attached_thread);
       return;
     }
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: OutOfMemoryError
-      env->ExceptionDescribe(); // print out exception to stderr
+      env->ExceptionDescribe();  // print out exception to stderr
       env->DeleteLocalRef(jmsg);
       releaseJniEnv(attached_thread);
       return;
     }
 
     env->CallVoidMethod(m_jcallback_obj, m_jLogMethodId, jlog_level, jmsg);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown
-      env->ExceptionDescribe(); // print out exception to stderr
+      env->ExceptionDescribe();  // print out exception to stderr
       env->DeleteLocalRef(jmsg);
       releaseJniEnv(attached_thread);
       return;
@@ -172,11 +170,13 @@ void LoggerJniCallback::Logv(const InfoLogLevel log_level,
   }
 }
 
-std::unique_ptr<char[]> LoggerJniCallback::format_str(const char* format, va_list ap) const {
+std::unique_ptr<char[]> LoggerJniCallback::format_str(const char* format,
+                                                      va_list ap) const {
   va_list ap_copy;
 
   va_copy(ap_copy, ap);
-  const size_t required = vsnprintf(nullptr, 0, format, ap_copy) + 1; // Extra space for '\0'
+  const size_t required =
+      vsnprintf(nullptr, 0, format, ap_copy) + 1;  // Extra space for '\0'
   va_end(ap_copy);
 
   std::unique_ptr<char[]> buf(new char[required]);
@@ -192,27 +192,27 @@ LoggerJniCallback::~LoggerJniCallback() {
   JNIEnv* env = getJniEnv(&attached_thread);
   assert(env != nullptr);
 
-  if(m_jdebug_level != nullptr) {
+  if (m_jdebug_level != nullptr) {
     env->DeleteGlobalRef(m_jdebug_level);
   }
 
-  if(m_jinfo_level != nullptr) {
+  if (m_jinfo_level != nullptr) {
     env->DeleteGlobalRef(m_jinfo_level);
   }
 
-  if(m_jwarn_level != nullptr) {
+  if (m_jwarn_level != nullptr) {
     env->DeleteGlobalRef(m_jwarn_level);
   }
 
-  if(m_jerror_level != nullptr) {
+  if (m_jerror_level != nullptr) {
     env->DeleteGlobalRef(m_jerror_level);
   }
 
-  if(m_jfatal_level != nullptr) {
+  if (m_jfatal_level != nullptr) {
     env->DeleteGlobalRef(m_jfatal_level);
   }
 
-  if(m_jheader_level != nullptr) {
+  if (m_jheader_level != nullptr) {
     env->DeleteGlobalRef(m_jheader_level);
   }
 
@@ -226,8 +226,9 @@ LoggerJniCallback::~LoggerJniCallback() {
  * Method:    createNewLoggerOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Logger_createNewLoggerOptions(
-    JNIEnv* env, jobject jobj, jlong joptions) {
+jlong Java_org_rocksdb_Logger_createNewLoggerOptions(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*joptions*/) {
   auto* sptr_logger = new std::shared_ptr<rocksdb::LoggerJniCallback>(
       new rocksdb::LoggerJniCallback(env, jobj));
 
@@ -243,10 +244,11 @@ jlong Java_org_rocksdb_Logger_createNewLoggerOptions(
  * Method:    createNewLoggerDbOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(
-    JNIEnv* env, jobject jobj, jlong jdb_options) {
+jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong /*jdb_options*/) {
   auto* sptr_logger = new std::shared_ptr<rocksdb::LoggerJniCallback>(
-    new rocksdb::LoggerJniCallback(env, jobj));
+      new rocksdb::LoggerJniCallback(env, jobj));
 
   // set log level
   auto* db_options = reinterpret_cast<rocksdb::DBOptions*>(jdb_options);
@@ -260,12 +262,13 @@ jlong Java_org_rocksdb_Logger_createNewLoggerDbOptions(
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Logger_setInfoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jlog_level) {
+void Java_org_rocksdb_Logger_setInfoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong /*jhandle*/,
+                                             jbyte /*jlog_level*/) {
   auto* handle =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(jhandle);
-  handle->get()->
-      SetInfoLogLevel(static_cast<rocksdb::InfoLogLevel>(jlog_level));
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
+  handle->get()->SetInfoLogLevel(
+      static_cast<rocksdb::InfoLogLevel>(jlog_level));
 }
 
 /*
@@ -273,10 +276,10 @@ void Java_org_rocksdb_Logger_setInfoLogLevel(
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Logger_infoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Logger_infoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
+                                           jlong /*jhandle*/) {
   auto* handle =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   return static_cast<jbyte>(handle->get()->GetInfoLogLevel());
 }
 
@@ -285,9 +288,9 @@ jbyte Java_org_rocksdb_Logger_infoLogLevel(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Logger_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_Logger_disposeInternal(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong /*jhandle*/) {
   auto* handle =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(jhandle);
   delete handle;  // delete std::shared_ptr
 }

--- a/java/rocksjni/lru_cache.cc
+++ b/java/rocksjni/lru_cache.cc
@@ -16,13 +16,14 @@
  * Method:    newLRUCache
  * Signature: (JIZD)J
  */
-jlong Java_org_rocksdb_LRUCache_newLRUCache(
-    JNIEnv* env, jclass jcls, jlong jcapacity, jint jnum_shard_bits,
-    jboolean jstrict_capacity_limit, jdouble jhigh_pri_pool_ratio) {
+jlong Java_org_rocksdb_LRUCache_newLRUCache(JNIEnv* /*env*/, jclass /*jcls*/,
+                                            jlong /*jcapacity*/,
+                                            jint /*jnum_shard_bits*/,
+                                            jboolean /*jstrict_capacity_limit*/,
+                                            jdouble /*jhigh_pri_pool_ratio*/) {
   auto* sptr_lru_cache =
       new std::shared_ptr<rocksdb::Cache>(rocksdb::NewLRUCache(
-          static_cast<size_t>(jcapacity),
-          static_cast<int>(jnum_shard_bits),
+          static_cast<size_t>(jcapacity), static_cast<int>(jnum_shard_bits),
           static_cast<bool>(jstrict_capacity_limit),
           static_cast<double>(jhigh_pri_pool_ratio)));
   return reinterpret_cast<jlong>(sptr_lru_cache);
@@ -33,9 +34,10 @@ jlong Java_org_rocksdb_LRUCache_newLRUCache(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_LRUCache_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_LRUCache_disposeInternal(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* sptr_lru_cache =
-      reinterpret_cast<std::shared_ptr<rocksdb::Cache> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
   delete sptr_lru_cache;  // delete std::shared_ptr
 }

--- a/java/rocksjni/lru_cache.cc
+++ b/java/rocksjni/lru_cache.cc
@@ -17,10 +17,10 @@
  * Signature: (JIZD)J
  */
 jlong Java_org_rocksdb_LRUCache_newLRUCache(JNIEnv* /*env*/, jclass /*jcls*/,
-                                            jlong /*jcapacity*/,
-                                            jint /*jnum_shard_bits*/,
-                                            jboolean /*jstrict_capacity_limit*/,
-                                            jdouble /*jhigh_pri_pool_ratio*/) {
+                                            jlong jcapacity,
+                                            jint jnum_shard_bits,
+                                            jboolean jstrict_capacity_limit,
+                                            jdouble jhigh_pri_pool_ratio) {
   auto* sptr_lru_cache =
       new std::shared_ptr<rocksdb::Cache>(rocksdb::NewLRUCache(
           static_cast<size_t>(jcapacity), static_cast<int>(jnum_shard_bits),

--- a/java/rocksjni/memtablejni.cc
+++ b/java/rocksjni/memtablejni.cc
@@ -5,12 +5,12 @@
 //
 // This file implements the "bridge" between Java and C++ for MemTables.
 
-#include "rocksjni/portal.h"
-#include "include/org_rocksdb_HashSkipListMemTableConfig.h"
 #include "include/org_rocksdb_HashLinkedListMemTableConfig.h"
-#include "include/org_rocksdb_VectorMemTableConfig.h"
+#include "include/org_rocksdb_HashSkipListMemTableConfig.h"
 #include "include/org_rocksdb_SkipListMemTableConfig.h"
+#include "include/org_rocksdb_VectorMemTableConfig.h"
 #include "rocksdb/memtablerep.h"
+#include "rocksjni/portal.h"
 
 /*
  * Class:     org_rocksdb_HashSkipListMemTableConfig
@@ -18,13 +18,12 @@
  * Signature: (JII)J
  */
 jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject jobj, jlong jbucket_count,
-    jint jheight, jint jbranching_factor) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jbucket_count*/,
+    jint /*jheight*/, jint /*jbranching_factor*/) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jbucket_count);
   if (s.ok()) {
     return reinterpret_cast<jlong>(rocksdb::NewHashSkipListRepFactory(
-        static_cast<size_t>(jbucket_count),
-        static_cast<int32_t>(jheight),
+        static_cast<size_t>(jbucket_count), static_cast<int32_t>(jheight),
         static_cast<int32_t>(jbranching_factor)));
   }
   rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
@@ -37,9 +36,10 @@ jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (JJIZI)J
  */
 jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject jobj, jlong jbucket_count, jlong jhuge_page_tlb_size,
-    jint jbucket_entries_logging_threshold,
-    jboolean jif_log_bucket_dist_when_flash, jint jthreshold_use_skiplist) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jbucket_count*/,
+    jlong /*jhuge_page_tlb_size*/, jint /*jbucket_entries_logging_threshold*/,
+    jboolean /*jif_log_bucket_dist_when_flash*/,
+    jint /*jthreshold_use_skiplist*/) {
   rocksdb::Status statusBucketCount =
       rocksdb::check_if_jlong_fits_size_t(jbucket_count);
   rocksdb::Status statusHugePageTlb =
@@ -52,8 +52,8 @@ jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
         static_cast<bool>(jif_log_bucket_dist_when_flash),
         static_cast<int32_t>(jthreshold_use_skiplist)));
   }
-  rocksdb::IllegalArgumentExceptionJni::ThrowNew(env,
-      !statusBucketCount.ok()?statusBucketCount:statusHugePageTlb);
+  rocksdb::IllegalArgumentExceptionJni::ThrowNew(
+      env, !statusBucketCount.ok() ? statusBucketCount : statusHugePageTlb);
   return 0;
 }
 
@@ -63,11 +63,11 @@ jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* env, jobject jobj, jlong jreserved_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jreserved_size*/) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jreserved_size);
   if (s.ok()) {
-    return reinterpret_cast<jlong>(new rocksdb::VectorRepFactory(
-        static_cast<size_t>(jreserved_size)));
+    return reinterpret_cast<jlong>(
+        new rocksdb::VectorRepFactory(static_cast<size_t>(jreserved_size)));
   }
   rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   return 0;
@@ -79,11 +79,11 @@ jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SkipListMemTableConfig_newMemTableFactoryHandle0(
-    JNIEnv* env, jobject jobj, jlong jlookahead) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jlookahead*/) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jlookahead);
   if (s.ok()) {
-    return reinterpret_cast<jlong>(new rocksdb::SkipListFactory(
-        static_cast<size_t>(jlookahead)));
+    return reinterpret_cast<jlong>(
+        new rocksdb::SkipListFactory(static_cast<size_t>(jlookahead)));
   }
   rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   return 0;

--- a/java/rocksjni/memtablejni.cc
+++ b/java/rocksjni/memtablejni.cc
@@ -18,8 +18,8 @@
  * Signature: (JII)J
  */
 jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jbucket_count*/,
-    jint /*jheight*/, jint /*jbranching_factor*/) {
+    JNIEnv* env, jobject /*jobj*/, jlong jbucket_count, jint jheight,
+    jint jbranching_factor) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jbucket_count);
   if (s.ok()) {
     return reinterpret_cast<jlong>(rocksdb::NewHashSkipListRepFactory(
@@ -36,10 +36,9 @@ jlong Java_org_rocksdb_HashSkipListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (JJIZI)J
  */
 jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jbucket_count*/,
-    jlong /*jhuge_page_tlb_size*/, jint /*jbucket_entries_logging_threshold*/,
-    jboolean /*jif_log_bucket_dist_when_flash*/,
-    jint /*jthreshold_use_skiplist*/) {
+    JNIEnv* env, jobject /*jobj*/, jlong jbucket_count,
+    jlong jhuge_page_tlb_size, jint jbucket_entries_logging_threshold,
+    jboolean jif_log_bucket_dist_when_flash, jint jthreshold_use_skiplist) {
   rocksdb::Status statusBucketCount =
       rocksdb::check_if_jlong_fits_size_t(jbucket_count);
   rocksdb::Status statusHugePageTlb =
@@ -63,7 +62,7 @@ jlong Java_org_rocksdb_HashLinkedListMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jreserved_size*/) {
+    JNIEnv* env, jobject /*jobj*/, jlong jreserved_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jreserved_size);
   if (s.ok()) {
     return reinterpret_cast<jlong>(
@@ -79,7 +78,7 @@ jlong Java_org_rocksdb_VectorMemTableConfig_newMemTableFactoryHandle(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SkipListMemTableConfig_newMemTableFactoryHandle0(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jlookahead*/) {
+    JNIEnv* env, jobject /*jobj*/, jlong jlookahead) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jlookahead);
   if (s.ok()) {
     return reinterpret_cast<jlong>(

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -29,7 +29,7 @@
  * Signature: (C)J
  */
 jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jchar /*jdelim*/) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jchar jdelim) {
   auto* sptr_string_append_op = new std::shared_ptr<rocksdb::MergeOperator>(
       rocksdb::MergeOperators::CreateStringAppendOperator((char)jdelim));
   return reinterpret_cast<jlong>(sptr_string_append_op);

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -6,21 +6,21 @@
 // This file implements the "bridge" between Java and C++
 // for rocksdb::MergeOperator.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "include/org_rocksdb_StringAppendOperator.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/db.h"
-#include "rocksdb/options.h"
-#include "rocksdb/statistics.h"
 #include "rocksdb/memtablerep.h"
-#include "rocksdb/table.h"
-#include "rocksdb/slice_transform.h"
 #include "rocksdb/merge_operator.h"
+#include "rocksdb/options.h"
+#include "rocksdb/slice_transform.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/table.h"
+#include "rocksjni/portal.h"
 #include "utilities/merge_operators.h"
 
 /*
@@ -28,10 +28,10 @@
  * Method:    newSharedStringAppendOperator
  * Signature: (C)J
  */
-jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator
-(JNIEnv* env, jclass jclazz, jchar jdelim) {
+jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator(
+    JNIEnv* /*env*/, jclass /*jclazz*/, jchar /*jdelim*/) {
   auto* sptr_string_append_op = new std::shared_ptr<rocksdb::MergeOperator>(
-    rocksdb::MergeOperators::CreateStringAppendOperator((char) jdelim));
+      rocksdb::MergeOperators::CreateStringAppendOperator((char)jdelim));
   return reinterpret_cast<jlong>(sptr_string_append_op);
 }
 
@@ -40,9 +40,10 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_StringAppendOperator_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_StringAppendOperator_disposeInternal(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* sptr_string_append_op =
-      reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>* >(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
   delete sptr_string_append_op;  // delete std::shared_ptr
 }

--- a/java/rocksjni/native_comparator_wrapper_test.cc
+++ b/java/rocksjni/native_comparator_wrapper_test.cc
@@ -13,38 +13,31 @@
 
 namespace rocksdb {
 
-class NativeComparatorWrapperTestStringComparator
-    : public Comparator {
-
+class NativeComparatorWrapperTestStringComparator : public Comparator {
   const char* Name() const {
     return "NativeComparatorWrapperTestStringComparator";
   }
 
-  int Compare(
-      const Slice& a, const Slice& b) const {
+  int Compare(const Slice& /*a*/, const Slice& /*b*/) const {
     return a.ToString().compare(b.ToString());
   }
 
-  void FindShortestSeparator(
-      std::string* start, const Slice& limit) const {
+  void FindShortestSeparator(std::string* /*start*/,
+                             const Slice& /*limit*/) const {
     return;
   }
 
-  void FindShortSuccessor(
-      std::string* key) const {
-    return;
-  }
+  void FindShortSuccessor(std::string* /*key*/) const { return; }
 };
-}  // end of rocksdb namespace
+}  // namespace rocksdb
 
 /*
- * Class:     org_rocksdb_NativeComparatorWrapperTest_NativeStringComparatorWrapper
+ * Class: org_rocksdb_NativeComparatorWrapperTest_NativeStringComparatorWrapper
  * Method:    newStringComparator
  * Signature: ()J
  */
 jlong Java_org_rocksdb_NativeComparatorWrapperTest_00024NativeStringComparatorWrapper_newStringComparator(
-    JNIEnv* env , jobject jobj) {
-  auto* comparator =
-      new rocksdb::NativeComparatorWrapperTestStringComparator();
+    JNIEnv* /*env*/, jobject /*jobj*/) {
+  auto* comparator = new rocksdb::NativeComparatorWrapperTestStringComparator();
   return reinterpret_cast<jlong>(comparator);
 }

--- a/java/rocksjni/native_comparator_wrapper_test.cc
+++ b/java/rocksjni/native_comparator_wrapper_test.cc
@@ -18,7 +18,7 @@ class NativeComparatorWrapperTestStringComparator : public Comparator {
     return "NativeComparatorWrapperTestStringComparator";
   }
 
-  int Compare(const Slice& /*a*/, const Slice& /*b*/) const {
+  int Compare(const Slice& a, const Slice& b) const {
     return a.ToString().compare(b.ToString());
   }
 

--- a/java/rocksjni/optimistic_transaction_db.cc
+++ b/java/rocksjni/optimistic_transaction_db.cc
@@ -22,11 +22,11 @@
  * Signature: (JLjava/lang/String;)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2(
-    JNIEnv* env, jclass jcls, jlong joptions_handle, jstring jdb_path) {
+    JNIEnv* env, jclass /*jcls*/, jlong joptions_handle, jstring jdb_path) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
   if (db_path == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return 0;
+    // exception thrown: OutOfMemoryError
+    return 0;
   }
 
   auto* options = reinterpret_cast<rocksdb::Options*>(joptions_handle);
@@ -48,13 +48,14 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2(
  * Method:    open
  * Signature: (JLjava/lang/String;[[B[J)[J
  */
-jlongArray Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3_3B_3J(
-    JNIEnv* env, jclass jcls, jlong jdb_options_handle, jstring jdb_path,
+jlongArray
+Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3_3B_3J(
+    JNIEnv* env, jclass /*jcls*/, jlong jdb_options_handle, jstring jdb_path,
     jobjectArray jcolumn_names, jlongArray jcolumn_options_handles) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
   if (db_path == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    return nullptr;
   }
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
@@ -66,50 +67,50 @@ jlongArray Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3
       return nullptr;
     }
 
-    jlong* jco =
-        env->GetLongArrayElements(jcolumn_options_handles, nullptr);
-    if(jco == nullptr) {
-        // exception thrown: OutOfMemoryError
-        env->ReleaseStringUTFChars(jdb_path, db_path);
-        return nullptr;
+    jlong* jco = env->GetLongArrayElements(jcolumn_options_handles, nullptr);
+    if (jco == nullptr) {
+      // exception thrown: OutOfMemoryError
+      env->ReleaseStringUTFChars(jdb_path, db_path);
+      return nullptr;
     }
 
     for (int i = 0; i < len_cols; i++) {
-        const jobject jcn = env->GetObjectArrayElement(jcolumn_names, i);
-        if (env->ExceptionCheck()) {
-            // exception thrown: ArrayIndexOutOfBoundsException
-            env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
-            env->ReleaseStringUTFChars(jdb_path, db_path);
-            return nullptr;
-        }
+      const jobject jcn = env->GetObjectArrayElement(jcolumn_names, i);
+      if (env->ExceptionCheck()) {
+        // exception thrown: ArrayIndexOutOfBoundsException
+        env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
+        env->ReleaseStringUTFChars(jdb_path, db_path);
+        return nullptr;
+      }
 
-        const jbyteArray jcn_ba = reinterpret_cast<jbyteArray>(jcn);
-        const jsize jcf_name_len = env->GetArrayLength(jcn_ba);
-        if (env->EnsureLocalCapacity(jcf_name_len) != 0) {
-          // out of memory
-          env->DeleteLocalRef(jcn);
-          env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
-          env->ReleaseStringUTFChars(jdb_path, db_path);
-          return nullptr;
-        }
-
-        jbyte* jcf_name = env->GetByteArrayElements(jcn_ba, nullptr);
-        if (jcf_name == nullptr) {
-            // exception thrown: OutOfMemoryError
-            env->DeleteLocalRef(jcn);
-            env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
-            env->ReleaseStringUTFChars(jdb_path, db_path);
-            return nullptr;
-        }
-
-        const std::string cf_name(reinterpret_cast<char *>(jcf_name), jcf_name_len);
-        const rocksdb::ColumnFamilyOptions* cf_options =
-            reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[i]);
-        column_families.push_back(
-            rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
-
-        env->ReleaseByteArrayElements(jcn_ba, jcf_name, JNI_ABORT);
+      const jbyteArray jcn_ba = reinterpret_cast<jbyteArray>(jcn);
+      const jsize jcf_name_len = env->GetArrayLength(jcn_ba);
+      if (env->EnsureLocalCapacity(jcf_name_len) != 0) {
+        // out of memory
         env->DeleteLocalRef(jcn);
+        env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
+        env->ReleaseStringUTFChars(jdb_path, db_path);
+        return nullptr;
+      }
+
+      jbyte* jcf_name = env->GetByteArrayElements(jcn_ba, nullptr);
+      if (jcf_name == nullptr) {
+        // exception thrown: OutOfMemoryError
+        env->DeleteLocalRef(jcn);
+        env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
+        env->ReleaseStringUTFChars(jdb_path, db_path);
+        return nullptr;
+      }
+
+      const std::string cf_name(reinterpret_cast<char*>(jcf_name),
+                                jcf_name_len);
+      const rocksdb::ColumnFamilyOptions* cf_options =
+          reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[i]);
+      column_families.push_back(
+          rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
+
+      env->ReleaseByteArrayElements(jcn_ba, jcf_name, JNI_ABORT);
+      env->DeleteLocalRef(jcn);
     }
     env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
   }
@@ -117,8 +118,8 @@ jlongArray Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3
   auto* db_options = reinterpret_cast<rocksdb::DBOptions*>(jdb_options_handle);
   std::vector<rocksdb::ColumnFamilyHandle*> handles;
   rocksdb::OptimisticTransactionDB* otdb = nullptr;
-  const rocksdb::Status s = rocksdb::OptimisticTransactionDB::Open(*db_options,
-      db_path, column_families, &handles, &otdb);
+  const rocksdb::Status s = rocksdb::OptimisticTransactionDB::Open(
+      *db_options, db_path, column_families, &handles, &otdb);
 
   env->ReleaseStringUTFChars(jdb_path, db_path);
 
@@ -134,13 +135,13 @@ jlongArray Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3
 
     jlongArray jresults = env->NewLongArray(resultsLen);
     if (jresults == nullptr) {
-        // exception thrown: OutOfMemoryError
-        return nullptr;
+      // exception thrown: OutOfMemoryError
+      return nullptr;
     }
     env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
     if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException
-        return nullptr;
+      // exception thrown: ArrayIndexOutOfBoundsException
+      return nullptr;
     }
     return jresults;
   }
@@ -155,7 +156,8 @@ jlongArray Java_org_rocksdb_OptimisticTransactionDB_open__JLjava_lang_String_2_3
  * Signature: (JJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
   auto* write_options =
@@ -171,18 +173,17 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong joptimistic_txn_options_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong joptimistic_txn_options_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* optimistic_txn_options =
       reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(
-      joptimistic_txn_options_handle);
-  rocksdb::Transaction* txn =
-      optimistic_txn_db->BeginTransaction(*write_options,
-      *optimistic_txn_options);
+          joptimistic_txn_options_handle);
+  rocksdb::Transaction* txn = optimistic_txn_db->BeginTransaction(
+      *write_options, *optimistic_txn_options);
   return reinterpret_cast<jlong>(txn);
 }
 
@@ -192,19 +193,16 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction__JJJ(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong jold_txn_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong jold_txn_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
-  auto* old_txn =
-      reinterpret_cast<rocksdb::Transaction*>(
-      jold_txn_handle);
+  auto* old_txn = reinterpret_cast<rocksdb::Transaction*>(jold_txn_handle);
   rocksdb::OptimisticTransactionOptions optimistic_txn_options;
-  rocksdb::Transaction* txn =
-      optimistic_txn_db->BeginTransaction(*write_options,
-          optimistic_txn_options, old_txn);
+  rocksdb::Transaction* txn = optimistic_txn_db->BeginTransaction(
+      *write_options, optimistic_txn_options, old_txn);
 
   // RocksJava relies on the assumption that
   // we do not allocate a new Transaction object
@@ -220,21 +218,19 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJ(
  * Signature: (JJJJ)J
  */
 jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong joptimistic_txn_options_handle, jlong jold_txn_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong joptimistic_txn_options_handle,
+    jlong jold_txn_handle) {
   auto* optimistic_txn_db =
       reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* optimistic_txn_options =
       reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(
-        joptimistic_txn_options_handle);
-  auto* old_txn =
-      reinterpret_cast<rocksdb::Transaction*>(
-      jold_txn_handle);
-  rocksdb::Transaction* txn =
-      optimistic_txn_db->BeginTransaction(*write_options,
-      *optimistic_txn_options, old_txn);
+          joptimistic_txn_options_handle);
+  auto* old_txn = reinterpret_cast<rocksdb::Transaction*>(jold_txn_handle);
+  rocksdb::Transaction* txn = optimistic_txn_db->BeginTransaction(
+      *write_options, *optimistic_txn_options, old_txn);
 
   // RocksJava relies on the assumption that
   // we do not allocate a new Transaction object
@@ -249,8 +245,9 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_beginTransaction_1withOld__JJJJ(
  * Method:    getBaseDB
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_OptimisticTransactionDB_getBaseDB(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_OptimisticTransactionDB_getBaseDB(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* optimistic_txn_db =
       reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
   return reinterpret_cast<jlong>(optimistic_txn_db->GetBaseDB());
@@ -261,7 +258,8 @@ jlong Java_org_rocksdb_OptimisticTransactionDB_getBaseDB(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_OptimisticTransactionDB_disposeInternal(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_OptimisticTransactionDB_disposeInternal(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle) {
   delete reinterpret_cast<rocksdb::OptimisticTransactionDB*>(jhandle);
 }

--- a/java/rocksjni/optimistic_transaction_options.cc
+++ b/java/rocksjni/optimistic_transaction_options.cc
@@ -19,7 +19,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_OptimisticTransactionOptions_newOptimisticTransactionOptions(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   rocksdb::OptimisticTransactionOptions* opts =
       new rocksdb::OptimisticTransactionOptions();
   return reinterpret_cast<jlong>(opts);
@@ -31,7 +31,7 @@ jlong Java_org_rocksdb_OptimisticTransactionOptions_newOptimisticTransactionOpti
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_OptimisticTransactionOptions_isSetSnapshot(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opts =
       reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(jhandle);
   return opts->set_snapshot;
@@ -42,8 +42,8 @@ jboolean Java_org_rocksdb_OptimisticTransactionOptions_isSetSnapshot(
  * Method:    setSetSnapshot
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_OptimisticTransactionOptions_setSetSnapshot(JNIEnv* env,
-    jobject jobj, jlong jhandle, jboolean jset_snapshot) {
+void Java_org_rocksdb_OptimisticTransactionOptions_setSetSnapshot(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jset_snapshot) {
   auto* opts =
       reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(jhandle);
   opts->set_snapshot = jset_snapshot;
@@ -55,7 +55,8 @@ void Java_org_rocksdb_OptimisticTransactionOptions_setSetSnapshot(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_OptimisticTransactionOptions_setComparator(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcomparator_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jcomparator_handle) {
   auto* opts =
       reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(jhandle);
   opts->cmp = reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
@@ -66,7 +67,7 @@ void Java_org_rocksdb_OptimisticTransactionOptions_setComparator(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_OptimisticTransactionOptions_disposeInternal(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_OptimisticTransactionOptions_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   delete reinterpret_cast<rocksdb::OptimisticTransactionOptions*>(jhandle);
 }

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2393,7 +2393,7 @@ jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setArenaBlockSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* /*env*/,
+void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env,
                                                 jobject /*jobj*/, jlong jhandle,
                                                 jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
@@ -2493,7 +2493,7 @@ jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jinplace_update_num_locks) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
@@ -2569,7 +2569,7 @@ jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jmax_successive_merges) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
@@ -2680,7 +2680,7 @@ jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMemtableHugePageSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jmemtable_huge_page_size) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
@@ -2821,7 +2821,7 @@ void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
  * Signature: (J)[I
  */
 jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle) {
   auto mbflma = reinterpret_cast<rocksdb::Options*>(jhandle)
                     ->max_bytes_for_level_multiplier_additional;
 
@@ -2859,7 +2859,7 @@ jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals = env->GetIntArrayElements(
@@ -3039,7 +3039,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
  * Signature: (Ljava/util/String;)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps(
-    JNIEnv* /*env*/, jclass jclazz, jstring jopt_string) {
+    JNIEnv* env, jclass /*jclazz*/, jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
   if (opt_string == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -3181,7 +3181,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jstring jop_name) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jstring jop_name) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
   if (op_name == nullptr) {
@@ -3242,7 +3242,7 @@ Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jwrite_buffer_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jwrite_buffer_size);
   if (s.ok()) {
@@ -3306,7 +3306,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
  * Signature: (J)Ljava/lang/String
  */
 jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   rocksdb::MemTableRepFactory* tf = opt->memtable_factory.get();
 
@@ -3358,7 +3358,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
  * Method:    tableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* /*env*/,
+jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* env,
                                                               jobject /*jobj*/,
                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
@@ -3451,7 +3451,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv* /*env*/,
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jbyteArray jcompressionLevels) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto uptr_compression_levels =
@@ -3469,7 +3469,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb_compression_list_helper(env,
                                          cf_options->compression_per_level);
@@ -3820,7 +3820,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jarena_block_size) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->arena_block_size =
@@ -3917,7 +3917,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jinplace_update_num_locks) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
@@ -3994,7 +3994,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jmax_successive_merges) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
@@ -4047,7 +4047,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong jmemtable_huge_page_size) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
@@ -4186,7 +4186,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
  */
 jintArray
 Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle) {
   auto mbflma = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
                     ->max_bytes_for_level_multiplier_additional;
 
@@ -4223,7 +4223,7 @@ Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals =
@@ -4400,8 +4400,8 @@ jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* /*env*/, jclass jcls,
  * Method:    getDBOptionsFromProps
  * Signature: (Ljava/util/String;)J
  */
-jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* /*env*/,
-                                                       jclass jclazz,
+jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* env,
+                                                       jclass /*jclazz*/,
                                                        jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
   if (opt_string == nullptr) {
@@ -4763,7 +4763,7 @@ jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject /*jobj*/,
                                            jlong jhandle, jobjectArray jpaths,
                                            jlongArray jtarget_sizes) {
   std::vector<rocksdb::DbPath> db_paths;
@@ -4784,7 +4784,7 @@ void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
       return;
     }
     std::string path = rocksdb::JniUtil::copyStdString(
-        /*env*/, static_cast<jstring>(jpath), &has_exception);
+        env, static_cast<jstring>(jpath), &has_exception);
     env->DeleteLocalRef(jpath);
 
     if (has_exception == JNI_TRUE) {
@@ -4820,7 +4820,7 @@ jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject /*jobj*/,
                                         jlong jhandle, jobjectArray jpaths,
                                         jlongArray jtarget_sizes) {
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
@@ -4859,7 +4859,7 @@ void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject /*jobj*/,
                                             jlong jhandle,
                                             jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
@@ -4877,7 +4877,7 @@ void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
+jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject /*jobj*/,
                                             jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->db_log_dir.c_str());
@@ -4888,7 +4888,7 @@ jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject /*jobj*/,
                                           jlong jhandle, jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, 0);
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.assign(wal_dir);
@@ -4900,7 +4900,7 @@ void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* /*env*/, jobject /*jobj*/,
+jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject /*jobj*/,
                                           jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.c_str());
@@ -5053,7 +5053,7 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* /*env*/,
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* /*env*/,
+void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env,
                                                   jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jlong max_log_file_size) {
@@ -5083,7 +5083,7 @@ jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong log_file_time_to_roll) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(log_file_time_to_roll);
@@ -5111,7 +5111,7 @@ jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv* /*env*/,
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* /*env*/,
+void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env,
                                                   jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jlong keep_log_file_num) {
@@ -5141,7 +5141,7 @@ jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setRecycleLogFileNum(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong recycle_log_file_num) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(recycle_log_file_num);
   if (s.ok()) {
@@ -5264,7 +5264,7 @@ jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
     jlong preallocation_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(preallocation_size);
   if (s.ok()) {
@@ -6035,7 +6035,7 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* /*env*/,
-                                                    jclass jcls) {
+                                                    jclass /*jcls*/) {
   auto* op = new rocksdb::WriteOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -6046,7 +6046,7 @@ jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* /*env*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* /*env*/,
-                                                     jclass jcls,
+                                                     jclass /*jcls*/,
                                                      jlong jhandle) {
   auto new_opt = new rocksdb::WriteOptions(
       *(reinterpret_cast<rocksdb::WriteOptions*>(jhandle)));
@@ -6059,7 +6059,7 @@ jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* /*env*/,
  * Signature: ()V
  */
 void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* /*env*/,
-                                                   jobject jwrite_options,
+                                                   jobject /*jwrite_options*/,
                                                    jlong jhandle) {
   auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(jhandle);
   assert(write_options != nullptr);
@@ -6072,7 +6072,7 @@ void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* /*env*/,
-                                           jobject jwrite_options,
+                                           jobject /*jwrite_options*/,
                                            jlong jhandle, jboolean jflag) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync = jflag;
 }
@@ -6083,7 +6083,7 @@ void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* /*env*/,
-                                            jobject jwrite_options,
+                                            jobject /*jwrite_options*/,
                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync;
 }
@@ -6094,7 +6094,7 @@ jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* /*env*/,
-                                                 jobject jwrite_options,
+                                                 jobject /*jwrite_options*/,
                                                  jlong jhandle,
                                                  jboolean jflag) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->disableWAL = jflag;
@@ -6106,7 +6106,7 @@ void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* /*env*/,
-                                                  jobject jwrite_options,
+                                                  jobject /*jwrite_options*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->disableWAL;
 }
@@ -6117,7 +6117,7 @@ jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* /*env*/,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
-    JNIEnv* /*env*/, jobject jwrite_options, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jwrite_options*/, jlong jhandle,
     jboolean jignore_missing_column_families) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
       ->ignore_missing_column_families =
@@ -6130,7 +6130,7 @@ void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
-    JNIEnv* /*env*/, jobject jwrite_options, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jwrite_options*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
       ->ignore_missing_column_families;
 }
@@ -6141,7 +6141,7 @@ jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* /*env*/,
-                                                 jobject jwrite_options,
+                                                 jobject /*jwrite_options*/,
                                                  jlong jhandle,
                                                  jboolean jno_slowdown) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->no_slowdown =
@@ -6154,7 +6154,7 @@ void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* /*env*/,
-                                                  jobject jwrite_options,
+                                                  jobject /*jwrite_options*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->no_slowdown;
 }
@@ -6168,7 +6168,7 @@ jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* /*env*/,
-                                                  jclass jcls) {
+                                                  jclass /*jcls*/) {
   auto* read_options = new rocksdb::ReadOptions();
   return reinterpret_cast<jlong>(read_options);
 }
@@ -6178,7 +6178,7 @@ jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* /*env*/,
  * Method:    copyReadOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* /*env*/, jclass jcls,
+jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* /*env*/, jclass /*jcls*/,
                                                    jlong jhandle) {
   auto new_opt = new rocksdb::ReadOptions(
       *(reinterpret_cast<rocksdb::ReadOptions*>(jhandle)));
@@ -6505,7 +6505,7 @@ jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv* /*env*/,
-                                                              jclass jcls) {
+                                                              jclass /*jcls*/) {
   auto* comparator_opt = new rocksdb::ComparatorJniCallbackOptions();
   return reinterpret_cast<jlong>(comparator_opt);
 }
@@ -6557,7 +6557,7 @@ void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv* /*env*/,
-                                                    jclass jcls) {
+                                                    jclass /*jcls*/) {
   auto* flush_opt = new rocksdb::FlushOptions();
   return reinterpret_cast<jlong>(flush_opt);
 }

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -2030,7 +2030,8 @@ jbyteArray rocksdb_compression_list_helper(
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_Options_setCompressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyteArray jcompressionLevels) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle,
+    jbyteArray jcompressionLevels) {
   auto uptr_compression_levels =
       rocksdb_compression_vector_helper(env, jcompressionLevels);
   if (!uptr_compression_levels) {
@@ -2047,7 +2048,7 @@ void Java_org_rocksdb_Options_setCompressionPerLevel(
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env,
-                                                        jobject jobj,
+                                                        jobject /*jobj*/,
                                                         jlong jhandle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb_compression_list_helper(env, options->compression_per_level);
@@ -2059,7 +2060,8 @@ jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setBottommostCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jcompression_type_value) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
   options->bottommost_compression =
       rocksdb::CompressionTypeJni::toCppCompressionType(
@@ -2071,8 +2073,8 @@ void Java_org_rocksdb_Options_setBottommostCompressionType(
  * Method:    bottommostCompressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv* env,
-                                                         jobject jobj,
+jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::CompressionTypeJni::toJavaCompressionType(
@@ -2085,7 +2087,7 @@ jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompressionOptions(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompression_options_handle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
   auto* compression_options = reinterpret_cast<rocksdb::CompressionOptions*>(
@@ -2098,7 +2100,8 @@ void Java_org_rocksdb_Options_setCompressionOptions(
  * Method:    setCompactionStyle
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jbyte compaction_style) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_style =
@@ -2110,7 +2113,8 @@ void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv* env, jobject jobj,
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv* env, jobject jobj,
+jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_style;
 }
@@ -2121,7 +2125,8 @@ jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_table_files_size) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->compaction_options_fifo.max_table_files_size =
       static_cast<uint64_t>(jmax_table_files_size);
@@ -2132,7 +2137,8 @@ void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
  * Method:    maxTableFilesSizeFIFO
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->compaction_options_fifo.max_table_files_size;
@@ -2143,7 +2149,7 @@ jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv* env, jobject jobj,
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_numLevels(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_Options_numLevels(JNIEnv* /*env*/, jobject /*jobj*/,
                                         jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->num_levels;
 }
@@ -2153,7 +2159,7 @@ jint Java_org_rocksdb_Options_numLevels(JNIEnv* env, jobject jobj,
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setNumLevels(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_setNumLevels(JNIEnv* /*env*/, jobject /*jobj*/,
                                            jlong jhandle, jint jnum_levels) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->num_levels =
       static_cast<int>(jnum_levels);
@@ -2164,9 +2170,8 @@ void Java_org_rocksdb_Options_setNumLevels(JNIEnv* env, jobject jobj,
  * Method:    levelZeroFileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv* env,
-                                                                jobject jobj,
-                                                                jlong jhandle) {
+jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_file_num_compaction_trigger;
 }
@@ -2177,7 +2182,7 @@ jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_file_num_compaction_trigger =
@@ -2189,8 +2194,8 @@ void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
  * Method:    levelZeroSlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv* env,
-                                                             jobject jobj,
+jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_slowdown_writes_trigger;
@@ -2202,7 +2207,7 @@ jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->level0_slowdown_writes_trigger =
       static_cast<int>(jlevel0_slowdown_writes_trigger);
@@ -2213,8 +2218,8 @@ void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
  * Method:    levelZeroStopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv* env,
-                                                         jobject jobj,
+jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_stop_writes_trigger;
@@ -2226,7 +2231,7 @@ jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevelZeroStopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->level0_stop_writes_trigger =
       static_cast<int>(jlevel0_stop_writes_trigger);
@@ -2237,7 +2242,8 @@ void Java_org_rocksdb_Options_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_base;
 }
@@ -2248,7 +2254,8 @@ jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setTargetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jtarget_file_size_base) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jtarget_file_size_base) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_base =
       static_cast<uint64_t>(jtarget_file_size_base);
 }
@@ -2258,8 +2265,8 @@ void Java_org_rocksdb_Options_setTargetFileSizeBase(
  * Method:    targetFileSizeMultiplier
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv* env,
-                                                       jobject jobj,
+jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->target_file_size_multiplier;
@@ -2271,7 +2278,7 @@ jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jtarget_file_size_multiplier) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_multiplier =
       static_cast<int>(jtarget_file_size_multiplier);
@@ -2282,7 +2289,8 @@ void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_bytes_for_level_base;
 }
@@ -2293,7 +2301,8 @@ jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_bytes_for_level_base) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_bytes_for_level_base) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_bytes_for_level_base =
       static_cast<int64_t>(jmax_bytes_for_level_base);
 }
@@ -2304,7 +2313,7 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level_compaction_dynamic_level_bytes;
 }
@@ -2315,7 +2324,7 @@ jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jenable_dynamic_level_bytes) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
@@ -2326,8 +2335,8 @@ void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
  * Method:    maxBytesForLevelMultiplier
  * Signature: (J)D
  */
-jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv* env,
-                                                            jobject jobj,
+jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->max_bytes_for_level_multiplier;
@@ -2339,7 +2348,7 @@ jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv* env,
  * Signature: (JD)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jdouble jmax_bytes_for_level_multiplier) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_bytes_for_level_multiplier =
       static_cast<double>(jmax_bytes_for_level_multiplier);
@@ -2350,7 +2359,8 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplier(
  * Method:    maxCompactionBytes
  * Signature: (J)I
  */
-jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return static_cast<jlong>(
       reinterpret_cast<rocksdb::Options*>(jhandle)->max_compaction_bytes);
@@ -2362,7 +2372,8 @@ jlong Java_org_rocksdb_Options_maxCompactionBytes(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxCompactionBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_compaction_bytes) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_compaction_bytes) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_compaction_bytes =
       static_cast<uint64_t>(jmax_compaction_bytes);
 }
@@ -2372,7 +2383,7 @@ void Java_org_rocksdb_Options_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->arena_block_size;
 }
@@ -2382,8 +2393,8 @@ jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv* env, jobject jobj,
  * Method:    setArenaBlockSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
@@ -2399,8 +2410,8 @@ void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jobject jobj,
  * Method:    disableAutoCompactions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv* env,
-                                                         jobject jobj,
+jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->disable_auto_compactions;
 }
@@ -2411,7 +2422,7 @@ jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setDisableAutoCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jdisable_auto_compactions) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->disable_auto_compactions =
       static_cast<bool>(jdisable_auto_compactions);
@@ -2422,8 +2433,8 @@ void Java_org_rocksdb_Options_setDisableAutoCompactions(
  * Method:    maxSequentialSkipInIterations
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv* env,
-                                                             jobject jobj,
+jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->max_sequential_skip_in_iterations;
@@ -2435,7 +2446,7 @@ jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jmax_sequential_skip_in_iterations) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->max_sequential_skip_in_iterations =
@@ -2447,8 +2458,8 @@ void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
  * Method:    inplaceUpdateSupport
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv* env,
-                                                       jobject jobj,
+jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_support;
 }
@@ -2459,7 +2470,7 @@ jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateSupport(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jinplace_update_support) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_support =
       static_cast<bool>(jinplace_update_support);
@@ -2470,7 +2481,8 @@ void Java_org_rocksdb_Options_setInplaceUpdateSupport(
  * Method:    inplaceUpdateNumLocks
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_num_locks;
 }
@@ -2481,7 +2493,8 @@ jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jinplace_update_num_locks) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jinplace_update_num_locks) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
   if (s.ok()) {
@@ -2497,8 +2510,8 @@ void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
  * Method:    memtablePrefixBloomSizeRatio
  * Signature: (J)I
  */
-jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv* env,
-                                                              jobject jobj,
+jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->memtable_prefix_bloom_size_ratio;
@@ -2510,7 +2523,7 @@ jdouble Java_org_rocksdb_Options_memtablePrefixBloomSizeRatio(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMemtablePrefixBloomSizeRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jdouble jmemtable_prefix_bloom_size_ratio) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->memtable_prefix_bloom_size_ratio =
@@ -2522,7 +2535,7 @@ void Java_org_rocksdb_Options_setMemtablePrefixBloomSizeRatio(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_bloomLocality(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_Options_bloomLocality(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->bloom_locality;
 }
@@ -2532,8 +2545,8 @@ jint Java_org_rocksdb_Options_bloomLocality(JNIEnv* env, jobject jobj,
  * Method:    setBloomLocality
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setBloomLocality(JNIEnv* env, jobject jobj,
-                                               jlong jhandle,
+void Java_org_rocksdb_Options_setBloomLocality(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
                                                jint jbloom_locality) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->bloom_locality =
       static_cast<int32_t>(jbloom_locality);
@@ -2544,7 +2557,8 @@ void Java_org_rocksdb_Options_setBloomLocality(JNIEnv* env, jobject jobj,
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_successive_merges;
 }
@@ -2555,7 +2569,8 @@ jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_successive_merges) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_successive_merges) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
   if (s.ok()) {
@@ -2571,8 +2586,8 @@ void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
  * Method:    optimizeFiltersForHits
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv* env,
-                                                         jobject jobj,
+jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->optimize_filters_for_hits;
@@ -2584,7 +2599,7 @@ jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setOptimizeFiltersForHits(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean joptimize_filters_for_hits) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->optimize_filters_for_hits =
       static_cast<bool>(joptimize_filters_for_hits);
@@ -2595,7 +2610,8 @@ void Java_org_rocksdb_Options_setOptimizeFiltersForHits(
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_optimizeForSmallDb(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_optimizeForSmallDb(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeForSmallDb();
 }
@@ -2606,7 +2622,8 @@ void Java_org_rocksdb_Options_optimizeForSmallDb(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeForPointLookup(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong block_cache_size_mb) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong block_cache_size_mb) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeForPointLookup(
       block_cache_size_mb);
 }
@@ -2617,7 +2634,8 @@ void Java_org_rocksdb_Options_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong memtable_memory_budget) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeLevelStyleCompaction(
       memtable_memory_budget);
 }
@@ -2628,7 +2646,8 @@ void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong memtable_memory_budget) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
@@ -2638,7 +2657,8 @@ void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
  * Method:    prepareForBulkLoad
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->PrepareForBulkLoad();
 }
@@ -2648,7 +2668,8 @@ void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv* env, jobject jobj,
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->memtable_huge_page_size;
 }
@@ -2659,7 +2680,8 @@ jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMemtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmemtable_huge_page_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmemtable_huge_page_size) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
   if (s.ok()) {
@@ -2675,8 +2697,8 @@ void Java_org_rocksdb_Options_setMemtableHugePageSize(
  * Method:    softPendingCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv* env,
-                                                               jobject jobj,
+jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
                                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->soft_pending_compaction_bytes_limit;
@@ -2688,7 +2710,7 @@ jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jsoft_pending_compaction_bytes_limit) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->soft_pending_compaction_bytes_limit =
@@ -2700,8 +2722,8 @@ void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
  * Method:    softHardCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv* env,
-                                                               jobject jobj,
+jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
                                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->hard_pending_compaction_bytes_limit;
@@ -2713,7 +2735,7 @@ jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jhard_pending_compaction_bytes_limit) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->hard_pending_compaction_bytes_limit =
@@ -2725,8 +2747,8 @@ void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
  * Method:    level0FileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv* env,
-                                                             jobject jobj,
+jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_file_num_compaction_trigger;
@@ -2738,7 +2760,7 @@ jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_file_num_compaction_trigger =
@@ -2750,8 +2772,8 @@ void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
  * Method:    level0SlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv* env,
-                                                          jobject jobj,
+jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_slowdown_writes_trigger;
@@ -2763,7 +2785,7 @@ jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->level0_slowdown_writes_trigger =
       static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
@@ -2774,7 +2796,8 @@ void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
  * Method:    level0StopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
                                                       jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->level0_stop_writes_trigger;
@@ -2786,7 +2809,7 @@ jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->level0_stop_writes_trigger =
       static_cast<int32_t>(jlevel0_stop_writes_trigger);
@@ -2798,7 +2821,7 @@ void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
  * Signature: (J)[I
  */
 jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto mbflma = reinterpret_cast<rocksdb::Options*>(jhandle)
                     ->max_bytes_for_level_multiplier_additional;
 
@@ -2836,7 +2859,7 @@ jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals = env->GetIntArrayElements(
@@ -2862,7 +2885,8 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
  * Method:    paranoidFileChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_file_checks;
 }
@@ -2873,7 +2897,8 @@ jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setParanoidFileChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jparanoid_file_checks) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jparanoid_file_checks) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_file_checks =
       static_cast<bool>(jparanoid_file_checks);
 }
@@ -2884,7 +2909,7 @@ void Java_org_rocksdb_Options_setParanoidFileChecks(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setCompactionPriority(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jbyte jcompaction_priority_value) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   opts->compaction_pri =
@@ -2897,7 +2922,8 @@ void Java_org_rocksdb_Options_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv* env, jobject jobj,
+jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::CompactionPriorityJni::toJavaCompactionPriority(
@@ -2909,7 +2935,8 @@ jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv* env, jobject jobj,
  * Method:    setReportBgIoStats
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jboolean jreport_bg_io_stats) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
@@ -2921,7 +2948,8 @@ void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv* env, jobject jobj,
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<bool>(opts->report_bg_io_stats);
@@ -2933,7 +2961,7 @@ jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   auto* opts_uni = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
@@ -2947,7 +2975,7 @@ void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionOptionsFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompaction_options_fifo_handle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   auto* opts_fifo = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
@@ -2961,7 +2989,7 @@ void Java_org_rocksdb_Options_setCompactionOptionsFIFO(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setForceConsistencyChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jforce_consistency_checks) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   opts->force_consistency_checks = static_cast<bool>(jforce_consistency_checks);
@@ -2972,8 +3000,8 @@ void Java_org_rocksdb_Options_setForceConsistencyChecks(
  * Method:    forceConsistencyChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv* env,
-                                                         jobject jobj,
+jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<bool>(opts->force_consistency_checks);
@@ -2987,8 +3015,8 @@ jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv* env,
  * Method:    newColumnFamilyOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(JNIEnv* env,
-                                                                  jclass jcls) {
+jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
+    JNIEnv* /*env*/, jclass jcls) {
   auto* op = new rocksdb::ColumnFamilyOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -2999,7 +3027,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
-    JNIEnv* env, jclass jcls, jlong jhandle) {
+    JNIEnv* /*env*/, jclass jcls, jlong jhandle) {
   auto new_opt = new rocksdb::ColumnFamilyOptions(
       *(reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
@@ -3011,7 +3039,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
  * Signature: (Ljava/util/String;)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps(
-    JNIEnv* env, jclass jclazz, jstring jopt_string) {
+    JNIEnv* /*env*/, jclass jclazz, jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
   if (opt_string == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -3041,8 +3069,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(JNIEnv* env,
-                                                          jobject jobj,
+void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong handle) {
   auto* cfo = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(handle);
   assert(cfo != nullptr);
@@ -3054,8 +3082,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(JNIEnv* env,
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(JNIEnv* env,
-                                                             jobject jobj,
+void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->OptimizeForSmallDb();
@@ -3067,7 +3095,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong block_cache_size_mb) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong block_cache_size_mb) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->OptimizeForPointLookup(block_cache_size_mb);
 }
@@ -3078,7 +3107,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong memtable_memory_budget) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->OptimizeLevelStyleCompaction(memtable_memory_budget);
 }
@@ -3089,7 +3119,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeUniversalStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong memtable_memory_budget) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
@@ -3100,7 +3131,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeUniversalStyleCompaction(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JI(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint builtinComparator) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint builtinComparator) {
   switch (builtinComparator) {
     case 1:
       reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->comparator =
@@ -3119,8 +3150,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JI(
  * Signature: (JJB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
-    JNIEnv* env, jobject jobj, jlong jopt_handle, jlong jcomparator_handle,
-    jbyte jcomparator_type) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jopt_handle,
+    jlong jcomparator_handle, jbyte jcomparator_type) {
   rocksdb::Comparator* comparator = nullptr;
   switch (jcomparator_type) {
     // JAVA_COMPARATOR
@@ -3150,7 +3181,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jop_name) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jstring jop_name) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
   if (op_name == nullptr) {
@@ -3169,7 +3200,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong mergeOperatorHandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong mergeOperatorHandle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->merge_operator =
       *(reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(
           mergeOperatorHandle));
@@ -3181,7 +3213,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
-    JNIEnv* env, jobject jobj, jlong jopt_handle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jopt_handle,
     jlong jcompactionfilter_handle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)
       ->compaction_filter =
@@ -3195,7 +3227,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
  */
 void JNICALL
 Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
-    JNIEnv* env, jobject jobj, jlong jopt_handle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jopt_handle,
     jlong jcompactionfilterfactory_handle) {
   auto* cff_factory =
       reinterpret_cast<std::shared_ptr<rocksdb::CompactionFilterFactory>*>(
@@ -3210,7 +3242,8 @@ Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_buffer_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_buffer_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jwrite_buffer_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
@@ -3225,8 +3258,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
  * Method:    writeBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv* env,
-                                                           jobject jobj,
+jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->write_buffer_size;
@@ -3238,7 +3271,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_write_buffer_number) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jmax_write_buffer_number) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number = jmax_write_buffer_number;
 }
@@ -3248,8 +3282,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
  * Method:    maxWriteBufferNumber
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv* env,
-                                                               jobject jobj,
+jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
                                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number;
@@ -3260,7 +3294,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jfactory_handle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->memtable_factory.reset(
           reinterpret_cast<rocksdb::MemTableRepFactory*>(jfactory_handle));
@@ -3272,7 +3306,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
  * Signature: (J)Ljava/lang/String
  */
 jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   rocksdb::MemTableRepFactory* tf = opt->memtable_factory.get();
 
@@ -3293,7 +3327,7 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->prefix_extractor.reset(
           rocksdb::NewFixedPrefixTransform(static_cast<int>(jprefix_length)));
@@ -3304,7 +3338,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->prefix_extractor.reset(
           rocksdb::NewCappedPrefixTransform(static_cast<int>(jprefix_length)));
@@ -3315,7 +3349,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jfactory_handle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->table_factory.reset(
       reinterpret_cast<rocksdb::TableFactory*>(jfactory_handle));
 }
@@ -3324,8 +3358,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
  * Method:    tableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* env,
-                                                              jobject jobj,
+jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   rocksdb::TableFactory* tf = opt->table_factory.get();
@@ -3343,7 +3377,7 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* env,
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->min_write_buffer_number_to_merge;
 }
@@ -3354,7 +3388,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMinWriteBufferNumberToMerge(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jmin_write_buffer_number_to_merge) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->min_write_buffer_number_to_merge =
@@ -3367,7 +3401,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMinWriteBufferNumberToMerge(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumberToMaintain(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number_to_maintain;
 }
@@ -3378,7 +3412,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumberToMaintain(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumberToMaintain(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jmax_write_buffer_number_to_maintain) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_write_buffer_number_to_maintain =
@@ -3391,7 +3425,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumberToMaintain(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jcompression_type_value) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opts->compression = rocksdb::CompressionTypeJni::toCppCompressionType(
       jcompression_type_value);
@@ -3402,8 +3437,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionType(
  * Method:    compressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv* env,
-                                                           jobject jobj,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb::CompressionTypeJni::toJavaCompressionType(
@@ -3416,7 +3451,8 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv* env,
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyteArray jcompressionLevels) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyteArray jcompressionLevels) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto uptr_compression_levels =
       rocksdb_compression_vector_helper(env, jcompressionLevels);
@@ -3433,7 +3469,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
  * Signature: (J)[B
  */
 jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb_compression_list_helper(env,
                                          cf_options->compression_per_level);
@@ -3445,7 +3481,8 @@ jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jcompression_type_value) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_options->bottommost_compression =
       rocksdb::CompressionTypeJni::toCppCompressionType(
@@ -3458,7 +3495,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBottommostCompressionType(
  * Signature: (J)B
  */
 jbyte Java_org_rocksdb_ColumnFamilyOptions_bottommostCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb::CompressionTypeJni::toJavaCompressionType(
       cf_options->bottommost_compression);
@@ -3470,7 +3507,7 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_bottommostCompressionType(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionOptions(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompression_options_handle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto* compression_options = reinterpret_cast<rocksdb::CompressionOptions*>(
@@ -3484,7 +3521,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionOptions(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte compaction_style) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jbyte compaction_style) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->compaction_style =
       static_cast<rocksdb::CompactionStyle>(compaction_style);
 }
@@ -3494,8 +3531,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionStyle(
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv* env,
-                                                           jobject jobj,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->compaction_style;
@@ -3507,7 +3544,8 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_table_files_size) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->compaction_options_fifo.max_table_files_size =
       static_cast<uint64_t>(jmax_table_files_size);
@@ -3519,7 +3557,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->compaction_options_fifo.max_table_files_size;
 }
@@ -3529,7 +3567,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->num_levels;
 }
@@ -3539,8 +3578,8 @@ jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv* env, jobject jobj,
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv* env,
-                                                       jobject jobj,
+void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle,
                                                        jint jnum_levels) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->num_levels =
@@ -3553,7 +3592,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv* env,
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger;
 }
@@ -3564,7 +3603,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger =
@@ -3577,7 +3616,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger;
 }
@@ -3588,7 +3627,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger =
@@ -3601,7 +3640,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger;
 }
@@ -3612,7 +3651,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger =
@@ -3624,8 +3663,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv* env,
-                                                              jobject jobj,
+jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_base;
@@ -3637,7 +3676,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jtarget_file_size_base) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jtarget_file_size_base) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_base = static_cast<uint64_t>(jtarget_file_size_base);
 }
@@ -3648,7 +3688,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_multiplier;
 }
@@ -3659,7 +3699,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jtarget_file_size_multiplier) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->target_file_size_multiplier =
@@ -3671,9 +3711,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv* env,
-                                                                jobject jobj,
-                                                                jlong jhandle) {
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_base;
 }
@@ -3684,7 +3723,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_bytes_for_level_base) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_bytes_for_level_base) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_base =
       static_cast<int64_t>(jmax_bytes_for_level_base);
@@ -3696,7 +3736,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level_compaction_dynamic_level_bytes;
 }
@@ -3707,7 +3747,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jenable_dynamic_level_bytes) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
@@ -3719,7 +3759,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
  * Signature: (J)D
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_multiplier;
 }
@@ -3730,7 +3770,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplier(
  * Signature: (JD)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jdouble jmax_bytes_for_level_multiplier) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_bytes_for_level_multiplier =
@@ -3742,8 +3782,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplier(
  * Method:    maxCompactionBytes
  * Signature: (J)I
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv* env,
-                                                              jobject jobj,
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   return static_cast<jlong>(
       reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
@@ -3756,7 +3796,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxCompactionBytes(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxCompactionBytes(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_compaction_bytes) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_compaction_bytes) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_compaction_bytes = static_cast<uint64_t>(jmax_compaction_bytes);
 }
@@ -3766,8 +3807,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv* env,
-                                                          jobject jobj,
+jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->arena_block_size;
@@ -3779,7 +3820,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jarena_block_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->arena_block_size =
@@ -3795,7 +3836,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->disable_auto_compactions;
 }
@@ -3806,7 +3847,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jdisable_auto_compactions) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->disable_auto_compactions = static_cast<bool>(jdisable_auto_compactions);
@@ -3818,7 +3859,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_sequential_skip_in_iterations;
 }
@@ -3829,7 +3870,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jmax_sequential_skip_in_iterations) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_sequential_skip_in_iterations =
@@ -3842,7 +3883,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_support;
 }
@@ -3853,7 +3894,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jinplace_update_support) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_support = static_cast<bool>(jinplace_update_support);
@@ -3865,7 +3906,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->inplace_update_num_locks;
 }
@@ -3876,7 +3917,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jinplace_update_num_locks) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jinplace_update_num_locks) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
   if (s.ok()) {
@@ -3893,7 +3935,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
  * Signature: (J)I
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_memtablePrefixBloomSizeRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->memtable_prefix_bloom_size_ratio;
 }
@@ -3904,7 +3946,7 @@ jdouble Java_org_rocksdb_ColumnFamilyOptions_memtablePrefixBloomSizeRatio(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtablePrefixBloomSizeRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jdouble jmemtable_prefix_bloom_size_ratio) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->memtable_prefix_bloom_size_ratio =
@@ -3916,8 +3958,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtablePrefixBloomSizeRatio(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv* env,
-                                                        jobject jobj,
+jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
                                                         jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->bloom_locality;
@@ -3929,7 +3971,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setBloomLocality(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jbloom_locality) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jbloom_locality) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->bloom_locality =
       static_cast<int32_t>(jbloom_locality);
 }
@@ -3939,8 +3981,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBloomLocality(
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv* env,
-                                                               jobject jobj,
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
                                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->max_successive_merges;
@@ -3952,7 +3994,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_successive_merges) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_successive_merges) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
   if (s.ok()) {
@@ -3969,7 +4012,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->optimize_filters_for_hits;
 }
@@ -3980,7 +4023,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean joptimize_filters_for_hits) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->optimize_filters_for_hits =
@@ -3992,9 +4035,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv* env,
-                                                                jobject jobj,
-                                                                jlong jhandle) {
+jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->memtable_huge_page_size;
 }
@@ -4005,7 +4047,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmemtable_huge_page_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmemtable_huge_page_size) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
   if (s.ok()) {
@@ -4022,7 +4065,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->soft_pending_compaction_bytes_limit;
 }
@@ -4033,7 +4076,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jsoft_pending_compaction_bytes_limit) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->soft_pending_compaction_bytes_limit =
@@ -4046,7 +4089,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->hard_pending_compaction_bytes_limit;
 }
@@ -4057,7 +4100,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jhard_pending_compaction_bytes_limit) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->hard_pending_compaction_bytes_limit =
@@ -4070,7 +4113,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger;
 }
@@ -4081,7 +4124,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_file_num_compaction_trigger =
@@ -4094,7 +4137,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger;
 }
@@ -4105,7 +4148,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_slowdown_writes_trigger =
@@ -4118,7 +4161,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger;
 }
@@ -4129,7 +4172,7 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->level0_stop_writes_trigger =
@@ -4143,7 +4186,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
  */
 jintArray
 Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto mbflma = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
                     ->max_bytes_for_level_multiplier_additional;
 
@@ -4180,7 +4223,7 @@ Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
  * Signature: (J[I)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditional(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
   jint* additionals =
@@ -4207,7 +4250,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditiona
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->paranoid_file_checks;
 }
@@ -4218,7 +4261,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setParanoidFileChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jparanoid_file_checks) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jparanoid_file_checks) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
       ->paranoid_file_checks = static_cast<bool>(jparanoid_file_checks);
 }
@@ -4229,7 +4273,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setParanoidFileChecks(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jbyte jcompaction_priority_value) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opts->compaction_pri =
@@ -4242,8 +4286,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv* env,
-                                                              jobject jobj,
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb::CompactionPriorityJni::toJavaCompactionPriority(
@@ -4256,7 +4300,8 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setReportBgIoStats(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jreport_bg_io_stats) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jreport_bg_io_stats) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opts->report_bg_io_stats = static_cast<bool>(jreport_bg_io_stats);
 }
@@ -4266,8 +4311,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setReportBgIoStats(
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv* env,
-                                                              jobject jobj,
+jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
                                                               jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return static_cast<bool>(cf_opts->report_bg_io_stats);
@@ -4279,7 +4324,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto* opts_uni = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
@@ -4293,7 +4338,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompaction_options_fifo_handle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto* opts_fifo = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
@@ -4307,7 +4352,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsFIFO(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setForceConsistencyChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jforce_consistency_checks) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opts->force_consistency_checks =
@@ -4320,7 +4365,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setForceConsistencyChecks(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return static_cast<bool>(cf_opts->force_consistency_checks);
 }
@@ -4333,7 +4378,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
  * Method:    newDBOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* /*env*/, jclass jcls) {
   auto* dbop = new rocksdb::DBOptions();
   return reinterpret_cast<jlong>(dbop);
 }
@@ -4343,7 +4388,7 @@ jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env, jclass jcls) {
  * Method:    copyDBOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
+jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* /*env*/, jclass jcls,
                                                jlong jhandle) {
   auto new_opt =
       new rocksdb::DBOptions(*(reinterpret_cast<rocksdb::DBOptions*>(jhandle)));
@@ -4355,7 +4400,7 @@ jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
  * Method:    getDBOptionsFromProps
  * Signature: (Ljava/util/String;)J
  */
-jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* env,
+jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* /*env*/,
                                                        jclass jclazz,
                                                        jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
@@ -4387,7 +4432,8 @@ jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong handle) {
   auto* dbo = reinterpret_cast<rocksdb::DBOptions*>(handle);
   assert(dbo != nullptr);
@@ -4399,7 +4445,8 @@ void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv* env, jobject jobj,
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->OptimizeForSmallDb();
 }
@@ -4409,8 +4456,8 @@ void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv* env, jobject jobj,
  * Method:    setEnv
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setEnv(JNIEnv* env, jobject jobj, jlong jhandle,
-                                       jlong jenv_handle) {
+void Java_org_rocksdb_DBOptions_setEnv(JNIEnv* /*env*/, jobject /*jobj*/,
+                                       jlong jhandle, jlong jenv_handle) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->env =
       reinterpret_cast<rocksdb::Env*>(jenv_handle);
 }
@@ -4420,8 +4467,8 @@ void Java_org_rocksdb_DBOptions_setEnv(JNIEnv* env, jobject jobj, jlong jhandle,
  * Method:    setIncreaseParallelism
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv* env,
-                                                       jobject jobj,
+void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle,
                                                        jint totalThreads) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->IncreaseParallelism(
@@ -4433,7 +4480,8 @@ void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv* env,
  * Method:    setCreateIfMissing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jboolean flag) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->create_if_missing = flag;
@@ -4444,7 +4492,8 @@ void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv* env, jobject jobj,
  * Method:    createIfMissing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->create_if_missing;
 }
@@ -4454,8 +4503,8 @@ jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv* env, jobject jobj,
  * Method:    setCreateMissingColumnFamilies
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv* env,
-                                                               jobject jobj,
+void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
                                                                jlong jhandle,
                                                                jboolean flag) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
@@ -4467,9 +4516,8 @@ void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv* env,
  * Method:    createMissingColumnFamilies
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv* env,
-                                                                jobject jobj,
-                                                                jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->create_missing_column_families;
 }
@@ -4479,7 +4527,8 @@ jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv* env,
  * Method:    setErrorIfExists
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jboolean error_if_exists) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->error_if_exists =
@@ -4491,7 +4540,8 @@ void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv* env, jobject jobj,
  * Method:    errorIfExists
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->error_if_exists;
 }
@@ -4501,7 +4551,8 @@ jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv* env, jobject jobj,
  * Method:    setParanoidChecks
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jboolean paranoid_checks) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->paranoid_checks =
@@ -4513,7 +4564,8 @@ void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv* env, jobject jobj,
  * Method:    paranoidChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->paranoid_checks;
 }
@@ -4523,8 +4575,8 @@ jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv* env, jobject jobj,
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv* env, jobject jobj,
-                                               jlong jhandle,
+void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
                                                jlong jrate_limiter_handle) {
   std::shared_ptr<rocksdb::RateLimiter>* pRateLimiter =
       reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(
@@ -4538,7 +4590,8 @@ void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setSstFileManager(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jsst_file_manager_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jsst_file_manager_handle) {
   auto* sptr_sst_file_manager =
       reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(
           jsst_file_manager_handle);
@@ -4551,7 +4604,7 @@ void Java_org_rocksdb_DBOptions_setSstFileManager(
  * Method:    setLogger
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* /*env*/, jobject /*jobj*/,
                                           jlong jhandle, jlong jlogger_handle) {
   std::shared_ptr<rocksdb::LoggerJniCallback>* pLogger =
       reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(
@@ -4564,8 +4617,8 @@ void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jobject jobj,
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv* env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jbyte jlog_level) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->info_log_level =
       static_cast<rocksdb::InfoLogLevel>(jlog_level);
@@ -4576,7 +4629,7 @@ void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv* env, jobject jobj,
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv* env, jobject jobj,
+jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->info_log_level);
@@ -4587,7 +4640,8 @@ jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv* env, jobject jobj,
  * Method:    setMaxTotalWalSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jlong jmax_total_wal_size) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_total_wal_size =
@@ -4599,7 +4653,8 @@ void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv* env, jobject jobj,
  * Method:    maxTotalWalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_total_wal_size;
 }
@@ -4609,8 +4664,8 @@ jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv* env, jobject jobj,
  * Method:    setMaxOpenFiles
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv* env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jint max_open_files) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_open_files =
       static_cast<int>(max_open_files);
@@ -4621,7 +4676,7 @@ void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv* env, jobject jobj,
  * Method:    maxOpenFiles
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_open_files;
 }
@@ -4632,7 +4687,8 @@ jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setMaxFileOpeningThreads(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_file_opening_threads) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jmax_file_opening_threads) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_file_opening_threads =
       static_cast<int>(jmax_file_opening_threads);
 }
@@ -4642,7 +4698,8 @@ void Java_org_rocksdb_DBOptions_setMaxFileOpeningThreads(
  * Method:    maxFileOpeningThreads
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<int>(opt->max_file_opening_threads);
@@ -4653,7 +4710,7 @@ jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv* env, jobject jobj,
  * Method:    setStatistics
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle,
                                               jlong jstatistics_handle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
@@ -4667,7 +4724,7 @@ void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv* env, jobject jobj,
  * Method:    statistics
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   std::shared_ptr<rocksdb::Statistics> sptr = opt->statistics;
@@ -4685,7 +4742,7 @@ jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv* env, jobject jobj,
  * Method:    setUseFsync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle, jboolean use_fsync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_fsync =
       static_cast<bool>(use_fsync);
@@ -4696,7 +4753,7 @@ void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv* env, jobject jobj,
  * Method:    useFsync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_fsync;
 }
@@ -4706,7 +4763,7 @@ jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv* env, jobject jobj,
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
                                            jlong jhandle, jobjectArray jpaths,
                                            jlongArray jtarget_sizes) {
   std::vector<rocksdb::DbPath> db_paths;
@@ -4727,7 +4784,7 @@ void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject jobj,
       return;
     }
     std::string path = rocksdb::JniUtil::copyStdString(
-        env, static_cast<jstring>(jpath), &has_exception);
+        /*env*/, static_cast<jstring>(jpath), &has_exception);
     env->DeleteLocalRef(jpath);
 
     if (has_exception == JNI_TRUE) {
@@ -4752,7 +4809,7 @@ void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject jobj,
  * Method:    dbPathsLen
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_paths.size());
@@ -4763,7 +4820,7 @@ jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv* env, jobject jobj,
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* /*env*/, jobject /*jobj*/,
                                         jlong jhandle, jobjectArray jpaths,
                                         jlongArray jtarget_sizes) {
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
@@ -4802,7 +4859,7 @@ void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject jobj,
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle,
                                             jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
@@ -4820,7 +4877,7 @@ void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject jobj,
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject jobj,
+jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->db_log_dir.c_str());
@@ -4831,7 +4888,7 @@ jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject jobj,
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* /*env*/, jobject /*jobj*/,
                                           jlong jhandle, jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, 0);
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.assign(wal_dir);
@@ -4843,7 +4900,7 @@ void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject jobj,
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject jobj,
+jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* /*env*/, jobject /*jobj*/,
                                           jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.c_str());
@@ -4855,7 +4912,7 @@ jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setDeleteObsoleteFilesPeriodMicros(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong micros) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong micros) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->delete_obsolete_files_period_micros = static_cast<int64_t>(micros);
 }
@@ -4866,7 +4923,7 @@ void Java_org_rocksdb_DBOptions_setDeleteObsoleteFilesPeriodMicros(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_DBOptions_deleteObsoleteFilesPeriodMicros(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->delete_obsolete_files_period_micros;
 }
@@ -4876,8 +4933,8 @@ jlong Java_org_rocksdb_DBOptions_deleteObsoleteFilesPeriodMicros(
  * Method:    setBaseBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(JNIEnv* env,
-                                                             jobject jobj,
+void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle,
                                                              jint max) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->base_background_compactions =
@@ -4889,8 +4946,8 @@ void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(JNIEnv* env,
  * Method:    baseBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(JNIEnv* env,
-                                                          jobject jobj,
+jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->base_background_compactions;
@@ -4901,8 +4958,8 @@ jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(JNIEnv* env,
  * Method:    setMaxBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv* env,
-                                                            jobject jobj,
+void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle,
                                                             jint max) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_compactions =
@@ -4914,8 +4971,8 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv* env,
  * Method:    maxBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv* env,
-                                                         jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->max_background_compactions;
@@ -4926,7 +4983,8 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv* env,
  * Method:    setMaxSubcompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle, jint max) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_subcompactions =
       static_cast<int32_t>(max);
@@ -4937,7 +4995,8 @@ void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv* env, jobject jobj,
  * Method:    maxSubcompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_subcompactions;
 }
@@ -4948,7 +5007,8 @@ jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setMaxBackgroundFlushes(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max_background_flushes) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint max_background_flushes) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_flushes =
       static_cast<int>(max_background_flushes);
 }
@@ -4958,7 +5018,8 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundFlushes(
  * Method:    maxBackgroundFlushes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_flushes;
 }
@@ -4968,7 +5029,8 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv* env, jobject jobj,
  * Method:    setMaxBackgroundJobs
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle,
                                                      jint max_background_jobs) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_jobs =
@@ -4980,7 +5042,8 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
  * Method:    maxBackgroundJobs
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_jobs;
 }
@@ -4990,7 +5053,8 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* env, jobject jobj,
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jlong max_log_file_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(max_log_file_size);
@@ -5007,7 +5071,8 @@ void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jobject jobj,
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_log_file_size;
 }
@@ -5018,7 +5083,8 @@ jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong log_file_time_to_roll) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong log_file_time_to_roll) {
   rocksdb::Status s =
       rocksdb::check_if_jlong_fits_size_t(log_file_time_to_roll);
   if (s.ok()) {
@@ -5034,7 +5100,8 @@ void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
  * Method:    logFileTimeToRoll
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->log_file_time_to_roll;
 }
@@ -5044,7 +5111,8 @@ jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv* env, jobject jobj,
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jlong keep_log_file_num) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(keep_log_file_num);
@@ -5061,7 +5129,8 @@ void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jobject jobj,
  * Method:    keepLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->keep_log_file_num;
 }
@@ -5072,7 +5141,8 @@ jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setRecycleLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong recycle_log_file_num) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong recycle_log_file_num) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(recycle_log_file_num);
   if (s.ok()) {
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->recycle_log_file_num =
@@ -5087,7 +5157,8 @@ void Java_org_rocksdb_DBOptions_setRecycleLogFileNum(
  * Method:    recycleLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->recycle_log_file_num;
 }
@@ -5098,7 +5169,8 @@ jlong Java_org_rocksdb_DBOptions_recycleLogFileNum(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setMaxManifestFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max_manifest_file_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong max_manifest_file_size) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_manifest_file_size =
       static_cast<int64_t>(max_manifest_file_size);
 }
@@ -5108,7 +5180,8 @@ void Java_org_rocksdb_DBOptions_setMaxManifestFileSize(
  * Method:    maxManifestFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_manifest_file_size;
 }
@@ -5119,7 +5192,8 @@ jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setTableCacheNumshardbits(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint table_cache_numshardbits) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint table_cache_numshardbits) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->table_cache_numshardbits =
       static_cast<int>(table_cache_numshardbits);
 }
@@ -5129,8 +5203,8 @@ void Java_org_rocksdb_DBOptions_setTableCacheNumshardbits(
  * Method:    tableCacheNumshardbits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv* env,
-                                                       jobject jobj,
+jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->table_cache_numshardbits;
@@ -5141,7 +5215,8 @@ jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv* env,
  * Method:    setWalTtlSeconds
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle,
                                                  jlong WAL_ttl_seconds) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_ttl_seconds =
@@ -5153,7 +5228,8 @@ void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv* env, jobject jobj,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_ttl_seconds;
 }
@@ -5163,7 +5239,8 @@ jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv* env, jobject jobj,
  * Method:    setWalSizeLimitMB
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jlong WAL_size_limit_MB) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_size_limit_MB =
@@ -5175,7 +5252,8 @@ void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv* env, jobject jobj,
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_size_limit_MB;
 }
@@ -5186,7 +5264,8 @@ jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv* env, jobject jobj,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong preallocation_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong preallocation_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(preallocation_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)
@@ -5201,8 +5280,8 @@ void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv* env,
-                                                           jobject jobj,
+jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->manifest_preallocation_size;
@@ -5213,7 +5292,8 @@ jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv* env,
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_direct_reads;
 }
@@ -5223,7 +5303,8 @@ jboolean Java_org_rocksdb_DBOptions_useDirectReads(JNIEnv* env, jobject jobj,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jboolean use_direct_reads) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_direct_reads =
@@ -5236,7 +5317,7 @@ void Java_org_rocksdb_DBOptions_setUseDirectReads(JNIEnv* env, jobject jobj,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_useDirectIoForFlushAndCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->use_direct_io_for_flush_and_compaction;
 }
@@ -5247,7 +5328,7 @@ jboolean Java_org_rocksdb_DBOptions_useDirectIoForFlushAndCompaction(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setUseDirectIoForFlushAndCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean use_direct_io_for_flush_and_compaction) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->use_direct_io_for_flush_and_compaction =
@@ -5259,7 +5340,8 @@ void Java_org_rocksdb_DBOptions_setUseDirectIoForFlushAndCompaction(
  * Method:    setAllowFAllocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jboolean jallow_fallocate) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_fallocate =
@@ -5271,7 +5353,8 @@ void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv* env, jobject jobj,
  * Method:    allowFAllocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_fallocate);
@@ -5282,7 +5365,8 @@ jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv* env, jobject jobj,
  * Method:    setAllowMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle,
                                                   jboolean allow_mmap_reads) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_reads =
@@ -5294,7 +5378,8 @@ void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv* env, jobject jobj,
  * Method:    allowMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_reads;
 }
@@ -5304,7 +5389,8 @@ jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv* env, jobject jobj,
  * Method:    setAllowMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jboolean allow_mmap_writes) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_writes =
@@ -5316,7 +5402,8 @@ void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv* env, jobject jobj,
  * Method:    allowMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_writes;
 }
@@ -5327,7 +5414,8 @@ jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean is_fd_close_on_exec) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean is_fd_close_on_exec) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->is_fd_close_on_exec =
       static_cast<bool>(is_fd_close_on_exec);
 }
@@ -5337,7 +5425,8 @@ void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
  * Method:    isFdCloseOnExec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->is_fd_close_on_exec;
 }
@@ -5348,7 +5437,8 @@ jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv* env, jobject jobj,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_DBOptions_setStatsDumpPeriodSec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint stats_dump_period_sec) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint stats_dump_period_sec) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->stats_dump_period_sec =
       static_cast<int>(stats_dump_period_sec);
 }
@@ -5358,7 +5448,8 @@ void Java_org_rocksdb_DBOptions_setStatsDumpPeriodSec(
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->stats_dump_period_sec;
 }
@@ -5369,7 +5460,8 @@ jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAdviseRandomOnOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean advise_random_on_open) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean advise_random_on_open) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->advise_random_on_open =
       static_cast<bool>(advise_random_on_open);
 }
@@ -5379,8 +5471,8 @@ void Java_org_rocksdb_DBOptions_setAdviseRandomOnOpen(
  * Method:    adviseRandomOnOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv* env,
-                                                       jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->advise_random_on_open;
 }
@@ -5391,7 +5483,8 @@ jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdb_write_buffer_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jdb_write_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->db_write_buffer_size = static_cast<size_t>(jdb_write_buffer_size);
 }
@@ -5401,7 +5494,8 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_write_buffer_size);
@@ -5413,7 +5507,8 @@ jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv* env, jobject jobj,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_DBOptions_setAccessHintOnCompactionStart(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jaccess_hint_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jaccess_hint_value) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->access_hint_on_compaction_start =
       rocksdb::AccessHintJni::toCppAccessHint(jaccess_hint_value);
@@ -5424,8 +5519,8 @@ void Java_org_rocksdb_DBOptions_setAccessHintOnCompactionStart(
  * Method:    accessHintOnCompactionStart
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv* env,
-                                                             jobject jobj,
+jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return rocksdb::AccessHintJni::toJavaAccessHint(
@@ -5438,7 +5533,7 @@ jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setNewTableReaderForCompactionInputs(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jnew_table_reader_for_compaction_inputs) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->new_table_reader_for_compaction_inputs =
@@ -5451,7 +5546,7 @@ void Java_org_rocksdb_DBOptions_setNewTableReaderForCompactionInputs(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_newTableReaderForCompactionInputs(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<bool>(opt->new_table_reader_for_compaction_inputs);
 }
@@ -5462,7 +5557,7 @@ jboolean Java_org_rocksdb_DBOptions_newTableReaderForCompactionInputs(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jcompaction_readahead_size) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->compaction_readahead_size =
@@ -5474,8 +5569,8 @@ void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv* env,
-                                                         jobject jobj,
+jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->compaction_readahead_size);
@@ -5487,7 +5582,7 @@ jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setRandomAccessMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jrandom_access_max_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->random_access_max_buffer_size =
@@ -5499,8 +5594,8 @@ void Java_org_rocksdb_DBOptions_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv* env,
-                                                           jobject jobj,
+jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->random_access_max_buffer_size);
@@ -5512,7 +5607,7 @@ jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv* env,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setWritableFileMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jwritable_file_max_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->writable_file_max_buffer_size =
@@ -5524,8 +5619,8 @@ void Java_org_rocksdb_DBOptions_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv* env,
-                                                           jobject jobj,
+jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->writable_file_max_buffer_size);
@@ -5537,7 +5632,8 @@ jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setUseAdaptiveMutex(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean use_adaptive_mutex) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean use_adaptive_mutex) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_adaptive_mutex =
       static_cast<bool>(use_adaptive_mutex);
 }
@@ -5547,7 +5643,8 @@ void Java_org_rocksdb_DBOptions_setUseAdaptiveMutex(
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_adaptive_mutex;
 }
@@ -5557,8 +5654,8 @@ jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv* env, jobject jobj,
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv* env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jlong bytes_per_sync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->bytes_per_sync =
       static_cast<int64_t>(bytes_per_sync);
@@ -5569,7 +5666,7 @@ void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv* env, jobject jobj,
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->bytes_per_sync;
 }
@@ -5579,7 +5676,8 @@ jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv* env, jobject jobj,
  * Method:    setWalBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jlong jwal_bytes_per_sync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_bytes_per_sync =
@@ -5591,7 +5689,8 @@ void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv* env, jobject jobj,
  * Method:    walBytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->wal_bytes_per_sync);
@@ -5603,7 +5702,7 @@ jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setEnableThreadTracking(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jenable_thread_tracking) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->enable_thread_tracking = static_cast<bool>(jenable_thread_tracking);
@@ -5614,8 +5713,8 @@ void Java_org_rocksdb_DBOptions_setEnableThreadTracking(
  * Method:    enableThreadTracking
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv* env,
-                                                         jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->enable_thread_tracking);
@@ -5626,7 +5725,8 @@ jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv* env,
  * Method:    setDelayedWriteRate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle,
                                                     jlong jdelayed_write_rate) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
@@ -5638,7 +5738,8 @@ void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv* env, jobject jobj,
  * Method:    delayedWriteRate
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->delayed_write_rate);
@@ -5650,7 +5751,7 @@ jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean allow) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->allow_concurrent_memtable_write = static_cast<bool>(allow);
 }
@@ -5661,7 +5762,7 @@ void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->allow_concurrent_memtable_write;
 }
@@ -5672,7 +5773,7 @@ jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean yield) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean yield) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->enable_write_thread_adaptive_yield = static_cast<bool>(yield);
 }
@@ -5683,7 +5784,7 @@ void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->enable_write_thread_adaptive_yield;
 }
@@ -5693,8 +5794,8 @@ jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
  * Method:    setWriteThreadMaxYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv* env,
-                                                           jobject jobj,
+void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle,
                                                            jlong max) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->write_thread_max_yield_usec =
@@ -5706,8 +5807,8 @@ void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv* env,
  * Method:    writeThreadMaxYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv* env,
-                                                         jobject jobj,
+jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->write_thread_max_yield_usec;
@@ -5718,8 +5819,8 @@ jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv* env,
  * Method:    setWriteThreadSlowYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv* env,
-                                                            jobject jobj,
+void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle,
                                                             jlong slow) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->write_thread_slow_yield_usec =
@@ -5731,8 +5832,8 @@ void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv* env,
  * Method:    writeThreadSlowYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv* env,
-                                                          jobject jobj,
+jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->write_thread_slow_yield_usec;
@@ -5744,7 +5845,7 @@ jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setSkipStatsUpdateOnDbOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jskip_stats_update_on_db_open) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->skip_stats_update_on_db_open =
@@ -5756,8 +5857,8 @@ void Java_org_rocksdb_DBOptions_setSkipStatsUpdateOnDbOpen(
  * Method:    skipStatsUpdateOnDbOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv* env,
-                                                            jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->skip_stats_update_on_db_open);
@@ -5769,7 +5870,8 @@ jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv* env,
  * Signature: (JB)V
  */
 void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jwal_recovery_mode_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jwal_recovery_mode_value) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->wal_recovery_mode = rocksdb::WALRecoveryModeJni::toCppWALRecoveryMode(
       jwal_recovery_mode_value);
@@ -5780,7 +5882,8 @@ void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
  * Method:    walRecoveryMode
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv* env, jobject jobj,
+jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return rocksdb::WALRecoveryModeJni::toJavaWALRecoveryMode(
@@ -5792,7 +5895,7 @@ jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv* env, jobject jobj,
  * Method:    setAllow2pc
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle,
                                             jboolean jallow_2pc) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
@@ -5804,7 +5907,7 @@ void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv* env, jobject jobj,
  * Method:    allow2pc
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_2pc);
@@ -5815,7 +5918,7 @@ jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* env, jobject jobj,
  * Method:    setRowCache
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle,
                                             jlong jrow_cache_handle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
@@ -5830,7 +5933,7 @@ void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setFailIfOptionsFileError(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jfail_if_options_file_error) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->fail_if_options_file_error =
@@ -5842,8 +5945,8 @@ void Java_org_rocksdb_DBOptions_setFailIfOptionsFileError(
  * Method:    failIfOptionsFileError
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv* env,
-                                                           jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->fail_if_options_file_error);
@@ -5855,7 +5958,8 @@ jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setDumpMallocStats(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jdump_malloc_stats) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jdump_malloc_stats) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->dump_malloc_stats = static_cast<bool>(jdump_malloc_stats);
 }
@@ -5865,7 +5969,8 @@ void Java_org_rocksdb_DBOptions_setDumpMallocStats(
  * Method:    dumpMallocStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->dump_malloc_stats);
@@ -5877,7 +5982,7 @@ jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean javoid_flush_during_recovery) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->avoid_flush_during_recovery =
@@ -5889,8 +5994,8 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
  * Method:    avoidFlushDuringRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv* env,
-                                                             jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
@@ -5902,7 +6007,7 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean javoid_flush_during_shutdown) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->avoid_flush_during_shutdown =
@@ -5914,8 +6019,8 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
  * Method:    avoidFlushDuringShutdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* env,
-                                                             jobject jobj,
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
@@ -5929,7 +6034,8 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* env,
  * Method:    newWriteOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* /*env*/,
+                                                    jclass jcls) {
   auto* op = new rocksdb::WriteOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -5939,7 +6045,8 @@ jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* env, jclass jcls) {
  * Method:    copyWriteOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* env, jclass jcls,
+jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* /*env*/,
+                                                     jclass jcls,
                                                      jlong jhandle) {
   auto new_opt = new rocksdb::WriteOptions(
       *(reinterpret_cast<rocksdb::WriteOptions*>(jhandle)));
@@ -5951,7 +6058,7 @@ jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* env, jclass jcls,
  * Method:    disposeInternal
  * Signature: ()V
  */
-void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* env,
+void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* /*env*/,
                                                    jobject jwrite_options,
                                                    jlong jhandle) {
   auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(jhandle);
@@ -5964,7 +6071,8 @@ void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* env,
  * Method:    setSync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* env, jobject jwrite_options,
+void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* /*env*/,
+                                           jobject jwrite_options,
                                            jlong jhandle, jboolean jflag) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync = jflag;
 }
@@ -5974,7 +6082,8 @@ void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* env, jobject jwrite_options,
  * Method:    sync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* env, jobject jwrite_options,
+jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* /*env*/,
+                                            jobject jwrite_options,
                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync;
 }
@@ -5984,7 +6093,7 @@ jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* env, jobject jwrite_options,
  * Method:    setDisableWAL
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* env,
+void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* /*env*/,
                                                  jobject jwrite_options,
                                                  jlong jhandle,
                                                  jboolean jflag) {
@@ -5996,7 +6105,7 @@ void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* env,
  * Method:    disableWAL
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* env,
+jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* /*env*/,
                                                   jobject jwrite_options,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->disableWAL;
@@ -6008,7 +6117,7 @@ jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle,
+    JNIEnv* /*env*/, jobject jwrite_options, jlong jhandle,
     jboolean jignore_missing_column_families) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
       ->ignore_missing_column_families =
@@ -6021,7 +6130,7 @@ void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle) {
+    JNIEnv* /*env*/, jobject jwrite_options, jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
       ->ignore_missing_column_families;
 }
@@ -6031,7 +6140,7 @@ jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
  * Method:    setNoSlowdown
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* env,
+void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* /*env*/,
                                                  jobject jwrite_options,
                                                  jlong jhandle,
                                                  jboolean jno_slowdown) {
@@ -6044,7 +6153,7 @@ void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* env,
  * Method:    noSlowdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* env,
+jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* /*env*/,
                                                   jobject jwrite_options,
                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->no_slowdown;
@@ -6058,7 +6167,8 @@ jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* env,
  * Method:    newReadOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* /*env*/,
+                                                  jclass jcls) {
   auto* read_options = new rocksdb::ReadOptions();
   return reinterpret_cast<jlong>(read_options);
 }
@@ -6068,7 +6178,7 @@ jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* env, jclass jcls) {
  * Method:    copyReadOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* env, jclass jcls,
+jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* /*env*/, jclass jcls,
                                                    jlong jhandle) {
   auto new_opt = new rocksdb::ReadOptions(
       *(reinterpret_cast<rocksdb::ReadOptions*>(jhandle)));
@@ -6080,7 +6190,8 @@ jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* env, jclass jcls,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
                                                   jlong jhandle) {
   auto* read_options = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   assert(read_options != nullptr);
@@ -6093,7 +6204,8 @@ void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jverify_checksums) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jverify_checksums) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->verify_checksums =
       static_cast<bool>(jverify_checksums);
 }
@@ -6103,7 +6215,8 @@ void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
  * Method:    verifyChecksums
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
                                                       jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->verify_checksums;
 }
@@ -6113,8 +6226,8 @@ jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv* env, jobject jobj,
  * Method:    setFillCache
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv* env, jobject jobj,
-                                               jlong jhandle,
+void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
                                                jboolean jfill_cache) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->fill_cache =
       static_cast<bool>(jfill_cache);
@@ -6125,7 +6238,8 @@ void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv* env, jobject jobj,
  * Method:    fillCache
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->fill_cache;
 }
@@ -6135,7 +6249,7 @@ jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv* env, jobject jobj,
  * Method:    setTailing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle, jboolean jtailing) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->tailing =
       static_cast<bool>(jtailing);
@@ -6146,7 +6260,7 @@ void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv* env, jobject jobj,
  * Method:    tailing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->tailing;
 }
@@ -6156,7 +6270,7 @@ jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv* env, jobject jobj,
  * Method:    managed
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->managed;
 }
@@ -6166,7 +6280,7 @@ jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv* env, jobject jobj,
  * Method:    setManaged
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle, jboolean jmanaged) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->managed =
       static_cast<bool>(jmanaged);
@@ -6177,7 +6291,8 @@ void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv* env, jobject jobj,
  * Method:    totalOrderSeek
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->total_order_seek;
 }
@@ -6188,7 +6303,8 @@ jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv* env, jobject jobj,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setTotalOrderSeek(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jtotal_order_seek) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jtotal_order_seek) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->total_order_seek =
       static_cast<bool>(jtotal_order_seek);
 }
@@ -6198,8 +6314,8 @@ void Java_org_rocksdb_ReadOptions_setTotalOrderSeek(
  * Method:    prefixSameAsStart
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv* env,
-                                                        jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
                                                         jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->prefix_same_as_start;
 }
@@ -6210,7 +6326,8 @@ jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setPrefixSameAsStart(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jprefix_same_as_start) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jprefix_same_as_start) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->prefix_same_as_start =
       static_cast<bool>(jprefix_same_as_start);
 }
@@ -6220,7 +6337,7 @@ void Java_org_rocksdb_ReadOptions_setPrefixSameAsStart(
  * Method:    pinData
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->pin_data;
 }
@@ -6230,7 +6347,7 @@ jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv* env, jobject jobj,
  * Method:    setPinData
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv* /*env*/, jobject /*jobj*/,
                                              jlong jhandle,
                                              jboolean jpin_data) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->pin_data =
@@ -6243,7 +6360,7 @@ void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv* env, jobject jobj,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_ReadOptions_backgroundPurgeOnIteratorCleanup(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->background_purge_on_iterator_cleanup);
 }
@@ -6254,7 +6371,7 @@ jboolean Java_org_rocksdb_ReadOptions_backgroundPurgeOnIteratorCleanup(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setBackgroundPurgeOnIteratorCleanup(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jbackground_purge_on_iterator_cleanup) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   opt->background_purge_on_iterator_cleanup =
@@ -6266,7 +6383,8 @@ void Java_org_rocksdb_ReadOptions_setBackgroundPurgeOnIteratorCleanup(
  * Method:    readaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->readahead_size);
@@ -6277,7 +6395,8 @@ jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv* env, jobject jobj,
  * Method:    setReadaheadSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jlong jreadahead_size) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
@@ -6289,8 +6408,8 @@ void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv* env, jobject jobj,
  * Method:    ignoreRangeDeletions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv* env,
-                                                           jobject jobj,
+jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->ignore_range_deletions);
@@ -6302,7 +6421,7 @@ jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setIgnoreRangeDeletions(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jignore_range_deletions) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   opt->ignore_range_deletions = static_cast<bool>(jignore_range_deletions);
@@ -6313,7 +6432,7 @@ void Java_org_rocksdb_ReadOptions_setIgnoreRangeDeletions(
  * Method:    setSnapshot
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle, jlong jsnapshot) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->snapshot =
       reinterpret_cast<rocksdb::Snapshot*>(jsnapshot);
@@ -6324,7 +6443,7 @@ void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv* env, jobject jobj,
  * Method:    snapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   auto& snapshot = reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->snapshot;
   return reinterpret_cast<jlong>(snapshot);
@@ -6335,7 +6454,7 @@ jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv* env, jobject jobj,
  * Method:    readTier
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv* env, jobject jobj,
+jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv* /*env*/, jobject /*jobj*/,
                                             jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->read_tier);
@@ -6346,7 +6465,7 @@ jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv* env, jobject jobj,
  * Method:    setReadTier
  * Signature: (JB)V
  */
-void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong jhandle, jbyte jread_tier) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->read_tier =
       static_cast<rocksdb::ReadTier>(jread_tier);
@@ -6358,7 +6477,8 @@ void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv* env, jobject jobj,
  * Signature: (JJ)I
  */
 void Java_org_rocksdb_ReadOptions_setIterateUpperBound(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jupper_bound_slice_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jupper_bound_slice_handle) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->iterate_upper_bound =
       reinterpret_cast<rocksdb::Slice*>(jupper_bound_slice_handle);
 }
@@ -6368,7 +6488,8 @@ void Java_org_rocksdb_ReadOptions_setIterateUpperBound(
  * Method:    iterateUpperBound
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv* env, jobject jobj,
+jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong jhandle) {
   auto& upper_bound_slice_handle =
       reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->iterate_upper_bound;
@@ -6383,7 +6504,7 @@ jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv* env, jobject jobj,
  * Method:    newComparatorOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv* env,
+jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv* /*env*/,
                                                               jclass jcls) {
   auto* comparator_opt = new rocksdb::ComparatorJniCallbackOptions();
   return reinterpret_cast<jlong>(comparator_opt);
@@ -6394,8 +6515,8 @@ jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv* env,
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(JNIEnv* env,
-                                                             jobject jobj,
+jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle)
       ->use_adaptive_mutex;
@@ -6407,7 +6528,8 @@ jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(JNIEnv* env,
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ComparatorOptions_setUseAdaptiveMutex(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean juse_adaptive_mutex) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean juse_adaptive_mutex) {
   reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle)
       ->use_adaptive_mutex = static_cast<bool>(juse_adaptive_mutex);
 }
@@ -6417,8 +6539,8 @@ void Java_org_rocksdb_ComparatorOptions_setUseAdaptiveMutex(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv* env,
-                                                        jobject jobj,
+void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
                                                         jlong jhandle) {
   auto* comparator_opt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle);
@@ -6434,7 +6556,8 @@ void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv* env,
  * Method:    newFlushOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv* /*env*/,
+                                                    jclass jcls) {
   auto* flush_opt = new rocksdb::FlushOptions();
   return reinterpret_cast<jlong>(flush_opt);
 }
@@ -6444,7 +6567,8 @@ jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv* env, jclass jcls) {
  * Method:    setWaitForFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jboolean jwait) {
   reinterpret_cast<rocksdb::FlushOptions*>(jhandle)->wait =
@@ -6456,7 +6580,8 @@ void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv* env, jobject jobj,
  * Method:    waitForFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::FlushOptions*>(jhandle)->wait;
 }
@@ -6466,7 +6591,8 @@ jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv* env, jobject jobj,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_FlushOptions_disposeInternal(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_FlushOptions_disposeInternal(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle) {
   auto* flush_opt = reinterpret_cast<rocksdb::FlushOptions*>(jhandle);
   assert(flush_opt != nullptr);

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -5,34 +5,34 @@
 //
 // This file implements the "bridge" between Java and C++ for rocksdb::Options.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <memory>
 #include <vector>
 
-#include "include/org_rocksdb_Options.h"
-#include "include/org_rocksdb_DBOptions.h"
 #include "include/org_rocksdb_ColumnFamilyOptions.h"
-#include "include/org_rocksdb_WriteOptions.h"
-#include "include/org_rocksdb_ReadOptions.h"
 #include "include/org_rocksdb_ComparatorOptions.h"
+#include "include/org_rocksdb_DBOptions.h"
 #include "include/org_rocksdb_FlushOptions.h"
+#include "include/org_rocksdb_Options.h"
+#include "include/org_rocksdb_ReadOptions.h"
+#include "include/org_rocksdb_WriteOptions.h"
 
 #include "rocksjni/comparatorjnicallback.h"
 #include "rocksjni/portal.h"
 #include "rocksjni/statisticsjni.h"
 
-#include "rocksdb/db.h"
-#include "rocksdb/options.h"
-#include "rocksdb/statistics.h"
-#include "rocksdb/memtablerep.h"
-#include "rocksdb/table.h"
-#include "rocksdb/slice_transform.h"
-#include "rocksdb/rate_limiter.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/convenience.h"
+#include "rocksdb/db.h"
+#include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
+#include "rocksdb/options.h"
+#include "rocksdb/rate_limiter.h"
+#include "rocksdb/slice_transform.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/table.h"
 #include "utilities/merge_operators.h"
 
 /*
@@ -40,7 +40,7 @@
  * Method:    newOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_Options_newOptions__(JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_Options_newOptions__(JNIEnv* /*env*/, jclass /*jcls*/) {
   auto* op = new rocksdb::Options();
   return reinterpret_cast<jlong>(op);
 }
@@ -50,11 +50,12 @@ jlong Java_org_rocksdb_Options_newOptions__(JNIEnv* env, jclass jcls) {
  * Method:    newOptions
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* env, jclass jcls,
-    jlong jdboptions, jlong jcfoptions) {
+jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* /*env*/, jclass /*jcls*/,
+                                              jlong jdboptions,
+                                              jlong jcfoptions) {
   auto* dbOpt = reinterpret_cast<const rocksdb::DBOptions*>(jdboptions);
-  auto* cfOpt = reinterpret_cast<const rocksdb::ColumnFamilyOptions*>(
-      jcfoptions);
+  auto* cfOpt =
+      reinterpret_cast<const rocksdb::ColumnFamilyOptions*>(jcfoptions);
   auto* op = new rocksdb::Options(*dbOpt, *cfOpt);
   return reinterpret_cast<jlong>(op);
 }
@@ -64,10 +65,10 @@ jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* env, jclass jcls,
  * Method:    copyOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* env, jclass jcls,
-    jlong jhandle) {
-  auto new_opt = new rocksdb::Options(
-      *(reinterpret_cast<rocksdb::Options*>(jhandle)));
+jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* /*env*/, jclass /*jcls*/,
+                                           jlong /*jhandle*/) {
+  auto new_opt =
+      new rocksdb::Options(*(reinterpret_cast<rocksdb::Options*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
 }
 
@@ -76,8 +77,8 @@ jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* env, jclass jcls,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_Options_disposeInternal(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong handle) {
   auto* op = reinterpret_cast<rocksdb::Options*>(handle);
   assert(op != nullptr);
   delete op;
@@ -88,10 +89,12 @@ void Java_org_rocksdb_Options_disposeInternal(
  * Method:    setIncreaseParallelism
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setIncreaseParallelism(
-    JNIEnv * env, jobject jobj, jlong jhandle, jint totalThreads) {
-  reinterpret_cast<rocksdb::Options*>
-      (jhandle)->IncreaseParallelism(static_cast<int>(totalThreads));
+void Java_org_rocksdb_Options_setIncreaseParallelism(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle,
+                                                     jint totalThreads) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->IncreaseParallelism(
+      static_cast<int>(totalThreads));
 }
 
 /*
@@ -99,8 +102,9 @@ void Java_org_rocksdb_Options_setIncreaseParallelism(
  * Method:    setCreateIfMissing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setCreateIfMissing(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
+void Java_org_rocksdb_Options_setCreateIfMissing(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle, jboolean flag) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->create_if_missing = flag;
 }
 
@@ -109,8 +113,9 @@ void Java_org_rocksdb_Options_setCreateIfMissing(
  * Method:    createIfMissing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_createIfMissing(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_createIfMissing(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->create_if_missing;
 }
 
@@ -119,10 +124,12 @@ jboolean Java_org_rocksdb_Options_createIfMissing(
  * Method:    setCreateMissingColumnFamilies
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
-  reinterpret_cast<rocksdb::Options*>
-      (jhandle)->create_missing_column_families = flag;
+void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
+                                                             jlong jhandle,
+                                                             jboolean flag) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->create_missing_column_families =
+      flag;
 }
 
 /*
@@ -130,10 +137,11 @@ void Java_org_rocksdb_Options_setCreateMissingColumnFamilies(
  * Method:    createMissingColumnFamilies
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>
-      (jhandle)->create_missing_column_families;
+jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->create_missing_column_families;
 }
 
 /*
@@ -141,8 +149,10 @@ jboolean Java_org_rocksdb_Options_createMissingColumnFamilies(
  * Method:    setComparatorHandle
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setComparatorHandle__JI(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint builtinComparator) {
+void Java_org_rocksdb_Options_setComparatorHandle__JI(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong jhandle,
+                                                      jint builtinComparator) {
   switch (builtinComparator) {
     case 1:
       reinterpret_cast<rocksdb::Options*>(jhandle)->comparator =
@@ -160,28 +170,29 @@ void Java_org_rocksdb_Options_setComparatorHandle__JI(
  * Method:    setComparatorHandle
  * Signature: (JJB)V
  */
-void Java_org_rocksdb_Options_setComparatorHandle__JJB(
-    JNIEnv* env, jobject jobj, jlong jopt_handle, jlong jcomparator_handle,
-    jbyte jcomparator_type) {
-  rocksdb::Comparator *comparator = nullptr;
-  switch(jcomparator_type) {
-      // JAVA_COMPARATOR
-      case 0x0:
-        comparator =
-            reinterpret_cast<rocksdb::ComparatorJniCallback*>(jcomparator_handle);
-        break;
+void Java_org_rocksdb_Options_setComparatorHandle__JJB(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jopt_handle,
+                                                       jlong jcomparator_handle,
+                                                       jbyte jcomparator_type) {
+  rocksdb::Comparator* comparator = nullptr;
+  switch (jcomparator_type) {
+    // JAVA_COMPARATOR
+    case 0x0:
+      comparator =
+          reinterpret_cast<rocksdb::ComparatorJniCallback*>(jcomparator_handle);
+      break;
 
-      // JAVA_DIRECT_COMPARATOR
-      case 0x1:
-        comparator =
-            reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(jcomparator_handle);
-        break;
+    // JAVA_DIRECT_COMPARATOR
+    case 0x1:
+      comparator = reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(
+          jcomparator_handle);
+      break;
 
-      // JAVA_NATIVE_COMPARATOR_WRAPPER
-      case 0x2:
-        comparator =
-            reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
-        break;
+    // JAVA_NATIVE_COMPARATOR_WRAPPER
+    case 0x2:
+      comparator = reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
+      break;
   }
   auto* opt = reinterpret_cast<rocksdb::Options*>(jopt_handle);
   opt->comparator = comparator;
@@ -192,17 +203,19 @@ void Java_org_rocksdb_Options_setComparatorHandle__JJB(
  * Method:    setMergeOperatorName
  * Signature: (JJjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setMergeOperatorName(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jop_name) {
+void Java_org_rocksdb_Options_setMergeOperatorName(JNIEnv* env,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle,
+                                                   jstring jop_name) {
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
-  if(op_name == nullptr) {
+  if (op_name == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
-  options->merge_operator = rocksdb::MergeOperators::CreateFromStringId(
-        op_name);
+  options->merge_operator =
+      rocksdb::MergeOperators::CreateFromStringId(op_name);
 
   env->ReleaseStringUTFChars(jop_name, op_name);
 }
@@ -212,11 +225,12 @@ void Java_org_rocksdb_Options_setMergeOperatorName(
  * Method:    setMergeOperator
  * Signature: (JJjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setMergeOperator(
-  JNIEnv* env, jobject jobj, jlong jhandle, jlong mergeOperatorHandle) {
+void Java_org_rocksdb_Options_setMergeOperator(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jlong mergeOperatorHandle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->merge_operator =
-    *(reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>
-      (mergeOperatorHandle));
+      *(reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(
+          mergeOperatorHandle));
 }
 
 /*
@@ -224,8 +238,9 @@ void Java_org_rocksdb_Options_setMergeOperator(
  * Method:    setWriteBufferSize
  * Signature: (JJ)I
  */
-void Java_org_rocksdb_Options_setWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_buffer_size) {
+void Java_org_rocksdb_Options_setWriteBufferSize(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jlong jwrite_buffer_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jwrite_buffer_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->write_buffer_size =
@@ -240,8 +255,9 @@ void Java_org_rocksdb_Options_setWriteBufferSize(
  * Method:    writeBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_writeBufferSize(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->write_buffer_size;
 }
 
@@ -251,9 +267,10 @@ jlong Java_org_rocksdb_Options_writeBufferSize(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxWriteBufferNumber(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_write_buffer_number) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jmax_write_buffer_number) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_write_buffer_number =
-          jmax_write_buffer_number;
+      jmax_write_buffer_number;
 }
 
 /*
@@ -261,12 +278,12 @@ void Java_org_rocksdb_Options_setMaxWriteBufferNumber(
  * Method:    setStatistics
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setStatistics(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jstatistics_handle) {
+void Java_org_rocksdb_Options_setStatistics(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong jhandle,
+                                            jlong jstatistics_handle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto* pSptr =
-      reinterpret_cast<std::shared_ptr<rocksdb::StatisticsJni>*>(
-          jstatistics_handle);
+  auto* pSptr = reinterpret_cast<std::shared_ptr<rocksdb::StatisticsJni>*>(
+      jstatistics_handle);
   opt->statistics = *pSptr;
 }
 
@@ -275,8 +292,8 @@ void Java_org_rocksdb_Options_setStatistics(
  * Method:    statistics
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_statistics(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_statistics(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   std::shared_ptr<rocksdb::Statistics> sptr = opt->statistics;
   if (sptr == nullptr) {
@@ -293,8 +310,9 @@ jlong Java_org_rocksdb_Options_statistics(
  * Method:    maxWriteBufferNumber
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxWriteBufferNumber(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxWriteBufferNumber(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_write_buffer_number;
 }
 
@@ -303,8 +321,9 @@ jint Java_org_rocksdb_Options_maxWriteBufferNumber(
  * Method:    errorIfExists
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_errorIfExists(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_errorIfExists(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->error_if_exists;
 }
 
@@ -313,8 +332,9 @@ jboolean Java_org_rocksdb_Options_errorIfExists(
  * Method:    setErrorIfExists
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setErrorIfExists(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean error_if_exists) {
+void Java_org_rocksdb_Options_setErrorIfExists(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jboolean error_if_exists) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->error_if_exists =
       static_cast<bool>(error_if_exists);
 }
@@ -324,8 +344,9 @@ void Java_org_rocksdb_Options_setErrorIfExists(
  * Method:    paranoidChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_paranoidChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_paranoidChecks(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_checks;
 }
 
@@ -334,8 +355,9 @@ jboolean Java_org_rocksdb_Options_paranoidChecks(
  * Method:    setParanoidChecks
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setParanoidChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean paranoid_checks) {
+void Java_org_rocksdb_Options_setParanoidChecks(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
+                                                jboolean paranoid_checks) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_checks =
       static_cast<bool>(paranoid_checks);
 }
@@ -345,8 +367,8 @@ void Java_org_rocksdb_Options_setParanoidChecks(
  * Method:    setEnv
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setEnv(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jenv) {
+void Java_org_rocksdb_Options_setEnv(JNIEnv* /*env*/, jobject /*jobj*/,
+                                     jlong jhandle, jlong jenv) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->env =
       reinterpret_cast<rocksdb::Env*>(jenv);
 }
@@ -356,9 +378,10 @@ void Java_org_rocksdb_Options_setEnv(
  * Method:    setMaxTotalWalSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMaxTotalWalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_total_wal_size) {
+void Java_org_rocksdb_Options_setMaxTotalWalSize(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jlong jmax_total_wal_size) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_total_wal_size =
       static_cast<jlong>(jmax_total_wal_size);
 }
@@ -368,10 +391,10 @@ void Java_org_rocksdb_Options_setMaxTotalWalSize(
  * Method:    maxTotalWalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxTotalWalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->
-      max_total_wal_size;
+jlong Java_org_rocksdb_Options_maxTotalWalSize(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->max_total_wal_size;
 }
 
 /*
@@ -379,8 +402,8 @@ jlong Java_org_rocksdb_Options_maxTotalWalSize(
  * Method:    maxOpenFiles
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxOpenFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxOpenFiles(JNIEnv* /*env*/, jobject /*jobj*/,
+                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_open_files;
 }
 
@@ -389,8 +412,9 @@ jint Java_org_rocksdb_Options_maxOpenFiles(
  * Method:    setMaxOpenFiles
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxOpenFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max_open_files) {
+void Java_org_rocksdb_Options_setMaxOpenFiles(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle,
+                                              jint max_open_files) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_open_files =
       static_cast<int>(max_open_files);
 }
@@ -401,7 +425,8 @@ void Java_org_rocksdb_Options_setMaxOpenFiles(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxFileOpeningThreads(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_file_opening_threads) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jmax_file_opening_threads) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_file_opening_threads =
       static_cast<int>(jmax_file_opening_threads);
 }
@@ -411,8 +436,9 @@ void Java_org_rocksdb_Options_setMaxFileOpeningThreads(
  * Method:    maxFileOpeningThreads
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxFileOpeningThreads(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxFileOpeningThreads(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<int>(opt->max_file_opening_threads);
 }
@@ -422,8 +448,8 @@ jint Java_org_rocksdb_Options_maxFileOpeningThreads(
  * Method:    useFsync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useFsync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_useFsync(JNIEnv* /*env*/, jobject /*jobj*/,
+                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->use_fsync;
 }
 
@@ -432,8 +458,8 @@ jboolean Java_org_rocksdb_Options_useFsync(
  * Method:    setUseFsync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseFsync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean use_fsync) {
+void Java_org_rocksdb_Options_setUseFsync(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle, jboolean use_fsync) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->use_fsync =
       static_cast<bool>(use_fsync);
 }
@@ -443,35 +469,33 @@ void Java_org_rocksdb_Options_setUseFsync(
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_Options_setDbPaths(
-    JNIEnv* env, jobject jobj, jlong jhandle, jobjectArray jpaths,
-    jlongArray jtarget_sizes) {
+void Java_org_rocksdb_Options_setDbPaths(JNIEnv* env, jobject /*jobj*/,
+                                         jlong jhandle, jobjectArray jpaths,
+                                         jlongArray jtarget_sizes) {
   std::vector<rocksdb::DbPath> db_paths;
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
-  if(ptr_jtarget_size == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return;
+  if (ptr_jtarget_size == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
   }
 
   jboolean has_exception = JNI_FALSE;
   const jsize len = env->GetArrayLength(jpaths);
-  for(jsize i = 0; i < len; i++) {
-    jobject jpath = reinterpret_cast<jstring>(env->
-        GetObjectArrayElement(jpaths, i));
-    if(env->ExceptionCheck()) {
+  for (jsize i = 0; i < len; i++) {
+    jobject jpath =
+        reinterpret_cast<jstring>(env->GetObjectArrayElement(jpaths, i));
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
     std::string path = rocksdb::JniUtil::copyStdString(
         env, static_cast<jstring>(jpath), &has_exception);
     env->DeleteLocalRef(jpath);
 
-    if(has_exception == JNI_TRUE) {
-        env->ReleaseLongArrayElements(
-            jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
-        return;
+    if (has_exception == JNI_TRUE) {
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      return;
     }
 
     jlong jtarget_size = ptr_jtarget_size[i];
@@ -491,8 +515,8 @@ void Java_org_rocksdb_Options_setDbPaths(
  * Method:    dbPathsLen
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_dbPathsLen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_dbPathsLen(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->db_paths.size());
 }
@@ -502,33 +526,31 @@ jlong Java_org_rocksdb_Options_dbPathsLen(
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_Options_dbPaths(
-    JNIEnv* env, jobject jobj, jlong jhandle, jobjectArray jpaths,
-    jlongArray jtarget_sizes) {
+void Java_org_rocksdb_Options_dbPaths(JNIEnv* env, jobject /*jobj*/,
+                                      jlong jhandle, jobjectArray jpaths,
+                                      jlongArray jtarget_sizes) {
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
-  if(ptr_jtarget_size == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return;
+  if (ptr_jtarget_size == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
   }
 
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   const jsize len = env->GetArrayLength(jpaths);
-  for(jsize i = 0; i < len; i++) {
+  for (jsize i = 0; i < len; i++) {
     rocksdb::DbPath db_path = opt->db_paths[i];
 
     jstring jpath = env->NewStringUTF(db_path.path.c_str());
-    if(jpath == nullptr) {
+    if (jpath == nullptr) {
       // exception thrown: OutOfMemoryError
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
     env->SetObjectArrayElement(jpaths, i, jpath);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jpath);
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
 
@@ -543,8 +565,8 @@ void Java_org_rocksdb_Options_dbPaths(
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_dbLogDir(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_Options_dbLogDir(JNIEnv* env, jobject /*jobj*/,
+                                          jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::Options*>(jhandle)->db_log_dir.c_str());
 }
@@ -554,10 +576,10 @@ jstring Java_org_rocksdb_Options_dbLogDir(
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setDbLogDir(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jdb_log_dir) {
+void Java_org_rocksdb_Options_setDbLogDir(JNIEnv* env, jobject /*jobj*/,
+                                          jlong jhandle, jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
-  if(log_dir == nullptr) {
+  if (log_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -570,8 +592,8 @@ void Java_org_rocksdb_Options_setDbLogDir(
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_walDir(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_Options_walDir(JNIEnv* env, jobject /*jobj*/,
+                                        jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::Options*>(jhandle)->wal_dir.c_str());
 }
@@ -581,10 +603,10 @@ jstring Java_org_rocksdb_Options_walDir(
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_Options_setWalDir(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jwal_dir) {
+void Java_org_rocksdb_Options_setWalDir(JNIEnv* env, jobject /*jobj*/,
+                                        jlong jhandle, jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, nullptr);
-  if(wal_dir == nullptr) {
+  if (wal_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -597,8 +619,9 @@ void Java_org_rocksdb_Options_setWalDir(
  * Method:    deleteObsoleteFilesPeriodMicros
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->delete_obsolete_files_period_micros;
 }
@@ -609,10 +632,9 @@ jlong Java_org_rocksdb_Options_deleteObsoleteFilesPeriodMicros(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setDeleteObsoleteFilesPeriodMicros(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong micros) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong micros) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
-      ->delete_obsolete_files_period_micros =
-          static_cast<int64_t>(micros);
+      ->delete_obsolete_files_period_micros = static_cast<int64_t>(micros);
 }
 
 /*
@@ -620,10 +642,12 @@ void Java_org_rocksdb_Options_setDeleteObsoleteFilesPeriodMicros(
  * Method:    setBaseBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setBaseBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)
-      ->base_background_compactions = static_cast<int>(max);
+void Java_org_rocksdb_Options_setBaseBackgroundCompactions(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle,
+                                                           jint max) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->base_background_compactions =
+      static_cast<int>(max);
 }
 
 /*
@@ -631,8 +655,9 @@ void Java_org_rocksdb_Options_setBaseBackgroundCompactions(
  * Method:    baseBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_baseBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_baseBackgroundCompactions(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->base_background_compactions;
 }
@@ -642,10 +667,11 @@ jint Java_org_rocksdb_Options_baseBackgroundCompactions(
  * Method:    maxBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_background_compactions;
+jint Java_org_rocksdb_Options_maxBackgroundCompactions(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->max_background_compactions;
 }
 
 /*
@@ -653,10 +679,12 @@ jint Java_org_rocksdb_Options_maxBackgroundCompactions(
  * Method:    setMaxBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)
-      ->max_background_compactions = static_cast<int>(max);
+void Java_org_rocksdb_Options_setMaxBackgroundCompactions(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle,
+                                                          jint max) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_compactions =
+      static_cast<int>(max);
 }
 
 /*
@@ -664,10 +692,11 @@ void Java_org_rocksdb_Options_setMaxBackgroundCompactions(
  * Method:    setMaxSubcompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxSubcompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)
-      ->max_subcompactions = static_cast<int32_t>(max);
+void Java_org_rocksdb_Options_setMaxSubcompactions(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle, jint max) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->max_subcompactions =
+      static_cast<int32_t>(max);
 }
 
 /*
@@ -675,8 +704,9 @@ void Java_org_rocksdb_Options_setMaxSubcompactions(
  * Method:    maxSubcompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxSubcompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxSubcompactions(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_subcompactions;
 }
 
@@ -685,8 +715,9 @@ jint Java_org_rocksdb_Options_maxSubcompactions(
  * Method:    maxBackgroundFlushes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundFlushes(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxBackgroundFlushes(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_flushes;
 }
 
@@ -696,7 +727,8 @@ jint Java_org_rocksdb_Options_maxBackgroundFlushes(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxBackgroundFlushes(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max_background_flushes) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint max_background_flushes) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_flushes =
       static_cast<int>(max_background_flushes);
 }
@@ -706,7 +738,8 @@ void Java_org_rocksdb_Options_setMaxBackgroundFlushes(
  * Method:    maxBackgroundJobs
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv* env, jobject jobj,
+jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_jobs;
 }
@@ -716,7 +749,8 @@ jint Java_org_rocksdb_Options_maxBackgroundJobs(JNIEnv* env, jobject jobj,
  * Method:    setMaxBackgroundJobs
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
                                                    jlong jhandle,
                                                    jint max_background_jobs) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_background_jobs =
@@ -728,8 +762,8 @@ void Java_org_rocksdb_Options_setMaxBackgroundJobs(JNIEnv* env, jobject jobj,
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxLogFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxLogFileSize(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_log_file_size;
 }
 
@@ -738,8 +772,9 @@ jlong Java_org_rocksdb_Options_maxLogFileSize(
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMaxLogFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max_log_file_size) {
+void Java_org_rocksdb_Options_setMaxLogFileSize(JNIEnv* env, jobject /*jobj*/,
+                                                jlong jhandle,
+                                                jlong max_log_file_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(max_log_file_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->max_log_file_size =
@@ -754,8 +789,9 @@ void Java_org_rocksdb_Options_setMaxLogFileSize(
  * Method:    logFileTimeToRoll
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_logFileTimeToRoll(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_logFileTimeToRoll(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->log_file_time_to_roll;
 }
 
@@ -765,9 +801,9 @@ jlong Java_org_rocksdb_Options_logFileTimeToRoll(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setLogFileTimeToRoll(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong log_file_time_to_roll) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      log_file_time_to_roll);
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong log_file_time_to_roll) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(log_file_time_to_roll);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->log_file_time_to_roll =
         log_file_time_to_roll;
@@ -781,8 +817,8 @@ void Java_org_rocksdb_Options_setLogFileTimeToRoll(
  * Method:    keepLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_keepLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_keepLogFileNum(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->keep_log_file_num;
 }
 
@@ -791,8 +827,9 @@ jlong Java_org_rocksdb_Options_keepLogFileNum(
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setKeepLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong keep_log_file_num) {
+void Java_org_rocksdb_Options_setKeepLogFileNum(JNIEnv* env, jobject /*jobj*/,
+                                                jlong jhandle,
+                                                jlong keep_log_file_num) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(keep_log_file_num);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->keep_log_file_num =
@@ -807,8 +844,9 @@ void Java_org_rocksdb_Options_setKeepLogFileNum(
  * Method:    recycleLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_recycleLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_recycleLogFileNum(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->recycle_log_file_num;
 }
 
@@ -817,10 +855,11 @@ jlong Java_org_rocksdb_Options_recycleLogFileNum(
  * Method:    setRecycleLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRecycleLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong recycle_log_file_num) {
-  rocksdb::Status s =
-      rocksdb::check_if_jlong_fits_size_t(recycle_log_file_num);
+void Java_org_rocksdb_Options_setRecycleLogFileNum(JNIEnv* env,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle,
+                                                   jlong recycle_log_file_num) {
+  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(recycle_log_file_num);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->recycle_log_file_num =
         recycle_log_file_num;
@@ -834,8 +873,9 @@ void Java_org_rocksdb_Options_setRecycleLogFileNum(
  * Method:    maxManifestFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxManifestFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxManifestFileSize(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_manifest_file_size;
 }
 
@@ -843,8 +883,9 @@ jlong Java_org_rocksdb_Options_maxManifestFileSize(
  * Method:    memTableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_memTableFactoryName(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_Options_memTableFactoryName(JNIEnv* env,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   rocksdb::MemTableRepFactory* tf = opt->memtable_factory.get();
 
@@ -866,7 +907,8 @@ jstring Java_org_rocksdb_Options_memTableFactoryName(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxManifestFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max_manifest_file_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong max_manifest_file_size) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->max_manifest_file_size =
       static_cast<int64_t>(max_manifest_file_size);
 }
@@ -875,8 +917,10 @@ void Java_org_rocksdb_Options_setMaxManifestFileSize(
  * Method:    setMemTableFactory
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMemTableFactory(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
+void Java_org_rocksdb_Options_setMemTableFactory(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jlong jfactory_handle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->memtable_factory.reset(
       reinterpret_cast<rocksdb::MemTableRepFactory*>(jfactory_handle));
 }
@@ -886,13 +930,13 @@ void Java_org_rocksdb_Options_setMemTableFactory(
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRateLimiter(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrate_limiter_handle) {
-  std::shared_ptr<rocksdb::RateLimiter> *pRateLimiter =
-      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(
+void Java_org_rocksdb_Options_setRateLimiter(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong jhandle,
+                                             jlong jrate_limiter_handle) {
+  std::shared_ptr<rocksdb::RateLimiter>* pRateLimiter =
+      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(
           jrate_limiter_handle);
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      rate_limiter = *pRateLimiter;
+  reinterpret_cast<rocksdb::Options*>(jhandle)->rate_limiter = *pRateLimiter;
 }
 
 /*
@@ -901,12 +945,13 @@ void Java_org_rocksdb_Options_setRateLimiter(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setSstFileManager(
-    JNIEnv* env, jobject job, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*job*/, jlong jhandle,
     jlong jsst_file_manager_handle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jsst_file_manager_handle);
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      sst_file_manager = *sptr_sst_file_manager;
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(
+          jsst_file_manager_handle);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->sst_file_manager =
+      *sptr_sst_file_manager;
 }
 
 /*
@@ -914,10 +959,10 @@ void Java_org_rocksdb_Options_setSstFileManager(
  * Method:    setLogger
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setLogger(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jlogger_handle) {
-std::shared_ptr<rocksdb::LoggerJniCallback> *pLogger =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(
+void Java_org_rocksdb_Options_setLogger(JNIEnv* /*env*/, jobject /*jobj*/,
+                                        jlong jhandle, jlong jlogger_handle) {
+  std::shared_ptr<rocksdb::LoggerJniCallback>* pLogger =
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(
           jlogger_handle);
   reinterpret_cast<rocksdb::Options*>(jhandle)->info_log = *pLogger;
 }
@@ -927,8 +972,8 @@ std::shared_ptr<rocksdb::LoggerJniCallback> *pLogger =
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setInfoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jlog_level) {
+void Java_org_rocksdb_Options_setInfoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle, jbyte jlog_level) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->info_log_level =
       static_cast<rocksdb::InfoLogLevel>(jlog_level);
 }
@@ -938,8 +983,8 @@ void Java_org_rocksdb_Options_setInfoLogLevel(
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_infoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_infoLogLevel(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<rocksdb::Options*>(jhandle)->info_log_level);
 }
@@ -949,8 +994,9 @@ jbyte Java_org_rocksdb_Options_infoLogLevel(
  * Method:    tableCacheNumshardbits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_tableCacheNumshardbits(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_tableCacheNumshardbits(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->table_cache_numshardbits;
 }
 
@@ -960,7 +1006,8 @@ jint Java_org_rocksdb_Options_tableCacheNumshardbits(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setTableCacheNumshardbits(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint table_cache_numshardbits) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint table_cache_numshardbits) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->table_cache_numshardbits =
       static_cast<int>(table_cache_numshardbits);
 }
@@ -970,21 +1017,21 @@ void Java_org_rocksdb_Options_setTableCacheNumshardbits(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_useFixedLengthPrefixExtractor(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint jprefix_length) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->prefix_extractor.reset(
-      rocksdb::NewFixedPrefixTransform(
-          static_cast<int>(jprefix_length)));
+      rocksdb::NewFixedPrefixTransform(static_cast<int>(jprefix_length)));
 }
 
 /*
  * Method:    useCappedPrefixExtractor
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_useCappedPrefixExtractor(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
+void Java_org_rocksdb_Options_useCappedPrefixExtractor(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle,
+                                                       jint jprefix_length) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->prefix_extractor.reset(
-      rocksdb::NewCappedPrefixTransform(
-          static_cast<int>(jprefix_length)));
+      rocksdb::NewCappedPrefixTransform(static_cast<int>(jprefix_length)));
 }
 
 /*
@@ -992,8 +1039,8 @@ void Java_org_rocksdb_Options_useCappedPrefixExtractor(
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walTtlSeconds(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_walTtlSeconds(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->WAL_ttl_seconds;
 }
 
@@ -1002,8 +1049,9 @@ jlong Java_org_rocksdb_Options_walTtlSeconds(
  * Method:    setWalTtlSeconds
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalTtlSeconds(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong WAL_ttl_seconds) {
+void Java_org_rocksdb_Options_setWalTtlSeconds(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jlong WAL_ttl_seconds) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->WAL_ttl_seconds =
       static_cast<int64_t>(WAL_ttl_seconds);
 }
@@ -1013,8 +1061,8 @@ void Java_org_rocksdb_Options_setWalTtlSeconds(
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walSizeLimitMB(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_walSizeLimitMB(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->WAL_size_limit_MB;
 }
 
@@ -1023,8 +1071,9 @@ jlong Java_org_rocksdb_Options_walSizeLimitMB(
  * Method:    setWalSizeLimitMB
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalSizeLimitMB(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong WAL_size_limit_MB) {
+void Java_org_rocksdb_Options_setWalSizeLimitMB(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
+                                                jlong WAL_size_limit_MB) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->WAL_size_limit_MB =
       static_cast<int64_t>(WAL_size_limit_MB);
 }
@@ -1034,8 +1083,9 @@ void Java_org_rocksdb_Options_setWalSizeLimitMB(
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_manifestPreallocationSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_manifestPreallocationSize(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->manifest_preallocation_size;
 }
@@ -1046,7 +1096,7 @@ jlong Java_org_rocksdb_Options_manifestPreallocationSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setManifestPreallocationSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong preallocation_size) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong preallocation_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(preallocation_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->manifest_preallocation_size =
@@ -1060,8 +1110,9 @@ void Java_org_rocksdb_Options_setManifestPreallocationSize(
  * Method:    setTableFactory
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setTableFactory(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
+void Java_org_rocksdb_Options_setTableFactory(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle,
+                                              jlong jfactory_handle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->table_factory.reset(
       reinterpret_cast<rocksdb::TableFactory*>(jfactory_handle));
 }
@@ -1071,8 +1122,9 @@ void Java_org_rocksdb_Options_setTableFactory(
  * Method:    allowMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowMmapReads(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_allowMmapReads(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->allow_mmap_reads;
 }
 
@@ -1081,8 +1133,9 @@ jboolean Java_org_rocksdb_Options_allowMmapReads(
  * Method:    setAllowMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowMmapReads(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow_mmap_reads) {
+void Java_org_rocksdb_Options_setAllowMmapReads(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
+                                                jboolean allow_mmap_reads) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->allow_mmap_reads =
       static_cast<bool>(allow_mmap_reads);
 }
@@ -1092,8 +1145,9 @@ void Java_org_rocksdb_Options_setAllowMmapReads(
  * Method:    allowMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowMmapWrites(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_allowMmapWrites(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->allow_mmap_writes;
 }
 
@@ -1102,8 +1156,10 @@ jboolean Java_org_rocksdb_Options_allowMmapWrites(
  * Method:    setAllowMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowMmapWrites(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow_mmap_writes) {
+void Java_org_rocksdb_Options_setAllowMmapWrites(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jboolean allow_mmap_writes) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->allow_mmap_writes =
       static_cast<bool>(allow_mmap_writes);
 }
@@ -1113,7 +1169,8 @@ void Java_org_rocksdb_Options_setAllowMmapWrites(
  * Method:    useDirectReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->use_direct_reads;
 }
@@ -1123,8 +1180,8 @@ jboolean Java_org_rocksdb_Options_useDirectReads(JNIEnv* env, jobject jobj,
  * Method:    setUseDirectReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv* env, jobject jobj,
-                                                jlong jhandle,
+void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
                                                 jboolean use_direct_reads) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->use_direct_reads =
       static_cast<bool>(use_direct_reads);
@@ -1136,7 +1193,7 @@ void Java_org_rocksdb_Options_setUseDirectReads(JNIEnv* env, jobject jobj,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_useDirectIoForFlushAndCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->use_direct_io_for_flush_and_compaction;
 }
@@ -1147,7 +1204,7 @@ jboolean Java_org_rocksdb_Options_useDirectIoForFlushAndCompaction(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setUseDirectIoForFlushAndCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean use_direct_io_for_flush_and_compaction) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->use_direct_io_for_flush_and_compaction =
@@ -1159,8 +1216,9 @@ void Java_org_rocksdb_Options_setUseDirectIoForFlushAndCompaction(
  * Method:    setAllowFAllocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowFAllocate(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_fallocate) {
+void Java_org_rocksdb_Options_setAllowFAllocate(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong jhandle,
+                                                jboolean jallow_fallocate) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->allow_fallocate =
       static_cast<bool>(jallow_fallocate);
 }
@@ -1170,8 +1228,9 @@ void Java_org_rocksdb_Options_setAllowFAllocate(
  * Method:    allowFAllocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowFAllocate(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_allowFAllocate(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->allow_fallocate);
 }
@@ -1181,8 +1240,9 @@ jboolean Java_org_rocksdb_Options_allowFAllocate(
  * Method:    isFdCloseOnExec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_isFdCloseOnExec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_isFdCloseOnExec(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->is_fd_close_on_exec;
 }
 
@@ -1191,8 +1251,10 @@ jboolean Java_org_rocksdb_Options_isFdCloseOnExec(
  * Method:    setIsFdCloseOnExec
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setIsFdCloseOnExec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean is_fd_close_on_exec) {
+void Java_org_rocksdb_Options_setIsFdCloseOnExec(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jboolean is_fd_close_on_exec) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->is_fd_close_on_exec =
       static_cast<bool>(is_fd_close_on_exec);
 }
@@ -1202,8 +1264,9 @@ void Java_org_rocksdb_Options_setIsFdCloseOnExec(
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_statsDumpPeriodSec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_statsDumpPeriodSec(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->stats_dump_period_sec;
 }
 
@@ -1213,7 +1276,8 @@ jint Java_org_rocksdb_Options_statsDumpPeriodSec(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setStatsDumpPeriodSec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint stats_dump_period_sec) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint stats_dump_period_sec) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->stats_dump_period_sec =
       static_cast<int>(stats_dump_period_sec);
 }
@@ -1223,8 +1287,9 @@ void Java_org_rocksdb_Options_setStatsDumpPeriodSec(
  * Method:    adviseRandomOnOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->advise_random_on_open;
 }
 
@@ -1234,7 +1299,8 @@ jboolean Java_org_rocksdb_Options_adviseRandomOnOpen(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAdviseRandomOnOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean advise_random_on_open) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean advise_random_on_open) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->advise_random_on_open =
       static_cast<bool>(advise_random_on_open);
 }
@@ -1245,7 +1311,8 @@ void Java_org_rocksdb_Options_setAdviseRandomOnOpen(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setDbWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdb_write_buffer_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jdb_write_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->db_write_buffer_size = static_cast<size_t>(jdb_write_buffer_size);
 }
@@ -1255,8 +1322,9 @@ void Java_org_rocksdb_Options_setDbWriteBufferSize(
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_dbWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_dbWriteBufferSize(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->db_write_buffer_size);
 }
@@ -1267,7 +1335,8 @@ jlong Java_org_rocksdb_Options_dbWriteBufferSize(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setAccessHintOnCompactionStart(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jaccess_hint_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jaccess_hint_value) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->access_hint_on_compaction_start =
       rocksdb::AccessHintJni::toCppAccessHint(jaccess_hint_value);
@@ -1278,8 +1347,9 @@ void Java_org_rocksdb_Options_setAccessHintOnCompactionStart(
  * Method:    accessHintOnCompactionStart
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::AccessHintJni::toJavaAccessHint(
       opt->access_hint_on_compaction_start);
@@ -1291,7 +1361,7 @@ jbyte Java_org_rocksdb_Options_accessHintOnCompactionStart(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setNewTableReaderForCompactionInputs(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jnew_table_reader_for_compaction_inputs) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->new_table_reader_for_compaction_inputs =
@@ -1304,7 +1374,7 @@ void Java_org_rocksdb_Options_setNewTableReaderForCompactionInputs(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_newTableReaderForCompactionInputs(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<bool>(opt->new_table_reader_for_compaction_inputs);
 }
@@ -1315,7 +1385,8 @@ jboolean Java_org_rocksdb_Options_newTableReaderForCompactionInputs(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcompaction_readahead_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jcompaction_readahead_size) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->compaction_readahead_size =
       static_cast<size_t>(jcompaction_readahead_size);
@@ -1326,8 +1397,9 @@ void Java_org_rocksdb_Options_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_compactionReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_compactionReadaheadSize(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->compaction_readahead_size);
 }
@@ -1338,7 +1410,7 @@ jlong Java_org_rocksdb_Options_compactionReadaheadSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setRandomAccessMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jrandom_access_max_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->random_access_max_buffer_size =
@@ -1350,8 +1422,9 @@ void Java_org_rocksdb_Options_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->random_access_max_buffer_size);
 }
@@ -1362,7 +1435,7 @@ jlong Java_org_rocksdb_Options_randomAccessMaxBufferSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setWritableFileMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jlong jwritable_file_max_buffer_size) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->writable_file_max_buffer_size =
@@ -1374,8 +1447,9 @@ void Java_org_rocksdb_Options_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->writable_file_max_buffer_size);
 }
@@ -1385,8 +1459,9 @@ jlong Java_org_rocksdb_Options_writableFileMaxBufferSize(
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_useAdaptiveMutex(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_useAdaptiveMutex(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->use_adaptive_mutex;
 }
 
@@ -1395,8 +1470,10 @@ jboolean Java_org_rocksdb_Options_useAdaptiveMutex(
  * Method:    setUseAdaptiveMutex
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setUseAdaptiveMutex(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean use_adaptive_mutex) {
+void Java_org_rocksdb_Options_setUseAdaptiveMutex(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle,
+                                                  jboolean use_adaptive_mutex) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->use_adaptive_mutex =
       static_cast<bool>(use_adaptive_mutex);
 }
@@ -1406,8 +1483,8 @@ void Java_org_rocksdb_Options_setUseAdaptiveMutex(
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_bytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_bytesPerSync(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->bytes_per_sync;
 }
 
@@ -1416,8 +1493,9 @@ jlong Java_org_rocksdb_Options_bytesPerSync(
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong bytes_per_sync) {
+void Java_org_rocksdb_Options_setBytesPerSync(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle,
+                                              jlong bytes_per_sync) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->bytes_per_sync =
       static_cast<int64_t>(bytes_per_sync);
 }
@@ -1427,8 +1505,10 @@ void Java_org_rocksdb_Options_setBytesPerSync(
  * Method:    setWalBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWalBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwal_bytes_per_sync) {
+void Java_org_rocksdb_Options_setWalBytesPerSync(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jlong jwal_bytes_per_sync) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->wal_bytes_per_sync =
       static_cast<int64_t>(jwal_bytes_per_sync);
 }
@@ -1438,8 +1518,9 @@ void Java_org_rocksdb_Options_setWalBytesPerSync(
  * Method:    walBytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_walBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_walBytesPerSync(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->wal_bytes_per_sync);
 }
@@ -1450,7 +1531,7 @@ jlong Java_org_rocksdb_Options_walBytesPerSync(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnableThreadTracking(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jenable_thread_tracking) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->enable_thread_tracking = static_cast<bool>(jenable_thread_tracking);
@@ -1461,8 +1542,9 @@ void Java_org_rocksdb_Options_setEnableThreadTracking(
  * Method:    enableThreadTracking
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_enableThreadTracking(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_enableThreadTracking(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->enable_thread_tracking);
 }
@@ -1472,8 +1554,10 @@ jboolean Java_org_rocksdb_Options_enableThreadTracking(
  * Method:    setDelayedWriteRate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setDelayedWriteRate(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdelayed_write_rate) {
+void Java_org_rocksdb_Options_setDelayedWriteRate(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle,
+                                                  jlong jdelayed_write_rate) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->delayed_write_rate = static_cast<uint64_t>(jdelayed_write_rate);
 }
@@ -1483,8 +1567,9 @@ void Java_org_rocksdb_Options_setDelayedWriteRate(
  * Method:    delayedWriteRate
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_delayedWriteRate(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_delayedWriteRate(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jlong>(opt->delayed_write_rate);
 }
@@ -1494,10 +1579,12 @@ jlong Java_org_rocksdb_Options_delayedWriteRate(
  * Method:    setAllowConcurrentMemtableWrite
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      allow_concurrent_memtable_write = static_cast<bool>(allow);
+void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle,
+                                                              jboolean allow) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->allow_concurrent_memtable_write = static_cast<bool>(allow);
 }
 
 /*
@@ -1505,10 +1592,11 @@ void Java_org_rocksdb_Options_setAllowConcurrentMemtableWrite(
  * Method:    allowConcurrentMemtableWrite
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->
-      allow_concurrent_memtable_write;
+jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->allow_concurrent_memtable_write;
 }
 
 /*
@@ -1517,9 +1605,9 @@ jboolean Java_org_rocksdb_Options_allowConcurrentMemtableWrite(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setEnableWriteThreadAdaptiveYield(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean yield) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      enable_write_thread_adaptive_yield = static_cast<bool>(yield);
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean yield) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->enable_write_thread_adaptive_yield = static_cast<bool>(yield);
 }
 
 /*
@@ -1528,9 +1616,9 @@ void Java_org_rocksdb_Options_setEnableWriteThreadAdaptiveYield(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_enableWriteThreadAdaptiveYield(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->
-      enable_write_thread_adaptive_yield;
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->enable_write_thread_adaptive_yield;
 }
 
 /*
@@ -1538,10 +1626,12 @@ jboolean Java_org_rocksdb_Options_enableWriteThreadAdaptiveYield(
  * Method:    setWriteThreadMaxYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      write_thread_max_yield_usec = static_cast<int64_t>(max);
+void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle,
+                                                         jlong max) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->write_thread_max_yield_usec =
+      static_cast<int64_t>(max);
 }
 
 /*
@@ -1549,10 +1639,11 @@ void Java_org_rocksdb_Options_setWriteThreadMaxYieldUsec(
  * Method:    writeThreadMaxYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->
-      write_thread_max_yield_usec;
+jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->write_thread_max_yield_usec;
 }
 
 /*
@@ -1560,10 +1651,12 @@ jlong Java_org_rocksdb_Options_writeThreadMaxYieldUsec(
  * Method:    setWriteThreadSlowYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong slow) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      write_thread_slow_yield_usec = static_cast<int64_t>(slow);
+void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle,
+                                                          jlong slow) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->write_thread_slow_yield_usec =
+      static_cast<int64_t>(slow);
 }
 
 /*
@@ -1571,10 +1664,11 @@ void Java_org_rocksdb_Options_setWriteThreadSlowYieldUsec(
  * Method:    writeThreadSlowYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->
-      write_thread_slow_yield_usec;
+jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->write_thread_slow_yield_usec;
 }
 
 /*
@@ -1583,7 +1677,7 @@ jlong Java_org_rocksdb_Options_writeThreadSlowYieldUsec(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setSkipStatsUpdateOnDbOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jskip_stats_update_on_db_open) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->skip_stats_update_on_db_open =
@@ -1595,8 +1689,9 @@ void Java_org_rocksdb_Options_setSkipStatsUpdateOnDbOpen(
  * Method:    skipStatsUpdateOnDbOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->skip_stats_update_on_db_open);
 }
@@ -1607,11 +1702,11 @@ jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setWalRecoveryMode(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jwal_recovery_mode_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jwal_recovery_mode_value) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  opt->wal_recovery_mode =
-      rocksdb::WALRecoveryModeJni::toCppWALRecoveryMode(
-          jwal_recovery_mode_value);
+  opt->wal_recovery_mode = rocksdb::WALRecoveryModeJni::toCppWALRecoveryMode(
+      jwal_recovery_mode_value);
 }
 
 /*
@@ -1619,8 +1714,9 @@ void Java_org_rocksdb_Options_setWalRecoveryMode(
  * Method:    walRecoveryMode
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_walRecoveryMode(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_walRecoveryMode(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::WALRecoveryModeJni::toJavaWALRecoveryMode(
       opt->wal_recovery_mode);
@@ -1631,8 +1727,8 @@ jbyte Java_org_rocksdb_Options_walRecoveryMode(
  * Method:    setAllow2pc
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAllow2pc(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_2pc) {
+void Java_org_rocksdb_Options_setAllow2pc(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle, jboolean jallow_2pc) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->allow_2pc = static_cast<bool>(jallow_2pc);
 }
@@ -1642,7 +1738,8 @@ void Java_org_rocksdb_Options_setAllow2pc(
  * Method:    allow2pc
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv* /*env*/, jobject /*jobj*/,
+                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->allow_2pc);
 }
@@ -1652,10 +1749,12 @@ jboolean Java_org_rocksdb_Options_allow2pc(JNIEnv* env, jobject jobj, jlong jhan
  * Method:    setRowCache
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setRowCache(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrow_cache_handle) {
+void Java_org_rocksdb_Options_setRowCache(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle,
+                                          jlong jrow_cache_handle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto* row_cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jrow_cache_handle);
+  auto* row_cache =
+      reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jrow_cache_handle);
   opt->row_cache = *row_cache;
 }
 
@@ -1665,7 +1764,7 @@ void Java_org_rocksdb_Options_setRowCache(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setFailIfOptionsFileError(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean jfail_if_options_file_error) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->fail_if_options_file_error =
@@ -1677,8 +1776,9 @@ void Java_org_rocksdb_Options_setFailIfOptionsFileError(
  * Method:    failIfOptionsFileError
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_failIfOptionsFileError(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_failIfOptionsFileError(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->fail_if_options_file_error);
 }
@@ -1688,8 +1788,10 @@ jboolean Java_org_rocksdb_Options_failIfOptionsFileError(
  * Method:    setDumpMallocStats
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setDumpMallocStats(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jdump_malloc_stats) {
+void Java_org_rocksdb_Options_setDumpMallocStats(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jboolean jdump_malloc_stats) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->dump_malloc_stats = static_cast<bool>(jdump_malloc_stats);
 }
@@ -1699,8 +1801,9 @@ void Java_org_rocksdb_Options_setDumpMallocStats(
  * Method:    dumpMallocStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_dumpMallocStats(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_dumpMallocStats(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->dump_malloc_stats);
 }
@@ -1711,10 +1814,11 @@ jboolean Java_org_rocksdb_Options_dumpMallocStats(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAvoidFlushDuringRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean javoid_flush_during_recovery) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  opt->avoid_flush_during_recovery = static_cast<bool>(javoid_flush_during_recovery);
+  opt->avoid_flush_during_recovery =
+      static_cast<bool>(javoid_flush_during_recovery);
 }
 
 /*
@@ -1722,8 +1826,9 @@ void Java_org_rocksdb_Options_setAvoidFlushDuringRecovery(
  * Method:    avoidFlushDuringRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
 }
@@ -1734,10 +1839,11 @@ jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setAvoidFlushDuringShutdown(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jboolean javoid_flush_during_shutdown) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
-  opt->avoid_flush_during_shutdown = static_cast<bool>(javoid_flush_during_shutdown);
+  opt->avoid_flush_during_shutdown =
+      static_cast<bool>(javoid_flush_during_shutdown);
 }
 
 /*
@@ -1745,8 +1851,9 @@ void Java_org_rocksdb_Options_setAvoidFlushDuringShutdown(
  * Method:    avoidFlushDuringShutdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
 }
@@ -1755,8 +1862,8 @@ jboolean Java_org_rocksdb_Options_avoidFlushDuringShutdown(
  * Method:    tableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_Options_tableFactoryName(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_Options_tableFactoryName(JNIEnv* env, jobject /*jobj*/,
+                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   rocksdb::TableFactory* tf = opt->table_factory.get();
 
@@ -1767,16 +1874,16 @@ jstring Java_org_rocksdb_Options_tableFactoryName(
   return env->NewStringUTF(tf->Name());
 }
 
-
 /*
  * Class:     org_rocksdb_Options
  * Method:    minWriteBufferNumberToMerge
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->min_write_buffer_number_to_merge;
+jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->min_write_buffer_number_to_merge;
 }
 
 /*
@@ -1785,19 +1892,19 @@ jint Java_org_rocksdb_Options_minWriteBufferNumberToMerge(
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMinWriteBufferNumberToMerge(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jmin_write_buffer_number_to_merge) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->min_write_buffer_number_to_merge =
-          static_cast<int>(jmin_write_buffer_number_to_merge);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->min_write_buffer_number_to_merge =
+      static_cast<int>(jmin_write_buffer_number_to_merge);
 }
 /*
  * Class:     org_rocksdb_Options
  * Method:    maxWriteBufferNumberToMaintain
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv* env,
-                                                             jobject jobj,
+jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
                                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)
       ->max_write_buffer_number_to_maintain;
@@ -1809,7 +1916,7 @@ jint Java_org_rocksdb_Options_maxWriteBufferNumberToMaintain(JNIEnv* env,
  * Signature: (JI)V
  */
 void Java_org_rocksdb_Options_setMaxWriteBufferNumberToMaintain(
-    JNIEnv* env, jobject jobj, jlong jhandle,
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
     jint jmax_write_buffer_number_to_maintain) {
   reinterpret_cast<rocksdb::Options*>(jhandle)
       ->max_write_buffer_number_to_maintain =
@@ -1822,7 +1929,8 @@ void Java_org_rocksdb_Options_setMaxWriteBufferNumberToMaintain(
  * Signature: (JB)V
  */
 void Java_org_rocksdb_Options_setCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jcompression_type_value) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jbyte jcompression_type_value) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   opts->compression = rocksdb::CompressionTypeJni::toCppCompressionType(
       jcompression_type_value);
@@ -1833,11 +1941,11 @@ void Java_org_rocksdb_Options_setCompressionType(
  * Method:    compressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_compressionType(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
-  return rocksdb::CompressionTypeJni::toJavaCompressionType(
-      opts->compression);
+  return rocksdb::CompressionTypeJni::toJavaCompressionType(opts->compression);
 }
 
 /**
@@ -1848,28 +1956,30 @@ jbyte Java_org_rocksdb_Options_compressionType(
  * @param jcompression_levels A reference to a java byte array
  *     where each byte indicates a compression level
  *
- * @return A unique_ptr to the vector, or unique_ptr(nullptr) if a JNI exception occurs
+ * @return A unique_ptr to the vector, or unique_ptr(nullptr) if a JNI exception
+ * occurs
  */
-std::unique_ptr<std::vector<rocksdb::CompressionType>> rocksdb_compression_vector_helper(
-    JNIEnv* env, jbyteArray jcompression_levels) {
+std::unique_ptr<std::vector<rocksdb::CompressionType>>
+rocksdb_compression_vector_helper(JNIEnv* env, jbyteArray jcompression_levels) {
   jsize len = env->GetArrayLength(jcompression_levels);
   jbyte* jcompression_level =
       env->GetByteArrayElements(jcompression_levels, nullptr);
-  if(jcompression_level == nullptr) {
+  if (jcompression_level == nullptr) {
     // exception thrown: OutOfMemoryError
     return std::unique_ptr<std::vector<rocksdb::CompressionType>>();
   }
 
   auto* compression_levels = new std::vector<rocksdb::CompressionType>();
-  std::unique_ptr<std::vector<rocksdb::CompressionType>> uptr_compression_levels(compression_levels);
+  std::unique_ptr<std::vector<rocksdb::CompressionType>>
+      uptr_compression_levels(compression_levels);
 
-  for(jsize i = 0; i < len; i++) {
+  for (jsize i = 0; i < len; i++) {
     jbyte jcl = jcompression_level[i];
     compression_levels->push_back(static_cast<rocksdb::CompressionType>(jcl));
   }
 
   env->ReleaseByteArrayElements(jcompression_levels, jcompression_level,
-      JNI_ABORT);
+                                JNI_ABORT);
 
   return uptr_compression_levels;
 }
@@ -1884,32 +1994,32 @@ std::unique_ptr<std::vector<rocksdb::CompressionType>> rocksdb_compression_vecto
  *
  * @return A jbytearray or nullptr if an exception occurs
  */
-jbyteArray rocksdb_compression_list_helper(JNIEnv* env,
-    std::vector<rocksdb::CompressionType> compression_levels) {
+jbyteArray rocksdb_compression_list_helper(
+    JNIEnv* env, std::vector<rocksdb::CompressionType> compression_levels) {
   const size_t len = compression_levels.size();
   jbyte* jbuf = new jbyte[len];
 
   for (size_t i = 0; i < len; i++) {
-      jbuf[i] = compression_levels[i];
+    jbuf[i] = compression_levels[i];
   }
 
   // insert in java array
   jbyteArray jcompression_levels = env->NewByteArray(static_cast<jsize>(len));
-  if(jcompression_levels == nullptr) {
-      // exception thrown: OutOfMemoryError
-      delete [] jbuf;
-      return nullptr;
+  if (jcompression_levels == nullptr) {
+    // exception thrown: OutOfMemoryError
+    delete[] jbuf;
+    return nullptr;
   }
   env->SetByteArrayRegion(jcompression_levels, 0, static_cast<jsize>(len),
-      jbuf);
-  if(env->ExceptionCheck()) {
-      // exception thrown: ArrayIndexOutOfBoundsException
-      env->DeleteLocalRef(jcompression_levels);
-      delete [] jbuf;
-      return nullptr;
+                          jbuf);
+  if (env->ExceptionCheck()) {
+    // exception thrown: ArrayIndexOutOfBoundsException
+    env->DeleteLocalRef(jcompression_levels);
+    delete[] jbuf;
+    return nullptr;
   }
 
-  delete [] jbuf;
+  delete[] jbuf;
 
   return jcompression_levels;
 }
@@ -1920,11 +2030,10 @@ jbyteArray rocksdb_compression_list_helper(JNIEnv* env,
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_Options_setCompressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jbyteArray jcompressionLevels) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jbyteArray jcompressionLevels) {
   auto uptr_compression_levels =
       rocksdb_compression_vector_helper(env, jcompressionLevels);
-  if(!uptr_compression_levels) {
+  if (!uptr_compression_levels) {
     // exception occurred
     return;
   }
@@ -1937,11 +2046,11 @@ void Java_org_rocksdb_Options_setCompressionPerLevel(
  * Method:    compressionPerLevel
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_Options_compressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyteArray Java_org_rocksdb_Options_compressionPerLevel(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong jhandle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
-  return rocksdb_compression_list_helper(env,
-      options->compression_per_level);
+  return rocksdb_compression_list_helper(env, options->compression_per_level);
 }
 
 /*
@@ -1962,8 +2071,9 @@ void Java_org_rocksdb_Options_setBottommostCompressionType(
  * Method:    bottommostCompressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_bottommostCompressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_bottommostCompressionType(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::CompressionTypeJni::toJavaCompressionType(
       options->bottommost_compression);
@@ -1978,8 +2088,8 @@ void Java_org_rocksdb_Options_setCompressionOptions(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jcompression_options_handle) {
   auto* options = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto* compression_options =
-      reinterpret_cast<rocksdb::CompressionOptions*>(jcompression_options_handle);
+  auto* compression_options = reinterpret_cast<rocksdb::CompressionOptions*>(
+      jcompression_options_handle);
   options->compression_opts = *compression_options;
 }
 
@@ -1988,8 +2098,9 @@ void Java_org_rocksdb_Options_setCompressionOptions(
  * Method:    setCompactionStyle
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Options_setCompactionStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte compaction_style) {
+void Java_org_rocksdb_Options_setCompactionStyle(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle,
+                                                 jbyte compaction_style) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_style =
       static_cast<rocksdb::CompactionStyle>(compaction_style);
 }
@@ -1999,8 +2110,8 @@ void Java_org_rocksdb_Options_setCompactionStyle(
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_compactionStyle(JNIEnv* env, jobject jobj,
+                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_style;
 }
 
@@ -2011,8 +2122,9 @@ jbyte Java_org_rocksdb_Options_compactionStyle(
  */
 void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_options_fifo.max_table_files_size =
-    static_cast<uint64_t>(jmax_table_files_size);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->compaction_options_fifo.max_table_files_size =
+      static_cast<uint64_t>(jmax_table_files_size);
 }
 
 /*
@@ -2020,9 +2132,10 @@ void Java_org_rocksdb_Options_setMaxTableFilesSizeFIFO(
  * Method:    maxTableFilesSizeFIFO
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(jhandle)->compaction_options_fifo.max_table_files_size;
+jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->compaction_options_fifo.max_table_files_size;
 }
 
 /*
@@ -2030,8 +2143,8 @@ jlong Java_org_rocksdb_Options_maxTableFilesSizeFIFO(
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_numLevels(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_numLevels(JNIEnv* env, jobject jobj,
+                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->num_levels;
 }
 
@@ -2040,8 +2153,8 @@ jint Java_org_rocksdb_Options_numLevels(
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setNumLevels(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jnum_levels) {
+void Java_org_rocksdb_Options_setNumLevels(JNIEnv* env, jobject jobj,
+                                           jlong jhandle, jint jnum_levels) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->num_levels =
       static_cast<int>(jnum_levels);
 }
@@ -2051,10 +2164,11 @@ void Java_org_rocksdb_Options_setNumLevels(
  * Method:    levelZeroFileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_file_num_compaction_trigger;
+jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(JNIEnv* env,
+                                                                jobject jobj,
+                                                                jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_file_num_compaction_trigger;
 }
 
 /*
@@ -2065,9 +2179,9 @@ jint Java_org_rocksdb_Options_levelZeroFileNumCompactionTrigger(
 void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_file_num_compaction_trigger =
-          static_cast<int>(jlevel0_file_num_compaction_trigger);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_file_num_compaction_trigger =
+      static_cast<int>(jlevel0_file_num_compaction_trigger);
 }
 
 /*
@@ -2075,10 +2189,11 @@ void Java_org_rocksdb_Options_setLevelZeroFileNumCompactionTrigger(
  * Method:    levelZeroSlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_slowdown_writes_trigger;
+jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_slowdown_writes_trigger;
 }
 
 /*
@@ -2089,9 +2204,8 @@ jint Java_org_rocksdb_Options_levelZeroSlowdownWritesTrigger(
 void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_slowdown_writes_trigger =
-          static_cast<int>(jlevel0_slowdown_writes_trigger);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->level0_slowdown_writes_trigger =
+      static_cast<int>(jlevel0_slowdown_writes_trigger);
 }
 
 /*
@@ -2099,10 +2213,11 @@ void Java_org_rocksdb_Options_setLevelZeroSlowdownWritesTrigger(
  * Method:    levelZeroStopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_stop_writes_trigger;
+jint Java_org_rocksdb_Options_levelZeroStopWritesTrigger(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_stop_writes_trigger;
 }
 
 /*
@@ -2122,8 +2237,8 @@ void Java_org_rocksdb_Options_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_targetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_targetFileSizeBase(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_base;
 }
 
@@ -2133,8 +2248,7 @@ jlong Java_org_rocksdb_Options_targetFileSizeBase(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setTargetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jtarget_file_size_base) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jtarget_file_size_base) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_base =
       static_cast<uint64_t>(jtarget_file_size_base);
 }
@@ -2144,10 +2258,11 @@ void Java_org_rocksdb_Options_setTargetFileSizeBase(
  * Method:    targetFileSizeMultiplier
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_targetFileSizeMultiplier(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->target_file_size_multiplier;
+jint Java_org_rocksdb_Options_targetFileSizeMultiplier(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->target_file_size_multiplier;
 }
 
 /*
@@ -2158,9 +2273,8 @@ jint Java_org_rocksdb_Options_targetFileSizeMultiplier(
 void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jtarget_file_size_multiplier) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->target_file_size_multiplier =
-          static_cast<int>(jtarget_file_size_multiplier);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->target_file_size_multiplier =
+      static_cast<int>(jtarget_file_size_multiplier);
 }
 
 /*
@@ -2168,10 +2282,9 @@ void Java_org_rocksdb_Options_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_bytes_for_level_base;
+jlong Java_org_rocksdb_Options_maxBytesForLevelBase(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->max_bytes_for_level_base;
 }
 
 /*
@@ -2180,11 +2293,9 @@ jlong Java_org_rocksdb_Options_maxBytesForLevelBase(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_bytes_for_level_base) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_bytes_for_level_base =
-          static_cast<int64_t>(jmax_bytes_for_level_base);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_bytes_for_level_base) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->max_bytes_for_level_base =
+      static_cast<int64_t>(jmax_bytes_for_level_base);
 }
 
 /*
@@ -2194,8 +2305,8 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelBase(
  */
 jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level_compaction_dynamic_level_bytes;
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level_compaction_dynamic_level_bytes;
 }
 
 /*
@@ -2206,9 +2317,8 @@ jboolean Java_org_rocksdb_Options_levelCompactionDynamicLevelBytes(
 void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jenable_dynamic_level_bytes) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level_compaction_dynamic_level_bytes =
-          (jenable_dynamic_level_bytes);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
 }
 
 /*
@@ -2219,8 +2329,8 @@ void Java_org_rocksdb_Options_setLevelCompactionDynamicLevelBytes(
 jdouble Java_org_rocksdb_Options_maxBytesForLevelMultiplier(JNIEnv* env,
                                                             jobject jobj,
                                                             jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_bytes_for_level_multiplier;
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->max_bytes_for_level_multiplier;
 }
 
 /*
@@ -2262,8 +2372,8 @@ void Java_org_rocksdb_Options_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_arenaBlockSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_arenaBlockSize(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->arena_block_size;
 }
 
@@ -2272,8 +2382,9 @@ jlong Java_org_rocksdb_Options_arenaBlockSize(
  * Method:    setArenaBlockSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setArenaBlockSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jarena_block_size) {
+void Java_org_rocksdb_Options_setArenaBlockSize(JNIEnv* env, jobject jobj,
+                                                jlong jhandle,
+                                                jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->arena_block_size =
@@ -2288,10 +2399,10 @@ void Java_org_rocksdb_Options_setArenaBlockSize(
  * Method:    disableAutoCompactions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_disableAutoCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->disable_auto_compactions;
+jboolean Java_org_rocksdb_Options_disableAutoCompactions(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->disable_auto_compactions;
 }
 
 /*
@@ -2302,9 +2413,8 @@ jboolean Java_org_rocksdb_Options_disableAutoCompactions(
 void Java_org_rocksdb_Options_setDisableAutoCompactions(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jdisable_auto_compactions) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->disable_auto_compactions =
-          static_cast<bool>(jdisable_auto_compactions);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->disable_auto_compactions =
+      static_cast<bool>(jdisable_auto_compactions);
 }
 
 /*
@@ -2312,10 +2422,11 @@ void Java_org_rocksdb_Options_setDisableAutoCompactions(
  * Method:    maxSequentialSkipInIterations
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_sequential_skip_in_iterations;
+jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->max_sequential_skip_in_iterations;
 }
 
 /*
@@ -2326,9 +2437,9 @@ jlong Java_org_rocksdb_Options_maxSequentialSkipInIterations(
 void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jmax_sequential_skip_in_iterations) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->max_sequential_skip_in_iterations =
-          static_cast<int64_t>(jmax_sequential_skip_in_iterations);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->max_sequential_skip_in_iterations =
+      static_cast<int64_t>(jmax_sequential_skip_in_iterations);
 }
 
 /*
@@ -2336,10 +2447,10 @@ void Java_org_rocksdb_Options_setMaxSequentialSkipInIterations(
  * Method:    inplaceUpdateSupport
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->inplace_update_support;
+jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_support;
 }
 
 /*
@@ -2350,9 +2461,8 @@ jboolean Java_org_rocksdb_Options_inplaceUpdateSupport(
 void Java_org_rocksdb_Options_setInplaceUpdateSupport(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jinplace_update_support) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->inplace_update_support =
-          static_cast<bool>(jinplace_update_support);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_support =
+      static_cast<bool>(jinplace_update_support);
 }
 
 /*
@@ -2360,10 +2470,9 @@ void Java_org_rocksdb_Options_setInplaceUpdateSupport(
  * Method:    inplaceUpdateNumLocks
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->inplace_update_num_locks;
+jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_num_locks;
 }
 
 /*
@@ -2372,10 +2481,9 @@ jlong Java_org_rocksdb_Options_inplaceUpdateNumLocks(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jinplace_update_num_locks) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jinplace_update_num_locks);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jinplace_update_num_locks) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->inplace_update_num_locks =
         jinplace_update_num_locks;
@@ -2414,8 +2522,8 @@ void Java_org_rocksdb_Options_setMemtablePrefixBloomSizeRatio(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_bloomLocality(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_Options_bloomLocality(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->bloom_locality;
 }
 
@@ -2424,8 +2532,9 @@ jint Java_org_rocksdb_Options_bloomLocality(
  * Method:    setBloomLocality
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setBloomLocality(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jbloom_locality) {
+void Java_org_rocksdb_Options_setBloomLocality(JNIEnv* env, jobject jobj,
+                                               jlong jhandle,
+                                               jint jbloom_locality) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->bloom_locality =
       static_cast<int32_t>(jbloom_locality);
 }
@@ -2435,8 +2544,8 @@ void Java_org_rocksdb_Options_setBloomLocality(
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxSuccessiveMerges(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::Options*>(jhandle)->max_successive_merges;
 }
 
@@ -2446,10 +2555,9 @@ jlong Java_org_rocksdb_Options_maxSuccessiveMerges(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_successive_merges) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jmax_successive_merges);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_successive_merges) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
   if (s.ok()) {
     reinterpret_cast<rocksdb::Options*>(jhandle)->max_successive_merges =
         jmax_successive_merges;
@@ -2463,10 +2571,11 @@ void Java_org_rocksdb_Options_setMaxSuccessiveMerges(
  * Method:    optimizeFiltersForHits
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->optimize_filters_for_hits;
+jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->optimize_filters_for_hits;
 }
 
 /*
@@ -2477,9 +2586,8 @@ jboolean Java_org_rocksdb_Options_optimizeFiltersForHits(
 void Java_org_rocksdb_Options_setOptimizeFiltersForHits(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean joptimize_filters_for_hits) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->optimize_filters_for_hits =
-          static_cast<bool>(joptimize_filters_for_hits);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->optimize_filters_for_hits =
+      static_cast<bool>(joptimize_filters_for_hits);
 }
 
 /*
@@ -2487,8 +2595,8 @@ void Java_org_rocksdb_Options_setOptimizeFiltersForHits(
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_optimizeForSmallDb(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_Options_optimizeForSmallDb(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
   reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeForSmallDb();
 }
 
@@ -2498,10 +2606,9 @@ void Java_org_rocksdb_Options_optimizeForSmallDb(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeForPointLookup(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong block_cache_size_mb) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      OptimizeForPointLookup(block_cache_size_mb);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong block_cache_size_mb) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeForPointLookup(
+      block_cache_size_mb);
 }
 
 /*
@@ -2510,10 +2617,9 @@ void Java_org_rocksdb_Options_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong memtable_memory_budget) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      OptimizeLevelStyleCompaction(memtable_memory_budget);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->OptimizeLevelStyleCompaction(
+      memtable_memory_budget);
 }
 
 /*
@@ -2522,10 +2628,9 @@ void Java_org_rocksdb_Options_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong memtable_memory_budget) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      OptimizeUniversalStyleCompaction(memtable_memory_budget);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
 
 /*
@@ -2533,10 +2638,9 @@ void Java_org_rocksdb_Options_optimizeUniversalStyleCompaction(
  * Method:    prepareForBulkLoad
  * Signature: (J)V
  */
-void Java_org_rocksdb_Options_prepareForBulkLoad(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  reinterpret_cast<rocksdb::Options*>(jhandle)->
-      PrepareForBulkLoad();
+void Java_org_rocksdb_Options_prepareForBulkLoad(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)->PrepareForBulkLoad();
 }
 
 /*
@@ -2544,10 +2648,9 @@ void Java_org_rocksdb_Options_prepareForBulkLoad(
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_memtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->memtable_huge_page_size;
+jlong Java_org_rocksdb_Options_memtableHugePageSize(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->memtable_huge_page_size;
 }
 
 /*
@@ -2556,14 +2659,12 @@ jlong Java_org_rocksdb_Options_memtableHugePageSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setMemtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmemtable_huge_page_size) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jmemtable_huge_page_size);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmemtable_huge_page_size) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::Options*>(
-        jhandle)->memtable_huge_page_size =
-            jmemtable_huge_page_size;
+    reinterpret_cast<rocksdb::Options*>(jhandle)->memtable_huge_page_size =
+        jmemtable_huge_page_size;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -2574,10 +2675,11 @@ void Java_org_rocksdb_Options_setMemtableHugePageSize(
  * Method:    softPendingCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->soft_pending_compaction_bytes_limit;
+jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(JNIEnv* env,
+                                                               jobject jobj,
+                                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->soft_pending_compaction_bytes_limit;
 }
 
 /*
@@ -2586,10 +2688,11 @@ jlong Java_org_rocksdb_Options_softPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jsoft_pending_compaction_bytes_limit) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->soft_pending_compaction_bytes_limit =
-          static_cast<int64_t>(jsoft_pending_compaction_bytes_limit);
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jsoft_pending_compaction_bytes_limit) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->soft_pending_compaction_bytes_limit =
+      static_cast<int64_t>(jsoft_pending_compaction_bytes_limit);
 }
 
 /*
@@ -2597,10 +2700,11 @@ void Java_org_rocksdb_Options_setSoftPendingCompactionBytesLimit(
  * Method:    softHardCompactionBytesLimit
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->hard_pending_compaction_bytes_limit;
+jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(JNIEnv* env,
+                                                               jobject jobj,
+                                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->hard_pending_compaction_bytes_limit;
 }
 
 /*
@@ -2609,10 +2713,11 @@ jlong Java_org_rocksdb_Options_hardPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jhard_pending_compaction_bytes_limit) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->hard_pending_compaction_bytes_limit =
-          static_cast<int64_t>(jhard_pending_compaction_bytes_limit);
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jhard_pending_compaction_bytes_limit) {
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->hard_pending_compaction_bytes_limit =
+      static_cast<int64_t>(jhard_pending_compaction_bytes_limit);
 }
 
 /*
@@ -2620,10 +2725,11 @@ void Java_org_rocksdb_Options_setHardPendingCompactionBytesLimit(
  * Method:    level0FileNumCompactionTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-    jhandle)->level0_file_num_compaction_trigger;
+jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_file_num_compaction_trigger;
 }
 
 /*
@@ -2634,9 +2740,9 @@ jint Java_org_rocksdb_Options_level0FileNumCompactionTrigger(
 void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_file_num_compaction_trigger =
-          static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
+  reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_file_num_compaction_trigger =
+      static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
 }
 
 /*
@@ -2644,10 +2750,11 @@ void Java_org_rocksdb_Options_setLevel0FileNumCompactionTrigger(
  * Method:    level0SlowdownWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-    jhandle)->level0_slowdown_writes_trigger;
+jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_slowdown_writes_trigger;
 }
 
 /*
@@ -2658,9 +2765,8 @@ jint Java_org_rocksdb_Options_level0SlowdownWritesTrigger(
 void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_slowdown_writes_trigger =
-          static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->level0_slowdown_writes_trigger =
+      static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
 }
 
 /*
@@ -2668,10 +2774,10 @@ void Java_org_rocksdb_Options_setLevel0SlowdownWritesTrigger(
  * Method:    level0StopWritesTrigger
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_level0StopWritesTrigger(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-    jhandle)->level0_stop_writes_trigger;
+jint Java_org_rocksdb_Options_level0StopWritesTrigger(JNIEnv* env, jobject jobj,
+                                                      jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)
+      ->level0_stop_writes_trigger;
 }
 
 /*
@@ -2682,9 +2788,8 @@ jint Java_org_rocksdb_Options_level0StopWritesTrigger(
 void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->level0_stop_writes_trigger =
-          static_cast<int32_t>(jlevel0_stop_writes_trigger);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->level0_stop_writes_trigger =
+      static_cast<int32_t>(jlevel0_stop_writes_trigger);
 }
 
 /*
@@ -2694,9 +2799,8 @@ void Java_org_rocksdb_Options_setLevel0StopWritesTrigger(
  */
 jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  auto mbflma =
-      reinterpret_cast<rocksdb::Options*>(jhandle)->
-          max_bytes_for_level_multiplier_additional;
+  auto mbflma = reinterpret_cast<rocksdb::Options*>(jhandle)
+                    ->max_bytes_for_level_multiplier_additional;
 
   const size_t size = mbflma.size();
 
@@ -2707,21 +2811,21 @@ jintArray Java_org_rocksdb_Options_maxBytesForLevelMultiplierAdditional(
 
   jsize jlen = static_cast<jsize>(size);
   jintArray result = env->NewIntArray(jlen);
-  if(result == nullptr) {
-      // exception thrown: OutOfMemoryError
-      delete [] additionals;
-      return nullptr;
+  if (result == nullptr) {
+    // exception thrown: OutOfMemoryError
+    delete[] additionals;
+    return nullptr;
   }
 
   env->SetIntArrayRegion(result, 0, jlen, additionals);
-  if(env->ExceptionCheck()) {
-      // exception thrown: ArrayIndexOutOfBoundsException
-      env->DeleteLocalRef(result);
-      delete [] additionals;
-      return nullptr;
+  if (env->ExceptionCheck()) {
+    // exception thrown: ArrayIndexOutOfBoundsException
+    env->DeleteLocalRef(result);
+    delete[] additionals;
+    return nullptr;
   }
 
-  delete [] additionals;
+  delete[] additionals;
 
   return result;
 }
@@ -2735,9 +2839,9 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
-  jint *additionals =
-      env->GetIntArrayElements(jmax_bytes_for_level_multiplier_additional, nullptr);
-  if(additionals == nullptr) {
+  jint* additionals = env->GetIntArrayElements(
+      jmax_bytes_for_level_multiplier_additional, nullptr);
+  if (additionals == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -2745,11 +2849,12 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
   auto* opt = reinterpret_cast<rocksdb::Options*>(jhandle);
   opt->max_bytes_for_level_multiplier_additional.clear();
   for (jsize i = 0; i < len; i++) {
-    opt->max_bytes_for_level_multiplier_additional.push_back(static_cast<int32_t>(additionals[i]));
+    opt->max_bytes_for_level_multiplier_additional.push_back(
+        static_cast<int32_t>(additionals[i]));
   }
 
   env->ReleaseIntArrayElements(jmax_bytes_for_level_multiplier_additional,
-      additionals, JNI_ABORT);
+                               additionals, JNI_ABORT);
 }
 
 /*
@@ -2757,10 +2862,9 @@ void Java_org_rocksdb_Options_setMaxBytesForLevelMultiplierAdditional(
  * Method:    paranoidFileChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_paranoidFileChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::Options*>(
-      jhandle)->paranoid_file_checks;
+jboolean Java_org_rocksdb_Options_paranoidFileChecks(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
+  return reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_file_checks;
 }
 
 /*
@@ -2770,9 +2874,8 @@ jboolean Java_org_rocksdb_Options_paranoidFileChecks(
  */
 void Java_org_rocksdb_Options_setParanoidFileChecks(
     JNIEnv* env, jobject jobj, jlong jhandle, jboolean jparanoid_file_checks) {
-  reinterpret_cast<rocksdb::Options*>(
-      jhandle)->paranoid_file_checks =
-          static_cast<bool>(jparanoid_file_checks);
+  reinterpret_cast<rocksdb::Options*>(jhandle)->paranoid_file_checks =
+      static_cast<bool>(jparanoid_file_checks);
 }
 
 /*
@@ -2785,7 +2888,8 @@ void Java_org_rocksdb_Options_setCompactionPriority(
     jbyte jcompaction_priority_value) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   opts->compaction_pri =
-      rocksdb::CompactionPriorityJni::toCppCompactionPriority(jcompaction_priority_value);
+      rocksdb::CompactionPriorityJni::toCppCompactionPriority(
+          jcompaction_priority_value);
 }
 
 /*
@@ -2793,8 +2897,8 @@ void Java_org_rocksdb_Options_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Options_compactionPriority(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Options_compactionPriority(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return rocksdb::CompactionPriorityJni::toJavaCompactionPriority(
       opts->compaction_pri);
@@ -2805,8 +2909,9 @@ jbyte Java_org_rocksdb_Options_compactionPriority(
  * Method:    setReportBgIoStats
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setReportBgIoStats(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jreport_bg_io_stats) {
+void Java_org_rocksdb_Options_setReportBgIoStats(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle,
+                                                 jboolean jreport_bg_io_stats) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   opts->report_bg_io_stats = static_cast<bool>(jreport_bg_io_stats);
 }
@@ -2816,8 +2921,8 @@ void Java_org_rocksdb_Options_setReportBgIoStats(
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_reportBgIoStats(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_reportBgIoStats(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<bool>(opts->report_bg_io_stats);
 }
@@ -2831,9 +2936,8 @@ void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto* opts_uni =
-      reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
-          jcompaction_options_universal_handle);
+  auto* opts_uni = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
+      jcompaction_options_universal_handle);
   opts->compaction_options_universal = *opts_uni;
 }
 
@@ -2843,11 +2947,11 @@ void Java_org_rocksdb_Options_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_Options_setCompactionOptionsFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcompaction_options_fifo_handle) {
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jcompaction_options_fifo_handle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
-  auto* opts_fifo =
-      reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
-          jcompaction_options_fifo_handle);
+  auto* opts_fifo = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
+      jcompaction_options_fifo_handle);
   opts->compaction_options_fifo = *opts_fifo;
 }
 
@@ -2868,8 +2972,9 @@ void Java_org_rocksdb_Options_setForceConsistencyChecks(
  * Method:    forceConsistencyChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_forceConsistencyChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::Options*>(jhandle);
   return static_cast<bool>(opts->force_consistency_checks);
 }
@@ -2882,8 +2987,8 @@ jboolean Java_org_rocksdb_Options_forceConsistencyChecks(
  * Method:    newColumnFamilyOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
-    JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(JNIEnv* env,
+                                                                  jclass jcls) {
   auto* op = new rocksdb::ColumnFamilyOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -2908,7 +3013,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
 jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps(
     JNIEnv* env, jclass jclazz, jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
-  if(opt_string == nullptr) {
+  if (opt_string == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -2936,8 +3041,9 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_getColumnFamilyOptionsFromProps(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong handle) {
   auto* cfo = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(handle);
   assert(cfo != nullptr);
   delete cfo;
@@ -2948,10 +3054,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_disposeInternal(
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      OptimizeForSmallDb();
+void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->OptimizeForSmallDb();
 }
 
 /*
@@ -2960,10 +3067,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForSmallDb(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong block_cache_size_mb) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      OptimizeForPointLookup(block_cache_size_mb);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong block_cache_size_mb) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->OptimizeForPointLookup(block_cache_size_mb);
 }
 
 /*
@@ -2972,10 +3078,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeForPointLookup(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong memtable_memory_budget) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      OptimizeLevelStyleCompaction(memtable_memory_budget);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->OptimizeLevelStyleCompaction(memtable_memory_budget);
 }
 
 /*
@@ -2984,10 +3089,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_optimizeLevelStyleCompaction(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_optimizeUniversalStyleCompaction(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong memtable_memory_budget) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      OptimizeUniversalStyleCompaction(memtable_memory_budget);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong memtable_memory_budget) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->OptimizeUniversalStyleCompaction(memtable_memory_budget);
 }
 
 /*
@@ -3017,25 +3121,24 @@ void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JI(
 void Java_org_rocksdb_ColumnFamilyOptions_setComparatorHandle__JJB(
     JNIEnv* env, jobject jobj, jlong jopt_handle, jlong jcomparator_handle,
     jbyte jcomparator_type) {
-  rocksdb::Comparator *comparator = nullptr;
-  switch(jcomparator_type) {
-      // JAVA_COMPARATOR
-      case 0x0:
-        comparator =
-            reinterpret_cast<rocksdb::ComparatorJniCallback*>(jcomparator_handle);
-        break;
+  rocksdb::Comparator* comparator = nullptr;
+  switch (jcomparator_type) {
+    // JAVA_COMPARATOR
+    case 0x0:
+      comparator =
+          reinterpret_cast<rocksdb::ComparatorJniCallback*>(jcomparator_handle);
+      break;
 
-      // JAVA_DIRECT_COMPARATOR
-      case 0x1:
-        comparator =
-            reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(jcomparator_handle);
-        break;
+    // JAVA_DIRECT_COMPARATOR
+    case 0x1:
+      comparator = reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(
+          jcomparator_handle);
+      break;
 
-      // JAVA_NATIVE_COMPARATOR_WRAPPER
-      case 0x2:
-        comparator =
-            reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
-        break;
+    // JAVA_NATIVE_COMPARATOR_WRAPPER
+    case 0x2:
+      comparator = reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
+      break;
   }
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle);
   opt->comparator = comparator;
@@ -3050,7 +3153,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
     JNIEnv* env, jobject jobj, jlong jhandle, jstring jop_name) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   const char* op_name = env->GetStringUTFChars(jop_name, nullptr);
-  if(op_name == nullptr) {
+  if (op_name == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -3066,10 +3169,10 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperatorName(
  * Signature: (JJjava/lang/String)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
-  JNIEnv* env, jobject jobj, jlong jhandle, jlong mergeOperatorHandle) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong mergeOperatorHandle) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->merge_operator =
-    *(reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>
-      (mergeOperatorHandle));
+      *(reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(
+          mergeOperatorHandle));
 }
 
 /*
@@ -3080,9 +3183,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMergeOperator(
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
     JNIEnv* env, jobject jobj, jlong jopt_handle,
     jlong jcompactionfilter_handle) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)->
-      compaction_filter = reinterpret_cast<rocksdb::CompactionFilter*>
-        (jcompactionfilter_handle);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)
+      ->compaction_filter =
+      reinterpret_cast<rocksdb::CompactionFilter*>(jcompactionfilter_handle);
 }
 
 /*
@@ -3090,14 +3193,15 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterHandle(
  * Method:    setCompactionFilterFactoryHandle
  * Signature: (JJ)V
  */
-void JNICALL Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
-    JNIEnv* env , jobject jobj, jlong jopt_handle,
+void JNICALL
+Java_org_rocksdb_ColumnFamilyOptions_setCompactionFilterFactoryHandle(
+    JNIEnv* env, jobject jobj, jlong jopt_handle,
     jlong jcompactionfilterfactory_handle) {
   auto* cff_factory =
-      reinterpret_cast<std::shared_ptr<rocksdb::CompactionFilterFactory> *>(
+      reinterpret_cast<std::shared_ptr<rocksdb::CompactionFilterFactory>*>(
           jcompactionfilterfactory_handle);
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)->
-      compaction_filter_factory = *cff_factory;
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jopt_handle)
+      ->compaction_filter_factory = *cff_factory;
 }
 
 /*
@@ -3109,8 +3213,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_buffer_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jwrite_buffer_size);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-        write_buffer_size = jwrite_buffer_size;
+    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+        ->write_buffer_size = jwrite_buffer_size;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -3121,10 +3225,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setWriteBufferSize(
  * Method:    writeBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      write_buffer_size;
+jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->write_buffer_size;
 }
 
 /*
@@ -3134,8 +3239,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_writeBufferSize(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
     JNIEnv* env, jobject jobj, jlong jhandle, jint jmax_write_buffer_number) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      max_write_buffer_number = jmax_write_buffer_number;
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_write_buffer_number = jmax_write_buffer_number;
 }
 
 /*
@@ -3143,10 +3248,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxWriteBufferNumber(
  * Method:    maxWriteBufferNumber
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      max_write_buffer_number;
+jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(JNIEnv* env,
+                                                               jobject jobj,
+                                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_write_buffer_number;
 }
 
 /*
@@ -3155,9 +3261,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_maxWriteBufferNumber(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemTableFactory(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      memtable_factory.reset(
-      reinterpret_cast<rocksdb::MemTableRepFactory*>(jfactory_handle));
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->memtable_factory.reset(
+          reinterpret_cast<rocksdb::MemTableRepFactory*>(jfactory_handle));
 }
 
 /*
@@ -3188,9 +3294,9 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_memTableFactoryName(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
     JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(
-          static_cast<int>(jprefix_length)));
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->prefix_extractor.reset(
+          rocksdb::NewFixedPrefixTransform(static_cast<int>(jprefix_length)));
 }
 
 /*
@@ -3199,9 +3305,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_useFixedLengthPrefixExtractor(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
     JNIEnv* env, jobject jobj, jlong jhandle, jint jprefix_length) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      prefix_extractor.reset(rocksdb::NewCappedPrefixTransform(
-          static_cast<int>(jprefix_length)));
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->prefix_extractor.reset(
+          rocksdb::NewCappedPrefixTransform(static_cast<int>(jprefix_length)));
 }
 
 /*
@@ -3210,17 +3316,17 @@ void Java_org_rocksdb_ColumnFamilyOptions_useCappedPrefixExtractor(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTableFactory(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jfactory_handle) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      table_factory.reset(reinterpret_cast<rocksdb::TableFactory*>(
-      jfactory_handle));
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->table_factory.reset(
+      reinterpret_cast<rocksdb::TableFactory*>(jfactory_handle));
 }
 
 /*
  * Method:    tableFactoryName
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(JNIEnv* env,
+                                                              jobject jobj,
+                                                              jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   rocksdb::TableFactory* tf = opt->table_factory.get();
 
@@ -3231,7 +3337,6 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(
   return env->NewStringUTF(tf->Name());
 }
 
-
 /*
  * Class:     org_rocksdb_ColumnFamilyOptions
  * Method:    minWriteBufferNumberToMerge
@@ -3239,8 +3344,8 @@ jstring Java_org_rocksdb_ColumnFamilyOptions_tableFactoryName(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->min_write_buffer_number_to_merge;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->min_write_buffer_number_to_merge;
 }
 
 /*
@@ -3251,9 +3356,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_minWriteBufferNumberToMerge(
 void Java_org_rocksdb_ColumnFamilyOptions_setMinWriteBufferNumberToMerge(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jmin_write_buffer_number_to_merge) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->min_write_buffer_number_to_merge =
-          static_cast<int>(jmin_write_buffer_number_to_merge);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->min_write_buffer_number_to_merge =
+      static_cast<int>(jmin_write_buffer_number_to_merge);
 }
 
 /*
@@ -3297,8 +3402,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionType(
  * Method:    compressionType
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb::CompressionTypeJni::toJavaCompressionType(
       cf_opts->compression);
@@ -3310,14 +3416,13 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compressionType(
  * Signature: (J[B)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompressionPerLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jbyteArray jcompressionLevels) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jbyteArray jcompressionLevels) {
   auto* options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   auto uptr_compression_levels =
       rocksdb_compression_vector_helper(env, jcompressionLevels);
-  if(!uptr_compression_levels) {
-      // exception occurred
-      return;
+  if (!uptr_compression_levels) {
+    // exception occurred
+    return;
   }
   options->compression_per_level = *(uptr_compression_levels.get());
 }
@@ -3331,7 +3436,7 @@ jbyteArray Java_org_rocksdb_ColumnFamilyOptions_compressionPerLevel(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb_compression_list_helper(env,
-      cf_options->compression_per_level);
+                                         cf_options->compression_per_level);
 }
 
 /*
@@ -3368,8 +3473,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompressionOptions(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jcompression_options_handle) {
   auto* cf_options = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
-  auto* compression_options =
-    reinterpret_cast<rocksdb::CompressionOptions*>(jcompression_options_handle);
+  auto* compression_options = reinterpret_cast<rocksdb::CompressionOptions*>(
+      jcompression_options_handle);
   cf_options->compression_opts = *compression_options;
 }
 
@@ -3389,10 +3494,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionStyle(
  * Method:    compactionStyle
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>
-      (jhandle)->compaction_style;
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->compaction_style;
 }
 
 /*
@@ -3402,8 +3508,9 @@ jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionStyle(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_table_files_size) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->compaction_options_fifo.max_table_files_size =
-    static_cast<uint64_t>(jmax_table_files_size);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->compaction_options_fifo.max_table_files_size =
+      static_cast<uint64_t>(jmax_table_files_size);
 }
 
 /*
@@ -3413,7 +3520,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxTableFilesSizeFIFO(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->compaction_options_fifo.max_table_files_size;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->compaction_options_fifo.max_table_files_size;
 }
 
 /*
@@ -3421,8 +3529,8 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxTableFilesSizeFIFO(
  * Method:    numLevels
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->num_levels;
 }
 
@@ -3431,8 +3539,10 @@ jint Java_org_rocksdb_ColumnFamilyOptions_numLevels(
  * Method:    setNumLevels
  * Signature: (JI)V
  */
-void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jnum_levels) {
+void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle,
+                                                       jint jnum_levels) {
   reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->num_levels =
       static_cast<int>(jnum_levels);
 }
@@ -3444,8 +3554,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setNumLevels(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_file_num_compaction_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_file_num_compaction_trigger;
 }
 
 /*
@@ -3456,9 +3566,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroFileNumCompactionTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_file_num_compaction_trigger =
-          static_cast<int>(jlevel0_file_num_compaction_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_file_num_compaction_trigger =
+      static_cast<int>(jlevel0_file_num_compaction_trigger);
 }
 
 /*
@@ -3468,8 +3578,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroFileNumCompactionTrigger(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_slowdown_writes_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_slowdown_writes_trigger;
 }
 
 /*
@@ -3480,9 +3590,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroSlowdownWritesTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_slowdown_writes_trigger =
-          static_cast<int>(jlevel0_slowdown_writes_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_slowdown_writes_trigger =
+      static_cast<int>(jlevel0_slowdown_writes_trigger);
 }
 
 /*
@@ -3492,8 +3602,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroSlowdownWritesTrigger(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_stop_writes_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_stop_writes_trigger;
 }
 
 /*
@@ -3504,9 +3614,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_levelZeroStopWritesTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      level0_stop_writes_trigger = static_cast<int>(
-      jlevel0_stop_writes_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_stop_writes_trigger =
+      static_cast<int>(jlevel0_stop_writes_trigger);
 }
 
 /*
@@ -3514,10 +3624,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelZeroStopWritesTrigger(
  * Method:    targetFileSizeBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      target_file_size_base;
+jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(JNIEnv* env,
+                                                              jobject jobj,
+                                                              jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->target_file_size_base;
 }
 
 /*
@@ -3526,10 +3637,9 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeBase(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jtarget_file_size_base) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      target_file_size_base = static_cast<uint64_t>(jtarget_file_size_base);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jtarget_file_size_base) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->target_file_size_base = static_cast<uint64_t>(jtarget_file_size_base);
 }
 
 /*
@@ -3539,8 +3649,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeBase(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->target_file_size_multiplier;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->target_file_size_multiplier;
 }
 
 /*
@@ -3551,9 +3661,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_targetFileSizeMultiplier(
 void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jtarget_file_size_multiplier) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->target_file_size_multiplier =
-          static_cast<int>(jtarget_file_size_multiplier);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->target_file_size_multiplier =
+      static_cast<int>(jtarget_file_size_multiplier);
 }
 
 /*
@@ -3561,10 +3671,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setTargetFileSizeMultiplier(
  * Method:    maxBytesForLevelBase
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_bytes_for_level_base;
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(JNIEnv* env,
+                                                                jobject jobj,
+                                                                jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_bytes_for_level_base;
 }
 
 /*
@@ -3573,11 +3684,10 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelBase(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_bytes_for_level_base) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_bytes_for_level_base =
-          static_cast<int64_t>(jmax_bytes_for_level_base);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_bytes_for_level_base) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_bytes_for_level_base =
+      static_cast<int64_t>(jmax_bytes_for_level_base);
 }
 
 /*
@@ -3587,8 +3697,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelBase(
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level_compaction_dynamic_level_bytes;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level_compaction_dynamic_level_bytes;
 }
 
 /*
@@ -3599,9 +3709,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_levelCompactionDynamicLevelBytes(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jenable_dynamic_level_bytes) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level_compaction_dynamic_level_bytes =
-          (jenable_dynamic_level_bytes);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level_compaction_dynamic_level_bytes = (jenable_dynamic_level_bytes);
 }
 
 /*
@@ -3611,8 +3720,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevelCompactionDynamicLevelBytes(
  */
 jdouble Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplier(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_bytes_for_level_multiplier;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_bytes_for_level_multiplier;
 }
 
 /*
@@ -3657,10 +3766,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxCompactionBytes(
  * Method:    arenaBlockSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      arena_block_size;
+jlong Java_org_rocksdb_ColumnFamilyOptions_arenaBlockSize(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->arena_block_size;
 }
 
 /*
@@ -3672,8 +3782,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong jarena_block_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(jarena_block_size);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-        arena_block_size = jarena_block_size;
+    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->arena_block_size =
+        jarena_block_size;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -3686,8 +3796,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setArenaBlockSize(
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->disable_auto_compactions;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->disable_auto_compactions;
 }
 
 /*
@@ -3698,9 +3808,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_disableAutoCompactions(
 void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jdisable_auto_compactions) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->disable_auto_compactions =
-          static_cast<bool>(jdisable_auto_compactions);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->disable_auto_compactions = static_cast<bool>(jdisable_auto_compactions);
 }
 
 /*
@@ -3710,8 +3819,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setDisableAutoCompactions(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_sequential_skip_in_iterations;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_sequential_skip_in_iterations;
 }
 
 /*
@@ -3722,9 +3831,9 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSequentialSkipInIterations(
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jmax_sequential_skip_in_iterations) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_sequential_skip_in_iterations =
-          static_cast<int64_t>(jmax_sequential_skip_in_iterations);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_sequential_skip_in_iterations =
+      static_cast<int64_t>(jmax_sequential_skip_in_iterations);
 }
 
 /*
@@ -3734,8 +3843,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSequentialSkipInIterations(
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->inplace_update_support;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->inplace_update_support;
 }
 
 /*
@@ -3746,9 +3855,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateSupport(
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jinplace_update_support) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->inplace_update_support =
-          static_cast<bool>(jinplace_update_support);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->inplace_update_support = static_cast<bool>(jinplace_update_support);
 }
 
 /*
@@ -3758,8 +3866,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateSupport(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->inplace_update_num_locks;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->inplace_update_num_locks;
 }
 
 /*
@@ -3768,13 +3876,12 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_inplaceUpdateNumLocks(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setInplaceUpdateNumLocks(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jinplace_update_num_locks) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jinplace_update_num_locks);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jinplace_update_num_locks) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jinplace_update_num_locks);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-        inplace_update_num_locks = jinplace_update_num_locks;
+    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+        ->inplace_update_num_locks = jinplace_update_num_locks;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -3809,10 +3916,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtablePrefixBloomSizeRatio(
  * Method:    bloomLocality
  * Signature: (J)I
  */
-jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      bloom_locality;
+jint Java_org_rocksdb_ColumnFamilyOptions_bloomLocality(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->bloom_locality;
 }
 
 /*
@@ -3831,10 +3939,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setBloomLocality(
  * Method:    maxSuccessiveMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-      max_successive_merges;
+jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(JNIEnv* env,
+                                                               jobject jobj,
+                                                               jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->max_successive_merges;
 }
 
 /*
@@ -3843,13 +3952,12 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_maxSuccessiveMerges(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_successive_merges) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jmax_successive_merges);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_successive_merges) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jmax_successive_merges);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)->
-        max_successive_merges = jmax_successive_merges;
+    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+        ->max_successive_merges = jmax_successive_merges;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -3862,8 +3970,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxSuccessiveMerges(
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->optimize_filters_for_hits;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->optimize_filters_for_hits;
 }
 
 /*
@@ -3874,9 +3982,9 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_optimizeFiltersForHits(
 void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean joptimize_filters_for_hits) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->optimize_filters_for_hits =
-          static_cast<bool>(joptimize_filters_for_hits);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->optimize_filters_for_hits =
+      static_cast<bool>(joptimize_filters_for_hits);
 }
 
 /*
@@ -3884,10 +3992,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setOptimizeFiltersForHits(
  * Method:    memtableHugePageSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->memtable_huge_page_size;
+jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(JNIEnv* env,
+                                                                jobject jobj,
+                                                                jlong jhandle) {
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->memtable_huge_page_size;
 }
 
 /*
@@ -3896,15 +4005,12 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_memtableHugePageSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmemtable_huge_page_size) {
-
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      jmemtable_huge_page_size);
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmemtable_huge_page_size) {
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(jmemtable_huge_page_size);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-        jhandle)->memtable_huge_page_size =
-            jmemtable_huge_page_size;
+    reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+        ->memtable_huge_page_size = jmemtable_huge_page_size;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -3917,8 +4023,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMemtableHugePageSize(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->soft_pending_compaction_bytes_limit;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->soft_pending_compaction_bytes_limit;
 }
 
 /*
@@ -3927,10 +4033,11 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_softPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jsoft_pending_compaction_bytes_limit) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->soft_pending_compaction_bytes_limit =
-          static_cast<int64_t>(jsoft_pending_compaction_bytes_limit);
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jsoft_pending_compaction_bytes_limit) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->soft_pending_compaction_bytes_limit =
+      static_cast<int64_t>(jsoft_pending_compaction_bytes_limit);
 }
 
 /*
@@ -3940,8 +4047,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setSoftPendingCompactionBytesLimit(
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->hard_pending_compaction_bytes_limit;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->hard_pending_compaction_bytes_limit;
 }
 
 /*
@@ -3950,10 +4057,11 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_hardPendingCompactionBytesLimit(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jhard_pending_compaction_bytes_limit) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->hard_pending_compaction_bytes_limit =
-          static_cast<int64_t>(jhard_pending_compaction_bytes_limit);
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jhard_pending_compaction_bytes_limit) {
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->hard_pending_compaction_bytes_limit =
+      static_cast<int64_t>(jhard_pending_compaction_bytes_limit);
 }
 
 /*
@@ -3963,8 +4071,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setHardPendingCompactionBytesLimit(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-    jhandle)->level0_file_num_compaction_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_file_num_compaction_trigger;
 }
 
 /*
@@ -3975,9 +4083,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0FileNumCompactionTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_file_num_compaction_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_file_num_compaction_trigger =
-          static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_file_num_compaction_trigger =
+      static_cast<int32_t>(jlevel0_file_num_compaction_trigger);
 }
 
 /*
@@ -3987,8 +4095,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0FileNumCompactionTrigger(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-    jhandle)->level0_slowdown_writes_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_slowdown_writes_trigger;
 }
 
 /*
@@ -3999,9 +4107,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0SlowdownWritesTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_slowdown_writes_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_slowdown_writes_trigger =
-          static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_slowdown_writes_trigger =
+      static_cast<int32_t>(jlevel0_slowdown_writes_trigger);
 }
 
 /*
@@ -4011,8 +4119,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0SlowdownWritesTrigger(
  */
 jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-    jhandle)->level0_stop_writes_trigger;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_stop_writes_trigger;
 }
 
 /*
@@ -4023,9 +4131,9 @@ jint Java_org_rocksdb_ColumnFamilyOptions_level0StopWritesTrigger(
 void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jint jlevel0_stop_writes_trigger) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->level0_stop_writes_trigger =
-          static_cast<int32_t>(jlevel0_stop_writes_trigger);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->level0_stop_writes_trigger =
+      static_cast<int32_t>(jlevel0_stop_writes_trigger);
 }
 
 /*
@@ -4033,10 +4141,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setLevel0StopWritesTrigger(
  * Method:    maxBytesForLevelMultiplierAdditional
  * Signature: (J)[I
  */
-jintArray Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
+jintArray
+Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditional(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  auto mbflma = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->max_bytes_for_level_multiplier_additional;
+  auto mbflma = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+                    ->max_bytes_for_level_multiplier_additional;
 
   const size_t size = mbflma.size();
 
@@ -4047,20 +4156,20 @@ jintArray Java_org_rocksdb_ColumnFamilyOptions_maxBytesForLevelMultiplierAdditio
 
   jsize jlen = static_cast<jsize>(size);
   jintArray result = env->NewIntArray(jlen);
-  if(result == nullptr) {
+  if (result == nullptr) {
     // exception thrown: OutOfMemoryError
-    delete [] additionals;
+    delete[] additionals;
     return nullptr;
   }
   env->SetIntArrayRegion(result, 0, jlen, additionals);
-  if(env->ExceptionCheck()) {
-      // exception thrown: ArrayIndexOutOfBoundsException
-      env->DeleteLocalRef(result);
-      delete [] additionals;
-      return nullptr;
+  if (env->ExceptionCheck()) {
+    // exception thrown: ArrayIndexOutOfBoundsException
+    env->DeleteLocalRef(result);
+    delete[] additionals;
+    return nullptr;
   }
 
-  delete [] additionals;
+  delete[] additionals;
 
   return result;
 }
@@ -4074,9 +4183,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditiona
     JNIEnv* env, jobject jobj, jlong jhandle,
     jintArray jmax_bytes_for_level_multiplier_additional) {
   jsize len = env->GetArrayLength(jmax_bytes_for_level_multiplier_additional);
-  jint *additionals =
+  jint* additionals =
       env->GetIntArrayElements(jmax_bytes_for_level_multiplier_additional, 0);
-  if(additionals == nullptr) {
+  if (additionals == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -4084,11 +4193,12 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditiona
   auto* cf_opt = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opt->max_bytes_for_level_multiplier_additional.clear();
   for (jsize i = 0; i < len; i++) {
-    cf_opt->max_bytes_for_level_multiplier_additional.push_back(static_cast<int32_t>(additionals[i]));
+    cf_opt->max_bytes_for_level_multiplier_additional.push_back(
+        static_cast<int32_t>(additionals[i]));
   }
 
   env->ReleaseIntArrayElements(jmax_bytes_for_level_multiplier_additional,
-      additionals, JNI_ABORT);
+                               additionals, JNI_ABORT);
 }
 
 /*
@@ -4098,8 +4208,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setMaxBytesForLevelMultiplierAdditiona
  */
 jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->paranoid_file_checks;
+  return reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->paranoid_file_checks;
 }
 
 /*
@@ -4109,9 +4219,8 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_paranoidFileChecks(
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setParanoidFileChecks(
     JNIEnv* env, jobject jobj, jlong jhandle, jboolean jparanoid_file_checks) {
-  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(
-      jhandle)->paranoid_file_checks =
-          static_cast<bool>(jparanoid_file_checks);
+  reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)
+      ->paranoid_file_checks = static_cast<bool>(jparanoid_file_checks);
 }
 
 /*
@@ -4124,7 +4233,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
     jbyte jcompaction_priority_value) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   cf_opts->compaction_pri =
-      rocksdb::CompactionPriorityJni::toCppCompactionPriority(jcompaction_priority_value);
+      rocksdb::CompactionPriorityJni::toCppCompactionPriority(
+          jcompaction_priority_value);
 }
 
 /*
@@ -4132,8 +4242,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionPriority(
  * Method:    compactionPriority
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_ColumnFamilyOptions_compactionPriority(JNIEnv* env,
+                                                              jobject jobj,
+                                                              jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return rocksdb::CompactionPriorityJni::toJavaCompactionPriority(
       cf_opts->compaction_pri);
@@ -4155,8 +4266,9 @@ void Java_org_rocksdb_ColumnFamilyOptions_setReportBgIoStats(
  * Method:    reportBgIoStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ColumnFamilyOptions_reportBgIoStats(JNIEnv* env,
+                                                              jobject jobj,
+                                                              jlong jhandle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
   return static_cast<bool>(cf_opts->report_bg_io_stats);
 }
@@ -4170,9 +4282,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jlong jcompaction_options_universal_handle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
-  auto* opts_uni =
-      reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
-          jcompaction_options_universal_handle);
+  auto* opts_uni = reinterpret_cast<rocksdb::CompactionOptionsUniversal*>(
+      jcompaction_options_universal_handle);
   cf_opts->compaction_options_universal = *opts_uni;
 }
 
@@ -4182,11 +4293,11 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsUniversal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_ColumnFamilyOptions_setCompactionOptionsFIFO(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcompaction_options_fifo_handle) {
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jcompaction_options_fifo_handle) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
-  auto* opts_fifo =
-      reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
-          jcompaction_options_fifo_handle);
+  auto* opts_fifo = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(
+      jcompaction_options_fifo_handle);
   cf_opts->compaction_options_fifo = *opts_fifo;
 }
 
@@ -4199,7 +4310,8 @@ void Java_org_rocksdb_ColumnFamilyOptions_setForceConsistencyChecks(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean jforce_consistency_checks) {
   auto* cf_opts = reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle);
-  cf_opts->force_consistency_checks = static_cast<bool>(jforce_consistency_checks);
+  cf_opts->force_consistency_checks =
+      static_cast<bool>(jforce_consistency_checks);
 }
 
 /*
@@ -4221,8 +4333,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
  * Method:    newDBOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env,
-    jclass jcls) {
+jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env, jclass jcls) {
   auto* dbop = new rocksdb::DBOptions();
   return reinterpret_cast<jlong>(dbop);
 }
@@ -4233,9 +4344,9 @@ jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
-    jlong jhandle) {
-  auto new_opt = new rocksdb::DBOptions(
-      *(reinterpret_cast<rocksdb::DBOptions*>(jhandle)));
+                                               jlong jhandle) {
+  auto new_opt =
+      new rocksdb::DBOptions(*(reinterpret_cast<rocksdb::DBOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
 }
 
@@ -4244,10 +4355,11 @@ jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* env, jclass jcls,
  * Method:    getDBOptionsFromProps
  * Signature: (Ljava/util/String;)J
  */
-jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(
-    JNIEnv* env, jclass jclazz, jstring jopt_string) {
+jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(JNIEnv* env,
+                                                       jclass jclazz,
+                                                       jstring jopt_string) {
   const char* opt_string = env->GetStringUTFChars(jopt_string, nullptr);
-  if(opt_string == nullptr) {
+  if (opt_string == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -4275,8 +4387,8 @@ jlong Java_org_rocksdb_DBOptions_getDBOptionsFromProps(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_DBOptions_disposeInternal(JNIEnv* env, jobject jobj,
+                                                jlong handle) {
   auto* dbo = reinterpret_cast<rocksdb::DBOptions*>(handle);
   assert(dbo != nullptr);
   delete dbo;
@@ -4287,8 +4399,8 @@ void Java_org_rocksdb_DBOptions_disposeInternal(
  * Method:    optimizeForSmallDb
  * Signature: (J)V
  */
-void Java_org_rocksdb_DBOptions_optimizeForSmallDb(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_DBOptions_optimizeForSmallDb(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->OptimizeForSmallDb();
 }
 
@@ -4297,8 +4409,8 @@ void Java_org_rocksdb_DBOptions_optimizeForSmallDb(
  * Method:    setEnv
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setEnv(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jenv_handle) {
+void Java_org_rocksdb_DBOptions_setEnv(JNIEnv* env, jobject jobj, jlong jhandle,
+                                       jlong jenv_handle) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->env =
       reinterpret_cast<rocksdb::Env*>(jenv_handle);
 }
@@ -4308,22 +4420,23 @@ void Java_org_rocksdb_DBOptions_setEnv(
  * Method:    setIncreaseParallelism
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setIncreaseParallelism(
-    JNIEnv * env, jobject jobj, jlong jhandle, jint totalThreads) {
-  reinterpret_cast<rocksdb::DBOptions*>
-      (jhandle)->IncreaseParallelism(static_cast<int>(totalThreads));
+void Java_org_rocksdb_DBOptions_setIncreaseParallelism(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle,
+                                                       jint totalThreads) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->IncreaseParallelism(
+      static_cast<int>(totalThreads));
 }
-
 
 /*
  * Class:     org_rocksdb_DBOptions
  * Method:    setCreateIfMissing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateIfMissing(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      create_if_missing = flag;
+void Java_org_rocksdb_DBOptions_setCreateIfMissing(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jboolean flag) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->create_if_missing = flag;
 }
 
 /*
@@ -4331,8 +4444,8 @@ void Java_org_rocksdb_DBOptions_setCreateIfMissing(
  * Method:    createIfMissing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createIfMissing(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_createIfMissing(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->create_if_missing;
 }
 
@@ -4341,10 +4454,12 @@ jboolean Java_org_rocksdb_DBOptions_createIfMissing(
  * Method:    setCreateMissingColumnFamilies
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean flag) {
-  reinterpret_cast<rocksdb::DBOptions*>
-      (jhandle)->create_missing_column_families = flag;
+void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(JNIEnv* env,
+                                                               jobject jobj,
+                                                               jlong jhandle,
+                                                               jboolean flag) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->create_missing_column_families = flag;
 }
 
 /*
@@ -4352,10 +4467,11 @@ void Java_org_rocksdb_DBOptions_setCreateMissingColumnFamilies(
  * Method:    createMissingColumnFamilies
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>
-      (jhandle)->create_missing_column_families;
+jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(JNIEnv* env,
+                                                                jobject jobj,
+                                                                jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->create_missing_column_families;
 }
 
 /*
@@ -4363,8 +4479,9 @@ jboolean Java_org_rocksdb_DBOptions_createMissingColumnFamilies(
  * Method:    setErrorIfExists
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setErrorIfExists(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean error_if_exists) {
+void Java_org_rocksdb_DBOptions_setErrorIfExists(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle,
+                                                 jboolean error_if_exists) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->error_if_exists =
       static_cast<bool>(error_if_exists);
 }
@@ -4374,8 +4491,8 @@ void Java_org_rocksdb_DBOptions_setErrorIfExists(
  * Method:    errorIfExists
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_errorIfExists(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_errorIfExists(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->error_if_exists;
 }
 
@@ -4384,8 +4501,9 @@ jboolean Java_org_rocksdb_DBOptions_errorIfExists(
  * Method:    setParanoidChecks
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setParanoidChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean paranoid_checks) {
+void Java_org_rocksdb_DBOptions_setParanoidChecks(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jboolean paranoid_checks) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->paranoid_checks =
       static_cast<bool>(paranoid_checks);
 }
@@ -4395,8 +4513,8 @@ void Java_org_rocksdb_DBOptions_setParanoidChecks(
  * Method:    paranoidChecks
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_paranoidChecks(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_paranoidChecks(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->paranoid_checks;
 }
 
@@ -4405,10 +4523,11 @@ jboolean Java_org_rocksdb_DBOptions_paranoidChecks(
  * Method:    setRateLimiter
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRateLimiter(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrate_limiter_handle) {
-  std::shared_ptr<rocksdb::RateLimiter> *pRateLimiter =
-      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(
+void Java_org_rocksdb_DBOptions_setRateLimiter(JNIEnv* env, jobject jobj,
+                                               jlong jhandle,
+                                               jlong jrate_limiter_handle) {
+  std::shared_ptr<rocksdb::RateLimiter>* pRateLimiter =
+      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(
           jrate_limiter_handle);
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->rate_limiter = *pRateLimiter;
 }
@@ -4419,12 +4538,12 @@ void Java_org_rocksdb_DBOptions_setRateLimiter(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setSstFileManager(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jsst_file_manager_handle) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jlong jsst_file_manager_handle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jsst_file_manager_handle);
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      sst_file_manager = *sptr_sst_file_manager;
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(
+          jsst_file_manager_handle);
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->sst_file_manager =
+      *sptr_sst_file_manager;
 }
 
 /*
@@ -4432,10 +4551,10 @@ void Java_org_rocksdb_DBOptions_setSstFileManager(
  * Method:    setLogger
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setLogger(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jlogger_handle) {
-  std::shared_ptr<rocksdb::LoggerJniCallback> *pLogger =
-      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback> *>(
+void Java_org_rocksdb_DBOptions_setLogger(JNIEnv* env, jobject jobj,
+                                          jlong jhandle, jlong jlogger_handle) {
+  std::shared_ptr<rocksdb::LoggerJniCallback>* pLogger =
+      reinterpret_cast<std::shared_ptr<rocksdb::LoggerJniCallback>*>(
           jlogger_handle);
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->info_log = *pLogger;
 }
@@ -4445,10 +4564,11 @@ void Java_org_rocksdb_DBOptions_setLogger(
  * Method:    setInfoLogLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_DBOptions_setInfoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jlog_level) {
+void Java_org_rocksdb_DBOptions_setInfoLogLevel(JNIEnv* env, jobject jobj,
+                                                jlong jhandle,
+                                                jbyte jlog_level) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->info_log_level =
-    static_cast<rocksdb::InfoLogLevel>(jlog_level);
+      static_cast<rocksdb::InfoLogLevel>(jlog_level);
 }
 
 /*
@@ -4456,8 +4576,8 @@ void Java_org_rocksdb_DBOptions_setInfoLogLevel(
  * Method:    infoLogLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_infoLogLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_DBOptions_infoLogLevel(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->info_log_level);
 }
@@ -4467,9 +4587,9 @@ jbyte Java_org_rocksdb_DBOptions_infoLogLevel(
  * Method:    setMaxTotalWalSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jlong jmax_total_wal_size) {
+void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jlong jmax_total_wal_size) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_total_wal_size =
       static_cast<jlong>(jmax_total_wal_size);
 }
@@ -4479,10 +4599,9 @@ void Java_org_rocksdb_DBOptions_setMaxTotalWalSize(
  * Method:    maxTotalWalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      max_total_wal_size;
+jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_total_wal_size;
 }
 
 /*
@@ -4490,8 +4609,9 @@ jlong Java_org_rocksdb_DBOptions_maxTotalWalSize(
  * Method:    setMaxOpenFiles
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxOpenFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max_open_files) {
+void Java_org_rocksdb_DBOptions_setMaxOpenFiles(JNIEnv* env, jobject jobj,
+                                                jlong jhandle,
+                                                jint max_open_files) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_open_files =
       static_cast<int>(max_open_files);
 }
@@ -4501,8 +4621,8 @@ void Java_org_rocksdb_DBOptions_setMaxOpenFiles(
  * Method:    maxOpenFiles
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxOpenFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_maxOpenFiles(JNIEnv* env, jobject jobj,
+                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_open_files;
 }
 
@@ -4522,8 +4642,8 @@ void Java_org_rocksdb_DBOptions_setMaxFileOpeningThreads(
  * Method:    maxFileOpeningThreads
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(JNIEnv* env, jobject jobj,
+                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<int>(opt->max_file_opening_threads);
 }
@@ -4533,12 +4653,12 @@ jint Java_org_rocksdb_DBOptions_maxFileOpeningThreads(
  * Method:    setStatistics
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setStatistics(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jstatistics_handle) {
+void Java_org_rocksdb_DBOptions_setStatistics(JNIEnv* env, jobject jobj,
+                                              jlong jhandle,
+                                              jlong jstatistics_handle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  auto* pSptr =
-      reinterpret_cast<std::shared_ptr<rocksdb::StatisticsJni>*>(
-          jstatistics_handle);
+  auto* pSptr = reinterpret_cast<std::shared_ptr<rocksdb::StatisticsJni>*>(
+      jstatistics_handle);
   opt->statistics = *pSptr;
 }
 
@@ -4547,8 +4667,8 @@ void Java_org_rocksdb_DBOptions_setStatistics(
  * Method:    statistics
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_statistics(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_statistics(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   std::shared_ptr<rocksdb::Statistics> sptr = opt->statistics;
   if (sptr == nullptr) {
@@ -4565,8 +4685,8 @@ jlong Java_org_rocksdb_DBOptions_statistics(
  * Method:    setUseFsync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setUseFsync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean use_fsync) {
+void Java_org_rocksdb_DBOptions_setUseFsync(JNIEnv* env, jobject jobj,
+                                            jlong jhandle, jboolean use_fsync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_fsync =
       static_cast<bool>(use_fsync);
 }
@@ -4576,8 +4696,8 @@ void Java_org_rocksdb_DBOptions_setUseFsync(
  * Method:    useFsync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useFsync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_useFsync(JNIEnv* env, jobject jobj,
+                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_fsync;
 }
 
@@ -4586,35 +4706,33 @@ jboolean Java_org_rocksdb_DBOptions_useFsync(
  * Method:    setDbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_setDbPaths(
-    JNIEnv* env, jobject jobj, jlong jhandle, jobjectArray jpaths,
-    jlongArray jtarget_sizes) {
+void Java_org_rocksdb_DBOptions_setDbPaths(JNIEnv* env, jobject jobj,
+                                           jlong jhandle, jobjectArray jpaths,
+                                           jlongArray jtarget_sizes) {
   std::vector<rocksdb::DbPath> db_paths;
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
-  if(ptr_jtarget_size == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return;
+  if (ptr_jtarget_size == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
   }
 
   jboolean has_exception = JNI_FALSE;
   const jsize len = env->GetArrayLength(jpaths);
-  for(jsize i = 0; i < len; i++) {
-    jobject jpath = reinterpret_cast<jstring>(env->
-        GetObjectArrayElement(jpaths, i));
-    if(env->ExceptionCheck()) {
+  for (jsize i = 0; i < len; i++) {
+    jobject jpath =
+        reinterpret_cast<jstring>(env->GetObjectArrayElement(jpaths, i));
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
     std::string path = rocksdb::JniUtil::copyStdString(
         env, static_cast<jstring>(jpath), &has_exception);
     env->DeleteLocalRef(jpath);
 
-    if(has_exception == JNI_TRUE) {
-        env->ReleaseLongArrayElements(
-            jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
-        return;
+    if (has_exception == JNI_TRUE) {
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      return;
     }
 
     jlong jtarget_size = ptr_jtarget_size[i];
@@ -4634,8 +4752,8 @@ void Java_org_rocksdb_DBOptions_setDbPaths(
  * Method:    dbPathsLen
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbPathsLen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_dbPathsLen(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_paths.size());
 }
@@ -4645,33 +4763,31 @@ jlong Java_org_rocksdb_DBOptions_dbPathsLen(
  * Method:    dbPaths
  * Signature: (J[Ljava/lang/String;[J)V
  */
-void Java_org_rocksdb_DBOptions_dbPaths(
-    JNIEnv* env, jobject jobj, jlong jhandle, jobjectArray jpaths,
-    jlongArray jtarget_sizes) {
+void Java_org_rocksdb_DBOptions_dbPaths(JNIEnv* env, jobject jobj,
+                                        jlong jhandle, jobjectArray jpaths,
+                                        jlongArray jtarget_sizes) {
   jlong* ptr_jtarget_size = env->GetLongArrayElements(jtarget_sizes, nullptr);
-  if(ptr_jtarget_size == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return;
+  if (ptr_jtarget_size == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return;
   }
 
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   const jsize len = env->GetArrayLength(jpaths);
-  for(jsize i = 0; i < len; i++) {
+  for (jsize i = 0; i < len; i++) {
     rocksdb::DbPath db_path = opt->db_paths[i];
 
     jstring jpath = env->NewStringUTF(db_path.path.c_str());
-    if(jpath == nullptr) {
+    if (jpath == nullptr) {
       // exception thrown: OutOfMemoryError
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
     env->SetObjectArrayElement(jpaths, i, jpath);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jpath);
-      env->ReleaseLongArrayElements(
-          jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
+      env->ReleaseLongArrayElements(jtarget_sizes, ptr_jtarget_size, JNI_ABORT);
       return;
     }
 
@@ -4686,10 +4802,11 @@ void Java_org_rocksdb_DBOptions_dbPaths(
  * Method:    setDbLogDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setDbLogDir(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jdb_log_dir) {
+void Java_org_rocksdb_DBOptions_setDbLogDir(JNIEnv* env, jobject jobj,
+                                            jlong jhandle,
+                                            jstring jdb_log_dir) {
   const char* log_dir = env->GetStringUTFChars(jdb_log_dir, nullptr);
-  if(log_dir == nullptr) {
+  if (log_dir == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -4703,8 +4820,8 @@ void Java_org_rocksdb_DBOptions_setDbLogDir(
  * Method:    dbLogDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_dbLogDir(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_DBOptions_dbLogDir(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->db_log_dir.c_str());
 }
@@ -4714,8 +4831,8 @@ jstring Java_org_rocksdb_DBOptions_dbLogDir(
  * Method:    setWalDir
  * Signature: (JLjava/lang/String)V
  */
-void Java_org_rocksdb_DBOptions_setWalDir(
-    JNIEnv* env, jobject jobj, jlong jhandle, jstring jwal_dir) {
+void Java_org_rocksdb_DBOptions_setWalDir(JNIEnv* env, jobject jobj,
+                                          jlong jhandle, jstring jwal_dir) {
   const char* wal_dir = env->GetStringUTFChars(jwal_dir, 0);
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.assign(wal_dir);
   env->ReleaseStringUTFChars(jwal_dir, wal_dir);
@@ -4726,8 +4843,8 @@ void Java_org_rocksdb_DBOptions_setWalDir(
  * Method:    walDir
  * Signature: (J)Ljava/lang/String
  */
-jstring Java_org_rocksdb_DBOptions_walDir(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jstring Java_org_rocksdb_DBOptions_walDir(JNIEnv* env, jobject jobj,
+                                          jlong jhandle) {
   return env->NewStringUTF(
       reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_dir.c_str());
 }
@@ -4740,8 +4857,7 @@ jstring Java_org_rocksdb_DBOptions_walDir(
 void Java_org_rocksdb_DBOptions_setDeleteObsoleteFilesPeriodMicros(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong micros) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->delete_obsolete_files_period_micros =
-          static_cast<int64_t>(micros);
+      ->delete_obsolete_files_period_micros = static_cast<int64_t>(micros);
 }
 
 /*
@@ -4760,10 +4876,12 @@ jlong Java_org_rocksdb_DBOptions_deleteObsoleteFilesPeriodMicros(
  * Method:    setBaseBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->base_background_compactions = static_cast<int>(max);
+void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle,
+                                                             jint max) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->base_background_compactions =
+      static_cast<int>(max);
 }
 
 /*
@@ -4771,8 +4889,9 @@ void Java_org_rocksdb_DBOptions_setBaseBackgroundCompactions(
  * Method:    baseBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->base_background_compactions;
 }
@@ -4782,10 +4901,12 @@ jint Java_org_rocksdb_DBOptions_baseBackgroundCompactions(
  * Method:    setMaxBackgroundCompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->max_background_compactions = static_cast<int>(max);
+void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(JNIEnv* env,
+                                                            jobject jobj,
+                                                            jlong jhandle,
+                                                            jint max) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_compactions =
+      static_cast<int>(max);
 }
 
 /*
@@ -4793,10 +4914,11 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundCompactions(
  * Method:    maxBackgroundCompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(
-      jhandle)->max_background_compactions;
+jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->max_background_compactions;
 }
 
 /*
@@ -4804,10 +4926,10 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundCompactions(
  * Method:    setMaxSubcompactions
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxSubcompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint max) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->max_subcompactions = static_cast<int32_t>(max);
+void Java_org_rocksdb_DBOptions_setMaxSubcompactions(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle, jint max) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_subcompactions =
+      static_cast<int32_t>(max);
 }
 
 /*
@@ -4815,10 +4937,9 @@ void Java_org_rocksdb_DBOptions_setMaxSubcompactions(
  * Method:    maxSubcompactions
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxSubcompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
-      ->max_subcompactions;
+jint Java_org_rocksdb_DBOptions_maxSubcompactions(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_subcompactions;
 }
 
 /*
@@ -4837,10 +4958,9 @@ void Java_org_rocksdb_DBOptions_setMaxBackgroundFlushes(
  * Method:    maxBackgroundFlushes
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      max_background_flushes;
+jint Java_org_rocksdb_DBOptions_maxBackgroundFlushes(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_background_flushes;
 }
 
 /*
@@ -4870,8 +4990,9 @@ jint Java_org_rocksdb_DBOptions_maxBackgroundJobs(JNIEnv* env, jobject jobj,
  * Method:    setMaxLogFileSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxLogFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max_log_file_size) {
+void Java_org_rocksdb_DBOptions_setMaxLogFileSize(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jlong max_log_file_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(max_log_file_size);
   if (s.ok()) {
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_log_file_size =
@@ -4886,8 +5007,8 @@ void Java_org_rocksdb_DBOptions_setMaxLogFileSize(
  * Method:    maxLogFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxLogFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_maxLogFileSize(JNIEnv* env, jobject jobj,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_log_file_size;
 }
 
@@ -4898,8 +5019,8 @@ jlong Java_org_rocksdb_DBOptions_maxLogFileSize(
  */
 void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong log_file_time_to_roll) {
-  rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(
-      log_file_time_to_roll);
+  rocksdb::Status s =
+      rocksdb::check_if_jlong_fits_size_t(log_file_time_to_roll);
   if (s.ok()) {
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->log_file_time_to_roll =
         log_file_time_to_roll;
@@ -4913,8 +5034,8 @@ void Java_org_rocksdb_DBOptions_setLogFileTimeToRoll(
  * Method:    logFileTimeToRoll
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->log_file_time_to_roll;
 }
 
@@ -4923,8 +5044,9 @@ jlong Java_org_rocksdb_DBOptions_logFileTimeToRoll(
  * Method:    setKeepLogFileNum
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setKeepLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong keep_log_file_num) {
+void Java_org_rocksdb_DBOptions_setKeepLogFileNum(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jlong keep_log_file_num) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(keep_log_file_num);
   if (s.ok()) {
     reinterpret_cast<rocksdb::DBOptions*>(jhandle)->keep_log_file_num =
@@ -4939,8 +5061,8 @@ void Java_org_rocksdb_DBOptions_setKeepLogFileNum(
  * Method:    keepLogFileNum
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_keepLogFileNum(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_keepLogFileNum(JNIEnv* env, jobject jobj,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->keep_log_file_num;
 }
 
@@ -4986,10 +5108,9 @@ void Java_org_rocksdb_DBOptions_setMaxManifestFileSize(
  * Method:    maxManifestFileSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      max_manifest_file_size;
+jlong Java_org_rocksdb_DBOptions_maxManifestFileSize(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->max_manifest_file_size;
 }
 
 /*
@@ -5008,10 +5129,11 @@ void Java_org_rocksdb_DBOptions_setTableCacheNumshardbits(
  * Method:    tableCacheNumshardbits
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      table_cache_numshardbits;
+jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->table_cache_numshardbits;
 }
 
 /*
@@ -5019,8 +5141,9 @@ jint Java_org_rocksdb_DBOptions_tableCacheNumshardbits(
  * Method:    setWalTtlSeconds
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalTtlSeconds(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong WAL_ttl_seconds) {
+void Java_org_rocksdb_DBOptions_setWalTtlSeconds(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle,
+                                                 jlong WAL_ttl_seconds) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_ttl_seconds =
       static_cast<int64_t>(WAL_ttl_seconds);
 }
@@ -5030,8 +5153,8 @@ void Java_org_rocksdb_DBOptions_setWalTtlSeconds(
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walTtlSeconds(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_walTtlSeconds(JNIEnv* env, jobject jobj,
+                                               jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_ttl_seconds;
 }
 
@@ -5040,8 +5163,9 @@ jlong Java_org_rocksdb_DBOptions_walTtlSeconds(
  * Method:    setWalSizeLimitMB
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong WAL_size_limit_MB) {
+void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jlong WAL_size_limit_MB) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_size_limit_MB =
       static_cast<int64_t>(WAL_size_limit_MB);
 }
@@ -5051,8 +5175,8 @@ void Java_org_rocksdb_DBOptions_setWalSizeLimitMB(
  * Method:    walTtlSeconds
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(JNIEnv* env, jobject jobj,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->WAL_size_limit_MB;
 }
 
@@ -5065,8 +5189,8 @@ void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
     JNIEnv* env, jobject jobj, jlong jhandle, jlong preallocation_size) {
   rocksdb::Status s = rocksdb::check_if_jlong_fits_size_t(preallocation_size);
   if (s.ok()) {
-    reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-        manifest_preallocation_size = preallocation_size;
+    reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+        ->manifest_preallocation_size = preallocation_size;
   } else {
     rocksdb::IllegalArgumentExceptionJni::ThrowNew(env, s);
   }
@@ -5077,8 +5201,9 @@ void Java_org_rocksdb_DBOptions_setManifestPreallocationSize(
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_manifestPreallocationSize(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
       ->manifest_preallocation_size;
 }
@@ -5134,8 +5259,9 @@ void Java_org_rocksdb_DBOptions_setUseDirectIoForFlushAndCompaction(
  * Method:    setAllowFAllocate
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowFAllocate(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_fallocate) {
+void Java_org_rocksdb_DBOptions_setAllowFAllocate(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jboolean jallow_fallocate) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_fallocate =
       static_cast<bool>(jallow_fallocate);
 }
@@ -5145,8 +5271,8 @@ void Java_org_rocksdb_DBOptions_setAllowFAllocate(
  * Method:    allowFAllocate
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowFAllocate(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_allowFAllocate(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_fallocate);
 }
@@ -5156,8 +5282,9 @@ jboolean Java_org_rocksdb_DBOptions_allowFAllocate(
  * Method:    setAllowMmapReads
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapReads(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow_mmap_reads) {
+void Java_org_rocksdb_DBOptions_setAllowMmapReads(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle,
+                                                  jboolean allow_mmap_reads) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_reads =
       static_cast<bool>(allow_mmap_reads);
 }
@@ -5167,8 +5294,8 @@ void Java_org_rocksdb_DBOptions_setAllowMmapReads(
  * Method:    allowMmapReads
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapReads(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_allowMmapReads(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_reads;
 }
 
@@ -5177,8 +5304,9 @@ jboolean Java_org_rocksdb_DBOptions_allowMmapReads(
  * Method:    setAllowMmapWrites
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllowMmapWrites(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow_mmap_writes) {
+void Java_org_rocksdb_DBOptions_setAllowMmapWrites(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jboolean allow_mmap_writes) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_writes =
       static_cast<bool>(allow_mmap_writes);
 }
@@ -5188,8 +5316,8 @@ void Java_org_rocksdb_DBOptions_setAllowMmapWrites(
  * Method:    allowMmapWrites
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_allowMmapWrites(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->allow_mmap_writes;
 }
 
@@ -5209,8 +5337,8 @@ void Java_org_rocksdb_DBOptions_setIsFdCloseOnExec(
  * Method:    isFdCloseOnExec
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_isFdCloseOnExec(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->is_fd_close_on_exec;
 }
 
@@ -5230,8 +5358,8 @@ void Java_org_rocksdb_DBOptions_setStatsDumpPeriodSec(
  * Method:    statsDumpPeriodSec
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_statsDumpPeriodSec(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->stats_dump_period_sec;
 }
 
@@ -5251,8 +5379,9 @@ void Java_org_rocksdb_DBOptions_setAdviseRandomOnOpen(
  * Method:    adviseRandomOnOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_adviseRandomOnOpen(JNIEnv* env,
+                                                       jobject jobj,
+                                                       jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->advise_random_on_open;
 }
 
@@ -5272,8 +5401,8 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_dbWriteBufferSize(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->db_write_buffer_size);
 }
@@ -5295,8 +5424,9 @@ void Java_org_rocksdb_DBOptions_setAccessHintOnCompactionStart(
  * Method:    accessHintOnCompactionStart
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_DBOptions_accessHintOnCompactionStart(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return rocksdb::AccessHintJni::toJavaAccessHint(
       opt->access_hint_on_compaction_start);
@@ -5332,7 +5462,8 @@ jboolean Java_org_rocksdb_DBOptions_newTableReaderForCompactionInputs(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcompaction_readahead_size) {
+    JNIEnv* env, jobject jobj, jlong jhandle,
+    jlong jcompaction_readahead_size) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->compaction_readahead_size =
       static_cast<size_t>(jcompaction_readahead_size);
@@ -5343,8 +5474,9 @@ void Java_org_rocksdb_DBOptions_setCompactionReadaheadSize(
  * Method:    compactionReadaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_compactionReadaheadSize(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->compaction_readahead_size);
 }
@@ -5367,8 +5499,9 @@ void Java_org_rocksdb_DBOptions_setRandomAccessMaxBufferSize(
  * Method:    randomAccessMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_randomAccessMaxBufferSize(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->random_access_max_buffer_size);
 }
@@ -5391,8 +5524,9 @@ void Java_org_rocksdb_DBOptions_setWritableFileMaxBufferSize(
  * Method:    writableFileMaxBufferSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_writableFileMaxBufferSize(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->writable_file_max_buffer_size);
 }
@@ -5413,8 +5547,8 @@ void Java_org_rocksdb_DBOptions_setUseAdaptiveMutex(
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->use_adaptive_mutex;
 }
 
@@ -5423,8 +5557,9 @@ jboolean Java_org_rocksdb_DBOptions_useAdaptiveMutex(
  * Method:    setBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong bytes_per_sync) {
+void Java_org_rocksdb_DBOptions_setBytesPerSync(JNIEnv* env, jobject jobj,
+                                                jlong jhandle,
+                                                jlong bytes_per_sync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->bytes_per_sync =
       static_cast<int64_t>(bytes_per_sync);
 }
@@ -5434,8 +5569,8 @@ void Java_org_rocksdb_DBOptions_setBytesPerSync(
  * Method:    bytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_bytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_bytesPerSync(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->bytes_per_sync;
 }
 
@@ -5444,8 +5579,9 @@ jlong Java_org_rocksdb_DBOptions_bytesPerSync(
  * Method:    setWalBytesPerSync
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWalBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwal_bytes_per_sync) {
+void Java_org_rocksdb_DBOptions_setWalBytesPerSync(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jlong jwal_bytes_per_sync) {
   reinterpret_cast<rocksdb::DBOptions*>(jhandle)->wal_bytes_per_sync =
       static_cast<int64_t>(jwal_bytes_per_sync);
 }
@@ -5455,8 +5591,8 @@ void Java_org_rocksdb_DBOptions_setWalBytesPerSync(
  * Method:    walBytesPerSync
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_walBytesPerSync(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_walBytesPerSync(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->wal_bytes_per_sync);
 }
@@ -5478,8 +5614,9 @@ void Java_org_rocksdb_DBOptions_setEnableThreadTracking(
  * Method:    enableThreadTracking
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->enable_thread_tracking);
 }
@@ -5489,8 +5626,9 @@ jboolean Java_org_rocksdb_DBOptions_enableThreadTracking(
  * Method:    setDelayedWriteRate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setDelayedWriteRate(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdelayed_write_rate) {
+void Java_org_rocksdb_DBOptions_setDelayedWriteRate(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle,
+                                                    jlong jdelayed_write_rate) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->delayed_write_rate = static_cast<uint64_t>(jdelayed_write_rate);
 }
@@ -5500,8 +5638,8 @@ void Java_org_rocksdb_DBOptions_setDelayedWriteRate(
  * Method:    delayedWriteRate
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_delayedWriteRate(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_delayedWriteRate(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->delayed_write_rate);
 }
@@ -5513,8 +5651,8 @@ jlong Java_org_rocksdb_DBOptions_delayedWriteRate(
  */
 void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
     JNIEnv* env, jobject jobj, jlong jhandle, jboolean allow) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      allow_concurrent_memtable_write = static_cast<bool>(allow);
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->allow_concurrent_memtable_write = static_cast<bool>(allow);
 }
 
 /*
@@ -5524,8 +5662,8 @@ void Java_org_rocksdb_DBOptions_setAllowConcurrentMemtableWrite(
  */
 jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      allow_concurrent_memtable_write;
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->allow_concurrent_memtable_write;
 }
 
 /*
@@ -5535,8 +5673,8 @@ jboolean Java_org_rocksdb_DBOptions_allowConcurrentMemtableWrite(
  */
 void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
     JNIEnv* env, jobject jobj, jlong jhandle, jboolean yield) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      enable_write_thread_adaptive_yield = static_cast<bool>(yield);
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->enable_write_thread_adaptive_yield = static_cast<bool>(yield);
 }
 
 /*
@@ -5546,8 +5684,8 @@ void Java_org_rocksdb_DBOptions_setEnableWriteThreadAdaptiveYield(
  */
 jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
     JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      enable_write_thread_adaptive_yield;
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->enable_write_thread_adaptive_yield;
 }
 
 /*
@@ -5555,10 +5693,12 @@ jboolean Java_org_rocksdb_DBOptions_enableWriteThreadAdaptiveYield(
  * Method:    setWriteThreadMaxYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong max) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      write_thread_max_yield_usec = static_cast<int64_t>(max);
+void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle,
+                                                           jlong max) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->write_thread_max_yield_usec =
+      static_cast<int64_t>(max);
 }
 
 /*
@@ -5566,10 +5706,11 @@ void Java_org_rocksdb_DBOptions_setWriteThreadMaxYieldUsec(
  * Method:    writeThreadMaxYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      write_thread_max_yield_usec;
+jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->write_thread_max_yield_usec;
 }
 
 /*
@@ -5577,10 +5718,12 @@ jlong Java_org_rocksdb_DBOptions_writeThreadMaxYieldUsec(
  * Method:    setWriteThreadSlowYieldUsec
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong slow) {
-  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      write_thread_slow_yield_usec = static_cast<int64_t>(slow);
+void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(JNIEnv* env,
+                                                            jobject jobj,
+                                                            jlong jhandle,
+                                                            jlong slow) {
+  reinterpret_cast<rocksdb::DBOptions*>(jhandle)->write_thread_slow_yield_usec =
+      static_cast<int64_t>(slow);
 }
 
 /*
@@ -5588,10 +5731,11 @@ void Java_org_rocksdb_DBOptions_setWriteThreadSlowYieldUsec(
  * Method:    writeThreadSlowYieldUsec
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)->
-      write_thread_slow_yield_usec;
+jlong Java_org_rocksdb_DBOptions_writeThreadSlowYieldUsec(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong jhandle) {
+  return reinterpret_cast<rocksdb::DBOptions*>(jhandle)
+      ->write_thread_slow_yield_usec;
 }
 
 /*
@@ -5612,8 +5756,9 @@ void Java_org_rocksdb_DBOptions_setSkipStatsUpdateOnDbOpen(
  * Method:    skipStatsUpdateOnDbOpen
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(JNIEnv* env,
+                                                            jobject jobj,
+                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->skip_stats_update_on_db_open);
 }
@@ -5626,9 +5771,8 @@ jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(
 void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
     JNIEnv* env, jobject jobj, jlong jhandle, jbyte jwal_recovery_mode_value) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  opt->wal_recovery_mode =
-      rocksdb::WALRecoveryModeJni::toCppWALRecoveryMode(
-          jwal_recovery_mode_value);
+  opt->wal_recovery_mode = rocksdb::WALRecoveryModeJni::toCppWALRecoveryMode(
+      jwal_recovery_mode_value);
 }
 
 /*
@@ -5636,8 +5780,8 @@ void Java_org_rocksdb_DBOptions_setWalRecoveryMode(
  * Method:    walRecoveryMode
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return rocksdb::WALRecoveryModeJni::toJavaWALRecoveryMode(
       opt->wal_recovery_mode);
@@ -5648,8 +5792,9 @@ jbyte Java_org_rocksdb_DBOptions_walRecoveryMode(
  * Method:    setAllow2pc
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAllow2pc(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jallow_2pc) {
+void Java_org_rocksdb_DBOptions_setAllow2pc(JNIEnv* env, jobject jobj,
+                                            jlong jhandle,
+                                            jboolean jallow_2pc) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   opt->allow_2pc = static_cast<bool>(jallow_2pc);
 }
@@ -5659,7 +5804,8 @@ void Java_org_rocksdb_DBOptions_setAllow2pc(
  * Method:    allow2pc
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* env, jobject jobj,
+                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->allow_2pc);
 }
@@ -5669,10 +5815,12 @@ jboolean Java_org_rocksdb_DBOptions_allow2pc(JNIEnv* env, jobject jobj, jlong jh
  * Method:    setRowCache
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setRowCache(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jrow_cache_handle) {
+void Java_org_rocksdb_DBOptions_setRowCache(JNIEnv* env, jobject jobj,
+                                            jlong jhandle,
+                                            jlong jrow_cache_handle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  auto* row_cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jrow_cache_handle);
+  auto* row_cache =
+      reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jrow_cache_handle);
   opt->row_cache = *row_cache;
 }
 
@@ -5694,8 +5842,9 @@ void Java_org_rocksdb_DBOptions_setFailIfOptionsFileError(
  * Method:    failIfOptionsFileError
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_failIfOptionsFileError(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->fail_if_options_file_error);
 }
@@ -5716,8 +5865,8 @@ void Java_org_rocksdb_DBOptions_setDumpMallocStats(
  * Method:    dumpMallocStats
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_dumpMallocStats(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->dump_malloc_stats);
 }
@@ -5731,7 +5880,8 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean javoid_flush_during_recovery) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  opt->avoid_flush_during_recovery = static_cast<bool>(javoid_flush_during_recovery);
+  opt->avoid_flush_during_recovery =
+      static_cast<bool>(javoid_flush_during_recovery);
 }
 
 /*
@@ -5739,8 +5889,9 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringRecovery(
  * Method:    avoidFlushDuringRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringRecovery(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
 }
@@ -5754,7 +5905,8 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
     JNIEnv* env, jobject jobj, jlong jhandle,
     jboolean javoid_flush_during_shutdown) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
-  opt->avoid_flush_during_shutdown = static_cast<bool>(javoid_flush_during_shutdown);
+  opt->avoid_flush_during_shutdown =
+      static_cast<bool>(javoid_flush_during_shutdown);
 }
 
 /*
@@ -5762,8 +5914,9 @@ void Java_org_rocksdb_DBOptions_setAvoidFlushDuringShutdown(
  * Method:    avoidFlushDuringShutdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
 }
@@ -5776,8 +5929,7 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(
  * Method:    newWriteOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_WriteOptions_newWriteOptions(
-    JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_WriteOptions_newWriteOptions(JNIEnv* env, jclass jcls) {
   auto* op = new rocksdb::WriteOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -5787,8 +5939,8 @@ jlong Java_org_rocksdb_WriteOptions_newWriteOptions(
  * Method:    copyWriteOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(
-    JNIEnv* env, jclass jcls, jlong jhandle) {
+jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(JNIEnv* env, jclass jcls,
+                                                     jlong jhandle) {
   auto new_opt = new rocksdb::WriteOptions(
       *(reinterpret_cast<rocksdb::WriteOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
@@ -5799,8 +5951,9 @@ jlong Java_org_rocksdb_WriteOptions_copyWriteOptions(
  * Method:    disposeInternal
  * Signature: ()V
  */
-void Java_org_rocksdb_WriteOptions_disposeInternal(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle) {
+void Java_org_rocksdb_WriteOptions_disposeInternal(JNIEnv* env,
+                                                   jobject jwrite_options,
+                                                   jlong jhandle) {
   auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(jhandle);
   assert(write_options != nullptr);
   delete write_options;
@@ -5811,8 +5964,8 @@ void Java_org_rocksdb_WriteOptions_disposeInternal(
  * Method:    setSync
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setSync(
-  JNIEnv* env, jobject jwrite_options, jlong jhandle, jboolean jflag) {
+void Java_org_rocksdb_WriteOptions_setSync(JNIEnv* env, jobject jwrite_options,
+                                           jlong jhandle, jboolean jflag) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync = jflag;
 }
 
@@ -5821,8 +5974,8 @@ void Java_org_rocksdb_WriteOptions_setSync(
  * Method:    sync
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_sync(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle) {
+jboolean Java_org_rocksdb_WriteOptions_sync(JNIEnv* env, jobject jwrite_options,
+                                            jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->sync;
 }
 
@@ -5831,8 +5984,10 @@ jboolean Java_org_rocksdb_WriteOptions_sync(
  * Method:    setDisableWAL
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setDisableWAL(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle, jboolean jflag) {
+void Java_org_rocksdb_WriteOptions_setDisableWAL(JNIEnv* env,
+                                                 jobject jwrite_options,
+                                                 jlong jhandle,
+                                                 jboolean jflag) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->disableWAL = jflag;
 }
 
@@ -5841,8 +5996,9 @@ void Java_org_rocksdb_WriteOptions_setDisableWAL(
  * Method:    disableWAL
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_disableWAL(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle) {
+jboolean Java_org_rocksdb_WriteOptions_disableWAL(JNIEnv* env,
+                                                  jobject jwrite_options,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->disableWAL;
 }
 
@@ -5854,9 +6010,9 @@ jboolean Java_org_rocksdb_WriteOptions_disableWAL(
 void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
     JNIEnv* env, jobject jwrite_options, jlong jhandle,
     jboolean jignore_missing_column_families) {
-  reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->
-      ignore_missing_column_families =
-          static_cast<bool>(jignore_missing_column_families);
+  reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
+      ->ignore_missing_column_families =
+      static_cast<bool>(jignore_missing_column_families);
 }
 
 /*
@@ -5866,8 +6022,8 @@ void Java_org_rocksdb_WriteOptions_setIgnoreMissingColumnFamilies(
  */
 jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
     JNIEnv* env, jobject jwrite_options, jlong jhandle) {
-  return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->
-      ignore_missing_column_families;
+  return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)
+      ->ignore_missing_column_families;
 }
 
 /*
@@ -5875,8 +6031,10 @@ jboolean Java_org_rocksdb_WriteOptions_ignoreMissingColumnFamilies(
  * Method:    setNoSlowdown
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_WriteOptions_setNoSlowdown(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle, jboolean jno_slowdown) {
+void Java_org_rocksdb_WriteOptions_setNoSlowdown(JNIEnv* env,
+                                                 jobject jwrite_options,
+                                                 jlong jhandle,
+                                                 jboolean jno_slowdown) {
   reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->no_slowdown =
       static_cast<bool>(jno_slowdown);
 }
@@ -5886,8 +6044,9 @@ void Java_org_rocksdb_WriteOptions_setNoSlowdown(
  * Method:    noSlowdown
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteOptions_noSlowdown(
-    JNIEnv* env, jobject jwrite_options, jlong jhandle) {
+jboolean Java_org_rocksdb_WriteOptions_noSlowdown(JNIEnv* env,
+                                                  jobject jwrite_options,
+                                                  jlong jhandle) {
   return reinterpret_cast<rocksdb::WriteOptions*>(jhandle)->no_slowdown;
 }
 
@@ -5899,8 +6058,7 @@ jboolean Java_org_rocksdb_WriteOptions_noSlowdown(
  * Method:    newReadOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ReadOptions_newReadOptions(
-    JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_ReadOptions_newReadOptions(JNIEnv* env, jclass jcls) {
   auto* read_options = new rocksdb::ReadOptions();
   return reinterpret_cast<jlong>(read_options);
 }
@@ -5910,8 +6068,8 @@ jlong Java_org_rocksdb_ReadOptions_newReadOptions(
  * Method:    copyReadOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_copyReadOptions(
-    JNIEnv* env, jclass jcls, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_copyReadOptions(JNIEnv* env, jclass jcls,
+                                                   jlong jhandle) {
   auto new_opt = new rocksdb::ReadOptions(
       *(reinterpret_cast<rocksdb::ReadOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
@@ -5922,8 +6080,8 @@ jlong Java_org_rocksdb_ReadOptions_copyReadOptions(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ReadOptions_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_ReadOptions_disposeInternal(JNIEnv* env, jobject jobj,
+                                                  jlong jhandle) {
   auto* read_options = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   assert(read_options != nullptr);
   delete read_options;
@@ -5935,8 +6093,7 @@ void Java_org_rocksdb_ReadOptions_disposeInternal(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
-    JNIEnv* env, jobject jobj, jlong jhandle,
-    jboolean jverify_checksums) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jverify_checksums) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->verify_checksums =
       static_cast<bool>(jverify_checksums);
 }
@@ -5946,10 +6103,9 @@ void Java_org_rocksdb_ReadOptions_setVerifyChecksums(
  * Method:    verifyChecksums
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::ReadOptions*>(
-      jhandle)->verify_checksums;
+jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(JNIEnv* env, jobject jobj,
+                                                      jlong jhandle) {
+  return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->verify_checksums;
 }
 
 /*
@@ -5957,8 +6113,9 @@ jboolean Java_org_rocksdb_ReadOptions_verifyChecksums(
  * Method:    setFillCache
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setFillCache(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jfill_cache) {
+void Java_org_rocksdb_ReadOptions_setFillCache(JNIEnv* env, jobject jobj,
+                                               jlong jhandle,
+                                               jboolean jfill_cache) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->fill_cache =
       static_cast<bool>(jfill_cache);
 }
@@ -5968,8 +6125,8 @@ void Java_org_rocksdb_ReadOptions_setFillCache(
  * Method:    fillCache
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_fillCache(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_fillCache(JNIEnv* env, jobject jobj,
+                                                jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->fill_cache;
 }
 
@@ -5978,8 +6135,8 @@ jboolean Java_org_rocksdb_ReadOptions_fillCache(
  * Method:    setTailing
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setTailing(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jtailing) {
+void Java_org_rocksdb_ReadOptions_setTailing(JNIEnv* env, jobject jobj,
+                                             jlong jhandle, jboolean jtailing) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->tailing =
       static_cast<bool>(jtailing);
 }
@@ -5989,8 +6146,8 @@ void Java_org_rocksdb_ReadOptions_setTailing(
  * Method:    tailing
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_tailing(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_tailing(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->tailing;
 }
 
@@ -5999,8 +6156,8 @@ jboolean Java_org_rocksdb_ReadOptions_tailing(
  * Method:    managed
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_managed(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_managed(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->managed;
 }
 
@@ -6009,8 +6166,8 @@ jboolean Java_org_rocksdb_ReadOptions_managed(
  * Method:    setManaged
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setManaged(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jmanaged) {
+void Java_org_rocksdb_ReadOptions_setManaged(JNIEnv* env, jobject jobj,
+                                             jlong jhandle, jboolean jmanaged) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->managed =
       static_cast<bool>(jmanaged);
 }
@@ -6020,8 +6177,8 @@ void Java_org_rocksdb_ReadOptions_setManaged(
  * Method:    totalOrderSeek
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_totalOrderSeek(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->total_order_seek;
 }
 
@@ -6041,8 +6198,9 @@ void Java_org_rocksdb_ReadOptions_setTotalOrderSeek(
  * Method:    prefixSameAsStart
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_prefixSameAsStart(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->prefix_same_as_start;
 }
 
@@ -6062,8 +6220,8 @@ void Java_org_rocksdb_ReadOptions_setPrefixSameAsStart(
  * Method:    pinData
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_pinData(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_pinData(JNIEnv* env, jobject jobj,
+                                              jlong jhandle) {
   return reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->pin_data;
 }
 
@@ -6072,8 +6230,9 @@ jboolean Java_org_rocksdb_ReadOptions_pinData(
  * Method:    setPinData
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_ReadOptions_setPinData(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jpin_data) {
+void Java_org_rocksdb_ReadOptions_setPinData(JNIEnv* env, jobject jobj,
+                                             jlong jhandle,
+                                             jboolean jpin_data) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->pin_data =
       static_cast<bool>(jpin_data);
 }
@@ -6107,8 +6266,8 @@ void Java_org_rocksdb_ReadOptions_setBackgroundPurgeOnIteratorCleanup(
  * Method:    readaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_readaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_readaheadSize(JNIEnv* env, jobject jobj,
+                                                 jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   return static_cast<jlong>(opt->readahead_size);
 }
@@ -6118,8 +6277,9 @@ jlong Java_org_rocksdb_ReadOptions_readaheadSize(
  * Method:    setReadaheadSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setReadaheadSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jreadahead_size) {
+void Java_org_rocksdb_ReadOptions_setReadaheadSize(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jlong jreadahead_size) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   opt->readahead_size = static_cast<size_t>(jreadahead_size);
 }
@@ -6129,8 +6289,9 @@ void Java_org_rocksdb_ReadOptions_setReadaheadSize(
  * Method:    ignoreRangeDeletions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ReadOptions_ignoreRangeDeletions(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<rocksdb::ReadOptions*>(jhandle);
   return static_cast<jboolean>(opt->ignore_range_deletions);
 }
@@ -6152,8 +6313,8 @@ void Java_org_rocksdb_ReadOptions_setIgnoreRangeDeletions(
  * Method:    setSnapshot
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_ReadOptions_setSnapshot(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jsnapshot) {
+void Java_org_rocksdb_ReadOptions_setSnapshot(JNIEnv* env, jobject jobj,
+                                              jlong jhandle, jlong jsnapshot) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->snapshot =
       reinterpret_cast<rocksdb::Snapshot*>(jsnapshot);
 }
@@ -6163,10 +6324,9 @@ void Java_org_rocksdb_ReadOptions_setSnapshot(
  * Method:    snapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_snapshot(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  auto& snapshot =
-      reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->snapshot;
+jlong Java_org_rocksdb_ReadOptions_snapshot(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
+  auto& snapshot = reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->snapshot;
   return reinterpret_cast<jlong>(snapshot);
 }
 
@@ -6175,8 +6335,8 @@ jlong Java_org_rocksdb_ReadOptions_snapshot(
  * Method:    readTier
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_ReadOptions_readTier(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_ReadOptions_readTier(JNIEnv* env, jobject jobj,
+                                            jlong jhandle) {
   return static_cast<jbyte>(
       reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->read_tier);
 }
@@ -6186,8 +6346,8 @@ jbyte Java_org_rocksdb_ReadOptions_readTier(
  * Method:    setReadTier
  * Signature: (JB)V
  */
-void Java_org_rocksdb_ReadOptions_setReadTier(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jread_tier) {
+void Java_org_rocksdb_ReadOptions_setReadTier(JNIEnv* env, jobject jobj,
+                                              jlong jhandle, jbyte jread_tier) {
   reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->read_tier =
       static_cast<rocksdb::ReadTier>(jread_tier);
 }
@@ -6208,8 +6368,8 @@ void Java_org_rocksdb_ReadOptions_setIterateUpperBound(
  * Method:    iterateUpperBound
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(JNIEnv* env, jobject jobj,
+                                                     jlong jhandle) {
   auto& upper_bound_slice_handle =
       reinterpret_cast<rocksdb::ReadOptions*>(jhandle)->iterate_upper_bound;
   return reinterpret_cast<jlong>(upper_bound_slice_handle);
@@ -6223,8 +6383,8 @@ jlong Java_org_rocksdb_ReadOptions_iterateUpperBound(
  * Method:    newComparatorOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(
-    JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(JNIEnv* env,
+                                                              jclass jcls) {
   auto* comparator_opt = new rocksdb::ComparatorJniCallbackOptions();
   return reinterpret_cast<jlong>(comparator_opt);
 }
@@ -6234,10 +6394,11 @@ jlong Java_org_rocksdb_ComparatorOptions_newComparatorOptions(
  * Method:    useAdaptiveMutex
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(
-    JNIEnv * env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(JNIEnv* env,
+                                                             jobject jobj,
+                                                             jlong jhandle) {
   return reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle)
-    ->use_adaptive_mutex;
+      ->use_adaptive_mutex;
 }
 
 /*
@@ -6246,9 +6407,9 @@ jboolean Java_org_rocksdb_ComparatorOptions_useAdaptiveMutex(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_ComparatorOptions_setUseAdaptiveMutex(
-    JNIEnv * env, jobject jobj, jlong jhandle, jboolean juse_adaptive_mutex) {
+    JNIEnv* env, jobject jobj, jlong jhandle, jboolean juse_adaptive_mutex) {
   reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle)
-    ->use_adaptive_mutex = static_cast<bool>(juse_adaptive_mutex);
+      ->use_adaptive_mutex = static_cast<bool>(juse_adaptive_mutex);
 }
 
 /*
@@ -6256,8 +6417,9 @@ void Java_org_rocksdb_ComparatorOptions_setUseAdaptiveMutex(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_ComparatorOptions_disposeInternal(
-    JNIEnv * env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_ComparatorOptions_disposeInternal(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong jhandle) {
   auto* comparator_opt =
       reinterpret_cast<rocksdb::ComparatorJniCallbackOptions*>(jhandle);
   assert(comparator_opt != nullptr);
@@ -6272,8 +6434,7 @@ void Java_org_rocksdb_ComparatorOptions_disposeInternal(
  * Method:    newFlushOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_FlushOptions_newFlushOptions(
-    JNIEnv* env, jclass jcls) {
+jlong Java_org_rocksdb_FlushOptions_newFlushOptions(JNIEnv* env, jclass jcls) {
   auto* flush_opt = new rocksdb::FlushOptions();
   return reinterpret_cast<jlong>(flush_opt);
 }
@@ -6283,10 +6444,11 @@ jlong Java_org_rocksdb_FlushOptions_newFlushOptions(
  * Method:    setWaitForFlush
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_FlushOptions_setWaitForFlush(
-    JNIEnv * env, jobject jobj, jlong jhandle, jboolean jwait) {
-  reinterpret_cast<rocksdb::FlushOptions*>(jhandle)
-    ->wait = static_cast<bool>(jwait);
+void Java_org_rocksdb_FlushOptions_setWaitForFlush(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle,
+                                                   jboolean jwait) {
+  reinterpret_cast<rocksdb::FlushOptions*>(jhandle)->wait =
+      static_cast<bool>(jwait);
 }
 
 /*
@@ -6294,10 +6456,9 @@ void Java_org_rocksdb_FlushOptions_setWaitForFlush(
  * Method:    waitForFlush
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_FlushOptions_waitForFlush(
-    JNIEnv * env, jobject jobj, jlong jhandle) {
-  return reinterpret_cast<rocksdb::FlushOptions*>(jhandle)
-    ->wait;
+jboolean Java_org_rocksdb_FlushOptions_waitForFlush(JNIEnv* env, jobject jobj,
+                                                    jlong jhandle) {
+  return reinterpret_cast<rocksdb::FlushOptions*>(jhandle)->wait;
 }
 
 /*
@@ -6305,8 +6466,8 @@ jboolean Java_org_rocksdb_FlushOptions_waitForFlush(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_FlushOptions_disposeInternal(
-    JNIEnv * env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_FlushOptions_disposeInternal(JNIEnv* env, jobject jobj,
+                                                   jlong jhandle) {
   auto* flush_opt = reinterpret_cast<rocksdb::FlushOptions*>(jhandle);
   assert(flush_opt != nullptr);
   delete flush_opt;

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -3016,7 +3016,7 @@ jboolean Java_org_rocksdb_Options_forceConsistencyChecks(JNIEnv* /*env*/,
  * Signature: ()J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
-    JNIEnv* /*env*/, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   auto* op = new rocksdb::ColumnFamilyOptions();
   return reinterpret_cast<jlong>(op);
 }
@@ -3027,7 +3027,7 @@ jlong Java_org_rocksdb_ColumnFamilyOptions_newColumnFamilyOptions(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_ColumnFamilyOptions_copyColumnFamilyOptions(
-    JNIEnv* /*env*/, jclass jcls, jlong jhandle) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jhandle) {
   auto new_opt = new rocksdb::ColumnFamilyOptions(
       *(reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);
@@ -4378,7 +4378,7 @@ jboolean Java_org_rocksdb_ColumnFamilyOptions_forceConsistencyChecks(
  * Method:    newDBOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* /*env*/, jclass jcls) {
+jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* /*env*/, jclass /*jcls*/) {
   auto* dbop = new rocksdb::DBOptions();
   return reinterpret_cast<jlong>(dbop);
 }
@@ -4388,7 +4388,7 @@ jlong Java_org_rocksdb_DBOptions_newDBOptions(JNIEnv* /*env*/, jclass jcls) {
  * Method:    copyDBOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* /*env*/, jclass jcls,
+jlong Java_org_rocksdb_DBOptions_copyDBOptions(JNIEnv* /*env*/, jclass /*jcls*/,
                                                jlong jhandle) {
   auto new_opt =
       new rocksdb::DBOptions(*(reinterpret_cast<rocksdb::DBOptions*>(jhandle)));

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -66,7 +66,7 @@ jlong Java_org_rocksdb_Options_newOptions__JJ(JNIEnv* /*env*/, jclass /*jcls*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_Options_copyOptions(JNIEnv* /*env*/, jclass /*jcls*/,
-                                           jlong /*jhandle*/) {
+                                           jlong jhandle) {
   auto new_opt =
       new rocksdb::Options(*(reinterpret_cast<rocksdb::Options*>(jhandle)));
   return reinterpret_cast<jlong>(new_opt);

--- a/java/rocksjni/options_util.cc
+++ b/java/rocksjni/options_util.cc
@@ -17,7 +17,7 @@
 
 void build_column_family_descriptor_list(
     JNIEnv* env, jobject jcfds,
-    std::vector<rocksdb::ColumnFamilyDescriptor>& cf_descs) {
+    std::vector<rocksdb::ColumnFamilyDescriptor>& /*cf_descs*/) {
   jmethodID add_mid = rocksdb::ListJni::getListAddMethodId(env);
   if (add_mid == nullptr) {
     // exception occurred accessing method
@@ -54,7 +54,7 @@ void build_column_family_descriptor_list(
  * Signature: (Ljava/lang/String;JLjava/util/List;Z)V
  */
 void Java_org_rocksdb_OptionsUtil_loadLatestOptions(
-    JNIEnv* env, jclass jcls, jstring jdbpath, jlong jenv_handle,
+    JNIEnv* env, jclass /*jcls*/, jstring jdbpath, jlong jenv_handle,
     jlong jdb_opts_handle, jobject jcfds, jboolean ignore_unknown_options) {
   const char* db_path = env->GetStringUTFChars(jdbpath, nullptr);
   std::vector<rocksdb::ColumnFamilyDescriptor> cf_descs;
@@ -77,7 +77,7 @@ void Java_org_rocksdb_OptionsUtil_loadLatestOptions(
  * Signature: (Ljava/lang/String;JJLjava/util/List;Z)V
  */
 void Java_org_rocksdb_OptionsUtil_loadOptionsFromFile(
-    JNIEnv* env, jclass jcls, jstring jopts_file_name, jlong jenv_handle,
+    JNIEnv* env, jclass /*jcls*/, jstring jopts_file_name, jlong jenv_handle,
     jlong jdb_opts_handle, jobject jcfds, jboolean ignore_unknown_options) {
   const char* opts_file_name = env->GetStringUTFChars(jopts_file_name, nullptr);
   std::vector<rocksdb::ColumnFamilyDescriptor> cf_descs;
@@ -100,7 +100,7 @@ void Java_org_rocksdb_OptionsUtil_loadOptionsFromFile(
  * Signature: (Ljava/lang/String;J)Ljava/lang/String;
  */
 jstring Java_org_rocksdb_OptionsUtil_getLatestOptionsFileName(
-    JNIEnv* env, jclass jcls, jstring jdbpath, jlong jenv_handle) {
+    JNIEnv* env, jclass /*jcls*/, jstring jdbpath, jlong jenv_handle) {
   const char* db_path = env->GetStringUTFChars(jdbpath, nullptr);
   std::string options_file_name;
   if (db_path != nullptr) {

--- a/java/rocksjni/options_util.cc
+++ b/java/rocksjni/options_util.cc
@@ -17,7 +17,7 @@
 
 void build_column_family_descriptor_list(
     JNIEnv* env, jobject jcfds,
-    std::vector<rocksdb::ColumnFamilyDescriptor>& /*cf_descs*/) {
+    std::vector<rocksdb::ColumnFamilyDescriptor>& cf_descs) {
   jmethodID add_mid = rocksdb::ListJni::getListAddMethodId(env);
   if (add_mid == nullptr) {
     // exception occurred accessing method

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -484,7 +484,7 @@ class StatusJni : public RocksDBNativeClass<rocksdb::Status*, StatusJni> {
       // exception occurred
       return nullptr;
     }
-    
+
     jmethodID mid_code_value = rocksdb::CodeJni::getValueMethod(env);
     if (mid_code_value == nullptr) {
       // exception occurred
@@ -2583,7 +2583,7 @@ class WriteTypeJni : public JavaClass {
   static jobject LOG(JNIEnv* env) {
     return getEnum(env, "LOG");
   }
-  
+
   // Returns the equivalent org.rocksdb.WBWIRocksIterator.WriteType for the
   // provided C++ rocksdb::WriteType enum
   static jbyte toJavaWriteType(const rocksdb::WriteType& writeType) {
@@ -4506,7 +4506,7 @@ class JniUtil {
      */
     static std::unique_ptr<rocksdb::Status> kv_op(
         std::function<rocksdb::Status(rocksdb::Slice, rocksdb::Slice)> op,
-        JNIEnv* env, jobject jobj,
+        JNIEnv* env, jobject /*jobj*/,
         jbyteArray jkey, jint jkey_len,
         jbyteArray jvalue, jint jvalue_len) {
       jbyte* key = env->GetByteArrayElements(jkey, nullptr);
@@ -4548,7 +4548,7 @@ class JniUtil {
      */
     static std::unique_ptr<rocksdb::Status> k_op(
         std::function<rocksdb::Status(rocksdb::Slice)> op,
-        JNIEnv* env, jobject jobj,
+        JNIEnv* env, jobject /*jobj*/,
         jbyteArray jkey, jint jkey_len) {
       jbyte* key = env->GetByteArrayElements(jkey, nullptr);
       if(env->ExceptionCheck()) {
@@ -4796,7 +4796,7 @@ class HashMapJni : public JavaClass {
 
   /**
    * A function which maps a std::pair<K,V> to a std::pair<jobject, jobject>
-   * 
+   *
    * @return Either a pointer to a std::pair<jobject, jobject>, or nullptr
    *     if an error occurs during the mapping
    */

--- a/java/rocksjni/ratelimiterjni.cc
+++ b/java/rocksjni/ratelimiterjni.cc
@@ -15,9 +15,9 @@
  * Signature: (JJIBZ)J
  */
 jlong Java_org_rocksdb_RateLimiter_newRateLimiterHandle(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jrate_bytes_per_second*/,
-    jlong /*jrefill_period_micros*/, jint /*jfairness*/,
-    jbyte /*jrate_limiter_mode*/, jboolean /*jauto_tune*/) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong jrate_bytes_per_second,
+    jlong jrefill_period_micros, jint jfairness, jbyte jrate_limiter_mode,
+    jboolean jauto_tune) {
   auto rate_limiter_mode =
       rocksdb::RateLimiterModeJni::toCppRateLimiterMode(jrate_limiter_mode);
   auto* sptr_rate_limiter =
@@ -36,7 +36,7 @@ jlong Java_org_rocksdb_RateLimiter_newRateLimiterHandle(
  */
 void Java_org_rocksdb_RateLimiter_disposeInternal(JNIEnv* /*env*/,
                                                   jobject /*jobj*/,
-                                                  jlong /*jhandle*/) {
+                                                  jlong jhandle) {
   auto* handle =
       reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(jhandle);
   delete handle;  // delete std::shared_ptr
@@ -47,9 +47,10 @@ void Java_org_rocksdb_RateLimiter_disposeInternal(JNIEnv* /*env*/,
  * Method:    setBytesPerSecond
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RateLimiter_setBytesPerSecond(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*handle*/,
-    jlong /*jbytes_per_second*/) {
+void Java_org_rocksdb_RateLimiter_setBytesPerSecond(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong handle,
+                                                    jlong jbytes_per_second) {
   reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->SetBytesPerSecond(jbytes_per_second);
@@ -62,7 +63,7 @@ void Java_org_rocksdb_RateLimiter_setBytesPerSecond(
  */
 jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(JNIEnv* /*env*/,
                                                      jobject /*jobj*/,
-                                                     jlong /*handle*/) {
+                                                     jlong handle) {
   return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->GetBytesPerSecond();
@@ -74,7 +75,7 @@ jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jobject /*jobj*/,
-                                          jlong /*handle*/, jlong /*jbytes*/) {
+                                          jlong handle, jlong jbytes) {
   reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->Request(jbytes, rocksdb::Env::IO_TOTAL);
@@ -87,7 +88,7 @@ void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jobject /*jobj*/,
  */
 jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(JNIEnv* /*env*/,
                                                        jobject /*jobj*/,
-                                                       jlong /*handle*/) {
+                                                       jlong handle) {
   return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->GetSingleBurstBytes();
@@ -100,7 +101,7 @@ jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(JNIEnv* /*env*/,
  */
 jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(JNIEnv* /*env*/,
                                                         jobject /*jobj*/,
-                                                        jlong /*handle*/) {
+                                                        jlong handle) {
   return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->GetTotalBytesThrough();
@@ -113,7 +114,7 @@ jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(JNIEnv* /*env*/,
  */
 jlong Java_org_rocksdb_RateLimiter_getTotalRequests(JNIEnv* /*env*/,
                                                     jobject /*jobj*/,
-                                                    jlong /*handle*/) {
+                                                    jlong handle) {
   return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
       ->get()
       ->GetTotalRequests();

--- a/java/rocksjni/ratelimiterjni.cc
+++ b/java/rocksjni/ratelimiterjni.cc
@@ -5,9 +5,9 @@
 //
 // This file implements the "bridge" between Java and C++ for RateLimiter.
 
-#include "rocksjni/portal.h"
 #include "include/org_rocksdb_RateLimiter.h"
 #include "rocksdb/rate_limiter.h"
+#include "rocksjni/portal.h"
 
 /*
  * Class:     org_rocksdb_RateLimiter
@@ -15,18 +15,16 @@
  * Signature: (JJIBZ)J
  */
 jlong Java_org_rocksdb_RateLimiter_newRateLimiterHandle(
-    JNIEnv* env, jclass jclazz, jlong jrate_bytes_per_second,
-    jlong jrefill_period_micros, jint jfairness, jbyte jrate_limiter_mode,
-    jboolean jauto_tune) {
-  auto rate_limiter_mode = rocksdb::RateLimiterModeJni::toCppRateLimiterMode(
-      jrate_limiter_mode);
-  auto * sptr_rate_limiter =
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jrate_bytes_per_second*/,
+    jlong /*jrefill_period_micros*/, jint /*jfairness*/,
+    jbyte /*jrate_limiter_mode*/, jboolean /*jauto_tune*/) {
+  auto rate_limiter_mode =
+      rocksdb::RateLimiterModeJni::toCppRateLimiterMode(jrate_limiter_mode);
+  auto* sptr_rate_limiter =
       new std::shared_ptr<rocksdb::RateLimiter>(rocksdb::NewGenericRateLimiter(
           static_cast<int64_t>(jrate_bytes_per_second),
           static_cast<int64_t>(jrefill_period_micros),
-          static_cast<int32_t>(jfairness),
-          rate_limiter_mode,
-          jauto_tune));
+          static_cast<int32_t>(jfairness), rate_limiter_mode, jauto_tune));
 
   return reinterpret_cast<jlong>(sptr_rate_limiter);
 }
@@ -36,10 +34,11 @@ jlong Java_org_rocksdb_RateLimiter_newRateLimiterHandle(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RateLimiter_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_RateLimiter_disposeInternal(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong /*jhandle*/) {
   auto* handle =
-      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(jhandle);
   delete handle;  // delete std::shared_ptr
 }
 
@@ -49,10 +48,11 @@ void Java_org_rocksdb_RateLimiter_disposeInternal(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_RateLimiter_setBytesPerSecond(
-    JNIEnv* env, jobject jobj, jlong handle,
-    jlong jbytes_per_second) {
-  reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->get()->
-      SetBytesPerSecond(jbytes_per_second);
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*handle*/,
+    jlong /*jbytes_per_second*/) {
+  reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->SetBytesPerSecond(jbytes_per_second);
 }
 
 /*
@@ -60,10 +60,12 @@ void Java_org_rocksdb_RateLimiter_setBytesPerSecond(
  * Method:    getBytesPerSecond
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(
-    JNIEnv* env, jobject jobj, jlong handle) {
-  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->get()->
-      GetBytesPerSecond();
+jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*handle*/) {
+  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->GetBytesPerSecond();
 }
 
 /*
@@ -71,11 +73,11 @@ jlong Java_org_rocksdb_RateLimiter_getBytesPerSecond(
  * Method:    request
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RateLimiter_request(
-    JNIEnv* env, jobject jobj, jlong handle,
-    jlong jbytes) {
-  reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->get()->
-      Request(jbytes, rocksdb::Env::IO_TOTAL);
+void Java_org_rocksdb_RateLimiter_request(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong /*handle*/, jlong /*jbytes*/) {
+  reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->Request(jbytes, rocksdb::Env::IO_TOTAL);
 }
 
 /*
@@ -83,10 +85,12 @@ void Java_org_rocksdb_RateLimiter_request(
  * Method:    getSingleBurstBytes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(
-    JNIEnv* env, jobject jobj, jlong handle) {
-  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->
-      get()->GetSingleBurstBytes();
+jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong /*handle*/) {
+  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->GetSingleBurstBytes();
 }
 
 /*
@@ -94,10 +98,12 @@ jlong Java_org_rocksdb_RateLimiter_getSingleBurstBytes(
  * Method:    getTotalBytesThrough
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(
-    JNIEnv* env, jobject jobj, jlong handle) {
-  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->
-      get()->GetTotalBytesThrough();
+jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong /*handle*/) {
+  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->GetTotalBytesThrough();
 }
 
 /*
@@ -105,8 +111,10 @@ jlong Java_org_rocksdb_RateLimiter_getTotalBytesThrough(
  * Method:    getTotalRequests
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RateLimiter_getTotalRequests(
-    JNIEnv* env, jobject jobj, jlong handle) {
-  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter> *>(handle)->
-      get()->GetTotalRequests();
+jlong Java_org_rocksdb_RateLimiter_getTotalRequests(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong /*handle*/) {
+  return reinterpret_cast<std::shared_ptr<rocksdb::RateLimiter>*>(handle)
+      ->get()
+      ->GetTotalRequests();
 }

--- a/java/rocksjni/remove_emptyvalue_compactionfilterjni.cc
+++ b/java/rocksjni/remove_emptyvalue_compactionfilterjni.cc
@@ -8,16 +8,14 @@
 #include "include/org_rocksdb_RemoveEmptyValueCompactionFilter.h"
 #include "utilities/compaction_filters/remove_emptyvalue_compactionfilter.h"
 
-
 /*
  * Class:     org_rocksdb_RemoveEmptyValueCompactionFilter
  * Method:    createNewRemoveEmptyValueCompactionFilter0
  * Signature: ()J
  */
 jlong Java_org_rocksdb_RemoveEmptyValueCompactionFilter_createNewRemoveEmptyValueCompactionFilter0(
-    JNIEnv* env, jclass jcls) {
-  auto* compaction_filter =
-      new rocksdb::RemoveEmptyValueCompactionFilter();
+    JNIEnv* /*env*/, jclass /*jcls*/) {
+  auto* compaction_filter = new rocksdb::RemoveEmptyValueCompactionFilter();
 
   // set the native handle to our native compaction filter
   return reinterpret_cast<jlong>(compaction_filter);

--- a/java/rocksjni/restorejni.cc
+++ b/java/rocksjni/restorejni.cc
@@ -21,7 +21,7 @@
  * Signature: (Z)J
  */
 jlong Java_org_rocksdb_RestoreOptions_newRestoreOptions(
-    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*keep_log_files*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean keep_log_files) {
   auto* ropt = new rocksdb::RestoreOptions(keep_log_files);
   return reinterpret_cast<jlong>(ropt);
 }

--- a/java/rocksjni/restorejni.cc
+++ b/java/rocksjni/restorejni.cc
@@ -7,21 +7,21 @@
 // calling C++ rocksdb::RestoreOptions methods
 // from Java side.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <string>
 
 #include "include/org_rocksdb_RestoreOptions.h"
-#include "rocksjni/portal.h"
 #include "rocksdb/utilities/backupable_db.h"
+#include "rocksjni/portal.h"
 /*
  * Class:     org_rocksdb_RestoreOptions
  * Method:    newRestoreOptions
  * Signature: (Z)J
  */
-jlong Java_org_rocksdb_RestoreOptions_newRestoreOptions(JNIEnv* env,
-    jclass jcls, jboolean keep_log_files) {
+jlong Java_org_rocksdb_RestoreOptions_newRestoreOptions(
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*keep_log_files*/) {
   auto* ropt = new rocksdb::RestoreOptions(keep_log_files);
   return reinterpret_cast<jlong>(ropt);
 }
@@ -31,8 +31,9 @@ jlong Java_org_rocksdb_RestoreOptions_newRestoreOptions(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RestoreOptions_disposeInternal(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_RestoreOptions_disposeInternal(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle) {
   auto* ropt = reinterpret_cast<rocksdb::RestoreOptions*>(jhandle);
   assert(ropt);
   delete ropt;

--- a/java/rocksjni/rocks_callback_object.cc
+++ b/java/rocksjni/rocks_callback_object.cc
@@ -16,13 +16,16 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksCallbackObject_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
-      // TODO(AR) is deleting from the super class JniCallback OK, or must we delete the subclass?
-      // Example hierarchies:
-      //   1) Comparator -> BaseComparatorJniCallback + JniCallback -> DirectComparatorJniCallback
-      //   2) Comparator -> BaseComparatorJniCallback + JniCallback -> ComparatorJniCallback
-      // I think this is okay, as Comparator and JniCallback both have virtual destructors...
-      delete reinterpret_cast<rocksdb::JniCallback*>(handle);
-// @lint-ignore TXT4 T25377293 Grandfathered in
+void Java_org_rocksdb_RocksCallbackObject_disposeInternal(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong handle) {
+  // TODO(AR) is deleting from the super class JniCallback OK, or must we delete
+  // the subclass? Example hierarchies:
+  //   1) Comparator -> BaseComparatorJniCallback + JniCallback ->
+  //   DirectComparatorJniCallback 2) Comparator -> BaseComparatorJniCallback +
+  //   JniCallback -> ComparatorJniCallback
+  // I think this is okay, as Comparator and JniCallback both have virtual
+  // destructors...
+  delete reinterpret_cast<rocksdb::JniCallback*>(handle);
+  // @lint-ignore TXT4 T25377293 Grandfathered in
 }

--- a/java/rocksjni/rocksdb_exception_test.cc
+++ b/java/rocksjni/rocksdb_exception_test.cc
@@ -17,7 +17,7 @@
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseException(JNIEnv* env,
-                                                          jobject jobj) {
+                                                          jobject /*jobj*/) {
   rocksdb::RocksDBExceptionJni::ThrowNew(env, std::string("test message"));
 }
 
@@ -27,7 +27,7 @@ void Java_org_rocksdb_RocksDBExceptionTest_raiseException(JNIEnv* env,
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionWithStatusCode(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* env, jobject /*jobj*/) {
   rocksdb::RocksDBExceptionJni::ThrowNew(env, "test message",
                                          rocksdb::Status::NotSupported());
 }
@@ -38,7 +38,7 @@ void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionWithStatusCode(
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionNoMsgWithStatusCode(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* env, jobject /*jobj*/) {
   rocksdb::RocksDBExceptionJni::ThrowNew(env, rocksdb::Status::NotSupported());
 }
 
@@ -48,7 +48,7 @@ void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionNoMsgWithStatusCode(
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionWithStatusCodeSubCode(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* env, jobject /*jobj*/) {
   rocksdb::RocksDBExceptionJni::ThrowNew(
       env, "test message",
       rocksdb::Status::TimedOut(rocksdb::Status::SubCode::kLockTimeout));
@@ -60,7 +60,7 @@ void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionWithStatusCodeSubCode(
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionNoMsgWithStatusCodeSubCode(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* env, jobject /*jobj*/) {
   rocksdb::RocksDBExceptionJni::ThrowNew(
       env, rocksdb::Status::TimedOut(rocksdb::Status::SubCode::kLockTimeout));
 }
@@ -71,7 +71,7 @@ void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionNoMsgWithStatusCodeSubC
  * Signature: ()V
  */
 void Java_org_rocksdb_RocksDBExceptionTest_raiseExceptionWithStatusCodeState(
-    JNIEnv* env, jobject jobj) {
+    JNIEnv* env, jobject /*jobj*/) {
   rocksdb::Slice state("test state");
   rocksdb::RocksDBExceptionJni::ThrowNew(env, "test message",
                                          rocksdb::Status::NotSupported(state));

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -32,8 +32,8 @@
 jlong rocksdb_open_helper(
     JNIEnv* env, jlong jopt_handle, jstring jdb_path,
     std::function<rocksdb::Status(const rocksdb::Options&, const std::string&,
-                                  rocksdb::DB**)> /*open_fn*/
-) {
+                                  rocksdb::DB**)>
+        open_fn) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
   if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -91,8 +91,8 @@ jlongArray rocksdb_open_helper(
     std::function<rocksdb::Status(
         const rocksdb::DBOptions&, const std::string&,
         const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-        std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)> /*open_fn*/
-) {
+        std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)>
+        open_fn) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
   if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -240,11 +240,11 @@ jobjectArray Java_org_rocksdb_RocksDB_listColumnFamilies(JNIEnv* env,
 /**
  * @return true if the put succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                        const rocksdb::WriteOptions& /*write_options*/,
-                        rocksdb::ColumnFamilyHandle* /*cf_handle*/,
-                        jbyteArray jkey, jint jkey_off, jint jkey_len,
-                        jbyteArray jval, jint jval_off, jint jval_len) {
+bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* db,
+                        const rocksdb::WriteOptions& write_options,
+                        rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jkey,
+                        jint jkey_off, jint jkey_len, jbyteArray jval,
+                        jint jval_off, jint jval_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
   if (env->ExceptionCheck()) {
@@ -415,9 +415,9 @@ void Java_org_rocksdb_RocksDB_write1(JNIEnv* env, jobject /*jdb*/,
 
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::KeyMayExist
-jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                              const rocksdb::ReadOptions& /*read_opt*/,
-                              rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* db,
+                              const rocksdb::ReadOptions& read_opt,
+                              rocksdb::ColumnFamilyHandle* cf_handle,
                               jbyteArray jkey, jint jkey_off, jint jkey_len,
                               jobject jstring_builder, bool* has_exception) {
   jbyte* key = new jbyte[jkey_len];
@@ -542,10 +542,10 @@ Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIIJLjava_lang_StringBuilder_2(
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::Get
 
-jbyteArray rocksdb_get_helper(
-    JNIEnv* env, rocksdb::DB* /*db*/, const rocksdb::ReadOptions& /*read_opt*/,
-    rocksdb::ColumnFamilyHandle* /*column_family_handle*/, jbyteArray jkey,
-    jint jkey_off, jint jkey_len) {
+jbyteArray rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
+                              const rocksdb::ReadOptions& read_opt,
+                              rocksdb::ColumnFamilyHandle* column_family_handle,
+                              jbyteArray jkey, jint jkey_off, jint jkey_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
   if (env->ExceptionCheck()) {
@@ -658,9 +658,9 @@ jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BIIJ(
   }
 }
 
-jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                        const rocksdb::ReadOptions& /*read_options*/,
-                        rocksdb::ColumnFamilyHandle* /*column_family_handle*/,
+jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
+                        const rocksdb::ReadOptions& read_options,
+                        rocksdb::ColumnFamilyHandle* column_family_handle,
                         jbyteArray jkey, jint jkey_off, jint jkey_len,
                         jbyteArray jval, jint jval_off, jint jval_len,
                         bool* has_exception) {
@@ -725,7 +725,7 @@ jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* /*db*/,
 }
 
 inline void multi_get_helper_release_keys(
-    JNIEnv* env, std::vector<std::pair<jbyte*, jobject>>& /*keys_to_free*/) {
+    JNIEnv* env, std::vector<std::pair<jbyte*, jobject>>& keys_to_free) {
   auto end = keys_to_free.end();
   for (auto it = keys_to_free.begin(); it != end; ++it) {
     delete[] it->first;
@@ -739,8 +739,8 @@ inline void multi_get_helper_release_keys(
  *
  * @return byte[][] of values or nullptr if an exception occurs
  */
-jobjectArray multi_get_helper(JNIEnv* env, jobject /*jdb*/, rocksdb::DB* /*db*/,
-                              const rocksdb::ReadOptions& /*rOpt*/,
+jobjectArray multi_get_helper(JNIEnv* env, jobject /*jdb*/, rocksdb::DB* db,
+                              const rocksdb::ReadOptions& rOpt,
                               jobjectArray jkeys, jintArray jkey_offs,
                               jintArray jkey_lens,
                               jlongArray jcolumn_family_handles) {
@@ -1023,9 +1023,9 @@ jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BIIJ(
 /**
  * @return true if the delete succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_delete_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                           const rocksdb::WriteOptions& /*write_options*/,
-                           rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+bool rocksdb_delete_helper(JNIEnv* env, rocksdb::DB* db,
+                           const rocksdb::WriteOptions& write_options,
+                           rocksdb::ColumnFamilyHandle* cf_handle,
                            jbyteArray jkey, jint jkey_off, jint jkey_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
@@ -1136,11 +1136,10 @@ void Java_org_rocksdb_RocksDB_delete__JJ_3BIIJ(
  * @return true if the single delete succeeded, false if a Java Exception
  *     was thrown
  */
-bool rocksdb_single_delete_helper(
-    JNIEnv* env, rocksdb::DB* /*db*/,
-    const rocksdb::WriteOptions& /*write_options*/,
-    rocksdb::ColumnFamilyHandle* /*cf_handle*/, jbyteArray jkey,
-    jint /*jkey_len*/) {
+bool rocksdb_single_delete_helper(JNIEnv* env, rocksdb::DB* db,
+                                  const rocksdb::WriteOptions& write_options,
+                                  rocksdb::ColumnFamilyHandle* cf_handle,
+                                  jbyteArray jkey, jint jkey_len) {
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1252,9 +1251,9 @@ void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BIJ(
  * @return true if the delete range succeeded, false if a Java Exception
  *     was thrown
  */
-bool rocksdb_delete_range_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                                 const rocksdb::WriteOptions& /*write_options*/,
-                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+bool rocksdb_delete_range_helper(JNIEnv* env, rocksdb::DB* db,
+                                 const rocksdb::WriteOptions& write_options,
+                                 rocksdb::ColumnFamilyHandle* cf_handle,
                                  jbyteArray jbegin_key, jint jbegin_key_off,
                                  jint jbegin_key_len, jbyteArray jend_key,
                                  jint jend_key_off, jint jend_key_len) {
@@ -1381,9 +1380,9 @@ void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BIIJ(
 /**
  * @return true if the merge succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                          const rocksdb::WriteOptions& /*write_options*/,
-                          rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* db,
+                          const rocksdb::WriteOptions& write_options,
+                          rocksdb::ColumnFamilyHandle* cf_handle,
                           jbyteArray jkey, jint jkey_off, jint jkey_len,
                           jbyteArray jval, jint jval_off, jint jval_len) {
   jbyte* key = new jbyte[jkey_len];
@@ -1519,9 +1518,9 @@ void Java_org_rocksdb_RocksDB_disposeInternal(JNIEnv* /*env*/,
   delete db;
 }
 
-jlong rocksdb_iterator_helper(rocksdb::DB* /*db*/,
-                              rocksdb::ReadOptions /*read_options*/,
-                              rocksdb::ColumnFamilyHandle* /*cf_handle*/) {
+jlong rocksdb_iterator_helper(rocksdb::DB* db,
+                              rocksdb::ReadOptions read_options,
+                              rocksdb::ColumnFamilyHandle* cf_handle) {
   rocksdb::Iterator* iterator = nullptr;
   if (cf_handle != nullptr) {
     iterator = db->NewIterator(read_options, cf_handle);
@@ -1738,7 +1737,7 @@ void Java_org_rocksdb_RocksDB_releaseSnapshot(JNIEnv* /*env*/, jobject /*jdb*/,
  */
 jstring Java_org_rocksdb_RocksDB_getProperty0__JLjava_lang_String_2I(
     JNIEnv* env, jobject /*jdb*/, jlong db_handle, jstring jproperty,
-    jint /*jproperty_len*/) {
+    jint jproperty_len) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
   if (property == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1766,7 +1765,7 @@ jstring Java_org_rocksdb_RocksDB_getProperty0__JLjava_lang_String_2I(
  */
 jstring Java_org_rocksdb_RocksDB_getProperty0__JJLjava_lang_String_2I(
     JNIEnv* env, jobject /*jdb*/, jlong db_handle, jlong jcf_handle,
-    jstring jproperty, jint /*jproperty_len*/) {
+    jstring jproperty, jint jproperty_len) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
   if (property == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1795,7 +1794,7 @@ jstring Java_org_rocksdb_RocksDB_getProperty0__JJLjava_lang_String_2I(
  */
 jlong Java_org_rocksdb_RocksDB_getLongProperty__JLjava_lang_String_2I(
     JNIEnv* env, jobject /*jdb*/, jlong db_handle, jstring jproperty,
-    jint /*jproperty_len*/) {
+    jint jproperty_len) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
   if (property == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1823,7 +1822,7 @@ jlong Java_org_rocksdb_RocksDB_getLongProperty__JLjava_lang_String_2I(
  */
 jlong Java_org_rocksdb_RocksDB_getLongProperty__JJLjava_lang_String_2I(
     JNIEnv* env, jobject /*jdb*/, jlong db_handle, jlong jcf_handle,
-    jstring jproperty, jint /*jproperty_len*/) {
+    jstring jproperty, jint jproperty_len) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
   if (property == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1848,10 +1847,9 @@ jlong Java_org_rocksdb_RocksDB_getLongProperty__JJLjava_lang_String_2I(
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::Flush
 
-void rocksdb_flush_helper(
-    JNIEnv* env, rocksdb::DB* /*db*/,
-    const rocksdb::FlushOptions& /*flush_options*/,
-    rocksdb::ColumnFamilyHandle* /*column_family_handle*/) {
+void rocksdb_flush_helper(JNIEnv* env, rocksdb::DB* db,
+                          const rocksdb::FlushOptions& flush_options,
+                          rocksdb::ColumnFamilyHandle* column_family_handle) {
   rocksdb::Status s;
   if (column_family_handle != nullptr) {
     s = db->Flush(flush_options, column_family_handle);
@@ -1895,8 +1893,8 @@ void Java_org_rocksdb_RocksDB_flush__JJJ(JNIEnv* env, jobject /*jdb*/,
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::CompactRange - Full
 
-void rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+void rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
+                                 rocksdb::ColumnFamilyHandle* cf_handle,
                                  jboolean jreduce_level, jint jtarget_level,
                                  jint jtarget_path_id) {
   rocksdb::Status s;
@@ -1953,8 +1951,8 @@ void Java_org_rocksdb_RocksDB_compactRange__JZIIJ(
  * @return true if the compact range succeeded, false if a Java Exception
  *     was thrown
  */
-bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* /*db*/,
-                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
+                                 rocksdb::ColumnFamilyHandle* cf_handle,
                                  jbyteArray jbegin, jint jbegin_len,
                                  jbyteArray jend, jint jend_len,
                                  jboolean jreduce_level, jint jtarget_level,

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -29,12 +29,13 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::Open
-jlong rocksdb_open_helper(JNIEnv* env, jlong jopt_handle, jstring jdb_path,
-    std::function<rocksdb::Status(
-      const rocksdb::Options&, const std::string&, rocksdb::DB**)> open_fn
-    ) {
+jlong rocksdb_open_helper(
+    JNIEnv* env, jlong jopt_handle, jstring jdb_path,
+    std::function<rocksdb::Status(const rocksdb::Options&, const std::string&,
+                                  rocksdb::DB**)> /*open_fn*/
+) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -58,13 +59,15 @@ jlong rocksdb_open_helper(JNIEnv* env, jlong jopt_handle, jstring jdb_path,
  * Method:    open
  * Signature: (JLjava/lang/String;)J
  */
-jlong Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2(
-    JNIEnv* env, jclass jcls, jlong jopt_handle, jstring jdb_path) {
-  return rocksdb_open_helper(env, jopt_handle, jdb_path,
-    (rocksdb::Status(*)
-      (const rocksdb::Options&, const std::string&, rocksdb::DB**)
-    )&rocksdb::DB::Open
-  );
+jlong Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2(JNIEnv* env,
+                                                          jclass /*jcls*/,
+                                                          jlong jopt_handle,
+                                                          jstring jdb_path) {
+  return rocksdb_open_helper(
+      env, jopt_handle, jdb_path,
+      (rocksdb::Status(*)(const rocksdb::Options&, const std::string&,
+                          rocksdb::DB**)) &
+          rocksdb::DB::Open);
 }
 
 /*
@@ -73,31 +76,32 @@ jlong Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2(
  * Signature: (JLjava/lang/String;)J
  */
 jlong Java_org_rocksdb_RocksDB_openROnly__JLjava_lang_String_2(
-    JNIEnv* env, jclass jcls, jlong jopt_handle, jstring jdb_path) {
-  return rocksdb_open_helper(env, jopt_handle, jdb_path, [](
-      const rocksdb::Options& options,
-      const std::string& db_path, rocksdb::DB** db) {
-    return rocksdb::DB::OpenForReadOnly(options, db_path, db);
-  });
+    JNIEnv* env, jclass /*jcls*/, jlong jopt_handle, jstring jdb_path) {
+  return rocksdb_open_helper(env, jopt_handle, jdb_path,
+                             [](const rocksdb::Options& options,
+                                const std::string& db_path, rocksdb::DB** db) {
+                               return rocksdb::DB::OpenForReadOnly(options,
+                                                                   db_path, db);
+                             });
 }
 
-jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
-    jstring jdb_path, jobjectArray jcolumn_names, jlongArray jcolumn_options,
+jlongArray rocksdb_open_helper(
+    JNIEnv* env, jlong jopt_handle, jstring jdb_path,
+    jobjectArray jcolumn_names, jlongArray jcolumn_options,
     std::function<rocksdb::Status(
-      const rocksdb::DBOptions&, const std::string&,
-      const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-      std::vector<rocksdb::ColumnFamilyHandle*>*,
-      rocksdb::DB**)> open_fn
-    ) {
+        const rocksdb::DBOptions&, const std::string&,
+        const std::vector<rocksdb::ColumnFamilyDescriptor>&,
+        std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)> /*open_fn*/
+) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
 
   const jsize len_cols = env->GetArrayLength(jcolumn_names);
   jlong* jco = env->GetLongArrayElements(jcolumn_options, nullptr);
-  if(jco == nullptr) {
+  if (jco == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseStringUTFChars(jdb_path, db_path);
     return nullptr;
@@ -106,22 +110,21 @@ jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   jboolean has_exception = JNI_FALSE;
   rocksdb::JniUtil::byteStrings<std::string>(
-    env,
-    jcolumn_names,
-    [](const char* str_data, const size_t str_len) {
-      return std::string(str_data, str_len);
-    },
-    [&jco, &column_families](size_t idx, std::string cf_name) {
-      rocksdb::ColumnFamilyOptions* cf_options =
-          reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[idx]);
-      column_families.push_back(
-          rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
-    },
-    &has_exception);
+      env, jcolumn_names,
+      [](const char* str_data, const size_t str_len) {
+        return std::string(str_data, str_len);
+      },
+      [&jco, &column_families](size_t idx, std::string cf_name) {
+        rocksdb::ColumnFamilyOptions* cf_options =
+            reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[idx]);
+        column_families.push_back(
+            rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
+      },
+      &has_exception);
 
   env->ReleaseLongArrayElements(jcolumn_options, jco, JNI_ABORT);
 
-  if(has_exception == JNI_TRUE) {
+  if (has_exception == JNI_TRUE) {
     // exception occurred
     env->ReleaseStringUTFChars(jdb_path, db_path);
     return nullptr;
@@ -130,30 +133,29 @@ jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jopt_handle);
   std::vector<rocksdb::ColumnFamilyHandle*> handles;
   rocksdb::DB* db = nullptr;
-  rocksdb::Status s = open_fn(*opt, db_path, column_families,
-      &handles, &db);
+  rocksdb::Status s = open_fn(*opt, db_path, column_families, &handles, &db);
 
   // we have now finished with db_path
   env->ReleaseStringUTFChars(jdb_path, db_path);
 
   // check if open operation was successful
   if (s.ok()) {
-    const jsize resultsLen = 1 + len_cols; //db handle + column family handles
+    const jsize resultsLen = 1 + len_cols;  // db handle + column family handles
     std::unique_ptr<jlong[]> results =
         std::unique_ptr<jlong[]>(new jlong[resultsLen]);
     results[0] = reinterpret_cast<jlong>(db);
-    for(int i = 1; i <= len_cols; i++) {
+    for (int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);
     }
 
     jlongArray jresults = env->NewLongArray(resultsLen);
-    if(jresults == nullptr) {
+    if (jresults == nullptr) {
       // exception thrown: OutOfMemoryError
       return nullptr;
     }
 
     env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jresults);
       return nullptr;
@@ -172,16 +174,16 @@ jlongArray rocksdb_open_helper(JNIEnv* env, jlong jopt_handle,
  * Signature: (JLjava/lang/String;[[B[J)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_openROnly__JLjava_lang_String_2_3_3B_3J(
-    JNIEnv* env, jclass jcls, jlong jopt_handle, jstring jdb_path,
+    JNIEnv* env, jclass /*jcls*/, jlong jopt_handle, jstring jdb_path,
     jobjectArray jcolumn_names, jlongArray jcolumn_options) {
-  return rocksdb_open_helper(env, jopt_handle, jdb_path, jcolumn_names,
-    jcolumn_options, [](
-        const rocksdb::DBOptions& options, const std::string& db_path,
-        const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
-        std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** db) {
-      return rocksdb::DB::OpenForReadOnly(options, db_path, column_families,
-        handles, db);
-  });
+  return rocksdb_open_helper(
+      env, jopt_handle, jdb_path, jcolumn_names, jcolumn_options,
+      [](const rocksdb::DBOptions& options, const std::string& db_path,
+         const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
+         std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** db) {
+        return rocksdb::DB::OpenForReadOnly(options, db_path, column_families,
+                                            handles, db);
+      });
 }
 
 /*
@@ -190,15 +192,15 @@ jlongArray Java_org_rocksdb_RocksDB_openROnly__JLjava_lang_String_2_3_3B_3J(
  * Signature: (JLjava/lang/String;[[B[J)[J
  */
 jlongArray Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2_3_3B_3J(
-    JNIEnv* env, jclass jcls, jlong jopt_handle, jstring jdb_path,
+    JNIEnv* env, jclass /*jcls*/, jlong jopt_handle, jstring jdb_path,
     jobjectArray jcolumn_names, jlongArray jcolumn_options) {
-  return rocksdb_open_helper(env, jopt_handle, jdb_path, jcolumn_names,
-    jcolumn_options, (rocksdb::Status(*)
-      (const rocksdb::DBOptions&, const std::string&,
-        const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-        std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)
-      )&rocksdb::DB::Open
-    );
+  return rocksdb_open_helper(
+      env, jopt_handle, jdb_path, jcolumn_names, jcolumn_options,
+      (rocksdb::Status(*)(const rocksdb::DBOptions&, const std::string&,
+                          const std::vector<rocksdb::ColumnFamilyDescriptor>&,
+                          std::vector<rocksdb::ColumnFamilyHandle*>*,
+                          rocksdb::DB**)) &
+          rocksdb::DB::Open);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -209,18 +211,20 @@ jlongArray Java_org_rocksdb_RocksDB_open__JLjava_lang_String_2_3_3B_3J(
  * Method:    listColumnFamilies
  * Signature: (JLjava/lang/String;)[[B
  */
-jobjectArray Java_org_rocksdb_RocksDB_listColumnFamilies(
-    JNIEnv* env, jclass jclazz, jlong jopt_handle, jstring jdb_path) {
+jobjectArray Java_org_rocksdb_RocksDB_listColumnFamilies(JNIEnv* env,
+                                                         jclass /*jclazz*/,
+                                                         jlong jopt_handle,
+                                                         jstring jdb_path) {
   std::vector<std::string> column_family_names;
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
 
   auto* opt = reinterpret_cast<rocksdb::Options*>(jopt_handle);
-  rocksdb::Status s = rocksdb::DB::ListColumnFamilies(*opt, db_path,
-      &column_family_names);
+  rocksdb::Status s =
+      rocksdb::DB::ListColumnFamilies(*opt, db_path, &column_family_names);
 
   env->ReleaseStringUTFChars(jdb_path, db_path);
 
@@ -236,25 +240,25 @@ jobjectArray Java_org_rocksdb_RocksDB_listColumnFamilies(
 /**
  * @return true if the put succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* db,
-                        const rocksdb::WriteOptions& write_options,
-                        rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jkey,
-                        jint jkey_off, jint jkey_len, jbyteArray jval,
-                        jint jval_off, jint jval_len) {
+bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                        const rocksdb::WriteOptions& /*write_options*/,
+                        rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+                        jbyteArray jkey, jint jkey_off, jint jkey_len,
+                        jbyteArray jval, jint jval_off, jint jval_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] key;
+    delete[] key;
     return false;
   }
 
   jbyte* value = new jbyte[jval_len];
   env->GetByteArrayRegion(jval, jval_off, jval_len, value);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] value;
-    delete [] key;
+    delete[] value;
+    delete[] key;
     return false;
   }
 
@@ -270,8 +274,8 @@ bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* db,
   }
 
   // cleanup
-  delete [] value;
-  delete [] key;
+  delete[] value;
+  delete[] key;
 
   if (s.ok()) {
     return true;
@@ -286,7 +290,7 @@ bool rocksdb_put_helper(JNIEnv* env, rocksdb::DB* db,
  * Method:    put
  * Signature: (J[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject jdb,
+void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject /*jdb*/,
                                                jlong jdb_handle,
                                                jbyteArray jkey, jint jkey_off,
                                                jint jkey_len, jbyteArray jval,
@@ -304,7 +308,7 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BII(JNIEnv* env, jobject jdb,
  * Method:    put
  * Signature: (J[BII[BIIJ)V
  */
-void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
+void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject /*jdb*/,
                                                 jlong jdb_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len, jbyteArray jval,
@@ -318,8 +322,8 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
     rocksdb_put_helper(env, db, default_write_options, cf_handle, jkey,
                        jkey_off, jkey_len, jval, jval_off, jval_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -328,15 +332,15 @@ void Java_org_rocksdb_RocksDB_put__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
  * Method:    put
  * Signature: (JJ[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject jdb,
+void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject /*jdb*/,
                                                 jlong jdb_handle,
                                                 jlong jwrite_options_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len, jbyteArray jval,
                                                 jint jval_off, jint jval_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(
-      jwrite_options_handle);
+  auto* write_options =
+      reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
 
   rocksdb_put_helper(env, db, *write_options, nullptr, jkey, jkey_off, jkey_len,
                      jval, jval_off, jval_len);
@@ -348,19 +352,19 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BII(JNIEnv* env, jobject jdb,
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(
-      jwrite_options_handle);
+  auto* write_options =
+      reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     rocksdb_put_helper(env, db, *write_options, cf_handle, jkey, jkey_off,
                        jkey_len, jval, jval_off, jval_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -371,12 +375,13 @@ void Java_org_rocksdb_RocksDB_put__JJ_3BII_3BIIJ(
  * Method:    write0
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_RocksDB_write0(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options_handle, jlong jwb_handle) {
+void Java_org_rocksdb_RocksDB_write0(JNIEnv* env, jobject /*jdb*/,
+                                     jlong jdb_handle,
+                                     jlong jwrite_options_handle,
+                                     jlong jwb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(
-      jwrite_options_handle);
+  auto* write_options =
+      reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
 
   rocksdb::Status s = db->Write(*write_options, wb);
@@ -391,12 +396,13 @@ void Java_org_rocksdb_RocksDB_write0(
  * Method:    write1
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_RocksDB_write1(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options_handle, jlong jwbwi_handle) {
+void Java_org_rocksdb_RocksDB_write1(JNIEnv* env, jobject /*jdb*/,
+                                     jlong jdb_handle,
+                                     jlong jwrite_options_handle,
+                                     jlong jwbwi_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto* write_options = reinterpret_cast<rocksdb::WriteOptions*>(
-      jwrite_options_handle);
+  auto* write_options =
+      reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* wb = wbwi->GetWriteBatch();
 
@@ -409,16 +415,16 @@ void Java_org_rocksdb_RocksDB_write1(
 
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::KeyMayExist
-jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* db,
-    const rocksdb::ReadOptions& read_opt,
-    rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jkey, jint jkey_off,
-    jint jkey_len, jobject jstring_builder, bool* has_exception) {
-
+jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                              const rocksdb::ReadOptions& /*read_opt*/,
+                              rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+                              jbyteArray jkey, jint jkey_off, jint jkey_len,
+                              jobject jstring_builder, bool* has_exception) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] key;
+    delete[] key;
     *has_exception = true;
     return false;
   }
@@ -429,22 +435,20 @@ jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* db,
   bool value_found = false;
   bool keyMayExist;
   if (cf_handle != nullptr) {
-    keyMayExist = db->KeyMayExist(read_opt, cf_handle, key_slice,
-        &value, &value_found);
+    keyMayExist =
+        db->KeyMayExist(read_opt, cf_handle, key_slice, &value, &value_found);
   } else {
-    keyMayExist = db->KeyMayExist(read_opt, key_slice,
-        &value, &value_found);
+    keyMayExist = db->KeyMayExist(read_opt, key_slice, &value, &value_found);
   }
 
   // cleanup
-  delete [] key;
+  delete[] key;
 
   // extract the value
   if (value_found && !value.empty()) {
     jobject jresult_string_builder =
-        rocksdb::StringBuilderJni::append(env, jstring_builder,
-            value.c_str());
-    if(jresult_string_builder == nullptr) {
+        rocksdb::StringBuilderJni::append(env, jstring_builder, value.c_str());
+    if (jresult_string_builder == nullptr) {
       *has_exception = true;
       return false;
     }
@@ -460,12 +464,13 @@ jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* db,
  * Signature: (J[BIILjava/lang/StringBuilder;)Z
  */
 jboolean Java_org_rocksdb_RocksDB_keyMayExist__J_3BIILjava_lang_StringBuilder_2(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jkey, jint jkey_off,
-    jint jkey_len, jobject jstring_builder) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jkey,
+    jint jkey_off, jint jkey_len, jobject jstring_builder) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   bool has_exception = false;
-  return key_may_exist_helper(env, db, rocksdb::ReadOptions(),
-      nullptr, jkey, jkey_off, jkey_len, jstring_builder, &has_exception);
+  return key_may_exist_helper(env, db, rocksdb::ReadOptions(), nullptr, jkey,
+                              jkey_off, jkey_len, jstring_builder,
+                              &has_exception);
 }
 
 /*
@@ -473,19 +478,20 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExist__J_3BIILjava_lang_StringBuilder_2(
  * Method:    keyMayExist
  * Signature: (J[BIIJLjava/lang/StringBuilder;)Z
  */
-jboolean Java_org_rocksdb_RocksDB_keyMayExist__J_3BIIJLjava_lang_StringBuilder_2(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jkey, jint jkey_off,
-    jint jkey_len, jlong jcf_handle, jobject jstring_builder) {
+jboolean
+Java_org_rocksdb_RocksDB_keyMayExist__J_3BIIJLjava_lang_StringBuilder_2(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jkey,
+    jint jkey_off, jint jkey_len, jlong jcf_handle, jobject jstring_builder) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(
-      jcf_handle);
+  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     bool has_exception = false;
-    return key_may_exist_helper(env, db, rocksdb::ReadOptions(),
-        cf_handle, jkey, jkey_off, jkey_len, jstring_builder, &has_exception);
+    return key_may_exist_helper(env, db, rocksdb::ReadOptions(), cf_handle,
+                                jkey, jkey_off, jkey_len, jstring_builder,
+                                &has_exception);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     return true;
   }
 }
@@ -495,15 +501,16 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExist__J_3BIIJLjava_lang_StringBuilder_2
  * Method:    keyMayExist
  * Signature: (JJ[BIILjava/lang/StringBuilder;)Z
  */
-jboolean Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIILjava_lang_StringBuilder_2(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jread_options_handle,
+jboolean
+Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIILjava_lang_StringBuilder_2(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jobject jstring_builder) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto& read_options = *reinterpret_cast<rocksdb::ReadOptions*>(
-      jread_options_handle);
+  auto& read_options =
+      *reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
   bool has_exception = false;
-  return key_may_exist_helper(env, db, read_options,
-      nullptr, jkey, jkey_off, jkey_len, jstring_builder, &has_exception);
+  return key_may_exist_helper(env, db, read_options, nullptr, jkey, jkey_off,
+                              jkey_len, jstring_builder, &has_exception);
 }
 
 /*
@@ -511,22 +518,23 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIILjava_lang_StringBuilder_2
  * Method:    keyMayExist
  * Signature: (JJ[BIIJLjava/lang/StringBuilder;)Z
  */
-jboolean Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIIJLjava_lang_StringBuilder_2(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jread_options_handle,
+jboolean
+Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIIJLjava_lang_StringBuilder_2(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle,
     jobject jstring_builder) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  auto& read_options = *reinterpret_cast<rocksdb::ReadOptions*>(
-      jread_options_handle);
-  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(
-      jcf_handle);
+  auto& read_options =
+      *reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
+  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     bool has_exception = false;
-    return key_may_exist_helper(env, db, read_options, cf_handle,
-        jkey, jkey_off, jkey_len, jstring_builder, &has_exception);
+    return key_may_exist_helper(env, db, read_options, cf_handle, jkey,
+                                jkey_off, jkey_len, jstring_builder,
+                                &has_exception);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     return true;
   }
 }
@@ -535,20 +543,18 @@ jboolean Java_org_rocksdb_RocksDB_keyMayExist__JJ_3BIIJLjava_lang_StringBuilder_
 // rocksdb::DB::Get
 
 jbyteArray rocksdb_get_helper(
-    JNIEnv* env, rocksdb::DB* db, const rocksdb::ReadOptions& read_opt,
-    rocksdb::ColumnFamilyHandle* column_family_handle, jbyteArray jkey,
+    JNIEnv* env, rocksdb::DB* /*db*/, const rocksdb::ReadOptions& /*read_opt*/,
+    rocksdb::ColumnFamilyHandle* /*column_family_handle*/, jbyteArray jkey,
     jint jkey_off, jint jkey_len) {
-
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] key;
+    delete[] key;
     return nullptr;
   }
 
-  rocksdb::Slice key_slice(
-      reinterpret_cast<char*>(key), jkey_len);
+  rocksdb::Slice key_slice(reinterpret_cast<char*>(key), jkey_len);
 
   std::string value;
   rocksdb::Status s;
@@ -560,7 +566,7 @@ jbyteArray rocksdb_get_helper(
   }
 
   // cleanup
-  delete [] key;
+  delete[] key;
 
   if (s.IsNotFound()) {
     return nullptr;
@@ -568,7 +574,7 @@ jbyteArray rocksdb_get_helper(
 
   if (s.ok()) {
     jbyteArray jret_value = rocksdb::JniUtil::copyBytes(env, value);
-    if(jret_value == nullptr) {
+    if (jret_value == nullptr) {
       // exception occurred
       return nullptr;
     }
@@ -584,13 +590,13 @@ jbyteArray rocksdb_get_helper(
  * Method:    get
  * Signature: (J[BII)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_len) {
-  return rocksdb_get_helper(env,
-      reinterpret_cast<rocksdb::DB*>(jdb_handle),
-      rocksdb::ReadOptions(), nullptr,
-      jkey, jkey_off, jkey_len);
+jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(JNIEnv* env, jobject /*jdb*/,
+                                                jlong jdb_handle,
+                                                jbyteArray jkey, jint jkey_off,
+                                                jint jkey_len) {
+  return rocksdb_get_helper(env, reinterpret_cast<rocksdb::DB*>(jdb_handle),
+                            rocksdb::ReadOptions(), nullptr, jkey, jkey_off,
+                            jkey_len);
 }
 
 /*
@@ -598,17 +604,19 @@ jbyteArray Java_org_rocksdb_RocksDB_get__J_3BII(
  * Method:    get
  * Signature: (J[BIIJ)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle) {
+jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(JNIEnv* env, jobject /*jdb*/,
+                                                 jlong jdb_handle,
+                                                 jbyteArray jkey, jint jkey_off,
+                                                 jint jkey_len,
+                                                 jlong jcf_handle) {
   auto db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
-    return rocksdb_get_helper(env, db_handle, rocksdb::ReadOptions(),
-        cf_handle, jkey, jkey_off, jkey_len);
+    return rocksdb_get_helper(env, db_handle, rocksdb::ReadOptions(), cf_handle,
+                              jkey, jkey_off, jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     return nullptr;
   }
 }
@@ -618,13 +626,15 @@ jbyteArray Java_org_rocksdb_RocksDB_get__J_3BIIJ(
  * Method:    get
  * Signature: (JJ[BII)[B
  */
-jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_len) {
-  return rocksdb_get_helper(env,
-      reinterpret_cast<rocksdb::DB*>(jdb_handle),
-      *reinterpret_cast<rocksdb::ReadOptions*>(jropt_handle), nullptr,
-      jkey, jkey_off, jkey_len);
+jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(JNIEnv* env, jobject /*jdb*/,
+                                                 jlong jdb_handle,
+                                                 jlong jropt_handle,
+                                                 jbyteArray jkey, jint jkey_off,
+                                                 jint jkey_len) {
+  return rocksdb_get_helper(
+      env, reinterpret_cast<rocksdb::DB*>(jdb_handle),
+      *reinterpret_cast<rocksdb::ReadOptions*>(jropt_handle), nullptr, jkey,
+      jkey_off, jkey_len);
 }
 
 /*
@@ -633,24 +643,24 @@ jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BII(
  * Signature: (JJ[BIIJ)[B
  */
 jbyteArray Java_org_rocksdb_RocksDB_get__JJ_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jropt_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle) {
   auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto& ro_opt = *reinterpret_cast<rocksdb::ReadOptions*>(jropt_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
-    return rocksdb_get_helper(env, db_handle, ro_opt, cf_handle,
-        jkey, jkey_off, jkey_len);
+    return rocksdb_get_helper(env, db_handle, ro_opt, cf_handle, jkey, jkey_off,
+                              jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     return nullptr;
   }
 }
 
-jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
-                        const rocksdb::ReadOptions& read_options,
-                        rocksdb::ColumnFamilyHandle* column_family_handle,
+jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                        const rocksdb::ReadOptions& /*read_options*/,
+                        rocksdb::ColumnFamilyHandle* /*column_family_handle*/,
                         jbyteArray jkey, jint jkey_off, jint jkey_len,
                         jbyteArray jval, jint jval_off, jint jval_len,
                         bool* has_exception) {
@@ -659,9 +669,9 @@ jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
 
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: OutOfMemoryError
-    delete [] key;
+    delete[] key;
     *has_exception = true;
     return kStatusError;
   }
@@ -679,7 +689,7 @@ jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
   }
 
   // cleanup
-  delete [] key;
+  delete[] key;
 
   if (s.IsNotFound()) {
     *has_exception = false;
@@ -701,9 +711,10 @@ jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
   const jint cvalue_len = static_cast<jint>(cvalue.size());
   const jint length = std::min(jval_len, cvalue_len);
 
-  env->SetByteArrayRegion(jval, jval_off, length,
-                          const_cast<jbyte*>(reinterpret_cast<const jbyte*>(cvalue.c_str())));
-  if(env->ExceptionCheck()) {
+  env->SetByteArrayRegion(
+      jval, jval_off, length,
+      const_cast<jbyte*>(reinterpret_cast<const jbyte*>(cvalue.c_str())));
+  if (env->ExceptionCheck()) {
     // exception thrown: OutOfMemoryError
     *has_exception = true;
     return kStatusError;
@@ -713,11 +724,11 @@ jint rocksdb_get_helper(JNIEnv* env, rocksdb::DB* db,
   return cvalue_len;
 }
 
-inline void multi_get_helper_release_keys(JNIEnv* env,
-    std::vector<std::pair<jbyte*, jobject>> &keys_to_free) {
+inline void multi_get_helper_release_keys(
+    JNIEnv* env, std::vector<std::pair<jbyte*, jobject>>& /*keys_to_free*/) {
   auto end = keys_to_free.end();
   for (auto it = keys_to_free.begin(); it != end; ++it) {
-    delete [] it->first;
+    delete[] it->first;
     env->DeleteLocalRef(it->second);
   }
   keys_to_free.clear();
@@ -728,23 +739,23 @@ inline void multi_get_helper_release_keys(JNIEnv* env,
  *
  * @return byte[][] of values or nullptr if an exception occurs
  */
-jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
-    const rocksdb::ReadOptions& rOpt, jobjectArray jkeys,
-    jintArray jkey_offs, jintArray jkey_lens,
-    jlongArray jcolumn_family_handles) {
+jobjectArray multi_get_helper(JNIEnv* env, jobject /*jdb*/, rocksdb::DB* /*db*/,
+                              const rocksdb::ReadOptions& /*rOpt*/,
+                              jobjectArray jkeys, jintArray jkey_offs,
+                              jintArray jkey_lens,
+                              jlongArray jcolumn_family_handles) {
   std::vector<rocksdb::ColumnFamilyHandle*> cf_handles;
   if (jcolumn_family_handles != nullptr) {
     const jsize len_cols = env->GetArrayLength(jcolumn_family_handles);
 
     jlong* jcfh = env->GetLongArrayElements(jcolumn_family_handles, nullptr);
-    if(jcfh == nullptr) {
+    if (jcfh == nullptr) {
       // exception thrown: OutOfMemoryError
       return nullptr;
     }
 
     for (jsize i = 0; i < len_cols; i++) {
-      auto* cf_handle =
-          reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
+      auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
       cf_handles.push_back(cf_handle);
     }
     env->ReleaseLongArrayElements(jcolumn_family_handles, jcfh, JNI_ABORT);
@@ -757,13 +768,13 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
   }
 
   jint* jkey_off = env->GetIntArrayElements(jkey_offs, nullptr);
-  if(jkey_off == nullptr) {
+  if (jkey_off == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
 
   jint* jkey_len = env->GetIntArrayElements(jkey_lens, nullptr);
-  if(jkey_len == nullptr) {
+  if (jkey_len == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
     return nullptr;
@@ -773,7 +784,7 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
   std::vector<std::pair<jbyte*, jobject>> keys_to_free;
   for (jsize i = 0; i < len_keys; i++) {
     jobject jkey = env->GetObjectArrayElement(jkeys, i);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->ReleaseIntArrayElements(jkey_lens, jkey_len, JNI_ABORT);
       env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
@@ -786,9 +797,9 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
     const jint len_key = jkey_len[i];
     jbyte* key = new jbyte[len_key];
     env->GetByteArrayRegion(jkey_ba, jkey_off[i], len_key, key);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
-      delete [] key;
+      delete[] key;
       env->DeleteLocalRef(jkey);
       env->ReleaseIntArrayElements(jkey_lens, jkey_len, JNI_ABORT);
       env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
@@ -820,7 +831,7 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
   // prepare the results
   jobjectArray jresults =
       rocksdb::ByteJni::new2dByteArray(env, static_cast<jsize>(s.size()));
-  if(jresults == nullptr) {
+  if (jresults == nullptr) {
     // exception occurred
     return nullptr;
   }
@@ -837,21 +848,22 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject jdb, rocksdb::DB* db,
       std::string* value = &values[i];
       const jsize jvalue_len = static_cast<jsize>(value->size());
       jbyteArray jentry_value = env->NewByteArray(jvalue_len);
-      if(jentry_value == nullptr) {
+      if (jentry_value == nullptr) {
         // exception thrown: OutOfMemoryError
         return nullptr;
       }
 
-      env->SetByteArrayRegion(jentry_value, 0, static_cast<jsize>(jvalue_len),
+      env->SetByteArrayRegion(
+          jentry_value, 0, static_cast<jsize>(jvalue_len),
           const_cast<jbyte*>(reinterpret_cast<const jbyte*>(value->c_str())));
-      if(env->ExceptionCheck()) {
+      if (env->ExceptionCheck()) {
         // exception thrown: ArrayIndexOutOfBoundsException
         env->DeleteLocalRef(jentry_value);
         return nullptr;
       }
 
       env->SetObjectArrayElement(jresults, static_cast<jsize>(i), jentry_value);
-      if(env->ExceptionCheck()) {
+      if (env->ExceptionCheck()) {
         // exception thrown: ArrayIndexOutOfBoundsException
         env->DeleteLocalRef(jentry_value);
         return nullptr;
@@ -873,7 +885,8 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I(
     JNIEnv* env, jobject jdb, jlong jdb_handle, jobjectArray jkeys,
     jintArray jkey_offs, jintArray jkey_lens) {
   return multi_get_helper(env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
-      rocksdb::ReadOptions(), jkeys, jkey_offs, jkey_lens, nullptr);
+                          rocksdb::ReadOptions(), jkeys, jkey_offs, jkey_lens,
+                          nullptr);
 }
 
 /*
@@ -886,8 +899,8 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I_3J(
     jintArray jkey_offs, jintArray jkey_lens,
     jlongArray jcolumn_family_handles) {
   return multi_get_helper(env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
-      rocksdb::ReadOptions(), jkeys, jkey_offs, jkey_lens,
-      jcolumn_family_handles);
+                          rocksdb::ReadOptions(), jkeys, jkey_offs, jkey_lens,
+                          jcolumn_family_handles);
 }
 
 /*
@@ -898,7 +911,8 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__J_3_3B_3I_3I_3J(
 jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I(
     JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
     jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens) {
-  return multi_get_helper(env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
+  return multi_get_helper(
+      env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
       *reinterpret_cast<rocksdb::ReadOptions*>(jropt_handle), jkeys, jkey_offs,
       jkey_lens, nullptr);
 }
@@ -912,7 +926,8 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
     JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
     jobjectArray jkeys, jintArray jkey_offs, jintArray jkey_lens,
     jlongArray jcolumn_family_handles) {
-  return multi_get_helper(env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
+  return multi_get_helper(
+      env, jdb, reinterpret_cast<rocksdb::DB*>(jdb_handle),
       *reinterpret_cast<rocksdb::ReadOptions*>(jropt_handle), jkeys, jkey_offs,
       jkey_lens, jcolumn_family_handles);
 }
@@ -922,7 +937,7 @@ jobjectArray Java_org_rocksdb_RocksDB_multiGet__JJ_3_3B_3I_3I_3J(
  * Method:    get
  * Signature: (J[BII[BII)I
  */
-jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject jdb,
+jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject /*jdb*/,
                                                jlong jdb_handle,
                                                jbyteArray jkey, jint jkey_off,
                                                jint jkey_len, jbyteArray jval,
@@ -930,8 +945,7 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject jdb,
   bool has_exception = false;
   return rocksdb_get_helper(env, reinterpret_cast<rocksdb::DB*>(jdb_handle),
                             rocksdb::ReadOptions(), nullptr, jkey, jkey_off,
-                            jkey_len, jval, jval_off, jval_len,
-                            &has_exception);
+                            jkey_len, jval, jval_off, jval_len, &has_exception);
 }
 
 /*
@@ -939,7 +953,7 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BII(JNIEnv* env, jobject jdb,
  * Method:    get
  * Signature: (J[BII[BIIJ)I
  */
-jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
+jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject /*jdb*/,
                                                 jlong jdb_handle,
                                                 jbyteArray jkey, jint jkey_off,
                                                 jint jkey_len, jbyteArray jval,
@@ -953,8 +967,8 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
                               jkey, jkey_off, jkey_len, jval, jval_off,
                               jval_len, &has_exception);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     // will never be evaluated
     return 0;
   }
@@ -965,7 +979,7 @@ jint Java_org_rocksdb_RocksDB_get__J_3BII_3BIIJ(JNIEnv* env, jobject jdb,
  * Method:    get
  * Signature: (JJ[BII[BII)I
  */
-jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jobject jdb,
+jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jobject /*jdb*/,
                                                 jlong jdb_handle,
                                                 jlong jropt_handle,
                                                 jbyteArray jkey, jint jkey_off,
@@ -984,7 +998,7 @@ jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BII(JNIEnv* env, jobject jdb,
  * Signature: (JJ[BII[BIIJ)I
  */
 jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jropt_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jropt_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcf_handle) {
   auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -996,8 +1010,8 @@ jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BIIJ(
                               jkey_len, jval, jval_off, jval_len,
                               &has_exception);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
     // will never be evaluated
     return 0;
   }
@@ -1009,15 +1023,15 @@ jint Java_org_rocksdb_RocksDB_get__JJ_3BII_3BIIJ(
 /**
  * @return true if the delete succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_delete_helper(
-    JNIEnv* env, rocksdb::DB* db, const rocksdb::WriteOptions& write_options,
-    rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jkey, jint jkey_off,
-    jint jkey_len) {
+bool rocksdb_delete_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                           const rocksdb::WriteOptions& /*write_options*/,
+                           rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+                           jbyteArray jkey, jint jkey_off, jint jkey_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] key;
+    delete[] key;
     return false;
   }
   rocksdb::Slice key_slice(reinterpret_cast<char*>(key), jkey_len);
@@ -1031,7 +1045,7 @@ bool rocksdb_delete_helper(
   }
 
   // cleanup
-  delete [] key;
+  delete[] key;
 
   if (s.ok()) {
     return true;
@@ -1046,14 +1060,14 @@ bool rocksdb_delete_helper(
  * Method:    delete
  * Signature: (J[BII)V
  */
-void Java_org_rocksdb_RocksDB_delete__J_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_len) {
+void Java_org_rocksdb_RocksDB_delete__J_3BII(JNIEnv* env, jobject /*jdb*/,
+                                             jlong jdb_handle, jbyteArray jkey,
+                                             jint jkey_off, jint jkey_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   static const rocksdb::WriteOptions default_write_options =
       rocksdb::WriteOptions();
-  rocksdb_delete_helper(env, db, default_write_options, nullptr,
-      jkey, jkey_off, jkey_len);
+  rocksdb_delete_helper(env, db, default_write_options, nullptr, jkey, jkey_off,
+                        jkey_len);
 }
 
 /*
@@ -1061,19 +1075,20 @@ void Java_org_rocksdb_RocksDB_delete__J_3BII(
  * Method:    delete
  * Signature: (J[BIIJ)V
  */
-void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle) {
+void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(JNIEnv* env, jobject /*jdb*/,
+                                              jlong jdb_handle, jbyteArray jkey,
+                                              jint jkey_off, jint jkey_len,
+                                              jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   static const rocksdb::WriteOptions default_write_options =
       rocksdb::WriteOptions();
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
-    rocksdb_delete_helper(env, db, default_write_options, cf_handle,
-        jkey, jkey_off, jkey_len);
+    rocksdb_delete_helper(env, db, default_write_options, cf_handle, jkey,
+                          jkey_off, jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1082,14 +1097,16 @@ void Java_org_rocksdb_RocksDB_delete__J_3BIIJ(
  * Method:    delete
  * Signature: (JJ[BII)V
  */
-void Java_org_rocksdb_RocksDB_delete__JJ_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options, jbyteArray jkey, jint jkey_off, jint jkey_len) {
+void Java_org_rocksdb_RocksDB_delete__JJ_3BII(JNIEnv* env, jobject /*jdb*/,
+                                              jlong jdb_handle,
+                                              jlong jwrite_options,
+                                              jbyteArray jkey, jint jkey_off,
+                                              jint jkey_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options);
   rocksdb_delete_helper(env, db, *write_options, nullptr, jkey, jkey_off,
-      jkey_len);
+                        jkey_len);
 }
 
 /*
@@ -1098,19 +1115,18 @@ void Java_org_rocksdb_RocksDB_delete__JJ_3BII(
  * Signature: (JJ[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_delete__JJ_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options, jbyteArray jkey, jint jkey_off, jint jkey_len,
-    jlong jcf_handle) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options,
+    jbyteArray jkey, jint jkey_off, jint jkey_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     rocksdb_delete_helper(env, db, *write_options, cf_handle, jkey, jkey_off,
-        jkey_len);
+                          jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1121,10 +1137,12 @@ void Java_org_rocksdb_RocksDB_delete__JJ_3BIIJ(
  *     was thrown
  */
 bool rocksdb_single_delete_helper(
-    JNIEnv* env, rocksdb::DB* db, const rocksdb::WriteOptions& write_options,
-    rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jkey, jint jkey_len) {
+    JNIEnv* env, rocksdb::DB* /*db*/,
+    const rocksdb::WriteOptions& /*write_options*/,
+    rocksdb::ColumnFamilyHandle* /*cf_handle*/, jbyteArray jkey,
+    jint /*jkey_len*/) {
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
-  if(key == nullptr) {
+  if (key == nullptr) {
     // exception thrown: OutOfMemoryError
     return false;
   }
@@ -1156,14 +1174,15 @@ bool rocksdb_single_delete_helper(
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_len) {
+void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(JNIEnv* env, jobject /*jdb*/,
+                                                  jlong jdb_handle,
+                                                  jbyteArray jkey,
+                                                  jint jkey_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   static const rocksdb::WriteOptions default_write_options =
       rocksdb::WriteOptions();
-  rocksdb_single_delete_helper(env, db, default_write_options, nullptr,
-      jkey, jkey_len);
+  rocksdb_single_delete_helper(env, db, default_write_options, nullptr, jkey,
+                               jkey_len);
 }
 
 /*
@@ -1171,19 +1190,21 @@ void Java_org_rocksdb_RocksDB_singleDelete__J_3BI(
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
+void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(JNIEnv* env, jobject /*jdb*/,
+                                                   jlong jdb_handle,
+                                                   jbyteArray jkey,
+                                                   jint jkey_len,
+                                                   jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   static const rocksdb::WriteOptions default_write_options =
       rocksdb::WriteOptions();
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     rocksdb_single_delete_helper(env, db, default_write_options, cf_handle,
-        jkey, jkey_len);
+                                 jkey, jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1192,14 +1213,16 @@ void Java_org_rocksdb_RocksDB_singleDelete__J_3BIJ(
  * Method:    singleDelete
  * Signature: (JJ[BIJ)V
  */
-void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options, jbyteArray jkey, jint jkey_len) {
+void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(JNIEnv* env, jobject /*jdb*/,
+                                                   jlong jdb_handle,
+                                                   jlong jwrite_options,
+                                                   jbyteArray jkey,
+                                                   jint jkey_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options);
   rocksdb_single_delete_helper(env, db, *write_options, nullptr, jkey,
-      jkey_len);
+                               jkey_len);
 }
 
 /*
@@ -1208,19 +1231,18 @@ void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BI(
  * Signature: (JJ[BIJ)V
  */
 void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jwrite_options, jbyteArray jkey, jint jkey_len,
-    jlong jcf_handle) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options,
+    jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   if (cf_handle != nullptr) {
     rocksdb_single_delete_helper(env, db, *write_options, cf_handle, jkey,
-        jkey_len);
+                                 jkey_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1230,9 +1252,9 @@ void Java_org_rocksdb_RocksDB_singleDelete__JJ_3BIJ(
  * @return true if the delete range succeeded, false if a Java Exception
  *     was thrown
  */
-bool rocksdb_delete_range_helper(JNIEnv* env, rocksdb::DB* db,
-                                 const rocksdb::WriteOptions& write_options,
-                                 rocksdb::ColumnFamilyHandle* cf_handle,
+bool rocksdb_delete_range_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                                 const rocksdb::WriteOptions& /*write_options*/,
+                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
                                  jbyteArray jbegin_key, jint jbegin_key_off,
                                  jint jbegin_key_len, jbyteArray jend_key,
                                  jint jend_key_off, jint jend_key_len) {
@@ -1278,7 +1300,7 @@ bool rocksdb_delete_range_helper(JNIEnv* env, rocksdb::DB* db,
  * Signature: (J[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jbegin_key,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin_key,
     jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
     jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -1295,7 +1317,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BII(
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jbegin_key,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin_key,
     jint jbegin_key_off, jint jbegin_key_len, jbyteArray jend_key,
     jint jend_key_off, jint jend_key_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -1318,7 +1340,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__J_3BII_3BIIJ(
  * Signature: (JJ[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jbegin_key, jint jbegin_key_off, jint jbegin_key_len,
     jbyteArray jend_key, jint jend_key_off, jint jend_key_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -1335,7 +1357,7 @@ void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BII(
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jwrite_options,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options,
     jbyteArray jbegin_key, jint jbegin_key_off, jint jbegin_key_len,
     jbyteArray jend_key, jint jend_key_off, jint jend_key_len,
     jlong jcf_handle) {
@@ -1359,26 +1381,26 @@ void Java_org_rocksdb_RocksDB_deleteRange__JJ_3BII_3BIIJ(
 /**
  * @return true if the merge succeeded, false if a Java Exception was thrown
  */
-bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* db,
-                          const rocksdb::WriteOptions& write_options,
-                          rocksdb::ColumnFamilyHandle* cf_handle,
+bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                          const rocksdb::WriteOptions& /*write_options*/,
+                          rocksdb::ColumnFamilyHandle* /*cf_handle*/,
                           jbyteArray jkey, jint jkey_off, jint jkey_len,
                           jbyteArray jval, jint jval_off, jint jval_len) {
   jbyte* key = new jbyte[jkey_len];
   env->GetByteArrayRegion(jkey, jkey_off, jkey_len, key);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] key;
+    delete[] key;
     return false;
   }
   rocksdb::Slice key_slice(reinterpret_cast<char*>(key), jkey_len);
 
   jbyte* value = new jbyte[jval_len];
   env->GetByteArrayRegion(jval, jval_off, jval_len, value);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
-    delete [] value;
-    delete [] key;
+    delete[] value;
+    delete[] key;
     return false;
   }
   rocksdb::Slice value_slice(reinterpret_cast<char*>(value), jval_len);
@@ -1391,8 +1413,8 @@ bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* db,
   }
 
   // cleanup
-  delete [] value;
-  delete [] key;
+  delete[] value;
+  delete[] key;
 
   if (s.ok()) {
     return true;
@@ -1407,7 +1429,7 @@ bool rocksdb_merge_helper(JNIEnv* env, rocksdb::DB* db,
  * Method:    merge
  * Signature: (J[BII[BII)V
  */
-void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jobject jdb,
+void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jobject /*jdb*/,
                                                  jlong jdb_handle,
                                                  jbyteArray jkey, jint jkey_off,
                                                  jint jkey_len, jbyteArray jval,
@@ -1426,8 +1448,8 @@ void Java_org_rocksdb_RocksDB_merge__J_3BII_3BII(JNIEnv* env, jobject jdb,
  * Signature: (J[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_merge__J_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jkey, jint jkey_off,
-    jint jkey_len, jbyteArray jval, jint jval_off, jint jval_len,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jkey,
+    jint jkey_off, jint jkey_len, jbyteArray jval, jint jval_off, jint jval_len,
     jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   static const rocksdb::WriteOptions default_write_options =
@@ -1437,8 +1459,8 @@ void Java_org_rocksdb_RocksDB_merge__J_3BII_3BIIJ(
     rocksdb_merge_helper(env, db, default_write_options, cf_handle, jkey,
                          jkey_off, jkey_len, jval, jval_off, jval_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1448,7 +1470,7 @@ void Java_org_rocksdb_RocksDB_merge__J_3BII_3BIIJ(
  * Signature: (JJ[BII[BII)V
  */
 void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BII(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -1465,7 +1487,7 @@ void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BII(
  * Signature: (JJ[BII[BIIJ)V
  */
 void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jwrite_options_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jwrite_options_handle,
     jbyteArray jkey, jint jkey_off, jint jkey_len, jbyteArray jval,
     jint jval_off, jint jval_len, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -1476,8 +1498,8 @@ void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BIIJ(
     rocksdb_merge_helper(env, db, *write_options, cf_handle, jkey, jkey_off,
                          jkey_len, jval, jval_off, jval_len);
   } else {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid ColumnFamilyHandle."));
   }
 }
 
@@ -1489,16 +1511,17 @@ void Java_org_rocksdb_RocksDB_merge__JJ_3BII_3BIIJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_disposeInternal(
-    JNIEnv* env, jobject java_db, jlong jhandle) {
+void Java_org_rocksdb_RocksDB_disposeInternal(JNIEnv* /*env*/,
+                                              jobject /*java_db*/,
+                                              jlong jhandle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jhandle);
   assert(db != nullptr);
   delete db;
 }
 
-jlong rocksdb_iterator_helper(
-    rocksdb::DB* db, rocksdb::ReadOptions read_options,
-    rocksdb::ColumnFamilyHandle* cf_handle) {
+jlong rocksdb_iterator_helper(rocksdb::DB* /*db*/,
+                              rocksdb::ReadOptions /*read_options*/,
+                              rocksdb::ColumnFamilyHandle* /*cf_handle*/) {
   rocksdb::Iterator* iterator = nullptr;
   if (cf_handle != nullptr) {
     iterator = db->NewIterator(read_options, cf_handle);
@@ -1513,11 +1536,10 @@ jlong rocksdb_iterator_helper(
  * Method:    iterator
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_iterator__J(
-    JNIEnv* env, jobject jdb, jlong db_handle) {
+jlong Java_org_rocksdb_RocksDB_iterator__J(JNIEnv* /*env*/, jobject /*jdb*/,
+                                           jlong db_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
-  return rocksdb_iterator_helper(db, rocksdb::ReadOptions(),
-      nullptr);
+  return rocksdb_iterator_helper(db, rocksdb::ReadOptions(), nullptr);
 }
 
 /*
@@ -1525,14 +1547,13 @@ jlong Java_org_rocksdb_RocksDB_iterator__J(
  * Method:    iterator
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_RocksDB_iterator__JJ(
-    JNIEnv* env, jobject jdb, jlong db_handle,
-    jlong jread_options_handle) {
+jlong Java_org_rocksdb_RocksDB_iterator__JJ(JNIEnv* /*env*/, jobject /*jdb*/,
+                                            jlong db_handle,
+                                            jlong jread_options_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
-  auto& read_options = *reinterpret_cast<rocksdb::ReadOptions*>(
-      jread_options_handle);
-  return rocksdb_iterator_helper(db, read_options,
-      nullptr);
+  auto& read_options =
+      *reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
+  return rocksdb_iterator_helper(db, read_options, nullptr);
 }
 
 /*
@@ -1540,12 +1561,12 @@ jlong Java_org_rocksdb_RocksDB_iterator__JJ(
  * Method:    iteratorCF
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_RocksDB_iteratorCF__JJ(
-    JNIEnv* env, jobject jdb, jlong db_handle, jlong jcf_handle) {
+jlong Java_org_rocksdb_RocksDB_iteratorCF__JJ(JNIEnv* /*env*/, jobject /*jdb*/,
+                                              jlong db_handle,
+                                              jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
-  return rocksdb_iterator_helper(db, rocksdb::ReadOptions(),
-        cf_handle);
+  return rocksdb_iterator_helper(db, rocksdb::ReadOptions(), cf_handle);
 }
 
 /*
@@ -1553,15 +1574,15 @@ jlong Java_org_rocksdb_RocksDB_iteratorCF__JJ(
  * Method:    iteratorCF
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_RocksDB_iteratorCF__JJJ(
-    JNIEnv* env, jobject jdb, jlong db_handle, jlong jcf_handle,
-    jlong jread_options_handle) {
+jlong Java_org_rocksdb_RocksDB_iteratorCF__JJJ(JNIEnv* /*env*/, jobject /*jdb*/,
+                                               jlong db_handle,
+                                               jlong jcf_handle,
+                                               jlong jread_options_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
-  auto& read_options = *reinterpret_cast<rocksdb::ReadOptions*>(
-      jread_options_handle);
-  return rocksdb_iterator_helper(db, read_options,
-        cf_handle);
+  auto& read_options =
+      *reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
+  return rocksdb_iterator_helper(db, read_options, cf_handle);
 }
 
 /*
@@ -1569,25 +1590,25 @@ jlong Java_org_rocksdb_RocksDB_iteratorCF__JJJ(
  * Method:    iterators
  * Signature: (J[JJ)[J
  */
-jlongArray Java_org_rocksdb_RocksDB_iterators(
-    JNIEnv* env, jobject jdb, jlong db_handle,
-    jlongArray jcolumn_family_handles, jlong jread_options_handle) {
+jlongArray Java_org_rocksdb_RocksDB_iterators(JNIEnv* env, jobject /*jdb*/,
+                                              jlong db_handle,
+                                              jlongArray jcolumn_family_handles,
+                                              jlong jread_options_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
-  auto& read_options = *reinterpret_cast<rocksdb::ReadOptions*>(
-        jread_options_handle);
+  auto& read_options =
+      *reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
 
   std::vector<rocksdb::ColumnFamilyHandle*> cf_handles;
   if (jcolumn_family_handles != nullptr) {
     const jsize len_cols = env->GetArrayLength(jcolumn_family_handles);
     jlong* jcfh = env->GetLongArrayElements(jcolumn_family_handles, nullptr);
-    if(jcfh == nullptr) {
+    if (jcfh == nullptr) {
       // exception thrown: OutOfMemoryError
       return nullptr;
     }
 
     for (jsize i = 0; i < len_cols; i++) {
-      auto* cf_handle =
-          reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
+      auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
       cf_handles.push_back(cf_handle);
     }
 
@@ -1595,21 +1616,21 @@ jlongArray Java_org_rocksdb_RocksDB_iterators(
   }
 
   std::vector<rocksdb::Iterator*> iterators;
-  rocksdb::Status s = db->NewIterators(read_options,
-      cf_handles, &iterators);
+  rocksdb::Status s = db->NewIterators(read_options, cf_handles, &iterators);
   if (s.ok()) {
     jlongArray jLongArray =
         env->NewLongArray(static_cast<jsize>(iterators.size()));
-    if(jLongArray == nullptr) {
+    if (jLongArray == nullptr) {
       // exception thrown: OutOfMemoryError
       return nullptr;
     }
 
-    for (std::vector<rocksdb::Iterator*>::size_type i = 0;
-        i < iterators.size(); i++) {
-      env->SetLongArrayRegion(jLongArray, static_cast<jsize>(i), 1,
-                              const_cast<jlong*>(reinterpret_cast<const jlong*>(&iterators[i])));
-      if(env->ExceptionCheck()) {
+    for (std::vector<rocksdb::Iterator*>::size_type i = 0; i < iterators.size();
+         i++) {
+      env->SetLongArrayRegion(
+          jLongArray, static_cast<jsize>(i), 1,
+          const_cast<jlong*>(reinterpret_cast<const jlong*>(&iterators[i])));
+      if (env->ExceptionCheck()) {
         // exception thrown: ArrayIndexOutOfBoundsException
         env->DeleteLocalRef(jLongArray);
         return nullptr;
@@ -1628,8 +1649,9 @@ jlongArray Java_org_rocksdb_RocksDB_iterators(
  * Method:    getDefaultColumnFamily
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(
-    JNIEnv* env, jobject jobj, jlong jdb_handle) {
+jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong jdb_handle) {
   auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* cf_handle = db_handle->DefaultColumnFamily();
   return reinterpret_cast<jlong>(cf_handle);
@@ -1640,16 +1662,17 @@ jlong Java_org_rocksdb_RocksDB_getDefaultColumnFamily(
  * Method:    createColumnFamily
  * Signature: (J[BJ)J
  */
-jlong Java_org_rocksdb_RocksDB_createColumnFamily(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jbyteArray jcolumn_name, jlong jcolumn_options) {
+jlong Java_org_rocksdb_RocksDB_createColumnFamily(JNIEnv* env, jobject /*jdb*/,
+                                                  jlong jdb_handle,
+                                                  jbyteArray jcolumn_name,
+                                                  jlong jcolumn_options) {
   rocksdb::ColumnFamilyHandle* handle;
   jboolean has_exception = JNI_FALSE;
-  std::string column_name = rocksdb::JniUtil::byteString<std::string>(env,
-    jcolumn_name,
-    [](const char* str, const size_t len) { return std::string(str, len); },
-    &has_exception);
-  if(has_exception == JNI_TRUE) {
+  std::string column_name = rocksdb::JniUtil::byteString<std::string>(
+      env, jcolumn_name,
+      [](const char* str, const size_t len) { return std::string(str, len); },
+      &has_exception);
+  if (has_exception == JNI_TRUE) {
     // exception occurred
     return 0;
   }
@@ -1658,8 +1681,8 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(
   auto* cfOptions =
       reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jcolumn_options);
 
-  rocksdb::Status s = db_handle->CreateColumnFamily(
-      *cfOptions, column_name, &handle);
+  rocksdb::Status s =
+      db_handle->CreateColumnFamily(*cfOptions, column_name, &handle);
 
   if (s.ok()) {
     return reinterpret_cast<jlong>(handle);
@@ -1674,8 +1697,9 @@ jlong Java_org_rocksdb_RocksDB_createColumnFamily(
  * Method:    dropColumnFamily
  * Signature: (JJ)V;
  */
-void Java_org_rocksdb_RocksDB_dropColumnFamily(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jcf_handle) {
+void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject /*jdb*/,
+                                               jlong jdb_handle,
+                                               jlong jcf_handle) {
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::Status s = db_handle->DropColumnFamily(cf_handle);
@@ -1688,8 +1712,8 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(
  * Method:    getSnapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_RocksDB_getSnapshot(
-    JNIEnv* env, jobject jdb, jlong db_handle) {
+jlong Java_org_rocksdb_RocksDB_getSnapshot(JNIEnv* /*env*/, jobject /*jdb*/,
+                                           jlong db_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   const rocksdb::Snapshot* snapshot = db->GetSnapshot();
   return reinterpret_cast<jlong>(snapshot);
@@ -1699,8 +1723,9 @@ jlong Java_org_rocksdb_RocksDB_getSnapshot(
  * Method:    releaseSnapshot
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RocksDB_releaseSnapshot(
-    JNIEnv* env, jobject jdb, jlong db_handle, jlong snapshot_handle) {
+void Java_org_rocksdb_RocksDB_releaseSnapshot(JNIEnv* /*env*/, jobject /*jdb*/,
+                                              jlong db_handle,
+                                              jlong snapshot_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   auto* snapshot = reinterpret_cast<rocksdb::Snapshot*>(snapshot_handle);
   db->ReleaseSnapshot(snapshot);
@@ -1712,16 +1737,16 @@ void Java_org_rocksdb_RocksDB_releaseSnapshot(
  * Signature: (JLjava/lang/String;I)Ljava/lang/String;
  */
 jstring Java_org_rocksdb_RocksDB_getProperty0__JLjava_lang_String_2I(
-    JNIEnv* env, jobject jdb, jlong db_handle, jstring jproperty,
-    jint jproperty_len) {
+    JNIEnv* env, jobject /*jdb*/, jlong db_handle, jstring jproperty,
+    jint /*jproperty_len*/) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
-  if(property == nullptr) {
+  if (property == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
   rocksdb::Slice property_slice(property, jproperty_len);
 
-  auto *db = reinterpret_cast<rocksdb::DB*>(db_handle);
+  auto* db = reinterpret_cast<rocksdb::DB*>(db_handle);
   std::string property_value;
   bool retCode = db->GetProperty(property_slice, &property_value);
   env->ReleaseStringUTFChars(jproperty, property);
@@ -1740,10 +1765,10 @@ jstring Java_org_rocksdb_RocksDB_getProperty0__JLjava_lang_String_2I(
  * Signature: (JJLjava/lang/String;I)Ljava/lang/String;
  */
 jstring Java_org_rocksdb_RocksDB_getProperty0__JJLjava_lang_String_2I(
-    JNIEnv* env, jobject jdb, jlong db_handle, jlong jcf_handle,
-    jstring jproperty, jint jproperty_len) {
+    JNIEnv* env, jobject /*jdb*/, jlong db_handle, jlong jcf_handle,
+    jstring jproperty, jint /*jproperty_len*/) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
-  if(property == nullptr) {
+  if (property == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
@@ -1769,10 +1794,10 @@ jstring Java_org_rocksdb_RocksDB_getProperty0__JJLjava_lang_String_2I(
  * Signature: (JLjava/lang/String;I)L;
  */
 jlong Java_org_rocksdb_RocksDB_getLongProperty__JLjava_lang_String_2I(
-    JNIEnv* env, jobject jdb, jlong db_handle, jstring jproperty,
-    jint jproperty_len) {
+    JNIEnv* env, jobject /*jdb*/, jlong db_handle, jstring jproperty,
+    jint /*jproperty_len*/) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
-  if(property == nullptr) {
+  if (property == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -1797,10 +1822,10 @@ jlong Java_org_rocksdb_RocksDB_getLongProperty__JLjava_lang_String_2I(
  * Signature: (JJLjava/lang/String;I)L;
  */
 jlong Java_org_rocksdb_RocksDB_getLongProperty__JJLjava_lang_String_2I(
-    JNIEnv* env, jobject jdb, jlong db_handle, jlong jcf_handle,
-    jstring jproperty, jint jproperty_len) {
+    JNIEnv* env, jobject /*jdb*/, jlong db_handle, jlong jcf_handle,
+    jstring jproperty, jint /*jproperty_len*/) {
   const char* property = env->GetStringUTFChars(jproperty, nullptr);
-  if(property == nullptr) {
+  if (property == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -1824,8 +1849,9 @@ jlong Java_org_rocksdb_RocksDB_getLongProperty__JJLjava_lang_String_2I(
 // rocksdb::DB::Flush
 
 void rocksdb_flush_helper(
-    JNIEnv* env, rocksdb::DB* db, const rocksdb::FlushOptions& flush_options,
-  rocksdb::ColumnFamilyHandle* column_family_handle) {
+    JNIEnv* env, rocksdb::DB* /*db*/,
+    const rocksdb::FlushOptions& /*flush_options*/,
+    rocksdb::ColumnFamilyHandle* /*column_family_handle*/) {
   rocksdb::Status s;
   if (column_family_handle != nullptr) {
     s = db->Flush(flush_options, column_family_handle);
@@ -1833,7 +1859,7 @@ void rocksdb_flush_helper(
     s = db->Flush(flush_options);
   }
   if (!s.ok()) {
-      rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -1842,9 +1868,9 @@ void rocksdb_flush_helper(
  * Method:    flush
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_RocksDB_flush__JJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jflush_options) {
+void Java_org_rocksdb_RocksDB_flush__JJ(JNIEnv* env, jobject /*jdb*/,
+                                        jlong jdb_handle,
+                                        jlong jflush_options) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* flush_options =
       reinterpret_cast<rocksdb::FlushOptions*>(jflush_options);
@@ -1856,9 +1882,9 @@ void Java_org_rocksdb_RocksDB_flush__JJ(
  * Method:    flush
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_RocksDB_flush__JJJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-    jlong jflush_options, jlong jcf_handle) {
+void Java_org_rocksdb_RocksDB_flush__JJJ(JNIEnv* env, jobject /*jdb*/,
+                                         jlong jdb_handle, jlong jflush_options,
+                                         jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* flush_options =
       reinterpret_cast<rocksdb::FlushOptions*>(jflush_options);
@@ -1869,10 +1895,10 @@ void Java_org_rocksdb_RocksDB_flush__JJJ(
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::CompactRange - Full
 
-void rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
-    rocksdb::ColumnFamilyHandle* cf_handle, jboolean jreduce_level,
-    jint jtarget_level, jint jtarget_path_id) {
-
+void rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+                                 jboolean jreduce_level, jint jtarget_level,
+                                 jint jtarget_path_id) {
   rocksdb::Status s;
   rocksdb::CompactRangeOptions compact_options;
   compact_options.change_level = jreduce_level;
@@ -1896,12 +1922,14 @@ void rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
  * Method:    compactRange0
  * Signature: (JZII)V
  */
-void Java_org_rocksdb_RocksDB_compactRange0__JZII(JNIEnv* env,
-    jobject jdb, jlong jdb_handle, jboolean jreduce_level,
-    jint jtarget_level, jint jtarget_path_id) {
+void Java_org_rocksdb_RocksDB_compactRange0__JZII(JNIEnv* env, jobject /*jdb*/,
+                                                  jlong jdb_handle,
+                                                  jboolean jreduce_level,
+                                                  jint jtarget_level,
+                                                  jint jtarget_path_id) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  rocksdb_compactrange_helper(env, db, nullptr, jreduce_level,
-      jtarget_level, jtarget_path_id);
+  rocksdb_compactrange_helper(env, db, nullptr, jreduce_level, jtarget_level,
+                              jtarget_path_id);
 }
 
 /*
@@ -1910,13 +1938,12 @@ void Java_org_rocksdb_RocksDB_compactRange0__JZII(JNIEnv* env,
  * Signature: (JZIIJ)V
  */
 void Java_org_rocksdb_RocksDB_compactRange__JZIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle,
-     jboolean jreduce_level, jint jtarget_level,
-     jint jtarget_path_id, jlong jcf_handle) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jboolean jreduce_level,
+    jint jtarget_level, jint jtarget_path_id, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
-  rocksdb_compactrange_helper(env, db, cf_handle, jreduce_level,
-      jtarget_level, jtarget_path_id);
+  rocksdb_compactrange_helper(env, db, cf_handle, jreduce_level, jtarget_level,
+                              jtarget_path_id);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1926,19 +1953,20 @@ void Java_org_rocksdb_RocksDB_compactRange__JZIIJ(
  * @return true if the compact range succeeded, false if a Java Exception
  *     was thrown
  */
-bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
-    rocksdb::ColumnFamilyHandle* cf_handle, jbyteArray jbegin, jint jbegin_len,
-    jbyteArray jend, jint jend_len, jboolean jreduce_level, jint jtarget_level,
-    jint jtarget_path_id) {
-
+bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* /*db*/,
+                                 rocksdb::ColumnFamilyHandle* /*cf_handle*/,
+                                 jbyteArray jbegin, jint jbegin_len,
+                                 jbyteArray jend, jint jend_len,
+                                 jboolean jreduce_level, jint jtarget_level,
+                                 jint jtarget_path_id) {
   jbyte* begin = env->GetByteArrayElements(jbegin, nullptr);
-  if(begin == nullptr) {
+  if (begin == nullptr) {
     // exception thrown: OutOfMemoryError
     return false;
   }
 
   jbyte* end = env->GetByteArrayElements(jend, nullptr);
-  if(end == nullptr) {
+  if (end == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseByteArrayElements(jbegin, begin, JNI_ABORT);
     return false;
@@ -1975,13 +2003,14 @@ bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
  * Method:    compactRange0
  * Signature: (J[BI[BIZII)V
  */
-void Java_org_rocksdb_RocksDB_compactRange0__J_3BI_3BIZII(JNIEnv* env,
-    jobject jdb, jlong jdb_handle, jbyteArray jbegin, jint jbegin_len,
-    jbyteArray jend, jint jend_len, jboolean jreduce_level,
+void Java_org_rocksdb_RocksDB_compactRange0__J_3BI_3BIZII(
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin,
+    jint jbegin_len, jbyteArray jend, jint jend_len, jboolean jreduce_level,
     jint jtarget_level, jint jtarget_path_id) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
-  rocksdb_compactrange_helper(env, db, nullptr, jbegin, jbegin_len,
-      jend, jend_len, jreduce_level, jtarget_level, jtarget_path_id);
+  rocksdb_compactrange_helper(env, db, nullptr, jbegin, jbegin_len, jend,
+                              jend_len, jreduce_level, jtarget_level,
+                              jtarget_path_id);
 }
 
 /*
@@ -1990,14 +2019,14 @@ void Java_org_rocksdb_RocksDB_compactRange0__J_3BI_3BIZII(JNIEnv* env,
  * Signature: (JJ[BI[BIZII)V
  */
 void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIZIIJ(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jbyteArray jbegin,
-    jint jbegin_len, jbyteArray jend, jint jend_len,
-    jboolean jreduce_level, jint jtarget_level,
-    jint jtarget_path_id, jlong jcf_handle) {
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin,
+    jint jbegin_len, jbyteArray jend, jint jend_len, jboolean jreduce_level,
+    jint jtarget_level, jint jtarget_path_id, jlong jcf_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
-  rocksdb_compactrange_helper(env, db, cf_handle, jbegin, jbegin_len,
-      jend, jend_len, jreduce_level, jtarget_level, jtarget_path_id);
+  rocksdb_compactrange_helper(env, db, cf_handle, jbegin, jbegin_len, jend,
+                              jend_len, jreduce_level, jtarget_level,
+                              jtarget_path_id);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2008,8 +2037,8 @@ void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIZIIJ(
  * Method:    pauseBackgroundWork
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_pauseBackgroundWork(
-    JNIEnv* env, jobject jobj, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_pauseBackgroundWork(JNIEnv* env, jobject /*jobj*/,
+                                                  jlong jdb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto s = db->PauseBackgroundWork();
   if (!s.ok()) {
@@ -2025,8 +2054,9 @@ void Java_org_rocksdb_RocksDB_pauseBackgroundWork(
  * Method:    continueBackgroundWork
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_continueBackgroundWork(
-    JNIEnv* env, jobject jobj, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_continueBackgroundWork(JNIEnv* env,
+                                                     jobject /*jobj*/,
+                                                     jlong jdb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto s = db->ContinueBackgroundWork();
   if (!s.ok()) {
@@ -2042,8 +2072,9 @@ void Java_org_rocksdb_RocksDB_continueBackgroundWork(
  * Method:    getLatestSequenceNumber
  * Signature: (J)V
  */
-jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv* env,
-    jobject jdb, jlong jdb_handle) {
+jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv* /*env*/,
+                                                       jobject /*jdb*/,
+                                                       jlong jdb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   return db->GetLatestSequenceNumber();
 }
@@ -2056,8 +2087,8 @@ jlong Java_org_rocksdb_RocksDB_getLatestSequenceNumber(JNIEnv* env,
  * Method:    enableFileDeletions
  * Signature: (J)V
  */
-void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env,
-    jobject jdb, jlong jdb_handle) {
+void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env, jobject /*jdb*/,
+                                                   jlong jdb_handle) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::Status s = db->DisableFileDeletions();
   if (!s.ok()) {
@@ -2070,8 +2101,9 @@ void Java_org_rocksdb_RocksDB_disableFileDeletions(JNIEnv* env,
  * Method:    enableFileDeletions
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env,
-    jobject jdb, jlong jdb_handle, jboolean jforce) {
+void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env, jobject /*jdb*/,
+                                                  jlong jdb_handle,
+                                                  jboolean jforce) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::Status s = db->EnableFileDeletions(jforce);
   if (!s.ok()) {
@@ -2087,8 +2119,9 @@ void Java_org_rocksdb_RocksDB_enableFileDeletions(JNIEnv* env,
  * Method:    getUpdatesSince
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env,
-    jobject jdb, jlong jdb_handle, jlong jsequence_number) {
+jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env, jobject /*jdb*/,
+                                               jlong jdb_handle,
+                                               jlong jsequence_number) {
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::SequenceNumber sequence_number =
       static_cast<rocksdb::SequenceNumber>(jsequence_number);
@@ -2107,22 +2140,23 @@ jlong Java_org_rocksdb_RocksDB_getUpdatesSince(JNIEnv* env,
  * Method:    setOptions
  * Signature: (JJ[Ljava/lang/String;[Ljava/lang/String;)V
  */
-void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject jdb,
-    jlong jdb_handle, jlong jcf_handle, jobjectArray jkeys,
-    jobjectArray jvalues) {
+void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject /*jdb*/,
+                                         jlong jdb_handle, jlong jcf_handle,
+                                         jobjectArray jkeys,
+                                         jobjectArray jvalues) {
   const jsize len = env->GetArrayLength(jkeys);
   assert(len == env->GetArrayLength(jvalues));
 
   std::unordered_map<std::string, std::string> options_map;
   for (jsize i = 0; i < len; i++) {
     jobject jobj_key = env->GetObjectArrayElement(jkeys, i);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       return;
     }
 
     jobject jobj_value = env->GetObjectArrayElement(jvalues, i);
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jobj_key);
       return;
@@ -2132,7 +2166,7 @@ void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject jdb,
     jstring jval = reinterpret_cast<jstring>(jobj_value);
 
     const char* key = env->GetStringUTFChars(jkey, nullptr);
-    if(key == nullptr) {
+    if (key == nullptr) {
       // exception thrown: OutOfMemoryError
       env->DeleteLocalRef(jobj_value);
       env->DeleteLocalRef(jobj_key);
@@ -2140,7 +2174,7 @@ void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject jdb,
     }
 
     const char* value = env->GetStringUTFChars(jval, nullptr);
-    if(value == nullptr) {
+    if (value == nullptr) {
       // exception thrown: OutOfMemoryError
       env->ReleaseStringUTFChars(jkey, key);
       env->DeleteLocalRef(jobj_value);
@@ -2172,14 +2206,13 @@ void Java_org_rocksdb_RocksDB_setOptions(JNIEnv* env, jobject jdb,
  * Signature: (JJ[Ljava/lang/String;IJ)V
  */
 void Java_org_rocksdb_RocksDB_ingestExternalFile(
-    JNIEnv* env, jobject jdb, jlong jdb_handle, jlong jcf_handle,
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jlong jcf_handle,
     jobjectArray jfile_path_list, jint jfile_path_list_len,
     jlong jingest_external_file_options_handle) {
   jboolean has_exception = JNI_FALSE;
-  std::vector<std::string> file_path_list =
-      rocksdb::JniUtil::copyStrings(env, jfile_path_list, jfile_path_list_len,
-          &has_exception);
-  if(has_exception == JNI_TRUE) {
+  std::vector<std::string> file_path_list = rocksdb::JniUtil::copyStrings(
+      env, jfile_path_list, jfile_path_list_len, &has_exception);
+  if (has_exception == JNI_TRUE) {
     // exception occurred
     return;
   }
@@ -2187,9 +2220,8 @@ void Java_org_rocksdb_RocksDB_ingestExternalFile(
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* column_family =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
-  auto* ifo =
-      reinterpret_cast<rocksdb::IngestExternalFileOptions*>(
-          jingest_external_file_options_handle);
+  auto* ifo = reinterpret_cast<rocksdb::IngestExternalFileOptions*>(
+      jingest_external_file_options_handle);
   rocksdb::Status s =
       db->IngestExternalFile(column_family, file_path_list, *ifo);
   if (!s.ok()) {
@@ -2202,18 +2234,19 @@ void Java_org_rocksdb_RocksDB_ingestExternalFile(
  * Method:    destroyDB
  * Signature: (Ljava/lang/String;J)V
  */
-void Java_org_rocksdb_RocksDB_destroyDB(
-    JNIEnv* env, jclass jcls, jstring jdb_path, jlong joptions_handle) {
+void Java_org_rocksdb_RocksDB_destroyDB(JNIEnv* env, jclass /*jcls*/,
+                                        jstring jdb_path,
+                                        jlong joptions_handle) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
   auto* options = reinterpret_cast<rocksdb::Options*>(joptions_handle);
   if (options == nullptr) {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument("Invalid Options."));
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Invalid Options."));
   }
 
   rocksdb::Status s = rocksdb::DestroyDB(db_path, *options);

--- a/java/rocksjni/slice.cc
+++ b/java/rocksjni/slice.cc
@@ -251,7 +251,7 @@ void Java_org_rocksdb_Slice_disposeInternalBuf(JNIEnv* /*env*/,
 jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice0(JNIEnv* env,
                                                          jclass /*jcls*/,
                                                          jobject data,
-                                                         jint /*length*/) {
+                                                         jint length) {
   assert(data != nullptr);
   void* data_addr = env->GetDirectBufferAddress(data);
   if (data_addr == nullptr) {

--- a/java/rocksjni/slice.cc
+++ b/java/rocksjni/slice.cc
@@ -6,14 +6,14 @@
 // This file implements the "bridge" between Java and C++ for
 // rocksdb::Slice.
 
+#include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <jni.h>
 #include <string>
 
 #include "include/org_rocksdb_AbstractSlice.h"
-#include "include/org_rocksdb_Slice.h"
 #include "include/org_rocksdb_DirectSlice.h"
+#include "include/org_rocksdb_Slice.h"
 #include "rocksdb/slice.h"
 #include "rocksjni/portal.h"
 
@@ -24,10 +24,11 @@
  * Method:    createNewSliceFromString
  * Signature: (Ljava/lang/String;)J
  */
-jlong Java_org_rocksdb_AbstractSlice_createNewSliceFromString(
-    JNIEnv * env, jclass jcls, jstring jstr) {
+jlong Java_org_rocksdb_AbstractSlice_createNewSliceFromString(JNIEnv* env,
+                                                              jclass /*jcls*/,
+                                                              jstring jstr) {
   const auto* str = env->GetStringUTFChars(jstr, nullptr);
-  if(str == nullptr) {
+  if (str == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -51,8 +52,8 @@ jlong Java_org_rocksdb_AbstractSlice_createNewSliceFromString(
  * Method:    size0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_AbstractSlice_size0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jint Java_org_rocksdb_AbstractSlice_size0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong handle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   return static_cast<jint>(slice->size());
 }
@@ -62,8 +63,8 @@ jint Java_org_rocksdb_AbstractSlice_size0(
  * Method:    empty0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_AbstractSlice_empty0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jboolean Java_org_rocksdb_AbstractSlice_empty0(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong handle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   return slice->empty();
 }
@@ -73,8 +74,8 @@ jboolean Java_org_rocksdb_AbstractSlice_empty0(
  * Method:    toString0
  * Signature: (JZ)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_AbstractSlice_toString0(
-    JNIEnv* env, jobject jobj, jlong handle, jboolean hex) {
+jstring Java_org_rocksdb_AbstractSlice_toString0(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong handle, jboolean hex) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   const std::string s = slice->ToString(hex);
   return env->NewStringUTF(s.c_str());
@@ -85,11 +86,10 @@ jstring Java_org_rocksdb_AbstractSlice_toString0(
  * Method:    compare0
  * Signature: (JJ)I;
  */
-jint Java_org_rocksdb_AbstractSlice_compare0(
-    JNIEnv* env, jobject jobj, jlong handle, jlong otherHandle) {
+jint Java_org_rocksdb_AbstractSlice_compare0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong handle, jlong otherHandle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
-  const auto* otherSlice =
-    reinterpret_cast<rocksdb::Slice*>(otherHandle);
+  const auto* otherSlice = reinterpret_cast<rocksdb::Slice*>(otherHandle);
   return slice->compare(*otherSlice);
 }
 
@@ -98,11 +98,12 @@ jint Java_org_rocksdb_AbstractSlice_compare0(
  * Method:    startsWith0
  * Signature: (JJ)Z;
  */
-jboolean Java_org_rocksdb_AbstractSlice_startsWith0(
-    JNIEnv* env, jobject jobj, jlong handle, jlong otherHandle) {
+jboolean Java_org_rocksdb_AbstractSlice_startsWith0(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong handle,
+                                                    jlong otherHandle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
-  const auto* otherSlice =
-    reinterpret_cast<rocksdb::Slice*>(otherHandle);
+  const auto* otherSlice = reinterpret_cast<rocksdb::Slice*>(otherHandle);
   return slice->starts_with(*otherSlice);
 }
 
@@ -111,8 +112,9 @@ jboolean Java_org_rocksdb_AbstractSlice_startsWith0(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_AbstractSlice_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_AbstractSlice_disposeInternal(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong handle) {
   delete reinterpret_cast<rocksdb::Slice*>(handle);
 }
 
@@ -125,15 +127,16 @@ void Java_org_rocksdb_AbstractSlice_disposeInternal(
  * Method:    createNewSlice0
  * Signature: ([BI)J
  */
-jlong Java_org_rocksdb_Slice_createNewSlice0(
-    JNIEnv * env, jclass jcls, jbyteArray data, jint offset) {
+jlong Java_org_rocksdb_Slice_createNewSlice0(JNIEnv* env, jclass /*jcls*/,
+                                             jbyteArray data, jint offset) {
   const jsize dataSize = env->GetArrayLength(data);
   const int len = dataSize - offset;
 
-  // NOTE: buf will be deleted in the Java_org_rocksdb_Slice_disposeInternalBuf method
+  // NOTE: buf will be deleted in the Java_org_rocksdb_Slice_disposeInternalBuf
+  // method
   jbyte* buf = new jbyte[len];
   env->GetByteArrayRegion(data, offset, len, buf);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
     return 0;
   }
@@ -147,22 +150,22 @@ jlong Java_org_rocksdb_Slice_createNewSlice0(
  * Method:    createNewSlice1
  * Signature: ([B)J
  */
-jlong Java_org_rocksdb_Slice_createNewSlice1(
-    JNIEnv * env, jclass jcls, jbyteArray data) {
+jlong Java_org_rocksdb_Slice_createNewSlice1(JNIEnv* env, jclass /*jcls*/,
+                                             jbyteArray data) {
   jbyte* ptrData = env->GetByteArrayElements(data, nullptr);
-  if(ptrData == nullptr) {
+  if (ptrData == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
   const int len = env->GetArrayLength(data) + 1;
 
-  // NOTE: buf will be deleted in the Java_org_rocksdb_Slice_disposeInternalBuf method
+  // NOTE: buf will be deleted in the Java_org_rocksdb_Slice_disposeInternalBuf
+  // method
   char* buf = new char[len];
   memcpy(buf, ptrData, len - 1);
-  buf[len-1] = '\0';
+  buf[len - 1] = '\0';
 
-  const auto* slice =
-      new rocksdb::Slice(buf, len - 1);
+  const auto* slice = new rocksdb::Slice(buf, len - 1);
 
   env->ReleaseByteArrayElements(data, ptrData, JNI_ABORT);
 
@@ -174,19 +177,20 @@ jlong Java_org_rocksdb_Slice_createNewSlice1(
  * Method:    data0
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_Slice_data0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jbyteArray Java_org_rocksdb_Slice_data0(JNIEnv* env, jobject /*jobj*/,
+                                        jlong handle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   const jsize len = static_cast<jsize>(slice->size());
   const jbyteArray data = env->NewByteArray(len);
-  if(data == nullptr) {
+  if (data == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
-  
-  env->SetByteArrayRegion(data, 0, len,
-    const_cast<jbyte*>(reinterpret_cast<const jbyte*>(slice->data())));
-  if(env->ExceptionCheck()) {
+
+  env->SetByteArrayRegion(
+      data, 0, len,
+      const_cast<jbyte*>(reinterpret_cast<const jbyte*>(slice->data())));
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
     env->DeleteLocalRef(data);
     return nullptr;
@@ -200,13 +204,13 @@ jbyteArray Java_org_rocksdb_Slice_data0(
  * Method:    clear0
  * Signature: (JZJ)V
  */
-void Java_org_rocksdb_Slice_clear0(
-    JNIEnv * env, jobject jobj, jlong handle, jboolean shouldRelease,
-    jlong internalBufferOffset) {
+void Java_org_rocksdb_Slice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                   jlong handle, jboolean shouldRelease,
+                                   jlong internalBufferOffset) {
   auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
-  if(shouldRelease == JNI_TRUE) {
+  if (shouldRelease == JNI_TRUE) {
     const char* buf = slice->data_ - internalBufferOffset;
-    delete [] buf;
+    delete[] buf;
   }
   slice->clear();
 }
@@ -216,8 +220,8 @@ void Java_org_rocksdb_Slice_clear0(
  * Method:    removePrefix0
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Slice_removePrefix0(
-    JNIEnv * env, jobject jobj, jlong handle, jint length) {
+void Java_org_rocksdb_Slice_removePrefix0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong handle, jint length) {
   auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   slice->remove_prefix(length);
 }
@@ -227,11 +231,12 @@ void Java_org_rocksdb_Slice_removePrefix0(
  * Method:    disposeInternalBuf
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Slice_disposeInternalBuf(
-    JNIEnv * env, jobject jobj, jlong handle, jlong internalBufferOffset) {
+void Java_org_rocksdb_Slice_disposeInternalBuf(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong handle,
+                                               jlong internalBufferOffset) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   const char* buf = slice->data_ - internalBufferOffset;
-  delete [] buf;
+  delete[] buf;
 }
 
 // </editor-fold>
@@ -243,21 +248,21 @@ void Java_org_rocksdb_Slice_disposeInternalBuf(
  * Method:    createNewDirectSlice0
  * Signature: (Ljava/nio/ByteBuffer;I)J
  */
-jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice0(
-    JNIEnv* env, jclass jcls, jobject data, jint length) {
+jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice0(JNIEnv* env,
+                                                         jclass /*jcls*/,
+                                                         jobject data,
+                                                         jint /*length*/) {
   assert(data != nullptr);
   void* data_addr = env->GetDirectBufferAddress(data);
-  if(data_addr == nullptr) {
+  if (data_addr == nullptr) {
     // error: memory region is undefined, given object is not a direct
     // java.nio.Buffer, or JNI access to direct buffers is not supported by JVM
-    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument(
-            "Could not access DirectBuffer"));
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Could not access DirectBuffer"));
     return 0;
   }
 
-  const auto* ptrData =
-     reinterpret_cast<char*>(data_addr);
+  const auto* ptrData = reinterpret_cast<char*>(data_addr);
   const auto* slice = new rocksdb::Slice(ptrData, length);
   return reinterpret_cast<jlong>(slice);
 }
@@ -267,15 +272,15 @@ jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice0(
  * Method:    createNewDirectSlice1
  * Signature: (Ljava/nio/ByteBuffer;)J
  */
-jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice1(
-    JNIEnv* env, jclass jcls, jobject data) {
+jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice1(JNIEnv* env,
+                                                         jclass /*jcls*/,
+                                                         jobject data) {
   void* data_addr = env->GetDirectBufferAddress(data);
-  if(data_addr == nullptr) {
+  if (data_addr == nullptr) {
     // error: memory region is undefined, given object is not a direct
     // java.nio.Buffer, or JNI access to direct buffers is not supported by JVM
-    rocksdb::IllegalArgumentExceptionJni::ThrowNew(env,
-        rocksdb::Status::InvalidArgument(
-            "Could not access DirectBuffer"));
+    rocksdb::IllegalArgumentExceptionJni::ThrowNew(
+        env, rocksdb::Status::InvalidArgument("Could not access DirectBuffer"));
     return 0;
   }
 
@@ -289,11 +294,11 @@ jlong Java_org_rocksdb_DirectSlice_createNewDirectSlice1(
  * Method:    data0
  * Signature: (J)Ljava/lang/Object;
  */
-jobject Java_org_rocksdb_DirectSlice_data0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jobject Java_org_rocksdb_DirectSlice_data0(JNIEnv* env, jobject /*jobj*/,
+                                           jlong handle) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   return env->NewDirectByteBuffer(const_cast<char*>(slice->data()),
-    slice->size());
+                                  slice->size());
 }
 
 /*
@@ -301,8 +306,8 @@ jobject Java_org_rocksdb_DirectSlice_data0(
  * Method:    get0
  * Signature: (JI)B
  */
-jbyte Java_org_rocksdb_DirectSlice_get0(
-    JNIEnv* env, jobject jobj, jlong handle, jint offset) {
+jbyte Java_org_rocksdb_DirectSlice_get0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                        jlong handle, jint offset) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   return (*slice)[offset];
 }
@@ -312,13 +317,13 @@ jbyte Java_org_rocksdb_DirectSlice_get0(
  * Method:    clear0
  * Signature: (JZJ)V
  */
-void Java_org_rocksdb_DirectSlice_clear0(
-    JNIEnv* env, jobject jobj, jlong handle,
-    jboolean shouldRelease, jlong internalBufferOffset) {
+void Java_org_rocksdb_DirectSlice_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong handle, jboolean shouldRelease,
+                                         jlong internalBufferOffset) {
   auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
-  if(shouldRelease == JNI_TRUE) {
+  if (shouldRelease == JNI_TRUE) {
     const char* buf = slice->data_ - internalBufferOffset;
-    delete [] buf;
+    delete[] buf;
   }
   slice->clear();
 }
@@ -328,8 +333,9 @@ void Java_org_rocksdb_DirectSlice_clear0(
  * Method:    removePrefix0
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DirectSlice_removePrefix0(
-    JNIEnv* env, jobject jobj, jlong handle, jint length) {
+void Java_org_rocksdb_DirectSlice_removePrefix0(JNIEnv* /*env*/,
+                                                jobject /*jobj*/, jlong handle,
+                                                jint length) {
   auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   slice->remove_prefix(length);
 }
@@ -340,10 +346,11 @@ void Java_org_rocksdb_DirectSlice_removePrefix0(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DirectSlice_disposeInternalBuf(
-    JNIEnv* env, jobject jobj, jlong handle, jlong internalBufferOffset) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong handle,
+    jlong internalBufferOffset) {
   const auto* slice = reinterpret_cast<rocksdb::Slice*>(handle);
   const char* buf = slice->data_ - internalBufferOffset;
-  delete [] buf;
+  delete[] buf;
 }
 
 // </editor-fold>

--- a/java/rocksjni/snapshot.cc
+++ b/java/rocksjni/snapshot.cc
@@ -18,9 +18,9 @@
  * Method:    getSequenceNumber
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Snapshot_getSequenceNumber(JNIEnv* env,
-    jobject jobj, jlong jsnapshot_handle) {
-  auto* snapshot = reinterpret_cast<rocksdb::Snapshot*>(
-      jsnapshot_handle);
+jlong Java_org_rocksdb_Snapshot_getSequenceNumber(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jsnapshot_handle) {
+  auto* snapshot = reinterpret_cast<rocksdb::Snapshot*>(jsnapshot_handle);
   return snapshot->GetSequenceNumber();
 }

--- a/java/rocksjni/sst_file_manager.cc
+++ b/java/rocksjni/sst_file_manager.cc
@@ -20,34 +20,33 @@
  * Signature: (JJJDJ)J
  */
 jlong Java_org_rocksdb_SstFileManager_newSstFileManager(
-    JNIEnv* jnienv, jclass jcls, jlong jenv_handle, jlong jlogger_handle,
+    JNIEnv* jnienv, jclass /*jcls*/, jlong jenv_handle, jlong jlogger_handle,
     jlong jrate_bytes, jdouble jmax_trash_db_ratio,
     jlong jmax_delete_chunk_bytes) {
-      
   auto* env = reinterpret_cast<rocksdb::Env*>(jenv_handle);
   rocksdb::Status s;
   rocksdb::SstFileManager* sst_file_manager = nullptr;
 
   if (jlogger_handle != 0) {
     auto* sptr_logger =
-        reinterpret_cast<std::shared_ptr<rocksdb::Logger> *>(jlogger_handle);
-    sst_file_manager = rocksdb::NewSstFileManager(env, *sptr_logger, "",
-        jrate_bytes, true, &s, jmax_trash_db_ratio,
+        reinterpret_cast<std::shared_ptr<rocksdb::Logger>*>(jlogger_handle);
+    sst_file_manager = rocksdb::NewSstFileManager(
+        env, *sptr_logger, "", jrate_bytes, true, &s, jmax_trash_db_ratio,
         jmax_delete_chunk_bytes);
   } else {
-      sst_file_manager = rocksdb::NewSstFileManager(env, nullptr, "",
-          jrate_bytes, true, &s, jmax_trash_db_ratio,
-          jmax_delete_chunk_bytes);
+    sst_file_manager = rocksdb::NewSstFileManager(env, nullptr, "", jrate_bytes,
+                                                  true, &s, jmax_trash_db_ratio,
+                                                  jmax_delete_chunk_bytes);
   }
 
   if (!s.ok()) {
     if (sst_file_manager != nullptr) {
-        delete sst_file_manager;
+      delete sst_file_manager;
     }
     rocksdb::RocksDBExceptionJni::ThrowNew(jnienv, s);
   }
-  auto* sptr_sst_file_manager
-      = new std::shared_ptr<rocksdb::SstFileManager>(sst_file_manager);
+  auto* sptr_sst_file_manager =
+      new std::shared_ptr<rocksdb::SstFileManager>(sst_file_manager);
 
   return reinterpret_cast<jlong>(sptr_sst_file_manager);
 }
@@ -58,9 +57,10 @@ jlong Java_org_rocksdb_SstFileManager_newSstFileManager(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setMaxAllowedSpaceUsage(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_allowed_space) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_allowed_space) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   sptr_sst_file_manager->get()->SetMaxAllowedSpaceUsage(jmax_allowed_space);
 }
 
@@ -70,10 +70,12 @@ void Java_org_rocksdb_SstFileManager_setMaxAllowedSpaceUsage(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setCompactionBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jcompaction_buffer_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jcompaction_buffer_size) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
-  sptr_sst_file_manager->get()->SetCompactionBufferSize(jcompaction_buffer_size);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
+  sptr_sst_file_manager->get()->SetCompactionBufferSize(
+      jcompaction_buffer_size);
 }
 
 /*
@@ -82,9 +84,9 @@ void Java_org_rocksdb_SstFileManager_setCompactionBufferSize(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReached(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   return sptr_sst_file_manager->get()->IsMaxAllowedSpaceReached();
 }
 
@@ -93,11 +95,13 @@ jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReached(
  * Method:    isMaxAllowedSpaceReachedIncludingCompactions
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReachedIncludingCompactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean
+Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReachedIncludingCompactions(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
-  return sptr_sst_file_manager->get()->IsMaxAllowedSpaceReachedIncludingCompactions();
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
+  return sptr_sst_file_manager->get()
+      ->IsMaxAllowedSpaceReachedIncludingCompactions();
 }
 
 /*
@@ -105,10 +109,11 @@ jboolean Java_org_rocksdb_SstFileManager_isMaxAllowedSpaceReachedIncludingCompac
  * Method:    getTotalSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_SstFileManager_getTotalSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_SstFileManager_getTotalSize(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   return sptr_sst_file_manager->get()->GetTotalSize();
 }
 
@@ -117,38 +122,43 @@ jlong Java_org_rocksdb_SstFileManager_getTotalSize(
  * Method:    getTrackedFiles
  * Signature: (J)Ljava/util/Map;
  */
-jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(JNIEnv* env,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   auto tracked_files = sptr_sst_file_manager->get()->GetTrackedFiles();
-  
-  const jobject jtracked_files = rocksdb::HashMapJni::construct(env,
-      static_cast<uint32_t>(tracked_files.size()));
+
+  const jobject jtracked_files = rocksdb::HashMapJni::construct(
+      env, static_cast<uint32_t>(tracked_files.size()));
   if (jtracked_files == nullptr) {
-      // exception occurred
-      return nullptr;
+    // exception occurred
+    return nullptr;
   }
 
-  const rocksdb::HashMapJni::FnMapKV<const std::string, const uint64_t> fn_map_kv =
-      [env, &tracked_files](const std::pair<const std::string, const uint64_t>& pair) {
-          const jstring jtracked_file_path = env->NewStringUTF(pair.first.c_str());
-          if (jtracked_file_path == nullptr) {
-             // an error occurred
-             return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
-          }
-          const jobject jtracked_file_size =
-              rocksdb::LongJni::valueOf(env, pair.second);
-          if (jtracked_file_size == nullptr) {
+  const rocksdb::HashMapJni::FnMapKV<const std::string, const uint64_t>
+      fn_map_kv =
+          [env, &tracked_files](
+              const std::pair<const std::string, const uint64_t>& pair) {
+            const jstring jtracked_file_path =
+                env->NewStringUTF(pair.first.c_str());
+            if (jtracked_file_path == nullptr) {
               // an error occurred
               return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
-          }
-          return std::unique_ptr<std::pair<jobject, jobject>>(new std::pair<jobject, jobject>(jtracked_file_path,
-              jtracked_file_size));
-      };
+            }
+            const jobject jtracked_file_size =
+                rocksdb::LongJni::valueOf(env, pair.second);
+            if (jtracked_file_size == nullptr) {
+              // an error occurred
+              return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
+            }
+            return std::unique_ptr<std::pair<jobject, jobject>>(
+                new std::pair<jobject, jobject>(jtracked_file_path,
+                                                jtracked_file_size));
+          };
 
-  if(!rocksdb::HashMapJni::putAll(env, jtracked_files,
-      tracked_files.begin(), tracked_files.end(), fn_map_kv)) {
+  if (!rocksdb::HashMapJni::putAll(env, jtracked_files, tracked_files.begin(),
+                                   tracked_files.end(), fn_map_kv)) {
     // exception occcurred
     return nullptr;
   }
@@ -162,9 +172,9 @@ jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_SstFileManager_getDeleteRateBytesPerSecond(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   return sptr_sst_file_manager->get()->GetDeleteRateBytesPerSecond();
 }
 
@@ -174,9 +184,9 @@ jlong Java_org_rocksdb_SstFileManager_getDeleteRateBytesPerSecond(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_SstFileManager_setDeleteRateBytesPerSecond(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdelete_rate) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jdelete_rate) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   sptr_sst_file_manager->get()->SetDeleteRateBytesPerSecond(jdelete_rate);
 }
 
@@ -185,10 +195,11 @@ void Java_org_rocksdb_SstFileManager_setDeleteRateBytesPerSecond(
  * Method:    getMaxTrashDBRatio
  * Signature: (J)D
  */
-jdouble Java_org_rocksdb_SstFileManager_getMaxTrashDBRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jdouble Java_org_rocksdb_SstFileManager_getMaxTrashDBRatio(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   return sptr_sst_file_manager->get()->GetMaxTrashDBRatio();
 }
 
@@ -197,10 +208,12 @@ jdouble Java_org_rocksdb_SstFileManager_getMaxTrashDBRatio(
  * Method:    setMaxTrashDBRatio
  * Signature: (JD)V
  */
-void Java_org_rocksdb_SstFileManager_setMaxTrashDBRatio(
-    JNIEnv* env, jobject jobj, jlong jhandle, jdouble jratio) {
+void Java_org_rocksdb_SstFileManager_setMaxTrashDBRatio(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle,
+                                                        jdouble jratio) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   sptr_sst_file_manager->get()->SetMaxTrashDBRatio(jratio);
 }
 
@@ -209,9 +222,10 @@ void Java_org_rocksdb_SstFileManager_setMaxTrashDBRatio(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileManager_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_SstFileManager_disposeInternal(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle) {
   auto* sptr_sst_file_manager =
-      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager> *>(jhandle);
+      reinterpret_cast<std::shared_ptr<rocksdb::SstFileManager>*>(jhandle);
   delete sptr_sst_file_manager;
 }

--- a/java/rocksjni/sst_file_writerjni.cc
+++ b/java/rocksjni/sst_file_writerjni.cc
@@ -22,28 +22,27 @@
  * Method:    newSstFileWriter
  * Signature: (JJJB)J
  */
-jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJJB(JNIEnv *env,
-    jclass jcls, jlong jenvoptions,  jlong joptions, jlong jcomparator_handle,
-    jbyte jcomparator_type) {
+jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJJB(
+    JNIEnv * /*env*/, jclass /*jcls*/, jlong jenvoptions, jlong joptions,
+    jlong jcomparator_handle, jbyte jcomparator_type) {
   rocksdb::Comparator *comparator = nullptr;
-  switch(jcomparator_type) {
-      // JAVA_COMPARATOR
-      case 0x0:
-        comparator =
-            reinterpret_cast<rocksdb::ComparatorJniCallback*>(jcomparator_handle);
-        break;
+  switch (jcomparator_type) {
+    // JAVA_COMPARATOR
+    case 0x0:
+      comparator = reinterpret_cast<rocksdb::ComparatorJniCallback *>(
+          jcomparator_handle);
+      break;
 
-      // JAVA_DIRECT_COMPARATOR
-      case 0x1:
-        comparator =
-            reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(jcomparator_handle);
-        break;
+    // JAVA_DIRECT_COMPARATOR
+    case 0x1:
+      comparator = reinterpret_cast<rocksdb::DirectComparatorJniCallback *>(
+          jcomparator_handle);
+      break;
 
-      // JAVA_NATIVE_COMPARATOR_WRAPPER
-      case 0x2:
-        comparator =
-            reinterpret_cast<rocksdb::Comparator*>(jcomparator_handle);
-        break;
+    // JAVA_NATIVE_COMPARATOR_WRAPPER
+    case 0x2:
+      comparator = reinterpret_cast<rocksdb::Comparator *>(jcomparator_handle);
+      break;
   }
   auto *env_options =
       reinterpret_cast<const rocksdb::EnvOptions *>(jenvoptions);
@@ -58,9 +57,10 @@ jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJJB(JNIEnv *env,
  * Method:    newSstFileWriter
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJ(JNIEnv *env, jclass jcls,
-                                                      jlong jenvoptions,
-                                                      jlong joptions) {
+jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJ(JNIEnv * /*env*/,
+                                                          jclass /*jcls*/,
+                                                          jlong jenvoptions,
+                                                          jlong joptions) {
   auto *env_options =
       reinterpret_cast<const rocksdb::EnvOptions *>(jenvoptions);
   auto *options = reinterpret_cast<const rocksdb::Options *>(joptions);
@@ -74,10 +74,10 @@ jlong Java_org_rocksdb_SstFileWriter_newSstFileWriter__JJ(JNIEnv *env, jclass jc
  * Method:    open
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jobject /*jobj*/,
                                          jlong jhandle, jstring jfile_path) {
   const char *file_path = env->GetStringUTFChars(jfile_path, nullptr);
-  if(file_path == nullptr) {
+  if (file_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
@@ -95,14 +95,13 @@ void Java_org_rocksdb_SstFileWriter_open(JNIEnv *env, jobject jobj,
  * Method:    put
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject /*jobj*/,
                                              jlong jhandle, jlong jkey_handle,
                                              jlong jvalue_handle) {
   auto *key_slice = reinterpret_cast<rocksdb::Slice *>(jkey_handle);
   auto *value_slice = reinterpret_cast<rocksdb::Slice *>(jvalue_handle);
-  rocksdb::Status s =
-    reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Put(*key_slice,
-                                                             *value_slice);
+  rocksdb::Status s = reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Put(
+      *key_slice, *value_slice);
   if (!s.ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
@@ -113,29 +112,28 @@ void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject jobj,
  * Method:    put
  * Signature: (JJJ)V
  */
- void Java_org_rocksdb_SstFileWriter_put__J_3B_3B(JNIEnv *env, jobject jobj,
-                                                  jlong jhandle, jbyteArray jkey,
-                                                  jbyteArray jval) {
-  jbyte* key = env->GetByteArrayElements(jkey, nullptr);
-  if(key == nullptr) {
+void Java_org_rocksdb_SstFileWriter_put__J_3B_3B(JNIEnv *env, jobject /*jobj*/,
+                                                 jlong jhandle, jbyteArray jkey,
+                                                 jbyteArray jval) {
+  jbyte *key = env->GetByteArrayElements(jkey, nullptr);
+  if (key == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
-  rocksdb::Slice key_slice(
-      reinterpret_cast<char*>(key),  env->GetArrayLength(jkey));
+  rocksdb::Slice key_slice(reinterpret_cast<char *>(key),
+                           env->GetArrayLength(jkey));
 
-  jbyte* value = env->GetByteArrayElements(jval, nullptr);
-  if(value == nullptr) {
+  jbyte *value = env->GetByteArrayElements(jval, nullptr);
+  if (value == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
     return;
   }
-  rocksdb::Slice value_slice(
-      reinterpret_cast<char*>(value),  env->GetArrayLength(jval));
+  rocksdb::Slice value_slice(reinterpret_cast<char *>(value),
+                             env->GetArrayLength(jval));
 
-  rocksdb::Status s =
-  reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Put(key_slice,
-                                                           value_slice);
+  rocksdb::Status s = reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Put(
+      key_slice, value_slice);
 
   env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
   env->ReleaseByteArrayElements(jval, value, JNI_ABORT);
@@ -150,14 +148,14 @@ void Java_org_rocksdb_SstFileWriter_put__JJJ(JNIEnv *env, jobject jobj,
  * Method:    merge
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jobject /*jobj*/,
                                                jlong jhandle, jlong jkey_handle,
                                                jlong jvalue_handle) {
   auto *key_slice = reinterpret_cast<rocksdb::Slice *>(jkey_handle);
   auto *value_slice = reinterpret_cast<rocksdb::Slice *>(jvalue_handle);
   rocksdb::Status s =
-    reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Merge(*key_slice,
-                                                               *value_slice);
+      reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Merge(*key_slice,
+                                                                 *value_slice);
   if (!s.ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
@@ -168,30 +166,31 @@ void Java_org_rocksdb_SstFileWriter_merge__JJJ(JNIEnv *env, jobject jobj,
  * Method:    merge
  * Signature: (J[B[B)V
  */
-void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env, jobject jobj,
-                                                   jlong jhandle, jbyteArray jkey,
+void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle,
+                                                   jbyteArray jkey,
                                                    jbyteArray jval) {
-
-  jbyte* key = env->GetByteArrayElements(jkey, nullptr);
-  if(key == nullptr) {
+  jbyte *key = env->GetByteArrayElements(jkey, nullptr);
+  if (key == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
-  rocksdb::Slice key_slice(
-      reinterpret_cast<char*>(key),  env->GetArrayLength(jkey));
+  rocksdb::Slice key_slice(reinterpret_cast<char *>(key),
+                           env->GetArrayLength(jkey));
 
-  jbyte* value = env->GetByteArrayElements(jval, nullptr);
-  if(value == nullptr) {
+  jbyte *value = env->GetByteArrayElements(jval, nullptr);
+  if (value == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
     return;
   }
-  rocksdb::Slice value_slice(
-      reinterpret_cast<char*>(value),  env->GetArrayLength(jval));
+  rocksdb::Slice value_slice(reinterpret_cast<char *>(value),
+                             env->GetArrayLength(jval));
 
   rocksdb::Status s =
-    reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Merge(key_slice,
-                                                               value_slice);
+      reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Merge(key_slice,
+                                                                 value_slice);
 
   env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
   env->ReleaseByteArrayElements(jval, value, JNI_ABORT);
@@ -206,18 +205,19 @@ void Java_org_rocksdb_SstFileWriter_merge__J_3B_3B(JNIEnv *env, jobject jobj,
  * Method:    delete
  * Signature: (JJJ)V
  */
-void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject jobj,
-                                               jlong jhandle, jbyteArray jkey) {
-  jbyte* key = env->GetByteArrayElements(jkey, nullptr);
-  if(key == nullptr) {
+void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jbyteArray jkey) {
+  jbyte *key = env->GetByteArrayElements(jkey, nullptr);
+  if (key == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
-  rocksdb::Slice key_slice(
-      reinterpret_cast<char*>(key),  env->GetArrayLength(jkey));
+  rocksdb::Slice key_slice(reinterpret_cast<char *>(key),
+                           env->GetArrayLength(jkey));
 
   rocksdb::Status s =
-    reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Delete(key_slice);
+      reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Delete(key_slice);
 
   env->ReleaseByteArrayElements(jkey, key, JNI_ABORT);
 
@@ -231,11 +231,12 @@ void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject jobj,
  * Method:    delete
  * Signature: (JJJ)V
  */
- void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jobject jobj,
-  jlong jhandle, jlong jkey_handle) {
+void Java_org_rocksdb_SstFileWriter_delete__JJ(JNIEnv *env, jobject /*jobj*/,
+                                               jlong jhandle,
+                                               jlong jkey_handle) {
   auto *key_slice = reinterpret_cast<rocksdb::Slice *>(jkey_handle);
   rocksdb::Status s =
-    reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Delete(*key_slice);
+      reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Delete(*key_slice);
   if (!s.ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
@@ -246,7 +247,7 @@ void Java_org_rocksdb_SstFileWriter_delete__J_3B(JNIEnv *env, jobject jobj,
  * Method:    finish
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jobject /*jobj*/,
                                            jlong jhandle) {
   rocksdb::Status s =
       reinterpret_cast<rocksdb::SstFileWriter *>(jhandle)->Finish();
@@ -260,7 +261,8 @@ void Java_org_rocksdb_SstFileWriter_finish(JNIEnv *env, jobject jobj,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_SstFileWriter_disposeInternal(JNIEnv *env, jobject jobj,
+void Java_org_rocksdb_SstFileWriter_disposeInternal(JNIEnv * /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong jhandle) {
   delete reinterpret_cast<rocksdb::SstFileWriter *>(jhandle);
 }

--- a/java/rocksjni/statistics.cc
+++ b/java/rocksjni/statistics.cc
@@ -11,9 +11,9 @@
 #include <set>
 
 #include "include/org_rocksdb_Statistics.h"
+#include "rocksdb/statistics.h"
 #include "rocksjni/portal.h"
 #include "rocksjni/statisticsjni.h"
-#include "rocksdb/statistics.h"
 
 /*
  * Class:     org_rocksdb_Statistics
@@ -21,8 +21,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_Statistics_newStatistics__(JNIEnv* env, jclass jcls) {
-  return Java_org_rocksdb_Statistics_newStatistics___3BJ(
-      env, jcls, nullptr, 0);
+  return Java_org_rocksdb_Statistics_newStatistics___3BJ(env, jcls, nullptr, 0);
 }
 
 /*
@@ -41,10 +40,10 @@ jlong Java_org_rocksdb_Statistics_newStatistics__J(
  * Method:    newStatistics
  * Signature: ([B)J
  */
-jlong Java_org_rocksdb_Statistics_newStatistics___3B(
-    JNIEnv* env, jclass jcls, jbyteArray jhistograms) {
-  return Java_org_rocksdb_Statistics_newStatistics___3BJ(
-      env, jcls, jhistograms, 0);
+jlong Java_org_rocksdb_Statistics_newStatistics___3B(JNIEnv* env, jclass jcls,
+                                                     jbyteArray jhistograms) {
+  return Java_org_rocksdb_Statistics_newStatistics___3BJ(env, jcls, jhistograms,
+                                                         0);
 }
 
 /*
@@ -53,9 +52,8 @@ jlong Java_org_rocksdb_Statistics_newStatistics___3B(
  * Signature: ([BJ)J
  */
 jlong Java_org_rocksdb_Statistics_newStatistics___3BJ(
-    JNIEnv* env, jclass jcls, jbyteArray jhistograms,
+    JNIEnv* env, jclass /*jcls*/, jbyteArray jhistograms,
     jlong jother_statistics_handle) {
-
   std::shared_ptr<rocksdb::Statistics>* pSptr_other_statistics = nullptr;
   if (jother_statistics_handle > 0) {
     pSptr_other_statistics =
@@ -68,7 +66,7 @@ jlong Java_org_rocksdb_Statistics_newStatistics___3BJ(
     const jsize len = env->GetArrayLength(jhistograms);
     if (len > 0) {
       jbyte* jhistogram = env->GetByteArrayElements(jhistograms, nullptr);
-      if (jhistogram == nullptr ) {
+      if (jhistogram == nullptr) {
         // exception thrown: OutOfMemoryError
         return 0;
       }
@@ -85,7 +83,7 @@ jlong Java_org_rocksdb_Statistics_newStatistics___3BJ(
 
   std::shared_ptr<rocksdb::Statistics> sptr_other_statistics = nullptr;
   if (pSptr_other_statistics != nullptr) {
-      sptr_other_statistics =   *pSptr_other_statistics;
+    sptr_other_statistics = *pSptr_other_statistics;
   }
 
   auto* pSptr_statistics = new std::shared_ptr<rocksdb::StatisticsJni>(
@@ -99,9 +97,10 @@ jlong Java_org_rocksdb_Statistics_newStatistics___3BJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Statistics_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-  if(jhandle > 0) {
+void Java_org_rocksdb_Statistics_disposeInternal(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
+  if (jhandle > 0) {
     auto* pSptr_statistics =
         reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
     delete pSptr_statistics;
@@ -113,12 +112,13 @@ void Java_org_rocksdb_Statistics_disposeInternal(
  * Method:    statsLevel
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Statistics_statsLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Statistics_statsLevel(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong jhandle) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
-  return rocksdb::StatsLevelJni::toJavaStatsLevel(pSptr_statistics->get()->stats_level_);
+  return rocksdb::StatsLevelJni::toJavaStatsLevel(
+      pSptr_statistics->get()->stats_level_);
 }
 
 /*
@@ -126,8 +126,9 @@ jbyte Java_org_rocksdb_Statistics_statsLevel(
  * Method:    setStatsLevel
  * Signature: (JB)V
  */
-void Java_org_rocksdb_Statistics_setStatsLevel(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jstats_level) {
+void Java_org_rocksdb_Statistics_setStatsLevel(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jbyte jstats_level) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
@@ -140,8 +141,10 @@ void Java_org_rocksdb_Statistics_setStatsLevel(
  * Method:    getTickerCount
  * Signature: (JB)J
  */
-jlong Java_org_rocksdb_Statistics_getTickerCount(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jticker_type) {
+jlong Java_org_rocksdb_Statistics_getTickerCount(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jbyte jticker_type) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
@@ -154,8 +157,10 @@ jlong Java_org_rocksdb_Statistics_getTickerCount(
  * Method:    getAndResetTickerCount
  * Signature: (JB)J
  */
-jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jticker_type) {
+jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle,
+                                                         jbyte jticker_type) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
@@ -168,34 +173,36 @@ jlong Java_org_rocksdb_Statistics_getAndResetTickerCount(
  * Method:    getHistogramData
  * Signature: (JB)Lorg/rocksdb/HistogramData;
  */
-jobject Java_org_rocksdb_Statistics_getHistogramData(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jhistogram_type) {
+jobject Java_org_rocksdb_Statistics_getHistogramData(JNIEnv* env,
+                                                     jobject /*jobj*/,
+                                                     jlong jhandle,
+                                                     jbyte jhistogram_type) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
 
-  rocksdb::HistogramData data;  // TODO(AR) perhaps better to construct a Java Object Wrapper that uses ptr to C++ `new HistogramData`
+  rocksdb::HistogramData
+      data;  // TODO(AR) perhaps better to construct a Java Object Wrapper that
+             // uses ptr to C++ `new HistogramData`
   auto histogram = rocksdb::HistogramTypeJni::toCppHistograms(jhistogram_type);
   pSptr_statistics->get()->histogramData(
       static_cast<rocksdb::Histograms>(histogram), &data);
 
   jclass jclazz = rocksdb::HistogramDataJni::getJClass(env);
-  if(jclazz == nullptr) {
+  if (jclazz == nullptr) {
     // exception occurred accessing class
     return nullptr;
   }
 
-  jmethodID mid = rocksdb::HistogramDataJni::getConstructorMethodId(
-      env);
-  if(mid == nullptr) {
+  jmethodID mid = rocksdb::HistogramDataJni::getConstructorMethodId(env);
+  if (mid == nullptr) {
     // exception occurred accessing method
     return nullptr;
   }
 
-  return env->NewObject(
-      jclazz,
-      mid, data.median, data.percentile95,data.percentile99, data.average,
-      data.standard_deviation);
+  return env->NewObject(jclazz, mid, data.median, data.percentile95,
+                        data.percentile99, data.average,
+                        data.standard_deviation);
 }
 
 /*
@@ -203,8 +210,10 @@ jobject Java_org_rocksdb_Statistics_getHistogramData(
  * Method:    getHistogramString
  * Signature: (JB)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Statistics_getHistogramString(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jhistogram_type) {
+jstring Java_org_rocksdb_Statistics_getHistogramString(JNIEnv* env,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle,
+                                                       jbyte jhistogram_type) {
   auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
@@ -218,14 +227,14 @@ jstring Java_org_rocksdb_Statistics_getHistogramString(
  * Method:    reset
  * Signature: (J)V
  */
-void Java_org_rocksdb_Statistics_reset(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-   auto* pSptr_statistics =
+void Java_org_rocksdb_Statistics_reset(JNIEnv* env, jobject /*jobj*/,
+                                       jlong jhandle) {
+  auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
   rocksdb::Status s = pSptr_statistics->get()->Reset();
   if (!s.ok()) {
-   rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
 }
 
@@ -234,9 +243,9 @@ void Java_org_rocksdb_Statistics_reset(
  * Method:    toString
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Statistics_toString(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
-   auto* pSptr_statistics =
+jstring Java_org_rocksdb_Statistics_toString(JNIEnv* env, jobject /*jobj*/,
+                                             jlong jhandle) {
+  auto* pSptr_statistics =
       reinterpret_cast<std::shared_ptr<rocksdb::Statistics>*>(jhandle);
   assert(pSptr_statistics != nullptr);
   auto str = pSptr_statistics->get()->ToString();

--- a/java/rocksjni/table.cc
+++ b/java/rocksjni/table.cc
@@ -5,10 +5,10 @@
 //
 // This file implements the "bridge" between Java and C++ for rocksdb::Options.
 
-#include <jni.h>
-#include "include/org_rocksdb_PlainTableConfig.h"
-#include "include/org_rocksdb_BlockBasedTableConfig.h"
 #include "rocksdb/table.h"
+#include <jni.h>
+#include "include/org_rocksdb_BlockBasedTableConfig.h"
+#include "include/org_rocksdb_PlainTableConfig.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/filter_policy.h"
 
@@ -18,18 +18,17 @@
  * Signature: (IIDIIBZZ)J
  */
 jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
-    JNIEnv* env, jobject jobj, jint jkey_size, jint jbloom_bits_per_key,
-    jdouble jhash_table_ratio, jint jindex_sparseness,
-    jint jhuge_page_tlb_size, jbyte jencoding_type,
-    jboolean jfull_scan_mode, jboolean jstore_index_in_file) {
+    JNIEnv * /*env*/, jobject /*jobj*/, jint jkey_size,
+    jint jbloom_bits_per_key, jdouble jhash_table_ratio, jint jindex_sparseness,
+    jint jhuge_page_tlb_size, jbyte jencoding_type, jboolean jfull_scan_mode,
+    jboolean jstore_index_in_file) {
   rocksdb::PlainTableOptions options = rocksdb::PlainTableOptions();
   options.user_key_len = jkey_size;
   options.bloom_bits_per_key = jbloom_bits_per_key;
   options.hash_table_ratio = jhash_table_ratio;
   options.index_sparseness = jindex_sparseness;
   options.huge_page_tlb_size = jhuge_page_tlb_size;
-  options.encoding_type = static_cast<rocksdb::EncodingType>(
-      jencoding_type);
+  options.encoding_type = static_cast<rocksdb::EncodingType>(jencoding_type);
   options.full_scan_mode = jfull_scan_mode;
   options.store_index_in_file = jstore_index_in_file;
   return reinterpret_cast<jlong>(rocksdb::NewPlainTableFactory(options));
@@ -41,9 +40,9 @@ jlong Java_org_rocksdb_PlainTableConfig_newTableFactoryHandle(
  * Signature: (ZJIJJIIZIZZZJIBBI)J
  */
 jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
-    JNIEnv *env, jobject jobj, jboolean no_block_cache, jlong block_cache_size,
-    jint block_cache_num_shardbits, jlong jblock_cache, jlong block_size,
-    jint block_size_deviation, jint block_restart_interval,
+    JNIEnv * /*env*/, jobject /*jobj*/, jboolean no_block_cache,
+    jlong block_cache_size, jint block_cache_num_shardbits, jlong jblock_cache,
+    jlong block_size, jint block_size_deviation, jint block_restart_interval,
     jboolean whole_key_filtering, jlong jfilter_policy,
     jboolean cache_index_and_filter_blocks,
     jboolean pin_l0_filter_and_index_blocks_in_cache,
@@ -83,16 +82,15 @@ jlong Java_org_rocksdb_BlockBasedTableConfig_newTableFactoryHandle(
   options.hash_index_allow_collision = hash_index_allow_collision;
   if (block_cache_compressed_size > 0) {
     if (block_cache_compressd_num_shard_bits > 0) {
-      options.block_cache =
-          rocksdb::NewLRUCache(block_cache_compressed_size,
-              block_cache_compressd_num_shard_bits);
+      options.block_cache = rocksdb::NewLRUCache(
+          block_cache_compressed_size, block_cache_compressd_num_shard_bits);
     } else {
       options.block_cache = rocksdb::NewLRUCache(block_cache_compressed_size);
     }
   }
   options.checksum = static_cast<rocksdb::ChecksumType>(jchecksum_type);
-  options.index_type = static_cast<
-      rocksdb::BlockBasedTableOptions::IndexType>(jindex_type);
+  options.index_type =
+      static_cast<rocksdb::BlockBasedTableOptions::IndexType>(jindex_type);
   options.format_version = jformat_version;
 
   return reinterpret_cast<jlong>(rocksdb::NewBlockBasedTableFactory(options));

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -83,7 +83,7 @@ void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* /*env*/,
  * Method:    prepare
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_prepare(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jobject /*jobj*/,
                                           jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Prepare();
@@ -97,7 +97,7 @@ void Java_org_rocksdb_Transaction_prepare(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    commit
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_commit(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jobject /*jobj*/,
                                          jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Commit();
@@ -111,7 +111,7 @@ void Java_org_rocksdb_Transaction_commit(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    rollback
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_rollback(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jobject /*jobj*/,
                                            jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Rollback();

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -21,8 +21,8 @@ using namespace std::placeholders;
  * Method:    setSnapshot
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->SetSnapshot();
 }
@@ -32,8 +32,8 @@ void Java_org_rocksdb_Transaction_setSnapshot(JNIEnv* env, jobject jobj,
  * Method:    setSnapshotOnNextOperation
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->SetSnapshotOnNextOperation(nullptr);
 }
@@ -43,8 +43,9 @@ void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__J(JNIEnv* env,
  * Method:    setSnapshotOnNextOperation
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__JJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jtxn_notifier_handle) {
+void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__JJ(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jtxn_notifier_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* txn_notifier =
       reinterpret_cast<std::shared_ptr<rocksdb::TransactionNotifier>*>(
@@ -57,8 +58,9 @@ void Java_org_rocksdb_Transaction_setSnapshotOnNextOperation__JJ(JNIEnv* env,
  * Method:    getSnapshot
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   const rocksdb::Snapshot* snapshot = txn->GetSnapshot();
   return reinterpret_cast<jlong>(snapshot);
@@ -69,8 +71,9 @@ jlong Java_org_rocksdb_Transaction_getSnapshot(JNIEnv* env, jobject jobj,
  * Method:    clearSnapshot
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->ClearSnapshot();
 }
@@ -80,8 +83,8 @@ void Java_org_rocksdb_Transaction_clearSnapshot(JNIEnv* env, jobject jobj,
  * Method:    prepare
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_prepare(JNIEnv* /*env*/, jobject /*jobj*/,
+                                          jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Prepare();
   if (!s.ok()) {
@@ -94,8 +97,8 @@ void Java_org_rocksdb_Transaction_prepare(JNIEnv* env, jobject jobj,
  * Method:    commit
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_commit(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Commit();
   if (!s.ok()) {
@@ -108,8 +111,8 @@ void Java_org_rocksdb_Transaction_commit(JNIEnv* env, jobject jobj,
  * Method:    rollback
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_rollback(JNIEnv* /*env*/, jobject /*jobj*/,
+                                           jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->Rollback();
   if (!s.ok()) {
@@ -122,8 +125,9 @@ void Java_org_rocksdb_Transaction_rollback(JNIEnv* env, jobject jobj,
  * Method:    setSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->SetSavePoint();
 }
@@ -133,8 +137,9 @@ void Java_org_rocksdb_Transaction_setSavePoint(JNIEnv* env, jobject jobj,
  * Method:    rollbackToSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_rollbackToSavePoint(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_rollbackToSavePoint(JNIEnv* env,
+                                                      jobject /*jobj*/,
+                                                      jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Status s = txn->RollbackToSavePoint();
   if (!s.ok()) {
@@ -142,19 +147,18 @@ void Java_org_rocksdb_Transaction_rollbackToSavePoint(JNIEnv* env, jobject jobj,
   }
 }
 
-typedef std::function<rocksdb::Status (
-    const rocksdb::ReadOptions&,
-    const rocksdb::Slice&,
-    std::string*)> FnGet;
+typedef std::function<rocksdb::Status(const rocksdb::ReadOptions&,
+                                      const rocksdb::Slice&, std::string*)>
+    FnGet;
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
-jbyteArray txn_get_helper(JNIEnv* env, const FnGet &fn_get,
-    const jlong &jread_options_handle, const jbyteArray &jkey,
-    const jint &jkey_part_len) {
+jbyteArray txn_get_helper(JNIEnv* env, const FnGet& fn_get,
+                          const jlong& jread_options_handle,
+                          const jbyteArray& jkey, const jint& jkey_part_len) {
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    return nullptr;
   }
   rocksdb::Slice key_slice(reinterpret_cast<char*>(key), jkey_part_len);
 
@@ -173,21 +177,20 @@ jbyteArray txn_get_helper(JNIEnv* env, const FnGet &fn_get,
   }
 
   if (s.ok()) {
-    jbyteArray jret_value =
-        env->NewByteArray(static_cast<jsize>(value.size()));
+    jbyteArray jret_value = env->NewByteArray(static_cast<jsize>(value.size()));
     if (jret_value == nullptr) {
-        // exception thrown: OutOfMemoryError
-        return nullptr;
+      // exception thrown: OutOfMemoryError
+      return nullptr;
     }
     env->SetByteArrayRegion(jret_value, 0, static_cast<jsize>(value.size()),
-        reinterpret_cast<const jbyte*>(value.c_str()));
+                            reinterpret_cast<const jbyte*>(value.c_str()));
     if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException
-        return nullptr;
+      // exception thrown: ArrayIndexOutOfBoundsException
+      return nullptr;
     }
     return jret_value;
   }
-  
+
   rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   return nullptr;
 }
@@ -197,17 +200,17 @@ jbyteArray txn_get_helper(JNIEnv* env, const FnGet &fn_get,
  * Method:    get
  * Signature: (JJ[BIJ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jread_options_handle, jbyteArray jkey, jint jkey_part_len,
-    jlong jcolumn_family_handle) {
+jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jbyteArray jkey, jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnGet fn_get =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, std::string*)>(
-          &rocksdb::Transaction::Get, txn, _1, column_family_handle, _2, _3);
-  return txn_get_helper(env, fn_get, jread_options_handle, jkey,
-      jkey_part_len);
+  FnGet fn_get = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*,
+      const rocksdb::Slice&, std::string*)>(&rocksdb::Transaction::Get, txn, _1,
+                                            column_family_handle, _2, _3);
+  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_part_len);
 }
 
 /*
@@ -215,15 +218,14 @@ jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    get
  * Signature: (JJ[BI)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BI(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jread_options_handle, jbyteArray jkey,
-    jint jkey_part_len) {
+jbyteArray Java_org_rocksdb_Transaction_get__JJ_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jbyteArray jkey, jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnGet fn_get =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*)>(
-          &rocksdb::Transaction::Get, txn, _1, _2, _3);
-  return txn_get_helper(env, fn_get, jread_options_handle, jkey,
-      jkey_part_len);
+  FnGet fn_get = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*)>(
+      &rocksdb::Transaction::Get, txn, _1, _2, _3);
+  return txn_get_helper(env, fn_get, jread_options_handle, jkey, jkey_part_len);
 }
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
@@ -234,50 +236,53 @@ std::vector<rocksdb::ColumnFamilyHandle*> txn_column_families_helper(
   if (jcolumn_family_handles != nullptr) {
     const jsize len_cols = env->GetArrayLength(jcolumn_family_handles);
     if (len_cols > 0) {
-        if (env->EnsureLocalCapacity(len_cols) != 0) {
-          // out of memory
-          *has_exception = JNI_TRUE;
-          return std::vector<rocksdb::ColumnFamilyHandle*>();
-        }
+      if (env->EnsureLocalCapacity(len_cols) != 0) {
+        // out of memory
+        *has_exception = JNI_TRUE;
+        return std::vector<rocksdb::ColumnFamilyHandle*>();
+      }
 
-        jlong* jcfh = env->GetLongArrayElements(jcolumn_family_handles, nullptr);
-        if (jcfh == nullptr) {
-            // exception thrown: OutOfMemoryError
-            *has_exception = JNI_TRUE;
-            return std::vector<rocksdb::ColumnFamilyHandle*>();
-        }
-        for (int i = 0; i < len_cols; i++) {
-          auto* cf_handle =
-              reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
-          cf_handles.push_back(cf_handle);
-        }
-        env->ReleaseLongArrayElements(jcolumn_family_handles, jcfh, JNI_ABORT);
+      jlong* jcfh = env->GetLongArrayElements(jcolumn_family_handles, nullptr);
+      if (jcfh == nullptr) {
+        // exception thrown: OutOfMemoryError
+        *has_exception = JNI_TRUE;
+        return std::vector<rocksdb::ColumnFamilyHandle*>();
+      }
+      for (int i = 0; i < len_cols; i++) {
+        auto* cf_handle =
+            reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcfh[i]);
+        cf_handles.push_back(cf_handle);
+      }
+      env->ReleaseLongArrayElements(jcolumn_family_handles, jcfh, JNI_ABORT);
     }
   }
   return cf_handles;
 }
 
-typedef std::function<std::vector<rocksdb::Status> (
-    const rocksdb::ReadOptions&,
-    const std::vector<rocksdb::Slice>&,
-    std::vector<std::string>*)> FnMultiGet;
+typedef std::function<std::vector<rocksdb::Status>(
+    const rocksdb::ReadOptions&, const std::vector<rocksdb::Slice>&,
+    std::vector<std::string>*)>
+    FnMultiGet;
 
-void free_key_parts(JNIEnv* env, std::vector<std::tuple<jbyteArray, jbyte*, jobject>> key_parts_to_free) {
-    for (std::vector<std::tuple<jbyteArray, jbyte*, jobject>>::size_type i = 0;
-        i < key_parts_to_free.size(); i++) {
-        jobject jk;
-        jbyteArray jk_ba;
-        jbyte* jk_val;
-        std::tie(jk_ba, jk_val, jk) = key_parts_to_free[i];
-        env->ReleaseByteArrayElements(jk_ba, jk_val, JNI_ABORT);
-        env->DeleteLocalRef(jk);
-    }
+void free_key_parts(
+    JNIEnv* env,
+    std::vector<std::tuple<jbyteArray, jbyte*, jobject>> key_parts_to_free) {
+  for (std::vector<std::tuple<jbyteArray, jbyte*, jobject>>::size_type i = 0;
+       i < key_parts_to_free.size(); i++) {
+    jobject jk;
+    jbyteArray jk_ba;
+    jbyte* jk_val;
+    std::tie(jk_ba, jk_val, jk) = key_parts_to_free[i];
+    env->ReleaseByteArrayElements(jk_ba, jk_val, JNI_ABORT);
+    env->DeleteLocalRef(jk);
+  }
 }
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
 // cf multi get
-jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet &fn_multi_get,
-    const jlong &jread_options_handle, const jobjectArray &jkey_parts) {
+jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet& fn_multi_get,
+                                  const jlong& jread_options_handle,
+                                  const jobjectArray& jkey_parts) {
   const jsize len_key_parts = env->GetArrayLength(jkey_parts);
   if (env->EnsureLocalCapacity(len_key_parts) != 0) {
     // out of memory
@@ -289,9 +294,9 @@ jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet &fn_multi_get,
   for (int i = 0; i < len_key_parts; i++) {
     const jobject jk = env->GetObjectArrayElement(jkey_parts, i);
     if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException
-        free_key_parts(env, key_parts_to_free);
-        return nullptr;
+      // exception thrown: ArrayIndexOutOfBoundsException
+      free_key_parts(env, key_parts_to_free);
+      return nullptr;
     }
     jbyteArray jk_ba = reinterpret_cast<jbyteArray>(jk);
     const jsize len_key = env->GetArrayLength(jk_ba);
@@ -315,8 +320,8 @@ jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet &fn_multi_get,
     key_parts_to_free.push_back(std::make_tuple(jk_ba, jk_val, jk));
   }
 
-  auto* read_options = 
-       reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
+  auto* read_options =
+      reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
   std::vector<std::string> value_parts;
   std::vector<rocksdb::Status> s =
       fn_multi_get(*read_options, key_parts, &value_parts);
@@ -329,8 +334,8 @@ jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet &fn_multi_get,
   jobjectArray jresults =
       env->NewObjectArray(static_cast<jsize>(s.size()), jcls_ba, nullptr);
   if (jresults == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    return nullptr;
   }
 
   // add to the jresults
@@ -365,8 +370,8 @@ jobjectArray txn_multi_get_helper(JNIEnv* env, const FnMultiGet &fn_multi_get,
  * Method:    multiGet
  * Signature: (JJ[[B[J)[[B
  */
-jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jread_options_handle,
+jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts, jlongArray jcolumn_family_handles) {
   bool has_exception = false;
   const std::vector<rocksdb::ColumnFamilyHandle*> column_family_handles =
@@ -377,11 +382,14 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(JNIEnv* env,
   }
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnMultiGet fn_multi_get =
-      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const std::vector<rocksdb::ColumnFamilyHandle*>&, const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
+      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*)(
+          const rocksdb::ReadOptions&,
+          const std::vector<rocksdb::ColumnFamilyHandle*>&,
+          const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
           &rocksdb::Transaction::MultiGet, txn, _1, column_family_handles, _2,
           _3);
   return txn_multi_get_helper(env, fn_multi_get, jread_options_handle,
-      jkey_parts);
+                              jkey_parts);
 }
 
 /*
@@ -389,15 +397,17 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B_3J(JNIEnv* env,
  * Method:    multiGet
  * Signature: (JJ[[B)[[B
  */
-jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jread_options_handle,
+jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnMultiGet fn_multi_get =
-      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
-          &rocksdb::Transaction::MultiGet, txn, _1, _2, _3);
+      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*)(
+          const rocksdb::ReadOptions&, const std::vector<rocksdb::Slice>&,
+          std::vector<std::string>*)>(&rocksdb::Transaction::MultiGet, txn, _1,
+                                      _2, _3);
   return txn_multi_get_helper(env, fn_multi_get, jread_options_handle,
-      jkey_parts);
+                              jkey_parts);
 }
 
 /*
@@ -405,18 +415,20 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(JNIEnv* env,
  * Method:    getForUpdate
  * Signature: (JJ[BIJZ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jread_options_handle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jexclusive) {
+jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jbyteArray jkey, jint jkey_part_len, jlong jcolumn_family_handle,
+    jboolean jexclusive) {
   auto* column_family_handle =
-        reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
+      reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnGet fn_get_for_update =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, std::string*, bool)>(
-          &rocksdb::Transaction::GetForUpdate, txn, _1, column_family_handle,
-          _2, _3, jexclusive);
+  FnGet fn_get_for_update = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*,
+      const rocksdb::Slice&, std::string*, bool)>(
+      &rocksdb::Transaction::GetForUpdate, txn, _1, column_family_handle, _2,
+      _3, jexclusive);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
-      jkey_part_len);
+                        jkey_part_len);
 }
 
 /*
@@ -424,15 +436,15 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZ(JNIEnv* env,
  * Method:    getForUpdate
  * Signature: (JJ[BIZ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jread_options_handle, jbyteArray jkey,
-    jint jkey_part_len, jboolean jexclusive) {
+jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jbyteArray jkey, jint jkey_part_len, jboolean jexclusive) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnGet fn_get_for_update =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*, bool)>(
-          &rocksdb::Transaction::GetForUpdate, txn, _1, _2, _3, jexclusive);
+  FnGet fn_get_for_update = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*, bool)>(
+      &rocksdb::Transaction::GetForUpdate, txn, _1, _2, _3, jexclusive);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
-      jkey_part_len);
+                        jkey_part_len);
 }
 
 /*
@@ -441,7 +453,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZ(JNIEnv* env,
  * Signature: (JJ[[B[J)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B_3J(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jread_options_handle,
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jobjectArray jkey_parts, jlongArray jcolumn_family_handles) {
   bool has_exception = false;
   const std::vector<rocksdb::ColumnFamilyHandle*> column_family_handles =
@@ -452,11 +464,14 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B_3J(
   }
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnMultiGet fn_multi_get_for_update =
-      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const std::vector<rocksdb::ColumnFamilyHandle*>&, const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
+      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*)(
+          const rocksdb::ReadOptions&,
+          const std::vector<rocksdb::ColumnFamilyHandle*>&,
+          const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
           &rocksdb::Transaction::MultiGetForUpdate, txn, _1,
           column_family_handles, _2, _3);
   return txn_multi_get_helper(env, fn_multi_get_for_update,
-      jread_options_handle, jkey_parts);
+                              jread_options_handle, jkey_parts);
 }
 
 /*
@@ -465,14 +480,16 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B_3J(
  * Signature: (JJ[[B)[[B
  */
 jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
-  JNIEnv* env, jobject jobj, jlong jhandle, jlong jread_options_handle,
-  jobjectArray jkey_parts) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
+    jobjectArray jkey_parts) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnMultiGet fn_multi_get_for_update =
-      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*) (const rocksdb::ReadOptions&, const std::vector<rocksdb::Slice>&, std::vector<std::string>*)>(
-          &rocksdb::Transaction::MultiGetForUpdate, txn, _1, _2, _3);
+      std::bind<std::vector<rocksdb::Status> (rocksdb::Transaction::*)(
+          const rocksdb::ReadOptions&, const std::vector<rocksdb::Slice>&,
+          std::vector<std::string>*)>(&rocksdb::Transaction::MultiGetForUpdate,
+                                      txn, _1, _2, _3);
   return txn_multi_get_helper(env, fn_multi_get_for_update,
-      jread_options_handle, jkey_parts);
+                              jread_options_handle, jkey_parts);
 }
 
 /*
@@ -480,13 +497,14 @@ jobjectArray Java_org_rocksdb_Transaction_multiGetForUpdate__JJ_3_3B(
  * Method:    getIterator
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_Transaction_getIterator__JJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jread_options_handle) {
+jlong Java_org_rocksdb_Transaction_getIterator__JJ(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle,
+                                                   jlong jread_options_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* read_options =
       reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
-  return reinterpret_cast<jlong>(
-      txn->GetIterator(*read_options));
+  return reinterpret_cast<jlong>(txn->GetIterator(*read_options));
 }
 
 /*
@@ -494,8 +512,9 @@ jlong Java_org_rocksdb_Transaction_getIterator__JJ(JNIEnv* env, jobject jobj,
  * Method:    getIterator
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_Transaction_getIterator__JJJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jread_options_handle, jlong jcolumn_family_handle) {
+jlong Java_org_rocksdb_Transaction_getIterator__JJJ(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jread_options_handle, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* read_options =
       reinterpret_cast<rocksdb::ReadOptions*>(jread_options_handle);
@@ -505,14 +524,14 @@ jlong Java_org_rocksdb_Transaction_getIterator__JJJ(JNIEnv* env, jobject jobj,
       txn->GetIterator(*read_options, column_family_handle));
 }
 
-typedef std::function<rocksdb::Status (
-    const rocksdb::Slice&,
-    const rocksdb::Slice&)> FnWriteKV;
+typedef std::function<rocksdb::Status(const rocksdb::Slice&,
+                                      const rocksdb::Slice&)>
+    FnWriteKV;
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
-void txn_write_kv_helper(JNIEnv* env, const FnWriteKV &fn_write_kv,
-    const jbyteArray &jkey, const jint &jkey_part_len,
-    const jbyteArray &jval, const jint &jval_len) {
+void txn_write_kv_helper(JNIEnv* env, const FnWriteKV& fn_write_kv,
+                         const jbyteArray& jkey, const jint& jkey_part_len,
+                         const jbyteArray& jval, const jint& jval_len) {
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -546,15 +565,17 @@ void txn_write_kv_helper(JNIEnv* env, const FnWriteKV &fn_write_kv,
  * Method:    put
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3BI_3BIJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len, jbyteArray jval,
-    jint jval_len, jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_put__J_3BI_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnWriteKV fn_put =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Put, txn, column_family_handle, _1, _2);
+  FnWriteKV fn_put = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
+      const rocksdb::Slice&)>(&rocksdb::Transaction::Put, txn,
+                              column_family_handle, _1, _2);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -563,21 +584,24 @@ void Java_org_rocksdb_Transaction_put__J_3BI_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    put
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_Transaction_put__J_3BI_3BI(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len, jbyteArray jval,
-    jint jval_len) {
+void Java_org_rocksdb_Transaction_put__J_3BI_3BI(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong jhandle, jbyteArray jkey,
+                                                 jint jkey_part_len,
+                                                 jbyteArray jval,
+                                                 jint jval_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKV fn_put =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Put, txn, _1, _2);
+  FnWriteKV fn_put = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::Slice&, const rocksdb::Slice&)>(&rocksdb::Transaction::Put,
+                                                     txn, _1, _2);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
 }
 
-typedef std::function<rocksdb::Status (
-    const rocksdb::SliceParts&,
-    const rocksdb::SliceParts&)> FnWriteKVParts;
+typedef std::function<rocksdb::Status(const rocksdb::SliceParts&,
+                                      const rocksdb::SliceParts&)>
+    FnWriteKVParts;
 
-void free_key_value_parts(JNIEnv* env, const int32_t len,
+void free_key_value_parts(
+    JNIEnv* env, const int32_t len,
     std::tuple<jbyteArray, jbyte*, jobject> jkey_parts_to_free[],
     std::tuple<jbyteArray, jbyte*, jobject> jvalue_parts_to_free[]) {
   for (int32_t i = len - 1; i >= 0; --i) {
@@ -592,8 +616,7 @@ void free_key_value_parts(JNIEnv* env, const int32_t len,
     jbyteArray jba_key_part;
     jbyte* jkey_part;
     jobject jobj_key_part;
-    std::tie(jba_key_part, jkey_part, jobj_key_part) =
-        jkey_parts_to_free[i];
+    std::tie(jba_key_part, jkey_part, jobj_key_part) = jkey_parts_to_free[i];
     env->ReleaseByteArrayElements(jba_key_part, jkey_part, JNI_ABORT);
     env->DeleteLocalRef(jobj_key_part);
   }
@@ -601,15 +624,18 @@ void free_key_value_parts(JNIEnv* env, const int32_t len,
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
 void txn_write_kv_parts_helper(JNIEnv* env,
-    const FnWriteKVParts &fn_write_kv_parts, const jobjectArray &jkey_parts,
-    const jint &jkey_parts_len, const jobjectArray &jvalue_parts,
-    const jint &jvalue_parts_len) {
+                               const FnWriteKVParts& fn_write_kv_parts,
+                               const jobjectArray& jkey_parts,
+                               const jint& jkey_parts_len,
+                               const jobjectArray& jvalue_parts,
+                               const jint& jvalue_parts_len) {
   assert(jkey_parts_len == jvalue_parts_len);
 
   rocksdb::Slice key_parts[jkey_parts_len];
   rocksdb::Slice value_parts[jvalue_parts_len];
   std::tuple<jbyteArray, jbyte*, jobject> jkey_parts_to_free[jkey_parts_len];
-  std::tuple<jbyteArray, jbyte*, jobject> jvalue_parts_to_free[jvalue_parts_len];
+  std::tuple<jbyteArray, jbyte*, jobject>
+      jvalue_parts_to_free[jvalue_parts_len];
 
   // convert java key_parts/value_parts byte[][] to Slice(s)
   for (jsize i = 0; i < jkey_parts_len; ++i) {
@@ -617,7 +643,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
     if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
     const jobject jobj_value_part = env->GetObjectArrayElement(jvalue_parts, i);
@@ -625,7 +651,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jobj_key_part);
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
 
@@ -636,7 +662,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       env->DeleteLocalRef(jobj_value_part);
       env->DeleteLocalRef(jobj_key_part);
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
     jbyte* jkey_part = env->GetByteArrayElements(jba_key_part, nullptr);
@@ -645,18 +671,19 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       env->DeleteLocalRef(jobj_value_part);
       env->DeleteLocalRef(jobj_key_part);
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
 
-    const jbyteArray jba_value_part = reinterpret_cast<jbyteArray>(jobj_value_part);
+    const jbyteArray jba_value_part =
+        reinterpret_cast<jbyteArray>(jobj_value_part);
     const jsize jvalue_part_len = env->GetArrayLength(jba_value_part);
     if (env->EnsureLocalCapacity(jvalue_part_len) != 0) {
       // out of memory
       env->DeleteLocalRef(jobj_value_part);
       env->DeleteLocalRef(jobj_key_part);
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
     jbyte* jvalue_part = env->GetByteArrayElements(jba_value_part, nullptr);
@@ -666,7 +693,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       env->DeleteLocalRef(jobj_value_part);
       env->DeleteLocalRef(jobj_key_part);
       free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-          jvalue_parts_to_free);
+                           jvalue_parts_to_free);
       return;
     }
 
@@ -682,13 +709,13 @@ void txn_write_kv_parts_helper(JNIEnv* env,
   }
 
   // call the write_multi function
-  rocksdb::Status s = fn_write_kv_parts(
-    rocksdb::SliceParts(key_parts, jkey_parts_len),
-    rocksdb::SliceParts(value_parts, jvalue_parts_len));
+  rocksdb::Status s =
+      fn_write_kv_parts(rocksdb::SliceParts(key_parts, jkey_parts_len),
+                        rocksdb::SliceParts(value_parts, jvalue_parts_len));
 
   // cleanup temporary memory
   free_key_value_parts(env, jkey_parts_len, jkey_parts_to_free,
-    jvalue_parts_to_free);
+                       jvalue_parts_to_free);
 
   // return
   if (s.ok()) {
@@ -703,18 +730,20 @@ void txn_write_kv_parts_helper(JNIEnv* env,
  * Method:    put
  * Signature: (J[[BI[[BIJ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jobjectArray jvalue_parts, jint jvalue_parts_len,
+void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKVParts fn_put_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::Put, txn, column_family_handle, _1, _2);
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
+          const rocksdb::SliceParts&)>(&rocksdb::Transaction::Put, txn,
+                                       column_family_handle, _1, _2);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
-      jvalue_parts, jvalue_parts_len);
+                            jvalue_parts, jvalue_parts_len);
 }
 
 /*
@@ -722,15 +751,16 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJ(JNIEnv* env,
  * Method:    put
  * Signature: (J[[BI[[BI)V
  */
-void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jobjectArray jvalue_parts, jint jvalue_parts_len) {
+void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnWriteKVParts fn_put_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
           &rocksdb::Transaction::Put, txn, _1, _2);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
-      jvalue_parts, jvalue_parts_len);
+                            jvalue_parts, jvalue_parts_len);
 }
 
 /*
@@ -738,15 +768,17 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(JNIEnv* env,
  * Method:    merge
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len, jbyteArray jval,
-    jint jval_len, jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnWriteKV fn_merge =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Merge, txn, column_family_handle, _1, _2);
+  FnWriteKV fn_merge = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
+      const rocksdb::Slice&)>(&rocksdb::Transaction::Merge, txn,
+                              column_family_handle, _1, _2);
   txn_write_kv_helper(env, fn_merge, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -755,22 +787,21 @@ void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    merge
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_Transaction_merge__J_3BI_3BI(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len, jbyteArray jval,
-    jint jval_len) {
+void Java_org_rocksdb_Transaction_merge__J_3BI_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKV fn_merge =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Merge, txn, _1, _2);
+  FnWriteKV fn_merge = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::Slice&, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::Merge, txn, _1, _2);
   txn_write_kv_helper(env, fn_merge, jkey, jkey_part_len, jval, jval_len);
 }
 
-typedef std::function<rocksdb::Status (
-    const rocksdb::Slice&)> FnWriteK;
+typedef std::function<rocksdb::Status(const rocksdb::Slice&)> FnWriteK;
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
-void txn_write_k_helper(JNIEnv* env, const FnWriteK &fn_write_k,
-    const jbyteArray &jkey, const jint &jkey_part_len) {
+void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
+                        const jbyteArray& jkey, const jint& jkey_part_len) {
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -796,15 +827,16 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK &fn_write_k,
  * Method:    delete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3BIJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_delete__J_3BIJ(JNIEnv* env, jobject /*jobj*/,
+                                                 jlong jhandle, jbyteArray jkey,
+                                                 jint jkey_part_len,
+                                                 jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnWriteK fn_delete =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Delete, txn, column_family_handle, _1);
+  FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::Delete, txn, column_family_handle, _1);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
 }
 
@@ -813,19 +845,20 @@ void Java_org_rocksdb_Transaction_delete__J_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3BI(JNIEnv* env, jobject jobj,
-    jlong jhandle, jbyteArray jkey, jint jkey_part_len) {
+void Java_org_rocksdb_Transaction_delete__J_3BI(JNIEnv* env, jobject /*jobj*/,
+                                                jlong jhandle, jbyteArray jkey,
+                                                jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteK fn_delete =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&)>(
-          &rocksdb::Transaction::Delete, txn, _1);
+  FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+      const rocksdb::Slice&)>(&rocksdb::Transaction::Delete, txn, _1);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
 }
 
-typedef std::function<rocksdb::Status (
-    const rocksdb::SliceParts&)> FnWriteKParts;
+typedef std::function<rocksdb::Status(const rocksdb::SliceParts&)>
+    FnWriteKParts;
 
-void free_key_parts(JNIEnv* env, const int32_t len,
+void free_key_parts(
+    JNIEnv* env, const int32_t len,
     std::tuple<jbyteArray, jbyte*, jobject> jkey_parts_to_free[]) {
   for (int32_t i = len - 1; i >= 0; --i) {
     jbyteArray jba_key_part;
@@ -839,9 +872,9 @@ void free_key_parts(JNIEnv* env, const int32_t len,
 
 // TODO(AR) consider refactoring to share this between here and rocksjni.cc
 void txn_write_k_parts_helper(JNIEnv* env,
-    const FnWriteKParts &fn_write_k_parts, const jobjectArray &jkey_parts,
-    const jint &jkey_parts_len) {
-
+                              const FnWriteKParts& fn_write_k_parts,
+                              const jobjectArray& jkey_parts,
+                              const jint& jkey_parts_len) {
   rocksdb::Slice key_parts[jkey_parts_len];
   std::tuple<jbyteArray, jbyte*, jobject> jkey_parts_to_free[jkey_parts_len];
 
@@ -873,12 +906,13 @@ void txn_write_k_parts_helper(JNIEnv* env,
     jkey_parts_to_free[i] = std::tuple<jbyteArray, jbyte*, jobject>(
         jba_key_part, jkey_part, jobj_key_part);
 
-    key_parts[i] = rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len);
+    key_parts[i] =
+        rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len);
   }
 
   // call the write_multi function
-  rocksdb::Status s = fn_write_k_parts(
-    rocksdb::SliceParts(key_parts, jkey_parts_len));
+  rocksdb::Status s =
+      fn_write_k_parts(rocksdb::SliceParts(key_parts, jkey_parts_len));
 
   // cleanup temporary memory
   free_key_parts(env, jkey_parts_len, jkey_parts_to_free);
@@ -895,14 +929,15 @@ void txn_write_k_parts_helper(JNIEnv* env,
  * Method:    delete
  * Signature: (J[[BIJ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3_3BIJ(JNIEnv* env, jobject jobj,
-    jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_delete__J_3_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_delete_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
           &rocksdb::Transaction::Delete, txn, column_family_handle, _1);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
 }
@@ -912,12 +947,14 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BIJ(JNIEnv* env, jobject jobj,
  * Method:    delete
  * Signature: (J[[BI)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject jobj,
-    jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len) {
+void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
+                                                  jlong jhandle,
+                                                  jobjectArray jkey_parts,
+                                                  jint jkey_parts_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnWriteKParts fn_delete_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::Delete, txn, _1);
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          const rocksdb::SliceParts&)>(&rocksdb::Transaction::Delete, txn, _1);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
 }
 
@@ -926,14 +963,15 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject jobj,
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_singleDelete__J_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_single_delete =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
 }
@@ -944,11 +982,14 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BIJ(JNIEnv* env,
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len) {
+                                                      jobject /*jobj*/,
+                                                      jlong jhandle,
+                                                      jbyteArray jkey,
+                                                      jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnWriteK fn_single_delete =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&)>(
-          &rocksdb::Transaction::SingleDelete, txn, _1);
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          const rocksdb::Slice&)>(&rocksdb::Transaction::SingleDelete, txn, _1);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
 }
 
@@ -957,17 +998,18 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
  * Method:    singleDelete
  * Signature: (J[[BIJ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_single_delete_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,
-      jkey_parts_len);
+                           jkey_parts_len);
 }
 
 /*
@@ -976,13 +1018,16 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJ(JNIEnv* env,
  * Signature: (J[[BI)V
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len) {
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle,
+                                                        jobjectArray jkey_parts,
+                                                        jint jkey_parts_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKParts fn_single_delete_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::SingleDelete, txn, _1);
+  FnWriteKParts fn_single_delete_parts = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(const rocksdb::SliceParts&)>(
+      &rocksdb::Transaction::SingleDelete, txn, _1);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,
-      jkey_parts_len);
+                           jkey_parts_len);
 }
 
 /*
@@ -990,18 +1035,19 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BI(JNIEnv* env,
  * Method:    putUntracked
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jbyteArray jval, jint jval_len, jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnWriteKV fn_put_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::PutUntracked, txn, column_family_handle, _1,
-          _2);
+  FnWriteKV fn_put_untracked = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(rocksdb::ColumnFamilyHandle*,
+                               const rocksdb::Slice&, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::PutUntracked, txn, column_family_handle, _1, _2);
   txn_write_kv_helper(env, fn_put_untracked, jkey, jkey_part_len, jval,
-      jval_len);
+                      jval_len);
 }
 
 /*
@@ -1009,15 +1055,15 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BIJ(JNIEnv* env,
  * Method:    putUntracked
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jbyteArray jval, jint jval_len) {
+void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKV fn_put_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::PutUntracked, txn, _1, _2);
+  FnWriteKV fn_put_untracked = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(const rocksdb::Slice&, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::PutUntracked, txn, _1, _2);
   txn_write_kv_helper(env, fn_put_untracked, jkey, jkey_part_len, jval,
-      jval_len);
+                      jval_len);
 }
 
 /*
@@ -1025,19 +1071,20 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3BI_3BI(JNIEnv* env,
  * Method:    putUntracked
  * Signature: (J[[BI[[BIJ)V
  */
-void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jobjectArray jvalue_parts, jint jvalue_parts_len,
+void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
     jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKVParts fn_put_parts_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::PutUntracked, txn, column_family_handle, _1,
-          _2);
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
+          const rocksdb::SliceParts&)>(&rocksdb::Transaction::PutUntracked, txn,
+                                       column_family_handle, _1, _2);
   txn_write_kv_parts_helper(env, fn_put_parts_untracked, jkey_parts,
-      jkey_parts_len, jvalue_parts, jvalue_parts_len);
+                            jkey_parts_len, jvalue_parts, jvalue_parts_len);
 }
 
 /*
@@ -1045,15 +1092,16 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BIJ(JNIEnv* env,
  * Method:    putUntracked
  * Signature: (J[[BI[[BI)V
  */
-void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jobjectArray jvalue_parts, jint jvalue_parts_len) {
+void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnWriteKVParts fn_put_parts_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          const rocksdb::SliceParts&, const rocksdb::SliceParts&)>(
           &rocksdb::Transaction::PutUntracked, txn, _1, _2);
   txn_write_kv_parts_helper(env, fn_put_parts_untracked, jkey_parts,
-      jkey_parts_len, jvalue_parts, jvalue_parts_len);
+                            jkey_parts_len, jvalue_parts, jvalue_parts_len);
 }
 
 /*
@@ -1061,18 +1109,19 @@ void Java_org_rocksdb_Transaction_putUntracked__J_3_3BI_3_3BI(JNIEnv* env,
  * Method:    mergeUntracked
  * Signature: (J[BI[BIJ)V
  */
-void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jbyteArray jval, jint jval_len, jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len,
+    jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
-  FnWriteKV fn_merge_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::MergeUntracked, txn, column_family_handle, _1,
-          _2);
+  FnWriteKV fn_merge_untracked = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(rocksdb::ColumnFamilyHandle*,
+                               const rocksdb::Slice&, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::MergeUntracked, txn, column_family_handle, _1, _2);
   txn_write_kv_helper(env, fn_merge_untracked, jkey, jkey_part_len, jval,
-      jval_len);
+                      jval_len);
 }
 
 /*
@@ -1080,15 +1129,15 @@ void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BIJ(JNIEnv* env,
  * Method:    mergeUntracked
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jbyteArray jval, jint jval_len) {
+void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jbyteArray jval, jint jval_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKV fn_merge_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::MergeUntracked, txn, _1, _2);
+  FnWriteKV fn_merge_untracked = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(const rocksdb::Slice&, const rocksdb::Slice&)>(
+      &rocksdb::Transaction::MergeUntracked, txn, _1, _2);
   txn_write_kv_helper(env, fn_merge_untracked, jkey, jkey_part_len, jval,
-      jval_len);
+                      jval_len);
 }
 
 /*
@@ -1096,14 +1145,15 @@ void Java_org_rocksdb_Transaction_mergeUntracked__J_3BI_3BI(JNIEnv* env,
  * Method:    deleteUntracked
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_Transaction_deleteUntracked__J_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_deleteUntracked__J_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_delete_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
           &rocksdb::Transaction::DeleteUntracked, txn, column_family_handle,
           _1);
   txn_write_k_helper(env, fn_delete_untracked, jkey, jkey_part_len);
@@ -1115,11 +1165,14 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3BIJ(JNIEnv* env,
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_deleteUntracked__J_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len) {
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle,
+                                                         jbyteArray jkey,
+                                                         jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteK fn_delete_untracked =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::Slice&)>(
-          &rocksdb::Transaction::DeleteUntracked, txn, _1);
+  FnWriteK fn_delete_untracked = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(const rocksdb::Slice&)>(
+      &rocksdb::Transaction::DeleteUntracked, txn, _1);
   txn_write_k_helper(env, fn_delete_untracked, jkey, jkey_part_len);
 }
 
@@ -1128,18 +1181,19 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3BI(JNIEnv* env,
  * Method:    deleteUntracked
  * Signature: (J[[BIJ)V
  */
-void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts, jint jkey_parts_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
+    jint jkey_parts_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_delete_untracked_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
+      std::bind<rocksdb::Status (rocksdb::Transaction::*)(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
           &rocksdb::Transaction::DeleteUntracked, txn, column_family_handle,
           _1);
   txn_write_k_parts_helper(env, fn_delete_untracked_parts, jkey_parts,
-      jkey_parts_len);
+                           jkey_parts_len);
 }
 
 /*
@@ -1147,15 +1201,15 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BIJ(JNIEnv* env,
  * Method:    deleteUntracked
  * Signature: (J[[BI)V
  */
-void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jobjectArray jkey_parts,
+void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BI(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
-  FnWriteKParts fn_delete_untracked_parts =
-      std::bind<rocksdb::Status (rocksdb::Transaction::*) (const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::DeleteUntracked, txn, _1);
+  FnWriteKParts fn_delete_untracked_parts = std::bind<rocksdb::Status (
+      rocksdb::Transaction::*)(const rocksdb::SliceParts&)>(
+      &rocksdb::Transaction::DeleteUntracked, txn, _1);
   txn_write_k_parts_helper(env, fn_delete_untracked_parts, jkey_parts,
-      jkey_parts_len);
+                           jkey_parts_len);
 }
 
 /*
@@ -1163,8 +1217,9 @@ void Java_org_rocksdb_Transaction_deleteUntracked__J_3_3BI(JNIEnv* env,
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len) {
+void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env, jobject /*jobj*/,
+                                             jlong jhandle, jbyteArray jkey,
+                                             jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
 
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
@@ -1187,8 +1242,9 @@ void Java_org_rocksdb_Transaction_putLogData(JNIEnv* env,
  * Method:    disableIndexing
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_disableIndexing(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_disableIndexing(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->DisableIndexing();
 }
@@ -1198,8 +1254,9 @@ void Java_org_rocksdb_Transaction_disableIndexing(JNIEnv* env, jobject jobj,
  * Method:    enableIndexing
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_enableIndexing(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_enableIndexing(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->EnableIndexing();
 }
@@ -1209,8 +1266,8 @@ void Java_org_rocksdb_Transaction_enableIndexing(JNIEnv* env, jobject jobj,
  * Method:    getNumKeys
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetNumKeys();
 }
@@ -1220,8 +1277,8 @@ jlong Java_org_rocksdb_Transaction_getNumKeys(JNIEnv* env, jobject jobj,
  * Method:    getNumPuts
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetNumPuts();
 }
@@ -1231,8 +1288,9 @@ jlong Java_org_rocksdb_Transaction_getNumPuts(JNIEnv* env, jobject jobj,
  * Method:    getNumDeletes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumDeletes(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getNumDeletes(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetNumDeletes();
 }
@@ -1242,8 +1300,9 @@ jlong Java_org_rocksdb_Transaction_getNumDeletes(JNIEnv* env, jobject jobj,
  * Method:    getNumMerges
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getNumMerges(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getNumMerges(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetNumMerges();
 }
@@ -1253,8 +1312,9 @@ jlong Java_org_rocksdb_Transaction_getNumMerges(JNIEnv* env, jobject jobj,
  * Method:    getElapsedTime
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getElapsedTime(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getElapsedTime(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetElapsedTime();
 }
@@ -1264,8 +1324,9 @@ jlong Java_org_rocksdb_Transaction_getElapsedTime(JNIEnv* env, jobject jobj,
  * Method:    getWriteBatch
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getWriteBatch(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getWriteBatch(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return reinterpret_cast<jlong>(txn->GetWriteBatch());
 }
@@ -1275,8 +1336,10 @@ jlong Java_org_rocksdb_Transaction_getWriteBatch(JNIEnv* env, jobject jobj,
  * Method:    setLockTimeout
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_setLockTimeout(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jlock_timeout) {
+void Java_org_rocksdb_Transaction_setLockTimeout(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle,
+                                                 jlong jlock_timeout) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->SetLockTimeout(jlock_timeout);
 }
@@ -1286,8 +1349,9 @@ void Java_org_rocksdb_Transaction_setLockTimeout(JNIEnv* env, jobject jobj,
  * Method:    getWriteOptions
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getWriteOptions(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getWriteOptions(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return reinterpret_cast<jlong>(txn->GetWriteOptions());
 }
@@ -1297,8 +1361,10 @@ jlong Java_org_rocksdb_Transaction_getWriteOptions(JNIEnv* env, jobject jobj,
  * Method:    setWriteOptions
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_setWriteOptions(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jwrite_options_handle) {
+void Java_org_rocksdb_Transaction_setWriteOptions(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle,
+                                                  jlong jwrite_options_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
@@ -1310,9 +1376,9 @@ void Java_org_rocksdb_Transaction_setWriteOptions(JNIEnv* env, jobject jobj,
  * Method:    undo
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BIJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len,
-    jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BIJ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jlong jcolumn_family_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -1334,7 +1400,10 @@ void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BIJ(JNIEnv* env,
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BI(JNIEnv* env,
-    jobject jobj, jlong jhandle, jbyteArray jkey, jint jkey_part_len) {
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle,
+                                                          jbyteArray jkey,
+                                                          jint jkey_part_len) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   jbyte* key = env->GetByteArrayElements(jkey, nullptr);
   if (key == nullptr) {
@@ -1353,8 +1422,8 @@ void Java_org_rocksdb_Transaction_undoGetForUpdate__J_3BI(JNIEnv* env,
  * Method:    rebuildFromWriteBatch
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_rebuildFromWriteBatch(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jwrite_batch_handle) {
+void Java_org_rocksdb_Transaction_rebuildFromWriteBatch(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jwrite_batch_handle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* write_batch =
       reinterpret_cast<rocksdb::WriteBatch*>(jwrite_batch_handle);
@@ -1369,8 +1438,9 @@ void Java_org_rocksdb_Transaction_rebuildFromWriteBatch(JNIEnv* env,
  * Method:    getCommitTimeWriteBatch
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getCommitTimeWriteBatch(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getCommitTimeWriteBatch(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return reinterpret_cast<jlong>(txn->GetCommitTimeWriteBatch());
 }
@@ -1380,8 +1450,9 @@ jlong Java_org_rocksdb_Transaction_getCommitTimeWriteBatch(JNIEnv* env,
  * Method:    setLogNumber
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* env, jobject jobj,
-    jlong jhandle, jlong jlog_number) {
+void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* /*env*/,
+                                               jobject /*jobj*/, jlong jhandle,
+                                               jlong jlog_number) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   txn->SetLogNumber(jlog_number);
 }
@@ -1391,8 +1462,9 @@ void Java_org_rocksdb_Transaction_setLogNumber(JNIEnv* env, jobject jobj,
  * Method:    getLogNumber
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getLogNumber(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getLogNumber(JNIEnv* /*env*/,
+                                                jobject /*jobj*/,
+                                                jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return txn->GetLogNumber();
 }
@@ -1402,8 +1474,8 @@ jlong Java_org_rocksdb_Transaction_getLogNumber(JNIEnv* env, jobject jobj,
  * Method:    setName
  * Signature: (JLjava/lang/String;)V
  */
-void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jobject jobj,
-    jlong jhandle, jstring jname) {
+void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jobject /*jobj*/,
+                                          jlong jhandle, jstring jname) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   const char* name = env->GetStringUTFChars(jname, nullptr);
   if (name == nullptr) {
@@ -1425,8 +1497,8 @@ void Java_org_rocksdb_Transaction_setName(JNIEnv* env, jobject jobj,
  * Method:    getName
  * Signature: (J)Ljava/lang/String;
  */
-jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jobject /*jobj*/,
+                                             jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::TransactionName name = txn->GetName();
   return env->NewStringUTF(name.data());
@@ -1437,8 +1509,8 @@ jstring Java_org_rocksdb_Transaction_getName(JNIEnv* env, jobject jobj,
  * Method:    getID
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getID(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getID(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::TransactionID id = txn->GetID();
   return static_cast<jlong>(id);
@@ -1449,8 +1521,9 @@ jlong Java_org_rocksdb_Transaction_getID(JNIEnv* env, jobject jobj,
  * Method:    isDeadlockDetect
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Transaction_isDeadlockDetect(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_Transaction_isDeadlockDetect(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   return static_cast<jboolean>(txn->IsDeadlockDetect());
 }
@@ -1461,15 +1534,15 @@ jboolean Java_org_rocksdb_Transaction_isDeadlockDetect(JNIEnv* env,
  * Signature: (J)Lorg/rocksdb/Transaction/WaitingTransactions;
  */
 jobject Java_org_rocksdb_Transaction_getWaitingTxns(JNIEnv* env,
-    jobject jtransaction_obj, jlong jhandle) {
+                                                    jobject jtransaction_obj,
+                                                    jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   uint32_t column_family_id;
   std::string key;
   std::vector<rocksdb::TransactionID> waiting_txns =
       txn->GetWaitingTxns(&column_family_id, &key);
-  jobject jwaiting_txns =
-      rocksdb::TransactionJni::newWaitingTransactions(
-          env, jtransaction_obj, column_family_id, key, waiting_txns);
+  jobject jwaiting_txns = rocksdb::TransactionJni::newWaitingTransactions(
+      env, jtransaction_obj, column_family_id, key, waiting_txns);
   return jwaiting_txns;
 }
 
@@ -1478,8 +1551,8 @@ jobject Java_org_rocksdb_Transaction_getWaitingTxns(JNIEnv* env,
  * Method:    getState
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   rocksdb::Transaction::TransactionState txn_status = txn->GetState();
   switch (txn_status) {
@@ -1517,8 +1590,8 @@ jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* env,
  * Method:    getId
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Transaction_getId(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+jlong Java_org_rocksdb_Transaction_getId(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong jhandle) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   uint64_t id = txn->GetId();
   return static_cast<jlong>(id);
@@ -1529,7 +1602,8 @@ jlong Java_org_rocksdb_Transaction_getId(JNIEnv* env, jobject jobj,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_Transaction_disposeInternal(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_Transaction_disposeInternal(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong jhandle) {
   delete reinterpret_cast<rocksdb::Transaction*>(jhandle);
 }

--- a/java/rocksjni/transaction_db.cc
+++ b/java/rocksjni/transaction_db.cc
@@ -11,7 +11,6 @@
 #include <memory>
 #include <utility>
 
-
 #include "include/org_rocksdb_TransactionDB.h"
 
 #include "rocksdb/options.h"
@@ -25,9 +24,9 @@
  * Method:    open
  * Signature: (JJLjava/lang/String;)J
  */
-jlong Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2(JNIEnv* env,
-    jclass jcls, jlong joptions_handle, jlong jtxn_db_options_handle,
-    jstring jdb_path) {
+jlong Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2(
+    JNIEnv* env, jclass /*jcls*/, jlong joptions_handle,
+    jlong jtxn_db_options_handle, jstring jdb_path) {
   auto* options = reinterpret_cast<rocksdb::Options*>(joptions_handle);
   auto* txn_db_options =
       reinterpret_cast<rocksdb::TransactionDBOptions*>(jtxn_db_options_handle);
@@ -55,9 +54,8 @@ jlong Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2(JNIEnv* env,
  * Signature: (JJLjava/lang/String;[[B[J)[J
  */
 jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
-    JNIEnv* env, jclass jcls, jlong jdb_options_handle,
-    jlong jtxn_db_options_handle, jstring jdb_path,
-    jobjectArray jcolumn_names,
+    JNIEnv* env, jclass /*jcls*/, jlong jdb_options_handle,
+    jlong jtxn_db_options_handle, jstring jdb_path, jobjectArray jcolumn_names,
     jlongArray jcolumn_options_handles) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
   if (db_path == nullptr) {
@@ -74,18 +72,18 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
 
   jlong* jco = env->GetLongArrayElements(jcolumn_options_handles, nullptr);
   if (jco == nullptr) {
-      // exception thrown: OutOfMemoryError
-      env->ReleaseStringUTFChars(jdb_path, db_path);
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    env->ReleaseStringUTFChars(jdb_path, db_path);
+    return nullptr;
   }
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   for (int i = 0; i < len_cols; i++) {
     const jobject jcn = env->GetObjectArrayElement(jcolumn_names, i);
     if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException
-        env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
-        env->ReleaseStringUTFChars(jdb_path, db_path);
-        return nullptr;
+      // exception thrown: ArrayIndexOutOfBoundsException
+      env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
+      env->ReleaseStringUTFChars(jdb_path, db_path);
+      return nullptr;
     }
     const jbyteArray jcn_ba = reinterpret_cast<jbyteArray>(jcn);
     jbyte* jcf_name = env->GetByteArrayElements(jcn_ba, nullptr);
@@ -99,18 +97,18 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
 
     const int jcf_name_len = env->GetArrayLength(jcn_ba);
     if (env->EnsureLocalCapacity(jcf_name_len) != 0) {
-        // out of memory
-        env->ReleaseByteArrayElements(jcn_ba, jcf_name, JNI_ABORT);
-        env->DeleteLocalRef(jcn);
-        env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
-        env->ReleaseStringUTFChars(jdb_path, db_path);
-        return nullptr;
+      // out of memory
+      env->ReleaseByteArrayElements(jcn_ba, jcf_name, JNI_ABORT);
+      env->DeleteLocalRef(jcn);
+      env->ReleaseLongArrayElements(jcolumn_options_handles, jco, JNI_ABORT);
+      env->ReleaseStringUTFChars(jdb_path, db_path);
+      return nullptr;
     }
-    const std::string cf_name(reinterpret_cast<char *>(jcf_name), jcf_name_len);
+    const std::string cf_name(reinterpret_cast<char*>(jcf_name), jcf_name_len);
     const rocksdb::ColumnFamilyOptions* cf_options =
-      reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[i]);
+        reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[i]);
     column_families.push_back(
-      rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
+        rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
 
     env->ReleaseByteArrayElements(jcn_ba, jcf_name, JNI_ABORT);
     env->DeleteLocalRef(jcn);
@@ -122,8 +120,8 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
       reinterpret_cast<rocksdb::TransactionDBOptions*>(jtxn_db_options_handle);
   std::vector<rocksdb::ColumnFamilyHandle*> handles;
   rocksdb::TransactionDB* tdb = nullptr;
-  const rocksdb::Status s = rocksdb::TransactionDB::Open(*db_options, *txn_db_options,
-      db_path, column_families, &handles, &tdb);
+  const rocksdb::Status s = rocksdb::TransactionDB::Open(
+      *db_options, *txn_db_options, db_path, column_families, &handles, &tdb);
 
   // check if open operation was successful
   if (s.ok()) {
@@ -137,14 +135,14 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
 
     jlongArray jresults = env->NewLongArray(resultsLen);
     if (jresults == nullptr) {
-        // exception thrown: OutOfMemoryError
-        return nullptr;
+      // exception thrown: OutOfMemoryError
+      return nullptr;
     }
     env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
     if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException
-        env->DeleteLocalRef(jresults);
-        return nullptr;
+      // exception thrown: ArrayIndexOutOfBoundsException
+      env->DeleteLocalRef(jresults);
+      return nullptr;
     }
     return jresults;
   } else {
@@ -158,8 +156,9 @@ jlongArray Java_org_rocksdb_TransactionDB_open__JJLjava_lang_String_2_3_3B_3J(
  * Method:    beginTransaction
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jwrite_options_handle) {
+jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJ(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
@@ -172,9 +171,9 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJ(JNIEnv* env,
  * Method:    beginTransaction
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJJ(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong jtxn_options_handle) {
+jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJJ(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong jtxn_options_handle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
@@ -191,8 +190,8 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction__JJJ(JNIEnv* env,
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong jold_txn_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong jold_txn_handle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
@@ -215,16 +214,17 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJ(
  * Signature: (JJJJ)J
  */
 jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJJ(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jwrite_options_handle,
-    jlong jtxn_options_handle, jlong jold_txn_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jwrite_options_handle, jlong jtxn_options_handle,
+    jlong jold_txn_handle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   auto* write_options =
       reinterpret_cast<rocksdb::WriteOptions*>(jwrite_options_handle);
   auto* txn_options =
       reinterpret_cast<rocksdb::TransactionOptions*>(jtxn_options_handle);
   auto* old_txn = reinterpret_cast<rocksdb::Transaction*>(jold_txn_handle);
-  rocksdb::Transaction* txn = txn_db->BeginTransaction(*write_options,
-      *txn_options, old_txn);
+  rocksdb::Transaction* txn =
+      txn_db->BeginTransaction(*write_options, *txn_options, old_txn);
 
   // RocksJava relies on the assumption that
   // we do not allocate a new Transaction object
@@ -240,12 +240,14 @@ jlong Java_org_rocksdb_TransactionDB_beginTransaction_1withOld__JJJJ(
  * Signature: (JLjava/lang/String;)J
  */
 jlong Java_org_rocksdb_TransactionDB_getTransactionByName(JNIEnv* env,
-    jobject jobj, jlong jhandle, jstring jname) {
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle,
+                                                          jstring jname) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   const char* name = env->GetStringUTFChars(jname, nullptr);
   if (name == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return 0;
+    // exception thrown: OutOfMemoryError
+    return 0;
   }
   rocksdb::Transaction* txn = txn_db->GetTransactionByName(name);
   env->ReleaseStringUTFChars(jname, name);
@@ -258,7 +260,7 @@ jlong Java_org_rocksdb_TransactionDB_getTransactionByName(JNIEnv* env,
  * Signature: (J)[J
  */
 jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   std::vector<rocksdb::Transaction*> txns;
   txn_db->GetAllPreparedTransactions(&txns);
@@ -269,19 +271,19 @@ jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
   const jsize len = static_cast<jsize>(size);
   jlong tmp[len];
   for (jsize i = 0; i < len; ++i) {
-      tmp[i] = reinterpret_cast<jlong>(txns[i]);
+    tmp[i] = reinterpret_cast<jlong>(txns[i]);
   }
 
   jlongArray jtxns = env->NewLongArray(len);
   if (jtxns == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    return nullptr;
   }
   env->SetLongArrayRegion(jtxns, 0, len, tmp);
   if (env->ExceptionCheck()) {
-      // exception thrown: ArrayIndexOutOfBoundsException
-      env->DeleteLocalRef(jtxns);
-      return nullptr;
+    // exception thrown: ArrayIndexOutOfBoundsException
+    env->DeleteLocalRef(jtxns);
+    return nullptr;
   }
 
   return jtxns;
@@ -292,38 +294,44 @@ jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
  * Method:    getLockStatusData
  * Signature: (J)Ljava/util/Map;
  */
-jobject Java_org_rocksdb_TransactionDB_getLockStatusData(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jobject Java_org_rocksdb_TransactionDB_getLockStatusData(JNIEnv* env,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
-  const std::unordered_multimap<uint32_t, rocksdb::KeyLockInfo> lock_status_data =
-      txn_db->GetLockStatusData();
-  const jobject jlock_status_data = rocksdb::HashMapJni::construct(env,
-        static_cast<uint32_t>(lock_status_data.size()));
+  const std::unordered_multimap<uint32_t, rocksdb::KeyLockInfo>
+      lock_status_data = txn_db->GetLockStatusData();
+  const jobject jlock_status_data = rocksdb::HashMapJni::construct(
+      env, static_cast<uint32_t>(lock_status_data.size()));
   if (jlock_status_data == nullptr) {
-      // exception occurred
-      return nullptr;
+    // exception occurred
+    return nullptr;
   }
 
-  const rocksdb::HashMapJni::FnMapKV<const int32_t, const rocksdb::KeyLockInfo> fn_map_kv =
-      [env, txn_db, &lock_status_data](const std::pair<const int32_t, const rocksdb::KeyLockInfo>& pair) {
-          const jobject jlong_column_family_id =
-              rocksdb::LongJni::valueOf(env, pair.first);
-          if (jlong_column_family_id == nullptr) {
+  const rocksdb::HashMapJni::FnMapKV<const int32_t, const rocksdb::KeyLockInfo>
+      fn_map_kv =
+          [env, txn_db, &lock_status_data](
+              const std::pair<const int32_t, const rocksdb::KeyLockInfo>&
+                  pair) {
+            const jobject jlong_column_family_id =
+                rocksdb::LongJni::valueOf(env, pair.first);
+            if (jlong_column_family_id == nullptr) {
               // an error occurred
               return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
-          }
-          const jobject jkey_lock_info =
-              rocksdb::KeyLockInfoJni::construct(env, pair.second);
-          if (jkey_lock_info == nullptr) {
-             // an error occurred
-             return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
-          }
-          return std::unique_ptr<std::pair<jobject, jobject>>(new std::pair<jobject, jobject>(jlong_column_family_id,
-              jkey_lock_info));
-      };
+            }
+            const jobject jkey_lock_info =
+                rocksdb::KeyLockInfoJni::construct(env, pair.second);
+            if (jkey_lock_info == nullptr) {
+              // an error occurred
+              return std::unique_ptr<std::pair<jobject, jobject>>(nullptr);
+            }
+            return std::unique_ptr<std::pair<jobject, jobject>>(
+                new std::pair<jobject, jobject>(jlong_column_family_id,
+                                                jkey_lock_info));
+          };
 
-  if(!rocksdb::HashMapJni::putAll(env, jlock_status_data,
-      lock_status_data.begin(), lock_status_data.end(), fn_map_kv)) {
+  if (!rocksdb::HashMapJni::putAll(env, jlock_status_data,
+                                   lock_status_data.begin(),
+                                   lock_status_data.end(), fn_map_kv)) {
     // exception occcurred
     return nullptr;
   }
@@ -332,10 +340,10 @@ jobject Java_org_rocksdb_TransactionDB_getLockStatusData(
 }
 
 /*
-* Class:     org_rocksdb_TransactionDB
-* Method:    getDeadlockInfoBuffer
-* Signature: (J)[Lorg/rocksdb/TransactionDB/DeadlockPath;
-*/
+ * Class:     org_rocksdb_TransactionDB
+ * Method:    getDeadlockInfoBuffer
+ * Signature: (J)[Lorg/rocksdb/TransactionDB/DeadlockPath;
+ */
 jobjectArray Java_org_rocksdb_TransactionDB_getDeadlockInfoBuffer(
     JNIEnv* env, jobject jobj, jlong jhandle) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
@@ -346,63 +354,67 @@ jobjectArray Java_org_rocksdb_TransactionDB_getDeadlockInfoBuffer(
       static_cast<jsize>(deadlock_info_buffer.size());
   jobjectArray jdeadlock_info_buffer =
       env->NewObjectArray(deadlock_info_buffer_len,
-        rocksdb::DeadlockPathJni::getJClass(env), nullptr);
+                          rocksdb::DeadlockPathJni::getJClass(env), nullptr);
   if (jdeadlock_info_buffer == nullptr) {
-      // exception thrown: OutOfMemoryError
-      return nullptr;
+    // exception thrown: OutOfMemoryError
+    return nullptr;
   }
   jsize jdeadlock_info_buffer_offset = 0;
 
   auto buf_end = deadlock_info_buffer.end();
-  for (auto buf_it = deadlock_info_buffer.begin(); buf_it != buf_end; ++buf_it) {
+  for (auto buf_it = deadlock_info_buffer.begin(); buf_it != buf_end;
+       ++buf_it) {
     const rocksdb::DeadlockPath deadlock_path = *buf_it;
-    const std::vector<rocksdb::DeadlockInfo> deadlock_infos
-        = deadlock_path.path;
+    const std::vector<rocksdb::DeadlockInfo> deadlock_infos =
+        deadlock_path.path;
     const jsize deadlock_infos_len =
         static_cast<jsize>(deadlock_info_buffer.size());
-    jobjectArray jdeadlock_infos = env->NewObjectArray(deadlock_infos_len,
-        rocksdb::DeadlockInfoJni::getJClass(env), nullptr);
+    jobjectArray jdeadlock_infos = env->NewObjectArray(
+        deadlock_infos_len, rocksdb::DeadlockInfoJni::getJClass(env), nullptr);
     if (jdeadlock_infos == nullptr) {
-        // exception thrown: OutOfMemoryError
-        env->DeleteLocalRef(jdeadlock_info_buffer);
-        return nullptr;
+      // exception thrown: OutOfMemoryError
+      env->DeleteLocalRef(jdeadlock_info_buffer);
+      return nullptr;
     }
     jsize jdeadlock_infos_offset = 0;
 
     auto infos_end = deadlock_infos.end();
-    for (auto infos_it = deadlock_infos.begin(); infos_it != infos_end; ++infos_it) {
-        const rocksdb::DeadlockInfo deadlock_info = *infos_it;
-        const jobject jdeadlock_info = rocksdb::TransactionDBJni::newDeadlockInfo(
-            env, jobj, deadlock_info.m_txn_id, deadlock_info.m_cf_id,
-            deadlock_info.m_waiting_key, deadlock_info.m_exclusive);
-        if (jdeadlock_info == nullptr) {
-            // exception occcurred
-            env->DeleteLocalRef(jdeadlock_info_buffer);
-            return nullptr;
-        }
-        env->SetObjectArrayElement(jdeadlock_infos, jdeadlock_infos_offset++, jdeadlock_info);
-        if (env->ExceptionCheck()) {
-            // exception thrown: ArrayIndexOutOfBoundsException or ArrayStoreException
-            env->DeleteLocalRef(jdeadlock_info);
-            env->DeleteLocalRef(jdeadlock_info_buffer);
-            return nullptr;
-        }
-    }
-
-    const jobject jdeadlock_path =
-        rocksdb::DeadlockPathJni::construct(env, jdeadlock_infos,
-            deadlock_path.limit_exceeded);
-    if(jdeadlock_path == nullptr) {
+    for (auto infos_it = deadlock_infos.begin(); infos_it != infos_end;
+         ++infos_it) {
+      const rocksdb::DeadlockInfo deadlock_info = *infos_it;
+      const jobject jdeadlock_info = rocksdb::TransactionDBJni::newDeadlockInfo(
+          env, jobj, deadlock_info.m_txn_id, deadlock_info.m_cf_id,
+          deadlock_info.m_waiting_key, deadlock_info.m_exclusive);
+      if (jdeadlock_info == nullptr) {
         // exception occcurred
         env->DeleteLocalRef(jdeadlock_info_buffer);
         return nullptr;
-    }
-    env->SetObjectArrayElement(jdeadlock_info_buffer, jdeadlock_info_buffer_offset++, jdeadlock_path);
-    if (env->ExceptionCheck()) {
-        // exception thrown: ArrayIndexOutOfBoundsException or ArrayStoreException
-        env->DeleteLocalRef(jdeadlock_path);
+      }
+      env->SetObjectArrayElement(jdeadlock_infos, jdeadlock_infos_offset++,
+                                 jdeadlock_info);
+      if (env->ExceptionCheck()) {
+        // exception thrown: ArrayIndexOutOfBoundsException or
+        // ArrayStoreException
+        env->DeleteLocalRef(jdeadlock_info);
         env->DeleteLocalRef(jdeadlock_info_buffer);
         return nullptr;
+      }
+    }
+
+    const jobject jdeadlock_path = rocksdb::DeadlockPathJni::construct(
+        env, jdeadlock_infos, deadlock_path.limit_exceeded);
+    if (jdeadlock_path == nullptr) {
+      // exception occcurred
+      env->DeleteLocalRef(jdeadlock_info_buffer);
+      return nullptr;
+    }
+    env->SetObjectArrayElement(jdeadlock_info_buffer,
+                               jdeadlock_info_buffer_offset++, jdeadlock_path);
+    if (env->ExceptionCheck()) {
+      // exception thrown: ArrayIndexOutOfBoundsException or ArrayStoreException
+      env->DeleteLocalRef(jdeadlock_path);
+      env->DeleteLocalRef(jdeadlock_info_buffer);
+      return nullptr;
     }
   }
 
@@ -410,12 +422,13 @@ jobjectArray Java_org_rocksdb_TransactionDB_getDeadlockInfoBuffer(
 }
 
 /*
-* Class:     org_rocksdb_TransactionDB
-* Method:    setDeadlockInfoBufferSize
-* Signature: (JI)V
-*/
+ * Class:     org_rocksdb_TransactionDB
+ * Method:    setDeadlockInfoBufferSize
+ * Signature: (JI)V
+ */
 void Java_org_rocksdb_TransactionDB_setDeadlockInfoBufferSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jint jdeadlock_info_buffer_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint jdeadlock_info_buffer_size) {
   auto* txn_db = reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
   txn_db->SetDeadlockInfoBufferSize(jdeadlock_info_buffer_size);
 }
@@ -425,7 +438,8 @@ void Java_org_rocksdb_TransactionDB_setDeadlockInfoBufferSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionDB_disposeInternal(JNIEnv* env, jobject jobj,
-    jlong jhandle) {
+void Java_org_rocksdb_TransactionDB_disposeInternal(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
+                                                    jlong jhandle) {
   delete reinterpret_cast<rocksdb::TransactionDB*>(jhandle);
 }

--- a/java/rocksjni/transaction_db_options.cc
+++ b/java/rocksjni/transaction_db_options.cc
@@ -20,7 +20,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_newTransactionDBOptions(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   rocksdb::TransactionDBOptions* opts = new rocksdb::TransactionDBOptions();
   return reinterpret_cast<jlong>(opts);
 }
@@ -30,8 +30,9 @@ jlong Java_org_rocksdb_TransactionDBOptions_newTransactionDBOptions(
  * Method:    getMaxNumLocks
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_TransactionDBOptions_getMaxNumLocks(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_TransactionDBOptions_getMaxNumLocks(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   return opts->max_num_locks;
 }
@@ -41,8 +42,8 @@ jlong Java_org_rocksdb_TransactionDBOptions_getMaxNumLocks(JNIEnv* env,
  * Method:    setMaxNumLocks
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_TransactionDBOptions_setMaxNumLocks(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jmax_num_locks) {
+void Java_org_rocksdb_TransactionDBOptions_setMaxNumLocks(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jlong jmax_num_locks) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   opts->max_num_locks = jmax_num_locks;
 }
@@ -52,8 +53,9 @@ void Java_org_rocksdb_TransactionDBOptions_setMaxNumLocks(JNIEnv* env,
  * Method:    getNumStripes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_TransactionDBOptions_getNumStripes(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_TransactionDBOptions_getNumStripes(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   return opts->num_stripes;
 }
@@ -63,8 +65,10 @@ jlong Java_org_rocksdb_TransactionDBOptions_getNumStripes(JNIEnv* env,
  * Method:    setNumStripes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_TransactionDBOptions_setNumStripes(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jnum_stripes) {
+void Java_org_rocksdb_TransactionDBOptions_setNumStripes(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle,
+                                                         jlong jnum_stripes) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   opts->num_stripes = jnum_stripes;
 }
@@ -75,7 +79,7 @@ void Java_org_rocksdb_TransactionDBOptions_setNumStripes(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getTransactionLockTimeout(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   return opts->transaction_lock_timeout;
 }
@@ -86,7 +90,8 @@ jlong Java_org_rocksdb_TransactionDBOptions_getTransactionLockTimeout(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setTransactionLockTimeout(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jtransaction_lock_timeout) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jtransaction_lock_timeout) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   opts->transaction_lock_timeout = jtransaction_lock_timeout;
 }
@@ -97,7 +102,7 @@ void Java_org_rocksdb_TransactionDBOptions_setTransactionLockTimeout(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionDBOptions_getDefaultLockTimeout(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   return opts->default_lock_timeout;
 }
@@ -108,7 +113,8 @@ jlong Java_org_rocksdb_TransactionDBOptions_getDefaultLockTimeout(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_TransactionDBOptions_setDefaultLockTimeout(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdefault_lock_timeout) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jdefault_lock_timeout) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   opts->default_lock_timeout = jdefault_lock_timeout;
 }
@@ -118,19 +124,23 @@ void Java_org_rocksdb_TransactionDBOptions_setDefaultLockTimeout(
  * Method:    getWritePolicy
  * Signature: (J)B
  */
-jbyte Java_org_rocksdb_TransactionDBOptions_getWritePolicy(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jbyte Java_org_rocksdb_TransactionDBOptions_getWritePolicy(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
-  return rocksdb::TxnDBWritePolicyJni::toJavaTxnDBWritePolicy(opts->write_policy);
+  return rocksdb::TxnDBWritePolicyJni::toJavaTxnDBWritePolicy(
+      opts->write_policy);
 }
 
 /*
-* Class:     org_rocksdb_TransactionDBOptions
-* Method:    setWritePolicy
-* Signature: (JB)V
-*/
-void Java_org_rocksdb_TransactionDBOptions_setWritePolicy(
-    JNIEnv* env, jobject jobj, jlong jhandle, jbyte jwrite_policy) {
+ * Class:     org_rocksdb_TransactionDBOptions
+ * Method:    setWritePolicy
+ * Signature: (JB)V
+ */
+void Java_org_rocksdb_TransactionDBOptions_setWritePolicy(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
+                                                          jlong jhandle,
+                                                          jbyte jwrite_policy) {
   auto* opts = reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
   opts->write_policy =
       rocksdb::TxnDBWritePolicyJni::toCppTxnDBWritePolicy(jwrite_policy);
@@ -141,7 +151,8 @@ void Java_org_rocksdb_TransactionDBOptions_setWritePolicy(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionDBOptions_disposeInternal(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_TransactionDBOptions_disposeInternal(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   delete reinterpret_cast<rocksdb::TransactionDBOptions*>(jhandle);
 }

--- a/java/rocksjni/transaction_log.cc
+++ b/java/rocksjni/transaction_log.cc
@@ -19,8 +19,9 @@
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionLogIterator_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_TransactionLogIterator_disposeInternal(JNIEnv* /*env*/,
+                                                             jobject /*jobj*/,
+                                                             jlong handle) {
   delete reinterpret_cast<rocksdb::TransactionLogIterator*>(handle);
 }
 
@@ -29,8 +30,9 @@ void Java_org_rocksdb_TransactionLogIterator_disposeInternal(
  * Method:    isValid
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_TransactionLogIterator_isValid(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jboolean Java_org_rocksdb_TransactionLogIterator_isValid(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong handle) {
   return reinterpret_cast<rocksdb::TransactionLogIterator*>(handle)->Valid();
 }
 
@@ -39,8 +41,9 @@ jboolean Java_org_rocksdb_TransactionLogIterator_isValid(
  * Method:    next
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionLogIterator_next(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_TransactionLogIterator_next(JNIEnv* /*env*/,
+                                                  jobject /*jobj*/,
+                                                  jlong handle) {
   reinterpret_cast<rocksdb::TransactionLogIterator*>(handle)->Next();
 }
 
@@ -49,10 +52,11 @@ void Java_org_rocksdb_TransactionLogIterator_next(
  * Method:    status
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionLogIterator_status(
-    JNIEnv* env, jobject jobj, jlong handle) {
-  rocksdb::Status s = reinterpret_cast<
-      rocksdb::TransactionLogIterator*>(handle)->status();
+void Java_org_rocksdb_TransactionLogIterator_status(JNIEnv* env,
+                                                    jobject /*jobj*/,
+                                                    jlong handle) {
+  rocksdb::Status s =
+      reinterpret_cast<rocksdb::TransactionLogIterator*>(handle)->status();
   if (!s.ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   }
@@ -63,8 +67,9 @@ void Java_org_rocksdb_TransactionLogIterator_status(
  * Method:    getBatch
  * Signature: (J)Lorg/rocksdb/TransactionLogIterator$BatchResult
  */
-jobject Java_org_rocksdb_TransactionLogIterator_getBatch(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jobject Java_org_rocksdb_TransactionLogIterator_getBatch(JNIEnv* env,
+                                                         jobject /*jobj*/,
+                                                         jlong handle) {
   rocksdb::BatchResult batch_result =
       reinterpret_cast<rocksdb::TransactionLogIterator*>(handle)->GetBatch();
   return rocksdb::BatchResultJni::construct(env, batch_result);

--- a/java/rocksjni/transaction_notifier.cc
+++ b/java/rocksjni/transaction_notifier.cc
@@ -31,12 +31,12 @@ jlong Java_org_rocksdb_AbstractTransactionNotifier_createNewTransactionNotifier(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_AbstractTransactionNotifier_disposeInternal(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_AbstractTransactionNotifier_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   // TODO(AR) refactor to use JniCallback::JniCallback
   // when https://github.com/facebook/rocksdb/pull/1241/ is merged
   std::shared_ptr<rocksdb::TransactionNotifierJniCallback>* handle =
-      reinterpret_cast<std::shared_ptr<
-          rocksdb::TransactionNotifierJniCallback>*>(jhandle);
+      reinterpret_cast<
+          std::shared_ptr<rocksdb::TransactionNotifierJniCallback>*>(jhandle);
   delete handle;
 }

--- a/java/rocksjni/transaction_options.cc
+++ b/java/rocksjni/transaction_options.cc
@@ -17,8 +17,8 @@
  * Method:    newTransactionOptions
  * Signature: ()J
  */
-jlong Java_org_rocksdb_TransactionOptions_newTransactionOptions(JNIEnv* env,
-    jclass jcls) {
+jlong Java_org_rocksdb_TransactionOptions_newTransactionOptions(
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   auto* opts = new rocksdb::TransactionOptions();
   return reinterpret_cast<jlong>(opts);
 }
@@ -28,8 +28,9 @@ jlong Java_org_rocksdb_TransactionOptions_newTransactionOptions(JNIEnv* env,
  * Method:    isSetSnapshot
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_TransactionOptions_isSetSnapshot(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_TransactionOptions_isSetSnapshot(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->set_snapshot;
 }
@@ -39,8 +40,8 @@ jboolean Java_org_rocksdb_TransactionOptions_isSetSnapshot(JNIEnv* env,
  * Method:    setSetSnapshot
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_TransactionOptions_setSetSnapshot(JNIEnv* env,
-    jobject jobj, jlong jhandle, jboolean jset_snapshot) {
+void Java_org_rocksdb_TransactionOptions_setSetSnapshot(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean jset_snapshot) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->set_snapshot = jset_snapshot;
 }
@@ -50,19 +51,21 @@ void Java_org_rocksdb_TransactionOptions_setSetSnapshot(JNIEnv* env,
  * Method:    isDeadlockDetect
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_TransactionOptions_isDeadlockDetect(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+jboolean Java_org_rocksdb_TransactionOptions_isDeadlockDetect(JNIEnv* /*env*/,
+                                                              jobject /*jobj*/,
+                                                              jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->deadlock_detect;
 }
 
 /*
-* Class:     org_rocksdb_TransactionOptions
-* Method:    setDeadlockDetect
-* Signature: (JZ)V
-*/
+ * Class:     org_rocksdb_TransactionOptions
+ * Method:    setDeadlockDetect
+ * Signature: (JZ)V
+ */
 void Java_org_rocksdb_TransactionOptions_setDeadlockDetect(
-    JNIEnv* env, jobject jobj, jlong jhandle, jboolean jdeadlock_detect) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean jdeadlock_detect) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->deadlock_detect = jdeadlock_detect;
 }
@@ -72,8 +75,9 @@ void Java_org_rocksdb_TransactionOptions_setDeadlockDetect(
  * Method:    getLockTimeout
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_TransactionOptions_getLockTimeout(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_TransactionOptions_getLockTimeout(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->lock_timeout;
 }
@@ -83,8 +87,10 @@ jlong Java_org_rocksdb_TransactionOptions_getLockTimeout(JNIEnv* env,
  * Method:    setLockTimeout
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_TransactionOptions_setLockTimeout(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jlock_timeout) {
+void Java_org_rocksdb_TransactionOptions_setLockTimeout(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle,
+                                                        jlong jlock_timeout) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->lock_timeout = jlock_timeout;
 }
@@ -94,8 +100,9 @@ void Java_org_rocksdb_TransactionOptions_setLockTimeout(JNIEnv* env,
  * Method:    getExpiration
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_TransactionOptions_getExpiration(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+jlong Java_org_rocksdb_TransactionOptions_getExpiration(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->expiration;
 }
@@ -105,8 +112,10 @@ jlong Java_org_rocksdb_TransactionOptions_getExpiration(JNIEnv* env,
  * Method:    setExpiration
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_TransactionOptions_setExpiration(JNIEnv* env,
-    jobject jobj, jlong jhandle, jlong jexpiration) {
+void Java_org_rocksdb_TransactionOptions_setExpiration(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong jhandle,
+                                                       jlong jexpiration) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->expiration = jexpiration;
 }
@@ -117,40 +126,43 @@ void Java_org_rocksdb_TransactionOptions_setExpiration(JNIEnv* env,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_TransactionOptions_getDeadlockDetectDepth(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->deadlock_detect_depth;
 }
 
 /*
-* Class:     org_rocksdb_TransactionOptions
-* Method:    setDeadlockDetectDepth
-* Signature: (JJ)V
-*/
+ * Class:     org_rocksdb_TransactionOptions
+ * Method:    setDeadlockDetectDepth
+ * Signature: (JJ)V
+ */
 void Java_org_rocksdb_TransactionOptions_setDeadlockDetectDepth(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jdeadlock_detect_depth) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jdeadlock_detect_depth) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->deadlock_detect_depth = jdeadlock_detect_depth;
 }
 
 /*
-* Class:     org_rocksdb_TransactionOptions
-* Method:    getMaxWriteBatchSize
-* Signature: (J)J
-*/
-jlong Java_org_rocksdb_TransactionOptions_getMaxWriteBatchSize(
-    JNIEnv* env, jobject jobj, jlong jhandle) {
+ * Class:     org_rocksdb_TransactionOptions
+ * Method:    getMaxWriteBatchSize
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_TransactionOptions_getMaxWriteBatchSize(JNIEnv* /*env*/,
+                                                               jobject /*jobj*/,
+                                                               jlong jhandle) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   return opts->max_write_batch_size;
 }
 
 /*
-* Class:     org_rocksdb_TransactionOptions
-* Method:    setMaxWriteBatchSize
-* Signature: (JJ)V
-*/
+ * Class:     org_rocksdb_TransactionOptions
+ * Method:    setMaxWriteBatchSize
+ * Signature: (JJ)V
+ */
 void Java_org_rocksdb_TransactionOptions_setMaxWriteBatchSize(
-    JNIEnv* env, jobject jobj, jlong jhandle, jlong jmax_write_batch_size) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jlong jmax_write_batch_size) {
   auto* opts = reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
   opts->max_write_batch_size = jmax_write_batch_size;
 }
@@ -160,7 +172,8 @@ void Java_org_rocksdb_TransactionOptions_setMaxWriteBatchSize(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_TransactionOptions_disposeInternal(JNIEnv* env,
-    jobject jobj, jlong jhandle) {
+void Java_org_rocksdb_TransactionOptions_disposeInternal(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
+                                                         jlong jhandle) {
   delete reinterpret_cast<rocksdb::TransactionOptions*>(jhandle);
 }

--- a/java/rocksjni/ttl.cc
+++ b/java/rocksjni/ttl.cc
@@ -10,9 +10,9 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "include/org_rocksdb_TtlDB.h"
 #include "rocksdb/utilities/db_ttl.h"
@@ -23,19 +23,19 @@
  * Method:    open
  * Signature: (JLjava/lang/String;IZ)J
  */
-jlong Java_org_rocksdb_TtlDB_open(JNIEnv* env,
-    jclass jcls, jlong joptions_handle, jstring jdb_path,
-    jint jttl, jboolean jread_only) {
+jlong Java_org_rocksdb_TtlDB_open(JNIEnv* env, jclass /*jcls*/,
+                                  jlong joptions_handle, jstring jdb_path,
+                                  jint jttl, jboolean jread_only) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
 
   auto* opt = reinterpret_cast<rocksdb::Options*>(joptions_handle);
   rocksdb::DBWithTTL* db = nullptr;
-  rocksdb::Status s = rocksdb::DBWithTTL::Open(*opt, db_path, &db,
-      jttl, jread_only);
+  rocksdb::Status s =
+      rocksdb::DBWithTTL::Open(*opt, db_path, &db, jttl, jread_only);
   env->ReleaseStringUTFChars(jdb_path, db_path);
 
   // as TTLDB extends RocksDB on the java side, we can reuse
@@ -53,20 +53,20 @@ jlong Java_org_rocksdb_TtlDB_open(JNIEnv* env,
  * Method:    openCF
  * Signature: (JLjava/lang/String;[[B[J[IZ)[J
  */
-jlongArray
-    Java_org_rocksdb_TtlDB_openCF(
-    JNIEnv* env, jclass jcls, jlong jopt_handle, jstring jdb_path,
-    jobjectArray jcolumn_names, jlongArray jcolumn_options,
-    jintArray jttls, jboolean jread_only) {
+jlongArray Java_org_rocksdb_TtlDB_openCF(JNIEnv* env, jclass /*jcls*/,
+                                         jlong jopt_handle, jstring jdb_path,
+                                         jobjectArray jcolumn_names,
+                                         jlongArray jcolumn_options,
+                                         jintArray jttls, jboolean jread_only) {
   const char* db_path = env->GetStringUTFChars(jdb_path, nullptr);
-  if(db_path == nullptr) {
+  if (db_path == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
 
   const jsize len_cols = env->GetArrayLength(jcolumn_names);
   jlong* jco = env->GetLongArrayElements(jcolumn_options, nullptr);
-  if(jco == nullptr) {
+  if (jco == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseStringUTFChars(jdb_path, db_path);
     return nullptr;
@@ -75,22 +75,21 @@ jlongArray
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   jboolean has_exception = JNI_FALSE;
   rocksdb::JniUtil::byteStrings<std::string>(
-    env,
-    jcolumn_names,
-    [](const char* str_data, const size_t str_len) {
-      return std::string(str_data, str_len);
-    },
-    [&jco, &column_families](size_t idx, std::string cf_name) {
-      rocksdb::ColumnFamilyOptions* cf_options =
-          reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[idx]);
-      column_families.push_back(
-          rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
-    },
-    &has_exception);
+      env, jcolumn_names,
+      [](const char* str_data, const size_t str_len) {
+        return std::string(str_data, str_len);
+      },
+      [&jco, &column_families](size_t idx, std::string cf_name) {
+        rocksdb::ColumnFamilyOptions* cf_options =
+            reinterpret_cast<rocksdb::ColumnFamilyOptions*>(jco[idx]);
+        column_families.push_back(
+            rocksdb::ColumnFamilyDescriptor(cf_name, *cf_options));
+      },
+      &has_exception);
 
   env->ReleaseLongArrayElements(jcolumn_options, jco, JNI_ABORT);
 
-  if(has_exception == JNI_TRUE) {
+  if (has_exception == JNI_TRUE) {
     // exception occurred
     env->ReleaseStringUTFChars(jdb_path, db_path);
     return nullptr;
@@ -98,13 +97,13 @@ jlongArray
 
   std::vector<int32_t> ttl_values;
   jint* jttlv = env->GetIntArrayElements(jttls, nullptr);
-  if(jttlv == nullptr) {
+  if (jttlv == nullptr) {
     // exception thrown: OutOfMemoryError
     env->ReleaseStringUTFChars(jdb_path, db_path);
     return nullptr;
   }
   const jsize len_ttls = env->GetArrayLength(jttls);
-  for(jsize i = 0; i < len_ttls; i++) {
+  for (jsize i = 0; i < len_ttls; i++) {
     ttl_values.push_back(jttlv[i]);
   }
   env->ReleaseIntArrayElements(jttls, jttlv, JNI_ABORT);
@@ -112,30 +111,30 @@ jlongArray
   auto* opt = reinterpret_cast<rocksdb::DBOptions*>(jopt_handle);
   std::vector<rocksdb::ColumnFamilyHandle*> handles;
   rocksdb::DBWithTTL* db = nullptr;
-  rocksdb::Status s = rocksdb::DBWithTTL::Open(*opt, db_path, column_families,
-      &handles, &db, ttl_values, jread_only);
+  rocksdb::Status s = rocksdb::DBWithTTL::Open(
+      *opt, db_path, column_families, &handles, &db, ttl_values, jread_only);
 
   // we have now finished with db_path
   env->ReleaseStringUTFChars(jdb_path, db_path);
 
   // check if open operation was successful
   if (s.ok()) {
-    const jsize resultsLen = 1 + len_cols; //db handle + column family handles
+    const jsize resultsLen = 1 + len_cols;  // db handle + column family handles
     std::unique_ptr<jlong[]> results =
         std::unique_ptr<jlong[]>(new jlong[resultsLen]);
     results[0] = reinterpret_cast<jlong>(db);
-    for(int i = 1; i <= len_cols; i++) {
+    for (int i = 1; i <= len_cols; i++) {
       results[i] = reinterpret_cast<jlong>(handles[i - 1]);
     }
 
     jlongArray jresults = env->NewLongArray(resultsLen);
-    if(jresults == nullptr) {
+    if (jresults == nullptr) {
       // exception thrown: OutOfMemoryError
       return nullptr;
     }
 
     env->SetLongArrayRegion(jresults, 0, resultsLen, results.get());
-    if(env->ExceptionCheck()) {
+    if (env->ExceptionCheck()) {
       // exception thrown: ArrayIndexOutOfBoundsException
       env->DeleteLocalRef(jresults);
       return nullptr;
@@ -154,11 +153,10 @@ jlongArray
  * Signature: (JLorg/rocksdb/ColumnFamilyDescriptor;[BJI)J;
  */
 jlong Java_org_rocksdb_TtlDB_createColumnFamilyWithTtl(
-    JNIEnv* env, jobject jobj, jlong jdb_handle,
-    jbyteArray jcolumn_name, jlong jcolumn_options, jint jttl) {
-
+    JNIEnv* env, jobject /*jobj*/, jlong jdb_handle, jbyteArray jcolumn_name,
+    jlong jcolumn_options, jint jttl) {
   jbyte* cfname = env->GetByteArrayElements(jcolumn_name, nullptr);
-  if(cfname == nullptr) {
+  if (cfname == nullptr) {
     // exception thrown: OutOfMemoryError
     return 0;
   }
@@ -170,8 +168,8 @@ jlong Java_org_rocksdb_TtlDB_createColumnFamilyWithTtl(
   auto* db_handle = reinterpret_cast<rocksdb::DBWithTTL*>(jdb_handle);
   rocksdb::ColumnFamilyHandle* handle;
   rocksdb::Status s = db_handle->CreateColumnFamilyWithTtl(
-      *cfOptions, std::string(reinterpret_cast<char *>(cfname),
-          len), &handle, jttl);
+      *cfOptions, std::string(reinterpret_cast<char*>(cfname), len), &handle,
+      jttl);
 
   env->ReleaseByteArrayElements(jcolumn_name, cfname, 0);
 

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -465,7 +465,7 @@ jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/,
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -478,7 +478,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -491,7 +491,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -504,7 +504,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -517,7 +517,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -530,7 +530,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -543,7 +543,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -555,8 +555,8 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
  * Method:    markWalTerminationPoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* env,
-                                                         jobject jobj,
+void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* /*env*/,
+                                                         jobject /*jobj*/,
                                                          jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -570,7 +570,7 @@ void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* env,
  * Signature: (J)Lorg/rocksdb/WriteBatch/SavePoint;
  */
 jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(JNIEnv* env,
-                                                           jobject jobj,
+                                                           jobject /*jobj*/,
                                                            jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
@@ -584,7 +584,8 @@ jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_disposeInternal(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WriteBatch_disposeInternal(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
                                                  jlong handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(handle);
   assert(wb != nullptr);

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -29,7 +29,7 @@
  */
 jlong Java_org_rocksdb_WriteBatch_newWriteBatch__I(JNIEnv* /*env*/,
                                                    jclass /*jcls*/,
-                                                   jint /*jreserved_bytes*/) {
+                                                   jint jreserved_bytes) {
   auto* wb = new rocksdb::WriteBatch(static_cast<size_t>(jreserved_bytes));
   return reinterpret_cast<jlong>(wb);
 }
@@ -39,9 +39,10 @@ jlong Java_org_rocksdb_WriteBatch_newWriteBatch__I(JNIEnv* /*env*/,
  * Method:    newWriteBatch
  * Signature: ([BI)J
  */
-jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(
-    JNIEnv* /*env*/, jclass /*jcls*/, jbyteArray /*jserialized*/,
-    jint /*jserialized_length*/) {
+jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(JNIEnv* env,
+                                                      jclass /*jcls*/,
+                                                      jbyteArray jserialized,
+                                                      jint jserialized_length) {
   jboolean has_exception = JNI_FALSE;
   std::string serialized = rocksdb::JniUtil::byteString<std::string>(
       env, jserialized, jserialized_length,
@@ -62,7 +63,7 @@ jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(
  * Signature: (J)I
  */
 jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                        jlong /*jwb_handle*/) {
+                                        jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -75,7 +76,7 @@ jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)V
  */
 void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
-                                        jlong /*jwb_handle*/) {
+                                        jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -89,7 +90,7 @@ void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
  */
 void Java_org_rocksdb_WriteBatch_setSavePoint0(JNIEnv* /*env*/,
                                                jobject /*jobj*/,
-                                               jlong /*jwb_handle*/) {
+                                               jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -101,9 +102,9 @@ void Java_org_rocksdb_WriteBatch_setSavePoint0(JNIEnv* /*env*/,
  * Method:    rollbackToSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* /*env*/,
+void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* env,
                                                       jobject /*jobj*/,
-                                                      jlong /*jwb_handle*/) {
+                                                      jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -120,8 +121,8 @@ void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* /*env*/,
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* /*env*/, jobject /*jobj*/,
-                                              jlong /*jwb_handle*/) {
+void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* env, jobject /*jobj*/,
+                                              jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -139,8 +140,8 @@ void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_WriteBatch_setMaxBytes(JNIEnv* /*env*/, jobject /*jobj*/,
-                                             jlong /*jwb_handle*/,
-                                             jlong /*jmax_bytes*/) {
+                                             jlong jwb_handle,
+                                             jlong jmax_bytes) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -152,10 +153,11 @@ void Java_org_rocksdb_WriteBatch_setMaxBytes(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    put
  * Signature: (J[BI[BI)V
  */
-void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/) {
+void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(JNIEnv* env, jobject jobj,
+                                                jlong jwb_handle,
+                                                jbyteArray jkey, jint jkey_len,
+                                                jbyteArray jentry_value,
+                                                jint jentry_value_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto put = [&wb](rocksdb::Slice key, rocksdb::Slice value) {
@@ -174,9 +176,8 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -197,9 +198,8 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto merge = [&wb](rocksdb::Slice key, rocksdb::Slice value) {
@@ -218,9 +218,8 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey, jint jkey_len,
+    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -240,11 +239,9 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* /*env*/,
-                                               jobject /*jobj*/,
-                                               jlong /*jwb_handle*/,
-                                               jbyteArray /*jkey*/,
-                                               jint /*jkey_len*/) {
+void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* env, jobject jobj,
+                                               jlong jwb_handle,
+                                               jbyteArray jkey, jint jkey_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto remove = [&wb](rocksdb::Slice key) { return wb->Delete(key); };
@@ -260,9 +257,10 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* /*env*/,
  * Method:    delete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
+void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(JNIEnv* env, jobject jobj,
+                                                jlong jwb_handle,
+                                                jbyteArray jkey, jint jkey_len,
+                                                jlong jcf_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -282,11 +280,10 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong /*jwb_handle*/,
-                                                     jbyteArray /*jkey*/,
-                                                     jint /*jkey_len*/) {
+void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* env, jobject jobj,
+                                                     jlong jwb_handle,
+                                                     jbyteArray jkey,
+                                                     jint jkey_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto single_delete = [&wb](rocksdb::Slice key) {
@@ -304,9 +301,11 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* /*env*/,
  * Method:    singleDelete
  * Signature: (J[BIJ)V
  */
-void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
+void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(JNIEnv* env, jobject jobj,
+                                                      jlong jwb_handle,
+                                                      jbyteArray jkey,
+                                                      jint jkey_len,
+                                                      jlong jcf_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -327,9 +326,8 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
-    jint /*jend_key_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
+    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto deleteRange = [&wb](rocksdb::Slice beginKey, rocksdb::Slice endKey) {
@@ -349,9 +347,9 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
-    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
-    jint /*jend_key_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
+    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
+    jlong jcf_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -373,10 +371,9 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* /*env*/, jobject /*jobj*/,
-                                            jlong /*jwb_handle*/,
-                                            jbyteArray /*jblob*/,
-                                            jint /*jblob_len*/) {
+void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* env, jobject jobj,
+                                            jlong jwb_handle, jbyteArray jblob,
+                                            jint jblob_len) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto putLogData = [&wb](rocksdb::Slice blob) { return wb->PutLogData(blob); };
@@ -392,9 +389,9 @@ void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    iterate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* /*env*/, jobject /*jobj*/,
-                                         jlong /*jwb_handle*/,
-                                         jlong /*handlerHandle*/) {
+void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jobject jobj,
+                                         jlong jwb_handle,
+                                         jlong handlerHandle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -412,8 +409,8 @@ void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    data
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* /*env*/, jobject /*jobj*/,
-                                            jlong /*jwb_handle*/) {
+jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* env, jobject /*jobj*/,
+                                            jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -427,7 +424,7 @@ jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jobject /*jobj*/,
-                                              jlong /*jwb_handle*/) {
+                                              jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -441,7 +438,7 @@ jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jobject /*jobj*/,
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jobject /*jobj*/,
-                                            jlong /*jwb_handle*/) {
+                                            jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -455,7 +452,7 @@ jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jobject /*jobj*/,
  */
 jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/,
                                                jobject /*jobj*/,
-                                               jlong /*jwb_handle*/) {
+                                               jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -389,7 +389,7 @@ void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* env, jobject jobj,
  * Method:    iterate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* env, jobject /*jobj*/,
                                          jlong jwb_handle,
                                          jlong handlerHandle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);

--- a/java/rocksjni/write_batch.cc
+++ b/java/rocksjni/write_batch.cc
@@ -27,8 +27,9 @@
  * Method:    newWriteBatch
  * Signature: (I)J
  */
-jlong Java_org_rocksdb_WriteBatch_newWriteBatch__I(
-    JNIEnv* env, jclass jcls, jint jreserved_bytes) {
+jlong Java_org_rocksdb_WriteBatch_newWriteBatch__I(JNIEnv* /*env*/,
+                                                   jclass /*jcls*/,
+                                                   jint /*jreserved_bytes*/) {
   auto* wb = new rocksdb::WriteBatch(static_cast<size_t>(jreserved_bytes));
   return reinterpret_cast<jlong>(wb);
 }
@@ -39,14 +40,14 @@ jlong Java_org_rocksdb_WriteBatch_newWriteBatch__I(
  * Signature: ([BI)J
  */
 jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(
-    JNIEnv* env, jclass jcls, jbyteArray jserialized,
-    jint jserialized_length) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jbyteArray /*jserialized*/,
+    jint /*jserialized_length*/) {
   jboolean has_exception = JNI_FALSE;
-  std::string serialized = rocksdb::JniUtil::byteString<std::string>(env,
-    jserialized, jserialized_length,
-    [](const char* str, const size_t len) { return std::string(str, len); },
-    &has_exception);
-  if(has_exception == JNI_TRUE) {
+  std::string serialized = rocksdb::JniUtil::byteString<std::string>(
+      env, jserialized, jserialized_length,
+      [](const char* str, const size_t len) { return std::string(str, len); },
+      &has_exception);
+  if (has_exception == JNI_TRUE) {
     // exception occurred
     return 0;
   }
@@ -60,8 +61,8 @@ jlong Java_org_rocksdb_WriteBatch_newWriteBatch___3BI(
  * Method:    count0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* env, jobject jobj,
-    jlong jwb_handle) {
+jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                        jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -73,8 +74,8 @@ jint Java_org_rocksdb_WriteBatch_count0(JNIEnv* env, jobject jobj,
  * Method:    clear0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* env, jobject jobj,
-    jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* /*env*/, jobject /*jobj*/,
+                                        jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -86,8 +87,9 @@ void Java_org_rocksdb_WriteBatch_clear0(JNIEnv* env, jobject jobj,
  * Method:    setSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_setSavePoint0(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_setSavePoint0(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -99,8 +101,9 @@ void Java_org_rocksdb_WriteBatch_setSavePoint0(
  * Method:    rollbackToSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -117,8 +120,8 @@ void Java_org_rocksdb_WriteBatch_rollbackToSavePoint0(
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_popSavePoint(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_popSavePoint(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -135,8 +138,9 @@ void Java_org_rocksdb_WriteBatch_popSavePoint(
  * Method:    setMaxBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_setMaxBytes(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jlong jmax_bytes) {
+void Java_org_rocksdb_WriteBatch_setMaxBytes(JNIEnv* /*env*/, jobject /*jobj*/,
+                                             jlong /*jwb_handle*/,
+                                             jlong /*jmax_bytes*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -149,16 +153,16 @@ void Java_org_rocksdb_WriteBatch_setMaxBytes(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len,
-    jbyteArray jentry_value, jint jentry_value_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
-  auto put = [&wb] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto put = [&wb](rocksdb::Slice key, rocksdb::Slice value) {
     return wb->Put(key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(put, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      put, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -170,18 +174,18 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len,
-    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto put = [&wb, &cf_handle] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto put = [&wb, &cf_handle](rocksdb::Slice key, rocksdb::Slice value) {
     return wb->Put(cf_handle, key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(put, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      put, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -193,16 +197,16 @@ void Java_org_rocksdb_WriteBatch_put__J_3BI_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len,
-    jbyteArray jentry_value, jint jentry_value_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
-  auto merge = [&wb] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto merge = [&wb](rocksdb::Slice key, rocksdb::Slice value) {
     return wb->Merge(key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(merge, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      merge, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -214,18 +218,18 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len,
-    jbyteArray jentry_value, jint jentry_value_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto merge = [&wb, &cf_handle] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto merge = [&wb, &cf_handle](rocksdb::Slice key, rocksdb::Slice value) {
     return wb->Merge(cf_handle, key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(merge, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      merge, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -236,16 +240,16 @@ void Java_org_rocksdb_WriteBatch_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_delete__J_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len) {
+void Java_org_rocksdb_WriteBatch_delete__J_3BI(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong /*jwb_handle*/,
+                                               jbyteArray /*jkey*/,
+                                               jint /*jkey_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
-  auto remove = [&wb] (rocksdb::Slice key) {
-    return wb->Delete(key);
-  };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(remove, env,
-      jobj, jkey, jkey_len);
+  auto remove = [&wb](rocksdb::Slice key) { return wb->Delete(key); };
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -257,17 +261,17 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BI(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle,
-    jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto remove = [&wb, &cf_handle] (rocksdb::Slice key) {
+  auto remove = [&wb, &cf_handle](rocksdb::Slice key) {
     return wb->Delete(cf_handle, key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(remove, env,
-      jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -278,16 +282,18 @@ void Java_org_rocksdb_WriteBatch_delete__J_3BIJ(
  * Method:    singleDelete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey,
-    jint jkey_len) {
+void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*jwb_handle*/,
+                                                     jbyteArray /*jkey*/,
+                                                     jint /*jkey_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
-  auto single_delete = [&wb] (rocksdb::Slice key) {
+  auto single_delete = [&wb](rocksdb::Slice key) {
     return wb->SingleDelete(key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(single_delete,
-      env, jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(single_delete, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -299,17 +305,17 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BI(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jkey,
-    jint jkey_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto single_delete = [&wb, &cf_handle] (rocksdb::Slice key) {
+  auto single_delete = [&wb, &cf_handle](rocksdb::Slice key) {
     return wb->SingleDelete(cf_handle, key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(single_delete,
-      env, jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(single_delete, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -321,16 +327,17 @@ void Java_org_rocksdb_WriteBatch_singleDelete__J_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
-    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
+    jint /*jend_key_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto deleteRange = [&wb](rocksdb::Slice beginKey, rocksdb::Slice endKey) {
     return wb->DeleteRange(beginKey, endKey);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
-      deleteRange, env, jobj, jbegin_key, jbegin_key_len, jend_key,
-      jend_key_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+                              jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -342,20 +349,20 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jbegin_key,
-    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
-    jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwb_handle*/,
+    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
+    jint /*jend_key_len*/, jlong /*jcf_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
   auto deleteRange = [&wb, &cf_handle](rocksdb::Slice beginKey,
-      rocksdb::Slice endKey) {
+                                       rocksdb::Slice endKey) {
     return wb->DeleteRange(cf_handle, beginKey, endKey);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
-      deleteRange, env, jobj, jbegin_key, jbegin_key_len, jend_key,
-      jend_key_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+                              jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -366,16 +373,15 @@ void Java_org_rocksdb_WriteBatch_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatch_putLogData(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jbyteArray jblob,
-    jint jblob_len) {
+void Java_org_rocksdb_WriteBatch_putLogData(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong /*jwb_handle*/,
+                                            jbyteArray /*jblob*/,
+                                            jint /*jblob_len*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
-  auto putLogData = [&wb] (rocksdb::Slice blob) {
-    return wb->PutLogData(blob);
-  };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(putLogData,
-      env, jobj, jblob, jblob_len);
+  auto putLogData = [&wb](rocksdb::Slice blob) { return wb->PutLogData(blob); };
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(putLogData, env, jobj, jblob, jblob_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -386,13 +392,14 @@ void Java_org_rocksdb_WriteBatch_putLogData(
  * Method:    iterate
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatch_iterate(
-    JNIEnv* env, jobject jobj, jlong jwb_handle, jlong handlerHandle) {
+void Java_org_rocksdb_WriteBatch_iterate(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong /*jwb_handle*/,
+                                         jlong /*handlerHandle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
   rocksdb::Status s = wb->Iterate(
-    reinterpret_cast<rocksdb::WriteBatchHandlerJniCallback*>(handlerHandle));
+      reinterpret_cast<rocksdb::WriteBatchHandlerJniCallback*>(handlerHandle));
 
   if (s.ok()) {
     return;
@@ -405,8 +412,8 @@ void Java_org_rocksdb_WriteBatch_iterate(
  * Method:    data
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_WriteBatch_data(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+jbyteArray Java_org_rocksdb_WriteBatch_data(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -419,8 +426,8 @@ jbyteArray Java_org_rocksdb_WriteBatch_data(
  * Method:    getDataSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteBatch_getDataSize(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+jlong Java_org_rocksdb_WriteBatch_getDataSize(JNIEnv* /*env*/, jobject /*jobj*/,
+                                              jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -433,8 +440,8 @@ jlong Java_org_rocksdb_WriteBatch_getDataSize(
  * Method:    hasPut
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteBatch_hasPut(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+jboolean Java_org_rocksdb_WriteBatch_hasPut(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -446,8 +453,9 @@ jboolean Java_org_rocksdb_WriteBatch_hasPut(
  * Method:    hasDelete
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WriteBatch_hasDelete(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+jboolean Java_org_rocksdb_WriteBatch_hasDelete(JNIEnv* /*env*/,
+                                               jobject /*jobj*/,
+                                               jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -460,7 +468,7 @@ jboolean Java_org_rocksdb_WriteBatch_hasDelete(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -473,7 +481,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasSingleDelete(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -486,7 +494,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasDeleteRange(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -499,7 +507,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasMerge(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -512,7 +520,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasBeginPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -525,7 +533,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasEndPrepare(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -538,7 +546,7 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasCommit(
  * Signature: (J)Z
  */
 JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
-    JNIEnv* env , jobject jobj, jlong jwb_handle) {
+    JNIEnv* env, jobject jobj, jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -550,8 +558,9 @@ JNIEXPORT jboolean JNICALL Java_org_rocksdb_WriteBatch_hasRollback(
  * Method:    markWalTerminationPoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(JNIEnv* env,
+                                                         jobject jobj,
+                                                         jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -563,8 +572,9 @@ void Java_org_rocksdb_WriteBatch_markWalTerminationPoint(
  * Method:    getWalTerminationPoint
  * Signature: (J)Lorg/rocksdb/WriteBatch/SavePoint;
  */
-jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(
-    JNIEnv* env, jobject jobj, jlong jwb_handle) {
+jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(JNIEnv* env,
+                                                           jobject jobj,
+                                                           jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -577,8 +587,8 @@ jobject Java_org_rocksdb_WriteBatch_getWalTerminationPoint(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatch_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WriteBatch_disposeInternal(JNIEnv* env, jobject jobj,
+                                                 jlong handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(handle);
   assert(wb != nullptr);
   delete wb;
@@ -589,8 +599,8 @@ void Java_org_rocksdb_WriteBatch_disposeInternal(
  * Method:    createNewHandler0
  * Signature: ()J
  */
-jlong Java_org_rocksdb_WriteBatch_00024Handler_createNewHandler0(
-    JNIEnv* env, jobject jobj) {
+jlong Java_org_rocksdb_WriteBatch_00024Handler_createNewHandler0(JNIEnv* env,
+                                                                 jobject jobj) {
   auto* wbjnic = new rocksdb::WriteBatchHandlerJniCallback(env, jobj);
   return reinterpret_cast<jlong>(wbjnic);
 }

--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -30,9 +30,9 @@
  * Method:    getContents
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* /*env*/,
+jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* env,
                                                        jclass /*jclazz*/,
-                                                       jlong /*jwb_handle*/) {
+                                                       jlong jwb_handle) {
   auto* b = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(b != nullptr);
 
@@ -154,7 +154,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* /*env*/,
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_WriteBatchTestInternalHelper_setSequence(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle*/, jlong /*jsn*/) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong jwb_handle, jlong jsn) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -167,8 +167,9 @@ void Java_org_rocksdb_WriteBatchTestInternalHelper_setSequence(
  * Method:    sequence
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteBatchTestInternalHelper_sequence(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle*/) {
+jlong Java_org_rocksdb_WriteBatchTestInternalHelper_sequence(JNIEnv* /*env*/,
+                                                             jclass /*jclazz*/,
+                                                             jlong jwb_handle) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -180,9 +181,10 @@ jlong Java_org_rocksdb_WriteBatchTestInternalHelper_sequence(
  * Method:    append
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatchTestInternalHelper_append(
-    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle_1*/,
-    jlong /*jwb_handle_2*/) {
+void Java_org_rocksdb_WriteBatchTestInternalHelper_append(JNIEnv* /*env*/,
+                                                          jclass /*jclazz*/,
+                                                          jlong jwb_handle_1,
+                                                          jlong jwb_handle_2) {
   auto* wb1 = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle_1);
   assert(wb1 != nullptr);
   auto* wb2 = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle_2);

--- a/java/rocksjni/write_batch_test.cc
+++ b/java/rocksjni/write_batch_test.cc
@@ -30,8 +30,9 @@
  * Method:    getContents
  * Signature: (J)[B
  */
-jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
-    JNIEnv* env, jclass jclazz, jlong jwb_handle) {
+jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(JNIEnv* /*env*/,
+                                                       jclass /*jclazz*/,
+                                                       jlong /*jwb_handle*/) {
   auto* b = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(b != nullptr);
 
@@ -55,8 +56,8 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
       rocksdb::WriteBatchInternal::InsertInto(b, &cf_mems_default, nullptr);
   int count = 0;
   rocksdb::Arena arena;
-  rocksdb::ScopedArenaIterator iter(mem->NewIterator(
-      rocksdb::ReadOptions(), &arena));
+  rocksdb::ScopedArenaIterator iter(
+      mem->NewIterator(rocksdb::ReadOptions(), &arena));
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     rocksdb::ParsedInternalKey ikey;
     ikey.clear();
@@ -130,14 +131,15 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
   delete mem->Unref();
 
   jbyteArray jstate = env->NewByteArray(static_cast<jsize>(state.size()));
-  if(jstate == nullptr) {
+  if (jstate == nullptr) {
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
 
-  env->SetByteArrayRegion(jstate, 0, static_cast<jsize>(state.size()),
-                          const_cast<jbyte*>(reinterpret_cast<const jbyte*>(state.c_str())));
-  if(env->ExceptionCheck()) {
+  env->SetByteArrayRegion(
+      jstate, 0, static_cast<jsize>(state.size()),
+      const_cast<jbyte*>(reinterpret_cast<const jbyte*>(state.c_str())));
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
     env->DeleteLocalRef(jstate);
     return nullptr;
@@ -152,7 +154,7 @@ jbyteArray Java_org_rocksdb_WriteBatchTest_getContents(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_WriteBatchTestInternalHelper_setSequence(
-    JNIEnv* env, jclass jclazz, jlong jwb_handle, jlong jsn) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle*/, jlong /*jsn*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -166,7 +168,7 @@ void Java_org_rocksdb_WriteBatchTestInternalHelper_setSequence(
  * Signature: (J)J
  */
 jlong Java_org_rocksdb_WriteBatchTestInternalHelper_sequence(
-    JNIEnv* env, jclass jclazz, jlong jwb_handle) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle*/) {
   auto* wb = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle);
   assert(wb != nullptr);
 
@@ -179,7 +181,8 @@ jlong Java_org_rocksdb_WriteBatchTestInternalHelper_sequence(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_WriteBatchTestInternalHelper_append(
-    JNIEnv* env, jclass jclazz, jlong jwb_handle_1, jlong jwb_handle_2) {
+    JNIEnv* /*env*/, jclass /*jclazz*/, jlong /*jwb_handle_1*/,
+    jlong /*jwb_handle_2*/) {
   auto* wb1 = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle_1);
   assert(wb1 != nullptr);
   auto* wb2 = reinterpret_cast<rocksdb::WriteBatch*>(jwb_handle_2);

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -471,7 +471,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(JNIEnv* /*env*/,
  * Signature: (JJ[BI)[B
  */
 jbyteArray JNICALL Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jdbopt_handle,
+    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdbopt_handle,
     jbyteArray jkey, jint jkey_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* dbopt = reinterpret_cast<rocksdb::DBOptions*>(jdbopt_handle);
@@ -489,7 +489,7 @@ jbyteArray JNICALL Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BI(
  * Signature: (JJ[BIJ)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jdbopt_handle,
+    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdbopt_handle,
     jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* dbopt = reinterpret_cast<rocksdb::DBOptions*>(jdbopt_handle);
@@ -509,7 +509,7 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BIJ(
  * Signature: (JJJ[BI)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jdb_handle,
+    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdb_handle,
     jlong jreadopt_handle, jbyteArray jkey, jint jkey_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -529,7 +529,7 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BI(
  * Signature: (JJJ[BIJ)[B
  */
 jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jdb_handle,
+    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle, jlong jdb_handle,
     jlong jreadopt_handle, jbyteArray jkey, jint jkey_len, jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
@@ -549,8 +549,8 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* env,
-                                                          jobject jobj,
+void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* /*env*/,
+                                                          jobject /*jobj*/,
                                                           jlong handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(handle);
   assert(wbwi != nullptr);
@@ -564,8 +564,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* env,
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* env,
-                                                        jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
                                                         jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   assert(it != nullptr);
@@ -577,7 +577,8 @@ void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* env,
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* env, jobject jobj,
+jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong handle) {
   return reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Valid();
 }
@@ -587,7 +588,8 @@ jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* env, jobject jobj,
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
                                                      jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->SeekToFirst();
 }
@@ -597,7 +599,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* env, jobject jobj,
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* /*env*/,
+                                                    jobject /*jobj*/,
                                                     jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->SeekToLast();
 }
@@ -607,7 +610,7 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* env, jobject jobj,
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Next();
 }
@@ -617,7 +620,7 @@ void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* env, jobject jobj,
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Prev();
 }
@@ -627,7 +630,7 @@ void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* env, jobject jobj,
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* /*env*/, jobject /*jobj*/,
                                               jlong handle, jbyteArray jtarget,
                                               jint jtarget_len) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
@@ -649,7 +652,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject jobj,
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env,
+                                                     jobject /*jobj*/,
                                                      jlong handle,
                                                      jbyteArray jtarget,
                                                      jint jtarget_len) {
@@ -672,7 +676,7 @@ void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env, jobject jobj,
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject jobj,
+void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject /*jobj*/,
                                                 jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   rocksdb::Status s = it->status();
@@ -689,7 +693,8 @@ void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject jobj,
  * Method:    entry1
  * Signature: (J)[J
  */
-jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env, jobject jobj,
+jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env,
+                                                     jobject /*jobj*/,
                                                      jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   const rocksdb::WriteEntry& we = it->Entry();

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -6,10 +6,10 @@
 // This file implements the "bridge" between Java and C++ and enables
 // calling c++ rocksdb::WriteBatchWithIndex methods from Java side.
 
+#include "rocksdb/utilities/write_batch_with_index.h"
 #include "include/org_rocksdb_WBWIRocksIterator.h"
 #include "include/org_rocksdb_WriteBatchWithIndex.h"
 #include "rocksdb/comparator.h"
-#include "rocksdb/utilities/write_batch_with_index.h"
 #include "rocksjni/portal.h"
 
 /*
@@ -18,7 +18,7 @@
  * Signature: ()J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__(
-    JNIEnv* env, jclass jcls) {
+    JNIEnv* /*env*/, jclass /*jcls*/) {
   auto* wbwi = new rocksdb::WriteBatchWithIndex();
   return reinterpret_cast<jlong>(wbwi);
 }
@@ -29,10 +29,9 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__(
  * Signature: (Z)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__Z(
-    JNIEnv* env, jclass jcls, jboolean joverwrite_key) {
-  auto* wbwi =
-      new rocksdb::WriteBatchWithIndex(rocksdb::BytewiseComparator(), 0,
-          static_cast<bool>(joverwrite_key));
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*joverwrite_key*/) {
+  auto* wbwi = new rocksdb::WriteBatchWithIndex(
+      rocksdb::BytewiseComparator(), 0, static_cast<bool>(joverwrite_key));
   return reinterpret_cast<jlong>(wbwi);
 }
 
@@ -42,32 +41,33 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__Z(
  * Signature: (JBIZ)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__JBIZ(
-    JNIEnv* env, jclass jcls, jlong jfallback_index_comparator_handle,
-    jbyte jcomparator_type, jint jreserved_bytes, jboolean joverwrite_key) {
-  rocksdb::Comparator *fallback_comparator = nullptr;
-  switch(jcomparator_type) {
-      // JAVA_COMPARATOR
-      case 0x0:
-        fallback_comparator =
-            reinterpret_cast<rocksdb::ComparatorJniCallback*>(jfallback_index_comparator_handle);
-        break;
+    JNIEnv* /*env*/, jclass /*jcls*/,
+    jlong /*jfallback_index_comparator_handle*/, jbyte /*jcomparator_type*/,
+    jint /*jreserved_bytes*/, jboolean /*joverwrite_key*/) {
+  rocksdb::Comparator* fallback_comparator = nullptr;
+  switch (jcomparator_type) {
+    // JAVA_COMPARATOR
+    case 0x0:
+      fallback_comparator = reinterpret_cast<rocksdb::ComparatorJniCallback*>(
+          jfallback_index_comparator_handle);
+      break;
 
-      // JAVA_DIRECT_COMPARATOR
-      case 0x1:
-        fallback_comparator =
-            reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(jfallback_index_comparator_handle);
-        break;
+    // JAVA_DIRECT_COMPARATOR
+    case 0x1:
+      fallback_comparator =
+          reinterpret_cast<rocksdb::DirectComparatorJniCallback*>(
+              jfallback_index_comparator_handle);
+      break;
 
-      // JAVA_NATIVE_COMPARATOR_WRAPPER
-      case 0x2:
-        fallback_comparator =
-            reinterpret_cast<rocksdb::Comparator*>(jfallback_index_comparator_handle);
-        break;
+    // JAVA_NATIVE_COMPARATOR_WRAPPER
+    case 0x2:
+      fallback_comparator = reinterpret_cast<rocksdb::Comparator*>(
+          jfallback_index_comparator_handle);
+      break;
   }
-  auto* wbwi =
-      new rocksdb::WriteBatchWithIndex(
-          fallback_comparator,
-          static_cast<size_t>(jreserved_bytes), static_cast<bool>(joverwrite_key));
+  auto* wbwi = new rocksdb::WriteBatchWithIndex(
+      fallback_comparator, static_cast<size_t>(jreserved_bytes),
+      static_cast<bool>(joverwrite_key));
   return reinterpret_cast<jlong>(wbwi);
 }
 
@@ -76,8 +76,9 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__JBIZ(
  * Method:    count0
  * Signature: (J)I
  */
-jint Java_org_rocksdb_WriteBatchWithIndex_count0(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+jint Java_org_rocksdb_WriteBatchWithIndex_count0(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -90,15 +91,16 @@ jint Java_org_rocksdb_WriteBatchWithIndex_count0(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
-  auto put = [&wbwi] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto put = [&wbwi](rocksdb::Slice key, rocksdb::Slice value) {
     return wbwi->Put(key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(put, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      put, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -110,18 +112,18 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
-    jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto put = [&wbwi, &cf_handle] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto put = [&wbwi, &cf_handle](rocksdb::Slice key, rocksdb::Slice value) {
     return wbwi->Put(cf_handle, key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(put, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      put, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -133,15 +135,16 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
-  auto merge = [&wbwi] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto merge = [&wbwi](rocksdb::Slice key, rocksdb::Slice value) {
     return wbwi->Merge(key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(merge, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      merge, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -153,18 +156,18 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
-    jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
+    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto merge = [&wbwi, &cf_handle] (rocksdb::Slice key, rocksdb::Slice value) {
+  auto merge = [&wbwi, &cf_handle](rocksdb::Slice key, rocksdb::Slice value) {
     return wbwi->Merge(cf_handle, key, value);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(merge, env,
-      jobj, jkey, jkey_len, jentry_value, jentry_value_len);
+  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
+      merge, env, jobj, jkey, jkey_len, jentry_value, jentry_value_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -175,16 +178,16 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong /*jwbwi_handle*/,
+                                                        jbyteArray /*jkey*/,
+                                                        jint /*jkey_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
-  auto remove = [&wbwi] (rocksdb::Slice key) {
-    return wbwi->Delete(key);
-  };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(remove, env,
-      jobj, jkey, jkey_len);
+  auto remove = [&wbwi](rocksdb::Slice key) { return wbwi->Delete(key); };
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -196,17 +199,17 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto remove = [&wbwi, &cf_handle] (rocksdb::Slice key) {
+  auto remove = [&wbwi, &cf_handle](rocksdb::Slice key) {
     return wbwi->Delete(cf_handle, key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(remove, env,
-      jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(remove, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -218,15 +221,15 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-    jint jkey_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
-  auto single_delete = [&wbwi] (rocksdb::Slice key) {
+  auto single_delete = [&wbwi](rocksdb::Slice key) {
     return wbwi->SingleDelete(key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(single_delete,
-      env, jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(single_delete, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -238,17 +241,17 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
-  JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
-  jint jkey_len, jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
-  auto single_delete = [&wbwi, &cf_handle] (rocksdb::Slice key) {
+  auto single_delete = [&wbwi, &cf_handle](rocksdb::Slice key) {
     return wbwi->SingleDelete(cf_handle, key);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(single_delete,
-      env, jobj, jkey, jkey_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(single_delete, env, jobj, jkey, jkey_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -260,16 +263,17 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
-    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
+    jint /*jend_key_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto deleteRange = [&wbwi](rocksdb::Slice beginKey, rocksdb::Slice endKey) {
     return wbwi->DeleteRange(beginKey, endKey);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
-      deleteRange, env, jobj, jbegin_key, jbegin_key_len, jend_key,
-      jend_key_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+                              jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -281,20 +285,20 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
-    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
-    jlong jcf_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
+    jint /*jend_key_len*/, jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   assert(cf_handle != nullptr);
   auto deleteRange = [&wbwi, &cf_handle](rocksdb::Slice beginKey,
-      rocksdb::Slice endKey) {
+                                         rocksdb::Slice endKey) {
     return wbwi->DeleteRange(cf_handle, beginKey, endKey);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::kv_op(
-      deleteRange, env, jobj, jbegin_key, jbegin_key_len, jend_key,
-      jend_key_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::kv_op(deleteRange, env, jobj, jbegin_key,
+                              jbegin_key_len, jend_key, jend_key_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -305,16 +309,18 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_putLogData(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jblob,
-    jint jblob_len) {
+void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*jwbwi_handle*/,
+                                                     jbyteArray /*jblob*/,
+                                                     jint /*jblob_len*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
-  auto putLogData = [&wbwi] (rocksdb::Slice blob) {
+  auto putLogData = [&wbwi](rocksdb::Slice blob) {
     return wbwi->PutLogData(blob);
   };
-  std::unique_ptr<rocksdb::Status> status = rocksdb::JniUtil::k_op(putLogData,
-      env, jobj, jblob, jblob_len);
+  std::unique_ptr<rocksdb::Status> status =
+      rocksdb::JniUtil::k_op(putLogData, env, jobj, jblob, jblob_len);
   if (status != nullptr && !status->ok()) {
     rocksdb::RocksDBExceptionJni::ThrowNew(env, status);
   }
@@ -325,8 +331,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_putLogData(
  * Method:    clear
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_clear0(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_clear0(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -339,7 +346,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_clear0(
  * Signature: (J)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -352,7 +359,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(
  * Signature: (J)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -370,8 +377,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* /*env*/,
+                                                       jobject /*jobj*/,
+                                                       jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -389,8 +397,10 @@ void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(
  * Method:    setMaxBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jmax_bytes) {
+void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong /*jwbwi_handle*/,
+                                                      jlong /*jmax_bytes*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -403,7 +413,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(
  * Signature: (J)Lorg/rocksdb/WriteBatch;
  */
 jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -418,8 +428,9 @@ jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(
  * Method:    iterator0
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle) {
+jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*jwbwi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* wbwi_iterator = wbwi->NewIterator();
   return reinterpret_cast<jlong>(wbwi_iterator);
@@ -430,8 +441,10 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(
  * Method:    iterator1
  * Signature: (JJ)J
  */
-jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jcf_handle) {
+jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(JNIEnv* /*env*/,
+                                                     jobject /*jobj*/,
+                                                     jlong /*jwbwi_handle*/,
+                                                     jlong /*jcf_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* wbwi_iterator = wbwi->NewIterator(cf_handle);
@@ -444,8 +457,8 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(
  * Signature: (JJJ)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(
-    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jlong jcf_handle,
-    jlong jbi_handle) {
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
+    jlong /*jcf_handle*/, jlong /*jbi_handle*/) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* base_iterator = reinterpret_cast<rocksdb::Iterator*>(jbi_handle);
@@ -483,11 +496,10 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatch__JJ_3BIJ(
   auto* dbopt = reinterpret_cast<rocksdb::DBOptions*>(jdbopt_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
 
-  auto getter =
-      [&wbwi, &cf_handle, &dbopt](const rocksdb::Slice& key,
-                                  std::string* value) {
-        return wbwi->GetFromBatch(cf_handle, *dbopt, key, value);
-      };
+  auto getter = [&wbwi, &cf_handle, &dbopt](const rocksdb::Slice& key,
+                                            std::string* value) {
+    return wbwi->GetFromBatch(cf_handle, *dbopt, key, value);
+  };
 
   return rocksdb::JniUtil::v_op(getter, env, jkey, jkey_len);
 }
@@ -504,10 +516,10 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BI(
   auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   auto* readopt = reinterpret_cast<rocksdb::ReadOptions*>(jreadopt_handle);
 
-  auto getter =
-      [&wbwi, &db, &readopt](const rocksdb::Slice& key, std::string* value) {
-        return wbwi->GetFromBatchAndDB(db, *readopt, key, value);
-      };
+  auto getter = [&wbwi, &db, &readopt](const rocksdb::Slice& key,
+                                       std::string* value) {
+    return wbwi->GetFromBatchAndDB(db, *readopt, key, value);
+  };
 
   return rocksdb::JniUtil::v_op(getter, env, jkey, jkey_len);
 }
@@ -525,11 +537,10 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
   auto* readopt = reinterpret_cast<rocksdb::ReadOptions*>(jreadopt_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
 
-  auto getter =
-      [&wbwi, &db, &cf_handle, &readopt](const rocksdb::Slice& key,
-                                         std::string* value) {
-        return wbwi->GetFromBatchAndDB(db, *readopt, cf_handle, key, value);
-      };
+  auto getter = [&wbwi, &db, &cf_handle, &readopt](const rocksdb::Slice& key,
+                                                   std::string* value) {
+    return wbwi->GetFromBatchAndDB(db, *readopt, cf_handle, key, value);
+  };
 
   return rocksdb::JniUtil::v_op(getter, env, jkey, jkey_len);
 }
@@ -539,8 +550,9 @@ jbyteArray Java_org_rocksdb_WriteBatchWithIndex_getFromBatchAndDB__JJJ_3BIJ(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(JNIEnv* env,
+                                                          jobject jobj,
+                                                          jlong handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(handle);
   assert(wbwi != nullptr);
   delete wbwi;
@@ -553,8 +565,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_disposeInternal(
  * Method:    disposeInternal
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   assert(it != nullptr);
   delete it;
@@ -565,8 +578,8 @@ void Java_org_rocksdb_WBWIRocksIterator_disposeInternal(
  * Method:    isValid0
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(JNIEnv* env, jobject jobj,
+                                                     jlong handle) {
   return reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Valid();
 }
 
@@ -575,8 +588,8 @@ jboolean Java_org_rocksdb_WBWIRocksIterator_isValid0(
  * Method:    seekToFirst0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(JNIEnv* env, jobject jobj,
+                                                     jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->SeekToFirst();
 }
 
@@ -585,8 +598,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToFirst0(
  * Method:    seekToLast0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(JNIEnv* env, jobject jobj,
+                                                    jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->SeekToLast();
 }
 
@@ -595,8 +608,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekToLast0(
  * Method:    next0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_next0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_next0(JNIEnv* env, jobject jobj,
+                                              jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Next();
 }
 
@@ -605,8 +618,8 @@ void Java_org_rocksdb_WBWIRocksIterator_next0(
  * Method:    prev0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_prev0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* env, jobject jobj,
+                                              jlong handle) {
   reinterpret_cast<rocksdb::WBWIIterator*>(handle)->Prev();
 }
 
@@ -615,18 +628,17 @@ void Java_org_rocksdb_WBWIRocksIterator_prev0(
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seek0(
-    JNIEnv* env, jobject jobj, jlong handle, jbyteArray jtarget,
-    jint jtarget_len) {
+void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject jobj,
+                                              jlong handle, jbyteArray jtarget,
+                                              jint jtarget_len) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
-  if(target == nullptr) {
+  if (target == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
-  rocksdb::Slice target_slice(
-      reinterpret_cast<char*>(target), jtarget_len);
+  rocksdb::Slice target_slice(reinterpret_cast<char*>(target), jtarget_len);
 
   it->Seek(target_slice);
 
@@ -638,18 +650,18 @@ void Java_org_rocksdb_WBWIRocksIterator_seek0(
  * Method:    seekForPrev0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(
-    JNIEnv* env, jobject jobj, jlong handle, jbyteArray jtarget,
-    jint jtarget_len) {
+void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(JNIEnv* env, jobject jobj,
+                                                     jlong handle,
+                                                     jbyteArray jtarget,
+                                                     jint jtarget_len) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   jbyte* target = env->GetByteArrayElements(jtarget, nullptr);
-  if(target == nullptr) {
+  if (target == nullptr) {
     // exception thrown: OutOfMemoryError
     return;
   }
 
-  rocksdb::Slice target_slice(
-      reinterpret_cast<char*>(target), jtarget_len);
+  rocksdb::Slice target_slice(reinterpret_cast<char*>(target), jtarget_len);
 
   it->SeekForPrev(target_slice);
 
@@ -661,8 +673,8 @@ void Java_org_rocksdb_WBWIRocksIterator_seekForPrev0(
  * Method:    status0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_status0(
-    JNIEnv* env, jobject jobj, jlong handle) {
+void Java_org_rocksdb_WBWIRocksIterator_status0(JNIEnv* env, jobject jobj,
+                                                jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   rocksdb::Status s = it->status();
 
@@ -678,8 +690,8 @@ void Java_org_rocksdb_WBWIRocksIterator_status0(
  * Method:    entry1
  * Signature: (J)[J
  */
-jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(
-    JNIEnv* env, jobject jobj, jlong handle) {
+jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(JNIEnv* env, jobject jobj,
+                                                     jlong handle) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);
   const rocksdb::WriteEntry& we = it->Entry();
 
@@ -688,13 +700,14 @@ jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(
   // set the type of the write entry
   results[0] = rocksdb::WriteTypeJni::toJavaWriteType(we.type);
 
-  // NOTE: key_slice and value_slice will be freed by org.rocksdb.DirectSlice#close
+  // NOTE: key_slice and value_slice will be freed by
+  // org.rocksdb.DirectSlice#close
 
   auto* key_slice = new rocksdb::Slice(we.key.data(), we.key.size());
   results[1] = reinterpret_cast<jlong>(key_slice);
-  if (we.type == rocksdb::kDeleteRecord
-      || we.type == rocksdb::kSingleDeleteRecord
-      || we.type == rocksdb::kLogDataRecord) {
+  if (we.type == rocksdb::kDeleteRecord ||
+      we.type == rocksdb::kSingleDeleteRecord ||
+      we.type == rocksdb::kLogDataRecord) {
     // set native handle of value slice to null if no value available
     results[2] = 0;
   } else {
@@ -703,9 +716,9 @@ jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(
   }
 
   jlongArray jresults = env->NewLongArray(3);
-  if(jresults == nullptr) {
+  if (jresults == nullptr) {
     // exception thrown: OutOfMemoryError
-    if(results[2] != 0) {
+    if (results[2] != 0) {
       auto* value_slice = reinterpret_cast<rocksdb::Slice*>(results[2]);
       delete value_slice;
     }
@@ -714,10 +727,10 @@ jlongArray Java_org_rocksdb_WBWIRocksIterator_entry1(
   }
 
   env->SetLongArrayRegion(jresults, 0, 3, results);
-  if(env->ExceptionCheck()) {
+  if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
     env->DeleteLocalRef(jresults);
-    if(results[2] != 0) {
+    if (results[2] != 0) {
       auto* value_slice = reinterpret_cast<rocksdb::Slice*>(results[2]);
       delete value_slice;
     }

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -29,7 +29,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__(
  * Signature: (Z)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__Z(
-    JNIEnv* /*env*/, jclass /*jcls*/, jboolean /*joverwrite_key*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jboolean joverwrite_key) {
   auto* wbwi = new rocksdb::WriteBatchWithIndex(
       rocksdb::BytewiseComparator(), 0, static_cast<bool>(joverwrite_key));
   return reinterpret_cast<jlong>(wbwi);
@@ -41,9 +41,8 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__Z(
  * Signature: (JBIZ)J
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__JBIZ(
-    JNIEnv* /*env*/, jclass /*jcls*/,
-    jlong /*jfallback_index_comparator_handle*/, jbyte /*jcomparator_type*/,
-    jint /*jreserved_bytes*/, jboolean /*joverwrite_key*/) {
+    JNIEnv* /*env*/, jclass /*jcls*/, jlong jfallback_index_comparator_handle,
+    jbyte jcomparator_type, jint jreserved_bytes, jboolean joverwrite_key) {
   rocksdb::Comparator* fallback_comparator = nullptr;
   switch (jcomparator_type) {
     // JAVA_COMPARATOR
@@ -78,7 +77,7 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_newWriteBatchWithIndex__JBIZ(
  */
 jint Java_org_rocksdb_WriteBatchWithIndex_count0(JNIEnv* /*env*/,
                                                  jobject /*jobj*/,
-                                                 jlong /*jwbwi_handle*/) {
+                                                 jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -91,9 +90,8 @@ jint Java_org_rocksdb_WriteBatchWithIndex_count0(JNIEnv* /*env*/,
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto put = [&wbwi](rocksdb::Slice key, rocksdb::Slice value) {
@@ -112,9 +110,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
+    jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -135,9 +133,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_put__J_3BI_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto merge = [&wbwi](rocksdb::Slice key, rocksdb::Slice value) {
@@ -156,9 +153,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jbyteArray /*jentry_value*/,
-    jint /*jentry_value_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jbyteArray jentry_value, jint jentry_value_len,
+    jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -178,11 +175,11 @@ void Java_org_rocksdb_WriteBatchWithIndex_merge__J_3BI_3BIJ(
  * Method:    delete
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* /*env*/,
-                                                        jobject /*jobj*/,
-                                                        jlong /*jwbwi_handle*/,
-                                                        jbyteArray /*jkey*/,
-                                                        jint /*jkey_len*/) {
+void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* env,
+                                                        jobject jobj,
+                                                        jlong jwbwi_handle,
+                                                        jbyteArray jkey,
+                                                        jint jkey_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto remove = [&wbwi](rocksdb::Slice key) { return wbwi->Delete(key); };
@@ -199,8 +196,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BI(JNIEnv* /*env*/,
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -221,8 +218,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_delete__J_3BIJ(
  * Signature: (J[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto single_delete = [&wbwi](rocksdb::Slice key) {
@@ -241,8 +238,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BI(
  * Signature: (J[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jkey*/, jint /*jkey_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jkey,
+    jint jkey_len, jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -263,9 +260,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_singleDelete__J_3BIJ(
  * Signature: (J[BI[BI)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
-    jint /*jend_key_len*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
+    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto deleteRange = [&wbwi](rocksdb::Slice beginKey, rocksdb::Slice endKey) {
@@ -285,9 +281,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BI(
  * Signature: (J[BI[BIJ)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jbyteArray /*jbegin_key*/, jint /*jbegin_key_len*/, jbyteArray /*jend_key*/,
-    jint /*jend_key_len*/, jlong /*jcf_handle*/) {
+    JNIEnv* env, jobject jobj, jlong jwbwi_handle, jbyteArray jbegin_key,
+    jint jbegin_key_len, jbyteArray jend_key, jint jend_key_len,
+    jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
@@ -309,11 +305,10 @@ void Java_org_rocksdb_WriteBatchWithIndex_deleteRange__J_3BI_3BIJ(
  * Method:    putLogData
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* /*env*/,
-                                                     jobject /*jobj*/,
-                                                     jlong /*jwbwi_handle*/,
-                                                     jbyteArray /*jblob*/,
-                                                     jint /*jblob_len*/) {
+void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* env, jobject jobj,
+                                                     jlong jwbwi_handle,
+                                                     jbyteArray jblob,
+                                                     jint jblob_len) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
   auto putLogData = [&wbwi](rocksdb::Slice blob) {
@@ -333,7 +328,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_putLogData(JNIEnv* /*env*/,
  */
 void Java_org_rocksdb_WriteBatchWithIndex_clear0(JNIEnv* /*env*/,
                                                  jobject /*jobj*/,
-                                                 jlong /*jwbwi_handle*/) {
+                                                 jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -345,8 +340,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_clear0(JNIEnv* /*env*/,
  * Method:    setSavePoint0
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
+void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(JNIEnv* /*env*/,
+                                                        jobject /*jobj*/,
+                                                        jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -359,7 +355,7 @@ void Java_org_rocksdb_WriteBatchWithIndex_setSavePoint0(
  * Signature: (J)V
  */
 void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
+    JNIEnv* env, jobject /*jobj*/, jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -377,9 +373,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_rollbackToSavePoint0(
  * Method:    popSavePoint
  * Signature: (J)V
  */
-void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* /*env*/,
+void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* env,
                                                        jobject /*jobj*/,
-                                                       jlong /*jwbwi_handle*/) {
+                                                       jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -399,8 +395,8 @@ void Java_org_rocksdb_WriteBatchWithIndex_popSavePoint(JNIEnv* /*env*/,
  */
 void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(JNIEnv* /*env*/,
                                                       jobject /*jobj*/,
-                                                      jlong /*jwbwi_handle*/,
-                                                      jlong /*jmax_bytes*/) {
+                                                      jlong jwbwi_handle,
+                                                      jlong jmax_bytes) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -412,8 +408,9 @@ void Java_org_rocksdb_WriteBatchWithIndex_setMaxBytes(JNIEnv* /*env*/,
  * Method:    getWriteBatch
  * Signature: (J)Lorg/rocksdb/WriteBatch;
  */
-jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/) {
+jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(JNIEnv* env,
+                                                           jobject /*jobj*/,
+                                                           jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   assert(wbwi != nullptr);
 
@@ -430,7 +427,7 @@ jobject Java_org_rocksdb_WriteBatchWithIndex_getWriteBatch(
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(JNIEnv* /*env*/,
                                                      jobject /*jobj*/,
-                                                     jlong /*jwbwi_handle*/) {
+                                                     jlong jwbwi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* wbwi_iterator = wbwi->NewIterator();
   return reinterpret_cast<jlong>(wbwi_iterator);
@@ -443,8 +440,8 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator0(JNIEnv* /*env*/,
  */
 jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(JNIEnv* /*env*/,
                                                      jobject /*jobj*/,
-                                                     jlong /*jwbwi_handle*/,
-                                                     jlong /*jcf_handle*/) {
+                                                     jlong jwbwi_handle,
+                                                     jlong jcf_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* wbwi_iterator = wbwi->NewIterator(cf_handle);
@@ -456,9 +453,11 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iterator1(JNIEnv* /*env*/,
  * Method:    iteratorWithBase
  * Signature: (JJJ)J
  */
-jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(
-    JNIEnv* /*env*/, jobject /*jobj*/, jlong /*jwbwi_handle*/,
-    jlong /*jcf_handle*/, jlong /*jbi_handle*/) {
+jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(JNIEnv* /*env*/,
+                                                            jobject /*jobj*/,
+                                                            jlong jwbwi_handle,
+                                                            jlong jcf_handle,
+                                                            jlong jbi_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* base_iterator = reinterpret_cast<rocksdb::Iterator*>(jbi_handle);

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -630,7 +630,7 @@ void Java_org_rocksdb_WBWIRocksIterator_prev0(JNIEnv* /*env*/, jobject /*jobj*/,
  * Method:    seek0
  * Signature: (J[BI)V
  */
-void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* /*env*/, jobject /*jobj*/,
+void Java_org_rocksdb_WBWIRocksIterator_seek0(JNIEnv* env, jobject /*jobj*/,
                                               jlong handle, jbyteArray jtarget,
                                               jint jtarget_len) {
   auto* it = reinterpret_cast<rocksdb::WBWIIterator*>(handle);

--- a/memtable/memtablerep_bench.cc
+++ b/memtable/memtablerep_bench.cc
@@ -479,8 +479,8 @@ class FillBenchmark : public Benchmark {
     num_write_ops_per_thread_ = FLAGS_num_operations;
   }
 
-  void RunThreads(std::vector<port::Thread>* threads, uint64_t* bytes_written,
-                  uint64_t* bytes_read, bool write,
+  void RunThreads(std::vector<port::Thread>* /*threads*/, uint64_t* bytes_written,
+                  uint64_t* bytes_read, bool /*write*/,
                   uint64_t* read_hits) override {
     FillBenchmarkThread(table_, key_gen_, bytes_written, bytes_read, sequence_,
                         num_write_ops_per_thread_, read_hits)();
@@ -496,7 +496,7 @@ class ReadBenchmark : public Benchmark {
   }
 
   void RunThreads(std::vector<port::Thread>* threads, uint64_t* bytes_written,
-                  uint64_t* bytes_read, bool write,
+                  uint64_t* bytes_read, bool /*write*/,
                   uint64_t* read_hits) override {
     for (int i = 0; i < FLAGS_num_threads; ++i) {
       threads->emplace_back(
@@ -520,7 +520,7 @@ class SeqReadBenchmark : public Benchmark {
   }
 
   void RunThreads(std::vector<port::Thread>* threads, uint64_t* bytes_written,
-                  uint64_t* bytes_read, bool write,
+                  uint64_t* bytes_read, bool /*write*/,
                   uint64_t* read_hits) override {
     for (int i = 0; i < FLAGS_num_threads; ++i) {
       threads->emplace_back(SeqReadBenchmarkThread(
@@ -547,7 +547,7 @@ class ReadWriteBenchmark : public Benchmark {
   }
 
   void RunThreads(std::vector<port::Thread>* threads, uint64_t* bytes_written,
-                  uint64_t* bytes_read, bool write,
+                  uint64_t* bytes_read, bool /*write*/,
                   uint64_t* read_hits) override {
     std::atomic_int threads_done;
     threads_done.store(0);

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -60,6 +60,8 @@ WriteBufferManager::WriteBufferManager(size_t _buffer_size,
     // Construct the cache key using the pointer to this.
     cache_rep_.reset(new CacheRep(cache));
   }
+#else
+  (void)cache;
 #endif  // ROCKSDB_LITE
 }
 
@@ -92,6 +94,8 @@ void WriteBufferManager::ReserveMemWithCache(size_t mem) {
     cache_rep_->dummy_handles_.push_back(handle);
     cache_rep_->cache_allocated_size_ += kSizeDummyEntry;
   }
+#else
+  (void)mem;
 #endif  // ROCKSDB_LITE
 }
 
@@ -119,6 +123,8 @@ void WriteBufferManager::FreeMemWithCache(size_t mem) {
     cache_rep_->dummy_handles_.pop_back();
     cache_rep_->cache_allocated_size_ -= kSizeDummyEntry;
   }
+#else
+  (void)mem;
 #endif  // ROCKSDB_LITE
 }
 }  // namespace rocksdb

--- a/monitoring/thread_status_impl.cc
+++ b/monitoring/thread_status_impl.cc
@@ -84,10 +84,8 @@ const std::string& ThreadStatus::GetOperationPropertyName(
   }
 }
 
-std::map<std::string, uint64_t>
-    ThreadStatus::InterpretOperationProperties(
-    ThreadStatus::OperationType op_type,
-    const uint64_t* op_properties) {
+std::map<std::string, uint64_t> ThreadStatus::InterpretOperationProperties(
+    ThreadStatus::OperationType op_type, const uint64_t* op_properties) {
   int num_properties;
   switch (op_type) {
     case OP_COMPACTION:
@@ -102,20 +100,14 @@ std::map<std::string, uint64_t>
 
   std::map<std::string, uint64_t> property_map;
   for (int i = 0; i < num_properties; ++i) {
-    if (op_type == OP_COMPACTION &&
-        i == COMPACTION_INPUT_OUTPUT_LEVEL) {
-      property_map.insert(
-          {"BaseInputLevel", op_properties[i] >> 32});
+    if (op_type == OP_COMPACTION && i == COMPACTION_INPUT_OUTPUT_LEVEL) {
+      property_map.insert({"BaseInputLevel", op_properties[i] >> 32});
       property_map.insert(
           {"OutputLevel", op_properties[i] % (uint64_t(1) << 32U)});
-    } else if (op_type == OP_COMPACTION &&
-               i == COMPACTION_PROP_FLAGS) {
-      property_map.insert(
-          {"IsManual", ((op_properties[i] & 2) >> 1)});
-      property_map.insert(
-          {"IsDeletion", ((op_properties[i] & 4) >> 2)});
-      property_map.insert(
-          {"IsTrivialMove", ((op_properties[i] & 8) >> 3)});
+    } else if (op_type == OP_COMPACTION && i == COMPACTION_PROP_FLAGS) {
+      property_map.insert({"IsManual", ((op_properties[i] & 2) >> 1)});
+      property_map.insert({"IsDeletion", ((op_properties[i] & 4) >> 2)});
+      property_map.insert({"IsTrivialMove", ((op_properties[i] & 8) >> 3)});
     } else {
       property_map.insert(
           {GetOperationPropertyName(op_type, i), op_properties[i]});
@@ -124,49 +116,46 @@ std::map<std::string, uint64_t>
   return property_map;
 }
 
-
 #else
 
 std::string ThreadStatus::GetThreadTypeName(
-    ThreadStatus::ThreadType thread_type) {
+    ThreadStatus::ThreadType /*thread_type*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
 const std::string& ThreadStatus::GetOperationName(
-    ThreadStatus::OperationType op_type) {
+    ThreadStatus::OperationType /*op_type*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
 const std::string& ThreadStatus::GetOperationStageName(
-    ThreadStatus::OperationStage stage) {
+    ThreadStatus::OperationStage /*stage*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
 const std::string& ThreadStatus::GetStateName(
-    ThreadStatus::StateType state_type) {
+    ThreadStatus::StateType /*state_type*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
-const std::string ThreadStatus::MicrosToString(
-    uint64_t op_elapsed_time) {
+const std::string ThreadStatus::MicrosToString(uint64_t /*op_elapsed_time*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
 const std::string& ThreadStatus::GetOperationPropertyName(
-    ThreadStatus::OperationType op_type, int i) {
+    ThreadStatus::OperationType /*op_type*/, int /*i*/) {
   static std::string dummy_str = "";
   return dummy_str;
 }
 
-std::map<std::string, uint64_t>
-    ThreadStatus::InterpretOperationProperties(
-    ThreadStatus::OperationType op_type,
-    const uint64_t* op_properties) {
+std::map<std::string, uint64_t> ThreadStatus::InterpretOperationProperties(
+    ThreadStatus::OperationType /*op_type*/,
+    const uint64_t* /*op_properties*/) {
   return std::map<std::string, uint64_t>();
 }
 

--- a/monitoring/thread_status_updater.cc
+++ b/monitoring/thread_status_updater.cc
@@ -15,8 +15,8 @@ namespace rocksdb {
 
 __thread ThreadStatusData* ThreadStatusUpdater::thread_status_data_ = nullptr;
 
-void ThreadStatusUpdater::RegisterThread(
-    ThreadStatus::ThreadType ttype, uint64_t thread_id) {
+void ThreadStatusUpdater::RegisterThread(ThreadStatus::ThreadType ttype,
+                                         uint64_t thread_id) {
   if (UNLIKELY(thread_status_data_ == nullptr)) {
     thread_status_data_ = new ThreadStatusData();
     thread_status_data_->thread_type = ttype;
@@ -43,8 +43,7 @@ void ThreadStatusUpdater::ResetThreadStatus() {
   SetColumnFamilyInfoKey(nullptr);
 }
 
-void ThreadStatusUpdater::SetColumnFamilyInfoKey(
-    const void* cf_key) {
+void ThreadStatusUpdater::SetColumnFamilyInfoKey(const void* cf_key) {
   auto* data = Get();
   if (data == nullptr) {
     return;
@@ -78,13 +77,12 @@ void ThreadStatusUpdater::SetThreadOperation(
   data->operation_type.store(type, std::memory_order_release);
   if (type == ThreadStatus::OP_UNKNOWN) {
     data->operation_stage.store(ThreadStatus::STAGE_UNKNOWN,
-        std::memory_order_relaxed);
+                                std::memory_order_relaxed);
     ClearThreadOperationProperties();
   }
 }
 
-void ThreadStatusUpdater::SetThreadOperationProperty(
-    int i, uint64_t value) {
+void ThreadStatusUpdater::SetThreadOperationProperty(int i, uint64_t value) {
   auto* data = GetLocalThreadStatus();
   if (data == nullptr) {
     return;
@@ -92,8 +90,8 @@ void ThreadStatusUpdater::SetThreadOperationProperty(
   data->op_properties[i].store(value, std::memory_order_relaxed);
 }
 
-void ThreadStatusUpdater::IncreaseThreadOperationProperty(
-    int i, uint64_t delta) {
+void ThreadStatusUpdater::IncreaseThreadOperationProperty(int i,
+                                                          uint64_t delta) {
   auto* data = GetLocalThreadStatus();
   if (data == nullptr) {
     return;
@@ -115,9 +113,9 @@ void ThreadStatusUpdater::ClearThreadOperation() {
     return;
   }
   data->operation_stage.store(ThreadStatus::STAGE_UNKNOWN,
-      std::memory_order_relaxed);
-  data->operation_type.store(
-      ThreadStatus::OP_UNKNOWN, std::memory_order_relaxed);
+                              std::memory_order_relaxed);
+  data->operation_type.store(ThreadStatus::OP_UNKNOWN,
+                             std::memory_order_relaxed);
   ClearThreadOperationProperties();
 }
 
@@ -137,12 +135,10 @@ ThreadStatus::OperationStage ThreadStatusUpdater::SetThreadOperationStage(
   if (data == nullptr) {
     return ThreadStatus::STAGE_UNKNOWN;
   }
-  return data->operation_stage.exchange(
-      stage, std::memory_order_relaxed);
+  return data->operation_stage.exchange(stage, std::memory_order_relaxed);
 }
 
-void ThreadStatusUpdater::SetThreadState(
-    const ThreadStatus::StateType type) {
+void ThreadStatusUpdater::SetThreadState(const ThreadStatus::StateType type) {
   auto* data = GetLocalThreadStatus();
   if (data == nullptr) {
     return;
@@ -155,8 +151,8 @@ void ThreadStatusUpdater::ClearThreadState() {
   if (data == nullptr) {
     return;
   }
-  data->state_type.store(
-      ThreadStatus::STATE_UNKNOWN, std::memory_order_relaxed);
+  data->state_type.store(ThreadStatus::STATE_UNKNOWN,
+                         std::memory_order_relaxed);
 }
 
 Status ThreadStatusUpdater::GetThreadList(
@@ -168,16 +164,13 @@ Status ThreadStatusUpdater::GetThreadList(
   std::lock_guard<std::mutex> lck(thread_list_mutex_);
   for (auto* thread_data : thread_data_set_) {
     assert(thread_data);
-    auto thread_id = thread_data->thread_id.load(
-        std::memory_order_relaxed);
-    auto thread_type = thread_data->thread_type.load(
-        std::memory_order_relaxed);
+    auto thread_id = thread_data->thread_id.load(std::memory_order_relaxed);
+    auto thread_type = thread_data->thread_type.load(std::memory_order_relaxed);
     // Since any change to cf_info_map requires thread_list_mutex,
     // which is currently held by GetThreadList(), here we can safely
     // use "memory_order_relaxed" to load the cf_key.
-    auto cf_key = thread_data->cf_key.load(
-        std::memory_order_relaxed);
-    
+    auto cf_key = thread_data->cf_key.load(std::memory_order_relaxed);
+
     ThreadStatus::OperationType op_type = ThreadStatus::OP_UNKNOWN;
     ThreadStatus::OperationStage op_stage = ThreadStatus::STAGE_UNKNOWN;
     ThreadStatus::StateType state_type = ThreadStatus::STATE_UNKNOWN;
@@ -186,19 +179,16 @@ Status ThreadStatusUpdater::GetThreadList(
 
     auto iter = cf_info_map_.find(cf_key);
     if (iter != cf_info_map_.end()) {
-      op_type = thread_data->operation_type.load(
-          std::memory_order_acquire);
+      op_type = thread_data->operation_type.load(std::memory_order_acquire);
       // display lower-level info only when higher-level info is available.
       if (op_type != ThreadStatus::OP_UNKNOWN) {
         op_elapsed_micros = now_micros - thread_data->op_start_time.load(
-            std::memory_order_relaxed);
-        op_stage = thread_data->operation_stage.load(
-            std::memory_order_relaxed);
-        state_type = thread_data->state_type.load(
-            std::memory_order_relaxed);
+                                             std::memory_order_relaxed);
+        op_stage = thread_data->operation_stage.load(std::memory_order_relaxed);
+        state_type = thread_data->state_type.load(std::memory_order_relaxed);
         for (int i = 0; i < ThreadStatus::kNumOperationProperties; ++i) {
-          op_props[i] = thread_data->op_properties[i].load(
-              std::memory_order_relaxed);
+          op_props[i] =
+              thread_data->op_properties[i].load(std::memory_order_relaxed);
         }
       }
     }
@@ -206,9 +196,8 @@ Status ThreadStatusUpdater::GetThreadList(
     thread_list->emplace_back(
         thread_id, thread_type,
         iter != cf_info_map_.end() ? iter->second.db_name : "",
-        iter != cf_info_map_.end() ? iter->second.cf_name : "",
-        op_type, op_elapsed_micros, op_stage, op_props,
-        state_type);
+        iter != cf_info_map_.end() ? iter->second.cf_name : "", op_type,
+        op_elapsed_micros, op_stage, op_props, state_type);
   }
 
   return Status::OK();
@@ -219,23 +208,23 @@ ThreadStatusData* ThreadStatusUpdater::GetLocalThreadStatus() {
     return nullptr;
   }
   if (!thread_status_data_->enable_tracking) {
-    assert(thread_status_data_->cf_key.load(
-        std::memory_order_relaxed) == nullptr);
+    assert(thread_status_data_->cf_key.load(std::memory_order_relaxed) ==
+           nullptr);
     return nullptr;
   }
   return thread_status_data_;
 }
 
-void ThreadStatusUpdater::NewColumnFamilyInfo(
-    const void* db_key, const std::string& db_name,
-    const void* cf_key, const std::string& cf_name) {
+void ThreadStatusUpdater::NewColumnFamilyInfo(const void* db_key,
+                                              const std::string& db_name,
+                                              const void* cf_key,
+                                              const std::string& cf_name) {
   // Acquiring same lock as GetThreadList() to guarantee
   // a consistent view of global column family table (cf_info_map).
   std::lock_guard<std::mutex> lck(thread_list_mutex_);
 
-  cf_info_map_.emplace(std::piecewise_construct,
-      std::make_tuple(cf_key),
-      std::make_tuple(db_key, db_name, cf_name));
+  cf_info_map_.emplace(std::piecewise_construct, std::make_tuple(cf_key),
+                       std::make_tuple(db_key, db_name, cf_name));
   db_key_map_[db_key].insert(cf_key);
 }
 
@@ -243,7 +232,7 @@ void ThreadStatusUpdater::EraseColumnFamilyInfo(const void* cf_key) {
   // Acquiring same lock as GetThreadList() to guarantee
   // a consistent view of global column family table (cf_info_map).
   std::lock_guard<std::mutex> lck(thread_list_mutex_);
-  
+
   auto cf_pair = cf_info_map_.find(cf_key);
   if (cf_pair != cf_info_map_.end()) {
     // Remove its entry from db_key_map_ by the following steps:
@@ -281,58 +270,45 @@ void ThreadStatusUpdater::EraseDatabaseInfo(const void* db_key) {
 
 #else
 
-void ThreadStatusUpdater::RegisterThread(
-    ThreadStatus::ThreadType ttype, uint64_t thread_id) {
-}
+void ThreadStatusUpdater::RegisterThread(ThreadStatus::ThreadType /*ttype*/,
+                                         uint64_t /*thread_id*/) {}
 
-void ThreadStatusUpdater::UnregisterThread() {
-}
+void ThreadStatusUpdater::UnregisterThread() {}
 
-void ThreadStatusUpdater::ResetThreadStatus() {
-}
+void ThreadStatusUpdater::ResetThreadStatus() {}
 
-void ThreadStatusUpdater::SetColumnFamilyInfoKey(
-    const void* cf_key) {
-}
+void ThreadStatusUpdater::SetColumnFamilyInfoKey(const void* /*cf_key*/) {}
 
 void ThreadStatusUpdater::SetThreadOperation(
-    const ThreadStatus::OperationType type) {
-}
+    const ThreadStatus::OperationType /*type*/) {}
 
-void ThreadStatusUpdater::ClearThreadOperation() {
-}
+void ThreadStatusUpdater::ClearThreadOperation() {}
 
 void ThreadStatusUpdater::SetThreadState(
-    const ThreadStatus::StateType type) {
-}
+    const ThreadStatus::StateType /*type*/) {}
 
-void ThreadStatusUpdater::ClearThreadState() {
-}
+void ThreadStatusUpdater::ClearThreadState() {}
 
 Status ThreadStatusUpdater::GetThreadList(
-    std::vector<ThreadStatus>* thread_list) {
+    std::vector<ThreadStatus>* /*thread_list*/) {
   return Status::NotSupported(
       "GetThreadList is not supported in the current running environment.");
 }
 
-void ThreadStatusUpdater::NewColumnFamilyInfo(
-    const void* db_key, const std::string& db_name,
-    const void* cf_key, const std::string& cf_name) {
-}
+void ThreadStatusUpdater::NewColumnFamilyInfo(const void* /*db_key*/,
+                                              const std::string& /*db_name*/,
+                                              const void* /*cf_key*/,
+                                              const std::string& /*cf_name*/) {}
 
-void ThreadStatusUpdater::EraseColumnFamilyInfo(const void* cf_key) {
-}
+void ThreadStatusUpdater::EraseColumnFamilyInfo(const void* /*cf_key*/) {}
 
-void ThreadStatusUpdater::EraseDatabaseInfo(const void* db_key) {
-}
+void ThreadStatusUpdater::EraseDatabaseInfo(const void* /*db_key*/) {}
 
-void ThreadStatusUpdater::SetThreadOperationProperty(
-    int i, uint64_t value) {
-}
+void ThreadStatusUpdater::SetThreadOperationProperty(int /*i*/,
+                                                     uint64_t /*value*/) {}
 
-void ThreadStatusUpdater::IncreaseThreadOperationProperty(
-    int i, uint64_t delta) {
-}
+void ThreadStatusUpdater::IncreaseThreadOperationProperty(int /*i*/,
+                                                          uint64_t /*delta*/) {}
 
 #endif  // ROCKSDB_USING_THREAD_STATUS
 }  // namespace rocksdb

--- a/monitoring/thread_status_updater_debug.cc
+++ b/monitoring/thread_status_updater_debug.cc
@@ -13,8 +13,7 @@ namespace rocksdb {
 #ifndef NDEBUG
 #ifdef ROCKSDB_USING_THREAD_STATUS
 void ThreadStatusUpdater::TEST_VerifyColumnFamilyInfoMap(
-    const std::vector<ColumnFamilyHandle*>& handles,
-    bool check_exist) {
+    const std::vector<ColumnFamilyHandle*>& handles, bool check_exist) {
   std::unique_lock<std::mutex> lock(thread_list_mutex_);
   if (check_exist) {
     assert(cf_info_map_.size() == handles.size());
@@ -34,12 +33,10 @@ void ThreadStatusUpdater::TEST_VerifyColumnFamilyInfoMap(
 #else
 
 void ThreadStatusUpdater::TEST_VerifyColumnFamilyInfoMap(
-    const std::vector<ColumnFamilyHandle*>& handles,
-    bool check_exist) {
+    const std::vector<ColumnFamilyHandle*>& /*handles*/, bool /*check_exist*/) {
 }
 
 #endif  // ROCKSDB_USING_THREAD_STATUS
 #endif  // !NDEBUG
-
 
 }  // namespace rocksdb

--- a/monitoring/thread_status_util.cc
+++ b/monitoring/thread_status_util.cc
@@ -10,20 +10,18 @@
 
 namespace rocksdb {
 
-
 #ifdef ROCKSDB_USING_THREAD_STATUS
-__thread ThreadStatusUpdater*
-    ThreadStatusUtil::thread_updater_local_cache_ = nullptr;
+__thread ThreadStatusUpdater* ThreadStatusUtil::thread_updater_local_cache_ =
+    nullptr;
 __thread bool ThreadStatusUtil::thread_updater_initialized_ = false;
 
-void ThreadStatusUtil::RegisterThread(
-    const Env* env, ThreadStatus::ThreadType thread_type) {
+void ThreadStatusUtil::RegisterThread(const Env* env,
+                                      ThreadStatus::ThreadType thread_type) {
   if (!MaybeInitThreadLocalUpdater(env)) {
     return;
   }
   assert(thread_updater_local_cache_);
-  thread_updater_local_cache_->RegisterThread(
-      thread_type, env->GetThreadID());
+  thread_updater_local_cache_->RegisterThread(thread_type, env->GetThreadID());
 }
 
 void ThreadStatusUtil::UnregisterThread() {
@@ -80,28 +78,25 @@ ThreadStatus::OperationStage ThreadStatusUtil::SetThreadOperationStage(
   return thread_updater_local_cache_->SetThreadOperationStage(stage);
 }
 
-void ThreadStatusUtil::SetThreadOperationProperty(
-    int code, uint64_t value) {
+void ThreadStatusUtil::SetThreadOperationProperty(int code, uint64_t value) {
   if (thread_updater_local_cache_ == nullptr) {
     // thread_updater_local_cache_ must be set in SetColumnFamily
     // or other ThreadStatusUtil functions.
     return;
   }
 
-  thread_updater_local_cache_->SetThreadOperationProperty(
-      code, value);
+  thread_updater_local_cache_->SetThreadOperationProperty(code, value);
 }
 
-void ThreadStatusUtil::IncreaseThreadOperationProperty(
-    int code, uint64_t delta) {
+void ThreadStatusUtil::IncreaseThreadOperationProperty(int code,
+                                                       uint64_t delta) {
   if (thread_updater_local_cache_ == nullptr) {
     // thread_updater_local_cache_ must be set in SetColumnFamily
     // or other ThreadStatusUtil functions.
     return;
   }
 
-  thread_updater_local_cache_->IncreaseThreadOperationProperty(
-      code, delta);
+  thread_updater_local_cache_->IncreaseThreadOperationProperty(code, delta);
 }
 
 void ThreadStatusUtil::SetThreadState(ThreadStatus::StateType state) {
@@ -135,8 +130,7 @@ void ThreadStatusUtil::NewColumnFamilyInfo(const DB* db,
   }
 }
 
-void ThreadStatusUtil::EraseColumnFamilyInfo(
-    const ColumnFamilyData* cfd) {
+void ThreadStatusUtil::EraseColumnFamilyInfo(const ColumnFamilyData* cfd) {
   if (thread_updater_local_cache_ == nullptr) {
     return;
   }
@@ -173,49 +167,39 @@ AutoThreadOperationStageUpdater::~AutoThreadOperationStageUpdater() {
 ThreadStatusUpdater* ThreadStatusUtil::thread_updater_local_cache_ = nullptr;
 bool ThreadStatusUtil::thread_updater_initialized_ = false;
 
-bool ThreadStatusUtil::MaybeInitThreadLocalUpdater(const Env* env) {
+bool ThreadStatusUtil::MaybeInitThreadLocalUpdater(const Env* /*env*/) {
   return false;
 }
 
-void ThreadStatusUtil::SetColumnFamily(const ColumnFamilyData* cfd,
-                                       const Env* env,
-                                       bool enable_thread_tracking) {}
+void ThreadStatusUtil::SetColumnFamily(const ColumnFamilyData* /*cfd*/,
+                                       const Env* /*env*/,
+                                       bool /*enable_thread_tracking*/) {}
 
-void ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType op) {
-}
+void ThreadStatusUtil::SetThreadOperation(ThreadStatus::OperationType /*op*/) {}
 
-void ThreadStatusUtil::SetThreadOperationProperty(
-    int code, uint64_t value) {
-}
+void ThreadStatusUtil::SetThreadOperationProperty(int /*code*/,
+                                                  uint64_t /*value*/) {}
 
-void ThreadStatusUtil::IncreaseThreadOperationProperty(
-    int code, uint64_t delta) {
-}
+void ThreadStatusUtil::IncreaseThreadOperationProperty(int /*code*/,
+                                                       uint64_t /*delta*/) {}
 
-void ThreadStatusUtil::SetThreadState(ThreadStatus::StateType state) {
-}
+void ThreadStatusUtil::SetThreadState(ThreadStatus::StateType /*state*/) {}
 
-void ThreadStatusUtil::NewColumnFamilyInfo(const DB* db,
-                                           const ColumnFamilyData* cfd,
-                                           const std::string& cf_name,
-                                           const Env* env) {}
+void ThreadStatusUtil::NewColumnFamilyInfo(const DB* /*db*/,
+                                           const ColumnFamilyData* /*cfd*/,
+                                           const std::string& /*cf_name*/,
+                                           const Env* /*env*/) {}
 
-void ThreadStatusUtil::EraseColumnFamilyInfo(
-    const ColumnFamilyData* cfd) {
-}
+void ThreadStatusUtil::EraseColumnFamilyInfo(const ColumnFamilyData* /*cfd*/) {}
 
-void ThreadStatusUtil::EraseDatabaseInfo(const DB* db) {
-}
+void ThreadStatusUtil::EraseDatabaseInfo(const DB* /*db*/) {}
 
-void ThreadStatusUtil::ResetThreadStatus() {
-}
+void ThreadStatusUtil::ResetThreadStatus() {}
 
 AutoThreadOperationStageUpdater::AutoThreadOperationStageUpdater(
-    ThreadStatus::OperationStage stage) {
-}
+    ThreadStatus::OperationStage /*stage*/) {}
 
-AutoThreadOperationStageUpdater::~AutoThreadOperationStageUpdater() {
-}
+AutoThreadOperationStageUpdater::~AutoThreadOperationStageUpdater() {}
 
 #endif  // ROCKSDB_USING_THREAD_STATUS
 

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -95,12 +95,14 @@ Status BlockBasedTableFactory::SanitizeOptions(
     const DBOptions& /*db_opts*/, const ColumnFamilyOptions& cf_opts) const {
   if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
       cf_opts.prefix_extractor == nullptr) {
-    return Status::InvalidArgument("Hash index is specified for block-based "
+    return Status::InvalidArgument(
+        "Hash index is specified for block-based "
         "table, but prefix_extractor is not given");
   }
   if (table_options_.cache_index_and_filter_blocks &&
       table_options_.no_block_cache) {
-    return Status::InvalidArgument("Enable cache_index_and_filter_blocks, "
+    return Status::InvalidArgument(
+        "Enable cache_index_and_filter_blocks, "
         ", but block cache is disabled");
   }
   if (table_options_.pin_l0_filter_and_index_blocks_in_cache &&
@@ -115,7 +117,8 @@ Status BlockBasedTableFactory::SanitizeOptions(
         "include/rocksdb/table.h for more info");
   }
   if (table_options_.block_align && (cf_opts.compression != kNoCompression)) {
-    return Status::InvalidArgument("Enable block_align, but compression "
+    return Status::InvalidArgument(
+        "Enable block_align, but compression "
         "enabled");
   }
   if (table_options_.block_align &&
@@ -153,8 +156,7 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
   snprintf(buffer, kBufferSize, "  hash_index_allow_collision: %d\n",
            table_options_.hash_index_allow_collision);
   ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  checksum: %d\n",
-           table_options_.checksum);
+  snprintf(buffer, kBufferSize, "  checksum: %d\n", table_options_.checksum);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  no_block_cache: %d\n",
            table_options_.no_block_cache);
@@ -216,8 +218,9 @@ std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
            table_options_.use_delta_encoding);
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  filter_policy: %s\n",
-           table_options_.filter_policy == nullptr ?
-             "nullptr" : table_options_.filter_policy->Name());
+           table_options_.filter_policy == nullptr
+               ? "nullptr"
+               : table_options_.filter_policy->Name());
   ret.append(buffer);
   snprintf(buffer, kBufferSize, "  whole_key_filtering: %d\n",
            table_options_.whole_key_filtering);
@@ -284,7 +287,7 @@ Status BlockBasedTableFactory::GetOptionString(
 }
 #else
 Status BlockBasedTableFactory::GetOptionString(
-    std::string* opt_string, const std::string& delimiter) const {
+    std::string* /*opt_string*/, const std::string& /*delimiter*/) const {
   return Status::OK();
 }
 #endif  // !ROCKSDB_LITE
@@ -318,8 +321,8 @@ std::string ParseBlockBasedTableOption(const std::string& name,
         cache = NewLRUCache(ParseSizeT(value));
       } else {
         LRUCacheOptions cache_opts;
-        if(!ParseOptionHelper(reinterpret_cast<char*>(&cache_opts),
-                              OptionType::kLRUCacheOptions, value)) {
+        if (!ParseOptionHelper(reinterpret_cast<char*>(&cache_opts),
+                               OptionType::kLRUCacheOptions, value)) {
           return "Invalid cache options";
         }
         cache = NewLRUCache(cache_opts);

--- a/table/cuckoo_table_factory.h
+++ b/table/cuckoo_table_factory.h
@@ -24,6 +24,8 @@ static inline uint64_t CuckooHash(
   if (get_slice_hash != nullptr) {
     return get_slice_hash(user_key, hash_cnt, table_size_);
   }
+#else
+  (void)get_slice_hash;
 #endif
 
   uint64_t value = 0;

--- a/table/format.h
+++ b/table/format.h
@@ -69,6 +69,9 @@ class BlockHandle {
 
 inline uint32_t GetCompressFormatForVersion(
     CompressionType compression_type, uint32_t version) {
+#ifdef NDEBUG
+  (void)compression_type;
+#endif
   // snappy is not versioned
   assert(compression_type != kSnappyCompression &&
          compression_type != kXpressCompression &&

--- a/table/format.h
+++ b/table/format.h
@@ -8,11 +8,11 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #pragma once
-#include <string>
 #include <stdint.h>
+#include <string>
+#include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
-#include "rocksdb/options.h"
 #include "rocksdb/table.h"
 
 #include "options/cf_options.h"
@@ -53,13 +53,9 @@ class BlockHandle {
 
   // if the block handle's offset and size are both "0", we will view it
   // as a null block handle that points to no where.
-  bool IsNull() const {
-    return offset_ == 0 && size_ == 0;
-  }
+  bool IsNull() const { return offset_ == 0 && size_ == 0; }
 
-  static const BlockHandle& NullBlockHandle() {
-    return kNullBlockHandle;
-  }
+  static const BlockHandle& NullBlockHandle() { return kNullBlockHandle; }
 
   // Maximum encoding length of a BlockHandle
   enum { kMaxEncodedLength = 10 + 10 };
@@ -71,8 +67,8 @@ class BlockHandle {
   static const BlockHandle kNullBlockHandle;
 };
 
-inline uint32_t GetCompressFormatForVersion(CompressionType compression_type,
-                                            uint32_t version) {
+inline uint32_t GetCompressFormatForVersion(
+    CompressionType /*compression_type*/, uint32_t version) {
   // snappy is not versioned
   assert(compression_type != kSnappyCompression &&
          compression_type != kXpressCompression &&
@@ -182,8 +178,8 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
 static const size_t kBlockTrailerSize = 5;
 
 struct BlockContents {
-  Slice data;           // Actual contents of data
-  bool cachable;        // True iff data can be cached
+  Slice data;     // Actual contents of data
+  bool cachable;  // True iff data can be cached
   CompressionType compression_type;
   std::unique_ptr<char[]> allocation;
 
@@ -200,7 +196,9 @@ struct BlockContents {
         compression_type(_compression_type),
         allocation(std::move(_data)) {}
 
-  BlockContents(BlockContents&& other) ROCKSDB_NOEXCEPT { *this = std::move(other); }
+  BlockContents(BlockContents&& other) ROCKSDB_NOEXCEPT {
+    *this = std::move(other);
+  }
 
   BlockContents& operator=(BlockContents&& other) {
     data = std::move(other.data);
@@ -231,7 +229,7 @@ extern Status UncompressBlockContents(const char* data, size_t n,
                                       BlockContents* contents,
                                       uint32_t compress_format_version,
                                       const Slice& compression_dict,
-                                      const ImmutableCFOptions &ioptions);
+                                      const ImmutableCFOptions& ioptions);
 
 // This is an extension to UncompressBlockContents that accepts
 // a specific compression type. This is used by un-wrapped blocks
@@ -239,7 +237,7 @@ extern Status UncompressBlockContents(const char* data, size_t n,
 extern Status UncompressBlockContentsForCompressionType(
     const char* data, size_t n, BlockContents* contents,
     uint32_t compress_format_version, const Slice& compression_dict,
-    CompressionType compression_type, const ImmutableCFOptions &ioptions);
+    CompressionType compression_type, const ImmutableCFOptions& ioptions);
 
 // Implementation details follow.  Clients should ignore,
 
@@ -247,9 +245,7 @@ extern Status UncompressBlockContentsForCompressionType(
 // BlockHandle. Currently we use zeros for null and use negation-of-zeros for
 // uninitialized.
 inline BlockHandle::BlockHandle()
-    : BlockHandle(~static_cast<uint64_t>(0),
-                  ~static_cast<uint64_t>(0)) {
-}
+    : BlockHandle(~static_cast<uint64_t>(0), ~static_cast<uint64_t>(0)) {}
 
 inline BlockHandle::BlockHandle(uint64_t _offset, uint64_t _size)
     : offset_(_offset), size_(_size) {}

--- a/table/format.h
+++ b/table/format.h
@@ -68,7 +68,7 @@ class BlockHandle {
 };
 
 inline uint32_t GetCompressFormatForVersion(
-    CompressionType /*compression_type*/, uint32_t version) {
+    CompressionType compression_type, uint32_t version) {
   // snappy is not versioned
   assert(compression_type != kSnappyCompression &&
          compression_type != kXpressCompression &&

--- a/table/full_filter_block.cc
+++ b/table/full_filter_block.cc
@@ -77,6 +77,9 @@ FullFilterBlockReader::FullFilterBlockReader(
 bool FullFilterBlockReader::KeyMayMatch(const Slice& key, uint64_t block_offset,
                                         const bool /*no_io*/,
                                         const Slice* const /*const_ikey_ptr*/) {
+#ifdef NDEBUG
+  (void)block_offset;
+#endif
   assert(block_offset == kNotValid);
   if (!whole_key_filtering_) {
     return true;
@@ -87,6 +90,9 @@ bool FullFilterBlockReader::KeyMayMatch(const Slice& key, uint64_t block_offset,
 bool FullFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, uint64_t block_offset, const bool /*no_io*/,
     const Slice* const /*const_ikey_ptr*/) {
+#ifdef NDEBUG
+  (void)block_offset;
+#endif
   assert(block_offset == kNotValid);
   if (!prefix_extractor_) {
     return true;

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -29,6 +29,10 @@ void appendToReplayLog(std::string* replay_log, ValueType type, Slice value) {
     replay_log->push_back(type);
     PutLengthPrefixedSlice(replay_log, value);
   }
+#else
+  (void)replay_log;
+  (void)type;
+  (void)value;
 #endif  // ROCKSDB_LITE
 }
 
@@ -242,6 +246,10 @@ void replayGetContextLog(const Slice& replay_log, const Slice& user_key,
         &dont_care, value_pinner);
   }
 #else   // ROCKSDB_LITE
+  (void)replay_log;
+  (void)user_key;
+  (void)get_context;
+  (void)value_pinner;
   assert(false);
 #endif  // ROCKSDB_LITE
 }

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -165,6 +165,9 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
 bool PartitionedFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, uint64_t block_offset, const bool no_io,
     const Slice* const const_ikey_ptr) {
+#ifdef NDEBUG
+  (void)block_offset;
+#endif
   assert(const_ikey_ptr != nullptr);
   assert(block_offset == kNotValid);
   if (!prefix_extractor_) {

--- a/table/persistent_cache_helper.cc
+++ b/table/persistent_cache_helper.cc
@@ -49,6 +49,9 @@ void PersistentCacheHelper::InsertUncompressedPage(
 Status PersistentCacheHelper::LookupRawPage(
     const PersistentCacheOptions& cache_options, const BlockHandle& handle,
     std::unique_ptr<char[]>* raw_data, const size_t raw_data_size) {
+#ifdef NDEBUG
+  (void)raw_data_size;
+#endif
   assert(cache_options.persistent_cache);
   assert(cache_options.persistent_cache->IsCompressed());
 

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -70,7 +70,7 @@ uint64_t Now(Env* env, bool measured_by_nanosecond) {
 namespace {
 void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
                           ReadOptions& read_options, int num_keys1,
-                          int num_keys2, int num_iter, int prefix_len,
+                          int num_keys2, int num_iter, int /*prefix_len*/,
                           bool if_query_empty_keys, bool for_iterator,
                           bool through_db, bool measured_by_nanosecond) {
   rocksdb::InternalKeyComparator ikc(opts.comparator);

--- a/tools/blob_dump.cc
+++ b/tools/blob_dump.cc
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 }
 #else
 #include <stdio.h>
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "Not supported in lite mode.\n");
   return -1;
 }

--- a/tools/db_repl_stress.cc
+++ b/tools/db_repl_stress.cc
@@ -12,8 +12,8 @@ int main() {
 }
 #else
 
-#include <cstdio>
 #include <atomic>
+#include <cstdio>
 
 #include "db/write_batch_internal.h"
 #include "rocksdb/db.h"
@@ -34,7 +34,7 @@ using GFLAGS_NAMESPACE::SetUsageMessage;
 
 struct DataPumpThread {
   size_t no_records;
-  DB* db; // Assumption DB is Open'ed already.
+  DB* db;  // Assumption DB is Open'ed already.
 };
 
 static std::string RandomString(Random* rnd, int len) {
@@ -48,9 +48,10 @@ static void DataPumpThreadBody(void* arg) {
   DB* db = t->db;
   Random rnd(301);
   size_t i = 0;
-  while(i++ < t->no_records) {
-    if(!db->Put(WriteOptions(), Slice(RandomString(&rnd, 500)),
-                Slice(RandomString(&rnd, 500))).ok()) {
+  while (i++ < t->no_records) {
+    if (!db->Put(WriteOptions(), Slice(RandomString(&rnd, 500)),
+                 Slice(RandomString(&rnd, 500)))
+             .ok()) {
       fprintf(stderr, "Error in put\n");
       exit(1);
     }
@@ -71,29 +72,29 @@ static void ReplicationThreadBody(void* arg) {
   while (!t->stop.load(std::memory_order_acquire)) {
     iter.reset();
     Status s;
-    while(!db->GetUpdatesSince(currentSeqNum, &iter).ok()) {
+    while (!db->GetUpdatesSince(currentSeqNum, &iter).ok()) {
       if (t->stop.load(std::memory_order_acquire)) {
         return;
       }
     }
     fprintf(stderr, "Refreshing iterator\n");
-    for(;iter->Valid(); iter->Next(), t->no_read++, currentSeqNum++) {
+    for (; iter->Valid(); iter->Next(), t->no_read++, currentSeqNum++) {
       BatchResult res = iter->GetBatch();
       if (res.sequence != currentSeqNum) {
-        fprintf(stderr,
-                "Missed a seq no. b/w %ld and %ld\n",
-                (long)currentSeqNum,
-                (long)res.sequence);
+        fprintf(stderr, "Missed a seq no. b/w %ld and %ld\n",
+                (long)currentSeqNum, (long)res.sequence);
         exit(1);
       }
     }
   }
 }
 
-DEFINE_uint64(num_inserts, 1000, "the num of inserts the first thread should"
+DEFINE_uint64(num_inserts, 1000,
+              "the num of inserts the first thread should"
               " perform.");
 DEFINE_uint64(wal_ttl_seconds, 1000, "the wal ttl for the run(in seconds)");
-DEFINE_uint64(wal_size_limit_MB, 10, "the wal size limit for the run"
+DEFINE_uint64(wal_size_limit_MB, 10,
+              "the wal size limit for the run"
               "(in MB)");
 
 int main(int argc, const char** argv) {
@@ -132,7 +133,8 @@ int main(int argc, const char** argv) {
   replThread.stop.store(false, std::memory_order_release);
 
   env->StartThread(ReplicationThreadBody, &replThread);
-  while(replThread.no_read < FLAGS_num_inserts);
+  while (replThread.no_read < FLAGS_num_inserts)
+    ;
   replThread.stop.store(true, std::memory_order_release);
   if (replThread.no_read < dataPump.no_records) {
     // no. read should be => than inserted.
@@ -150,7 +152,7 @@ int main(int argc, const char** argv) {
 
 #else  // ROCKSDB_LITE
 #include <stdio.h>
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "Not supported in lite mode.\n");
   return 1;
 }

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2246,7 +2246,7 @@ class StressTest {
     shared->SetVerificationFailure();
   }
 
-  bool VerifyValue(int cf, int64_t key, const ReadOptions& opts,
+  bool VerifyValue(int cf, int64_t key, const ReadOptions& /*opts*/,
                    SharedState* shared, const std::string& value_from_db,
                    Status s, bool strict = false) const {
     if (shared->HasVerificationFailedYet()) {

--- a/tools/ldb.cc
+++ b/tools/ldb.cc
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
 }
 #else
 #include <stdio.h>
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "Not supported in lite mode.\n");
   return 1;
 }

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1123,6 +1123,10 @@ std::string ReadableTime(int unixtime) {
 void IncBucketCounts(std::vector<uint64_t>& bucket_counts, int ttl_start,
                      int time_range, int bucket_size, int timekv,
                      int num_buckets) {
+#ifdef NDEBUG
+  (void)time_range;
+  (void)num_buckets;
+#endif
   assert(time_range > 0 && timekv >= ttl_start && bucket_size > 0 &&
     timekv < (ttl_start + time_range) && num_buckets > 1);
   int bucket = (timekv - ttl_start) / bucket_size;

--- a/tools/sst_dump.cc
+++ b/tools/sst_dump.cc
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
 }
 #else
 #include <stdio.h>
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "Not supported in lite mode.\n");
   return 1;
 }

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -62,6 +62,8 @@ Arena::Arena(size_t block_size, AllocTracker* tracker, size_t huge_page_size)
   if (hugetlb_size_ && kBlockSize > hugetlb_size_) {
     hugetlb_size_ = ((kBlockSize - 1U) / hugetlb_size_ + 1U) * hugetlb_size_;
   }
+#else
+  (void)huge_page_size;
 #endif
   if (tracker_ != nullptr) {
     tracker_->Allocate(kInlineSize);
@@ -152,6 +154,7 @@ char* Arena::AllocateFromHugePage(size_t bytes) {
   }
   return reinterpret_cast<char*>(addr);
 #else
+  (void)bytes;
   return nullptr;
 #endif
 }
@@ -179,6 +182,9 @@ char* Arena::AllocateAligned(size_t bytes, size_t huge_page_size,
       return addr;
     }
   }
+#else
+  (void)huge_page_size;
+  (void)logger;
 #endif
 
   size_t current_mod =

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -119,6 +119,9 @@ int FullFilterBitsBuilder::CalculateNumEntry(const uint32_t space) {
 
 inline void FullFilterBitsBuilder::AddHash(uint32_t h, char* data,
     uint32_t num_lines, uint32_t total_bits) {
+#ifdef NDEBUG
+  (void)total_bits;
+#endif
   assert(num_lines > 0 && total_bits > 0);
 
   const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits

--- a/util/compaction_job_stats_impl.cc
+++ b/util/compaction_job_stats_impl.cc
@@ -79,7 +79,7 @@ void CompactionJobStats::Add(const CompactionJobStats& stats) {
 
 void CompactionJobStats::Reset() {}
 
-void CompactionJobStats::Add(const CompactionJobStats& stats) {}
+void CompactionJobStats::Add(const CompactionJobStats& /*stats*/) {}
 
 #endif  // !ROCKSDB_LITE
 

--- a/util/compression.h
+++ b/util/compression.h
@@ -229,12 +229,10 @@ inline bool GetDecompressedSizeInfo(const char** input_data,
 // header in varint32 format
 // @param compression_dict Data for presetting the compression library's
 //    dictionary.
-inline bool Zlib_Compress(
-    const CompressionOptions& /*opts*/ pts* /,
-    uint /*compress_format_version*/ _version* /, co /*input*/ har* /*input*/,
-    /*length*/ size_t /*lengt /*output*/
-    : std::string* /*output*/,
-      /*compression_dict*/ t Slice& /*compression_dict*/ = Slice()) {
+inline bool Zlib_Compress(const CompressionOptions& opts,
+                          uint32_t compress_format_version, const char* input,
+                          size_t length, ::std::string* output,
+                          const Slice& compression_dict = Slice()) {
 #ifdef ZLIB
   if (length > std::numeric_limits<uint32_t>::max()) {
     // Can't compress more than 4GB
@@ -296,6 +294,12 @@ inline bool Zlib_Compress(
   deflateEnd(&_stream);
   return compressed;
 #else
+  (void)opts;
+  (void)compress_format_version;
+  (void)input;
+  (void)length;
+  (void)output;
+  (void)compression_dict;
   return false;
 #endif
 }
@@ -306,14 +310,11 @@ inline bool Zlib_Compress(
 // header in varint32 format
 // @param compression_dict Data for presetting the compression library's
 //    dictionary.
-inline char /*input_data*/ ompress(
-    c /*input_length*/ /*input_data*/,
-    size_t /*input_leng /*decompress_size*/
-    int*   /*decompress_s /*compress_format_version*/
-        uint32_t /*compress_format_ver /*compression_dict*/ const
-            Slice& /*compress /*windowBits*/
-    = Slice(),
-    int /*windowBits*/ = -14) {
+inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
+                             int* decompress_size,
+                             uint32_t compress_format_version,
+                             const Slice& compression_dict = Slice(),
+                             int windowBits = -14) {
 #ifdef ZLIB
   uint32_t output_len = 0;
   if (compress_format_version == 2) {
@@ -399,6 +400,12 @@ inline char /*input_data*/ ompress(
   inflateEnd(&_stream);
   return output;
 #else
+  (void)input_data;
+  (void)input_length;
+  (void)decompress_size;
+  (void)compress_format_version;
+  (void)compression_dict;
+  (void)windowBits;
   return nullptr;
 #endif
 }

--- a/util/compression.h
+++ b/util/compression.h
@@ -172,6 +172,9 @@ inline bool Snappy_Compress(const CompressionOptions& /*opts*/,
   output->resize(outlen);
   return true;
 #else
+  (void)input;
+  (void)length;
+  (void)output;
   return false;
 #endif
 }
@@ -181,6 +184,9 @@ inline bool Snappy_GetUncompressedLength(const char* input, size_t length,
 #ifdef SNAPPY
   return snappy::GetUncompressedLength(input, length, result);
 #else
+  (void)input;
+  (void)length;
+  (void)result;
   return false;
 #endif
 }
@@ -190,6 +196,9 @@ inline bool Snappy_Uncompress(const char* input, size_t length,
 #ifdef SNAPPY
   return snappy::RawUncompress(input, length, output);
 #else
+  (void)input;
+  (void)length;
+  (void)output;
   return false;
 #endif
 }
@@ -444,6 +453,10 @@ inline bool BZip2_Compress(const CompressionOptions& /*opts*/,
   BZ2_bzCompressEnd(&_stream);
   return compressed;
 #else
+  (void)compress_format_version;
+  (void)input;
+  (void)length;
+  (void)output;
   return false;
 #endif
 }
@@ -524,6 +537,10 @@ inline char* BZip2_Uncompress(const char* input_data, size_t input_length,
   BZ2_bzDecompressEnd(&_stream);
   return output;
 #else
+  (void)input_data;
+  (void)input_length;
+  (void)decompress_size;
+  (void)compress_format_version;
   return nullptr;
 #endif
 }
@@ -588,6 +605,11 @@ inline bool LZ4_Compress(const CompressionOptions& /*opts*/,
   output->resize(static_cast<size_t>(output_header_len + outlen));
   return true;
 #else  // LZ4
+  (void)compress_format_version;
+  (void)input;
+  (void)length;
+  (void)output;
+  (void)compression_dict;
   return false;
 #endif
 }
@@ -645,6 +667,11 @@ inline char* LZ4_Uncompress(const char* input_data, size_t input_length,
   assert(*decompress_size == static_cast<int>(output_len));
   return output;
 #else  // LZ4
+  (void)input_data;
+  (void)input_length;
+  (void)decompress_size;
+  (void)compress_format_version;
+  (void)compression_dict;
   return nullptr;
 #endif
 }
@@ -718,6 +745,12 @@ inline bool LZ4HC_Compress(const CompressionOptions& opts,
   output->resize(static_cast<size_t>(output_header_len + outlen));
   return true;
 #else  // LZ4
+  (void)opts;
+  (void)compress_format_version;
+  (void)input;
+  (void)length;
+  (void)output;
+  (void)compression_dict;
   return false;
 #endif
 }
@@ -782,6 +815,11 @@ inline bool ZSTD_Compress(const CompressionOptions& opts, const char* input,
   output->resize(output_header_len + outlen);
   return true;
 #else // ZSTD
+  (void)opts;
+  (void)input;
+  (void)length;
+  (void)output;
+  (void)compression_dict;
   return false;
 #endif
 }
@@ -814,6 +852,10 @@ inline char* ZSTD_Uncompress(const char* input_data, size_t input_length,
   *decompress_size = static_cast<int>(actual_output_length);
   return output;
 #else // ZSTD
+  (void)input_data;
+  (void)input_length;
+  (void)decompress_size;
+  (void)compression_dict;
   return nullptr;
 #endif
 }
@@ -836,6 +878,9 @@ inline std::string ZSTD_TrainDictionary(const std::string& samples,
   return dict_data;
 #else   // up to v0.7.x
   assert(false);
+  (void)samples;
+  (void)sample_lens;
+  (void)max_dict_bytes;
   return "";
 #endif  // ZSTD_VERSION_NUMBER >= 800
 }
@@ -852,6 +897,9 @@ inline std::string ZSTD_TrainDictionary(const std::string& samples,
   return ZSTD_TrainDictionary(samples, sample_lens, max_dict_bytes);
 #else   // up to v0.7.x
   assert(false);
+  (void)samples;
+  (void)sample_len_shift;
+  (void)max_dict_bytes;
   return "";
 #endif  // ZSTD_VERSION_NUMBER >= 800
 }

--- a/util/compression.h
+++ b/util/compression.h
@@ -191,8 +191,7 @@ inline bool Snappy_GetUncompressedLength(const char* input, size_t length,
 #endif
 }
 
-inline bool Snappy_Uncompress(const char* input, size_t length,
-                              char* output) {
+inline bool Snappy_Uncompress(const char* input, size_t length, char* output) {
 #ifdef SNAPPY
   return snappy::RawUncompress(input, length, output);
 #else
@@ -230,10 +229,12 @@ inline bool GetDecompressedSizeInfo(const char** input_data,
 // header in varint32 format
 // @param compression_dict Data for presetting the compression library's
 //    dictionary.
-inline bool Zlib_Compress(const CompressionOptions& opts,
-                          uint32_t compress_format_version, const char* input,
-                          size_t length, ::std::string* output,
-                          const Slice& compression_dict = Slice()) {
+inline bool Zlib_Compress(
+    const CompressionOptions& /*opts*/ pts* /,
+    uint /*compress_format_version*/ _version* /, co /*input*/ har* /*input*/,
+    /*length*/ size_t /*lengt /*output*/
+    : std::string* /*output*/,
+      /*compression_dict*/ t Slice& /*compression_dict*/ = Slice()) {
 #ifdef ZLIB
   if (length > std::numeric_limits<uint32_t>::max()) {
     // Can't compress more than 4GB
@@ -275,7 +276,7 @@ inline bool Zlib_Compress(const CompressionOptions& opts,
   }
 
   // Compress the input, and put compressed data in output.
-  _stream.next_in = (Bytef *)input;
+  _stream.next_in = (Bytef*)input;
   _stream.avail_in = static_cast<unsigned int>(length);
 
   // Initialize the output size.
@@ -305,11 +306,14 @@ inline bool Zlib_Compress(const CompressionOptions& opts,
 // header in varint32 format
 // @param compression_dict Data for presetting the compression library's
 //    dictionary.
-inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
-                             int* decompress_size,
-                             uint32_t compress_format_version,
-                             const Slice& compression_dict = Slice(),
-                             int windowBits = -14) {
+inline char /*input_data*/ ompress(
+    c /*input_length*/ /*input_data*/,
+    size_t /*input_leng /*decompress_size*/
+    int*   /*decompress_s /*compress_format_version*/
+        uint32_t /*compress_format_ver /*compression_dict*/ const
+            Slice& /*compress /*windowBits*/
+    = Slice(),
+    int /*windowBits*/ = -14) {
 #ifdef ZLIB
   uint32_t output_len = 0;
   if (compress_format_version == 2) {
@@ -332,8 +336,8 @@ inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
   // For raw inflate, the windowBits should be -8..-15.
   // If windowBits is bigger than zero, it will use either zlib
   // header or gzip header. Adding 32 to it will do automatic detection.
-  int st = inflateInit2(&_stream,
-      windowBits > 0 ? windowBits + 32 : windowBits);
+  int st =
+      inflateInit2(&_stream, windowBits > 0 ? windowBits + 32 : windowBits);
   if (st != Z_OK) {
     return nullptr;
   }
@@ -348,12 +352,12 @@ inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
     }
   }
 
-  _stream.next_in = (Bytef *)input_data;
+  _stream.next_in = (Bytef*)input_data;
   _stream.avail_in = static_cast<unsigned int>(input_length);
 
   char* output = new char[output_len];
 
-  _stream.next_out = (Bytef *)output;
+  _stream.next_out = (Bytef*)output;
   _stream.avail_out = static_cast<unsigned int>(output_len);
 
   bool done = false;
@@ -369,7 +373,7 @@ inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
         // compress_format_version == 2
         assert(compress_format_version != 2);
         size_t old_sz = output_len;
-        uint32_t output_len_delta = output_len/5;
+        uint32_t output_len_delta = output_len / 5;
         output_len += output_len_delta < 10 ? 10 : output_len_delta;
         char* tmp = new char[output_len];
         memcpy(tmp, output, old_sz);
@@ -377,7 +381,7 @@ inline char* Zlib_Uncompress(const char* input_data, size_t input_length,
         output = tmp;
 
         // Set more output.
-        _stream.next_out = (Bytef *)(output + old_sz);
+        _stream.next_out = (Bytef*)(output + old_sz);
         _stream.avail_out = static_cast<unsigned int>(output_len - old_sz);
         break;
       }
@@ -420,7 +424,6 @@ inline bool BZip2_Compress(const CompressionOptions& /*opts*/,
   // This may not be big enough if the compression actually expands data.
   output->resize(output_header_len + length);
 
-
   bz_stream _stream;
   memset(&_stream, 0, sizeof(bz_stream));
 
@@ -433,7 +436,7 @@ inline bool BZip2_Compress(const CompressionOptions& /*opts*/,
   }
 
   // Compress the input, and put compressed data in output.
-  _stream.next_in = (char *)input;
+  _stream.next_in = (char*)input;
   _stream.avail_in = static_cast<unsigned int>(length);
 
   // Initialize the output size.
@@ -492,12 +495,12 @@ inline char* BZip2_Uncompress(const char* input_data, size_t input_length,
     return nullptr;
   }
 
-  _stream.next_in = (char *)input_data;
+  _stream.next_in = (char*)input_data;
   _stream.avail_in = static_cast<unsigned int>(input_length);
 
   char* output = new char[output_len];
 
-  _stream.next_out = (char *)output;
+  _stream.next_out = (char*)output;
   _stream.avail_out = static_cast<unsigned int>(output_len);
 
   bool done = false;
@@ -520,7 +523,7 @@ inline char* BZip2_Uncompress(const char* input_data, size_t input_length,
         output = tmp;
 
         // Set more output.
-        _stream.next_out = (char *)(output + old_sz);
+        _stream.next_out = (char*)(output + old_sz);
         _stream.avail_out = static_cast<unsigned int>(output_len - old_sz);
         break;
       }
@@ -585,9 +588,9 @@ inline bool LZ4_Compress(const CompressionOptions& /*opts*/,
                  static_cast<int>(compression_dict.size()));
   }
 #if LZ4_VERSION_NUMBER >= 10700  // r129+
-  outlen = LZ4_compress_fast_continue(
-      stream, input, &(*output)[output_header_len], static_cast<int>(length),
-      compress_bound, 1);
+  outlen =
+      LZ4_compress_fast_continue(stream, input, &(*output)[output_header_len],
+                                 static_cast<int>(length), compress_bound, 1);
 #else  // up to r128
   outlen = LZ4_compress_limitedOutput_continue(
       stream, input, &(*output)[output_header_len], static_cast<int>(length),
@@ -768,8 +771,7 @@ inline bool XPRESS_Compress(const char* /*input*/, size_t /*length*/,
 #endif
 
 #ifdef XPRESS
-inline char* XPRESS_Uncompress(const char* input_data,
-                               size_t input_length,
+inline char* XPRESS_Uncompress(const char* input_data, size_t input_length,
                                int* decompress_size) {
   return port::xpress::Decompress(input_data, input_length, decompress_size);
 }
@@ -780,7 +782,6 @@ inline char* XPRESS_Uncompress(const char* /*input_data*/,
   return nullptr;
 }
 #endif
-
 
 // @param compression_dict Data for presetting the compression library's
 //    dictionary.
@@ -805,7 +806,7 @@ inline bool ZSTD_Compress(const CompressionOptions& opts, const char* input,
       context, &(*output)[output_header_len], compressBound, input, length,
       compression_dict.data(), compression_dict.size(), opts.level);
   ZSTD_freeCCtx(context);
-#else  // up to v0.4.x
+#else   // up to v0.4.x
   outlen = ZSTD_compress(&(*output)[output_header_len], compressBound, input,
                          length, opts.level);
 #endif  // ZSTD_VERSION_NUMBER >= 500
@@ -814,7 +815,7 @@ inline bool ZSTD_Compress(const CompressionOptions& opts, const char* input,
   }
   output->resize(output_header_len + outlen);
   return true;
-#else // ZSTD
+#else  // ZSTD
   (void)opts;
   (void)input;
   (void)length;
@@ -844,14 +845,14 @@ inline char* ZSTD_Uncompress(const char* input_data, size_t input_length,
       context, output, output_len, input_data, input_length,
       compression_dict.data(), compression_dict.size());
   ZSTD_freeDCtx(context);
-#else  // up to v0.4.x
+#else   // up to v0.4.x
   actual_output_length =
       ZSTD_decompress(output, output_len, input_data, input_length);
 #endif  // ZSTD_VERSION_NUMBER >= 500
   assert(actual_output_length == output_len);
   *decompress_size = static_cast<int>(actual_output_length);
   return output;
-#else // ZSTD
+#else  // ZSTD
   (void)input_data;
   (void)input_length;
   (void)decompress_size;

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -303,7 +303,7 @@ TEST_F(DeleteSchedulerTest, DisableRateLimiting) {
   int bg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
@@ -410,7 +410,7 @@ TEST_F(DeleteSchedulerTest, StartBGEmptyTrashMultipleTimes) {
   int bg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   rate_bytes_per_sec_ = 1024 * 1024;  // 1 MB / sec
@@ -473,7 +473,7 @@ TEST_F(DeleteSchedulerTest, DestructorWithNonEmptyQueue) {
   int bg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   rate_bytes_per_sec_ = 1;  // 1 Byte / sec
@@ -500,10 +500,10 @@ TEST_F(DeleteSchedulerTest, DISABLED_DynamicRateLimiting1) {
   int fg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteFile",
-      [&](void* arg) { fg_delete_file++; });
+      [&](void* /*arg*/) { fg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::BackgroundEmptyTrash:Wait",
       [&](void* arg) { penalties.push_back(*(static_cast<int*>(arg))); });
@@ -582,9 +582,9 @@ TEST_F(DeleteSchedulerTest, ImmediateDeleteOn25PercDBSize) {
   int fg_delete_file = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DeleteScheduler::DeleteTrashFile:DeleteFile",
-      [&](void* arg) { bg_delete_file++; });
+      [&](void* /*arg*/) { bg_delete_file++; });
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DeleteScheduler::DeleteFile", [&](void* arg) { fg_delete_file++; });
+      "DeleteScheduler::DeleteFile", [&](void* /*arg*/) { fg_delete_file++; });
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -199,7 +199,7 @@ TEST_F(RateLimiterTest, AutoTuneIncreaseWhenFull) {
   // computes the next refill time (ensuring refill time in the future allows
   // the next request to drain the rate limiter).
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "GenericRateLimiter::Refill", [&](void* arg) {
+      "GenericRateLimiter::Refill", [&](void* /*arg*/) {
         special_env.SleepForMicroseconds(static_cast<int>(
             std::chrono::microseconds(kTimePerRefill).count()));
       });

--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -235,15 +235,16 @@ SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<Logger> info_log,
 
 #else
 
-SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<Logger> info_log,
-                                  std::string trash_dir,
-                                  int64_t rate_bytes_per_sec,
-                                  bool delete_existing_trash, Status* status,
-                                  double max_trash_db_ratio,
-                                  uint64_t bytes_max_delete_chunk) {
+SstFileManager* NewSstFileManager(Env* /*env*/,
+                                  std::shared_ptr<Logger> /*info_log*/,
+                                  std::string /*trash_dir*/,
+                                  int64_t /*rate_bytes_per_sec*/,
+                                  bool /*delete_existing_trash*/,
+                                  Status* status, double /*max_trash_db_ratio*/,
+                                  uint64_t /*bytes_max_delete_chunk*/) {
   if (status) {
     *status =
-      Status::NotSupported("SstFileManager is not supported in ROCKSDB_LITE");
+        Status::NotSupported("SstFileManager is not supported in ROCKSDB_LITE");
   }
   return nullptr;
 }

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -22,7 +22,7 @@ namespace test {
 Slice RandomString(Random* rnd, int len, std::string* dst) {
   dst->resize(len);
   for (int i = 0; i < len; i++) {
-    (*dst)[i] = static_cast<char>(' ' + rnd->Uniform(95));   // ' ' .. '~'
+    (*dst)[i] = static_cast<char>(' ' + rnd->Uniform(95));  // ' ' .. '~'
   }
   return Slice(*dst);
 }
@@ -39,9 +39,8 @@ extern std::string RandomHumanReadableString(Random* rnd, int len) {
 std::string RandomKey(Random* rnd, int len, RandomKeyType type) {
   // Make sure to generate a wide variety of characters so we
   // test the boundary conditions for short-key optimizations.
-  static const char kTestChars[] = {
-    '\0', '\1', 'a', 'b', 'c', 'd', 'e', '\xfd', '\xfe', '\xff'
-  };
+  static const char kTestChars[] = {'\0', '\1', 'a',    'b',    'c',
+                                    'd',  'e',  '\xfd', '\xfe', '\xff'};
   std::string result;
   for (int i = 0; i < len; i++) {
     std::size_t indx = 0;
@@ -64,7 +63,6 @@ std::string RandomKey(Random* rnd, int len, RandomKeyType type) {
   return result;
 }
 
-
 extern Slice CompressibleString(Random* rnd, double compressed_fraction,
                                 int len, std::string* dst) {
   int raw = static_cast<int>(len * compressed_fraction);
@@ -84,7 +82,7 @@ extern Slice CompressibleString(Random* rnd, double compressed_fraction,
 namespace {
 class Uint64ComparatorImpl : public Comparator {
  public:
-  Uint64ComparatorImpl() { }
+  Uint64ComparatorImpl() {}
 
   virtual const char* Name() const override {
     return "rocksdb.Uint64Comparator";
@@ -121,9 +119,7 @@ class Uint64ComparatorImpl : public Comparator {
 static port::OnceType once;
 static const Comparator* uint64comp;
 
-static void InitModule() {
-  uint64comp = new Uint64ComparatorImpl;
-}
+static void InitModule() { uint64comp = new Uint64ComparatorImpl; }
 
 const Comparator* Uint64Comparator() {
   port::InitOnce(&once, InitModule);
@@ -225,6 +221,8 @@ TableFactory* RandomTableFactory(Random* rnd, int pre_defined) {
       return NewBlockBasedTableFactory();
   }
 #else
+  (void)rnd;
+  (void)pre_defined;
   return NewBlockBasedTableFactory();
 #endif  // !ROCKSDB_LITE
 }

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -795,7 +795,7 @@ Status BackupEngineImpl::CreateNewBackupWithMetadata(
     uint64_t sequence_number = 0;
     s = checkpoint.CreateCustomCheckpoint(
         db->GetDBOptions(),
-        [&](const std::string& src_dirname, const std::string& fname,
+        [&](const std::string& /*src_dirname*/, const std::string& /*fname*/,
             FileType) {
           // custom checkpoint will switch to calling copy_file_cb after it sees
           // NotSupported returned from link_file_cb.

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -152,10 +152,10 @@ public:
   // Create a Row containing columns.
   RowValue(Columns columns,
            int64_t last_modified_time);
-  RowValue(const RowValue& that) = delete;
-  RowValue(RowValue&& that) noexcept = default;
-  RowValue& operator=(const RowValue& that) = delete;
-  RowValue& operator=(RowValue&& that) = default;
+  RowValue(const RowValue& /*that*/) = delete;
+  RowValue(RowValue&& /*that*/) noexcept = default;
+  RowValue& operator=(const RowValue& /*that*/) = delete;
+  RowValue& operator=(RowValue&& /*that*/) = default;
 
   std::size_t Size() const;;
   bool IsTombstone() const;

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -366,7 +366,7 @@ TEST_F(CheckpointTest, CheckpointCFNoFlush) {
   Status s;
   // Take a snapshot
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "DBImpl::BackgroundCallFlush:start", [&](void* arg) {
+      "DBImpl::BackgroundCallFlush:start", [&](void* /*arg*/) {
         // Flush should never trigger.
         FAIL();
       });

--- a/utilities/env_timed.cc
+++ b/utilities/env_timed.cc
@@ -141,7 +141,7 @@ Env* NewTimedEnv(Env* base_env) { return new TimedEnv(base_env); }
 
 #else  // ROCKSDB_LITE
 
-Env* NewTimedEnv(Env* base_env) { return nullptr; }
+Env* NewTimedEnv(Env* /*base_env*/) { return nullptr; }
 
 #endif  // !ROCKSDB_LITE
 

--- a/utilities/lua/rocks_lua_compaction_filter.cc
+++ b/utilities/lua/rocks_lua_compaction_filter.cc
@@ -218,7 +218,7 @@ RocksLuaCompactionFilterFactory::RocksLuaCompactionFilterFactory(
 
 std::unique_ptr<CompactionFilter>
 RocksLuaCompactionFilterFactory::CreateCompactionFilter(
-    const CompactionFilter::Context& context) {
+    const CompactionFilter::Context& /*context*/) {
   std::lock_guard<std::mutex> lock(opt_mutex_);
   return std::unique_ptr<CompactionFilter>(new RocksLuaCompactionFilter(opt_));
 }

--- a/utilities/lua/rocks_lua_test.cc
+++ b/utilities/lua/rocks_lua_test.cc
@@ -483,7 +483,7 @@ int main(int argc, char** argv) {
 
 #else
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   printf("LUA_PATH is not set.  Ignoring the test.\n");
 }
 

--- a/utilities/merge_operators/bytesxor.cc
+++ b/utilities/merge_operators/bytesxor.cc
@@ -14,11 +14,11 @@ std::shared_ptr<MergeOperator> MergeOperators::CreateBytesXOROperator() {
   return std::make_shared<BytesXOROperator>();
 }
 
-bool BytesXOROperator::Merge(const Slice& key,
+bool BytesXOROperator::Merge(const Slice& /*key*/,
                             const Slice* existing_value,
                             const Slice& value,
                             std::string* new_value,
-                            Logger* logger) const {
+                            Logger* /*logger*/) const {
   XOR(existing_value, value, new_value);
   return true;
 }

--- a/utilities/option_change_migration/option_change_migration.cc
+++ b/utilities/option_change_migration/option_change_migration.cc
@@ -157,8 +157,9 @@ Status OptionChangeMigration(std::string dbname, const Options& old_opts,
 }  // namespace rocksdb
 #else
 namespace rocksdb {
-Status OptionChangeMigration(std::string dbname, const Options& old_opts,
-                             const Options& new_opts) {
+Status OptionChangeMigration(std::string /*dbname*/,
+                             const Options& /*old_opts*/,
+                             const Options& /*new_opts*/) {
   return Status::NotSupported();
 }
 }  // namespace rocksdb

--- a/utilities/persistent_cache/block_cache_tier.h
+++ b/utilities/persistent_cache/block_cache_tier.h
@@ -92,7 +92,7 @@ class BlockCacheTier : public PersistentCacheTier {
     ~InsertOp() {}
 
     InsertOp() = delete;
-    InsertOp(InsertOp&& rhs) = default;
+    InsertOp(InsertOp&& /*rhs*/) = default;
     InsertOp& operator=(InsertOp&& rhs) = default;
 
     // used for estimating size by bounded queue

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -179,7 +179,7 @@ class SimCacheImpl : public SimCache {
     Handle* h = key_only_cache_->Lookup(key);
     if (h == nullptr) {
       key_only_cache_->Insert(key, nullptr, charge,
-                              [](const Slice& k, void* v) {}, nullptr,
+                              [](const Slice& /*k*/, void* /*v*/) {}, nullptr,
                               priority);
     } else {
       key_only_cache_->Release(h);

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -15,10 +15,10 @@ namespace rocksdb {
 
 #ifdef ROCKSDB_LITE
 WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
-    WritePreparedTxnDB* txn_db) {}
+    WritePreparedTxnDB* /*txn_db*/) {}
 
 bool WritePreparedSnapshotChecker::IsInSnapshot(
-    SequenceNumber sequence, SequenceNumber snapshot_sequence) const {
+    SequenceNumber /*sequence*/, SequenceNumber /*snapshot_sequence*/) const {
   // Should never be called in LITE mode.
   assert(false);
   return true;

--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -591,6 +591,9 @@ void TransactionLockMgr::UnLockKey(const PessimisticTransaction* txn,
                                    const std::string& key,
                                    LockMapStripe* stripe, LockMap* lock_map,
                                    Env* env) {
+#ifdef NDEBUG
+  (void)env;
+#endif
   TransactionID txn_id = txn->GetID();
 
   auto stripe_iter = stripe->keys.find(key);

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -198,7 +198,7 @@ TEST_P(TransactionTest, WaitingTxn) {
   ASSERT_TRUE(txn2);
 
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "TransactionLockMgr::AcquireWithTimeout:WaitingTxn", [&](void* arg) {
+      "TransactionLockMgr::AcquireWithTimeout:WaitingTxn", [&](void* /*arg*/) {
         std::string key;
         uint32_t cf_id;
         std::vector<TransactionID> wait = txn2->GetWaitingTxns(&cf_id, &key);
@@ -425,7 +425,7 @@ TEST_P(TransactionTest, DeadlockCycleShared) {
   std::atomic<uint32_t> checkpoints(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "TransactionLockMgr::AcquireWithTimeout:WaitingTxn",
-      [&](void* arg) { checkpoints.fetch_add(1); });
+      [&](void* /*arg*/) { checkpoints.fetch_add(1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   // We want the leaf transactions to block and hold everyone back.
@@ -550,7 +550,7 @@ TEST_P(TransactionTest, DeadlockCycleShared) {
   std::atomic<uint32_t> checkpoints_shared(0);
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "TransactionLockMgr::AcquireWithTimeout:WaitingTxn",
-      [&](void* arg) { checkpoints_shared.fetch_add(1); });
+      [&](void* /*arg*/) { checkpoints_shared.fetch_add(1); });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
   std::vector<port::Thread> threads_shared;
@@ -622,7 +622,7 @@ TEST_P(TransactionTest, DeadlockCycle) {
     std::atomic<uint32_t> checkpoints(0);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
         "TransactionLockMgr::AcquireWithTimeout:WaitingTxn",
-        [&](void* arg) { checkpoints.fetch_add(1); });
+        [&](void* /*arg*/) { checkpoints.fetch_add(1); });
     rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
     // We want the last transaction in the chain to block and hold everyone
@@ -4764,7 +4764,7 @@ TEST_P(TransactionTest, ExpiredTransactionDataRace1) {
   rocksdb::SyncPoint::GetInstance()->LoadDependency(
       {{"TransactionTest::ExpirableTransactionDataRace:1"}});
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "TransactionTest::ExpirableTransactionDataRace:1", [&](void* arg) {
+      "TransactionTest::ExpirableTransactionDataRace:1", [&](void* /*arg*/) {
         WriteOptions write_options;
         TransactionOptions txn_options;
 

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1012,9 +1012,9 @@ TEST_P(WritePreparedTransactionTest, SeqAdvanceConcurrentTest) {
     std::atomic<bool> batch_formed(false);
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
         "WriteThread::EnterAsBatchGroupLeader:End",
-        [&](void* arg) { batch_formed = true; });
+        [&](void* /*arg*/) { batch_formed = true; });
     rocksdb::SyncPoint::GetInstance()->SetCallBack(
-        "WriteThread::JoinBatchGroup:Wait", [&](void* arg) {
+        "WriteThread::JoinBatchGroup:Wait", [&](void* /*arg*/) {
           linked++;
           if (linked == 1) {
             // Wait until the others are linked too.

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -172,6 +172,9 @@ Status WritePreparedTxn::CommitInternal() {
     explicit PublishSeqPreReleaseCallback(DBImpl* db_impl)
         : db_impl_(db_impl) {}
     virtual Status Callback(SequenceNumber seq, bool is_mem_disabled) override {
+#ifdef NDEBUG
+      (void)is_mem_disabled;
+#endif
       assert(is_mem_disabled);
       assert(db_impl_->immutable_db_options().two_write_queues);
       db_impl_->SetLastPublishedSequence(seq);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -54,6 +54,9 @@ Status WritePreparedTxnDB::Initialize(
         : db_(db) {}
     virtual Status Callback(SequenceNumber commit_seq,
                             bool is_mem_disabled) override {
+#ifdef NDEBUG
+      (void)is_mem_disabled;
+#endif
       assert(!is_mem_disabled);
       const bool PREPARE_SKIPPED = true;
       db_->AddCommitted(commit_seq, commit_seq, PREPARE_SKIPPED);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -626,6 +626,9 @@ class AddPreparedCallback : public PreReleaseCallback {
   }
   virtual Status Callback(SequenceNumber prepare_seq,
                           bool is_mem_disabled) override {
+#ifdef NDEBUG
+    (void)is_mem_disabled;
+#endif
     assert(!two_write_queues_ || !is_mem_disabled);  // implies the 1st queue
     for (size_t i = 0; i < sub_batch_cnt_; i++) {
       db_->AddPrepared(prepare_seq + i);
@@ -664,6 +667,9 @@ class WritePreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled) override {
+#ifdef NDEBUG
+    (void)is_mem_disabled;
+#endif
     assert(includes_data_ || prep_seq_ != kMaxSequenceNumber);
     const uint64_t last_commit_seq = LIKELY(data_batch_cnt_ <= 1)
                                          ? commit_seq


### PR DESCRIPTION
This PR comments out the rest of the unused arguments which allow us to turn on the -Wunused-parameter flag. This is the second part of a codemod relating to https://github.com/facebook/rocksdb/pull/3557. 

Test Plan: 
```
make -j64 check
make clean && ROCKSDB_NO_FBCODE=1 make check -j64
```