### PR TITLE
 DataBlockHashIndex: Standalone Implementation with Unit Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,7 +922,7 @@ if(WITH_TESTS)
         table/cleanable_test.cc
         table/cuckoo_table_builder_test.cc
         table/cuckoo_table_reader_test.cc
-        table/data_block_hash_index.cc
+        table/data_block_hash_index_test.cc
         table/full_filter_block_test.cc
         table/merger_test.cc
         table/table_test.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,7 @@ set(SOURCES
         table/cuckoo_table_builder.cc
         table/cuckoo_table_factory.cc
         table/cuckoo_table_reader.cc
+        table/data_block_hash_index.cc
         table/flush_block_policy.cc
         table/format.cc
         table/full_filter_block.cc
@@ -921,6 +922,7 @@ if(WITH_TESTS)
         table/cleanable_test.cc
         table/cuckoo_table_builder_test.cc
         table/cuckoo_table_reader_test.cc
+        table/data_block_hash_index.cc
         table/full_filter_block_test.cc
         table/merger_test.cc
         table/table_test.cc

--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,7 @@ TESTS = \
 	table_properties_collector_test \
 	arena_test \
 	block_test \
+	data_block_hash_index_test \
 	cache_test \
 	corruption_test \
 	slice_transform_test \
@@ -1348,6 +1349,9 @@ table_test: table/table_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 block_test: table/block_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+data_block_hash_index_test: table/data_block_hash_index_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 inlineskiplist_test: memtable/inlineskiplist_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -375,6 +375,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "data_block_hash_index_test",
+        "table/data_block_hash_index_test.cc",
+        "serial",
+    ],
+    [
         "block_test",
         "table/block_test.cc",
         "serial",
@@ -1082,4 +1087,3 @@ if not is_opt_mode:
           deps = [":" + test_bin],
           command = [TEST_RUNNER, BUCK_BINS + test_bin]
         )
-

