### PR TITLE
Fix a map lookup that may throw exception.

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -340,6 +340,7 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
         ExternalSstFilePropertyNames::kGlobalSeqno);
     if (offsets_iter == props->properties_offsets.end() ||
         offsets_iter->second == 0) {
+      file_to_ingest->global_seqno_offset = 0;
       return Status::Corruption("Was not able to find file global seqno field");
     }
     file_to_ingest->global_seqno_offset = offsets_iter->second;

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -336,12 +336,13 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
 
     // Set the global sequence number
     file_to_ingest->original_seqno = DecodeFixed64(seqno_iter->second.c_str());
-    file_to_ingest->global_seqno_offset = props->properties_offsets.at(
+    auto offsets_iter = props->properties_offsets.find(
         ExternalSstFilePropertyNames::kGlobalSeqno);
-
-    if (file_to_ingest->global_seqno_offset == 0) {
+    if (offsets_iter == props->properties_offsets.end() ||
+        offsets_iter->second == 0) {
       return Status::Corruption("Was not able to find file global seqno field");
     }
+    file_to_ingest->global_seqno_offset = offsets_iter->second;
   } else if (file_to_ingest->version == 1) {
     // SST file V1 should not have global seqno field
     assert(seqno_iter == uprops.end());


### PR DESCRIPTION
`std::map::at(key)` throws std::out_of_range if key does not exist. Current
code does not handle this. Although this case is unlikely, I feel it's safe to
use `std::map::find`.

Test plan:
```
$ make clean && make -j16
$ ./external_sst_file_basic_test
$ ./external_sst_file_test
```

Optional:
```
$ make -j16 all check
```