### PR TITLE
tools/check_format_compatible.sh to cover forward option reading too

### DIFF
--- a/tools/check_format_compatible.sh
+++ b/tools/check_format_compatible.sh
@@ -42,8 +42,9 @@ EOF
 done
 
 declare -a backward_compatible_checkout_objs=("2.2.fb.branch" "2.3.fb.branch" "2.4.fb.branch" "2.5.fb.branch" "2.6.fb.branch" "2.7.fb.branch" "2.8.1.fb" "3.0.fb.branch" "3.1.fb" "3.2.fb" "3.3.fb" "3.4.fb" "3.5.fb" "3.6.fb" "3.7.fb" "3.8.fb" "3.9.fb")
-declare -a forward_compatible_checkout_objs=("3.10.fb" "3.11.fb" "3.12.fb" "3.13.fb" "4.0.fb" "4.1.fb" "4.2.fb" "4.3.fb" "4.4.fb" "4.5.fb" "4.6.fb" "4.7.fb" "4.8.fb" "4.9.fb" "4.10.fb" "4.11.fb" "4.12.fb" "4.13.fb" "5.0.fb" "5.1.fb" "5.2.fb" "5.3.fb" "5.4.fb" "5.5.fb" "5.6.fb" "5.7.fb" "5.8.fb" "5.9.fb" "5.10.fb" "5.11.fb" "5.12.fb")
-declare -a checkout_objs=(${backward_compatible_checkout_objs[@]} ${forward_compatible_checkout_objs[@]})
+declare -a forward_compatible_checkout_objs=("3.10.fb" "3.11.fb" "3.12.fb" "3.13.fb" "4.0.fb" "4.1.fb" "4.2.fb" "4.3.fb" "4.4.fb" "4.5.fb" "4.6.fb" "4.7.fb" "4.8.fb" "4.9.fb" "4.10.fb" "4.11.fb" "4.12.fb" "4.13.fb" "5.0.fb" "5.1.fb" "5.2.fb" "5.3.fb" "5.4.fb" "5.5.fb" "5.6.fb" "5.7.fb" "5.8.fb" "5.9.fb" "5.10.fb")
+declare -a forward_compatible_with_options_checkout_objs=("5.11.fb" "5.12.fb" "5.13.fb" "5.14.fb")
+declare -a checkout_objs=(${backward_compatible_checkout_objs[@]} ${forward_compatible_checkout_objs[@]} ${forward_compatible_with_options_checkout_objs[@]})
 
 generate_db()
 {
@@ -59,7 +60,7 @@ generate_db()
 compare_db()
 {
     set +e
-    $script_copy_dir/verify_random_db.sh $1 $2 $3 $4
+    $script_copy_dir/verify_random_db.sh $1 $2 $3 $4 $5
     if [ $? -ne 0 ]; then
         echo ==== Read different content from $1 and $2 or error happened. ====
         exit 1
@@ -96,7 +97,7 @@ generate_db $input_data_path $compare_base_db_dir
 for checkout_obj in "${checkout_objs[@]}"
 do
    echo == Opening DB from "$checkout_obj" using debug build of $checkout_flag ...
-   compare_db $test_dir/$checkout_obj $compare_base_db_dir db_dump.txt 1
+   compare_db $test_dir/$checkout_obj $compare_base_db_dir db_dump.txt 1 0
 done
 
 for checkout_obj in "${forward_compatible_checkout_objs[@]}"
@@ -106,6 +107,15 @@ do
    make clean
    make ldb -j32
    compare_db $test_dir/$checkout_obj $compare_base_db_dir forward_${checkout_obj}_dump.txt 0
+done
+
+for checkout_obj in "${forward_compatible_with_options_checkout_objs[@]}"
+do
+   echo == Build "$checkout_obj" and try to open DB generated using $checkout_flag with its options...
+   git checkout $checkout_obj
+   make clean
+   make ldb -j32
+   compare_db $test_dir/$checkout_obj $compare_base_db_dir forward_${checkout_obj}_dump.txt 1 1
 done
 
 echo ==== Compatibility Test PASSED ====

--- a/tools/verify_random_db.sh
+++ b/tools/verify_random_db.sh
@@ -7,7 +7,7 @@
 
 scriptpath=`dirname $BASH_SOURCE`
 if [ "$#" -lt 2 ]; then
-  echo "usage: $BASH_SOURCE <db_directory> <compare_base_db_directory> [dump_file_name] [if_try_load_options]"
+  echo "usage: $BASH_SOURCE <db_directory> <compare_base_db_directory> [dump_file_name] [if_try_load_options] [if_ignore_unknown_options]"
   exit 1
 fi
 
@@ -15,12 +15,17 @@ db_dir=$1
 base_db_dir=$2
 dump_file_name=${3:-"dump_file.txt"}
 try_load_options=${4:-"1"}
+ignore_unknown_options=${5:-"0"}
 db_dump=$db_dir"/"$dump_file_name
 base_db_dump=$base_db_dir"/"$dump_file_name
 extra_param=
 
 if [ "$try_load_options" = "1" ]; then
  extra_param=" --try_load_options "
+fi
+
+if [ "$ignore_unknown_options" = "1" ]; then
+ extra_param=" --ignore_unknown_options "
 fi
 
 set -e


### PR DESCRIPTION
Summary: Make sure that some recent releases can read master's option files while ignoring unknown options. Also add two more recent release branches.

Test Plan: Run it.