### PR TITLE
Implement MultiGet(PinnableSlice)

### DIFF
--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -72,7 +72,8 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     }
   }
   std::vector<Status> statuses(keys.size(), Status::NotFound());
-  values->resize(keys.size());
+  // values->resize(keys.size());
+  assert(values->size() == keys.size());
   int idx = 0;
   for (auto* r : reader_list) {
     if (r != nullptr) {

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -59,7 +59,7 @@ Status CompactedDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle*,
 
 std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>&,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
   autovector<TableReader*, 16> reader_list;
   for (const auto& key : keys) {
     const FdWithKeyRange& f = files_.files[FindFile(key)];
@@ -72,12 +72,12 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     }
   }
   std::vector<Status> statuses(keys.size(), Status::NotFound());
-  values->resize(keys.size());
+  values.resize(keys.size());
   int idx = 0;
   for (auto* r : reader_list) {
     if (r != nullptr) {
       GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                             GetContext::kNotFound, keys[idx], &(*values)[idx],
+                             GetContext::kNotFound, keys[idx], (values)[idx],
                              nullptr, nullptr, nullptr, nullptr);
       LookupKey lkey(keys[idx], kMaxSequenceNumber);
       r->Get(options, lkey.internal_key(), &get_context, nullptr);

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -72,7 +72,9 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     }
   }
   std::vector<Status> statuses(keys.size(), Status::NotFound());
-  assert(values->size() == keys.size());
+  if (values->size() != keys.size()) {
+    return statuses;
+  }
   int idx = 0;
   for (auto* r : reader_list) {
     if (r != nullptr) {

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -59,7 +59,7 @@ Status CompactedDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle*,
 
 std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>&,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
   autovector<TableReader*, 16> reader_list;
   for (const auto& key : keys) {
     const FdWithKeyRange& f = files_.files[FindFile(key)];
@@ -72,12 +72,12 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     }
   }
   std::vector<Status> statuses(keys.size(), Status::NotFound());
-  values.resize(keys.size());
+  values->resize(keys.size());
   int idx = 0;
   for (auto* r : reader_list) {
     if (r != nullptr) {
       GetContext get_context(user_comparator_, nullptr, nullptr, nullptr,
-                             GetContext::kNotFound, keys[idx], (values)[idx],
+                             GetContext::kNotFound, keys[idx], &(*values)[idx],
                              nullptr, nullptr, nullptr, nullptr);
       LookupKey lkey(keys[idx], kMaxSequenceNumber);
       r->Get(options, lkey.internal_key(), &get_context, nullptr);

--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -72,7 +72,6 @@ std::vector<Status> CompactedDBImpl::MultiGet(const ReadOptions& options,
     }
   }
   std::vector<Status> statuses(keys.size(), Status::NotFound());
-  // values->resize(keys.size());
   assert(values->size() == keys.size());
   int idx = 0;
   for (auto* r : reader_list) {

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -25,11 +25,11 @@ class CompactedDBImpl : public DBImpl {
                      ColumnFamilyHandle* column_family, const Slice& key,
                      PinnableSlice* value) override;
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>&,
-      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values)
-    override;
+  void MultiGet(const ReadOptions& options,
+                const std::vector<ColumnFamilyHandle*>&,
+                const std::vector<Slice>& keys,
+                std::vector<PinnableSlice>* values,
+                std::vector<Status>& statuses) override;
 
   using DBImpl::Put;
   virtual Status Put(const WriteOptions& /*options*/,

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -28,7 +28,7 @@ class CompactedDBImpl : public DBImpl {
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>&,
-      const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values)
+      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values)
     override;
 
   using DBImpl::Put;

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -28,7 +28,7 @@ class CompactedDBImpl : public DBImpl {
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>&,
-      const std::vector<Slice>& keys, std::vector<std::string>* values)
+      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values)
     override;
 
   using DBImpl::Put;

--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -28,7 +28,7 @@ class CompactedDBImpl : public DBImpl {
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>&,
-      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values)
+      const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values)
     override;
 
   using DBImpl::Put;

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -761,6 +761,7 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     ASSERT_OK(s[4]);
     ASSERT_TRUE(s[5].IsNotFound());
     SetPerfLevel(kDisable);
+    values.clear();
   } while (ChangeCompactOptions());
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -738,9 +738,10 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     std::vector<Slice> keys({"k1", "k2", "k3", "k4", "k5", "no_key"});
 
     std::string tmp_string("Temporary data to be overwritten");
