### PR TITLE
Clock cache should check if deleter is nullptr before calling it

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -367,7 +367,9 @@ ClockCacheShard::~ClockCacheShard() {
   for (auto& handle : list_) {
     uint32_t flags = handle.flags.load(std::memory_order_relaxed);
     if (InCache(flags) || CountRefs(flags) > 0) {
-      (*handle.deleter)(handle.key, handle.value);
+      if (handle.deleter != nullptr) {
+        (*handle.deleter)(handle.key, handle.value);
+      }
       delete[] handle.key.data();
     }
   }


### PR DESCRIPTION
Summary:
Clock cache should check if deleter is nullptr before calling it.

Test Plan:
existing tests.