### PR TITLE
Fixed the db_bench MergeRandom only access CF_default

### DIFF
--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -18,8 +18,7 @@ using namespace std::placeholders;
 
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable : 4503)  // identifier' : decorated name length
-                                 // exceeded, name was truncated
+#pragma warning(disable : 4503) // identifier' : decorated name length exceeded, name was truncated
 #endif
 
 /*
@@ -272,8 +271,8 @@ typedef std::function<std::vector<rocksdb::Status>(
 
 void free_parts(
     JNIEnv* env,
-    std::vector<std::tuple<jbyteArray, jbyte*, jobject>>& parts_to_free) {
-  for (auto& value : parts_to_free) {
+    std::vector<std::tuple<jbyteArray, jbyte*, jobject>> &parts_to_free) {
+  for (auto &value : parts_to_free) {
     jobject jk;
     jbyteArray jk_ba;
     jbyte* jk_val;
@@ -672,10 +671,10 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       return;
     }
 
-    jparts_to_free.push_back(
-        std::make_tuple(jba_key_part, jkey_part, jobj_key_part));
-    jparts_to_free.push_back(
-        std::make_tuple(jba_value_part, jvalue_part, jobj_value_part));
+    jparts_to_free.push_back(std::make_tuple(
+        jba_key_part, jkey_part, jobj_key_part));
+    jparts_to_free.push_back(std::make_tuple(
+        jba_value_part, jvalue_part, jobj_value_part));
 
     key_parts.push_back(
         rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
@@ -685,8 +684,8 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 
   // call the write_multi function
   rocksdb::Status s = fn_write_kv_parts(
-      rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()),
-      rocksdb::SliceParts(value_parts.data(), (int)value_parts.size()));
+    rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()),
+    rocksdb::SliceParts(value_parts.data(), (int)value_parts.size()));
 
   // cleanup temporary memory
   free_parts(env, jparts_to_free);
@@ -837,6 +836,7 @@ void txn_write_k_parts_helper(JNIEnv* env,
                               const FnWriteKParts& fn_write_k_parts,
                               const jobjectArray& jkey_parts,
                               const jint& jkey_parts_len) {
+
   std::vector<rocksdb::Slice> key_parts;
   std::vector<std::tuple<jbyteArray, jbyte*, jobject>> jkey_parts_to_free;
 
@@ -868,13 +868,12 @@ void txn_write_k_parts_helper(JNIEnv* env,
     jkey_parts_to_free.push_back(std::tuple<jbyteArray, jbyte*, jobject>(
         jba_key_part, jkey_part, jobj_key_part));
 
-    key_parts.push_back(
-        rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
+    key_parts.push_back(rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
   }
 
   // call the write_multi function
-  rocksdb::Status s = fn_write_k_parts(
-      rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()));
+  rocksdb::Status s =
+      fn_write_k_parts(rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()));
 
   // cleanup temporary memory
   free_parts(env, jkey_parts_to_free);

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -18,7 +18,8 @@ using namespace std::placeholders;
 
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable : 4503) // identifier' : decorated name length exceeded, name was truncated
+#pragma warning(disable : 4503)  // identifier' : decorated name length
+                                 // exceeded, name was truncated
 #endif
 
 /*
@@ -271,8 +272,8 @@ typedef std::function<std::vector<rocksdb::Status>(
 
 void free_parts(
     JNIEnv* env,
-    std::vector<std::tuple<jbyteArray, jbyte*, jobject>> &parts_to_free) {
-  for (auto &value : parts_to_free) {
+    std::vector<std::tuple<jbyteArray, jbyte*, jobject>>& parts_to_free) {
+  for (auto& value : parts_to_free) {
     jobject jk;
     jbyteArray jk_ba;
     jbyte* jk_val;
@@ -671,10 +672,10 @@ void txn_write_kv_parts_helper(JNIEnv* env,
       return;
     }
 
-    jparts_to_free.push_back(std::make_tuple(
-        jba_key_part, jkey_part, jobj_key_part));
-    jparts_to_free.push_back(std::make_tuple(
-        jba_value_part, jvalue_part, jobj_value_part));
+    jparts_to_free.push_back(
+        std::make_tuple(jba_key_part, jkey_part, jobj_key_part));
+    jparts_to_free.push_back(
+        std::make_tuple(jba_value_part, jvalue_part, jobj_value_part));
 
     key_parts.push_back(
         rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
@@ -684,8 +685,8 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 
   // call the write_multi function
   rocksdb::Status s = fn_write_kv_parts(
-    rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()),
-    rocksdb::SliceParts(value_parts.data(), (int)value_parts.size()));
+      rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()),
+      rocksdb::SliceParts(value_parts.data(), (int)value_parts.size()));
 
   // cleanup temporary memory
   free_parts(env, jparts_to_free);
@@ -836,7 +837,6 @@ void txn_write_k_parts_helper(JNIEnv* env,
                               const FnWriteKParts& fn_write_k_parts,
                               const jobjectArray& jkey_parts,
                               const jint& jkey_parts_len) {
-
   std::vector<rocksdb::Slice> key_parts;
   std::vector<std::tuple<jbyteArray, jbyte*, jobject>> jkey_parts_to_free;
 
@@ -868,12 +868,13 @@ void txn_write_k_parts_helper(JNIEnv* env,
     jkey_parts_to_free.push_back(std::tuple<jbyteArray, jbyte*, jobject>(
         jba_key_part, jkey_part, jobj_key_part));
 
-    key_parts.push_back(rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
+    key_parts.push_back(
+        rocksdb::Slice(reinterpret_cast<char*>(jkey_part), jkey_part_len));
   }
 
   // call the write_multi function
-  rocksdb::Status s =
-      fn_write_k_parts(rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()));
+  rocksdb::Status s = fn_write_k_parts(
+      rocksdb::SliceParts(key_parts.data(), (int)key_parts.size()));
 
   // cleanup temporary memory
   free_parts(env, jkey_parts_to_free);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5062,7 +5062,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     Duration duration(FLAGS_duration, readwrites_);
     while (!duration.Done(1)) {
       DBWithColumnFamilies* db_with_cfh = SelectDBWithCfh(thread);
-      int64_t key_rand = GetRandomKey(&thread->rand);
+      int64_t key_rand = thread->rand.Next() % merge_keys_;
       GenerateKeyFromInt(key_rand, merge_keys_, &key);
 
       Status s;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5061,17 +5061,27 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     // The number of iterations is the larger of read_ or write_
     Duration duration(FLAGS_duration, readwrites_);
     while (!duration.Done(1)) {
-      DB* db = SelectDB(thread);
-      GenerateKeyFromInt(thread->rand.Next() % merge_keys_, merge_keys_, &key);
+      DBWithColumnFamilies* db_with_cfh = SelectDBWithCfh(thread);
+      int64_t key_rand = GetRandomKey(&thread->rand);
+      GenerateKeyFromInt(key_rand, merge_keys_, &key);
 
-      Status s = db->Merge(write_options_, key, gen.Generate(value_size_));
+      Status s;
+      if (FLAGS_num_column_families > 1) {
+        s = db_with_cfh->db->Merge(write_options_,
+                                   db_with_cfh->GetCfh(key_rand), key,
+                                   gen.Generate(value_size_));
+      } else {
+        s = db_with_cfh->db->Merge(write_options_,
+                                   db_with_cfh->db->DefaultColumnFamily(), key,
+                                   gen.Generate(value_size_));
+      }
 
       if (!s.ok()) {
         fprintf(stderr, "merge error: %s\n", s.ToString().c_str());
         exit(1);
       }
       bytes += key.size() + value_size_;
-      thread->stats.FinishedOps(nullptr, db, 1, kMerge);
+      thread->stats.FinishedOps(nullptr, db_with_cfh->db, 1, kMerge);
     }
 
     // Print some statistics


### PR DESCRIPTION
When running the tracing and analyzing, I found that MergeRandom benchmark in db_bench only access the default column family even the -num_column_families is specified > 1.

changes: Using the db_with_cfh as DB to randomly select the column family to execute the Merge operation if -num_column_families is specified > 1.

Tested with make asan_check and verified in tracing