### PR TITLE
Propagate fill_cache config to partitioned index iterator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1027,6 +1027,9 @@ librocksdb_env_basic_test.a: env/env_basic_test.o $(LIBOBJECTS) $(TESTHARNESS)
 db_bench: tools/db_bench.o $(BENCHTOOLOBJECTS)
 	$(AM_LINK)
 
+iter_error: iter_error.o $(BENCHTOOLOBJECTS)
+	$(AM_LINK)
+
 cache_bench: cache/cache_bench.o $(LIBOBJECTS) $(TESTUTIL)
 	$(AM_LINK)
 

--- a/Makefile
+++ b/Makefile
@@ -1027,9 +1027,6 @@ librocksdb_env_basic_test.a: env/env_basic_test.o $(LIBOBJECTS) $(TESTHARNESS)
 db_bench: tools/db_bench.o $(BENCHTOOLOBJECTS)
 	$(AM_LINK)
 
-iter_error: iter_error.o $(BENCHTOOLOBJECTS)
-	$(AM_LINK)
-
 cache_bench: cache/cache_bench.o $(LIBOBJECTS) $(TESTUTIL)
 	$(AM_LINK)
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1033,10 +1033,11 @@ struct ReadOptions {
   // Default: true
   bool verify_checksums;
 
-  // Should the "data block"/"index block"/"filter block" read for this
-  // iteration be cached in memory?
+  // Should the "data block"/"index block"" read for this iteration be placed in
+  // block cache? 
   // Callers may wish to set this field to false for bulk scans.
-  // Default: true
+  // This would help not to the change eviction order of existing items in the
+  // block cache. Default: true
   bool fill_cache;
 
   // Specify to create a tailing iterator -- a special iterator that has a

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1034,7 +1034,7 @@ struct ReadOptions {
   bool verify_checksums;
 
   // Should the "data block"/"index block"" read for this iteration be placed in
-  // block cache? 
+  // block cache?
   // Callers may wish to set this field to false for bulk scans.
   // This would help not to the change eviction order of existing items in the
   // block cache. Default: true

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -208,7 +208,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
 
   // return a two-level iterator: first level is on the partition index
   virtual InternalIterator* NewIterator(BlockIter* /*iter*/ = nullptr,
-                                        bool /*dont_care*/ = true) override {
+                                        bool /*dont_care*/ = true, bool fill_cache = true) override {
     // Filters are already checked before seeking the index
     if (!partition_map_.empty()) {
       return NewTwoLevelIterator(
@@ -217,7 +217,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
           index_block_->NewIterator(icomparator_, nullptr, true));
     } else {
       auto ro = ReadOptions();
-      ro.fill_cache = false;
+      ro.fill_cache = fill_cache;
       return new BlockBasedTableIterator(
           table_, ro, *icomparator_,
           index_block_->NewIterator(icomparator_, nullptr, true), false);
@@ -367,7 +367,7 @@ class BinarySearchIndexReader : public IndexReader {
   }
 
   virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                        bool /*dont_care*/ = true) override {
+                                        bool /*dont_care*/ = true, bool /*dont_care*/ = true) override {
     return index_block_->NewIterator(icomparator_, iter, true);
   }
 
@@ -477,7 +477,7 @@ class HashIndexReader : public IndexReader {
   }
 
   virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                        bool total_order_seek = true) override {
+                                        bool total_order_seek = true, bool /*dont_care*/ = true) override {
     return index_block_->NewIterator(icomparator_, iter, total_order_seek);
   }
 
@@ -1369,12 +1369,13 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
   // index reader has already been pre-populated.
   if (rep_->index_reader) {
     return rep_->index_reader->NewIterator(
-        input_iter, read_options.total_order_seek);
+        input_iter, read_options.total_order_seek, read_options.fill_cache);
   }
   // we have a pinned index block
   if (rep_->index_entry.IsSet()) {
     return rep_->index_entry.value->NewIterator(input_iter,
-                                                read_options.total_order_seek);
+                                                read_options.total_order_seek,
+                                                read_options.fill_cache);
   }
 
   PERF_TIMER_GUARD(read_index_block_nanos);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -268,7 +268,6 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     // After prefetch, read the partitions one by one
     biter.SeekToFirst();
     auto ro = ReadOptions();
