### PR TITLE
Fix a bug caused by not copying the block trailer.

### DIFF
--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -104,7 +104,6 @@ extern SstFileManager* NewSstFileManager(
     Env* env, std::shared_ptr<Logger> info_log = nullptr,
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
     bool delete_existing_trash = true, Status* status = nullptr,
-    double max_trash_db_ratio = 0.25,
-    uint64_t bytes_max_delete_chunk = 0);
+    double max_trash_db_ratio = 0.25, uint64_t bytes_max_delete_chunk = 0);
 
 }  // namespace rocksdb

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -166,7 +166,8 @@ void BlockFetcher::GetBlockContents() {
     *contents_ = BlockContents(Slice(slice_.data(), block_size_),
                                immortal_source_, compression_type);
   } else {
-    // page is uncompressed, the buffer either stack or heap provided
+    // page can be either uncompressed or compressed, the buffer either stack
+    // or heap provided. Refer to https://github.com/facebook/rocksdb/pull/4096
     if (got_from_prefetch_buffer_ || used_buf_ == &stack_buf_[0]) {
       heap_buf_.reset(new char[block_size_ + kBlockTrailerSize]);
       memcpy(heap_buf_.get(), used_buf_, block_size_ + kBlockTrailerSize);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -168,8 +168,8 @@ void BlockFetcher::GetBlockContents() {
   } else {
     // page is uncompressed, the buffer either stack or heap provided
     if (got_from_prefetch_buffer_ || used_buf_ == &stack_buf_[0]) {
-      heap_buf_.reset(new char[block_size_]);
-      memcpy(heap_buf_.get(), used_buf_, block_size_);
+      heap_buf_.reset(new char[block_size_ + kBlockTrailerSize]);
+      memcpy(heap_buf_.get(), used_buf_, block_size_ + kBlockTrailerSize);
     }
     *contents_ = BlockContents(std::move(heap_buf_), block_size_, true,
                                compression_type);


### PR DESCRIPTION
This was caught by crash test, and the following is a simple way to reproduce it and verify the fix.
One way to trigger this code path is to use the following configuration:
- Compress SST file
- Enable direct IO and prefetch buffer
- Do NOT use compressed block cache

Test plan:
```
$ make clean
$ OPT=-g make -j16
$ TEST_TMPDIR=/data/compaction_bench ./db_bench -benchmarks=seekrandomwhilewriting -write_buffer_size=1048576 -compressed_cache_size=1048576 -compression_type=zstd -cache_size=1048576 -value_size=1024 -block_size=4096 -compaction_readahead_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -use_direct_reads=true -use_direct_io_for_flush_and_compaction=true -seek_nexts=128
```