### PR TITLE
Reduce binary search during iterator reseek

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -1068,6 +1068,90 @@ TEST_P(DBIteratorTest, DBIteratorBoundOptimizationTest) {
   ASSERT_FALSE(iter->Valid());
   ASSERT_EQ(upper_bound_hits, 1);
 }
+
+TEST_P(DBIteratorTest, AvoidReseekLevelIterator) {
+  Options options = CurrentOptions();
+  options.compression = CompressionType::kNoCompression;
+  BlockBasedTableOptions table_options;
+  table_options.block_size = 800;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  Reopen(options);
+
+  Random rnd(301);
+  std::string random_str = RandomString(&rnd, 180);
+
+  ASSERT_OK(Put("1", random_str));
+  ASSERT_OK(Put("2", random_str));
+  ASSERT_OK(Put("3", random_str));
+  ASSERT_OK(Put("4", random_str));
+  ASSERT_OK(Put("5", random_str));
+  ASSERT_OK(Put("6", random_str));
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("7", random_str));
+  ASSERT_OK(Put("8", random_str));
+  ASSERT_OK(Flush());
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+
+  int num_find_file_in_level = 0;
+  int num_idx_blk_seek = 0;
+  SyncPoint::GetInstance()->SetCallBack(
+      "LevelIterator::Seek:BeforeFindFile",
+      [&](void* /*arg*/) { num_find_file_in_level++; });
+  SyncPoint::GetInstance()->SetCallBack(
+      "IndexBlockIter::Seek:0", [&](void* /*arg*/) { num_idx_blk_seek++; });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  {
+    std::unique_ptr<Iterator> iter(NewIterator(ReadOptions()));
+    iter->Seek("1");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(1, num_idx_blk_seek);
+
+    iter->Seek("2");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(1, num_idx_blk_seek);
+
+    iter->Seek("3");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(1, num_idx_blk_seek);
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(1, num_idx_blk_seek);
+
+    iter->Seek("5");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(2, num_idx_blk_seek);
+
+    iter->Seek("6");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(1, num_find_file_in_level);
+    ASSERT_EQ(2, num_idx_blk_seek);
+
+    iter->Seek("7");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(2, num_find_file_in_level);
+    ASSERT_EQ(3, num_idx_blk_seek);
+
+    iter->Seek("8");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(2, num_find_file_in_level);
+    ASSERT_EQ(3, num_idx_blk_seek);
+
+    iter->Seek("5");
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(3, num_find_file_in_level);
+    ASSERT_EQ(4, num_idx_blk_seek);
+  }
+
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
 // TODO(3.13): fix the issue of Seek() + Prev() which might not necessary
 //             return the biggest key which is smaller than the seek key.
 TEST_P(DBIteratorTest, PrevAfterAndNextAfterMerge) {

--- a/table/block.cc
+++ b/table/block.cc
@@ -186,6 +186,7 @@ void DataBlockIter::Seek(const Slice& target) {
 }
 
 void IndexBlockIter::Seek(const Slice& target) {
+  TEST_SYNC_POINT("IndexBlockIter::Seek:0");
   Slice seek_key = target;
   if (!key_includes_seq_) {
     seek_key = ExtractUserKey(target);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1966,8 +1966,7 @@ bool BlockBasedTable::PrefixMayMatch(
         // and we're not really sure that we're past the end
         // of the file
         may_match = iiter->status().IsIncomplete();
-      } else if (rep_->table_properties &&
-                 iiter->parsed_internal_key().user_key.starts_with(
+      } else if (iiter->parsed_internal_key().user_key.starts_with(
                      ExtractUserKey(internal_prefix))) {
         // we need to check for this subtle case because our only
         // guarantee is that "the key is a string >= last key in that data

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -561,6 +561,10 @@ class BlockBasedTableIterator : public InternalIterator {
     assert(Valid());
     return block_iter_.key();
   }
+  ParsedInternalKey parsed_internal_key() const override {
+    assert(Valid());
+    return block_iter_.parsed_internal_key();
+  }
   Slice value() const override {
     assert(Valid());
     return block_iter_.value();
@@ -626,6 +630,7 @@ class BlockBasedTableIterator : public InternalIterator {
   void InitDataBlock();
   void FindKeyForward();
   void FindKeyBackward();
+  bool IsReseekToSameBlock(const Slice& target);
 
  private:
   BlockBasedTable* table_;

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include "db/dbformat.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/status.h"
@@ -61,6 +62,15 @@ class InternalIterator : public Cleanable {
   // the iterator.
   // REQUIRES: Valid()
   virtual Slice key() const = 0;
+
+  // Return the key in the parsed form for the current entry.
+  // The same precondition as key().
+  // REQUIRES: Valid()
+  virtual ParsedInternalKey parsed_internal_key() const {
+    ParsedInternalKey pik;
+    ParseInternalKey(key(), &pik);
+    return pik;
+  }
 
   // Return the value for the current entry.  The underlying storage for
   // the returned slice is valid only until the next modification of

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1417,7 +1417,7 @@ TEST_P(BlockBasedTableTest, PrefetchTest) {
   // BlockBasedTable.
   Options opt;
   unique_ptr<InternalKeyComparator> ikc;
-  ikc.reset(new test::PlainInternalKeyComparator(opt.comparator));
+  ikc.reset(new InternalKeyComparator(opt.comparator));
   opt.compression = kNoCompression;
   BlockBasedTableOptions table_options = GetBlockBasedTableOptions();
   table_options.block_size = 1024;


### PR DESCRIPTION
Summary: When users call Seek() multiple times in the same iterator, there is usually some locality among the seek keys. Profiling shows that CPU used by the binary search for finding the file in a level, and in index block is not eligible. In one production profiling, FindFile() takes 8% of the CPU in iterator Seek(). Binary search of index block takes another about 4%. In many cases it is much higher than 4%.

For those reseeking dominated workloads, we have opportunity to reduce them. To reduce binary search in those cases, we can always check whether the current data file and data block cover the seek key, if it is the case, we can avoid the binary search to find the file or block.

Whether we can use the same data file is figured out by looking at the smallest and largest key of the current file; for data block, we seek to the first key of the data block to check the lower bound, and use the key of the current index iterator to check the upper bound.

The fact that index iter can be either user key or internal key highly complicated things. InternalIterator::parsed_internal_key() is introduced to consolidate the interface of the two. There are code chagne everywhere to adapt this new interface, but I believe it actually simplifies the code so it's a good change anyway.

Test Plan: Add a unit test.