### PR TITLE
initialize the first wal log with manual_wal_flush

### DIFF
--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1090,7 +1090,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
             new_log_number,
             new log::Writer(
                 std::move(file_writer), new_log_number,
-                impl->immutable_db_options_.recycle_log_file_num > 0));
+                impl->immutable_db_options_.recycle_log_file_num > 0,
+                impl->immutable_db_options_.manual_wal_flush));
       }
 
       // set column family handles

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -362,7 +362,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     }
   }
-  printf("%s\n", status.ToString().c_str());
 
   bool should_exit_batch_group = true;
   if (in_parallel_group) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -362,6 +362,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     }
   }
+  printf("%s\n", status.ToString().c_str());
 
   bool should_exit_batch_group = true;
   if (in_parallel_group) {

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -50,6 +50,10 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
   std::atomic<int> leader_count{0};
   std::vector<port::Thread> threads;
   mock_env->SetFilesystemActive(false);
+
+  WriteOptions write_options;
+  write_options.sync = true; // handle the situation where manual_wal_flush is true
+
   // Wait until all threads linked to write threads, to make sure
   // all threads join the same batch group.
   SyncPoint::GetInstance()->SetCallBack(
@@ -68,7 +72,7 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
     threads.push_back(port::Thread(
         [&](int index) {
           // All threads should fail.
-          ASSERT_FALSE(Put("key" + ToString(index), "value").ok());
+          ASSERT_FALSE(Put("key" + ToString(index), "value", write_options).ok());
         },
         i));
   }

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -124,6 +124,8 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.allow_ingest_behind;
   options.preserve_deletes =
       immutable_db_options.preserve_deletes;
+  options.two_write_queues = immutable_db_options.two_write_queues;
+  options.manual_wal_flush = immutable_db_options.manual_wal_flush;
 
   return options;
 }


### PR DESCRIPTION
Seems like the first wal log won't be initialized with `manual_wal_flush`.