### PR TITLE
env_librados.h: drop redundant #endif

### DIFF
--- a/include/rocksdb/utilities/env_librados.h
+++ b/include/rocksdb/utilities/env_librados.h
@@ -173,4 +173,3 @@ class EnvLibrados : public EnvWrapper {
   friend class LibradosWritableFile;
 };
 }
-#endif


### PR DESCRIPTION
without this change, rocksdb_env_librados_test fails to build.

it's a regression introduced by 64324e32

Signed-off-by: Kefu Chai <tchaikov@gmail.com>