### PR TITLE
Ttl-triggered and snapshot-release-triggered compactions should not be manual compactions

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1172,11 +1172,11 @@ void LevelCompactionBuilder::SetupInitialFiles() {
   // if we didn't find a compaction, check if there are any files marked for
   // compaction
   if (start_level_inputs_.empty()) {
-    is_manual_ = true;
     parent_index_ = base_index_ = -1;
 
     PickFilesMarkedForCompaction();
     if (!start_level_inputs_.empty()) {
+      is_manual_ = true;
       compaction_reason_ = CompactionReason::kFilesMarkedForCompaction;
       return;
     }


### PR DESCRIPTION
Ttl-triggered and snapshot-release-triggered compactions should not be considered as manual compactions. This is a bug. 

Test Plan:
Updated tests:
- DBCompactionTest.LevelCompactExpiredTtlFiles
- DBCompactionTest. CompactBottomLevelFilesWithDeletions

make check