### PR TITLE
Fix segfault caused by object premature destruction

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -53,22 +53,11 @@ ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {
       listener->OnColumnFamilyHandleDeletionStarted(this);
     }
 #endif  // ROCKSDB_LITE
-    // Job id == 0 means that this is not our background process, but rather
-    // user thread
-    // Need to hold some shared pointers owned by the initial_cf_options
-    // before final cleaning up finishes.
-    ColumnFamilyOptions initial_cf_options_copy = cfd_->initial_cf_options();
-    JobContext job_context(0);
     mutex_->Lock();
     if (cfd_->Unref()) {
       delete cfd_;
     }
-    db_->FindObsoleteFiles(&job_context, false, true);
     mutex_->Unlock();
-    if (job_context.HaveSomethingToDelete()) {
-      db_->PurgeObsoleteFiles(job_context);
-    }
-    job_context.Clean();
   }
 }
 

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2827,6 +2827,27 @@ TEST_F(ColumnFamilyTest, CreateAndDestoryOptions) {
   ASSERT_OK(db_->DestroyColumnFamilyHandle(cfh));
 }
 
+TEST_F(ColumnFamilyTest, CreateDropAndDestroy) {
+  ColumnFamilyHandle* cfh;
+  Open();
+  ASSERT_OK(db_->CreateColumnFamily(ColumnFamilyOptions(), "yoyo", &cfh));
+  ASSERT_OK(db_->Put(WriteOptions(), cfh, "foo", "bar"));
+  ASSERT_OK(db_->Flush(FlushOptions(), cfh));
+  ASSERT_OK(db_->DropColumnFamily(cfh));
+  ASSERT_OK(db_->DestroyColumnFamilyHandle(cfh));
+}
+
+TEST_F(ColumnFamilyTest, CreateDropAndDestroy1) {
+  ColumnFamilyHandle* cfh;
+  Open();
+  ASSERT_OK(db_->CreateColumnFamily(ColumnFamilyOptions(), "yoyo", &cfh));
+  ASSERT_OK(db_->Put(WriteOptions(), cfh, "foo", "bar"));
+  ASSERT_OK(db_->Flush(FlushOptions(), cfh));
+  ASSERT_OK(db_->DisableFileDeletions());
+  ASSERT_OK(db_->DropColumnFamily(cfh));
+  ASSERT_OK(db_->DestroyColumnFamilyHandle(cfh));
+}
+
 #ifndef ROCKSDB_LITE
 TEST_F(ColumnFamilyTest, FlushCloseWALFiles) {
   SpecialEnv env(Env::Default());

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2837,7 +2837,7 @@ TEST_F(ColumnFamilyTest, CreateDropAndDestroy) {
   ASSERT_OK(db_->DestroyColumnFamilyHandle(cfh));
 }
 
-TEST_F(ColumnFamilyTest, CreateDropAndDestroy1) {
+TEST_F(ColumnFamilyTest, CreateDropAndDestroyWithoutFileDeletion) {
   ColumnFamilyHandle* cfh;
   Open();
   ASSERT_OK(db_->CreateColumnFamily(ColumnFamilyOptions(), "yoyo", &cfh));

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -400,7 +400,7 @@ extern TableFactory* NewCuckooTableFactory(
 class RandomAccessFileReader;
 
 // A base class for table factories.
-class TableFactory {
+class TableFactory : public std::enable_shared_from_this<TableFactory> {
  public:
   virtual ~TableFactory() {}
 

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -68,7 +68,7 @@ Status BlockBasedTableFactory::NewTableReader(
     bool prefetch_index_and_filter_in_cache) const {
   return BlockBasedTable::Open(
       table_reader_options.ioptions, table_reader_options.env_options,
-      shared_from_this(),
+      GetPtr(),
       table_reader_options.internal_comparator, std::move(file), file_size,
       table_reader, table_reader_options.prefix_extractor,
       prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -68,8 +68,9 @@ Status BlockBasedTableFactory::NewTableReader(
     bool prefetch_index_and_filter_in_cache) const {
   return BlockBasedTable::Open(
       table_reader_options.ioptions, table_reader_options.env_options,
-      table_options_, table_reader_options.internal_comparator, std::move(file),
-      file_size, table_reader, table_reader_options.prefix_extractor,
+      table_options_, shared_from_this(),
+      table_reader_options.internal_comparator, std::move(file), file_size,
+      table_reader, table_reader_options.prefix_extractor,
       prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
       table_reader_options.level);
 }

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -68,7 +68,7 @@ Status BlockBasedTableFactory::NewTableReader(
     bool prefetch_index_and_filter_in_cache) const {
   return BlockBasedTable::Open(
       table_reader_options.ioptions, table_reader_options.env_options,
-      table_options_, shared_from_this(),
+      shared_from_this(),
       table_reader_options.internal_comparator, std::move(file), file_size,
       table_reader, table_reader_options.prefix_extractor,
       prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -26,7 +26,9 @@ struct EnvOptions;
 using std::unique_ptr;
 class BlockBasedTableBuilder;
 
-class BlockBasedTableFactory : public TableFactory, public std::enable_shared_from_this<BlockBasedTableFactory> {
+class BlockBasedTableFactory : public TableFactory,
+    public std::enable_shared_from_this<BlockBasedTableFactory> {
+
  public:
   explicit BlockBasedTableFactory(
       const BlockBasedTableOptions& table_options = BlockBasedTableOptions());

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -26,8 +26,7 @@ struct EnvOptions;
 using std::unique_ptr;
 class BlockBasedTableBuilder;
 
-class BlockBasedTableFactory : public TableFactory,
-    public std::enable_shared_from_this<BlockBasedTableFactory> {
+class BlockBasedTableFactory : public TableFactory {
 
  public:
   explicit BlockBasedTableFactory(
@@ -36,6 +35,12 @@ class BlockBasedTableFactory : public TableFactory,
   ~BlockBasedTableFactory() {}
 
   const char* Name() const override { return kName.c_str(); }
+
+  std::shared_ptr<BlockBasedTableFactory> GetPtr() const {
+    std::shared_ptr<const TableFactory> cptr = shared_from_this();
+    std::shared_ptr<TableFactory> ptr = std::const_pointer_cast<TableFactory>(cptr);
+    return std::static_pointer_cast<BlockBasedTableFactory>(ptr);
+  }
 
   Status NewTableReader(
       const TableReaderOptions& table_reader_options,

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -26,7 +26,7 @@ struct EnvOptions;
 using std::unique_ptr;
 class BlockBasedTableBuilder;
 
-class BlockBasedTableFactory : public TableFactory {
+class BlockBasedTableFactory : public TableFactory, public std::enable_shared_from_this<BlockBasedTableFactory> {
  public:
   explicit BlockBasedTableFactory(
       const BlockBasedTableOptions& table_options = BlockBasedTableOptions());

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -289,7 +289,9 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     // After prefetch, read the partitions one by one
     biter.SeekToFirst();
     auto ro = ReadOptions();
-    Cache* block_cache = rep->table_options.block_cache.get();
+    const BlockBasedTableOptions& table_opts =
+        rep->table_factory->table_options();
+    Cache* block_cache = table_opts.block_cache.get();
     for (; biter.Valid(); biter.Next()) {
       input = biter.value();
       s = handle.DecodeFrom(&input);
@@ -533,20 +535,22 @@ void BlockBasedTable::SetupCacheKeyPrefix(Rep* rep, uint64_t file_size) {
   assert(kMaxCacheKeyPrefixSize >= 10);
   rep->cache_key_prefix_size = 0;
   rep->compressed_cache_key_prefix_size = 0;
-  if (rep->table_options.block_cache != nullptr) {
-    GenerateCachePrefix(rep->table_options.block_cache.get(), rep->file->file(),
+  const BlockBasedTableOptions& table_opts =
+    rep->table_factory->table_options();
+  if (table_opts.block_cache != nullptr) {
+    GenerateCachePrefix(table_opts.block_cache.get(), rep->file->file(),
                         &rep->cache_key_prefix[0], &rep->cache_key_prefix_size);
     // Create dummy offset of index reader which is beyond the file size.
     rep->dummy_index_reader_offset =
-        file_size + rep->table_options.block_cache->NewId();
+        file_size + table_opts.block_cache->NewId();
   }
-  if (rep->table_options.persistent_cache != nullptr) {
+  if (table_opts.persistent_cache != nullptr) {
     GenerateCachePrefix(/*cache=*/nullptr, rep->file->file(),
                         &rep->persistent_cache_key_prefix[0],
                         &rep->persistent_cache_key_prefix_size);
   }
-  if (rep->table_options.block_cache_compressed != nullptr) {
-    GenerateCachePrefix(rep->table_options.block_cache_compressed.get(),
+  if (table_opts.block_cache_compressed != nullptr) {
+    GenerateCachePrefix(table_opts.block_cache_compressed.get(),
                         rep->file->file(), &rep->compressed_cache_key_prefix[0],
                         &rep->compressed_cache_key_prefix_size);
   }
@@ -661,7 +665,6 @@ Slice BlockBasedTable::GetCacheKey(const char* cache_key_prefix,
 
 Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
                              const EnvOptions& env_options,
-                             const BlockBasedTableOptions& table_options,
                              std::shared_ptr<const BlockBasedTableFactory> table_factory,
                              const InternalKeyComparator& internal_comparator,
                              unique_ptr<RandomAccessFileReader>&& file,
@@ -710,12 +713,13 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   // Better not mutate rep_ after the creation. eg. internal_prefix_transform
   // raw pointer will be used to create HashIndexReader, whose reset may
   // access a dangling pointer.
-  Rep* rep = new BlockBasedTable::Rep(ioptions, env_options, table_options,
+  const BlockBasedTableOptions& table_opts = table_factory->table_options();
+  Rep* rep = new BlockBasedTable::Rep(ioptions, env_options, table_opts,
       table_factory, internal_comparator, skip_filters);
   rep->file = std::move(file);
   rep->footer = footer;
-  rep->index_type = table_options.index_type;
-  rep->hash_index_allow_collision = table_options.hash_index_allow_collision;
+  rep->index_type = table_opts.index_type;
+  rep->hash_index_allow_collision = table_opts.hash_index_allow_collision;
   // We need to wrap data with internal_prefix_transform to make sure it can
   // handle prefix correctly.
   rep->internal_prefix_transform.reset(
@@ -725,7 +729,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
 
   // page cache options
   rep->persistent_cache_options =
-      PersistentCacheOptions(rep->table_options.persistent_cache,
+      PersistentCacheOptions(table_opts.persistent_cache,
                              std::string(rep->persistent_cache_key_prefix,
                                          rep->persistent_cache_key_prefix_size),
                                          rep->ioptions.statistics);
@@ -874,13 +878,13 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   }
 
   const bool pin =
-      rep->table_options.pin_l0_filter_and_index_blocks_in_cache && level == 0;
+      table_opts.pin_l0_filter_and_index_blocks_in_cache && level == 0;
   // pre-fetching of blocks is turned on
   // Will use block cache for index/filter blocks access
   // Always prefetch index and filter for level 0
-  if (table_options.cache_index_and_filter_blocks) {
+  if (table_opts.cache_index_and_filter_blocks) {
     if (prefetch_index_and_filter_in_cache || level == 0) {
-      assert(table_options.block_cache != nullptr);
+      assert(table_opts.block_cache != nullptr);
       // Hack: Call NewIndexIterator() to implicitly add index to the
       // block_cache
 
@@ -903,7 +907,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         if (pin) {
           rep->index_entry = std::move(index_entry);
         } else {
-          index_entry.Release(table_options.block_cache.get());
+          index_entry.Release(table_opts.block_cache.get());
         }
 
         // Hack: Call GetFilter() to implicitly add filter to the block_cache
@@ -918,7 +922,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         if (pin) {
           rep->filter_entry = filter_entry;
         } else {
-          filter_entry.Release(table_options.block_cache.get());
+          filter_entry.Release(table_opts.block_cache.get());
         }
       }
     }
@@ -1275,6 +1279,8 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
     filter_type = Rep::FilterType::kFullFilter;
   }
 
+  const BlockBasedTableOptions& table_opts =
+    rep->table_factory->table_options();
   switch (filter_type) {
     case Rep::FilterType::kPartitionedFilter: {
       return new PartitionedFilterBlockReader(
@@ -1286,7 +1292,7 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
     case Rep::FilterType::kBlockFilter:
       return new BlockBasedFilterBlockReader(
           rep->prefix_filtering ? prefix_extractor : nullptr,
-          rep->table_options, rep->whole_key_filtering, std::move(block),
+          table_opts, rep->whole_key_filtering, std::move(block),
           rep->ioptions.statistics);
 
     case Rep::FilterType::kFullFilter: {
@@ -1324,12 +1330,14 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   // We will return rep_->filter anyway. rep_->filter can be nullptr if filter
   // read fails at Open() time. We don't want to reload again since it will
   // most probably fail again.
+  const BlockBasedTableOptions& table_opts =
+      rep_->table_factory->table_options();
   if (!is_a_filter_partition &&
-      !rep_->table_options.cache_index_and_filter_blocks) {
+      !table_opts.cache_index_and_filter_blocks) {
     return {rep_->filter.get(), nullptr /* cache handle */};
   }
 
-  Cache* block_cache = rep_->table_options.block_cache.get();
+  Cache* block_cache = table_opts.block_cache.get();
   if (rep_->filter_policy == nullptr /* do not use filter */ ||
       block_cache == nullptr /* no block cache at all */) {
     return {nullptr /* filter */, nullptr /* cache handle */};
@@ -1364,7 +1372,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     if (filter != nullptr) {
       Status s = block_cache->Insert(
           key, filter, filter->size(), &DeleteCachedFilterEntry, &cache_handle,
-          rep_->table_options.cache_index_and_filter_blocks_with_high_priority
+          table_opts.cache_index_and_filter_blocks_with_high_priority
               ? Cache::Priority::HIGH
               : Cache::Priority::LOW);
       if (s.ok()) {
@@ -1414,7 +1422,9 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
   PERF_TIMER_GUARD(read_index_block_nanos);
 
   const bool no_io = read_options.read_tier == kBlockCacheTier;
-  Cache* block_cache = rep_->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      rep_->table_factory->table_options();
+  Cache* block_cache = table_opts.block_cache.get();
   char cache_key[kMaxCacheKeyPrefixSize + kMaxVarint64Length];
   auto key =
       GetCacheKeyFromOffset(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
@@ -1450,7 +1460,7 @@ InternalIterator* BlockBasedTable::NewIndexIterator(
       s = block_cache->Insert(
           key, index_reader, index_reader->usable_size(),
           &DeleteCachedIndexEntry, &cache_handle,
-          rep_->table_options.cache_index_and_filter_blocks_with_high_priority
+          table_opts.cache_index_and_filter_blocks_with_high_priority
               ? Cache::Priority::HIGH
               : Cache::Priority::LOW);
     }
@@ -1519,7 +1529,9 @@ BlockIter* BlockBasedTable::NewDataBlockIterator(
   PERF_TIMER_GUARD(new_table_block_iter_nanos);
 
   const bool no_io = (ro.read_tier == kBlockCacheTier);
-  Cache* block_cache = rep->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      rep->table_factory->table_options();
+  Cache* block_cache = table_opts.block_cache.get();
   CachableEntry<Block> block;
   Slice compression_dict;
   if (s.ok()) {
@@ -1552,7 +1564,7 @@ BlockIter* BlockBasedTable::NewDataBlockIterator(
                             rep->footer, ro, handle, &block_value, rep->ioptions,
                             rep->blocks_maybe_compressed, compression_dict,
                             rep->persistent_cache_options, rep->global_seqno,
-                            rep->table_options.read_amp_bytes_per_bit);
+                            table_opts.read_amp_bytes_per_bit);
     }
     if (s.ok()) {
       block.value = block_value.release();
@@ -1612,9 +1624,11 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
     CachableEntry<Block>* block_entry, bool is_index, GetContext* get_context) {
   assert(block_entry != nullptr);
   const bool no_io = (ro.read_tier == kBlockCacheTier);
-  Cache* block_cache = rep->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      rep->table_factory->table_options();
+  Cache* block_cache = table_opts.block_cache.get();
   Cache* block_cache_compressed =
-      rep->table_options.block_cache_compressed.get();
+      table_opts.block_cache_compressed.get();
 
   // If either block cache is enabled, we'll try to read from it.
   Status s;
@@ -1639,8 +1653,8 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
 
     s = GetDataBlockFromCache(
         key, ckey, block_cache, block_cache_compressed, rep->ioptions, ro,
-        block_entry, rep->table_options.format_version, compression_dict,
-        rep->table_options.read_amp_bytes_per_bit, is_index, get_context);
+        block_entry, table_opts.format_version, compression_dict,
+        table_opts.read_amp_bytes_per_bit, is_index, get_context);
 
     if (block_entry->value == nullptr && !no_io && ro.fill_cache) {
       std::unique_ptr<Block> raw_block;
@@ -1651,16 +1665,16 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
             &raw_block, rep->ioptions,
             block_cache_compressed == nullptr && rep->blocks_maybe_compressed,
             compression_dict, rep->persistent_cache_options, rep->global_seqno,
-            rep->table_options.read_amp_bytes_per_bit);
+            table_opts.read_amp_bytes_per_bit);
       }
 
       if (s.ok()) {
         s = PutDataBlockToCache(
             key, ckey, block_cache, block_cache_compressed, ro, rep->ioptions,
-            block_entry, raw_block.release(), rep->table_options.format_version,
-            compression_dict, rep->table_options.read_amp_bytes_per_bit,
+            block_entry, raw_block.release(), table_opts.format_version,
+            compression_dict, table_opts.read_amp_bytes_per_bit,
             is_index,
-            is_index && rep->table_options
+            is_index && table_opts
                             .cache_index_and_filter_blocks_with_high_priority
                 ? Cache::Priority::HIGH
                 : Cache::Priority::LOW,
@@ -1694,7 +1708,9 @@ BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
     PERF_COUNTER_ADD(block_cache_hit_count, 1);
     RecordTick(rep->ioptions.statistics, BLOCK_CACHE_INDEX_HIT);
     RecordTick(rep->ioptions.statistics, BLOCK_CACHE_HIT);
-    Cache* block_cache = rep->table_options.block_cache.get();
+    const BlockBasedTableOptions& table_opts =
+        rep->table_factory->table_options();
+    Cache* block_cache = table_opts.block_cache.get();
     assert(block_cache);
     RecordTick(rep->ioptions.statistics, BLOCK_CACHE_BYTES_READ,
                block_cache->GetUsage(block->second.cache_handle));
@@ -1806,7 +1822,9 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key,
   // don't call, in this case we have a local copy in rep_->filter_entry,
   // it's pinned to the cache and will be released in the destructor
   if (!rep_->filter_entry.IsSet()) {
-    filter_entry.Release(rep_->table_options.block_cache.get());
+    const BlockBasedTableOptions& table_opts =
+        rep_->table_factory->table_options();
+    filter_entry.Release(table_opts.block_cache.get());
   }
 
   return may_match;
@@ -2054,7 +2072,9 @@ InternalIterator* BlockBasedTable::NewRangeTombstoneIterator(
     // iterator based on it since the returned iterator may outlive this table
     // reader.
     assert(rep_->range_del_entry.value != nullptr);
-    Cache* block_cache = rep_->table_options.block_cache.get();
+    const BlockBasedTableOptions& table_opts =
+        rep_->table_factory->table_options();
+    Cache* block_cache = table_opts.block_cache.get();
     assert(block_cache != nullptr);
     if (block_cache->Ref(rep_->range_del_entry.cache_handle)) {
       auto iter = rep_->range_del_entry.value->NewIterator(
@@ -2204,7 +2224,9 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   // don't call, in this case we have a local copy in rep_->filter_entry,
   // it's pinned to the cache and will be released in the destructor
   if (!rep_->filter_entry.IsSet()) {
-    filter_entry.Release(rep_->table_options.block_cache.get());
+    const BlockBasedTableOptions& table_opts =
+        rep_->table_factory->table_options();
+    filter_entry.Release(table_opts.block_cache.get());
   }
   return s;
 }
@@ -2328,7 +2350,9 @@ bool BlockBasedTable::TEST_KeyInCache(const ReadOptions& options,
   Slice input = iiter->value();
   Status s = handle.DecodeFrom(&input);
   assert(s.ok());
-  Cache* block_cache = rep_->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      rep_->table_factory->table_options();
+  Cache* block_cache = table_opts.block_cache.get();
   assert(block_cache != nullptr);
 
   char cache_key_storage[kMaxCacheKeyPrefixSize + kMaxVarint64Length];
@@ -2339,7 +2363,7 @@ bool BlockBasedTable::TEST_KeyInCache(const ReadOptions& options,
 
   s = GetDataBlockFromCache(
       cache_key, ckey, block_cache, nullptr, rep_->ioptions, options, &block,
-      rep_->table_options.format_version,
+      table_opts.format_version,
       rep_->compression_dict_block ? rep_->compression_dict_block->data
                                    : Slice(),
       0 /* read_amp_bytes_per_bit */);
@@ -2666,21 +2690,23 @@ void BlockBasedTable::Close() {
   if (rep_->closed) {
     return;
   }
-  rep_->filter_entry.Release(rep_->table_options.block_cache.get());
-  rep_->index_entry.Release(rep_->table_options.block_cache.get());
-  rep_->range_del_entry.Release(rep_->table_options.block_cache.get());
+  const BlockBasedTableOptions& table_opts =
+      rep_->table_factory->table_options();
+  rep_->filter_entry.Release(table_opts.block_cache.get());
+  rep_->index_entry.Release(table_opts.block_cache.get());
+  rep_->range_del_entry.Release(table_opts.block_cache.get());
   // cleanup index and filter blocks to avoid accessing dangling pointer
-  if (!rep_->table_options.no_block_cache) {
+  if (!table_opts.no_block_cache) {
     char cache_key[kMaxCacheKeyPrefixSize + kMaxVarint64Length];
     // Get the filter block key
     auto key = GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
                            rep_->filter_handle, cache_key);
-    rep_->table_factory->table_options().block_cache.get()->Erase(key);
+    table_opts.block_cache.get()->Erase(key);
     // Get the index block key
     key = GetCacheKeyFromOffset(rep_->cache_key_prefix,
                                 rep_->cache_key_prefix_size,
                                 rep_->dummy_index_reader_offset, cache_key);
-    rep_->table_options.block_cache.get()->Erase(key);
+    table_opts.block_cache.get()->Erase(key);
   }
   rep_->closed = true;
 }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -665,7 +665,7 @@ Slice BlockBasedTable::GetCacheKey(const char* cache_key_prefix,
 
 Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
                              const EnvOptions& env_options,
-                             std::shared_ptr<const BlockBasedTableFactory> table_factory,
+                             std::shared_ptr<BlockBasedTableFactory> table_factory,
                              const InternalKeyComparator& internal_comparator,
                              unique_ptr<RandomAccessFileReader>&& file,
                              uint64_t file_size,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -87,7 +87,6 @@ class BlockBasedTable : public TableReader {
   //    are set.
   static Status Open(const ImmutableCFOptions& ioptions,
                      const EnvOptions& env_options,
-                     const BlockBasedTableOptions& table_options,
                      std::shared_ptr<const BlockBasedTableFactory> table_factory,
                      const InternalKeyComparator& internal_key_comparator,
                      unique_ptr<RandomAccessFileReader>&& file,
@@ -274,7 +273,7 @@ class BlockBasedTable : public TableReader {
   //
   // Note: ErrorIterator with Status::Incomplete shall be returned if all the
   // following conditions are met:
-  //  1. We enabled table_options.cache_index_and_filter_blocks.
+  //  1. We enabled table_factory.table_options.cache_index_and_filter_blocks.
   //  2. index is not present in block cache.
   //  3. We disallowed any io to be performed, that is, read_options ==
   //     kBlockCacheTier
@@ -419,8 +418,8 @@ struct BlockBasedTable::Rep {
       const InternalKeyComparator& _internal_comparator, bool skip_filters)
       : ioptions(_ioptions),
         env_options(_env_options),
-        table_options(_table_opt),
-        table_factory(std::const_pointer_cast<BlockBasedTableFactory>(_table_factory)),
+        table_factory(
+            std::const_pointer_cast<BlockBasedTableFactory>(_table_factory)),
         filter_policy(skip_filters ? nullptr : _table_opt.filter_policy.get()),
         internal_comparator(_internal_comparator),
         filter_type(FilterType::kNoFilter),
@@ -433,7 +432,6 @@ struct BlockBasedTable::Rep {
 
   const ImmutableCFOptions& ioptions;
   const EnvOptions& env_options;
-  const BlockBasedTableOptions& table_options;
   std::shared_ptr<BlockBasedTableFactory> table_factory;
   const FilterPolicy* const filter_policy;
   const InternalKeyComparator& internal_comparator;

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -23,6 +23,7 @@
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
 #include "table/block.h"
+#include "table/block_based_table_factory.h"
 #include "table/filter_block.h"
 #include "table/format.h"
 #include "table/persistent_cache_helper.h"
@@ -87,6 +88,7 @@ class BlockBasedTable : public TableReader {
   static Status Open(const ImmutableCFOptions& ioptions,
                      const EnvOptions& env_options,
                      const BlockBasedTableOptions& table_options,
+                     std::shared_ptr<const BlockBasedTableFactory> table_factory,
                      const InternalKeyComparator& internal_key_comparator,
                      unique_ptr<RandomAccessFileReader>&& file,
                      uint64_t file_size, unique_ptr<TableReader>* table_reader,
@@ -413,10 +415,12 @@ struct BlockBasedTable::CachableEntry {
 struct BlockBasedTable::Rep {
   Rep(const ImmutableCFOptions& _ioptions, const EnvOptions& _env_options,
       const BlockBasedTableOptions& _table_opt,
+      std::shared_ptr<const BlockBasedTableFactory> _table_factory,
       const InternalKeyComparator& _internal_comparator, bool skip_filters)
       : ioptions(_ioptions),
         env_options(_env_options),
         table_options(_table_opt),
+        table_factory(std::const_pointer_cast<BlockBasedTableFactory>(_table_factory)),
         filter_policy(skip_filters ? nullptr : _table_opt.filter_policy.get()),
         internal_comparator(_internal_comparator),
         filter_type(FilterType::kNoFilter),
@@ -430,6 +434,7 @@ struct BlockBasedTable::Rep {
   const ImmutableCFOptions& ioptions;
   const EnvOptions& env_options;
   const BlockBasedTableOptions& table_options;
+  std::shared_ptr<BlockBasedTableFactory> table_factory;
   const FilterPolicy* const filter_policy;
   const InternalKeyComparator& internal_comparator;
   Status status;

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -87,7 +87,7 @@ class BlockBasedTable : public TableReader {
   //    are set.
   static Status Open(const ImmutableCFOptions& ioptions,
                      const EnvOptions& env_options,
-                     std::shared_ptr<const BlockBasedTableFactory> table_factory,
+                     std::shared_ptr<BlockBasedTableFactory> table_factory,
                      const InternalKeyComparator& internal_key_comparator,
                      unique_ptr<RandomAccessFileReader>&& file,
                      uint64_t file_size, unique_ptr<TableReader>* table_reader,
@@ -414,12 +414,11 @@ struct BlockBasedTable::CachableEntry {
 struct BlockBasedTable::Rep {
   Rep(const ImmutableCFOptions& _ioptions, const EnvOptions& _env_options,
       const BlockBasedTableOptions& _table_opt,
-      std::shared_ptr<const BlockBasedTableFactory> _table_factory,
+      std::shared_ptr<BlockBasedTableFactory> _table_factory,
       const InternalKeyComparator& _internal_comparator, bool skip_filters)
       : ioptions(_ioptions),
         env_options(_env_options),
-        table_factory(
-            std::const_pointer_cast<BlockBasedTableFactory>(_table_factory)),
+        table_factory(_table_factory),
         filter_policy(skip_filters ? nullptr : _table_opt.filter_policy.get()),
         internal_comparator(_internal_comparator),
         filter_type(FilterType::kNoFilter),

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -106,7 +106,9 @@ PartitionedFilterBlockReader::~PartitionedFilterBlockReader() {
   // TODO(myabandeh): if instead of filter object we store only the blocks in
   // block cache, then we don't have to manually earse them from block cache
   // here.
-  auto block_cache = table_->rep_->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      table_->rep_->table_factory->table_options();
+  auto block_cache = table_opts.block_cache.get();
   if (UNLIKELY(block_cache == nullptr)) {
     return;
   }
@@ -158,7 +160,9 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
     return res;
   }
   if (LIKELY(filter_partition.IsSet())) {
-    filter_partition.Release(table_->rep_->table_options.block_cache.get());
+    const BlockBasedTableOptions& table_opts =
+        table_->rep_->table_factory->table_options();
+    filter_partition.Release(table_opts.block_cache.get());
   } else {
     delete filter_partition.value;
   }
@@ -197,7 +201,9 @@ bool PartitionedFilterBlockReader::PrefixMayMatch(
     return res;
   }
   if (LIKELY(filter_partition.IsSet())) {
-    filter_partition.Release(table_->rep_->table_options.block_cache.get());
+    const BlockBasedTableOptions& table_opts =
+        table_->rep_->table_factory->table_options();
+    filter_partition.Release(table_opts.block_cache.get());
   } else {
     delete filter_partition.value;
   }
@@ -225,7 +231,9 @@ PartitionedFilterBlockReader::GetFilterPartition(
   auto s = fltr_blk_handle.DecodeFrom(handle_value);
   assert(s.ok());
   const bool is_a_filter_partition = true;
-  auto block_cache = table_->rep_->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      table_->rep_->table_factory->table_options();
+  auto block_cache = table_opts.block_cache.get();
   if (LIKELY(block_cache != nullptr)) {
     if (filter_map_.size() != 0) {
       auto iter = filter_map_.find(fltr_blk_handle.offset());
@@ -303,7 +311,9 @@ void PartitionedFilterBlockReader::CacheDependencies(
 
   // After prefetch, read the partitions one by one
   biter.SeekToFirst();
-  Cache* block_cache = rep->table_options.block_cache.get();
+  const BlockBasedTableOptions& table_opts =
+      rep->table_factory->table_options();
+  Cache* block_cache = table_opts.block_cache.get();
   for (; biter.Valid(); biter.Next()) {
     input = biter.value();
     s = handle.DecodeFrom(&input);


### PR DESCRIPTION
Please refer to earlier discussion in [issue 3609](https://github.com/facebook/rocksdb/issues/3609).

To summarize the cause of the problem. Upon creation of a column family, a `BlockBasedTableFactory` object is `new`ed and encapsulated by a `std::shared_ptr`. Since there is no other `std::shared_ptr` pointing to this `BlockBasedTableFactory`, when the column family is dropped, the `ColumnFamilyData` is `delete`d, causing the destructor of `std::shared_ptr`. Since there is no other `std::shared_ptr`, the underlying memory is also freed.
Later when the db exits, it releases all the table readers, including the table readers that have been operating on the dropped column family. This needs to access the `table_options` owned by `BlockBasedTableFactory` that has already been deleted. Therefore, a segfault is raised.
Previous workaround is to purge all obsolete files upon `ColumnFamilyData` destruction, which leads to a force release of table readers of the dropped column family. However this does not work when the user disables file deletion.

Test plan
```
$ make -j16
$ ./column_family_test --gtest_filter=ColumnFamilyTest.CreateDropAndDestroy:ColumnFamilyTest.CreateDropAndDestroyWithoutFileDeletion
```

Expected behavior:
All tests should pass.

Update:
Another alternative is to keep track of all table readers using a `BlockBasedTableFactory` in RocksDB code. When we destruct the table factory, we destruct all table readers. This may increase the bookkeeping cost in RocksDB with many table readers.