### PR TITLE
Remove trace_analyzer_tool from LIB_SOURCES

### DIFF
--- a/src.mk
+++ b/src.mk
@@ -122,7 +122,6 @@ LIB_SOURCES =                                                   \
   table/plain_table_reader.cc                                   \
   table/sst_file_writer.cc                                      \
   table/table_properties.cc                                     \
-  tools/trace_analyzer_tool.cc                                  \
   table/two_level_iterator.cc                                   \
   tools/dump/db_dump_tool.cc                                    \
   util/arena.cc                                                 \


### PR DESCRIPTION
trace_analyzer_tool should only be in ANALYZER_LIB_SOURCES and not in LIB_SOURCES. 
This fixes java_test travis build failures seen in jtest.
Blame: a6d3de4e7a29a19d9e5ef58a31d645f336258a75

Test Plan:
I was able to reproduce the `make jtest` failures on master in a local travis env; couldn't reproduce outside of travis env. This patch fixes it. 
`OPT=-DTRAVIS V=1 make rocksdbjava jtest -j4` on a travis docker container. 