### PR TITLE
fix memory leak in two_level_iterator

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -391,6 +391,9 @@ class ColumnFamilyTest : public testing::Test {
   void AssertFilesPerLevel(const std::string& value, int cf) {
 #ifndef ROCKSDB_LITE
     ASSERT_EQ(value, FilesPerLevel(cf));
+#else
+    (void) value;
+    (void) cf;
 #endif
   }
 
@@ -405,6 +408,8 @@ class ColumnFamilyTest : public testing::Test {
   void AssertCountLiveFiles(int expected_value) {
 #ifndef ROCKSDB_LITE
     ASSERT_EQ(expected_value, CountLiveFiles());
+#else
+    (void) expected_value;
 #endif
   }
 
@@ -453,6 +458,8 @@ class ColumnFamilyTest : public testing::Test {
   void AssertCountLiveLogFiles(int value) {
 #ifndef ROCKSDB_LITE  // GetSortedWalFiles is not supported
     ASSERT_EQ(value, CountLiveLogFiles());
+#else
+    (void) value;
 #endif  // !ROCKSDB_LITE
   }
 

--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -318,9 +318,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as DBImpl::CompactFiles is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -319,6 +319,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as DBImpl::CompactFiles is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/compaction_job_stats_test.cc
+++ b/db/compaction_job_stats_test.cc
@@ -1034,9 +1034,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED, not supported in ROCKSDB_LITE\n");
   return 0;
 }
@@ -1045,9 +1043,5 @@ int main(int argc, char** argv) {
 
 #else
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
-  return 0;
-}
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 #endif  // !defined(IOS_CROSS_COMPILE)

--- a/db/compaction_job_stats_test.cc
+++ b/db/compaction_job_stats_test.cc
@@ -1035,6 +1035,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED, not supported in ROCKSDB_LITE\n");
   return 0;
 }
@@ -1043,5 +1045,9 @@ int main(int argc, char** argv) {
 
 #else
 
-int main(int argc, char** argv) { return 0; }
+int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
+  return 0;
+}
 #endif  // !defined(IOS_CROSS_COMPILE)

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -947,6 +947,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as CompactionJobStats is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -946,9 +946,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as CompactionJobStats is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -510,9 +510,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as RepairDB() is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -511,6 +511,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as RepairDB() is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/cuckoo_table_db_test.cc
+++ b/db/cuckoo_table_db_test.cc
@@ -334,6 +334,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/cuckoo_table_db_test.cc
+++ b/db/cuckoo_table_db_test.cc
@@ -333,9 +333,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3766,6 +3766,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/db_dynamic_level_test.cc
+++ b/db/db_dynamic_level_test.cc
@@ -501,6 +501,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -289,6 +289,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/db_tailing_iter_test.cc
+++ b/db/db_tailing_iter_test.cc
@@ -809,6 +809,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -1899,6 +1899,8 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 #else
+  (void) argc;
+  (void) argv;
   return 0;
 #endif
 }

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -501,6 +501,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as DBImpl::DeleteFile is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -500,9 +500,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as DBImpl::DeleteFile is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2007,6 +2007,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as External SST File Writer and Ingestion are not supported "
           "in ROCKSDB_LITE\n");

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2006,9 +2006,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as External SST File Writer and Ingestion are not supported "
           "in ROCKSDB_LITE\n");

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -209,6 +209,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as DBImpl::DeleteFile is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -208,9 +208,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as DBImpl::DeleteFile is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/options_file_test.cc
+++ b/db/options_file_test.cc
@@ -112,9 +112,7 @@ int main(int argc, char** argv) {
 
 #include <cstdio>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   printf("Skipped as Options file is not supported in RocksDBLite.\n");
   return 0;
 }

