### PR TITLE
Make BlockIter final

### DIFF
--- a/table/block.h
+++ b/table/block.h
@@ -195,7 +195,7 @@ class Block {
   void operator=(const Block&) = delete;
 };
 
-class BlockIter : public InternalIterator {
+class BlockIter final : public InternalIterator {
  public:
   // Object created using this constructor will behave like an iterator
   // against an empty block. The state after the creation: Valid()=false


### PR DESCRIPTION
Summary: Now BlockBasedTableIterator directly uses BlockIter. By making BlockIter final, we can prevent unintended virtual function overriding.

Test Plan:Make sure all tests pass.