### PR TITLE
Reduce execution time of IngestFileWithGlobalSeqnoRandomized

### DIFF
--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1476,7 +1476,7 @@ TEST_F(ExternalSSTFileTest, IngestFileWithGlobalSeqnoRandomized) {
 
     Random rnd(301);
     std::map<std::string, std::string> true_data;
-    for (int i = 0; i < 2000; i++) {
+    for (int i = 0; i < 500; i++) {
       std::vector<std::pair<std::string, std::string>> random_data;
       for (int j = 0; j < 100; j++) {
         std::string k;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -525,8 +525,7 @@ DEFINE_bool(read_cache_direct_write, true,
 DEFINE_bool(read_cache_direct_read, true,
             "Whether to use Direct IO for reading from read cache");
 
-DEFINE_bool(use_keep_filter, false,
-            "Whether to use a noop compaction filter");
+DEFINE_bool(use_keep_filter, false, "Whether to use a noop compaction filter");
 
 static bool ValidateCacheNumshardbits(const char* flagname, int32_t value) {
   if (value >= 20) {


### PR DESCRIPTION
Make `ExternalSSTFileTest.IngestFileWithGlobalSeqnoRandomized` run faster.

`make format`

Test plan:
```
$make clean && make -j16
$./external_sst_file_test --gtest_filter=ExternalSSTFileTest.IngestFileWithGlobalSeqnoRandomized
```