### PR TITLE
Change db path for BlockBasedTableTest.BadOptions

### DIFF
--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3397,7 +3397,8 @@ TEST_P(BlockBasedTableTest, BadOptions) {
   bbto.block_size = 4000;
   bbto.block_align = true;
 
-  const std::string kDBPath = test::TmpDir() + "/table_block_based_bad_options_test";
+  const std::string kDBPath =
+      test::TmpDir() + "/block_based_table_bad_options_test";
   options.table_factory.reset(NewBlockBasedTableFactory(bbto));
   DestroyDB(kDBPath, options);
   rocksdb::DB* db;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3397,7 +3397,7 @@ TEST_P(BlockBasedTableTest, BadOptions) {
   bbto.block_size = 4000;
   bbto.block_align = true;
 
-  const std::string kDBPath = test::TmpDir() + "/table_prefix_test";
+  const std::string kDBPath = test::TmpDir() + "/table_block_based_bad_options_test";
   options.table_factory.reset(NewBlockBasedTableFactory(bbto));
   DestroyDB(kDBPath, options);
   rocksdb::DB* db;


### PR DESCRIPTION
Summary:
BadOptions test creates a temporary db path changed to
table_block_based_bad_options_test to avoid collide with that created by
the PrefixAndWholeKeyTest

Test Plan:
`make check`
also verified via gdb / fprintf.