### PR TITLE
Check status when reading HashIndexPrefixesMetadataBlock

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -484,7 +484,7 @@ class HashIndexReader : public IndexReader {
         file, prefetch_buffer, footer, ReadOptions(), prefixes_meta_handle,
         &prefixes_meta_contents, ioptions, true /* decompress */,
         dummy_comp_dict /*compression dict*/, cache_options);
-    prefixes_meta_block_fetcher.ReadBlockContents();
+    s = prefixes_meta_block_fetcher.ReadBlockContents();
     if (!s.ok()) {
       // TODO: log error
       return Status::OK();


### PR DESCRIPTION
This was missed in a refactor of `ReadBlockContents` (2f1a3a4).