### PR TITLE
BlobDB: Implement DisableFileDeletions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,7 @@ set(SOURCES
         utilities/blob_db/blob_compaction_filter.cc
         utilities/blob_db/blob_db.cc
         utilities/blob_db/blob_db_impl.cc
+        utilities/blob_db/blob_db_impl_filesnapshot.cc
         utilities/blob_db/blob_dump_tool.cc
         utilities/blob_db/blob_file.cc
         utilities/blob_db/blob_log_reader.cc

--- a/TARGETS
+++ b/TARGETS
@@ -195,6 +195,7 @@ cpp_library(
         "tools/ldb_cmd.cc",
         "tools/ldb_tool.cc",
         "tools/sst_dump_tool.cc",
+        "tools/trace_analyzer_tool.cc",
         "util/arena.cc",
         "util/auto_roll_logger.cc",
         "util/bloom.cc",

--- a/TARGETS
+++ b/TARGETS
@@ -195,7 +195,6 @@ cpp_library(
         "tools/ldb_cmd.cc",
         "tools/ldb_tool.cc",
         "tools/sst_dump_tool.cc",
-        "tools/trace_analyzer_tool.cc",
         "util/arena.cc",
         "util/auto_roll_logger.cc",
         "util/bloom.cc",
@@ -233,6 +232,7 @@ cpp_library(
         "utilities/blob_db/blob_compaction_filter.cc",
         "utilities/blob_db/blob_db.cc",
         "utilities/blob_db/blob_db_impl.cc",
+        "utilities/blob_db/blob_db_impl_filesnapshot.cc",
         "utilities/blob_db/blob_dump_tool.cc",
         "utilities/blob_db/blob_file.cc",
         "utilities/blob_db/blob_log_format.cc",
@@ -377,11 +377,6 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
-        "data_block_hash_index_test",
-        "table/data_block_hash_index_test.cc",
-        "serial",
-    ],
-    [
         "block_test",
         "table/block_test.cc",
         "serial",
@@ -504,6 +499,11 @@ ROCKS_TESTS = [
     [
         "cuckoo_table_reader_test",
         "table/cuckoo_table_reader_test.cc",
+        "serial",
+    ],
+    [
+        "data_block_hash_index_test",
+        "table/data_block_hash_index_test.cc",
         "serial",
     ],
     [
@@ -957,11 +957,6 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
-        "trace_analyzer_test",
-        "tools/trace_analyzer_test.cc",
-        "serial",
-    ],
-    [
         "statistics_test",
         "monitoring/statistics_test.cc",
         "serial",
@@ -994,6 +989,11 @@ ROCKS_TESTS = [
     [
         "timer_queue_test",
         "util/timer_queue_test.cc",
+        "serial",
+    ],
+    [
+        "trace_analyzer_test",
+        "tools/trace_analyzer_test.cc",
         "serial",
     ],
     [
@@ -1094,3 +1094,4 @@ if not is_opt_mode:
           deps = [":" + test_bin],
           command = [TEST_RUNNER, BUCK_BINS + test_bin]
         )
+

--- a/src.mk
+++ b/src.mk
@@ -122,6 +122,7 @@ LIB_SOURCES =                                                   \
   table/plain_table_reader.cc                                   \
   table/sst_file_writer.cc                                      \
   table/table_properties.cc                                     \
+  tools/trace_analyzer_tool.cc                                  \
   table/two_level_iterator.cc                                   \
   tools/dump/db_dump_tool.cc                                    \
   util/arena.cc                                                 \

--- a/src.mk
+++ b/src.mk
@@ -161,6 +161,7 @@ LIB_SOURCES =                                                   \
   utilities/blob_db/blob_compaction_filter.cc                   \
   utilities/blob_db/blob_db.cc                                  \
   utilities/blob_db/blob_db_impl.cc                             \
+  utilities/blob_db/blob_db_impl_filesnapshot.cc                \
   utilities/blob_db/blob_file.cc                                \
   utilities/blob_db/blob_log_format.cc                          \
   utilities/blob_db/blob_log_reader.cc                          \

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -413,6 +413,12 @@ class BlobDBImpl : public BlobDB {
 
   // DeleteObsoleteFiles, DiableFileDeletions and EnableFileDeletions block
   // on the mutex to avoid contention.
+  //
+  // While DeleteObsoleteFiles hold both mutex_ and delete_file_mutex_, note
+  // the difference. mutex_ only needs to be held when access the
+  // data-structure, and delete_file_mutex_ needs to be held the whole time
+  // during DeleteObsoleteFiles to avoid being run simultaneously with
+  // DisableFileDeletions.
   mutable port::Mutex delete_file_mutex_;
 
   // Each call of DisableFileDeletions will increase disable_file_deletion_

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -419,6 +419,9 @@ class BlobDBImpl : public BlobDB {
   // data-structure, and delete_file_mutex_ needs to be held the whole time
   // during DeleteObsoleteFiles to avoid being run simultaneously with
   // DisableFileDeletions.
+  //
+  // If both of mutex_ and delete_file_mutex_ needs to be held, it is adviced
+  // to hold delete_file_mutex_ first to avoid deadlock.
   mutable port::Mutex delete_file_mutex_;
 
   // Each call of DisableFileDeletions will increase disable_file_deletion_

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -30,8 +30,8 @@ Status BlobDBImpl::DisableFileDeletions() {
     count = ++disable_file_deletions_;
   }
 
-  ROCKS_LOG_INFO(db_options_.info_log, "Disalbed file deletions. count: %d",
-                 count);
+  ROCKS_LOG_INFO(db_options_.info_log,
+                 "Disalbed blob file deletions. count: %d", count);
   return Status::OK();
 }
 
@@ -53,7 +53,7 @@ Status BlobDBImpl::EnableFileDeletions(bool force) {
     assert(count >= 0);
   }
 
-  ROCKS_LOG_INFO(db_options_.info_log, "Enabled file deletions. count: %d",
+  ROCKS_LOG_INFO(db_options_.info_log, "Enabled blob file deletions. count: %d",
                  count);
   // Consider trigger DeleteobsoleteFiles once after re-enabled, if we are to
   // make DeleteobsoleteFiles re-run interval configuration.

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -47,7 +47,7 @@ Status BlobDBImpl::EnableFileDeletions(bool force) {
     MutexLock l(&delete_file_mutex_);
     if (force) {
       disable_file_deletions_ = 0;
-    } else {
+    } else if (disable_file_deletions_ > 0) {
       count = --disable_file_deletions_;
     }
     assert(count >= 0);
@@ -55,6 +55,8 @@ Status BlobDBImpl::EnableFileDeletions(bool force) {
 
   ROCKS_LOG_INFO(db_options_.info_log, "Enabled file deletions. count: %d",
                  count);
+  // Consider trigger DeleteobsoleteFiles once after re-enabled, if we are to
+  // make DeleteobsoleteFiles re-run interval configuration.
   return Status::OK();
 }
 

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -1,0 +1,95 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#ifndef ROCKSDB_LITE
+
+#include "utilities/blob_db/blob_db_impl.h"
+
+#include "util/logging.h"
+#include "util/mutexlock.h"
+
+// BlobDBImpl methods to get snapshot of files, e.g. for replication.
+
+namespace rocksdb {
+namespace blob_db {
+
+Status BlobDBImpl::DisableFileDeletions() {
+  // Disable base DB file deletions.
+  Status s = db_impl_->DisableFileDeletions();
+  if (!s.ok()) {
+    return s;
+  }
+
+  int count = 0;
+  {
+    // Hold delete_file_mutex_ to make sure no DeleteObsoleteFiles job
+    // is running.
+    MutexLock l(&delete_file_mutex_);
+    count = ++disable_file_deletions_;
+  }
+
+  ROCKS_LOG_INFO(db_options_.info_log, "Disalbed file deletions. count: %d",
+                 count);
+  return Status::OK();
+}
+
+Status BlobDBImpl::EnableFileDeletions(bool force) {
+  // Enable base DB file deletions.
+  Status s = db_impl_->EnableFileDeletions(force);
+  if (!s.ok()) {
+    return s;
+  }
+
+  int count = 0;
+  {
+    MutexLock l(&delete_file_mutex_);
+    if (force) {
+      disable_file_deletions_ = 0;
+    } else {
+      count = --disable_file_deletions_;
+    }
+    assert(count >= 0);
+  }
+
+  ROCKS_LOG_INFO(db_options_.info_log, "Enabled file deletions. count: %d",
+                 count);
+  return Status::OK();
+}
+
+Status BlobDBImpl::GetLiveFiles(std::vector<std::string>& ret,
+                                uint64_t* manifest_file_size,
+                                bool flush_memtable) {
+  // Hold a lock in the beginning to avoid updates to base DB during the call
+  ReadLock rl(&mutex_);
+  Status s = db_->GetLiveFiles(ret, manifest_file_size, flush_memtable);
+  if (!s.ok()) {
+    return s;
+  }
+  ret.reserve(ret.size() + blob_files_.size());
+  for (auto bfile_pair : blob_files_) {
+    auto blob_file = bfile_pair.second;
+    ret.emplace_back(blob_file->PathName());
+  }
+  return Status::OK();
+}
+
+void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
+  // Hold a lock in the beginning to avoid updates to base DB during the call
+  ReadLock rl(&mutex_);
+  db_->GetLiveFilesMetaData(metadata);
+  for (auto bfile_pair : blob_files_) {
+    auto blob_file = bfile_pair.second;
+    LiveFileMetaData filemetadata;
+    filemetadata.size = blob_file->GetFileSize();
+    filemetadata.name = blob_file->PathName();
+    auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(DefaultColumnFamily());
+    filemetadata.column_family_name = cfh->GetName();
+    metadata->emplace_back(filemetadata);
+  }
+}
+
+}  // namespace blob_db
+}  // namespace rocksdb
+#endif  // !ROCKSDB_LITE


### PR DESCRIPTION
Summary:
`DB::DiableFileDeletions` and `DB::EnableFileDeletions` are used for applications to stop RocksDB background jobs to delete files while they are doing replication. Implement these methods for BlobDB. `DeleteObsolteFiles` now needs to check `disable_file_deletions_` before starting, and will hold `delete_file_mutex_` the whole time while it is running. `DisableFileDeletions` needs to wait on `delete_file_mutex_` for running `DeleteObsolteFiles` job and set `disable_file_deletions_` flag.

Test Plan:
See the new test