### PR TITLE
Disallow to open RandomRW file if the file doesn't exist

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 * The background thread naming convention changed (on supporting platforms) to "rocksdb:<thread pool priority><thread number>", e.g., "rocksdb:low0".
 * Add a new ticker stat rocksdb.number.multiget.keys.found to count number of keys successfully read in MultiGet calls
 * Touch-up to write-related counters in PerfContext. New counters added: write_scheduling_flushes_compactions_time, write_thread_wait_nanos. Counters whose behavior was fixed or modified: write_memtable_time, write_pre_and_post_process_time, write_delay_time.
+* Posix Env's NewRandomRWFile() will fail if the file doesn't exist.
 
 ### New Features
 * Introduce TTL for level compaction so that all files older than ttl go through the compaction process to get rid of old data.

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -441,8 +441,7 @@ class PosixEnv : public Env {
     int fd = -1;
     while (fd < 0) {
       IOSTATS_TIMER_GUARD(open_nanos);
-      fd = open(fname.c_str(), O_CREAT | O_RDWR,
-                GetDBFileMode(allow_non_owner_access_));
+      fd = open(fname.c_str(), O_RDWR, GetDBFileMode(allow_non_owner_access_));
       if (fd < 0) {
         // Error while opening the file
         if (errno == EINTR) {

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -175,6 +175,8 @@ TEST_F(EnvPosixTest, DISABLED_FilePermission) {
         test::TmpDir(env_) + "/testfile", test::TmpDir(env_) + "/testfile1"};
     unique_ptr<WritableFile> wfile;
     ASSERT_OK(env_->NewWritableFile(fileNames[0], &wfile, soptions));
+    ASSERT_OK(env_->NewWritableFile(fileNames[1], &wfile, soptions));
+    wfile.reset();
     unique_ptr<RandomRWFile> rwfile;
     ASSERT_OK(env_->NewRandomRWFile(fileNames[1], &rwfile, soptions));
 
@@ -188,6 +190,8 @@ TEST_F(EnvPosixTest, DISABLED_FilePermission) {
 
     env_->SetAllowNonOwnerAccess(false);
     ASSERT_OK(env_->NewWritableFile(fileNames[0], &wfile, soptions));
+    ASSERT_OK(env_->NewWritableFile(fileNames[1], &wfile, soptions));
+    wfile.reset();
     ASSERT_OK(env_->NewRandomRWFile(fileNames[1], &rwfile, soptions));
 
     for (const auto& filename : fileNames) {
@@ -1432,6 +1436,16 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFile) {
   env_->DeleteFile(path);
 
   std::unique_ptr<RandomRWFile> file;
+
+  // Cannot open non-existing file.
+  ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
+
+  // Create the file using WriteableFile
+  {
+    std::unique_ptr<WritableFile> wf;
+    ASSERT_OK(env_->NewWritableFile(path, &wf, EnvOptions()));
+  }
+
   ASSERT_OK(env_->NewRandomRWFile(path, &file, EnvOptions()));
 
   char buf[10000];
@@ -1549,6 +1563,16 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFileRandomized) {
   env_->DeleteFile(path);
 
   unique_ptr<RandomRWFile> file;
+
+  // Cannot open non-existing file.
+  ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
+
+  // Create the file using WriteableFile
+  {
+    std::unique_ptr<WritableFile> wf;
+    ASSERT_OK(env_->NewWritableFile(path, &wf, EnvOptions()));
+  }
+
   ASSERT_OK(env_->NewRandomRWFile(path, &file, EnvOptions()));
   RandomRWFileWithMirrorString file_with_mirror(file.get());
 

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1437,9 +1437,11 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFile) {
 
   std::unique_ptr<RandomRWFile> file;
 
+#ifdef OS_LINUX
   // Cannot open non-existing file.
   ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
-
+#endif
+  
   // Create the file using WriteableFile
   {
     std::unique_ptr<WritableFile> wf;
@@ -1564,9 +1566,11 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFileRandomized) {
 
   unique_ptr<RandomRWFile> file;
 
+#ifdef OS_LINUX
   // Cannot open non-existing file.
   ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
-
+#endif
+  
   // Create the file using WriteableFile
   {
     std::unique_ptr<WritableFile> wf;

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1441,7 +1441,7 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFile) {
   // Cannot open non-existing file.
   ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
 #endif
-  
+
   // Create the file using WriteableFile
   {
     std::unique_ptr<WritableFile> wf;
@@ -1570,7 +1570,7 @@ TEST_P(EnvPosixTestWithParam, PosixRandomRWFileRandomized) {
   // Cannot open non-existing file.
   ASSERT_NOK(env_->NewRandomRWFile(path, &file, EnvOptions()));
 #endif
-  
+
   // Create the file using WriteableFile
   {
     std::unique_ptr<WritableFile> wf;


### PR DESCRIPTION
Summary: The only use of RandomRW is to change seqno when bulkloading, and in this use case, the file should exist. We should fail the file opening in this case.

Test Plan: Fix env_test and make sure all tests pass.