### PR TITLE
Remove block-based table assertion for non-empty filter block

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1332,7 +1332,6 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     filter =
         ReadFilter(prefetch_buffer, filter_blk_handle, is_a_filter_partition);
     if (filter != nullptr) {
-      assert(filter->size() > 0);
       Status s = block_cache->Insert(
           key, filter, filter->size(), &DeleteCachedFilterEntry, &cache_handle,
           rep_->table_options.cache_index_and_filter_blocks_with_high_priority


### PR DESCRIPTION
7a6353bd1c516fe3f7118248c77035697c5ac247 prevents empty filter blocks from being written for SST files containing range deletions only. However the assertion this PR removes is still a problem as we could be reading from a DB generated by a RocksDB build without the 7a6353bd1c516fe3f7118248c77035697c5ac247 patch. So remove the assertion. We already don't do this check when `cache_index_and_filter_blocks=false`, so it should be safe.

Test Plan:

test command:

```
$ rm -rf tmp-db/ && ./ldb --bloom_bits=8 --db=./tmp-db put a hi --create_if_missing && ./ldb --bloom_bits=8 --db=./tmp-db deleterange a z && ./ldb --bloom_bits=8 --db=./tmp-db put b hi && ./ldb --bloom_bits=8 --db=./tmp-db get a
```

output before this PR:

```
ldb: table/block_based_table_reader.cc:1330: virtual rocksdb::BlockBasedTable::CachableEntry<rocksdb::FilterBlockReader> rocksdb::BlockBasedTable::GetFilter(rocksdb::FilePrefetchBuffer*, const rocksdb::BlockHandle&, bool, bool, rocksdb::GetContext*) const: Assertion `filter->size() > 0' failed.
Aborted (core dumped)
```

output after this PR:

```
Failed: NotFound:
```