### PR TITLE
db_bench periodically dump stats to info log

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1028,6 +1028,8 @@ DEFINE_bool(identity_as_first_hash, false, "the first hash function of cuckoo "
             "table becomes an identity function. This is only valid when key "
             "is 8 bytes");
 DEFINE_bool(dump_malloc_stats, true, "Dump malloc stats in LOG ");
+DEFINE_uint32(stats_dump_period_sec, rocksdb::Options().stats_dump_period_sec,
+              "Gap between printing stats to log in seconds");
 
 enum RepFactory {
   kSkipList,
@@ -3367,6 +3369,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     options.wal_dir = FLAGS_wal_dir;
     options.create_if_missing = !FLAGS_use_existing_db;
     options.dump_malloc_stats = FLAGS_dump_malloc_stats;
+    options.stats_dump_period_sec = FLAGS_stats_dump_period_sec;
 
     options.compression_opts.level = FLAGS_compression_level;
     options.compression_opts.max_dict_bytes = FLAGS_compression_max_dict_bytes;


### PR DESCRIPTION
give control of how often stats are printed, including jemalloc stats if enabled. Previously the default was 10 minutes so we'd only see updated stats for very long benchmark runs.

Test Plan:

run commands and verify it works

```
$ TEST_TMPDIR=/dev/shm ./db_bench -use_existing_db=true -benchmarks=readwhilewriting -reads=10000000 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -block_size=16384 -benchmark_write_rate_limit=4194304 -stats_dump_period_sec=5 -cache_size=1048576000
$ grep -i 'dumping stats' /dev/shm/dbbench/LOG
2018/07/10-17:05:01.200625 7f0cd0364700 [WARN] [db/db_impl.cc:534] ------- DUMPING STATS -------
2018/07/10-17:05:06.699916 7f0cd0364700 [WARN] [db/db_impl.cc:534] ------- DUMPING STATS -------
2018/07/10-17:05:12.106641 7f0cd0364700 [WARN] [db/db_impl.cc:534] ------- DUMPING STATS -------
2018/07/10-17:05:17.514710 7f0cd0364700 [WARN] [db/db_impl.cc:534] ------- DUMPING STATS -------
...
```