### PR TITLE
Support range deletion tombstones in IngestExternalFile SSTs

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -26,7 +26,7 @@ Learn more about those use cases in a Tech Talk by Ankit Gupta and Naveen Somasu
 Yahoo is using RocksDB as a storage engine for their biggest distributed data store Sherpa. Learn more about it here: http://yahooeng.tumblr.com/post/120730204806/sherpa-scales-new-heights
 
 ## CockroachDB
-CockroachDB is an open-source geo-replicated transactional database (still in development). They are using RocksDB as their storage engine. Check out their github: https://github.com/cockroachdb/cockroach
+CockroachDB is an open-source geo-replicated transactional database. They are using RocksDB as their storage engine. Check out their github: https://github.com/cockroachdb/cockroach
 
 ## DNANexus
 DNANexus is using RocksDB to speed up processing of genomics data.

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -24,10 +24,10 @@ class DBRangeDelTest : public DBTestBase {
 };
 
 const int kRangeDelSkipConfigs =
-  // Plain tables do not support range deletions.
-  DBRangeDelTest::kSkipPlainTable |
-  // MmapReads disables the iterator pinning that RangeDelAggregator requires.
-  DBRangeDelTest::kSkipMmapReads;
+    // Plain tables do not support range deletions.
+    DBRangeDelTest::kSkipPlainTable |
+    // MmapReads disables the iterator pinning that RangeDelAggregator requires.
+    DBRangeDelTest::kSkipMmapReads;
 
 // PlainTableFactory and NumTableFilesAtLevel() are not supported in
 // ROCKSDB_LITE
@@ -39,17 +39,17 @@ TEST_F(DBRangeDelTest, NonBlockBasedTableNotSupported) {
   for (auto config : {kPlainTableAllBytesPrefix, /* kWalDirAndMmapReads */}) {
     option_config_ = config;
     DestroyAndReopen(CurrentOptions());
-    ASSERT_TRUE(
-      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "dr1", "dr1")
-          .IsNotSupported());
+    ASSERT_TRUE(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
+                                 "dr1", "dr1")
+                    .IsNotSupported());
   }
 }
 
 TEST_F(DBRangeDelTest, FlushOutputHasOnlyRangeTombstones) {
   do {
     DestroyAndReopen(CurrentOptions());
-    ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "dr1",
-                              "dr2"));
+    ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
+                               "dr1", "dr2"));
     ASSERT_OK(db_->Flush(FlushOptions()));
     ASSERT_EQ(1, NumTableFilesAtLevel(0));
   } while (ChangeOptions(kRangeDelSkipConfigs));

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -23,12 +23,6 @@ class DBRangeDelTest : public DBTestBase {
   }
 };
 
-const int kRangeDelSkipConfigs =
-    // Plain tables do not support range deletions.
-    DBRangeDelTest::kSkipPlainTable |
-    // MmapReads disables the iterator pinning that RangeDelAggregator requires.
-    DBRangeDelTest::kSkipMmapReads;
-
 // PlainTableFactory and NumTableFilesAtLevel() are not supported in
 // ROCKSDB_LITE
 #ifndef ROCKSDB_LITE

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -733,6 +733,13 @@ class DBTestBase : public testing::Test {
     kSkipMmapReads = 256,
   };
 
