### PR TITLE
Export Import sst files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,7 @@ set(SOURCES
         db/event_helpers.cc
         db/experimental.cc
         db/external_sst_file_ingestion_job.cc
+        db/external_sst_file_import_job.cc
         db/file_indexer.cc
         db/flush_job.cc
         db/flush_scheduler.cc

--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,7 @@ TESTS = \
 	plain_table_db_test \
 	comparator_db_test \
 	external_sst_file_test \
+	external_sst_file_import_test \
 	prefix_test \
 	skiplist_test \
 	write_buffer_manager_test \
@@ -529,6 +530,7 @@ PARALLEL_TEST = \
 	db_universal_compaction_test \
 	db_wal_test \
 	external_sst_file_test \
+	external_sst_file_import_test \
 	fault_injection_test \
 	inlineskiplist_test \
 	manual_compaction_test \
@@ -1187,6 +1189,9 @@ external_sst_file_basic_test: db/external_sst_file_basic_test.o db/db_test_util.
 	$(AM_LINK)
 
 external_sst_file_test: db/external_sst_file_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+external_sst_file_import_test: db/external_sst_file_import_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 db_tailing_iter_test: db/db_tailing_iter_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -96,6 +96,7 @@ cpp_library(
         "db/event_helpers.cc",
         "db/experimental.cc",
         "db/external_sst_file_ingestion_job.cc",
+        "db/external_sst_file_import_job.cc",
         "db/file_indexer.cc",
         "db/flush_job.cc",
         "db/flush_scheduler.cc",

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -84,6 +84,13 @@ class CompactedDBImpl : public DBImpl {
       const IngestExternalFileOptions& /*ingestion_options*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
+  using DB::ImportExternalFile;
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* /*column_family*/,
+      const std::vector<LiveFileMetaData>& /*external_file_metadata*/,
+      const ImportExternalFileOptions& /*import_options*/) override {
+    return Status::NotSupported("Not supported in compacted db mode.");
+  }
 
  private:
   friend class DB;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -23,6 +23,7 @@
 #include "db/compaction_job.h"
 #include "db/dbformat.h"
 #include "db/external_sst_file_ingestion_job.h"
+#include "db/external_sst_file_import_job.h"
 #include "db/flush_job.h"
 #include "db/flush_scheduler.h"
 #include "db/internal_stats.h"
@@ -324,6 +325,12 @@ class DBImpl : public DB {
       ColumnFamilyHandle* column_family,
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
+
+  using DB::ImportExternalFile;
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* column_family,
+      const std::vector<LiveFileMetaData>& external_file_metadata,
+      const ImportExternalFileOptions& import_options) override;
 
   virtual Status VerifyChecksum() override;
 
@@ -684,6 +691,8 @@ class DBImpl : public DB {
 #ifndef ROCKSDB_LITE
   void NotifyOnExternalFileIngested(
       ColumnFamilyData* cfd, const ExternalSstFileIngestionJob& ingestion_job);
+  void NotifyOnExternalFileImported(
+      ColumnFamilyData* cfd, const ExternalSstFileImportJob& import_job);
 #endif  // !ROCKSDB_LITE
 
   void NewThreadStatusCfInfo(ColumnFamilyData* cfd) const;
@@ -1315,7 +1324,7 @@ class DBImpl : public DB {
   // Additonal options for compaction and flush
   EnvOptions env_options_for_compaction_;
 
-  // Number of running IngestExternalFile() calls.
+  // Number of running IngestExternalFile() or ImportExternalFile() calls.
   // REQUIRES: mutex held
   int num_running_ingest_file_;
 

--- a/db/db_impl_readonly.h
+++ b/db/db_impl_readonly.h
@@ -114,6 +114,14 @@ class DBImplReadOnly : public DBImpl {
     return Status::NotSupported("Not supported operation in read only mode.");
   }
 
+  using DB::ImportExternalFile;
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* /*column_family*/,
+      const std::vector<LiveFileMetaData>& /*external_file_metadata*/,
+      const ImportExternalFileOptions& /*import_options*/) override {
+    return Status::NotSupported("Not supported operation in read only mode.");
+  }
+
  private:
   friend class DB;
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2272,6 +2272,14 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
+  using DB::ImportExternalFile;
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* /*column_family*/,
+      const std::vector<LiveFileMetaData>& /*external_file_metadata*/,
+      const ImportExternalFileOptions& /*import_options*/) override {
+    return Status::NotSupported("Not implemented.");
+  }
+
   virtual Status VerifyChecksum() override {
     return Status::NotSupported("Not implemented.");
   }

--- a/db/external_sst_file_import_job.cc
+++ b/db/external_sst_file_import_job.cc
@@ -1,0 +1,327 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#ifndef ROCKSDB_LITE
+
+#include "db/external_sst_file_import_job.h"
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "db/version_edit.h"
+#include "table/merging_iterator.h"
+#include "table/scoped_arena_iterator.h"
+#include "table/sst_file_writer_collectors.h"
+#include "table/table_builder.h"
+#include "util/file_reader_writer.h"
+#include "util/file_util.h"
+#include "util/stop_watch.h"
+#include "util/sync_point.h"
+
+namespace rocksdb {
+
+Status ExternalSstFileImportJob::Prepare() {
+  Status status;
+
+  // Read the information of files we are importing
+  for (const auto& file_metadata : external_file_metadata_) {
+    std::string file_path = file_metadata.db_path + "/" + file_metadata.name;
+    IngestedFileInfo file_to_import;
+    status = GetIngestedFileInfo(file_path, &file_to_import);
+    if (!status.ok()) {
+      return status;
+    }
+    files_to_import_.push_back(file_to_import);
+  }
+
+  const Comparator* ucmp = cfd_->internal_comparator().user_comparator();
+  auto num_files = files_to_import_.size();
+  if (num_files == 0) {
+    return Status::InvalidArgument("The list of files is empty");
+  } else if (num_files > 1) {
+    // Verify that passed files don't have overlapping ranges in any particular
+    // level.
+    int min_level = 1;  // Check for overlaps in Level 1 and above.
+    int max_level = -1;
+    for (const auto& file_metadata : external_file_metadata_) {
+      if (file_metadata.level > max_level) {
+        max_level = file_metadata.level;
+      }
+    }
+    for (int level = min_level; level <= max_level; ++level) {
+      autovector<const IngestedFileInfo*> sorted_files;
+      for (size_t i = 0; i < num_files; i++) {
+        if (external_file_metadata_[i].level == level) {
+          sorted_files.push_back(&files_to_import_[i]);
+        }
+      }
+
+      std::sort(sorted_files.begin(), sorted_files.end(),
+                [&ucmp](const IngestedFileInfo* info1,
+                        const IngestedFileInfo* info2) {
+                  return ucmp->Compare(info1->smallest_user_key,
+                                       info2->smallest_user_key) < 0;
+                });
+
+      for (int i = 0; i < (int)sorted_files.size() - 1; i++) {
+        if (ucmp->Compare(sorted_files[i]->largest_user_key,
+                          sorted_files[i + 1]->smallest_user_key) >= 0) {
+          return Status::NotSupported("Files have overlapping ranges");
+        }
+      }
+    }
+  }
+
+  for (const auto& f : files_to_import_) {
+    if (f.num_entries == 0) {
+      return Status::InvalidArgument("File contain no entries");
+    }
+
+    if (!f.smallest_internal_key().Valid() ||
+        !f.largest_internal_key().Valid()) {
+      return Status::Corruption("File has corrupted keys");
+    }
+  }
+
+  // Copy/Move external files into DB
+  for (auto& f : files_to_import_) {
+    f.fd = FileDescriptor(versions_->NewFileNumber(), 0, f.file_size);
+
+    const std::string path_outside_db = f.external_file_path;
+    const std::string path_inside_db =
+        TableFileName(db_options_.db_paths, f.fd.GetNumber(), f.fd.GetPathId());
+
+    if (import_options_.move_files) {
+      status = env_->LinkFile(path_outside_db, path_inside_db);
+      if (status.IsNotSupported()) {
+        // Original file is on a different FS, use copy instead of hard linking
+        status = CopyFile(env_, path_outside_db, path_inside_db, 0,
+                          db_options_.use_fsync);
+      }
+    } else {
+      status = CopyFile(env_, path_outside_db, path_inside_db, 0,
+                        db_options_.use_fsync);
+    }
+    TEST_SYNC_POINT("DBImpl::AddFile:FileCopied");
+    if (!status.ok()) {
+      break;
+    }
+    f.internal_file_path = path_inside_db;
+  }
+
+  if (!status.ok()) {
+    // We failed, remove all files that we copied into the db
+    for (const auto& f : files_to_import_) {
+      if (f.internal_file_path == "") {
+        break;
+      }
+      Status s = env_->DeleteFile(f.internal_file_path);
+      if (!s.ok()) {
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "AddFile() clean up for file %s failed : %s",
+                       f.internal_file_path.c_str(), s.ToString().c_str());
+      }
+    }
+  }
+
+  return status;
+}
+
+Status ExternalSstFileImportJob::NeedsFlush(bool* flush_needed,
+                                               SuperVersion* super_version) {
+  autovector<Range> ranges;
+  for (const auto& file_to_import : files_to_import_) {
+    ranges.emplace_back(file_to_import.smallest_user_key,
+                        file_to_import.largest_user_key);
+  }
+  Status status =
+      cfd_->RangesOverlapWithMemtables(ranges, super_version, flush_needed);
+  if (status.ok() && *flush_needed) {
+    status = Status::InvalidArgument("External file requires flush");
+  }
+  return status;
+}
+
+// REQUIRES: we have become the only writer by entering both write_thread_ and
+// nonmem_write_thread_
+Status ExternalSstFileImportJob::Run() {
+  Status status;
+  SuperVersion* super_version = cfd_->GetSuperVersion();
+#ifndef NDEBUG
+  // We should never run the job with a memtable that is overlapping
+  // with the files we are importing
+  bool need_flush = false;
+  status = NeedsFlush(&need_flush, super_version);
+  assert(status.ok() && need_flush == false);
+#endif
+
+  edit_.SetColumnFamily(cfd_->GetID());
+
+  // Check for overlap with existing files at all levels.
+  for (unsigned int i = 0; i < files_to_import_.size(); ++i) {
+    auto& f = files_to_import_[i];
+    status = CheckLevelOverlapForImportFile(super_version, &f);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+
+  for (unsigned int i = 0; i < files_to_import_.size(); ++i) {
+    const auto& f = files_to_import_[i];
+    const auto& file_metadata = external_file_metadata_[i];
+    edit_.AddFile(file_metadata.level, f.fd.GetNumber(), f.fd.GetPathId(),
+                  f.fd.GetFileSize(), f.smallest_internal_key(),
+                  f.largest_internal_key(), file_metadata.smallest_seqno,
+                  file_metadata.largest_seqno, false);
+    // If incoming sequence number is higher, update local sequence number.
+    if (file_metadata.largest_seqno > versions_->LastSequence()) {
+      versions_->SetLastAllocatedSequence(file_metadata.largest_seqno);
+      versions_->SetLastPublishedSequence(file_metadata.largest_seqno);
+      versions_->SetLastSequence(file_metadata.largest_seqno);
+    }
+  }
+
+  return status;
+}
+
+Status ExternalSstFileImportJob::CheckLevelOverlapForImportFile(
+    SuperVersion* sv, IngestedFileInfo* file_to_import) {
+  Status status;
+  ReadOptions ro;
+  ro.total_order_seek = true;
+  auto* vstorage = cfd_->current()->storage_info();
+
+  for (int lvl = 0; lvl < cfd_->NumberLevels(); lvl++) {
+    if (lvl > 0 && lvl < vstorage->base_level()) {
+      continue;
+    }
+
+    if (vstorage->NumLevelFiles(lvl) > 0) {
+      bool overlap_with_level = false;
+      status = sv->current->OverlapWithLevelIterator(
+          ro, env_options_, file_to_import->smallest_user_key,
+          file_to_import->largest_user_key, lvl, &overlap_with_level);
+      if (status.ok() && overlap_with_level) {
+        status = Status::InvalidArgument(
+            "External file overlaps with existing file");
+      }
+      if (!status.ok()) {
+        break;
+      }
+    }
+  }
+  return status;
+}
+
+void ExternalSstFileImportJob::UpdateStats() {
+  // TBD: Add stats for import.
+}
+
+void ExternalSstFileImportJob::Cleanup(const Status& status) {
+  if (!status.ok()) {
+    // We failed to add the files to the database
+    // remove all the files we copied
+    for (const auto& f : files_to_import_) {
+      Status s = env_->DeleteFile(f.internal_file_path);
+      if (!s.ok()) {
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "AddFile() clean up for file %s failed : %s",
+                       f.internal_file_path.c_str(), s.ToString().c_str());
+      }
+    }
+  } else if (status.ok() && import_options_.move_files) {
+    // The files were moved and added successfully, remove original file links
+    for (IngestedFileInfo& f : files_to_import_) {
+      Status s = env_->DeleteFile(f.external_file_path);
+      if (!s.ok()) {
+        ROCKS_LOG_WARN(
+            db_options_.info_log,
+            "%s was added to DB successfully but failed to remove original "
+            "file link : %s",
+            f.external_file_path.c_str(), s.ToString().c_str());
+      }
+    }
+  }
+}
+
+Status ExternalSstFileImportJob::GetIngestedFileInfo(
+    const std::string& external_file, IngestedFileInfo* file_to_import) {
+  file_to_import->external_file_path = external_file;
+
+  // Get external file size
+  Status status = env_->GetFileSize(external_file, &file_to_import->file_size);
+  if (!status.ok()) {
+    return status;
+  }
+
+  // Create TableReader for external file
+  std::unique_ptr<TableReader> table_reader;
+  std::unique_ptr<RandomAccessFile> sst_file;
+  std::unique_ptr<RandomAccessFileReader> sst_file_reader;
+
+  status = env_->NewRandomAccessFile(external_file, &sst_file, env_options_);
+  if (!status.ok()) {
+    return status;
+  }
+  sst_file_reader.reset(new RandomAccessFileReader(std::move(sst_file),
+                                                   external_file));
+
+  status = cfd_->ioptions()->table_factory->NewTableReader(
+      TableReaderOptions(*cfd_->ioptions(), env_options_,
+                         cfd_->internal_comparator()),
+      std::move(sst_file_reader), file_to_import->file_size, &table_reader);
+  if (!status.ok()) {
+    return status;
+  }
+
+  // Get the external file properties
+  auto props = table_reader->GetTableProperties();
+
+  // Set original_seqno to 0.
+  file_to_import->original_seqno = 0;
+
+  // Get number of entries in table
+  file_to_import->num_entries = props->num_entries;
+
+  ParsedInternalKey key;
+  ReadOptions ro;
+  // During reading the external file we can cache blocks that we read into
+  // the block cache, if we later change the global seqno of this file, we will
+  // have block in cache that will include keys with wrong seqno.
+  // We need to disable fill_cache so that we read from the file without
+  // updating the block cache.
+  ro.fill_cache = false;
+  std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(ro));
+
+  // Get first (smallest) key from file
+  iter->SeekToFirst();
+  if (!ParseInternalKey(iter->key(), &key)) {
+    return Status::Corruption("external file have corrupted keys");
+  }
+  file_to_import->smallest_user_key = key.user_key.ToString();
+
+  // Get last (largest) key from file
+  iter->SeekToLast();
+  if (!ParseInternalKey(iter->key(), &key)) {
+    return Status::Corruption("external file have corrupted keys");
+  }
+  file_to_import->largest_user_key = key.user_key.ToString();
+
+  file_to_import->cf_id = static_cast<uint32_t>(props->column_family_id);
+
+  file_to_import->table_properties = *props;
+
+  return status;
+}
+
+}  // namespace rocksdb
+
+#endif  // !ROCKSDB_LITE

