### PR TITLE
initialize local variable for UBSAN in PosixEnv function

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -479,7 +479,7 @@ class PosixEnv : public Env {
     if (status.ok()) {
       status = GetFileSize(fname, &size);
     }
-    void* base;
+    void* base = nullptr;
     if (status.ok()) {
       base = mmap(nullptr, static_cast<size_t>(size), PROT_READ | PROT_WRITE,
                   MAP_SHARED, fd, 0);


### PR DESCRIPTION
this is a repeat commit of a8a28da2159648a2f72c35ea507371df8a97a2a9, which got reverted together with 6afe22db2e667799d8c903db61750d676bffe152, but forgotten about when that commit was un-reverted in 46152d53bf58748fc3ed0681d8970c342bcfc47a.

Test Plan:

```
$ TEST_TMPDIR=/dev/shm/rocksdb COMPILE_WITH_UBSAN=1 OPT=-g make -j64 ubsan_check
```