-    //ro.fill_cache = false;
     Cache* block_cache = rep->table_options.block_cache.get();
     for (; biter.Valid(); biter.Next()) {
       input = biter.value();
@@ -1329,9 +1328,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   } else {
     filter =
         ReadFilter(prefetch_buffer, filter_blk_handle, is_a_filter_partition);
-    const bool fill_cache = true;
-    //const bool fill_cache = false;
-    if (filter != nullptr && fill_cache) {
+    if (filter != nullptr) {
       assert(filter->size() > 0);
       Status s = block_cache->Insert(
           key, filter, filter->size(), &DeleteCachedFilterEntry, &cache_handle,
@@ -1563,8 +1560,8 @@ BlockIter* BlockBasedTable::NewDataBlockIterator(
                                   cache_handle);
           }
         } else {
-         //delete block.value;
-         //block.value = nullptr;
+          delete block.value;
+          block.value = nullptr;
         }
       }
       iter->RegisterCleanup(&DeleteHeldResource<Block>, block.value, nullptr);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -208,7 +208,8 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
 
   // return a two-level iterator: first level is on the partition index
   virtual InternalIterator* NewIterator(BlockIter* /*iter*/ = nullptr,
-                                        bool /*dont_care*/ = true, bool fill_cache = true) override {
+                                        bool /*dont_care*/ = true,
+                                        bool fill_cache = true) override {
     // Filters are already checked before seeking the index
     if (!partition_map_.empty()) {
       return NewTwoLevelIterator(
@@ -366,7 +367,8 @@ class BinarySearchIndexReader : public IndexReader {
   }
 
   virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                        bool /*dont_care*/ = true, bool /*dont_care*/ = true) override {
+                                        bool /*dont_care*/ = true,
+                                        bool /*dont_care*/ = true) override {
     return index_block_->NewIterator(icomparator_, iter, true);
   }
 
@@ -476,7 +478,8 @@ class HashIndexReader : public IndexReader {
   }
 
   virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                        bool total_order_seek = true, bool /*dont_care*/ = true) override {
+                                        bool total_order_seek = true,
+                                        bool /*dont_care*/ = true) override {
     return index_block_->NewIterator(icomparator_, iter, total_order_seek);
   }
 
@@ -1370,9 +1373,8 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
   }
   // we have a pinned index block
   if (rep_->index_entry.IsSet()) {
-    return rep_->index_entry.value->NewIterator(input_iter,
-                                                read_options.total_order_seek,
-                                                read_options.fill_cache);
+    return rep_->index_entry.value->NewIterator(
+        input_iter, read_options.total_order_seek, read_options.fill_cache);
   }
 
   PERF_TIMER_GUARD(read_index_block_nanos);

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -167,7 +167,7 @@ class BlockBasedTable : public TableReader {
     // a different object then iter and the callee has the ownership of the
     // returned object.
     virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                          bool total_order_seek = true) = 0;
+                                          bool total_order_seek = true, bool fill_cache = true) = 0;
 
     // The size of the index.
     virtual size_t size() const = 0;

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -167,7 +167,8 @@ class BlockBasedTable : public TableReader {
     // a different object then iter and the callee has the ownership of the
     // returned object.
     virtual InternalIterator* NewIterator(BlockIter* iter = nullptr,
-                                          bool total_order_seek = true, bool fill_cache = true) = 0;
+                                          bool total_order_seek = true,
+                                          bool fill_cache = true) = 0;
 
     // The size of the index.
     virtual size_t size() const = 0;


### PR DESCRIPTION
Currently the partitioned index iterator creates a new ReadOptions which ignores the fill_cache config set to ReadOptions passed by the user. The patch propagates fill_cache from the user's ReadOptions to that of partition index iterator.
Also it clarifies the contract of fill_cache that i) it does not apply to filters, ii) it still charges block cache for the size of the data block, it still pin the block if it is already in the block cache.