--- a/db/external_sst_file_import_job.h
+++ b/db/external_sst_file_import_job.h
@@ -1,0 +1,100 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "db/column_family.h"
+#include "db/dbformat.h"
+#include "db/external_sst_file_ingestion_job.h"
+#include "db/internal_stats.h"
+#include "db/snapshot_impl.h"
+#include "options/db_options.h"
+#include "rocksdb/db.h"
+#include "rocksdb/env.h"
+#include "rocksdb/metadata.h"
+#include "rocksdb/sst_file_writer.h"
+#include "util/autovector.h"
+
+namespace rocksdb {
+
+class ExternalSstFileImportJob {
+ public:
+  ExternalSstFileImportJob(
+      Env* env, VersionSet* versions, ColumnFamilyData* cfd,
+      const ImmutableDBOptions& db_options, const EnvOptions& env_options,
+      SnapshotList* db_snapshots,
+      const std::vector<LiveFileMetaData>& file_metadata,
+      const ImportExternalFileOptions& import_options)
+      : env_(env),
+        versions_(versions),
+        cfd_(cfd),
+        db_options_(db_options),
+        env_options_(env_options),
+        db_snapshots_(db_snapshots),
+        job_start_time_(env_->NowMicros()),
+        external_file_metadata_(file_metadata),
+        import_options_(import_options) {}
+
+  // Prepare the job by copying external files into the DB.
+  Status Prepare();
+
+  // Check if we need to flush the memtable before running the import job
+  // This will be true if the files we are importing are overlapping with any
+  // key range in the memtable.
+  //
+  // @param super_version A referenced SuperVersion that will be held for the
+  //    duration of this function.
+  //
+  // Thread-safe
+  Status NeedsFlush(bool* flush_needed, SuperVersion* super_version);
+
+  // Will execute the import job and prepare edit() to be applied.
+  // REQUIRES: Mutex held
+  Status Run();
+
+  // Update column family stats.
+  // REQUIRES: Mutex held
+  void UpdateStats();
+
+  // Cleanup after successful/failed job
+  void Cleanup(const Status& status);
+
+  VersionEdit* edit() { return &edit_; }
+
+  const autovector<IngestedFileInfo>& files_to_import() const {
+    return files_to_import_;
+  }
+
+  const std::vector<LiveFileMetaData>& external_file_metadata() const {
+    return external_file_metadata_;
+  }
+
+ private:
+  // Open the external file and populate `file_to_import` with all the
+  // external information we need to import this file.
+  Status GetIngestedFileInfo(const std::string& external_file,
+                             IngestedFileInfo* file_to_import);
+
+  // Checks whether the file being imported has any overlap with existing files
+  Status CheckLevelOverlapForImportFile(SuperVersion* sv,
+                                        IngestedFileInfo* file_to_import);
+
+  Env* env_;
+  VersionSet* versions_;
+  ColumnFamilyData* cfd_;
+  const ImmutableDBOptions& db_options_;
+  const EnvOptions& env_options_;
+  SnapshotList* db_snapshots_;
+  autovector<IngestedFileInfo> files_to_import_;
+  VersionEdit edit_;
+  uint64_t job_start_time_;
+  std::vector<LiveFileMetaData> external_file_metadata_;
+  const ImportExternalFileOptions& import_options_;
+};
+
+}  // namespace rocksdb

