### PR TITLE
Fix compiler warning with gcc-8.1.1

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -25,7 +25,7 @@ const char* Status::CopyState(const char* state) {
   ret = strncpy_s(result, cch, state, cch - 1);
   assert(ret == 0);
 #else
-  std::strncpy(result, state, cch - 1);
+  std::strncpy(result, state, cch);
 #endif
   return result;
 }


### PR DESCRIPTION
Summary:
Fixes #4017 

--------------
util/status.cc: In static member function ‘static const char*
rocksdb::Status::CopyState(const char*)’:
util/status.cc:28:15: error: ‘char* strncpy(char*, const char*, size_t)’
output truncated before terminating nul copying as many bytes from a
string as its length [-Werror=stringop-truncation]
   std::strncpy(result, state, cch - 1);
   ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
   util/status.cc:19:18: note: length computed here
             std::strlen(state) + 1; // +1 for the null terminator
                    ~~~~~~~~~~~^~~~~~~
                    cc1plus: all warnings being treated as `errors`
                    ------------------------

Test Plan:
make check

