### PR TITLE
Invoke OnTableFileCreated for empty SSTs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
+* `OnTableFileCreated` will now be called for empty files generated during compaction. In that case, `TableFileCreationInfo::file_path` will be "(nil)" and `TableFileCreationInfo::file_size` will be zero.
+
 ### New Features
 ### Bug Fixes
 

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1310,7 +1310,7 @@ Status CompactionJob::FinishCompactionOutputFile(
     sub_compact->outputs.pop_back();
     sub_compact->builder.reset();
     sub_compact->current_output_file_size = 0;
-    return s;
+    meta = nullptr;
   }
 
   if (s.ok() && (current_entries > 0 || tp.num_range_deletions > 0)) {

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1308,8 +1308,6 @@ Status CompactionJob::FinishCompactionOutputFile(
     // VersionEdit.
     assert(!sub_compact->outputs.empty());
     sub_compact->outputs.pop_back();
-    sub_compact->builder.reset();
-    sub_compact->current_output_file_size = 0;
     meta = nullptr;
   }
 


### PR DESCRIPTION
The API comment on `OnTableFileCreationStarted` (https://github.com/facebook/rocksdb/blob/b6280d01f9f9c4305c536dfb804775fce3956280/include/rocksdb/listener.h#L331-L333) led users to believe a call to `OnTableFileCreationStarted` will always be matched with a call to `OnTableFileCreated`. However, we were skipping the `OnTableFileCreated` call in one case: no error happens but also no file is generated since there's no data.

This PR adds the call to `OnTableFileCreated` for that case. The filename will be "(nil)" and the size will be zero.

Test Plan:

- Made `db_stress` verify the two functions are called the same number of times when it runs to completion. 
- Ran db_crashtest with 99% deletions, 1% updates, and small number of keys. This ensures empty files are generated often.

```
python tools/db_crashtest.py whitebox --write_buffer_size=131072 --target_file_size_base=131072 --max_bytes_for_level_base=524288 --compression_type=none --max_background_compactions=8 --value_size_mult=33 --ops_per_thread=1000 --max_key=10000 --delpercent=99 --writepercent=1 --iterpercent=0 --readpercent=0 --prefixpercent=0
```