### PR TITLE
Fix clang build failure with -Wgnu-redeclared-enum

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -53,7 +53,6 @@ struct ExternalSstFileInfo;
 class WriteBatch;
 class Env;
 class EventListener;
-enum EntryType;
 
 using std::unique_ptr;
 


### PR DESCRIPTION
Summary:
In include/rocksdb/db.h, enum EntryType is redeclared even though
original declaration in types.h in included.

Test Plan:
make check

