### PR TITLE
Allow partitioned index to be empty

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -268,6 +268,11 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     // Index partitions are assumed to be consecuitive. Prefetch them all.
     // Read the first block offset
     biter.SeekToFirst();
+    if (!biter.Valid() && biter.status().ok()) {
+      // No partitions -- this should be an SST file containing only range
+      // deletions
+      return;
+    }
     Slice input = biter.value();
     Status s = handle.DecodeFrom(&input);
     assert(s.ok());

--- a/table/index_builder.cc
+++ b/table/index_builder.cc
@@ -143,7 +143,6 @@ void PartitionedIndexBuilder::AddIndexEntry(
 
 Status PartitionedIndexBuilder::Finish(
     IndexBlocks* index_blocks, const BlockHandle& last_partition_block_handle) {
-  assert(!entries_.empty());
   // It must be set to null after last key is added
   assert(sub_index_builder_ == nullptr);
   if (finishing_indexes == true) {


### PR DESCRIPTION
An index block will have no entries when a file contains only range deletions. This PR adds support for empty partitioned index blocks.

Test Plan:

- updated the unit test for SST file containing range deletion only