### PR TITLE
Expose GetTotalTrashSize in SstFileManager interface

### DIFF
--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -75,6 +75,10 @@ class SstFileManager {
   // Update trash/DB size ratio where new files will be deleted immediately
   // thread-safe
   virtual void SetMaxTrashDBRatio(double ratio) = 0;
+
+  // Return the total size of trash files
+  // thread-safe
+  virtual uint64_t GetTotalTrashSize() = 0;
 };
 
 // Create a new SstFileManager that can be shared among multiple RocksDB

--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -162,6 +162,10 @@ void SstFileManagerImpl::SetMaxTrashDBRatio(double r) {
   return delete_scheduler_.SetMaxTrashDBRatio(r);
 }
 
+uint64_t SstFileManagerImpl::GetTotalTrashSize() {
+  return delete_scheduler_.GetTotalTrashSize();
+}
+
 Status SstFileManagerImpl::ScheduleFileDeletion(
     const std::string& file_path, const std::string& path_to_sync) {
   return delete_scheduler_.DeleteFile(file_path, path_to_sync);

--- a/util/sst_file_manager_impl.h
+++ b/util/sst_file_manager_impl.h
@@ -93,6 +93,9 @@ class SstFileManagerImpl : public SstFileManager {
   // Update trash/DB size ratio where new files will be deleted immediately
   virtual void SetMaxTrashDBRatio(double ratio) override;
 
+  // Return the total size of trash files
+  uint64_t GetTotalTrashSize();
+
   // Mark file as trash and schedule it's deletion.
   virtual Status ScheduleFileDeletion(const std::string& file_path,
                                       const std::string& dir_to_sync);

--- a/util/sst_file_manager_impl.h
+++ b/util/sst_file_manager_impl.h
@@ -94,7 +94,7 @@ class SstFileManagerImpl : public SstFileManager {
   virtual void SetMaxTrashDBRatio(double ratio) override;
 
   // Return the total size of trash files
-  uint64_t GetTotalTrashSize();
+  uint64_t GetTotalTrashSize() override;
 
   // Mark file as trash and schedule it's deletion.
   virtual Status ScheduleFileDeletion(const std::string& file_path,


### PR DESCRIPTION
Hi, it would be great if we could expose this API, so that LogDevice can use it to track the total size of trash files and alarm if it grows too large in relation to disk size. There's probably other customers that would be interested in this as well. :)