### PR TITLE
Utility to run task periodically in a thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,6 +946,7 @@ if(WITH_TESTS)
         util/hash_test.cc
         util/heap_test.cc
         util/rate_limiter_test.cc
+        util/repeatable_thread_test.cc
         util/slice_transform_test.cc
         util/timer_queue_test.cc
         util/thread_list_test.cc

--- a/Makefile
+++ b/Makefile
@@ -533,6 +533,7 @@ TESTS = \
 	write_unprepared_transaction_test \
 	db_universal_compaction_test \
 	trace_analyzer_test \
+	repeatable_thread_test \
 
 PARALLEL_TEST = \
 	backupable_db_test \
@@ -1554,6 +1555,9 @@ range_del_aggregator_bench: db/range_del_aggregator_bench.o $(LIBOBJECTS) $(TEST
 	$(AM_LINK)
 
 blob_db_test: utilities/blob_db/blob_db_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+repeatable_thread_test: util/repeatable_thread_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/TARGETS
+++ b/TARGETS
@@ -1,3 +1,4 @@
+
 load("@fbcode_macros//build_defs:auto_headers.bzl", "AutoHeaders")
 
 REPO_PATH = package_name() + "/"
@@ -305,7 +306,6 @@ cpp_library(
     srcs = [
         "db/db_test_util.cc",
         "table/mock_table.cc",
-        "tools/trace_analyzer_tool.cc",
         "util/fault_injection_test_env.cc",
         "util/testharness.cc",
         "util/testutil.cc",
@@ -920,11 +920,6 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
-        "range_del_aggregator_bench",
-        "db/range_del_aggregator_bench.cc",
-        "serial",
-    ],
-    [
         "rate_limiter_test",
         "util/rate_limiter_test.cc",
         "serial",
@@ -937,6 +932,11 @@ ROCKS_TESTS = [
     [
         "repair_test",
         "db/repair_test.cc",
+        "serial",
+    ],
+    [
+        "repeatable_thread_test",
+        "util/repeatable_thread_test.cc",
         "serial",
     ],
     [
@@ -1086,19 +1086,20 @@ if not is_opt_mode:
         ttype = "gtest" if test_cfg[2] == "parallel" else "simple"
         test_bin = test_name + "_bin"
 
-        cpp_binary(
-            name = test_bin,
-            srcs = [test_cc],
-            arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
-            compiler_flags = rocksdb_compiler_flags,
-            preprocessor_flags = rocksdb_preprocessor_flags,
-            deps = [":rocksdb_test_lib"],
-            external_deps = rocksdb_external_deps,
+        cpp_binary (
+          name = test_bin,
+          srcs = [test_cc],
+          deps = [":rocksdb_test_lib"],
+          preprocessor_flags = rocksdb_preprocessor_flags,
+          arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
+          compiler_flags = rocksdb_compiler_flags,
+          external_deps = rocksdb_external_deps,
         )
 
         custom_unittest(
-            name = test_name,
-            command = [TEST_RUNNER, BUCK_BINS + test_bin],
-            type = ttype,
-            deps = [":" + test_bin],
+          name = test_name,
+          type = ttype,
+          deps = [":" + test_bin],
+          command = [TEST_RUNNER, BUCK_BINS + test_bin]
         )
+

--- a/TARGETS
+++ b/TARGETS
@@ -1,4 +1,3 @@
-
 load("@fbcode_macros//build_defs:auto_headers.bzl", "AutoHeaders")
 
 REPO_PATH = package_name() + "/"
@@ -306,6 +305,7 @@ cpp_library(
     srcs = [
         "db/db_test_util.cc",
         "table/mock_table.cc",
+        "tools/trace_analyzer_tool.cc",
         "util/fault_injection_test_env.cc",
         "util/testharness.cc",
         "util/testutil.cc",
@@ -920,6 +920,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "range_del_aggregator_bench",
+        "db/range_del_aggregator_bench.cc",
+        "serial",
+    ],
+    [
         "rate_limiter_test",
         "util/rate_limiter_test.cc",
         "serial",
@@ -1086,20 +1091,19 @@ if not is_opt_mode:
         ttype = "gtest" if test_cfg[2] == "parallel" else "simple"
         test_bin = test_name + "_bin"
 
-        cpp_binary (
-          name = test_bin,
-          srcs = [test_cc],
-          deps = [":rocksdb_test_lib"],
-          preprocessor_flags = rocksdb_preprocessor_flags,
-          arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
-          compiler_flags = rocksdb_compiler_flags,
-          external_deps = rocksdb_external_deps,
+        cpp_binary(
+            name = test_bin,
+            srcs = [test_cc],
+            arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
+            compiler_flags = rocksdb_compiler_flags,
+            preprocessor_flags = rocksdb_preprocessor_flags,
+            deps = [":rocksdb_test_lib"],
+            external_deps = rocksdb_external_deps,
         )
 
         custom_unittest(
-          name = test_name,
-          type = ttype,
-          deps = [":" + test_bin],
-          command = [TEST_RUNNER, BUCK_BINS + test_bin]
+            name = test_name,
+            command = [TEST_RUNNER, BUCK_BINS + test_bin],
+            type = ttype,
+            deps = [":" + test_bin],
         )
-

--- a/src.mk
+++ b/src.mk
@@ -378,6 +378,7 @@ MAIN_SOURCES =                                                          \
   util/filelock_test.cc                                                 \
   util/log_write_bench.cc                                               \
   util/rate_limiter_test.cc                                             \
+  util/repeatable_thread_test.cc                                        \
   util/slice_transform_test.cc                                          \
   util/timer_queue_test.cc                                              \
   util/thread_list_test.cc                                              \

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -52,6 +52,8 @@ class RepeatableThread {
   // then wait for one run of RepeatableThread. Tests can use provide a
   // custom env object to mock time, and use the callback here to bump current
   // time and trigger RepeatableThread. See repeatable_thread_test for example.
+  //
+  // Note: only support one caller of this method.
   void TEST_WaitForRun(std::function<void()> callback = nullptr) {
     MutexLock l(&mutex_);
     while (!waiting_) {

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -97,7 +97,9 @@ class RepeatableThread {
 #if __GLIBC_PREREQ(2, 12)
     // Set thread name.
     auto thread_handle = thread_.native_handle();
-    pthread_setname_np(thread_handle, thread_name_.c_str());
+    int ret __attribute__((__unused__)) =
+        pthread_setname_np(thread_handle, thread_name_.c_str());
+    assert(ret == 0);
 #endif
 #endif
 

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -1,0 +1,131 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "port/port.h"
+#include "rocksdb/env.h"
+#include "util/mutexlock.h"
+
+namespace rocksdb {
+
+class RepeatableThread {
+ public:
+  RepeatableThread(std::function<void()> function,
+                   const std::string& thread_name, Env* env, uint64_t delay_us,
+                   uint64_t initial_delay_us = 0)
+      : function_(function),
+        thread_name_("rocksdb:" + thread_name),
+        env_(env),
+        delay_us_(delay_us),
+        initial_delay_us_(initial_delay_us),
+        cond_var_(&mutex_),
+        running_(true),
+#ifndef NDEBUG
+        waiting_(false),
+        executed_(false),
+#endif
+        thread_([this] { thread(); }) {
+  }
+
+  void cancel() {
+    {
+      MutexLock l(&mutex_);
+      if (!running_) {
+        return;
+      }
+      running_ = false;
+      cond_var_.SignalAll();
+    }
+    thread_.join();
+  }
+
+  ~RepeatableThread() { cancel(); }
+
+#ifndef NDEBUG
+  // Wait until RepeatableThread starting waiting, call the optional callback,
+  // then wait for one run of RepeatableThread. Tests can use provide a
+  // custom env object to mock time, and use the callback here to bump current
+  // time and trigger RepeatableThread. See repeatable_thread_test for example.
+  void TEST_WaitForRun(std::function<void()> callback = nullptr) {
+    MutexLock l(&mutex_);
+    while (!waiting_) {
+      cond_var_.Wait();
+    }
+    if (callback != nullptr) {
+      callback();
+    }
+    executed_ = false;
+    cond_var_.SignalAll();
+    while (!executed_) {
+      cond_var_.Wait();
+    }
+  }
+#endif
+
+ private:
+  bool wait(uint64_t delay) {
+    MutexLock l(&mutex_);
+    if (running_ && delay > 0) {
+      uint64_t wait_until = env_->NowMicros() + delay;
+#ifndef NDEBUG
+      waiting_ = true;
+      cond_var_.SignalAll();
+#endif
+      while (running_) {
+        cond_var_.TimedWait(wait_until);
+        if (env_->NowMicros() >= wait_until) {
+          break;
+        }
+      }
+#ifndef NDEBUG
+      waiting_ = false;
+      executed_ = true;
+      cond_var_.SignalAll();
+#endif
+    }
+    return running_;
+  }
+
+  void thread() {
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+    // Set thread name.
+    auto thread_handle = thread_.native_handle();
+    pthread_setname_np(thread_handle, thread_name_.c_str());
+#endif
+#endif
+
+    assert(delay_us_ > 0);
+    if (!wait(initial_delay_us_)) {
+      return;
+    }
+    do {
+      function_();
+    } while (wait(delay_us_));
+  }
+
+  const std::function<void()> function_;
+  const std::string thread_name_;
+  Env* const env_;
+  const uint64_t delay_us_;
+  const uint64_t initial_delay_us_;
+
+  port::Mutex mutex_;
+  port::CondVar cond_var_;
+  bool running_;
+#ifndef NDEBUG
+  // RepeatableThread waiting for timeout.
+  bool waiting_;
+  // Function ran after caller of TEST_WaitForRun start waiting.
+  bool executed_;
+#endif
+  port::Thread thread_;
+};
+
+}  // namespace rocksdb

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -85,8 +85,6 @@ class RepeatableThread {
       }
 #ifndef NDEBUG
       waiting_ = false;
-      executed_ = true;
-      cond_var_.SignalAll();
 #endif
     }
     return running_;
@@ -109,6 +107,10 @@ class RepeatableThread {
     }
     do {
       function_();
+#ifndef NDEBUG
+      executed_ = true;
+      cond_var_.SignalAll();
+#endif
     } while (wait(delay_us_));
   }
 

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -60,7 +60,7 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
                                    1 * kSecond, 1 * kSecond);
   for (int i = 1; i <= kIteration; i++) {
     // Bump current time
-    thread.TEST_WaitForRun([&] { mock_env_->set_current_time(i + 1); });
+    thread.TEST_WaitForRun([&] { mock_env_->set_current_time(i); });
   }
   // Test function should be exectued exactly kIteraion times.
   ASSERT_EQ(kIteration, count.load());

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -1,0 +1,76 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <atomic>
+#include <memory>
+
+#include "db/db_test_util.h"
+#include "util/repeatable_thread.h"
+#include "util/testharness.h"
+
+class RepeatableThreadTest : public testing::Test {
+ public:
+  RepeatableThreadTest()
+      : mock_env_(new rocksdb::MockTimeEnv(rocksdb::Env::Default())) {}
+
+ protected:
+  std::unique_ptr<rocksdb::MockTimeEnv> mock_env_;
+};
+
+TEST_F(RepeatableThreadTest, TimedTest) {
+  constexpr uint64_t kSecond = 1000000;  // in microseconds
+  constexpr int kIteration = 3;
+  rocksdb::Env* env = rocksdb::Env::Default();
+  rocksdb::port::Mutex mutex;
+  rocksdb::port::CondVar test_cv(&mutex);
+  int count = 0;
+  uint64_t prev_time = env->NowMicros();
+  rocksdb::RepeatableThread thread(
+      [&] {
+        rocksdb::MutexLock l(&mutex);
+        count++;
+        uint64_t now = env->NowMicros();
+        assert(count == 1 || prev_time + 1 * kSecond <= now);
+        prev_time = now;
+        if (count >= kIteration) {
+          test_cv.SignalAll();
+        }
+      },
+      "repeatable_thread_test", env, 1 * kSecond);
+  // Wait for execution finish.
+  {
+    rocksdb::MutexLock l(&mutex);
+    while (count < kIteration) {
+      test_cv.Wait();
+    }
+  }
+
+  // Test cancel
+  thread.cancel();
+}
+
+TEST_F(RepeatableThreadTest, MockEnvTest) {
+  constexpr uint64_t kSecond = 1000000;  // in microseconds
+  constexpr int kIteration = 3;
+  mock_env_->set_current_time(0);  // in seconds
+  std::atomic<int> count{0};
+  rocksdb::RepeatableThread thread([&] { count++; }, "repeatable_thread_test",
+                                   mock_env_.get(), 1 * kSecond, 1 * kSecond);
+  for (int i = 1; i <= kIteration; i++) {
+    // Bump current time
+    thread.TEST_WaitForRun([&] { mock_env_->set_current_time(i + 1); });
+  }
+  // Test function should be exectued exactly kIteraion times.
+  ASSERT_EQ(kIteration, count.load());
+
+  // Test cancel
+  thread.cancel();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -20,7 +20,7 @@ class RepeatableThreadTest : public testing::Test {
 };
 
 TEST_F(RepeatableThreadTest, TimedTest) {
-  constexpr uint64_t kSecond = 1000000;  // in microseconds
+  constexpr uint64_t kSecond = 1000000;  // 1s = 1000000us
   constexpr int kIteration = 3;
   rocksdb::Env* env = rocksdb::Env::Default();
   rocksdb::port::Mutex mutex;
@@ -52,7 +52,7 @@ TEST_F(RepeatableThreadTest, TimedTest) {
 }
 
 TEST_F(RepeatableThreadTest, MockEnvTest) {
-  constexpr uint64_t kSecond = 1000000;  // in microseconds
+  constexpr uint64_t kSecond = 1000000;  // 1s = 1000000us
   constexpr int kIteration = 3;
   mock_env_->set_current_time(0);  // in seconds
   std::atomic<int> count{0};

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -38,7 +38,7 @@ TEST_F(RepeatableThreadTest, TimedTest) {
           test_cv.SignalAll();
         }
       },
-      "repeatable_thread_test", env, 1 * kSecond);
+      "rt_test", env, 1 * kSecond);
   // Wait for execution finish.
   {
     rocksdb::MutexLock l(&mutex);
@@ -56,8 +56,8 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
   constexpr int kIteration = 3;
   mock_env_->set_current_time(0);  // in seconds
   std::atomic<int> count{0};
-  rocksdb::RepeatableThread thread([&] { count++; }, "repeatable_thread_test",
-                                   mock_env_.get(), 1 * kSecond, 1 * kSecond);
+  rocksdb::RepeatableThread thread([&] { count++; }, "rt_test", mock_env_.get(),
+                                   1 * kSecond, 1 * kSecond);
   for (int i = 1; i <= kIteration; i++) {
     // Bump current time
     thread.TEST_WaitForRun([&] { mock_env_->set_current_time(i + 1); });


### PR DESCRIPTION
Summary:
Introduce `RepeatableThread` utility to run task periodically in a separate thread. It is basically the same as the the same class in fbcode, and in addition provide a helper method to let tests mock time and trigger execution one at a time.

We can use this class to replace `TimerQueue` in #4382 and `BlobDB`.

Test Plan:
New tests.