### PR TITLE
log_reader: skip the block if 6 initial_offset bytes left  in a block.

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -49,7 +49,8 @@ bool Reader::SkipToInitialBlock() {
   uint64_t block_start_location = initial_offset_ - initial_offset_in_block;
 
   // Don't search a block if we'd be in the trailer
-  if (initial_offset_in_block > kBlockSize - 6) {
+  const int64_t leftover = kBlockSize - initial_offset_in_block;
+  if (leftover < kHeaderSize) {
     block_start_location += kBlockSize;
   }
 


### PR DESCRIPTION
Summary:
If given initial_offset, When there are 6 bytes, it maybe:

* in the middle of record
* \x00 filled by the log_writer

so, if initial_offset_ is 6 bytes left, need to skip this block.

Signed-off-by: JiYou <jiyou09@gmail.com>