### PR TITLE
Fix pre_release callback argument list.

### DIFF
--- a/db/pre_release_callback.h
+++ b/db/pre_release_callback.h
@@ -26,7 +26,7 @@ class PreReleaseCallback {
   // released.
   // is_mem_disabled is currently used for debugging purposes to assert that
   // the callback is done from the right write queue.
-  virtual Status Callback(SequenceNumber seq, const bool is_mem_disabled) = 0;
+  virtual Status Callback(SequenceNumber seq, bool is_mem_disabled) = 0;
 };
 
 }  //  namespace rocksdb

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -295,7 +295,7 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                     PublishSeqCallback(DBImpl* db_impl_in)
                         : db_impl_(db_impl_in) {}
                     virtual Status Callback(SequenceNumber last_seq,
-                                            const bool /*not used*/) override {
+                                            bool /*not used*/) override {
                       db_impl_->SetLastPublishedSequence(last_seq);
                       return Status::OK();
                     }


### PR DESCRIPTION
  Primitive types constness does not affect the signature of the
  method and has no influence on whether the overriding method would
  actually have that const bool instead of just bool. In addition,
  it is rarely useful but does produce a compatibility warnings
  in VS 2015 compiler.