### PR TITLE
Dump mutable FIFO and Universal compaction options

### DIFF
--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -190,6 +190,33 @@ void MutableCFOptions::Dump(Logger* log) const {
                  report_bg_io_stats);
   ROCKS_LOG_INFO(log, "                              compression: %d",
                  static_cast<int>(compression));
+
+  // Universal Compaction Options
+  ROCKS_LOG_INFO(log, "compaction_options_universal.size_ratio : %d",
+                 compaction_options_universal.size_ratio);
+  ROCKS_LOG_INFO(log, "compaction_options_universal.min_merge_width : %d",
+                 compaction_options_universal.min_merge_width);
+  ROCKS_LOG_INFO(log, "compaction_options_universal.max_merge_width : %d",
+                 compaction_options_universal.max_merge_width);
+  ROCKS_LOG_INFO(
+      log, "compaction_options_universal.max_size_amplification_percent : %d",
+      compaction_options_universal.max_size_amplification_percent);
+  ROCKS_LOG_INFO(log,
+                 "compaction_options_universal.compression_size_percent : %d",
+                 compaction_options_universal.compression_size_percent);
+  ROCKS_LOG_INFO(log, "compaction_options_universal.stop_style : %d",
+                 compaction_options_universal.stop_style);
+  ROCKS_LOG_INFO(
+      log, "compaction_options_universal.allow_trivial_move : %d",
+      static_cast<int>(compaction_options_universal.allow_trivial_move));
+
+  // FIFO Compaction Options
+  ROCKS_LOG_INFO(log, "compaction_options_fifo.max_table_files_size : %" PRIu64,
+                 compaction_options_fifo.max_table_files_size);
+  ROCKS_LOG_INFO(log, "compaction_options_fifo.ttl : %" PRIu64,
+                 compaction_options_fifo.ttl);
+  ROCKS_LOG_INFO(log, "compaction_options_fifo.allow_compaction : %d",
+                 compaction_options_fifo.allow_compaction);
 }
 
 MutableCFOptions::MutableCFOptions(const Options& options)


### PR DESCRIPTION
We forgot to dump FIFO and Universal compaction options to the LOG when any option was dynamically changed via `SetOptions` API. Now added those options also to `MutableCFOptions::Dump`. 

