### PR TITLE
Add a stat for MultiGet keys found, update memtable hit/miss stats

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Public API Change
 * Add a BlockBasedTableOption to align uncompressed data blocks on the smaller of block size or page size boundary, to reduce flash reads by avoiding reads spanning 4K pages.
 * The background thread naming convention changed (on supporting platforms) to "rocksdb:<thread pool priority><thread number>", e.g., "rocksdb:low0".
+* Add a new ticker stat rocksdb.number.multiget.keys.found to count number of keys successfully read in MultiGet calls
 
 ### New Features
 * Introduce TTL for level compaction so that all files older than ttl go through the compaction process to get rid of old data.

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -321,6 +321,7 @@ enum Tickers : uint32_t {
   TXN_SNAPSHOT_MUTEX_OVERHEAD,
 
   // Number of keys actually found in MultiGet calls (vs number requested by caller)
+  // NUMBER_MULTIGET_KEYS_READ gives the number requested by caller
   NUMBER_MULTIGET_KEYS_FOUND,
   TICKER_ENUM_MAX
 };

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -320,6 +320,8 @@ enum Tickers : uint32_t {
   // # of times snapshot_mutex_ is acquired in the fast path.
   TXN_SNAPSHOT_MUTEX_OVERHEAD,
 
+  // Number of keys actually found in MultiGet calls (vs number requested by caller)
+  NUMBER_MULTIGET_KEYS_FOUND,
   TICKER_ENUM_MAX
 };
 
@@ -471,6 +473,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
      "rocksdb.txn.overhead.mutex.old.commit.map"},
     {TXN_DUPLICATE_KEY_OVERHEAD, "rocksdb.txn.overhead.duplicate.key"},
     {TXN_SNAPSHOT_MUTEX_OVERHEAD, "rocksdb.txn.overhead.mutex.snapshot"},
+    {NUMBER_MULTIGET_KEYS_FOUND, "rocksdb.number.multiget.keys.found"},
 };
 
 /**

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -3295,8 +3295,10 @@ class TickerTypeJni {
         return 0x5C;
       case rocksdb::Tickers::NUMBER_ITER_SKIP:
         return 0x5D;
-      case rocksdb::Tickers::TICKER_ENUM_MAX:
+      case rocksdb::Tickers::NUMBER_MULTIGET_KEYS_FOUND:
         return 0x5E;
+      case rocksdb::Tickers::TICKER_ENUM_MAX:
+        return 0x5F;
 
       default:
         // undefined/default
@@ -3497,6 +3499,8 @@ class TickerTypeJni {
       case 0x5D:
         return rocksdb::Tickers::NUMBER_ITER_SKIP;
       case 0x5E:
+        return rocksdb::Tickers::NUMBER_MULTIGET_KEYS_FOUND;
+      case 0x5F:
         return rocksdb::Tickers::TICKER_ENUM_MAX;
 
       default:

--- a/java/src/main/java/org/rocksdb/TickerType.java
+++ b/java/src/main/java/org/rocksdb/TickerType.java
@@ -465,7 +465,17 @@ public enum TickerType {
      */
     NUMBER_RATE_LIMITER_DRAINS((byte) 0x5C),
 
-    TICKER_ENUM_MAX((byte) 0x5D);
+    /**
+     * Number of internal skipped during iteration
+     */
+    NUMBER_ITER_SKIP((byte) 0x5D),
+
+    /**
+     * Number of MultiGet keys found (vs number requested)
+     */
+    NUMBER_MULTIGET_KEYS_FOUND((byte) 0x5E),
+
+    TICKER_ENUM_MAX((byte) 0x5F);
 
 
     private final byte value;


### PR DESCRIPTION
1. Add a new ticker stat rocksdb.number.multiget.keys.found to track the
number of keys successfully read
2. Update rocksdb.memtable.hit/miss in DBImpl::MultiGet(). It was being done in
DBImpl::GetImpl(), but not MultiGet

Test Plan:
1. make check
2. ./db_bench --benchmarks="filluniquerandom,stats" --statistics -num 1000000 -writes 100000 &&
./db_bench --benchmarks="multireadrandom,stats" --statistics --use_existing_db -num 1000000
rocksdb.number.multiget.keys.read COUNT : 1000000
rocksdb.number.multiget.keys.found COUNT : 99371