### PR TITLE
Extend stress test to format_version 4

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -54,7 +54,7 @@ default_params = {
     "verify_checksum": 1,
     "write_buffer_size": 4 * 1024 * 1024,
     "writepercent": 35,
-    "format_version": lambda: random.randint(2, 3),
+    "format_version": lambda: random.randint(2, 4),
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'


### PR DESCRIPTION
Stress tests currently cover format_version 2 and 3. The patch adds 4 as well.