### PR TITLE
Avoid acquiring SyncPoint mutex when it is disabled

### DIFF
--- a/util/sync_point_impl.cc
+++ b/util/sync_point_impl.cc
@@ -89,11 +89,11 @@ void SyncPoint::Data::ClearAllCallBacks() {
 }
 
 void SyncPoint::Data::Process(const std::string& point, void* cb_arg) {
-  std::unique_lock<std::mutex> lock(mutex_);
   if (!enabled_) {
     return;
   }
 
+  std::unique_lock<std::mutex> lock(mutex_);
   auto thread_id = std::this_thread::get_id();
 
   auto marker_iter = markers_.find(point);


### PR DESCRIPTION
In `db_stress` profile the vast majority of CPU time is spent acquiring the `SyncPoint` mutex. I mistakenly assumed #3939 had fixed this mutex contention problem by disabling `SyncPoint` processing. But actually the lock was still being acquired just to check whether processing is enabled. We can avoid that overhead by using an atomic to track whether it's enabled.

Test Plan:

- run perf during `db_stress` run and verify SyncPoint no longer shows up