### PR TITLE
Run manual compaction in stress/crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -25,6 +25,8 @@ default_params = {
     "block_size": 16384,
     "cache_size": 1048576,
     "clear_column_family_one_in": 0,
+    "compact_files_one_in": 1000000,
+    "compact_range_one_in": 1000000,
     "delpercent": 5,
     "destroy_db_initially": 0,
     "expected_values_path": expected_values_file.name,

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -383,12 +383,12 @@ DEFINE_bool(use_txn, false,
             "TxnDBWritePolicy::WRITE_PREPARED");
 
 DEFINE_int32(compact_files_one_in, 0,
-             "If non-zero, then CompactFiles() will be called one for every N "
-             "operations IN AVERAGE.  0 indicates CompactFiles() is disabled.");
+             "If non-zero, then CompactFiles() will be called once for every N "
+             "operations on average.  0 indicates CompactFiles() is disabled.");
 
 DEFINE_int32(compact_range_one_in, 0,
-             "If non-zero, then CompactRange() will be called one for every N "
-             "operations IN AVERAGE.  0 indicates CompactRange() is disabled.");
+             "If non-zero, then CompactRange() will be called once for every N "
+             "operations on average.  0 indicates CompactRange() is disabled.");
 
 DEFINE_int32(compact_range_width, 10000,
              "The width of the ranges passed to CompactRange().");

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -382,10 +382,16 @@ DEFINE_bool(use_txn, false,
             "Use TransactionDB. Currently the default write policy is "
             "TxnDBWritePolicy::WRITE_PREPARED");
 
-// Temporarily disable this to allows it to detect new bugs
 DEFINE_int32(compact_files_one_in, 0,
              "If non-zero, then CompactFiles() will be called one for every N "
              "operations IN AVERAGE.  0 indicates CompactFiles() is disabled.");
+
+DEFINE_int32(compact_range_one_in, 0,
+             "If non-zero, then CompactRange() will be called one for every N "
+             "operations IN AVERAGE.  0 indicates CompactRange() is disabled.");
+
+DEFINE_int32(compact_range_width, 10000,
+             "The width of the ranges passed to CompactRange().");
 
 DEFINE_int32(acquire_snapshot_one_in, 0,
              "If non-zero, then acquires a snapshot once every N operations on "
@@ -1812,6 +1818,27 @@ class StressTest {
       }
 
       auto column_family = column_families_[rand_column_family];
+
+      if (FLAGS_compact_range_one_in > 0 &&
+          thread->rand.Uniform(FLAGS_compact_range_one_in) == 0) {
+        int64_t end_key_num;
+        if (port::kMaxInt64 - rand_key < FLAGS_compact_range_width) {
+          end_key_num = port::kMaxInt64;
+        } else {
+          end_key_num = FLAGS_compact_range_width + rand_key;
+        }
+        std::string end_key_buf = Key(end_key_num);
+        Slice end_key(end_key_buf);
+
+        CompactRangeOptions cro;
+        cro.exclusive_manual_compaction =
+            static_cast<bool>(thread->rand.Next() % 2);
+        Status status = db_->CompactRange(cro, column_family, &key, &end_key);
+        if (!status.ok()) {
+          printf("Unable to perform CompactRange(): %s\n",
+                 status.ToString().c_str());
+        }
+      }
 
       if (FLAGS_acquire_snapshot_one_in > 0 &&
           thread->rand.Uniform(FLAGS_acquire_snapshot_one_in) == 0) {


### PR DESCRIPTION
- Add support to `db_stress` for `CompactRange`
- Enable `CompactRange` and `CompactFiles` in crash tests

Test Plan:

- run crash tests and make sure they run manual compactions

```
$ TEST_TMPDIR=/data/compaction_bench python -u tools/db_crashtest.py whitebox
$ grep -i 'score -1' /data/compaction_bench/rocksdb_crashtest_whitebox/LOG*
/data/compaction_bench/rocksdb_crashtest_whitebox/LOG.old.1528868662203409:2018/06/12-22:44:09.937139 7fcb1b7fa700 [db/compaction_job.cc:1534] [3] [JOB 164] Compacting 1@0 + 1@1 files to L1, score -1.00
/data/compaction_bench/rocksdb_crashtest_whitebox/LOG.old.1528868838766791:2018/06/12-22:47:16.699041 7f2047246700 [db/compaction_job.cc:1534] [3] [JOB 44] Compacting 1@0 + 2@1 files to L1, score -1.00
...
```