### PR TITLE
Fix dangling checkpoint pointer in db_stress

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1794,6 +1794,7 @@ class StressTest {
           s = FLAGS_env->GetChildren(checkpoint_dir, &files);
         }
         DestroyDB(checkpoint_dir, Options());
+        delete checkpoint;
         if (!s.ok()) {
           printf("A checkpoint operation failed with: %s\n",
                  s.ToString().c_str());


### PR DESCRIPTION
Summary:
Fix db_stress failed to delete checkpoint pointer. It's caught by asan_crash test.

Test Plan:
`make db_stress`