### PR TITLE
Clarify max_total_wal_size's scope

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -430,6 +430,8 @@ struct DBOptions {
   // (i.e. the ones that are causing all the space amplification). If set to 0
   // (default), we will dynamically choose the WAL size limit to be
   // [sum of all write_buffer_size * max_write_buffer_number] * 4
+  // This option takes effect only when there are more than one column family as
+  // otherwise the wal size is dictated by the write_buffer_size.
   // Default: 0
   uint64_t max_total_wal_size = 0;
 

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -262,6 +262,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    * </p>
    * <p>If set to 0 (default), we will dynamically choose the WAL size limit to
    * be [sum of all write_buffer_size * max_write_buffer_number] * 2</p>
+   * <p>This option takes effect only when there are more than one column family as
+   * otherwise the wal size is dictated by the write_buffer_size.</p>
    * <p>Default: 0</p>
    *
    * @param maxTotalWalSize max total wal size.


### PR DESCRIPTION
max_total_wal_size takes effect only when there are more than one column families. The patch clarify that in the inline docs

Closes https://github.com/facebook/rocksdb/issues/4180