### PR TITLE
Fix Copying of data between buffers in FilePrefetchBuffer

### DIFF
--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -121,6 +121,7 @@ public:
         ~static_cast<uintptr_t>(alignment_ - 1));
 
     if (copy_data) {
+      assert(bufstart_ + copy_offset + copy_len <= bufstart_ + cursize_);
       memcpy(new_bufstart, bufstart_ + copy_offset, copy_len);
       cursize_ = copy_len;
     } else {

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -672,7 +672,14 @@ Status FilePrefetchBuffer::Prefetch(RandomAccessFileReader* reader,
       chunk_len = buffer_len_ - chunk_offset_in_buffer;
       assert(chunk_offset_in_buffer % alignment == 0);
       assert(chunk_len % alignment == 0);
-      copy_data_to_new_buffer = true;
+      assert(chunk_offset_in_buffer + chunk_len <=
+             buffer_offset_ + buffer_len_);
+      if (chunk_len > 0) {
+        copy_data_to_new_buffer = true;
+      } else {
+        // this reset is not necessary, but just to be safe.
+        chunk_offset_in_buffer = 0;
+      }
     }
   }
 


### PR DESCRIPTION
Copy data between buffers inside FilePrefetchBuffer only when chunk length is greater than 0. Otherwise AlignedBuffer was accessing memory out of its range causing crashes. 

Removing the tracking of buffer length outside of `AlignedBuffer`, i.e. in `FilePrefetchBuffer` and `ReadaheadRandomAccessFile`, will follow in a separate PR, as it is not the root cause of the crash reported in #4051. (`FilePrefetchBuffer` itself has been this way from its inception, and `ReadaheadRandomAccessFile` was updated to add the buffer length at some point).  

Comprehensive tests for `FilePrefetchBuffer` also to follow in a separate PR. 

Test Plan:
- Used gdb to reproduce the problem reported in #4051, and fixed it. 
- `make check` succeeds
- Unit tests for `FilePrefetchBuffer` and `AlignedBuffer` to follow. 