### PR TITLE
Extend crash test with index_block_restart_interval

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 * Avoid creating empty SSTs and subsequently deleting them in certain cases during compaction.
 * Sync CURRENT file contents during checkpoint.
+* Fix format_version 4 bug with partitioned filters
 
 ## 5.16.0 (8/21/2018)
 ### Public API Change

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -55,6 +55,7 @@ default_params = {
     "write_buffer_size": 4 * 1024 * 1024,
     "writepercent": 35,
     "format_version": lambda: random.randint(2, 4),
+    "index_block_restart_interval": lambda: random.choice(1, 16),
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -232,6 +232,11 @@ DEFINE_int32(
     static_cast<int32_t>(rocksdb::BlockBasedTableOptions().format_version),
     "Format version of SST files.");
 
+DEFINE_int32(index_block_restart_interval,
+             rocksdb::BlockBasedTableOptions().index_block_restart_interval,
+             "Number of keys between restart points "
+             "for delta encoding of keys in index block.");
+
 DEFINE_int32(max_background_compactions,
              rocksdb::Options().max_background_compactions,
              "The maximum number of concurrent background compactions "
@@ -2283,6 +2288,8 @@ class StressTest {
       block_based_options.block_size = FLAGS_block_size;
       block_based_options.format_version =
           static_cast<uint32_t>(FLAGS_format_version);
+      block_based_options.index_block_restart_interval =
+          static_cast<int32_t>(FLAGS_index_block_restart_interval);
       block_based_options.filter_policy = filter_policy_;
       options_.table_factory.reset(
           NewBlockBasedTableFactory(block_based_options));


### PR DESCRIPTION
The default for index_block_restart_interval is 1 but some use 16 in production. The patch extends crash test to test both values.