### PR TITLE
Simplify some code in flush code path.

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1123,7 +1123,6 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     // SwitchMemtable() will release and reacquire mutex during execution
     s = SwitchMemtable(cfd, &context, flush_reason);
     flush_memtable_id = cfd->imm()->GetLatestMemTableID();
-    cfd->imm()->FlushRequested();
 
     if (!writes_stopped) {
       write_thread_.ExitUnbatched(&w);

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1121,18 +1121,13 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     }
 
     // SwitchMemtable() will release and reacquire mutex during execution
-    s = SwitchMemtable(cfd, &context);
+    s = SwitchMemtable(cfd, &context, flush_reason);
     flush_memtable_id = cfd->imm()->GetLatestMemTableID();
+    cfd->imm()->FlushRequested();
 
     if (!writes_stopped) {
       write_thread_.ExitUnbatched(&w);
     }
-
-    cfd->imm()->FlushRequested();
-
-    // schedule flush
-    SchedulePendingFlush(cfd, flush_reason);
-    MaybeScheduleFlushOrCompaction();
   }
 
   if (s.ok() && flush_options.wait) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1054,7 +1054,6 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
       if (!status.ok()) {
         break;
       }
-      cfd->imm()->FlushRequested();
       SchedulePendingFlush(cfd, FlushReason::kWriteBufferManager);
     }
   }
@@ -1101,7 +1100,6 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
     status = SwitchMemtable(cfd_picked, write_context,
                             FlushReason::kWriteBufferFull);
     if (status.ok()) {
-      cfd_picked->imm()->FlushRequested();
       SchedulePendingFlush(cfd_picked, FlushReason::kWriteBufferFull);
       MaybeScheduleFlushOrCompaction();
     }
@@ -1397,6 +1395,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   cfd->imm()->Add(cfd->mem(), &context->memtables_to_free_);
   new_mem->Ref();
   cfd->SetMemtable(new_mem);
+  cfd->imm()->FlushRequested();
   InstallSuperVersionAndScheduleWork(cfd, &context->superversion_context,
                                      mutable_cf_options, flush_reason);
   if (two_write_queues_) {


### PR DESCRIPTION
Since `SwitchMemtable` calls `InstallSuperVersionAndScheduleWork` which calls
`SchedulePendingFlush`, `SchedulePendingCompaction` and
`MaybeScheduleFlushOrCompaction`. It does not need to call these functions after
`SwitchMemtable` returns.
I also noticed that, in the original code, `SwitchMemtable` is called with `flush_reason=kOther`. It looks like the reason is `kManual` here.

Hope this fix works, simplifying the flush code path.

@ajkr could you PTAL once the tests pass? Thanks!