### PR TITLE
Pending output file number should be released after bulkload failure

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2937,6 +2937,7 @@ Status DBImpl::IngestExternalFile(
   status = ingestion_job.Prepare(external_files, super_version);
   CleanupSuperVersion(super_version);
   if (!status.ok()) {
+    ReleaseFileNumberFromPendingOutputs(pending_output_elem);
     return status;
   }
 
@@ -2959,6 +2960,7 @@ Status DBImpl::IngestExternalFile(
 
     // We cannot ingest a file into a dropped CF
     if (cfd->IsDropped()) {
+      ReleaseFileNumberFromPendingOutputs(pending_output_elem);
       status = Status::InvalidArgument(
           "Cannot ingest an external file into a dropped CF");
     }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2960,7 +2960,6 @@ Status DBImpl::IngestExternalFile(
 
     // We cannot ingest a file into a dropped CF
     if (cfd->IsDropped()) {
-      ReleaseFileNumberFromPendingOutputs(pending_output_elem);
       status = Status::InvalidArgument(
           "Cannot ingest an external file into a dropped CF");
     }

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -1299,7 +1299,7 @@ TEST_F(ExternalSSTFileTest, IngestNonExistingFile) {
 
   Status s = db_->IngestExternalFile({"non_existing_file"},
                                      IngestExternalFileOptions());
-  ASSERT_FALSE(s.ok());
+  ASSERT_NOK(s);
 
   // Verify file deletion is not impacted (verify a bug fix)
   ASSERT_OK(Put(Key(1), Key(1)));

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -10,6 +10,7 @@
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/sst_file_writer.h"
+#include "util/filename.h"
 #include "util/testutil.h"
 
 namespace rocksdb {
@@ -1290,6 +1291,39 @@ TEST_F(ExternalSSTFileTest, PickedLevelBug) {
   delete iter;
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(ExternalSSTFileTest, IngestNonExistingFile) {
+  Options options = CurrentOptions();
+  DestroyAndReopen(options);
+
+  Status s = db_->IngestExternalFile({"non_existing_file"},
+                                     IngestExternalFileOptions());
+  ASSERT_FALSE(s.ok());
+
+  // Verify file deletion is not impacted (verify a bug fix)
+  ASSERT_OK(Put(Key(1), Key(1)));
+  ASSERT_OK(Put(Key(9), Key(9)));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(Put(Key(1), Key(1)));
+  ASSERT_OK(Put(Key(9), Key(9)));
+  ASSERT_OK(Flush());
+
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  // After full compaction, there should be only 1 file.
+  std::vector<std::string> files;
+  env_->GetChildren(dbname_, &files);
+  int num_sst_files = 0;
+  for (auto& f : files) {
+    uint64_t number;
+    FileType type;
+    if (ParseFileName(f, &number, &type) && type == kTableFile) {
+      num_sst_files++;
+    }
+  }
+  ASSERT_EQ(1, num_sst_files);
 }
 
 TEST_F(ExternalSSTFileTest, CompactDuringAddFileRandom) {


### PR DESCRIPTION
Summary: If bulkload fails for an input error, the pending output file number wasn't released. This bug can cause all future files with larger number than the current number won't be deleted, even they are compacted. This commit fixes the bug.

Test Plan: Add a unit test which was failing, but now passes.