### PR TITLE
DataBlockHashIndex: Remove the division from EstimateSize()

### DIFF
--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -106,7 +106,6 @@ size_t BlockBuilder::EstimateSizeAfterKV(const Slice& key, const Slice& value)
     estimate += VarintLength(value.size());  // varint for value length.
   }
 
-  // TODO(fwu): add the delta of the DataBlockHashIndex
   return estimate;
 }
 

--- a/table/data_block_hash_index.cc
+++ b/table/data_block_hash_index.cc
@@ -23,12 +23,13 @@ void DataBlockHashIndexBuilder::Add(const Slice& key,
   uint32_t hash_value = GetSliceHash(key);
   hash_and_restart_pairs_.emplace_back(hash_value,
                                        static_cast<uint8_t>(restart_index));
+  estimated_num_buckets_ += bucket_per_key_;
 }
 
 void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
   assert(Valid());
-  uint16_t num_buckets = static_cast<uint16_t>(
-      static_cast<double>(hash_and_restart_pairs_.size()) / util_ratio_);
+  uint16_t num_buckets = static_cast<uint16_t>(estimated_num_buckets_);
+
   if (num_buckets == 0) {
     num_buckets = 1;  // sanity check
   }
@@ -66,8 +67,9 @@ void DataBlockHashIndexBuilder::Finish(std::string& buffer) {
 }
 
 void DataBlockHashIndexBuilder::Reset() {
-  hash_and_restart_pairs_.clear();
+  estimated_num_buckets_ = 0;
   valid_ = true;
+  hash_and_restart_pairs_.clear();
 }
 
 void DataBlockHashIndex::Initialize(const char* data, uint16_t size,


### PR DESCRIPTION
Summary:
`BlockBasedTableBuilder::Add()` eventually calls
`DataBlockHashIndexBuilder::EstimateSize()`. The previous implementation
divides the `num_keys` by the `util_ratio_` to get an estimizted `num_buckets`.
Such division is expensive as it happens in every
`BlockBasedTableBuilder::Add()`.

This diff estimates the `num_buckets` by double addition instead of double
division. Specifically, in each `Add()`, we add `bucket_per_key_`
(inverse of `util_ratio_`) to the current `estimiated_num_buckets_`. The cost is
that we are gonna have the `estimated_num_buckets_` stored as one extra field
in the DataBlockHashIndexBuilder.