### PR TITLE
Return new operator for Status allocations for Windows

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -19,7 +19,8 @@ namespace rocksdb {
 
 const char* Status::CopyState(const char* state) {
 #ifdef OS_WIN
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
+  const size_t cch =
+      std::strlen(state) + 1; // +1 for the null terminator
   char* result = new char[cch];
   errno_t ret;
   ret = strncpy_s(result, cch, state, cch - 1);
@@ -27,25 +28,13 @@ const char* Status::CopyState(const char* state) {
   assert(ret == 0);
   return result;
 #else
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
+  const size_t cch =
+      std::strlen(state) + 1; // +1 for the null terminator
   return std::strncpy(new char[cch], state, cch);
 #endif
 }
 
-static const char* msgs[static_cast<int>(Status::kMaxSubCode)] = {
-    "",                                                   // kNone
-    "Timeout Acquiring Mutex",                            // kMutexTimeout
-    "Timeout waiting to lock key",                        // kLockTimeout
-    "Failed to acquire lock due to max_num_locks limit",  // kLockLimit
-    "No space left on device",                            // kNoSpace
-    "Deadlock",                                           // kDeadlock
-    "Stale file handle",                                  // kStaleFile
-    "Memory limit reached",                               // kMemoryLimit
-    "Space limit reached"                                 // kSpaceLimit
-};
-
-Status::Status(Code _code, SubCode _subcode, const Slice& msg,
-               const Slice& msg2)
+Status::Status(Code _code, SubCode _subcode, const Slice& msg, const Slice& msg2)
     : code_(_code), subcode_(_subcode), sev_(kNoError) {
   assert(code_ != kOk);
   assert(subcode_ != kMaxSubCode);

--- a/util/status.cc.orig
+++ b/util/status.cc.orig
@@ -19,7 +19,8 @@ namespace rocksdb {
 
 const char* Status::CopyState(const char* state) {
 #ifdef OS_WIN
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
+  const size_t cch =
+      std::strlen(state) + 1; // +1 for the null terminator
   char* result = new char[cch];
   errno_t ret;
   ret = strncpy_s(result, cch, state, cch - 1);
@@ -27,25 +28,13 @@ const char* Status::CopyState(const char* state) {
   assert(ret == 0);
   return result;
 #else
-  const size_t cch = std::strlen(state) + 1;  // +1 for the null terminator
+  const size_t cch =
+      std::strlen(state) + 1; // +1 for the null terminator
   return std::strncpy(new char[cch], state, cch);
 #endif
 }
 
-static const char* msgs[static_cast<int>(Status::kMaxSubCode)] = {
-    "",                                                   // kNone
-    "Timeout Acquiring Mutex",                            // kMutexTimeout
-    "Timeout waiting to lock key",                        // kLockTimeout
-    "Failed to acquire lock due to max_num_locks limit",  // kLockLimit
-    "No space left on device",                            // kNoSpace
-    "Deadlock",                                           // kDeadlock
-    "Stale file handle",                                  // kStaleFile
-    "Memory limit reached",                               // kMemoryLimit
-    "Space limit reached"                                 // kSpaceLimit
-};
-
-Status::Status(Code _code, SubCode _subcode, const Slice& msg,
-               const Slice& msg2)
+Status::Status(Code _code, SubCode _subcode, const Slice& msg, const Slice& msg2)
     : code_(_code), subcode_(_subcode), sev_(kNoError) {
   assert(code_ != kOk);
   assert(subcode_ != kMaxSubCode);


### PR DESCRIPTION
Windows requires new/delete for memory allocations to be overriden. Refactor to be less intrusive.
Cc: @grooverdan 
Some misc adjustments