### PR TITLE
Skip deleted WALs during recovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,7 @@ set(SOURCES
         db/flush_scheduler.cc
         db/forward_iterator.cc
         db/internal_stats.cc
+        db/logs_with_prep_tracker.cc
         db/log_reader.cc
         db/log_writer.cc
         db/malloc_stats.cc

--- a/TARGETS
+++ b/TARGETS
@@ -103,6 +103,7 @@ cpp_library(
         "db/internal_stats.cc",
         "db/log_reader.cc",
         "db/log_writer.cc",
+        "db/logs_with_prep_tracker.cc",
         "db/malloc_stats.cc",
         "db/managed_iterator.cc",
         "db/memtable.cc",
@@ -660,11 +661,6 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
-        "obsolete_files_test",
-        "db/obsolete_files_test.cc",
-        "serial",
-    ],
-    [
         "dynamic_bloom_test",
         "util/dynamic_bloom_test.cc",
         "serial",
@@ -832,6 +828,11 @@ ROCKS_TESTS = [
     [
         "object_registry_test",
         "utilities/object_registry_test.cc",
+        "serial",
+    ],
+    [
+        "obsolete_files_test",
+        "db/obsolete_files_test.cc",
         "serial",
     ],
     [

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -558,7 +558,9 @@ uint64_t ColumnFamilyData::OldestLogToKeep() {
   auto current_log = GetLogNumber();
 
   if (allow_2pc_) {
-    auto imm_prep_log = imm()->GetMinLogContainingPrepSection();
+    autovector<MemTable*> empty_list;
+    auto imm_prep_log =
+        imm()->PrecomputeMinLogContainingPrepSection(empty_list);
     auto mem_prep_log = mem()->GetMinLogContainingPrepSection();
 
     if (imm_prep_log > 0 && imm_prep_log < current_log) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3019,5 +3019,4 @@ void DBImpl::WaitForIngestFile() {
 }
 
 #endif  // ROCKSDB_LITE
-
 }  // namespace rocksdb

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -183,7 +183,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       last_stats_dump_time_microsec_(0),
       next_job_id_(1),
       has_unpersisted_data_(false),
-      unable_to_flush_oldest_log_(false),
+      unable_to_release_oldest_log_(false),
       env_options_(BuildDBOptions(immutable_db_options_, mutable_db_options_)),
       env_options_for_compaction_(env_->OptimizeForCompactionTableWrite(
           env_options_, immutable_db_options_)),

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1433,13 +1433,14 @@ extern CompressionType GetCompressionFlush(
 // Return the earliest log file to keep after the memtable flush is
 // finalized.
 // `cfd_to_flush` is the column family whose memtable (specified in
-// `memtables_to_flush` will be flushed and thus will not depend on any WAL
+// `memtables_to_flush`) will be flushed and thus will not depend on any WAL
 // file. nullptr means no memtable is being flushed.
 // The function is only applicable to 2pc mode.
 extern uint64_t PrecomputeMinLogNumberToKeep(
-    ColumnFamilyData* cfd_to_flush, autovector<VersionEdit*> edit_list,
+    VersionSet* vset, ColumnFamilyData* cfd_to_flush,
+    autovector<VersionEdit*> edit_list,
     const autovector<MemTable*>& memtables_to_flush,
-    LogsWithPrepTracker* prep_tracker, VersionSet* vset);
+    LogsWithPrepTracker* prep_tracker);
 
 // `cfd_to_flush` is the column family whose memtable will be flushed and thus
 // will not depend on any WAL file. nullptr means no memtable is being flushed.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1434,10 +1434,10 @@ extern CompressionType GetCompressionFlush(
 // finalized.
 // `cfd_to_flush` is the column family whose memtable (specified in
 // `memtables_to_flush`) will be flushed and thus will not depend on any WAL
-// file. nullptr means no memtable is being flushed.
+// file.
 // The function is only applicable to 2pc mode.
 extern uint64_t PrecomputeMinLogNumberToKeep(
-    VersionSet* vset, ColumnFamilyData* cfd_to_flush,
+    VersionSet* vset, const ColumnFamilyData& cfd_to_flush,
     autovector<VersionEdit*> edit_list,
     const autovector<MemTable*>& memtables_to_flush,
     LogsWithPrepTracker* prep_tracker);
@@ -1446,7 +1446,7 @@ extern uint64_t PrecomputeMinLogNumberToKeep(
 // will not depend on any WAL file. nullptr means no memtable is being flushed.
 // The function is only applicable to 2pc mode.
 extern uint64_t FindMinPrepLogReferencedByMemTable(
-    VersionSet* vset, ColumnFamilyData* cfd_to_flush,
+    VersionSet* vset, const ColumnFamilyData* cfd_to_flush,
     const autovector<MemTable*>& memtables_to_flush);
 
 // Fix user-supplied options to be reasonable

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -160,7 +160,7 @@ Status DBImpl::FlushMemTableToOutputFile(
   // and EventListener callback will be called when the db_mutex
   // is unlocked by the current thread.
   if (s.ok()) {
-    s = flush_job.Run(&file_meta);
+    s = flush_job.Run(&logs_with_prep_tracker_, &file_meta);
   } else {
     flush_job.Cancel();
   }

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -196,31 +196,9 @@ size_t DBImpl::TEST_LogsWithPrepSize() {
 }
 
 uint64_t DBImpl::TEST_FindMinPrepLogReferencedByMemTable() {
-  uint64_t min_log = 0;
-
-  // we must look through the memtables for two phase transactions
-  // that have been committed but not yet flushed
-  for (auto loop_cfd : *versions_->GetColumnFamilySet()) {
-    if (loop_cfd->IsDropped()) {
-      continue;
-    }
-
-    autovector<MemTable*> empty_list;
-    auto log =
-        loop_cfd->imm()->PrecomputeMinLogContainingPrepSection(empty_list);
-
-    if (log > 0 && (min_log == 0 || log < min_log)) {
-      min_log = log;
-    }
-
-    log = loop_cfd->mem()->GetMinLogContainingPrepSection();
-
-    if (log > 0 && (min_log == 0 || log < min_log)) {
-      min_log = log;
-    }
-  }
-
-  return min_log;
+  autovector<MemTable*> empty_list;
+  return FindMinPrepLogReferencedByMemTable(versions_.get(), nullptr,
+                                            empty_list);
 }
 
 Status DBImpl::TEST_GetLatestMutableCFOptions(

--- a/db/db_impl_files.cc
+++ b/db/db_impl_files.cc
@@ -539,9 +539,10 @@ uint64_t FindMinPrepLogReferencedByMemTable(
 }
 
 uint64_t PrecomputeMinLogNumberToKeep(
-    ColumnFamilyData* cfd_to_flush, autovector<VersionEdit*> edit_list,
+    VersionSet* vset, ColumnFamilyData* cfd_to_flush,
+    autovector<VersionEdit*> edit_list,
     const autovector<MemTable*>& memtables_to_flush,
-    LogsWithPrepTracker* prep_tracker, VersionSet* vset) {
+    LogsWithPrepTracker* prep_tracker) {
   assert(prep_tracker != nullptr);
   // Calculate updated min_log_number_to_keep
   // Since the function should only be called in 2pc mode, log number in
@@ -556,7 +557,7 @@ uint64_t PrecomputeMinLogNumberToKeep(
   if (cf_min_log_number_to_keep == 0) {
     // No version edit contains information on log number. The log number
     // should stay the same as it is.
-    cf_min_log_number_to_keep = cfd_to_flush->GetLogNumber();
+    cf_min_log_number_to_keep = vset->MinLogNumberWithUnflushedData();
   }
 
   uint64_t min_log_number_to_keep =

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -532,6 +532,13 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
   bool flushed = false;
   uint64_t corrupted_log_number = kMaxSequenceNumber;
   for (auto log_number : log_numbers) {
+    if (log_number < versions_->latest_min_log_number_to_keep()) {
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "Skipping log #%" PRIu64
+                     " since it is older than min log to keep #%" PRIu64,
+                     log_number, versions_->latest_min_log_number_to_keep());
+      continue;
+    }
     // The previous incarnation may not have written any MANIFEST
     // records after allocating this log number.  So we manually
     // update the file number allocation counter in VersionSet.

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -532,11 +532,11 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
   bool flushed = false;
   uint64_t corrupted_log_number = kMaxSequenceNumber;
   for (auto log_number : log_numbers) {
-    if (log_number < versions_->latest_min_log_number_to_keep()) {
+    if (log_number < versions_->min_log_number_to_keep_2pc()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Skipping log #%" PRIu64
                      " since it is older than min log to keep #%" PRIu64,
-                     log_number, versions_->latest_min_log_number_to_keep());
+                     log_number, versions_->min_log_number_to_keep_2pc());
       continue;
     }
     // The previous incarnation may not have written any MANIFEST

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1033,7 +1033,8 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
   }
 
   auto oldest_alive_log = alive_log_files_.begin()->number;
-  auto oldest_log_with_uncommited_prep = FindMinLogContainingOutstandingPrep();
+  auto oldest_log_with_uncommited_prep =
+      logs_with_prep_tracker_.FindMinLogContainingOutstandingPrep();
 
   if (allow_2pc() &&
       oldest_log_with_uncommited_prep > 0 &&

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1033,29 +1033,30 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
   }
 
   auto oldest_alive_log = alive_log_files_.begin()->number;
-  bool flush_will_release_oldest_log = false;
+  bool flush_wont_release_oldest_log = false;
   if (allow_2pc()) {
     auto oldest_log_with_uncommited_prep =
         logs_with_prep_tracker_.FindMinLogContainingOutstandingPrep();
 
+    assert(oldest_log_with_uncommited_prep == 0 ||
+           oldest_log_with_uncommited_prep >= oldest_alive_log);
     if (oldest_log_with_uncommited_prep > 0 &&
-        oldest_log_with_uncommited_prep <= oldest_alive_log) {
+        oldest_log_with_uncommited_prep == oldest_alive_log) {
       if (unable_to_release_oldest_log_) {
         // we already attempted to flush all column families dependent on
-        // the oldest alive log but the log still contained uncommited transactions.
-        // the oldest alive log STILL contains uncommited transaction so there
-        // is still nothing that we can do.
+        // the oldest alive log but the log still contained uncommited
+        // transactions so there is still nothing that we can do.
         return status;
       } else {
         ROCKS_LOG_WARN(
             immutable_db_options_.info_log,
             "Unable to release oldest log due to uncommited transaction");
         unable_to_release_oldest_log_ = true;
-        flush_will_release_oldest_log = true;
+        flush_wont_release_oldest_log = true;
       }
     }
   }
-  if (!flush_will_release_oldest_log) {
+  if (!flush_wont_release_oldest_log) {
     // we only mark this log as getting flushed if we have successfully
     // flushed all data in this log. If this log contains outstanding prepared
     // transactions then we cannot flush this log until those transactions are commited.

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -451,8 +451,9 @@ class SpecialEnv : public EnvWrapper {
     return s;
   }
 
-  Status NewSequentialFile(const std::string& f, unique_ptr<SequentialFile>* r,
-                           const EnvOptions& soptions) override {
+  virtual Status NewSequentialFile(const std::string& f,
+                                   unique_ptr<SequentialFile>* r,
+                                   const EnvOptions& soptions) override {
     class CountingFile : public SequentialFile {
      public:
       CountingFile(unique_ptr<SequentialFile>&& target,

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1413,8 +1413,12 @@ TEST_F(ExternalSSTFileTest, AddFileTrivialMoveBug) {
         // fit in L3 but will overlap with compaction so will be added
         // to L2 but a compaction will trivially move it to L3
         // and break LSM consistency
-        ASSERT_OK(dbfull()->SetOptions({{"max_bytes_for_level_base", "1"}}));
-        ASSERT_OK(GenerateAndAddExternalFile(options, {15, 16}, 7));
+        static std::atomic<bool> called = {false};
+        if (!called) {
+          called = true;
+          ASSERT_OK(dbfull()->SetOptions({{"max_bytes_for_level_base", "1"}}));
+          ASSERT_OK(GenerateAndAddExternalFile(options, {15, 16}, 7));
+        }
       });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -185,7 +185,8 @@ void FlushJob::PickMemTable() {
   base_->Ref();  // it is likely that we do not need this reference
 }
 
-Status FlushJob::Run(FileMetaData* file_meta) {
+Status FlushJob::Run(LogsWithPrepTracker* prep_tracker,
+                     FileMetaData* file_meta) {
   db_mutex_->AssertHeld();
   assert(pick_memtable_called);
   AutoThreadOperationStageUpdater stage_run(
@@ -226,7 +227,7 @@ Status FlushJob::Run(FileMetaData* file_meta) {
     TEST_SYNC_POINT("FlushJob::InstallResults");
     // Replace immutable memtable with the generated Table
     s = cfd_->imm()->InstallMemtableFlushResults(
-        cfd_, mutable_cf_options_, mems_, versions_, db_mutex_,
+        cfd_, mutable_cf_options_, mems_, prep_tracker, versions_, db_mutex_,
         meta_.fd.GetNumber(), &job_context_->memtables_to_free, db_directory_,
         log_buffer_);
   }

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -22,6 +22,7 @@
 #include "db/internal_stats.h"
 #include "db/job_context.h"
 #include "db/log_writer.h"
+#include "db/logs_with_prep_tracker.h"
 #include "db/memtable_list.h"
 #include "db/snapshot_impl.h"
 #include "db/version_edit.h"
@@ -42,6 +43,7 @@
 
 namespace rocksdb {
 
+class DBImpl;
 class MemTable;
 class SnapshotChecker;
 class TableCache;
@@ -71,7 +73,8 @@ class FlushJob {
   // Require db_mutex held.
   // Once PickMemTable() is called, either Run() or Cancel() has to be called.
   void PickMemTable();
-  Status Run(FileMetaData* file_meta = nullptr);
+  Status Run(LogsWithPrepTracker* prep_tracker = nullptr,
+             FileMetaData* file_meta = nullptr);
   void Cancel();
   TableProperties GetTableProperties() const { return table_properties_; }
 

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -150,7 +150,7 @@ TEST_F(FlushJobTest, NonEmpty) {
   FileMetaData fd;
   mutex_.Lock();
   flush_job.PickMemTable();
-  ASSERT_OK(flush_job.Run(&fd));
+  ASSERT_OK(flush_job.Run(nullptr, &fd));
   mutex_.Unlock();
   db_options_.statistics->histogramData(FLUSH_TIME, &hist);
   ASSERT_GT(hist.average, 0.0);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -19,8 +19,8 @@ class ColumnFamilyData;
 
 namespace rocksdb {
 
-class MemTableList;
 class DBImpl;
+class MemTableList;
 
 // Config for retrieving a property's value.
 struct DBPropertyInfo {

--- a/db/logs_with_prep_tracker.cc
+++ b/db/logs_with_prep_tracker.cc
@@ -5,12 +5,14 @@
 //
 #include "db/logs_with_prep_tracker.h"
 
+#include "port/likely.h"
+
 namespace rocksdb {
 void LogsWithPrepTracker::MarkLogAsHavingPrepSectionFlushed(uint64_t log) {
   assert(log != 0);
   std::lock_guard<std::mutex> lock(prepared_section_completed_mutex_);
   auto it = prepared_section_completed_.find(log);
-  if (it == prepared_section_completed_.end()) {
+  if (UNLIKELY(it == prepared_section_completed_.end())) {
     prepared_section_completed_[log] = 1;
   } else {
     it->second += 1;

--- a/db/logs_with_prep_tracker.cc
+++ b/db/logs_with_prep_tracker.cc
@@ -1,0 +1,65 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+#include "db/logs_with_prep_tracker.h"
+
+namespace rocksdb {
+void LogsWithPrepTracker::MarkLogAsHavingPrepSectionFlushed(uint64_t log) {
+  assert(log != 0);
+  std::lock_guard<std::mutex> lock(prepared_section_completed_mutex_);
+  auto it = prepared_section_completed_.find(log);
+  if (it == prepared_section_completed_.end()) {
+    prepared_section_completed_[log] = 1;
+  } else {
+    it->second += 1;
+  }
+}
+
+void LogsWithPrepTracker::MarkLogAsContainingPrepSection(uint64_t log) {
+  assert(log != 0);
+  std::lock_guard<std::mutex> lock(logs_with_prep_mutex_);
+
+  auto rit = logs_with_prep_.rbegin();
+  bool updated = false;
+  // Most probably the last log is the one that is being marked for
+  // having a prepare section; so search from the end.
+  for (; rit != logs_with_prep_.rend() && rit->log >= log; ++rit) {
+    if (rit->log == log) {
+      rit->cnt++;
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    // We are either at the start, or at a position with rit->log < log
+    logs_with_prep_.insert(rit.base(), {log, 1});
+  }
+}
+
+uint64_t LogsWithPrepTracker::FindMinLogContainingOutstandingPrep() {
+  std::lock_guard<std::mutex> lock(logs_with_prep_mutex_);
+  auto it = logs_with_prep_.begin();
+  // start with the smallest log
+  for (; it != logs_with_prep_.end();) {
+    auto min_log = it->log;
+    {
+      std::lock_guard<std::mutex> lock2(prepared_section_completed_mutex_);
+      auto completed_it = prepared_section_completed_.find(min_log);
+      if (completed_it == prepared_section_completed_.end() ||
+          completed_it->second < it->cnt) {
+        return min_log;
+      }
+      assert(completed_it != prepared_section_completed_.end() &&
+             completed_it->second == it->cnt);
+      prepared_section_completed_.erase(completed_it);
+    }
+    // erase from beginning in vector is not efficient but this function is not
+    // on the fast path.
+    it = logs_with_prep_.erase(it);
+  }
+  // no such log found
+  return 0;
+}
+}  // namespace rocksdb

--- a/db/logs_with_prep_tracker.h
+++ b/db/logs_with_prep_tracker.h
@@ -14,10 +14,14 @@
 
 namespace rocksdb {
 
+// This class is used to track the log files with outstanding prepare entries.
 class LogsWithPrepTracker {
  public:
+  // Called when a transaction prepared in `log` has been committed or aborted.
   void MarkLogAsHavingPrepSectionFlushed(uint64_t log);
+  // Called when a transaction is prepared in `log`.
   void MarkLogAsContainingPrepSection(uint64_t log);
+  // Return the earliest log file with outstanding prepare entries.
   uint64_t FindMinLogContainingOutstandingPrep();
   size_t TEST_PreparedSectionCompletedSize() {
     return prepared_section_completed_.size();

--- a/db/logs_with_prep_tracker.h
+++ b/db/logs_with_prep_tracker.h
@@ -28,7 +28,6 @@ class LogsWithPrepTracker {
   }
   size_t TEST_LogsWithPrepSize() { return logs_with_prep_.size(); }
 
-  
  private:
   // REQUIRES: logs_with_prep_mutex_ held
   //

--- a/db/logs_with_prep_tracker.h
+++ b/db/logs_with_prep_tracker.h
@@ -1,0 +1,58 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+#pragma once
+
+#include <stdint.h>
+#include <cassert>
+#include <cstdlib>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace rocksdb {
+
+class LogsWithPrepTracker {
+ public:
+  void MarkLogAsHavingPrepSectionFlushed(uint64_t log);
+  void MarkLogAsContainingPrepSection(uint64_t log);
+  uint64_t FindMinLogContainingOutstandingPrep();
+  size_t TEST_PreparedSectionCompletedSize() {
+    return prepared_section_completed_.size();
+  }
+  size_t TEST_LogsWithPrepSize() { return logs_with_prep_.size(); }
+
+  
+ private:
+  // REQUIRES: logs_with_prep_mutex_ held
+  //
+  // sorted list of log numbers still containing prepared data.
+  // this is used by FindObsoleteFiles to determine which
+  // flushed logs we must keep around because they still
+  // contain prepared data which has not been committed or rolled back
+  struct LogCnt {
+    uint64_t log;  // the log number
+    uint64_t cnt;  // number of prepared sections in the log
+  };
+  std::vector<LogCnt> logs_with_prep_;
+  std::mutex logs_with_prep_mutex_;
+
+  // REQUIRES: prepared_section_completed_mutex_ held
+  //
+  // to be used in conjunction with logs_with_prep_.
+  // once a transaction with data in log L is committed or rolled back
+  // rather than updating logs_with_prep_ directly we keep track of that
+  // in prepared_section_completed_ which maps LOG -> instance_count. This helps
+  // avoiding contention between a commit thread and the prepare threads.
+  //
+  // when trying to determine the minimum log still active we first
+  // consult logs_with_prep_. while that root value maps to
+  // an equal value in prepared_section_completed_ we erase the log from
+  // both logs_with_prep_ and prepared_section_completed_.
+  std::unordered_map<uint64_t, uint64_t> prepared_section_completed_;
+  std::mutex prepared_section_completed_mutex_;
+
+};
+}  // namespace rocksdb

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -387,7 +387,7 @@ Status MemTableList::InstallMemtableFlushResults(
         // We piggyback the information of  earliest log file to keep in the
         // manifest entry for the last file flushed.
         edit_list.back()->SetMinLogNumberToKeep(PrecomputeMinLogNumberToKeep(
-            vset, cfd, edit_list, memtables_to_flush, prep_tracker));
+            vset, *cfd, edit_list, memtables_to_flush, prep_tracker));
       }
 
       // this can release and reacquire the mutex.

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -387,7 +387,7 @@ Status MemTableList::InstallMemtableFlushResults(
         // We piggyback the information of  earliest log file to keep in the
         // manifest entry for the last file flushed.
         edit_list.back()->SetMinLogNumberToKeep(PrecomputeMinLogNumberToKeep(
-            cfd, edit_list, memtables_to_flush, prep_tracker, vset));
+            vset, cfd, edit_list, memtables_to_flush, prep_tracker));
       }
 
       // this can release and reacquire the mutex.

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -349,6 +349,8 @@ uint64_t FindMinPrepLogReferencedByMemTable(
   return min_log;
 }
 
+// Return the earliest log file to keep after the memtable flush is
+// finalized.
 uint64_t PrecomputeMinLogNumberToKeep(
     ColumnFamilyData* cfd, autovector<VersionEdit*> edit_list,
     const autovector<MemTable*>& memtables_to_flush,
@@ -463,6 +465,8 @@ Status MemTableList::InstallMemtableFlushResults(
     if (batch_count > 0) {
       if (vset->db_options()->allow_2pc) {
         assert(edit_list.size() > 0);
+        // We piggyback the information of  earliest log file to keep in the
+        // manifest entry for the last file flushed.
         edit_list.back()->SetMinLogNumberToKeep(PrecomputeMinLogNumberToKeep(
             cfd, edit_list, memtables_to_flush, prep_tracker, vset));
       }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "db/dbformat.h"
+#include "db/logs_with_prep_tracker.h"
 #include "db/memtable.h"
 #include "db/range_del_aggregator.h"
 #include "monitoring/instrumented_mutex.h"
@@ -210,9 +211,10 @@ class MemTableList {
   // Commit a successful flush in the manifest file
   Status InstallMemtableFlushResults(
       ColumnFamilyData* cfd, const MutableCFOptions& mutable_cf_options,
-      const autovector<MemTable*>& m, VersionSet* vset, InstrumentedMutex* mu,
-      uint64_t file_number, autovector<MemTable*>* to_delete,
-      Directory* db_directory, LogBuffer* log_buffer);
+      const autovector<MemTable*>& m, LogsWithPrepTracker* prep_tracker,
+      VersionSet* vset, InstrumentedMutex* mu, uint64_t file_number,
+      autovector<MemTable*>* to_delete, Directory* db_directory,
+      LogBuffer* log_buffer);
 
   // New memtables are inserted at the front of the list.
   // Takes ownership of the referenced held on *m by the caller of Add().
@@ -243,7 +245,8 @@ class MemTableList {
 
   size_t* current_memory_usage() { return &current_memory_usage_; }
 
-  uint64_t GetMinLogContainingPrepSection();
+  uint64_t PrecomputeMinLogContainingPrepSection(
+      const autovector<MemTable*>& memtables_to_flush);
 
   uint64_t GetEarliestMemTableID() const {
     auto& memlist = current_->memlist_;

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -245,6 +245,8 @@ class MemTableList {
 
   size_t* current_memory_usage() { return &current_memory_usage_; }
 
+  // Returns the min log containing the prep section after memtables listsed in
+  // `memtables_to_flush` are flushed and their status is persisted in manifest.
   uint64_t PrecomputeMinLogContainingPrepSection(
       const autovector<MemTable*>& memtables_to_flush);
 

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -82,10 +82,10 @@ class MemTableListTest : public testing::Test {
     // Create dummy mutex.
     InstrumentedMutex mutex;
     InstrumentedMutexLock l(&mutex);
-
-    return list->InstallMemtableFlushResults(cfd, mutable_cf_options, m,
-                                             &versions, &mutex, 1, to_delete,
-                                             nullptr, &log_buffer);
+    LogsWithPrepTracker dummy_prep_tracker;
+    return list->InstallMemtableFlushResults(
+        cfd, mutable_cf_options, m, &dummy_prep_tracker, &versions, &mutex, 1,
+        to_delete, nullptr, &log_buffer);
   }
 };
 

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -30,6 +30,7 @@ enum Tag {
   kNewFile = 7,
   // 8 was used for large value refs
   kPrevLogNumber = 9,
+  kMinLogNumberToKeep = 10,
 
   // these are new formats divergent from open source leveldb
   kNewFile2 = 100,
@@ -44,6 +45,11 @@ enum Tag {
 enum CustomTag {
   kTerminate = 1,  // The end of customized fields
   kNeedCompaction = 2,
+  // Since Manifest is not entirely currently forward-compatible, and the only
+  // forward-compatbile part is the CutsomtTag of kNewFile, we currently encode
+  // kMinLogNumberToKeep as part of a CustomTag as a hack. This should be
+  // removed when manifest becomes forward-comptabile.
+  kMinLogNumberToKeepHack = 3,
   kPathId = 65,
 };
 // If this bit for the custom tag is set, opening DB should fail if
@@ -63,12 +69,14 @@ void VersionEdit::Clear() {
   last_sequence_ = 0;
   next_file_number_ = 0;
   max_column_family_ = 0;
+  min_log_number_to_keep_ = 0;
   has_comparator_ = false;
   has_log_number_ = false;
   has_prev_log_number_ = false;
   has_next_file_number_ = false;
   has_last_sequence_ = false;
   has_max_column_family_ = false;
+  has_min_log_number_to_keep_ = false;
   deleted_files_.clear();
   new_files_.clear();
   column_family_ = 0;
@@ -97,19 +105,19 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
   if (has_max_column_family_) {
     PutVarint32Varint32(dst, kMaxColumnFamily, max_column_family_);
   }
-
   for (const auto& deleted : deleted_files_) {
     PutVarint32Varint32Varint64(dst, kDeletedFile, deleted.first /* level */,
                                 deleted.second /* file number */);
   }
 
+  bool min_log_num_written = false;
   for (size_t i = 0; i < new_files_.size(); i++) {
     const FileMetaData& f = new_files_[i].second;
     if (!f.smallest.Valid() || !f.largest.Valid()) {
       return false;
     }
     bool has_customized_fields = false;
-    if (f.marked_for_compaction) {
+    if (f.marked_for_compaction || has_min_log_number_to_keep_) {
       PutVarint32(dst, kNewFile4);
       has_customized_fields = true;
     } else if (f.fd.GetPathId() == 0) {
@@ -165,6 +173,13 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
         char p = static_cast<char>(1);
         PutLengthPrefixedSlice(dst, Slice(&p, 1));
       }
+      if (has_min_log_number_to_keep_ && !min_log_num_written) {
+        PutVarint32(dst, CustomTag::kMinLogNumberToKeepHack);
+        std::string varint_log_number;
+        PutFixed64(&varint_log_number, min_log_number_to_keep_);
+        PutLengthPrefixedSlice(dst, Slice(varint_log_number));
+        min_log_num_written = true;
+      }
       TEST_SYNC_POINT_CALLBACK("VersionEdit::EncodeTo:NewFile4:CustomizeFields",
                                dst);
 
@@ -218,6 +233,9 @@ const char* VersionEdit::DecodeNewFile4From(Slice* input) {
   uint64_t number;
   uint32_t path_id = 0;
   uint64_t file_size;
+  // Since this is the only forward-compatible part of the code, we hack new
+  // extension into this record. When we do, we set this boolean to distinguish
+  // the record from the normal NewFile records.
   if (GetLevel(input, &level, &msg) && GetVarint64(input, &number) &&
       GetVarint64(input, &file_size) && GetInternalKey(input, &f.smallest) &&
       GetInternalKey(input, &f.largest) &&
@@ -251,6 +269,14 @@ const char* VersionEdit::DecodeNewFile4From(Slice* input) {
             return "need_compaction field wrong size";
           }
           f.marked_for_compaction = (field[0] == 1);
+          break;
+        case kMinLogNumberToKeepHack:
+          // This is a hack to encode kMinLogNumberToKeep in a
+          // forward-compatbile fashion.
+          if (!GetFixed64(&field, &min_log_number_to_keep_)) {
+            return "deleted log number malformatted";
+          }
+          has_min_log_number_to_keep_ = true;
           break;
         default:
           if ((custom_tag & kCustomTagNonSafeIgnoreMask) != 0) {
@@ -328,6 +354,14 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
           has_max_column_family_ = true;
         } else {
           msg = "max column family";
+        }
+        break;
+
+      case kMinLogNumberToKeep:
+        if (GetVarint64(&input, &min_log_number_to_keep_)) {
+          has_min_log_number_to_keep_ = true;
+        } else {
+          msg = "min log number to kee";
         }
         break;
 
@@ -475,6 +509,10 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append("\n  NextFileNumber: ");
     AppendNumberTo(&r, next_file_number_);
   }
+  if (has_min_log_number_to_keep_) {
+    r.append("\n  MinLogNumberToKeep: ");
+    AppendNumberTo(&r, min_log_number_to_keep_);
+  }
   if (has_last_sequence_) {
     r.append("\n  LastSeq: ");
     AppendNumberTo(&r, last_sequence_);
@@ -581,6 +619,9 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
   }
   if (has_max_column_family_) {
     jw << "MaxColumnFamily" << max_column_family_;
+  }
+  if (has_min_log_number_to_keep_) {
+    jw << "MinLogNumberToKeep" << min_log_number_to_keep_;
   }
 
   jw.EndObject();

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -199,6 +199,14 @@ class VersionEdit {
     has_max_column_family_ = true;
     max_column_family_ = max_column_family;
   }
+  void SetMinLogNumberToKeep(uint64_t num) {
+    has_min_log_number_to_keep_ = true;
+    min_log_number_to_keep_ = num;
+  }
+
+  bool has_log_number() { return has_log_number_; }
+
+  uint64_t log_number() { return log_number_; }
 
   // Add the specified file at the specified number.
   // REQUIRES: This version has not been saved (see VersionSet::SaveTo)
@@ -285,6 +293,8 @@ class VersionEdit {
   uint64_t prev_log_number_;
   uint64_t next_file_number_;
   uint32_t max_column_family_;
+  // The most recent WAL log number that is deleted
+  uint64_t min_log_number_to_keep_;
   SequenceNumber last_sequence_;
   bool has_comparator_;
   bool has_log_number_;
@@ -292,6 +302,7 @@ class VersionEdit {
   bool has_next_file_number_;
   bool has_last_sequence_;
   bool has_max_column_family_;
+  bool has_min_log_number_to_keep_;
 
   DeletedFileSet deleted_files_;
   std::vector<std::pair<int, FileMetaData>> new_files_;

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -181,6 +181,16 @@ TEST_F(VersionEditTest, ColumnFamilyTest) {
   TestEncodeDecode(edit);
 }
 
+TEST_F(VersionEditTest, MinLogNumberToKeep) {
+  VersionEdit edit;
+  edit.SetMinLogNumberToKeep(13);
+  TestEncodeDecode(edit);
+
+  edit.Clear();
+  edit.SetMinLogNumberToKeep(23);
+  TestEncodeDecode(edit);
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3669,8 +3669,8 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
       }
 
       if (cfd != nullptr && edit.has_min_log_number_to_keep_ &&
-          edit.has_min_log_number_to_keep_ > latest_min_log_number_to_keep_) {
-        latest_min_log_number_to_keep_ = edit.has_min_log_number_to_keep_;
+          edit.min_log_number_to_keep_ > latest_min_log_number_to_keep_) {
+        latest_min_log_number_to_keep_ = edit.min_log_number_to_keep_;
       }
 
       if (edit.has_prev_log_number_) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2974,7 +2974,7 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
       }
       if (min_log_number_to_keep != 0) {
         // Should only be set in 2PC mode.
-        MarkMinLogNumberToKeep(min_log_number_to_keep);
+        MarkMinLogNumberToKeep2PC(min_log_number_to_keep);
       }
 
       AppendVersion(column_family_data, v);
@@ -3302,7 +3302,7 @@ Status VersionSet::Recover(
 
     // When reading DB generated using old release, min_log_number_to_keep=0.
     // All log files will be scanned for potential prepare entries.
-    MarkMinLogNumberToKeep(min_log_number_to_keep);
+    MarkMinLogNumberToKeep2PC(min_log_number_to_keep);
     MarkFileNumberUsed(previous_log_number);
     MarkFileNumberUsed(log_number);
   }
@@ -3379,8 +3379,7 @@ Status VersionSet::Recover(
         manifest_filename.c_str(), (unsigned long)manifest_file_number_,
         (unsigned long)next_file_number_.load(), (unsigned long)last_sequence_,
         (unsigned long)log_number, (unsigned long)prev_log_number_,
-        column_family_set_->GetMaxColumnFamily(),
-        latest_min_log_number_to_keep());
+        column_family_set_->GetMaxColumnFamily(), min_log_number_to_keep_2pc());
 
     for (auto cfd : *column_family_set_) {
       if (cfd->IsDropped()) {
@@ -3668,10 +3667,6 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
         cfd->SetLogNumber(edit.log_number_);
       }
 
-      if (cfd != nullptr && edit.has_min_log_number_to_keep_ &&
-          edit.min_log_number_to_keep_ > latest_min_log_number_to_keep_) {
-        latest_min_log_number_to_keep_ = edit.min_log_number_to_keep_;
-      }
 
       if (edit.has_prev_log_number_) {
         previous_log_number = edit.prev_log_number_;
@@ -3693,7 +3688,7 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
       }
 
       if (edit.has_min_log_number_to_keep_) {
-        MarkMinLogNumberToKeep(edit.min_log_number_to_keep_);
+        MarkMinLogNumberToKeep2PC(edit.min_log_number_to_keep_);
       }
     }
   }
@@ -3757,8 +3752,7 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
         "%" PRIu64 "\n",
         (unsigned long)next_file_number_.load(), (unsigned long)last_sequence,
         (unsigned long)previous_log_number,
-        column_family_set_->GetMaxColumnFamily(),
-        latest_min_log_number_to_keep());
+        column_family_set_->GetMaxColumnFamily(), min_log_number_to_keep_2pc());
   }
 
   return s;
@@ -3775,9 +3769,9 @@ void VersionSet::MarkFileNumberUsed(uint64_t number) {
 
 // Called only either from ::LogAndApply which is protected by mutex or during
 // recovery which is single-threaded.
-void VersionSet::MarkMinLogNumberToKeep(uint64_t number) {
-  if (latest_min_log_number_to_keep_.load(std::memory_order_relaxed) < number) {
-    latest_min_log_number_to_keep_.store(number, std::memory_order_relaxed);
+void VersionSet::MarkMinLogNumberToKeep2PC(uint64_t number) {
+  if (min_log_number_to_keep_2pc_.load(std::memory_order_relaxed) < number) {
+    min_log_number_to_keep_2pc_.store(number, std::memory_order_relaxed);
   }
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2663,16 +2663,16 @@ struct VersionSet::ManifestWriter {
 };
 
 VersionSet::VersionSet(const std::string& dbname,
-                       const ImmutableDBOptions* db_options,
+                       const ImmutableDBOptions* _db_options,
                        const EnvOptions& storage_options, Cache* table_cache,
                        WriteBufferManager* write_buffer_manager,
                        WriteController* write_controller)
     : column_family_set_(
-          new ColumnFamilySet(dbname, db_options, storage_options, table_cache,
+          new ColumnFamilySet(dbname, _db_options, storage_options, table_cache,
                               write_buffer_manager, write_controller)),
-      env_(db_options->env),
+      env_(_db_options->env),
       dbname_(dbname),
-      db_options_(db_options),
+      db_options_(_db_options),
       next_file_number_(2),
       manifest_file_number_(0),  // Filled by Recover()
       options_file_number_(0),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2957,16 +2957,26 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
       }
     } else {
       uint64_t max_log_number_in_batch  = 0;
+      uint64_t min_log_number_to_keep = 0;
       for (auto& e : batch_edits) {
         if (e->has_log_number_) {
           max_log_number_in_batch =
               std::max(max_log_number_in_batch, e->log_number_);
+        }
+        if (e->has_min_log_number_to_keep_) {
+          min_log_number_to_keep =
+              std::max(min_log_number_to_keep, e->min_log_number_to_keep_);
         }
       }
       if (max_log_number_in_batch != 0) {
         assert(column_family_data->GetLogNumber() <= max_log_number_in_batch);
         column_family_data->SetLogNumber(max_log_number_in_batch);
       }
+      if (min_log_number_to_keep != 0) {
+        // Should only be set in 2PC mode.
+        MarkMinLogNumberToKeep(min_log_number_to_keep);
+      }
+
       AppendVersion(column_family_data, v);
     }
 
@@ -3122,6 +3132,7 @@ Status VersionSet::Recover(
   uint64_t log_number = 0;
   uint64_t previous_log_number = 0;
   uint32_t max_column_family = 0;
+  uint64_t min_log_number_to_keep = 0;
   std::unordered_map<uint32_t, BaseReferencedVersionBuilder*> builders;
 
   // add default column family
@@ -3262,6 +3273,11 @@ Status VersionSet::Recover(
         max_column_family = edit.max_column_family_;
       }
 
+      if (edit.has_min_log_number_to_keep_) {
+        min_log_number_to_keep =
+            std::max(min_log_number_to_keep, edit.min_log_number_to_keep_);
+      }
+
       if (edit.has_last_sequence_) {
         last_sequence = edit.last_sequence_;
         have_last_sequence = true;
@@ -3284,6 +3300,9 @@ Status VersionSet::Recover(
 
     column_family_set_->UpdateMaxColumnFamily(max_column_family);
 
+    // When reading DB generated using old release, min_log_number_to_keep=0.
+    // All log files will be scanned for potential prepare entries.
+    MarkMinLogNumberToKeep(min_log_number_to_keep);
     MarkFileNumberUsed(previous_log_number);
     MarkFileNumberUsed(log_number);
   }
@@ -3355,11 +3374,13 @@ Status VersionSet::Recover(
         "manifest_file_number is %lu, next_file_number is %lu, "
         "last_sequence is %lu, log_number is %lu,"
         "prev_log_number is %lu,"
-        "max_column_family is %u\n",
+        "max_column_family is %u,"
+        "min_log_number_to_keep is %lu\n",
         manifest_filename.c_str(), (unsigned long)manifest_file_number_,
         (unsigned long)next_file_number_.load(), (unsigned long)last_sequence_,
         (unsigned long)log_number, (unsigned long)prev_log_number_,
-        column_family_set_->GetMaxColumnFamily());
+        column_family_set_->GetMaxColumnFamily(),
+        latest_min_log_number_to_keep());
 
     for (auto cfd : *column_family_set_) {
       if (cfd->IsDropped()) {
@@ -3647,6 +3668,11 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
         cfd->SetLogNumber(edit.log_number_);
       }
 
+      if (cfd != nullptr && edit.has_min_log_number_to_keep_ &&
+          edit.has_min_log_number_to_keep_ > latest_min_log_number_to_keep_) {
+        latest_min_log_number_to_keep_ = edit.has_min_log_number_to_keep_;
+      }
+
       if (edit.has_prev_log_number_) {
         previous_log_number = edit.prev_log_number_;
         have_prev_log_number = true;
@@ -3664,6 +3690,10 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
 
       if (edit.has_max_column_family_) {
         column_family_set_->UpdateMaxColumnFamily(edit.max_column_family_);
+      }
+
+      if (edit.has_min_log_number_to_keep_) {
+        MarkMinLogNumberToKeep(edit.min_log_number_to_keep_);
       }
     }
   }
@@ -3723,10 +3753,12 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
 
     printf(
         "next_file_number %lu last_sequence "
-        "%lu  prev_log_number %lu max_column_family %u\n",
+        "%lu  prev_log_number %lu max_column_family %u min_log_number_to_keep "
+        "%" PRIu64 "\n",
         (unsigned long)next_file_number_.load(), (unsigned long)last_sequence,
         (unsigned long)previous_log_number,
-        column_family_set_->GetMaxColumnFamily());
+        column_family_set_->GetMaxColumnFamily(),
+        latest_min_log_number_to_keep());
   }
 
   return s;
@@ -3738,6 +3770,14 @@ void VersionSet::MarkFileNumberUsed(uint64_t number) {
   // works because there can't be concurrent calls
   if (next_file_number_.load(std::memory_order_relaxed) <= number) {
     next_file_number_.store(number + 1, std::memory_order_relaxed);
+  }
+}
+
+// Called only either from ::LogAndApply which is protected by mutex or during
+// recovery which is single-threaded.
+void VersionSet::MarkMinLogNumberToKeep(uint64_t number) {
+  if (latest_min_log_number_to_keep_.load(std::memory_order_relaxed) < number) {
+    latest_min_log_number_to_keep_.store(number, std::memory_order_relaxed);
   }
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -872,7 +872,7 @@ class VersionSet {
   // Returns the minimum log number which still has data not flushed to any SST
   // file, except data from `cfd_to_skip`.
   uint64_t PreComputeMinLogNumberWithUnflushedData(
-      ColumnFamilyData* cfd_to_skip) const {
+      const ColumnFamilyData* cfd_to_skip) const {
     uint64_t min_log_num = std::numeric_limits<uint64_t>::max();
     for (auto cfd : *column_family_set_) {
       if (cfd == cfd_to_skip) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -802,6 +802,10 @@ class VersionSet {
 
   uint64_t current_next_file_number() const { return next_file_number_.load(); }
 
+  uint64_t latest_min_log_number_to_keep() const {
+    return latest_min_log_number_to_keep_.load();
+  }
+
   // Allocate and return a new file number
   uint64_t NewFileNumber() { return next_file_number_.fetch_add(1); }
 
@@ -849,15 +853,24 @@ class VersionSet {
   // REQUIRED: this is only called during single-threaded recovery or repair.
   void MarkFileNumberUsed(uint64_t number);
 
+  // Mark the specified log number as deleted
+  // REQUIRED: this is only called during single-threaded recovery or repair, or
+  // from ::LogAndApply where the global mutex is held.
+  void MarkMinLogNumberToKeep(uint64_t number);
+
   // Return the log file number for the log file that is currently
   // being compacted, or zero if there is no such log file.
   uint64_t prev_log_number() const { return prev_log_number_; }
 
   // Returns the minimum log number such that all
   // log numbers less than or equal to it can be deleted
-  uint64_t MinLogNumber() const {
+  uint64_t MinLogNumber() const { return PreComputeMinLogNumber(nullptr); }
+  uint64_t PreComputeMinLogNumber(ColumnFamilyData* cfd_to_skip) const {
     uint64_t min_log_num = std::numeric_limits<uint64_t>::max();
     for (auto cfd : *column_family_set_) {
+      if (cfd == cfd_to_skip) {
+        continue;
+      }
       // It's safe to ignore dropped column families here:
       // cfd->IsDropped() becomes true after the drop is persisted in MANIFEST.
       if (min_log_num > cfd->GetLogNumber() && !cfd->IsDropped()) {
@@ -908,6 +921,8 @@ class VersionSet {
         new_options.writable_file_max_buffer_size;
   }
 
+  const ImmutableDBOptions* db_options() const { return db_options_; }
+
   static uint64_t GetNumLiveVersions(Version* dummy_versions);
 
   static uint64_t GetTotalSstFilesSize(Version* dummy_versions);
@@ -946,6 +961,10 @@ class VersionSet {
   const std::string dbname_;
   const ImmutableDBOptions* const db_options_;
   std::atomic<uint64_t> next_file_number_;
+  // Any log number equal or lower than this should be ignored during recovery,
+  // and is qualified for being deleted in 2PC mode. In non-2PC mode, this
+  // number is ignored.
+  std::atomic<uint64_t> latest_min_log_number_to_keep_ = {0};
   uint64_t manifest_file_number_;
   uint64_t options_file_number_;
   uint64_t pending_manifest_file_number_;

--- a/src.mk
+++ b/src.mk
@@ -33,6 +33,7 @@ LIB_SOURCES =                                                   \
   db/flush_scheduler.cc                                         \
   db/forward_iterator.cc                                        \
   db/internal_stats.cc                                          \
+  db/logs_with_prep_tracker.cc                                  \
   db/log_reader.cc                                              \
   db/log_writer.cc                                              \
   db/malloc_stats.cc                                            \

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -197,7 +197,8 @@ Status PessimisticTransaction::Prepare() {
     s = PrepareInternal();
     if (s.ok()) {
       assert(log_number_ != 0);
-      dbimpl_->MarkLogAsContainingPrepSection(log_number_);
+      dbimpl_->logs_with_prep_tracker()->MarkLogAsContainingPrepSection(
+          log_number_);
       txn_state_.store(PREPARED);
     }
   } else if (txn_state_ == LOCKS_STOLEN) {
@@ -284,7 +285,8 @@ Status PessimisticTransaction::Commit() {
     // to determine what prep logs must be kept around,
     // not the prep section heap.
     assert(log_number_ > 0);
-    dbimpl_->MarkLogAsHavingPrepSectionFlushed(log_number_);
+    dbimpl_->logs_with_prep_tracker()->MarkLogAsHavingPrepSectionFlushed(
+        log_number_);
     txn_db_impl_->UnregisterTransaction(this);
 
     Clear();
@@ -341,7 +343,8 @@ Status PessimisticTransaction::Rollback() {
     if (s.ok()) {
       // we do not need to keep our prepared section around
       assert(log_number_ > 0);
-      dbimpl_->MarkLogAsHavingPrepSectionFlushed(log_number_);
+      dbimpl_->logs_with_prep_tracker()->MarkLogAsHavingPrepSectionFlushed(
+          log_number_);
       Clear();
       txn_state_.store(ROLLEDBACK);
     }

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -1815,14 +1815,14 @@ TEST_P(TransactionTest, TwoPhaseLogRollingTest2) {
       assert(false);
   }
 
-  ASSERT_TRUE(!db_impl->TEST_UnableToFlushOldestLog());
+  ASSERT_TRUE(!db_impl->TEST_UnableToReleaseOldestLog());
 
   // request a flush for all column families such that the earliest
   // alive log file can be killed
   db_impl->TEST_SwitchWAL();
   // log cannot be flushed because txn2 has not been commited
   ASSERT_TRUE(!db_impl->TEST_IsLogGettingFlushed());
-  ASSERT_TRUE(db_impl->TEST_UnableToFlushOldestLog());
+  ASSERT_TRUE(db_impl->TEST_UnableToReleaseOldestLog());
 
   // assert that cfa has a flush requested
   ASSERT_TRUE(cfh_a->cfd()->imm()->HasFlushRequested());
@@ -1846,7 +1846,7 @@ TEST_P(TransactionTest, TwoPhaseLogRollingTest2) {
   ASSERT_OK(s);
 
   db_impl->TEST_SwitchWAL();
-  ASSERT_TRUE(!db_impl->TEST_UnableToFlushOldestLog());
+  ASSERT_TRUE(!db_impl->TEST_UnableToReleaseOldestLog());
 
   // we should see that cfb now has a flush requested
   ASSERT_TRUE(cfh_b->cfd()->imm()->HasFlushRequested());


### PR DESCRIPTION
Summary:
This patch record min log number to keep to the manifest while flushing SST files to ignore them and any WAL older than them during recovery. This is to avoid scenarios when we have a gap between the WAL files are fed to the recovery procedure. The gap could happen by for example out-of-order WAL deletion. Such gap could cause problems in 2PC recovery where the prepared and commit entry are placed into two separate WAL and gap in the WALs could result into not processing the WAL with the commit entry and hence breaking the 2PC recovery logic.

Before the commit, for 2PC case, we determined which log number to keep in FindObsoleteFiles(). We looked at the earliest logs with outstanding prepare entries, or prepare entries whose respective commit or abort are in memtable. With the commit, the same calculation is done while we apply the SST flush. Just before installing the flush file, we precompute the earliest log file to keep after the flush finishes using the same logic (but skipping the memtables just flushed), record this information to the manifest entry for this new flushed SST file. This pre-computed value is also remembered in memory, and will later be used to determine whether a log file can be deleted. This value is unlikely to change until next flush because the commit entry will stay in memtable. (In WritePrepared, we could have removed the older log files as soon as all prepared entries are committed. It's not yet done anyway. Even if we do it, the only thing we loss with this new approach is earlier log deletion between two flushes, which does not guarantee to happen anyway because the obsolete file clean-up function is only executed after flush or compaction)

This min log number to keep is stored in the manifest using the safely-ignore customized field of AddFile entry, in order to guarantee that the DB generated using newer release can be opened by previous releases no older than 4.2.

Test Plan: 1. Modify and run existing transaction_test; 2. manual test forward compatibility with DB generated with the newer release.