### PR TITLE
Generate appropriate number of keys in db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -3794,7 +3794,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
 
     Duration duration(test_duration, max_ops, ops_per_stage);
     for (size_t i = 0; i < num_key_gens; i++) {
-      key_gens[i].reset(new KeyGenerator(&(thread->rand), write_mode, num_,
+      key_gens[i].reset(new KeyGenerator(&(thread->rand), write_mode,
+                                         num_ + max_num_range_tombstones_,
                                          ops_per_stage));
     }
 


### PR DESCRIPTION
Summary: If range tombstones are generated every few writes, the
KeyGenerator's limit is now extended to account for the additional
Next() calls. This is primarily important for `filluniquerandom`
benchmarks that enforce the call limit.

Test Plan: `./db_bench -db=/dev/shm/5k-rts -use_existing_db=false
-benchmarks=filluniquerandom -write_buffer_size=1048576
-compression_type=lz4 -target_file_size_base=1048576
-max_bytes_for_level_base=4194304 -value_size=112 -key_size=16
-block_size=4096 -level_compaction_dynamic_level_bytes=true -num=5000000
-max_background_jobs=12 -benchmark_write_rate_limit=20971520
-range_tombstone_width=100 -writes_per_range_tombstone=100
-max_num_range_tombstones=50000 -bloom_bits=8`