### PR TITLE
Revert "Digest ZSTD compression dictionary once per SST file (#4251)"

### DIFF
--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -103,19 +103,19 @@ bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
 }  // namespace
 
 // format_version is the block format as defined in include/rocksdb/table.h
-Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
+Slice CompressBlock(const Slice& raw, const CompressionContext& compression_ctx,
                     CompressionType* type, uint32_t format_version,
                     std::string* compressed_output) {
-  *type = compression_info.type();
-  if (compression_info.type() == kNoCompression) {
+  *type = compression_ctx.type();
+  if (compression_ctx.type() == kNoCompression) {
     return raw;
   }
 
   // Will return compressed block contents if (1) the compression method is
   // supported in this platform and (2) the compression rate is "good enough".
-  switch (compression_info.type()) {
+  switch (compression_ctx.type()) {
     case kSnappyCompression:
-      if (Snappy_Compress(compression_info, raw.data(), raw.size(),
+      if (Snappy_Compress(compression_ctx, raw.data(), raw.size(),
                           compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
@@ -123,7 +123,7 @@ Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
       break;  // fall back to no compression.
     case kZlibCompression:
       if (Zlib_Compress(
-              compression_info,
+              compression_ctx,
               GetCompressFormatForVersion(kZlibCompression, format_version),
               raw.data(), raw.size(), compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
@@ -132,7 +132,7 @@ Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
       break;  // fall back to no compression.
     case kBZip2Compression:
       if (BZip2_Compress(
-              compression_info,
+              compression_ctx,
               GetCompressFormatForVersion(kBZip2Compression, format_version),
               raw.data(), raw.size(), compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
@@ -141,7 +141,7 @@ Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
       break;  // fall back to no compression.
     case kLZ4Compression:
       if (LZ4_Compress(
-              compression_info,
+              compression_ctx,
               GetCompressFormatForVersion(kLZ4Compression, format_version),
               raw.data(), raw.size(), compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
@@ -150,7 +150,7 @@ Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
       break;  // fall back to no compression.
     case kLZ4HCCompression:
       if (LZ4HC_Compress(
-              compression_info,
+              compression_ctx,
               GetCompressFormatForVersion(kLZ4HCCompression, format_version),
               raw.data(), raw.size(), compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
@@ -166,7 +166,7 @@ Slice CompressBlock(const Slice& raw, const CompressionInfo& compression_info,
       break;
     case kZSTD:
     case kZSTDNotFinalCompression:
-      if (ZSTD_Compress(compression_info, raw.data(), raw.size(),
+      if (ZSTD_Compress(compression_ctx, raw.data(), raw.size(),
                         compressed_output) &&
           GoodCompressionRatio(compressed_output->size(), raw.size())) {
         return *compressed_output;
@@ -260,9 +260,8 @@ struct BlockBasedTableBuilder::Rep {
   PartitionedIndexBuilder* p_index_builder_ = nullptr;
 
   std::string last_key;
-  CompressionType compression_type;
-  CompressionOptions compression_opts;
-  CompressionDict compression_dict;
+  // Compression dictionary or nullptr
+  const std::string* compression_dict;
   CompressionContext compression_ctx;
   std::unique_ptr<UncompressionContext> verify_ctx;
   TableProperties props;
@@ -313,9 +312,8 @@ struct BlockBasedTableBuilder::Rep {
                    table_options.data_block_hash_table_util_ratio),
         range_del_block(1 /* block_restart_interval */),
         internal_prefix_transform(_moptions.prefix_extractor.get()),
-        compression_type(_compression_type),
-        compression_opts(_compression_opts),
-        compression_ctx(_compression_type),
+        compression_dict(_compression_dict),
+        compression_ctx(_compression_type, _compression_opts),
         use_delta_encoding_for_index_values(table_opt.format_version >= 4 &&
                                             !table_opt.block_align),
         compressed_cache_key_prefix_size(0),
@@ -326,15 +324,6 @@ struct BlockBasedTableBuilder::Rep {
         column_family_name(_column_family_name),
         creation_time(_creation_time),
         oldest_key_time(_oldest_key_time) {
-    if (_compression_dict != nullptr) {
-      compression_dict.Init(*_compression_dict,
-                            CompressionDict::Mode::kCompression,
-                            _compression_type, _compression_opts.level);
-    } else {
-      compression_dict.Init(Slice() /* dict */,
-                            CompressionDict::Mode::kEmpty,
-                            _compression_type, _compression_opts.level);
-    }
     if (table_options.index_type ==
         BlockBasedTableOptions::kTwoLevelIndexSearch) {
       p_index_builder_ = PartitionedIndexBuilder::CreateIndexBuilder(
@@ -365,7 +354,7 @@ struct BlockBasedTableBuilder::Rep {
             _moptions.prefix_extractor != nullptr));
     if (table_options.verify_compression) {
       verify_ctx.reset(new UncompressionContext(UncompressionContext::NoCache(),
-                                                compression_type));
+                                                compression_ctx.type()));
     }
   }
 
@@ -509,7 +498,7 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
   assert(ok());
   Rep* r = rep_;
 
-  auto type = r->compression_type;
+  auto type = r->compression_ctx.type();
   Slice block_contents;
   bool abort_compression = false;
 
@@ -517,12 +506,24 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     ShouldReportDetailedTime(r->ioptions.env, r->ioptions.statistics));
 
   if (raw_block_contents.size() < kCompressionSizeLimit) {
-    CompressionInfo compression_info(
-        r->compression_opts, r->compression_ctx,
-        is_data_block ? r->compression_dict : CompressionDict::GetEmptyDict(),
-        r->compression_type);
+    Slice compression_dict;
+    if (is_data_block && r->compression_dict && r->compression_dict->size()) {
+      r->compression_ctx.dict() = *r->compression_dict;
+      if (r->table_options.verify_compression) {
+        assert(r->verify_ctx != nullptr);
+        r->verify_ctx->dict() = *r->compression_dict;
+      }
+    } else {
+      // Clear dictionary
+      r->compression_ctx.dict() = Slice();
+      if (r->table_options.verify_compression) {
+        assert(r->verify_ctx != nullptr);
+        r->verify_ctx->dict() = Slice();
+      }
+    }
+
     block_contents =
-        CompressBlock(raw_block_contents, compression_info, &type,
+        CompressBlock(raw_block_contents, r->compression_ctx, &type,
                       r->table_options.format_version, &r->compressed_output);
 
     // Some of the compression algorithms are known to be unreliable. If
@@ -531,12 +532,8 @@ void BlockBasedTableBuilder::WriteBlock(const Slice& raw_block_contents,
     if (type != kNoCompression && r->table_options.verify_compression) {
       // Retrieve the uncompressed contents into a new buffer
       BlockContents contents;
-      UncompressionInfo uncompression_info(
-          *r->verify_ctx,
-          is_data_block ? r->compression_dict : CompressionDict::GetEmptyDict(),
-          r->compression_type);
       Status stat = UncompressBlockContentsForCompressionType(
-          uncompression_info, block_contents.data(), block_contents.size(),
+          *r->verify_ctx, block_contents.data(), block_contents.size(),
           &contents, r->table_options.format_version, r->ioptions);
 
       if (stat.ok()) {
@@ -783,7 +780,7 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
             ? rep_->ioptions.merge_operator->Name()
             : "nullptr";
     rep_->props.compression_name =
-        CompressionTypeToString(rep_->compression_type);
+        CompressionTypeToString(rep_->compression_ctx.type());
     rep_->props.prefix_extractor_name =
         rep_->moptions.prefix_extractor != nullptr
             ? rep_->moptions.prefix_extractor->Name()
@@ -832,10 +829,10 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
 
 void BlockBasedTableBuilder::WriteCompressionDictBlock(
     MetaIndexBuilder* meta_index_builder) {
-  if (rep_->compression_dict.GetRawDict().size()) {
+  if (rep_->compression_dict && rep_->compression_dict->size()) {
     BlockHandle compression_dict_block_handle;
     if (ok()) {
-      WriteRawBlock(rep_->compression_dict.GetRawDict(), kNoCompression,
+      WriteRawBlock(*rep_->compression_dict, kNoCompression,
                     &compression_dict_block_handle);
     }
     if (ok()) {

--- a/table/block_based_table_builder.h
+++ b/table/block_based_table_builder.h
@@ -131,7 +131,7 @@ class BlockBasedTableBuilder : public TableBuilder {
   const uint64_t kCompressionSizeLimit = std::numeric_limits<int>::max();
 };
 
-Slice CompressBlock(const Slice& raw, const CompressionInfo& info,
+Slice CompressBlock(const Slice& raw, const CompressionContext& compression_ctx,
                     CompressionType* type, uint32_t format_version,
                     std::string* compressed_output);
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1226,12 +1226,9 @@ Status BlockBasedTable::GetDataBlockFromCache(
 
   // Retrieve the uncompressed contents into a new buffer
   BlockContents contents;
-  UncompressionContext context(compressed_block->compression_type());
-  CompressionDict dict;
-  dict.Init(compression_dict, CompressionDict::Mode::kUncompression,
-            compressed_block->compression_type());
-  UncompressionInfo info(context, dict, compressed_block->compression_type());
-  s = UncompressBlockContents(info, compressed_block->data(),
+  UncompressionContext uncompresssion_ctx(compressed_block->compression_type(),
+                                          compression_dict);
+  s = UncompressBlockContents(uncompresssion_ctx, compressed_block->data(),
                               compressed_block->size(), &contents,
                               format_version, ioptions);
 
@@ -1304,13 +1301,11 @@ Status BlockBasedTable::PutDataBlockToCache(
   BlockContents contents;
   Statistics* statistics = ioptions.statistics;
   if (raw_block->compression_type() != kNoCompression) {
-    UncompressionContext context(raw_block->compression_type());
-    CompressionDict dict;
-    dict.Init(compression_dict, CompressionDict::Mode::kUncompression,
-              raw_block->compression_type());
-    UncompressionInfo info(context, dict, raw_block->compression_type());
-    s = UncompressBlockContents(info, raw_block->data(), raw_block->size(),
-                                &contents, format_version, ioptions);
+    UncompressionContext uncompression_ctx(raw_block->compression_type(),
+                                           compression_dict);
+    s = UncompressBlockContents(uncompression_ctx, raw_block->data(),
+                                raw_block->size(), &contents, format_version,
+                                ioptions);
   }
   if (!s.ok()) {
     delete raw_block;

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -227,13 +227,10 @@ Status BlockFetcher::ReadBlockContents() {
 
   if (do_uncompress_ && compression_type != kNoCompression) {
     // compressed page, uncompress, update cache
-    UncompressionContext context(compression_type);
-    CompressionDict dict;
-    dict.Init(compression_dict_, CompressionDict::Mode::kUncompression,
-              compression_type);
-    UncompressionInfo info(context, dict, compression_type);
-    status_ = UncompressBlockContents(info, slice_.data(), block_size_,
-                                      contents_, footer_.version(), ioptions_);
+    UncompressionContext uncompression_ctx(compression_type, compression_dict_);
+    status_ =
+        UncompressBlockContents(uncompression_ctx, slice_.data(), block_size_,
+                                contents_, footer_.version(), ioptions_);
   } else {
     GetBlockContents();
   }

--- a/table/format.h
+++ b/table/format.h
@@ -250,17 +250,16 @@ extern Status ReadBlockContents(
 // free this buffer.
 // For description of compress_format_version and possible values, see
 // util/compression.h
-extern Status UncompressBlockContents(const UncompressionInfo& info,
-                                      const char* data, size_t n,
-                                      BlockContents* contents,
-                                      uint32_t compress_format_version,
-                                      const ImmutableCFOptions& ioptions);
+extern Status UncompressBlockContents(
+    const UncompressionContext& uncompression_ctx, const char* data, size_t n,
+    BlockContents* contents, uint32_t compress_format_version,
+    const ImmutableCFOptions& ioptions);
 
 // This is an extension to UncompressBlockContents that accepts
 // a specific compression type. This is used by un-wrapped blocks
 // with no compression header.
 extern Status UncompressBlockContentsForCompressionType(
-    const UncompressionInfo& info, const char* data, size_t n,
+    const UncompressionContext& uncompression_ctx, const char* data, size_t n,
     BlockContents* contents, uint32_t compress_format_version,
     const ImmutableCFOptions& ioptions);
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1991,28 +1991,28 @@ class Benchmark {
     return true;
   }
 
-  inline bool CompressSlice(const CompressionInfo& compression_info,
+  inline bool CompressSlice(const CompressionContext& compression_ctx,
                             const Slice& input, std::string* compressed) {
     bool ok = true;
     switch (FLAGS_compression_type_e) {
       case rocksdb::kSnappyCompression:
-        ok = Snappy_Compress(compression_info, input.data(), input.size(),
+        ok = Snappy_Compress(compression_ctx, input.data(), input.size(),
                              compressed);
         break;
       case rocksdb::kZlibCompression:
-        ok = Zlib_Compress(compression_info, 2, input.data(), input.size(),
+        ok = Zlib_Compress(compression_ctx, 2, input.data(), input.size(),
                            compressed);
         break;
       case rocksdb::kBZip2Compression:
-        ok = BZip2_Compress(compression_info, 2, input.data(), input.size(),
+        ok = BZip2_Compress(compression_ctx, 2, input.data(), input.size(),
                             compressed);
         break;
       case rocksdb::kLZ4Compression:
-        ok = LZ4_Compress(compression_info, 2, input.data(), input.size(),
+        ok = LZ4_Compress(compression_ctx, 2, input.data(), input.size(),
                           compressed);
         break;
       case rocksdb::kLZ4HCCompression:
-        ok = LZ4HC_Compress(compression_info, 2, input.data(), input.size(),
+        ok = LZ4HC_Compress(compression_ctx, 2, input.data(), input.size(),
                             compressed);
         break;
       case rocksdb::kXpressCompression:
@@ -2020,7 +2020,7 @@ class Benchmark {
           input.size(), compressed);
         break;
       case rocksdb::kZSTD:
-        ok = ZSTD_Compress(compression_info, input.data(), input.size(),
+        ok = ZSTD_Compress(compression_ctx, input.data(), input.size(),
                            compressed);
         break;
       default:
@@ -2103,11 +2103,10 @@ class Benchmark {
       const int len = FLAGS_block_size;
       std::string input_str(len, 'y');
       std::string compressed;
-      CompressionOptions opts;
-      CompressionContext context(FLAGS_compression_type_e);
-      CompressionInfo info(opts, context, CompressionDict::GetEmptyDict(),
-                           FLAGS_compression_type_e);
-      bool result = CompressSlice(info, Slice(input_str), &compressed);
+      CompressionContext compression_ctx(FLAGS_compression_type_e,
+                                         Options().compression_opts);
+      bool result =
+          CompressSlice(compression_ctx, Slice(input_str), &compressed);
 
       if (!result) {
         fprintf(stdout, "WARNING: %s compression is not enabled\n",
@@ -2957,14 +2956,13 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     int64_t produced = 0;
     bool ok = true;
     std::string compressed;
-    CompressionOptions opts;
-    CompressionContext context(FLAGS_compression_type_e);
-    CompressionInfo info(opts, context, CompressionDict::GetEmptyDict(),
-                         FLAGS_compression_type_e);
+    CompressionContext compression_ctx(FLAGS_compression_type_e,
+                                       Options().compression_opts);
+
     // Compress 1G
     while (ok && bytes < int64_t(1) << 30) {
       compressed.clear();
-      ok = CompressSlice(info, input, &compressed);
+      ok = CompressSlice(compression_ctx, input, &compressed);
       produced += compressed.size();
       bytes += input.size();
       thread->stats.FinishedOps(nullptr, nullptr, 1, kCompress);
@@ -2986,17 +2984,11 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     Slice input = gen.Generate(FLAGS_block_size);
     std::string compressed;
 
-    CompressionContext compression_ctx(FLAGS_compression_type_e);
-    CompressionOptions compression_opts;
-    CompressionInfo compression_info(compression_opts, compression_ctx,
-                                     CompressionDict::GetEmptyDict(),
-                                     FLAGS_compression_type_e);
     UncompressionContext uncompression_ctx(FLAGS_compression_type_e);
-    UncompressionInfo uncompression_info(uncompression_ctx,
-                                         CompressionDict::GetEmptyDict(),
-                                         FLAGS_compression_type_e);
+    CompressionContext compression_ctx(FLAGS_compression_type_e,
+                                       Options().compression_opts);
 
-    bool ok = CompressSlice(compression_info, input, &compressed);
+    bool ok = CompressSlice(compression_ctx, input, &compressed);
     int64_t bytes = 0;
     int decompress_size;
     while (ok && bytes < 1024 * 1048576) {
@@ -3016,7 +3008,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
           break;
         }
       case rocksdb::kZlibCompression:
-        uncompressed = Zlib_Uncompress(uncompression_info, compressed.data(),
+        uncompressed = Zlib_Uncompress(uncompression_ctx, compressed.data(),
                                        compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
@@ -3026,12 +3018,12 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kLZ4Compression:
-        uncompressed = LZ4_Uncompress(uncompression_info, compressed.data(),
+        uncompressed = LZ4_Uncompress(uncompression_ctx, compressed.data(),
                                       compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kLZ4HCCompression:
-        uncompressed = LZ4_Uncompress(uncompression_info, compressed.data(),
+        uncompressed = LZ4_Uncompress(uncompression_ctx, compressed.data(),
                                       compressed.size(), &decompress_size, 2);
         ok = uncompressed != nullptr;
         break;
@@ -3041,7 +3033,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         ok = uncompressed != nullptr;
         break;
       case rocksdb::kZSTD:
-        uncompressed = ZSTD_Uncompress(uncompression_info, compressed.data(),
+        uncompressed = ZSTD_Uncompress(uncompression_ctx, compressed.data(),
                                        compressed.size(), &decompress_size);
         ok = uncompressed != nullptr;
         break;

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -738,11 +738,9 @@ Slice BlobDBImpl::GetCompressedSlice(const Slice& raw,
     return raw;
   }
   StopWatch compression_sw(env_, statistics_, BLOB_DB_COMPRESSION_MICROS);
-  CompressionType type = bdb_options_.compression;
-  CompressionOptions opts;
-  CompressionContext context(type);
-  CompressionInfo info(opts, context, CompressionDict::GetEmptyDict(), type);
-  CompressBlock(raw, info, &type, kBlockBasedTableVersionFormat,
+  CompressionType ct = bdb_options_.compression;
+  CompressionContext compression_ctx(ct);
+  CompressBlock(raw, compression_ctx, &ct, kBlockBasedTableVersionFormat,
                 compression_output);
   return *compression_output;
 }
@@ -1075,11 +1073,9 @@ Status BlobDBImpl::GetBlobValue(const Slice& key, const Slice& index_entry,
     {
       StopWatch decompression_sw(env_, statistics_,
                                  BLOB_DB_DECOMPRESSION_MICROS);
-      UncompressionContext context(bfile->compression());
-      UncompressionInfo info(context, CompressionDict::GetEmptyDict(),
-                             bfile->compression());
+      UncompressionContext uncompression_ctx(bfile->compression());
       s = UncompressBlockContentsForCompressionType(
-          info, blob_value.data(), blob_value.size(), &contents,
+          uncompression_ctx, blob_value.data(), blob_value.size(), &contents,
           kBlockBasedTableVersionFormat, *(cfh->cfd()->ioptions()));
     }
     value->PinSelf(contents.data);

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -208,11 +208,9 @@ Status BlobDumpTool::DumpRecord(DisplayType show_key, DisplayType show_blob,
   if (compression != kNoCompression &&
       (show_uncompressed_blob != DisplayType::kNone || show_summary)) {
     BlockContents contents;
-    UncompressionContext context(compression);
-    UncompressionInfo info(context, CompressionDict::GetEmptyDict(),
-                           compression);
+    UncompressionContext uncompression_ctx(compression);
     s = UncompressBlockContentsForCompressionType(
-        info, slice.data() + key_size, value_size, &contents,
+        uncompression_ctx, slice.data() + key_size, value_size, &contents,
         2 /*compress_format_version*/, ImmutableCFOptions(Options()));
     if (!s.ok()) {
       return s;

--- a/utilities/column_aware_encoding_util.cc
+++ b/utilities/column_aware_encoding_util.cc
@@ -89,9 +89,8 @@ void ColumnAwareEncodingReader::DecodeBlocks(
     CompressionType type =
         (CompressionType)slice_final_with_bit[slice_final_with_bit.size() - 1];
     if (type != kNoCompression) {
-      UncompressionContext context(type);
-      UncompressionInfo info(context, CompressionDict::GetEmptyDict(), type);
-      UncompressBlockContents(info, slice_final_with_bit.c_str(),
+      UncompressionContext uncompression_ctx(type);
+      UncompressBlockContents(uncompression_ctx, slice_final_with_bit.c_str(),
                               slice_final_with_bit.size() - 1, &contents,
                               format_version, ioptions);
       content_ptr = contents.data.data();
@@ -172,9 +171,8 @@ void ColumnAwareEncodingReader::DecodeBlocksFromRowFormat(
     CompressionType type =
         (CompressionType)slice_final_with_bit[slice_final_with_bit.size() - 1];
     if (type != kNoCompression) {
-      UncompressionContext context(type);
-      UncompressionInfo info(context, CompressionDict::GetEmptyDict(), type);
-      UncompressBlockContents(info, slice_final_with_bit.c_str(),
+      UncompressionContext uncompression_ctx(type);
+      UncompressBlockContents(uncompression_ctx, slice_final_with_bit.c_str(),
                               slice_final_with_bit.size() - 1, &contents,
                               format_version, ioptions);
       decoded_content = std::string(contents.data.data(), contents.data.size());
@@ -245,12 +243,10 @@ namespace {
 
 void CompressDataBlock(const std::string& output_content, Slice* slice_final,
                        CompressionType* type, std::string* compressed_output) {
-  CompressionContext context(*type);
-  CompressionOptions opts;
-  CompressionInfo info(opts, context, CompressionDict::GetEmptyDict(), *type);
+  CompressionContext compression_ctx(*type);
   uint32_t format_version = 2;  // hard-coded version
-  *slice_final = CompressBlock(output_content, info, type, format_version,
-                               compressed_output);
+  *slice_final = CompressBlock(output_content, compression_ctx, type,
+                               format_version, compressed_output);
 }
 
 }  // namespace


### PR DESCRIPTION
Reverting is needed to unblock a user building against master, who is blocked for multiple days due to a thread-safety issue in `GetEmptyDict`. We haven't been able to fix it quickly, so reverting.

Simply ran `git revert 6c40806e51a89386d2b066fddf73d3fd03a36f65`. There were no merge conflicts.

Test Plan: `make check -j64`