### PR TITLE
initialize local variable for UBSAN in PosixEnv function

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -479,7 +479,7 @@ class PosixEnv : public Env {
     if (status.ok()) {
       status = GetFileSize(fname, &size);
     }
-    void* base;
+    void* base = nullptr;
     if (status.ok()) {
       base = mmap(nullptr, static_cast<size_t>(size), PROT_READ | PROT_WRITE,
                   MAP_SHARED, fd, 0);


### PR DESCRIPTION
It seems clear to me that the variable is initialized before line 492, but it wasn't clear to UBSAN. The failure was:

```
In file included from ./env/io_posix.h:14:0,
                 from env/env_posix.cc:44:
./include/rocksdb/env.h: In member function ‘virtual rocksdb::Status rocksdb::{anonymous}::PosixEnv::NewMemoryMappedFileBuffer(const string&, std::unique_ptr<rocksdb::MemoryMappedFileBuffer>*)’:
./include/rocksdb/env.h:822:36: error: ‘base’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       : base(_base), length(_length) {}
                                    ^
env/env_posix.cc:482:11: note: ‘base’ was declared here
     void* base;
```

We can just initialize to nullptr to keep UBSAN happy.

Test Plan:

`COMPILE_WITH_UBSAN=1 OPT=-g make -j64 ubsan_check`