### PR TITLE
Fix db_stress build on mac

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -857,7 +857,7 @@ class SharedState {
             "Cannot use --expected_values_path on when "
             "--clear_column_family_one_in is greater than zero.");
       }
-      size_t size = 0;
+      uint64_t size = 0;
       if (status.ok()) {
         status = FLAGS_env->GetFileSize(FLAGS_expected_values_path, &size);
       }


### PR DESCRIPTION
I noticed, while debugging an unrelated issue, that db_stress is failing to build on mac, leading to a failed `make all`.
```
$ make db_stress -j4
...
tools/db_stress.cc:862:69: error: cannot initialize a parameter of type 'uint64_t *' (aka 'unsigned long long *') with an rvalue of type 'size_t *' (aka 'unsigned long *')
        status = FLAGS_env->GetFileSize(FLAGS_expected_values_path, &size);
                                                                    ^~~~~
./include/rocksdb/env.h:277:66: note: passing argument to parameter 'file_size' here
  virtual Status GetFileSize(const std::string& fname, uint64_t* file_size) = 0;
                                                                 ^
1 error generated.
make: *** [tools/db_stress.o] Error 1
make: *** Waiting for unfinished jobs....
```
Test Plan:
Verified with `make all`