### PR TITLE
[FB Internal] Remove two CI tests

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -690,6 +690,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "error_handler_test",
+        "db/error_handler_test.cc",
+        "serial",
+    ],
+    [
         "event_logger_test",
         "util/event_logger_test.cc",
         "serial",
@@ -1078,14 +1083,3 @@ if not is_opt_mode:
           command = [TEST_RUNNER, BUCK_BINS + test_bin]
         )
 
-custom_unittest(
-    name = "make_rocksdbjavastatic",
-    command = ["internal_repo_rocksdb/make_rocksdbjavastatic.sh"],
-    type = "simple",
-)
-
-custom_unittest(
-    name = "make_rocksdb_lite_release",
-    command = ["internal_repo_rocksdb/make_rocksdb_lite_release.sh"],
-    type = "simple",
-)

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -135,15 +135,4 @@ if not is_opt_mode:
           command = [TEST_RUNNER, BUCK_BINS + test_bin]
         )
 
-custom_unittest(
-    name = "make_rocksdbjavastatic",
-    command = ["internal_repo_rocksdb/make_rocksdbjavastatic.sh"],
-    type = "simple",
-)
-
-custom_unittest(
-    name = "make_rocksdb_lite_release",
-    command = ["internal_repo_rocksdb/make_rocksdb_lite_release.sh"],
-    type = "simple",
-)
 """


### PR DESCRIPTION
Summary: Two CI tests never pass because of the environment problem. Delete them.