### PR TITLE
Fix LRUCache missing null check on destruct

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -474,10 +474,13 @@ LRUCache::LRUCache(size_t capacity, int num_shard_bits,
 }
 
 LRUCache::~LRUCache() {
-  for (int i = 0; i < num_shards_; i++) {
-    shards_[i].~LRUCacheShard();
+  if (shards_ != nullptr) {
+    assert(num_shards_ > 0);
+    for (int i = 0; i < num_shards_; i++) {
+      shards_[i].~LRUCacheShard();
+    }
+    port::cacheline_aligned_free(shards_);
   }
-  port::cacheline_aligned_free(shards_);
 }
 
 CacheShard* LRUCache::GetShard(int shard) {
@@ -504,6 +507,7 @@ void LRUCache::DisownData() {
 // Do not drop data if compile with ASAN to suppress leak warning.
 #ifndef __SANITIZE_ADDRESS__
   shards_ = nullptr;
+  num_shards_ = 0;
 #endif  // !__SANITIZE_ADDRESS__
 }
 

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -295,7 +295,7 @@ class LRUCache : public ShardedCache {
   double GetHighPriPoolRatio();
 
  private:
-  LRUCacheShard* shards_;
+  LRUCacheShard* shards_ = nullptr;
   int num_shards_ = 0;
 };
 


### PR DESCRIPTION
Summary:
Fix LRUCache missing null check on destruct. The check is needed if LRUCache::DisownData is called.

Test Plan:
Existing tests.