### PR TITLE
DataBlockHashIndex: avoiding expensive iiter->Next when handling hash kNoEntry

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -235,7 +235,7 @@ void DataBlockIter::Seek(const Slice& target) {
 //
 // If the return value is FALSE, iter location is undefined, and it means:
 // 1) there is no key in this block falling into the range:
-//    ["seek_user_key @ type | seqno", "seek_user_key @ type |  0"],
+//    ["seek_user_key @ type | seqno", "seek_user_key @ kTypeDeletion | 0"],
 //    inclusive; AND
 // 2) the last key of this block has a greater user_key from seek_user_key
 //

--- a/table/block.cc
+++ b/table/block.cc
@@ -264,7 +264,7 @@ bool DataBlockIter::SeekForGetImpl(const Slice& target) {
     //
     // In this case, we pretend the key is the the last restart interval.
     // The linear search in the while-loop below will handle it correctly.
-    entry = num_restarts_ - 1;
+    entry = static_cast<uint8_t>(num_restarts_ - 1);
   }
 
   if (entry == kCollision) {

--- a/table/block.cc
+++ b/table/block.cc
@@ -260,10 +260,11 @@ bool DataBlockIter::SeekForGetImpl(const Slice& target) {
     //
     // If seek_key = axy@60, the search will starts from Block N.
     // Even if the user_key is not found in the hash map, the caller still
-    // have to conntinue searching the next block. So we invalidate the
-    // iterator to tell the caller to go on.
-    current_ = restarts_;  // Invalidate the iter
-    return true;
+    // have to conntinue searching the next block.
+    //
+    // In this case, we pretend the key is the the last restart interval.
+    // The linear search in the while-loop below will handle it correctly.
+    entry = num_restarts_ - 1;
   }
 
   if (entry == kCollision) {


### PR DESCRIPTION
Summary:
When returning `kNoEntry` from HashIndex lookup, previously we invalidate the
`biter` by set `current_=restarts_`, so that the search can continue to the next
block in case the search result may reside in the next block.

There is one problem: when we are searching for a missing key, if the search
finds a `kNoEntry` and continue the search to the next block, there is also a
non-trivial possibility that the HashIndex return `kNoEntry` too, and the
expensive index iterator `Next()` will happen several times for nothing.

The solution is that if the hash table returns `kNoEntry`, `SeekForGetImpl()` just search the last restart interval for the key. It will stop at the first key that is large than the seek_key, or to the end of the block, and each case will be handled correctly.


Microbenchmark script:
```
TEST_TMPDIR=/dev/shm ./db_bench --benchmarks=fillseq,readtocache,readmissing \
          --cache_size=20000000000  --use_data_block_hash_index={true|false}
```

`readmissing` performance (lower is better):
```
binary:                      3.6098 micros/op
hash (before applying diff): 4.1048 micros/op
hash (after  applying diff): 3.3502 micros/op
```
