### PR TITLE
WritePrepared Txn: enable rollback in stress test

### DIFF
--- a/util/transaction_test_util.cc
+++ b/util/transaction_test_util.cc
@@ -184,9 +184,7 @@ bool RandomTransactionInserter::DoInsert(DB* db, Transaction* txn,
         s = txn->Prepare();
         assert(s.ok());
       }
-      // TODO(myabandeh): enable this when WritePreparedTxnDB::RollbackPrepared
-      // is updated to handle in-the-middle rollbacks.
-      if (!rand_->OneIn(0)) {
+      if (!rand_->OneIn(20)) {
         s = txn->Commit();
       } else {
         // Also try 5% rollback

--- a/utilities/transactions/pessimistic_transaction_db.h
+++ b/utilities/transactions/pessimistic_transaction_db.h
@@ -120,7 +120,7 @@ class PessimisticTransactionDB : public TransactionDB {
   // an odd performance drop we observed when the added std::atomic member to
   // the base class even when the subclass do not read it in the fast path.
   virtual void UpdateCFComparatorMap(const std::vector<ColumnFamilyHandle*>&) {}
-  virtual void UpdateCFComparatorMap(const ColumnFamilyHandle*) {}
+  virtual void UpdateCFComparatorMap(ColumnFamilyHandle*) {}
 
  protected:
   DBImpl* db_impl_;

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -211,6 +211,8 @@ Status WritePreparedTxn::RollbackInternal() {
   WriteBatch rollback_batch;
   assert(GetId() != kMaxSequenceNumber);
   assert(GetId() > 0);
+  auto cf_map_shared_ptr = wpt_db_->GetCFHandleMap();
+  auto cf_comp_map_shared_ptr = wpt_db_->GetCFComparatorMap();
   // In WritePrepared, the txn is is the same as prepare seq
   auto last_visible_txn = GetId() - 1;
   struct RollbackWriteBatchBuilder : public WriteBatch::Handler {
@@ -302,8 +304,7 @@ Status WritePreparedTxn::RollbackInternal() {
    protected:
     virtual bool WriteAfterCommit() const override { return false; }
   } rollback_handler(db_impl_, wpt_db_, last_visible_txn, &rollback_batch,
-                     *wpt_db_->GetCFComparatorMap(),
-                     *wpt_db_->GetCFHandleMap(),
+                     *cf_comp_map_shared_ptr.get(), *cf_map_shared_ptr.get(),
                      wpt_db_->txn_db_options_.rollback_merge_operands);
   auto s = GetWriteBatch()->GetWriteBatch()->Iterate(&rollback_handler);
   assert(s.ok());

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -235,34 +235,32 @@ void WritePreparedTxnDB::UpdateCFComparatorMap(
     auto id = h->GetID();
     const Comparator* comparator = h->GetComparator();
     (*cf_map)[id] = comparator;
-    if (id != 0) { // this pointer to the default cf handle will be deleted
+    if (id != 0) {
       (*handle_map)[id] = h;
     } else {
+      // The pointer to the default cf handle in the handles will be deleted.
+      // Use the pointer maintained by the db instead.
       (*handle_map)[id] = DefaultColumnFamily();
     }
   }
-  cf_map_.store(cf_map);
-  cf_map_gc_.reset(cf_map);
-  handle_map_.store(handle_map);
-  handle_map_gc_.reset(handle_map);
+  cf_map_.reset(cf_map);
+  handle_map_.reset(handle_map);
 }
 
-void WritePreparedTxnDB::UpdateCFComparatorMap(
-    ColumnFamilyHandle* h) {
-  auto old_cf_map_ptr = cf_map_.load();
+void WritePreparedTxnDB::UpdateCFComparatorMap(ColumnFamilyHandle* h) {
+  auto old_cf_map_ptr = cf_map_.get();
   assert(old_cf_map_ptr);
   auto cf_map = new std::map<uint32_t, const Comparator*>(*old_cf_map_ptr);
-  auto old_handle_map_ptr = handle_map_.load();
+  auto old_handle_map_ptr = handle_map_.get();
   assert(old_handle_map_ptr);
-  auto handle_map = new std::map<uint32_t, ColumnFamilyHandle*>(*old_handle_map_ptr);
+  auto handle_map =
+      new std::map<uint32_t, ColumnFamilyHandle*>(*old_handle_map_ptr);
   auto id = h->GetID();
   const Comparator* comparator = h->GetComparator();
   (*cf_map)[id] = comparator;
   (*handle_map)[id] = h;
-  cf_map_.store(cf_map);
-  cf_map_gc_.reset(cf_map);
-  handle_map_.store(handle_map);
-  handle_map_gc_.reset(handle_map);
+  cf_map_.reset(cf_map);
+  handle_map_.reset(handle_map);
 }
 
 

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -350,9 +350,12 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   std::map<uint32_t, const Comparator*>* GetCFComparatorMap() {
     return cf_map_.load();
   }
+  std::map<uint32_t, ColumnFamilyHandle*>* GetCFHandleMap() {
+    return handle_map_.load();
+  }
   void UpdateCFComparatorMap(
       const std::vector<ColumnFamilyHandle*>& handles) override;
-  void UpdateCFComparatorMap(const ColumnFamilyHandle* handle) override;
+  void UpdateCFComparatorMap(ColumnFamilyHandle* handle) override;
 
   virtual const Snapshot* GetSnapshot() override;
 
@@ -598,6 +601,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   std::atomic<std::map<uint32_t, const Comparator*>*> cf_map_;
   // GC of the object above
   std::unique_ptr<std::map<uint32_t, const Comparator*>> cf_map_gc_;
+  // A cache of the cf handles
+  std::atomic<std::map<uint32_t, ColumnFamilyHandle*>*> handle_map_;
+  // GC of the object above
+  std::unique_ptr<std::map<uint32_t, ColumnFamilyHandle*>> handle_map_gc_;
 };
 
 class WritePreparedTxnReadCallback : public ReadCallback {


### PR DESCRIPTION
Rollback was disabled in stress test since there was a concurrency issue in WritePrepared rollback algorithm. The issue is fixed by caching the column family handles in WritePrepared to skip getting them from the db when needed for rollback.

Tested by running transaction stress test under tsan.