### PR TITLE
Improve log handling when recover without flush

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -464,6 +464,7 @@ class DBImpl : public DB {
 
   int TEST_BGCompactionsAllowed() const;
   int TEST_BGFlushesAllowed() const;
+  size_t TEST_GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
 
 #endif  // NDEBUG
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -934,6 +934,12 @@ class DBImpl : public DB {
   Status WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
                                      MemTable* mem, VersionEdit* edit);
 
+  // Reconstruct alive_log_files_ and total_log_size_ after recovery.
+  // It needs to run only when there's no flush during recovery
+  // (e.g. avoid_flush_during_recovery=true). May also trigger flush
+  // in case total_log_size > max_total_wal_size.
+  Status ReconstructAliveLogFiles(const std::vector<uint64_t>& log_numbers);
+
   // num_bytes: for slowdown case, delay time is calculated based on
   //            `num_bytes` going through.
   Status DelayWrite(uint64_t num_bytes, const WriteOptions& write_options);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -934,11 +934,11 @@ class DBImpl : public DB {
   Status WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
                                      MemTable* mem, VersionEdit* edit);
 
-  // Reconstruct alive_log_files_ and total_log_size_ after recovery.
+  // Restore alive_log_files_ and total_log_size_ after recovery.
   // It needs to run only when there's no flush during recovery
   // (e.g. avoid_flush_during_recovery=true). May also trigger flush
   // in case total_log_size > max_total_wal_size.
-  Status ReconstructAliveLogFiles(const std::vector<uint64_t>& log_numbers);
+  Status RestoreAliveLogFiles(const std::vector<uint64_t>& log_numbers);
 
   // num_bytes: for slowdown case, delay time is calculated based on
   //            `num_bytes` going through.

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -237,5 +237,11 @@ SequenceNumber DBImpl::TEST_GetLastVisibleSequence() const {
   }
 }
 
+size_t DBImpl::TEST_GetWalPreallocateBlockSize(
+    uint64_t write_buffer_size) const {
+  InstrumentedMutexLock l(&mutex_);
+  return GetWalPreallocateBlockSize(write_buffer_size);
+}
+
 }  // namespace rocksdb
 #endif  // NDEBUG

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -315,6 +315,9 @@ class SpecialEnv : public EnvWrapper {
         }
       }
       uint64_t GetFileSize() override { return base_->GetFileSize(); }
+      Status Allocate(uint64_t offset, uint64_t len) override {
+        return base_->Allocate(offset, len);
+      }
 
      private:
       SpecialEnv* env_;
