### PR TITLE
Skip sstables that are entirely covered by a range tombstone

### DIFF
--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -38,6 +38,7 @@ class ForwardLevelIterator : public InternalIterator {
       : cfd_(cfd),
         read_options_(read_options),
         files_(files),
+        range_del_agg_(cfd->internal_comparator(), {} /* snapshots */),
         valid_(false),
         file_index_(std::numeric_limits<uint32_t>::max()),
         file_iter_(nullptr),
@@ -71,16 +72,14 @@ class ForwardLevelIterator : public InternalIterator {
       delete file_iter_;
     }
 
-    RangeDelAggregator range_del_agg(
-        cfd_->internal_comparator(), {} /* snapshots */);
     file_iter_ = cfd_->table_cache()->NewIterator(
         read_options_, *(cfd_->soptions()), cfd_->internal_comparator(),
         *files_[file_index_],
-        read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
+        read_options_.ignore_range_deletions ? nullptr : &range_del_agg_,
         prefix_extractor_, nullptr /* table_reader_ptr */, nullptr, false);
     file_iter_->SetPinnedItersMgr(pinned_iters_mgr_);
     valid_ = false;
-    if (!range_del_agg.IsEmpty()) {
+    if (!range_del_agg_.IsEmpty()) {
       status_ = Status::NotSupported(
           "Range tombstones unsupported with ForwardIterator");
     }
@@ -184,6 +183,7 @@ class ForwardLevelIterator : public InternalIterator {
   const ColumnFamilyData* const cfd_;
   const ReadOptions& read_options_;
   const std::vector<FileMetaData*>& files_;
+  RangeDelAggregator range_del_agg_;
 
   bool valid_;
   uint32_t file_index_;
@@ -202,6 +202,7 @@ ForwardIterator::ForwardIterator(DBImpl* db, const ReadOptions& read_options,
       prefix_extractor_(current_sv->mutable_cf_options.prefix_extractor.get()),
       user_comparator_(cfd->user_comparator()),
       immutable_min_heap_(MinIterComparator(&cfd_->internal_comparator())),
+      range_del_agg_(cfd->internal_comparator(), {} /* snapshots */),
       sv_(current_sv),
       mutable_iter_(nullptr),
       current_(nullptr),
@@ -608,16 +609,14 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
     // New
     sv_ = cfd_->GetReferencedSuperVersion(&(db_->mutex_));
   }
-  RangeDelAggregator range_del_agg(
-      cfd_->internal_comparator(), {} /* snapshots */);
   mutable_iter_ = sv_->mem->NewIterator(read_options_, &arena_);
   sv_->imm->AddIterators(read_options_, &imm_iters_, &arena_);
   if (!read_options_.ignore_range_deletions) {
     std::unique_ptr<InternalIterator> range_del_iter(
         sv_->mem->NewRangeTombstoneIterator(read_options_));
-    range_del_agg.AddTombstones(std::move(range_del_iter));
+    range_del_agg_.AddTombstones(std::move(range_del_iter));
     sv_->imm->AddRangeTombstoneIterators(read_options_, &arena_,
-                                         &range_del_agg);
+                                         &range_del_agg_);
   }
   has_iter_trimmed_for_upper_bound_ = false;
 
@@ -636,7 +635,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
     }
     l0_iters_.push_back(cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(), *l0,
-        read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
+        read_options_.ignore_range_deletions ? nullptr : &range_del_agg_,
         sv_->mutable_cf_options.prefix_extractor.get()));
   }
   BuildLevelIterators(vstorage);
@@ -644,7 +643,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
   is_prev_set_ = false;
 
   UpdateChildrenPinnedItersMgr();
