### PR TITLE
Add CompactRangeOptions for Java

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -13,6 +13,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/compaction_filter_factory_jnicallback.cc
         rocksjni/compaction_options_fifo.cc
         rocksjni/compaction_options_universal.cc
+        rocksjni/compact_range_options.cc
         rocksjni/comparator.cc
         rocksjni/comparatorjnicallback.cc
         rocksjni/compression_options.cc
@@ -79,6 +80,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.ColumnFamilyOptions
         org.rocksdb.CompactionOptionsFIFO
         org.rocksdb.CompactionOptionsUniversal
+        org.rocksdb.CompactRangeOptions
         org.rocksdb.Comparator
         org.rocksdb.ComparatorOptions
         org.rocksdb.CompressionOptions
@@ -192,6 +194,7 @@ add_jar(
   src/main/java/org/rocksdb/CompactionOptionsFIFO.java
   src/main/java/org/rocksdb/CompactionOptionsUniversal.java
   src/main/java/org/rocksdb/CompactionPriority.java
+  src/main/java/org/rocksdb/CompactRangeOptions.java
   src/main/java/org/rocksdb/CompactionStopStyle.java
   src/main/java/org/rocksdb/CompactionStyle.java
   src/main/java/org/rocksdb/Comparator.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -14,6 +14,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.ColumnFamilyOptions\
 	org.rocksdb.CompactionOptionsFIFO\
 	org.rocksdb.CompactionOptionsUniversal\
+	org.rocksdb.CompactRangeOptions\
 	org.rocksdb.Comparator\
 	org.rocksdb.ComparatorOptions\
 	org.rocksdb.CompressionOptions\

--- a/java/rocksjni/compact_range_options.cc
+++ b/java/rocksjni/compact_range_options.cc
@@ -4,7 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 // This file implements the "bridge" between Java and C++ for
-// rocksdb::FilterPolicy.
+// rocksdb::CompactRangeOptions.
 
 #include <jni.h>
 

--- a/java/rocksjni/compact_range_options.cc
+++ b/java/rocksjni/compact_range_options.cc
@@ -1,0 +1,196 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ for
+// rocksdb::FilterPolicy.
+
+#include <jni.h>
+
+#include "include/org_rocksdb_CompactRangeOptions.h"
+#include "rocksdb/options.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    newCompactRangeOptions
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_CompactRangeOptions_newCompactRangeOptions(
+    JNIEnv* /*env*/, jclass /*jclazz*/) {
+  auto* options = new rocksdb::CompactRangeOptions();
+  return reinterpret_cast<jlong>(options);
+}
+
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    exclusiveManualCompaction
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_CompactRangeOptions_exclusiveManualCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jboolean>(options->exclusive_manual_compaction);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setExclusiveManualCompaction
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setExclusiveManualCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean exclusive_manual_compaction) {
+  auto* options =
+      reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->exclusive_manual_compaction = static_cast<bool>(exclusive_manual_compaction);
+}
+
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    bottommostLevelCompaction
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_CompactRangeOptions_bottommostLevelCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return rocksdb::BottommostLevelCompactionJni::toJavaBottommostLevelCompaction(
+    options->bottommost_level_compaction);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setBottommostLevelCompaction
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setBottommostLevelCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jint bottommost_level_compaction) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->bottommost_level_compaction =
+    rocksdb::BottommostLevelCompactionJni::toCppBottommostLevelCompaction(bottommost_level_compaction);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    changeLevel
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_CompactRangeOptions_changeLevel
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jboolean>(options->change_level);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setChangeLevel
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setChangeLevel
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean change_level) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->change_level = static_cast<bool>(change_level);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    targetLevel
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_CompactRangeOptions_targetLevel
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jint>(options->target_level);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setTargetLevel
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setTargetLevel
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint target_level) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->target_level = static_cast<int>(target_level);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    targetPathId
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_CompactRangeOptions_targetPathId
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jint>(options->target_path_id);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setTargetPathId
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setTargetPathId
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint target_path_id) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->target_path_id = static_cast<uint32_t>(target_path_id);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    allowWriteStall
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_CompactRangeOptions_allowWriteStall
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jboolean>(options->allow_write_stall);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setAllowWriteStall
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setAllowWriteStall
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jboolean allow_write_stall) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->allow_write_stall = static_cast<bool>(allow_write_stall);
+}
+
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    maxSubcompactions
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_CompactRangeOptions_maxSubcompactions
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  return static_cast<jint>(options->max_subcompactions);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    setMaxSubcompactions
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_setMaxSubcompactions
+  (JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle, jint max_subcompactions) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  options->max_subcompactions = static_cast<uint32_t>(max_subcompactions);
+}
+
+/*
+ * Class:     org_rocksdb_CompactRangeOptions
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_CompactRangeOptions_disposeInternal(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jhandle);
+  delete options;
+}

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2896,6 +2896,43 @@ class BatchResultJni : public JavaClass {
   }
 };
 
+// The portal class for org.rocksdb.BottommostLevelCompactionJni
+class BottommostLevelCompactionJni {
+ public:
+  // Returns the equivalent org.rocksdb.BottommostLevelCompaction for the provided
+  // C++ rocksdb::BottommostLevelCompaction enum
+  static jint toJavaBottommostLevelCompaction(
+      const rocksdb::BottommostLevelCompaction& bottommost_level_compaction) {
+    switch(bottommost_level_compaction) {
+      case rocksdb::BottommostLevelCompaction::kSkip:
+        return 0x0;
+      case rocksdb::BottommostLevelCompaction::kIfHaveCompactionFilter:
+        return 0x1;
+      case rocksdb::BottommostLevelCompaction::kForce:
+        return 0x2;
+      default:
+        return 0x7F;  // undefined
+    }
+  }
+
+  // Returns the equivalent C++ rocksdb::BottommostLevelCompaction enum for the
+  // provided Java org.rocksdb.BottommostLevelCompaction
+  static rocksdb::BottommostLevelCompaction toCppBottommostLevelCompaction(
+      jint bottommost_level_compaction) {
+    switch(bottommost_level_compaction) {
+      case 0x0:
+        return rocksdb::BottommostLevelCompaction::kSkip;
+      case 0x1:
+        return rocksdb::BottommostLevelCompaction::kIfHaveCompactionFilter;
+      case 0x2:
+        return rocksdb::BottommostLevelCompaction::kForce;
+      default:
+        // undefined/default
+        return rocksdb::BottommostLevelCompaction::kIfHaveCompactionFilter;
+    }
+  }
+};
+
 // The portal class for org.rocksdb.CompactionStopStyle
 class CompactionStopStyleJni {
  public:

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -2896,7 +2896,7 @@ class BatchResultJni : public JavaClass {
   }
 };
 
-// The portal class for org.rocksdb.BottommostLevelCompactionJni
+// The portal class for org.rocksdb.BottommostLevelCompaction
 class BottommostLevelCompactionJni {
  public:
   // Returns the equivalent org.rocksdb.BottommostLevelCompaction for the provided

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1955,8 +1955,7 @@ bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
                                  rocksdb::ColumnFamilyHandle* cf_handle,
                                  jbyteArray jbegin, jint jbegin_len,
                                  jbyteArray jend, jint jend_len,
-                                 jboolean jreduce_level, jint jtarget_level,
-                                 jint jtarget_path_id) {
+                                 const rocksdb::CompactRangeOptions& compact_options) {
   jbyte* begin = env->GetByteArrayElements(jbegin, nullptr);
   if (begin == nullptr) {
     // exception thrown: OutOfMemoryError
@@ -1974,10 +1973,6 @@ bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
   const rocksdb::Slice end_slice(reinterpret_cast<char*>(end), jend_len);
 
   rocksdb::Status s;
-  rocksdb::CompactRangeOptions compact_options;
-  compact_options.change_level = jreduce_level;
-  compact_options.target_level = jtarget_level;
-  compact_options.target_path_id = static_cast<uint32_t>(jtarget_path_id);
   if (cf_handle != nullptr) {
     s = db->CompactRange(compact_options, cf_handle, &begin_slice, &end_slice);
   } else {
@@ -1994,6 +1989,25 @@ bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
 
   rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
   return false;
+}
+
+/**
+ * @return true if the compact range succeeded, false if a Java Exception
+ *     was thrown
+ */
+bool rocksdb_compactrange_helper(JNIEnv* env, rocksdb::DB* db,
+                                 rocksdb::ColumnFamilyHandle* cf_handle,
+                                 jbyteArray jbegin, jint jbegin_len,
+                                 jbyteArray jend, jint jend_len,
+                                 jboolean jreduce_level, jint jtarget_level,
+                                 jint jtarget_path_id) {
+    rocksdb::CompactRangeOptions compact_options;
+    compact_options.change_level = jreduce_level;
+    compact_options.target_level = jtarget_level;
+    compact_options.target_path_id = static_cast<uint32_t>(jtarget_path_id);
+
+    return rocksdb_compactrange_helper(env, db, cf_handle, jbegin, jbegin_len,
+      jend, jend_len, compact_options);
 }
 
 /*
@@ -2026,6 +2040,20 @@ void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIZIIJ(
                               jend_len, jreduce_level, jtarget_level,
                               jtarget_path_id);
 }
+
+
+void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIJJ( // TODO Check method signature
+    JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin,
+    jint jbegin_len, jbyteArray jend, jint jend_len,
+    jlong jcompact_options_handle, jlong jcf_handle) {
+  auto* db = reinterpret_cast<rocksdb::DB*>(jdb_handle);
+  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
+  auto* compact_options = reinterpret_cast<rocksdb::CompactRangeOptions*>(jcompact_options_handle);
+
+  rocksdb_compactrange_helper(env, db, cf_handle, jbegin, jbegin_len, jend,
+                              jend_len, *compact_options);
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 // rocksdb::DB::PauseBackgroundWork

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -2042,7 +2042,7 @@ void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIZIIJ(
 }
 
 
-void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIJJ( // TODO Check method signature
+void Java_org_rocksdb_RocksDB_compactRange__J_3BI_3BIJJ(
     JNIEnv* env, jobject /*jdb*/, jlong jdb_handle, jbyteArray jbegin,
     jint jbegin_len, jbyteArray jend, jint jend_len,
     jlong jcompact_options_handle, jlong jcf_handle) {

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -11,21 +11,25 @@ package org.rocksdb;
  */
 public class CompactRangeOptions extends RocksObject {
 
+  private final static byte VALUE_kSkip = 0;
+  private final static byte VALUE_kIfHaveCompactionFilter = 1;
+  private final static byte VALUE_kForce = 2;
+
   // For level based compaction, we can configure if we want to skip/force bottommost level compaction.
   // The order of this neum MUST follow the C++ layer. See BottommostLevelCompaction in db/options.h
   public enum BottommostLevelCompaction {
     /**
      * Skip bottommost level compaction
      */
-    kSkip((byte)0x0),
+    kSkip((byte)VALUE_kSkip),
     /**
      * Only compact bottommost level if there is a compaction filter. This is the default option
      */
-    kIfHaveCompactionFilter((byte)0x1),
+    kIfHaveCompactionFilter(VALUE_kIfHaveCompactionFilter),
     /**
      * Always compact bottommost level
      */
-    kForce((byte)0x2);
+    kForce(VALUE_kForce);
 
     private final byte value;
 
@@ -49,9 +53,9 @@ public class CompactRangeOptions extends RocksObject {
      */
     public static BottommostLevelCompaction fromRocksId(final int bottommostLevelCompaction) {
       switch (bottommostLevelCompaction) {
-        case 0: return kSkip;
-        case 1: return kIfHaveCompactionFilter;
-        case 2: return kForce;
+        case VALUE_kSkip: return kSkip;
+        case VALUE_kIfHaveCompactionFilter: return kIfHaveCompactionFilter;
+        case VALUE_kForce: return kForce;
         default: return null;
       }
     }

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -1,0 +1,199 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+/**
+ * CompactRangeOptions is used by CompactRange() call. In the documentation of the methods "the compaction" refers to
+ * any compaction that is using this CompactRangeOptions.
+ */
+public class CompactRangeOptions extends RocksObject {
+
+  // For level based compaction, we can configure if we want to skip/force bottommost level compaction.
+  // The order of this neum MUST follow the C++ layer. See BottommostLevelCompaction in db/options.h
+  public enum BottommostLevelCompaction {
+    /**
+     * Skip bottommost level compaction
+     */
+    kSkip,
+    /**
+     * Only compact bottommost level if there is a compaction filter. This is the default option
+     */
+    kIfHaveCompactionFilter,
+    /**
+     * Always compact bottommost level
+     */
+    kForce,;
+
+    /**
+     * Returns the native C++ rocks enum value
+     * @return the native C++ rocks enum value
+     */
+    public int rocksId() {
+      return this.ordinal(); // identical with the C++ layer
+    }
+
+    /**
+     * Returns the BottommostLevelCompaction for the given C++ rocks enum value.
+     * @param bottommostLevelCompaction
+     * @return BottommostLevelCompaction instance, or null if none matches
+     */
+    public static BottommostLevelCompaction fromRocksId(int bottommostLevelCompaction) {
+      switch (bottommostLevelCompaction) {
+        case 0: return kSkip;
+        case 1: return kIfHaveCompactionFilter;
+        case 2: return kForce;
+        default: return null;
+      }
+    }
+  }
+
+  ;
+
+
+  /**
+   * Construct CompactRangeOptions.
+   */
+  public CompactRangeOptions() {
+    super(newCompactRangeOptions());
+  }
+
+  /**
+   * Returns whether the compaction is exclusive or other compactions may run concurrently at the same time.
+   *
+   * @return true if exclusive, false if concurrent
+   */
+  public boolean exclusiveManualCompaction() {
+    return exclusiveManualCompaction(nativeHandle_);
+  }
+
+  /**
+   * Sets whether the compaction is exclusive or other compaction are allowed run concurrently at the same time.
+   *
+   * @param exclusiveCompaction true if compaction should be exclusive
+   */
+  public CompactRangeOptions setExclusiveManualCompaction(boolean exclusiveCompaction) {
+    setExclusiveManualCompaction(nativeHandle_, exclusiveCompaction);
+    return this;
+  }
+
+
+  public BottommostLevelCompaction bottommostLevelCompaction() {
+    return BottommostLevelCompaction.fromRocksId(bottommostLevelCompaction(nativeHandle_));
+  }
+
+  public CompactRangeOptions setBottommostLevelCompaction(BottommostLevelCompaction bottommostLevelCompaction) {
+    setBottommostLevelCompaction(nativeHandle_, bottommostLevelCompaction.rocksId());
+    return this;
+  }
+
+  /**
+   * Returns whether compacted files will be moved to the minimum level capable of holding the data or given level
+   * (specified non-negative target_level).
+   * @return true, if compacted files will be moved to the minimum level
+   */
+  public boolean changeLevel() {
+    return changeLevel(nativeHandle_);
+  }
+
+  /**
+   * Whether compacted files will be moved to the minimum level capable of holding the data or given level
+   * (specified non-negative target_level).
+   * @param changeLevel If true, compacted files will be moved to the minimum level
+   */
+  public void setChangeLevel(boolean changeLevel) {
+    setChangeLevel(nativeHandle_, changeLevel);
+  }
+
+  /**
+   * If change_level is true and target_level have non-negative value, compacted files will be moved to target_level.
+   */
+  public int targetLevel() {
+    return targetLevel(nativeHandle_);
+  }
+
+
+  /**
+   * If change_level is true and target_level have non-negative value, compacted files will be moved to target_level.
+   */
+  public void setTargetLevel(int targetLevel) {
+    setTargetLevel(nativeHandle_, targetLevel);
+  }
+
+  /**
+   * target_path_id for compaction output. Compaction outputs will be placed in options.db_paths[target_path_id].
+   *
+   * @return target_path_id
+   */
+  public int targetPathId() {
+    return targetPathId(nativeHandle_);
+  }
+
+  /**
+   * Compaction outputs will be placed in options.db_paths[target_path_id]. Behavior is undefined if target_path_id is
+   * out of range.
+   *
+   * @param targetPathId target path id
+   */
+  public void setTargetPathId(int targetPathId) {
+    setTargetPathId(nativeHandle_, targetPathId);
+  }
+
+  /**
+   * If true, compaction will execute immediately even if doing so would cause the DB to
+   // enter write stall mode. Otherwise, it'll sleep until load is low enough.
+   * @return true if compaction will execute immediately
+   */
+  public boolean allowWriteStall() {
+    return allowWriteStall(nativeHandle_);
+  }
+
+
+  /**
+   * If true, compaction will execute immediately even if doing so would cause the DB to
+   // enter write stall mode. Otherwise, it'll sleep until load is low enough.
+
+   * @param allowWriteStall true if compaction should execute immediately
+   */
+  public void setAllowWriteStall(boolean allowWriteStall) {
+    setAllowWriteStall(nativeHandle_, allowWriteStall);
+  }
+
+  /**
+   * If &gt; 0, it will replace the option in the DBOptions for this compaction
+   * @return number of subcompactions
+   */
+  public int maxSubcompactions() {
+    return maxSubcompactions(nativeHandle_);
+  }
+
+  /**
+   * If &gt; 0, it will replace the option in the DBOptions for this compaction
+   * @param maxSubcompactions number of subcompactions
+   */
+  public void setMaxSubcompactions(int maxSubcompactions) {
+    setMaxSubcompactions(nativeHandle_, maxSubcompactions);
+  }
+
+  private native static long newCompactRangeOptions();
+  private native boolean exclusiveManualCompaction(final long handle);
+  private native void setExclusiveManualCompaction(final long handle, boolean exclusive_manual_compaction);
+  private native int bottommostLevelCompaction(final long handle);
+  private native void setBottommostLevelCompaction(final long handle, int bottommostLevelCompaction);
+  private native boolean changeLevel(final long handle);
+  private native void setChangeLevel(final long handle, boolean changeLevel);
+  private native int targetLevel(long nativeHandle_);
+  private native void setTargetLevel(long nativeHandle_, int targetLevel);
+  private native int targetPathId(long nativeHandle_);
+  private native void setTargetPathId(long nativeHandle_, int /* uint32_t */ targetPathId);
+  private native boolean allowWriteStall(long nativeHandle_);
+  private native void setAllowWriteStall(long nativeHandle_, boolean allowWriteStall);
+  private native void setMaxSubcompactions(long nativeHandle_, int /* uint32_t */ maxSubcompactions);
+  private native int maxSubcompactions(long nativeHandle_);
+
+  @Override
+  protected final native void disposeInternal(final long handle);
+
+}

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -57,9 +57,6 @@ public class CompactRangeOptions extends RocksObject {
     }
   }
 
-  ;
-
-
   /**
    * Construct CompactRangeOptions.
    */

--- a/java/src/main/java/org/rocksdb/CompactRangeOptions.java
+++ b/java/src/main/java/org/rocksdb/CompactRangeOptions.java
@@ -17,30 +17,37 @@ public class CompactRangeOptions extends RocksObject {
     /**
      * Skip bottommost level compaction
      */
-    kSkip,
+    kSkip((byte)0x0),
     /**
      * Only compact bottommost level if there is a compaction filter. This is the default option
      */
-    kIfHaveCompactionFilter,
+    kIfHaveCompactionFilter((byte)0x1),
     /**
      * Always compact bottommost level
      */
-    kForce,;
+    kForce((byte)0x2);
+
+    private final byte value;
+
+    BottommostLevelCompaction(final byte value) {
+      this.value = value;
+    }
 
     /**
-     * Returns the native C++ rocks enum value
-     * @return the native C++ rocks enum value
+     * <p>Returns the byte value of the enumerations value.</p>
+     *
+     * @return byte representation
      */
-    public int rocksId() {
-      return this.ordinal(); // identical with the C++ layer
+    public byte getValue() {
+      return value;
     }
 
     /**
      * Returns the BottommostLevelCompaction for the given C++ rocks enum value.
-     * @param bottommostLevelCompaction
+     * @param bottommostLevelCompaction The value of the BottommostLevelCompaction
      * @return BottommostLevelCompaction instance, or null if none matches
      */
-    public static BottommostLevelCompaction fromRocksId(int bottommostLevelCompaction) {
+    public static BottommostLevelCompaction fromRocksId(final int bottommostLevelCompaction) {
       switch (bottommostLevelCompaction) {
         case 0: return kSkip;
         case 1: return kIfHaveCompactionFilter;
@@ -73,19 +80,30 @@ public class CompactRangeOptions extends RocksObject {
    * Sets whether the compaction is exclusive or other compaction are allowed run concurrently at the same time.
    *
    * @param exclusiveCompaction true if compaction should be exclusive
+   * @return This CompactRangeOptions
    */
-  public CompactRangeOptions setExclusiveManualCompaction(boolean exclusiveCompaction) {
+  public CompactRangeOptions setExclusiveManualCompaction(final boolean exclusiveCompaction) {
     setExclusiveManualCompaction(nativeHandle_, exclusiveCompaction);
     return this;
   }
 
 
+  /**
+   * Returns the policy for compacting the bottommost level
+   * @return The BottommostLevelCompaction policy
+   */
   public BottommostLevelCompaction bottommostLevelCompaction() {
     return BottommostLevelCompaction.fromRocksId(bottommostLevelCompaction(nativeHandle_));
   }
 
-  public CompactRangeOptions setBottommostLevelCompaction(BottommostLevelCompaction bottommostLevelCompaction) {
-    setBottommostLevelCompaction(nativeHandle_, bottommostLevelCompaction.rocksId());
+  /**
+   * Sets the policy for compacting the bottommost level
+   *
+   * @param bottommostLevelCompaction The policy for compacting the bottommost level
+   * @return This CompactRangeOptions
+   */
+  public CompactRangeOptions setBottommostLevelCompaction(final BottommostLevelCompaction bottommostLevelCompaction) {
+    setBottommostLevelCompaction(nativeHandle_, bottommostLevelCompaction.getValue());
     return this;
   }
 
@@ -101,14 +119,18 @@ public class CompactRangeOptions extends RocksObject {
   /**
    * Whether compacted files will be moved to the minimum level capable of holding the data or given level
    * (specified non-negative target_level).
+   *
    * @param changeLevel If true, compacted files will be moved to the minimum level
+   * @return This CompactRangeOptions
    */
-  public void setChangeLevel(boolean changeLevel) {
+  public CompactRangeOptions setChangeLevel(final boolean changeLevel) {
     setChangeLevel(nativeHandle_, changeLevel);
+    return this;
   }
 
   /**
    * If change_level is true and target_level have non-negative value, compacted files will be moved to target_level.
+   * @return The target level for the compacted files
    */
   public int targetLevel() {
     return targetLevel(nativeHandle_);
@@ -117,9 +139,13 @@ public class CompactRangeOptions extends RocksObject {
 
   /**
    * If change_level is true and target_level have non-negative value, compacted files will be moved to target_level.
+   *
+   * @param targetLevel target level for the compacted files
+   * @return This CompactRangeOptions
    */
-  public void setTargetLevel(int targetLevel) {
+  public CompactRangeOptions setTargetLevel(final int targetLevel) {
     setTargetLevel(nativeHandle_, targetLevel);
+    return this;
   }
 
   /**
@@ -136,14 +162,16 @@ public class CompactRangeOptions extends RocksObject {
    * out of range.
    *
    * @param targetPathId target path id
+   * @return This CompactRangeOptions
    */
-  public void setTargetPathId(int targetPathId) {
+  public CompactRangeOptions setTargetPathId(final int targetPathId) {
     setTargetPathId(nativeHandle_, targetPathId);
+    return this;
   }
 
   /**
    * If true, compaction will execute immediately even if doing so would cause the DB to
-   // enter write stall mode. Otherwise, it'll sleep until load is low enough.
+   * enter write stall mode. Otherwise, it'll sleep until load is low enough.
    * @return true if compaction will execute immediately
    */
   public boolean allowWriteStall() {
@@ -153,12 +181,14 @@ public class CompactRangeOptions extends RocksObject {
 
   /**
    * If true, compaction will execute immediately even if doing so would cause the DB to
-   // enter write stall mode. Otherwise, it'll sleep until load is low enough.
-
+   * enter write stall mode. Otherwise, it'll sleep until load is low enough.
+   *
+   * @return This CompactRangeOptions
    * @param allowWriteStall true if compaction should execute immediately
    */
-  public void setAllowWriteStall(boolean allowWriteStall) {
+  public CompactRangeOptions setAllowWriteStall(final boolean allowWriteStall) {
     setAllowWriteStall(nativeHandle_, allowWriteStall);
+    return this;
   }
 
   /**
@@ -171,27 +201,30 @@ public class CompactRangeOptions extends RocksObject {
 
   /**
    * If &gt; 0, it will replace the option in the DBOptions for this compaction
+   *
    * @param maxSubcompactions number of subcompactions
+   * @return This CompactRangeOptions
    */
-  public void setMaxSubcompactions(int maxSubcompactions) {
+  public CompactRangeOptions setMaxSubcompactions(final int maxSubcompactions) {
     setMaxSubcompactions(nativeHandle_, maxSubcompactions);
+    return this;
   }
 
   private native static long newCompactRangeOptions();
   private native boolean exclusiveManualCompaction(final long handle);
-  private native void setExclusiveManualCompaction(final long handle, boolean exclusive_manual_compaction);
+  private native void setExclusiveManualCompaction(final long handle, final boolean exclusive_manual_compaction);
   private native int bottommostLevelCompaction(final long handle);
-  private native void setBottommostLevelCompaction(final long handle, int bottommostLevelCompaction);
+  private native void setBottommostLevelCompaction(final long handle, final int bottommostLevelCompaction);
   private native boolean changeLevel(final long handle);
-  private native void setChangeLevel(final long handle, boolean changeLevel);
-  private native int targetLevel(long nativeHandle_);
-  private native void setTargetLevel(long nativeHandle_, int targetLevel);
-  private native int targetPathId(long nativeHandle_);
-  private native void setTargetPathId(long nativeHandle_, int /* uint32_t */ targetPathId);
-  private native boolean allowWriteStall(long nativeHandle_);
-  private native void setAllowWriteStall(long nativeHandle_, boolean allowWriteStall);
-  private native void setMaxSubcompactions(long nativeHandle_, int /* uint32_t */ maxSubcompactions);
-  private native int maxSubcompactions(long nativeHandle_);
+  private native void setChangeLevel(final long handle, final boolean changeLevel);
+  private native int targetLevel(final long handle);
+  private native void setTargetLevel(final long handle, final int targetLevel);
+  private native int targetPathId(final long handle);
+  private native void setTargetPathId(final long handle, final int /* uint32_t */ targetPathId);
+  private native boolean allowWriteStall(final long handle);
+  private native void setAllowWriteStall(final long handle, final boolean allowWriteStall);
+  private native void setMaxSubcompactions(final long handle, final int /* uint32_t */ maxSubcompactions);
+  private native int maxSubcompactions(final long handle);
 
   @Override
   protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -1823,6 +1823,8 @@ public class RocksDB extends RocksObject {
    * <li>{@link #compactRange(byte[], byte[], boolean, int, int)}</li>
    * </ul>
    *
+   * @deprecated Use {@link #compactRange(ColumnFamilyHandle, byte[], byte[], CompactRangeOptions)} instead
+   *
    * @param reduce_level reduce level after compaction
    * @param target_level target level to compact to
    * @param target_path_id the target path id of output path
@@ -1830,6 +1832,7 @@ public class RocksDB extends RocksObject {
    * @throws RocksDBException thrown if an error occurs within the native
    *     part of the library.
    */
+  @Deprecated
   public void compactRange(final boolean reduce_level,
       final int target_level, final int target_path_id)
       throws RocksDBException {
@@ -1855,6 +1858,8 @@ public class RocksDB extends RocksObject {
    * <li>{@link #compactRange(byte[], byte[])}</li>
    * </ul>
    *
+   * @deprecated Use {@link #compactRange(ColumnFamilyHandle, byte[], byte[], CompactRangeOptions)} instead
+   *
    * @param begin start of key range (included in range)
    * @param end end of key range (excluded from range)
    * @param reduce_level reduce level after compaction
@@ -1864,6 +1869,7 @@ public class RocksDB extends RocksObject {
    * @throws RocksDBException thrown if an error occurs within the native
    *     part of the library.
    */
+  @Deprecated
   public void compactRange(final byte[] begin, final byte[] end,
       final boolean reduce_level, final int target_level,
       final int target_path_id) throws RocksDBException {
@@ -1935,6 +1941,27 @@ public class RocksDB extends RocksObject {
         false, -1, 0, columnFamilyHandle.nativeHandle_);
   }
 
+
+  /**
+   * <p>Range compaction of column family.</p>
+   * <p><strong>Note</strong>: After the database has been compacted,
+   * all data will have been pushed down to the last level containing
+   * any data.</p>
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle} instance.
+   * @param begin start of key range (included in range)
+   * @param end end of key range (excluded from range)
+   * @param compactRangeOptions options for the compaction
+   *
+   * @throws RocksDBException thrown if an error occurs within the native
+   *     part of the library.
+   */
+  public void compactRange(final ColumnFamilyHandle columnFamilyHandle,
+    final byte[] begin, final byte[] end, CompactRangeOptions compactRangeOptions) throws RocksDBException {
+    compactRange(nativeHandle_, begin, begin.length, end, end.length,
+      compactRangeOptions.nativeHandle_, columnFamilyHandle.nativeHandle_);
+  }
+
   /**
    * <p>Range compaction of column family.</p>
    * <p><strong>Note</strong>: After the database has been compacted,
@@ -1957,6 +1984,8 @@ public class RocksDB extends RocksObject {
    * </li>
    * </ul>
    *
+   * @deprecated Use {@link #compactRange(ColumnFamilyHandle, byte[], byte[], CompactRangeOptions)} instead
+   *
    * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
    *     instance.
    * @param reduce_level reduce level after compaction
@@ -1966,6 +1995,7 @@ public class RocksDB extends RocksObject {
    * @throws RocksDBException thrown if an error occurs within the native
    *     part of the library.
    */
+  @Deprecated
   public void compactRange(final ColumnFamilyHandle columnFamilyHandle,
       final boolean reduce_level, final int target_level,
       final int target_path_id) throws RocksDBException {
@@ -1994,6 +2024,8 @@ public class RocksDB extends RocksObject {
    * </li>
    * </ul>
    *
+   * @deprecated Use {@link #compactRange(ColumnFamilyHandle, byte[], byte[], CompactRangeOptions)} instead
+   *
    * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
    *     instance.
    * @param begin start of key range (included in range)
@@ -2005,6 +2037,7 @@ public class RocksDB extends RocksObject {
    * @throws RocksDBException thrown if an error occurs within the native
    *     part of the library.
    */
+  @Deprecated
   public void compactRange(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] begin, final byte[] end, final boolean reduce_level,
       final int target_level, final int target_path_id)
@@ -2377,6 +2410,9 @@ public class RocksDB extends RocksObject {
   private native void compactRange0(long handle, byte[] begin, int beginLen,
       byte[] end, int endLen, boolean reduce_level, int target_level,
       int target_path_id) throws RocksDBException;
+  private native void compactRange(long handle, byte[] begin, int beginLen,
+    byte[] end, int endLen, long compactRangeOptHandle, long cfHandle)
+    throws RocksDBException;
   private native void compactRange(long handle, boolean reduce_level,
       int target_level, int target_path_id, long cfHandle)
       throws RocksDBException;

--- a/java/src/test/java/org/rocksdb/CompacRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompacRangeOptionsTest.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import org.junit.Test;
+import org.rocksdb.CompactRangeOptions.BottommostLevelCompaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompacRangeOptionsTest {
+
+  static {
+    RocksDB.loadLibrary();
+  }
+
+  private native void setMaxSubcompactions(long nativeHandle_, int /* uint32_t */ maxSubcompactions);
+  private native int maxSubcompactions(long nativeHandle_);
+
+  @Test
+  public void exclusiveManualCompaction() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    boolean value = false;
+    opt.setExclusiveManualCompaction(value);
+    assertThat(opt.exclusiveManualCompaction()).isEqualTo(value);
+    value = true;
+    opt.setExclusiveManualCompaction(value);
+    assertThat(opt.exclusiveManualCompaction()).isEqualTo(value);
+  }
+
+  @Test
+  public void bottommostLevelCompaction() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    BottommostLevelCompaction value = BottommostLevelCompaction.kSkip;
+    opt.setBottommostLevelCompaction(value);
+    assertThat(opt.bottommostLevelCompaction()).isEqualTo(value);
+    value = BottommostLevelCompaction.kForce;
+    opt.setBottommostLevelCompaction(value);
+    assertThat(opt.bottommostLevelCompaction()).isEqualTo(value);
+    value = BottommostLevelCompaction.kIfHaveCompactionFilter;
+    opt.setBottommostLevelCompaction(value);
+    assertThat(opt.bottommostLevelCompaction()).isEqualTo(value);
+  }
+
+  @Test
+  public void changeLevel() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    boolean value = false;
+    opt.setChangeLevel(value);
+    assertThat(opt.changeLevel()).isEqualTo(value);
+    value = true;
+    opt.setChangeLevel(value);
+    assertThat(opt.changeLevel()).isEqualTo(value);
+  }
+
+  @Test
+  public void targetLevel() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    int value = 2;
+    opt.setTargetLevel(value);
+    assertThat(opt.targetLevel()).isEqualTo(value);
+    value = 3;
+    opt.setTargetLevel(value);
+    assertThat(opt.targetLevel()).isEqualTo(value);
+  }
+
+  @Test
+  public void targetPathId() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    int value = 2;
+    opt.setTargetPathId(value);
+    assertThat(opt.targetPathId()).isEqualTo(value);
+    value = 3;
+    opt.setTargetPathId(value);
+    assertThat(opt.targetPathId()).isEqualTo(value);
+  }
+
+  @Test
+  public void allowWriteStall() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    boolean value = false;
+    opt.setAllowWriteStall(value);
+    assertThat(opt.allowWriteStall()).isEqualTo(value);
+    value = true;
+    opt.setAllowWriteStall(value);
+    assertThat(opt.allowWriteStall()).isEqualTo(value);
+  }
+
+  @Test
+  public void maxSubcompactions() {
+    CompactRangeOptions opt = new CompactRangeOptions();
+    int value = 2;
+    opt.setMaxSubcompactions(value);
+    assertThat(opt.maxSubcompactions()).isEqualTo(value);
+    value = 3;
+    opt.setMaxSubcompactions(value);
+    assertThat(opt.maxSubcompactions()).isEqualTo(value);
+  }
+}

--- a/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
@@ -15,9 +15,6 @@ public class CompactRangeOptionsTest {
     RocksDB.loadLibrary();
   }
 
-  private native void setMaxSubcompactions(long nativeHandle_, int /* uint32_t */ maxSubcompactions);
-  private native int maxSubcompactions(long nativeHandle_);
-
   @Test
   public void exclusiveManualCompaction() {
     CompactRangeOptions opt = new CompactRangeOptions();

--- a/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
@@ -11,6 +11,7 @@ import org.rocksdb.CompactRangeOptions.BottommostLevelCompaction;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompactRangeOptionsTest {
+
   static {
     RocksDB.loadLibrary();
   }

--- a/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
@@ -10,7 +10,7 @@ import org.rocksdb.CompactRangeOptions.BottommostLevelCompaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CompacRangeOptionsTest {
+public class CompactRangeOptionsTest {
 
   static {
     RocksDB.loadLibrary();

--- a/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/CompactRangeOptionsTest.java
@@ -11,7 +11,6 @@ import org.rocksdb.CompactRangeOptions.BottommostLevelCompaction;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompactRangeOptionsTest {
-
   static {
     RocksDB.loadLibrary();
   }

--- a/src.mk
+++ b/src.mk
@@ -413,6 +413,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/compaction_filter.cc                          \
   java/rocksjni/compaction_filter_factory.cc                  \
   java/rocksjni/compaction_filter_factory_jnicallback.cc      \
+  java/rocksjni/compact_range_options.cc                      \
   java/rocksjni/compaction_options_fifo.cc                    \
   java/rocksjni/compaction_options_universal.cc               \
   java/rocksjni/comparator.cc                                 \


### PR DESCRIPTION
Closes https://github.com/facebook/rocksdb/issues/4195

CompactRangeOptions are available the CPP API, but not in the Java API. This PR adds CompactRangeOptions to the Java API and adds an overloaded compactRange() method. See https://github.com/facebook/rocksdb/issues/4195 for the original discussion.

This change supports all fields of CompactRangeOptions, including the required enum converters in the JNI portal.

Significant changes:
- Make CompactRangeOptions available in the compactRange() for Java.
- Deprecate other compactRange() methods that have individual option params, like in the CPP code.
- Migrate rocksdb_compactrange_helper() to  CompactRangeOptions.
- Add Java unit tests for CompactRangeOptions.