### PR TITLE
fix compilation error: implicit conversion loses integer precision

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2595,7 +2595,7 @@ class StressTest {
         // after a crash, rollback to commit recovered transactions
         std::vector<Transaction*> trans;
         txn_db_->GetAllPreparedTransactions(&trans);
-        Random rand(FLAGS_seed);
+        Random rand(static_cast<uint32_t>(FLAGS_seed));
         for (auto txn : trans) {
           if (rand.OneIn(2)) {
             s = txn->Commit();


### PR DESCRIPTION
Fix compilation error with clang:
> tools/db_stress.cc:2598:21: error: implicit conversion loses integer precision: 'gflags::uint64' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
        Random rand(FLAGS_seed);
               ~~~~ ^~~~~~~~~~

Test plan: 
>  USE_CLANG=1 make -j1 release