### PR TITLE
Fix issue with docs/feed.xml validation

### DIFF
--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -6,7 +6,7 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ absolute_url }}/</link>
+    <link>https://rocksdb.org/feed.xml</link>
     <atom:link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>


### PR DESCRIPTION
Per #4387 this should address the validation error with the link tag.  This is a quick fix, a future iteration could significantly upgrade the jekyll integration. 