### PR TITLE
Prefetch cache lines for filter lookup

### DIFF
--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -228,6 +228,8 @@ bool FullFilterBitsReader::HashMayMatch(const uint32_t& hash,
   uint32_t h = hash;
   const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
   uint32_t b = (h % num_lines) * (cache_line_size * 8);
+  PREFETCH(&data[b / 8], 0 /* rw */, 1 /* locality */);
+  PREFETCH(&data[b / 8 + cache_line_size - 1], 0 /* rw */, 1 /* locality */);
 
   for (uint32_t i = 0; i < num_probes; ++i) {
     // Since CACHE_LINE_SIZE is defined as 2^n, this line will be optimized


### PR DESCRIPTION
Since the filter data is unaligned, even though we ensure all probes are within a span of `cache_line_size` bytes, those bytes can span two cache lines. In that case I doubt hardware prefetching does a great job considering we don't necessarily access those two cache lines in order. This guess seems correct since adding explicit prefetch instructions reduced filter lookup overhead by 19.4%.

Test Plan:

populate DB command:

```
$ TEST_TMPDIR=/data/compaction_bench ./db_bench -benchmarks=fillrandom -bloom_bits=8 -num=4000000 -key_size=17 -value_size=48 -write_buffer_size=33554432 -disable_auto_compactions=true -benchmark_write_rate_limit=16777216  -disable_wal=true
```

experiment command:

```
$ TEST_TMPDIR=/data/compaction_bench /usr/bin/time ./db_bench.before -benchmarks=readrandom -duration=60 -use_existing_db=true -bloom_bits=10 -num=4000000 -reads=1000000 -key_size=16 -value_size=48 -write_buffer_size=33554432 -disable_auto_compactions=true -disable_wal=true
```

perf result before:

```
  Overhead  Command          Shared Object       Symbol                                                                                                                                          ◆
+   21.87%  db_bench.before  db_bench.before     [.] rocksdb::(anonymous namespace)::FullFilterBitsReader::MayMatch
```

perf result after:

```
  Overhead  Command          Shared Object       Symbol                                                                                                                                          ◆
+   17.63%  db_bench.test    db_bench.test       [.] rocksdb::(anonymous namespace)::FullFilterBitsReader::MayMatch                                                                              ▒
```