### PR TITLE
Hide jemalloc aligned allocation functions into .cc

### DIFF
--- a/port/win/port_win.h
+++ b/port/win/port_win.h
@@ -244,14 +244,9 @@ extern void InitOnce(OnceType* once, void (*initializer)());
 #endif
 
 #ifdef ROCKSDB_JEMALLOC
-#include "jemalloc/jemalloc.h"
 // Separate inlines so they can be replaced if needed
-inline void* jemalloc_aligned_alloc( size_t size, size_t alignment) {
-  return je_aligned_alloc(alignment, size);
-}
-inline void jemalloc_aligned_free(void* p) {
-  je_free(p);
-}
+void* jemalloc_aligned_alloc(size_t size, size_t alignment) ROCKSDB_NOEXCEPT;
+void jemalloc_aligned_free(void* p) ROCKSDB_NOEXCEPT;
 #endif
 
 inline void *cacheline_aligned_alloc(size_t size) {

--- a/port/win/win_jemalloc.cc
+++ b/port/win/win_jemalloc.cc
@@ -13,6 +13,7 @@
 
 #include <stdexcept>
 #include "jemalloc/jemalloc.h"
+#include "port/win/port_win.h"
 
 #if defined(ZSTD) && defined(ZSTD_STATIC_LINKING_ONLY)
 #include <zstd.h>
@@ -35,6 +36,13 @@ ZSTD_customMem GetJeZstdAllocationOverrides() {
 
 // Global operators to be replaced by a linker when this file is
 // a part of the build
+
+void* jemalloc_aligned_alloc( size_t size, size_t alignment) ROCKSDB_NOEXCEPT {
+  return je_aligned_alloc(alignment, size);
+}
+void jemalloc_aligned_free(void* p) ROCKSDB_NOEXCEPT {
+  je_free(p);
+}
 
 void* operator new(size_t size) {
   void* p = je_malloc(size);


### PR DESCRIPTION
  so they could be overriden