### PR TITLE
Fix mis-spoken assert on prefetch_filter and prefetch_index

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -922,7 +922,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
       prefetch_all || (table_options.pin_top_level_index_and_filter &&
                        rep->filter_type == Rep::FilterType::kPartitionedFilter);
   // Partition fitlers cannot be enabled without partition indexes
-  assert(!prefetch_index || prefetch_filter);
+  assert(!prefetch_filter || prefetch_index);
   // pin both index and filters, down to all partitions
   const bool pin_all =
       rep->table_options.pin_l0_filter_and_index_blocks_in_cache && level == 0;


### PR DESCRIPTION
We can have prefetch_index without prefetch_filter but not the other way around. The assert statement is fixed.