Test Plan:
Ran a sample test and saw that the FIFO and Universal options are also printed out to the LOG on calling `SetOptions`. 
```
TEST_TMPDIR=/dev/shm KEEP_DB=1 ./db_options_test --gtest_filter=DBOptionsTest.SetFIFOCompactionOptions
```
```
2018/07/16-12:43:02.329119 7f0e06e38200 [db/db_impl.cc:624] SetOptions() on column family [default], inputs:
2018/07/16-12:43:02.329122 7f0e06e38200 [db/db_impl.cc:627] compaction_options_fifo: {allow_compaction=true;}
2018/07/16-12:43:02.329124 7f0e06e38200 [db/db_impl.cc:631] [default] SetOptions() succeeded
2018/07/16-12:43:02.329125 7f0e06e38200 [options/cf_options.cc:129]                         write_buffer_size: 65536
2018/07/16-12:43:02.329126 7f0e06e38200 [options/cf_options.cc:131]                   max_write_buffer_number: 2
2018/07/16-12:43:02.329126 7f0e06e38200 [options/cf_options.cc:134]                          arena_block_size: 4096
2018/07/16-12:43:02.329127 7f0e06e38200 [options/cf_options.cc:136]               memtable_prefix_bloom_ratio: 0.000000
2018/07/16-12:43:02.329129 7f0e06e38200 [options/cf_options.cc:139]                   memtable_huge_page_size: 0
2018/07/16-12:43:02.329130 7f0e06e38200 [options/cf_options.cc:142]                     max_successive_merges: 0
2018/07/16-12:43:02.329130 7f0e06e38200 [options/cf_options.cc:145]                  inplace_update_num_locks: 10000
2018/07/16-12:43:02.329131 7f0e06e38200 [options/cf_options.cc:148]                          prefix_extractor: nullptr
2018/07/16-12:43:02.329132 7f0e06e38200 [options/cf_options.cc:150]                  disable_auto_compactions: 0
2018/07/16-12:43:02.329135 7f0e06e38200 [options/cf_options.cc:152]       soft_pending_compaction_bytes_limit: 68719476736
2018/07/16-12:43:02.329136 7f0e06e38200 [options/cf_options.cc:154]       hard_pending_compaction_bytes_limit: 274877906944
2018/07/16-12:43:02.329137 7f0e06e38200 [options/cf_options.cc:156]        level0_file_num_compaction_trigger: 6
2018/07/16-12:43:02.329138 7f0e06e38200 [options/cf_options.cc:158]            level0_slowdown_writes_trigger: 2147483647
2018/07/16-12:43:02.329139 7f0e06e38200 [options/cf_options.cc:160]                level0_stop_writes_trigger: 2147483647
2018/07/16-12:43:02.329140 7f0e06e38200 [options/cf_options.cc:162]                      max_compaction_bytes: 1677721600
2018/07/16-12:43:02.329140 7f0e06e38200 [options/cf_options.cc:164]                     target_file_size_base: 67108864
2018/07/16-12:43:02.329158 7f0e06e38200 [options/cf_options.cc:166]               target_file_size_multiplier: 1
2018/07/16-12:43:02.329159 7f0e06e38200 [options/cf_options.cc:168]                  max_bytes_for_level_base: 268435456
2018/07/16-12:43:02.329160 7f0e06e38200 [options/cf_options.cc:170]            max_bytes_for_level_multiplier: 10.000000
2018/07/16-12:43:02.329162 7f0e06e38200 [options/cf_options.cc:184] max_bytes_for_level_multiplier_additional: 1, 1, 1, 1, 1, 1, 1
2018/07/16-12:43:02.329163 7f0e06e38200 [options/cf_options.cc:186]         max_sequential_skip_in_iterations: 8
2018/07/16-12:43:02.329164 7f0e06e38200 [options/cf_options.cc:188]                      paranoid_file_checks: 0
2018/07/16-12:43:02.329164 7f0e06e38200 [options/cf_options.cc:190]                        report_bg_io_stats: 0
2018/07/16-12:43:02.329165 7f0e06e38200 [options/cf_options.cc:192]                               compression: 0
2018/07/16-12:43:02.329166 7f0e06e38200 [options/cf_options.cc:196] compaction_options_universal.size_ratio : 1
2018/07/16-12:43:02.329166 7f0e06e38200 [options/cf_options.cc:198] compaction_options_universal.min_merge_width : 2
2018/07/16-12:43:02.329167 7f0e06e38200 [options/cf_options.cc:200] compaction_options_universal.max_merge_width : -1
2018/07/16-12:43:02.329172 7f0e06e38200 [options/cf_options.cc:202] compaction_options_universal.max_size_amplification_percent : 200
2018/07/16-12:43:02.329173 7f0e06e38200 [options/cf_options.cc:204] compaction_options_universal.compression_size_percent : -1
2018/07/16-12:43:02.329173 7f0e06e38200 [options/cf_options.cc:206] compaction_options_universal.stop_style : 1
2018/07/16-12:43:02.329174 7f0e06e38200 [options/cf_options.cc:208] compaction_options_universal.allow_trivial_move : 0
2018/07/16-12:43:02.329175 7f0e06e38200 [options/cf_options.cc:212] compaction_options_fifo.max_table_files_size : 512000
2018/07/16-12:43:02.329175 7f0e06e38200 [options/cf_options.cc:214] compaction_options_fifo.ttl : 0
2018/07/16-12:43:02.329176 7f0e06e38200 [options/cf_options.cc:216] compaction_options_fifo.allow_compaction : 1
```