### PR TITLE
Add read retry support to log reader

### DIFF
--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -598,7 +598,8 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
     // to be skipped instead of propagating bad information (like overly
     // large sequence numbers).
     log::Reader reader(immutable_db_options_.info_log, std::move(file_reader),
-                       &reporter, true /*checksum*/, log_number);
+                       &reporter, true /*checksum*/, log_number,
+                       false /* retry_after_eof */);
 
     // Determine if we should tolerate incomplete records at the tail end of the
     // Read all the records and add to a memtable

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -291,6 +291,7 @@ bool Reader::ReadMore(size_t* drop_size, int *error) {
     } else if (buffer_.size() < static_cast<size_t>(kBlockSize)) {
       eof_ = true;
       eof_offset_ = buffer_.size();
+      TEST_SYNC_POINT("LogReader::ReadMore:FirstEOF");
     }
     return true;
   } else if (retry_after_eof_ && !read_error_) {
@@ -356,9 +357,9 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result, size_t* drop_size) {
         if (!eof_) {
           return kBadRecordLen;
         }
-        // If the end of the file has been reached without reading |length| bytes
-        // of payload, assume the writer died in the middle of writing the record.
-        // Don't report a corruption unless requested.
+        // If the end of the file has been reached without reading |length|
+        // bytes of payload, assume the writer died in the middle of writing the
+        // record. Don't report a corruption unless requested.
         if (*drop_size) {
           return kBadHeader;
         }

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -136,9 +136,6 @@ class Reader {
   // Read some more
   bool ReadMore(size_t* drop_size, int *error);
 
-  // Read some more with retries
-  bool ReadMoreWithRetries(size_t* drop_size, int* error);
-
   // Reports dropped bytes to the reporter.
   // buffer_ must be updated to remove the dropped bytes prior to invocation.
   void ReportCorruption(size_t bytes, const char* reason);

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -53,7 +53,7 @@ class Reader {
   Reader(std::shared_ptr<Logger> info_log,
          // @lint-ignore TXT2 T25377293 Grandfathered in
          unique_ptr<SequentialFileReader>&& file, Reporter* reporter,
-         bool checksum, uint64_t log_num);
+         bool checksum, uint64_t log_num, bool retry_after_eof);
 
   ~Reader();
 
@@ -110,6 +110,8 @@ class Reader {
   // Whether this is a recycled log file
   bool recycled_;
 
+  const bool retry_after_eof_;
+
   // Extend record types with the following special values
   enum {
     kEof = kMaxRecordType + 1,
@@ -133,6 +135,9 @@ class Reader {
 
   // Read some more
   bool ReadMore(size_t* drop_size, int *error);
+
+  // Read some more with retries
+  bool ReadMoreWithRetries(size_t* drop_size, int* error);
 
   // Reports dropped bytes to the reporter.
   // buffer_ must be updated to remove the dropped bytes prior to invocation.

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -110,6 +110,9 @@ class Reader {
   // Whether this is a recycled log file
   bool recycled_;
 
+  // Whether retry after encountering EOF
+  // TODO (yanqin) add support for retry policy, e.g. sleep, max retry limit,
+  // etc.
   const bool retry_after_eof_;
 
   // Extend record types with the following special values

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -761,7 +761,6 @@ class RetriableLogTest : public ::testing::TestWithParam<int> {
 
 TEST_P(RetriableLogTest, TailLog) {
   Write("foo");
-  fprintf(stderr, "y7jin\n");
   std::string record = Read();
   ASSERT_EQ("foo", record);
 }

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -164,7 +164,8 @@ class LogTest : public ::testing::TestWithParam<int> {
             new StringSource(reader_contents_), "" /* file name */)),
         writer_(std::move(dest_holder_), 123, GetParam()),
         reader_(nullptr, std::move(source_holder_), &report_,
-                true /* checksum */, 123 /* log_number */) {
+                true /* checksum */, 123 /* log_number */,
+                false /* retry_after_eof */) {
     int header_size = GetParam() ? kRecyclableHeaderSize : kHeaderSize;
     initial_offset_last_record_offsets_[0] = 0;
     initial_offset_last_record_offsets_[1] = header_size + 10000;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -353,7 +353,8 @@ class Repairer {
     // propagating bad information (like overly large sequence
     // numbers).
     log::Reader reader(db_options_.info_log, std::move(lfile_reader), &reporter,
-                       true /*enable checksum*/, log);
+                       true /*enable checksum*/, log,
+                       false /* retry_after_eof */);
 
     // Initialize per-column family memtables
     for (auto* cfd : *vset_.GetColumnFamilySet()) {

--- a/db/transaction_log_impl.cc
+++ b/db/transaction_log_impl.cc
@@ -314,7 +314,8 @@ Status TransactionLogIteratorImpl::OpenLogReader(const LogFile* logFile) {
   assert(file);
   currentLogReader_.reset(
       new log::Reader(options_->info_log, std::move(file), &reporter_,
-                      read_options_.verify_checksums_, logFile->LogNumber()));
+                      read_options_.verify_checksums_, logFile->LogNumber(),
+                      false /* retry_after_eof */));
   return Status::OK();
 }
 }  //  namespace rocksdb

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3424,7 +3424,8 @@ Status VersionSet::Recover(
     VersionSet::LogReporter reporter;
     reporter.status = &s;
     log::Reader reader(nullptr, std::move(manifest_file_reader), &reporter,
-                       true /* checksum */, 0 /* log_number */);
+                       true /* checksum */, 0 /* log_number */,
+                       false /* retry_after_eof */);
     Slice record;
     std::string scratch;
     std::vector<VersionEdit> replay_buffer;
@@ -3630,7 +3631,8 @@ Status VersionSet::ListColumnFamilies(std::vector<std::string>* column_families,
   VersionSet::LogReporter reporter;
   reporter.status = &s;
   log::Reader reader(nullptr, std::move(file_reader), &reporter,
-                     true /* checksum */, 0 /* log_number */);
+                     true /* checksum */, 0 /* log_number */,
+                     false /* retry_after_eof */);
   Slice record;
   std::string scratch;
   while (reader.ReadRecord(&record, &scratch) && s.ok()) {
@@ -3790,7 +3792,8 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
     VersionSet::LogReporter reporter;
     reporter.status = &s;
     log::Reader reader(nullptr, std::move(file_reader), &reporter,
-                       true /* checksum */, 0 /* log_number */);
+                       true /* checksum */, 0 /* log_number */,
+                       false /* retry_after_eof */);
     Slice record;
     std::string scratch;
     while (reader.ReadRecord(&record, &scratch) && s.ok()) {

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -457,7 +457,7 @@ Status WalManager::ReadFirstLine(const std::string& fname,
   reporter.status = &status;
   reporter.ignore_error = !db_options_.paranoid_checks;
   log::Reader reader(db_options_.info_log, std::move(file_reader), &reporter,
-                     true /*checksum*/, number);
+                     true /*checksum*/, number, false /* retry_after_eof */);
   std::string scratch;
   Slice record;
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1999,7 +1999,8 @@ void DumpWalFile(std::string wal_file, bool print_header, bool print_values,
     }
     DBOptions db_options;
     log::Reader reader(db_options.info_log, std::move(wal_file_reader),
-                       &reporter, true /* checksum */, log_number);
+                       &reporter, true /* checksum */, log_number,
+                       false /* retry_after_eof */);
     std::string scratch;
     WriteBatch batch;
     Slice record;


### PR DESCRIPTION
Current `log::Reader` does not perform retry after encountering `EOF`. In the future, we need the log reader to be able to retry tailing the log even after `EOF`.

Current implementation is simple. It does not provide more advanced retry policies. Will address this in the future.

Test plan:
```
$make clean && make -j32
$./log_test
```