### PR TITLE
Avoid single-deleting merge operands in db_stress

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2126,9 +2126,12 @@ class StressTest {
         Slice v(value, sz);
         if (!FLAGS_test_batches_snapshots) {
           // If the chosen key does not allow overwrite and it already
-          // exists, choose another key.
+          // exists, choose another key. Also avoid using merge operands in
+          // no-overwrite positions (where single delete will be called later),
+          // as those features have undefined behavior when used together.
           while (!shared->AllowsOverwrite(rand_column_family, rand_key) &&
-                 shared->Exists(rand_column_family, rand_key)) {
+                 (FLAGS_use_merge ||
+                  shared->Exists(rand_column_family, rand_key))) {
             l.reset();
             rand_key = thread->rand.Next() % max_key;
             rand_column_family = thread->rand.Next() % FLAGS_column_families;
@@ -2917,6 +2920,10 @@ int main(int argc, char** argv) {
   if (FLAGS_value_size_mult * kRandomValueMaxFactor > kValueMaxLen) {
     fprintf(stderr, "Error: value_size_mult can be at most %d\n",
             kValueMaxLen / kRandomValueMaxFactor);
+    exit(1);
+  }
+  if (FLAGS_use_merge && FLAGS_nooverwritepercent == 100) {
+    fprintf(stderr, "Error: nooverwritepercent must not be 100 when using merge operands");
     exit(1);
   }
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2923,7 +2923,9 @@ int main(int argc, char** argv) {
     exit(1);
   }
   if (FLAGS_use_merge && FLAGS_nooverwritepercent == 100) {
-    fprintf(stderr, "Error: nooverwritepercent must not be 100 when using merge operands");
+    fprintf(
+        stderr,
+        "Error: nooverwritepercent must not be 100 when using merge operands");
     exit(1);
   }
 


### PR DESCRIPTION
I repro'd some of the "unexpected value" failures showing up in our CI lately and they always happened on keys that have a mix of single deletes and merge operands. The `SingleDelete()` API comment mentions it's incompatible with `Merge()`, so this PR prevents `db_stress` from mixing them.

Test Plan:

Before this PR, the below command used to fail within a minute. After this PR, ummm, it fails after several minutes.
 
```
$ python tools/db_crashtest.py --simple whitebox  --nooverwritepercent=50 --use_merge=1 --delpercent=50 --writepercent=50 --readpercent=0 --iterpercent=0 --max_key=10000000 --value_size_mult=33 --write_buffer_size=4194304 --target_file_size_base=4194304 --max_bytes_for_level_base=16777216 --compression_type=none --random_kill_odd=345678 --max_background_compactions=8
```