### PR TITLE
add missing range in random.choice argument

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -56,7 +56,7 @@ default_params = {
     "write_buffer_size": 4 * 1024 * 1024,
     "writepercent": 35,
     "format_version": lambda: random.randint(2, 4),
-    "index_block_restart_interval": lambda: random.choice(1, 16),
+    "index_block_restart_interval": lambda: random.choice(range(1, 16)),
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'


### PR DESCRIPTION
This will fix the broken asan crash test:
> Traceback (most recent call last):
  File "tools/db_crashtest.py", line 384, in <module>
    main()
  File "tools/db_crashtest.py", line 368, in main
    parser.add_argument("--" + k, type=type(v() if callable(v) else v))
  File "tools/db_crashtest.py", line 59, in <lambda>
    "index_block_restart_interval": lambda: random.choice(1, 16),
TypeError: choice() takes exactly 2 arguments (3 given)