### PR TITLE
Charge block cache for cache internal usage

### DIFF
--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -178,8 +178,8 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   virtual Status Insert(const Slice& key, uint32_t hash, void* value,
                         size_t charge,
                         void (*deleter)(const Slice& key, void* value),
-                        Cache::Handle** handle,
-                        Cache::Priority priority) override;
+                        Cache::Handle** handle, Cache::Priority priority,
+                        bool charge_internal_usage) override;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) override;
   virtual bool Ref(Cache::Handle* handle) override;
   virtual bool Release(Cache::Handle* handle,

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -36,7 +36,8 @@ class LRUCacheTest : public testing::Test {
   void Insert(const std::string& key,
               Cache::Priority priority = Cache::Priority::LOW) {
     cache_->Insert(key, 0 /*hash*/, nullptr /*value*/, 1 /*charge*/,
-                   nullptr /*deleter*/, nullptr /*handle*/, priority);
+                   nullptr /*deleter*/, nullptr /*handle*/, priority,
+                   false /*charge_internal_usage*/);
   }
 
   void Insert(char key, Cache::Priority priority = Cache::Priority::LOW) {

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -47,10 +47,12 @@ void ShardedCache::SetStrictCapacityLimit(bool strict_capacity_limit) {
 
 Status ShardedCache::Insert(const Slice& key, void* value, size_t charge,
                             void (*deleter)(const Slice& key, void* value),
-                            Handle** handle, Priority priority) {
+                            Handle** handle, Priority priority,
+                            bool charge_internal_usage) {
   uint32_t hash = HashSlice(key);
   return GetShard(Shard(hash))
-      ->Insert(key, hash, value, charge, deleter, handle, priority);
+      ->Insert(key, hash, value, charge, deleter, handle, priority,
+               charge_internal_usage);
 }
 
 Cache::Handle* ShardedCache::Lookup(const Slice& key, Statistics* /*stats*/) {

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -27,7 +27,8 @@ class CacheShard {
   virtual Status Insert(const Slice& key, uint32_t hash, void* value,
                         size_t charge,
                         void (*deleter)(const Slice& key, void* value),
-                        Cache::Handle** handle, Cache::Priority priority) = 0;
+                        Cache::Handle** handle, Cache::Priority priority,
+                        bool charge_internal_usage) = 0;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) = 0;
   virtual bool Ref(Cache::Handle* handle) = 0;
   virtual bool Release(Cache::Handle* handle, bool force_erase = false) = 0;
@@ -62,7 +63,8 @@ class ShardedCache : public Cache {
 
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
-                        Handle** handle, Priority priority) override;
+                        Handle** handle, Priority priority,
+                        bool charge_internal_usage) override;
   virtual Handle* Lookup(const Slice& key, Statistics* stats) override;
   virtual bool Ref(Handle* handle) override;
   virtual bool Release(Handle* handle, bool force_erase = false) override;

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -397,13 +397,15 @@ class MockCache : public LRUCache {
 
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
-                        Handle** handle, Priority priority) override {
+                        Handle** handle, Priority priority,
+                        bool charge_internal_usage) override {
     if (priority == Priority::LOW) {
       low_pri_insert_count++;
     } else {
       high_pri_insert_count++;
     }
-    return LRUCache::Insert(key, value, charge, deleter, handle, priority);
+    return LRUCache::Insert(key, value, charge, deleter, handle, priority,
+                            charge_internal_usage);
   }
 };
 

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -11,13 +11,6 @@
 #include <sys/ioctl.h>
 #endif
 
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
 #include <sys/types.h>
 
 #include <iostream>
@@ -38,6 +31,7 @@
 #endif
 
 #include "env/env_chroot.h"
+#include "port/malloc.h"
 #include "port/port.h"
 #include "rocksdb/env.h"
 #include "util/coding.h"

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -126,10 +126,14 @@ class Cache {
   //
   // When the inserted entry is no longer needed, the key and
   // value will be passed to "deleter".
+  //
+  // If charge_internal_usage is true, add size of any memory used by the
+  // cache implementation for the new entry to charge.
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle = nullptr,
-                        Priority priority = Priority::LOW) = 0;
+                        Priority priority = Priority::LOW,
+                        bool charge_internal_usage = false) = 0;
 
   // If the cache has no mapping for "key", returns nullptr.
   //

