### PR TITLE
[DNM] Cache: Expose usage/capacity for high priority pool.

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -290,7 +290,7 @@ bool LRUCacheShard::Ref(Cache::Handle* h) {
   return true;
 }
 
-void LRUCacheShard::SetHighPriorityPoolRatio(double high_pri_pool_ratio) {
+void LRUCacheShard::SetHighPriPoolRatio(double high_pri_pool_ratio) {
   MutexLock l(&mutex_);
   high_pri_pool_ratio_ = high_pri_pool_ratio;
   high_pri_pool_capacity_ = capacity_ * high_pri_pool_ratio_;
@@ -547,6 +547,12 @@ double LRUCache::GetHighPriPoolRatio() const {
     result = shards_[0].GetHighPriPoolRatio();
   }
   return result;
+}
+
+void LRUCache::SetHighPriPoolRatio(double high_pri_pool_ratio) {
+  for (int i = 0; i < num_shards_; i++) {
+    shards_[i].SetHighPriPoolRatio(high_pri_pool_ratio);
+  }
 }
 
 std::shared_ptr<Cache> NewLRUCache(const LRUCacheOptions& cache_opts) {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -251,7 +251,7 @@ void LRUCacheShard::SetCapacity(size_t capacity) {
   {
     MutexLock l(&mutex_);
     capacity_ = capacity;
-    high_pri_pool_capacity_ = capacity_ * high_pri_pool_ratio_;
+    ResetHighPriPoolCapacity();
     EvictFromLRU(0, &last_reference_list);
   }
   // we free the entries here outside of mutex for
@@ -293,8 +293,13 @@ bool LRUCacheShard::Ref(Cache::Handle* h) {
 void LRUCacheShard::SetHighPriPoolRatio(double high_pri_pool_ratio) {
   MutexLock l(&mutex_);
   high_pri_pool_ratio_ = high_pri_pool_ratio;
-  high_pri_pool_capacity_ = capacity_ * high_pri_pool_ratio_;
+  ResetHighPriPoolCapacity();
   MaintainPoolSize();
+}
+
+void LRUCacheShard::ResetHighPriPoolCapacity() {
+  high_pri_pool_capacity_ = 
+      static_cast<size_t>(capacity_ * high_pri_pool_ratio_);
 }
 
 bool LRUCacheShard::Release(Cache::Handle* handle, bool force_erase) {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -449,6 +449,16 @@ size_t LRUCacheShard::GetPinnedUsage() const {
   return usage_ - lru_usage_;
 }
 
+size_t LRUCacheShard::GetHighPriPoolCapacity() {
+  MutexLock l(&mutex_);
+  return high_pri_pool_capacity_;
+}
+
+size_t LRUCacheShard::GetHighPriPoolUsage() {
+  MutexLock l(&mutex_);
+  return high_pri_pool_usage_;
+}
+
 std::string LRUCacheShard::GetPrintableOptions() const {
   const int kBufferSize = 200;
   char buffer[kBufferSize];
@@ -513,6 +523,22 @@ size_t LRUCache::TEST_GetLRUSize() {
     lru_size_of_all_shards += shards_[i].TEST_GetLRUSize();
   }
   return lru_size_of_all_shards;
+}
+
+size_t LRUCache::GetHighPriPoolCapacity() {
+  size_t size = 0;
+  for (int i = 0; i < num_shards_; i++) {
+    size += shards_[i].GetHighPriPoolCapacity();
+  }
+  return size;
+}
+
+size_t LRUCache::GetHighPriPoolUsage() {
+  size_t size = 0;
+  for (int i = 0; i < num_shards_; i++) {
+    size += shards_[i].GetHighPriPoolUsage();
+  }
+  return size;
 }
 
 double LRUCache::GetHighPriPoolRatio() {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -175,7 +175,7 @@ size_t LRUCacheShard::TEST_GetLRUSize() {
   return lru_size;
 }
 
-double LRUCacheShard::GetHighPriPoolRatio() {
+double LRUCacheShard::GetHighPriPoolRatio() const{
   MutexLock l(&mutex_);
   return high_pri_pool_ratio_;
 }
@@ -449,12 +449,12 @@ size_t LRUCacheShard::GetPinnedUsage() const {
   return usage_ - lru_usage_;
 }
 
-size_t LRUCacheShard::GetHighPriPoolCapacity() {
+size_t LRUCacheShard::GetHighPriPoolCapacity() const {
   MutexLock l(&mutex_);
   return high_pri_pool_capacity_;
 }
 
-size_t LRUCacheShard::GetHighPriPoolUsage() {
+size_t LRUCacheShard::GetHighPriPoolUsage() const {
   MutexLock l(&mutex_);
   return high_pri_pool_usage_;
 }
@@ -525,7 +525,7 @@ size_t LRUCache::TEST_GetLRUSize() {
   return lru_size_of_all_shards;
 }
 
-size_t LRUCache::GetHighPriPoolCapacity() {
+size_t LRUCache::GetHighPriPoolCapacity() const {
   size_t size = 0;
   for (int i = 0; i < num_shards_; i++) {
     size += shards_[i].GetHighPriPoolCapacity();
@@ -533,7 +533,7 @@ size_t LRUCache::GetHighPriPoolCapacity() {
   return size;
 }
 
-size_t LRUCache::GetHighPriPoolUsage() {
+size_t LRUCache::GetHighPriPoolUsage() const {
   size_t size = 0;
   for (int i = 0; i < num_shards_; i++) {
     size += shards_[i].GetHighPriPoolUsage();
@@ -541,7 +541,7 @@ size_t LRUCache::GetHighPriPoolUsage() {
   return size;
 }
 
-double LRUCache::GetHighPriPoolRatio() {
+double LRUCache::GetHighPriPoolRatio() const {
   double result = 0.0;
   if (num_shards_ > 0) {
     result = shards_[0].GetHighPriPoolRatio();

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -202,11 +202,15 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
 
   void TEST_GetLRUList(LRUHandle** lru, LRUHandle** lru_low_pri);
 
-  //  Retrieves number of elements in LRU, for unit test purpose only
-  //  not threadsafe
+  // Retrieves number of elements in LRU, for unit test purpose only
+  // not threadsafe
   size_t TEST_GetLRUSize();
 
-  //  Retrives high pri pool ratio
+  // Retrieve pool capacities and usages.  Protected with mutex_.
+  size_t GetHighPriPoolCapacity();
+  size_t GetHighPriPoolUsage();
+
+  // Retrives high pri pool ratio
   double GetHighPriPoolRatio();
 
  private:
@@ -289,9 +293,13 @@ class LRUCache : public ShardedCache {
   virtual uint32_t GetHash(Handle* handle) const override;
   virtual void DisownData() override;
 
-  //  Retrieves number of elements in LRU, for unit test purpose only
+  // Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
-  //  Retrives high pri pool ratio
+  // Retrieves high pri pool ratio
+  size_t GetHighPriPoolCapacity();
+  // Retrieves high pri pool capacty
+  size_t GetHighPriPoolUsage();
+  // Retrieves high pri pool ratio
   double GetHighPriPoolRatio();
 
  private:

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -229,6 +229,9 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   // holding the mutex_
   void EvictFromLRU(size_t charge, autovector<LRUHandle*>* deleted);
 
+  // Reset the high-pri pool capacity based on the capacity and ratio.
+  void ResetHighPriPoolCapacity();
+
   // Initialized before use.
   size_t capacity_;
 
@@ -243,7 +246,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
 
   // High-pri pool size, equals to capacity * high_pri_pool_ratio.
   // Remember the value to avoid recomputing each time.
-  double high_pri_pool_capacity_;
+  size_t high_pri_pool_capacity_;
 
   // Dummy head of LRU list.
   // lru.prev is newest entry, lru.next is oldest entry.

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -293,10 +293,10 @@ class LRUCache : public ShardedCache {
   virtual size_t GetCharge(Handle* handle) const override;
   virtual uint32_t GetHash(Handle* handle) const override;
   virtual void DisownData() override;
-  virtual size_t GetHighPriPoolCapacity() const;
-  virtual size_t GetHighPriPoolUsage() const;
-  virtual double GetHighPriPoolRatio() const;
-  virtual void SetHighPriPoolRatio(double high_pri_pool_ratio);
+  virtual size_t GetHighPriPoolCapacity() const override;
+  virtual size_t GetHighPriPoolUsage() const override;
+  virtual double GetHighPriPoolRatio() const override;
+  virtual void SetHighPriPoolRatio(double high_pri_pool_ratio) override;
   // Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
 

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -172,7 +172,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) override;
 
   // Set percentage of capacity reserved for high-pri cache entries.
-  void SetHighPriorityPoolRatio(double high_pri_pool_ratio);
+  void SetHighPriPoolRatio(double high_pri_pool_ratio);
 
   // Like Cache methods, but with an extra "hash" parameter.
   virtual Status Insert(const Slice& key, uint32_t hash, void* value,
@@ -293,7 +293,7 @@ class LRUCache : public ShardedCache {
   virtual size_t GetHighPriPoolCapacity() const;
   virtual size_t GetHighPriPoolUsage() const;
   virtual double GetHighPriPoolRatio() const;
-
+  virtual void SetHighPriPoolRatio(double high_pri_pool_ratio);
   // Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
 

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -206,12 +206,10 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   // not threadsafe
   size_t TEST_GetLRUSize();
 
-  // Retrieve pool capacities and usages.  Protected with mutex_.
-  size_t GetHighPriPoolCapacity();
-  size_t GetHighPriPoolUsage();
-
-  // Retrives high pri pool ratio
-  double GetHighPriPoolRatio();
+  // Retrieve pool capacities/usages/ratio.  Protected with mutex_.
+  virtual size_t GetHighPriPoolCapacity() const;
+  virtual size_t GetHighPriPoolUsage() const;
+  virtual double GetHighPriPoolRatio() const;
 
  private:
   void LRU_Remove(LRUHandle* e);
@@ -292,15 +290,12 @@ class LRUCache : public ShardedCache {
   virtual size_t GetCharge(Handle* handle) const override;
   virtual uint32_t GetHash(Handle* handle) const override;
   virtual void DisownData() override;
+  virtual size_t GetHighPriPoolCapacity() const;
+  virtual size_t GetHighPriPoolUsage() const;
+  virtual double GetHighPriPoolRatio() const;
 
   // Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
-  // Retrieves high pri pool ratio
-  size_t GetHighPriPoolCapacity();
-  // Retrieves high pri pool capacty
-  size_t GetHighPriPoolUsage();
-  // Retrieves high pri pool ratio
-  double GetHighPriPoolRatio();
 
  private:
   LRUCacheShard* shards_;

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -59,7 +59,7 @@ class ShardedCache : public Cache {
 
   virtual void SetCapacity(size_t capacity) override;
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) override;
-
+  virtual void SetHighPriPoolRatio(double high_pri_pool_ratio) override = 0;
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle, Priority priority) override;
@@ -69,10 +69,14 @@ class ShardedCache : public Cache {
   virtual void Erase(const Slice& key) override;
   virtual uint64_t NewId() override;
   virtual size_t GetCapacity() const override;
+  virtual size_t GetHighPriPoolCapacity() const override = 0;
   virtual bool HasStrictCapacityLimit() const override;
   virtual size_t GetUsage() const override;
   virtual size_t GetUsage(Handle* handle) const override;
   virtual size_t GetPinnedUsage() const override;
+  virtual size_t GetHighPriPoolUsage() const override = 0;
+  virtual double GetHighPriPoolRatio() const override = 0;
+
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) override;
   virtual void EraseUnRefEntries() override;

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -186,6 +186,11 @@ class Cache {
   // capacity.
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) = 0;
 
+  // Set the high priority pool ratio
+  virtual void SetHighPriPoolRatio(double high_pri_pool_ratio) {
+    // default implementation is noop
+  }
+
   // Get the flag whether to return error on insertion when cache reaches its
   // full capacity.
   virtual bool HasStrictCapacityLimit() const = 0;

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -193,6 +193,12 @@ class Cache {
   // returns the maximum configured capacity of the cache
   virtual size_t GetCapacity() const = 0;
 
+  // returns the capacity of the high priority pool
+  virtual size_t GetHighPriPoolCapacity() const {
+    // default implementation returns 0
+    return 0;
+  }
+
   // returns the memory size for the entries residing in the cache.
   virtual size_t GetUsage() const = 0;
 
@@ -201,6 +207,18 @@ class Cache {
 
   // returns the memory size for the entries in use by the system
   virtual size_t GetPinnedUsage() const = 0;
+
+  // returns the memory size for the entries in the high priority pool
+  virtual size_t GetHighPriPoolUsage() const {
+    // default implementation returns 0
+    return 0;
+  }
+
+  // returns the ratio of memory usaged by the high priority pool
+  virtual double GetHighPriPoolRatio() const {
+    // default implementation returns 0
+    return 0;
+  }
 
   // Call this on shutdown if you want to speed it up. Cache will disown
   // any underlying data and will not free it on delete. This call will leak

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -189,6 +189,7 @@ class Cache {
   // Set the high priority pool ratio
   virtual void SetHighPriPoolRatio(double high_pri_pool_ratio) {
     // default implementation is noop
+    (void)high_pri_pool_ratio;
   }
 
   // Get the flag whether to return error on insertion when cache reaches its


### PR DESCRIPTION
This is a rebased version of #3732 and is what we are using for testing high priority cache prioritization in Ceph.