### PR TITLE
[cmake] Search paths provided by intel's "tbbvars.sh".

### DIFF
--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -5,13 +5,17 @@
 # TBB_LIBRARIES - List of libraries when using TBB.
 # TBB_FOUND - True if TBB found.
 
+if(NOT DEFINED TBB_ROOT_DIR)
+  set(TBB_ROOT_DIR "$ENV{TBBROOT}")
+endif()
+
 find_path(TBB_INCLUDE_DIR
 NAMES tbb/tbb.h
 HINTS ${TBB_ROOT_DIR}/include)
 
 find_library(TBB_LIBRARIES
 NAMES tbb
-HINTS ${TBB_ROOT_DIR}/lib)
+HINTS ${TBB_ROOT_DIR}/lib ENV LIBRARY_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(TBB DEFAULT_MSG TBB_LIBRARIES TBB_INCLUDE_DIR)


### PR DESCRIPTION
TBBROOT and LIBRARY_PATH are set in env by the script.

With TBB 2018 the library path is $TBBROOT/lib/intel64/gcc4.7 for anything above gcc 4.7, which is both compiler and architecture related. We cannot simply do ${TBB_ROOT_DIR}/lib.