### PR TITLE
Improve db_stress with transactions

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -17,7 +17,8 @@ import argparse
 #       simple_default_params < blackbox|whitebox_simple_default_params < args
 
 default_params = {
-    "acquire_snapshot_one_in": 10000,
+    "acquire_snapshot_one_in": 10,
+    "use_txn": 1,
     "block_size": 16384,
     "cache_size": 1048576,
     "use_clock_cache": "false",
@@ -86,6 +87,7 @@ whitebox_default_params = {
 
 simple_default_params = {
     "block_size": 16384,
+    "use_txn": 1,
     "cache_size": 1048576,
     "use_clock_cache": "false",
     "column_families": 1,
@@ -140,6 +142,8 @@ def finalize_and_sanitize(src_params):
     dest_params = dict([(k,  v() if callable(v) else v)
                         for (k, v) in src_params.items()])
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
+        dest_params["memtablerep"] = "skip_list"
+    if dest_params.get("use_txn", 1) == 1:
         dest_params["memtablerep"] = "skip_list"
     return dest_params
 
@@ -347,6 +351,7 @@ def whitebox_crash_main(args):
 
         if (errorcount > 0):
             print "TEST FAILED. Output has 'error'!!!\n"
+            print stdoutdata
             sys.exit(2)
         if (stdoutdata.find('fail') >= 0):
             print "TEST FAILED. Output has 'fail'!!!\n"

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -351,7 +351,6 @@ def whitebox_crash_main(args):
 
         if (errorcount > 0):
             print "TEST FAILED. Output has 'error'!!!\n"
-            print stdoutdata
             sys.exit(2)
         if (stdoutdata.find('fail') >= 0):
             print "TEST FAILED. Output has 'fail'!!!\n"

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -17,8 +17,7 @@ import argparse
 #       simple_default_params < blackbox|whitebox_simple_default_params < args
 
 default_params = {
-    "acquire_snapshot_one_in": 10,
-    "use_txn": 1,
+    "acquire_snapshot_one_in": 10000,
     "block_size": 16384,
     "cache_size": 1048576,
     "use_clock_cache": "false",
@@ -87,7 +86,6 @@ whitebox_default_params = {
 
 simple_default_params = {
     "block_size": 16384,
-    "use_txn": 1,
     "cache_size": 1048576,
     "use_clock_cache": "false",
     "column_families": 1,
@@ -142,8 +140,6 @@ def finalize_and_sanitize(src_params):
     dest_params = dict([(k,  v() if callable(v) else v)
                         for (k, v) in src_params.items()])
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
-        dest_params["memtablerep"] = "skip_list"
-    if dest_params.get("use_txn", 1) == 1:
         dest_params["memtablerep"] = "skip_list"
     return dest_params
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2008,6 +2008,8 @@ class StressTest {
                 if (s.ok()) {
                   s = CommitTxn(txn);
                 }
+                else printf("Name: %s Status: %s\n", (txn)->GetName().c_str(),
+                   s.ToString().c_str());
               }
 #endif
             }
@@ -2023,6 +2025,8 @@ class StressTest {
                 if (s.ok()) {
                   s = CommitTxn(txn);
                 }
+                else printf("Name: %s Status: %s\n", (txn)->GetName().c_str(),
+                   s.ToString().c_str());
               }
 #endif
             }
@@ -2576,10 +2580,19 @@ class StressTest {
         Random rand(FLAGS_seed);
         for (auto txn: trans) {
           if (rand.OneIn(2)) {
-            txn->Commit();
+            s = txn->Commit();
+            assert(s.ok());
           } else {
-            txn->Rollback();
+            s = txn->Rollback();
+            assert(s.ok());
           }
+          delete txn;
+        }
+        trans.clear();
+        txn_db_->GetAllPreparedTransactions(&trans);
+        for (auto txn: trans) {
+          assert(0);
+          txn->Commit();
         }
 #endif
       }

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2011,8 +2011,6 @@ class StressTest {
                 if (s.ok()) {
                   s = CommitTxn(txn);
                 }
-                else printf("Name: %s Status: %s\n", (txn)->GetName().c_str(),
-                   s.ToString().c_str());
               }
 #endif
             }
@@ -2028,8 +2026,6 @@ class StressTest {
                 if (s.ok()) {
                   s = CommitTxn(txn);
                 }
-                else printf("Name: %s Status: %s\n", (txn)->GetName().c_str(),
-                   s.ToString().c_str());
               }
 #endif
             }
@@ -2581,7 +2577,7 @@ class StressTest {
         std::vector<Transaction*> trans;
         txn_db_->GetAllPreparedTransactions(&trans);
         Random rand(FLAGS_seed);
-        for (auto txn: trans) {
+        for (auto txn : trans) {
           if (rand.OneIn(2)) {
             s = txn->Commit();
             assert(s.ok());
@@ -2593,14 +2589,14 @@ class StressTest {
         }
         trans.clear();
         txn_db_->GetAllPreparedTransactions(&trans);
-        for (auto txn: trans) {
+        for (auto txn : trans) {
           assert(0);
           txn->Commit();
         }
 #endif
       }
       assert(!s.ok() || column_families_.size() ==
-                                static_cast<size_t>(FLAGS_column_families));
+                            static_cast<size_t>(FLAGS_column_families));
     } else {
 #ifndef ROCKSDB_LITE
       DBWithTTL* db_with_ttl;

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2589,10 +2589,7 @@ class StressTest {
         }
         trans.clear();
         txn_db_->GetAllPreparedTransactions(&trans);
-        for (auto txn : trans) {
-          assert(0);
-          txn->Commit();
-        }
+        assert(trans.size() == 0);
 #endif
       }
       assert(!s.ok() || column_families_.size() ==

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1912,6 +1912,9 @@ class StressTest {
              i == thread->snapshot_queue.front().first) {
         auto snap_state = thread->snapshot_queue.front().second;
         assert(snap_state.snapshot);
+        // Note: this is unsafe as the cf might be dropped concurrently. But it
+        // is ok since unclean cf drop is cunnrently not supported by write
+        // prepared transactions.
         Status s =
             AssertSame(db_, column_families_[snap_state.cf_at], snap_state);
         if (!s.ok()) {

--- a/util/duplicate_detector.h
+++ b/util/duplicate_detector.h
@@ -5,6 +5,12 @@
 
 #pragma once
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
 #include "util/set_comparator.h"
 
 namespace rocksdb {
@@ -41,7 +47,23 @@ class DuplicateDetector {
   using CFKeys = std::set<Slice, SetComparator>;
   std::map<uint32_t, CFKeys> keys_;
   void InitWithComp(const uint32_t cf) {
-    auto cmp = db_->GetColumnFamilyHandle(cf)->GetComparator();
+    auto h = db_->GetColumnFamilyHandle(cf);
+    if (!h) {
+      // TODO(myabandeh): This is not a concern in MyRocks as drop cf is not
+      // implemented yet. When it does, we should return proper error instead
+      // of throwing exception.
+      ROCKS_LOG_FATAL(
+          db_->immutable_db_options().info_log,
+          "Recovering an entry from the dropped column family %" PRIu32
+          ". WAL must must have been emptied before dropping the column "
+          "family");
+      throw std::runtime_error(
+          "Recovering an entry from the dropped column family %" PRIu32
+          ". WAL must must have been flushed before dropping the column "
+          "family");
+      return;
+    }
+    auto cmp = h->GetComparator();
     keys_[cf] = CFKeys(SetComparator(cmp));
   }
 };

--- a/util/duplicate_detector.h
+++ b/util/duplicate_detector.h
@@ -57,10 +57,12 @@ class DuplicateDetector {
           "Recovering an entry from the dropped column family %" PRIu32
           ". WAL must must have been emptied before dropping the column "
           "family");
+#ifndef ROCKSDB_LITE
       throw std::runtime_error(
           "Recovering an entry from the dropped column family %" PRIu32
           ". WAL must must have been flushed before dropping the column "
           "family");
+#endif
       return;
     }
     auto cmp = h->GetComparator();


### PR DESCRIPTION
db_stress was already capable running transactions by setting use_txn. Running it under stress showed a couple of problems fixed in this patch.
- The uncommitted transaction must be either rolled back or commit after recovery.
- Current implementation of WritePrepared transaction cannot handle cf drop before crash. Clarified that in the comments and added safety checks. When running with use_txn, clear_column_family_one_in must be set to 0.