### PR TITLE
Exclude time waiting for rate limiter from rocksdb.sst.read.micros

### DIFF
--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -50,13 +50,13 @@ class StopWatch {
   void DelayStart() {
     // if delay_start_time_ is not 0, it means we are already tracking delay,
     // so delay_start_time_ should not be overwritten
-    if (delay_enabled_ && delay_start_time_ == 0) {
+    if (elapsed_ && delay_enabled_ && delay_start_time_ == 0) {
       delay_start_time_ = env_->NowMicros();
     }
   }
 
   void DelayStop() {
-    if (delay_enabled_ && delay_start_time_ != 0) {
+    if (elapsed_ && delay_enabled_ && delay_start_time_ != 0) {
       total_delay_ += env_->NowMicros() - delay_start_time_;
     }
     // reset to 0 means currently no delay is being tracked, so two consecutive

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -15,13 +15,17 @@ namespace rocksdb {
 class StopWatch {
  public:
   StopWatch(Env* const env, Statistics* statistics, const uint32_t hist_type,
-            uint64_t* elapsed = nullptr, bool overwrite = true)
+            uint64_t* elapsed = nullptr, bool overwrite = true,
+            bool delay_enabled = false)
       : env_(env),
         statistics_(statistics),
         hist_type_(hist_type),
         elapsed_(elapsed),
         overwrite_(overwrite),
         stats_enabled_(statistics && statistics->HistEnabledForType(hist_type)),
+        delay_enabled_(delay_enabled),
+        total_delay_(0),
+        delay_start_time_(0),
         start_time_((stats_enabled_ || elapsed != nullptr) ? env->NowMicros()
                                                            : 0) {}
 
@@ -33,12 +37,34 @@ class StopWatch {
         *elapsed_ += env_->NowMicros() - start_time_;
       }
     }
+    if (elapsed_ && delay_enabled_) {
+      *elapsed_ -= total_delay_;
+    }
     if (stats_enabled_) {
       statistics_->measureTime(hist_type_,
           (elapsed_ != nullptr) ? *elapsed_ :
                                   (env_->NowMicros() - start_time_));
     }
   }
+
+  void DelayStart() {
+    // if delay_start_time_ is not 0, it means we are already tracking delay,
+    // so delay_start_time_ should not be overwritten
+    if (delay_enabled_ && delay_start_time_ == 0) {
+      delay_start_time_ = env_->NowMicros();
+    }
+  }
+
+  void DelayStop() {
+    if (delay_enabled_ && delay_start_time_ != 0) {
+      total_delay_ += env_->NowMicros() - delay_start_time_;
+    }
+    // reset to 0 means currently no delay is being tracked, so two consecutive
+    // calls to DelayStop will not increase total_delay_
+    delay_start_time_ = 0;
+  }
+
+  uint64_t GetDelay() const { return delay_enabled_ ? total_delay_ : 0; }
 
   uint64_t start_time() const { return start_time_; }
 
@@ -49,6 +75,9 @@ class StopWatch {
   uint64_t* elapsed_;
   bool overwrite_;
   bool stats_enabled_;
+  bool delay_enabled_;
+  uint64_t total_delay_;
+  uint64_t delay_start_time_;
   const uint64_t start_time_;
 };
 


### PR DESCRIPTION
Our "rocksdb.sst.read.micros" stat includes time spent waiting for rate limiter. It probably only affects people rate limiting compaction reads, which is fairly rare.