### PR TITLE
Fix error parsing in build_tools/error_filter.py

### DIFF
--- a/build_tools/error_filter.py
+++ b/build_tools/error_filter.py
@@ -64,8 +64,12 @@ class MatchErrorParser(ErrorParserBase):
 
 class CompilerErrorParser(MatchErrorParser):
     def __init__(self):
-        # format: '<filename>:<line #>:<column #>: error: <error msg>'
-        super(CompilerErrorParser, self).__init__(r'\S+:\d+:\d+: error:')
+        # format (compile error):
+        #   '<filename>:<line #>:<column #>: error: <error msg>'
+        # format (compile error):
+        #   '<filename>:<line #>: error: <error msg>'
+        # The below regex catches both
+        super(CompilerErrorParser, self).__init__(r'\S+:\d+: error:')
 
 
 class ScanBuildErrorParser(MatchErrorParser):

--- a/build_tools/error_filter.py
+++ b/build_tools/error_filter.py
@@ -66,7 +66,7 @@ class CompilerErrorParser(MatchErrorParser):
     def __init__(self):
         # format (compile error):
         #   '<filename>:<line #>:<column #>: error: <error msg>'
-        # format (compile error):
+        # format (link error):
         #   '<filename>:<line #>: error: <error msg>'
         # The below regex catches both
         super(CompilerErrorParser, self).__init__(r'\S+:\d+: error:')


### PR DESCRIPTION
The error_filter.py script parses the output of the "Build and run" stage of continuous tests to check for errors. It is currently only detecting compile errors and not link errors. This change fixes that. 