### PR TITLE
Improve external SST file ingestion validation checks. File level che…

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -328,6 +328,8 @@ class DBImpl : public DB {
 
   virtual Status VerifyChecksum() override;
 
+  Status VerifyChecksumPreIngestion(const std::vector<std::string>& external_files);
+
 #endif  // ROCKSDB_LITE
 
   // Similar to GetSnapshot(), but also lets the db know that this snapshot

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -644,6 +644,9 @@ struct DBOptions {
   // Default: true
   bool advise_random_on_open = true;
 
+  // Perform checksum verification before ingesting external SST file
+  bool check_checksum_before_ingesting = false;
+
   // Amount of data to build up in memtables across all column
   // families before writing to disk.
   //

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -231,7 +231,8 @@ MutableDBOptions::MutableDBOptions()
       max_open_files(-1),
       bytes_per_sync(0),
       wal_bytes_per_sync(0),
-      compaction_readahead_size(0) {}
+      compaction_readahead_size(0),
+      check_checksum_before_ingestion(false) {}
 
 MutableDBOptions::MutableDBOptions(const DBOptions& options)
     : max_background_jobs(options.max_background_jobs),
@@ -247,7 +248,8 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       max_open_files(options.max_open_files),
       bytes_per_sync(options.bytes_per_sync),
       wal_bytes_per_sync(options.wal_bytes_per_sync),
-      compaction_readahead_size(options.compaction_readahead_size) {}
+      compaction_readahead_size(options.compaction_readahead_size),
+      check_checksum_before_ingestion(options.check_checksum_before_ingesting) {}
 
 void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.max_background_jobs: %d",
@@ -279,6 +281,8 @@ void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "      Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
                    compaction_readahead_size);
+  ROCKS_LOG_HEADER(log, "            Options.check_checksum_before_ingesting: %d",
+                   check_checksum_before_ingestion);
 }
 
 }  // namespace rocksdb

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -100,6 +100,7 @@ struct MutableDBOptions {
   uint64_t bytes_per_sync;
   uint64_t wal_bytes_per_sync;
   size_t compaction_readahead_size;
+  bool check_checksum_before_ingestion;
 };
 
 }  // namespace rocksdb

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -126,6 +126,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.preserve_deletes;
   options.two_write_queues = immutable_db_options.two_write_queues;
   options.manual_wal_flush = immutable_db_options.manual_wal_flush;
+  options.check_checksum_before_ingesting = mutable_db_options.check_checksum_before_ingestion;
 
   return options;
 }
@@ -1515,6 +1516,9 @@ std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct DBOptions, manual_wal_flush), OptionType::kBoolean,
           OptionVerificationType::kNormal, false,
           offsetof(struct ImmutableDBOptions, manual_wal_flush)}},
+        {"check_checksum_before_ingesting",
+                {offsetof(struct DBOptions, check_checksum_before_ingesting), OptionType::kBoolean,
+                        OptionVerificationType::kNormal, false, 0}},
         {"seq_per_batch",
          {0, OptionType::kBoolean, OptionVerificationType::kDeprecated, false,
           0}}};

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -289,6 +289,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "two_write_queues=false;"
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;",
+                             "check_checksum_before_ingesting=false;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),


### PR DESCRIPTION
…cks are done now before any other checks, thus allowing user to understand if there are file level issues that are causing an ingestion to fail. Functionality and an option to do checksum validations on external SST file before ingestion are also added