### PR TITLE
BlobDB: is_fifo=true also evict non-TTL blob files

### DIFF
--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -38,9 +38,7 @@ struct BlobDBOptions {
 
   // When max_db_size is reached, evict blob files to free up space
   // instead of returnning NoSpace error on write. Blob files will be
-  // evicted in this order until enough space is free up:
-  //  * the TTL blob file cloeset to expire,
-  //  * the oldest non-TTL blob file.
+  // evicted from oldest to newest, based on file creation time.
   bool is_fifo = false;
 
   // Maximum size of the database (including SST files and blob files).

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -54,13 +54,7 @@ WalFilter::WalProcessingOption BlobReconcileWalFilter::LogRecordFound(
 
 bool blobf_compare_ttl::operator()(const std::shared_ptr<BlobFile>& lhs,
                                    const std::shared_ptr<BlobFile>& rhs) const {
-  if (lhs->HasTTL() && rhs->HasTTL()) {
-    return lhs->expiration_range_.second > rhs->expiration_range_.second;
-  } else if (!lhs->HasTTL() && !rhs->HasTTL()) {
-    return lhs->BlobFileNumber() > rhs->BlobFileNumber();
-  } else {
-    return !lhs->HasTTL();
-  }
+  return lhs->BlobFileNumber() > rhs->BlobFileNumber();
 }
 
 BlobDBImpl::BlobDBImpl(const std::string& dbname,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -64,7 +64,12 @@ class BlobReconcileWalFilter : public WalFilter {
 
 // Comparator to sort "TTL" aware Blob files based on the lower value of
 // TTL range.
-struct blobf_compare_ttl {
+struct BlobFileComparatorTTL {
+  bool operator()(const std::shared_ptr<BlobFile>& lhs,
+                  const std::shared_ptr<BlobFile>& rhs) const;
+};
+
+struct BlobFileComparator {
   bool operator()(const std::shared_ptr<BlobFile>& lhs,
                   const std::shared_ptr<BlobFile>& rhs) const;
 };
@@ -371,7 +376,7 @@ class BlobDBImpl : public BlobDB {
 
   // all the blob files which are currently being appended to based
   // on variety of incoming TTL's
-  std::set<std::shared_ptr<BlobFile>, blobf_compare_ttl> open_ttl_files_;
+  std::set<std::shared_ptr<BlobFile>, BlobFileComparatorTTL> open_ttl_files_;
 
   // Flag to check whether Close() has been called on this DB
   bool closed_;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -315,9 +315,7 @@ class BlobDBImpl : public BlobDB {
   bool VisibleToActiveSnapshot(const std::shared_ptr<BlobFile>& file);
   bool FileDeleteOk_SnapshotCheckLocked(const std::shared_ptr<BlobFile>& bfile);
 
-  void CopyBlobFiles(
-      std::vector<std::shared_ptr<BlobFile>>* bfiles_copy,
-      std::function<bool(const std::shared_ptr<BlobFile>&)> predicate = {});
+  void CopyBlobFiles(std::vector<std::shared_ptr<BlobFile>>* bfiles_copy);
 
   uint64_t EpochNow() { return env_->NowMicros() / 1000000; }
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1128,8 +1128,7 @@ TEST_F(BlobDBTest, FIFOEviction) {
   // key1 will exist until corresponding file be deleted.
   VerifyDB({{"key1", value}, {"key2", value}});
 
-  // Adding another 100 bytes blob without TTL. Data with TTL will get
-  // evicted first.
+  // Adding another 100 bytes blob without TTL. 
   ASSERT_OK(blob_db_->Put(WriteOptions(), "key3", value));
   ASSERT_EQ(2, evict_count);
   // key1 and key2 will exist until corresponding file be deleted.

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1120,7 +1120,7 @@ TEST_F(BlobDBTest, FIFOEviction) {
 
   ASSERT_EQ(1, blob_db_impl()->TEST_GetBlobFiles().size());
 
-  // Adding another 100 byte blob would take the total size to 264 bytes
+  // Adding another 100 bytes blob would take the total size to 264 bytes
   // (2*132). max_db_size will be exceeded
   // than max_db_size and trigger FIFO eviction.
   ASSERT_OK(blob_db_->PutWithTTL(WriteOptions(), "key2", value, 60));
@@ -1128,18 +1128,35 @@ TEST_F(BlobDBTest, FIFOEviction) {
   // key1 will exist until corresponding file be deleted.
   VerifyDB({{"key1", value}, {"key2", value}});
 
+  // Adding another 100 bytes blob without TTL. Data with TTL will get
+  // evicted first.
+  ASSERT_OK(blob_db_->Put(WriteOptions(), "key3", value));
+  ASSERT_EQ(2, evict_count);
+  // key1 and key2 will exist until corresponding file be deleted.
+  VerifyDB({{"key1", value}, {"key2", value}, {"key3", value}});
+
+  // The fourth blob file, without TTL.
+  ASSERT_OK(blob_db_->Put(WriteOptions(), "key4", value));
+  ASSERT_EQ(3, evict_count);
+  VerifyDB(
+      {{"key1", value}, {"key2", value}, {"key3", value}, {"key4", value}});
+
   auto blob_files = blob_db_impl()->TEST_GetBlobFiles();
-  ASSERT_EQ(2, blob_files.size());
+  ASSERT_EQ(4, blob_files.size());
   ASSERT_TRUE(blob_files[0]->Obsolete());
-  ASSERT_FALSE(blob_files[1]->Obsolete());
+  ASSERT_TRUE(blob_files[1]->Obsolete());
+  ASSERT_TRUE(blob_files[2]->Obsolete());
+  ASSERT_FALSE(blob_files[3]->Obsolete());
   auto obsolete_files = blob_db_impl()->TEST_GetObsoleteFiles();
-  ASSERT_EQ(1, obsolete_files.size());
+  ASSERT_EQ(3, obsolete_files.size());
   ASSERT_EQ(blob_files[0], obsolete_files[0]);
+  ASSERT_EQ(blob_files[1], obsolete_files[1]);
+  ASSERT_EQ(blob_files[2], obsolete_files[2]);
 
   blob_db_impl()->TEST_DeleteObsoleteFiles();
   obsolete_files = blob_db_impl()->TEST_GetObsoleteFiles();
   ASSERT_TRUE(obsolete_files.empty());
-  VerifyDB({{"key2", value}});
+  VerifyDB({{"key4", value}});
 }
 
 TEST_F(BlobDBTest, FIFOEviction_NoOldestFileToEvict) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1128,7 +1128,7 @@ TEST_F(BlobDBTest, FIFOEviction) {
   // key1 will exist until corresponding file be deleted.
   VerifyDB({{"key1", value}, {"key2", value}});
 
-  // Adding another 100 bytes blob without TTL. 
+  // Adding another 100 bytes blob without TTL.
   ASSERT_OK(blob_db_->Put(WriteOptions(), "key3", value));
   ASSERT_EQ(2, evict_count);
   // key1 and key2 will exist until corresponding file be deleted.

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -23,7 +23,8 @@ class BlobDBImpl;
 
 class BlobFile {
   friend class BlobDBImpl;
-  friend struct blobf_compare_ttl;
+  friend struct BlobFileComparator;
+  friend struct BlobFileComparatorTTL;
 
  private:
   // access to parent


### PR DESCRIPTION
Summary:
Previously with is_fifo=true we only evict TTL file. Changing it to also evict non-TTL files from oldest to newest, after exhausted TTL files.

Test Plan:
updated blob_db_test