-    std::vector<PinnableSlice> values;
+    std::vector<PinnableSlice> values(20);
     for (size_t i = 0; i < 20; ++i) {
-      values.emplace_back(&tmp_string);
+      std::string* self_str_ptr = values[i].GetSelf();
+      self_str_ptr->assign(tmp_string);
     }
     std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -140,7 +140,7 @@ TEST_F(DBBasicTest, CompactedDB) {
   ASSERT_EQ("NOT_FOUND", Get("kkk"));
 
   // MultiGet
-  std::vector<std::string> values;
+  std::vector<std::string> values(6);
   std::vector<Status> status_list = dbfull()->MultiGet(
       ReadOptions(),
       std::vector<Slice>({Slice("aaa"), Slice("ccc"), Slice("eee"),
@@ -738,20 +738,20 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     std::vector<Slice> keys({"k1", "k2", "k3", "k4", "k5", "no_key"});
 
     std::string tmp_string("Temporary data to be overwritten");
-    std::vector<PinnableSlice> values(20);
-    for (size_t i = 0; i < 20; ++i) {
+    std::vector<PinnableSlice> values(6);
+    for (size_t i = 0; i < 6; ++i) {
       std::string* self_str_ptr = values[i].GetSelf();
-      self_str_ptr->assign(tmp_string);
+      self_str_ptr->assign(std::string(tmp_string));
     }
     std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
 
     get_perf_context()->Reset();
     std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(values.size(), keys.size());
-    ASSERT_EQ(values[0].data(), "v1");
-    ASSERT_EQ(values[1].data(), "v2");
-    ASSERT_EQ(values[2].data(), "v3");
-    ASSERT_EQ(values[4].data(), "v5");
+    ASSERT_STREQ(values[0].data(), "v1");
+    ASSERT_STREQ(values[1].data(), "v2");
+    ASSERT_STREQ(values[2].data(), "v3");
+    ASSERT_STREQ(values[4].data(), "v5");
     // four kv pairs * two bytes per value
     ASSERT_EQ(8, (int)get_perf_context()->multiget_read_bytes);
 
@@ -790,7 +790,8 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     keys[1] = "b";
     cfs.push_back(handles_[0]);
     cfs.push_back(handles_[1]);
-    s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
+    std::vector<PinnableSlice> values2(2);
+    s = db_->MultiGet(ReadOptions(), cfs, keys, &values2);
     ASSERT_EQ(static_cast<int>(s.size()), 2);
     ASSERT_TRUE(s[0].IsNotFound() && s[1].IsNotFound());
   } while (ChangeCompactOptions());

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -737,21 +737,20 @@ TEST_F(DBBasicTest, MultiGetSimple) {
 
     std::vector<Slice> keys({"k1", "k2", "k3", "k4", "k5", "no_key"});
 
-    std::vector<PinnableSlice*> values;
+    std::string tmp_string("Temporary data to be overwritten");
+    std::vector<PinnableSlice> values;
     for (size_t i = 0; i < 20; ++i) {
-      std::string tmp_string("Temporary data to be overwritten");
-      PinnableSlice* pinnable_val = new PinnableSlice(&tmp_string);
-      values.push_back(pinnable_val);
+      values.emplace_back(&tmp_string);
     }
     std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
 
     get_perf_context()->Reset();
-    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, values);
+    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(values.size(), keys.size());
-    ASSERT_EQ(values[0]->data(), "v1");
-    ASSERT_EQ(values[1]->data(), "v2");
-    ASSERT_EQ(values[2]->data(), "v3");
-    ASSERT_EQ(values[4]->data(), "v5");
+    ASSERT_EQ(values[0].data(), "v1");
+    ASSERT_EQ(values[1].data(), "v2");
+    ASSERT_EQ(values[2].data(), "v3");
+    ASSERT_EQ(values[4].data(), "v5");
     // four kv pairs * two bytes per value
     ASSERT_EQ(8, (int)get_perf_context()->multiget_read_bytes);
 
@@ -762,7 +761,6 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     ASSERT_OK(s[4]);
     ASSERT_TRUE(s[5].IsNotFound());
     SetPerfLevel(kDisable);
-    values.clear();
   } while (ChangeCompactOptions());
 }
 
@@ -771,9 +769,9 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
     // Empty Key Set
     std::vector<Slice> keys;
-    std::vector<PinnableSlice*> values;
+    std::vector<PinnableSlice> values;
     std::vector<ColumnFamilyHandle*> cfs;
-    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, values);
+    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(s.size(), 0U);
 
     // Empty Database, Empty Key Set
@@ -781,7 +779,7 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     options.create_if_missing = true;
     DestroyAndReopen(options);
     CreateAndReopenWithCF({"pikachu"}, options);
-    s = db_->MultiGet(ReadOptions(), cfs, keys, values);
+    s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(s.size(), 0U);
 
     // Empty Database, Search for Keys
@@ -790,7 +788,7 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     keys[1] = "b";
     cfs.push_back(handles_[0]);
     cfs.push_back(handles_[1]);
-    s = db_->MultiGet(ReadOptions(), cfs, keys, values);
+    s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(static_cast<int>(s.size()), 2);
     ASSERT_TRUE(s[0].IsNotFound() && s[1].IsNotFound());
   } while (ChangeCompactOptions());

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -746,7 +746,8 @@ TEST_F(DBBasicTest, MultiGetSimple) {
     std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
 
     get_perf_context()->Reset();
-    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
+    std::vector<Status> s(keys.size());
+    db_->MultiGet(ReadOptions(), cfs, keys, &values, s);
     ASSERT_EQ(values.size(), keys.size());
     ASSERT_STREQ(values[0].data(), "v1");
     ASSERT_STREQ(values[1].data(), "v2");
@@ -773,7 +774,8 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     std::vector<Slice> keys;
     std::vector<PinnableSlice> values;
     std::vector<ColumnFamilyHandle*> cfs;
-    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
+    std::vector<Status> s;
+    db_->MultiGet(ReadOptions(), cfs, keys, &values, s);
     ASSERT_EQ(s.size(), 0U);
 
     // Empty Database, Empty Key Set
@@ -781,7 +783,7 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     options.create_if_missing = true;
     DestroyAndReopen(options);
     CreateAndReopenWithCF({"pikachu"}, options);
-    s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
+    db_->MultiGet(ReadOptions(), cfs, keys, &values, s);
     ASSERT_EQ(s.size(), 0U);
 
     // Empty Database, Search for Keys
@@ -791,7 +793,8 @@ TEST_F(DBBasicTest, MultiGetEmpty) {
     cfs.push_back(handles_[0]);
     cfs.push_back(handles_[1]);
     std::vector<PinnableSlice> values2(2);
-    s = db_->MultiGet(ReadOptions(), cfs, keys, &values2);
+    s.resize(2);
+    db_->MultiGet(ReadOptions(), cfs, keys, &values2, s);
     ASSERT_EQ(static_cast<int>(s.size()), 2);
     ASSERT_TRUE(s[0].IsNotFound() && s[1].IsNotFound());
   } while (ChangeCompactOptions());

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1180,7 +1180,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
 std::vector<Status> DBImpl::MultiGet(
     const ReadOptions& read_options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
   StopWatch sw(env_, stats_, DB_MULTIGET);
   PERF_TIMER_GUARD(get_snapshot_time);
 
@@ -1223,7 +1223,7 @@ std::vector<Status> DBImpl::MultiGet(
   // Note: this always resizes the values array
   size_t num_keys = keys.size();
   std::vector<Status> stat_list(num_keys);
-  values->resize(num_keys);
+  values.resize(num_keys);
 
   // Keep track of bytes that we read for statistics-recording later
   uint64_t bytes_read = 0;
@@ -1237,7 +1237,7 @@ std::vector<Status> DBImpl::MultiGet(
   for (size_t i = 0; i < num_keys; ++i) {
     merge_context.Clear();
     Status& s = stat_list[i];
-    PinnableSlice* pinnable_val = &(*values)[i];
+    PinnableSlice* pinnable_val = values[i];
 
     LookupKey lkey(keys[i], snapshot);
     auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family[i]);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1223,7 +1223,8 @@ std::vector<Status> DBImpl::MultiGet(
   // Note: this always resizes the values array
   size_t num_keys = keys.size();
   std::vector<Status> stat_list(num_keys);
-  values->resize(num_keys);
+  // values->resize(num_keys);
+  assert(values->size() == num_keys);
 
   // Keep track of bytes that we read for statistics-recording later
   uint64_t bytes_read = 0;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1180,7 +1180,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
 std::vector<Status> DBImpl::MultiGet(
     const ReadOptions& read_options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
   StopWatch sw(env_, stats_, DB_MULTIGET);
   PERF_TIMER_GUARD(get_snapshot_time);
 
@@ -1223,7 +1223,7 @@ std::vector<Status> DBImpl::MultiGet(
   // Note: this always resizes the values array
   size_t num_keys = keys.size();
   std::vector<Status> stat_list(num_keys);
-  values.resize(num_keys);
+  values->resize(num_keys);
 
   // Keep track of bytes that we read for statistics-recording later
   uint64_t bytes_read = 0;
@@ -1237,7 +1237,7 @@ std::vector<Status> DBImpl::MultiGet(
   for (size_t i = 0; i < num_keys; ++i) {
     merge_context.Clear();
     Status& s = stat_list[i];
-    PinnableSlice* pinnable_val = values[i];
+    PinnableSlice* pinnable_val = &(*values)[i];
 
     LookupKey lkey(keys[i], snapshot);
     auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family[i]);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1177,10 +1177,11 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   return s;
 }
 
-std::vector<Status> DBImpl::MultiGet(
-    const ReadOptions& read_options,
-    const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
+void DBImpl::MultiGet(const ReadOptions& read_options,
+                      const std::vector<ColumnFamilyHandle*>& column_family,
+                      const std::vector<Slice>& keys,
+                      std::vector<PinnableSlice>* values,
+                      std::vector<Status>& statuses) {
   StopWatch sw(env_, stats_, DB_MULTIGET);
   PERF_TIMER_GUARD(get_snapshot_time);
 
@@ -1221,7 +1222,7 @@ std::vector<Status> DBImpl::MultiGet(
   MergeContext merge_context;
 
   size_t num_keys = keys.size();
-  std::vector<Status> stat_list(num_keys);
+  // std::vector<Status> statuses(num_keys);
   assert(values->size() == num_keys);
 
   // Keep track of bytes that we read for statistics-recording later
@@ -1235,7 +1236,7 @@ std::vector<Status> DBImpl::MultiGet(
   size_t num_found = 0;
   for (size_t i = 0; i < num_keys; ++i) {
     merge_context.Clear();
-    Status& s = stat_list[i];
+    Status& s = statuses[i];
     PinnableSlice* pinnable_val = &(*values)[i];
 
     LookupKey lkey(keys[i], snapshot);
@@ -1307,7 +1308,7 @@ std::vector<Status> DBImpl::MultiGet(
   PERF_COUNTER_ADD(multiget_read_bytes, bytes_read);
   PERF_TIMER_STOP(get_post_process_time);
 
-  return stat_list;
+  return;
 }
 
 Status DBImpl::CreateColumnFamily(const ColumnFamilyOptions& cf_options,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -114,11 +114,11 @@ class DBImpl : public DB {
                  bool* is_blob_index = nullptr);
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override;
+  virtual void MultiGet(const ReadOptions& options,
+                        const std::vector<ColumnFamilyHandle*>& column_family,
+                        const std::vector<Slice>& keys,
+                        std::vector<PinnableSlice>* values,
+                        std::vector<Status>& statuses) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -118,7 +118,7 @@ class DBImpl : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice*>& values) override;
+      std::vector<PinnableSlice>* values) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -118,7 +118,7 @@ class DBImpl : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override;
+      std::vector<PinnableSlice*>& values) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -118,7 +118,7 @@ class DBImpl : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override;
+      std::vector<PinnableSlice>* values) override;
 
   virtual Status CreateColumnFamily(const ColumnFamilyOptions& cf_options,
                                     const std::string& column_family,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -338,9 +338,9 @@ TEST_F(DBTest, ReadFromPersistedTier) {
       std::vector<Slice> multiget_keys;
       multiget_keys.push_back("foo");
       multiget_keys.push_back("bar");
-      std::vector<PinnableSlice> multiget_values;
+      std::vector<PinnableSlice*> multiget_values;
       auto statuses =
-          db_->MultiGet(ropt, multiget_cfs, multiget_keys, &multiget_values);
+          db_->MultiGet(ropt, multiget_cfs, multiget_keys, multiget_values);
       if (wopt.disableWAL) {
         ASSERT_TRUE(statuses[0].IsNotFound());
         ASSERT_TRUE(statuses[1].IsNotFound());
@@ -371,11 +371,11 @@ TEST_F(DBTest, ReadFromPersistedTier) {
       multiget_cfs.push_back(handles_[1]);
       multiget_keys.push_back("rocksdb");
       statuses =
-          db_->MultiGet(ropt, multiget_cfs, multiget_keys, &multiget_values);
+          db_->MultiGet(ropt, multiget_cfs, multiget_keys, multiget_values);
       ASSERT_TRUE(statuses[0].ok());
-      ASSERT_EQ("first", multiget_values[0].data());
+      ASSERT_EQ("first", multiget_values[0]->data());
       ASSERT_TRUE(statuses[1].ok());
-      ASSERT_EQ("one", multiget_values[1].data());
+      ASSERT_EQ("one", multiget_values[1]->data());
       if (wopt.disableWAL) {
         ASSERT_TRUE(statuses[2].IsNotFound());
       } else {
@@ -400,16 +400,16 @@ TEST_F(DBTest, ReadFromPersistedTier) {
       ASSERT_EQ(value, "hello");
 
       statuses =
-          db_->MultiGet(ropt, multiget_cfs, multiget_keys, &multiget_values);
+          db_->MultiGet(ropt, multiget_cfs, multiget_keys, multiget_values);
       ASSERT_TRUE(statuses[0].IsNotFound());
       if (wopt.disableWAL) {
         ASSERT_TRUE(statuses[1].ok());
-        ASSERT_EQ("one", multiget_values[1].data());
+        ASSERT_EQ("one", multiget_values[1]->data());
       } else {
         ASSERT_TRUE(statuses[1].IsNotFound());
       }
       ASSERT_TRUE(statuses[2].ok());
-      ASSERT_EQ("hello", multiget_values[2].data());
+      ASSERT_EQ("hello", multiget_values[2]->data());
       if (wopt.disableWAL == 0) {
         DestroyAndReopen(options);
       }
@@ -2017,9 +2017,9 @@ static void MTThreadBody(void* arg) {
       // and that writes to all column families were atomic (unique_id is the
       // same)
       std::vector<Slice> keys(kColumnFamilies, Slice(keybuf));
-      std::vector<PinnableSlice> values;
+      std::vector<PinnableSlice*> values;
       std::vector<Status> statuses =
-          db->MultiGet(ReadOptions(), t->state->test->handles_, keys, &values);
+          db->MultiGet(ReadOptions(), t->state->test->handles_, keys, values);
       Status s = statuses[0];
       // all statuses have to be the same
       for (size_t i = 1; i < statuses.size(); ++i) {
@@ -2035,9 +2035,9 @@ static void MTThreadBody(void* arg) {
         int unique_id = -1;
         for (int i = 0; i < kColumnFamilies; ++i) {
           int k, w, c, cf, u;
-          ASSERT_EQ(5, sscanf(values[i].data(), "%d.%d.%d.%d.%d", &k, &w, &c,
+          ASSERT_EQ(5, sscanf(values[i]->data(), "%d.%d.%d.%d.%d", &k, &w, &c,
                               &cf, &u))
-              << values[i].data();
+              << values[i]->data();
           ASSERT_EQ(k, key);
           ASSERT_GE(w, 0);
           ASSERT_LT(w, kNumThreads);
@@ -2259,7 +2259,7 @@ class ModelDB : public DB {
       const ReadOptions& /*options*/,
       const std::vector<ColumnFamilyHandle*>& /*column_family*/,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* /*values*/) override {
+      std::vector<PinnableSlice*>& /*values*/) override {
     std::vector<Status> s(keys.size(),
                           Status::NotSupported("Not implemented."));
     return s;

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -458,7 +458,7 @@ namespace {
   void ValidateKeyExistence(DB* db, const std::vector<Slice>& keys_must_exist,
     const std::vector<Slice>& keys_must_not_exist) {
     // Ensure that expected keys exist
-    std::vector<std::string> values;
+    std::vector<std::string> values(keys_must_exist.size());
     if (keys_must_exist.size() > 0) {
       std::vector<Status> status_list =
         db->MultiGet(ReadOptions(), keys_must_exist, &values);
@@ -468,6 +468,8 @@ namespace {
     }
 
     // Ensure that given keys don't exist
+    values.clear();
+    values.resize(keys_must_not_exist.size());
     if (keys_must_not_exist.size() > 0) {
       std::vector<Status> status_list =
         db->MultiGet(ReadOptions(), keys_must_not_exist, &values);

--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -298,7 +298,7 @@ void ProfileQueries(bool enabled_time = false) {
     std::string value;
 
     std::vector<Slice> multiget_keys = {Slice(key)};
-    std::vector<std::string> values;
+    std::vector<std::string> values(1, "");
 
     get_perf_context()->Reset();
     ASSERT_OK(db->Get(read_options, key, &value));
@@ -412,7 +412,7 @@ void ProfileQueries(bool enabled_time = false) {
     std::string value;
 
     std::vector<Slice> multiget_keys = {Slice(key)};
-    std::vector<std::string> values;
+    std::vector<std::string> values(1);
 
     get_perf_context()->Reset();
     ASSERT_OK(db->Get(read_options, key, &value));

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -373,7 +373,7 @@ class DB {
       if (s[i].ok() && pinnable_vector[i].IsPinned()) {
         (*values)[i].assign(pinnable_vector[i].data(), pinnable_vector[i].size());
       }
-    }  // else value is already assigned
+    }
     pinnable_vector.clear();
     return s;
   }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -353,7 +353,7 @@ class DB {
   // the i'th returned status will have Status::ok() true, and (*values)[i]
   // will store the value associated with keys[i].
   //
-  // (*values) will always be resized to be the same size as (keys).
+  // (*values) is required to be the same size as (keys).
   // Similarly, the number of returned statuses will be the number of keys.
   // Note: keys will not be "de-duplicated". Duplicate keys will return
   // duplicate values in order.
@@ -365,8 +365,7 @@ class DB {
     std::vector<PinnableSlice> pinnable_vector(values->size());
     for (size_t i = 0; i < values->size(); ++i) {
       assert(!pinnable_vector[i].IsPinned());
-      std::string* self_str_ptr = pinnable_vector[i].GetSelf();
-      self_str_ptr->assign((*values)[i]);
+      pinnable_vector[i].ResetSelf(&(*values)[i]);
     }
     std::vector<Status> s = MultiGet(options, column_family, keys, &pinnable_vector);
     assert(s.size() == pinnable_vector.size());

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -361,20 +361,21 @@ class DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys, std::vector<std::string>* values) {
-    std::vector<PinnableSlice> pinnable_vector;
+    assert(values != nullptr);
+    std::vector<PinnableSlice*> pinnable_vector;
     for (size_t i = 0; i < values->size(); ++i) {
-      assert((*values)[i] != nullptr);
-      PinnableSlice pinnable_val(&(*values)[i]);
-      assert(!pinnable_val.IsPinned());
-      pinnable_vector.emplace_back(&(*values)[i]);
+      PinnableSlice* pinnable_val = new PinnableSlice(&(*values)[i]);
+      assert(!pinnable_val->IsPinned());
+      pinnable_vector.push_back(pinnable_val);
     }
-    std::vector<Status> s = MultiGet(options, column_family, keys, &pinnable_vector);
+    std::vector<Status> s = MultiGet(options, column_family, keys, pinnable_vector);
     assert(s.size() == pinnable_vector.size());
     for (size_t i = 0; i < s.size(); ++i) {
-      if (s[i].ok() && pinnable_vector[i].IsPinned()) {
-        (*values)[i].assign(pinnable_vector[i].data(), pinnable_vector[i].size());
+      if (s[i].ok() && pinnable_vector[i]->IsPinned()) {
+        (*values)[i].assign(pinnable_vector[i]->data(), pinnable_vector[i]->size());
       }
     }  // else value is already assigned
+    pinnable_vector.clear();
     return s;
   }
   virtual std::vector<Status> MultiGet(const ReadOptions& options,
@@ -387,7 +388,7 @@ class DB {
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) = 0;
+      const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) = 0;
 
   // If the key definitely does not exist in the database, then this method
   // returns false, else true. If the caller wants to obtain value when the key

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -360,7 +360,23 @@ class DB {
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys, std::vector<std::string>* values) = 0;
+      const std::vector<Slice>& keys, std::vector<std::string>* values) {
+    std::vector<PinnableSlice> pinnable_vector;
+    for (size_t i = 0; i < values->size(); ++i) {
+      assert((*values)[i] != nullptr);
+      PinnableSlice pinnable_val(&(*values)[i]);
+      assert(!pinnable_val.IsPinned());
+      pinnable_vector.emplace_back(&(*values)[i]);
+    }
+    std::vector<Status> s = MultiGet(options, column_family, keys, &pinnable_vector);
+    assert(s.size() == pinnable_vector.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+      if (s[i].ok() && pinnable_vector[i].IsPinned()) {
+        (*values)[i].assign(pinnable_vector[i].data(), pinnable_vector[i].size());
+      }
+    }  // else value is already assigned
+    return s;
+  }
   virtual std::vector<Status> MultiGet(const ReadOptions& options,
                                        const std::vector<Slice>& keys,
                                        std::vector<std::string>* values) {
@@ -368,6 +384,10 @@ class DB {
                                  keys.size(), DefaultColumnFamily()),
                     keys, values);
   }
+  virtual std::vector<Status> MultiGet(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) = 0;
 
   // If the key definitely does not exist in the database, then this method
   // returns false, else true. If the caller wants to obtain value when the key

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -362,8 +362,8 @@ class DB {
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys, std::vector<std::string>* values) {
     std::vector<PinnableSlice> pinnable_vector;
+    assert(values != nullptr);
     for (size_t i = 0; i < values->size(); ++i) {
-      assert((*values)[i] != nullptr);
       PinnableSlice pinnable_val(&(*values)[i]);
       assert(!pinnable_val.IsPinned());
       pinnable_vector.emplace_back(&(*values)[i]);
@@ -375,6 +375,7 @@ class DB {
         (*values)[i].assign(pinnable_vector[i].data(), pinnable_vector[i].size());
       }
     }  // else value is already assigned
+    pinnable_vector.clear();
     return s;
   }
   virtual std::vector<Status> MultiGet(const ReadOptions& options,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -361,12 +361,12 @@ class DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys, std::vector<std::string>* values) {
-    std::vector<PinnableSlice> pinnable_vector;
     assert(values != nullptr);
+    std::vector<PinnableSlice> pinnable_vector(values->size());
     for (size_t i = 0; i < values->size(); ++i) {
-      PinnableSlice pinnable_val(&(*values)[i]);
-      assert(!pinnable_val.IsPinned());
-      pinnable_vector.emplace_back(&(*values)[i]);
+      assert(!pinnable_vector[i].IsPinned());
+      std::string* self_str_ptr = pinnable_vector[i].GetSelf();
+      self_str_ptr->assign((*values)[i]);
     }
     std::vector<Status> s = MultiGet(options, column_family, keys, &pinnable_vector);
     assert(s.size() == pinnable_vector.size());

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -152,6 +152,31 @@ class PinnableSlice : public Slice, public Cleanable {
   PinnableSlice(PinnableSlice&) = delete;
   PinnableSlice& operator=(PinnableSlice&) = delete;
 
+  PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
+
+  PinnableSlice& operator=(PinnableSlice&& other) {
+    if (this != &other) {
+      // cleanup itself.
+      Reset();
+
+      Slice::operator=(other);
+      Cleanable::operator=(std::move(other));
+      pinned_ = other.pinned_;
+      if (!pinned_ && other.buf_ == &other.self_space_) {
+        self_space_ = std::move(other.self_space_);
+        buf_ = &self_space_;
+        data_ = buf_->data();
+      } else {
+        buf_ = other.buf_;
+      }
+      // Re-initialize the other PinnablaeSlice.
+      other.self_space_.clear();
+      other.buf_ = &other.self_space_;
+      other.pinned_ = false;
+    }
+    return *this;
+  }
+
   inline void PinSlice(const Slice& s, CleanupFunction f, void* arg1,
                        void* arg2) {
     assert(!pinned_);

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -152,31 +152,6 @@ class PinnableSlice : public Slice, public Cleanable {
   PinnableSlice(PinnableSlice&) = delete;
   PinnableSlice& operator=(PinnableSlice&) = delete;
 
-  PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
-
-  PinnableSlice& operator=(PinnableSlice&& other) {
-    if (this != &other) {
-      // cleanup itself.
-      Reset();
-
-      Slice::operator=(other);
-      Cleanable::operator=(std::move(other));
-      pinned_ = other.pinned_;
-      if (!pinned_ && other.buf_ == &other.self_space_) {
-        self_space_ = std::move(other.self_space_);
-        buf_ = &self_space_;
-        data_ = buf_->data();
-      } else {
-        buf_ = other.buf_;
-      }
-      // Re-initialize the other PinnablaeSlice.
-      other.self_space_.clear();
-      other.buf_ = &other.self_space_;
-      other.pinned_ = false;
-    }
-    return *this;
-  }
-
   inline void PinSlice(const Slice& s, CleanupFunction f, void* arg1,
                        void* arg2) {
     assert(!pinned_);

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -152,30 +152,30 @@ class PinnableSlice : public Slice, public Cleanable {
   PinnableSlice(PinnableSlice&) = delete;
   PinnableSlice& operator=(PinnableSlice&) = delete;
 
-  PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
-
-  PinnableSlice& operator=(PinnableSlice&& other) {
-    if (this != &other) {
-      // cleanup itself.
-      Reset();
-
-      Slice::operator=(other);
-      Cleanable::operator=(std::move(other));
-      pinned_ = other.pinned_;
-      if (!pinned_ && other.buf_ == &other.self_space_) {
-        self_space_ = std::move(other.self_space_);
-        buf_ = &self_space_;
-        data_ = buf_->data();
-      } else {
-        buf_ = other.buf_;
-      }
-      // Re-initialize the other PinnablaeSlice.
-      other.self_space_.clear();
-      other.buf_ = &other.self_space_;
-      other.pinned_ = false;
-    }
-    return *this;
-  }
+  // PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
+  //
+  // PinnableSlice& operator=(PinnableSlice&& other) {
+  //   if (this != &other) {
+  //     // cleanup itself.
+  //     Reset();
+  //
+  //     Slice::operator=(other);
+  //     Cleanable::operator=(std::move(other));
+  //     pinned_ = other.pinned_;
+  //     if (!pinned_ && other.buf_ == &other.self_space_) {
+  //       self_space_ = std::move(other.self_space_);
+  //       buf_ = &self_space_;
+  //       data_ = buf_->data();
+  //     } else {
+  //       buf_ = other.buf_;
+  //     }
+  //     // Re-initialize the other PinnableSlice.
+  //     other.self_space_.clear();
+  //     other.buf_ = &other.self_space_;
+  //     other.pinned_ = false;
+  //   }
+  //   return *this;
+  // }
 
   inline void PinSlice(const Slice& s, CleanupFunction f, void* arg1,
                        void* arg2) {

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -152,30 +152,30 @@ class PinnableSlice : public Slice, public Cleanable {
   PinnableSlice(PinnableSlice&) = delete;
   PinnableSlice& operator=(PinnableSlice&) = delete;
 
-  // PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
-  //
-  // PinnableSlice& operator=(PinnableSlice&& other) {
-  //   if (this != &other) {
-  //     // cleanup itself.
-  //     Reset();
-  //
-  //     Slice::operator=(other);
-  //     Cleanable::operator=(std::move(other));
-  //     pinned_ = other.pinned_;
-  //     if (!pinned_ && other.buf_ == &other.self_space_) {
-  //       self_space_ = std::move(other.self_space_);
-  //       buf_ = &self_space_;
-  //       data_ = buf_->data();
-  //     } else {
-  //       buf_ = other.buf_;
-  //     }
-  //     // Re-initialize the other PinnableSlice.
-  //     other.self_space_.clear();
-  //     other.buf_ = &other.self_space_;
-  //     other.pinned_ = false;
-  //   }
-  //   return *this;
-  // }
+  PinnableSlice(PinnableSlice&& other) { *this = std::move(other); }
+
+  PinnableSlice& operator=(PinnableSlice&& other) {
+    if (this != &other) {
+      // cleanup itself.
+      Reset();
+
+      Slice::operator=(other);
+      Cleanable::operator=(std::move(other));
+      pinned_ = other.pinned_;
+      if (!pinned_ && other.buf_ == &other.self_space_) {
+        self_space_ = std::move(other.self_space_);
+        buf_ = &self_space_;
+        data_ = buf_->data();
+      } else {
+        buf_ = other.buf_;
+      }
+      // Re-initialize the other PinnablaeSlice.
+      other.self_space_.clear();
+      other.buf_ = &other.self_space_;
+      other.pinned_ = false;
+    }
+    return *this;
+  }
 
   inline void PinSlice(const Slice& s, CleanupFunction f, void* arg1,
                        void* arg2) {

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -207,6 +207,8 @@ class PinnableSlice : public Slice, public Cleanable {
 
   inline std::string* GetSelf() { return buf_; }
 
+  inline void ResetSelf(std::string* buf) { buf_ = buf; }
+
   inline bool IsPinned() { return pinned_; }
 
  private:

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,7 +95,7 @@ class StackableDB : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override {
+      std::vector<PinnableSlice>* values) override {
     return db_->MultiGet(options, column_family, keys, values);
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,7 +95,7 @@ class StackableDB : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override {
+      std::vector<PinnableSlice*>& values) override {
     return db_->MultiGet(options, column_family, keys, values);
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -95,7 +95,7 @@ class StackableDB : public DB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice*>& values) override {
+      std::vector<PinnableSlice>* values) override {
     return db_->MultiGet(options, column_family, keys, values);
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -91,12 +91,12 @@ class StackableDB : public DB {
   }
 
   using DB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override {
-    return db_->MultiGet(options, column_family, keys, values);
+  virtual void MultiGet(const ReadOptions& options,
+                        const std::vector<ColumnFamilyHandle*>& column_family,
+                        const std::vector<Slice>& keys,
+                        std::vector<PinnableSlice>* values,
+                        std::vector<Status>& statuses) override {
+    db_->MultiGet(options, column_family, keys, values, statuses);
   }
 
   using DB::IngestExternalFile;

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -205,6 +205,12 @@ class Transaction {
                                        const std::vector<Slice>& keys,
                                        std::vector<std::string>* values) = 0;
 
+  // virtual std::vector<Status> MultiGet(
+  //    const ReadOptions& options,
+  //    const std::vector<ColumnFamilyHandle*>& column_family,
+  //    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
+  //
+  // }
   // Read this key and ensure that this transaction will only
   // be able to be committed if this key is not written outside this
   // transaction after it has first been read (or after the snapshot if a

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -205,12 +205,6 @@ class Transaction {
                                        const std::vector<Slice>& keys,
                                        std::vector<std::string>* values) = 0;
 
-  // virtual std::vector<Status> MultiGet(
-  //    const ReadOptions& options,
-  //    const std::vector<ColumnFamilyHandle*>& column_family,
-  //    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
-  //
-  // }
   // Read this key and ensure that this transaction will only
   // be able to be committed if this key is not written outside this
   // transaction after it has first been read (or after the snapshot if a

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -817,7 +817,7 @@ jobjectArray multi_get_helper(JNIEnv* env, jobject /*jdb*/, rocksdb::DB* db,
   env->ReleaseIntArrayElements(jkey_lens, jkey_len, JNI_ABORT);
   env->ReleaseIntArrayElements(jkey_offs, jkey_off, JNI_ABORT);
 
-  std::vector<std::string> values;
+  std::vector<std::string> values(keys.size());
   std::vector<rocksdb::Status> s;
   if (cf_handles.size() == 0) {
     s = db->MultiGet(rOpt, keys, &values);

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -162,7 +162,7 @@ class BlobDB : public StackableDB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,
       const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override {
+      std::vector<PinnableSlice>* values) override {
     for (auto column_family : column_families) {
       if (column_family != DefaultColumnFamily()) {
         return std::vector<Status>(
@@ -171,7 +171,11 @@ class BlobDB : public StackableDB {
                 "Blob DB doesn't support non-default column family."));
       }
     }
-    return MultiGet(options, keys, values);
+    std::vector<std::string> string_values;
+    for (size_t i = 0; i < values->size(); ++i) {
+      string_values.push_back(*(*values)[i].GetSelf());
+    }
+    return MultiGet(options, keys, &string_values);
   }
 
   using rocksdb::StackableDB::SingleDelete;

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -162,7 +162,7 @@ class BlobDB : public StackableDB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override {
+      std::vector<PinnableSlice*>& values) override {
     for (auto column_family : column_families) {
       if (column_family != DefaultColumnFamily()) {
         return std::vector<Status>(
@@ -172,8 +172,8 @@ class BlobDB : public StackableDB {
       }
     }
     std::vector<std::string> string_values;
-    for (size_t i = 0; i < values->size(); ++i) {
-      string_values.push_back(*(*values)[i].GetSelf());
+    for (size_t i = 0; i < values.size(); ++i) {
+      string_values.push_back(*values[i]->GetSelf());
     }
     return MultiGet(options, keys, &string_values);
   }

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -158,6 +158,7 @@ class BlobDB : public StackableDB {
       const ReadOptions& options,
       const std::vector<Slice>& keys,
       std::vector<std::string>* values) override = 0;
+  // TODO (yiwu): add support for MultiGet which takes PinnableSlice
   virtual std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -162,7 +162,7 @@ class BlobDB : public StackableDB {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice*>& values) override {
+      std::vector<PinnableSlice>* values) override {
     for (auto column_family : column_families) {
       if (column_family != DefaultColumnFamily()) {
         return std::vector<Status>(
@@ -172,8 +172,8 @@ class BlobDB : public StackableDB {
       }
     }
     std::vector<std::string> string_values;
-    for (size_t i = 0; i < values.size(); ++i) {
-      string_values.push_back(*values[i]->GetSelf());
+    for (size_t i = 0; i < values->size(); ++i) {
+      string_values.push_back(*(*values)[i].GetSelf());
     }
     return MultiGet(options, keys, &string_values);
   }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -806,7 +806,7 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ColumnFamilyHandle *default_handle = blob_db_->DefaultColumnFamily();
   ColumnFamilyHandle *handle = nullptr;
   std::string value;
-  std::vector<std::string> values;
+  std::vector<PinnableSlice> values;
   // The call simply pass through to base db. It should succeed.
   ASSERT_OK(
       blob_db_->CreateColumnFamily(ColumnFamilyOptions(), "foo", &handle));

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -806,7 +806,7 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ColumnFamilyHandle *default_handle = blob_db_->DefaultColumnFamily();
   ColumnFamilyHandle *handle = nullptr;
   std::string value;
-  std::vector<PinnableSlice> values;
+  std::vector<PinnableSlice*> values;
   // The call simply pass through to base db. It should succeed.
   ASSERT_OK(
       blob_db_->CreateColumnFamily(ColumnFamilyOptions(), "foo", &handle));
@@ -823,7 +823,7 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ASSERT_TRUE(
       blob_db_->Get(ReadOptions(), handle, "k", &value).IsNotSupported());
   auto statuses = blob_db_->MultiGet(ReadOptions(), {default_handle, handle},
-                                     {"k1", "k2"}, &values);
+                                     {"k1", "k2"}, values);
   ASSERT_EQ(2, statuses.size());
   ASSERT_TRUE(statuses[0].IsNotSupported());
   ASSERT_TRUE(statuses[1].IsNotSupported());

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -806,7 +806,7 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ColumnFamilyHandle *default_handle = blob_db_->DefaultColumnFamily();
   ColumnFamilyHandle *handle = nullptr;
   std::string value;
-  std::vector<PinnableSlice*> values;
+  std::vector<PinnableSlice> values;
   // The call simply pass through to base db. It should succeed.
   ASSERT_OK(
       blob_db_->CreateColumnFamily(ColumnFamilyOptions(), "foo", &handle));
@@ -823,7 +823,7 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ASSERT_TRUE(
       blob_db_->Get(ReadOptions(), handle, "k", &value).IsNotSupported());
   auto statuses = blob_db_->MultiGet(ReadOptions(), {default_handle, handle},
-                                     {"k1", "k2"}, values);
+                                     {"k1", "k2"}, &values);
   ASSERT_EQ(2, statuses.size());
   ASSERT_TRUE(statuses[0].IsNotSupported());
   ASSERT_TRUE(statuses[1].IsNotSupported());

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -822,8 +822,9 @@ TEST_F(BlobDBTest, ColumnFamilyNotSupported) {
   ASSERT_TRUE(blob_db_->Get(ReadOptions(), "k1", &value).IsNotFound());
   ASSERT_TRUE(
       blob_db_->Get(ReadOptions(), handle, "k", &value).IsNotSupported());
-  auto statuses = blob_db_->MultiGet(ReadOptions(), {default_handle, handle},
-                                     {"k1", "k2"}, &values);
+  std::vector<Status> statuses(2);
+  blob_db_->MultiGet(ReadOptions(), {default_handle, handle}, {"k1", "k2"},
+                     &values, statuses);
   ASSERT_EQ(2, statuses.size());
   ASSERT_TRUE(statuses[0].IsNotSupported());
   ASSERT_TRUE(statuses[1].IsNotSupported());

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -217,17 +217,17 @@ Status DBWithTTLImpl::Get(const ReadOptions& options,
 std::vector<Status> DBWithTTLImpl::MultiGet(
     const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
   auto statuses = db_->MultiGet(options, column_family, keys, values);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = SanityCheckTimestamp((*values)[i].data());
+    statuses[i] = SanityCheckTimestamp(values[i]->data());
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = StripTS((*values)[i].GetSelf());
+    statuses[i] = StripTS(values[i]->GetSelf());
   }
   return statuses;
 }

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -217,17 +217,17 @@ Status DBWithTTLImpl::Get(const ReadOptions& options,
 std::vector<Status> DBWithTTLImpl::MultiGet(
     const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice*>& values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
   auto statuses = db_->MultiGet(options, column_family, keys, values);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = SanityCheckTimestamp(values[i]->data());
+    statuses[i] = SanityCheckTimestamp((*values)[i].data());
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = StripTS(values[i]->GetSelf());
+    statuses[i] = StripTS((*values)[i].GetSelf());
   }
   return statuses;
 }

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -217,17 +217,17 @@ Status DBWithTTLImpl::Get(const ReadOptions& options,
 std::vector<Status> DBWithTTLImpl::MultiGet(
     const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<std::string>* values) {
+    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
   auto statuses = db_->MultiGet(options, column_family, keys, values);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = SanityCheckTimestamp((*values)[i]);
+    statuses[i] = SanityCheckTimestamp((*values)[i].data());
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = StripTS(&(*values)[i]);
+    statuses[i] = StripTS((*values)[i].GetSelf());
   }
   return statuses;
 }

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -227,7 +227,7 @@ std::vector<Status> DBWithTTLImpl::MultiGet(
     if (!statuses[i].ok()) {
       continue;
     }
-    statuses[i] = StripTS((*values)[i].GetSelf());
+    statuses[i] = StripTS(&(*values)[i]);
   }
   return statuses;
 }

--- a/utilities/ttl/db_ttl_impl.cc
+++ b/utilities/ttl/db_ttl_impl.cc
@@ -214,11 +214,12 @@ Status DBWithTTLImpl::Get(const ReadOptions& options,
   return StripTS(value);
 }
 
-std::vector<Status> DBWithTTLImpl::MultiGet(
+void DBWithTTLImpl::MultiGet(
     const ReadOptions& options,
     const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values) {
-  auto statuses = db_->MultiGet(options, column_family, keys, values);
+    const std::vector<Slice>& keys, std::vector<PinnableSlice>* values,
+    std::vector<Status>& statuses) {
+  db_->MultiGet(options, column_family, keys, values, statuses);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!statuses[i].ok()) {
       continue;
@@ -229,7 +230,7 @@ std::vector<Status> DBWithTTLImpl::MultiGet(
     }
     statuses[i] = StripTS(&(*values)[i]);
   }
-  return statuses;
+  return;
 }
 
 bool DBWithTTLImpl::KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -58,7 +58,7 @@ class DBWithTTLImpl : public DBWithTTL {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override;
+      std::vector<PinnableSlice>* values) override;
 
   using StackableDB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -58,7 +58,7 @@ class DBWithTTLImpl : public DBWithTTL {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override;
+      std::vector<PinnableSlice*>& values) override;
 
   using StackableDB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -54,11 +54,11 @@ class DBWithTTLImpl : public DBWithTTL {
                      PinnableSlice* value) override;
 
   using StackableDB::MultiGet;
-  virtual std::vector<Status> MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      std::vector<PinnableSlice>* values) override;
+  virtual void MultiGet(const ReadOptions& options,
+                        const std::vector<ColumnFamilyHandle*>& column_family,
+                        const std::vector<Slice>& keys,
+                        std::vector<PinnableSlice>* values,
+                        std::vector<Status>& statuses) override;
 
   using StackableDB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -58,7 +58,7 @@ class DBWithTTLImpl : public DBWithTTL {
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
       const std::vector<Slice>& keys,
-      std::vector<PinnableSlice*>& values) override;
+      std::vector<PinnableSlice>* values) override;
 
   using StackableDB::KeyMayExist;
   virtual bool KeyMayExist(const ReadOptions& options,

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -208,7 +208,7 @@ class TtlTest : public testing::Test {
     size_t i = 0;
     for (auto& kv : kvmap_) {
       ASSERT_OK(statuses[i]);
-      ASSERT_EQ(values[i], kv.second);
+      ASSERT_EQ(values[i].data(), kv.second);
       ++i;
     }
   }

--- a/utilities/ttl/ttl_test.cc
+++ b/utilities/ttl/ttl_test.cc
@@ -198,11 +198,11 @@ class TtlTest : public testing::Test {
   void SimpleMultiGetTest() {
     static ReadOptions ropts;
     std::vector<Slice> keys;
-    std::vector<std::string> values;
 
     for (auto& kv : kvmap_) {
       keys.emplace_back(kv.first);
     }
+    std::vector<std::string> values(keys.size(), "");
 
     auto statuses = db_ttl_->MultiGet(ropts, keys, &values);
     size_t i = 0;


### PR DESCRIPTION
In #1756 `DB::Get` API is extended to receive a `PinnableSlice` instead of std::string. 
This PR adds support for `PinnableSlice` interface for `DB::MultiGet`
Fixes https://github.com/facebook/rocksdb/issues/4171
@ot 