### PR TITLE
Exclude dir name from log lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,10 @@ ARFLAGS = -X64 rs
 STRIPFLAGS = -X64 -x
 endif
 
+# This helps shorter file names in logged lines. $< is the name of the first
+# prerequisite which should normally be the source file name.
+CXXFLAGS+=-D__FILENAME__='"$(notdir $<)"'
+
 ifeq ($(PLATFORM), OS_SOLARIS)
 	PLATFORM_CXXFLAGS += -D _GLIBCXX_USE_C99
 endif

--- a/util/logging.h
+++ b/util/logging.h
@@ -16,7 +16,12 @@
 // Helper macros that include information about file name and line number
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
+#ifdef __FILENAME__
+#define PREPEND_FILE_LINE(FMT) \
+  ("[" __FILENAME__ ":" TOSTRING(__LINE__) "] " FMT)
+#else
 #define PREPEND_FILE_LINE(FMT) ("[" __FILE__ ":" TOSTRING(__LINE__) "] " FMT)
+#endif
 
 // Don't inclide file/line info in HEADER level
 #define ROCKS_LOG_HEADER(LGR, FMT, ...) \


### PR DESCRIPTION
Log lines also print the file and line number from which they are generated. In some cases however the filename could include the full path and hence too long. The patch enables the build system to pass `__FILENAME__` which could be the shorter version of the full path.
One drawback of this patch is that it assumes the first file passed to GCC is the source file, which seems to be the case on our build system.
Fixes https://github.com/facebook/rocksdb/issues/3820