### PR TITLE
Implement Env::NumFileLinks for Windows

### DIFF
--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -144,6 +144,9 @@ public:
   virtual Status LinkFile(const std::string& src,
     const std::string& target);
 
+  virtual Status NumFileLinks(const std::string& /*fname*/,
+    uint64_t* /*count*/);
+
   virtual Status AreFilesSame(const std::string& first,
     const std::string& second, bool* res);
 
@@ -267,6 +270,9 @@ public:
 
   Status LinkFile(const std::string& src,
     const std::string& target) override;
+
+  Status NumFileLinks(const std::string& fname,
+    uint64_t* count) override;
 
   Status AreFilesSame(const std::string& first,
     const std::string& second, bool* res) override;

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -580,6 +580,11 @@ enum RepFactory StringToRepFactory(const char* ctype) {
   return kSkipList;
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// truncation of constant value on static_cast
+#pragma warning(disable: 4309)
+#endif
 bool GetNextPrefix(const rocksdb::Slice& src, std::string* v) {
   std::string ret = src.ToString();
   for (int i = static_cast<int>(ret.size()) - 1; i >= 0; i--) {
@@ -596,6 +601,9 @@ bool GetNextPrefix(const rocksdb::Slice& src, std::string* v) {
   *v = ret;
   return true;
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 }  // namespace
 
 static enum RepFactory FLAGS_rep_factory;

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -53,11 +53,12 @@ void createSST(const std::string& file_name,
   rocksdb::InternalKeyComparator ikc(opts.comparator);
   unique_ptr<TableBuilder> tb;
 
-  env->NewWritableFile(file_name, &file, env_options);
+  ASSERT_OK(env->NewWritableFile(file_name, &file, env_options));
+
   opts.table_factory = tf;
   std::vector<std::unique_ptr<IntTblPropCollectorFactory> >
       int_tbl_prop_collector_factories;
-  unique_ptr<WritableFileWriter> file_writer(
+  std::unique_ptr<WritableFileWriter> file_writer(
       new WritableFileWriter(std::move(file), EnvOptions()));
   std::string column_family_name;
   int unknown_level = -1;
@@ -90,30 +91,45 @@ void cleanup(const std::string& file_name) {
 
 // Test for sst dump tool "raw" mode
 class SSTDumpToolTest : public testing::Test {
- public:
+  std::string testDir_;
+public:
   BlockBasedTableOptions table_options_;
 
-  SSTDumpToolTest() {}
+  SSTDumpToolTest() {
+    testDir_ = test::TmpDir();
+  }
 
   ~SSTDumpToolTest() {}
+
+  std::string MakeFilePath(const std::string& file_name) const {
+    std::string path(testDir_);
+    path.append("/").append(file_name);
+    return path;
+  }
+
+  template<std::size_t N>
+  void PopulateCommandArgs(const std::string& file_path, const char* command,
+    char* (&usage)[N]) const {
+    for (int i = 0; i < N; ++i) {
+      usage[i] = new char[optLength];
+    }
+    snprintf(usage[0], optLength, "./sst_dump");
+    snprintf(usage[1], optLength, "%s", command);
+    snprintf(usage[2], optLength, "--file=%s", file_path.c_str());
+  }
 };
 
 TEST_F(SSTDumpToolTest, EmptyFilter) {
-  std::string file_name = "rocksdb_sst_test.sst";
-  createSST(file_name, table_options_);
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(file_path, table_options_);
 
   char* usage[3];
-  for (int i = 0; i < 3; i++) {
-    usage[i] = new char[optLength];
-  }
-  snprintf(usage[0], optLength, "./sst_dump");
-  snprintf(usage[1], optLength, "--command=raw");
-  snprintf(usage[2], optLength, "--file=rocksdb_sst_test.sst");
+  PopulateCommandArgs(file_path, "--command=raw", usage);
 
   rocksdb::SSTDumpTool tool;
   ASSERT_TRUE(!tool.Run(3, usage));
 
-  cleanup(file_name);
+  cleanup(file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];
   }
@@ -121,21 +137,16 @@ TEST_F(SSTDumpToolTest, EmptyFilter) {
 
 TEST_F(SSTDumpToolTest, FilterBlock) {
   table_options_.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, true));
-  std::string file_name = "rocksdb_sst_test.sst";
-  createSST(file_name, table_options_);
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(file_path, table_options_);
 
   char* usage[3];
-  for (int i = 0; i < 3; i++) {
-    usage[i] = new char[optLength];
-  }
-  snprintf(usage[0], optLength, "./sst_dump");
-  snprintf(usage[1], optLength, "--command=raw");
-  snprintf(usage[2], optLength, "--file=rocksdb_sst_test.sst");
+  PopulateCommandArgs(file_path, "--command=raw", usage);
 
   rocksdb::SSTDumpTool tool;
   ASSERT_TRUE(!tool.Run(3, usage));
 
-  cleanup(file_name);
+  cleanup(file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];
   }
@@ -143,21 +154,16 @@ TEST_F(SSTDumpToolTest, FilterBlock) {
 
 TEST_F(SSTDumpToolTest, FullFilterBlock) {
   table_options_.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
-  std::string file_name = "rocksdb_sst_test.sst";
-  createSST(file_name, table_options_);
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(file_path, table_options_);
 
   char* usage[3];
-  for (int i = 0; i < 3; i++) {
-    usage[i] = new char[optLength];
-  }
-  snprintf(usage[0], optLength, "./sst_dump");
-  snprintf(usage[1], optLength, "--command=raw");
-  snprintf(usage[2], optLength, "--file=rocksdb_sst_test.sst");
+  PopulateCommandArgs(file_path, "--command=raw", usage);
 
   rocksdb::SSTDumpTool tool;
   ASSERT_TRUE(!tool.Run(3, usage));
 
-  cleanup(file_name);
+  cleanup(file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];
   }
@@ -165,21 +171,16 @@ TEST_F(SSTDumpToolTest, FullFilterBlock) {
 
 TEST_F(SSTDumpToolTest, GetProperties) {
   table_options_.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
-  std::string file_name = "rocksdb_sst_test.sst";
-  createSST(file_name, table_options_);
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(file_path, table_options_);
 
   char* usage[3];
-  for (int i = 0; i < 3; i++) {
-    usage[i] = new char[optLength];
-  }
-  snprintf(usage[0], optLength, "./sst_dump");
-  snprintf(usage[1], optLength, "--show_properties");
-  snprintf(usage[2], optLength, "--file=rocksdb_sst_test.sst");
+  PopulateCommandArgs(file_path, "--show_properties", usage);
 
   rocksdb::SSTDumpTool tool;
   ASSERT_TRUE(!tool.Run(3, usage));
 
-  cleanup(file_name);
+  cleanup(file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];
   }
@@ -187,21 +188,16 @@ TEST_F(SSTDumpToolTest, GetProperties) {
 
 TEST_F(SSTDumpToolTest, CompressedSizes) {
   table_options_.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
-  std::string file_name = "rocksdb_sst_test.sst";
-  createSST(file_name, table_options_);
+  std::string file_path = MakeFilePath("rocksdb_sst_test.sst");
+  createSST(file_path, table_options_);
 
   char* usage[3];
-  for (int i = 0; i < 3; i++) {
-    usage[i] = new char[optLength];
-  }
+  PopulateCommandArgs(file_path, "--command=recompress", usage);
 
-  snprintf(usage[0], optLength, "./sst_dump");
-  snprintf(usage[1], optLength, "--command=recompress");
-  snprintf(usage[2], optLength, "--file=rocksdb_sst_test.sst");
   rocksdb::SSTDumpTool tool;
   ASSERT_TRUE(!tool.Run(3, usage));
 
-  cleanup(file_name);
+  cleanup(file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];
   }


### PR DESCRIPTION
There is an interface Env. NumFileLInks() which currently returns NotImplemnted on Windows. The delete_scheduler makes use of the interface and it does allow for the interface not to be implemented to support platforms that do not implement it. However, the delete_scheduler_test requires it, otherwise it fails, so it does not support backward compatibility. The patch implements it for Windows.
Address compiler warnings
Make sst_dump_test use test directory structure as the current execution directory may not be writiable.