-  if (!range_del_agg.IsEmpty()) {
+  if (!range_del_agg_.IsEmpty()) {
     status_ = Status::NotSupported(
         "Range tombstones unsupported with ForwardIterator");
     valid_ = false;
@@ -666,14 +665,12 @@ void ForwardIterator::RenewIterators() {
 
   mutable_iter_ = svnew->mem->NewIterator(read_options_, &arena_);
   svnew->imm->AddIterators(read_options_, &imm_iters_, &arena_);
-  RangeDelAggregator range_del_agg(
-      cfd_->internal_comparator(), {} /* snapshots */);
   if (!read_options_.ignore_range_deletions) {
     std::unique_ptr<InternalIterator> range_del_iter(
         svnew->mem->NewRangeTombstoneIterator(read_options_));
-    range_del_agg.AddTombstones(std::move(range_del_iter));
+    range_del_agg_.AddTombstones(std::move(range_del_iter));
     svnew->imm->AddRangeTombstoneIterators(read_options_, &arena_,
-                                           &range_del_agg);
+                                           &range_del_agg_);
   }
 
   const auto* vstorage = sv_->current->storage_info();
@@ -707,7 +704,7 @@ void ForwardIterator::RenewIterators() {
     l0_iters_new.push_back(cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
         *l0_files_new[inew],
-        read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
+        read_options_.ignore_range_deletions ? nullptr : &range_del_agg_,
         svnew->mutable_cf_options.prefix_extractor.get()));
   }
 
@@ -728,7 +725,7 @@ void ForwardIterator::RenewIterators() {
   sv_ = svnew;
 
   UpdateChildrenPinnedItersMgr();
-  if (!range_del_agg.IsEmpty()) {
+  if (!range_del_agg_.IsEmpty()) {
     status_ = Status::NotSupported(
         "Range tombstones unsupported with ForwardIterator");
     valid_ = false;

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -14,6 +14,7 @@
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "db/dbformat.h"
+#include "db/range_del_aggregator.h"
 #include "table/internal_iterator.h"
 #include "util/arena.h"
 
@@ -121,6 +122,7 @@ class ForwardIterator : public InternalIterator {
   const SliceTransform* const prefix_extractor_;
   const Comparator* user_comparator_;
   MinIterHeap immutable_min_heap_;
+  RangeDelAggregator range_del_agg_;
 
   SuperVersion* sv_;
   InternalIterator* mutable_iter_;

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -409,6 +409,58 @@ bool RangeDelAggregator::ShouldDeleteImpl(const ParsedInternalKey& parsed,
   return tombstone_map.ShouldDelete(parsed, mode);
 }
 
+bool RangeDelAggregator::ShouldDeleteRange(
+    const Slice& start, const Slice& end, SequenceNumber seqno) {
+  if (rep_ == nullptr) {
+    return false;
+  }
+  if (!collapse_deletions_) {
+    // Only supported in collapse deletions mode.
+    return false;
+  }
+
+  ParsedInternalKey parsed_start;
+  if (!ParseInternalKey(start, &parsed_start)) {
+    assert(false);
+  }
+  ParsedInternalKey parsed_end;
+  if (!ParseInternalKey(end, &parsed_end)) {
+    assert(false);
+  }
+  if (icmp_.user_comparator()->Compare(parsed_start.user_key, parsed_end.user_key) > 0) {
+    return false;
+  }
+
+  auto& positional_tombstone_map = GetPositionalTombstoneMap(seqno);
+  const auto& tombstone_map = positional_tombstone_map.raw_map;
+  if (tombstone_map.empty()) {
+    return false;
+  }
+
+  auto iter = tombstone_map.upper_bound(parsed_start.user_key);
+  if (iter == tombstone_map.begin()) {
+    // before start of deletion intervals
+    return false;
+  }
+  --iter;
+  if (icmp_.user_comparator()->Compare(parsed_start.user_key, iter->first) < 0) {
+    return false;
+  }
+  // Loop looking for a tombstone that is older than the range
+  // sequence number, or we determine that our range is completely
+  // covered by newer tombstones.
+  for (; iter != tombstone_map.end(); ++iter) {
+    if (icmp_.user_comparator()->Compare(parsed_end.user_key, iter->first) < 0) {
+      return true;
+    }
+    if (seqno >= iter->second.seq_) {
+      // Tombstone is older than range sequence number.
+      return false;
+    }
+  }
+  return false;
+}
+
 bool RangeDelAggregator::IsRangeOverlapped(const Slice& start,
                                            const Slice& end) {
   // Unimplemented because the only client of this method, file ingestion,

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -80,14 +80,14 @@ class UncollapsedRangeDelMap : public RangeDelMap {
     return false;
   }
 
-  RangeTombstone GetTombstone(const Slice& user_key, SequenceNumber seqno) {
-    // Unimplemented because the only client of this method, iteration, uses
-    // collapsed maps.
+  std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) {
+    // Unimplemented, though the lack of implementation only affects
+    // performance (not correctness) for sstable ingestion. Normal
+    // read operations use a CollapsedRangeDelMap.
     (void)user_key;
     (void)seqno;
-    fprintf(stderr, "UncollapsedRangeDelMap::GetTombstone unimplemented");
-    abort();
-    return RangeTombstone(Slice(), Slice(), 0);
+    return std::make_pair(RangePtr(), 0);
   }
 
   bool IsRangeOverlapped(const Slice& start, const Slice& end) {
@@ -193,7 +193,8 @@ class CollapsedRangeDelMap : public RangeDelMap {
   const Comparator* ucmp_;
 
  public:
-  CollapsedRangeDelMap(const Comparator* ucmp) : ucmp_(ucmp) {
+  CollapsedRangeDelMap(const Comparator* ucmp)
+      : rep_(stl_wrappers::LessOfComparator(ucmp)), ucmp_(ucmp) {
     InvalidatePosition();
   }
 
@@ -270,11 +271,12 @@ class CollapsedRangeDelMap : public RangeDelMap {
     }
     --iter;
     if (ucmp_->Compare(parsed_start.user_key, iter->first) < 0) {
+      assert(false);
       return false;
     }
-    // Loop looking for a tombstone that is older than the range
-    // sequence number, or we determine that our range is completely
-    // covered by newer tombstones.
+    // Loop looking for a tombstone that is older than the range sequence
+    // number, or we determine that our range is completely covered by newer
+    // tombstones.
     for (; iter != rep_.end(); ++iter) {
       if (ucmp_->Compare(parsed_end.user_key, iter->first) < 0) {
         return true;
@@ -287,20 +289,24 @@ class CollapsedRangeDelMap : public RangeDelMap {
     return false;
   }
 
-  RangeTombstone GetTombstone(const Slice& user_key, SequenceNumber seqno) {
+  std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) {
     auto iter = rep_.upper_bound(user_key);
     if (iter == rep_.begin()) {
       // before start of deletion intervals
-      return RangeTombstone(Slice(), iter->first, 0);
+      return std::make_pair(RangePtr(nullptr, &iter->first), 0);
     }
     auto prev = iter;
     --prev;
     if (iter == rep_.end()) {
       // after end of deletion intervals
-      return RangeTombstone(prev->first, Slice(), 0);
+      return std::make_pair(RangePtr(&prev->first, nullptr), 0);
     }
-    return RangeTombstone(prev->first, iter->first,
-                          prev->second >= seqno ? prev->second : 0);
+    // Note that a range tombstone does not cover a key at the same sequence
+    // number. This can occur in an sstable that has been ingested where all
+    // of the entries have the same sequence number.
+    return std::make_pair(RangePtr(&prev->first, &iter->first),
+                          prev->second > seqno ? prev->second : 0);
   }
 
   bool IsRangeOverlapped(const Slice&, const Slice&) {
@@ -420,7 +426,12 @@ class CollapsedRangeDelMap : public RangeDelMap {
     }
   }
 
-  size_t Size() const { return rep_.size() - 1; }
+  size_t Size() const {
+    if (rep_.empty()) {
+      return 0;
+    }
+    return rep_.size() - 1;
+  }
 
   void InvalidatePosition() { iter_ = rep_.end(); }
 
@@ -500,14 +511,14 @@ bool RangeDelAggregator::ShouldDeleteRange(
   return tombstone_map.ShouldDeleteRange(start, end, seqno);
 }
 
-RangeTombstone RangeDelAggregator::GetTombstone(const Slice& user_key,
-                                                SequenceNumber seqno) {
+std::pair<RangePtr,SequenceNumber> RangeDelAggregator::GetTombstone(
+    const Slice& user_key, SequenceNumber seqno) {
   if (rep_ == nullptr) {
-    return RangeTombstone(Slice(), Slice(), 0);
+    return std::make_pair(RangePtr(), 0);
   }
   auto& tombstone_map = GetRangeDelMap(seqno);
   if (tombstone_map.IsEmpty()) {
-    return RangeTombstone(Slice(), Slice(), 0);
+    return std::make_pair(RangePtr(), 0);
   }
   return tombstone_map.GetTombstone(user_key, seqno);
 }

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -64,8 +64,8 @@ class RangeDelMap {
                             RangeDelPositioningMode mode) = 0;
   virtual bool ShouldDeleteRange(const Slice& start, const Slice& end,
                                  SequenceNumber seqno) = 0;
-  virtual RangeTombstone GetTombstone(const Slice& user_key,
-                                      SequenceNumber seqno) = 0;  
+  virtual std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) = 0;  
   virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
   virtual void InvalidatePosition() = 0;
 
@@ -142,9 +142,9 @@ class RangeDelAggregator {
   // Get the range tombstone at the specified user_key and sequence number. A
   // valid tombstone is always returned, though it may cover an empty range of
   // keys or the sequence number may be 0 to indicate that no tombstone covers
-  // the specified range of keys.
-  RangeTombstone GetTombstone(const Slice& user_key,
-                              SequenceNumber seqno);
+  // the specified key. 
+  std::pair<RangePtr,SequenceNumber> GetTombstone(const Slice& user_key,
+                                                  SequenceNumber seqno);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -128,6 +128,13 @@ class RangeDelAggregator {
   bool ShouldDeleteImpl(const Slice& internal_key,
                         RangeDelPositioningMode mode);
 
+  // Return true if one or more tombstones that are newer than seqno fully
+  // cover the range [start,end] (both endpoints are inclusive). Beware the
+  // inclusive endpoint which differs from most other key ranges, but matches
+  // the largest_key metadata for an sstable.
+  bool ShouldDeleteRange(const Slice& start, const Slice& end,
+                         SequenceNumber seqno);
+
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.
   //

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -62,6 +62,10 @@ class RangeDelMap {
 
   virtual bool ShouldDelete(const ParsedInternalKey& parsed,
                             RangeDelPositioningMode mode) = 0;
+  virtual bool ShouldDeleteRange(const Slice& start, const Slice& end,
+                                 SequenceNumber seqno) = 0;
+  virtual RangeTombstone GetTombstone(const Slice& user_key,
+                                      SequenceNumber seqno) = 0;  
   virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
   virtual void InvalidatePosition() = 0;
 
@@ -134,6 +138,13 @@ class RangeDelAggregator {
   // the largest_key metadata for an sstable.
   bool ShouldDeleteRange(const Slice& start, const Slice& end,
                          SequenceNumber seqno);
+
+  // Get the range tombstone at the specified user_key and sequence number. A
+  // valid tombstone is always returned, though it may cover an empty range of
+  // keys or the sequence number may be 0 to indicate that no tombstone covers
+  // the specified range of keys.
+  RangeTombstone GetTombstone(const Slice& user_key,
+                              SequenceNumber seqno);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -141,7 +141,6 @@ void VerifyRangeDels(
 
 bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
                        const ExpectedRange& expected_range) {
-  auto icmp = InternalKeyComparator(BytewiseComparator());
   RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
   std::vector<std::string> keys, values;
   for (const auto& range_del : range_dels) {
@@ -157,6 +156,26 @@ bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
   AppendInternalKey(&begin, {expected_range.begin, expected_range.seq, kTypeValue});
   AppendInternalKey(&end, {expected_range.end, expected_range.seq, kTypeValue});
   return range_del_agg.ShouldDeleteRange(begin, end, expected_range.seq);
+}
+
+void VerifyGetTombstone(const std::vector<RangeTombstone>& range_dels,
+                        const ExpectedPoint& expected_point,
+                        const RangeTombstone& expected_tombstone) {
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  std::vector<std::string> keys, values;
+  for (const auto& range_del : range_dels) {
+    auto key_and_value = range_del.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  std::unique_ptr<test::VectorIterator> range_del_iter(
+      new test::VectorIterator(keys, values));
+  range_del_agg.AddTombstones(std::move(range_del_iter));
+
+  auto tombstone = range_del_agg.GetTombstone(expected_point.begin, expected_point.seq);
+  ASSERT_EQ(expected_tombstone.start_key_.ToString(), tombstone.start_key_.ToString());
+  ASSERT_EQ(expected_tombstone.end_key_.ToString(), tombstone.end_key_.ToString());
+  ASSERT_EQ(expected_tombstone.seq_, tombstone.seq_);
 }
 
 }  // anonymous namespace
@@ -360,6 +379,41 @@ TEST_F(RangeDelAggregatorTest, ShouldDeleteRange) {
   ASSERT_FALSE(ShouldDeleteRange(
       {{"a", "b", 10}, {"c", "e", 20}},
       {"c", "d", 20}));
+}
+
+TEST_F(RangeDelAggregatorTest, GetTombstone) {
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 9},
+      {"b", "d", 10});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 20},
+      {"b", "d", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"a", 9},
+      {"", "b", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"d", 9},
+      {"d", "", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"d", 9},
+      {"c", "e", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"b", 9},
+      {"a", "c", 10});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
 }
 
 }  // namespace rocksdb

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -240,8 +240,9 @@ InternalIterator* TableCache::NewIterator(
         !options.table_filter(*table_reader->GetTableProperties())) {
       result = NewEmptyInternalIterator(arena);
     } else {
-      result = table_reader->NewIterator(options, prefix_extractor, arena,
-                                         skip_filters, for_compaction);
+      result = table_reader->NewIterator(
+          options, prefix_extractor, range_del_agg, &file_meta,
+          arena, skip_filters, for_compaction);
     }
     if (create_new_table_reader) {
       assert(handle == nullptr);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -544,8 +544,8 @@ class LevelIterator final : public InternalIterator {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
     // Check to see if every key in the sstable is covered by a range
-    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
-    // skipping over an "empty" file if we return null.
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of skipping
+    // over an "empty" file if we return null.
     if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
                                           file_meta.file_metadata->largest_seqno)) {
       return nullptr;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1008,11 +1008,14 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
     // Merge all level zero files together since they may overlap
     for (size_t i = 0; i < storage_info_.LevelFilesBrief(0).num_files; i++) {
       const auto& file = storage_info_.LevelFilesBrief(0).files[i];
-      merge_iter_builder->AddIterator(cfd_->table_cache()->NewIterator(
-          read_options, soptions, cfd_->internal_comparator(), *file.file_metadata,
-          range_del_agg, mutable_cf_options_.prefix_extractor.get(), nullptr,
-          cfd_->internal_stats()->GetFileReadHist(0), false, arena,
-          false /* skip_filters */, 0 /* level */));
+      if (!range_del_agg->ShouldDeleteRange(
+              file.smallest_key, file.largest_key, file.file_metadata->largest_seqno)) {
+        merge_iter_builder->AddIterator(cfd_->table_cache()->NewIterator(
+            read_options, soptions, cfd_->internal_comparator(), *file.file_metadata,
+            range_del_agg, mutable_cf_options_.prefix_extractor.get(), nullptr,
+            cfd_->internal_stats()->GetFileReadHist(0), false, arena,
+            false /* skip_filters */, 0 /* level */));
+      }
     }
     if (should_sample) {
       // Count ones for every L0 files. This is done per iterator creation

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -543,6 +543,14 @@ class LevelIterator final : public InternalIterator {
   InternalIterator* NewFileIterator() {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
+    // Check to see if every key in the sstable is covered by a range
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
+    // skipping over an "empty" file if we return null.
+    if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
+                                          file_meta.file_metadata->largest_seqno)) {
+      return nullptr;
+    }
+
     if (should_sample_) {
       sample_file_read_inc(file_meta.file_metadata);
     }
@@ -593,8 +601,8 @@ void LevelIterator::SeekForPrev(const Slice& target) {
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
     file_iter_.SeekForPrev(target);
-    SkipEmptyFileBackward();
   }
+  SkipEmptyFileBackward();
 }
 
 void LevelIterator::SeekToFirst() {

--- a/table/cuckoo_table_reader.cc
+++ b/table/cuckoo_table_reader.cc
@@ -378,9 +378,13 @@ extern InternalIterator* NewErrorInternalIterator(const Status& status,
                                                   Arena* arena);
 
 InternalIterator* CuckooTableReader::NewIterator(
-    const ReadOptions& /*read_options*/,
-    const SliceTransform* /* prefix_extractor */, Arena* arena,
-    bool /*skip_filters*/, bool /*for_compaction*/) {
+    const ReadOptions& /* read_options */,
+    const SliceTransform* /* prefix_extractor */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* arena,
+    bool /* skip_filters */,
+    bool /* for_compaction */) {
   if (!status().ok()) {
     return NewErrorInternalIterator(
         Status::Corruption("CuckooTableReader status is not okay."), arena);

--- a/table/cuckoo_table_reader.h
+++ b/table/cuckoo_table_reader.h
@@ -48,6 +48,8 @@ class CuckooTableReader: public TableReader {
 
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
                                 Arena* arena = nullptr,
                                 bool skip_filters = false,
                                 bool for_compaction = false) override;

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -151,7 +151,7 @@ class CuckooReaderTest : public testing::Test {
                              GetSliceHash);
     ASSERT_OK(reader.status());
     InternalIterator* it =
-        reader.NewIterator(ReadOptions(), nullptr, nullptr, false);
+        reader.NewIterator(ReadOptions(), nullptr, nullptr, nullptr, nullptr, false);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->SeekToFirst();
@@ -190,7 +190,7 @@ class CuckooReaderTest : public testing::Test {
     delete it;
 
     Arena arena;
-    it = reader.NewIterator(ReadOptions(), nullptr, &arena);
+    it = reader.NewIterator(ReadOptions(), nullptr, nullptr, nullptr, &arena);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->Seek(keys[num_items/2]);

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -28,6 +28,8 @@ stl_wrappers::KVMap MakeMockFile(
 
 InternalIterator* MockTableReader::NewIterator(
     const ReadOptions&, const SliceTransform* /* prefix_extractor */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
     Arena* /*arena*/, bool /*skip_filters*/, bool /*for_compaction*/) {
   return new MockTableIterator(table_);
 }

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -40,6 +40,8 @@ class MockTableReader : public TableReader {
 
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
                                 Arena* arena = nullptr,
                                 bool skip_filters = false,
                                 bool for_compaction = false) override;

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -191,6 +191,8 @@ void PlainTableReader::SetupForCompaction() {
 
 InternalIterator* PlainTableReader::NewIterator(
     const ReadOptions& options, const SliceTransform* /* prefix_extractor */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
     Arena* arena, bool /*skip_filters*/, bool /*for_compaction*/) {
   bool use_prefix_seek = !IsTotalOrderMode() && !options.total_order_seek;
   if (arena == nullptr) {

--- a/table/plain_table_reader.h
+++ b/table/plain_table_reader.h
@@ -81,6 +81,8 @@ class PlainTableReader: public TableReader {
 
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
                                 Arena* arena = nullptr,
                                 bool skip_filters = false,
                                 bool for_compaction = false) override;

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -22,6 +22,8 @@ struct ReadOptions;
 struct TableProperties;
 class GetContext;
 class InternalIterator;
+struct FileMetaData;
+class RangeDelAggregator;
 
 // A Table is a sorted map from strings to strings.  Tables are
 // immutable and persistent.  A Table may be safely accessed from
@@ -41,6 +43,8 @@ class TableReader {
   //               option is effective only for block-based table format.
   virtual InternalIterator* NewIterator(const ReadOptions&,
                                         const SliceTransform* prefix_extractor,
+                                        RangeDelAggregator* range_del_agg = nullptr,
+                                        const FileMetaData* file_meta = nullptr,
                                         Arena* arena = nullptr,
                                         bool skip_filters = false,
                                         bool for_compaction = false) = 0;


### PR DESCRIPTION
During iteration skip sstables that are entirely covered by a range
tombstone. The check to do this is loose: we check that an sstable's
[smallest_key,largest_key) at largest_seqno is covered by a range
tombstone.

This PR still needs tests. I'm having trouble running them on by Mac
laptop. I wanted to get this out for review to see if there is anything
fundamentally wrong with this approach.