--- a/db/options_file_test.cc
+++ b/db/options_file_test.cc
@@ -113,6 +113,8 @@ int main(int argc, char** argv) {
 #include <cstdio>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   printf("Skipped as Options file is not supported in RocksDBLite.\n");
   return 0;
 }

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -1171,6 +1171,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as plain table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -1170,9 +1170,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as plain table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -888,6 +888,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as HashSkipList and HashLinkList are not supported in "
           "ROCKSDB_LITE\n");

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -887,9 +887,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as HashSkipList and HashLinkList are not supported in "
           "ROCKSDB_LITE\n");

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -356,9 +356,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as RepairDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -357,6 +357,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as RepairDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -303,9 +303,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as WalManager is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -304,6 +304,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as WalManager is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -432,9 +432,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as WriteWithCallback is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -433,6 +433,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as WriteWithCallback is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -890,10 +890,12 @@ void PosixWritableFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) {
   if (fcntl(fd_, F_SET_RW_HINT, &hint) == 0) {
     write_hint_ = hint;
   }
-#endif
 #else
   (void)hint;
-#endif
+#endif // ROCKSDB_VALGRIND_RUN
+#else
+  (void)hint;
+#endif // OS_LINUX
 }
 
 Status PosixWritableFile::InvalidateCache(size_t offset, size_t length) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -120,7 +120,7 @@ void ReleaseCachedEntry(void* arg, void* h) {
 void ForceReleaseCachedEntry(void* arg, void* h) {
   Cache* cache = reinterpret_cast<Cache*>(arg);
   Cache::Handle* handle = reinterpret_cast<Cache::Handle*>(h);
-  cache->Release(handle, true);
+  cache->Release(handle, true /* force_erase */);
 }
 
 Slice GetCacheKeyFromOffset(const char* cache_key_prefix,

--- a/table/cuckoo_table_builder_test.cc
+++ b/table/cuckoo_table_builder_test.cc
@@ -625,9 +625,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/table/cuckoo_table_builder_test.cc
+++ b/table/cuckoo_table_builder_test.cc
@@ -626,6 +626,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -560,9 +560,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -561,6 +561,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as Cuckoo table is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -25,8 +25,8 @@ class TwoLevelIterator : public InternalIterator {
                             InternalIterator* first_level_iter);
 
   virtual ~TwoLevelIterator() {
-    first_level_iter_.DeleteIter(false);
-    second_level_iter_.DeleteIter(false);
+    first_level_iter_.DeleteIter(false /* is_arena_mode */);
+    second_level_iter_.DeleteIter(false /* is_arena_mode */);
     delete state_;
   }
 

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -24,7 +24,11 @@ class TwoLevelIterator : public InternalIterator {
   explicit TwoLevelIterator(TwoLevelIteratorState* state,
                             InternalIterator* first_level_iter);
 
-  virtual ~TwoLevelIterator() { delete state_; }
+  virtual ~TwoLevelIterator() {
+    first_level_iter_.DeleteIter(false);
+    second_level_iter_.DeleteIter(false);
+    delete state_;
+  }
 
   virtual void Seek(const Slice& target) override;
   virtual void SeekForPrev(const Slice& target) override;

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -35,11 +35,7 @@ struct TwoLevelIteratorState {
 //
 // Uses a supplied function to convert an index_iter value into
 // an iterator over the contents of the corresponding block.
-// arena: If not null, the arena is used to allocate the Iterator.
-//        When destroying the iterator, the destructor will destroy
-//        all the states but those allocated in arena.
-// need_free_iter_and_state: free `state` and `first_level_iter` if
-//                           true. Otherwise, just call destructor.
+// Note: this function expects first_level_iter was not created using arena
 extern InternalIterator* NewTwoLevelIterator(
     TwoLevelIteratorState* state, InternalIterator* first_level_iter);
 

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -16,8 +16,8 @@ namespace rocksdb {
 
 struct ReadOptions;
 class InternalKeyComparator;
-class Arena;
 
+// TwoLevelIteratorState expects iterators are not created using the arena
 struct TwoLevelIteratorState {
   TwoLevelIteratorState() {}
 
@@ -35,7 +35,7 @@ struct TwoLevelIteratorState {
 //
 // Uses a supplied function to convert an index_iter value into
 // an iterator over the contents of the corresponding block.
-// Note: this function expects first_level_iter was not created using arena
+// Note: this function expects first_level_iter was not created using the arena
 extern InternalIterator* NewTwoLevelIterator(
     TwoLevelIteratorState* state, InternalIterator* first_level_iter);
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2944,6 +2944,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
               FLAGS_options_file.c_str(), s.ToString().c_str());
       exit(1);
     }
+#else
+    (void)opts;
 #endif
     return false;
   }
@@ -4000,6 +4002,9 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     }
     return Status::OK();
 #else
+    (void)thread;
+    (void)compaction_style;
+    (void)write_mode;
     fprintf(stderr, "Rocksdb Lite doesn't support filldeterministic\n");
     return Status::NotSupported(
         "Rocksdb Lite doesn't support filldeterministic");

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1023,9 +1023,7 @@ class DbStressListener : public EventListener {
         column_families_(column_families) {}
   virtual ~DbStressListener() {}
 #ifndef ROCKSDB_LITE
-  virtual void OnFlushCompleted(DB* db, const FlushJobInfo& info) override {
-    assert(db);
-    assert(db->GetName() == db_name_);
+  virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
     assert(IsValidColumnFamilyName(info.cf_name));
     VerifyFilePath(info.file_path);
     // pretending doing some work here
@@ -1033,10 +1031,8 @@ class DbStressListener : public EventListener {
         std::chrono::microseconds(Random::GetTLSInstance()->Uniform(5000)));
   }
 
-  virtual void OnCompactionCompleted(DB* db,
+  virtual void OnCompactionCompleted(DB* /*db*/,
                                      const CompactionJobInfo& ci) override {
-    assert(db);
-    assert(db->GetName() == db_name_);
     assert(IsValidColumnFamilyName(ci.cf_name));
     assert(ci.input_files.size() + ci.output_files.size() > 0U);
     for (const auto& file_path : ci.input_files) {
@@ -1095,6 +1091,8 @@ class DbStressListener : public EventListener {
       }
     }
     assert(false);
+#else
+    (void)file_dir;
 #endif  // !NDEBUG
   }
 
@@ -1105,6 +1103,8 @@ class DbStressListener : public EventListener {
     bool result = ParseFileName(file_name, &file_number, &file_type);
     assert(result);
     assert(file_type == kTableFile);
+#else
+    (void)file_name;
 #endif  // !NDEBUG
   }
 
@@ -1119,6 +1119,8 @@ class DbStressListener : public EventListener {
       }
       VerifyFileName(file_path.substr(pos));
     }
+#else
+    (void)file_path;
 #endif  // !NDEBUG
   }
 #endif  // !ROCKSDB_LITE
@@ -2299,6 +2301,7 @@ class StressTest {
     size_t value_sz =
         ((rand % kRandomValueMaxFactor) + 1) * FLAGS_value_size_mult;
     assert(value_sz <= max_sz && value_sz >= sizeof(uint32_t));
+    (void) max_sz;
     *((uint32_t*)v) = rand;
     for (size_t i=sizeof(uint32_t); i < value_sz; i++) {
       v[i] = (char)(rand ^ i);

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -54,9 +54,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as LDBCommand is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -55,6 +55,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as LDBCommand is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/tools/reduce_levels_test.cc
+++ b/tools/reduce_levels_test.cc
@@ -210,9 +210,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as LDBCommand is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/tools/reduce_levels_test.cc
+++ b/tools/reduce_levels_test.cc
@@ -211,6 +211,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as LDBCommand is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -216,6 +216,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as SSTDumpTool is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -215,9 +215,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as SSTDumpTool is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/util/auto_roll_logger_test.cc
+++ b/util/auto_roll_logger_test.cc
@@ -520,9 +520,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as AutoRollLogger is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/util/auto_roll_logger_test.cc
+++ b/util/auto_roll_logger_test.cc
@@ -521,6 +521,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as AutoRollLogger is not supported in ROCKSDB_LITE\n");
   return 0;

--- a/util/autovector_test.cc
+++ b/util/autovector_test.cc
@@ -27,6 +27,9 @@ template <class T>
 void AssertAutoVectorOnlyInStack(autovector<T, kSize>* vec, bool result) {
 #ifndef ROCKSDB_LITE
   ASSERT_EQ(vec->only_in_stack(), result);
+#else
+  (void) vec;
+  (void) result;
 #endif  // !ROCKSDB_LITE
 }
 }  // namespace

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -641,9 +641,7 @@ int main(int argc, char** argv) {
 }
 
 #else
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   printf("DeleteScheduler is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/util/delete_scheduler_test.cc
+++ b/util/delete_scheduler_test.cc
@@ -642,6 +642,8 @@ int main(int argc, char** argv) {
 
 #else
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   printf("DeleteScheduler is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -1621,6 +1621,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as BackupableDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -1620,9 +1620,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as BackupableDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1544,9 +1544,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as BlobDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1545,6 +1545,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as BlobDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -597,6 +597,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as Checkpoint is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -596,9 +596,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as Checkpoint is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/column_aware_encoding_exp.cc
+++ b/utilities/column_aware_encoding_exp.cc
@@ -169,9 +169,7 @@ int main() {
 }
 #endif  // GFLAGS
 #else
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "Not supported in lite mode.\n");
   return 1;
 }

--- a/utilities/column_aware_encoding_exp.cc
+++ b/utilities/column_aware_encoding_exp.cc
@@ -170,6 +170,8 @@ int main() {
 #endif  // GFLAGS
 #else
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "Not supported in lite mode.\n");
   return 1;
 }

--- a/utilities/date_tiered/date_tiered_test.cc
+++ b/utilities/date_tiered/date_tiered_test.cc
@@ -460,9 +460,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as DateTieredDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/date_tiered/date_tiered_test.cc
+++ b/utilities/date_tiered/date_tiered_test.cc
@@ -461,6 +461,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as DateTieredDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/document/document_db_test.cc
+++ b/utilities/document/document_db_test.cc
@@ -328,9 +328,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as DocumentDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/document/document_db_test.cc
+++ b/utilities/document/document_db_test.cc
@@ -329,6 +329,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as DocumentDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/document/json_document_test.cc
+++ b/utilities/document/json_document_test.cc
@@ -334,6 +334,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as JSONDocument is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/document/json_document_test.cc
+++ b/utilities/document/json_document_test.cc
@@ -333,9 +333,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as JSONDocument is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/env_timed_test.cc
+++ b/utilities/env_timed_test.cc
@@ -37,6 +37,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as TimedEnv is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/env_timed_test.cc
+++ b/utilities/env_timed_test.cc
@@ -36,9 +36,7 @@ int main(int argc, char** argv) {
 #else  // ROCKSDB_LITE
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as TimedEnv is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/lua/rocks_lua_test.cc
+++ b/utilities/lua/rocks_lua_test.cc
@@ -492,6 +492,8 @@ int main(int /*argc*/, char** /*argv*/) {
 #else
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   printf("Lua is not supported in RocksDBLite.  Ignoring the test.\n");
 }
 

--- a/utilities/lua/rocks_lua_test.cc
+++ b/utilities/lua/rocks_lua_test.cc
@@ -491,9 +491,7 @@ int main(int /*argc*/, char** /*argv*/) {
 
 #else
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   printf("Lua is not supported in RocksDBLite.  Ignoring the test.\n");
 }
 

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -269,9 +269,7 @@ int main(int argc, char** argv) {
 #else
 #include <cstdio>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   printf("Skipped in RocksDBLite as utilities are not supported.\n");
   return 0;
 }

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -270,6 +270,8 @@ int main(int argc, char** argv) {
 #include <cstdio>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   printf("Skipped in RocksDBLite as utilities are not supported.\n");
   return 0;
 }

--- a/utilities/object_registry_test.cc
+++ b/utilities/object_registry_test.cc
@@ -66,6 +66,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as EnvRegistry is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/object_registry_test.cc
+++ b/utilities/object_registry_test.cc
@@ -65,9 +65,7 @@ int main(int argc, char** argv) {
 #else  // ROCKSDB_LITE
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as EnvRegistry is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -312,6 +312,8 @@ int main(int argc, char** argv) {
 #include <cstdio>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   printf("Skipped in RocksDBLite as utilities are not supported.\n");
   return 0;
 }

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -311,9 +311,7 @@ int main(int argc, char** argv) {
 #else
 #include <cstdio>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   printf("Skipped in RocksDBLite as utilities are not supported.\n");
   return 0;
 }

--- a/utilities/redis/redis_lists_test.cc
+++ b/utilities/redis/redis_lists_test.cc
@@ -886,9 +886,7 @@ int main(int argc, char* argv[]) {
 #else
 #include <stdio.h>
 
-int main(int argc, char* argv[]) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as redis is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/redis/redis_lists_test.cc
+++ b/utilities/redis/redis_lists_test.cc
@@ -887,6 +887,8 @@ int main(int argc, char* argv[]) {
 #include <stdio.h>
 
 int main(int argc, char* argv[]) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as redis is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/spatialdb/spatial_db_test.cc
+++ b/utilities/spatialdb/spatial_db_test.cc
@@ -300,6 +300,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as SpatialDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/spatialdb/spatial_db_test.cc
+++ b/utilities/spatialdb/spatial_db_test.cc
@@ -299,9 +299,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as SpatialDB is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
@@ -172,6 +172,8 @@ int main(int /*argc*/, char** /*argv*/) {
 }
 #else
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as RocksDBLite does not include utilities.\n");
   return 0;
 }

--- a/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
@@ -171,9 +171,7 @@ int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "PASSED\n");
 }
 #else
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as RocksDBLite does not include utilities.\n");
   return 0;
 }

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1389,6 +1389,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(
       stderr,
       "SKIPPED as optimistic_transaction is not supported in ROCKSDB_LITE\n");

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -1388,9 +1388,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(
       stderr,
       "SKIPPED as optimistic_transaction is not supported in ROCKSDB_LITE\n");

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5556,9 +5556,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as Transactions are not supported in ROCKSDB_LITE\n");
   return 0;

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -5557,6 +5557,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as Transactions are not supported in ROCKSDB_LITE\n");
   return 0;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2048,9 +2048,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr,
           "SKIPPED as Transactions are not supported in ROCKSDB_LITE\n");
   return 0;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2049,6 +2049,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr,
           "SKIPPED as Transactions are not supported in ROCKSDB_LITE\n");
   return 0;

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -655,9 +655,7 @@ int main(int argc, char** argv) {
 #else
 #include <stdio.h>
 
-int main(int argc, char** argv) {
-  (void) argc;
-  (void) argv;
+int main(int /*argc*/, char** /*argv*/) {
   fprintf(stderr, "SKIPPED as DBWithTTL is not supported in ROCKSDB_LITE\n");
   return 0;
 }

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -656,6 +656,8 @@ int main(int argc, char** argv) {
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  (void) argc;
+  (void) argv;
   fprintf(stderr, "SKIPPED as DBWithTTL is not supported in ROCKSDB_LITE\n");
   return 0;
 }


### PR DESCRIPTION
this PR fixes a few failed contbuild:
1. ASAN memory leak in Block::NewIterator (table/block.cc:429). the proper destruction of first_level_iter_ and second_level_iter_ of two_level_iterator.cc is missing from the code after the refactoring in https://github.com/facebook/rocksdb/pull/3406 
2. various unused param errors introduced by https://github.com/facebook/rocksdb/pull/3662
3. updated comment for `ForceReleaseCachedEntry` to emphasize the use of `force_erase` flag.

test plan: run asan, clang_release, lite, release, release_481 locally