### PR TITLE
Windows JNI build fixes

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.4)
 set(JNI_NATIVE_SOURCES
         rocksjni/backupablejni.cc
         rocksjni/backupenginejni.cc
+        rocksjni/cassandra_compactionfilterjni.cc
+        rocksjni/cassandra_value_operator.cc
         rocksjni/checkpoint.cc
         rocksjni/clock_cache.cc
         rocksjni/columnfamilyhandle.cc
@@ -25,14 +27,14 @@ set(JNI_NATIVE_SOURCES
         rocksjni/memtablejni.cc
         rocksjni/merge_operator.cc
         rocksjni/native_comparator_wrapper_test.cc
+        rocksjni/optimistic_transaction_db.cc
+        rocksjni/optimistic_transaction_options.cc
         rocksjni/options.cc
         rocksjni/options_util.cc
         rocksjni/ratelimiterjni.cc
         rocksjni/remove_emptyvalue_compactionfilterjni.cc
-        rocksjni/rocks_callback_object.cc
-        rocksjni/cassandra_compactionfilterjni.cc
-        rocksjni/cassandra_value_operator.cc
         rocksjni/restorejni.cc
+        rocksjni/rocks_callback_object.cc
         rocksjni/rocksdb_exception_test.cc
         rocksjni/rocksjni.cc
         rocksjni/slice.cc
@@ -42,28 +44,33 @@ set(JNI_NATIVE_SOURCES
         rocksjni/statistics.cc
         rocksjni/statisticsjni.cc
         rocksjni/table.cc
+        rocksjni/transaction.cc
+        rocksjni/transaction_db.cc
+        rocksjni/transaction_db_options.cc
         rocksjni/transaction_log.cc
+        rocksjni/transaction_notifier.cc
+        rocksjni/transaction_notifier_jnicallback.cc
+        rocksjni/transaction_options.cc
         rocksjni/ttl.cc
         rocksjni/write_batch.cc
+        rocksjni/writebatchhandlerjnicallback.cc
         rocksjni/write_batch_test.cc
         rocksjni/write_batch_with_index.cc
-        rocksjni/writebatchhandlerjnicallback.cc
 )
 
 set(NATIVE_JAVA_CLASSES
         org.rocksdb.AbstractCompactionFilter
         org.rocksdb.AbstractCompactionFilterFactory
+        org.rocksdb.AbstractComparator
         org.rocksdb.AbstractImmutableNativeReference
         org.rocksdb.AbstractNativeReference
         org.rocksdb.AbstractRocksIterator
         org.rocksdb.AbstractSlice
-        org.rocksdb.AbstractWriteBatch
+        org.rocksdb.AbstractTransactionNotifier
         org.rocksdb.BackupableDBOptions
         org.rocksdb.BackupEngine
-        org.rocksdb.BackupEngineTest
         org.rocksdb.BlockBasedTableConfig
         org.rocksdb.BloomFilter
-        org.rocksdb.Cache
         org.rocksdb.CassandraCompactionFilter
         org.rocksdb.CassandraValueMergeOperator
         org.rocksdb.Checkpoint
@@ -88,10 +95,10 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.Logger
         org.rocksdb.LRUCache
         org.rocksdb.MemTableConfig
-        org.rocksdb.MergeOperator
         org.rocksdb.NativeComparatorWrapper
-        org.rocksdb.NativeComparatorWrapperTest.NativeStringComparatorWrapper
         org.rocksdb.NativeLibraryLoader
+        org.rocksdb.OptimisticTransactionDB
+        org.rocksdb.OptimisticTransactionOptions
         org.rocksdb.Options
         org.rocksdb.OptionsUtil
         org.rocksdb.PlainTableConfig
@@ -101,7 +108,6 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.RestoreOptions
         org.rocksdb.RocksCallbackObject
         org.rocksdb.RocksDB
-        org.rocksdb.RocksDBExceptionTest
         org.rocksdb.RocksEnv
         org.rocksdb.RocksIterator
         org.rocksdb.RocksIteratorInterface
@@ -111,24 +117,29 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.SkipListMemTableConfig
         org.rocksdb.Slice
         org.rocksdb.Snapshot
-        org.rocksdb.SnapshotTest
         org.rocksdb.SstFileManager
         org.rocksdb.SstFileWriter
         org.rocksdb.Statistics
         org.rocksdb.StringAppendOperator
         org.rocksdb.TableFormatConfig
+        org.rocksdb.Transaction
+        org.rocksdb.TransactionDB
+        org.rocksdb.TransactionDBOptions
         org.rocksdb.TransactionLogIterator
+        org.rocksdb.TransactionOptions
         org.rocksdb.TtlDB
         org.rocksdb.VectorMemTableConfig
         org.rocksdb.WBWIRocksIterator
         org.rocksdb.WriteBatch
         org.rocksdb.WriteBatch.Handler
-        org.rocksdb.WriteBatchTest
-        org.rocksdb.WriteBatchTestInternalHelper
+        org.rocksdb.WriteBatchInterface
         org.rocksdb.WriteBatchWithIndex
         org.rocksdb.WriteOptions
-        org.rocksdb.util.CapturingWriteBatchHandler
-        org.rocksdb.util.WriteBatchGetter
+        org.rocksdb.NativeComparatorWrapperTest
+        org.rocksdb.RocksDBExceptionTest
+        org.rocksdb.SnapshotTest
+        org.rocksdb.WriteBatchTest
+        org.rocksdb.WriteBatchTestInternalHelper
 )
 
 include(FindJava)
@@ -150,13 +161,14 @@ set(JAVA_TESTCLASSPATH ${JAVA_JUNIT_JAR} ${JAVA_HAMCR_JAR} ${JAVA_MOCKITO_JAR} $
 add_jar(
   rocksdbjni_classes
   SOURCES
-  src/main/java/org/rocksdb/AbstractCompactionFilter.java
   src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
+  src/main/java/org/rocksdb/AbstractCompactionFilter.java
   src/main/java/org/rocksdb/AbstractComparator.java
   src/main/java/org/rocksdb/AbstractImmutableNativeReference.java
   src/main/java/org/rocksdb/AbstractNativeReference.java
   src/main/java/org/rocksdb/AbstractRocksIterator.java
   src/main/java/org/rocksdb/AbstractSlice.java
+  src/main/java/org/rocksdb/AbstractTransactionNotifier.java
   src/main/java/org/rocksdb/AbstractWriteBatch.java
   src/main/java/org/rocksdb/AccessHint.java
   src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
@@ -175,8 +187,8 @@ add_jar(
   src/main/java/org/rocksdb/ClockCache.java
   src/main/java/org/rocksdb/ColumnFamilyDescriptor.java
   src/main/java/org/rocksdb/ColumnFamilyHandle.java
-  src/main/java/org/rocksdb/ColumnFamilyOptions.java
   src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/ColumnFamilyOptions.java
   src/main/java/org/rocksdb/CompactionOptionsFIFO.java
   src/main/java/org/rocksdb/CompactionOptionsUniversal.java
   src/main/java/org/rocksdb/CompactionPriority.java
@@ -187,8 +199,8 @@ add_jar(
   src/main/java/org/rocksdb/ComparatorType.java
   src/main/java/org/rocksdb/CompressionOptions.java
   src/main/java/org/rocksdb/CompressionType.java
-  src/main/java/org/rocksdb/DBOptions.java
   src/main/java/org/rocksdb/DBOptionsInterface.java
+  src/main/java/org/rocksdb/DBOptions.java
   src/main/java/org/rocksdb/DbPath.java
   src/main/java/org/rocksdb/DirectComparator.java
   src/main/java/org/rocksdb/DirectSlice.java
@@ -209,10 +221,12 @@ add_jar(
   src/main/java/org/rocksdb/LRUCache.java
   src/main/java/org/rocksdb/MemTableConfig.java
   src/main/java/org/rocksdb/MergeOperator.java
-  src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
   src/main/java/org/rocksdb/MutableColumnFamilyOptionsInterface.java
+  src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
   src/main/java/org/rocksdb/NativeComparatorWrapper.java
   src/main/java/org/rocksdb/NativeLibraryLoader.java
+  src/main/java/org/rocksdb/OptimisticTransactionDB.java
+  src/main/java/org/rocksdb/OptimisticTransactionOptions.java
   src/main/java/org/rocksdb/Options.java
   src/main/java/org/rocksdb/OptionsUtil.java
   src/main/java/org/rocksdb/PlainTableConfig.java
@@ -223,11 +237,11 @@ add_jar(
   src/main/java/org/rocksdb/RemoveEmptyValueCompactionFilter.java
   src/main/java/org/rocksdb/RestoreOptions.java
   src/main/java/org/rocksdb/RocksCallbackObject.java
-  src/main/java/org/rocksdb/RocksDB.java
   src/main/java/org/rocksdb/RocksDBException.java
+  src/main/java/org/rocksdb/RocksDB.java
   src/main/java/org/rocksdb/RocksEnv.java
-  src/main/java/org/rocksdb/RocksIterator.java
   src/main/java/org/rocksdb/RocksIteratorInterface.java
+  src/main/java/org/rocksdb/RocksIterator.java
   src/main/java/org/rocksdb/RocksMemEnv.java
   src/main/java/org/rocksdb/RocksMutableObject.java
   src/main/java/org/rocksdb/RocksObject.java
@@ -236,22 +250,36 @@ add_jar(
   src/main/java/org/rocksdb/Snapshot.java
   src/main/java/org/rocksdb/SstFileManager.java
   src/main/java/org/rocksdb/SstFileWriter.java
+  src/main/java/org/rocksdb/StatisticsCollectorCallback.java
+  src/main/java/org/rocksdb/StatisticsCollector.java
   src/main/java/org/rocksdb/Statistics.java
+  src/main/java/org/rocksdb/StatsCollectorInput.java
   src/main/java/org/rocksdb/StatsLevel.java
   src/main/java/org/rocksdb/Status.java
   src/main/java/org/rocksdb/StringAppendOperator.java
   src/main/java/org/rocksdb/TableFormatConfig.java
   src/main/java/org/rocksdb/TickerType.java
+  src/main/java/org/rocksdb/TransactionalDB.java
+  src/main/java/org/rocksdb/TransactionalOptions.java
+  src/main/java/org/rocksdb/TransactionDB.java
+  src/main/java/org/rocksdb/TransactionDBOptions.java
+  src/main/java/org/rocksdb/Transaction.java
   src/main/java/org/rocksdb/TransactionLogIterator.java
+  src/main/java/org/rocksdb/TransactionOptions.java
   src/main/java/org/rocksdb/TtlDB.java
-  src/main/java/org/rocksdb/util/Environment.java
+  src/main/java/org/rocksdb/TxnDBWritePolicy.java
   src/main/java/org/rocksdb/VectorMemTableConfig.java
   src/main/java/org/rocksdb/WALRecoveryMode.java
   src/main/java/org/rocksdb/WBWIRocksIterator.java
-  src/main/java/org/rocksdb/WriteBatch.java
   src/main/java/org/rocksdb/WriteBatchInterface.java
+  src/main/java/org/rocksdb/WriteBatch.java
   src/main/java/org/rocksdb/WriteBatchWithIndex.java
   src/main/java/org/rocksdb/WriteOptions.java
+  src/main/java/org/rocksdb/util/BytewiseComparator.java
+  src/main/java/org/rocksdb/util/DirectBytewiseComparator.java
+  src/main/java/org/rocksdb/util/Environment.java
+  src/main/java/org/rocksdb/util/ReverseBytewiseComparator.java
+  src/main/java/org/rocksdb/util/SizeUnit.java
   src/test/java/org/rocksdb/BackupEngineTest.java
   src/test/java/org/rocksdb/IngestExternalFileOptionsTest.java
   src/test/java/org/rocksdb/NativeComparatorWrapperTest.java

--- a/java/rocksjni/transaction_db.cc
+++ b/java/rocksjni/transaction_db.cc
@@ -269,7 +269,7 @@ jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
   assert(size < UINT32_MAX);  // does it fit in a jint?
 
   const jsize len = static_cast<jsize>(size);
-  jlong tmp[len];
+  std::vector<jlong> tmp(len);
   for (jsize i = 0; i < len; ++i) {
     tmp[i] = reinterpret_cast<jlong>(txns[i]);
   }
@@ -279,7 +279,7 @@ jlongArray Java_org_rocksdb_TransactionDB_getAllPreparedTransactions(
     // exception thrown: OutOfMemoryError
     return nullptr;
   }
-  env->SetLongArrayRegion(jtxns, 0, len, tmp);
+  env->SetLongArrayRegion(jtxns, 0, len, tmp.data());
   if (env->ExceptionCheck()) {
     // exception thrown: ArrayIndexOutOfBoundsException
     env->DeleteLocalRef(jtxns);

--- a/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
+++ b/java/src/test/java/org/rocksdb/AbstractTransactionTest.java
@@ -688,7 +688,7 @@ public abstract class AbstractTransactionTest {
     final long preStartTxnTime = System.currentTimeMillis();
     try(final DBContainer dbContainer = startDb();
         final Transaction txn = dbContainer.beginTransaction()) {
-      Thread.sleep(1);
+      Thread.sleep(2);
 
       final long txnElapsedTime = txn.getElapsedTime();
       assertThat(txnElapsedTime).isLessThan(System.currentTimeMillis()


### PR DESCRIPTION
Fixing compilation, unsatisfied link exceptions (updated list of files that needs to be linked) and warnings for Windows build.
```C++
//MSVC 2015 does not support dynamic arrays like:
  rocksdb::Slice key_parts[jkey_parts_len];
//I have converted to:
  std::vector<rocksdb::Slice> key_parts;
```
Also reusing `free_key_parts` that does the same as `free_key_value_parts` that was removed.

Java elapsedTime unit test increase of sleep to 2 ms. Otherwise it was failing.
