### PR TITLE
fix intra-L0 FIFO for uncompressed use case

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -59,7 +59,7 @@ bool FindIntraL0Compaction(const std::vector<FileMetaData*>& level_files,
   }
 
   if (span_len >= min_files_to_compact &&
-      new_compact_bytes_per_del_file < max_compact_bytes_per_del_file) {
+      compact_bytes_per_del_file < max_compact_bytes_per_del_file) {
     assert(comp_inputs != nullptr);
     comp_inputs->level = 0;
     for (size_t i = 0; i < span_len; ++i) {
@@ -1583,8 +1583,11 @@ Compaction* FIFOCompactionPicker::PickSizeCompaction(
       if (FindIntraL0Compaction(
               level_files,
               mutable_cf_options
-                  .level0_file_num_compaction_trigger /* min_files_to_compact */,
-              mutable_cf_options.write_buffer_size, &comp_inputs)) {
+                  .level0_file_num_compaction_trigger /* min_files_to_compact */
+              ,
+              110 * mutable_cf_options.write_buffer_size /
+                  100 /* max_compact_bytes_per_del_file */,
+              &comp_inputs)) {
         Compaction* c = new Compaction(
             vstorage, ioptions_, mutable_cf_options, {comp_inputs}, 0,
             16 * 1024 * 1024 /* output file size limit */,


### PR DESCRIPTION
- inflate the argument passed as `max_compact_bytes_per_del_file` by a bit (10%). The intent of this argument is prevent L0 files from being intra-L0 compacted multiple times. Without compression, some intra-L0 compactions exceed this limit (and thus aren't executed), even though none of their files have gone through intra-L0 before.
- fix `FindIntraL0Compaction` as it was rejecting some valid intra-L0 compactions. In particular, `compact_bytes_per_del_file` is the work-per-deleted-file for the span [0, span_len), whereas `new_compact_bytes_per_del_file` is the work-per-deleted-file for the span [0, span_len+1). The former is more correct for checking whether we've found an eligible span.

Test Plan:

- command:

```
$ TEST_TMPDIR=/dev/shm ./db_bench -benchmarks=fillrandom -compaction_style=2 -level0_file_num_compaction_trigger=4 -write_buffer_size=1048576 -fifo_compaction_max_table_files_size_mb=1024 -compression_type=none
```

- before this PR:

```
$ grep -E Compacting /dev/shm/dbbench/LOG
2018/04/05-20:21:08.773169 7f2b69714700 [db/compaction_job.cc:1484] [default] [JOB 12] Compacting 6@0 files to L0, score 1.50
2018/04/05-20:21:09.101181 7f2b69714700 [db/compaction_job.cc:1484] [default] [JOB 89] Compacting 27@0 files to L0, score 7.00
```

- after this PR:

```
$ grep -E Compacting /dev/shm/dbbench/LOG | head -5
2018/04/05-20:19:36.431198 7f79eaee0700 [db/compaction_job.cc:1484] [default] [JOB 6] Compacting 4@0 files to L0, score 1.00
2018/04/05-20:19:36.478662 7f79eaee0700 [db/compaction_job.cc:1484] [default] [JOB 14] Compacting 4@0 files to L0, score 1.25
2018/04/05-20:19:36.529767 7f79eaee0700 [db/compaction_job.cc:1484] [default] [JOB 24] Compacting 4@0 files to L0, score 1.50
2018/04/05-20:19:36.580060 7f79eaee0700 [db/compaction_job.cc:1484] [default] [JOB 36] Compacting 4@0 files to L0, score 1.75
2018/04/05-20:19:36.629270 7f79eaee0700 [db/compaction_job.cc:1484] [default] [JOB 48] Compacting 4@0 files to L0, score 2.00
```