--- a/port/malloc.h
+++ b/port/malloc.h
@@ -1,0 +1,17 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+#pragma once
+
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
+#ifdef OS_FREEBSD
+#include <malloc_np.h>
+#else
+#include <malloc.h>
+#endif  // OS_FREEBSD
+#endif  // ROCKSDB_MALLOC_USABLE_SIZE

--- a/table/block.h
+++ b/table/block.h
@@ -12,16 +12,11 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
 
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
+#include "format.h"
+#include "port/malloc.h"
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
@@ -29,7 +24,6 @@
 #include "table/internal_iterator.h"
 #include "util/random.h"
 #include "util/sync_point.h"
-#include "format.h"
 
 namespace rocksdb {
 

--- a/table/format.h
+++ b/table/format.h
@@ -10,19 +10,13 @@
 #pragma once
 #include <stdint.h>
 #include <string>
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
 
 #include "options/cf_options.h"
+#include "port/malloc.h"
 #include "port/port.h"  // noexcept
 #include "table/persistent_cache_options.h"
 #include "util/file_reader_writer.h"

--- a/table/full_filter_block.cc
+++ b/table/full_filter_block.cc
@@ -5,15 +5,8 @@
 
 #include "table/full_filter_block.h"
 
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
-
 #include "monitoring/perf_context_imp.h"
+#include "port/malloc.h"
 #include "port/port.h"
 #include "rocksdb/filter_policy.h"
 #include "util/coding.h"

--- a/table/partitioned_filter_block.cc
+++ b/table/partitioned_filter_block.cc
@@ -5,16 +5,10 @@
 
 #include "table/partitioned_filter_block.h"
 
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
 #include <utility>
 
 #include "monitoring/perf_context_imp.h"
+#include "port/malloc.h"
 #include "port/port.h"
 #include "rocksdb/filter_policy.h"
 #include "table/block.h"

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2282,12 +2282,13 @@ class MockCache : public LRUCache {
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
                         Handle** handle = nullptr,
-                        Priority priority = Priority::LOW) override {
+                        Priority priority = Priority::LOW,
+                        bool charge_internal_usage = false) override {
     // Replace the deleter with our own so that we keep track of data blocks
     // erased from the cache
     deleters_[key.ToString()] = deleter;
     return ShardedCache::Insert(key, value, charge, &MockDeleter, handle,
-                                priority);
+                                priority, charge_internal_usage);
   }
   // This is called by the application right after inserting a data block
   virtual void TEST_mark_as_data_block(const Slice& key,

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -8,17 +8,11 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "util/arena.h"
-#ifdef ROCKSDB_MALLOC_USABLE_SIZE
-#ifdef OS_FREEBSD
-#include <malloc_np.h>
-#else
-#include <malloc.h>
-#endif
-#endif
 #ifndef OS_WIN
 #include <sys/mman.h>
 #endif
 #include <algorithm>
+#include "port/malloc.h"
 #include "port/port.h"
 #include "rocksdb/env.h"
 #include "util/logging.h"

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -170,7 +170,8 @@ class SimCacheImpl : public SimCache {
 
   virtual Status Insert(const Slice& key, void* value, size_t charge,
                         void (*deleter)(const Slice& key, void* value),
-                        Handle** handle, Priority priority) override {
+                        Handle** handle, Priority priority,
+                        bool charge_internal_usage) override {
     // The handle and value passed in are for real cache, so we pass nullptr
     // to key_only_cache_ for both instead. Also, the deleter function pointer
     // will be called by user to perform some external operation which should
@@ -180,14 +181,15 @@ class SimCacheImpl : public SimCache {
     if (h == nullptr) {
       key_only_cache_->Insert(key, nullptr, charge,
                               [](const Slice& /*k*/, void* /*v*/) {}, nullptr,
-                              priority);
+                              priority, charge_internal_usage);
     } else {
       key_only_cache_->Release(h);
     }
 
     cache_activity_logger_.ReportAdd(key, charge);
 
-    return cache_->Insert(key, value, charge, deleter, handle, priority);
+    return cache_->Insert(key, value, charge, deleter, handle, priority,
+                          charge_internal_usage);
   }
 
   virtual Handle* Lookup(const Slice& key, Statistics* stats) override {


### PR DESCRIPTION
Summary:
For our default block cache, each additional entry has extra memory overhead. It include LRUHandle (72 bytes currently) and the cache key (two varint64, file id and offset). The usage is not negligible. For example for block_size=4k, the overhead account for an extra 2% memory usage for the cache. The patch charging the cache for the extra usage, reducing untracked memory usage outside block cache.

Test Plan:
If the change looks good I'll go ahead and add tests.