--- a/db/external_sst_file_import_test.cc
+++ b/db/external_sst_file_import_test.cc
@@ -1,0 +1,915 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#ifndef ROCKSDB_LITE
+
+#include <functional>
+#include "db/db_test_util.h"
+#include "port/port.h"
+#include "port/stack_trace.h"
+#include "rocksdb/sst_file_writer.h"
+#include "util/testutil.h"
+
+namespace rocksdb {
+
+class ExternalSSTFileTest : public DBTestBase {
+ public:
+  ExternalSSTFileTest() : DBTestBase("/external_sst_file_test") {
+    sst_files_dir_ = dbname_ + "/sst_files/";
+    DestroyAndRecreateExternalSSTFilesDir();
+  }
+
+  void DestroyAndRecreateExternalSSTFilesDir() {
+    test::DestroyDir(env_, sst_files_dir_);
+    env_->CreateDir(sst_files_dir_);
+  }
+
+  void LimitOptions(Options& options, int num_levels = -1) {
+    if (options.num_levels < num_levels) {
+      options.num_levels = num_levels;
+    }
+  }
+
+  Status DeprecatedAddFile(
+      const std::vector<LiveFileMetaData>* import_files_metadata,
+      bool move_files = false) {
+    ImportExternalFileOptions opts;
+    opts.move_files = move_files;
+    return db_->ImportExternalFile(*import_files_metadata, opts);
+  }
+
+  Status DeprecatedAddFile(
+      ColumnFamilyHandle* column_family,
+      const std::vector<LiveFileMetaData>* import_files_metadata,
+      bool move_files = false) {
+    ImportExternalFileOptions opts;
+    opts.move_files = move_files;
+    return db_->ImportExternalFile(column_family, *import_files_metadata,
+                                   opts);
+  }
+
+  LiveFileMetaData LiveFileMetaDataInit(std::string name,
+                                        std::string path,
+                                        int level,
+                                        SequenceNumber smallest_seqno,
+                                        SequenceNumber largest_seqno) {
+    LiveFileMetaData metadata;
+    metadata.name = name;
+    metadata.db_path = path;
+    metadata.smallest_seqno = smallest_seqno;
+    metadata.largest_seqno = largest_seqno;
+    metadata.level = level;
+    return metadata;
+  }
+
+  ~ExternalSSTFileTest() { test::DestroyDir(env_, sst_files_dir_); }
+
+ protected:
+  int last_file_id_ = 0;
+  std::string sst_files_dir_;
+};
+
+TEST_F(ExternalSSTFileTest, Basic) {
+  do {
+    Options options = CurrentOptions();
+    // Test cases below assume atleast 2 levels in the DB
+    if (options.num_levels < 2) {
+      options.num_levels = 2;
+    }
+
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+
+    // Current file size should be 0 after sst_file_writer init and before open
+    // a file
+    ASSERT_EQ(sst_file_writer.FileSize(), 0);
+
+    // file1.sst (0 => 99)
+    std::string file1_name = "file1.sst";
+    std::string file1 = sst_files_dir_ + file1_name;
+    ASSERT_OK(sst_file_writer.Open(file1));
+    for (int k = 0; k < 100; k++) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+    }
+    ExternalSstFileInfo file1_info;
+    Status s = sst_file_writer.Finish(&file1_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+
+    // Current file size should be non-zero after success write
+    ASSERT_GT(sst_file_writer.FileSize(), 0);
+
+    ASSERT_EQ(file1_info.file_path, file1);
+    ASSERT_EQ(file1_info.num_entries, 100);
+    ASSERT_EQ(file1_info.smallest_key, Key(0));
+    ASSERT_EQ(file1_info.largest_key, Key(99));
+
+    // file2.sst (100 => 199)
+    std::string file2_name = "file2.sst";
+    std::string file2 = sst_files_dir_ + file2_name;
+    ASSERT_OK(sst_file_writer.Open(file2));
+    for (int k = 100; k < 200; k++) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+    }
+    ExternalSstFileInfo file2_info;
+    s = sst_file_writer.Finish(&file2_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_EQ(file2_info.file_path, file2);
+    ASSERT_EQ(file2_info.num_entries, 100);
+    ASSERT_EQ(file2_info.smallest_key, Key(100));
+    ASSERT_EQ(file2_info.largest_key, Key(199));
+
+    // file3.sst (195 => 299)
+    // This file values overlap with file2 values
+    std::string file3_name = "file3.sst";
+    std::string file3 = sst_files_dir_ + file3_name;
+    ASSERT_OK(sst_file_writer.Open(file3));
+    for (int k = 195; k < 300; k++) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val_overlap"));
+    }
+    ExternalSstFileInfo file3_info;
+    s = sst_file_writer.Finish(&file3_info);
+
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    // Current file size should be non-zero after success finish
+    ASSERT_GT(sst_file_writer.FileSize(), 0);
+    ASSERT_EQ(file3_info.file_path, file3);
+    ASSERT_EQ(file3_info.num_entries, 105);
+    ASSERT_EQ(file3_info.smallest_key, Key(195));
+    ASSERT_EQ(file3_info.largest_key, Key(299));
+
+    // file4.sst (30 => 39)
+    // This file values overlap with file1 values
+    std::string file4_name = "file4.sst";
+    std::string file4 = sst_files_dir_ + file4_name;
+    ASSERT_OK(sst_file_writer.Open(file4));
+    for (int k = 30; k < 40; k++) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val_overlap"));
+    }
+    ExternalSstFileInfo file4_info;
+    s = sst_file_writer.Finish(&file4_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_EQ(file4_info.file_path, file4);
+    ASSERT_EQ(file4_info.num_entries, 10);
+    ASSERT_EQ(file4_info.smallest_key, Key(30));
+    ASSERT_EQ(file4_info.largest_key, Key(39));
+
+    // file5.sst (400 => 499)
+    std::string file5_name = "file5.sst";
+    std::string file5 = sst_files_dir_ + file5_name;
+    ASSERT_OK(sst_file_writer.Open(file5));
+    for (int k = 400; k < 500; k++) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+    }
+    ExternalSstFileInfo file5_info;
+    s = sst_file_writer.Finish(&file5_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_EQ(file5_info.file_path, file5);
+    ASSERT_EQ(file5_info.num_entries, 100);
+    ASSERT_EQ(file5_info.smallest_key, Key(400));
+    ASSERT_EQ(file5_info.largest_key, Key(499));
+
+    DestroyAndReopen(options);
+    // Add file1 at L0
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 0, 0));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 100; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+    }
+
+    DestroyAndReopen(options);
+    // Add file1..file3 with file2-file3 overlap at L0 with file3 having lower
+    // sequence number
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 20, 29));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 0, 10, 19));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 0, 0, 0));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 200; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 200; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      ASSERT_EQ(db_->GetLatestSequenceNumber(), 29);
+    }
+
+    DestroyAndReopen(options);
+    // Add file1..file3 with file2-file3 overlap at L0 with file3 having higher
+    // sequence number
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 30, 39));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 0, 10, 19));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 0, 20, 29));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 195; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 195; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      ASSERT_EQ(db_->GetLatestSequenceNumber(), 39);
+    }
+
+    LimitOptions(options, 3);
+    DestroyAndReopen(options);
+    // Add file1..file3 with file2-file3 overlap and file 3 at higher level
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 30, 39));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 0, 10, 19));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 1, 20, 29));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 200; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 200; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      ASSERT_EQ(db_->GetLatestSequenceNumber(), 39);
+    }
+
+    LimitOptions(options, 3);
+    DestroyAndReopen(options);
+    // Add file1..file3 with file2-file3 overlap and file 2 at higher level
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 30, 39));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 1, 40, 49));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 0, 20, 29));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 195; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 195; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      ASSERT_EQ(db_->GetLatestSequenceNumber(), 49);
+    }
+
+    LimitOptions(options, 3);
+    DestroyAndReopen(options);
+    // Add file2 and file3 with overlapping files in different levels
+    // Add non-overlapping file1 in a subsequent call that should succeed
+    // Add overlapping file4 in a subsequent call that should fail
+    {
+      std::vector<LiveFileMetaData> import_files_metadata_0;
+      import_files_metadata_0.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 2, 0, 0));
+      import_files_metadata_0.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 1, 0, 0));
+
+      s = DeprecatedAddFile(&import_files_metadata_0, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+
+      std::vector<LiveFileMetaData> import_files_metadata_1;
+      import_files_metadata_1.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 0, 99));
+
+      s = DeprecatedAddFile(&import_files_metadata_1, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+
+      std::vector<LiveFileMetaData> import_files_metadata_2;
+      import_files_metadata_2.push_back(
+          LiveFileMetaDataInit(file4_name, sst_files_dir_, 0, 100, 199));
+
+      ASSERT_NOK(DeprecatedAddFile(&import_files_metadata_2, false));
+
+      for (int k = 0; k < 195; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 195; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      ASSERT_EQ(db_->GetLatestSequenceNumber(), 99);
+    }
+
+    LimitOptions(options, 5);
+    DestroyAndReopen(options);
+    // Add file1..5 at different levels
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 4, 0, 9));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 3, 10, 19));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 2, 20, 29));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file4_name, sst_files_dir_, 1, 30, 39));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file5_name, sst_files_dir_, 0, 40, 49));
+
+      s = DeprecatedAddFile(&import_files_metadata, false);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      for (int k = 0; k < 30; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 30; k < 40; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      for (int k = 40; k < 195; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+      for (int k = 195; k < 300; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val_overlap");
+      }
+      for (int k = 400; k < 499; k++) {
+        ASSERT_EQ(Get(Key(k)), Key(k) + "_val");
+      }
+    }
+
+    LimitOptions(options, 5);
+    DestroyAndReopen(options);
+    // Add file1..5 at different levels with overlaps at certain level
+    {
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file1_name, sst_files_dir_, 4, 0, 0));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file2_name, sst_files_dir_, 3, 0, 0));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file3_name, sst_files_dir_, 3, 0, 0));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file4_name, sst_files_dir_, 1, 0, 0));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file5_name, sst_files_dir_, 0, 0, 0));
+
+      ASSERT_NOK(DeprecatedAddFile(&import_files_metadata, false));
+    }
+
+    DestroyAndRecreateExternalSSTFilesDir();
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
+}
+
+TEST_F(ExternalSSTFileTest, FileWithCFInfo) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"koko", "toto"}, options);
+
+  SstFileWriter sfw_cf1(EnvOptions(), options, handles_[1]);
+  SstFileWriter sfw_unknown(EnvOptions(), options);
+
+  // cf1.sst
+  const std::string cf1_sst_name = "cf1.sst";
+  const std::string cf1_sst = sst_files_dir_ + cf1_sst_name;
+  ASSERT_OK(sfw_cf1.Open(cf1_sst));
+  ASSERT_OK(sfw_cf1.Put("K3", "V1"));
+  ASSERT_OK(sfw_cf1.Put("K4", "V2"));
+  ASSERT_OK(sfw_cf1.Finish());
+
+  // cf_unknown.sst
+  const std::string unknown_sst_name = "cf_unknown.sst";
+  const std::string unknown_sst = sst_files_dir_ + unknown_sst_name;
+  ASSERT_OK(sfw_unknown.Open(unknown_sst));
+  ASSERT_OK(sfw_unknown.Put("K5", "V1"));
+  ASSERT_OK(sfw_unknown.Put("K6", "V2"));
+  ASSERT_OK(sfw_unknown.Finish());
+
+  {
+    // Import sst file corresponding to cf1 onto cf1 and cf2 and verify
+    std::vector<LiveFileMetaData> import_files_metadata;
+    import_files_metadata.push_back(
+        LiveFileMetaDataInit(cf1_sst_name, sst_files_dir_, 0, 10, 19));
+
+    ASSERT_OK(DeprecatedAddFile(handles_[2], &import_files_metadata, false));
+    ASSERT_OK(DeprecatedAddFile(handles_[1], &import_files_metadata, false));
+    ASSERT_EQ(Get(1, "K3"), "V1");
+    ASSERT_EQ(Get(1, "K4"), "V2");
+    ASSERT_EQ(Get(2, "K3"), "V1");
+    ASSERT_EQ(Get(2, "K4"), "V2");
+  }
+
+  {
+    // Import sst file corresponding to unknown cf onto default cf and cf2
+    // and verify
+    std::vector<LiveFileMetaData> import_files_metadata;
+    import_files_metadata.push_back(
+        LiveFileMetaDataInit(unknown_sst_name, sst_files_dir_, 0, 20, 29));
+
+    ASSERT_OK(DeprecatedAddFile(handles_[0], &import_files_metadata, false));
+    ASSERT_OK(DeprecatedAddFile(handles_[2], &import_files_metadata, false));
+    ASSERT_EQ(Get(0, "K5"), "V1");
+    ASSERT_EQ(Get(0, "K6"), "V2");
+    ASSERT_EQ(Get(2, "K5"), "V1");
+    ASSERT_EQ(Get(2, "K6"), "V2");
+  }
+}
+
+TEST_F(ExternalSSTFileTest, IngestExportedSSTFromAnotherCF) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"koko", "toto"}, options);
+
+  for (int i = 0; i < 100; ++i) {
+    Put(1, Key(i), Key(i) + "_val");
+  }
+  ASSERT_OK(Flush(1));
+
+  ASSERT_OK(
+      db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
+  // Overwrite the value in the same set of keys
+  for (int i = 0; i < 100; ++i) {
+    Put(1, Key(i), Key(i) + "_overwrite");
+  }
+
+  // Flush to create L0 file
+  ASSERT_OK(Flush(1));
+  for (int i = 0; i < 100; ++i) {
+    Put(1, Key(i), Key(i) + "_overwrite2");
+  }
+
+  // Flush again to create another L0 file. It should have higher sequencer
+  ASSERT_OK(Flush(1));
+
+  std::vector<LiveFileMetaData> metadata_vec;
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+  const std::string export_name = test::TmpDir(env_) + "/export";
+  ASSERT_OK(DestroyDB(export_name, options));
+  env_->DeleteDir(export_name);
+  ASSERT_OK(checkpoint->ExportColumnFamilyFiles(handles_[1], &metadata_vec,
+                                                export_name));
+
+  ASSERT_OK(DeprecatedAddFile(handles_[2], &metadata_vec, false));
+  CreateColumnFamilies({"yoyo"}, options);
+
+  ASSERT_OK(DeprecatedAddFile(handles_[3], &metadata_vec, false));
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(Get(1, Key(i)), Get(2, Key(i)));
+    ASSERT_EQ(Get(1, Key(i)), Get(3, Key(i)));
+  }
+
+  for (int k = 0; k < 25; k++) {
+    ASSERT_OK(Delete(2, Key(k)));
+  }
+  for (int k = 25; k < 50; k++) {
+    ASSERT_OK(Put(2, Key(k), Key(k) + "_overwrite3"));
+  }
+
+  for (int i = 0; i < 25; ++i) {
+    ASSERT_EQ("NOT_FOUND", Get(2, Key(i)));
+  }
+  for (int i = 25; i < 50; ++i) {
+    ASSERT_EQ(Key(i) + "_overwrite3", Get(2, Key(i)));
+  }
+  for (int i = 50; i < 100; ++i) {
+    ASSERT_EQ(Key(i) + "_overwrite2", Get(2, Key(i)));
+  }
+
+  // Compact and check again
+  ASSERT_OK(Flush(2));
+  ASSERT_OK(
+      db_->CompactRange(CompactRangeOptions(), handles_[2], nullptr, nullptr));
+
+  for (int i = 0; i < 25; ++i) {
+    ASSERT_EQ("NOT_FOUND", Get(2, Key(i)));
+  }
+  for (int i = 25; i < 50; ++i) {
+    ASSERT_EQ(Key(i) + "_overwrite3", Get(2, Key(i)));
+  }
+  for (int i = 50; i < 100; ++i) {
+    ASSERT_EQ(Key(i) + "_overwrite2", Get(2, Key(i)));
+  }
+}
+
+TEST_F(ExternalSSTFileTest, IngestExportedSSTFromAnotherDB) {
+  Options options = CurrentOptions();
+  CreateAndReopenWithCF({"koko"}, options);
+
+  for (int i = 0; i < 100; ++i) {
+    Put(1, Key(i), Key(i) + "_val");
+  }
+  ASSERT_OK(Flush(1));
+  // Compact to create a L1 file
+  ASSERT_OK(
+      db_->CompactRange(CompactRangeOptions(), handles_[1], nullptr, nullptr));
+
+  // Overwrite the value in the same set of keys
+  for (int i = 0; i < 50; ++i) {
+    Put(1, Key(i), Key(i) + "_overwrite");
+  }
+  // Flush to create L0 file
+  ASSERT_OK(Flush(1));
+
+  for (int i = 0; i < 25; ++i) {
+    Put(1, Key(i), Key(i) + "_overwrite2");
+  }
+  // Flush again to create another L0 file. It should have higher sequencer
+  ASSERT_OK(Flush(1));
+
+  std::vector<LiveFileMetaData> metadata_vec;
+  Checkpoint* checkpoint;
+  ASSERT_OK(Checkpoint::Create(db_, &checkpoint));
+  const std::string export_name = test::TmpDir(env_) + "/export";
+  ASSERT_OK(DestroyDB(export_name, options));
+  env_->DeleteDir(export_name);
+  ASSERT_OK(checkpoint->ExportColumnFamilyFiles(handles_[1], &metadata_vec,
+                                                export_name));
+
+  // Create a new db and import the files.
+  DB* db_copy;
+  ASSERT_OK(DB::Open(options, dbname_ + "/db_copy", &db_copy));
+  ColumnFamilyHandle* cfh;
+  ASSERT_OK(
+      db_copy->CreateColumnFamily(ColumnFamilyOptions(), "yoyo", &cfh));
+  ASSERT_OK(db_copy->ImportExternalFile(cfh, metadata_vec,
+                                        ImportExternalFileOptions()));
+
+  for (int i = 0; i < 100; ++i) {
+    std::string value;
+    db_copy->Get(ReadOptions(), cfh, Key(i), &value);
+    ASSERT_EQ(Get(1, Key(i)), value);
+  }
+  db_copy->DropColumnFamily(cfh);
+  test::DestroyDir(env_, dbname_ + "/db_copy");
+}
+
+TEST_F(ExternalSSTFileTest, AddListAtomicity) {
+  do {
+    Options options = CurrentOptions();
+
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+
+    // files[0].sst (0 => 99)
+    // files[1].sst (100 => 199)
+    // ...
+    // file[8].sst (800 => 899)
+    int n = 9;
+    std::vector<LiveFileMetaData> import_files_metadata;
+    for (int i = 0; i < n; i++) {
+      std::string fname = "file" + std::to_string(i) + ".sst";
+      std::string fpath = sst_files_dir_ + fname;
+      ExternalSstFileInfo files_info;
+      ASSERT_OK(sst_file_writer.Open(fpath));
+      for (int k = i * 100; k < (i + 1) * 100; k++) {
+        ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+      }
+      Status s = sst_file_writer.Finish(&files_info);
+      ASSERT_TRUE(s.ok()) << s.ToString();
+      ASSERT_EQ(files_info.file_path, fpath);
+      ASSERT_EQ(files_info.num_entries, 100);
+      ASSERT_EQ(files_info.smallest_key, Key(i * 100));
+      ASSERT_EQ(files_info.largest_key, Key((i + 1) * 100 - 1));
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(fname, sst_files_dir_, 0, 0, 0));
+    }
+    import_files_metadata.push_back(LiveFileMetaDataInit(
+        "file" + std::to_string(n) + ".sst", sst_files_dir_, 0, 0, 0));
+    auto s = DeprecatedAddFile(&import_files_metadata, false);
+    ASSERT_NOK(s) << s.ToString();
+    for (int k = 0; k < n * 100; k++) {
+      ASSERT_EQ("NOT_FOUND", Get(Key(k)));
+    }
+    import_files_metadata.pop_back();
+    ASSERT_OK(DeprecatedAddFile(&import_files_metadata, false));
+    for (int k = 0; k < n * 100; k++) {
+      std::string value = Key(k) + "_val";
+      ASSERT_EQ(Get(Key(k)), value);
+    }
+    DestroyAndRecreateExternalSSTFilesDir();
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
+}
+
+TEST_F(ExternalSSTFileTest, MultiThreaded) {
+  // Bulk load 10 files every file contain 1000 keys
+  int num_files = 10;
+  int keys_per_file = 1000;
+
+  // Generate file names
+  std::vector<std::string> file_names;
+  for (int i = 0; i < num_files; i++) {
+    std::string file_name = "file_" + ToString(i) + ".sst";
+    file_names.push_back(file_name);
+  }
+
+  do {
+    Options options = CurrentOptions();
+
+    LimitOptions(options, 2);
+    std::atomic<int> thread_num(0);
+    std::function<void()> write_file_func = [&]() {
+      int file_idx = thread_num.fetch_add(1);
+      int range_start = file_idx * keys_per_file;
+      int range_end = range_start + keys_per_file;
+
+      SstFileWriter sst_file_writer(EnvOptions(), options);
+
+      ASSERT_OK(sst_file_writer.Open(sst_files_dir_ + file_names[file_idx]));
+
+      for (int k = range_start; k < range_end; k++) {
+        ASSERT_OK(sst_file_writer.Put(Key(k), Key(k)));
+      }
+
+      Status s = sst_file_writer.Finish();
+      ASSERT_TRUE(s.ok()) << s.ToString();
+    };
+    // Write num_files files in parallel
+    std::vector<port::Thread> sst_writer_threads;
+    for (int i = 0; i < num_files; ++i) {
+      sst_writer_threads.emplace_back(write_file_func);
+    }
+
+    for (auto& t : sst_writer_threads) {
+      t.join();
+    }
+
+
+    thread_num.store(0);
+    std::atomic<int> files_added(0);
+    // Thread 0 -> Load {f0,f1}
+    // Thread 1 -> Load {f0,f1}
+    // Thread 2 -> Load {f2,f3}
+    // Thread 3 -> Load {f2,f3}
+    // Thread 4 -> Load {f4,f5}
+    // Thread 5 -> Load {f4,f5}
+    // ...
+    std::function<void()> load_file_func = [&]() {
+      // We intentionally add every file twice, and assert that it was added
+      // only once and the other add failed
+      int thread_id = thread_num.fetch_add(1);
+      int file_idx = (thread_id / 2) * 2;
+      // sometimes we use copy, sometimes link .. the result should be the same
+      bool move_file = (thread_id % 3 == 0);
+
+      std::vector<LiveFileMetaData> import_files_metadata;
+      import_files_metadata.push_back(
+          LiveFileMetaDataInit(file_names[file_idx], sst_files_dir_, 1, 0, 0));
+
+      if (static_cast<size_t>(file_idx + 1) < file_names.size()) {
+        import_files_metadata.push_back(LiveFileMetaDataInit(
+            file_names[file_idx + 1], sst_files_dir_, 1, 0, 0));
+      }
+
+      Status s = DeprecatedAddFile(&import_files_metadata, move_file);
+      if (s.ok()) {
+        files_added += static_cast<int>(import_files_metadata.size());
+      }
+    };
+
+    // Bulk load num_files files in parallel
+    std::vector<port::Thread> add_file_threads;
+    DestroyAndReopen(options);
+    for (int i = 0; i < num_files; ++i) {
+      add_file_threads.emplace_back(load_file_func);
+    }
+
+    for (auto& t : add_file_threads) {
+      t.join();
+    }
+    ASSERT_EQ(files_added.load(), num_files);
+
+    // Overwrite values of keys divisible by 100
+    for (int k = 0; k < num_files * keys_per_file; k += 100) {
+      std::string key = Key(k);
+      Status s = Put(key, key + "_new");
+      ASSERT_TRUE(s.ok());
+    }
+
+    for (int k = 0; k < num_files * keys_per_file; ++k) {
+      std::string key = Key(k);
+      std::string value = (k % 100 == 0) ? (key + "_new") : key;
+      ASSERT_EQ(Get(key), value);
+    }
+
+    DestroyAndRecreateExternalSSTFilesDir();
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
+}
+
+TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {
+  Options options = CurrentOptions();
+  options.disable_auto_compactions = false;
+  options.level0_file_num_compaction_trigger = 2;
+  options.num_levels = 2;
+  DestroyAndReopen(options);
+
+  std::function<void()> bg_compact = [&]() {
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  };
+
+  int range_id = 0;
+  std::vector<int> file_keys;
+  std::function<void()> bg_addfile = [&]() {
+    SstFileWriter sst_file_writer(EnvOptions(), options);
+    ASSERT_EQ(sst_file_writer.FileSize(), 0);
+    std::string file1_name = "file.sst";
+    std::string file1 = sst_files_dir_ + file1_name;
+    ASSERT_OK(sst_file_writer.Open(file1));
+    for (auto k : file_keys) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + ToString(range_id)));
+    }
+    ExternalSstFileInfo file1_info;
+    Status s = sst_file_writer.Finish(&file1_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    std::vector<LiveFileMetaData> import_files_metadata;
+    import_files_metadata.push_back(
+        LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 0, 0));
+    ASSERT_OK(DeprecatedAddFile(&import_files_metadata, false));
+  };
+
+  std::vector<port::Thread> threads;
+  while (range_id < 5000) {
+    int range_start = range_id * 10;
+    int range_end = range_start + 10;
+
+    file_keys.clear();
+    for (int k = range_start + 1; k < range_end; k++) {
+      file_keys.push_back(k);
+    }
+    ASSERT_OK(Put(Key(range_start), Key(range_start)));
+    ASSERT_OK(Put(Key(range_end), Key(range_end)));
+    ASSERT_OK(Flush());
+
+    if (range_id % 10 == 0) {
+      threads.emplace_back(bg_compact);
+    }
+    threads.emplace_back(bg_addfile);
+
+    for (auto& t : threads) {
+      t.join();
+    }
+    threads.clear();
+
+    range_id++;
+  }
+
+  for (int rid = 0; rid < 5000; rid++) {
+    int range_start = rid * 10;
+    int range_end = range_start + 10;
+
+    ASSERT_EQ(Get(Key(range_start)), Key(range_start)) << rid;
+    ASSERT_EQ(Get(Key(range_end)), Key(range_end)) << rid;
+    for (int k = range_start + 1; k < range_end; k++) {
+      std::string v = Key(k) + ToString(rid);
+      ASSERT_EQ(Get(Key(k)), v) << rid;
+    }
+  }
+}
+
+TEST_F(ExternalSSTFileTest, AddExternalSstFileWithCustomCompartor) {
+  Options options = CurrentOptions();
+  options.comparator = ReverseBytewiseComparator();
+  DestroyAndReopen(options);
+
+  SstFileWriter sst_file_writer(EnvOptions(), options);
+
+  // Generate files with these key ranges
+  // {14  -> 0}
+  // {24 -> 10}
+  // {34 -> 20}
+  // {44 -> 30}
+  // ..
+  std::vector<LiveFileMetaData> generated_files_metadata;
+  for (int i = 0; i < 10; i++) {
+    std::string file_name = env_->GenerateUniqueId();
+    ASSERT_OK(sst_file_writer.Open(sst_files_dir_ + file_name));
+
+    int range_end = i * 10;
+    int range_start = range_end + 15;
+    for (int k = (range_start - 1); k >= range_end; k--) {
+      ASSERT_OK(sst_file_writer.Put(Key(k), Key(k)));
+    }
+    ExternalSstFileInfo file_info;
+    ASSERT_OK(sst_file_writer.Finish(&file_info));
+    generated_files_metadata.push_back(
+        LiveFileMetaDataInit(file_name, sst_files_dir_, 1, 0, 0));
+  }
+
+  std::vector<LiveFileMetaData> import_files_metadata;
+
+  // These 2nd and 3rd files overlap with each other
+  import_files_metadata = {
+      generated_files_metadata[0], generated_files_metadata[4],
+      generated_files_metadata[5], generated_files_metadata[7]};
+  ASSERT_NOK(DeprecatedAddFile(&import_files_metadata, false));
+
+  // These 2 files dont overlap with each other
+  import_files_metadata = {generated_files_metadata[0],
+                           generated_files_metadata[2]};
+  ASSERT_OK(DeprecatedAddFile(&import_files_metadata, false));
+
+  // These 2 files dont overlap with each other but overlap with keys in DB
+  import_files_metadata = {generated_files_metadata[3],
+                           generated_files_metadata[7]};
+  ASSERT_NOK(DeprecatedAddFile(&import_files_metadata, false));
+
+  // Files dont overlap and dont overlap with DB key range
+  import_files_metadata = {generated_files_metadata[4],
+                           generated_files_metadata[6],
+                           generated_files_metadata[8]};
+  ASSERT_OK(DeprecatedAddFile(&import_files_metadata, false));
+
+  for (int i = 0; i < 100; i++) {
+    if (i % 20 <= 14) {
+      ASSERT_EQ(Get(Key(i)), Key(i));
+    } else {
+      ASSERT_EQ(Get(Key(i)), "NOT_FOUND");
+    }
+  }
+}
+
+class TestImportExternalFileListener : public EventListener {
+ public:
+  void OnExternalFileImported(DB* /*db*/,
+                              const ExternalFileImportedInfo& info) override {
+    imported_files.push_back(info);
+  }
+
+  std::vector<ExternalFileImportedInfo> imported_files;
+};
+
+TEST_F(ExternalSSTFileTest, ImportedListener) {
+  Options options = CurrentOptions();
+  TestImportExternalFileListener* listener =
+      new TestImportExternalFileListener();
+  options.listeners.emplace_back(listener);
+  CreateAndReopenWithCF({"koko", "toto"}, options);
+
+  // file1.sst (0 => 99)
+  SstFileWriter sst_file_writer(EnvOptions(), options);
+  ASSERT_EQ(sst_file_writer.FileSize(), 0);
+  std::string file1_name = "file1.sst";
+  std::string file1 = sst_files_dir_ + file1_name;
+  ASSERT_OK(sst_file_writer.Open(file1));
+  for (int k = 0; k < 100; k++) {
+    ASSERT_OK(sst_file_writer.Put(Key(k), Key(k) + "_val"));
+  }
+  ExternalSstFileInfo file1_info;
+  Status s = sst_file_writer.Finish(&file1_info);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  std::vector<LiveFileMetaData> import_files_metadata;
+  import_files_metadata.push_back(
+      LiveFileMetaDataInit(file1_name, sst_files_dir_, 0, 0, 0));
+
+  // Ingest into default cf
+  ASSERT_OK(DeprecatedAddFile(&import_files_metadata, false));
+  ASSERT_EQ(listener->imported_files.size(), 1);
+  ASSERT_EQ(listener->imported_files.back().cf_name, "default");
+  ASSERT_EQ(listener->imported_files.back().smallest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().largest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().level, 0);
+
+  // Ingest into cf1
+  ASSERT_OK(DeprecatedAddFile(handles_[1], &import_files_metadata, false));
+  ASSERT_EQ(listener->imported_files.size(), 2);
+  ASSERT_EQ(listener->imported_files.back().cf_name, "koko");
+  ASSERT_EQ(listener->imported_files.back().smallest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().largest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().level, 0);
+
+  // Ingest into cf2
+  ASSERT_OK(DeprecatedAddFile(handles_[2], &import_files_metadata, false));
+  ASSERT_EQ(listener->imported_files.size(), 3);
+  ASSERT_EQ(listener->imported_files.back().cf_name, "toto");
+  ASSERT_EQ(listener->imported_files.back().smallest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().largest_seqnum, 0);
+  ASSERT_EQ(listener->imported_files.back().level, 0);
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  rocksdb::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+#else
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  fprintf(stderr,
+          "SKIPPED as External SST File Writer and Import are not supported "
+          "in ROCKSDB_LITE\n");
+  return 0;
+}
+
+#endif  // !ROCKSDB_LITE

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1032,6 +1032,24 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
+  // ImportExternalFile() will import external SST files into the specified
+  // column family.
+  //
+  // (1) External SST files can be created using SstFileWriter.
+  // (2) External SST files can be exported from a particular column family in
+  //     an existing DB.
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* column_family,
+      const std::vector<LiveFileMetaData>& external_file_metadata,
+      const ImportExternalFileOptions& options) = 0;
+
+  virtual Status ImportExternalFile(
+      const std::vector<LiveFileMetaData>& external_file_metadata,
+      const ImportExternalFileOptions& options) {
+    return ImportExternalFile(DefaultColumnFamily(), external_file_metadata,
+                              options);
+  }
+
   virtual Status VerifyChecksum() = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -238,6 +238,23 @@ struct ExternalFileIngestionInfo {
   TableProperties table_properties;
 };
 
