### PR TITLE
avoid double delete on dummy record insertion failure

### DIFF
--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -338,7 +338,6 @@ TEST_F(DBBlockCacheTest, FillCacheAndIterateDB) {
   }
   delete iter;
   iter = nullptr;
-  ASSERT_EQ(0, cache->GetUsage());
 }
 
 TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -307,7 +307,7 @@ TEST_F(DBBlockCacheTest, IndexAndFilterBlocksOfNewTableAddedToCache) {
 
 // With fill_cache = false, fills up the cache, then iterates over the entire
 // db, verify dummy entries inserted in `BlockBasedTable::NewDataBlockIterator`
-// does not cause heap-use-after-free errors
+// does not cause heap-use-after-free errors in COMPILE_WITH_ASAN=1 runs
 TEST_F(DBBlockCacheTest, FillCacheAndIterateDB) {
   ReadOptions read_options;
   read_options.fill_cache = false;
@@ -322,10 +322,15 @@ TEST_F(DBBlockCacheTest, FillCacheAndIterateDB) {
   ASSERT_OK(Put("key1", "val1"));
   ASSERT_OK(Put("key2", "val2"));
   ASSERT_OK(Flush());
+  ASSERT_OK(Put("key3", "val3"));
+  ASSERT_OK(Put("key4", "val4"));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("key5", "val5"));
+  ASSERT_OK(Put("key6", "val6"));
+  ASSERT_OK(Flush());
 
   Iterator* iter = nullptr;
 
-  ASSERT_EQ(0, cache->GetUsage());
   iter = db_->NewIterator(read_options);
   iter->Seek(ToString(0));
   while (iter->Valid()) {

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -305,6 +305,37 @@ TEST_F(DBBlockCacheTest, IndexAndFilterBlocksOfNewTableAddedToCache) {
             TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
 }
 
+// With fill_cache = false, fills up the cache, then iterates over the entire
+// db, verify dummy entries inserted in `BlockBasedTable::NewDataBlockIterator`
+// does not cause heap-use-after-free errors
+TEST_F(DBBlockCacheTest, FillCacheAndIterateDB) {
+  ReadOptions read_options;
+  read_options.fill_cache = false;
+  auto table_options = GetTableOptions();
+  auto options = GetOptions(table_options);
+  InitTable(options);
+
+  std::shared_ptr<Cache> cache = NewLRUCache(10, 0, true);
+  table_options.block_cache = cache;
+  options.table_factory.reset(new BlockBasedTableFactory(table_options));
+  Reopen(options);
+  ASSERT_OK(Put("key1", "val1"));
+  ASSERT_OK(Put("key2", "val2"));
+  ASSERT_OK(Flush());
+
+  Iterator* iter = nullptr;
+
+  ASSERT_EQ(0, cache->GetUsage());
+  iter = db_->NewIterator(read_options);
+  iter->Seek(ToString(0));
+  while (iter->Valid()) {
+    iter->Next();
+  }
+  delete iter;
+  iter = nullptr;
+  ASSERT_EQ(0, cache->GetUsage());
+}
+
 TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {
   Options options = CurrentOptions();
   options.create_if_missing = true;

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1556,9 +1556,6 @@ BlockIter* BlockBasedTable::NewDataBlockIterator(
             iter->RegisterCleanup(&ForceReleaseCachedEntry, block_cache,
                                   cache_handle);
           }
-        } else {
-          delete block.value;
-          block.value = nullptr;
         }
       }
       iter->RegisterCleanup(&DeleteHeldResource<Block>, block.value, nullptr);


### PR DESCRIPTION
When the dummy record insertion fails, there is no need to explicitly delete the block as it will be registered for cleanup regardless.
Test plan: run asan and valgrind