### PR TITLE
Two code changes to make "clang analyze" happy

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -384,7 +384,7 @@ class VersionBuilder::Rep {
     }
 
     std::atomic<size_t> next_file_meta_idx(0);
-    std::function<void()> load_handlers_func = [&]() {
+    std::function<void()> load_handlers_func([&]() {
       while (true) {
         size_t file_idx = next_file_meta_idx.fetch_add(1);
         if (file_idx >= files_meta.size()) {
@@ -405,7 +405,7 @@ class VersionBuilder::Rep {
               file_meta->table_reader_handle);
         }
       }
-    };
+    });
 
     std::vector<port::Thread> threads;
     for (int i = 1; i < max_threads; i++) {

--- a/util/dynamic_bloom_test.cc
+++ b/util/dynamic_bloom_test.cc
@@ -258,12 +258,12 @@ TEST_F(DynamicBloomTest, concurrent_with_perf) {
 
       timer.Start();
 
-      std::function<void(size_t)> adder = [&](size_t t) {
+      std::function<void(size_t)> adder([&](size_t t) {
         for (uint64_t i = 1 + t; i <= num_keys; i += num_threads) {
           std_bloom.AddConcurrently(
               Slice(reinterpret_cast<const char*>(&i), 8));
         }
-      };
+      });
       for (size_t t = 0; t < num_threads; ++t) {
         threads.emplace_back(adder, t);
       }
@@ -279,13 +279,13 @@ TEST_F(DynamicBloomTest, concurrent_with_perf) {
 
       timer.Start();
 
-      std::function<void(size_t)> hitter = [&](size_t t) {
+      std::function<void(size_t)> hitter([&](size_t t) {
         for (uint64_t i = 1 + t; i <= num_keys; i += num_threads) {
           bool f =
               std_bloom.MayContain(Slice(reinterpret_cast<const char*>(&i), 8));
           ASSERT_TRUE(f);
         }
-      };
+      });
       for (size_t t = 0; t < num_threads; ++t) {
         threads.emplace_back(hitter, t);
       }
@@ -302,7 +302,7 @@ TEST_F(DynamicBloomTest, concurrent_with_perf) {
       timer.Start();
 
       std::atomic<uint32_t> false_positives(0);
-      std::function<void(size_t)> misser = [&](size_t t) {
+      std::function<void(size_t)> misser([&](size_t t) {
         for (uint64_t i = num_keys + 1 + t; i <= 2 * num_keys;
              i += num_threads) {
           bool f =
@@ -311,7 +311,7 @@ TEST_F(DynamicBloomTest, concurrent_with_perf) {
             ++false_positives;
           }
         }
-      };
+      });
       for (size_t t = 0; t < num_threads; ++t) {
         threads.emplace_back(misser, t);
       }


### PR DESCRIPTION
Summary: Clang analyze is not happy in two pieces of code, with "Potential memory leak". No idea what the problem but slightly changing the code makes clang happy.