### PR TITLE
Correct description of GetColumnFamilyMetaData

### DIFF
--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -996,11 +996,6 @@ class DB {
       std::vector<LiveFileMetaData>* /*metadata*/) {}
 
   // Obtains the meta data of the specified column family of the DB.
-  // Status::NotFound() will be returned if the current DB does not have
-  // any column family match the specified name.
-  //
-  // If cf_name is not specified, then the metadata of the default
-  // column family will be returned.
   virtual void GetColumnFamilyMetaData(ColumnFamilyHandle* /*column_family*/,
                                        ColumnFamilyMetaData* /*metadata*/) {}
 


### PR DESCRIPTION
The inline doc was incorrectly mentioned a return status while the function does not return a value.