+  const int kRangeDelSkipConfigs =
+      // Plain tables do not support range deletions.
+      kSkipPlainTable |
+      // MmapReads disables the iterator pinning that RangeDelAggregator
+      // requires.
+      kSkipMmapReads;
+
   explicit DBTestBase(const std::string path);
 
   ~DBTestBase();

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -39,7 +39,8 @@ class ExternalSSTFileBasicTest : public DBTestBase {
 
   Status GenerateAndAddExternalFile(
       const Options options, std::vector<int> keys,
-      const std::vector<ValueType>& value_types, int file_id,
+      const std::vector<ValueType>& value_types,
+      std::vector<std::pair<int, int>> range_deletions, int file_id,
       std::map<std::string, std::string>* true_data) {
     assert(value_types.size() == 1 || keys.size() == value_types.size());
     std::string file_path = sst_files_dir_ + ToString(file_id);
@@ -48,6 +49,29 @@ class ExternalSSTFileBasicTest : public DBTestBase {
     Status s = sst_file_writer.Open(file_path);
     if (!s.ok()) {
       return s;
+    }
+    for (size_t i = 0; i < range_deletions.size(); i++) {
+      // Account for the effect of range deletions on true_data before
+      // all point operators, even though sst_file_writer.DeleteRange
+      // must be called before other sst_file_writer methods. This is
+      // because point writes take precedence over range deletions
+      // in the same ingested sst.
+      std::string start_key = Key(range_deletions[i].first);
+      std::string end_key = Key(range_deletions[i].second);
+      s = sst_file_writer.DeleteRange(start_key, end_key);
+      if (!s.ok()) {
+        sst_file_writer.Finish();
+        return s;
+      }
+      auto start_key_it = true_data->find(start_key);
+      if (start_key_it == true_data->end()) {
+        start_key_it = true_data->upper_bound(start_key);
+      }
+      auto end_key_it = true_data->find(end_key);
+      if (end_key_it == true_data->end()) {
+        end_key_it = true_data->upper_bound(end_key);
+      }
+      true_data->erase(start_key_it, end_key_it);
     }
     for (size_t i = 0; i < keys.size(); i++) {
       std::string key = Key(keys[i]);
@@ -84,6 +108,14 @@ class ExternalSSTFileBasicTest : public DBTestBase {
       s = db_->IngestExternalFile({file_path}, ifo);
     }
     return s;
+  }
+
+  Status GenerateAndAddExternalFile(
+      const Options options, std::vector<int> keys,
+      const std::vector<ValueType>& value_types, int file_id,
+      std::map<std::string, std::string>* true_data) {
+    return GenerateAndAddExternalFile(options, keys, value_types, {}, file_id,
+                                      true_data);
   }
 
   Status GenerateAndAddExternalFile(
@@ -126,8 +158,13 @@ TEST_F(ExternalSSTFileBasicTest, Basic) {
   ASSERT_EQ(file1_info.num_entries, 100);
   ASSERT_EQ(file1_info.smallest_key, Key(0));
   ASSERT_EQ(file1_info.largest_key, Key(99));
+  ASSERT_EQ(file1_info.num_range_del_entries, 0);
+  ASSERT_EQ(file1_info.smallest_range_del_key, "");
+  ASSERT_EQ(file1_info.largest_range_del_key, "");
   // sst_file_writer already finished, cannot add this value
   s = sst_file_writer.Put(Key(100), "bad_val");
+  ASSERT_FALSE(s.ok()) << s.ToString();
+  s = sst_file_writer.DeleteRange(Key(100), Key(200));
   ASSERT_FALSE(s.ok()) << s.ToString();
 
   DestroyAndReopen(options);
@@ -189,6 +226,7 @@ TEST_F(ExternalSSTFileBasicTest, NoCopy) {
   ASSERT_EQ(file3_info.num_entries, 15);
   ASSERT_EQ(file3_info.smallest_key, Key(110));
   ASSERT_EQ(file3_info.largest_key, Key(124));
+
   s = DeprecatedAddFile({file1}, true /* move file */);
   ASSERT_TRUE(s.ok()) << s.ToString();
   ASSERT_EQ(Status::NotFound(), env_->FileExists(file1));
@@ -197,8 +235,8 @@ TEST_F(ExternalSSTFileBasicTest, NoCopy) {
   ASSERT_TRUE(s.ok()) << s.ToString();
   ASSERT_OK(env_->FileExists(file2));
 
-  // This file have overlapping values with the existing data
-  s = DeprecatedAddFile({file2}, true /* move file */);
+  // This file has overlapping values with the existing data
+  s = DeprecatedAddFile({file3}, true /* move file */);
   ASSERT_FALSE(s.ok()) << s.ToString();
   ASSERT_OK(env_->FileExists(file3));
 
@@ -223,7 +261,6 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithGlobalSeqnoPickedSeqno) {
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13},
                                          ValueType::kTypeValue, file_id++,
-
                                          &true_data));
     // File dont overwrite any keys, No seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
@@ -319,7 +356,6 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMultipleValueType) {
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13},
                                          ValueType::kTypeValue, file_id++,
-
                                          &true_data));
     // File dont overwrite any keys, No seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
@@ -344,6 +380,24 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMultipleValueType) {
         options, {1, 130}, ValueType::kTypeDeletion, file_id++, &true_data));
     // File overwrite some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
