### PR TITLE
DBImpl::IngestExternalFile() should grab mutex when releasing file number in failure case

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2912,6 +2912,7 @@ Status DBImpl::IngestExternalFile(
   status = ingestion_job.Prepare(external_files, super_version);
   CleanupSuperVersion(super_version);
   if (!status.ok()) {
+    InstrumentedMutexLock l(&mutex_);
     ReleaseFileNumberFromPendingOutputs(pending_output_elem);
     return status;
   }


### PR DESCRIPTION
Summary: 995fcf757319da9cf12eca2df83a6fba4db0ebe4 has a bug: ReleaseFileNumberFromPendingOutputs() added is not protected by the DB mutex. Fix it by grabbing the lock for this operation.

Test Plan: Run external_sst_file_test using TSAN