### PR TITLE
Fix crash test allocation error under TSAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ifdef COMPILE_WITH_TSAN
 	LUA_PATH =
 	# Limit keys for crash test under TSAN to avoid error:
 	# "ThreadSanitizer: DenseSlabAllocator overflow. Dying."
-	CRASH_TEST_EXT_ARGS += --max_key=10000000
+	CRASH_TEST_EXT_ARGS += --max_key=1000000
 endif
 
 # AIX doesn't work with -pg

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,9 @@ ifdef COMPILE_WITH_TSAN
 	PROFILING_FLAGS =
 	# LUA is not supported under TSAN
 	LUA_PATH =
+	# Limit keys for crash test under TSAN to avoid error:
+	# "ThreadSanitizer: DenseSlabAllocator overflow. Dying."
+	CRASH_TEST_EXT_ARGS += --max_key=10000000
 endif
 
 # AIX doesn't work with -pg


### PR DESCRIPTION
We were seeing the following error: "ThreadSanitizer: DenseSlabAllocator overflow. Dying."

It is fixable by mmap'ing a smaller region for keys' expected values, which this PR achieves by reducing the number of keys.

Test Plan:

- run the command that our CI uses:

```
$ TEST_TMPDIR=/dev/shm/rocksdb OPT=-g COMPILE_WITH_TSAN=1 CRASH_TEST_KILL_ODD=1887 CRASH_TEST_EXT_ARGS=--log2_keys_per_lock=22 make crash_test
```