### PR TITLE
Support compaction filter in db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2432,7 +2432,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     PrintHeader();
     std::stringstream benchmark_stream(FLAGS_benchmarks);
     std::string name;
-    std::unique_ptr<CompactionFilter> filter;
+    std::unique_ptr<ExpiredTimeFilter> filter;
     while (std::getline(benchmark_stream, name, ',')) {
       // Sanitize parameters
       num_ = FLAGS_num;
@@ -2488,11 +2488,6 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         }
       }
 
-      if (FLAGS_use_keep_filter && FLAGS_expire_style != "compaction_filter") {
-        filter.reset(new KeepFilter());
-        fprintf(stdout, "A noop compaction filter is used\n");
-        open_options_.compaction_filter = filter.get();
-      }
       // Both fillseqdeterministic and filluniquerandomdeterministic
       // fill the levels except the max level with UNIQUE_RANDOM
       // and fill the max level with fillseq and filluniquerandom, respectively
@@ -3441,6 +3436,12 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         OpenDb(options, GetPathForMultiple(FLAGS_db, i), &multi_dbs_[i]);
       }
       options.wal_dir = wal_dir;
+    }
+
+    // KeepFilter is a noop filter, this can be used to test compaction filter
+    if (FLAGS_use_keep_filter) {
+      options.compaction_filter = new KeepFilter();
+      fprintf(stdout, "A noop compaction filter is used\n");
     }
   }
 


### PR DESCRIPTION
Right now there is no support for enabling compaction filter in db_bench, we should add support for that to facilitate testing of compaction filter. 
This PR adds a compaction filter called KeepFilter and make `Filter` always returns false, essentially a noop compaction filter. This will allow us to test compaction filter code path without having to support arbitrary compaction filters