### PR TITLE
Reduce #iterations to shorten execution time.

### DIFF
--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1194,8 +1194,9 @@ TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {
     ASSERT_OK(GenerateAndAddExternalFile(options, file_keys, range_id));
   };
 
+  const int num_of_ranges = 1000;
   std::vector<port::Thread> threads;
-  while (range_id < 5000) {
+  while (range_id < num_of_ranges) {
     int range_start = range_id * 10;
     int range_end = range_start + 10;
 
@@ -1220,7 +1221,7 @@ TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {
     range_id++;
   }
 
-  for (int rid = 0; rid < 5000; rid++) {
+  for (int rid = 0; rid < num_of_ranges; rid++) {
     int range_start = rid * 10;
     int range_end = range_start + 10;
 


### PR DESCRIPTION
Reduce #iterations from 5000 to 1000 so that
`ExternalSSTFileTest.CompactDuringAddFileRandom` can finish faster.
On the one hand, 5000 iterations does not seem to improve the quality of unit
test in comparison with 1000. On the other hand, long running tests should belong to stress tests.

Test plan:
```
$make clean && make -j16
$./external_sst_file_test --gtest_filter=ExternalSSTFileTest.CompactDuringAddFileRandom
```