### PR TITLE
Add DeleteFilesInRange API for Java

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -1358,6 +1358,10 @@ public class RocksDB extends RocksObject {
     deleteRange(nativeHandle_, beginKey, 0, beginKey.length, endKey, 0, endKey.length);
   }
 
+  public void deleteFilesInRange(final byte[] beginKey, final byte[] endKey) throws RocksDBException {
+    deleteFilesInRange(nativeHandle_, beginKey, 0, beginKey.length, endKey, 0, endKey.length);
+  }
+
   /**
    * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
    * including "beginKey" and excluding "endKey". a non-OK status on error. It
@@ -2331,6 +2335,9 @@ public class RocksDB extends RocksObject {
       long handle, long writeOptHandle,
       byte[] key, int keyLen, long cfHandle) throws RocksDBException;
   protected native void deleteRange(long handle, byte[] beginKey, int beginKeyOffset,
+      int beginKeyLength, byte[] endKey, int endKeyOffset, int endKeyLength)
+      throws RocksDBException;
+  protected native void deleteFilesInRange(long handle, byte[] beginKey, int beginKeyOffset,
       int beginKeyLength, byte[] endKey, int endKeyOffset, int endKeyLength)
       throws RocksDBException;
   protected native void deleteRange(long handle, byte[] beginKey, int beginKeyOffset,

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -1358,10 +1358,6 @@ public class RocksDB extends RocksObject {
     deleteRange(nativeHandle_, beginKey, 0, beginKey.length, endKey, 0, endKey.length);
   }
 
-  public void deleteFilesInRange(final byte[] beginKey, final byte[] endKey) throws RocksDBException {
-    deleteFilesInRange(nativeHandle_, beginKey, 0, beginKey.length, endKey, 0, endKey.length);
-  }
-
   /**
    * Removes the database entries in the range ["beginKey", "endKey"), i.e.,
    * including "beginKey" and excluding "endKey". a non-OK status on error. It
@@ -1437,6 +1433,25 @@ public class RocksDB extends RocksObject {
       final byte[] beginKey, final byte[] endKey) throws RocksDBException {
     deleteRange(nativeHandle_, writeOpt.nativeHandle_, beginKey, 0, beginKey.length, endKey, 0,
         endKey.length, columnFamilyHandle.nativeHandle_);
+  }
+
+  /**
+   * Delete files which are entirely in the given range for default column family.
+   * Could leave some keys in the range which are in files which are not
+   * entirely in the range. Also leaves L0 files regardless of whether they're
+   * in the range.
+   * Snapshots before the delete might not see the data in the given range.
+   *
+   * @param beginKey
+   *          First key to delete within database (included)
+   * @param endKey
+   *          Last key to delete within database (included)
+   *
+   * @throws RocksDBException
+   *           thrown if error happens in underlying native library.
+   */
+  public void deleteFilesInRange(final byte[] beginKey, final byte[] endKey) throws RocksDBException {
+    deleteFilesInRange(nativeHandle_, beginKey, 0, beginKey.length, endKey, 0, endKey.length);
   }
 
   /**

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -276,6 +276,25 @@ public class RocksDBTest {
   }
 
   @Test
+  public void deleteFilesInRange() throws RocksDBException {
+    try (final RocksDB db = RocksDB.open(dbFolder.getRoot().getAbsolutePath());
+         final WriteOptions wOpt = new WriteOptions()) {
+      db.put("key1".getBytes(), "value".getBytes());
+      db.put("key2".getBytes(), "12345678".getBytes());
+      db.put("key3".getBytes(), "abcdefg".getBytes());
+      db.put("key4".getBytes(), "xyz".getBytes());
+      db.flush(new FlushOptions().setWaitForFlush(true));
+      db.compactRange();
+      //make sure all files are covered by the delete range to verify
+      db.deleteFilesInRange("key1".getBytes(), "key4".getBytes());
+      assertThat(db.get("key1".getBytes())).isNull();
+      assertThat(db.get("key2".getBytes())).isNull();
+      assertThat(db.get("key3".getBytes())).isNull();
+      assertThat(db.get("key4".getBytes())).isNull();
+    }
+  }
+
+  @Test
   public void getIntProperty() throws RocksDBException {
     try (
         final Options options = new Options()


### PR DESCRIPTION
DeleteFilesInRange is quite useful for immediately release disk pressure. Add Java support so that we can use it in Cassandra cleanup process.