### PR TITLE
Reduce default --nooverwritepercent in black-box crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -32,6 +32,7 @@ default_params = {
     "max_write_buffer_number": 3,
     "memtablerep": "prefix_hash",
     "mmap_read": lambda: random.randint(0, 1),
+    "nooverwritepercent": 1,
     "open_files": 500000,
     "prefix_size": 7,
     "prefixpercent": 5,
@@ -76,7 +77,6 @@ blackbox_default_params = {
 whitebox_default_params = {
     "duration": 10000,
     "log2_keys_per_lock": 10,
-    "nooverwritepercent": 1,
     "ops_per_thread": 200000,
     "test_batches_snapshots": lambda: random.randint(0, 1),
     "write_buffer_size": 4 * 1024 * 1024,
@@ -100,6 +100,7 @@ simple_default_params = {
     "max_write_buffer_number": 3,
     "memtablerep": "skip_list",
     "mmap_read": lambda: random.randint(0, 1),
+    "nooverwritepercent": 1,
     "prefix_size": 0,
     "prefixpercent": 0,
     "progress_reports": 0,
@@ -128,7 +129,6 @@ blackbox_simple_default_params = {
 whitebox_simple_default_params = {
     "duration": 10000,
     "log2_keys_per_lock": 10,
-    "nooverwritepercent": 1,
     "open_files": 500000,
     "ops_per_thread": 200000,
     "write_buffer_size": 32 * 1024 * 1024,


### PR DESCRIPTION
Previously `python tools/db_crashtest.py blackbox` would do no useful work as the crash interval (two minutes) was shorter than the preparation phase. The preparation phase is slow because of the ridiculously inefficient way it computes which keys should not be overwritten. It was doing this for 60M keys since default values were `FLAGS_nooverwritepercent == 60` and `FLAGS_max_key == 100000000`. 

Move the "nooverwritepercent" override from whitebox-specific to the general options so it also applies to blackbox test runs. Now preparation phase takes a few seconds.