### PR TITLE
Avoid sleep in DBTest.GroupCommitTest to fix flakiness

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -211,6 +211,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   // and protects against concurrent loggers and concurrent writes
   // into memtables
 
+  TEST_SYNC_POINT("DBImpl::WriteImpl:BeforeLeaderEnters");
   last_batch_group_size_ =
       write_thread_.EnterAsBatchGroupLeader(&w, &write_group);
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -318,6 +318,7 @@ void WriteThread::JoinBatchGroup(Writer* w) {
      * 3.2) an existing memtable writer group leader tell us to finish memtable
      *      writes in parallel.
      */
+    TEST_SYNC_POINT_CALLBACK("WriteThread::JoinBatchGroup:BeganWaiting", w);
     AwaitState(w, STATE_GROUP_LEADER | STATE_MEMTABLE_WRITER_LEADER |
                       STATE_PARALLEL_MEMTABLE_WRITER | STATE_COMPLETED,
                &jbg_ctx);


### PR DESCRIPTION
DBTest.GroupCommitTest would often fail when run under valgrind because its sleeps were insufficient to guarantee a group commit had multiple entries. Instead we can use sync point to force a leader to wait until a non-leader thread has enqueued its work, thus guaranteeing a leader can do group commit work for multiple threads.

Test Plan:

- `make check -j64`
- run the valgrind test that previously failed for a while:

```
$ while TEST_TMPDIR=/dev/shm /mnt/gvfs/third-party2/valgrind/423431d61786b20bcc3bde8972901130cb29e6b3/3.11.0/gcc-5-glibc-2.23/9bc6787/bin/valgrind --error-exitcode=2 --leak-check=full ./db_test --gtest_filter=DBTest.GroupCommitTest ; do : ; done
```