### PR TITLE
fix calling SetOptions on deprecated options

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1148,8 +1148,9 @@ void ColumnFamilyData::ResetThreadLocalSuperVersions() {
 Status ColumnFamilyData::SetOptions(
       const std::unordered_map<std::string, std::string>& options_map) {
   MutableCFOptions new_mutable_cf_options;
-  Status s = GetMutableOptionsFromStrings(mutable_cf_options_, options_map,
-                                          &new_mutable_cf_options);
+  Status s =
+      GetMutableOptionsFromStrings(mutable_cf_options_, options_map,
+                                   ioptions_.info_log, &new_mutable_cf_options);
   if (s.ok()) {
     mutable_cf_options_ = new_mutable_cf_options;
     mutable_cf_options_.RefreshDerivedOptions(ioptions_);

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -31,7 +31,7 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
 Status GetMutableOptionsFromStrings(
     const MutableCFOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
-    MutableCFOptions* new_options);
+    Logger* info_log, MutableCFOptions* new_options);
 
 Status GetMutableDBOptionsFromStrings(
     const MutableDBOptions& base_options,


### PR DESCRIPTION
In `cf_options_type_info`, the deprecated options are all considered to have offset zero in the `MutableCFOptions` struct. Previously we weren't checking in `GetMutableOptionsFromStrings` whether the provided option was deprecated or not and simply writing the provided value to the offset specified by `cf_options_type_info`. That meant setting any deprecated option would overwrite the first element in the struct, which is `write_buffer_size`. `db_stress` hit this often since it calls `SetOptions` with `soft_rate_limit=0` and `hard_rate_limit=0`, which are both deprecated so cause `write_buffer_size` to be set to zero, which causes it to crash on the following assertion:

```
db_stress: db/memtable.cc:106: rocksdb::MemTable::MemTable(const rocksdb::InternalKeyComparator&, const rocksdb::ImmutableCFOptions&, const rocksdb::MutableCFOptions&, rocksdb::WriteBufferManager*, rocksdb::SequenceNumber, uint32_t): Assertion `!ShouldScheduleFlush()' failed.
```

We fix it by skipping deprecated options (and logging a warning) when users provide them to `SetOptions`. I didn't want to fail the call for compatibility reasons.

Test Plan:

- verify deprecated options can be set to zero without anything crashing
```
$ ./db_stress --max_background_compactions=20 --use_merge=1 --max_write_buffer_number=3 --sync=0 --reopen=20 --acquire_snapshot_one_in=10000 --delpercent=5 --log2_keys_per_lock=2 --block_size=16384 --allow_concurrent_memtable_write=0 --target_file_size_multiplier=2 --use_full_merge_v1=0 --target_file_size_base=2097152 --mmap_read=0 --writepercent=35 --readpercent=45 --subcompactions=1 --memtablerep=prefix_hash --set_options_one_in=1000 --prefix_size=7 --test_batches_snapshots=1 --db=/tmp/rocksdb_crashtest_blackbox4a_Y0u --max_bytes_for_level_base=10485760 --threads=32 --disable_wal=0 --open_files=500000 --destroy_db_initially=0 --progress_reports=0 --snapshot_hold_ops=100000 --iterpercent=10 --max_key=100000000 --prefixpercent=5 --ops_per_thread=100000000 --use_clock_cache=false --cache_size=1048576 --verify_checksum=1 --write_buffer_size=4194304 --nooverwritepercent=1
...
$ grep deprecated /tmp/rocksdb_crashtest_blackbox4a_Y0u/LOG | head
2018/04/10-11:28:47.579514 7f3e3441d700 [WARN] [options/options_helper.cc:726] hard_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:47.579592 7f3e3441d700 [WARN] [options/options_helper.cc:726] soft_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:49.318132 7f3e28405700 [WARN] [options/options_helper.cc:726] hard_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:49.318139 7f3e28405700 [WARN] [options/options_helper.cc:726] soft_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:51.947711 7f3e36421700 [WARN] [options/options_helper.cc:726] hard_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:51.947717 7f3e36421700 [WARN] [options/options_helper.cc:726] soft_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:52.325816 7f3e2ec12700 [WARN] [options/options_helper.cc:726] hard_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:52.325820 7f3e2ec12700 [WARN] [options/options_helper.cc:726] soft_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:52.699696 7f3e2cc0e700 [WARN] [options/options_helper.cc:726] hard_rate_limit is a deprecated option and cannot be set
2018/04/10-11:28:52.699700 7f3e2cc0e700 [WARN] [options/options_helper.cc:726] soft_rate_limit is a deprecated option and cannot be set
```