### PR TITLE
Remove random write from SST file ingestion

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -547,24 +547,8 @@ Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
         "field");
   }
 
-  std::unique_ptr<RandomRWFile> rwfile;
-  Status status = env_->NewRandomRWFile(file_to_ingest->internal_file_path,
-                                        &rwfile, env_options_);
-  if (!status.ok()) {
-    return status;
-  }
-
-  // Write the new seqno in the global sequence number field in the file
-  std::string seqno_val;
-  PutFixed64(&seqno_val, seqno);
-  status = rwfile->Write(file_to_ingest->global_seqno_offset, seqno_val);
-  if (status.ok()) {
-    status = rwfile->Fsync();
-  }
-  if (status.ok()) {
-    file_to_ingest->assigned_seqno = seqno;
-  }
-  return status;
+  file_to_ingest->assigned_seqno = seqno;
+  return Status::OK();
 }
 
 bool ExternalSstFileIngestionJob::IngestedFileFitInLevel(

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -462,7 +462,7 @@ class Repairer {
                                 file_size);
     std::shared_ptr<const TableProperties> props;
     if (status.ok()) {
-      status = table_cache_->GetTableProperties(env_options_, icmp_, t->meta.fd,
+      status = table_cache_->GetTableProperties(env_options_, icmp_, t->meta,
                                                 &props);
     }
     if (status.ok()) {

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -87,7 +87,7 @@ class TableCache {
   // @param level == -1 means not specified
   Status FindTable(const EnvOptions& toptions,
                    const InternalKeyComparator& internal_comparator,
-                   const FileDescriptor& file_fd, Cache::Handle**,
+                   const FileMetaData& file_meta, Cache::Handle**,
                    const SliceTransform* prefix_extractor = nullptr,
                    const bool no_io = false, bool record_read_stats = true,
                    HistogramImpl* file_read_hist = nullptr,
@@ -105,7 +105,7 @@ class TableCache {
   //            we set `no_io` to be true.
   Status GetTableProperties(const EnvOptions& toptions,
                             const InternalKeyComparator& internal_comparator,
-                            const FileDescriptor& file_meta,
+                            const FileMetaData& file_meta,
                             std::shared_ptr<const TableProperties>* properties,
                             const SliceTransform* prefix_extractor = nullptr,
                             bool no_io = false);
@@ -115,7 +115,7 @@ class TableCache {
   size_t GetMemoryUsageByTableReader(
       const EnvOptions& toptions,
       const InternalKeyComparator& internal_comparator,
-      const FileDescriptor& fd,
+      const FileMetaData& file_meta,
       const SliceTransform* prefix_extractor = nullptr);
 
   // Release the handle from a cache
@@ -137,7 +137,7 @@ class TableCache {
   // Build a table reader
   Status GetTableReader(const EnvOptions& env_options,
                         const InternalKeyComparator& internal_comparator,
-                        const FileDescriptor& fd, bool sequential_mode,
+                        const FileMetaData& file_meta, bool sequential_mode,
                         size_t readahead, bool record_read_stats,
                         HistogramImpl* file_read_hist,
                         unique_ptr<TableReader>* table_reader,

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -392,9 +392,9 @@ class VersionBuilder::Rep {
         auto* file_meta = files_meta[file_idx].first;
         int level = files_meta[file_idx].second;
         table_cache_->FindTable(
-            env_options_, *(base_vstorage_->InternalComparator()),
-            file_meta->fd, &file_meta->table_reader_handle, prefix_extractor,
-            false /*no_io */, true /* record_read_stats */,
+            env_options_, *(base_vstorage_->InternalComparator()), *file_meta,
+            &file_meta->table_reader_handle, prefix_extractor, false /*no_io */,
+            true /* record_read_stats */,
             internal_stats->GetFileReadHist(level), false, level,
             prefetch_index_and_filter_in_cache);
         if (file_meta->table_reader_handle != nullptr) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -727,7 +727,7 @@ Status Version::GetTableProperties(std::shared_ptr<const TableProperties>* tp,
   auto table_cache = cfd_->table_cache();
   auto ioptions = cfd_->ioptions();
   Status s = table_cache->GetTableProperties(
-      env_options_, cfd_->internal_comparator(), file_meta->fd, tp,
+      env_options_, cfd_->internal_comparator(), *file_meta, tp,
       mutable_cf_options_.prefix_extractor.get(), true /* no io */);
   if (s.ok()) {
     return s;
@@ -863,7 +863,8 @@ size_t Version::GetMemoryUsageByTableReaders() {
   for (auto& file_level : storage_info_.level_files_brief_) {
     for (size_t i = 0; i < file_level.num_files; i++) {
       total_usage += cfd_->table_cache()->GetMemoryUsageByTableReader(
-          env_options_, cfd_->internal_comparator(), file_level.files[i].fd,
+          env_options_, cfd_->internal_comparator(),
+          *(file_level.files[i].file_metadata),
           mutable_cf_options_.prefix_extractor.get());
     }
   }

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -203,6 +203,7 @@ Status BlockBasedTableFactory::NewTableReader(
       file_size, table_reader, table_reader_options.prefix_extractor,
       prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
       table_reader_options.level, table_reader_options.immortal,
+      table_reader_options.smallest_seqno, table_reader_options.largest_seqno,
       &tail_prefetch_stats_);
 }
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -664,7 +664,16 @@ bool IsFeatureSupported(const TableProperties& table_properties,
 }
 
 SequenceNumber GetGlobalSequenceNumber(const TableProperties& table_properties,
+                                       const SequenceNumber smallest_seqno,
+                                       const SequenceNumber largest_seqno,
                                        Logger* info_log) {
+  if (smallest_seqno < largest_seqno) {
+    // Not an external SST
+    return kDisableGlobalSequenceNumber;
+  } else if (smallest_seqno > largest_seqno) {
+    assert(smallest_seqno == kMaxSequenceNumber && largest_seqno == 0);
+    return kDisableGlobalSequenceNumber;
+  }
   auto& props = table_properties.user_collected_properties;
 
   auto version_pos = props.find(ExternalSstFilePropertyNames::kVersion);
@@ -696,7 +705,7 @@ SequenceNumber GetGlobalSequenceNumber(const TableProperties& table_properties,
     return kDisableGlobalSequenceNumber;
   }
 
-  SequenceNumber global_seqno = DecodeFixed64(seqno_pos->second.c_str());
+  SequenceNumber global_seqno = largest_seqno;
 
   if (global_seqno > kMaxSequenceNumber) {
     assert(false);
@@ -723,18 +732,17 @@ Slice BlockBasedTable::GetCacheKey(const char* cache_key_prefix,
   return Slice(cache_key, static_cast<size_t>(end - cache_key));
 }
 
-Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
-                             const EnvOptions& env_options,
-                             const BlockBasedTableOptions& table_options,
-                             const InternalKeyComparator& internal_comparator,
-                             unique_ptr<RandomAccessFileReader>&& file,
-                             uint64_t file_size,
-                             unique_ptr<TableReader>* table_reader,
-                             const SliceTransform* prefix_extractor,
-                             const bool prefetch_index_and_filter_in_cache,
-                             const bool skip_filters, const int level,
-                             const bool immortal_table,
-                             TailPrefetchStats* tail_prefetch_stats) {
+Status BlockBasedTable::Open(
+    const ImmutableCFOptions& ioptions, const EnvOptions& env_options,
+    const BlockBasedTableOptions& table_options,
+    const InternalKeyComparator& internal_comparator,
+    unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
+    unique_ptr<TableReader>* table_reader,
+    const SliceTransform* prefix_extractor,
+    const bool prefetch_index_and_filter_in_cache, const bool skip_filters,
+    const int level, const bool immortal_table,
+    const SequenceNumber smallest_seqno, const SequenceNumber largest_seqno,
+    TailPrefetchStats* tail_prefetch_stats) {
   table_reader->reset();
 
   Footer footer;
@@ -936,8 +944,9 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         *(rep->table_properties),
         BlockBasedTablePropertyNames::kPrefixFiltering, rep->ioptions.info_log);
 
-    rep->global_seqno = GetGlobalSequenceNumber(*(rep->table_properties),
-                                                rep->ioptions.info_log);
+    rep->global_seqno =
+        GetGlobalSequenceNumber(*(rep->table_properties), smallest_seqno,
+                                largest_seqno, rep->ioptions.info_log);
   }
 
   // Read the range del meta block

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -95,6 +95,8 @@ class BlockBasedTable : public TableReader {
                      bool prefetch_index_and_filter_in_cache = true,
                      bool skip_filters = false, int level = -1,
                      const bool immortal_table = false,
+                     const SequenceNumber smallest_seqno = kMaxSequenceNumber,
+                     const SequenceNumber largest_seqno = 0,
                      TailPrefetchStats* tail_prefetch_stats = nullptr);
 
   bool PrefixMayMatch(const Slice& internal_key,

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "db/dbformat.h"
 #include "db/table_properties_collector.h"
 #include "options/cf_options.h"
 #include "rocksdb/options.h"
@@ -31,14 +32,18 @@ struct TableReaderOptions {
                      const EnvOptions& _env_options,
                      const InternalKeyComparator& _internal_comparator,
                      bool _skip_filters = false, bool _immortal = false,
-                     int _level = -1)
+                     int _level = -1,
+                     SequenceNumber _smallest_seqno = kMaxSequenceNumber,
+                     SequenceNumber _largest_seqno = 0)
       : ioptions(_ioptions),
         prefix_extractor(_prefix_extractor),
         env_options(_env_options),
         internal_comparator(_internal_comparator),
         skip_filters(_skip_filters),
         immortal(_immortal),
-        level(_level) {}
+        level(_level),
+        smallest_seqno(_smallest_seqno),
+        largest_seqno(_largest_seqno) {}
 
   const ImmutableCFOptions& ioptions;
   const SliceTransform* prefix_extractor;
@@ -50,6 +55,17 @@ struct TableReaderOptions {
   bool immortal;
   // what level this table/file is on, -1 for "not set, don't know"
   int level;
+
+  // if smallest_seqno == largest_seqno, then there are two possibilities:
+  //   a) the table is external SST if table properties has global_seqno
+  //       field (even if its value is not used any more);
+  //   b) the table is NOT external SST if table properties does NOT have
+  //       global_seqno field.
+  //
+  // smallest seqno in the table
+  SequenceNumber smallest_seqno;
+  // largest seqno in the table
+  SequenceNumber largest_seqno;
 };
 
 struct TableBuilderOptions {

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3132,7 +3132,14 @@ TEST_F(PrefixTest, PrefixAndWholeKeyTest) {
   // rocksdb still works.
 }
 
-TEST_P(BlockBasedTableTest, TableWithGlobalSeqno) {
+/*
+ * Disable TableWithGlobalSeqno since RocksDB does not store global_seqno in
+ * the SST file any more. Instead, RocksDB deduces global_seqno from the
+ * MANIFEST while reading from an SST. Therefore, it's not possible to test the
+ * functionality of global_seqno in a single, isolated unit test without the
+ * involvement of Version, VersionSet, etc.
+ */
+TEST_P(BlockBasedTableTest, DISABLED_TableWithGlobalSeqno) {
   BlockBasedTableOptions bbto = GetBlockBasedTableOptions();
   test::StringSink* sink = new test::StringSink();
   unique_ptr<WritableFileWriter> file_writer(test::GetWritableFileWriter(sink));


### PR DESCRIPTION
RocksDB used to store global_seqno in external SST files written by
SstFileWriter. During file ingestion, RocksDB uses pwrite to update the
global_seqno. Since random write is not supported in some non-POSIX compliant
file systems, external SST file ingestion is not supported on these file
systems. To address this limitation, we no longer update global_seqno during
file ingestion. Later RocksDB uses the MANIFEST and other information in table
properties to deduce global seqno for externally-ingested SST files.

Test plan:
```
$make clean && make -j16 all check
$./external_sst_file_test
$./external_sst_file_basic_test
```