+
+    ASSERT_OK(GenerateAndAddExternalFile(options, {120},
+                                         {ValueType::kTypeValue}, {{120, 135}},
+                                         file_id++, &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 4);
+
+    ASSERT_OK(GenerateAndAddExternalFile(options, {}, {}, {{110, 120}},
+                                         file_id++, &true_data));
+    // The range deletion ends on a key, but it doesn't actually delete
+    // this key because the largest key in the range is exclusive. Still,
+    // if counts as an overlap so a new seqno will be assigned.
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
+
+    ASSERT_OK(GenerateAndAddExternalFile(options, {}, {}, {{100, 109}},
+                                         file_id++, &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
 
     // Write some keys through normal write path
     for (int i = 0; i < 50; i++) {
@@ -451,6 +505,29 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
     // File overwrite some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
+    ASSERT_OK(GenerateAndAddExternalFile(
+        options, {150, 151, 152},
+        {ValueType::kTypeValue, ValueType::kTypeMerge,
+         ValueType::kTypeDeletion},
+        {{150, 160}, {180, 190}}, file_id++, &true_data));
+    // File dont overwrite any keys, No seqno needed
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
+
+    ASSERT_OK(GenerateAndAddExternalFile(
+        options, {150, 151, 152},
+        {ValueType::kTypeValue, ValueType::kTypeMerge, ValueType::kTypeValue},
+        {{200, 250}}, file_id++, &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 4);
+
+    ASSERT_OK(GenerateAndAddExternalFile(
+        options, {300, 301, 302},
+        {ValueType::kTypeValue, ValueType::kTypeMerge,
+         ValueType::kTypeDeletion},
+        {{1, 2}, {152, 154}}, file_id++, &true_data));
+    // File overwrite some keys, a seqno will be assigned
+    ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
+
     // Write some keys through normal write path
     for (int i = 0; i < 50; i++) {
       ASSERT_OK(Put(Key(i), "memtable"));
@@ -466,8 +543,9 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
 
     ASSERT_OK(GenerateAndAddExternalFile(
-        options, {40, 41, 42}, {ValueType::kTypeValue, ValueType::kTypeDeletion,
-                                ValueType::kTypeDeletion},
+        options, {40, 41, 42},
+        {ValueType::kTypeValue, ValueType::kTypeDeletion,
+         ValueType::kTypeDeletion},
         file_id++, &true_data));
     // File overwrite some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
@@ -589,7 +667,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestionWithRangeDeletions) {
   SequenceNumber last_seqno = dbfull()->GetLatestSequenceNumber();
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {60, 90}, {ValueType::kTypeValue, ValueType::kTypeValue},
-      file_id++, &true_data));
+      {{65, 70}, {70, 85}}, file_id++, &true_data));
   ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), ++last_seqno);
   ASSERT_EQ(2, NumTableFilesAtLevel(0));
   ASSERT_EQ(0, NumTableFilesAtLevel(kNumLevels - 2));
