### PR TITLE
Align StatisticsImpl / StatisticsData

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ OPT += -momit-leaf-frame-pointer
 endif
 endif
 
+ifeq (,$(shell $(CXX) -fsyntax-only -faligned-new -xc++ /dev/null 2>&1))
+CXXFLAGS += -faligned-new -DHAVE_ALIGNED_NEW
+endif
+
 ifeq (,$(shell $(CXX) -fsyntax-only -maltivec -xc /dev/null 2>&1))
 CXXFLAGS += -DHAS_ALTIVEC
 CFLAGS += -DHAS_ALTIVEC

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -84,6 +84,10 @@ class ALIGN_AS(CACHE_LINE_SIZE) StatisticsImpl : public Statistics {
                   INTERNAL_HISTOGRAM_ENUM_MAX * sizeof(HistogramImpl)) %
                      CACHE_LINE_SIZE)] ROCKSDB_FIELD_UNUSED;
 #endif
+    void *operator new(size_t s) { return port::cacheline_aligned_alloc(s); }
+    void *operator new[](size_t s) { return port::cacheline_aligned_alloc(s); }
+    void operator delete(void *p) { port::cacheline_aligned_free(p); }
+    void operator delete[](void *p) { port::cacheline_aligned_free(p); }
   };
 
   static_assert(sizeof(StatisticsData) % CACHE_LINE_SIZE == 0, "Expected " TOSTRING(CACHE_LINE_SIZE) "-byte aligned");

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -22,6 +22,11 @@
 #define ROCKSDB_FIELD_UNUSED
 #endif  // __clang__
 
+#ifndef STRINGIFY
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#endif
+
 namespace rocksdb {
 
 enum TickersInternal : uint32_t {
@@ -35,7 +40,7 @@ enum HistogramsInternal : uint32_t {
 };
 
 
-class StatisticsImpl : public Statistics {
+class ALIGN_AS(CACHE_LINE_SIZE) StatisticsImpl : public Statistics {
  public:
   StatisticsImpl(std::shared_ptr<Statistics> stats,
                  bool enable_internal_stats);
@@ -69,17 +74,19 @@ class StatisticsImpl : public Statistics {
   // cores can never share the same cache line.
   //
   // Alignment attributes expand to nothing depending on the platform
-  struct StatisticsData {
+  struct ALIGN_AS(CACHE_LINE_SIZE) StatisticsData {
     std::atomic_uint_fast64_t tickers_[INTERNAL_TICKER_ENUM_MAX] = {{0}};
     HistogramImpl histograms_[INTERNAL_HISTOGRAM_ENUM_MAX];
+#ifndef HAVE_ALIGNED_NEW
     char
         padding[(CACHE_LINE_SIZE -
                  (INTERNAL_TICKER_ENUM_MAX * sizeof(std::atomic_uint_fast64_t) +
                   INTERNAL_HISTOGRAM_ENUM_MAX * sizeof(HistogramImpl)) %
                      CACHE_LINE_SIZE)] ROCKSDB_FIELD_UNUSED;
+#endif
   };
 
-  static_assert(sizeof(StatisticsData) % 64 == 0, "Expected 64-byte aligned");
+  static_assert(sizeof(StatisticsData) % CACHE_LINE_SIZE == 0, "Expected " TOSTRING(CACHE_LINE_SIZE) "-byte aligned");
 
   CoreLocalArray<StatisticsData> per_core_stats_;
 


### PR DESCRIPTION
Pinned the alignment of StatisticsData to the cacheline size rather than just extending its size (which could go over two cache lines)if unaligned in allocation.

Avoid compile errors in the process as per individual commit messages.

strengthen static_assert to CACHELINE rather than the highest common multiple.