### PR TITLE
Speedup ManualCompactionTest.Test

### DIFF
--- a/db/manual_compaction_test.cc
+++ b/db/manual_compaction_test.cc
@@ -19,7 +19,12 @@ using namespace rocksdb;
 
 namespace {
 
-const int kNumKeys = 1100000;
+// Reasoning: previously the number was 1100000. Since the keys are written to
+// the batch in one write each write will result into one SST file. each write
+// will result into one SST file. We reduced the write_buffer_size to 1K to
+// basically have the same effect with however less number of keys, which
+// results into less test runtime.
+const int kNumKeys = 1100;
 
 std::string Key1(int i) {
   char buf[100];
@@ -99,6 +104,7 @@ TEST_F(ManualCompactionTest, Test) {
   // specific scenario.
   rocksdb::DB* db;
   rocksdb::Options db_options;
+  db_options.write_buffer_size = 1024;
   db_options.create_if_missing = true;
   db_options.compression = rocksdb::kNoCompression;
   ASSERT_OK(rocksdb::DB::Open(db_options, dbname_, &db));


### PR DESCRIPTION
ManualCompactionTest.Test occasionally times out in tsan flavor of our test infra. The patch reduces the number of keys to make the test run faster. The change does not seem to negatively impact the coverage of the test.