@@ -603,6 +681,16 @@ TEST_F(ExternalSSTFileBasicTest, IngestionWithRangeDeletions) {
   ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), ++last_seqno);
   ASSERT_EQ(2, NumTableFilesAtLevel(0));
   ASSERT_EQ(1, NumTableFilesAtLevel(kNumLevels - 2));
+  ASSERT_EQ(1, NumTableFilesAtLevel(options.num_levels - 1));
+
+  // overlaps with L5 file but not memtable or L0 file, so flush is skipped and
+  // file is ingested into L4
+  ASSERT_OK(GenerateAndAddExternalFile(options, {}, {}, {{5, 15}}, file_id++,
+                                       &true_data));
+  ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), ++last_seqno);
+  ASSERT_EQ(2, NumTableFilesAtLevel(0));
+  ASSERT_EQ(1, NumTableFilesAtLevel(kNumLevels - 2));
+  ASSERT_EQ(1, NumTableFilesAtLevel(options.num_levels - 2));
   ASSERT_EQ(1, NumTableFilesAtLevel(options.num_levels - 1));
 
   // ingested file overlaps with memtable, so flush is triggered before the file
@@ -623,7 +711,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestionWithRangeDeletions) {
   // seqnum.
   ASSERT_OK(GenerateAndAddExternalFile(
       options, {151, 175}, {ValueType::kTypeValue, ValueType::kTypeValue},
-      file_id++, &true_data));
+      {{160, 200}}, file_id++, &true_data));
   ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
   ASSERT_EQ(4, NumTableFilesAtLevel(0));
   ASSERT_EQ(1, NumTableFilesAtLevel(kNumLevels - 2));

--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -256,33 +256,33 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithGlobalSeqnoPickedSeqno) {
     ASSERT_OK(GenerateAndAddExternalFile(options, {1, 2, 3, 4, 5, 6},
                                          ValueType::kTypeValue, file_id++,
                                          &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13},
                                          ValueType::kTypeValue, file_id++,
                                          &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 4, 6}, ValueType::kTypeValue, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {11, 15, 19}, ValueType::kTypeValue, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {120, 130}, ValueType::kTypeValue, file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 130}, ValueType::kTypeValue, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
     // Write some keys through normal write path
@@ -294,17 +294,17 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithGlobalSeqnoPickedSeqno) {
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {60, 61, 62}, ValueType::kTypeValue, file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {40, 41, 42}, ValueType::kTypeValue, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {20, 30, 40}, ValueType::kTypeValue, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 2);
 
     const Snapshot* snapshot = db_->GetSnapshot();
@@ -351,52 +351,52 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMultipleValueType) {
     ASSERT_OK(GenerateAndAddExternalFile(options, {1, 2, 3, 4, 5, 6},
                                          ValueType::kTypeValue, file_id++,
                                          &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {10, 11, 12, 13},
                                          ValueType::kTypeValue, file_id++,
                                          &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 4, 6}, ValueType::kTypeMerge, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {11, 15, 19},
                                          ValueType::kTypeDeletion, file_id++,
                                          &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {120, 130}, ValueType::kTypeMerge, file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 130}, ValueType::kTypeDeletion, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {120},
                                          {ValueType::kTypeValue}, {{120, 135}},
                                          file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 4);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {}, {}, {{110, 120}},
                                          file_id++, &true_data));
     // The range deletion ends on a key, but it doesn't actually delete
     // this key because the largest key in the range is exclusive. Still,
-    // if counts as an overlap so a new seqno will be assigned.
+    // it counts as an overlap so a new seqno will be assigned.
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {}, {}, {{100, 109}},
                                          file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
 
     // Write some keys through normal write path
