### PR TITLE
Add static cast to fix compilation warning/error.

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -219,7 +219,8 @@ DEFINE_int32(level0_stop_writes_trigger,
              rocksdb::Options().level0_stop_writes_trigger,
              "Number of files in level-0 that will trigger put stop.");
 
-DEFINE_int32(block_size, rocksdb::BlockBasedTableOptions().block_size,
+DEFINE_int32(block_size,
+             static_cast<int>(rocksdb::BlockBasedTableOptions().block_size),
              "Number of bytes in a block.");
 
 DEFINE_int32(


### PR DESCRIPTION
Test plan:
```
$ make clean && make -j16 all check
$ ./db_stress
```