### PR TITLE
Make rocksdb::Slice more interoperable with std::string_view

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -25,6 +25,10 @@
 #include <string.h>
 #include <string>
 
+#ifdef __cpp_lib_string_view
+#include <string_view>
+#endif
+
 #include "rocksdb/cleanable.h"
 
 namespace rocksdb {
@@ -40,6 +44,12 @@ class Slice {
   // Create a slice that refers to the contents of "s"
   /* implicit */
   Slice(const std::string& s) : data_(s.data()), size_(s.size()) { }
+
+#ifdef __cpp_lib_string_view
+  // Create a slice that refers to the same contents as "sv"
+  /* implicit */
+  Slice(std::string_view sv) : data_(sv.data()), size_(sv.size()) { }
+#endif
 
   // Create a slice that refers to s[0,strlen(s)-1]
   /* implicit */
@@ -85,6 +95,13 @@ class Slice {
   // Return a string that contains the copy of the referenced data.
   // when hex is true, returns a string of twice the length hex encoded (0-9A-F)
   std::string ToString(bool hex = false) const;
+
+#ifdef __cpp_lib_string_view
+  // Return a string_view that references the same data as this slice.
+  std::string_view ToStringView() const {
+    return std::string_view(data_, size_);
+  }
+#endif
 
   // Decodes the current slice interpreted as an hexadecimal string into result,
   // if successful returns true, if this isn't a valid hex string


### PR DESCRIPTION
This change allows using std::string_view objects directly in the
DB API:

    db->Get(some_string_view_object, ...);

The conversion from std::string_view to rocksdb::Slice is done
automatically, thanks to the added constructor.

I'm stopping short of adding an implicit conversion operator
from rocksdb::Slice to std::string_view, as I don't think that's
a good idea for PinnableSlices.