### PR TITLE
Eliminate db_stress whitebox lock contention in SyncPoint

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2834,17 +2834,8 @@ int main(int argc, char** argv) {
   ParseCommandLineFlags(&argc, &argv, true);
 #if !defined(NDEBUG) && !defined(OS_MACOSX) && !defined(OS_WIN) && \
   !defined(OS_SOLARIS) && !defined(OS_AIX)
-  rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "NewWritableFile:O_DIRECT", [&](void* arg) {
-        int* val = static_cast<int*>(arg);
-        *val &= ~O_DIRECT;
-      });
-  rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "NewRandomAccessFile:O_DIRECT", [&](void* arg) {
-        int* val = static_cast<int*>(arg);
-        *val &= ~O_DIRECT;
-      });
-  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing(
+      rocksdb::SyncPoint::Mode::kKillPoints);
 #endif
 
   if (FLAGS_statistics) {

--- a/util/sync_point.cc
+++ b/util/sync_point.cc
@@ -17,9 +17,7 @@ SyncPoint* SyncPoint::GetInstance() {
   return &sync_point;
 }
 
-SyncPoint::SyncPoint() : 
-  impl_(new Data) {
-}
+SyncPoint::SyncPoint() : impl_(new Data) {}
 
 SyncPoint:: ~SyncPoint() {
   delete impl_;
@@ -48,8 +46,8 @@ void SyncPoint::ClearAllCallBacks() {
   impl_->ClearAllCallBacks();
 }
 
-void SyncPoint::EnableProcessing() {
-  impl_->EnableProcessing();
+void SyncPoint::EnableProcessing(SyncPoint::Mode mode) {
+  impl_->EnableProcessing(mode);
 }
 
 void SyncPoint::DisableProcessing() {

--- a/util/sync_point.cc
+++ b/util/sync_point.cc
@@ -46,7 +46,8 @@ void SyncPoint::ClearAllCallBacks() {
   impl_->ClearAllCallBacks();
 }
 
-void SyncPoint::EnableProcessing(SyncPoint::Mode mode) {
+void SyncPoint::EnableProcessing(
+    SyncPoint::Mode mode /* = SyncPoint::Mode::kAll */) {
   impl_->EnableProcessing(mode);
 }
 

--- a/util/sync_point.h
+++ b/util/sync_point.h
@@ -60,6 +60,12 @@ namespace rocksdb {
 
 class SyncPoint {
  public:
+  enum class Mode {
+    kDisabled,
+    kKillPoints,
+    kAll,
+  };
+
   static SyncPoint* GetInstance();
 
   SyncPoint(const SyncPoint&) = delete;
@@ -95,7 +101,7 @@ class SyncPoint {
   void ClearAllCallBacks();
 
   // enable sync point processing (disabled on startup)
-  void EnableProcessing();
+  void EnableProcessing(Mode mode);
 
   // disable sync point processing
   void DisableProcessing();

--- a/util/sync_point.h
+++ b/util/sync_point.h
@@ -101,7 +101,7 @@ class SyncPoint {
   void ClearAllCallBacks();
 
   // enable sync point processing (disabled on startup)
-  void EnableProcessing(Mode mode);
+  void EnableProcessing(Mode mode = Mode::kAll);
 
   // disable sync point processing
   void DisableProcessing();

--- a/util/sync_point_impl.cc
+++ b/util/sync_point_impl.cc
@@ -89,10 +89,11 @@ void SyncPoint::Data::ClearAllCallBacks() {
 }
 
 void SyncPoint::Data::Process(const std::string& point, void* cb_arg) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  if (!enabled_) {
+  if (mode_ != Mode::kAll) {
     return;
   }
+
+  std::unique_lock<std::mutex> lock(mutex_);
 
   auto thread_id = std::this_thread::get_id();
 

--- a/util/sync_point_impl.h
+++ b/util/sync_point_impl.h
@@ -53,9 +53,7 @@ struct SyncPoint::Data {
 
   void ClearCallBack(const std::string& point);
   void ClearAllCallBacks();
-  void EnableProcessing(SyncPoint::Mode mode = SyncPoint::Mode::kAll) {
-    mode_ = mode;
-  }
+  void EnableProcessing(SyncPoint::Mode mode) { mode_ = mode; }
   void DisableProcessing() { mode_ = SyncPoint::Mode::kDisabled; }
   void ClearTrace() {
     std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
Our whitebox crash test needs killpoints so uses `SyncPoint::EnableProcessing`. Previously that function also enabled syncpoints which require accessing a global mutex. `perf` showed up to 80% of CPU used in accessing that mutex, which was totally irrelevant to killpoints.

This PR changes `SyncPoint` to support different processing modes: (1) kill-point only, or (2) kill-point and sync-point. It changes `db_stress` to use (1), saving most CPU, thus increasing coverage.

Test Plan:

- run crash test and verify most cpu is now spent on actual DB operations

```
$ python -u tools/db_crashtest.py --simple whitebox --random_kill_odd 888887 --open_files=-1
```

```
$ perf report -g
...
+    7.15%  db_stress        db_stress            [.] rocksdb::InlineSkipList<rocksdb::MemTableRep::KeyComparator const&>::FindGreaterOrEqual
+    7.01%  db_stress        db_stress            [.] rocksdb::MemTable::KeyComparator::operator()
+    6.91%  db_stress        libc-2.23.so         [.] __memcmp_sse4_1
+    5.80%  db_stress        db_stress            [.] rocksdb::Version::Get
+    5.21%  db_stress        db_stress            [.] rocksdb::(anonymous namespace)::BytewiseComparatorImpl::Compare
+    5.08%  db_stress        db_stress            [.] rocksdb::MemTable::KeyComparator::operator()
+    3.11%  db_stress        db_stress            [.] snappy::InternalUncompress<snappy::SnappyArrayWriter>
+    3.09%  db_stress        db_stress            [.] rocksdb::WriteThread::AwaitState
```