### PR TITLE
WritePrepared Txn: add write_committed option to dump_wal

### DIFF
--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -215,6 +215,7 @@ class LDBCommand {
   LDBOptions ldb_options_;
 
  private:
+  friend class WALDumperCommand;
   /**
    * Interpret command line options and flags to determine if the key
    * should be input/output in hex.

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1938,7 +1938,7 @@ class InMemoryHandler : public WriteBatch::Handler {
   virtual ~InMemoryHandler() {}
 
  protected:
-  virtual bool WriteAfterCommit() const { return write_after_commit_; }
+  virtual bool WriteAfterCommit() override const { return write_after_commit_; }
 
  private:
   std::stringstream& row_;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1938,7 +1938,7 @@ class InMemoryHandler : public WriteBatch::Handler {
   virtual ~InMemoryHandler() {}
 
  protected:
-  virtual bool WriteAfterCommit() override const { return write_after_commit_; }
+  virtual bool WriteAfterCommit() const override { return write_after_commit_; }
 
  private:
   std::stringstream& row_;

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -276,8 +276,10 @@ class WALDumperCommand : public LDBCommand {
   bool print_header_;
   std::string wal_file_;
   bool print_values_;
+  bool write_committed_policy_;  // default will be set to true
 
   static const std::string ARG_WAL_FILE;
+  static const std::string ARG_WRITE_COMMITTED;
   static const std::string ARG_PRINT_HEADER;
   static const std::string ARG_PRINT_VALUE;
 };

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -276,7 +276,7 @@ class WALDumperCommand : public LDBCommand {
   bool print_header_;
   std::string wal_file_;
   bool print_values_;
-  bool write_committed_policy_;  // default will be set to true
+  bool is_write_committed_;  // default will be set to true
 
   static const std::string ARG_WAL_FILE;
   static const std::string ARG_WRITE_COMMITTED;


### PR DESCRIPTION
Currently dump_wal cannot print the prepared records from the WAL that is generated by WRITE_PREPARED write policy since the default reaction of the handler is to return NotSupported if markers of WRITE_PREPARED are encountered. This patch enables the admin to pass --write_committed=false option, which will be accordingly passed to the handler. Note that DBFileDumperCommand and DBDumperCommand are still not updated by this patch but firstly they are not urgent and secondly we need to revise this approach later when we also add WRITE_UNPREPARED markers so I leave it for future work.

Tested by running it on a WAL generated by WRITE_PREPARED:
$ ./ldb dump_wal --walfile=/dev/shm/dbbench/000003.log  | grep BEGIN_PREARE | head -1
1,2,70,0,BEGIN_PREARE
$ ./ldb dump_wal --walfile=/dev/shm/dbbench/000003.log --write_committed=false | grep BEGIN_PREARE | head -1
1,2,70,0,BEGIN_PREARE PUT(0) : 0x30303031313330313938 PUT(0) : 0x30303032353732313935 END_PREPARE(0x74786E31313535383434323738303738363938313335312D30)