### PR TITLE
Rename pending_flush_ to queued_for_flush_.

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -427,7 +427,7 @@ ColumnFamilyData::ColumnFamilyData(
       log_number_(0),
       flush_reason_(FlushReason::kOthers),
       column_family_set_(column_family_set),
-      pending_flush_(false),
+      queued_for_flush_(false),
       pending_compaction_(false),
       prev_compaction_needed_bytes_(0),
       allow_2pc_(db_options.allow_2pc),
@@ -504,7 +504,7 @@ ColumnFamilyData::~ColumnFamilyData() {
 
   // It would be wrong if this ColumnFamilyData is in flush_queue_ or
   // compaction_queue_ and we destroyed it
-  assert(!pending_flush_);
+  assert(!queued_for_flush_);
   assert(!pending_compaction_);
 
   if (super_version_ != nullptr) {

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -345,9 +345,9 @@ class ColumnFamilyData {
   void ResetThreadLocalSuperVersions();
 
   // Protected by DB mutex
-  void set_pending_flush(bool value) { pending_flush_ = value; }
+  void set_queued_for_flush(bool value) { queued_for_flush_ = value; }
   void set_pending_compaction(bool value) { pending_compaction_ = value; }
-  bool pending_flush() { return pending_flush_; }
+  bool queued_for_flush() { return queued_for_flush_; }
   bool pending_compaction() { return pending_compaction_; }
 
   enum class WriteStallCause {
@@ -453,7 +453,7 @@ class ColumnFamilyData {
   std::unique_ptr<WriteControllerToken> write_controller_token_;
 
   // If true --> this ColumnFamily is currently present in DBImpl::flush_queue_
-  bool pending_flush_;
+  bool queued_for_flush_;
 
   // If true --> this ColumnFamily is currently present in
   // DBImpl::compaction_queue_

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1288,10 +1288,10 @@ ColumnFamilyData* DBImpl::PopFirstFromCompactionQueue() {
 }
 
 void DBImpl::AddToFlushQueue(ColumnFamilyData* cfd, FlushReason flush_reason) {
-  assert(!cfd->pending_flush());
+  assert(!cfd->queued_for_flush());
   cfd->Ref();
   flush_queue_.push_back(cfd);
-  cfd->set_pending_flush(true);
+  cfd->set_queued_for_flush(true);
   cfd->SetFlushReason(flush_reason);
 }
 
@@ -1299,15 +1299,15 @@ ColumnFamilyData* DBImpl::PopFirstFromFlushQueue() {
   assert(!flush_queue_.empty());
   auto cfd = *flush_queue_.begin();
   flush_queue_.pop_front();
-  assert(cfd->pending_flush());
-  cfd->set_pending_flush(false);
+  assert(cfd->queued_for_flush());
+  cfd->set_queued_for_flush(false);
   // TODO: need to unset flush reason?
   return cfd;
 }
 
 void DBImpl::SchedulePendingFlush(ColumnFamilyData* cfd,
                                   FlushReason flush_reason) {
-  if (!cfd->pending_flush() && cfd->imm()->IsFlushPending()) {
+  if (!cfd->queued_for_flush() && cfd->imm()->IsFlushPending()) {
     AddToFlushQueue(cfd, flush_reason);
     ++unscheduled_flushes_;
   }


### PR DESCRIPTION
With ColumnFamilyData::pending_flush_, we have the following code snippet in DBImpl::ScheedulePendingFlush

```
if (!cfd->pending_flush() && cfd->imm()->IsFlushPending()) {
...
}
```

`Pending` is ambiguous, and I feel `queued_for_flush` is a better name,
especially for the sake of readability.