### PR TITLE
Fix strncpy not copying the whole string

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -25,7 +25,7 @@ const char* Status::CopyState(const char* state) {
   ret = strncpy_s(result, cch, state, cch - 1);
   assert(ret == 0);
 #else
-  std::strncpy(result, state, cch - 1);
+  std::strncpy(result, state, cch);
 #endif
   return result;
 }


### PR DESCRIPTION
Not sure if this is the best way to solve the issue but at least this way it compiles without throwing errors.