### PR TITLE
 Support DeleteRange() for transactions

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -297,6 +297,10 @@ class DB {
   //
   // Consider setting ReadOptions::ignore_range_deletions = true to speed
   // up reads for key(s) that are known to be unaffected by range deletions.
+  //
+  // Because the pessimistic transaction must lock all of the keys before
+  // operating them, so use the Iterator to iterate over the range of keys
+  // before deleting them, it has a negative effect on performance.
   virtual Status DeleteRange(const WriteOptions& options,
                              ColumnFamilyHandle* column_family,
                              const Slice& begin_key, const Slice& end_key);

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -316,6 +316,14 @@ class Transaction {
                               const SliceParts& key) = 0;
   virtual Status SingleDelete(const SliceParts& key) = 0;
 
+  virtual Status DeleteRange(const ReadOptions& read_options,
+                             ColumnFamilyHandle* column_family,
+                             const Slice& begin_key,
+                             const Slice& end_key) = 0;
+  virtual Status DeleteRange(const ReadOptions& read_options,
+                             const Slice& begin_key,
+                             const Slice& end_key) = 0;
+
   // PutUntracked() will write a Put to the batch of operations to be committed
   // in this transaction.  This write will only happen if this transaction
   // gets committed successfully.  But unlike Transaction::Put(),
@@ -344,10 +352,19 @@ class Transaction {
   virtual Status DeleteUntracked(ColumnFamilyHandle* column_family,
                                  const SliceParts& key) = 0;
   virtual Status DeleteUntracked(const SliceParts& key) = 0;
+
   virtual Status SingleDeleteUntracked(ColumnFamilyHandle* column_family,
                                        const Slice& key) = 0;
 
   virtual Status SingleDeleteUntracked(const Slice& key) = 0;
+
+  virtual Status DeleteRangeUntracked(const ReadOptions& read_options,
+                                      ColumnFamilyHandle* column_family,
+                                      const Slice& begin_key,
+                                      const Slice& end_key) = 0;
+  virtual Status DeleteRangeUntracked(const ReadOptions& read_options,
+                                      const Slice& begin_key,
+                                      const Slice& end_key) = 0;
 
   // Similar to WriteBatch::PutLogData
   virtual void PutLogData(const Slice& blob) = 0;

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -409,14 +409,15 @@ Status TransactionBaseImpl::DeleteRange(const ReadOptions& read_options,
     s = TryLock(column_family, iter->key(), false /* read_only */, true /* exclusive */);
     if (s.ok()) {
       num_keys++;
-    } else {
-      return s;
     }
   }
+  delete iter;
 
-  s = GetBatchForWrite()->DeleteRange(column_family, begin_key, end_key);
   if (s.ok()) {
-    num_deletes_ += num_keys;
+    s = GetBatchForWrite()->DeleteRange(column_family, begin_key, end_key);
+    if (s.ok()) {
+      num_deletes_ += num_keys;
+    }
   }
 
   return s;

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -148,7 +148,7 @@ class TransactionBaseImpl : public Transaction {
   Status DeleteRange(const ReadOptions& read_options,
                      const Slice& begin_key,
                      const Slice& end_key) override {
-    return DeleteRange(options, nullptr, begin_key, end_key);
+    return DeleteRange(read_options, nullptr, begin_key, end_key);
   }
 
   Status PutUntracked(ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -141,6 +141,16 @@ class TransactionBaseImpl : public Transaction {
     return SingleDelete(nullptr, key);
   }
 
+  Status DeleteRange(const ReadOptions& read_options,
+                     ColumnFamilyHandle* column_family,
+                     const Slice& begin_key,
+                     const Slice& end_key) override;
+  Status DeleteRange(const ReadOptions& read_options,
+                     const Slice& begin_key,
+                     const Slice& end_key) override {
+    return DeleteRange(options, nullptr, begin_key, end_key);
+  }
+
   Status PutUntracked(ColumnFamilyHandle* column_family, const Slice& key,
                       const Slice& value) override;
   Status PutUntracked(const Slice& key, const Slice& value) override {
@@ -174,6 +184,16 @@ class TransactionBaseImpl : public Transaction {
                                const Slice& key) override;
   Status SingleDeleteUntracked(const Slice& key) override {
     return SingleDeleteUntracked(nullptr, key);
+  }
+
+  Status DeleteRangeUntracked(const ReadOptions& read_options,
+                              ColumnFamilyHandle* column_family,
+                              const Slice& begin_key,
+                              const Slice& end_key) override;
+  Status DeleteRangeUntracked(const ReadOptions& read_options,
+                              const Slice& begin_key,
+                              const Slice& end_key) override {
+    return DeleteRangeUntracked(read_options, nullptr, begin_key, end_key);
   }
 
   void PutLogData(const Slice& blob) override;

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -4356,6 +4356,64 @@ TEST_P(TransactionTest, SingleDeleteTest) {
   ASSERT_TRUE(s.IsNotFound());
 }
 
+TEST_P(TransactionTest, DeleteRangeTest) {
+  WriteOptions write_options;
+  ReadOptions read_options;
+  std::string value;
+  Status s;
+
+  Transaction* txn = db->BeginTransaction(write_options);
+  ASSERT_TRUE(txn);
+
+  // Write some keys to the db
+  s = db->Put(write_options, "A", "a");
+  ASSERT_OK(s);
+
+  s = db->Put(write_options, "G", "g");
+  ASSERT_OK(s);
+
+  s = db->Put(write_options, "F", "f");
+  ASSERT_OK(s);
+
+  s = db->Put(write_options, "C", "c");
+  ASSERT_OK(s);
+
+  s = db->Put(write_options, "D", "d");
+  ASSERT_OK(s);
+
+  s = db->Put(write_options, "E", "e");
+  ASSERT_OK(s);
+
+  s = txn->DeleteRange(read_options, "C", "F");
+  ASSERT_OK(s);
+
+  s = txn->Commit();
+  ASSERT_OK(s);
+
+  s = db->Get(read_options, "A", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ("a", value);
+
+  s = db->Get(read_options, "C", &value);
+  ASSERT_TRUE(s.IsNotFound());
+
+  s = db->Get(read_options, "D", &value);
+  ASSERT_TRUE(s.IsNotFound());
+
+  s = db->Get(read_options, "E", &value);
+  ASSERT_TRUE(s.IsNotFound());
+
+  s = db->Get(read_options, "F", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ("f", value);
+
+  s = db->Get(read_options, "G", &value);
+  ASSERT_OK(s);
+  ASSERT_EQ("g", value);
+
+  delete txn;
+}
+
 TEST_P(TransactionTest, MergeTest) {
   WriteOptions write_options;
   ReadOptions read_options;


### PR DESCRIPTION
Right now `Transactions` is not supported `DeleteRange()`, this PR still uses `WriteBatch` to support it. Because the pessimistic transaction must lock all of the keys before operating them, so use the `Iterator` to iterate over the range of keys before deleting them.

Signed-off-by: leviathan1995 leviathan0992@gmail.com