### PR TITLE
Fix singleton destruction order of PosixEnv and SyncPoint

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -1057,6 +1057,7 @@ Env* Env::Default() {
   // the destructor of static PosixEnv will go first, then the
   // the singletons of ThreadLocalPtr.
   ThreadLocalPtr::InitSingletons();
+  INIT_SYNC_POINT_SINGLETONS();
   static PosixEnv default_env;
   return &default_env;
 }

--- a/util/sync_point.h
+++ b/util/sync_point.h
@@ -45,6 +45,7 @@ extern void TestKillRandom(std::string kill_point, int odds,
 #define TEST_SYNC_POINT(x)
 #define TEST_IDX_SYNC_POINT(x, index)
 #define TEST_SYNC_POINT_CALLBACK(x, y)
+#define INIT_SYNC_POINT_SINGLETONS()
 #else
 
 namespace rocksdb {
@@ -134,4 +135,6 @@ class SyncPoint {
   rocksdb::SyncPoint::GetInstance()->Process(x + std::to_string(index))
 #define TEST_SYNC_POINT_CALLBACK(x, y) \
   rocksdb::SyncPoint::GetInstance()->Process(x, y)
+#define INIT_SYNC_POINT_SINGLETONS() \
+  (void)rocksdb::SyncPoint::GetInstance();
 #endif  // NDEBUG


### PR DESCRIPTION
Ensure the PosixEnv singleton is destroyed first since its destructor waits for background threads to all complete. This ensures background threads cannot hit sync points after the SyncPoint singleton is destroyed, which was previously possible.

Test Plan:

- verify fixes asan
- verify builds/runs in lite and release mode