### PR TITLE
Remove unused arg which causes compilation failure

### DIFF
--- a/java/rocksjni/sst_file_manager.cc
+++ b/java/rocksjni/sst_file_manager.cc
@@ -138,7 +138,7 @@ jobject Java_org_rocksdb_SstFileManager_getTrackedFiles(JNIEnv* env,
 
   const rocksdb::HashMapJni::FnMapKV<const std::string, const uint64_t>
       fn_map_kv =
-          [env, &tracked_files](
+          [env](
               const std::pair<const std::string, const uint64_t>& pair) {
             const jstring jtracked_file_path =
                 env->NewStringUTF(pair.first.c_str());


### PR DESCRIPTION
It seems that compilation has been made stricter about unused args.