### PR TITLE
add flush_before_backup parameter to c api rocksdb_backup_engine_create_new_backup

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -531,8 +531,10 @@ rocksdb_backup_engine_t* rocksdb_backup_engine_open(
 }
 
 void rocksdb_backup_engine_create_new_backup(rocksdb_backup_engine_t* be,
-                                             rocksdb_t* db, char** errptr) {
-  SaveError(errptr, be->rep->CreateNewBackup(db->rep));
+                                             rocksdb_t* db,
+                                             int flush_before_backup,
+                                             char** errptr) {
+  SaveError(errptr, be->rep->CreateNewBackup(db->rep, flush_before_backup));
 }
 
 void rocksdb_backup_engine_purge_old_backups(rocksdb_backup_engine_t* be,

--- a/db/c.cc
+++ b/db/c.cc
@@ -564,8 +564,8 @@ void rocksdb_restore_options_set_keep_log_files(rocksdb_restore_options_t* opt,
 
 
 void rocksdb_backup_engine_verify_backup(rocksdb_backup_engine_t* be,
-    uint32_t backup_id) {
-  be->rep->VerifyBackup(static_cast<BackupID>(backup_id));
+    uint32_t backup_id, char** errptr) {
+  SaveError(errptr, be->rep->VerifyBackup(static_cast<BackupID>(backup_id)));
 }
 
 void rocksdb_backup_engine_restore_db_from_latest_backup(

--- a/db/c.cc
+++ b/db/c.cc
@@ -90,6 +90,7 @@ using rocksdb::LiveFileMetaData;
 using rocksdb::BackupEngine;
 using rocksdb::BackupableDBOptions;
 using rocksdb::BackupInfo;
+using rocksdb::BackupID;
 using rocksdb::RestoreOptions;
 using rocksdb::CompactRangeOptions;
 using rocksdb::RateLimiter;
@@ -532,9 +533,14 @@ rocksdb_backup_engine_t* rocksdb_backup_engine_open(
 
 void rocksdb_backup_engine_create_new_backup(rocksdb_backup_engine_t* be,
                                              rocksdb_t* db,
-                                             unsigned char flush_before_backup,
                                              char** errptr) {
-  SaveError(errptr, be->rep->CreateNewBackup(db->rep, flush_before_backup));
+  SaveError(errptr, be->rep->CreateNewBackup(db->rep));
+}
+
+void rocksdb_backup_engine_create_new_backup_flush(rocksdb_backup_engine_t* be,
+                                                   rocksdb_t* db,
+                                                   char** errptr) {
+  SaveError(errptr, be->rep->CreateNewBackup(db->rep, true));
 }
 
 void rocksdb_backup_engine_purge_old_backups(rocksdb_backup_engine_t* be,
@@ -554,6 +560,12 @@ void rocksdb_restore_options_destroy(rocksdb_restore_options_t* opt) {
 void rocksdb_restore_options_set_keep_log_files(rocksdb_restore_options_t* opt,
                                                 int v) {
   opt->rep.keep_log_files = v;
+}
+
+
+void rocksdb_backup_engine_verify_backup(rocksdb_backup_engine_t* be,
+    uint32_t backup_id) {
+  be->rep->VerifyBackup(static_cast<BackupID>(backup_id));
 }
 
 void rocksdb_backup_engine_restore_db_from_latest_backup(

--- a/db/c.cc
+++ b/db/c.cc
@@ -539,8 +539,9 @@ void rocksdb_backup_engine_create_new_backup(rocksdb_backup_engine_t* be,
 
 void rocksdb_backup_engine_create_new_backup_flush(rocksdb_backup_engine_t* be,
                                                    rocksdb_t* db,
+                                                   unsigned char flush_before_backup,
                                                    char** errptr) {
-  SaveError(errptr, be->rep->CreateNewBackup(db->rep, true));
+  SaveError(errptr, be->rep->CreateNewBackup(db->rep, flush_before_backup));
 }
 
 void rocksdb_backup_engine_purge_old_backups(rocksdb_backup_engine_t* be,

--- a/db/c.cc
+++ b/db/c.cc
@@ -532,7 +532,7 @@ rocksdb_backup_engine_t* rocksdb_backup_engine_open(
 
 void rocksdb_backup_engine_create_new_backup(rocksdb_backup_engine_t* be,
                                              rocksdb_t* db,
-                                             int flush_before_backup,
+                                             unsigned char flush_before_backup,
                                              char** errptr) {
   SaveError(errptr, be->rep->CreateNewBackup(db->rep, flush_before_backup));
 }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -143,7 +143,8 @@ extern ROCKSDB_LIBRARY_API rocksdb_backup_engine_t* rocksdb_backup_engine_open(
     const rocksdb_options_t* options, const char* path, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup(
-    rocksdb_backup_engine_t* be, rocksdb_t* db, char** errptr);
+    rocksdb_backup_engine_t* be, rocksdb_t* db, int flush_before_backup,
+    char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_purge_old_backups(
     rocksdb_backup_engine_t* be, uint32_t num_backups_to_keep, char** errptr);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -160,7 +160,7 @@ extern ROCKSDB_LIBRARY_API void rocksdb_restore_options_set_keep_log_files(
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_verify_backup(rocksdb_backup_engine_t* be,
-    uint32_t backup_id);
+    uint32_t backup_id, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_restore_db_from_latest_backup(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -143,8 +143,10 @@ extern ROCKSDB_LIBRARY_API rocksdb_backup_engine_t* rocksdb_backup_engine_open(
     const rocksdb_options_t* options, const char* path, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup(
-    rocksdb_backup_engine_t* be, rocksdb_t* db, unsigned char flush_before_backup,
-    char** errptr);
+    rocksdb_backup_engine_t* be, rocksdb_t* db, char** errptr);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup_flush(
+    rocksdb_backup_engine_t* be, rocksdb_t* db, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_purge_old_backups(
     rocksdb_backup_engine_t* be, uint32_t num_backups_to_keep, char** errptr);
@@ -155,6 +157,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_restore_options_destroy(
     rocksdb_restore_options_t* opt);
 extern ROCKSDB_LIBRARY_API void rocksdb_restore_options_set_keep_log_files(
     rocksdb_restore_options_t* opt, int v);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_backup_engine_verify_backup(rocksdb_backup_engine_t* be,
+    uint32_t backup_id);
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_backup_engine_restore_db_from_latest_backup(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -143,7 +143,7 @@ extern ROCKSDB_LIBRARY_API rocksdb_backup_engine_t* rocksdb_backup_engine_open(
     const rocksdb_options_t* options, const char* path, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup(
-    rocksdb_backup_engine_t* be, rocksdb_t* db, int flush_before_backup,
+    rocksdb_backup_engine_t* be, rocksdb_t* db, unsigned char flush_before_backup,
     char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_purge_old_backups(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -146,7 +146,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup(
     rocksdb_backup_engine_t* be, rocksdb_t* db, char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_create_new_backup_flush(
-    rocksdb_backup_engine_t* be, rocksdb_t* db, char** errptr);
+    rocksdb_backup_engine_t* be, rocksdb_t* db, unsigned char flush_before_backup,
+    char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_backup_engine_purge_old_backups(
     rocksdb_backup_engine_t* be, uint32_t num_backups_to_keep, char** errptr);


### PR DESCRIPTION
Add flush_before_backup to rocksdb_backup_engine_create_new_backup. make c api able to control the flush before backup behavior. 