### PR TITLE
Converted db/merge_test.cc to use gtest

### DIFF
--- a/db/merge_test.cc
+++ b/db/merge_test.cc
@@ -88,7 +88,6 @@ std::shared_ptr<DB> OpenDb(const std::string& dbname, const bool ttl = false,
 // DBWithTTL is not supported in ROCKSDB_LITE
 #ifndef ROCKSDB_LITE
   if (ttl) {
-    // std::cout << "Opening database with TTL\n";
     DBWithTTL* db_with_ttl;
     s = DBWithTTL::Open(options, dbname, &db_with_ttl);
     db = db_with_ttl;
@@ -280,8 +279,6 @@ void testCounters(Counters& counters, DB* db, bool test_compaction) {
 
   dumpDb(db);
 
-  // std::cout << "1\n";
-
   // 1+...+49 = ?
   uint64_t sum = 0;
   for (int i = 1; i < 50; i++) {
@@ -290,17 +287,12 @@ void testCounters(Counters& counters, DB* db, bool test_compaction) {
   }
   assert(counters.assert_get("b") == sum);
 
-  // std::cout << "2\n";
   dumpDb(db);
-
-  // std::cout << "3\n";
 
   if (test_compaction) {
     db->Flush(o);
 
-    // std::cout << "Compaction started ...\n";
     db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
-    // std::cout << "Compaction ended\n";
 
     dumpDb(db);
 
@@ -416,13 +408,11 @@ void runTest(const std::string& dbname, const bool use_ttl = false) {
     auto db = OpenDb(dbname, use_ttl);
 
     {
-      // std::cout << "Test read-modify-write counters... \n";
       Counters counters(db, 0);
       testCounters(counters, db.get(), true);
     }
 
     {
-      // std::cout << "Test merge-based counters... \n";
       MergeBasedCounters counters(db, 0);
       testCounters(counters, db.get(), use_compression);
     }
@@ -431,7 +421,6 @@ void runTest(const std::string& dbname, const bool use_ttl = false) {
   DestroyDB(dbname, Options());
 
   {
-    // std::cout << "Test merge in memtable... \n";
     size_t max_merge = 5;
     auto db = OpenDb(dbname, use_ttl, max_merge);
     MergeBasedCounters counters(db, 0);
@@ -442,7 +431,6 @@ void runTest(const std::string& dbname, const bool use_ttl = false) {
   }
 
   {
-    // std::cout << "Test Partial-Merge\n";
     size_t max_merge = 100;
     // Min merge is hard-coded to 2.
     uint32_t min_merge = 2;
@@ -462,7 +450,6 @@ void runTest(const std::string& dbname, const bool use_ttl = false) {
   }
 
   {
-    // std::cout << "Test merge-operator not set after reopen\n";
     {
       auto db = OpenDb(dbname);
       MergeBasedCounters counters(db, 0);

--- a/util/compression.h
+++ b/util/compression.h
@@ -121,6 +121,8 @@ class ZSTDUncompressCachedData {
   int64_t GetCacheIndex() const { return -1; }
   void CreateIfNeeded() {}
   void InitFromCache(const ZSTDUncompressCachedData&, int64_t) {}
+ private:
+  void ignore_padding__() { padding = nullptr; }
 };
 }  // namespace rocksdb
 #endif

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3209,7 +3209,7 @@ TEST_P(TransactionTest, LockLimitTest) {
   ASSERT_OK(s);
 
   // Create a txn and verify we can only lock up to 3 keys
-  Transaction* txn = db->BeginTransaction(write_options);
+  Transaction* txn = db->BeginTransaction(write_options, txn_options);
   ASSERT_TRUE(txn);
 
   s = txn->Put("X", "x");
@@ -3242,7 +3242,7 @@ TEST_P(TransactionTest, LockLimitTest) {
   s = txn->Get(read_options, "W", &value);
   ASSERT_TRUE(s.IsNotFound());
 
-  Transaction* txn2 = db->BeginTransaction(write_options);
+  Transaction* txn2 = db->BeginTransaction(write_options, txn_options);
   ASSERT_TRUE(txn2);
 
   // "X" currently locked


### PR DESCRIPTION
Picked up a task to convert this to use the gtest framework.  It can't be this simple, can it?  

It works, but should all the std::cout be removed?

```
[$] ~/git/rocksdb [gft !]: ./merge_test
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from MergeTest
[ RUN      ] MergeTest.MergeDbTest
Test read-modify-write counters...
a: 3
1
2
a: 3
b: 1225
3
Compaction started ...
Compaction ended
a: 3
b: 1225
Test merge-based counters...
a: 3
1
2
a: 3
b: 1225
3
Test merge in memtable...
a: 3
1
2
a: 3
b: 1225
3
Test Partial-Merge
Test merge-operator not set after reopen
[       OK ] MergeTest.MergeDbTest (93 ms)
[ RUN      ] MergeTest.MergeDbTtlTest
Opening database with TTL
Test read-modify-write counters...
a: 3
1
2
a: 3
b: 1225
3
Compaction started ...
Compaction ended
a: 3
b: 1225
Test merge-based counters...
a: 3
1
2
a: 3
b: 1225
3
Test merge in memtable...
Opening database with TTL
a: 3
1
2
a: 3
b: 1225
3
Test Partial-Merge
Opening database with TTL
Opening database with TTL
Opening database with TTL
Opening database with TTL
Test merge-operator not set after reopen
[       OK ] MergeTest.MergeDbTtlTest (97 ms)
[----------] 2 tests from MergeTest (190 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (190 ms total)
[  PASSED  ] 2 tests.
```