### PR TITLE
Check conflict at output level in CompactFiles

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -852,11 +852,11 @@ Status CompactionPicker::SanitizeCompactionInputFilesForAllLevels(
         }
       }
     }
-    if (RangeOverlapWithCompaction(smallestkey, largestkey, output_level)) {
-      return Status::Aborted(
-          "A running compaction is writing to the same output level in an "
-          "overlapping key range");
-    }
+  }
+  if (RangeOverlapWithCompaction(smallestkey, largestkey, output_level)) {
+    return Status::Aborted(
+        "A running compaction is writing to the same output level in an "
+        "overlapping key range");
   }
   return Status::OK();
 }

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -852,6 +852,11 @@ Status CompactionPicker::SanitizeCompactionInputFilesForAllLevels(
         }
       }
     }
+    if (RangeOverlapWithCompaction(smallestkey, largestkey, output_level)) {
+      return Status::Aborted(
+          "A running compaction is writing to the same output level in an "
+          "overlapping key range");
+    }
   }
   return Status::OK();
 }


### PR DESCRIPTION
CompactFiles checked whether the existing files conflicted with the chosen compaction. But it missed checking whether future files would conflict, i.e., when another compaction was simultaneously writing new files to the same range at the same output level.

Test Plan:

- exposed the bug in a test case, verified it works after this fix