### PR TITLE
Suppress leak warning for clang(LLVM) asan

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -505,10 +505,16 @@ uint32_t LRUCache::GetHash(Handle* handle) const {
 
 void LRUCache::DisownData() {
 // Do not drop data if compile with ASAN to suppress leak warning.
+#if defined(__clang__)
+#if !defined(__has_feature) || !__has_feature(address_sanitizer)
+  shards_ = nullptr;
+#endif
+#else   // __clang__
 #ifndef __SANITIZE_ADDRESS__
   shards_ = nullptr;
   num_shards_ = 0;
 #endif  // !__SANITIZE_ADDRESS__
+#endif  // __clang__
 }
 
 size_t LRUCache::TEST_GetLRUSize() {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -508,13 +508,14 @@ void LRUCache::DisownData() {
 #if defined(__clang__)
 #if !defined(__has_feature) || !__has_feature(address_sanitizer)
   shards_ = nullptr;
+  num_shards_ = 0;
 #endif
 #else   // __clang__
 #ifndef __SANITIZE_ADDRESS__
   shards_ = nullptr;
+  num_shards_ = 0;
 #endif  // !__SANITIZE_ADDRESS__
 #endif  // __clang__
-  num_shards_ = 0;
 }
 
 size_t LRUCache::TEST_GetLRUSize() {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -512,9 +512,9 @@ void LRUCache::DisownData() {
 #else   // __clang__
 #ifndef __SANITIZE_ADDRESS__
   shards_ = nullptr;
-  num_shards_ = 0;
 #endif  // !__SANITIZE_ADDRESS__
 #endif  // __clang__
+  num_shards_ = 0;
 }
 
 size_t LRUCache::TEST_GetLRUSize() {


### PR DESCRIPTION
Instead of __SANITIZE_ADDRESS__ macro, LLVM uses __has_feature(address_sanitzer) to check if ASAN is enabled for the build. I tested it with MySQL sanitizer build that uses RocksDB as a submodule. 