### PR TITLE
Fix the build and test bugs in the Trace_analyzer

### DIFF
--- a/tools/trace_analyzer_test.cc
+++ b/tools/trace_analyzer_test.cc
@@ -55,8 +55,6 @@ class TraceAnalyzerTest : public testing::Test {
   void GenerateTrace(std::string trace_path) {
     Options options;
     options.create_if_missing = true;
-    options.IncreaseParallelism();
-    options.OptimizeLevelStyleCompaction();
     options.merge_operator = MergeOperators::CreatePutOperator();
     ReadOptions ro;
     WriteOptions wo;

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -740,7 +740,7 @@ Status TraceAnalyzer::MakeStatisticCorrelation(TraceStats& stats,
 
 // Process the statistics of QPS
 Status TraceAnalyzer::MakeStatisticQPS() {
-  uint32_t duration = (end_time_ - begin_time_) / 1000000;
+  uint32_t duration = static_cast<uint32_t>((end_time_ - begin_time_) / 1000000);
   int ret;
   Status s;
   std::vector<std::vector<uint32_t>> type_qps(
@@ -1098,7 +1098,7 @@ Status TraceAnalyzer::KeyStatsInsertion(const uint32_t& type,
   if (ts < begin_time_) {
     time_in_sec = 0;
   } else {
-    time_in_sec = (ts - begin_time_) / 1000000;
+    time_in_sec = static_cast<uint32_t>((ts - begin_time_) / 1000000);
   }
 
   uint64_t dist_value_size = value_size / FLAGS_value_interval;


### PR DESCRIPTION
The wrong options are used in the trace_analyzer_test, removed. The potential loses integer precision are fixed.

Pass the specified testing case, make asan_check