### PR TITLE
[bug fix] use delete[] to dealloc an array

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -818,7 +818,7 @@ class SharedState {
       }
       assert(cf_ids.size() == static_cast<size_t>(num_no_overwrite_keys));
     }
-    delete permutation;
+    delete[] permutation;
 
     if (FLAGS_test_batches_snapshots) {
       fprintf(stdout, "No lock creation because test_batches_snapshots set\n");


### PR DESCRIPTION
fix a bug in `db_stress` where an int array was incorrectly deallocated using delete instead of delete[]