### PR TITLE
Don't generate a notification for a 0 size SST

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -222,9 +222,11 @@ Status BuildTable(
   }
 
   // Output to event logger and fire events.
-  EventHelpers::LogAndNotifyTableFileCreationFinished(
-      event_logger, ioptions.listeners, dbname, column_family_name, fname,
-      job_id, meta->fd, tp, reason, s);
+  if (!s.ok() || meta->fd.GetFileSize() > 0) {
+    EventHelpers::LogAndNotifyTableFileCreationFinished(
+        event_logger, ioptions.listeners, dbname, column_family_name, fname,
+        job_id, meta->fd, tp, reason, s);
+  }
 
   return s;
 }


### PR DESCRIPTION
Summary:
Don't call the OnTableFileCreated listener callback when a 0 size SST
file gets created by Flush. Doing so causes an assertion failure in db_stress. It is also not correct behavior as we call env->DeleteFile() for such files right before the notification.

Test Plan:
make check

