### PR TITLE
Should only decode restart points for uncompressed blocks

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -427,13 +427,18 @@ Block::Block(BlockContents&& contents, SequenceNumber _global_seqno,
   if (size_ < sizeof(uint32_t)) {
     size_ = 0;  // Error marker
   } else {
-    num_restarts_ = NumRestarts();
-    restart_offset_ =
-        static_cast<uint32_t>(size_) - (1 + num_restarts_) * sizeof(uint32_t);
-    if (restart_offset_ > size_ - sizeof(uint32_t)) {
-      // The size is too small for NumRestarts() and therefore
-      // restart_offset_ wrapped around.
-      size_ = 0;
+    // Should only decode restart points for uncompressed blocks
+    if (compression_type() <= kSnappyCompression ||
+        (compression_type() > kZSTD &&
+         compression_type() != kZSTDNotFinalCompression)) {
+      num_restarts_ = NumRestarts();
+      restart_offset_ =
+          static_cast<uint32_t>(size_) - (1 + num_restarts_) * sizeof(uint32_t);
+      if (restart_offset_ > size_ - sizeof(uint32_t)) {
+        // The size is too small for NumRestarts() and therefore
+        // restart_offset_ wrapped around.
+        size_ = 0;
+      }
     }
   }
   if (read_amp_bytes_per_bit != 0 && statistics && size_ != 0) {


### PR DESCRIPTION
The Block object assumes contents are uncompressed. Block's constructor tries to read the number of restarts, but does not get an accurate number when its contents are compressed, which is causing issues like https://github.com/facebook/rocksdb/issues/3843. 
This PR address this issue by skipping reconstruction of restart points when blocks are known to be compressed. Somehow the restart points can be read directly when Snappy is used and some tests (for example https://github.com/facebook/rocksdb/blob/master/db/db_block_cache_test.cc#L196) expects blocks to be fully constructed even when Snappy compression is used, so here we keep the restart point logic for Snappy.