### PR TITLE
Speed up performance of range tombstones

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -282,17 +282,13 @@ Status RangeDelAggregator::AddTombstone(RangeTombstone tombstone) {
            new_range_dels_iter != new_range_dels.end()) {
       const Slice *tombstone_map_iter_end = nullptr,
                   *new_range_dels_iter_end = nullptr;
-      if (tombstone_map_iter != tombstone_map.end()) {
-        auto next_tombstone_map_iter = std::next(tombstone_map_iter);
-        if (next_tombstone_map_iter != tombstone_map.end()) {
-          tombstone_map_iter_end = &next_tombstone_map_iter->first;
-        }
+      auto next_tombstone_map_iter = std::next(tombstone_map_iter);
+      if (next_tombstone_map_iter != tombstone_map.end()) {
+        tombstone_map_iter_end = &next_tombstone_map_iter->first;
       }
-      if (new_range_dels_iter != new_range_dels.end()) {
-        auto next_new_range_dels_iter = std::next(new_range_dels_iter);
-        if (next_new_range_dels_iter != new_range_dels.end()) {
-          new_range_dels_iter_end = &next_new_range_dels_iter->start_key_;
-        }
+      auto next_new_range_dels_iter = std::next(new_range_dels_iter);
+      if (next_new_range_dels_iter != new_range_dels.end()) {
+        new_range_dels_iter_end = &next_new_range_dels_iter->start_key_;
       }
 
       // our positions in existing/new tombstone collections should always

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -303,17 +303,12 @@ Status RangeDelAggregator::AddTombstone(RangeTombstone tombstone) {
 
       int new_to_old_start_cmp = icmp_.user_comparator()->Compare(
           new_range_dels_iter->start_key_, tombstone_map_iter->first);
-      // nullptr end means extends infinitely rightwards, set new_to_old_end_cmp
-      // accordingly so we can use common code paths later.
-      int new_to_old_end_cmp;
-      if (new_range_dels_iter_end == nullptr &&
-          tombstone_map_iter_end == nullptr) {
-        new_to_old_end_cmp = 0;
-      } else if (new_range_dels_iter_end == nullptr) {
-        new_to_old_end_cmp = 1;
-      } else if (tombstone_map_iter_end == nullptr) {
-        new_to_old_end_cmp = -1;
-      } else {
+      // If we're looking at either the last new tombstone or the last existing
+      // tombstone, we can't compare against nullptr, but we know that the new
+      // tombstone logically ends before the existing tombstone.
+      int new_to_old_end_cmp = -1;
+      if (new_range_dels_iter_end != nullptr &&
+          tombstone_map_iter_end != nullptr) {
         new_to_old_end_cmp = icmp_.user_comparator()->Compare(
             *new_range_dels_iter_end, *tombstone_map_iter_end);
       }

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -547,4 +547,19 @@ bool RangeDelAggregator::AddFile(uint64_t file_number) {
   return rep_->added_files_.emplace(file_number).second;
 }
 
+RangeDelAggregator::CollapsedTombstoneMap
+RangeDelAggregator::DumpCollapsedTombstones() {
+  if (rep_ == nullptr) {
+    return CollapsedTombstoneMap();
+  }
+  assert(collapse_deletions_);
+  assert(rep_->stripe_map_.size() == 2);
+  auto& tombstone_map = GetPositionalTombstoneMap(1 /* valid seqno */).raw_map;
+  CollapsedTombstoneMap out;
+  for (auto it = tombstone_map.begin(); it != tombstone_map.end(); ++it) {
+    out.emplace(it->first, it->second.seq_);
+  }
+  return out;
+}
+
 }  // namespace rocksdb

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -143,6 +143,13 @@ class RangeDelAggregator {
   bool IsEmpty();
   bool AddFile(uint64_t file_number);
 
+  // Only for testing. DumpCollapsedTombstones can be called only if
+  // collapse_deletions_ is true and only the default snapshot stripes are
+  // present.
+  typedef std::multimap<Slice, SequenceNumber, stl_wrappers::LessOfComparator>
+    CollapsedTombstoneMap;
+  CollapsedTombstoneMap DumpCollapsedTombstones();
+
  private:
   // Maps tombstone user start key -> tombstone object
   typedef std::multimap<Slice, RangeTombstone, stl_wrappers::LessOfComparator>


### PR DESCRIPTION
I've discovered what seems to be a bug in the collapsing of overlapping range tombstones. Specifically, when adding a new tombstone to a collapsing RangeDelAggregator that overlapped with an existing tombstone, every tombstone to the right of the existing tombstone would be scanned over, instead of exiting the loop after the new tombstone's endpoints were inserted.

I have more testing/benchmarking to do, but the initial results are quite promising!

```
Before
    0 tombstones  14.330 micros/op 69783 ops/sec; (51 of 100 found)
 ~500 tombstones  646.740 micros/op 1546 ops/sec; (60 of 100 found)
~5000 tombstones  100793.870 micros/op 9 ops/sec; (58 of 100 found)

After
    0 tombstones  13.680 micros/op 73099 ops/sec; (51 of 100 found)
 ~500 tombstones  568.480 micros/op 1759 ops/sec; (60 of 100 found)
~5000 tombstones  5700.330 micros/op 175 ops/sec; (58 of 100 found)
```

(That's seekrandom -num=100 on a database created with fillrandom.)