### PR TITLE
Reduce empty SST creation/deletion during compaction

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Public API Change
 ### New Features
 ### Bug Fixes
+* Avoid creating empty SSTs and subsequently deleting them in certain cases during compaction.
 
 ## 5.16.0 (8/21/2018)
 ### Public API Change

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1077,7 +1077,8 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
   }
 
   if (status.ok() && sub_compact->builder == nullptr &&
-      sub_compact->outputs.size() == 0) {
+      sub_compact->outputs.size() == 0 &&
+      !range_del_agg->IsEmpty()) {
     // handle subcompaction containing only range deletions
     status = OpenCompactionOutputFile(sub_compact);
   }


### PR DESCRIPTION
#4104 removed the check on `RangeDelAggregator::ShouldAddTombstones` before opening an SST dedicated to range deletions. This caused empty SSTs to be generated in more cases. Empty SSTs are special because we invoke `OnTableFileCreationStarted` but not  `OnTableFileCreated`. But some users were relying on us always calling both of those functions, and #4104 made it more common that we only call one.

I have a PR to start calling `OnTableFileCreated` for empty SSTs: #4307. However, it is a behavior change so should not go into a patch release.

This PR adds back a check to make sure range deletions at least exist before starting file creation. This PR should be safe to backport to earlier versions.

Test Plan:

- `make check -j64`