### PR TITLE
Support manual flush in stress/crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -32,6 +32,7 @@ default_params = {
     "destroy_db_initially": 0,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     "expected_values_path": expected_values_file.name,
+    "flush_one_in": 1000000,
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1947,8 +1947,8 @@ class StressTest {
                 db_->CompactFiles(CompactionOptions(), random_cf, input_files,
                                   static_cast<int>(output_level));
             if (!s.ok()) {
-              printf("Unable to perform CompactFiles(): %s\n",
-                     s.ToString().c_str());
+              fprintf(stdout, "Unable to perform CompactFiles(): %s\n",
+                      s.ToString().c_str());
               thread->stats.AddNumCompactFilesFailed(1);
             } else {
               thread->stats.AddNumCompactFilesSucceed(1);

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1975,7 +1975,7 @@ class StressTest {
         FlushOptions flush_opts;
         Status status = db_->Flush(flush_opts, column_family);
         if (!status.ok()) {
-          printf("Unable to perform Flush(): %s\n", status.ToString().c_str());
+          fprintf(stdout, "Unable to perform Flush(): %s\n", status.ToString().c_str());
         }
       }
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -412,6 +412,10 @@ DEFINE_int32(compact_range_one_in, 0,
              "If non-zero, then CompactRange() will be called once for every N "
              "operations on average.  0 indicates CompactRange() is disabled.");
 
+DEFINE_int32(flush_one_in, 0,
+             "If non-zero, then Flush() will be called once for every N ops "
+             "on average.  0 indicates calls to Flush() are disabled.");
+
 DEFINE_int32(compact_range_width, 10000,
              "The width of the ranges passed to CompactRange().");
 
@@ -1965,6 +1969,16 @@ class StressTest {
       }
 
       auto column_family = column_families_[rand_column_family];
+
+      if (FLAGS_flush_one_in > 0 &&
+          thread->rand.Uniform(FLAGS_flush_one_in) == 0) {
+        FlushOptions flush_opts;
+        Status status = db_->Flush(flush_opts, column_family);
+        if (!status.ok()) {
+          printf("Unable to perform Flush(): %s\n",
+                 status.ToString().c_str());
+        }
+      }
 
       if (FLAGS_compact_range_one_in > 0 &&
           thread->rand.Uniform(FLAGS_compact_range_one_in) == 0) {

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1975,8 +1975,7 @@ class StressTest {
         FlushOptions flush_opts;
         Status status = db_->Flush(flush_opts, column_family);
         if (!status.ok()) {
-          printf("Unable to perform Flush(): %s\n",
-                 status.ToString().c_str());
+          printf("Unable to perform Flush(): %s\n", status.ToString().c_str());
         }
       }
 


### PR DESCRIPTION
- Made stress test call `Flush()` periodically according to `--flush_one_in` flag.
- Enabled by default in crash test.

Test Plan: ran `python tools/db_crashtest.py --simple blackbox`