### PR TITLE
Verify Customized LDB can open CFs with different comparators with "--try_load_options"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * Introduce a new IOError subcode, PathNotFound, to indicate trying to open a nonexistent file or directory for read.
 * Add initial support for multiple db instances sharing the same data in single-writer, multi-reader mode.
 * Removed some "using std::xxx" from public headers.
+* LDBCommandRunner::RunCommand() returns an error code instead of directly exiting.
 
 ### Bug Fixes
 * Fix JEMALLOC_CXX_THROW macro missing from older Jemalloc versions, causing build failures on some platforms.

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -256,7 +256,7 @@ class LDBCommandRunner {
  public:
   static void PrintHelp(const LDBOptions& ldb_options, const char* exec_name);
 
-  static void RunCommand(
+  static int RunCommand(
       int argc, char** argv, Options options, const LDBOptions& ldb_options,
       const std::vector<ColumnFamilyDescriptor>* column_families);
 };

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -94,12 +94,12 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   fprintf(stderr, "%s\n", ret.c_str());
 }
 
-void LDBCommandRunner::RunCommand(
+int LDBCommandRunner::RunCommand(
     int argc, char** argv, Options options, const LDBOptions& ldb_options,
     const std::vector<ColumnFamilyDescriptor>* column_families) {
   if (argc <= 2) {
     PrintHelp(ldb_options, argv[0]);
-    exit(1);
+    return 1;
   }
 
   LDBCommand* cmdObj = LDBCommand::InitFromCmdLineArgs(
@@ -107,11 +107,11 @@ void LDBCommandRunner::RunCommand(
   if (cmdObj == nullptr) {
     fprintf(stderr, "Unknown command\n");
     PrintHelp(ldb_options, argv[0]);
-    exit(1);
+    return 1;
   }
 
   if (!cmdObj->ValidateCmdLineOptions()) {
-    exit(1);
+    return 1;
   }
 
   cmdObj->Run();
@@ -119,14 +119,15 @@ void LDBCommandRunner::RunCommand(
   fprintf(stderr, "%s\n", ret.ToString().c_str());
   delete cmdObj;
 
-  exit(ret.IsFailed());
+  return ret.IsFailed();
 }
 
 void LDBTool::Run(int argc, char** argv, Options options,
                   const LDBOptions& ldb_options,
                   const std::vector<ColumnFamilyDescriptor>* column_families) {
-  LDBCommandRunner::RunCommand(argc, argv, options, ldb_options,
-                               column_families);
+  int exit_code = LDBCommandRunner::RunCommand(argc, argv, options, ldb_options,
+                                               column_families);
+  exit(exit_code);
 }
 } // namespace rocksdb
 


### PR DESCRIPTION
It's used to be that even customized LDB cannot open a DB with CFs of different comparator (unless number of column families are pre-defined to the tool), even if a
ll the comparators used are of known types. "--try_load_options" doesn't work as when loading options, comparators are not set.

With https://github.com/facebook/rocksdb/pull/5106 it is possible. This commit adds a unit test to test it.

Also introduces a change, which makes LDBCommandRunner::RunCommand() returns an error code instead of directly exiting, in order to make ldb more testable.