### PR TITLE
Add virtual Truncate method to Env

### DIFF
--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -575,6 +575,17 @@ Status MockEnv::DeleteFile(const std::string& fname) {
   return Status::OK();
 }
 
+Status MockEnv::Truncate(const std::string& fname, size_t size) {
+  auto fn = NormalizePath(fname);
+  MutexLock lock(&mutex_);
+  auto iter = file_map_.find(fn);
+  if (iter == file_map_.end()) {
+    return Status::IOError(fn, "File not found");
+  }
+  iter->second->Truncate(size);
+  return Status::OK();
+}
+
 Status MockEnv::CreateDir(const std::string& dirname) {
   auto dn = NormalizePath(dirname);
   if (file_map_.find(dn) == file_map_.end()) {
@@ -723,18 +734,6 @@ uint64_t MockEnv::NowMicros() {
 
 uint64_t MockEnv::NowNanos() {
   return EnvWrapper::NowNanos() + fake_sleep_micros_.load() * 1000;
-}
-
-// Non-virtual functions, specific to MockEnv
-Status MockEnv::Truncate(const std::string& fname, size_t size) {
-  auto fn = NormalizePath(fname);
-  MutexLock lock(&mutex_);
-  auto iter = file_map_.find(fn);
-  if (iter == file_map_.end()) {
-    return Status::IOError(fn, "File not found");
-  }
-  iter->second->Truncate(size);
-  return Status::OK();
 }
 
 Status MockEnv::CorruptBuffer(const std::string& fname) {

--- a/env/mock_env.h
+++ b/env/mock_env.h
@@ -60,6 +60,8 @@ class MockEnv : public EnvWrapper {
 
   virtual Status DeleteFile(const std::string& fname) override;
 
+  virtual Status Truncate(const std::string& fname, size_t size) override;
+
   virtual Status CreateDir(const std::string& dirname) override;
 
   virtual Status CreateDirIfMissing(const std::string& dirname) override;
@@ -91,9 +93,6 @@ class MockEnv : public EnvWrapper {
   virtual Status GetCurrentTime(int64_t* unix_time) override;
   virtual uint64_t NowMicros() override;
   virtual uint64_t NowNanos() override;
-
-  // Non-virtual functions, specific to MockEnv
-  Status Truncate(const std::string& fname, size_t size);
 
   Status CorruptBuffer(const std::string& fname);
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -259,7 +259,7 @@ class Env {
   virtual Status DeleteFile(const std::string& fname) = 0;
 
   // Truncate the named file to the specified size.
-  virtual Status Truncate(const std::string& fname, size_t size) {
+  virtual Status Truncate(const std::string& /*fname*/, size_t /*size*/) {
     return Status::NotSupported("Truncate is not supported for this Env");
   }
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -258,6 +258,11 @@ class Env {
   // Delete the named file.
   virtual Status DeleteFile(const std::string& fname) = 0;
 
+  // Truncate the named file to the specified size.
+  virtual Status Truncate(const std::string& fname, size_t size) {
+    return Status::NotSupported("Truncate is not supported for this Env");
+  }
+
   // Create the specified directory. Returns error if directory exists.
   virtual Status CreateDir(const std::string& dirname) = 0;
 


### PR DESCRIPTION
This change adds a virtual `Truncate` method to `Env`, which truncates
the named file to the specified size. At the moment, this is only
supported for `MockEnv`, but other `Env's` could be extended to override
the method too. This is the same approach that methods like `LinkFile` and
`AreSameFile` have taken.

This is useful for any user of the in-memory `Env`. The implementation's
header is not exported, so before this change, it was impossible to
access it's already existing `Truncate` method.