@@ -367,6 +370,9 @@ class SpecialEnv : public EnvWrapper {
       }
       bool IsSyncThreadSafe() const override {
         return env_->is_wal_sync_thread_safe_.load();
+      }
+      Status Allocate(uint64_t offset, uint64_t len) override {
+        return base_->Allocate(offset, len);
       }
 
      private:

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1339,12 +1339,13 @@ TEST_F(DBWALTest, RestoreTotalLogSizeAfterRecoverWithoutFlush) {
 
     TestFlushListener() = default;
 
-    void OnFlushBegin(DB* /*db*/, const FlushJobInfo& flush_job_info) {
+    void OnFlushBegin(DB* /*db*/, const FlushJobInfo& flush_job_info) override {
       count++;
       assert(FlushReason::kWriteBufferManager == flush_job_info.flush_reason);
     }
   };
-  std::shared_ptr<TestFlushListener> test_listener(new TestFlushListener());
+  std::shared_ptr<TestFlushListener> test_listener =
+      std::make_shared<TestFlushListener>();
 
   constexpr size_t kKB = 1024;
   constexpr size_t kMB = 1024 * 1024;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1100,7 +1100,6 @@ TEST_F(DBWALTest, AvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = false;
-  options.max_total_wal_size = 1000000000;  // large enough size
 
   // Test with flush after recovery.
   Reopen(options);
@@ -1152,7 +1151,6 @@ TEST_F(DBWALTest, WalCleanupAfterAvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = true;
-  options.max_total_wal_size = 1000000000;  // large enough size
   Reopen(options);
 
   ASSERT_OK(Put("foo", "v1"));
@@ -1178,7 +1176,6 @@ TEST_F(DBWALTest, RecoverWithoutFlush) {
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
   options.write_buffer_size = 64 * 1024 * 1024;
-  options.max_total_wal_size = 1000000000;  // large enough size
 
   size_t count = RecoveryTestHelper::FillData(this, &options);
   auto validateData = [this, count]() {
@@ -1221,7 +1218,6 @@ TEST_F(DBWALTest, RecoverWithoutFlushMultipleCF) {
   options.avoid_flush_during_recovery = true;
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
-  options.max_total_wal_size = 1000000000;  // large enough size
 
   auto countWalFiles = [this]() {
     VectorLogPtr log_files;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1100,7 +1100,7 @@ TEST_F(DBWALTest, AvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = false;
-  options.max_total_wal_size = 1000000000; // large enough size
+  options.max_total_wal_size = 1000000000;  // large enough size
 
   // Test with flush after recovery.
   Reopen(options);
@@ -1152,7 +1152,7 @@ TEST_F(DBWALTest, WalCleanupAfterAvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = true;
-  options.max_total_wal_size = 1000000000; // large enough size
+  options.max_total_wal_size = 1000000000;  // large enough size
   Reopen(options);
 
   ASSERT_OK(Put("foo", "v1"));
@@ -1178,7 +1178,7 @@ TEST_F(DBWALTest, RecoverWithoutFlush) {
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
   options.write_buffer_size = 64 * 1024 * 1024;
-  options.max_total_wal_size = 1000000000; // large enough size
+  options.max_total_wal_size = 1000000000;  // large enough size
 
   size_t count = RecoveryTestHelper::FillData(this, &options);
   auto validateData = [this, count]() {
@@ -1221,7 +1221,7 @@ TEST_F(DBWALTest, RecoverWithoutFlushMultipleCF) {
   options.avoid_flush_during_recovery = true;
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
-  options.max_total_wal_size = 1000000000; // large enough size
+  options.max_total_wal_size = 1000000000;  // large enough size
 
   auto countWalFiles = [this]() {
     VectorLogPtr log_files;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1400,6 +1400,7 @@ TEST_F(DBWALTest, RestoreTotalLogSizeAfterRecoverWithoutFlush) {
 }
 
 #if defined(ROCKSDB_PLATFORM_POSIX)
+#if defined(ROCKSDB_FALLOCATE_PRESENT)
 // Tests that we will truncate the preallocated space of the last log from
 // previous.
 TEST_F(DBWALTest, TruncateLastLogAfterRecoverWithoutFlush) {
@@ -1427,7 +1428,8 @@ TEST_F(DBWALTest, TruncateLastLogAfterRecoverWithoutFlush) {
   ASSERT_LT(GetAllocatedFileSize(dbname_ + file_before->PathName()),
             preallocated_size);
 }
-#endif
+#endif  // ROCKSDB_FALLOCATE_PRESENT
+#endif  // ROCKSDB_PLATFORM_POSIX
 
 #endif  // ROCKSDB_LITE
 

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1100,6 +1100,7 @@ TEST_F(DBWALTest, AvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = false;
+  options.max_total_wal_size = 1000000000; // large enough size
 
   // Test with flush after recovery.
   Reopen(options);
@@ -1151,6 +1152,7 @@ TEST_F(DBWALTest, WalCleanupAfterAvoidFlushDuringRecovery) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.avoid_flush_during_recovery = true;
+  options.max_total_wal_size = 1000000000; // large enough size
   Reopen(options);
 
   ASSERT_OK(Put("foo", "v1"));
@@ -1176,6 +1178,7 @@ TEST_F(DBWALTest, RecoverWithoutFlush) {
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
   options.write_buffer_size = 64 * 1024 * 1024;
+  options.max_total_wal_size = 1000000000; // large enough size
 
   size_t count = RecoveryTestHelper::FillData(this, &options);
   auto validateData = [this, count]() {
@@ -1218,6 +1221,7 @@ TEST_F(DBWALTest, RecoverWithoutFlushMultipleCF) {
   options.avoid_flush_during_recovery = true;
   options.create_if_missing = false;
   options.disable_auto_compactions = true;
+  options.max_total_wal_size = 1000000000; // large enough size
 
   auto countWalFiles = [this]() {
     VectorLogPtr log_files;

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1329,6 +1329,66 @@ TEST_F(DBWALTest, RecoverFromCorruptedWALWithoutFlush) {
   }
 }
 
+// Tests that total log size is recovered if we set
+// avoid_flush_during_recovery=true.
+// Flush should trigger if max_total_wal_size is reached.
+TEST_F(DBWALTest, RestoreTotalLogSizeAfterRecoverWithoutFlush) {
+  class TestFlushListener : public EventListener {
+   public:
+    std::atomic<int> count{0};
+
+    TestFlushListener() = default;
+
+    void OnFlushBegin(DB* /*db*/, const FlushJobInfo& flush_job_info) {
+      count++;
+      assert(FlushReason::kWriteBufferManager == flush_job_info.flush_reason);
+    }
+  };
+  std::shared_ptr<TestFlushListener> test_listener(new TestFlushListener());
+
+  constexpr size_t kKB = 1024;
+  constexpr size_t kMB = 1024 * 1024;
+  Options options = CurrentOptions();
+  options.avoid_flush_during_recovery = true;
+  options.max_total_wal_size = 1 * kMB;
+  options.listeners.push_back(test_listener);
+  // Have to open DB in multi-CF mode to trigger flush when
+  // max_total_wal_size is reached.
+  CreateAndReopenWithCF({"one"}, options);
+  // Write some keys and we will end up with one log file which is slightly
+  // smaller than 1MB.
+  std::string value_100k(100 * kKB, 'v');
+  std::string value_300k(300 * kKB, 'v');
+  ASSERT_OK(Put(0, "foo", "v1"));
+  for (int i = 0; i < 9; i++) {
+    ASSERT_OK(Put(1, "key" + ToString(i), value_100k));
+  }
+  // Get log files before reopen.
+  VectorLogPtr log_files_before;
+  ASSERT_OK(dbfull()->GetSortedWalFiles(log_files_before));
+  ASSERT_EQ(1, log_files_before.size());
+  uint64_t log_size_before = log_files_before[0]->SizeFileBytes();
+  ASSERT_GT(log_size_before, 900 * kKB);
+  ASSERT_LT(log_size_before, 1 * kMB);
+  ReopenWithColumnFamilies({"default", "one"}, options);
+  // Write one more value to make log larger than 1MB.
+  ASSERT_OK(Put(1, "bar", value_300k));
+  // Get log files again. A new log file will be opened.
+  VectorLogPtr log_files_after_reopen;
+  ASSERT_OK(dbfull()->GetSortedWalFiles(log_files_after_reopen));
+  ASSERT_EQ(2, log_files_after_reopen.size());
+  ASSERT_EQ(log_files_before[0]->LogNumber(),
+            log_files_after_reopen[0]->LogNumber());
+  ASSERT_GT(log_files_after_reopen[0]->SizeFileBytes() +
+                log_files_after_reopen[1]->SizeFileBytes(),
+            1 * kMB);
+  // Write one more key to trigger flush.
+  ASSERT_OK(Put(0, "foo", "v2"));
+  dbfull()->TEST_WaitForFlushMemTable();
+  // Flushed two column families.
+  ASSERT_EQ(2, test_listener->count.load());
+}
+
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBWALTest, WalTermTest) {


### PR DESCRIPTION
Summary:
Improve log handling when avoid_flush_during_recovery=true.
1. restore total_log_size_ after recovery, by summing up existing log sizes. Fixes #4253.
2. truncate the last existing log, since this log can contain preallocated space and it will be a waste to keep the space. It avoids a crash loop of user application cause a lot of log with non-trivial size being created and ultimately take up all disk space.

Test Plan:
New tests.