@@ -408,18 +408,18 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMultipleValueType) {
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {60, 61, 62}, ValueType::kTypeValue, file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {40, 41, 42}, ValueType::kTypeMerge, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(options, {20, 30, 40},
                                          ValueType::kTypeDeletion, file_id++,
                                          &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 2);
 
     const Snapshot* snapshot = db_->GetSnapshot();
@@ -468,7 +468,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeValue, ValueType::kTypeMerge, ValueType::kTypeValue,
          ValueType::kTypeMerge, ValueType::kTypeValue, ValueType::kTypeMerge},
         file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(
@@ -476,33 +476,33 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeValue, ValueType::kTypeMerge, ValueType::kTypeValue,
          ValueType::kTypeMerge},
         file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 0);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 4, 6}, {ValueType::kTypeDeletion, ValueType::kTypeValue,
                              ValueType::kTypeMerge},
         file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {11, 15, 19}, {ValueType::kTypeDeletion, ValueType::kTypeMerge,
                                 ValueType::kTypeValue},
         file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {120, 130}, {ValueType::kTypeValue, ValueType::kTypeMerge},
         file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 2);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {1, 130}, {ValueType::kTypeMerge, ValueType::kTypeDeletion},
         file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
     ASSERT_OK(GenerateAndAddExternalFile(
@@ -510,14 +510,14 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeValue, ValueType::kTypeMerge,
          ValueType::kTypeDeletion},
         {{150, 160}, {180, 190}}, file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 3);
 
     ASSERT_OK(GenerateAndAddExternalFile(
         options, {150, 151, 152},
         {ValueType::kTypeValue, ValueType::kTypeMerge, ValueType::kTypeValue},
         {{200, 250}}, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 4);
 
     ASSERT_OK(GenerateAndAddExternalFile(
@@ -525,7 +525,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeValue, ValueType::kTypeMerge,
          ValueType::kTypeDeletion},
         {{1, 2}, {152, 154}}, file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), 5);
 
     // Write some keys through normal write path
@@ -539,7 +539,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         options, {60, 61, 62},
         {ValueType::kTypeValue, ValueType::kTypeMerge, ValueType::kTypeValue},
         file_id++, &true_data));
