### PR TITLE
Avoid integer division in filter probing

### DIFF
--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -238,7 +238,6 @@ bool FullFilterBitsReader::HashMayMatch(const uint32_t& hash,
   // It is ensured the params are valid before calling it
   assert(num_probes != 0);
   assert(num_lines != 0 && (len - 5) % num_lines == 0);
-  uint32_t cache_line_size = 1 << log2_cache_line_size_;
   const char* data = filter.data();
 
   uint32_t h = hash;
@@ -246,7 +245,8 @@ bool FullFilterBitsReader::HashMayMatch(const uint32_t& hash,
   // Left shift by an extra 3 to convert bytes to bits
   uint32_t b = (h % num_lines) << (log2_cache_line_size_ + 3);
   PREFETCH(&data[b / 8], 0 /* rw */, 1 /* locality */);
-  PREFETCH(&data[b / 8 + cache_line_size - 1], 0 /* rw */, 1 /* locality */);
+  PREFETCH(&data[b / 8 + (1 << log2_cache_line_size_) - 1], 0 /* rw */,
+           1 /* locality */);
 
   for (uint32_t i = 0; i < num_probes; ++i) {
     // Since CACHE_LINE_SIZE is defined as 2^n, this line will be optimized

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -158,8 +158,8 @@ class FullFilterBitsReader : public FilterBitsReader {
             (data_len_ - 5) >> log2_cache_line_size_;
         if (num_lines_at_curr_cache_size == 0) {
           // The cache line size seems not a power of two. It's not supported
-          // and indicates a corruption that we can't report from here.
-          abort();
+          // and indicates a corruption so disable using this filter.
+          num_lines_ = 0;
         }
         if (num_lines_at_curr_cache_size == num_lines_) {
           break;

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -144,13 +144,28 @@ class FullFilterBitsReader : public FilterBitsReader {
       : data_(const_cast<char*>(contents.data())),
         data_len_(static_cast<uint32_t>(contents.size())),
         num_probes_(0),
-        num_lines_(0) {
+        num_lines_(0),
+        log2_cache_line_size_(0) {
     assert(data_);
     GetFilterMeta(contents, &num_probes_, &num_lines_);
     // Sanitize broken parameter
     if (num_lines_ != 0 && (data_len_-5) % num_lines_ != 0) {
       num_lines_ = 0;
       num_probes_ = 0;
+    } else if (num_lines_ != 0) {
+      while (true) {
+        uint32_t num_lines_at_curr_cache_size =
+            (data_len_ - 5) >> log2_cache_line_size_;
+        if (num_lines_at_curr_cache_size == 0) {
+          // The cache line size seems not a power of two. It's not supported
+          // and indicates a corruption that we can't report from here.
+          abort();
+        }
+        if (num_lines_at_curr_cache_size == num_lines_) {
+          break;
+        }
+        ++log2_cache_line_size_;
+      }
     }
   }
 
@@ -173,6 +188,7 @@ class FullFilterBitsReader : public FilterBitsReader {
   uint32_t data_len_;
   size_t num_probes_;
   uint32_t num_lines_;
+  uint32_t log2_cache_line_size_;
 
   // Get num_probes, and num_lines from filter
   // If filter format broken, set both to 0.
@@ -222,19 +238,20 @@ bool FullFilterBitsReader::HashMayMatch(const uint32_t& hash,
   // It is ensured the params are valid before calling it
   assert(num_probes != 0);
   assert(num_lines != 0 && (len - 5) % num_lines == 0);
-  uint32_t cache_line_size = (len - 5) / num_lines;
+  uint32_t cache_line_size = 1 << log2_cache_line_size_;
   const char* data = filter.data();
 
   uint32_t h = hash;
   const uint32_t delta = (h >> 17) | (h << 15);  // Rotate right 17 bits
-  uint32_t b = (h % num_lines) * (cache_line_size * 8);
+  // Left shift by an extra 3 to convert bytes to bits
+  uint32_t b = (h % num_lines) << (log2_cache_line_size_ + 3);
   PREFETCH(&data[b / 8], 0 /* rw */, 1 /* locality */);
   PREFETCH(&data[b / 8 + cache_line_size - 1], 0 /* rw */, 1 /* locality */);
 
   for (uint32_t i = 0; i < num_probes; ++i) {
     // Since CACHE_LINE_SIZE is defined as 2^n, this line will be optimized
     //  to a simple and operation by compiler.
-    const uint32_t bitpos = b + (h % (cache_line_size * 8));
+    const uint32_t bitpos = b + (h & ((1 << log2_cache_line_size_) - 1));
     if (((data[bitpos / 8]) & (1 << (bitpos % 8))) == 0) {
       return false;
     }

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -161,6 +161,7 @@ class FullFilterBitsReader : public FilterBitsReader {
           // and indicates a corruption so disable using this filter.
           assert(false);
           num_lines_ = 0;
+          num_probes_ = 0;
           break;
         }
         if (num_lines_at_curr_cache_size == num_lines_) {

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -251,7 +251,7 @@ bool FullFilterBitsReader::HashMayMatch(const uint32_t& hash,
   for (uint32_t i = 0; i < num_probes; ++i) {
     // Since CACHE_LINE_SIZE is defined as 2^n, this line will be optimized
     //  to a simple and operation by compiler.
-    const uint32_t bitpos = b + (h & ((1 << log2_cache_line_size_) - 1));
+    const uint32_t bitpos = b + (h & ((1 << (log2_cache_line_size_ + 3)) - 1));
     if (((data[bitpos / 8]) & (1 << (bitpos % 8))) == 0) {
       return false;
     }

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -159,7 +159,9 @@ class FullFilterBitsReader : public FilterBitsReader {
         if (num_lines_at_curr_cache_size == 0) {
           // The cache line size seems not a power of two. It's not supported
           // and indicates a corruption so disable using this filter.
+          assert(false);
           num_lines_ = 0;
+          break;
         }
         if (num_lines_at_curr_cache_size == num_lines_) {
           break;


### PR DESCRIPTION
The cache line size was computed dynamically based on the length of the filter bits, and the number of cache-lines encoded in the footer. This calculation had to be dynamic in case users migrate their data between platforms with different cache line sizes. The downside, though, was bloom filter probing became expensive as it did integer mod and division.

However, since we know all possible cache line sizes are powers of two, we should be able to use bit shift to find the cache line, and bitwise-and to find the bit within the cache line. To do this, we compute the log-base-two of cache line size in the constructor, and use that in bitwise operations to replace division/mod.

Test Plan:

populate DB command:

```
$ TEST_TMPDIR=/data/compaction_bench ./db_bench -benchmarks=fillrandom -bloom_bits=8 -num=4000000 -key_size=17 -value_size=48 -write_buffer_size=33554432 -disable_auto_compactions=true -benchmark_write_rate_limit=16777216  -disable_wal=true
```

experiment command:

```
$ TEST_TMPDIR=/data/compaction_bench /usr/bin/time ./db_bench.before -benchmarks=readrandom -duration=60 -use_existing_db=true -bloom_bits=10 -num=4000000 -reads=1000000 -key_size=16 -value_size=48 -write_buffer_size=33554432 -disable_auto_compactions=true -disable_wal=true
```

perf result before:

```
  Overhead  Command          Shared Object       Symbol                                                                                                                                          ◆
+   17.63%  db_bench.test    db_bench.test       [.] rocksdb::(anonymous namespace)::FullFilterBitsReader::MayMatch                                                                              ▒
```

perf result after:

```
  Overhead  Command          Shared Object       Symbol                                                                                                                                          ◆
+   14.50%  db_bench  db_bench            [.] rocksdb::(anonymous namespace)::FullFilterBitsReader::MayMatch
```