### PR TITLE
Disable a test, add a new one.

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -125,7 +125,7 @@ static void SetBool(void* ptr) {
   reinterpret_cast<std::atomic<bool>*>(ptr)->store(true);
 }
 
-TEST_F(EnvPosixTest, RunImmediately) {
+TEST_F(EnvPosixTest, DISABLED_RunImmediately) {
   for (int pri = Env::BOTTOM; pri < Env::TOTAL; ++pri) {
     std::atomic<bool> called(false);
     env_->SetBackgroundThreads(1, static_cast<Env::Priority>(pri));
@@ -133,6 +133,13 @@ TEST_F(EnvPosixTest, RunImmediately) {
     Env::Default()->SleepForMicroseconds(kDelayMicros);
     ASSERT_TRUE(called.load());
   }
+}
+
+TEST_F(EnvPosixTest, RunEventually) {
+  std::atomic<bool> called(false);
+  env_->StartThread(&SetBool, &called);
+  env_->WaitForJoin();
+  ASSERT_TRUE(called.load());
 }
 
 #ifdef OS_WIN


### PR DESCRIPTION
The original `EnvPosixTest.RunImmediately` assumes that after scheduling
a background thread, the thread is guaranteed to complete after 0.1 second.
I do not know about any non-real-time OS/runtime providing this guarantee. Nor
does C++11 standard say anything about this.
In fact, we have observed this test failure multiple times on appveyor, and we
haven't been able to reproduce the failure deterministically. Therefore,
I disable this test for now until we know for sure how it used to fail.

Instead, I add another test `EnvPosixTest.RunEventually` that checks that
a thread will be scheduled eventually.

Test plan:
```
$make clean && make -j16
$./env_test --gtest_filter=EnvPosixTest.RunImmediately # runs 0 test
$./env_test --gtest_filter=EnvPosixTest.RunEventually # runs 1 test successfully
```