+struct ExternalFileImportedInfo {
+  // the name of the column family
+  std::string cf_name;
+  // Path of the file outside the DB
+  std::string external_file_path;
+  // Path of the file inside the DB
+  std::string internal_file_path;
+  // Smallest sequency number assigned to this file
+  SequenceNumber smallest_seqnum;
+  // Largest sequency number assigned to this file
+  SequenceNumber largest_seqnum;
+  // Level at which file is being ingested
+  int level;
+  // Table properties of the table being flushed
+  TableProperties table_properties;
+};
+
 // EventListener class contains a set of callback functions that will
 // be called when specific RocksDB event happens such as flush.  It can
 // be used as a building block for developing custom features such as
@@ -370,6 +387,15 @@ class EventListener {
   // will be blocked from finishing.
   virtual void OnExternalFileIngested(
       DB* /*db*/, const ExternalFileIngestionInfo& /*info*/) {}
+
+  // A callback function for RocksDB which will be called after an external
+  // file is imported using ImportExternalFile.
+  //
+  // Note that this function will run on the same thread as
+  // ImportExternalFile(), if this function is blocked, ImportExternalFile()
+  // will be blocked from finishing.
+  virtual void OnExternalFileImported(
+      DB* /*db*/, const ExternalFileImportedInfo& /*info*/) {}
 
   // A callback function for RocksDB which will be called before setting the
   // background error status to a non-OK value. The new background error status

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1254,6 +1254,11 @@ struct IngestExternalFileOptions {
   bool ingest_behind = false;
 };
 
+// ImportExternalFileOptions is used by ImportExternalFile()
+struct ImportExternalFileOptions {
+  // Can be set to true to move the files instead of copying them.
+  bool move_files = false;
+};
 }  // namespace rocksdb
 
 #endif  // STORAGE_ROCKSDB_INCLUDE_OPTIONS_H_

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -9,11 +9,14 @@
 #ifndef ROCKSDB_LITE
 
 #include <string>
