### PR TITLE
Udpate db_universal_compaction_test according to PR #3970

### DIFF
--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -1363,7 +1363,7 @@ TEST_P(DBTestUniversalCompaction, UniversalCompactionCFPathUse) {
   options.memtable_factory.reset(
       new SpecialSkipListFactory(KNumKeysByGenerateNewFile - 1));
   options.compaction_style = kCompactionStyleUniversal;
-  options.compaction_options_universal.size_ratio = 5;
+  options.compaction_options_universal.size_ratio = 10;
   options.write_buffer_size = 111 << 10;  // 114KB
   options.arena_block_size = 4 << 10;
   options.level0_file_num_compaction_trigger = 2;


### PR DESCRIPTION
Summary:
The SST file sizes changed slightly after the improvement of PR #3970
which reduces the size of the properties block. Before PR #3970 a size
ratio compaction included all of the first four flushed files but it
only includes two files after. We increase the size_ratio universal
compaction option to make that compaction include all four files again.

Test Plan:
1. `make check -j64`
2. `./build_tools/rocksdb-lego-determinator run_no_compression`