### PR TITLE
Support backup and checkpoint in db_stress

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -22,6 +22,7 @@ expected_values_file = tempfile.NamedTemporaryFile()
 
 default_params = {
     "acquire_snapshot_one_in": 10000,
+    "backup_one_in": 1000000,
     "block_size": 16384,
     "cache_size": 1048576,
     "clear_column_family_one_in": 0,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -22,9 +22,9 @@ expected_values_file = tempfile.NamedTemporaryFile()
 
 default_params = {
     "acquire_snapshot_one_in": 10000,
-    "backup_one_in": 1000000,
     "block_size": 16384,
     "cache_size": 1048576,
+    "checkpoint_one_in": 1000000,
     "clear_column_family_one_in": 0,
     "compact_files_one_in": 1000000,
     "compact_range_one_in": 1000000,

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -385,8 +385,9 @@ DEFINE_bool(use_txn, false,
             "TxnDBWritePolicy::WRITE_PREPARED");
 
 DEFINE_int32(backup_one_in, 0,
-             "If non-zero, then CompactFiles() will be called once for every N "
-             "operations on average.  0 indicates CompactFiles() is disabled.");
+             "If non-zero, then CreateNewBackup() will be called once for "
+             "every N operations on average.  0 indicates CreateNewBackup() "
+             "is disabled.");
 
 DEFINE_int32(checkpoint_one_in, 0,
              "If non-zero, then CreateCheckpoint() will be called once for "

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1770,7 +1770,8 @@ class StressTest {
 #ifndef ROCKSDB_LITE
       if (FLAGS_checkpoint_one_in > 0 &&
           thread->rand.Uniform(FLAGS_checkpoint_one_in) == 0) {
-        std::string checkpoint_dir = FLAGS_db + "/.checkpoint" + ToString(thread->tid);
+        std::string checkpoint_dir =
+            FLAGS_db + "/.checkpoint" + ToString(thread->tid);
         Checkpoint* checkpoint;
         Status s = Checkpoint::Create(db_, &checkpoint);
         if (s.ok()) {


### PR DESCRIPTION
Add the `backup_one_in` and `checkpoint_one_in` options to periodically trigger backups and checkpoints. The directory names contain thread ID to avoid clashing with parallel backups/checkpoints. Enable checkpoint in crash test so our CI runs will use it. Didn't enable backup in crash test since it copies all the files which is too slow.

Test Plan:

run a crash test, verify checkpoints were generated