### PR TITLE
BlobDB: Can return expiration together with Get()

### DIFF
--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -240,7 +240,8 @@ class BlobDB : public StackableDB {
   // Update TTL for an existing key.
   //
   // Caveat: The operation is not atomic. Updating a key about to expire
-  // may make the key reappear after expiration.
+  // may make the key reappear after expiration. Also it may overwrite a
+  // concurrent write.
   virtual Status UpdateTTL(const UpdateTTLOptions& options, const Slice& key,
                            uint64_t ttl) = 0;
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1360,9 +1360,11 @@ Status BlobDBImpl::SyncBlobFiles() {
 // First read the key and expiration of the key, then write the key back
 // with updated expiration if needed.
 //
-// Caveat: updating a key about to expire may make the key reappear after
-// expiration. A fix would be somehow block all readers of the key before
-// blob index being updated.
+// Caveat: Updating a key about to expire may make the key reappear after
+// expiration. Also since the operation is not atomic, it may overwrite a
+// concurrent write. Fix is non-trivial. We may need to block readers to the
+// key until blob index get updated, and we need to use transaction to ensure
+// we don't overwrite concurrent writers.
 Status BlobDBImpl::UpdateTTL(const UpdateTTLOptions& options, const Slice& key,
                              uint64_t ttl) {
   assert(ttl < kNoExpiration - EpochNow());

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -130,6 +130,10 @@ class BlobDBImpl : public BlobDB {
   Status Get(const ReadOptions& read_options, ColumnFamilyHandle* column_family,
              const Slice& key, PinnableSlice* value) override;
 
+  Status Get(const ReadOptions& read_options, ColumnFamilyHandle* column_family,
+             const Slice& key, PinnableSlice* value,
+             uint64_t* expiration) override;
+
   using BlobDB::NewIterator;
   virtual Iterator* NewIterator(const ReadOptions& read_options) override;
 
@@ -176,9 +180,6 @@ class BlobDBImpl : public BlobDB {
   Status Open(std::vector<ColumnFamilyHandle*>* handles);
 
   Status SyncBlobFiles() override;
-
-  Status UpdateTTL(const UpdateTTLOptions& options, const Slice& key,
-                   uint64_t ttl) override;
 
   void UpdateLiveSSTSize();
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -177,6 +177,9 @@ class BlobDBImpl : public BlobDB {
 
   Status SyncBlobFiles() override;
 
+  Status UpdateTTL(const UpdateTTLOptions& options, const Slice& key,
+                   uint64_t ttl) override;
+
   void UpdateLiveSSTSize();
 
   void GetCompactionContext(BlobCompactionContext* context);
@@ -215,10 +218,10 @@ class BlobDBImpl : public BlobDB {
 
   Status GetImpl(const ReadOptions& read_options,
                  ColumnFamilyHandle* column_family, const Slice& key,
-                 PinnableSlice* value);
+                 PinnableSlice* value, uint64_t* expiration = nullptr);
 
   Status GetBlobValue(const Slice& key, const Slice& index_entry,
-                      PinnableSlice* value);
+                      PinnableSlice* value, uint64_t* expiration = nullptr);
 
   Slice GetCompressedSlice(const Slice& raw,
                            std::string* compression_output) const;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1548,6 +1548,73 @@ TEST_F(BlobDBTest, FilterForFIFOEviction) {
   VerifyDB(data_after_compact);
 }
 
+TEST_F(BlobDBTest, UpdateTTL) {
+  Options options;
+  options.env = mock_env_.get();
+  BlobDBOptions bdb_options;
+  bdb_options.disable_background_tasks = true;
+  mock_env_->set_current_time(100);
+  Open(bdb_options, options);
+
+  // key1 and key2 should expire before we update its TTL
+  ASSERT_OK(PutWithTTL("key1", "value1", 50));
+  ASSERT_OK(PutWithTTL("key2", "value2", 50));
+  mock_env_->set_current_time(200);
+  ReadOptions ro;
+  WriteOptions wo;
+  UpdateTTLOptions update(ro, wo, UpdateTTLMode::kUpdate);
+  UpdateTTLOptions extend(ro, wo, UpdateTTLMode::kExtend);
+  Status s;
+  s = blob_db_->UpdateTTL(update, "key1", 100);
+  ASSERT_TRUE(s.IsNotFound());
+  s = blob_db_->UpdateTTL(extend, "key2", 100);
+  ASSERT_TRUE(s.IsNotFound());
+
+  std::map<std::string, std::string> data;
+  // We will extend TTL of key2, and shorten TTL of key4 and key5,
+  // all with kUpdate mode.
+  ASSERT_OK(PutWithTTL("key3", "value3", 150, &data));
+  ASSERT_OK(PutWithTTL("key4", "value4", 150, &data));
+  ASSERT_OK(Put("key5", "value5", &data));
+  // We will extend TTL of key6, and shorten TTL of key7 and key8,
+  // all with kExtend mode.
+  ASSERT_OK(PutWithTTL("key6", "value6", 150, &data));
+  ASSERT_OK(PutWithTTL("key7", "value7", 150, &data));
+  ASSERT_OK(Put("key8", "value8", &data));
+
+  ASSERT_OK(blob_db_->UpdateTTL(update, "key3", 250));
+  ASSERT_OK(blob_db_->UpdateTTL(update, "key4", 50));
+  ASSERT_OK(blob_db_->UpdateTTL(update, "key5", 50));
+  ASSERT_OK(blob_db_->UpdateTTL(extend, "key6", 250));
+  ASSERT_OK(blob_db_->UpdateTTL(extend, "key7", 50));
+  ASSERT_OK(blob_db_->UpdateTTL(extend, "key8", 50));
+
+  // All key still exists.
+  VerifyDB(data);
+
+  // Move clock forward. key4 and key5 expired because of shorten TTL.
+  // However key7 and key8 survived because in extend mode the pre-existing
+  // longer TTL is used.
+  mock_env_->set_current_time(300);
+  data.erase("key4");
+  data.erase("key5");
+  VerifyDB(data);
+
+  // Move clock forward. key7 has expiration 250 at the beginning and should
+  // expired now.
+  mock_env_->set_current_time(400);
+  data.erase("key7");
+  VerifyDB(data);
+
+  // Move clock forward. Both key3 and key6 has expiration 350 and should
+  // expired now. key8 begin with no TTL and extending with a shorter TTL
+  // doesn't assign a TTL to it.
+  mock_env_->set_current_time(500);
+  data.erase("key3");
+  data.erase("key6");
+  VerifyDB(data);
+}
+
 }  //  namespace blob_db
 }  //  namespace rocksdb
 


### PR DESCRIPTION
Summary:
Add API to allow fetching expiration of a key with `Get()`. 

Test Plan:
New tests.