### PR TITLE
Bugfix list perf emcwaynegao concurrent list(iterator next) poor performance with java comparator in use by emc wayne gao

### DIFF
--- a/java/rocksjni/comparatorjnicallback.cc
+++ b/java/rocksjni/comparatorjnicallback.cc
@@ -18,20 +18,6 @@ ThreadLocalJObject::ThreadLocalJObject()
 
 ThreadLocalJObject::~ThreadLocalJObject() {
 	  lInited = 0;
-	  if (lObjAssigned == 1 && m_jSlice != nullptr ) //&& m_jvm != nullptr
-	  {
-			//jboolean attached_thread = JNI_FALSE;
-
-			//assert(m_pJniEnv != nullptr);
-			// free ASAP after thread detach this thread local obj
-			//m_pJniEnv->DeleteGlobalRef(m_jSlice); not free global variable
-
-			//JniUtil::releaseJniEnv(m_jvm, attached_thread);wgao try not release this in thread local
-
-			// delete m_jvm;
-			//m_jvm = nullptr;
-
-	  }
 }
 
 BaseComparatorJniCallback::BaseComparatorJniCallback(

--- a/java/samples/src/main/java/OptimisticTransactionSample.java
+++ b/java/samples/src/main/java/OptimisticTransactionSample.java
@@ -26,7 +26,7 @@ public class OptimisticTransactionSample {
 
         ////////////////////////////////////////////////////////
         //
-        // Simple OptimisticTransaction Example ("Read Committed")
+        // Simple OptimisticTransaction Example ("Read Committed")wgao
         //
         ////////////////////////////////////////////////////////
         readCommitted(txnDb, writeOptions, readOptions);


### PR DESCRIPTION
Hello Buddy

I found one RocksDBJava will be very poor performance on concurrent list with iterator next. The root cause is that if you use any Java compactor from your own. It will hit the mutex on the JNI code.

I locally fix this with thread local object that hold JNI global reference