### PR TITLE
Fix LRUCache destruction after data disowned

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -504,6 +504,7 @@ void LRUCache::DisownData() {
 // Do not drop data if compile with ASAN to suppress leak warning.
 #ifndef __SANITIZE_ADDRESS__
   shards_ = nullptr;
+  num_shards_ = 0;
 #endif  // !__SANITIZE_ADDRESS__
 }
 


### PR DESCRIPTION
The `LRUCache` destructor iterates over elements of `shards_` and deletes each of them. When `shard_` has been reset in `DisownData`, we need to prevent this iteration.

Fixes #3915.

Blame: 7a99c04311e781915dbd23c2e4e3c23257290cb4

Test Plan: run `db_bench` command that previously failed, verified now it succeeds

```
./db_bench --benchmarks=fillseq --num=10 --sync=0
```