-    // File dont overwrite any keys, No seqno needed
+    // File doesn't overwrite any keys, no seqno needed
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno);
 
     ASSERT_OK(GenerateAndAddExternalFile(
@@ -547,7 +547,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeValue, ValueType::kTypeDeletion,
          ValueType::kTypeDeletion},
         file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 1);
 
     ASSERT_OK(GenerateAndAddExternalFile(
@@ -555,7 +555,7 @@ TEST_F(ExternalSSTFileBasicTest, IngestFileWithMixedValueType) {
         {ValueType::kTypeDeletion, ValueType::kTypeDeletion,
          ValueType::kTypeDeletion},
         file_id++, &true_data));
-    // File overwrite some keys, a seqno will be assigned
+    // File overwrites some keys, a seqno will be assigned
     ASSERT_EQ(dbfull()->GetLatestSequenceNumber(), last_seqno + 2);
 
     const Snapshot* snapshot = db_->GetSnapshot();

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -36,6 +36,8 @@ struct IngestedFileInfo {
   uint64_t file_size;
   // total number of keys in external file
   uint64_t num_entries;
+  // total number of range deletions in external file
+  uint64_t num_range_deletions;
   // Id of column family this file shoule be ingested into
   uint32_t cf_id;
   // TableProperties read from external file

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <list>
 #include <map>
 #include <set>
 #include <string>
@@ -105,7 +106,7 @@ class RangeDelAggregator {
   // covered by a range tombstone residing in the same snapshot stripe.
   // @param mode If collapse_deletions_ is true, this dictates how we will find
   //             the deletion whose interval contains this key. Otherwise, its
-  //             value must be kFullScan indicating linear scan from beginning..
+  //             value must be kFullScan indicating linear scan from beginning.
   bool ShouldDelete(
       const ParsedInternalKey& parsed,
       RangeDelPositioningMode mode = RangeDelPositioningMode::kFullScan) {
@@ -173,6 +174,7 @@ class RangeDelAggregator {
   struct Rep {
     StripeMap stripe_map_;
     PinnedIteratorsManager pinned_iters_mgr_;
+    std::list<std::string> pinned_slices_;
     std::set<uint64_t> added_files_;
   };
   // Initializes rep_ lazily. This aggregator object is constructed for every

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -32,9 +32,12 @@ struct ExternalSstFileInfo {
       : file_path(""),
         smallest_key(""),
         largest_key(""),
+        smallest_range_del_key(""),
+        largest_range_del_key(""),
         sequence_number(0),
         file_size(0),
         num_entries(0),
+        num_range_del_entries(0),
         version(0) {}
 
   ExternalSstFileInfo(const std::string& _file_path,
@@ -45,17 +48,24 @@ struct ExternalSstFileInfo {
       : file_path(_file_path),
         smallest_key(_smallest_key),
         largest_key(_largest_key),
+        smallest_range_del_key(""),
+        largest_range_del_key(""),
         sequence_number(_sequence_number),
         file_size(_file_size),
         num_entries(_num_entries),
+        num_range_del_entries(0),
         version(_version) {}
 
-  std::string file_path;           // external sst file path
-  std::string smallest_key;        // smallest user key in file
-  std::string largest_key;         // largest user key in file
-  SequenceNumber sequence_number;  // sequence number of all keys in file
-  uint64_t file_size;              // file size in bytes
-  uint64_t num_entries;            // number of entries in file
+  std::string file_path;     // external sst file path
+  std::string smallest_key;  // smallest user key in file
+  std::string largest_key;   // largest user key in file
+  std::string
+      smallest_range_del_key;  // smallest range deletion user key in file
+  std::string largest_range_del_key;  // largest range deletion user key in file
+  SequenceNumber sequence_number;     // sequence number of all keys in file
+  uint64_t file_size;                 // file size in bytes
+  uint64_t num_entries;               // number of entries in file
+  uint64_t num_range_del_entries;  // number of range deletion entries in file
   int32_t version;                 // file version
 };
 
@@ -105,6 +115,9 @@ class SstFileWriter {
   // Add a deletion key to currently opened file
   // REQUIRES: key is after any previously added key according to comparator.
   Status Delete(const Slice& user_key);
+
+  // Add a range deletion tombstone to currently opened file
+  Status DeleteRange(const Slice& begin_key, const Slice& end_key);
 
   // Finalize writing to sst file and close file.
   //

--- a/java/rocksjni/backupenginejni.cc
+++ b/java/rocksjni/backupenginejni.cc
@@ -68,10 +68,11 @@ void Java_org_rocksdb_BackupEngine_createNewBackupWithMetadata(
   auto* backup_engine = reinterpret_cast<rocksdb::BackupEngine*>(jbe_handle);
 
   jboolean has_exception = JNI_FALSE;
-  std::string app_metadata = rocksdb::JniUtil::copyStdString(
-          env, japp_metadata, &has_exception);
+  std::string app_metadata =
+      rocksdb::JniUtil::copyStdString(env, japp_metadata, &has_exception);
   if (has_exception == JNI_TRUE) {
-    rocksdb::RocksDBExceptionJni::ThrowNew(env, "Could not copy jstring to std::string");
+    rocksdb::RocksDBExceptionJni::ThrowNew(
+        env, "Could not copy jstring to std::string");
     return;
   }
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2370,14 +2370,16 @@ class BackupInfoJni : public JavaClass {
    *     exception occurs
    */
   static jobject construct0(JNIEnv* env, uint32_t backup_id, int64_t timestamp,
-      uint64_t size, uint32_t number_files, const std::string& app_metadata) {
+                            uint64_t size, uint32_t number_files,
+                            const std::string& app_metadata) {
     jclass jclazz = getJClass(env);
     if(jclazz == nullptr) {
       // exception occurred accessing class
       return nullptr;
     }
 
-    static jmethodID mid = env->GetMethodID(jclazz, "<init>", "(IJJILjava/lang/String;)V");
+    static jmethodID mid =
+        env->GetMethodID(jclazz, "<init>", "(IJJILjava/lang/String;)V");
     if(mid == nullptr) {
       // exception occurred accessing method
       return nullptr;
@@ -2392,8 +2394,8 @@ class BackupInfoJni : public JavaClass {
       }
     }
 
-    jobject jbackup_info =
-        env->NewObject(jclazz, mid, backup_id, timestamp, size, number_files, japp_metadata);
+    jobject jbackup_info = env->NewObject(jclazz, mid, backup_id, timestamp,
+                                          size, number_files, japp_metadata);
     if(env->ExceptionCheck()) {
       env->DeleteLocalRef(japp_metadata);
       return nullptr;
@@ -2448,12 +2450,9 @@ class BackupInfoListJni {
     for (auto it = backup_infos.begin(); it != end; ++it) {
       auto backup_info = *it;
 
-      jobject obj = rocksdb::BackupInfoJni::construct0(env,
-          backup_info.backup_id,
-          backup_info.timestamp,
-          backup_info.size,
-          backup_info.number_files,
-          backup_info.app_metadata);
+      jobject obj = rocksdb::BackupInfoJni::construct0(
+          env, backup_info.backup_id, backup_info.timestamp, backup_info.size,
+          backup_info.number_files, backup_info.app_metadata);
       if(env->ExceptionCheck()) {
         // exception occurred constructing object
         if(obj != nullptr) {

--- a/java/src/main/java/org/rocksdb/BackupEngine.java
+++ b/java/src/main/java/org/rocksdb/BackupEngine.java
@@ -104,9 +104,8 @@ public class BackupEngine extends RocksObject implements AutoCloseable {
    *
    * @throws RocksDBException thrown if a new backup could not be created
    */
-  public void createNewBackupWithMetadata(
-      final RocksDB db, final String metadata, final boolean flushBeforeBackup)
-      throws RocksDBException {
+  public void createNewBackupWithMetadata(final RocksDB db, final String metadata,
+      final boolean flushBeforeBackup) throws RocksDBException {
     assert (isOwningHandle());
     createNewBackupWithMetadata(nativeHandle_, db.nativeHandle_, metadata, flushBeforeBackup);
   }

--- a/java/src/main/java/org/rocksdb/BackupInfo.java
+++ b/java/src/main/java/org/rocksdb/BackupInfo.java
@@ -19,8 +19,8 @@ public class BackupInfo {
    * @param size size of backup
    * @param numberFiles number of files related to this backup.
    */
-  BackupInfo(final int backupId, final long timestamp, final long size,
-      final int numberFiles, final String app_metadata) {
+  BackupInfo(final int backupId, final long timestamp, final long size, final int numberFiles,
+      final String app_metadata) {
     backupId_ = backupId;
     timestamp_ = timestamp;
     size_ = size;

--- a/java/src/test/java/org/rocksdb/BackupEngineTest.java
+++ b/java/src/test/java/org/rocksdb/BackupEngineTest.java
@@ -207,20 +207,17 @@ public class BackupEngineTest {
   }
 
   @Test
-  public void backupDbWithMetadata()
-      throws RocksDBException {
+  public void backupDbWithMetadata() throws RocksDBException {
     // Open empty database.
-    try(final Options opt = new Options().setCreateIfMissing(true);
-        final RocksDB db = RocksDB.open(opt,
-            dbFolder.getRoot().getAbsolutePath())) {
-
+    try (final Options opt = new Options().setCreateIfMissing(true);
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
       // Fill database with some test values
       prepareDatabase(db);
 
       // Create two backups
-      try(final BackupableDBOptions bopt = new BackupableDBOptions(
-          backupFolder.getRoot().getAbsolutePath());
-          final BackupEngine be = BackupEngine.open(opt.getEnv(), bopt)) {
+      try (final BackupableDBOptions bopt =
+               new BackupableDBOptions(backupFolder.getRoot().getAbsolutePath());
+           final BackupEngine be = BackupEngine.open(opt.getEnv(), bopt)) {
         final String metadata = String.valueOf(ThreadLocalRandom.current().nextInt());
         be.createNewBackupWithMetadata(db, metadata, true);
         final List<BackupInfo> backupInfoList = verifyNumberOfValidBackups(be, 1);

--- a/table/block.cc
+++ b/table/block.cc
@@ -285,13 +285,14 @@ bool BlockIter::ParseNextKey() {
     if (global_seqno_ != kDisableGlobalSequenceNumber) {
       // If we are reading a file with a global sequence number we should
       // expect that all encoded sequence numbers are zeros and any value
-      // type is kTypeValue, kTypeMerge or kTypeDeletion
+      // type is kTypeValue, kTypeMerge, kTypeDeletion, or kTypeRangeDeletion.
       assert(GetInternalKeySeqno(key_.GetInternalKey()) == 0);
 
       ValueType value_type = ExtractValueType(key_.GetInternalKey());
       assert(value_type == ValueType::kTypeValue ||
              value_type == ValueType::kTypeMerge ||
-             value_type == ValueType::kTypeDeletion);
+             value_type == ValueType::kTypeDeletion ||
+             value_type == ValueType::kTypeRangeDeletion);
 
       if (key_pinned_) {
         // TODO(tec): Investigate updating the seqno in the loaded block

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -903,6 +903,20 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
     }
   }
 
+  // Read the table properties, if provided.
+  if (rep->table_properties) {
+    rep->whole_key_filtering &=
+        IsFeatureSupported(*(rep->table_properties),
+                           BlockBasedTablePropertyNames::kWholeKeyFiltering,
+                           rep->ioptions.info_log);
+    rep->prefix_filtering &= IsFeatureSupported(
+        *(rep->table_properties),
+        BlockBasedTablePropertyNames::kPrefixFiltering, rep->ioptions.info_log);
+
+    rep->global_seqno = GetGlobalSequenceNumber(*(rep->table_properties),
+                                                rep->ioptions.info_log);
+  }
+
   // Read the range del meta block
   bool found_range_del_block;
   s = SeekToRangeDelBlock(meta_iter.get(), &found_range_del_block,
@@ -926,20 +940,6 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
             s.ToString().c_str());
       }
     }
-  }
-
-  // Determine whether whole key filtering is supported.
-  if (rep->table_properties) {
-    rep->whole_key_filtering &=
-        IsFeatureSupported(*(rep->table_properties),
-                           BlockBasedTablePropertyNames::kWholeKeyFiltering,
-                           rep->ioptions.info_log);
-    rep->prefix_filtering &= IsFeatureSupported(
-        *(rep->table_properties),
-        BlockBasedTablePropertyNames::kPrefixFiltering, rep->ioptions.info_log);
-
-    rep->global_seqno = GetGlobalSequenceNumber(*(rep->table_properties),
-                                                rep->ioptions.info_log);
   }
 
   bool need_upper_bound_check =

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -975,8 +975,8 @@ Status BackupEngineImpl::DeleteBackup(BackupID backup_id) {
     for (auto& itr : backuped_file_infos_) {
       if (itr.second->refs == 0) {
         Status s = backup_env_->DeleteFile(GetAbsolutePath(itr.first));
-        ROCKS_LOG_INFO(options_.info_log, "Deleting %s -- %s", itr.first.c_str(),
-                       s.ToString().c_str());
+        ROCKS_LOG_INFO(options_.info_log, "Deleting %s -- %s",
+                       itr.first.c_str(), s.ToString().c_str());
         to_delete.push_back(itr.first);
       }
     }


### PR DESCRIPTION
Fixes #3391.

This change adds a `DeleteRange` method to `SstFileWriter` and adds
support for ingesting SSTs with range deletion tombstones. This is
important for applications that need to atomically ingest SSTs while
clearing out any existing keys in a given key range.