### PR TITLE
Bugfix concurrent list(iterator next) poor performance with java comparator in use by emc wayne gao

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5471,7 +5471,7 @@ class WriteStallListener : public EventListener {
       expected_set_ = true;
       while (expected != condition_) {
         // We bail out on timeout 500 milliseconds
-        const uint64_t timeout_us = 500000;
+        const uint64_t timeout_us = 4*500000;
         if (cond_.TimedWait(timeout_us)) {
           expected_set_ = false;
           return false;

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -29,7 +29,7 @@ ThreadLocalJObject::~ThreadLocalJObject() {
 			// free ASAP after thread detach this thread local obj
 			m_pJniEnv->DeleteGlobalRef(m_jSlice);
 
-			JniUtil::releaseJniEnv(m_jvm, attached_thread);
+			//JniUtil::releaseJniEnv(m_jvm, attached_thread);wgao try not release this in thread local
 
 			// delete m_jvm;
 			m_jvm = nullptr;

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -142,12 +142,12 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
 	  }
 	  else
 	  {
-		  jObjA.m_jvm = new JavaVM();
-		  const jint rs = env->GetJavaVM(&jObjA.m_jvm);
-		  if (rs != JNI_OK) {
-			  // exception thrown
-			  jObjA.m_jvm = nullptr;
-		  }
+		  //jObjA.m_jvm = new JavaVM();
+		  //const jint rs = env->GetJavaVM(&jObjA.m_jvm);
+		  //if (rs != JNI_OK) {
+			 // // exception thrown
+			 // jObjA.m_jvm = nullptr;
+		  //}
 
 		  jObjA.lObjAssigned = 1;
 	  }
@@ -166,12 +166,12 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
 	  }
 	  else
 	  {
-		  jObjB.m_jvm = new JavaVM();
-		  const jint rs = env->GetJavaVM(&jObjB.m_jvm);
-		  if (rs != JNI_OK) {
-			  // exception thrown
-			  jObjB.m_jvm = nullptr;
-		  }
+		  //jObjB.m_jvm = new JavaVM();
+		  //const jint rs = env->GetJavaVM(&jObjB.m_jvm);
+		  //if (rs != JNI_OK) {
+			 // // exception thrown
+			 // jObjB.m_jvm = nullptr;
+		  //}
 
 		  jObjB.lObjAssigned = 1;
 	  }

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -21,18 +21,18 @@ ThreadLocalJObject::ThreadLocalJObject()
 
 ThreadLocalJObject::~ThreadLocalJObject() {
 	  lInited = 0;
-	  if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm != nullptr) 
+	  if (lObjAssigned == 1 && m_jSlice != nullptr ) //&& m_jvm != nullptr
 	  {
 			//jboolean attached_thread = JNI_FALSE;
 
-			assert(m_pJniEnv != nullptr);
+			//assert(m_pJniEnv != nullptr);
 			// free ASAP after thread detach this thread local obj
 			m_pJniEnv->DeleteGlobalRef(m_jSlice);
 
 			//JniUtil::releaseJniEnv(m_jvm, attached_thread);wgao try not release this in thread local
 
 			// delete m_jvm;
-			m_jvm = nullptr;
+			//m_jvm = nullptr;
 
 	  }
 }
@@ -383,11 +383,11 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   //
   // EMC Wayne Gao fix the concurrent list performance issue
   //
-  auto this_id = std::this_thread::get_id();
-  std::stringstream sID;
-  sID << this_id;
-  string sThreadID = sID.str();
-  map<string, int>::iterator it;
+  //auto this_id = std::this_thread::get_id();
+  //std::stringstream sID;
+  //sID << this_id;
+  //string sThreadID = sID.str();
+  //map<string, int>::iterator it;
   bool bMemOK = true;
   jobject jSliceA = nullptr;
   jobject jSliceB = nullptr;
@@ -402,11 +402,11 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
       // exception thrown: OutOfMemoryError
       bMemOK = false;
     } else {
-      const jint rs = env->GetJavaVM(&jObjA.m_jvm);
-      if (rs != JNI_OK) {
+      //const jint rs = env->GetJavaVM(&jObjA.m_jvm);
+      //if (rs != JNI_OK) {
         // exception thrown
-        jObjA.m_jvm = nullptr;
-      }
+        //jObjA.m_jvm = nullptr;
+      //}
 
 	  jObjA.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
 
@@ -424,11 +424,11 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
       // exception thrown: OutOfMemoryError
       bMemOK = false;
     } else {
-      const jint rs = env->GetJavaVM(&jObjB.m_jvm);
-      if (rs != JNI_OK) {
+      //const jint rs = env->GetJavaVM(&jObjB.m_jvm);
+      //if (rs != JNI_OK) {
         // exception thrown
-        jObjB.m_jvm = nullptr;
-      }
+       // jObjB.m_jvm = nullptr;
+      //}
 
 	  jObjB.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
 

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -397,7 +397,8 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   // cache
   //
   if (jObjA.lObjAssigned == 0) {
-    jObjA.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    //jObjA.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    jObjA.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
     if (jObjA.m_jSlice == nullptr) {
       // exception thrown: OutOfMemoryError
       bMemOK = false;
@@ -419,7 +420,8 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   }
 
   if (jObjB.lObjAssigned == 0) {
-    jObjB.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    //jObjB.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    jObjB.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
     if (jObjB.m_jSlice == nullptr) {
       // exception thrown: OutOfMemoryError
       bMemOK = false;

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -146,7 +146,7 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
 		  const jint rs = env->GetJavaVM(&jObjA.m_jvm);
 		  if (rs != JNI_OK) {
 			  // exception thrown
-			  jObjA.m_jvm = null;
+			  jObjA.m_jvm = nullptr;
 		  }
 
 		  jObjA.lObjAssigned = 1;
@@ -170,7 +170,7 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
 		  const jint rs = env->GetJavaVM(&jObjB.m_jvm);
 		  if (rs != JNI_OK) {
 			  // exception thrown
-			  jObjB.m_jvm = null;
+			  jObjB.m_jvm = nullptr;
 		  }
 
 		  jObjB.lObjAssigned = 1;

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -383,11 +383,6 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   //
   // EMC Wayne Gao fix the concurrent list performance issue
   //
-  //auto this_id = std::this_thread::get_id();
-  //std::stringstream sID;
-  //sID << this_id;
-  //string sThreadID = sID.str();
-  //map<string, int>::iterator it;
   bool bMemOK = true;
   jobject jSliceA = nullptr;
   jobject jSliceB = nullptr;
@@ -397,21 +392,12 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   // cache
   //
   if (jObjA.lObjAssigned == 0) {
-    //jObjA.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
-    jObjA.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
+    jObjA.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    
     if (jObjA.m_jSlice == nullptr) {
       // exception thrown: OutOfMemoryError
       bMemOK = false;
     } else {
-      //const jint rs = env->GetJavaVM(&jObjA.m_jvm);
-      //if (rs != JNI_OK) {
-        // exception thrown
-        //jObjA.m_jvm = nullptr;
-      //}
-
-	  //jObjA.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
-
-      //assert(jObjA.m_pJniEnv != nullptr);
 
       jObjA.lObjAssigned = 1;
     }
@@ -420,22 +406,12 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   }
 
   if (jObjB.lObjAssigned == 0) {
-    //jObjB.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
-    jObjB.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
+    jObjB.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    
     if (jObjB.m_jSlice == nullptr) {
       // exception thrown: OutOfMemoryError
       bMemOK = false;
     } else {
-      //const jint rs = env->GetJavaVM(&jObjB.m_jvm);
-      //if (rs != JNI_OK) {
-        // exception thrown
-       // jObjB.m_jvm = nullptr;
-      //}
-
-	  //jObjB.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
-
-      //assert(jObjB.m_pJniEnv != nullptr);
-
 
       jObjB.lObjAssigned = 1;
     }

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -14,7 +14,27 @@
 
 namespace rocksdb {
 
+ThreadLocalJObject::ThreadLocalJObject()
+{ 
+	lInited = 1; 
+}
 
+ThreadLocalJObject::~ThreadLocalJObject() {
+  lInited = 0;
+  if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm != nullptr) {
+    jboolean attached_thread = JNI_FALSE;
+
+    JNIEnv* env = JniUtil::getJniEnv(m_jvm, &attached_thread);
+    assert(env != nullptr);
+    // free ASAP after thread detach this thread local obj
+    env->DeleteGlobalRef(m_jSlice);
+
+    JniUtil::releaseJniEnv(m_jvm, attached_thread);
+
+    // delete m_jvm;
+    m_jvm = nullptr;
+  }
+}
 
 BaseComparatorJniCallback::BaseComparatorJniCallback(
     JNIEnv* env, jobject jComparator,
@@ -69,45 +89,7 @@ const char* BaseComparatorJniCallback::Name() const {
   return m_name.get();
 }
 
-//
-//wgao thread local jobject
-//
-static thread_local ThreadLocalJObject jObjA;
-static thread_local ThreadLocalJObject jObjB;
 
-int BaseComparatorJniCallback::CompareNoLock(JNIEnv* env, const jobject& jSliceA, const jobject& jSliceB, 
-											 const Slice& a, const Slice& b,
-											 jboolean attached_thread) const
-{
-    bool pending_exception =
-    AbstractSliceJni::setHandle(env, jSliceA, &a, JNI_FALSE);
-    if(pending_exception) {
-       if(env->ExceptionCheck()) {
-       // exception thrown from setHandle or descendant
-       env->ExceptionDescribe(); // print out exception to stderr
-       }
-       releaseJniEnv(attached_thread);
-       return 0;
-    }
-
-	pending_exception =
-    AbstractSliceJni::setHandle(env, jSliceB, &b, JNI_FALSE);
-	if(pending_exception) {
-		if(env->ExceptionCheck()) {
-		// exception thrown from setHandle or descendant
-		env->ExceptionDescribe(); // print out exception to stderr
-		}
-		releaseJniEnv(attached_thread);
-		return 0;
-	}
-
-	jint result = env->CallIntMethod(m_jcallback_obj, m_jCompareMethodId, 
-									 jSliceA,
-									 jSliceB);
-
-
-	return result;
-}
 
 int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   jboolean attached_thread = JNI_FALSE;
@@ -118,80 +100,12 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
   // local variables to avoid locking. Could make this configurable depending on
   // performance.
   
-  //
-  //EMC Wayne Gao fix the concurrent list performance issue
-  //
-  auto this_id = std::this_thread::get_id();
-  std::stringstream sID;
-  sID << this_id;
-  string sThreadID = sID.str();
-  map<string, int>::iterator it;
-  bool bMemOK = true;
-  jobject jSliceA = nullptr;
-  jobject jSliceB = nullptr;
-
-  //
-  //wgao new thread will new local ref, existing thread will resue thread local cache
-  //
-  if (jObjA.lObjAssigned == 0)
-  {
-	  jObjA.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
-	  if (jObjA.m_jSlice == nullptr) {
-		  // exception thrown: OutOfMemoryError
-		  bMemOK = false;
-	  }
-	  else
-	  {
-		  //jObjA.m_jvm = new JavaVM();
-		  //const jint rs = env->GetJavaVM(&jObjA.m_jvm);
-		  //if (rs != JNI_OK) {
-			 // // exception thrown
-			 // jObjA.m_jvm = nullptr;
-		  //}
-
-		  jObjA.lObjAssigned = 1;
-	  }
-  }
-  else
-  {
-	  jSliceA = jObjA.m_jSlice;
-  }
-
-  if (jObjB.lObjAssigned == 0)
-  {
-	  jObjB.m_jSlice = env->NewLocalRef(SliceJni::construct0(env));
-	  if (jObjB.m_jSlice == nullptr) {
-		  // exception thrown: OutOfMemoryError
-		  bMemOK = false;
-	  }
-	  else
-	  {
-		  //jObjB.m_jvm = new JavaVM();
-		  //const jint rs = env->GetJavaVM(&jObjB.m_jvm);
-		  //if (rs != JNI_OK) {
-			 // // exception thrown
-			 // jObjB.m_jvm = nullptr;
-		  //}
-
-		  jObjB.lObjAssigned = 1;
-	  }
-  }
-  else
-  {
-	  jSliceB = jObjB.m_jSlice;
-  }
   
-  jint result = 0;
-
-  if(bMemOK && jSliceA!=nullptr && jSliceB!=nullptr)
-  {	 
-    result = CompareNoLock(env, jSliceA, jSliceB, a, b, attached_thread);
-  }
-  else
-  {
      //
      // EMC Wayne Gao fix the concurrent list performance issue, below is original code
      //
+	 jint result = 0;
+
 	  mtx_compare.get()->Lock();  
 	  bool pending_exception =
 		  AbstractSliceJni::setHandle(env, m_jSliceA, &a, JNI_FALSE);
@@ -220,7 +134,7 @@ int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
 		  m_jSliceB);
 
 	  mtx_compare.get()->Unlock();
-  }
+  
 
 
 
@@ -417,6 +331,154 @@ ComparatorJniCallback::~ComparatorJniCallback() {
   }
 
   releaseJniEnv(attached_thread);
+}
+
+//
+// wgao thread local jobject
+//
+static thread_local ThreadLocalJObject jObjA;
+static thread_local ThreadLocalJObject jObjB;
+
+int ComparatorJniCallback::CompareNoLock(JNIEnv* env,
+                                             const jobject& jSliceA,
+                                             const jobject& jSliceB,
+                                             const Slice& a, const Slice& b,
+                                             jboolean attached_thread) const {
+  bool pending_exception =
+      AbstractSliceJni::setHandle(env, jSliceA, &a, JNI_FALSE);
+  if (pending_exception) {
+    if (env->ExceptionCheck()) {
+      // exception thrown from setHandle or descendant
+      env->ExceptionDescribe();  // print out exception to stderr
+    }
+    releaseJniEnv(attached_thread);
+    return 0;
+  }
+
+  pending_exception = AbstractSliceJni::setHandle(env, jSliceB, &b, JNI_FALSE);
+  if (pending_exception) {
+    if (env->ExceptionCheck()) {
+      // exception thrown from setHandle or descendant
+      env->ExceptionDescribe();  // print out exception to stderr
+    }
+    releaseJniEnv(attached_thread);
+    return 0;
+  }
+
+  jint result =
+      env->CallIntMethod(m_jcallback_obj, m_jCompareMethodId, jSliceA, jSliceB);
+
+  return result;
+}
+
+int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
+  jboolean attached_thread = JNI_FALSE;
+  JNIEnv* env = getJniEnv(&attached_thread);
+  assert(env != nullptr);
+
+  // TODO(adamretter): slice objects can potentially be cached using thread
+  // local variables to avoid locking. Could make this configurable depending on
+  // performance.
+
+  //
+  // EMC Wayne Gao fix the concurrent list performance issue
+  //
+  auto this_id = std::this_thread::get_id();
+  std::stringstream sID;
+  sID << this_id;
+  string sThreadID = sID.str();
+  map<string, int>::iterator it;
+  bool bMemOK = true;
+  jobject jSliceA = nullptr;
+  jobject jSliceB = nullptr;
+
+  //
+  // wgao new thread will new local ref, existing thread will resue thread local
+  // cache
+  //
+  if (jObjA.lObjAssigned == 0) {
+    jObjA.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    if (jObjA.m_jSlice == nullptr) {
+      // exception thrown: OutOfMemoryError
+      bMemOK = false;
+    } else {
+      const jint rs = env->GetJavaVM(&jObjA.m_jvm);
+      if (rs != JNI_OK) {
+        // exception thrown
+        jObjA.m_jvm = nullptr;
+      }
+
+      jObjA.lObjAssigned = 1;
+    }
+  } else {
+    jSliceA = jObjA.m_jSlice;
+  }
+
+  if (jObjB.lObjAssigned == 0) {
+    jObjB.m_jSlice = env->NewGlobalRef(SliceJni::construct0(env));
+    if (jObjB.m_jSlice == nullptr) {
+      // exception thrown: OutOfMemoryError
+      bMemOK = false;
+    } else {
+      const jint rs = env->GetJavaVM(&jObjB.m_jvm);
+      if (rs != JNI_OK) {
+        // exception thrown
+        jObjB.m_jvm = nullptr;
+      }
+
+      jObjB.lObjAssigned = 1;
+    }
+  } else {
+    jSliceB = jObjB.m_jSlice;
+  }
+
+  jint result = 0;
+
+  if (bMemOK && jSliceA != nullptr && jSliceB != nullptr) {
+    result = CompareNoLock(env, jSliceA, jSliceB, a, b, attached_thread);
+  } else {
+    //
+    // EMC Wayne Gao fix the concurrent list performance issue, below is
+    // original code
+    //
+    mtx_compare.get()->Lock();
+    bool pending_exception =
+        AbstractSliceJni::setHandle(env, m_jSliceA, &a, JNI_FALSE);
+    if (pending_exception) {
+      if (env->ExceptionCheck()) {
+        // exception thrown from setHandle or descendant
+        env->ExceptionDescribe();  // print out exception to stderr
+      }
+      releaseJniEnv(attached_thread);
+      return 0;
+    }
+
+    pending_exception =
+        AbstractSliceJni::setHandle(env, m_jSliceB, &b, JNI_FALSE);
+    if (pending_exception) {
+      if (env->ExceptionCheck()) {
+        // exception thrown from setHandle or descendant
+        env->ExceptionDescribe();  // print out exception to stderr
+      }
+      releaseJniEnv(attached_thread);
+      return 0;
+    }
+
+    result = env->CallIntMethod(m_jcallback_obj, m_jCompareMethodId, m_jSliceA,
+                                m_jSliceB);
+
+    mtx_compare.get()->Unlock();
+  }
+
+  if (env->ExceptionCheck()) {
+    // exception thrown from CallIntMethod
+    env->ExceptionDescribe();  // print out exception to stderr
+    result = 0;  // we could not get a result from java callback so use 0
+  }
+
+  releaseJniEnv(attached_thread);
+
+  return result;
 }
 
 DirectComparatorJniCallback::DirectComparatorJniCallback(

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -27,7 +27,7 @@ ThreadLocalJObject::~ThreadLocalJObject() {
 
 			//assert(m_pJniEnv != nullptr);
 			// free ASAP after thread detach this thread local obj
-			m_pJniEnv->DeleteGlobalRef(m_jSlice);
+			//m_pJniEnv->DeleteGlobalRef(m_jSlice); not free global variable
 
 			//JniUtil::releaseJniEnv(m_jvm, attached_thread);wgao try not release this in thread local
 
@@ -408,9 +408,9 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
         //jObjA.m_jvm = nullptr;
       //}
 
-	  jObjA.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
+	  //jObjA.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
 
-      assert(jObjA.m_pJniEnv != nullptr);
+      //assert(jObjA.m_pJniEnv != nullptr);
 
       jObjA.lObjAssigned = 1;
     }
@@ -430,9 +430,9 @@ int ComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
        // jObjB.m_jvm = nullptr;
       //}
 
-	  jObjB.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
+	  //jObjB.m_pJniEnv = JniUtil::getJniEnv(m_jvm, &attached_thread);
 
-      assert(jObjB.m_pJniEnv != nullptr);
+      //assert(jObjB.m_pJniEnv != nullptr);
 
 
       jObjB.lObjAssigned = 1;

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -23,7 +23,7 @@ ThreadLocalJObject::~ThreadLocalJObject() {
 	  lInited = 0;
 	  if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm != nullptr) 
 	  {
-			jboolean attached_thread = JNI_FALSE;
+			//jboolean attached_thread = JNI_FALSE;
 
 			assert(m_pJniEnv != nullptr);
 			// free ASAP after thread detach this thread local obj

--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -20,20 +20,21 @@ ThreadLocalJObject::ThreadLocalJObject()
 }
 
 ThreadLocalJObject::~ThreadLocalJObject() {
-  lInited = 0;
-  if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm != nullptr) {
-    jboolean attached_thread = JNI_FALSE;
+	  lInited = 0;
+	  if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm != nullptr) 
+	  {
+			jboolean attached_thread = JNI_FALSE;
 
-	assert(m_pJniEnv != nullptr);
-    // free ASAP after thread detach this thread local obj
-    m_pJniEnv->DeleteGlobalRef(m_jSlice);
+			assert(m_pJniEnv != nullptr);
+			// free ASAP after thread detach this thread local obj
+			m_pJniEnv->DeleteGlobalRef(m_jSlice);
 
-    JniUtil::releaseJniEnv(m_jvm, attached_thread);
+			JniUtil::releaseJniEnv(m_jvm, attached_thread);
 
-    // delete m_jvm;
-    m_jvm = nullptr;
+			// delete m_jvm;
+			m_jvm = nullptr;
 
-  }
+	  }
 }
 
 BaseComparatorJniCallback::BaseComparatorJniCallback(

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -19,6 +19,7 @@
 #include "port/port.h"
 
 
+
 using namespace std;
 
 namespace rocksdb {
@@ -51,17 +52,17 @@ public:
 		lInited = 0;
 		if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm!= nullptr)
 		{
-			jboolean attached_thread = JNI_FALSE;
+			//jboolean attached_thread = JNI_FALSE;
 
-			JNIEnv* env = JniUtil::getJniEnv(m_jvm, &attached_thread);
-			assert(env != nullptr);
-			// free ASAP after thread detach this thread local obj
-			env->DeleteLocalRef(m_jSlice);	
+			//JNIEnv* env = JniUtil::getJniEnv(m_jvm, &attached_thread);
+			//assert(env != nullptr);
+			//// free ASAP after thread detach this thread local obj
+			//env->DeleteLocalRef(m_jSlice);	
 
-			JniUtil::releaseJniEnv(m_jvm, attached_thread);
+			//JniUtil::releaseJniEnv(m_jvm, attached_thread);
 
-			delete m_jvm;
-			m_jvm = nullptr;
+			//delete m_jvm;
+			//m_jvm = nullptr;
 
 		}
 	}

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -41,32 +41,11 @@ struct ComparatorJniCallbackOptions {
 //
 class ThreadLocalJObject {
 public:
-	ThreadLocalJObject() {
-		lInited = 1;
+    ThreadLocalJObject();
 
-	}
+	~ThreadLocalJObject();
 
-	~ThreadLocalJObject()
-	{
-		
-		lInited = 0;
-		if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm!= nullptr)
-		{
-			//jboolean attached_thread = JNI_FALSE;
-
-			//JNIEnv* env = JniUtil::getJniEnv(m_jvm, &attached_thread);
-			//assert(env != nullptr);
-			//// free ASAP after thread detach this thread local obj
-			//env->DeleteLocalRef(m_jSlice);	
-
-			//JniUtil::releaseJniEnv(m_jvm, attached_thread);
-
-			//delete m_jvm;
-			//m_jvm = nullptr;
-
-		}
-	}
-
+public:
 	volatile long lInited = 0;
 	volatile long lObjAssigned = 0;
 	JavaVM* m_jvm = nullptr;
@@ -95,14 +74,12 @@ class BaseComparatorJniCallback : public JniCallback, public Comparator {
       const ComparatorJniCallbackOptions* copt);
     virtual const char* Name() const;
     virtual int Compare(const Slice& a, const Slice& b) const;
-	virtual int CompareNoLock(JNIEnv* env, const jobject& jSliceA, const jobject& jSliceB,
-		const Slice& a, const Slice& b,
-		jboolean attached_thread) const;
+
     virtual void FindShortestSeparator(
       std::string* start, const Slice& limit) const;
     virtual void FindShortSuccessor(std::string* key) const;
 
- private:
+protected:
     // used for synchronisation in compare method
     std::unique_ptr<port::Mutex> mtx_compare;
     // used for synchronisation in findShortestSeparator method
@@ -129,6 +106,10 @@ class ComparatorJniCallback : public BaseComparatorJniCallback {
         JNIEnv* env, jobject jComparator,
         const ComparatorJniCallbackOptions* copt);
       ~ComparatorJniCallback();
+      virtual int Compare(const Slice& a, const Slice& b) const;
+	  int CompareNoLock(JNIEnv* env, const jobject& jSliceA,
+                                const jobject& jSliceB, const Slice& a,
+                                const Slice& b, jboolean attached_thread) const;
 };
 
 class DirectComparatorJniCallback : public BaseComparatorJniCallback {

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -53,6 +53,7 @@ class BaseComparatorJniCallback : public JniCallback, public Comparator {
       const ComparatorJniCallbackOptions* copt);
     virtual const char* Name() const;
     virtual int Compare(const Slice& a, const Slice& b) const;
+	virtual int CompareNoLock(const jobject& jSliceA, const jobject& jSliceB, const Slice& a, const Slice& b) const;
     virtual void FindShortestSeparator(
       std::string* start, const Slice& limit) const;
     virtual void FindShortSuccessor(std::string* key) const;

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -53,7 +53,9 @@ class BaseComparatorJniCallback : public JniCallback, public Comparator {
       const ComparatorJniCallbackOptions* copt);
     virtual const char* Name() const;
     virtual int Compare(const Slice& a, const Slice& b) const;
-	virtual int CompareNoLock(const jobject& jSliceA, const jobject& jSliceB, const Slice& a, const Slice& b) const;
+	virtual int CompareNoLock(JNIEnv* env, const jobject& jSliceA, const jobject& jSliceB,
+		const Slice& a, const Slice& b,
+		jboolean attached_thread) const;
     virtual void FindShortestSeparator(
       std::string* start, const Slice& limit) const;
     virtual void FindShortSuccessor(std::string* key) const;

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -48,8 +48,9 @@ public:
 public:
 	volatile long lInited = 0;
 	volatile long lObjAssigned = 0;
-	JavaVM* m_jvm = nullptr;
-	jobject m_jSlice = nullptr;
+	JavaVM* m_jvm     = nullptr;
+    JNIEnv* m_pJniEnv = nullptr;
+	jobject m_jSlice  = nullptr;
 };
 
 /**
@@ -89,10 +90,6 @@ protected:
     jmethodID m_jFindShortestSeparatorMethodId;
     jmethodID m_jFindShortSuccessorMethodId;
 
-	// wgao used for synchronisation in thread local map method
-	std::unique_ptr<port::Mutex> mtx_threadMap;
-	map<std::string, int> mapThread2SliceObjectA;
-	map<std::string, jobject> mapThread2SliceObjectB;
 
  protected:
     jobject m_jSliceA;

--- a/java/rocksjni/comparatorjnicallback.h
+++ b/java/rocksjni/comparatorjnicallback.h
@@ -49,7 +49,7 @@ public:
 	{
 		
 		lInited = 0;
-		if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm!=null)
+		if (lObjAssigned == 1 && m_jSlice != nullptr && m_jvm!= nullptr)
 		{
 			jboolean attached_thread = JNI_FALSE;
 
@@ -61,14 +61,14 @@ public:
 			JniUtil::releaseJniEnv(m_jvm, attached_thread);
 
 			delete m_jvm;
-			m_jvm = null;
+			m_jvm = nullptr;
 
 		}
 	}
 
 	volatile long lInited = 0;
 	volatile long lObjAssigned = 0;
-	JavaVM* m_jvm = null;
+	JavaVM* m_jvm = nullptr;
 	jobject m_jSlice = nullptr;
 };
 


### PR DESCRIPTION
Hello Buddy 

I found one RocksDBJava will be very poor performance on concurrent list with iterator next. The root cause is that if you use any Java compactor from your own. It will hit the mutex on the JNI code.

I locally fix this with below yellow highlight code change. I stop use the lock and global m_ jSliceA, m_ jSliceB.

But I found I do not have permission to push the code. Could you please help review and help make this issue fixed? A better way is use thread local variable. But need more code.

int BaseComparatorJniCallback::Compare(const Slice& a, const Slice& b) const {
  jboolean attached_thread = JNI_FALSE;
  JNIEnv* env = getJniEnv(&attached_thread);
  assert(env != nullptr);

  // TODO(adamretter): slice objects can potentially be cached using thread
  // local variables to avoid locking. Could make this configurable depending on
  // performance.
  
  //
  //EMC Wayne Gao fix the concurrent list performance issue
  //
  //mtx_compare.get()->Lock();
  jobject jSliceA;
  jobject jSliceB;
  
  jSliceA = env->NewLocalRef(SliceJni::construct0(env)); 
  if(jSliceA == nullptr) {
    // exception thrown: OutOfMemoryError
  }
  
  jSliceB = env->NewLocalRef(SliceJni::construct0(env));
  if(jSliceB == nullptr) {
    // exception thrown: OutOfMemoryError
  }
  
  bool pending_exception =
      AbstractSliceJni::setHandle(env, jSliceA, &a, JNI_FALSE);
  if(pending_exception) {
    if(env->ExceptionCheck()) {
      // exception thrown from setHandle or descendant
      env->ExceptionDescribe(); // print out exception to stderr
    }
    releaseJniEnv(attached_thread);
    return 0;
  }

  pending_exception =
      AbstractSliceJni::setHandle(env, jSliceB, &b, JNI_FALSE);
  if(pending_exception) {
    if(env->ExceptionCheck()) {
      // exception thrown from setHandle or descendant
      env->ExceptionDescribe(); // print out exception to stderr
    }
    releaseJniEnv(attached_thread);
    return 0;
  }

  jint result =
    env->CallIntMethod(m_jcallback_obj, m_jCompareMethodId, jSliceA,
      jSliceB);

  //mtx_compare.get()->Unlock(); Wayne Gao remove lock
  
  if(jSliceA != nullptr) {
    // exception thrown: OutOfMemoryError
              env->DeleteLocalRef(jSliceA);

  }

  if(jSliceB != nullptr) {
    // exception thrown: OutOfMemoryError
              env->DeleteLocalRef(jSliceB);

  }
