### PR TITLE
Protect external file when ingesting

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2917,7 +2917,8 @@ Status DBImpl::IngestExternalFile(
 
   ExternalSstFileIngestionJob ingestion_job(env_, versions_.get(), cfd,
                                             immutable_db_options_, env_options_,
-                                            &snapshots_, ingestion_options);
+                                            &snapshots_, ingestion_options, &mutex_,
+                                            directories_.GetDbDir());
 
   std::list<uint64_t>::iterator pending_output_elem;
   {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2902,6 +2902,10 @@ Status DBImpl::IngestExternalFile(
     ColumnFamilyHandle* column_family,
     const std::vector<std::string>& external_files,
     const IngestExternalFileOptions& ingestion_options) {
+  if (external_files.empty()) {
+    return Status::InvalidArgument("external_files is empty");
+  }
+
   Status status;
   auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
   auto cfd = cfh->cfd();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2953,9 +2953,6 @@ Status DBImpl::IngestExternalFile(
   if (!status.ok()) {
     return status;
   }
-  if (next_file_number == 0) {
-    return Status::Aborted("Can't get next_file_number");
-  }
 
   SuperVersion* super_version = cfd->GetReferencedSuperVersion(&mutex_);
   status = ingestion_job.Prepare(external_files, next_file_number,

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -2091,7 +2091,8 @@ void DBImpl::InstallSuperVersionAndScheduleWork(
                         old_sv->mutable_cf_options.max_write_buffer_number;
   }
 
-  if (sv_context->new_superversion == nullptr) {
+  // this branch is unlikely to step in
+  if (UNLIKELY(sv_context->new_superversion == nullptr)) {
     sv_context->NewSuperVersion();
   }
   cfd->InstallSuperVersion(sv_context, &mutex_, mutable_cf_options);

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -89,8 +89,23 @@ Status ExternalSstFileIngestionJob::Prepare(
   }
 
   // Copy/Move external files into DB
+
+  // If crash happen after a hard link established, Recover function may
+  // reuse the file number that has already assigned to the internal file,
+  // and this will overwrite the external file. To protect the external
+  // file, we have to make sure the file number will never being reused.
+  uint64_t new_file_number =
+      versions_->FetchAddLastNewFileNumber(files_to_ingest_.size());
+  auto mutable_cf_options = cfd_->GetLatestMutableCFOptions();
+  {
+    VersionEdit tmp_edit;
+    InstrumentedMutexLock l(mutex_);
+    tmp_edit.SetNextFile(versions_->current_next_file_number());
+    versions_->LogAndApply(cfd_, *mutable_cf_options, &tmp_edit, mutex_,
+                           db_dir_);
+  }
   for (IngestedFileInfo& f : files_to_ingest_) {
-    f.fd = FileDescriptor(versions_->NewFileNumber(), 0, f.file_size);
+    f.fd = FileDescriptor(new_file_number++, 0, f.file_size);
 
     const std::string path_outside_db = f.external_file_path;
     const std::string path_inside_db =

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -91,7 +91,6 @@ Status ExternalSstFileIngestionJob::Prepare(
   }
 
   // Copy/Move external files into DB
-  assert(files_to_ingest_.size() <= external_files_paths.size());
   for (IngestedFileInfo& f : files_to_ingest_) {
     f.fd = FileDescriptor(next_file_number++, 0, f.file_size);
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -101,8 +101,11 @@ Status ExternalSstFileIngestionJob::Prepare(
     VersionEdit tmp_edit;
     InstrumentedMutexLock l(mutex_);
     tmp_edit.SetNextFile(versions_->current_next_file_number());
-    versions_->LogAndApply(cfd_, *mutable_cf_options, &tmp_edit, mutex_,
-                           db_dir_);
+    status = versions_->LogAndApply(cfd_, *mutable_cf_options, &tmp_edit, mutex_,
+                                    db_dir_);
+  }
+  if (!status.ok()) {
+    return status;
   }
   for (IngestedFileInfo& f : files_to_ingest_) {
     f.fd = FileDescriptor(new_file_number++, 0, f.file_size);

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -95,7 +95,7 @@ Status ExternalSstFileIngestionJob::Prepare(
   // and this will overwrite the external file. To protect the external
   // file, we have to make sure the file number will never being reused.
   uint64_t new_file_number =
-      versions_->FetchAddLastNewFileNumber(files_to_ingest_.size());
+      versions_->FetchAddFileNumber(files_to_ingest_.size());
   auto mutable_cf_options = cfd_->GetLatestMutableCFOptions();
   {
     VersionEdit tmp_edit;

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -75,7 +75,9 @@ class ExternalSstFileIngestionJob {
       Env* env, VersionSet* versions, ColumnFamilyData* cfd,
       const ImmutableDBOptions& db_options, const EnvOptions& env_options,
       SnapshotList* db_snapshots,
-      const IngestExternalFileOptions& ingestion_options)
+      const IngestExternalFileOptions& ingestion_options,
+      InstrumentedMutex* mutex,
+      Directory* db_dir)
       : env_(env),
         versions_(versions),
         cfd_(cfd),
@@ -83,7 +85,9 @@ class ExternalSstFileIngestionJob {
         env_options_(env_options),
         db_snapshots_(db_snapshots),
         ingestion_options_(ingestion_options),
-        job_start_time_(env_->NowMicros()) {}
+        job_start_time_(env_->NowMicros()),
+        mutex_(mutex),
+        db_dir_(db_dir) {}
 
   // Prepare the job by copying external files into the DB.
   Status Prepare(const std::vector<std::string>& external_files_paths,
@@ -157,6 +161,8 @@ class ExternalSstFileIngestionJob {
   const IngestExternalFileOptions& ingestion_options_;
   VersionEdit edit_;
   uint64_t job_start_time_;
+  InstrumentedMutex* mutex_;
+  Directory* db_dir_;
 };
 
 }  // namespace rocksdb

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -75,9 +75,7 @@ class ExternalSstFileIngestionJob {
       Env* env, VersionSet* versions, ColumnFamilyData* cfd,
       const ImmutableDBOptions& db_options, const EnvOptions& env_options,
       SnapshotList* db_snapshots,
-      const IngestExternalFileOptions& ingestion_options,
-      InstrumentedMutex* mutex,
-      Directory* db_dir)
+      const IngestExternalFileOptions& ingestion_options)
       : env_(env),
         versions_(versions),
         cfd_(cfd),
@@ -85,12 +83,11 @@ class ExternalSstFileIngestionJob {
         env_options_(env_options),
         db_snapshots_(db_snapshots),
         ingestion_options_(ingestion_options),
-        job_start_time_(env_->NowMicros()),
-        mutex_(mutex),
-        db_dir_(db_dir) {}
+        job_start_time_(env_->NowMicros()) {}
 
   // Prepare the job by copying external files into the DB.
   Status Prepare(const std::vector<std::string>& external_files_paths,
+                 uint64_t next_file_number,
                  SuperVersion* sv);
 
   // Check if we need to flush the memtable before running the ingestion job
@@ -161,8 +158,6 @@ class ExternalSstFileIngestionJob {
   const IngestExternalFileOptions& ingestion_options_;
   VersionEdit edit_;
   uint64_t job_start_time_;
-  InstrumentedMutex* mutex_;
-  Directory* db_dir_;
 };
 
 }  // namespace rocksdb

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -831,6 +831,11 @@ class VersionSet {
   // Allocate and return a new file number
   uint64_t NewFileNumber() { return next_file_number_.fetch_add(1); }
 
+  // Fetch And Add n new file number
+  uint64_t FetchAddLastNewFileNumber(uint64_t n) {
+    return next_file_number_.fetch_add(n);
+  }
+
   // Return the last sequence number.
   uint64_t LastSequence() const {
     return last_sequence_.load(std::memory_order_acquire);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -832,7 +832,7 @@ class VersionSet {
   uint64_t NewFileNumber() { return next_file_number_.fetch_add(1); }
 
   // Fetch And Add n new file number
-  uint64_t FetchAddLastNewFileNumber(uint64_t n) {
+  uint64_t FetchAddFileNumber(uint64_t n) {
     return next_file_number_.fetch_add(n);
   }
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1610,11 +1610,15 @@ class StressTest {
     if (!FLAGS_verbose) {
       return;
     }
-    fprintf(stdout, "[CF %d] %" PRIi64 " == > (%" ROCKSDB_PRIszt ") ", cf, key, sz);
+    std::string tmp;
+    tmp.reserve(sz * 2 + 16);
+    char buf[4];
     for (size_t i = 0; i < sz; i++) {
-      fprintf(stdout, "%X", value[i]);
+      snprintf(buf, 4, "%X", value[i]);
+      tmp.append(buf);
     }
-    fprintf(stdout, "\n");
+    fprintf(stdout, "[CF %d] %" PRIi64 " == > (%" ROCKSDB_PRIszt ") %s\n",
+            cf, key, sz, tmp.c_str());
   }
 
   static int64_t GenerateOneKey(ThreadState* thread, uint64_t iteration) {


### PR DESCRIPTION
If crash happen after a hard link established, Recover function may reuse the file number that has already assigned to the internal file, and this will overwrite the external file. To protect the external file, we have to make sure the file number will never being reused.

#3628 