### PR TITLE
Limit CACHE_LINE_SIZE to ::max_align_t if defined (#4022)

### DIFF
--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -51,6 +51,7 @@
 #endif
 #include <pthread.h>
 
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include <limits>
@@ -184,13 +185,19 @@ typedef pthread_once_t OnceType;
 #define LEVELDB_ONCE_INIT PTHREAD_ONCE_INIT
 extern void InitOnce(OnceType* once, void (*initializer)());
 
+
 #ifndef CACHE_LINE_SIZE
-  #if defined(__s390__)
-    #define CACHE_LINE_SIZE 256U
-  #elif defined(__powerpc__) || defined(__aarch64__)
-    #define CACHE_LINE_SIZE 128U
+  #if defined(__CLANG_MAX_ALIGN_T_DEFINED) || defined(_GCC_MAX_ALIGN_T)
+    #define POSIX_MIN_ALIGN(x) (x < sizeof(::max_align_t) ? x : (unsigned int) sizeof(::max_align_t))
   #else
-    #define CACHE_LINE_SIZE 64U
+    #define POSIX_MIN_ALIGN(x) x
+  #endif
+  #if defined(__s390__)
+    #define CACHE_LINE_SIZE POSIX_MIN_ALIGN(256U)
+  #elif defined(__powerpc__) || defined(__aarch64__)
+    #define CACHE_LINE_SIZE POSIX_MIN_ALIGN(128U)
+  #else
+    #define CACHE_LINE_SIZE POSIX_MIN_ALIGN(64U)
   #endif
 #endif
 


### PR DESCRIPTION
As discovered compiling on march=z10 a CACHE_LINE_SIZE of 256
exceeded the arbitrary std::max_align_t size defined in c/c++11.

As such we limit to that size if defined.

@koldat  can you test this on Z please.

I've tested this on ppc64le sles-12 (gcc-4.8.5) with faking the cache line size up to 256.
* /opt/at10.0/bin/gcc --version
gcc (GCC) 6.4.1 20170720 (Advance-Toolchain-at10.0) IBM AT 10 branch, based on subversion id 250395.
*  /opt/at11.0/bin/gcc --version
gcc (GCC) 7.3.1 20180207 (Advance-Toolchain-at11.0) [ibm/gcc-7-branch revision 257393]

std::max_align_t  didn't seem to be defined however ::max_align_t.

#define check stolen from https://github.com/kinetiknz/nestegg/pull/31/files#diff-c1e2ff9430871edfffa18153cf5ab5b5R25