### PR TITLE
Unit test for custom comparator RangeDelAggregator

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -173,7 +173,7 @@ class CollapsedRangeDelMap : public RangeDelMap {
   const Comparator* ucmp_;
 
  public:
-  CollapsedRangeDelMap(const Comparator* ucmp)
+  explicit CollapsedRangeDelMap(const Comparator* ucmp)
       : rep_(stl_wrappers::LessOfComparator(ucmp)), ucmp_(ucmp) {
     InvalidatePosition();
   }

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -173,7 +173,8 @@ class CollapsedRangeDelMap : public RangeDelMap {
   const Comparator* ucmp_;
 
  public:
-  CollapsedRangeDelMap(const Comparator* ucmp) : ucmp_(ucmp) {
+  CollapsedRangeDelMap(const Comparator* ucmp)
+      : rep_(stl_wrappers::LessOfComparator(ucmp)), ucmp_(ucmp) {
     InvalidatePosition();
   }
 


### PR DESCRIPTION
Add a unit test for range collapsing when non-default comparator is used. This exposes the bug fixed in #4386.

Test Plan: `make check -j64`