### PR TITLE
Remove an assersion about file size

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1252,7 +1252,6 @@ class DbStressListener : public EventListener {
     VerifyFilePath(info.file_path);
     assert(info.job_id > 0 || FLAGS_compact_files_one_in > 0);
     if (info.status.ok()) {
-      assert(info.file_size > 0);
       assert(info.table_properties.data_size > 0);
       assert(info.table_properties.raw_key_size > 0);
       assert(info.table_properties.num_entries > 0);


### PR DESCRIPTION
Due to 4ea56b1bd00b5f8751e5e9733d01ceb33ebd09e3, we should also remove the
assersion in stress test. This removal can be temporary, and we can add it back
once we figure out the reason for the 0-byte SSTs.

Test plan:
```
$make clean && make -j32
$./db_stress
```