### PR TITLE
Fix db_stress memory leak ASAN error

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -888,8 +888,9 @@ class SharedState {
       }
     }
     if (values_ == nullptr) {
-      values_ =
-          static_cast<std::atomic<uint32_t>*>(malloc(expected_values_size));
+      values_allocation_.reset(
+          new std::atomic<uint32_t>[FLAGS_column_families * max_key_]);
+      values_ = &values_allocation_[0];
       values_init_needed = true;
     }
     assert(values_ != nullptr);
@@ -1116,6 +1117,7 @@ class SharedState {
   std::vector<std::unordered_set<size_t> > no_overwrite_ids_;
 
   std::atomic<uint32_t>* values_;
+  std::unique_ptr<std::atomic<uint32_t>[]> values_allocation_;
   // Has to make it owned by a smart ptr as port::Mutex is not copyable
   // and storing it in the container may require copying depending on the impl.
   std::vector<std::vector<std::unique_ptr<port::Mutex> > > key_locks_;


### PR DESCRIPTION
In case `--expected_values_path` is unset, we allocate a buffer internally to hold the expected DB state. This PR makes sure it is freed.

Test Plan:

verify following command fails without this PR and passes with this PR:

```
./db_stress --options_file= --max_background_compactions=1 --expected_values_path=/tmp/tmpyNA8oM --max_write_buffer_number=3 --sync=0 --reopen=20 --write_buffer_size=33554432 --delpercent=5 --log2_keys_per_lock=22 --block_size=16384 --compression
_type=snappy --allow_concurrent_memtable_write=0 --test_batches_snapshots=0 --clear_column_family_one_in=0 --max_bytes_for_level_base=67108864 --target_file_size_base=16777216 --mmap_read=0 --writepercent=35 --readpercent=50 --subcompactions=2 --memtablerep=skip_list --set_options_
one_in=0 --prefix_size=0 --target_file_size_multiplier=1 --column_families=1 --db=/dev/shm/rocksdb/rocksdb_crashtest_blackbox --threads=32 --disable_wal=0 --open_files=-1 --destroy_db_initially=0 --progress_reports=0 --nooverwritepercent=1 --iterpercent=10 --max_key=10000000 --pref
ixpercent=0 --ops_per_thread=100000000 --use_clock_cache=false --cache_size=1048576 --verify_checksum=1
```