### PR TITLE
[formatting] run make format for PR 3838

### DIFF
--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -260,7 +260,6 @@ class ComparatorDBTest
   DB* db_;
   Options last_options_;
   std::unique_ptr<const Comparator> comparator_guard;
-  uint32_t format_;
 
  public:
   ComparatorDBTest() : env_(Env::Default()), db_(nullptr) {

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -49,6 +49,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "util/coding.h"
+#include "util/compression_context_cache.h"
 #include "util/logging.h"
 #include "util/random.h"
 #include "util/string_util.h"
@@ -1057,6 +1058,7 @@ Env* Env::Default() {
   // the destructor of static PosixEnv will go first, then the
   // the singletons of ThreadLocalPtr.
   ThreadLocalPtr::InitSingletons();
+  CompressionContextCache::InitSingleton();
   INIT_SYNC_POINT_SINGLETONS();
   static PosixEnv default_env;
   return &default_env;

--- a/port/win/env_default.cc
+++ b/port/win/env_default.cc
@@ -12,6 +12,7 @@
 #include <rocksdb/env.h>
 #include "port/win/env_win.h"
 #include "util/compression_context_cache.h"
+#include "util/sync_point.h"
 #include "util/thread_local.h"
 
 namespace rocksdb {
@@ -32,9 +33,9 @@ Env* Env::Default() {
   using namespace port;
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
+  INIT_SYNC_POINT_SINGLETONS();
   std::call_once(winenv_once_flag, []() { envptr = new WinEnv(); });
   return envptr;
 }
 
 }
-

--- a/port/win/win_jemalloc.cc
+++ b/port/win/win_jemalloc.cc
@@ -26,7 +26,7 @@ void JemallocDeallocateForZSTD(void* /* opaque */, void* address) {
   je_free(address);
 }
 ZSTD_customMem GetJeZstdAllocationOverrides() {
-  return { JemallocAllocateForZSTD, JemallocDeallocateForZSTD, nullptr };
+  return {JemallocAllocateForZSTD, JemallocDeallocateForZSTD, nullptr};
 }
 } // namespace port
 } // namespace rocksdb
@@ -63,4 +63,3 @@ void operator delete[](void* p) {
     je_free(p);
   }
 }
-

--- a/table/block_based_table_builder.h
+++ b/table/block_based_table_builder.h
@@ -122,8 +122,7 @@ class BlockBasedTableBuilder : public TableBuilder {
   const uint64_t kCompressionSizeLimit = std::numeric_limits<int>::max();
 };
 
