### PR TITLE
Support pipelined write in stress/crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -29,6 +29,7 @@ default_params = {
     "compact_range_one_in": 1000000,
     "delpercent": 5,
     "destroy_db_initially": 0,
+    "enable_pipelined_write": lambda: random.randint(0, 1),
     "expected_values_path": expected_values_file.name,
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -143,6 +143,8 @@ DEFINE_int32(value_size_mult, 8,
 
 DEFINE_int32(compaction_readahead_size, 0, "Compaction readahead size");
 
+DEFINE_bool(enable_pipelined_write, false, "Pipeline WAL/memtable writes");
+
 DEFINE_bool(verify_before_write, false, "Verify before write");
 
 DEFINE_bool(histogram, false, "Print histogram of operation timings");
@@ -2119,6 +2121,7 @@ class StressTest {
       options_.max_subcompactions = static_cast<uint32_t>(FLAGS_subcompactions);
       options_.allow_concurrent_memtable_write =
           FLAGS_allow_concurrent_memtable_write;
+      options_.enable_pipelined_write = FLAGS_enable_pipelined_write;
       options_.enable_write_thread_adaptive_yield =
           FLAGS_enable_write_thread_adaptive_yield;
       options_.compaction_options_universal.size_ratio =


### PR DESCRIPTION
Test Plan: ran crash test for a while, verified pipeline writes is sometimes enabled

```
$ TEST_TMPDIR=/data/compaction_bench python ./tools/db_crashtest.py blackbox --simple --interval=10 --max_key=10000000
```