### PR TITLE
Remove 'ALIGNAS' from StatisticsImpl.

### DIFF
--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -18,7 +18,13 @@
 namespace rocksdb {
 
 std::shared_ptr<Statistics> CreateDBStatistics() {
-  return std::make_shared<StatisticsImpl>(nullptr, false);
+  // C++ default 'new' does not work with over alignment, i.e. alignment
+  // greater than std::max_align_t (16). Thus we need to overload the new
+  // operator of StatisticsImpl. We cannot use std::make_shared either since it
+  // does not call the overloaded new. Similar problem observed here:
+  // https://github.com/MRtrix3/mrtrix3/issues/957
+  std::shared_ptr<Statistics> ret(new StatisticsImpl(nullptr, false));
+  return ret;
 }
 
 StatisticsImpl::StatisticsImpl(std::shared_ptr<Statistics> stats,

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -18,12 +18,6 @@
 namespace rocksdb {
 
 std::shared_ptr<Statistics> CreateDBStatistics() {
-  // C++ default 'new' does not work with over alignment, i.e. alignment
-  // greater than std::max_align_t (16). Thus we need to overload the new
-  // operator of StatisticsImpl if over-alignment is required (e.g. alignas)
-  // (currently no). Note that std::make_shared
-  // does not call overloaded new. Similar problem observed here:
-  // https://github.com/MRtrix3/mrtrix3/issues/957
   return std::make_shared<StatisticsImpl>(nullptr, false);
 }
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -20,11 +20,11 @@ namespace rocksdb {
 std::shared_ptr<Statistics> CreateDBStatistics() {
   // C++ default 'new' does not work with over alignment, i.e. alignment
   // greater than std::max_align_t (16). Thus we need to overload the new
-  // operator of StatisticsImpl. We cannot use std::make_shared either since it
-  // does not call the overloaded new. Similar problem observed here:
+  // operator of StatisticsImpl if over-alignment is required (e.g. alignas)
+  // (currently no). Note that std::make_shared
+  // does not call overloaded new. Similar problem observed here:
   // https://github.com/MRtrix3/mrtrix3/issues/957
-  std::shared_ptr<Statistics> ret(new StatisticsImpl(nullptr, false));
-  return ret;
+  return std::make_shared<StatisticsImpl>(nullptr, false);
 }
 
 StatisticsImpl::StatisticsImpl(std::shared_ptr<Statistics> stats,

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -40,7 +40,7 @@ enum HistogramsInternal : uint32_t {
 };
 
 
-class ALIGN_AS(CACHE_LINE_SIZE) StatisticsImpl : public Statistics {
+class StatisticsImpl : public Statistics {
  public:
   StatisticsImpl(std::shared_ptr<Statistics> stats,
                  bool enable_internal_stats);
@@ -59,11 +59,6 @@ class ALIGN_AS(CACHE_LINE_SIZE) StatisticsImpl : public Statistics {
   virtual Status Reset() override;
   virtual std::string ToString() const override;
   virtual bool HistEnabledForType(uint32_t type) const override;
-
-  void* operator new(size_t s) { return port::cacheline_aligned_alloc(s); }
-  void* operator new[](size_t s) { return port::cacheline_aligned_alloc(s); }
-  void operator delete(void* p) { port::cacheline_aligned_free(p); }
-  void operator delete[](void* p) { port::cacheline_aligned_free(p); }
 
  private:
   // If non-nullptr, forwards updates to the object pointed to by `stats_`.

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -60,6 +60,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) StatisticsImpl : public Statistics {
   virtual std::string ToString() const override;
   virtual bool HistEnabledForType(uint32_t type) const override;
 
+  void* operator new(size_t s) { return port::cacheline_aligned_alloc(s); }
+  void* operator new[](size_t s) { return port::cacheline_aligned_alloc(s); }
+  void operator delete(void* p) { port::cacheline_aligned_free(p); }
+  void operator delete[](void* p) { port::cacheline_aligned_free(p); }
+
  private:
   // If non-nullptr, forwards updates to the object pointed to by `stats_`.
   std::shared_ptr<Statistics> stats_;


### PR DESCRIPTION
Remove over-alignment on `StatisticsImpl` whose benefit is vague and causes UBSAN check to fail due to `std::make_shared` not respecting the over-alignment requirement.

Test plan
```
$ make clean && COMPILE_WITH_UBSAN=1 OPT=-g make -j16 ubsan_check
```