### PR TITLE
Smaller tail readahead when not reading index/filters

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -738,8 +738,17 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
 
   std::unique_ptr<FilePrefetchBuffer> prefetch_buffer;
 
-  // Before read footer, readahead backwards to prefetch data
-  const size_t kTailPrefetchSize = 512 * 1024;
+  // prefetch both index and filters, down to all partitions
+  const bool prefetch_all = prefetch_index_and_filter_in_cache || level == 0;
+  const bool preload_all = !table_options.cache_index_and_filter_blocks;
+  // Before read footer, readahead backwards to prefetch data. Do more readahead
+  // if we're going to read index/filter.
+  // TODO: This may incorrectly select small readahead in case partitioned
+  // index/filter is enabled and top-level partition pinning is enabled. That's
+  // because we need to issue readahead before we read the properties, at which
+  // point we don't yet know the index type.
+  const size_t kTailPrefetchSize =
+      prefetch_all || preload_all ? 512 * 1024 : 4 * 1024;
   size_t prefetch_off;
   size_t prefetch_len;
   if (file_size < kTailPrefetchSize) {
@@ -945,8 +954,6 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   bool need_upper_bound_check =
       PrefixExtractorChanged(rep->table_properties.get(), prefix_extractor);
 
-  // prefetch both index and filters, down to all partitions
-  const bool prefetch_all = prefetch_index_and_filter_in_cache || level == 0;
   BlockBasedTableOptions::IndexType index_type = new_table->UpdateIndexType();
   // prefetch the first level of index
   const bool prefetch_index =


### PR DESCRIPTION
In all cases during `BlockBasedTable::Open`, we issue at least three read requests to the file's tail: (1) footer, (2) metaindex block, and (3) properties block. Depending on the config, we may also read other metablocks like filter and index.

This PR issues smaller readahead when we expect to do only the three necessary reads mentioned above. Then, 4KB should be enough (ignoring the case where there are lots of user-defined properties). We can keep doing 512KB readahead when additional reads are expected.

Test Plan:

- verify 4KB readahead when index/filters are cached because they are not prefetched during `Open()`

```
$ TEST_TMPDIR=/data/compaction_bench strace -fe open,readahead,pread64 ./db_bench -use_existing_db=true -benchmarks=readrandom -reads=10 -num=10000000 -max_background_jobs=12 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -file_opening_threads=1 -cache_index_and_filter_blocks=true
...
[pid 1637620] open("/data/compaction_bench/dbbench/000875.sst", O_RDONLY) = 95
[pid 1637620] readahead(95, 1052594, 4096) = 0
[pid 1637620] pread64(95, "\1\326\276@\"\223\201@\2739\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 53, 1056637) = 53
[pid 1637620] pread64(95, "\0\22\5rocksdb.properties\323\272@\376\3\0\0\0\0\1\0"..., 39, 1056598) = 39
[pid 1637620] pread64(95, "\0$\4rocksdb.block.based.table.ind"..., 515, 1056083) = 515
```

- verify 512KB readahead when index/filters are not cached because they are preloaded during `Open()`

```
$ TEST_TMPDIR=/data/compaction_bench strace -fe open,readahead,pread64 ./db_bench -use_existing_db=true -benchmarks=readrandom -reads=10 -num=10000000 -max_background_jobs=12 -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -file_opening_threads=1
[pid 1636870] open("/data/compaction_bench/dbbench/000805.sst", O_RDONLY) = 93
[pid 1636870] readahead(93, 536422, 524288) = 0
[pid 1636870] pread64(93, "\1\212\336@\"\256\240@\3249\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 53, 1060657) = 53
[pid 1636870] pread64(93, "\0\22\5rocksdb.properties\207\332@\376\3\0\0\0\0\1\0"..., 39, 1060618) = 39
[pid 1636870] pread64(93, "\0$\4rocksdb.block.based.table.ind"..., 515, 1060103) = 515
[pid 1636870] pread64(93, "\0\20\3\0\0\0\0\0\0\0O\21\377\377\377\377\377\377\377\0\235\37\0\20\4\0\0\0\0\0\0\0"..., 7385, 1052718) = 7385
```