### PR TITLE
Disable DBFlushTest.SyncFail and DBTest.GroupCommitTest on Travis

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -55,6 +55,9 @@ TEST_F(DBFlushTest, FlushWhileWritingManifest) {
 #endif  // ROCKSDB_LITE
 }
 
+#ifndef TRAVIS
+// Disable this test temporarily on Travis as it fails intermittently.
+// Github issue: #4151
 TEST_F(DBFlushTest, SyncFail) {
   std::unique_ptr<FaultInjectionTestEnv> fault_injection_env(
       new FaultInjectionTestEnv(env_));
@@ -92,6 +95,7 @@ TEST_F(DBFlushTest, SyncFail) {
   ASSERT_EQ(refs_before, cfd->current()->TEST_refs());
   Destroy(options);
 }
+#endif  // TRAVIS
 
 TEST_F(DBFlushTest, FlushInLowPriThreadPool) {
   // Verify setting an empty high-pri (flush) thread pool causes flushes to be

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2149,6 +2149,9 @@ static void GCThreadBody(void* arg) {
 
 }  // namespace
 
+#ifndef TRAVIS
+// Disable this test temporarily on Travis as it fails intermittently.
+// Github issue: #4151
 TEST_F(DBTest, GroupCommitTest) {
   do {
     Options options = CurrentOptions();
@@ -2195,6 +2198,7 @@ TEST_F(DBTest, GroupCommitTest) {
     ASSERT_GT(hist_data.average, 0.0);
   } while (ChangeOptions(kSkipNoSeekToLast));
 }
+#endif  // TRAVIS
 
 namespace {
 typedef std::map<std::string, std::string> KVMap;


### PR DESCRIPTION
I am temporarily disabling DBFlushTest.SyncFail and DBTest.GroupCommitTest tests on Travis until we figure out the root-cause. These tests will still continue to run locally though. 
I haven't been able to reproduce these failures locally so far (even on a [local Travis environment](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image) ).

These tests  are failing way too frequently causing everyone to wonder why their PR failed on travis, and waste time in debugging. 

Test Plan:
- Monitor travis to see that these tests don't run in TEST_GROUP=1.
- Make sure that they are running locally:
```
svemuri@devbig187 ~/rocksdb (disable-travis-flaky) $ make check -j100

svemuri@devbig187 ~/rocksdb (disable-travis-flaky) $ ls -l t | egrep -i "groupcommittest|db_flush_test"
-rw-r--r--. 1 svemuri users  1248 Jul 18 14:33 log-db_flush_test
-rw-r--r--. 1 svemuri users   430 Jul 18 14:33 log-run-db_test-DBTest.GroupCommitTest
-r-xr-xr-x. 1 svemuri users   147 Jul 18 14:33 run-db_test-DBTest.GroupCommitTest

svemuri@devbig187 ~/rocksdb (disable-travis-flaky) $ cat t/log-run-db_test-DBTest.GroupCommitTest
Note: Google Test filter = DBTest.GroupCommitTest
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBTest
[ RUN      ] DBTest.GroupCommitTest
[       OK ] DBTest.GroupCommitTest (1522 ms)
[----------] 1 test from DBTest (1522 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1522 ms total)
[  PASSED  ] 1 test.

svemuri@devbig187 ~/rocksdb (disable-travis-flaky) $ cat t/log-db_flush_test | grep SyncFail
[ RUN      ] DBFlushTest.SyncFail
[       OK ] DBFlushTest.SyncFail (1005 ms)
```

For: #4151 