### PR TITLE
expose num_entries and num_deletions in SstFileMetaData

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3544,6 +3544,18 @@ const char* rocksdb_livefiles_largestkey(
   return lf->rep[index].largestkey.data();
 }
 
+uint64_t rocksdb_livefiles_entries(
+    const rocksdb_livefiles_t* lf,
+    int index) {
+  return lf->rep[index].num_entries;
+}
+
+uint64_t rocksdb_livefiles_deletions(
+    const rocksdb_livefiles_t* lf,
+    int index) {
+  return lf->rep[index].num_deletions;
+}
+
 extern void rocksdb_livefiles_destroy(
   const rocksdb_livefiles_t* lf) {
   delete lf;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4395,6 +4395,8 @@ void VersionSet::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
         filemetadata.largestkey = file->largest.user_key().ToString();
         filemetadata.smallest_seqno = file->fd.smallest_seqno;
         filemetadata.largest_seqno = file->fd.largest_seqno;
+        filemetadata.num_entries = file->num_entries;
+        filemetadata.num_deletions = file->num_deletions;
         metadata->push_back(filemetadata);
       }
     }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1422,6 +1422,10 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_smallestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_largestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
+extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_entries(
+    const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_deletions(
+    const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_destroy(
     const rocksdb_livefiles_t*);
 

--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -93,6 +93,9 @@ struct SstFileMetaData {
   std::string largestkey;      // Largest user defined key in the file.
   uint64_t num_reads_sampled;  // How many times the file is read.
   bool being_compacted;  // true if the file is currently being compacted.
+
+  uint64_t num_entries;
+  uint64_t num_deletions;
 };
 
 // The full set of metadata associated with each SST file.


### PR DESCRIPTION
the ratio of num_deletions to num_entries of a level can be useful to determine if a manual compaction needs to be triggered on a level. 