### PR TITLE
Link to FB internal build of ZSTD with -fPIC

### DIFF
--- a/build_tools/fbcode_config.sh
+++ b/build_tools/fbcode_config.sh
@@ -43,11 +43,15 @@ if test -z $PIC_BUILD; then
   LZ4_INCLUDE=" -I $LZ4_BASE/include/"
   LZ4_LIBS=" $LZ4_BASE/lib/liblz4.a"
   CFLAGS+=" -DLZ4"
-
-  ZSTD_INCLUDE=" -I $ZSTD_BASE/include/"
-  ZSTD_LIBS=" $ZSTD_BASE/lib/libzstd.a"
-  CFLAGS+=" -DZSTD"
 fi
+
+ZSTD_INCLUDE=" -I $ZSTD_BASE/include/"
+if test -z $PIC_BUILD; then
+  ZSTD_LIBS=" $ZSTD_BASE/lib/libzstd.a"
+else
+  ZSTD_LIBS=" $ZSTD_BASE/lib/libzstd_pic.a"
+fi
+CFLAGS+=" -DZSTD"
 
 # location of gflags headers and libraries
 GFLAGS_INCLUDE=" -I $GFLAGS_BASE/include/"


### PR DESCRIPTION
TSAN requires the code is built with -fPIC. This PR links against a libzstd built with -fPIC when necessary, which enables ZSTD compression to be used in TSAN builds.

Test Plan:

- verified code built with TSAN can now use ZSTD compression without failing.
```
$ TEST_TMPDIR=/dev/shm/ OPT=-g COMPILE_WITH_TSAN=1 CRASH_TEST_EXT_ARGS='--log2_keys_per_lock=22' CRASH_TEST_KILL_ODD=1887 make J=1 crash_test
...
```