### PR TITLE
Enable cancelling manual compactions if they hit the sfm size limit

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -928,6 +928,9 @@ class DBImpl : public DB {
   Status BackgroundFlush(bool* madeProgress, JobContext* job_context,
                          LogBuffer* log_buffer);
 
+  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs,
+      bool *sfm_bookkeeping, LogBuffer* log_buffer);
+
   void PrintStatistics();
 
   // dump rocksdb.stats to LOG

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -928,8 +928,8 @@ class DBImpl : public DB {
   Status BackgroundFlush(bool* madeProgress, JobContext* job_context,
                          LogBuffer* log_buffer);
 
-  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs,
-      bool *sfm_bookkeeping, LogBuffer* log_buffer);
+  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles>& inputs,
+                               bool* sfm_bookkeeping, LogBuffer* log_buffer);
 
   void PrintStatistics();
 

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1623,9 +1623,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
 
   // InternalKey manual_end_storage;
   // InternalKey* manual_end = &manual_end_storage;
-#ifndef ROCKSDB_LITE
   bool sfm_bookkeeping = false;
-#endif  // ROCKSDB_LITE
   if (is_manual) {
     ManualCompactionState* m = manual_compaction;
     assert(m->in_progress);

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -662,7 +662,9 @@ TEST_F(DBSSTTest, CancellingManualCompactionsWorks) {
 
   ASSERT_EQ(sfm->GetCompactionsReservedSize(), 0);
   // Make sure the stat is bumped
-  ASSERT_EQ(dbfull()->immutable_db_options().statistics.get()->getTickerCount(COMPACTION_CANCELLED), 1);
+  ASSERT_EQ(dbfull()->immutable_db_options().statistics.get()->getTickerCount(
+                COMPACTION_CANCELLED),
+            1);
 
   // Now make sure CompactFiles also gets cancelled
   auto l0_files = collector->GetFlushedFiles();
@@ -671,7 +673,9 @@ TEST_F(DBSSTTest, CancellingManualCompactionsWorks) {
   // Wait for manual compaction to get scheduled and finish
   dbfull()->TEST_WaitForCompact(true);
 
-  ASSERT_EQ(dbfull()->immutable_db_options().statistics.get()->getTickerCount(COMPACTION_CANCELLED), 2);
+  ASSERT_EQ(dbfull()->immutable_db_options().statistics.get()->getTickerCount(
+                COMPACTION_CANCELLED),
+            2);
   ASSERT_EQ(sfm->GetCompactionsReservedSize(), 0);
 
   // Now let the flush through and make sure GetCompactionsReservedSize
@@ -679,8 +683,7 @@ TEST_F(DBSSTTest, CancellingManualCompactionsWorks) {
   sfm->SetMaxAllowedSpaceUsage(0);
   int completed_compactions = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "CompactFilesImpl:End",
-      [&](void* arg) { completed_compactions++; });
+      "CompactFilesImpl:End", [&](void* arg) { completed_compactions++; });
 
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   dbfull()->CompactFiles(rocksdb::CompactionOptions(), l0_files, 0);

--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -106,13 +106,13 @@ bool SstFileManagerImpl::IsMaxAllowedSpaceReachedIncludingCompactions() {
          max_allowed_space_;
 }
 
-bool SstFileManagerImpl::EnoughRoomForCompaction(Compaction* c) {
+bool SstFileManagerImpl::EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs) {
   MutexLock l(&mu_);
   uint64_t size_added_by_compaction = 0;
   // First check if we even have the space to do the compaction
-  for (size_t i = 0; i < c->num_input_levels(); i++) {
-    for (size_t j = 0; j < c->num_input_files(i); j++) {
-      FileMetaData* filemeta = c->input(i, j);
+  for (size_t i = 0; i < inputs.size(); i++) {
+    for (size_t j = 0; j < inputs[i].size(); j++) {
+      FileMetaData* filemeta = inputs[i][j];
       size_added_by_compaction += filemeta->fd.GetFileSize();
     }
   }

--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -106,7 +106,8 @@ bool SstFileManagerImpl::IsMaxAllowedSpaceReachedIncludingCompactions() {
          max_allowed_space_;
 }
 
-bool SstFileManagerImpl::EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs) {
+bool SstFileManagerImpl::EnoughRoomForCompaction(
+    const std::vector<CompactionInputFiles>& inputs) {
   MutexLock l(&mu_);
   uint64_t size_added_by_compaction = 0;
   // First check if we even have the space to do the compaction

--- a/util/sst_file_manager_impl.h
+++ b/util/sst_file_manager_impl.h
@@ -67,7 +67,7 @@ class SstFileManagerImpl : public SstFileManager {
   // estimates how much space is currently being used by compactions (i.e.
   // if a compaction has started, this function bumps the used space by
   // the full compaction size).
-  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs);
+  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles>& inputs);
 
   // Bookkeeping so total_file_sizes_ goes back to normal after compaction
   // finishes

--- a/util/sst_file_manager_impl.h
+++ b/util/sst_file_manager_impl.h
@@ -67,7 +67,7 @@ class SstFileManagerImpl : public SstFileManager {
   // estimates how much space is currently being used by compactions (i.e.
   // if a compaction has started, this function bumps the used space by
   // the full compaction size).
-  bool EnoughRoomForCompaction(Compaction* c);
+  bool EnoughRoomForCompaction(const std::vector<CompactionInputFiles> inputs);
 
   // Bookkeeping so total_file_sizes_ goes back to normal after compaction
   // finishes


### PR DESCRIPTION
Manual compactions should be cancelled, just like scheduled compactions are cancelled, if sfm->EnoughRoomForCompaction is not true.

Test Plan: Added a new test in db_sst_test that checks a manual compaction is cancelled.