### PR TITLE
Pass manual_wal_flush also to the first wal file

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -718,6 +718,9 @@ Status DBImpl::FlushWAL(bool sync) {
     if (!s.ok()) {
       ROCKS_LOG_ERROR(immutable_db_options_.info_log, "WAL flush error %s",
                       s.ToString().c_str());
+      // In case there is a fs error we should set it globally to prevent the
+      // future writes
+      WriteStatusCheck(s);
     }
     if (!sync) {
       ROCKS_LOG_DEBUG(immutable_db_options_.info_log, "FlushWAL sync=false");

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -721,6 +721,8 @@ Status DBImpl::FlushWAL(bool sync) {
       // In case there is a fs error we should set it globally to prevent the
       // future writes
       WriteStatusCheck(s);
+      // whether sync or not, we should abort the rest of function upon error
+      return s;
     }
     if (!sync) {
       ROCKS_LOG_DEBUG(immutable_db_options_.info_log, "FlushWAL sync=false");

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -220,6 +220,7 @@ class DBImpl : public DB {
   virtual Status Flush(const FlushOptions& options,
                        ColumnFamilyHandle* column_family) override;
   virtual Status FlushWAL(bool sync) override;
+  bool TEST_WALBufferIsEmpty();
   virtual Status SyncWAL() override;
 
   virtual SequenceNumber GetLatestSequenceNumber() const override;

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -25,6 +25,12 @@ void DBImpl::TEST_SwitchWAL() {
   SwitchWAL(&write_context);
 }
 
+bool DBImpl::TEST_WALBufferIsEmpty() {
+    InstrumentedMutexLock wl(&log_write_mutex_);
+    log::Writer* cur_log_writer = logs_.back().writer;
+    return cur_log_writer->TEST_BufferIsEmpty();
+}
+
 int64_t DBImpl::TEST_MaxNextLevelOverlappingBytes(
     ColumnFamilyHandle* column_family) {
   ColumnFamilyData* cfd;

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -26,9 +26,9 @@ void DBImpl::TEST_SwitchWAL() {
 }
 
 bool DBImpl::TEST_WALBufferIsEmpty() {
-    InstrumentedMutexLock wl(&log_write_mutex_);
-    log::Writer* cur_log_writer = logs_.back().writer;
-    return cur_log_writer->TEST_BufferIsEmpty();
+  InstrumentedMutexLock wl(&log_write_mutex_);
+  log::Writer* cur_log_writer = logs_.back().writer;
+  return cur_log_writer->TEST_BufferIsEmpty();
 }
 
 int64_t DBImpl::TEST_MaxNextLevelOverlappingBytes(

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1218,7 +1218,9 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   if (s.ok()) {
     ROCKS_LOG_INFO(impl->immutable_db_options_.info_log, "DB pointer %p", impl);
     LogFlush(impl->immutable_db_options_.info_log);
-    impl->FlushWAL(false /*sync*/);
+    assert(impl->TEST_WALBufferIsEmpty());
+    // If the assert above fails then we need to FlushWAL before returning
+    // control back to the user.
     if (!persist_options_status.ok()) {
       s = Status::IOError(
           "DB::Open() failed --- Unable to persist Options file",

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1218,6 +1218,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   if (s.ok()) {
     ROCKS_LOG_INFO(impl->immutable_db_options_.info_log, "DB pointer %p", impl);
     LogFlush(impl->immutable_db_options_.info_log);
+    impl->FlushWAL(false /*sync*/);
     if (!persist_options_status.ok()) {
       s = Status::IOError(
           "DB::Open() failed --- Unable to persist Options file",

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1090,7 +1090,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
             new_log_number,
             new log::Writer(
                 std::move(file_writer), new_log_number,
-                impl->immutable_db_options_.recycle_log_file_num > 0));
+                impl->immutable_db_options_.recycle_log_file_num > 0,
+                impl->immutable_db_options_.manual_wal_flush));
       }
 
       // set column family handles

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -362,7 +362,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     }
   }
-  printf("%s\n", status.ToString().c_str());
 
   bool should_exit_batch_group = true;
   if (in_parallel_group) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -362,6 +362,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     }
   }
+  printf("%s\n", status.ToString().c_str());
 
   bool should_exit_batch_group = true;
   if (in_parallel_group) {

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -50,6 +50,10 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
   std::atomic<int> leader_count{0};
   std::vector<port::Thread> threads;
   mock_env->SetFilesystemActive(false);
+
+  WriteOptions write_options;
+  write_options.sync = true; // handle the situation where manual_wal_flush is true
+
   // Wait until all threads linked to write threads, to make sure
   // all threads join the same batch group.
   SyncPoint::GetInstance()->SetCallBack(
@@ -68,7 +72,7 @@ TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
     threads.push_back(port::Thread(
         [&](int index) {
           // All threads should fail.
-          ASSERT_FALSE(Put("key" + ToString(index), "value").ok());
+          ASSERT_FALSE(Put("key" + ToString(index), "value", write_options).ok());
         },
         i));
   }

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -92,6 +92,8 @@ Status Writer::AddRecord(const Slice& slice) {
   return s;
 }
 
+bool Writer::TEST_BufferIsEmpty() { return dest_->TEST_BufferIsEmpty(); }
+
 Status Writer::EmitPhysicalRecord(RecordType t, const char* ptr, size_t n) {
   assert(n <= 0xffff);  // Must fit in two bytes
 

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -86,6 +86,7 @@ class Writer {
   Status WriteBuffer();
 
   bool TEST_BufferIsEmpty();
+
  private:
   unique_ptr<WritableFileWriter> dest_;
   size_t block_offset_;       // Current offset in block

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -85,6 +85,7 @@ class Writer {
 
   Status WriteBuffer();
 
+  bool TEST_BufferIsEmpty();
  private:
   unique_ptr<WritableFileWriter> dest_;
   size_t block_offset_;       // Current offset in block

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -124,6 +124,8 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.allow_ingest_behind;
   options.preserve_deletes =
       immutable_db_options.preserve_deletes;
+  options.two_write_queues = immutable_db_options.two_write_queues;
+  options.manual_wal_flush = immutable_db_options.manual_wal_flush;
 
   return options;
 }

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -189,6 +189,7 @@ class WritableFileWriter {
 
   bool use_direct_io() { return writable_file_->use_direct_io(); }
 
+  bool TEST_BufferIsEmpty() { return buf_.CurrentSize() == 0; }
  private:
   // Used when os buffering is OFF and we are writing
   // DMA such as in Direct I/O mode

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -190,6 +190,7 @@ class WritableFileWriter {
   bool use_direct_io() { return writable_file_->use_direct_io(); }
 
   bool TEST_BufferIsEmpty() { return buf_.CurrentSize() == 0; }
+
  private:
   // Used when os buffering is OFF and we are writing
   // DMA such as in Direct I/O mode


### PR DESCRIPTION
Currently manual_wal_flush if set in the options will be used only for the wal files created during wal switch. The configuration thus does not affect the first wal file. The patch fixes that and also update the related unit tests.
This PR is built on top of https://github.com/facebook/rocksdb/pull/3756