### PR TITLE
Reclaim memory allocated to backup_engine.

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1804,7 +1804,7 @@ class StressTest {
           thread->rand.Uniform(FLAGS_backup_one_in) == 0) {
         std::string backup_dir = FLAGS_db + "/.backup" + ToString(thread->tid);
         BackupableDBOptions backup_opts(backup_dir);
-        BackupEngine* backup_engine;
+        BackupEngine* backup_engine = nullptr;
         Status s = BackupEngine::Open(FLAGS_env, backup_opts, &backup_engine);
         if (s.ok()) {
           s = backup_engine->CreateNewBackup(db_);
@@ -1815,6 +1815,9 @@ class StressTest {
         if (!s.ok()) {
           printf("A BackupEngine operation failed with: %s\n",
                  s.ToString().c_str());
+        }
+        if (backup_engine != nullptr) {
+          delete backup_engine;
         }
       }
 


### PR DESCRIPTION
Test plan:
```
$ make clean && make -j16
$ ./db_stress -backup_one_in=100
```