### PR TITLE
Fix a useless check

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -71,7 +71,7 @@ TEST_F(DBFlushTest, SyncFail) {
        {"DBImpl::SyncClosedLogs:Failed", "DBFlushTest::SyncFail:2"}});
   SyncPoint::GetInstance()->EnableProcessing();
 
-  Reopen(options);
+  CreateAndReopenWithCF({"cf1"}, options);
   Put("key", "value");
   auto* cfd =
       reinterpret_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily())

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -138,7 +138,7 @@ Status DBImpl::FlushMemTableToOutputFile(
 
   Status s;
   if (logfile_number_ > 0 &&
-      versions_->GetColumnFamilySet()->NumberOfColumnFamilies() > 0) {
+      versions_->GetColumnFamilySet()->NumberOfColumnFamilies() > 1) {
     // If there are more than one column families, we need to make sure that
     // all the log files except the most recent one are synced. Otherwise if
     // the host crashes after flushing and before WAL is persistent, the


### PR DESCRIPTION
In original `FlushMemtableToOutputFile`, we check whether the number of column families is greater than 0. which is always true. According to my understanding and the original comment, it should be compared with 1.

Test plan:
```
$ make clean && make -j32 all check
```

I also suspect that this is the reason for the `DBFlushTest.SyncFail` flaky test on Travis.