### PR TITLE
BlobDB: Avoid returning garbage value on key not found

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1131,6 +1131,7 @@ Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
     if (is_blob_index) {
       s = GetBlobValue(key, index_entry, value, expiration);
     } else {
+      // The index entry is the value itself in this case.
       value->PinSelf(index_entry);
     }
     RecordTick(statistics_, BLOB_DB_BYTES_READ, value->size());

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1127,18 +1127,17 @@ Status BlobDBImpl::GetImpl(const ReadOptions& read_options,
     *expiration = kNoExpiration;
   }
   RecordTick(statistics_, BLOB_DB_NUM_KEYS_READ);
-  if (!s.ok()) {
-    return s;
-  }
-  if (is_blob_index) {
-    s = GetBlobValue(key, index_entry, value, expiration);
-  } else {
-    value->PinSelf(index_entry);
+  if (s.ok()) {
+    if (is_blob_index) {
+      s = GetBlobValue(key, index_entry, value, expiration);
+    } else {
+      value->PinSelf(index_entry);
+    }
+    RecordTick(statistics_, BLOB_DB_BYTES_READ, value->size());
   }
   if (snapshot_created) {
     db_->ReleaseSnapshot(ro.snapshot);
   }
-  RecordTick(statistics_, BLOB_DB_BYTES_READ, value->size());
   return s;
 }
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1413,6 +1413,9 @@ TEST_F(BlobDBTest, EvictExpiredFile) {
   blob_db_impl()->TEST_DeleteObsoleteFiles();
   ASSERT_EQ(0, blob_db_impl()->TEST_GetBlobFiles().size());
   ASSERT_EQ(0, blob_db_impl()->TEST_GetObsoleteFiles().size());
+  std::string val = "";
+  ASSERT_TRUE(blob_db_->Get(ReadOptions(), "foo", &val).IsNotFound());
+  ASSERT_EQ("", val);
 }
 
 TEST_F(BlobDBTest, DisableFileDeletions) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1413,6 +1413,8 @@ TEST_F(BlobDBTest, EvictExpiredFile) {
   blob_db_impl()->TEST_DeleteObsoleteFiles();
   ASSERT_EQ(0, blob_db_impl()->TEST_GetBlobFiles().size());
   ASSERT_EQ(0, blob_db_impl()->TEST_GetObsoleteFiles().size());
+  // Make sure we don't return garbage value after blob file being evicted,
+  // but the blob index still exists in the LSM tree.
   std::string val = "";
   ASSERT_TRUE(blob_db_->Get(ReadOptions(), "foo", &val).IsNotFound());
   ASSERT_EQ("", val);


### PR DESCRIPTION
Summary:
When reading an expired key using `Get(..., std::string* value)` API, BlobDB first read the index entry and decode expiration from it. In this case, although BlobDB reset the PinnableSlice, the index entry is stored in user provided string `value`. The value will be returned as a garbage value, despite status being NotFound. Fixing it by use a different PinnableSlice to read the index entry.

Test Plan:
Updated blob_db_test