### PR TITLE
fix a division by zero bug

### DIFF
--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -410,7 +410,8 @@ TEST_F(DBIteratorStressTest, StressTest) {
       a /= 10;
       ++len;
     }
-    std::string s = ToString(rnd.Next() % (uint64_t)max_key);
+    std::string s =
+        max_key == 0 ? "" : ToString(rnd.Next() % uint64_t{max_key});
     s.insert(0, len - (int)s.size(), '0');
     return s;
   };

--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -404,14 +404,14 @@ TEST_F(DBIteratorStressTest, StressTest) {
   Random64 rnd(826909345792864532ll);
 
   auto gen_key = [&](int max_key) {
+    assert(max_key > 0);
     int len = 0;
     int a = max_key;
     while (a) {
       a /= 10;
       ++len;
     }
-    std::string s =
-        max_key == 0 ? "" : ToString(rnd.Next() % uint64_t{max_key});
+    std::string s = ToString(rnd.Next() % static_cast<uint64_t>(max_key));
     s.insert(0, len - (int)s.size(), '0');
     return s;
   };


### PR DESCRIPTION
fixes the failing clang_analyze contrun test

test plan: run `USE_CLANG=1 TEST_TMPDIR=/dev/shm/rocksdb OPT=-g make -j1 analyze` without errors