### PR TITLE
include thread-pool priority in thread names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * Add a BlockBasedTableOption to align uncompressed data blocks on the smaller of block size or page size boundary, to reduce flash reads by avoiding reads spanning 4K pages.
+* The background thread naming convention changed (on supporting platforms) to "rocksdb:<thread pool priority><thread number>", e.g., "rocksdb:low0".
 
 ### New Features
 * * Introduce TTL for level compaction so that all files older than ttl go through the compaction process to get rid of old data.

--- a/env/env.cc
+++ b/env/env.cc
@@ -22,6 +22,20 @@ namespace rocksdb {
 Env::~Env() {
 }
 
+std::string Env::PriorityToString(Env::Priority priority) {
+  switch (priority) {
+    case Env::Priority::BOTTOM:
+      return "Bottom";
+    case Env::Priority::LOW:
+      return "Low";
+    case Env::Priority::HIGH:
+      return "High";
+    case Env::Priority::TOTAL:
+      assert(false);
+  }
+  return "Invalid";
+}
+
 uint64_t Env::GetThreadID() const {
   std::hash<std::thread::id> hasher;
   return hasher(std::this_thread::get_id());

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -302,6 +302,8 @@ class Env {
   // Priority for scheduling job in thread pool
   enum Priority { BOTTOM, LOW, HIGH, TOTAL };
 
+  static std::string PriorityToString(Priority priority);
+
   // Priority for requesting bytes in rate limiter scheduler
   enum IOPriority {
     IO_LOW = 0,


### PR DESCRIPTION
Previously threads were named "rocksdb:bg\<index in thread pool\>", so the first thread in all thread pools would be named "rocksdb:bg0". Users want to be able to distinguish threads used for flush (high-pri) vs regular compaction (low-pri) vs compaction to bottom-level (bottom-pri). So I changed the thread naming convention to include the thread-pool priority.

Test Plan:

- run db_bench and verify thread names are as expected
```
$ ps -Lp `pgrep db_bench` | grep rocksdb | sort -k5
 807573  807575 pts/6    00:00:00 rocksdb:bottom0
 807573  807576 pts/6    00:00:00 rocksdb:bottom1
 807573  807580 pts/6    00:00:02 rocksdb:high0
 807573  807600 pts/6    00:00:02 rocksdb:high1
 807573  807601 pts/6    00:00:02 rocksdb:high2
 807573  807579 pts/6    00:00:09 rocksdb:low0
 807573  807586 pts/6    00:00:00 rocksdb:low1
 807573  807587 pts/6    00:00:00 rocksdb:low2
 807573  807588 pts/6    00:00:00 rocksdb:low3
 807573  807589 pts/6    00:00:00 rocksdb:low4
 807573  807592 pts/6    00:00:00 rocksdb:low5
 807573  807594 pts/6    00:00:04 rocksdb:low6
 807573  807596 pts/6    00:00:00 rocksdb:low7
 807573  807598 pts/6    00:00:00 rocksdb:low8
```