### PR TITLE
Implement dynamic update of number of levels in SetOptions. The API n…

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -111,8 +111,9 @@ CompressionType GetCompressionType(const ImmutableCFOptions& ioptions,
 }
 
 CompactionPicker::CompactionPicker(const ImmutableCFOptions& ioptions,
+                                   const MutableCFOptions& mutable_cf_options,
                                    const InternalKeyComparator* icmp)
-    : ioptions_(ioptions), icmp_(icmp) {}
+    : ioptions_(ioptions), mutable_cf_options_(mutable_cf_options), icmp_(icmp) {}
 
 CompactionPicker::~CompactionPicker() {}
 

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -32,6 +32,7 @@ struct CompactionInputFiles;
 class CompactionPicker {
  public:
   CompactionPicker(const ImmutableCFOptions& ioptions,
+                   const MutableCFOptions& mutable_cf_options,
                    const InternalKeyComparator* icmp);
   virtual ~CompactionPicker();
 
@@ -137,7 +138,7 @@ class CompactionPicker {
   void GetRange(const std::vector<CompactionInputFiles>& inputs,
                 InternalKey* smallest, InternalKey* largest) const;
 
-  int NumberLevels() const { return ioptions_.num_levels; }
+  int NumberLevels() const { return mutable_cf_options_.num_levels; }
 
   // Add more files to the inputs on "level" to make sure that
   // no newer version of a key is compacted to "level+1" while leaving an older
@@ -199,6 +200,7 @@ class CompactionPicker {
 
  protected:
   const ImmutableCFOptions& ioptions_;
+  const MutableCFOptions mutable_cf_options_;
 
 // A helper function to SanitizeCompactionInputFiles() that
 // sanitizes "input_files" by adding necessary files.
@@ -222,8 +224,9 @@ class CompactionPicker {
 class LevelCompactionPicker : public CompactionPicker {
  public:
   LevelCompactionPicker(const ImmutableCFOptions& ioptions,
+                        const MutableCFOptions& mutable_cf_options,
                         const InternalKeyComparator* icmp)
-      : CompactionPicker(ioptions, icmp) {}
+      : CompactionPicker(ioptions, mutable_cf_options, icmp) {}
   virtual Compaction* PickCompaction(const std::string& cf_name,
                                      const MutableCFOptions& mutable_cf_options,
                                      VersionStorageInfo* vstorage,
@@ -237,8 +240,9 @@ class LevelCompactionPicker : public CompactionPicker {
 class FIFOCompactionPicker : public CompactionPicker {
  public:
   FIFOCompactionPicker(const ImmutableCFOptions& ioptions,
+                       const MutableCFOptions& mutable_cf_options,
                        const InternalKeyComparator* icmp)
-      : CompactionPicker(ioptions, icmp) {}
+      : CompactionPicker(ioptions, mutable_cf_options, icmp) {}
 
   virtual Compaction* PickCompaction(const std::string& cf_name,
                                      const MutableCFOptions& mutable_cf_options,
@@ -273,8 +277,9 @@ class FIFOCompactionPicker : public CompactionPicker {
 class NullCompactionPicker : public CompactionPicker {
  public:
   NullCompactionPicker(const ImmutableCFOptions& ioptions,
+                       const MutableCFOptions& mutable_cf_options,
                        const InternalKeyComparator* icmp)
-      : CompactionPicker(ioptions, icmp) {}
+      : CompactionPicker(ioptions, mutable_cf_options, icmp) {}
   virtual ~NullCompactionPicker() {}
 
   // Always return "nullptr"

--- a/db/compaction_picker_universal.h
+++ b/db/compaction_picker_universal.h
@@ -16,8 +16,9 @@ namespace rocksdb {
 class UniversalCompactionPicker : public CompactionPicker {
  public:
   UniversalCompactionPicker(const ImmutableCFOptions& ioptions,
+                            const MutableCFOptions& mutable_cf_options,
                             const InternalKeyComparator* icmp)
-      : CompactionPicker(ioptions, icmp) {}
+      : CompactionPicker(ioptions, mutable_cf_options, icmp) {}
   virtual Compaction* PickCompaction(const std::string& cf_name,
                                      const MutableCFOptions& mutable_cf_options,
                                      VersionStorageInfo* vstorage,

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -556,8 +556,8 @@ Status DBImpl::SetOptions(
   WriteThread::Writer w;
   SuperVersionContext sv_context(/* create_superversion */ true);
   {
+    s = cfd->SetOptions(column_family, options_map);
     InstrumentedMutexLock l(&mutex_);
-    s = cfd->SetOptions(options_map);
     if (s.ok()) {
       new_options = *cfd->GetLatestMutableCFOptions();
       // Append new version to recompute compaction score.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -273,6 +273,10 @@ class DBImpl : public DB {
   Status PromoteL0(ColumnFamilyHandle* column_family,
                    int target_level) override;
 
+  Status ValidateAndProcessCompactionLevelsUpdate(ColumnFamilyHandle* column_family,
+                                                  VersionStorageInfo* vstorage,
+                                                  int new_levels);
+
   // Similar to Write() but will call the callback once on the single write
   // thread to determine whether it is safe to perform the write.
   virtual Status WriteWithCallback(const WriteOptions& write_options,

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -117,6 +117,76 @@ TEST_F(DBOptionsTest, GetLatestCFOptions) {
             GetMutableCFOptionsMap(dbfull()->GetOptions(handles_[1])));
 }
 
+TEST_F(DBOptionsTest, TestNumberLevelsReduceDynamic) {
+  // GetOptions should be able to get latest option changed by SetOptions.
+  Options options;
+  options.create_if_missing = true;
+  options.env = env_;
+  options.num_levels = 5;
+  Random rnd(228);
+  Reopen(options);
+  CreateColumnFamilies({"foo"}, options);
+  ReopenWithColumnFamilies({"default", "foo"}, options);
+  ASSERT_OK(
+          dbfull()->SetOptions({{"num_levels", "3"}}));
+  ASSERT_EQ(dbfull()->GetOptions().num_levels, 3);
+}
+
+TEST_F(DBOptionsTest, TestNumberLevelsWithDataReduceDynamic) {
+  const size_t kValueSize = 1024 * 1024;  // 1MB
+  const std::string kValue(kValueSize, 'v');
+  Options options;
+  options.create_if_missing = true;
+  options.env = env_;
+  options.num_levels = 5;
+  Random rnd(228);
+  Reopen(options);
+  CreateColumnFamilies({"foo"}, options);
+  ReopenWithColumnFamilies({"default", "foo"}, options);
+
+  for (int i = 0; i < 40; i++) {
+    Put(Key(i), kValue);
+  }
+  ASSERT_OK(
+          dbfull()->SetOptions({{"num_levels", "3"}}));
+  ASSERT_EQ(dbfull()->GetOptions().num_levels, 3);
+}
+
+TEST_F(DBOptionsTest, TestNumberLevelsIncreaseDynamic) {
+    // GetOptions should be able to get latest option changed by SetOptions.
+    Options options;
+    options.create_if_missing = true;
+    options.env = env_;
+    options.num_levels = 3;
+    Random rnd(228);
+    Reopen(options);
+    CreateColumnFamilies({"foo"}, options);
+    ReopenWithColumnFamilies({"default", "foo"}, options);
+    ASSERT_OK(
+            dbfull()->SetOptions({{"num_levels", "5"}}));
+    ASSERT_EQ(dbfull()->GetOptions().num_levels, 5);
+}
+
+TEST_F(DBOptionsTest, TestNumberLevelsWithDataIncreaseDynamic) {
+    const size_t kValueSize = 1024 * 1024;  // 1MB
+    const std::string kValue(kValueSize, 'v');
+    Options options;
+    options.create_if_missing = true;
+    options.env = env_;
+    options.num_levels = 3;
+    Random rnd(228);
+    Reopen(options);
+    CreateColumnFamilies({"foo"}, options);
+    ReopenWithColumnFamilies({"default", "foo"}, options);
+
+    for (int i = 0; i < 40; i++) {
+        Put(Key(i), kValue);
+    }
+    ASSERT_OK(
+            dbfull()->SetOptions({{"num_levels", "5"}}));
+    ASSERT_EQ(dbfull()->GetOptions().num_levels, 5);
+}
+
 TEST_F(DBOptionsTest, SetBytesPerSync) {
   const size_t kValueSize = 1024 * 1024;  // 1MB
   Options options;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -151,7 +151,7 @@ class VersionBuilder::Rep {
     }
 #endif
     // make sure the files are sorted correctly
-    for (int level = 0; level < num_levels_; level++) {
+    for (int level = 0; level < vstorage->num_levels(); level++) {
       auto& level_files = vstorage->LevelFiles(level);
       for (size_t i = 1; i < level_files.size(); i++) {
         auto f1 = level_files[i - 1];

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2423,12 +2423,12 @@ void VersionStorageInfo::CalculateBaseBytes(const ImmutableCFOptions& ioptions,
   }
   set_l0_delay_trigger_count(num_l0_count);
 
-  level_max_bytes_.resize(ioptions.num_levels);
+  level_max_bytes_.resize(options.num_levels);
   if (!ioptions.level_compaction_dynamic_level_bytes) {
     base_level_ = (ioptions.compaction_style == kCompactionStyleLevel) ? 1 : -1;
 
     // Calculate for static bytes base case
-    for (int i = 0; i < ioptions.num_levels; ++i) {
+    for (int i = 0; i < options.num_levels; ++i) {
       if (i == 0 && ioptions.compaction_style == kCompactionStyleUniversal) {
         level_max_bytes_[i] = options.max_bytes_for_level_base;
       } else if (i > 1) {
@@ -3469,7 +3469,7 @@ Status VersionSet::ReduceNumberOfLevels(const std::string& dbname,
                                         int new_levels) {
   if (new_levels <= 1) {
     return Status::InvalidArgument(
-        "Number of levels needs to be bigger than 1");
+          "Number of levels needs to be bigger than 1");
   }
 
   ImmutableDBOptions db_options(*options);
@@ -3525,7 +3525,7 @@ Status VersionSet::ReduceNumberOfLevels(const std::string& dbname,
   // avoid SIGSEGV in WriteSnapshot()
   // however, all levels bigger or equal to new_levels will be empty
   std::vector<FileMetaData*>* new_files_list =
-      new std::vector<FileMetaData*>[current_levels];
+          new std::vector<FileMetaData*>[current_levels];
   for (int i = 0; i < new_levels - 1; i++) {
     new_files_list[i] = vstorage->LevelFiles(i);
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -282,6 +282,28 @@ class VersionStorageInfo {
     return files_by_compaction_pri_[level];
   }
 
+  // The method requires the new Level files to have been copied over the
+  // old Level files data
+  Status ReplaceFilesAndUpdateNumberOfLevels(std::vector<FileMetaData*>* new_files_list,
+                                            int num_levels) {
+    if(new_files_list == nullptr) {
+      char msg[255];
+      snprintf(msg, sizeof(msg),
+               "Null new files list passed");
+      return Status::InvalidArgument(msg);
+    }
+
+    if(!(files_->empty())) {
+      delete[] files_;
+    }
+
+    files_ = new_files_list;
+
+    num_levels_ = num_levels;
+
+    return Status::OK();
+  }
+
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   // REQUIRES: DB mutex held during access
   const autovector<std::pair<int, FileMetaData*>>& FilesMarkedForCompaction()

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -64,7 +64,6 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
           db_options.access_hint_on_compaction_start),
       new_table_reader_for_compaction_inputs(
           db_options.new_table_reader_for_compaction_inputs),
-      num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),
       allow_ingest_behind(db_options.allow_ingest_behind),
@@ -106,10 +105,10 @@ uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
   }
 }
 
-void MutableCFOptions::RefreshDerivedOptions(int num_levels,
+void MutableCFOptions::RefreshDerivedOptions(int num_levels_input,
                                              CompactionStyle compaction_style) {
-  max_file_size.resize(num_levels);
-  for (int i = 0; i < num_levels; ++i) {
+  max_file_size.resize(num_levels_input);
+  for (int i = 0; i < num_levels_input; ++i) {
     if (i == 0 && compaction_style == kCompactionStyleUniversal) {
       max_file_size[i] = ULLONG_MAX;
     } else if (i > 1) {
@@ -139,6 +138,7 @@ void MutableCFOptions::Dump(Logger* log) const {
   ROCKS_LOG_INFO(log,
                  "                    max_successive_merges: %" ROCKSDB_PRIszt,
                  max_successive_merges);
+  ROCKS_LOG_HEADER(log, "            num_levels: %d", num_levels);
   ROCKS_LOG_INFO(log,
                  "                 inplace_update_num_locks: %" ROCKSDB_PRIszt,
                  inplace_update_num_locks);

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -97,8 +97,6 @@ struct ImmutableCFOptions {
 
   bool new_table_reader_for_compaction_inputs;
 
-  int num_levels;
-
   bool optimize_filters_for_hits;
 
   bool force_consistency_checks;
@@ -155,7 +153,8 @@ struct MutableCFOptions {
             options.max_sequential_skip_in_iterations),
         paranoid_file_checks(options.paranoid_file_checks),
         report_bg_io_stats(options.report_bg_io_stats),
-        compression(options.compression) {
+        compression(options.compression),
+        num_levels(options.num_levels) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -191,7 +190,7 @@ struct MutableCFOptions {
   void RefreshDerivedOptions(int num_levels, CompactionStyle compaction_style);
 
   void RefreshDerivedOptions(const ImmutableCFOptions& ioptions) {
-    RefreshDerivedOptions(ioptions.num_levels, ioptions.compaction_style);
+    RefreshDerivedOptions(num_levels, ioptions.compaction_style);
   }
 
   int MaxBytesMultiplerAdditional(int level) const {
@@ -239,6 +238,8 @@ struct MutableCFOptions {
   // Derived options
   // Per-level target file size.
   std::vector<uint64_t> max_file_size;
+
+  int num_levels;
 };
 
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -175,6 +175,8 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
     cf_opts.max_bytes_for_level_multiplier_additional.emplace_back(value);
   }
 
+  cf_opts.num_levels = mutable_cf_options.num_levels;
+
   cf_opts.compaction_options_fifo = mutable_cf_options.compaction_options_fifo;
   cf_opts.compaction_options_universal =
       mutable_cf_options.compaction_options_universal;
@@ -1709,7 +1711,8 @@ std::unordered_map<std::string, OptionTypeInfo>
           OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
         {"num_levels",
          {offset_of(&ColumnFamilyOptions::num_levels), OptionType::kInt,
-          OptionVerificationType::kNormal, false, 0}},
+          OptionVerificationType::kNormal, true,
+                 offsetof(struct MutableCFOptions, num_levels)}},
         {"source_compaction_factor",
          {0, OptionType::kInt, OptionVerificationType::kDeprecated, true, 0}},
         {"target_file_size_multiplier",


### PR DESCRIPTION
…ow supports directly setting number of levels, both increasing and decreasing.

The PR also makes number of levels as a mutable value in the engine, hence allowing SetOptions API to follow (mostly) the same pattern as other values.
Note: Reducing the number of levels might not always succeed if there is more than one non-empty level between old levels -1 and new levels -1 after
compaction