### PR TITLE
Fix clang-analyze warning in db_iter_stress_test

### DIFF
--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -410,7 +410,7 @@ TEST_F(DBIteratorStressTest, StressTest) {
       a /= 10;
       ++len;
     }
-    std::string s = ToString(rnd.Next() % (uint64_t)max_key);
+    std::string s = ToString(rnd.Next() % ((uint64_t)max_key + 1));
     s.insert(0, len - (int)s.size(), '0');
     return s;
   };
@@ -453,7 +453,7 @@ TEST_F(DBIteratorStressTest, StressTest) {
 
               // Generate data.
               Data data;
-              int max_key = (int)(num_entries * key_space) + 1;
+              int max_key = (int)(num_entries * key_space);
               for (int i = 0; i < num_entries; ++i) {
                 Entry e;
                 e.key = gen_key(max_key);


### PR DESCRIPTION
The warning was:
```
db/db_iter_stress_test.cc:413:41: warning: Division by zero
    std::string s = ToString(rnd.Next() % (uint64_t)max_key);
                             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```

Not sure why clang thought that `max_key` can be zero. This PR makes the nonzeroness of max_key somewhat more obvious. (And also makes the variable named `max_key` actually contain maximum allowed key, instead of maximum allowed key + 1.)