### PR TITLE
Fix a crash in WinEnvIO::GetSectorSize

### DIFF
--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -1097,7 +1097,7 @@ size_t WinEnvIO::GetSectorSize(const std::string& fname) {
 
     DISK_GEOMETRY_EX geometry = { 0 };
     ret = DeviceIoControl(hDevice, IOCTL_DISK_GET_DRIVE_GEOMETRY,
-           nullptr, 0, &geometry, sizeof(geometry), nullptr, nullptr);
+           nullptr, 0, &geometry, sizeof(geometry), &output_bytes, nullptr);
     if (ret) {
       sector_size = geometry.Geometry.BytesPerSector;
     }


### PR DESCRIPTION
Fix a crash in `WinEnvIO::GetSectorSize` that happens on old Windows systems (e.g Windows 7).
On old Windows systems that don't support querying StorageAccessAlignmentProperty using IOCTL_STORAGE_QUERY_PROPERTY, the flow calls a different DeviceIoControl with nullptr as lpBytesReturned.
When the code reaches this point, we get an access violation.