### PR TITLE
Create lgtm.yml for LGTM.com C/C++ analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  cpp:
+    index:
+      build_command: make

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,4 @@
 extraction:
   cpp:
     index:
-      build_command: make
+      build_command: make static_lib

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Linux/Mac Build Status](https://travis-ci.org/facebook/rocksdb.svg?branch=master)](https://travis-ci.org/facebook/rocksdb)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/fbgfu0so3afcno78/branch/master?svg=true)](https://ci.appveyor.com/project/Facebook/rocksdb/branch/master)
 [![PPC64le Build Status](http://140.211.168.68:8080/buildStatus/icon?job=Rocksdb)](http://140.211.168.68:8080/job/Rocksdb)
-
+[![Language Grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/facebook/rocksdb.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/facebook/rocksdb/context:cpp)
 
 RocksDB is developed and maintained by Facebook Database Engineering Team.
 It is built on earlier work on LevelDB by Sanjay Ghemawat (sanjay@google.com)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Linux/Mac Build Status](https://travis-ci.org/facebook/rocksdb.svg?branch=master)](https://travis-ci.org/facebook/rocksdb)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/fbgfu0so3afcno78/branch/master?svg=true)](https://ci.appveyor.com/project/Facebook/rocksdb/branch/master)
 [![PPC64le Build Status](http://140.211.168.68:8080/buildStatus/icon?job=Rocksdb)](http://140.211.168.68:8080/job/Rocksdb)
-[![Language Grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/facebook/rocksdb.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/facebook/rocksdb/context:cpp)
 
 RocksDB is developed and maintained by Facebook Database Engineering Team.
 It is built on earlier work on LevelDB by Sanjay Ghemawat (sanjay@google.com)


### PR DESCRIPTION
As discussed with @thatsafunnyname [here](https://discuss.lgtm.com/t/c-c-lang-missing-for-facebook-rocksdb/1079): this configuration enables C/C++ analysis for RocksDB on LGTM.com.

The initial commit will contain a build command (simple `make`) that previously resulted in a build error. The build log will then be available on LGTM.com for you to investigate (if you like). I'll immediately add a second commit to this PR to correct the build command to `make static_lib`, which worked when I tested it earlier today.

If you like you can also enable automatic code review in pull requests. This will alert you to any new code issues before they actually get merged into `master`. Here's an example of how that works for the AMPHTML project: https://github.com/ampproject/amphtml/pull/13060. You can enable it yourself here: https://lgtm.com/projects/g/facebook/rocksdb/ci/.

I'll also add a badge to your README.md in a separate commit — feel free to remove that from this PR if you don't like it.

(Full disclosure: I'm part of the LGTM.com team :slightly_smiling_face:. Ping @samlanning)