--- a/TARGETS
+++ b/TARGETS
@@ -172,6 +172,7 @@ cpp_library(
         "table/cuckoo_table_builder.cc",
         "table/cuckoo_table_factory.cc",
         "table/cuckoo_table_reader.cc",
+        "table/data_block_hash_index.cc",
         "table/flush_block_policy.cc",
         "table/format.cc",
         "table/full_filter_block.cc",

--- a/src.mk
+++ b/src.mk
@@ -104,7 +104,7 @@ LIB_SOURCES =                                                   \
   table/cuckoo_table_builder.cc                                 \
   table/cuckoo_table_factory.cc                                 \
   table/cuckoo_table_reader.cc                                  \
-  table/data_block_hash_index.cc                                   \
+  table/data_block_hash_index.cc                                \
   table/flush_block_policy.cc                                   \
   table/format.cc                                               \
   table/full_filter_block.cc                                    \
@@ -349,7 +349,7 @@ MAIN_SOURCES =                                                          \
   table/cleanable_test.cc                                               \
   table/cuckoo_table_builder_test.cc                                    \
   table/cuckoo_table_reader_test.cc                                     \
-  table/data_block_hash_index_test.cc                                      \
+  table/data_block_hash_index_test.cc                                   \
   table/full_filter_block_test.cc                                       \
   table/merger_test.cc                                                  \
   table/table_reader_bench.cc                                           \

--- a/src.mk
+++ b/src.mk
@@ -104,6 +104,7 @@ LIB_SOURCES =                                                   \
   table/cuckoo_table_builder.cc                                 \
   table/cuckoo_table_factory.cc                                 \
   table/cuckoo_table_reader.cc                                  \
+  table/data_block_hash_index.cc                                   \
   table/flush_block_policy.cc                                   \
   table/format.cc                                               \
   table/full_filter_block.cc                                    \
@@ -348,6 +349,7 @@ MAIN_SOURCES =                                                          \
   table/cleanable_test.cc                                               \
   table/cuckoo_table_builder_test.cc                                    \
   table/cuckoo_table_reader_test.cc                                     \
+  table/data_block_hash_index_test.cc                                      \
   table/full_filter_block_test.cc                                       \
   table/merger_test.cc                                                  \
   table/table_reader_bench.cc                                           \

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -16,7 +16,8 @@ const uint32_t kSeed = 2018;
 const uint32_t kSeed_tag = 214; /* second hash seed */
 
 inline uint16_t HashToBucket(const Slice& s, uint16_t num_buckets) {
-  return (uint16_t)rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
+  return static_cast<uint16_t>(
+      rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets);
 }
 
 void DataBlockHashIndexBuilder::Add(const Slice& key,

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -2,7 +2,6 @@
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -16,89 +15,89 @@ namespace rocksdb {
 const uint32_t kSeed = 2018;
 const uint32_t kSeed_tag = 214; /* second hash seed */
 
-inline uint32_t HashToBucket(const Slice& s, uint32_t num_buckets) {
-  return rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
+inline uint16_t HashToBucket(const Slice& s, uint16_t num_buckets) {
+  return (uint16_t)rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
 }
 
 void DataBlockHashIndexBuilder::Add(const Slice& key,
-                                  const uint32_t& restart_index) {
-  uint32_t idx = HashToBucket(key, num_buckets_);
+                                    const uint16_t& restart_index) {
+  uint16_t idx = HashToBucket(key, num_buckets_);
   /* push a TAG to avoid false postive */
   /* the TAG is the hash function value of another seed */
-  buckets_[idx].push_back(rocksdb::Hash(key.data(), key.size(), kSeed_tag));
+  uint16_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
+  buckets_[idx].push_back(tag);
   buckets_[idx].push_back(restart_index);
-  estimate_ += 2 * sizeof(uint32_t);
+  estimate_ += 2 * sizeof(uint16_t);
 }
 
 void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
+  // Because we use uint16_t address, we only support block less than 64KB
+  assert(buffer.size() < (1 << 16));
   // offset is the byte offset within the buffer
-  std::vector<uint32_t> bucket_offsets(num_buckets_, 0);
+  std::vector<uint16_t> bucket_offsets(num_buckets_, 0);
 
-  uint32_t map_start = static_cast<uint32_t>(buffer.size());
+  uint16_t map_start = static_cast<uint16_t>(buffer.size());
 
   // write each bucket to the string
-  for (uint32_t i = 0; i < num_buckets_; i++) {
+  for (uint16_t i = 0; i < num_buckets_; i++) {
     // remember the start offset of the buckets in bucket_offsets
-    bucket_offsets[i] = static_cast<uint32_t>(buffer.size());
-    for (uint32_t elem : buckets_[i]) {
+    bucket_offsets[i] = static_cast<uint16_t>(buffer.size());
+    for (uint16_t elem : buckets_[i]) {
       // the elem is alternative "TAG" and "offset"
-      PutFixed32(&buffer, elem);
+      PutFixed16(&buffer, elem);
     }
   }
 
   // write the bucket_offsets
-  for (uint32_t i = 0; i < num_buckets_; i++) {
-    PutFixed32(&buffer, bucket_offsets[i]);
+  for (uint16_t i = 0; i < num_buckets_; i++) {
+    PutFixed16(&buffer, bucket_offsets[i]);
   }
 
   // write NUM_BUCK
-  PutFixed32(&buffer, num_buckets_);
+  PutFixed16(&buffer, num_buckets_);
 
   // write MAP_START
-  PutFixed32(&buffer, map_start);
+  PutFixed16(&buffer, map_start);
 }
 
 void DataBlockHashIndexBuilder::Reset() {
 //  buckets_.clear();
-  std::fill(buckets_.begin(), buckets_.end(), std::vector<uint32_t>());
-  estimate_ = 0;
+std::fill(buckets_.begin(), buckets_.end(), std::vector<uint16_t>());
+estimate_ = 0;
 }
 
 DataBlockHashIndex::DataBlockHashIndex(Slice block_content) {
   assert(block_content.size() >=
-         2 * sizeof(uint32_t));  // NUM_BUCK and MAP_START
+         2 * sizeof(uint16_t));  // NUM_BUCK and MAP_START
 
   data_ = block_content.data();
-  size_ = static_cast<uint32_t>(block_content.size());
+  size_ = static_cast<uint16_t>(block_content.size());
 
-  map_start_ = data_ + DecodeFixed32(data_ + size_ - sizeof(uint32_t));
+  map_start_ = data_ + DecodeFixed16(data_ + size_ - sizeof(uint16_t));
   assert(map_start_ < data_ + size_);
 
-  num_buckets_ = DecodeFixed32(data_ + size_ - 2 * sizeof(uint32_t));
+  num_buckets_ = DecodeFixed16(data_ + size_ - 2 * sizeof(uint16_t));
   assert(num_buckets_ > 0);
 
-  assert(size_ >= sizeof(uint32_t) * (2 + num_buckets_));
-  bucket_table_ = data_ + size_ - sizeof(uint32_t) * (2 + num_buckets_);
+  assert(size_ >= sizeof(uint16_t) * (2 + num_buckets_));
+  bucket_table_ = data_ + size_ - sizeof(uint16_t) * (2 + num_buckets_);
 
   assert(map_start_ <  bucket_table_);
 }
 
 DataBlockHashIndexIterator* DataBlockHashIndex::NewIterator(
     const Slice& key) const {
-  uint32_t idx = HashToBucket(key, num_buckets_);
-  uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
+  uint16_t idx = HashToBucket(key, num_buckets_);
+  uint16_t bucket_off = DecodeFixed16(bucket_table_ + idx * sizeof(uint16_t));
   const char* limit;
   if (idx < num_buckets_ - 1) {
     // limited by the start offset of the next bucket
-    limit = data_ +
-            DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
+    limit = data_ + DecodeFixed16(bucket_table_ + (idx + 1) * sizeof(uint16_t));
   } else {
     // limited by the location of the NUM_BUCK
-    limit = data_ + (size_ - 2 * sizeof(uint32_t));
+    limit = data_ + (size_ - 2 * sizeof(uint16_t));
   }
-
-  uint32_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
-
+  uint16_t tag = (uint16_t)rocksdb::Hash(key.data(), key.size(), kSeed_tag);
   return new DataBlockHashIndexIterator(data_ + bucket_off, limit, tag);
 }
 
@@ -107,17 +106,18 @@ bool DataBlockHashIndexIterator::Valid() {
 }
 
 void DataBlockHashIndexIterator::Next() {
-  for (current_ += 2 * sizeof(uint32_t); current_ < end_;
-       current_ += 2 * sizeof(uint32_t)) {
+  for (current_ += 2 * sizeof(uint16_t); current_ < end_;
+       current_ += 2 * sizeof(uint16_t)) {
     // stop at a offset that match the tag, i.e. a possible match
-    if (DecodeFixed32(current_) == tag_) {
+    uint16_t tag_found = DecodeFixed16(current_);
+    if (tag_found == tag_) {
       break;
     }
   }
 }
 
-uint32_t DataBlockHashIndexIterator::Value() {
-  return DecodeFixed32(current_+ sizeof(uint32_t));
+uint16_t DataBlockHashIndexIterator::Value() {
+  return DecodeFixed16(current_ + sizeof(uint16_t));
 }
 
 }  // namespace rocksdb

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -83,30 +83,6 @@ DataBlockHashIndex::DataBlockHashIndex(Slice block_content) {
   assert(map_start_ <  bucket_table_);
 }
 
-void DataBlockHashIndex::Seek(const Slice& key, std::vector<uint32_t>& bucket) const {
-  assert(bucket.size() == 0);
-  uint32_t idx = HashToBucket(key, num_buckets_);
-  uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
-  const char* limit;
-  if (idx < num_buckets_ - 1) {
-    // limited by the start offset of the next bucket
-    limit = data_ +
-            DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
-  } else {
-    // limited by the location of the NUM_BUCK
-    limit = data_ + (size_ - 2 * sizeof(uint32_t));
-  }
-
-  uint32_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
-  for (const char* p = data_ + bucket_off; p < limit;
-       p += 2 * sizeof(uint32_t)) {
-    if (DecodeFixed32(p) == tag) {
-      // only if the tag matches the string do we return the restart_index
-      bucket.push_back(DecodeFixed32(p + sizeof(uint32_t)));
-    }
-  }
-}
-
 DataBlockHashIndexIterator* DataBlockHashIndex::NewIterator(
     const Slice& key) const {
   uint32_t idx = HashToBucket(key, num_buckets_);

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -33,8 +33,6 @@ void DataBlockHashIndexBuilder::Add(const Slice& key,
 }
 
 void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
-  // Because we use uint16_t address, we only support block less than 64KB
-  assert(buffer.size() < (1 << 16));
   // offset is the byte offset within the buffer
   std::vector<uint16_t> bucket_offsets(num_buckets_, 0);
 
@@ -60,6 +58,9 @@ void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
 
   // write MAP_START
   PutFixed16(&buffer, map_start);
+
+  // Because we use uint16_t address, we only support block less than 64KB
+  assert(buffer.size() < (1 << 16));
 }
 
 void DataBlockHashIndexBuilder::Reset() {

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -24,7 +24,8 @@ void DataBlockHashIndexBuilder::Add(const Slice& key,
   uint16_t idx = HashToBucket(key, num_buckets_);
   /* push a TAG to avoid false postive */
   /* the TAG is the hash function value of another seed */
-  uint16_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
+  uint16_t tag = static_cast<uint16_t>(
+      rocksdb::Hash(key.data(), key.size(), kSeed_tag));
   buckets_[idx].push_back(tag);
   buckets_[idx].push_back(restart_index);
   estimate_ += 2 * sizeof(uint16_t);

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -1,0 +1,147 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "rocksdb/slice.h"
+#include "table/data_block_hash_index.h"
+#include "util/coding.h"
+#include "util/hash.h"
+
+namespace rocksdb {
+
+const uint32_t kSeed = 2018;
+const uint32_t kSeed_tag = 214; /* second hash seed */
+
+inline uint32_t HashToBucket(const Slice& s, uint32_t num_buckets) {
+  return rocksdb::Hash(s.data(), s.size(), kSeed) % num_buckets;
+}
+
+void DataBlockHashIndexBuilder::Add(const Slice& key,
+                                  const uint32_t& restart_index) {
+  uint32_t idx = HashToBucket(key, num_buckets_);
+  /* push a TAG to avoid false postive */
+  /* the TAG is the hash function value of another seed */
+  buckets_[idx].push_back(rocksdb::Hash(key.data(), key.size(), kSeed_tag));
+  buckets_[idx].push_back(restart_index);
+  estimate_ += 2 * sizeof(uint32_t);
+}
+
+void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
+  // offset is the byte offset within the buffer
+  std::vector<uint32_t> bucket_offsets(num_buckets_, 0);
+
+  uint32_t map_start = static_cast<uint32_t>(buffer.size());
+
+  // write each bucket to the string
+  for (uint32_t i = 0; i < num_buckets_; i++) {
+    // remember the start offset of the buckets in bucket_offsets
+    bucket_offsets[i] = static_cast<uint32_t>(buffer.size());
+    for (uint32_t elem : buckets_[i]) {
+      // the elem is alternative "TAG" and "offset"
+      PutFixed32(&buffer, elem);
+    }
+  }
+
+  // write the bucket_offsets
+  for (uint32_t i = 0; i < num_buckets_; i++) {
+    PutFixed32(&buffer, bucket_offsets[i]);
+  }
+
+  // write NUM_BUCK
+  PutFixed32(&buffer, num_buckets_);
+
+  // write MAP_START
+  PutFixed32(&buffer, map_start);
+}
+
+void DataBlockHashIndexBuilder::Reset() {
+//  buckets_.clear();
+  std::fill(buckets_.begin(), buckets_.end(), std::vector<uint32_t>());
+  estimate_ = 0;
+}
+
+DataBlockHashIndex::DataBlockHashIndex(Slice block_content) {
+  assert(block_content.size() >=
+         2 * sizeof(uint32_t));  // NUM_BUCK and MAP_START
+
+  data_ = block_content.data();
+  size_ = static_cast<uint32_t>(block_content.size());
+
+  map_start_ = data_ + DecodeFixed32(data_ + size_ - sizeof(uint32_t));
+  assert(map_start_ < data_ + size_);
+
+  num_buckets_ = DecodeFixed32(data_ + size_ - 2 * sizeof(uint32_t));
+  assert(num_buckets_ > 0);
+
+  assert(size_ >= sizeof(uint32_t) * (2 + num_buckets_));
+  bucket_table_ = data_ + size_ - sizeof(uint32_t) * (2 + num_buckets_);
+
+  assert(map_start_ <  bucket_table_);
+}
+
+void DataBlockHashIndex::Seek(const Slice& key, std::vector<uint32_t>& bucket) const {
+  assert(bucket.size() == 0);
+  uint32_t idx = HashToBucket(key, num_buckets_);
+  uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
+  const char* limit;
+  if (idx < num_buckets_ - 1) {
+    // limited by the start offset of the next bucket
+    limit = data_ +
+            DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
+  } else {
+    // limited by the location of the NUM_BUCK
+    limit = data_ + (size_ - 2 * sizeof(uint32_t));
+  }
+
+  uint32_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
+  for (const char* p = data_ + bucket_off; p < limit;
+       p += 2 * sizeof(uint32_t)) {
+    if (DecodeFixed32(p) == tag) {
+      // only if the tag matches the string do we return the restart_index
+      bucket.push_back(DecodeFixed32(p + sizeof(uint32_t)));
+    }
+  }
+}
+
+DataBlockHashIndexIterator* DataBlockHashIndex::NewIterator(
+    const Slice& key) const {
+  uint32_t idx = HashToBucket(key, num_buckets_);
+  uint32_t bucket_off = DecodeFixed32(bucket_table_ + idx * sizeof(uint32_t));
+  const char* limit;
+  if (idx < num_buckets_ - 1) {
+    // limited by the start offset of the next bucket
+    limit = data_ +
+            DecodeFixed32(bucket_table_ + (idx + 1) * sizeof(uint32_t));
+  } else {
+    // limited by the location of the NUM_BUCK
+    limit = data_ + (size_ - 2 * sizeof(uint32_t));
+  }
+
+  uint32_t tag = rocksdb::Hash(key.data(), key.size(), kSeed_tag);
+
+  return new DataBlockHashIndexIterator(data_ + bucket_off, limit, tag);
+}
+
+bool DataBlockHashIndexIterator::Valid() {
+  return current_ < end_;
+}
+
+void DataBlockHashIndexIterator::Next() {
+  for (current_ += 2 * sizeof(uint32_t); current_ < end_;
+       current_ += 2 * sizeof(uint32_t)) {
+    // stop at a offset that match the tag, i.e. a possible match
+    if (DecodeFixed32(current_) == tag_) {
+      break;
+    }
+  }
+}
+
+uint32_t DataBlockHashIndexIterator::Value() {
+  return DecodeFixed32(current_+ sizeof(uint32_t));
+}
+
+}  // namespace rocksdb

--- a/table/data_block_hash_index.h
+++ b/table/data_block_hash_index.h
@@ -34,18 +34,19 @@ namespace rocksdb {
 
 class DataBlockHashIndexBuilder {
  public:
-  DataBlockHashIndexBuilder(uint32_t n) :
-      num_buckets_(n),
-      buckets_(n),
-      estimate_((n + 2) * sizeof(uint32_t) /* n buckets, 2 num at the end */){}
-  void Add(const Slice &key, const uint32_t &restart_index);
+  DataBlockHashIndexBuilder(uint16_t n)
+      : num_buckets_(n),
+        buckets_(n),
+        estimate_((n + 2) *
+                  sizeof(uint16_t) /* n buckets, 2 num at the end */) {}
+  void Add(const Slice& key, const uint16_t& restart_index);
   void Finish(std::string& buffer);
   void Reset();
   inline size_t EstimateSize() { return estimate_; }
 
  private:
-  uint32_t num_buckets_;
-  std::vector<std::vector<uint32_t>> buckets_;
+  uint16_t num_buckets_;
+  std::vector<std::vector<uint16_t>> buckets_;
   size_t estimate_;
 };
 
@@ -55,16 +56,16 @@ class DataBlockHashIndex {
  public:
   DataBlockHashIndex(Slice  block_content);
 
-  inline uint32_t DataBlockHashMapStart() const {
-    return static_cast<uint32_t>(map_start_ - data_);
+  inline uint16_t DataBlockHashMapStart() const {
+    return static_cast<uint16_t>(map_start_ - data_);
   }
 
   DataBlockHashIndexIterator* NewIterator(const Slice& key) const;
 
  private:
   const char *data_;
-  uint32_t size_;
-  uint32_t num_buckets_;
+  uint16_t size_;
+  uint16_t num_buckets_;
   const char *map_start_;    // start of the map
   const char *bucket_table_; // start offset of the bucket index table
 };
@@ -72,18 +73,19 @@ class DataBlockHashIndex {
 class DataBlockHashIndexIterator {
  public:
   DataBlockHashIndexIterator(const char* start, const char* end,
-                           const uint32_t tag):
-      start_(start), end_(end), tag_(tag) {
-    current_ = start - 2 * sizeof(uint32_t);
+                             const uint16_t tag)
+      : start_(start), end_(end), tag_(tag) {
+    current_ = start - 2 * sizeof(uint16_t);
     Next();
   }
   bool Valid();
   void Next();
-  uint32_t Value();
+  uint16_t Value();
+
  private:
   const char* start_; // [start_,  end_) defines the bucket range
   const char* end_;
-  const uint32_t tag_; // the fingerprint (2nd hash value) of the searching key
+  const uint16_t tag_;  // the fingerprint (2nd hash value) of the searching key
   const char* current_;
 };
 

--- a/table/data_block_hash_index.h
+++ b/table/data_block_hash_index.h
@@ -16,19 +16,18 @@ namespace rocksdb {
 //
 // NUM_BUCK: Number of buckets, which is the length of the IDX array.
 //
-// IDX:      Array of offsets, each pointing to the starting offset (relative to
-//           MAP_START) of one hash bucket.
+// IDX:      Array of offsets of the index hash bucket (relative to MAP_START).
 //
 // B:        B = bucket, an array consisting of a list of restart index, and the
-//           second hash tag value as tagBucket, an array consisting of a list
-//           of restart interval offsets.
+//           second hash value as tag.
 //           We do not have to store the length of individual buckets, as they
 //           are delimited by the next bucket offset.
 //
-// MAP_START: the start offset of the datablock hash map.
+// MAP_START: the starting offset of the datablock hash map.
 //
 // Each bucket B has the following structure:
 // [TAG RESTART_INDEX][TAG RESTART_INDEX]...[TAG RESTART_INDEX]
+// where TAG is the hash value of the second hash funtion.
 //
 // The datablock hash map is construct right in-place of the block without any
 // data been copied.
@@ -55,7 +54,6 @@ class DataBlockHashIndexIterator;
 class DataBlockHashIndex {
  public:
   DataBlockHashIndex(Slice  block_content);
-  void Seek(const Slice& key, std::vector<uint32_t>& bucket) const;
 
   inline uint32_t DataBlockHashMapStart() const {
     return static_cast<uint32_t>(map_start_ - data_);

--- a/table/data_block_hash_index.h
+++ b/table/data_block_hash_index.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace rocksdb {
+
+// The format of the datablock hash map is as follows:
+//
+// B B B ... B IDX NUM_BUCK MAP_START
+//
+// NUM_BUCK: Number of buckets, which is the length of the IDX array.
+//
+// IDX:      Array of offsets, each pointing to the starting offset (relative to
+//           MAP_START) of one hash bucket.
+//
+// B:        B = bucket, an array consisting of a list of restart index, and the
+//           second hash tag value as tagBucket, an array consisting of a list
+//           of restart interval offsets.
+//           We do not have to store the length of individual buckets, as they
+//           are delimited by the next bucket offset.
+//
+// MAP_START: the start offset of the datablock hash map.
+//
+// Each bucket B has the following structure:
+// [TAG RESTART_INDEX][TAG RESTART_INDEX]...[TAG RESTART_INDEX]
+//
+// The datablock hash map is construct right in-place of the block without any
+// data been copied.
+
+class DataBlockHashIndexBuilder {
+ public:
+  DataBlockHashIndexBuilder(uint32_t n) :
+      num_buckets_(n),
+      buckets_(n),
+      estimate_((n + 2) * sizeof(uint32_t) /* n buckets, 2 num at the end */){}
+  void Add(const Slice &key, const uint32_t &restart_index);
+  void Finish(std::string& buffer);
+  void Reset();
+  inline size_t EstimateSize() { return estimate_; }
+
+ private:
+  uint32_t num_buckets_;
+  std::vector<std::vector<uint32_t>> buckets_;
+  size_t estimate_;
+};
+
+class DataBlockHashIndexIterator;
+
+class DataBlockHashIndex {
+ public:
+  DataBlockHashIndex(Slice  block_content);
+  void Seek(const Slice& key, std::vector<uint32_t>& bucket) const;
+
+  inline uint32_t DataBlockHashMapStart() const {
+    return static_cast<uint32_t>(map_start_ - data_);
+  }
+
+  DataBlockHashIndexIterator* NewIterator(const Slice& key) const;
+
+ private:
+  const char *data_;
+  uint32_t size_;
+  uint32_t num_buckets_;
+  const char *map_start_;    // start of the map
+  const char *bucket_table_; // start offset of the bucket index table
+};
+
+class DataBlockHashIndexIterator {
+ public:
+  DataBlockHashIndexIterator(const char* start, const char* end,
+                           const uint32_t tag):
+      start_(start), end_(end), tag_(tag) {
+    current_ = start - 2 * sizeof(uint32_t);
+    Next();
+  }
+  bool Valid();
+  void Next();
+  uint32_t Value();
+ private:
+  const char* start_; // [start_,  end_) defines the bucket range
+  const char* end_;
+  const uint32_t tag_; // the fingerprint (2nd hash value) of the searching key
+  const char* current_;
+};
+
+}  // namespace rocksdb

--- a/table/data_block_hash_index.h
+++ b/table/data_block_hash_index.h
@@ -11,7 +11,7 @@
 namespace rocksdb {
 // This is an experimental feature aiming to reduce the CPU utilization of
 // point-lookup within a data-block. It is not used in per-table index-blocks.
-// It is suppport Get(), but not Seek() or Scan(). If the key does not exist,
+// It supports Get(), but not Seek() or Scan(). If the key does not exist,
 // the iterator is set to invalid.
 //
 // A serialized hash index is appended to the data-block. The new block data
@@ -75,7 +75,7 @@ namespace rocksdb {
 
 class DataBlockHashIndexBuilder {
  public:
-  DataBlockHashIndexBuilder(uint16_t n)
+  explicit DataBlockHashIndexBuilder(uint16_t n)
       : num_buckets_(n),
         buckets_(n),
         estimate_((n + 2) *
@@ -95,7 +95,7 @@ class DataBlockHashIndexIterator;
 
 class DataBlockHashIndex {
  public:
-  DataBlockHashIndex(Slice  block_content);
+  explicit DataBlockHashIndex(Slice  block_content);
 
   inline uint16_t DataBlockHashMapStart() const {
     return static_cast<uint16_t>(map_start_ - data_);

--- a/table/data_block_hash_index.h
+++ b/table/data_block_hash_index.h
@@ -74,7 +74,7 @@ class DataBlockHashIndexIterator {
  public:
   DataBlockHashIndexIterator(const char* start, const char* end,
                              const uint16_t tag)
-      : start_(start), end_(end), tag_(tag) {
+      : end_(end), tag_(tag) {
     current_ = start - 2 * sizeof(uint16_t);
     Next();
   }
@@ -83,8 +83,7 @@ class DataBlockHashIndexIterator {
   uint16_t Value();
 
  private:
-  const char* start_; // [start_,  end_) defines the bucket range
-  const char* end_;
+  const char* end_; // the end of the bucket
   const uint16_t tag_;  // the fingerprint (2nd hash value) of the searching key
   const char* current_;
 };

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -26,7 +26,7 @@ bool SearchForOffset(DataBlockHashIndex& index, const Slice& key,
   return false;
 }
 
-TEST(BlockTest, DataBlockHashTestSmall) {
+TEST(DataBlockHashIndex, DataBlockHashTestSmall) {
   // bucket_num = 5, #keys = 2. 40% utilization
   DataBlockHashIndexBuilder builder(5);
 
@@ -59,7 +59,7 @@ TEST(BlockTest, DataBlockHashTestSmall) {
   }
 }
 
-TEST(BlockTest, DataBlockHashTest) {
+TEST(DataBlockHashIndex, DataBlockHashTest) {
   // bucket_num = 200, #keys = 100. 50% utilization
   DataBlockHashIndexBuilder builder(200);
 
@@ -92,7 +92,7 @@ TEST(BlockTest, DataBlockHashTest) {
   }
 }
 
-TEST(BlockTest, DataBlockHashTestCollision) {
+TEST(DataBlockHashIndex, DataBlockHashTestCollision) {
   // bucket_num = 2. There will be intense hash collisions
   DataBlockHashIndexBuilder builder(2);
 
@@ -125,7 +125,7 @@ TEST(BlockTest, DataBlockHashTestCollision) {
   }
 }
 
-TEST(BlockTest, DataBlockHashTestLarge) {
+TEST(DataBlockHashIndex, DataBlockHashTestLarge) {
   DataBlockHashIndexBuilder builder(1000);
   std::unordered_map<std::string, uint16_t> m;
 

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -130,7 +130,9 @@ TEST(DataBlockHashIndex, DataBlockHashTestLarge) {
   std::unordered_map<std::string, uint16_t> m;
 
   for (uint16_t i = 0; i < 10000; i++) {
-    if (std::rand() % 2) continue;  // randomly leave half of the keys out
+    if (i % 2) {
+      continue;  // leave half of the keys out
+    }
     std::string key = "key" + std::to_string(i);
     uint16_t restart_point = i;
     builder.Add(key, restart_point);

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -1,0 +1,175 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+
+#include "rocksdb/slice.h"
+#include "table/data_block_hash_index.h"
+#include "util/testharness.h"
+#include "util/testutil.h"
+
+namespace rocksdb {
+
+bool SearchForOffset(DataBlockHashIndex& index, const Slice& key,
+                     uint32_t& restart_point) {
+  std::vector<uint32_t> bucket;
+  index.Seek(key, bucket);
+  for (auto& e : bucket) {
+    if (e == restart_point) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(BlockTest, DataBlockHashTestSmall) {
+  // bucket_num = 5, #keys = 2. 40% utilization
+  DataBlockHashIndexBuilder builder(5);
+
+  for (uint32_t i = 0; i < 2; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("fake"), buffer2;
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
+  builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
+  buffer2 = buffer; // test for the correctness of relative offset
+
+  Slice s(buffer2);
+  DataBlockHashIndex index(s);
+
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.DataBlockHashMapStart());
+  for (uint32_t i = 0; i < 2; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
+TEST(BlockTest, DataBlockHashTest) {
+  // bucket_num = 200, #keys = 100. 50% utilization
+  DataBlockHashIndexBuilder builder(200);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("fake content"), buffer2;
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
+  builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
+  buffer2 = buffer; // test for the correctness of relative offset
+
+  Slice s(buffer2);
+  DataBlockHashIndex index(s);
+
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.DataBlockHashMapStart());
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
+TEST(BlockTest, DataBlockHashTestCollision) {
+  // bucket_num = 2. There will be intense hash collisions
+  DataBlockHashIndexBuilder builder(2);
+
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+  }
+
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("some other fake content to take up space"), buffer2;
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
+  builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
+  buffer2 = buffer; // test for the correctness of relative offset
+
+  Slice s(buffer2);
+  DataBlockHashIndex index(s);
+
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.DataBlockHashMapStart());
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key("key" + std::to_string(i));
+    uint32_t restart_point = i;
+    ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+  }
+}
+
+TEST(BlockTest, DataBlockHashTestLarge) {
+  DataBlockHashIndexBuilder builder(1000);
+  std::unordered_map<std::string, uint32_t> m;
+
+  for (uint32_t i = 0; i < 10000000; i++) {
+    if (std::rand() % 2) continue;  // randomly leave half of the keys out
+    std::string key = "key" + std::to_string(i);
+    uint32_t restart_point = i;
+    builder.Add(key, restart_point);
+    m[key] = restart_point;
+  }
+
+  size_t estimated_size = builder.EstimateSize();
+
+  std::string buffer("filling stuff"), buffer2;
+  size_t original_size = buffer.size();
+  estimated_size += original_size;
+  builder.Finish(buffer);
+
+  ASSERT_EQ(buffer.size(), estimated_size);
+
+  buffer2 = buffer; // test for the correctness of relative offset
+
+  Slice s(buffer2);
+  DataBlockHashIndex index(s);
+
+  // the additional hash map should start at the end of the buffer
+  ASSERT_EQ(original_size, index.DataBlockHashMapStart());
+  for (uint32_t i = 0; i < 100; i++) {
+    std::string key = "key" + std::to_string(i);
+    uint32_t restart_point = i;
+    if (m.count(key)) {
+      ASSERT_TRUE(m[key] == restart_point);
+      ASSERT_TRUE(SearchForOffset(index, key, restart_point));
+    } else {
+      // we allow false positve, so don't test the nonexisting keys.
+      // when false positive happens, the search will continue to the
+      // restart intervals to see if the key really exist.
+    }
+  }
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -16,10 +16,10 @@ namespace rocksdb {
 
 bool SearchForOffset(DataBlockHashIndex& index, const Slice& key,
                      uint32_t& restart_point) {
-  std::vector<uint32_t> bucket;
-  index.Seek(key, bucket);
-  for (auto& e : bucket) {
-    if (e == restart_point) {
+  std::unique_ptr<DataBlockHashIndexIterator> iter;
+  iter.reset(index.NewIterator(key));
+  for (; iter->Valid(); iter->Next()) {
+    if (iter->Value() == restart_point) {
       return true;
     }
   }

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -15,7 +15,7 @@
 namespace rocksdb {
 
 bool SearchForOffset(DataBlockHashIndex& index, const Slice& key,
-                     uint32_t& restart_point) {
+                     uint16_t& restart_point) {
   std::unique_ptr<DataBlockHashIndexIterator> iter;
   iter.reset(index.NewIterator(key));
   for (; iter->Valid(); iter->Next()) {
@@ -30,9 +30,9 @@ TEST(BlockTest, DataBlockHashTestSmall) {
   // bucket_num = 5, #keys = 2. 40% utilization
   DataBlockHashIndexBuilder builder(5);
 
-  for (uint32_t i = 0; i < 2; i++) {
+  for (uint16_t i = 0; i < 2; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     builder.Add(key, restart_point);
   }
 
@@ -52,9 +52,9 @@ TEST(BlockTest, DataBlockHashTestSmall) {
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, index.DataBlockHashMapStart());
-  for (uint32_t i = 0; i < 2; i++) {
+  for (uint16_t i = 0; i < 2; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     ASSERT_TRUE(SearchForOffset(index, key, restart_point));
   }
 }
@@ -63,9 +63,9 @@ TEST(BlockTest, DataBlockHashTest) {
   // bucket_num = 200, #keys = 100. 50% utilization
   DataBlockHashIndexBuilder builder(200);
 
-  for (uint32_t i = 0; i < 100; i++) {
+  for (uint16_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     builder.Add(key, restart_point);
   }
 
@@ -85,9 +85,9 @@ TEST(BlockTest, DataBlockHashTest) {
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, index.DataBlockHashMapStart());
-  for (uint32_t i = 0; i < 100; i++) {
+  for (uint16_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     ASSERT_TRUE(SearchForOffset(index, key, restart_point));
   }
 }
@@ -96,9 +96,9 @@ TEST(BlockTest, DataBlockHashTestCollision) {
   // bucket_num = 2. There will be intense hash collisions
   DataBlockHashIndexBuilder builder(2);
 
-  for (uint32_t i = 0; i < 100; i++) {
+  for (uint16_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     builder.Add(key, restart_point);
   }
 
@@ -118,21 +118,21 @@ TEST(BlockTest, DataBlockHashTestCollision) {
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, index.DataBlockHashMapStart());
-  for (uint32_t i = 0; i < 100; i++) {
+  for (uint16_t i = 0; i < 100; i++) {
     std::string key("key" + std::to_string(i));
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     ASSERT_TRUE(SearchForOffset(index, key, restart_point));
   }
 }
 
 TEST(BlockTest, DataBlockHashTestLarge) {
   DataBlockHashIndexBuilder builder(1000);
-  std::unordered_map<std::string, uint32_t> m;
+  std::unordered_map<std::string, uint16_t> m;
 
-  for (uint32_t i = 0; i < 10000000; i++) {
+  for (uint16_t i = 0; i < 10000; i++) {
     if (std::rand() % 2) continue;  // randomly leave half of the keys out
     std::string key = "key" + std::to_string(i);
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     builder.Add(key, restart_point);
     m[key] = restart_point;
   }
@@ -153,9 +153,9 @@ TEST(BlockTest, DataBlockHashTestLarge) {
 
   // the additional hash map should start at the end of the buffer
   ASSERT_EQ(original_size, index.DataBlockHashMapStart());
-  for (uint32_t i = 0; i < 100; i++) {
+  for (uint16_t i = 0; i < 100; i++) {
     std::string key = "key" + std::to_string(i);
-    uint32_t restart_point = i;
+    uint16_t restart_point = i;
     if (m.count(key)) {
       ASSERT_TRUE(m[key] == restart_point);
       ASSERT_TRUE(SearchForOffset(index, key, restart_point));


### PR DESCRIPTION
Summary:
The first step of the `DataBlockHashIndex` implementation. A string based hash table is implemented and unit-tested.

`DataBlockHashIndexBuilder`: `Add()` takes pairs of `<key, restart_index>`, and formats it into a string when `Finish()` is called.
`DataBlockHashIndex`: initialized by the formatted string, and can interpret it as a hash table. Lookup for a key is supported by iterator operation.

Test Plan:
Unit test: `data_block_hash_index_test`
`make check -j 32`
