### PR TITLE
Store timestamp in deadlock detection

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -164,6 +164,7 @@ struct DeadlockInfo {
   uint32_t m_cf_id;
   std::string m_waiting_key;
   bool m_exclusive;
+  int64_t m_deadlock_time;
 };
 
 struct DeadlockPath {

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -164,18 +164,20 @@ struct DeadlockInfo {
   uint32_t m_cf_id;
   std::string m_waiting_key;
   bool m_exclusive;
-  int64_t m_deadlock_time;
 };
 
 struct DeadlockPath {
   std::vector<DeadlockInfo> path;
   bool limit_exceeded;
+  int64_t deadlock_time;
 
-  explicit DeadlockPath(std::vector<DeadlockInfo> path_entry)
-      : path(path_entry), limit_exceeded(false) {}
+  explicit DeadlockPath(
+      std::vector<DeadlockInfo> path_entry, const int64_t& dl_time)
+      : path(path_entry), limit_exceeded(false), deadlock_time(dl_time) {}
 
   // empty path, limit exceeded constructor and default constructor
-  explicit DeadlockPath(bool limit = false) : path(0), limit_exceeded(limit) {}
+  explicit DeadlockPath(const int64_t& dl_time = 0, bool limit = false)
+      : path(0), limit_exceeded(limit), deadlock_time(dl_time) {}
 
   bool empty() { return path.empty() && !limit_exceeded; }
 };

--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -352,6 +352,7 @@ Status TransactionLockMgr::AcquireWithTimeout(
     // If we weren't able to acquire the lock, we will keep retrying as long
     // as the timeout allows.
     bool timed_out = false;
+    int64_t unix_time = 0;
     do {
       // Decide how long to wait
       int64_t cv_end_time = -1;
@@ -371,12 +372,14 @@ Status TransactionLockMgr::AcquireWithTimeout(
       // detection.
       if (wait_ids.size() != 0) {
         if (txn->IsDeadlockDetect()) {
+          env->GetCurrentTime(&unix_time);
           if (IncrementWaiters(txn, wait_ids, key, column_family_id,
-                               lock_info.exclusive)) {
+                               lock_info.exclusive, unix_time)) {
             result = Status::Busy(Status::SubCode::kDeadlock);
             stripe->stripe_mutex->UnLock();
             return result;
           }
+          unix_time = 0;
         }
         txn->SetWaitingTxn(wait_ids, column_family_id, &key);
       }
@@ -444,7 +447,8 @@ void TransactionLockMgr::DecrementWaitersImpl(
 bool TransactionLockMgr::IncrementWaiters(
     const PessimisticTransaction* txn,
     const autovector<TransactionID>& wait_ids, const std::string& key,
-    const uint32_t& cf_id, const bool& exclusive) {
+    const uint32_t& cf_id, const bool& exclusive,
+    const int64_t& deadlock_time) {
   auto id = txn->GetID();
   std::vector<int> queue_parents(txn->GetDeadlockDetectDepth());
   std::vector<TransactionID> queue_values(txn->GetDeadlockDetectDepth());
@@ -494,7 +498,7 @@ bool TransactionLockMgr::IncrementWaiters(
         auto extracted_info = wait_txn_map_.Get(queue_values[head]);
         path.push_back({queue_values[head], extracted_info.m_cf_id,
                         extracted_info.m_waiting_key,
-                        extracted_info.m_exclusive});
+                        extracted_info.m_exclusive, deadlock_time});
         head = queue_parents[head];
       }
       std::reverse(path.begin(), path.end());

--- a/utilities/transactions/transaction_lock_mgr.h
+++ b/utilities/transactions/transaction_lock_mgr.h
@@ -143,7 +143,7 @@ class TransactionLockMgr {
   bool IncrementWaiters(const PessimisticTransaction* txn,
                         const autovector<TransactionID>& wait_ids,
                         const std::string& key, const uint32_t& cf_id,
-                        const bool& exclusive);
+                        const bool& exclusive, const int64_t& deadlock_time);
   void DecrementWaiters(const PessimisticTransaction* txn,
                         const autovector<TransactionID>& wait_ids);
   void DecrementWaitersImpl(const PessimisticTransaction* txn,

--- a/utilities/transactions/transaction_lock_mgr.h
+++ b/utilities/transactions/transaction_lock_mgr.h
@@ -143,7 +143,7 @@ class TransactionLockMgr {
   bool IncrementWaiters(const PessimisticTransaction* txn,
                         const autovector<TransactionID>& wait_ids,
                         const std::string& key, const uint32_t& cf_id,
-                        const bool& exclusive, const int64_t& deadlock_time);
+                        const bool& exclusive, Env* const env);
   void DecrementWaiters(const PessimisticTransaction* txn,
                         const autovector<TransactionID>& wait_ids);
   void DecrementWaitersImpl(const PessimisticTransaction* txn,

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -474,7 +474,7 @@ TEST_P(TransactionTest, DeadlockCycleShared) {
     TransactionID leaf_id =
         dlock_entry[dlock_entry.size() - 1].m_txn_id - offset_root;
 
-    decltype(DeadlockInfo::m_deadlock_time) pre_m_deadlock_time = 0;
+    int64_t pre_m_deadlock_time = 0;
     for (auto it = dlock_entry.rbegin(); it != dlock_entry.rend(); it++) {
       auto dl_node = *it;
       auto cur_m_deadlock_time = dl_node.m_deadlock_time;
@@ -676,7 +676,7 @@ TEST_P(TransactionTest, DeadlockCycle) {
     ASSERT_EQ(dlock_buffer[0].limit_exceeded, check_limit_flag);
 
     // Iterates backwards over path verifying decreasing txn_ids.
-    decltype(DeadlockInfo::m_deadlock_time) pre_m_deadlock_time = 0;
+    int64_t pre_m_deadlock_time = 0;
     for (auto it = dlock_entry.rbegin(); it != dlock_entry.rend(); it++) {
       auto dl_node = *it;
       auto cur_m_deadlock_time = dl_node.m_deadlock_time;


### PR DESCRIPTION
- Summary
    Add timestamp into the DeadlockInfo to store the timestamp when deadlock detected on the rocksdb side.

- Testplan: 
    `make check -j64`