### PR TITLE
[RFC] Standalone InBlockHashIndex implementation with unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,7 @@ set(SOURCES
         table/block_builder.cc
         table/block_fetcher.cc
         table/block_prefix_index.cc
+        table/block_suffix_index.cc
         table/bloom_block.cc
         table/cuckoo_table_builder.cc
         table/cuckoo_table_factory.cc
@@ -915,6 +916,7 @@ if(WITH_TESTS)
         options/options_settable_test.cc
         options/options_test.cc
         table/block_based_filter_block_test.cc
+        table/block_suffix_index_test.cc
         table/block_test.cc
         table/cleanable_test.cc
         table/cuckoo_table_builder_test.cc

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,7 @@ TESTS = \
 	table_properties_collector_test \
 	arena_test \
 	block_test \
+	block_suffix_index_test \
 	cache_test \
 	corruption_test \
 	slice_transform_test \
@@ -1340,6 +1341,9 @@ table_test: table/table_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 block_test: table/block_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+block_suffix_index_test: table/block_suffix_index_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 inlineskiplist_test: memtable/inlineskiplist_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -379,6 +379,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "block_suffix_index_test",
+        "table/block_suffix_index_test.cc",
+        "serial",
+    ],
+    [
         "bloom_test",
         "util/bloom_test.cc",
         "serial",

--- a/src.mk
+++ b/src.mk
@@ -99,6 +99,7 @@ LIB_SOURCES =                                                   \
   table/block_builder.cc                                        \
   table/block_fetcher.cc                                        \
   table/block_prefix_index.cc                                   \
+  table/block_suffix_index.cc                                   \
   table/bloom_block.cc                                          \
   table/cuckoo_table_builder.cc                                 \
   table/cuckoo_table_factory.cc                                 \
@@ -342,6 +343,7 @@ MAIN_SOURCES =                                                          \
   monitoring/statistics_test.cc                                         \
   options/options_test.cc                                               \
   table/block_based_filter_block_test.cc                                \
+  table/block_suffix_index_test.cc                                      \
   table/block_test.cc                                                   \
   table/cleanable_test.cc                                               \
   table/cuckoo_table_builder_test.cc                                    \

--- a/table/block_suffix_index.cc
+++ b/table/block_suffix_index.cc
@@ -2,33 +2,95 @@
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
+#include <iostream>
+#include <string>
+#include <vector>
 
 #include "rocksdb/slice.h"
 #include "table/block_suffix_index.h"
+#include "util/coding.h"
 #include "util/hash.h"
 
 namespace rocksdb {
 
 const uint32_t kSeed = 2018;
 
-inline uint16_t SuffixToBucket(const Slice& s, uint16_t num_buckets) {
+inline uint32_t SuffixToBucket(const Slice& s, uint32_t num_buckets) {
   return rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
 }
 
-// BlockSuffixIndexBuilder
-void BlockSuffixIndexBuilder::Add(const Slice& suffix, const uint16_t& pos) {
-  uint16_t idx = SuffixToBucket(suffix, num_buckets_);
-  bucket_[idx].push_back(pos);
+void BlockSuffixIndexBuilder::Add(const Slice& key, const uint32_t& pos) {
+  uint32_t idx = SuffixToBucket(key, num_buckets_);
+  buckets_[idx].push_back(pos);
 }
 
-void BlockSuffixIndexBuilder::Finish(std::string& /* suffix_index */) {
-  // TODO(fwu)
+std::string BlockSuffixIndexBuilder::Finish() {
+  std::string index_content;
+
+  // offset is relative to the start of map
+  std::vector<uint32_t> bucket_offsets(num_buckets_, 0);
+
+  // write each bucket to the string
+  for (uint32_t i = 0; i < num_buckets_; i++) {
+    // remember the start offset of the buckets in bucket_offsets
+    bucket_offsets[i] = index_content.size();
+    for (uint32_t restart_offset : buckets_[i])
+      PutFixed32(&index_content, restart_offset);
+  }
+
+  // write the bucket_offsets
+  for (uint32_t i = 0; i < num_buckets_; i++) {
+    PutFixed32(&index_content, bucket_offsets[i]);
+  }
+
+  // write NUM_BUCK
+  PutFixed32(&index_content, num_buckets_);
+
+  // write MAP_SIZE
+  uint32_t map_size = index_content.size() + sizeof(uint32_t) /* MAP_SIZE */;
+  PutFixed32(&index_content, map_size);
+
+  return index_content;
 }
 
+BlockSuffixIndex::BlockSuffixIndex(std::string& s) {
+  assert(s.size() >= 2 * sizeof(uint32_t));  // NUM_BUCK and MAP_SIZE
+  suffix_index_ = s;                         // can we avoid this memory copy?
 
-// BlockSuffixIndex
-bool BlockSuffixIndex::Seek(const Slice& /*key*/,  uint16_t* /*index*/) const {
-// TODO(fwu)
+  data_ = suffix_index_.data();
+  size_ = suffix_index_.size();
+
+  map_size_ = DecodeFixed32(data_ + size_ - sizeof(uint32_t));
+  assert(map_size_ > 0);
+
+  num_buckets_ = DecodeFixed32(data_ + size_ - 2 * sizeof(uint32_t));
+  assert(num_buckets_ > 0);
+
+  assert(size_ >= sizeof(uint32_t) * (2 + num_buckets_));
+  bucket_table_ = data_ + size_ - sizeof(uint32_t) * (2 + num_buckets_);
+
+  assert(size_ >= map_size_);
+  map_start_ = data_ + size_ - map_size_;
+  assert(map_start_ <= bucket_table_);
+}
+
+bool BlockSuffixIndex::Seek(const Slice& key,
+                            std::vector<uint32_t>& bucket) const {
+  assert(bucket.size() == 0);
+  uint32_t idx = SuffixToBucket(key, num_buckets_);
+  uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
+  const char* limit;
+  if (idx < num_buckets_ - 1)
+    // limited by the start offset of the next bucket
+    limit = map_start_ +
+            DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
+  else
+    // limited by the location of the NUM_BUCK
+    limit = map_start_ + (size_ - 2 * sizeof(uint32_t));
+  for (const char* p = map_start_ + bucket_off; p < limit;
+       p += sizeof(uint32_t)) {
+    bucket.push_back(DecodeFixed32(p));
+  }
   return false;
 }
 

--- a/table/block_suffix_index.cc
+++ b/table/block_suffix_index.cc
@@ -33,7 +33,7 @@ std::string BlockSuffixIndexBuilder::Finish() {
   // write each bucket to the string
   for (uint32_t i = 0; i < num_buckets_; i++) {
     // remember the start offset of the buckets in bucket_offsets
-    bucket_offsets[i] = index_content.size();
+    bucket_offsets[i] = static_cast<uint32_t>(index_content.size());
     for (uint32_t restart_offset : buckets_[i])
       PutFixed32(&index_content, restart_offset);
   }
@@ -47,7 +47,8 @@ std::string BlockSuffixIndexBuilder::Finish() {
   PutFixed32(&index_content, num_buckets_);
 
   // write MAP_SIZE
-  uint32_t map_size = index_content.size() + sizeof(uint32_t) /* MAP_SIZE */;
+  uint32_t map_size = static_cast<uint32_t>(index_content.size() +
+                                            sizeof(uint32_t)); /* MAP_SIZE */;
   PutFixed32(&index_content, map_size);
 
   return index_content;
@@ -58,7 +59,7 @@ BlockSuffixIndex::BlockSuffixIndex(std::string& s) {
   suffix_index_ = s;                         // can we avoid this memory copy?
 
   data_ = suffix_index_.data();
-  size_ = suffix_index_.size();
+  size_ = static_cast<uint32_t>(suffix_index_.size());
 
   map_size_ = DecodeFixed32(data_ + size_ - sizeof(uint32_t));
   assert(map_size_ > 0);

--- a/table/block_suffix_index.cc
+++ b/table/block_suffix_index.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/slice.h"
+#include "table/block_suffix_index.h"
+#include "util/hash.h"
+
+namespace rocksdb {
+
+const uint32_t kSeed = 2018;
+
+inline uint16_t SuffixToBucket(const Slice& s, uint16_t num_buckets) {
+  return rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
+}
+
+// BlockSuffixIndexBuilder
+void BlockSuffixIndexBuilder::Add(const Slice& suffix, const uint16_t& pos) {
+  uint16_t idx = SuffixToBucket(suffix, num_buckets_);
+  bucket_[idx].push_back(pos);
+}
+
+void BlockSuffixIndexBuilder::Finish(std::string& /* suffix_index */) {
+  // TODO(fwu)
+}
+
+
+// BlockSuffixIndex
+bool BlockSuffixIndex::Seek(const Slice& /*key*/,  uint16_t* /*index*/) const {
+// TODO(fwu)
+  return false;
+}
+
+}  // namespace rocksdb

--- a/table/block_suffix_index.cc
+++ b/table/block_suffix_index.cc
@@ -81,13 +81,14 @@ void BlockSuffixIndex::Seek(const Slice& key,
   uint32_t idx = SuffixToBucket(key, num_buckets_);
   uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
   const char* limit;
-  if (idx < num_buckets_ - 1)
+  if (idx < num_buckets_ - 1) {
     // limited by the start offset of the next bucket
     limit = data_ +
             DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
-  else
+  } else {
     // limited by the location of the NUM_BUCK
-    limit = map_start_ + (size_ - 2 * sizeof(uint32_t));
+    limit = data_ + (size_ - 2 * sizeof(uint32_t));
+  }
   for (const char* p = data_ + bucket_off; p < limit;
        p += sizeof(uint32_t)) {
     bucket.push_back(DecodeFixed32(p));

--- a/table/block_suffix_index.h
+++ b/table/block_suffix_index.h
@@ -6,35 +6,53 @@
 #ifndef BLOCK_SUFFIX_INDEX_H
 #define BLOCK_SUFFIX_INDEX_H
 
-#include<string>
-#include<vector>
+#include <string>
+#include <vector>
 
 namespace rocksdb {
 
+// The format of the suffix hash map is as follows:
+//
+// B B B ... B IDX NUM_BUCK MAP_SIZE
+//
+// NUM_BUCK: Number of buckets, which is the length of the IDX array.
+//
+// IDX:      Array of offsets, each pointing to the starting offset (relative to
+//           MAP_START) of one hash bucket.
+//
+// B:        Bucket, an array consisting of a list of restart interval offsets.
+//           We do not have to store the length of individual buckets, as they
+//           are delimited by the next bucket offset.
+//
+// MAP_SIZE: the size of the hash map.
+//
+// The suffix hash map is construct right in-place of the block without any data
+// been copied.
+
 class BlockSuffixIndexBuilder {
  public:
-
-  BlockSuffixIndexBuilder(uint16_t n): num_buckets_(n), bucket_(n) { }
-
-  void Add(const Slice& suffix, const uint16_t& pos);
-
-  void Finish(std::string&);
+  BlockSuffixIndexBuilder(uint32_t n) : num_buckets_(n), buckets_(n) {}
+  void Add(const Slice &suffix, const uint32_t &pos);
+  std::string Finish();
 
  private:
-  uint16_t num_buckets_;
-  std::vector<std::vector<uint16_t>> bucket_;
+  uint32_t num_buckets_;
+  std::vector<std::vector<uint32_t>> buckets_;
 };
 
 class BlockSuffixIndex {
  public:
-
-  BlockSuffixIndex(Slice* s): suffix_index_(s) {}
-
-  bool Seek(const Slice& target, uint16_t* pos) const;
+  BlockSuffixIndex(std::string &s);
+  bool Seek(const Slice &key, std::vector<uint32_t> &bucket) const;
 
  private:
-  Slice* suffix_index_;
-  uint16_t num_buckets_;
+  std::string suffix_index_;
+  const char *data_;
+  uint32_t size_;
+  uint32_t num_buckets_;
+  uint32_t map_size_;
+  const char *map_start_;
+  const char *bucket_table_;
 };
 
 }  // namespace rocksdb

--- a/table/block_suffix_index.h
+++ b/table/block_suffix_index.h
@@ -13,7 +13,7 @@ namespace rocksdb {
 
 // The format of the suffix hash map is as follows:
 //
-// B B B ... B IDX NUM_BUCK MAP_SIZE
+// B B B ... B IDX NUM_BUCK MAP_START
 //
 // NUM_BUCK: Number of buckets, which is the length of the IDX array.
 //
@@ -24,7 +24,7 @@ namespace rocksdb {
 //           We do not have to store the length of individual buckets, as they
 //           are delimited by the next bucket offset.
 //
-// MAP_SIZE: the size of the hash map.
+// MAP_START: the start offset of the suffix hash map.
 //
 // The suffix hash map is construct right in-place of the block without any data
 // been copied.
@@ -33,7 +33,9 @@ class BlockSuffixIndexBuilder {
  public:
   BlockSuffixIndexBuilder(uint32_t n) : num_buckets_(n), buckets_(n) {}
   void Add(const Slice &suffix, const uint32_t &pos);
-  std::string Finish();
+  void Finish(std::string& buffer);
+  void Reset();
+  size_t EstimateSize();
 
  private:
   uint32_t num_buckets_;
@@ -46,13 +48,11 @@ class BlockSuffixIndex {
   bool Seek(const Slice &key, std::vector<uint32_t> &bucket) const;
 
  private:
-  std::string suffix_index_;
   const char *data_;
   uint32_t size_;
   uint32_t num_buckets_;
-  uint32_t map_size_;
-  const char *map_start_;
-  const char *bucket_table_;
+  const char *map_start_;    // start of the map
+  const char *bucket_table_; // start offset of the bucket index table
 };
 
 }  // namespace rocksdb

--- a/table/block_suffix_index.h
+++ b/table/block_suffix_index.h
@@ -31,21 +31,29 @@ namespace rocksdb {
 
 class BlockSuffixIndexBuilder {
  public:
-  BlockSuffixIndexBuilder(uint32_t n) : num_buckets_(n), buckets_(n) {}
+  BlockSuffixIndexBuilder(uint32_t n) :
+      num_buckets_(n),
+      buckets_(n),
+      estimate_((n + 2) * sizeof(uint32_t) /* n buckets, 2 num at the end */){}
   void Add(const Slice &suffix, const uint32_t &pos);
   void Finish(std::string& buffer);
   void Reset();
-  size_t EstimateSize();
+  inline size_t EstimateSize() { return estimate_; }
 
  private:
   uint32_t num_buckets_;
   std::vector<std::vector<uint32_t>> buckets_;
+  size_t estimate_;
 };
 
 class BlockSuffixIndex {
  public:
   BlockSuffixIndex(std::string &s);
-  bool Seek(const Slice &key, std::vector<uint32_t> &bucket) const;
+  void Seek(const Slice &key, std::vector<uint32_t> &bucket) const;
+
+  inline uint32_t SuffixHashMapStart() {
+    return map_start_ - data_;
+  }
 
  private:
   const char *data_;

--- a/table/block_suffix_index.h
+++ b/table/block_suffix_index.h
@@ -52,7 +52,7 @@ class BlockSuffixIndex {
   void Seek(const Slice &key, std::vector<uint32_t> &bucket) const;
 
   inline uint32_t SuffixHashMapStart() {
-    return map_start_ - data_;
+    return static_cast<uint32_t>(map_start_ - data_);
   }
 
  private:

--- a/table/block_suffix_index.h
+++ b/table/block_suffix_index.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#ifndef BLOCK_SUFFIX_INDEX_H
+#define BLOCK_SUFFIX_INDEX_H
+
+#include<string>
+#include<vector>
+
+namespace rocksdb {
+
+class BlockSuffixIndexBuilder {
+ public:
+
+  BlockSuffixIndexBuilder(uint16_t n): num_buckets_(n), bucket_(n) { }
+
+  void Add(const Slice& suffix, const uint16_t& pos);
+
+  void Finish(std::string&);
+
+ private:
+  uint16_t num_buckets_;
+  std::vector<std::vector<uint16_t>> bucket_;
+};
+
+class BlockSuffixIndex {
+ public:
+
+  BlockSuffixIndex(Slice* s): suffix_index_(s) {}
+
+  bool Seek(const Slice& target, uint16_t* pos) const;
+
+ private:
+  Slice* suffix_index_;
+  uint16_t num_buckets_;
+};
+
+}  // namespace rocksdb
+#endif

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -63,9 +63,7 @@ TEST(BlockTest, BlockSuffixTestCollision) {
   builder.Finish(buffer);
   buffer2 = buffer; // test for the correctness of relative offset
 
-  builder.Finish(buffer2);
-
-  BlockSuffixIndex index(buffer);
+  BlockSuffixIndex index(buffer2);
 
   for (uint32_t i = 0; i < 100; i++) {
     Slice key("key" + std::to_string(i));
@@ -91,9 +89,7 @@ TEST(BlockTest, BlockSuffixTestLarge) {
   builder.Finish(buffer);
   buffer2 = buffer; // test for the correctness of relative offset
 
-  builder.Finish(buffer2);
-
-  BlockSuffixIndex index(buffer);
+  BlockSuffixIndex index(buffer2);
 
   for (uint32_t i = 0; i < 100; i++) {
     std::string key_str = "key" + std::to_string(i);

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -39,7 +39,8 @@ TEST(BlockTest, BlockSuffixTestSmall) {
   size_t estimated_size = builder.EstimateSize();
 
   std::string buffer("fake"), buffer2;
-  estimated_size += buffer.size();
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
   builder.Finish(buffer);
 
   ASSERT_EQ(buffer.size(), estimated_size);
@@ -48,6 +49,8 @@ TEST(BlockTest, BlockSuffixTestSmall) {
 
   BlockSuffixIndex index(buffer2);
 
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.SuffixHashMapStart());
   for (uint32_t i = 0; i < 2; i++) {
     Slice key("key" + std::to_string(i));
     uint32_t restart_point = i;
@@ -68,7 +71,8 @@ TEST(BlockTest, BlockSuffixTest) {
   size_t estimated_size = builder.EstimateSize();
 
   std::string buffer("fake content"), buffer2;
-  estimated_size += buffer.size();
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
   builder.Finish(buffer);
 
   ASSERT_EQ(buffer.size(), estimated_size);
@@ -77,6 +81,8 @@ TEST(BlockTest, BlockSuffixTest) {
 
   BlockSuffixIndex index(buffer2);
 
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.SuffixHashMapStart());
   for (uint32_t i = 0; i < 100; i++) {
     Slice key("key" + std::to_string(i));
     uint32_t restart_point = i;
@@ -97,7 +103,8 @@ TEST(BlockTest, BlockSuffixTestCollision) {
   size_t estimated_size = builder.EstimateSize();
 
   std::string buffer("some other fake content to take up space"), buffer2;
-  estimated_size += buffer.size();
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
   builder.Finish(buffer);
 
   ASSERT_EQ(buffer.size(), estimated_size);
@@ -106,6 +113,8 @@ TEST(BlockTest, BlockSuffixTestCollision) {
 
   BlockSuffixIndex index(buffer2);
 
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.SuffixHashMapStart());
   for (uint32_t i = 0; i < 100; i++) {
     Slice key("key" + std::to_string(i));
     uint32_t restart_point = i;
@@ -129,7 +138,8 @@ TEST(BlockTest, BlockSuffixTestLarge) {
   size_t estimated_size = builder.EstimateSize();
 
   std::string buffer("filling stuff"), buffer2;
-  estimated_size += buffer.size();
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
   builder.Finish(buffer);
 
   ASSERT_EQ(buffer.size(), estimated_size);
@@ -138,6 +148,8 @@ TEST(BlockTest, BlockSuffixTestLarge) {
 
   BlockSuffixIndex index(buffer2);
 
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.SuffixHashMapStart());
   for (uint32_t i = 0; i < 100; i++) {
     std::string key_str = "key" + std::to_string(i);
     Slice key(key_str);

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/slice.h"
+#include "table/block_suffix_index.h"
+#include "util/testharness.h"
+#include "util/testutil.h"
+
+namespace rocksdb {
+
+
+TEST(BlockTest, BlockSuffixTest) {
+  //TODO(fwu)
+  BlockSuffixIndexBuilder builder(128);
+
+  std::string s = "key";
+  Slice k(s);
+  uint16_t off = 7;
+  builder.Add(k, off);
+  ASSERT_TRUE(true);
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -3,6 +3,10 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+
 #include "rocksdb/slice.h"
 #include "table/block_suffix_index.h"
 #include "util/testharness.h"
@@ -10,21 +14,95 @@
 
 namespace rocksdb {
 
+bool SearchForOffset(BlockSuffixIndex& index, Slice& key,
+                     uint32_t& restart_point) {
+  std::vector<uint32_t> bucket;
+  index.Seek(key, bucket);
+  for (auto& e : bucket) {
+    if (e == restart_point) {
+      return true;
+    }
+  }
+  return false;
+}
 
 TEST(BlockTest, BlockSuffixTest) {
-  //TODO(fwu)
-  BlockSuffixIndexBuilder builder(128);
+  // bucket_num = 200, #keys = 100. 50% utilization
+  BlockSuffixIndexBuilder builder(200);
 
-  std::string s = "key";
-  Slice k(s);
-  uint16_t off = 7;
-  builder.Add(k, off);
-  ASSERT_TRUE(true);
+  for (uint32_t i = 0; i < 100; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  std::string suffix_index_content = builder.Finish();
+
+  BlockSuffixIndex index(suffix_index_content);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
+TEST(BlockTest, BlockSuffixTestCollision) {
+  // bucket_num = 2. There will be intense hash collisions
+  BlockSuffixIndexBuilder builder(2);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  std::string suffix_index_content = builder.Finish();
+
+  BlockSuffixIndex index(suffix_index_content);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
+TEST(BlockTest, BlockSuffixTestLarge) {
+  BlockSuffixIndexBuilder builder(1000);
+  std::unordered_map<std::string, uint32_t> m;
+
+  for (uint32_t i = 0; i < 10000000; i++) {
+    if (std::rand() % 2) continue;  // randomly leave half of the keys out
+    std::string key_str = "key" + std::to_string(i);
+    Slice key(key_str);
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+    m[key_str] = restart_point;
+  }
+
+  std::string suffix_index_content = builder.Finish();
+
+  BlockSuffixIndex index(suffix_index_content);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key_str = "key" + std::to_string(i);
+    Slice key(key_str);
+    uint32_t restart_point = i;
+    if (m.count(key_str)) {
+      ASSERT_TRUE(m[key_str] == restart_point);
+      ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+    } else {
+      // we allow false positve, so don't test the nonexisting keys.
+      // when false positive happens, the search will continue to the
+      // restart intervals to see if the key really exist.
+    }
+  }
 }
 
 }  // namespace rocksdb
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -26,6 +26,35 @@ bool SearchForOffset(BlockSuffixIndex& index, Slice& key,
   return false;
 }
 
+TEST(BlockTest, BlockSuffixTestSmall) {
+  // bucket_num = 5, #keys = 2. 40% utilization
+  BlockSuffixIndexBuilder builder(5);
+
+  for (uint32_t i = 0; i < 2; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("fake"), buffer2;
+  estimated_size += buffer.size();
+  builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
+  buffer2 = buffer; // test for the correctness of relative offset
+
+  BlockSuffixIndex index(buffer2);
+
+  for (uint32_t i = 0; i < 2; i++) {
+    Slice key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
 TEST(BlockTest, BlockSuffixTest) {
   // bucket_num = 200, #keys = 100. 50% utilization
   BlockSuffixIndexBuilder builder(200);
@@ -36,8 +65,14 @@ TEST(BlockTest, BlockSuffixTest) {
     builder.Add(key, restart_point);
   }
 
-  std::string buffer, buffer2;
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("fake content"), buffer2;
+  estimated_size += buffer.size();
   builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
   buffer2 = buffer; // test for the correctness of relative offset
 
   BlockSuffixIndex index(buffer2);
@@ -59,8 +94,14 @@ TEST(BlockTest, BlockSuffixTestCollision) {
     builder.Add(key, restart_point);
   }
 
-  std::string buffer, buffer2;
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("some other fake content to take up space"), buffer2;
+  estimated_size += buffer.size();
   builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
   buffer2 = buffer; // test for the correctness of relative offset
 
   BlockSuffixIndex index(buffer2);
@@ -85,8 +126,14 @@ TEST(BlockTest, BlockSuffixTestLarge) {
     m[key_str] = restart_point;
   }
 
-  std::string buffer, buffer2;
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("filling stuff"), buffer2;
+  estimated_size += buffer.size();
   builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
   buffer2 = buffer; // test for the correctness of relative offset
 
   BlockSuffixIndex index(buffer2);

--- a/table/block_suffix_index_test.cc
+++ b/table/block_suffix_index_test.cc
@@ -36,9 +36,11 @@ TEST(BlockTest, BlockSuffixTest) {
     builder.Add(key, restart_point);
   }
 
-  std::string suffix_index_content = builder.Finish();
+  std::string buffer, buffer2;
+  builder.Finish(buffer);
+  buffer2 = buffer; // test for the correctness of relative offset
 
-  BlockSuffixIndex index(suffix_index_content);
+  BlockSuffixIndex index(buffer2);
 
   for (uint32_t i = 0; i < 100; i++) {
     Slice key("key" + std::to_string(i));
@@ -57,9 +59,13 @@ TEST(BlockTest, BlockSuffixTestCollision) {
     builder.Add(key, restart_point);
   }
 
-  std::string suffix_index_content = builder.Finish();
+  std::string buffer, buffer2;
+  builder.Finish(buffer);
+  buffer2 = buffer; // test for the correctness of relative offset
 
-  BlockSuffixIndex index(suffix_index_content);
+  builder.Finish(buffer2);
+
+  BlockSuffixIndex index(buffer);
 
   for (uint32_t i = 0; i < 100; i++) {
     Slice key("key" + std::to_string(i));
@@ -81,9 +87,13 @@ TEST(BlockTest, BlockSuffixTestLarge) {
     m[key_str] = restart_point;
   }
 
-  std::string suffix_index_content = builder.Finish();
+  std::string buffer, buffer2;
+  builder.Finish(buffer);
+  buffer2 = buffer; // test for the correctness of relative offset
 
-  BlockSuffixIndex index(suffix_index_content);
+  builder.Finish(buffer2);
+
+  BlockSuffixIndex index(buffer);
 
   for (uint32_t i = 0; i < 100; i++) {
     std::string key_str = "key" + std::to_string(i);


### PR DESCRIPTION
 Summary:
 The first step of the BlockSuffixIndex implementation. A string
 based hash table is implemented and unit-tested.

 - `BlockSuffixIndexBuilder`: `Add()` takes pairs of
   `<key, restart_index>`, and formats it into a string when `Finish()`
   is called.
 - `BlockSuffixIndex`: initialized by the formatted string, and can
   interpret it as a hash table. Supporting `Seek()`.

 Test Plan:
 - Unit test: `block_suffix_index_test`
 - `make check -j 32`
 - `make asan_check`

 Reviewers:
 Sagar Vemuri
