### PR TITLE
Print histogram count and sum in statistics string

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Public API Change
+* For users of `Statistics` objects created via `CreateDBStatistics()`, the format of the string returned by its `ToString()` method has changed.
 
 ## 5.14.0 (5/16/2018)
 ### Public API Change

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -619,6 +619,8 @@ struct HistogramData {
   // zero-initialize new members since old Statistics::histogramData()
   // implementations won't write them.
   double max = 0.0;
+  uint64_t count = 0;
+  uint64_t sum = 0.0;
 };
 
 enum StatsLevel {

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -620,7 +620,7 @@ struct HistogramData {
   // implementations won't write them.
   double max = 0.0;
   uint64_t count = 0;
-  uint64_t sum = 0.0;
+  uint64_t sum = 0;
 };
 
 enum StatsLevel {

--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -235,6 +235,8 @@ void HistogramStat::Data(HistogramData * const data) const {
   data->max = static_cast<double>(max());
   data->average = Average();
   data->standard_deviation = StandardDeviation();
+  data->count = num();
+  data->sum = sum();
 }
 
 void HistogramImpl::Clear() {

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -176,7 +176,10 @@ std::string StatisticsImpl::ToString() const {
           "%s P50 : %f P95 : %f P99 : %f P100 : %f COUNT : %" PRIu64 " SUM : %"
           PRIu64 "\n", h.second.c_str(), hData.median, hData.percentile95,
           hData.percentile99, hData.max, hData.count, hData.sum);
-      assert(ret >= 0 && ret < kTmpStrBufferSize);
+      if (ret < 0 || ret >= kTmpStrBufferSize) {
+        assert(false);
+        continue;
+      }
       res.append(buffer);
     }
   }

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -169,11 +169,14 @@ std::string StatisticsImpl::ToString() const {
       char buffer[kTmpStrBufferSize];
       HistogramData hData;
       getHistogramImplLocked(h.first)->Data(&hData);
-      snprintf(
+      // don't handle failures - buffer should always be big enough and arguments
+      // should be provided correctly
+      int ret = snprintf(
           buffer, kTmpStrBufferSize,
-          "%s statistics Percentiles :=> 50 : %f 95 : %f 99 : %f 100 : %f\n",
-          h.second.c_str(), hData.median, hData.percentile95,
-          hData.percentile99, hData.max);
+          "%s P50 : %f P95 : %f P99 : %f P100 : %f COUNT : %" PRIu64 " SUM : %"
+          PRIu64 "\n", h.second.c_str(), hData.median, hData.percentile95,
+          hData.percentile99, hData.max, hData.count, hData.sum);
+      assert(ret >= 0 && ret < kTmpStrBufferSize);
       res.append(buffer);
     }
   }


### PR DESCRIPTION
Previously it only printed percentiles, even though our histogram keeps track of count and sum (and more). There have been many times we want to know more than the percentiles. For example, we currently want sum of "rocksdb.compression.times.nanos" and sum of "rocksdb.decompression.times.nanos", which would allow us to know the relative cost of compression vs decompression.

This PR adds count and sum to the string printed by `StatisticsImpl::ToString`. This is a bit risky as there are definitely parsers assuming the old format. I will mention it in HISTORY.md and hope for the best...

Test Plan:

- run a command that prints stats

```
$ ./db_bench -benchmarks=fillrandom -write_buffer_size=1048576 -statistics=true
...
rocksdb.db.flush.micros P50 : 74143.835616 P95 : 441750.000000 P99 : 1009282.000000 P100 : 1009282.000000 COUNT : 141 SUM : 18174634
```

- `make check -j64`