### PR TITLE
Suppress two CLANG Analyze warning

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -383,7 +383,6 @@ class VersionBuilder::Rep {
       }
     }
 
-    std::vector<port::Thread> threads;
     std::atomic<size_t> next_file_meta_idx(0);
     std::function<void()> load_handlers_func = [&]() {
       while (true) {
@@ -408,6 +407,7 @@ class VersionBuilder::Rep {
       }
     };
 
+    std::vector<port::Thread> threads;
     for (int i = 1; i < max_threads; i++) {
       threads.emplace_back(load_handlers_func);
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -383,6 +383,7 @@ class VersionBuilder::Rep {
       }
     }
 
+    std::vector<port::Thread> threads;
     std::atomic<size_t> next_file_meta_idx(0);
     std::function<void()> load_handlers_func = [&]() {
       while (true) {
@@ -407,7 +408,6 @@ class VersionBuilder::Rep {
       }
     };
 
-    std::vector<port::Thread> threads;
     for (int i = 1; i < max_threads; i++) {
       threads.emplace_back(load_handlers_func);
     }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2841,33 +2841,33 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file,
     out_file->Append(table_properties->ToString("\n  ", ": ").c_str());
     out_file->Append("\n");
 
-  // Output Filter blocks
-  if (!rep_->filter && !table_properties->filter_policy_name.empty()) {
-    // Support only BloomFilter as off now
-    rocksdb::BlockBasedTableOptions table_options;
-    table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(1));
-    if (table_properties->filter_policy_name.compare(
-            table_options.filter_policy->Name()) == 0) {
-      std::string filter_block_key = kFilterBlockPrefix;
-      filter_block_key.append(table_properties->filter_policy_name);
-      BlockHandle handle;
-      if (FindMetaBlock(meta_iter.get(), filter_block_key, &handle).ok()) {
-        BlockContents block;
-        Slice dummy_comp_dict;
-        BlockFetcher block_fetcher(
-            rep_->file.get(), nullptr /* prefetch_buffer */, rep_->footer,
-            ReadOptions(), handle, &block, rep_->ioptions, false /*decompress*/,
-            dummy_comp_dict /*compression dict*/,
-            rep_->persistent_cache_options);
-        s = block_fetcher.ReadBlockContents();
-        if (!s.ok()) {
-          rep_->filter.reset(new BlockBasedFilterBlockReader(
-              prefix_extractor, table_options,
-              table_options.whole_key_filtering, std::move(block),
-              rep_->ioptions.statistics));
+    // Output Filter blocks
+    if (!rep_->filter && !table_properties->filter_policy_name.empty()) {
+      // Support only BloomFilter as off now
+      rocksdb::BlockBasedTableOptions table_options;
+      table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(1));
+      if (table_properties->filter_policy_name.compare(
+              table_options.filter_policy->Name()) == 0) {
+        std::string filter_block_key = kFilterBlockPrefix;
+        filter_block_key.append(table_properties->filter_policy_name);
+        BlockHandle handle;
+        if (FindMetaBlock(meta_iter.get(), filter_block_key, &handle).ok()) {
+          BlockContents block;
+          Slice dummy_comp_dict;
+          BlockFetcher block_fetcher(
+              rep_->file.get(), nullptr /* prefetch_buffer */, rep_->footer,
+              ReadOptions(), handle, &block, rep_->ioptions,
+              false /*decompress*/, dummy_comp_dict /*compression dict*/,
+              rep_->persistent_cache_options);
+          s = block_fetcher.ReadBlockContents();
+          if (!s.ok()) {
+            rep_->filter.reset(new BlockBasedFilterBlockReader(
+                prefix_extractor, table_options,
+                table_options.whole_key_filtering, std::move(block),
+                rep_->ioptions.statistics));
+          }
         }
       }
-    }
   }
   }
   if (rep_->filter) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2868,7 +2868,7 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file,
           }
         }
       }
-  }
+    }
   }
   if (rep_->filter) {
     out_file->Append(

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2840,7 +2840,6 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file,
         "  ");
     out_file->Append(table_properties->ToString("\n  ", ": ").c_str());
     out_file->Append("\n");
-  }
 
   // Output Filter blocks
   if (!rep_->filter && !table_properties->filter_policy_name.empty()) {
@@ -2869,6 +2868,7 @@ Status BlockBasedTable::DumpTable(WritableFile* out_file,
         }
       }
     }
+  }
   }
   if (rep_->filter) {
     out_file->Append(

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -169,6 +169,7 @@ void BlockFetcher::GetBlockContents() {
     // page can be either uncompressed or compressed, the buffer either stack
     // or heap provided. Refer to https://github.com/facebook/rocksdb/pull/4096
     if (got_from_prefetch_buffer_ || used_buf_ == &stack_buf_[0]) {
+      assert(used_buf_ != heap_buf_.get());
       heap_buf_.reset(new char[block_size_ + kBlockTrailerSize]);
       memcpy(heap_buf_.get(), used_buf_, block_size_ + kBlockTrailerSize);
     }


### PR DESCRIPTION
Summary: Suppress two CLANG analyze warnings. They don't seem to be real bugs