### PR TITLE
move dump stats to a separate thread

### DIFF
--- a/db/compacted_db_impl.cc
+++ b/db/compacted_db_impl.cc
@@ -147,6 +147,7 @@ Status CompactedDBImpl::Open(const Options& options,
   std::unique_ptr<CompactedDBImpl> db(new CompactedDBImpl(db_options, dbname));
   Status s = db->Init(options);
   if (s.ok()) {
+    db->StartTimedTasks();
     ROCKS_LOG_INFO(db->immutable_db_options_.info_log,
                    "Opened the db as fully compacted mode");
     LogFlush(db->immutable_db_options_.info_log);

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -359,8 +359,6 @@ void DBImpl::WaitForBackgroundWork() {
 
 // Will lock the mutex_,  will wait for completion if wait is true
 void DBImpl::CancelAllBackgroundWork(bool wait) {
-  InstrumentedMutexLock l(&mutex_);
-
   if (thread_dump_stats_ != nullptr) {
     thread_dump_stats_->cancel();
     thread_dump_stats_ = nullptr;
@@ -369,6 +367,7 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "Shutdown: canceling all background work");
 
+  InstrumentedMutexLock l(&mutex_);
   if (!shutting_down_.load(std::memory_order_acquire) &&
       has_unpersisted_data_.load(std::memory_order_relaxed) &&
       !mutable_db_options_.avoid_flush_during_shutdown) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -578,9 +578,11 @@ void DBImpl::PrintStatistics() {
 }
 
 void DBImpl::StartTimedTasks() {
-  tqueue_.add(static_cast<int64_t>(
-              mutable_db_options_.stats_dump_period_sec * 1000),
-              std::bind(&DBImpl::MaybeDumpStats, this, std::placeholders::_1));
+  if (mutable_db_options_.stats_dump_period_sec > 0) {
+    timer_queue_.add(
+        static_cast<int64_t>(mutable_db_options_.stats_dump_period_sec) * 1000,
+        std::bind(&DBImpl::MaybeDumpStats, this, std::placeholders::_1));
+  }
 }
 
 std::pair<bool, int64_t> DBImpl::MaybeDumpStats(bool aborted) {
@@ -602,8 +604,7 @@ std::pair<bool, int64_t> DBImpl::MaybeDumpStats(bool aborted) {
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       if (cfd->initialized()) {
         cfd->internal_stats()->GetStringProperty(
-            *cf_property_info, DB::Properties::kCFStatsNoFileHistogram,
-            &stats);
+            *cf_property_info, DB::Properties::kCFStatsNoFileHistogram, &stats);
       }
     }
     for (auto cfd : *versions_->GetColumnFamilySet()) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -466,6 +466,7 @@ class DBImpl : public DB {
   int TEST_BGCompactionsAllowed() const;
   int TEST_BGFlushesAllowed() const;
   size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
+  void TEST_WaitForTimedTaskRun(std::function<void()> callback) const;
 
 #endif  // NDEBUG
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1472,7 +1472,7 @@ class DBImpl : public DB {
   // Only to be set during initialization
   std::unique_ptr<PreReleaseCallback> recoverable_state_pre_release_callback_;
 
-  std::unique_ptr<rocksdb::RepeatableThread> thread_dump_stats_;
+  rocksdb::RepeatableThread* thread_dump_stats_ = nullptr;
 
   // No copying allowed
   DBImpl(const DBImpl&);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1069,7 +1069,7 @@ class DBImpl : public DB {
   void PrintStatistics();
 
   // dump rocksdb.stats to LOG
-  void MaybeDumpStats();
+  void DumpStats();
 
   // Return the minimum empty level that could hold the total data in the
   // input level. Return the input level, if such level could not be found.
@@ -1472,7 +1472,9 @@ class DBImpl : public DB {
   // Only to be set during initialization
   std::unique_ptr<PreReleaseCallback> recoverable_state_pre_release_callback_;
 
-  rocksdb::RepeatableThread* thread_dump_stats_ = nullptr;
+  // handle for scheduling jobs at fixed intervals
+  // REQUIRES: mutex locked
+  std::unique_ptr<rocksdb::RepeatableThread> thread_dump_stats_;
 
   // No copying allowed
   DBImpl(const DBImpl&);
@@ -1553,7 +1555,7 @@ class DBImpl : public DB {
   // error recovery from going on in parallel. The latter, shutting_down_,
   // is set a little later during the shutdown after scheduling memtable
   // flushes
-  bool shutdown_initiated_;
+  std::atomic<bool> shutdown_initiated_;
   // Flag to indicate whether sst_file_manager object was allocated in
   // DB::Open() or passed to us
   bool own_sfm_;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1521,7 +1521,7 @@ class DBImpl : public DB {
   }
 
   // timer based queue to execute tasks
-  TimerQueue tqueue_;
+  TimerQueue timer_queue_;
 
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1655,7 +1655,6 @@ void DBImpl::BackgroundCallCompaction(PrepickedCompaction* prepicked_compaction,
   bool made_progress = false;
   JobContext job_context(next_job_id_.fetch_add(1), true);
   TEST_SYNC_POINT("BackgroundCallCompaction:0");
-  MaybeDumpStats();
   LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL,
                        immutable_db_options_.info_log.get());
   {

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -243,5 +243,10 @@ size_t DBImpl::TEST_GetWalPreallocateBlockSize(
   return GetWalPreallocateBlockSize(write_buffer_size);
 }
 
+void DBImpl::TEST_WaitForTimedTaskRun(std::function<void()> callback) const {
+  if (thread_dump_stats_ != nullptr) {
+    thread_dump_stats_->TEST_WaitForRun(callback);
+  }
+}
 }  // namespace rocksdb
 #endif  // NDEBUG

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1295,6 +1295,9 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
           persist_options_status.ToString());
     }
   }
+  if (s.ok()) {
+    impl->StartTimedTasks();
+  }
   if (!s.ok()) {
     for (auto* h : *handles) {
       delete h;

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -534,11 +534,11 @@ TEST_F(DBOptionsTest, RunStatsDumpPeriodSec) {
   ASSERT_GE(counter, 1);
 
   // Test cacel job through SetOptions
-  ASSERT_OK(dbfull()->SetDBOptions(
-      {{"stats_dump_period_sec", "0"}}));
+  ASSERT_OK(dbfull()->SetDBOptions({{"stats_dump_period_sec", "0"}}));
   int old_val = counter;
   env_->SleepForMicroseconds(10000000);
   ASSERT_EQ(counter, old_val);
+  Close();
 }
 
 static void assert_candidate_files_empty(DBImpl* dbfull, const bool empty) {

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -573,7 +573,7 @@ class SpecialEnv : public EnvWrapper {
 
   std::atomic<int> delete_count_;
 
-  bool time_elapse_only_sleep_;
+  std::atomic<bool> time_elapse_only_sleep_;
 
   bool no_slowdown_;
 

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -319,7 +319,7 @@ class TestMemLogger : public Logger {
   static const uint64_t flush_every_seconds_ = 5;
   std::atomic_uint_fast64_t last_flush_micros_;
   Env* env_;
-  bool flush_pending_;
+  std::atomic<bool> flush_pending_;
 
  public:
   TestMemLogger(std::unique_ptr<WritableFile> f, Env* env,


### PR DESCRIPTION
Currently statistics are supposed to be dumped to info log at intervals of `options.stats_dump_period_sec`. However the implementation choice was to bind it with compaction thread, meaning if the database has been serving very light traffic, the stats may not get dumped at all. 
We decided to separate stats dumping into a new timed thread using `TimerQueue`, which is already used in blob_db. This will allow us schedule new timed tasks with more deterministic behavior. 

Tested with db_bench using `--stats_dump_period_sec=20` in command line:
> LOG:2018/09/17-14:07:45.575025 7fe99fbfe700 [WARN] [db/db_impl.cc:605] ------- DUMPING STATS -------
LOG:2018/09/17-14:08:05.643286 7fe99fbfe700 [WARN] [db/db_impl.cc:605] ------- DUMPING STATS -------
LOG:2018/09/17-14:08:25.691325 7fe99fbfe700 [WARN] [db/db_impl.cc:605] ------- DUMPING STATS -------
LOG:2018/09/17-14:08:45.740989 7fe99fbfe700 [WARN] [db/db_impl.cc:605] ------- DUMPING STATS -------

LOG content:
> 2018/09/17-14:07:45.575025 7fe99fbfe700 [WARN] [db/db_impl.cc:605] ------- DUMPING STATS -------
2018/09/17-14:07:45.575080 7fe99fbfe700 [WARN] [db/db_impl.cc:606]
** DB Stats **
Uptime(secs): 20.0 total, 20.0 interval
Cumulative writes: 4447K writes, 4447K keys, 4447K commit groups, 1.0 writes per commit group, ingest: 5.57 GB, 285.01 MB/s
Cumulative WAL: 4447K writes, 0 syncs, 4447638.00 writes per sync, written: 5.57 GB, 285.01 MB/s
Cumulative stall: 00:00:0.012 H:M:S, 0.1 percent
Interval writes: 4447K writes, 4447K keys, 4447K commit groups, 1.0 writes per commit group, ingest: 5700.71 MB, 285.01 MB/s
Interval WAL: 4447K writes, 0 syncs, 4447638.00 writes per sync, written: 5.57 MB, 285.01 MB/s
Interval stall: 00:00:0.012 H:M:S, 0.1 percent
** Compaction Stats [default] **
Level    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
