### PR TITLE
Implement key shortening functions in ReverseBytewiseComparator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 * Fix `BackupableDBOptions::max_valid_backups_to_open` to not delete backup files when refcount cannot be accurately determined.
 * Fix memory leak when pin_l0_filter_and_index_blocks_in_cache is used with partitioned filters
 * Disable rollback of merge operands in WritePrepared transactions to work around an issue in MyRocks. It can be enabled back by setting TransactionDBOptions::rollback_merge_operands to true.
+* Fix wrong results by ReverseBytewiseComparator::FindShortSuccessor()
 
 ### Java API Changes
 * Add `BlockBasedTableConfig.setBlockCache` to allow sharing a block cache across DB instances.

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -2,6 +2,7 @@
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
+#include <array>
 #include <map>
 #include <string>
 
@@ -469,7 +470,7 @@ TEST_F(ComparatorDBTest, FindShortestSeparator) {
 
 TEST_F(ComparatorDBTest, SeparatorSuccessorRandomizeTest) {
   // Char list for boundary cases.
-  unsigned char char_list[] = {0, 1, 2, 253, 254, 255};
+  std::array<unsigned char, 6> char_list{{0, 1, 2, 253, 254, 255}};
   Random rnd(301);
 
   for (int attempts = 0; attempts < 1000; attempts++) {
@@ -519,7 +520,7 @@ TEST_F(ComparatorDBTest, SeparatorSuccessorRandomizeTest) {
           // Create a char within [-2, +2] of the matching char of s1.
           int diff = static_cast<int>(rnd.Uniform(5)) - 2;
           // char may be signed or unsigned based on platform.
-          int s1_char = (static_cast<int>(s1[pos]) + 256) % 256;
+          int s1_char = static_cast<int>(static_cast<unsigned char>(s1[pos]));
           int s2_char = s1_char + diff;
           if (s2_char < 0) {
             s2_char = 0;

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -433,6 +433,40 @@ TEST_F(ComparatorDBTest, TwoStrComparator) {
   }
 }
 
+TEST_F(ComparatorDBTest, FindShortestSeparator) {
+  std::string s1 = "abc1xyz";
+  std::string s2 = "abc3xy";
+
+  BytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_EQ("abc2", s1);
+
+  s1 = "abc5xyztt";
+
+  ReverseBytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_EQ("abc5", s1);
+
+  s1 = "abc3";
+  s2 = "abc2xy";
+  ReverseBytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_EQ("abc3", s1);
+
+  s1 = "abc3xyz";
+  s2 = "abc2xy";
+  ReverseBytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_EQ("abc3", s1);
+
+  s1 = "abc3xyz";
+  s2 = "abc2";
+  ReverseBytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_EQ("abc3", s1);
+
+  std::string old_s1 = s1 = "abc2xy";
+  s2 = "abc2";
+  ReverseBytewiseComparator()->FindShortestSeparator(&s1, s2);
+  ASSERT_TRUE(old_s1 >= s1);
+  ASSERT_TRUE(s1 > s2);
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -498,7 +498,6 @@ TEST_F(ComparatorDBTest, SeparatorSuccessorRandomizeTest) {
       } else {
         // Use one byte in char_list
         char c = static_cast<char>(char_list[rnd.Uniform(sizeof(char_list))]);
-        fprintf(stderr, "%d\n", int(c));
         s1 += c;
       }
     }

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -151,12 +151,11 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
       }
     }
   }
+
+  void FindShortSuccessor(std::string* /*key*/) const override {
+    // Don't do anything for simplicity.
+  }
 };
-
-void FindShortSuccessor(std::string* key) const override {
-  // Don't do anything for simplicity.
-}
-
 }// namespace
 
 const Comparator* BytewiseComparator() {

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -111,6 +111,46 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
   virtual int Compare(const Slice& a, const Slice& b) const override {
     return -a.compare(b);
   }
+
+  virtual void FindShortestSeparator(std::string* start,
+                                     const Slice& limit) const override {
+    // Find length of common prefix
+    size_t min_length = std::min(start->size(), limit.size());
+    size_t diff_index = 0;
+    while ((diff_index < min_length) &&
+           ((*start)[diff_index] == limit[diff_index])) {
+      diff_index++;
+    }
+
+    assert(diff_index <= min_length);
+    if (diff_index >= min_length) {
+      // Do not shorten if one string is a prefix of the other
+      //
+      // We could handle cases like:
+      //     V
+      // A A 2 X Y
+      // A A 2
+      // in a similar way as BytewiseComparator::FindShortestSeparator().
+      // We keep it simple but not implementing it. We can come back to it
+      // later when needed.
+    } else {
+      uint8_t start_byte = static_cast<uint8_t>((*start)[diff_index]);
+      uint8_t limit_byte = static_cast<uint8_t>(limit[diff_index]);
+      if (start_byte > limit_byte && diff_index < start->size() - 1) {
+        // Case like
+        //     V
+        // A A 3 A A
+        // A A 1 B B
+        //
+        // or
+        //     v
+        // A A 2 A A
+        // A A 1 B B
+        // In this case "AA2" will be good.
+        start->resize(diff_index + 1);
+      }
+    }
+  }
 };
 
 }// namespace

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -123,7 +123,7 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
     }
 
     assert(diff_index <= min_length);
-    if (diff_index >= min_length) {
+    if (diff_index == min_length) {
       // Do not shorten if one string is a prefix of the other
       //
       // We could handle cases like:
@@ -131,7 +131,7 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
       // A A 2 X Y
       // A A 2
       // in a similar way as BytewiseComparator::FindShortestSeparator().
-      // We keep it simple but not implementing it. We can come back to it
+      // We keep it simple by not implementing it. We can come back to it
       // later when needed.
     } else {
       uint8_t start_byte = static_cast<uint8_t>((*start)[diff_index]);
@@ -147,7 +147,14 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
         // A A 2 A A
         // A A 1 B B
         // In this case "AA2" will be good.
+#ifndef NDEBUG
+        std::string old_start = *start;
+#endif
         start->resize(diff_index + 1);
+#ifndef NDEBUG
+        assert(old_start >= *start);
+#endif
+        assert(Slice(*start).compare(limit) > 0);
       }
     }
   }

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -112,8 +112,8 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
     return -a.compare(b);
   }
 
-  virtual void FindShortestSeparator(std::string* start,
-                                     const Slice& limit) const override {
+  void FindShortestSeparator(std::string* start,
+                             const Slice& limit) const override {
     // Find length of common prefix
     size_t min_length = std::min(start->size(), limit.size());
     size_t diff_index = 0;
@@ -152,6 +152,10 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
     }
   }
 };
+
+void FindShortSuccessor(std::string* key) const override {
+  // Don't do anything for simplicity.
+}
 
 }// namespace
 


### PR DESCRIPTION
Summary: Right now ReverseBytewiseComparator::FindShortestSeparator() doesn't really shorten key, and ReverseBytewiseComparator::FindShortestSuccessor() seems to return wrong results. The code is confusing too as it uses BytewiseComparatorImpl::FindShortestSeparator() but the function actually won't do anything if the the first key is larger than the second.

Implement ReverseBytewiseComparator::FindShortestSeparator() and override ReverseBytewiseComparator::FindShortestSuccessor() to be empty.

Test Plan: Add a unit test