### PR TITLE
Fix a TSAN failure

### DIFF
--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -110,7 +110,7 @@ public:
   template<std::size_t N>
   void PopulateCommandArgs(const std::string& file_path, const char* command,
     char* (&usage)[N]) const {
-    for (int i = 0; i < N; ++i) {
+    for (int i = 0; i < static_cast<int>(N); ++i) {
       usage[i] = new char[optLength];
     }
     snprintf(usage[0], optLength, "./sst_dump");


### PR DESCRIPTION
TSAN fails due to comparison between signed int and unsigned long. Fix it by
static_casting.

Test plan:
```
$make clean && OPT=-g COMPILE_WITH_TSAN=1 make -j16
```