### PR TITLE
LRUCache midpoint insertion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * For users of `Statistics` objects created via `CreateDBStatistics()`, the format of the string returned by its `ToString()` method has changed.
+* With LRUCache, when high_pri_pool_ratio > 0, midpoint insertion strategy will be enabled to put low-pri items to the tail of low-pri list (the midpoint) when they first inserted into the cache. This is to make cache entries never get hit age out faster, improving cache efficiency when large background scan presents.
 
 ## 5.14.0 (5/16/2018)
 ### Public API Change

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -246,18 +246,6 @@ void LRUCacheShard::EvictFromLRU(size_t charge,
   }
 }
 
-void* LRUCacheShard::operator new(size_t size) {
-  return port::cacheline_aligned_alloc(size);
-}
-
-void* LRUCacheShard::operator new(size_t /*size*/, void* ptr) { return ptr; }
-
-void LRUCacheShard::operator delete(void* memblock) {
-  port::cacheline_aligned_free(memblock);
-}
-
-void LRUCacheShard::operator delete(void* /*memblock*/, void* /*ptr*/) {}
-
 void LRUCacheShard::SetCapacity(size_t capacity) {
   autovector<LRUHandle*> last_reference_list;
   {

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -77,6 +77,7 @@ struct LRUHandle {
   bool InCache() { return flags & 1; }
   bool IsHighPri() { return flags & 2; }
   bool InHighPriPool() { return flags & 4; }
+  bool HasHit() { return flags & 8; }
 
   void SetInCache(bool in_cache) {
     if (in_cache) {
@@ -101,6 +102,8 @@ struct LRUHandle {
       flags &= ~4;
     }
   }
+
+  void SetHit() { flags |= 8; }
 
   void Free() {
     assert((refs == 1 && InCache()) || (refs == 0 && !InCache()));
@@ -213,7 +216,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   // placement new
   void* operator new(size_t, void*);
 
-  void operator delete(void *);
+  void operator delete(void*);
 
   // placement delete, does nothing.
   void operator delete(void*, void*);

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -209,18 +209,6 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   //  Retrives high pri pool ratio
   double GetHighPriPoolRatio();
 
-  // Overloading to aligned it to cache line size
-  // They are used by tests.
-  void* operator new(size_t);
-
-  // placement new
-  void* operator new(size_t, void*);
-
-  void operator delete(void*);
-
-  // placement delete, does nothing.
-  void operator delete(void*, void*);
-
  private:
   void LRU_Remove(LRUHandle* e);
   void LRU_Insert(LRUHandle* e);

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -390,7 +390,10 @@ class MockCache : public LRUCache {
   static uint32_t high_pri_insert_count;
   static uint32_t low_pri_insert_count;
 
-  MockCache() : LRUCache(1 << 25, 0, false, 0.0) {}
+  MockCache()
+      : LRUCache((size_t)1 << 25 /*capacity*/, 0 /*num_shard_bits*/,
+                 false /*strict_capacity_limit*/, 0.0 /*high_pri_pool_ratio*/) {
+  }
 
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -47,6 +47,15 @@ struct LRUCacheOptions {
   bool strict_capacity_limit = false;
 
   // Percentage of cache reserved for high priority entries.
+  // If greater than zero, the LRU list will be split into a high-pri
+  // list and a low-pri list. High-pri entries will be insert to the
+  // tail of high-pri list, while low-pri entries will be first inserted to
+  // the low-pri list (the midpoint). This is refered to as
+  // midpoint insertion strategy to make entries never get hit in cache
+  // age out faster.
+  //
+  // See also
+  // BlockBasedTableOptions::cache_index_and_filter_blocks_with_high_priority.
   double high_pri_pool_ratio = 0.0;
 
   LRUCacheOptions() {}


### PR DESCRIPTION
Summary:
Implement midpoint insertion strategy where new blocks will be insert to the middle of LRU list, then move the head on the first hit in cache.

Test Plan:
Adding readwhilescanning to db_bench, which in addition to read random from N threads, has an extra thread doing full table scan. I ran readwhilescanning while setting `--read_random_exp_range` to skew the randomness of reads. The background scan will try to push hot blocks out of block cache. The bench was ran with direct IO enabled. The full command line:
```
./db_bench --use_existing_db --db={db_name} --num=100000000 --statistics --cache_size=1000000000 --threads=48 --read_random_exp_range=20.0 --cache_midpoint_insertion={true | false} --cache_high_pri_pool_ratio={0.0 | 0.5} --benchmarks=readrandom --use_direct_reads --reads=1000000
```
withouot midpoint insertion: throughput 49.9 MB/s, blocks read from disk ~31.6M
get latency p50: 14.0 us, p95 360.7 us, p99 471.3 us, p100 8316 us

with midpoint insertion: throughput 53.7 MB/s, blocks read from disk ~29.0M
get latency p50: 13.8 us, p95 353.8 us, p99 407.1 us, p100 6886 us

overall it is a 7% throughput improvement, and also some improvement over get latency, over this particular benchmark.