### PR TITLE
Disable readahead when using mmap for reads

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -98,7 +98,11 @@ Status TableCache::GetTableReader(
 
   RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   if (s.ok()) {
-    if (readahead > 0) {
+    if (readahead > 0 && !env_options.use_mmap_reads) {
+      // Not useful for (nor compatible with) mmap files since
+      // ReadaheadRandomAccessFile requires its wrapped file's Read() to copy
+      // data into the provided scratch buffer, which mmap files don't use.
+      // TODO(ajkr): try madvise for mmap files in place of buffered readahead.
       file = NewReadaheadRandomAccessFile(std::move(file), readahead);
     }
     if (!sequential_mode && ioptions_.advise_random_on_open) {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -99,9 +99,9 @@ Status TableCache::GetTableReader(
   RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   if (s.ok()) {
     if (readahead > 0 && !env_options.use_mmap_reads) {
-      // Not useful for (nor compatible with) mmap files since
-      // ReadaheadRandomAccessFile requires its wrapped file's Read() to copy
-      // data into the provided scratch buffer, which mmap files don't use.
+      // Not compatible with mmap files since ReadaheadRandomAccessFile requires
+      // its wrapped file's Read() to copy data into the provided scratch
+      // buffer, which mmap files don't use.
       // TODO(ajkr): try madvise for mmap files in place of buffered readahead.
       file = NewReadaheadRandomAccessFile(std::move(file), readahead);
     }

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -622,6 +622,7 @@ class ReadaheadRandomAccessFile : public RandomAccessFile {
     if (s.ok()) {
       buffer_offset_ = offset;
       buffer_len_ = result.size();
+      assert(buffer_.BufferStart() == result.data());
     }
     return s;
   }


### PR DESCRIPTION
`ReadaheadRandomAccessFile` had an unwritten assumption, which was that its wrapped file's `Read()` function always copies into the provided scratch buffer. Actually this was not true when the wrapped file was `PosixMmapReadableFile`, whose `Read()` implementation does no copying and instead returns a `Slice` pointing directly into the  `mmap`'d memory region. This PR:

- prevents `ReadaheadRandomAccessFile` from ever wrapping mmap readable files
- adds an assert for the assumption `ReadaheadRandomAccessFile` makes about the wrapped file's use of scratch buffer

Test Plan:

- test command:
```
python -u tools/db_crashtest.py whitebox  --random_kill_odd 12345 --duration=120 --max_key=100000 --compaction_readahead_size=2097152  --ops_per_thread=1000
```
- output before this PR:
```
multiput error: Corruption: Bad table magic number: expected 9863518390377041911, found 0 in /tmp/rocksdb_crashtest_whiteboxmlT2Ab/000034.sst
multiput error: Corruption: Bad table magic number: expected 9863518390377041911, found 0 in /tmp/rocksdb_crashtest_whiteboxmlT2Ab/000034.sst
multidelete error: Corruption: Bad table magic number: expected 9863518390377041911, found 0 in /tmp/rocksdb_crashtest_whiteboxmlT2Ab/000034.sst
multiput error: Corruption: Bad table magic number: expected 9863518390377041911, found 0 in /tmp/rocksdb_crashtest_whiteboxmlT2Ab/000034.sst
...
TEST FAILED. Output has 'error'!!!
```
- output after this PR:
```
2018/05/06-12:13:54  Verification successful
```