### PR TITLE
Update JobContext to support installing superversions for multiple column families

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -113,7 +113,8 @@ Status TableCache::GetTableReader(
         new RandomAccessFileReader(
             std::move(file), fname, ioptions_.env,
             record_read_stats ? ioptions_.statistics : nullptr, SST_READ_MICROS,
-            file_read_hist, ioptions_.rate_limiter, for_compaction));
+            file_read_hist, ioptions_.rate_limiter, for_compaction,
+            ioptions_.listeners));
     s = ioptions_.table_factory->NewTableReader(
         TableReaderOptions(ioptions_, prefix_extractor, env_options,
                            internal_comparator, skip_filters, level),

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2865,7 +2865,8 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
             db_options_->manifest_preallocation_size);
 
         unique_ptr<WritableFileWriter> file_writer(
-            new WritableFileWriter(std::move(descriptor_file), opt_env_opts));
+            new WritableFileWriter(std::move(descriptor_file), opt_env_opts,
+            nullptr, db_options_->listeners));
         descriptor_log_.reset(
             new log::Writer(std::move(file_writer), 0, false));
         s = WriteSnapshot(descriptor_log_.get());

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -141,6 +141,11 @@ struct TableFileDeletionInfo {
   Status status;
 };
 
+struct FileOperationInfo {
+  uint64_t start_timestamp;
+  uint64_t finish_timestamp;
+};
+
 struct FlushJobInfo {
   // the name of the column family
   std::string cf_name;
@@ -393,9 +398,9 @@ class EventListener {
   // returns.  Otherwise, RocksDB may be blocked.
   virtual void OnStallConditionsChanged(const WriteStallInfo& /*info*/) {}
 
-  virtual void OnFileReadStart() {}
+  virtual void OnFileReadStart(FileOperationInfo* /* info */) {}
 
-  virtual void OnFileReadFinish() {}
+  virtual void OnFileReadFinish(FileOperationInfo* /* info */) {}
 
   virtual ~EventListener() {}
 };

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -402,6 +402,10 @@ class EventListener {
 
   virtual void OnFileReadFinish(FileOperationInfo* /* info */) {}
 
+  virtual void OnFileWriteStart(FileOperationInfo* /* info */) {}
+
+  virtual void OnFileWriteFinish(FileOperationInfo* /* info */) {}
+
   virtual ~EventListener() {}
 };
 

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -393,6 +393,10 @@ class EventListener {
   // returns.  Otherwise, RocksDB may be blocked.
   virtual void OnStallConditionsChanged(const WriteStallInfo& /*info*/) {}
 
+  virtual void OnFileReadStart() {}
+
+  virtual void OnFileReadFinish() {}
+
   virtual ~EventListener() {}
 };
 

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -97,8 +97,12 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
           allowed = read_size;
         }
         Slice tmp;
+
+        NotifyOnFileReadStart();
         s = file_->Read(aligned_offset + buf.CurrentSize(), allowed, &tmp,
                         buf.Destination());
+        NotifyOnFileReadFinish();
+
         buf.Size(buf.CurrentSize() + tmp.size());
         if (!s.ok() || tmp.size() < allowed) {
           break;
@@ -124,7 +128,11 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
           allowed = n;
         }
         Slice tmp_result;
+
+        NotifyOnFileReadStart();
         s = file_->Read(offset + pos, allowed, &tmp_result, scratch + pos);
+        NotifyOnFileReadFinish();
+
         if (res_scratch == nullptr) {
           // we can't simply use `scratch` because reads of mmap'd files return
           // data in a different buffer.

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -416,7 +416,11 @@ Status WritableFileWriter::WriteBuffered(const char* data, size_t size) {
     {
       IOSTATS_TIMER_GUARD(write_nanos);
       TEST_SYNC_POINT("WritableFileWriter::Flush:BeforeAppend");
+
+      FileOperationInfo rw_info;
+      NotifyOnFileWriteStart(&rw_info);
       s = writable_file_->Append(Slice(src, allowed));
+      NotifyOnFileWriteFinish(&rw_info);
       if (!s.ok()) {
         return s;
       }

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -58,15 +58,15 @@ class SequentialFileReader {
 
 class RandomAccessFileReader {
  private:
-  void NotifyOnFileReadStart() const {
+  void NotifyOnFileReadStart(FileOperationInfo* info) const {
     for (auto& listener : listeners_) {
-      listener->OnFileReadStart();
+      listener->OnFileReadStart(info);
     }
   }
 
-  void NotifyOnFileReadFinish() const {
+  void NotifyOnFileReadFinish(FileOperationInfo* info) const {
     for (auto& listener : listeners_) {
-      listener->OnFileReadFinish();
+      listener->OnFileReadFinish(info);
     }
   }
 

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -58,6 +58,7 @@ class SequentialFileReader {
 
 class RandomAccessFileReader {
  private:
+#ifndef ROCKSDB_LITE
   void NotifyOnFileReadStart(FileOperationInfo* info) const {
     for (auto& listener : listeners_) {
       listener->OnFileReadStart(info);
@@ -69,6 +70,7 @@ class RandomAccessFileReader {
       listener->OnFileReadFinish(info);
     }
   }
+#endif // ROCKSDB_LITE
 
   std::unique_ptr<RandomAccessFile> file_;
   std::string     file_name_;
@@ -135,6 +137,7 @@ class RandomAccessFileReader {
 // Use posix write to write data to a file.
 class WritableFileWriter {
  private:
+#ifndef ROCKSDB_LITE
    void NotifyOnFileWriteStart(FileOperationInfo* info) {
      for (auto& listener : listeners_) {
        listener->OnFileWriteStart(info);
@@ -146,6 +149,7 @@ class WritableFileWriter {
        listener->OnFileWriteFinish(info);
      }
    }
+#endif // ROCKSDB_LITE
 
   std::unique_ptr<WritableFile> writable_file_;
   AlignedBuffer           buf_;


### PR DESCRIPTION
With this PR, it's possible to install superversions for multiple column families in a single `JobContext`.

Test plan:
```
$ make clean && make -j16 all check
```

All tests should pass.