+#include <vector>
 #include "rocksdb/status.h"
 
 namespace rocksdb {
 
 class DB;
+class ColumnFamilyHandle;
+struct LiveFileMetaData;
 
 class Checkpoint {
  public:
@@ -35,6 +38,17 @@ class Checkpoint {
   // Flush will always trigger if it is 2PC.
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
                                   uint64_t log_size_for_flush = 0);
+
+  // Gets the live set of SST files for a particular Column Family in
+  // export_tables_dir and metadata about the files in metadata_vec.
+  // The SST files will be created through hard links when the directory is in
+  // the same partition as the db, copied otherwise.
+  // The directory should not already exist and will be created by this API.
+  // The directory will be an absolute path. Triggers a flush.
+  virtual Status ExportColumnFamilyFiles(
+      ColumnFamilyHandle* column_family,
+      std::vector<LiveFileMetaData>* metadata_vec,
+      const std::string& export_files_dir);
 
   virtual ~Checkpoint() {}
 };

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -107,6 +107,15 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
+  using DB::ImportExternalFile;
+  virtual Status ImportExternalFile(
+      ColumnFamilyHandle* column_family,
+      const std::vector<LiveFileMetaData>& external_file_metadata,
+      const ImportExternalFileOptions& import_options) override {
+    return db_->ImportExternalFile(column_family, external_file_metadata,
+                                   import_options);
+  }
+
   virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
   using DB::KeyMayExist;

--- a/src.mk
+++ b/src.mk
@@ -28,6 +28,7 @@ LIB_SOURCES =                                                   \
   db/event_helpers.cc                                           \
   db/experimental.cc                                            \
   db/external_sst_file_ingestion_job.cc                         \
+  db/external_sst_file_import_job.cc                            \
   db/file_indexer.cc                                            \
   db/flush_job.cc                                               \
   db/flush_scheduler.cc                                         \

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -30,6 +30,18 @@ class CheckpointImpl : public Checkpoint {
   virtual Status CreateCheckpoint(const std::string& checkpoint_dir,
                                   uint64_t log_size_for_flush) override;
 
+  // Gets the live set of SST files for a particular Column Family in
+  // export_tables_dir and metadata about the files in metadata_vec.
+  // The SST files will be created through hard links when the directory is in
+  // the same partition as the db, copied otherwise.
+  // The directory should not already exist and will be created by this API.
+  // The directory will be an absolute path. Triggers a flush.
+  using Checkpoint::ExportColumnFamilyFiles;
+  virtual Status ExportColumnFamilyFiles(
+      ColumnFamilyHandle* column_family,
+      std::vector<LiveFileMetaData>* metadata_vec,
+      const std::string& export_tables_dir) override;
+
   // Checkpoint logic can be customized by providing callbacks for link, copy,
   // or create.
   Status CreateCustomCheckpoint(
@@ -45,6 +57,17 @@ class CheckpointImpl : public Checkpoint {
                            const std::string& contents, FileType type)>
           create_file_cb,
       uint64_t* sequence_number, uint64_t log_size_for_flush);
+
+ private:
+  // Export logic can be customized by providing callbacks for link or copy.
+  Status ExportFilesInMetaData(
+      const DBOptions& db_options, const ColumnFamilyMetaData* metadata,
+      std::function<Status(const std::string& src_dirname,
+                           const std::string& fname)>
+          link_file_cb,
+      std::function<Status(const std::string& src_dirname,
+                           const std::string& fname)>
+          copy_file_cb);
 
  private:
   DB* db_;


### PR DESCRIPTION
This is a review request for code change needed for - https://github.com/facebook/rocksdb/issues/3469
"Add support for taking snapshot of a column family and creating column family from a given CF snapshot"

We have an implementation for this that we have been testing internally. We have two new APIs that together provide this functionality.

(1) ExportColumnFamilyFiles() - This API is modelled after CreateCheckpoint() as below.
  // Gets the live set of SST files for a particular Column Family in
  // export_tables_dir and metadata about the files in metadata_vec.
  // The SST files will be created through hard links when the directory is in
  // the same partition as the db, copied otherwise.
  // The directory should not already exist and will be created by this API.
  // The directory will be an absolute path. Triggers a flush.
  virtual Status ExportColumnFamilyFiles(
      ColumnFamilyHandle* column_family,
      std::vector<LiveFileMetaData>* metadata_vec,
      const std::string& export_files_dir);

Internally, the API will DisableFileDeletions(), GetColumnFamilyMetaData(), Parse through
metadata, creating links/copies of all the sst files, EnableFileDeletions() and complete the call by
returning the list of file metadata.

(2) ImportExternalFile() - This API is modelled after IngestExternalFile() as below.
  // ImportExternalFile() will import external SST files into the specified
  // column family.
  //
  // (1) External SST files can be created using SstFileWriter.
  // (2) External SST files can be exported from a particular column family in
  //     an existing DB.
  virtual Status ImportExternalFile(
      ColumnFamilyHandle* column_family,
      const std::vector<LiveFileMetaData>& external_file_metadata,
      const ImportExternalFileOptions& options);

Internally, this API parses all the sst files and adds it to the specified column family, at the same
level and with same sequence number as in the metadata. Also performs safety checks with respect to
overlaps between the sst files being imported or between existing data and new files being imported.

If incoming sequence number is higher than current local sequence number, local sequence 
number is updated to reflect this.

Note, as the sst files is are being moved across Column Families, Column Family name in sst file 
will no longer match the actual column family on destination DB. The API does not modify Column 
Family name or id in the sst files being imported.
