### PR TITLE
make MockTimeEnv::current_time_ atomic to fix data race

### DIFF
--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -606,7 +606,7 @@ class MockTimeEnv : public EnvWrapper {
   }
 
  private:
-  uint64_t current_time_ = 0;
+  std::atomic<uint64_t> current_time_{0};
 };
 
 #ifndef ROCKSDB_LITE

--- a/util/status.cc
+++ b/util/status.cc
@@ -15,10 +15,11 @@
 namespace rocksdb {
 
 const char* Status::CopyState(const char* state) {
-  const size_t cch = 
+  const size_t cch =
       std::strlen(state) + 1; // +1 for the null terminator
   char* const result =
-      new char[cch]; 
+      new char[cch];
+  result[cch - 1] = '\0';
 #ifdef OS_WIN
   errno_t ret;
   ret = strncpy_s(result, cch, state, cch - 1);


### PR DESCRIPTION
fix a new TSAN failure 
https://gist.github.com/miasantreble/7599c33f4e17da1024c67d4540dbe397