### PR TITLE
Support lowering CPU priority of background threads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 * Introduce TTL for level compaction so that all files older than ttl go through the compaction process to get rid of old data.
 * TransactionDBOptions::write_policy can be configured to enable WritePrepared 2PC transactions. Read more about them in the wiki.
 * Add DB properties "rocksdb.block-cache-capacity", "rocksdb.block-cache-usage", "rocksdb.block-cache-pinned-usage" to show block cache usage.
+* Add `Env::LowerThreadPoolCPUPriority(Priority)` method, which lowers the CPU priority of background (esp. compaction) threads to minimize interference with foreground tasks.
 
 ### Bug Fixes
 * Fsync after writing global seq number to the ingestion file in ExternalSstFileIngestionJob.

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -815,6 +815,15 @@ class PosixEnv : public Env {
 #endif
   }
 
+  virtual void LowerThreadPoolCPUPriority(Priority pool = LOW) override {
+    assert(pool >= Priority::BOTTOM && pool <= Priority::HIGH);
+#ifdef OS_LINUX
+    thread_pools_[pool].LowerCPUPriority();
+#else
+    (void)pool;
+#endif
+  }
+
   virtual std::string TimeToString(uint64_t secondsSince1970) override {
     const time_t seconds = (time_t)secondsSince1970;
     struct tm t;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -397,6 +397,9 @@ class Env {
   // Lower IO priority for threads from the specified pool.
   virtual void LowerThreadPoolIOPriority(Priority /*pool*/ = LOW) {}
 
+  // Lower CPU priority for threads from the specified pool.
+  virtual void LowerThreadPoolCPUPriority(Priority /*pool*/ = LOW) {}
+
   // Converts seconds-since-Jan-01-1970 to a printable string
   virtual std::string TimeToString(uint64_t time) = 0;
 
@@ -1090,6 +1093,10 @@ class EnvWrapper : public Env {
 
   void LowerThreadPoolIOPriority(Priority pool = LOW) override {
     target_->LowerThreadPoolIOPriority(pool);
+  }
+
+  void LowerThreadPoolCPUPriority(Priority pool = LOW) override {
+    target_->LowerThreadPoolCPUPriority(pool);
   }
 
   std::string TimeToString(uint64_t time) override {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -992,6 +992,8 @@ DEFINE_int32(memtable_insert_with_hint_prefix_size, 0,
              "memtable insert with hint with the given prefix size.");
 DEFINE_bool(enable_io_prio, false, "Lower the background flush/compaction "
             "threads' IO priority");
+DEFINE_bool(enable_cpu_prio, false, "Lower the background flush/compaction "
+            "threads' CPU priority");
 DEFINE_bool(identity_as_first_hash, false, "the first hash function of cuckoo "
             "table becomes an identity function. This is only valid when key "
             "is 8 bytes");
@@ -3320,6 +3322,10 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     if (FLAGS_enable_io_prio) {
       FLAGS_env->LowerThreadPoolIOPriority(Env::LOW);
       FLAGS_env->LowerThreadPoolIOPriority(Env::HIGH);
+    }
+    if (FLAGS_enable_cpu_prio) {
+      FLAGS_env->LowerThreadPoolCPUPriority(Env::LOW);
+      FLAGS_env->LowerThreadPoolCPUPriority(Env::HIGH);
     }
     options.env = FLAGS_env;
 

--- a/util/threadpool_imp.h
+++ b/util/threadpool_imp.h
@@ -46,9 +46,13 @@ class ThreadPoolImpl : public ThreadPool {
   // start yet
   void WaitForJobsAndJoinAllThreads() override;
 
-  // Make threads to run at a lower kernel priority
+  // Make threads to run at a lower kernel IO priority
   // Currently only has effect on Linux
   void LowerIOPriority();
+
+  // Make threads to run at a lower kernel CPU priority
+  // Currently only has effect on Linux
+  void LowerCPUPriority();
 
   // Ensure there is at aleast num threads in the pool
   // but do not kill threads if there are more


### PR DESCRIPTION
Summary: Background activities like compaction can negatively affect
latency of higher-priority tasks like request processing. To avoid this,
rocksdb already lowers the IO priority of background threads on Linux
systems. While this takes care of typical IO-bound systems, it does not
help much when CPU (temporarily) becomes the bottleneck. This is
especially likely when using more expensive compression settings.

This patch adds an API to allow for lowering the CPU priority of
background threads, modeled on the IO priority API. Benchmarks (see
below) show significant latency and throughput improvements when CPU
bound. As a result, workloads with some CPU usage bursts should benefit
from lower latencies at a given utilization, or should be able to push
utilization higher at a given request latency target.

A useful side effect is that compaction CPU usage is now easily visible
in common tools, allowing for an easier estimation of the contribution
of compaction vs. request processing threads.

As with IO priority, the implementation is limited to Linux, degrading
to a no-op on other systems.

Test Plan:
`make check -j64`

## Benchmark: CPU bound, with & without background CPU priorities
Results: Best P99 of 10 runs each.
tl;dr: Mean latency -70-80%, P50 +18-22%, P99 -93-94%

Basic zstd compression:
```bash
./db_bench --compression_type=zstd --key_size 24 \
--max_background_jobs 16 --benchmarks readwhilewriting --num 3000000 \
--writes 300000 --threads 48 --histogram=1 --stats_interval=100000000 \
--enable_io_prio
```

Count: 192000000 Average: 32.3246  StdDev: 19.51
Percentiles: P50: 1.41 P75: 5.27 P99: 144.77 P99.9: 6835.64 P99.99: 24890.69

Basic zstd compression, low cpu priority:
```bash
./db_bench --compression_type=zstd --key_size 24 \
--max_background_jobs 16 --benchmarks readwhilewriting --num 3000000 \
--writes 300000 --threads 48 --histogram=1 --stats_interval=100000000 \
--enable_io_prio --enable_cpu_prio
```

Count: 192000000 Average: 6.5144  StdDev: 12.78
Percentiles: P50: 1.67 P75: 3.30 P99: 8.98 P99.9: 30.08 P99.99: 23877.45
Change vs. no CPU prio: Average -79.8%, P50 +18.4% , P99 -93.8%

Aggressive zstd compression:
```bash
./db_bench --compression_type=zstd --key_size 24 --max_background_jobs
16 --benchmarks readwhilewriting --num 3000000 --writes 300000 --threads
64 --histogram=1 --stats_interval=100000000 --enable_io_prio
--compression_level=6 --compression_max_dict_bytes=8
--compression_zstd_max_train_bytes=13
```

Count: 192000000 Average: 19.0564  StdDev: 18.53
Percentiles: P50: 1.37 P75: 2.92 P99: 129.14 P99.9: 526.23 P99.99: 20604.76

Aggressive zstd compression, low cpu priority:
```bash
./db_bench --compression_type=zstd --key_size 24 --max_background_jobs
16 --benchmarks readwhilewriting --num 3000000 --writes 300000 --threads
64 --histogram=1 --stats_interval=100000000 --enable_io_prio
--compression_level=6 --compression_max_dict_bytes=8
--compression_zstd_max_train_bytes=13 --enable_cpu_prio
```

Count: 192000000 Average: 6.1065  StdDev: 18.61
Percentiles: P50: 1.65 P75: 3.27 P99: 9.02 P99.9: 31.65 P99.99: 17240.06
Change vs. no CPU prio: Average -70.0%, P50 +21.9%, P99 -93.0%

Full benchmark log: https://gist.github.com/gwicke/3286cc87f09c81052d33e08a9d3d1cec