### PR TITLE
Fix clang build of db_stress

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1249,7 +1249,7 @@ class DbStressListener : public EventListener {
   }
 
   virtual void OnTableFileCreationStarted(
-      const TableFileCreationBriefInfo& /*info*/) {
+      const TableFileCreationBriefInfo& /*info*/) override {
     ++num_pending_file_creations_;
   }
   virtual void OnTableFileCreated(const TableFileCreationInfo& info) override {


### PR DESCRIPTION
Blame: #4307

Test Plan: `USE_CLANG=1 make -j64 check`