### PR TITLE
Compile error in db bench tool

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4529,7 +4529,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     ReadOptions read_options;
     Iterator* iter = db_.db->NewIterator(read_options);
 
-    fprintf(stderr, "num reads to do %lu\n", reads_);
+    fprintf(stderr, "num reads to do %lld\n", reads_);
     Duration duration(FLAGS_duration, reads_);
     uint64_t num_seek_to_first = 0;
     uint64_t num_next = 0;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4529,7 +4529,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     ReadOptions read_options;
     Iterator* iter = db_.db->NewIterator(read_options);
 
-    fprintf(stderr, "num reads to do %lld\n", reads_);
+    fprintf(stderr, "num reads to do %" PRIu64 "\n", reads_);
     Duration duration(FLAGS_duration, reads_);
     uint64_t num_seek_to_first = 0;
     uint64_t num_next = 0;


### PR DESCRIPTION
Small format error below causes build to fail. I believe that this : 
```
fprintf(stderr, "num reads to do %lu\n", reads_);
```
Can be changed to this: 
```
fprintf(stderr, "num reads to do %" PRIu64 "\n", reads_);
```
### Expected behavior
Successful build
### Actual behavior
```
  CC       utilities/blob_db/blob_dump_tool.o
  AR       librocksdb_debug.a
ar: creating archive librocksdb_debug.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: librocksdb_debug.a(rocks_lua_compaction_filter.o) has no symbols
  CC       tools/db_bench.o
  CC       tools/db_bench_tool.o
tools/db_bench_tool.cc:4532:46: error: format specifies type 'unsigned long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
    fprintf(stderr, "num reads to do %lu\n", reads_);
                                     ~~~     ^~~~~~
                                     %lld
1 error generated.
make: *** [tools/db_bench_tool.o] Error 1
```

### Steps to reproduce the behavior
```
$ cd rocksdb
$ make all

$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 9.1.0 (clang-902.0.39.1)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```