### PR TITLE
add kEntryRangeDeletion

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -46,6 +46,8 @@ EntryType GetEntryType(ValueType value_type) {
       return kEntrySingleDelete;
     case kTypeMerge:
       return kEntryMerge;
+    case kTypeRangeDeletion:
+      return kEntryRangeDeletion;
     default:
       return kEntryOther;
   }

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -22,6 +22,7 @@ enum EntryType {
   kEntryDelete,
   kEntrySingleDelete,
   kEntryMerge,
+  kEntryRangeDeletion,
   kEntryOther,
 };
 


### PR DESCRIPTION
When there are many range deletions in a range, we want to trigger manual compaction on this range to reclaim disk space as soon as possible and speed up read.
After this change, we can collect informations of range deletions and store them into user properties which can guide our manual compaction.