-Slice CompressBlock(const Slice& raw,
-                    const CompressionContext& compression_ctx,
+Slice CompressBlock(const Slice& raw, const CompressionContext& compression_ctx,
                     CompressionType* type, uint32_t format_version,
                     std::string* compressed_output);
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1103,12 +1103,10 @@ Status BlockBasedTable::GetDataBlockFromCache(
   // Retrieve the uncompressed contents into a new buffer
   BlockContents contents;
   UncompressionContext uncompresssion_ctx(compressed_block->compression_type(),
-    compression_dict);
-  s = UncompressBlockContents(uncompresssion_ctx,
-                              compressed_block->data(),
+                                          compression_dict);
+  s = UncompressBlockContents(uncompresssion_ctx, compressed_block->data(),
                               compressed_block->size(), &contents,
-                              format_version,
-                              ioptions);
+                              format_version, ioptions);
 
   // Insert uncompressed block into block cache
   if (s.ok()) {
@@ -1183,10 +1181,11 @@ Status BlockBasedTable::PutDataBlockToCache(
   BlockContents contents;
   Statistics* statistics = ioptions.statistics;
   if (raw_block->compression_type() != kNoCompression) {
-    UncompressionContext uncompression_ctx(raw_block->compression_type(), compression_dict);
+    UncompressionContext uncompression_ctx(raw_block->compression_type(),
+                                           compression_dict);
     s = UncompressBlockContents(uncompression_ctx, raw_block->data(),
-                                raw_block->size(), &contents,
-                                format_version, ioptions);
+                                raw_block->size(), &contents, format_version,
+                                ioptions);
   }
   if (!s.ok()) {
     delete raw_block;

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -226,10 +226,9 @@ Status BlockFetcher::ReadBlockContents() {
   if (do_uncompress_ && compression_type != kNoCompression) {
     // compressed page, uncompress, update cache
     UncompressionContext uncompression_ctx(compression_type, compression_dict_);
-    status_ = UncompressBlockContents(uncompression_ctx, 
-                                      slice_.data(), block_size_, contents_,
-                                      footer_.version(),
-                                      ioptions_);
+    status_ =
+        UncompressBlockContents(uncompression_ctx, slice_.data(), block_size_,
+                                contents_, footer_.version(), ioptions_);
   } else {
     GetBlockContents();
   }

--- a/table/format.cc
+++ b/table/format.cc
@@ -264,12 +264,14 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
   return Status::OK();
 }
 
-Status UncompressBlockContentsForCompressionType(const UncompressionContext& uncompression_ctx,
-    const char* data, size_t n, BlockContents* contents,
-    uint32_t format_version, const ImmutableCFOptions &ioptions) {
+Status UncompressBlockContentsForCompressionType(
+    const UncompressionContext& uncompression_ctx, const char* data, size_t n,
+    BlockContents* contents, uint32_t format_version,
+    const ImmutableCFOptions& ioptions) {
   std::unique_ptr<char[]> ubuf;
 
-  assert(uncompression_ctx.type() != kNoCompression && "Invalid compression type");
+  assert(uncompression_ctx.type() != kNoCompression &&
+         "Invalid compression type");
 
   StopWatchNano timer(ioptions.env,
     ShouldReportDetailedTime(ioptions.env, ioptions.statistics));
@@ -290,8 +292,8 @@ Status UncompressBlockContentsForCompressionType(const UncompressionContext& unc
       break;
     }
     case kZlibCompression:
-      ubuf.reset(Zlib_Uncompress(uncompression_ctx,
-          data, n, &decompress_size,
+      ubuf.reset(Zlib_Uncompress(
+          uncompression_ctx, data, n, &decompress_size,
           GetCompressFormatForVersion(kZlibCompression, format_version)));
       if (!ubuf) {
         static char zlib_corrupt_msg[] =
@@ -314,8 +316,8 @@ Status UncompressBlockContentsForCompressionType(const UncompressionContext& unc
           BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
       break;
     case kLZ4Compression:
-      ubuf.reset(LZ4_Uncompress(uncompression_ctx,
-          data, n, &decompress_size,
+      ubuf.reset(LZ4_Uncompress(
+          uncompression_ctx, data, n, &decompress_size,
           GetCompressFormatForVersion(kLZ4Compression, format_version)));
       if (!ubuf) {
         static char lz4_corrupt_msg[] =
@@ -326,8 +328,8 @@ Status UncompressBlockContentsForCompressionType(const UncompressionContext& unc
           BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
       break;
     case kLZ4HCCompression:
-      ubuf.reset(LZ4_Uncompress(uncompression_ctx,
-          data, n, &decompress_size,
+      ubuf.reset(LZ4_Uncompress(
+          uncompression_ctx, data, n, &decompress_size,
           GetCompressFormatForVersion(kLZ4HCCompression, format_version)));
       if (!ubuf) {
         static char lz4hc_corrupt_msg[] =
@@ -382,12 +384,11 @@ Status UncompressBlockContentsForCompressionType(const UncompressionContext& unc
 Status UncompressBlockContents(const UncompressionContext& uncompression_ctx,
                                const char* data, size_t n,
                                BlockContents* contents, uint32_t format_version,
-                               const ImmutableCFOptions &ioptions) {
+                               const ImmutableCFOptions& ioptions) {
   assert(data[n] != kNoCompression);
   assert(data[n] == uncompression_ctx.type());
   return UncompressBlockContentsForCompressionType(
-      uncompression_ctx, data, n, contents,
-      format_version, ioptions);
+      uncompression_ctx, data, n, contents, format_version, ioptions);
 }
 
 }  // namespace rocksdb

--- a/table/format.h
+++ b/table/format.h
@@ -228,19 +228,17 @@ extern Status ReadBlockContents(
 // free this buffer.
 // For description of compress_format_version and possible values, see
 // util/compression.h
-extern Status UncompressBlockContents(const UncompressionContext& uncompression_ctx,
-                                      const char* data, size_t n,
-                                      BlockContents* contents,
-                                      uint32_t compress_format_version,
-                                      const ImmutableCFOptions &ioptions);
+extern Status UncompressBlockContents(
+    const UncompressionContext& uncompression_ctx, const char* data, size_t n,
+    BlockContents* contents, uint32_t compress_format_version,
+    const ImmutableCFOptions& ioptions);
 
 // This is an extension to UncompressBlockContents that accepts
 // a specific compression type. This is used by un-wrapped blocks
 // with no compression header.
 extern Status UncompressBlockContentsForCompressionType(
-    const UncompressionContext& uncompression_ctx,
-    const char* data, size_t n, BlockContents* contents,
-    uint32_t compress_format_version,
+    const UncompressionContext& uncompression_ctx, const char* data, size_t n,
+    BlockContents* contents, uint32_t compress_format_version,
     const ImmutableCFOptions& ioptions);
 
 // Implementation details follow.  Clients should ignore,

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1947,36 +1947,36 @@ class Benchmark {
   }
 
   inline bool CompressSlice(const CompressionContext& compression_ctx,
-                          const Slice& input, std::string* compressed) {
+                            const Slice& input, std::string* compressed) {
     bool ok = true;
     switch (FLAGS_compression_type_e) {
       case rocksdb::kSnappyCompression:
-        ok = Snappy_Compress(compression_ctx, input.data(),
-                             input.size(), compressed);
+        ok = Snappy_Compress(compression_ctx, input.data(), input.size(),
+                             compressed);
         break;
       case rocksdb::kZlibCompression:
-        ok = Zlib_Compress(compression_ctx, 2, input.data(),
-                           input.size(), compressed);
+        ok = Zlib_Compress(compression_ctx, 2, input.data(), input.size(),
+                           compressed);
         break;
       case rocksdb::kBZip2Compression:
-        ok = BZip2_Compress(compression_ctx, 2, input.data(),
-                            input.size(), compressed);
+        ok = BZip2_Compress(compression_ctx, 2, input.data(), input.size(),
+                            compressed);
         break;
       case rocksdb::kLZ4Compression:
-        ok = LZ4_Compress(compression_ctx, 2, input.data(),
-                          input.size(), compressed);
+        ok = LZ4_Compress(compression_ctx, 2, input.data(), input.size(),
+                          compressed);
         break;
       case rocksdb::kLZ4HCCompression:
-        ok = LZ4HC_Compress(compression_ctx, 2, input.data(),
-                            input.size(), compressed);
+        ok = LZ4HC_Compress(compression_ctx, 2, input.data(), input.size(),
+                            compressed);
         break;
       case rocksdb::kXpressCompression:
         ok = XPRESS_Compress(input.data(),
           input.size(), compressed);
         break;
       case rocksdb::kZSTD:
-        ok = ZSTD_Compress(compression_ctx, input.data(),
-                            input.size(), compressed);
+        ok = ZSTD_Compress(compression_ctx, input.data(), input.size(),
+                           compressed);
         break;
       default:
         ok = false;
@@ -2058,8 +2058,10 @@ class Benchmark {
       const int len = FLAGS_block_size;
       std::string input_str(len, 'y');
       std::string compressed;
-      CompressionContext compression_ctx(FLAGS_compression_type_e, Options().compression_opts);
-      bool result = CompressSlice(compression_ctx, Slice(input_str), &compressed);
+      CompressionContext compression_ctx(FLAGS_compression_type_e,
+                                         Options().compression_opts);
+      bool result =
+          CompressSlice(compression_ctx, Slice(input_str), &compressed);
 
       if (!result) {
         fprintf(stdout, "WARNING: %s compression is not enabled\n",
@@ -2851,8 +2853,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     int64_t produced = 0;
     bool ok = true;
     std::string compressed;
-    CompressionContext compression_ctx(FLAGS_compression_type_e, 
-      Options().compression_opts);
+    CompressionContext compression_ctx(FLAGS_compression_type_e,
+                                       Options().compression_opts);
 
     // Compress 1G
     while (ok && bytes < int64_t(1) << 30) {
@@ -2881,7 +2883,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 
     UncompressionContext uncompression_ctx(FLAGS_compression_type_e);
     CompressionContext compression_ctx(FLAGS_compression_type_e,
-      Options().compression_opts);
+                                       Options().compression_opts);
 
     bool ok = CompressSlice(compression_ctx, input, &compressed);
     int64_t bytes = 0;
@@ -2904,8 +2906,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         }
       case rocksdb::kZlibCompression:
         uncompressed = Zlib_Uncompress(uncompression_ctx, compressed.data(),
-                                       compressed.size(),
-                                       &decompress_size, 2);
+                                       compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kBZip2Compression:
@@ -2915,14 +2916,12 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         break;
       case rocksdb::kLZ4Compression:
         uncompressed = LZ4_Uncompress(uncompression_ctx, compressed.data(),
-                                      compressed.size(),
-                                      &decompress_size, 2);
+                                      compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kLZ4HCCompression:
         uncompressed = LZ4_Uncompress(uncompression_ctx, compressed.data(),
-                                      compressed.size(),
-                                      &decompress_size, 2);
+                                      compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kXpressCompression:
@@ -2932,8 +2931,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         break;
       case rocksdb::kZSTD:
         uncompressed = ZSTD_Uncompress(uncompression_ctx, compressed.data(),
-                                       compressed.size(),
-                                       &decompress_size);
+                                       compressed.size(), &decompress_size);
         ok = uncompressed != nullptr;
         break;
       default:

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -219,7 +219,8 @@ DEFINE_int32(level0_stop_writes_trigger,
              rocksdb::Options().level0_stop_writes_trigger,
              "Number of files in level-0 that will trigger put stop.");
 
-DEFINE_int32(block_size, rocksdb::BlockBasedTableOptions().block_size,
+DEFINE_int32(block_size,
+             static_cast<int32_t>(rocksdb::BlockBasedTableOptions().block_size),
              "Number of bytes in a block.");
 
 DEFINE_int32(

--- a/util/compression_context_cache.h
+++ b/util/compression_context_cache.h
@@ -11,9 +11,9 @@
 // This helps with Random Read latencies and reduces CPU utilization
 // Caching is implemented using CoreLocal facility. Compression/Uncompression
 // instances are cached on a per core basis using CoreLocalArray. A borrowed
-// instance is atomically replaced with a sentinel value for the time of being used.
-// If it turns out that another thread is already makes use of the instance we still
-// create one on the heap which is later is destroyed.
+// instance is atomically replaced with a sentinel value for the time of being
+// used. If it turns out that another thread is already makes use of the
+// instance we still create one on the heap which is later is destroyed.
 
 #pragma once
 
@@ -23,7 +23,7 @@ namespace rocksdb {
 class ZSTDUncompressCachedData;
 
 class CompressionContextCache {
-public:
+ public:
   // Singleton
   static CompressionContextCache* Instance();
   static void InitSingleton();
@@ -33,13 +33,13 @@ public:
   ZSTDUncompressCachedData GetCachedZSTDUncompressData();
   void ReturnCachedZSTDUncompressData(int64_t idx);
 
-private:
+ private:
   // Singleton
-   CompressionContextCache();
+  CompressionContextCache();
   ~CompressionContextCache();
 
   class Rep;
   Rep* rep_;
 };
 
-}
+}  // namespace rocksdb

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1122,10 +1122,8 @@ Status BlobDBImpl::GetBlobValue(const Slice& key, const Slice& index_entry,
                                  BLOB_DB_DECOMPRESSION_MICROS);
       UncompressionContext uncompression_ctx(bfile->compression());
       s = UncompressBlockContentsForCompressionType(
-          uncompression_ctx,
-          blob_value.data(), blob_value.size(), &contents,
-          kBlockBasedTableVersionFormat,
-          *(cfh->cfd()->ioptions()));
+          uncompression_ctx, blob_value.data(), blob_value.size(), &contents,
+          kBlockBasedTableVersionFormat, *(cfh->cfd()->ioptions()));
     }
     value->PinSelf(contents.data);
   }

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -207,10 +207,8 @@ Status BlobDumpTool::DumpRecord(DisplayType show_key, DisplayType show_blob,
     BlockContents contents;
     UncompressionContext uncompression_ctx(compression);
     s = UncompressBlockContentsForCompressionType(
-      uncompression_ctx,
-        slice.data() + key_size, value_size, &contents,
-        2 /*compress_format_version*/,
-        ImmutableCFOptions(Options()));
+        uncompression_ctx, slice.data() + key_size, value_size, &contents,
+        2 /*compress_format_version*/, ImmutableCFOptions(Options()));
     if (!s.ok()) {
       return s;
     }

--- a/utilities/column_aware_encoding_util.cc
+++ b/utilities/column_aware_encoding_util.cc
@@ -173,8 +173,7 @@ void ColumnAwareEncodingReader::DecodeBlocksFromRowFormat(
         (CompressionType)slice_final_with_bit[slice_final_with_bit.size() - 1];
     if (type != kNoCompression) {
       UncompressionContext uncompression_ctx(type);
-      UncompressBlockContents(uncompression_ctx,
-                              slice_final_with_bit.c_str(),
+      UncompressBlockContents(uncompression_ctx, slice_final_with_bit.c_str(),
                               slice_final_with_bit.size() - 1, &contents,
                               format_version, ioptions);
       decoded_content = std::string(contents.data.data(), contents.data.size());
@@ -247,9 +246,8 @@ void CompressDataBlock(const std::string& output_content, Slice* slice_final,
                        CompressionType* type, std::string* compressed_output) {
   CompressionContext compression_ctx(*type);
   uint32_t format_version = 2;  // hard-coded version
-  *slice_final =
-      CompressBlock(output_content, compression_ctx, type, format_version,
-                    compressed_output);
+  *slice_final = CompressBlock(output_content, compression_ctx, type,
+                               format_version, compressed_output);
 }
 
 }  // namespace


### PR DESCRIPTION
PR https://github.com/facebook/rocksdb/pull/3838 made some changes that triggers lint warnings. 
Run `make format` to fix formatting as suggested by @siying .
Also piggyback two changes: 
1) fix singleton destruction order for windows and posix env
2) fix two clang warnings