### PR TITLE
Increase version number to 5.16

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 * Add a new table property, "rocksdb.num.range-deletions", which counts the number of range deletion tombstones in the table.
 * Improve the performance of iterators doing long range scans by using readahead, when using direct IO.
 * pin_top_level_index_and_filter (default true) in BlockBasedTableOptions can be used in combination with cache_index_and_filter_blocks to prefetch and pin the top-level index of partitioned index and filter blocks in cache. It has no impact when cache_index_and_filter_blocks is false.
+* Write properties meta-block at the end of block-based table to save read-ahead IO.
 
 ### Bug Fixes
 * Fix deadlock with enable_pipelined_write=true and max_successive_merges > 0

--- a/include/rocksdb/version.h
+++ b/include/rocksdb/version.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define ROCKSDB_MAJOR 5
-#define ROCKSDB_MINOR 15
+#define ROCKSDB_MINOR 16
 #define ROCKSDB_PATCH 0
 
 // Do not use these. We made the mistake of declaring macros starting with


### PR DESCRIPTION
Given that we have cut 5.15, we should bump the version number to the next
version, i.e. 5.16.
Also update HISTORY.md
cc @sagar0 