### PR TITLE
Revert changes in PR #4003

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -230,11 +230,9 @@ Status BuildTable(
   }
 
   // Output to event logger and fire events.
-  if (!s.ok() || meta->fd.GetFileSize() > 0) {
-    EventHelpers::LogAndNotifyTableFileCreationFinished(
-        event_logger, ioptions.listeners, dbname, column_family_name, fname,
-        job_id, meta->fd, tp, reason, s);
-  }
+  EventHelpers::LogAndNotifyTableFileCreationFinished(
+      event_logger, ioptions.listeners, dbname, column_family_name, fname,
+      job_id, meta->fd, tp, reason, s);
 
   return s;
 }


### PR DESCRIPTION
Revert this change. Not generating the OnTableFileCreated() notification for a 0 byte SST on flush breaks the assumption that every OnTableFileCreationStarted() notification is followed by a corresponding OnTableFileCreated().