### PR TITLE
Reduce empty SST creation/deletion in compaction

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -346,7 +346,7 @@ class CollapsedRangeDelMap : public RangeDelMap {
     }
   }
 
-  size_t Size() const override { return rep_.size() - 1; }
+  size_t Size() const override { return rep_.empty() ? 0 : rep_.size() - 1; }
 
   void InvalidatePosition() override { iter_ = rep_.end(); }
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1238,7 +1238,8 @@ class DbStressListener : public EventListener {
                    const std::vector<DbPath>& db_paths,
                    const std::vector<ColumnFamilyDescriptor>& column_families)
       : db_name_(db_name), db_paths_(db_paths),
-        column_families_(column_families) {}
+        column_families_(column_families),
+        num_pending_file_creations_(0) {}
   virtual ~DbStressListener() {
     assert(num_pending_file_creations_ == 0);
   }


### PR DESCRIPTION
This is a followup to #4311. Checking `!RangeDelAggregator::IsEmpty()` before opening a dedicated range tombstone SST did not properly prevent empty SSTs from being generated. That's because it relies on `CollapsedRangeDelMap::Size`, which had an underflow bug when the map was empty. This PR fixes that underflow bug.

Also fixed an uninitialized variable in db_stress.

Test Plan:

- new unit test exposing the unintentional file creation starting