### PR TITLE
Remove warnings caused by unused variables in jni

### DIFF
--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -612,7 +612,11 @@ void txn_write_kv_parts_helper(JNIEnv* env,
                                const jint& jkey_parts_len,
                                const jobjectArray& jvalue_parts,
                                const jint& jvalue_parts_len) {
+#ifndef DEBUG
+  (void) jvalue_parts_len;
+#else
   assert(jkey_parts_len == jvalue_parts_len);
+#endif
 
   auto key_parts = std::vector<rocksdb::Slice>();
   auto value_parts = std::vector<rocksdb::Slice>();

--- a/java/rocksjni/writebatchhandlerjnicallback.cc
+++ b/java/rocksjni/writebatchhandlerjnicallback.cc
@@ -306,7 +306,11 @@ rocksdb::Status WriteBatchHandlerJniCallback::PutBlobIndexCF(uint32_t column_fam
 }
 
 rocksdb::Status WriteBatchHandlerJniCallback::MarkBeginPrepare(bool unprepare) {
+#ifndef DEBUG
+  (void) unprepare;
+#else
   assert(!unprepare);
+#endif
   m_env->CallVoidMethod(m_jcallback_obj, m_jMarkBeginPrepareMethodId);
 
   // check for Exception, in-particular RocksDBException


### PR DESCRIPTION
Test plan
```
$make clean jclean
$make -j32 rocksdbjavastatic
$make -j32 rocksdbjava
```