### PR TITLE
Return correct usable_size for BlockContents

### DIFF
--- a/table/format.h
+++ b/table/format.h
@@ -212,7 +212,7 @@ struct BlockContents {
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE
       return malloc_usable_size(allocation.get());
 #else
-      return sizeof(*allocation.get());
+      return data.size();
 #endif  // ROCKSDB_MALLOC_USABLE_SIZE
     } else {
       return 0;  // no extra memory is occupied by the data


### PR DESCRIPTION
If jemalloc is disabled or the API is incorrectly referenced (jemalloc api on windows have a prefix je_) memory usage is incorrectly reported for all block sizes. This is because sizeof(char) is always 1. sizeof() is calculated at compile time and *(char*) is char. The patch uses the size of the slice to fix that.
Fixes #4245