### PR TITLE
fix clang analyzer warnings

### DIFF
--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1167,6 +1167,7 @@ Status CompactionJob::FinishCompactionOutputFile(
   // Check for iterator errors
   Status s = input_status;
   auto meta = &sub_compact->current_output()->meta;
+  assert(meta != nullptr);
   if (s.ok()) {
     Slice lower_bound_guard, upper_bound_guard;
     std::string smallest_user_key;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2758,7 +2758,8 @@ Status VersionSet::ProcessManifestWrites(
         break;
       }
       last_writer = *(it++);
-      assert(last_writer != nullptr && last_writer->cfd != nullptr);
+      assert(last_writer != nullptr);
+      assert(last_writer->cfd != nullptr);
       if (last_writer->cfd != nullptr && last_writer->cfd->IsDropped()) {
         continue;
       }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2758,7 +2758,7 @@ Status VersionSet::ProcessManifestWrites(
         break;
       }
       last_writer = *(it++);
-      assert(last_writer != nullptr);
+      assert(last_writer != nullptr && last_writer->cfd != nullptr);
       if (last_writer->cfd != nullptr && last_writer->cfd->IsDropped()) {
         continue;
       }


### PR DESCRIPTION
clang analyze is giving the following warnings:
> db/compaction_job.cc:1178:16: warning: Called C++ object pointer is null
    } else if (meta->smallest.size() > 0) {
               ^~~~~~~~~~~~~~~~~~~~~
db/compaction_job.cc:1201:33: warning: Access to field 'marked_for_compaction' results in a dereference of a null pointer (loaded from variable 'meta')
    meta->marked_for_compaction = sub_compact->builder->NeedCompact();
    ~~~~                 
db/version_set.cc:2770:26: warning: Called C++ object pointer is null
        uint32_t cf_id = last_writer->cfd->GetID();
                         ^~~~~~~~~~~~~~~~~~~~~~~~~