### PR TITLE
Modify verification logic of ObsoleteOptionsFileTest

### DIFF
--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -228,6 +228,8 @@ TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
   ASSERT_OK(dbi->EnableFileDeletions(true /* force */));
   ASSERT_EQ(optsfiles_nums.size(), optsfiles_keep.size());
 
+  CloseDB();
+
   std::vector<std::string> files;
   int opts_file_count = 0;
   ASSERT_OK(env_->GetChildren(dbname_, &files));
@@ -243,8 +245,6 @@ TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
     }
   }
   ASSERT_EQ(2, opts_file_count);
-
-  CloseDB();
 }
 
 } //namespace rocksdb

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -227,14 +227,22 @@ TEST_F(ObsoleteFilesTest, DeleteObsoleteOptionsFile) {
   }
   ASSERT_OK(dbi->EnableFileDeletions(true /* force */));
   ASSERT_EQ(optsfiles_nums.size(), optsfiles_keep.size());
-  int size = static_cast<int>(optsfiles_nums.size());
-  int kept_opts_files_count = 0;
-  for (int i = 0; i != size; ++i) {
-    if (optsfiles_keep[i]) {
-      ++kept_opts_files_count;
+
+  std::vector<std::string> files;
+  int opts_file_count = 0;
+  ASSERT_OK(env_->GetChildren(dbname_, &files));
+  for (const auto& file : files) {
+    uint64_t file_num;
+    Slice dummy_info_log_name_prefix;
+    FileType type;
+    WalFileType log_type;
+    if (ParseFileName(file, &file_num, dummy_info_log_name_prefix, &type,
+                      &log_type) &&
+        type == kOptionsFile) {
+      opts_file_count++;
     }
   }
-  ASSERT_EQ(2, kept_opts_files_count);
+  ASSERT_EQ(2, opts_file_count);
 
   CloseDB();
 }


### PR DESCRIPTION
The current verification logic does not consider the case in which multiple
threads (foreground and background) may execute `PurgeObsoleteFiles` function
simultaneously. Each invocation will trigger the callback adding elements to
a vector. Then we verify the elements in the vector, which can fail sometimes.

The solution is to give up checking the elements. Instead, we check the number
of OPTIONS file in the database dir.

Test plan:
```
$make clean && make -j16
$./obsolete_files_test
```