### PR TITLE
Improve truncated range tombstone support in RangeDelAggregator

### DIFF
--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -68,7 +68,7 @@ class RangeDelMap {
   virtual size_t Size() const = 0;
   bool IsEmpty() const { return Size() == 0; }
 
-  virtual void AddTombstone(RangeTombstone tombstone) = 0;
+  virtual void AddTombstone(RangeTombstone tombstone, bool is_truncated) = 0;
   virtual std::unique_ptr<RangeDelIterator> NewIterator() = 0;
 };
 

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -96,9 +96,6 @@ void VerifyRangeDels(
           if (expected_point.expectAlive) {
             ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key, mode));
           } else {
-            if (!range_del_agg.ShouldDelete(parsed_key, mode)) {
-              assert(false);
-            }
             ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key, mode));
           }
         }

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -64,7 +64,6 @@ void VerifyRangeDelIter(
     VerifyTombstonesEq(expected_range_dels[i], range_del_iter->Tombstone());
   }
   ASSERT_EQ(expected_range_dels.size(), i);
-  assert(!range_del_iter->Valid());
   ASSERT_FALSE(range_del_iter->Valid());
 }
 

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -27,6 +27,12 @@ enum Direction {
   kReverse,
 };
 
+struct AddTombstonesArgs {
+  const std::vector<RangeTombstone> tombstones;
+  const InternalKey* smallest;
+  const InternalKey* largest;
+};
+
 static auto bytewise_icmp = InternalKeyComparator(BytewiseComparator());
 
 void AddTombstones(RangeDelAggregator* range_del_agg,
@@ -54,31 +60,34 @@ void VerifyRangeDelIter(
     RangeDelIterator* range_del_iter,
     const std::vector<RangeTombstone>& expected_range_dels) {
   size_t i = 0;
-  for (; range_del_iter->Valid() && i < expected_range_dels.size();
-       range_del_iter->Next(), i++) {
+  for (; range_del_iter->Valid(); range_del_iter->Next(), i++) {
     VerifyTombstonesEq(expected_range_dels[i], range_del_iter->Tombstone());
   }
   ASSERT_EQ(expected_range_dels.size(), i);
+  assert(!range_del_iter->Valid());
   ASSERT_FALSE(range_del_iter->Valid());
 }
 
 void VerifyRangeDels(
-    const std::vector<RangeTombstone>& range_dels_in,
+    const std::vector<AddTombstonesArgs>& all_args,
     const std::vector<ExpectedPoint>& expected_points,
     const std::vector<RangeTombstone>& expected_collapsed_range_dels,
-    const InternalKey* smallest = nullptr, const InternalKey* largest = nullptr,
     const InternalKeyComparator& icmp = bytewise_icmp) {
   // Test same result regardless of which order the range deletions are added
   // and regardless of collapsed mode.
   for (bool collapsed : {false, true}) {
     for (Direction dir : {kForward, kReverse}) {
       RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, collapsed);
+      std::vector<RangeTombstone> all_range_dels;
 
-      std::vector<RangeTombstone> range_dels = range_dels_in;
-      if (dir == kReverse) {
-        std::reverse(range_dels.begin(), range_dels.end());
+      for (const auto& args : all_args) {
+        std::vector<RangeTombstone> range_dels = args.tombstones;
+        if (dir == kReverse) {
+          std::reverse(range_dels.begin(), range_dels.end());
+        }
+        all_range_dels.insert(all_range_dels.end(), range_dels.begin(), range_dels.end());
+        AddTombstones(&range_del_agg, range_dels, args.smallest, args.largest);
       }
-      AddTombstones(&range_del_agg, range_dels, smallest, largest);
 
       auto mode = RangeDelPositioningMode::kFullScan;
       if (collapsed) {
@@ -102,26 +111,29 @@ void VerifyRangeDels(
       }
 
       if (collapsed) {
-        range_dels = expected_collapsed_range_dels;
-        VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
-      } else if (smallest == nullptr && largest == nullptr) {
+        all_range_dels = expected_collapsed_range_dels;
+        VerifyRangeDelIter(range_del_agg.NewIterator().get(), all_range_dels);
+      } else if (all_args.size() == 1 && all_args[0].smallest == nullptr &&
+                 all_args[0].largest == nullptr) {
         // Tombstones in an uncollapsed map are presented in start key
         // order. Tombstones with the same start key are presented in
         // insertion order. We don't handle tombstone truncation here, so the
         // verification is only performed if no truncation was requested.
-        std::stable_sort(range_dels.begin(), range_dels.end(),
+        std::stable_sort(all_range_dels.begin(), all_range_dels.end(),
                          [&](const RangeTombstone& a, const RangeTombstone& b) {
                            return icmp.user_comparator()->Compare(
                                       a.start_key_, b.start_key_) < 0;
                          });
-        VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
+        VerifyRangeDelIter(range_del_agg.NewIterator().get(), all_range_dels);
       }
     }
   }
 
   RangeDelAggregator range_del_agg(icmp, {} /* snapshots */,
                                    false /* collapse_deletions */);
-  AddTombstones(&range_del_agg, range_dels_in);
+  for (const auto& args : all_args) {
+    AddTombstones(&range_del_agg, args.tombstones);
+  }
   for (size_t i = 1; i < expected_points.size(); ++i) {
     bool overlapped = range_del_agg.IsRangeOverlapped(
         expected_points[i - 1].begin, expected_points[i].begin);
@@ -138,65 +150,64 @@ void VerifyRangeDels(
 TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}, {}); }
 
 TEST_F(RangeDelAggregatorTest, SameStartAndEnd) {
-  VerifyRangeDels({{"a", "a", 5}}, {{" ", 0}, {"a", 0}, {"b", 0}}, {});
+  VerifyRangeDels({{{{"a", "a", 5}}}}, {{" ", 0}, {"a", 0}, {"b", 0}}, {});
 }
 
 TEST_F(RangeDelAggregatorTest, Single) {
-  VerifyRangeDels({{"a", "b", 10}}, {{" ", 0}, {"a", 10}, {"b", 0}},
+  VerifyRangeDels({{{{"a", "b", 10}}}}, {{" ", 0}, {"a", 10}, {"b", 0}},
                   {{"a", "b", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveLeft) {
-  VerifyRangeDels({{"a", "c", 10}, {"b", "d", 5}},
+  VerifyRangeDels({{{{"a", "c", 10}, {"b", "d", 5}}}},
                   {{" ", 0}, {"a", 10}, {"c", 5}, {"d", 0}},
                   {{"a", "c", 10}, {"c", "d", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveRight) {
-  VerifyRangeDels({{"a", "c", 5}, {"b", "d", 10}},
+  VerifyRangeDels({{{{"a", "c", 5}, {"b", "d", 10}}}},
                   {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}},
                   {{"a", "b", 5}, {"b", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveMiddle) {
-  VerifyRangeDels({{"a", "d", 5}, {"b", "c", 10}},
+  VerifyRangeDels({{{{"a", "d", 5}, {"b", "c", 10}}}},
                   {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 5}, {"d", 0}},
                   {{"a", "b", 5}, {"b", "c", 10}, {"c", "d", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveMiddleReverse) {
-  VerifyRangeDels({{"d", "a", 5}, {"c", "b", 10}},
+  VerifyRangeDels({{{{"d", "a", 5}, {"c", "b", 10}}}},
                   {{"z", 0}, {"d", 5}, {"c", 10}, {"b", 5}, {"a", 0}},
                   {{"d", "c", 5}, {"c", "b", 10}, {"b", "a", 5}},
-                  nullptr /* smallest */, nullptr /* largest */,
                   InternalKeyComparator(ReverseBytewiseComparator()));
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapFully) {
-  VerifyRangeDels({{"a", "d", 10}, {"b", "c", 5}},
+  VerifyRangeDels({{{{"a", "d", 10}, {"b", "c", 5}}}},
                   {{" ", 0}, {"a", 10}, {"d", 0}}, {{"a", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapPoint) {
-  VerifyRangeDels({{"a", "b", 5}, {"b", "c", 10}},
+  VerifyRangeDels({{{{"a", "b", 5}, {"b", "c", 10}}}},
                   {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 0}},
                   {{"a", "b", 5}, {"b", "c", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, SameStartKey) {
-  VerifyRangeDels({{"a", "c", 5}, {"a", "b", 10}},
+  VerifyRangeDels({{{{"a", "c", 5}, {"a", "b", 10}}}},
                   {{" ", 0}, {"a", 10}, {"b", 5}, {"c", 0}},
                   {{"a", "b", 10}, {"b", "c", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, SameEndKey) {
-  VerifyRangeDels({{"a", "d", 5}, {"b", "d", 10}},
+  VerifyRangeDels({{{{"a", "d", 5}, {"b", "d", 10}}}},
                   {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}},
                   {{"a", "b", 5}, {"b", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
-  VerifyRangeDels({{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}},
+  VerifyRangeDels({{{{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}}}},
                   {{" ", 0},
                    {"a", 5},
                    {"b", 0},
@@ -209,25 +220,25 @@ TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
 }
 
 TEST_F(RangeDelAggregatorTest, IdenticalSameSeqNo) {
-  VerifyRangeDels({{"a", "b", 5}, {"a", "b", 5}},
+  VerifyRangeDels({{{{"a", "b", 5}, {"a", "b", 5}}}},
                   {{" ", 0}, {"a", 5}, {"b", 0}},
                   {{"a", "b", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, ContiguousSameSeqNo) {
-  VerifyRangeDels({{"a", "b", 5}, {"b", "c", 5}},
+  VerifyRangeDels({{{{"a", "b", 5}, {"b", "c", 5}}}},
                   {{" ", 0}, {"a", 5}, {"b", 5}, {"c", 0}},
                   {{"a", "c", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlappingSameSeqNo) {
-  VerifyRangeDels({{"a", "c", 5}, {"b", "d", 5}},
+  VerifyRangeDels({{{{"a", "c", 5}, {"b", "d", 5}}}},
                   {{" ", 0}, {"a", 5}, {"b", 5}, {"c", 5}, {"d", 0}},
                   {{"a", "d", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, CoverSameSeqNo) {
-  VerifyRangeDels({{"a", "d", 5}, {"b", "c", 5}},
+  VerifyRangeDels({{{{"a", "d", 5}, {"b", "c", 5}}}},
                   {{" ", 0}, {"a", 5}, {"b", 5}, {"c", 5}, {"d", 0}},
                   {{"a", "d", 5}});
 }
@@ -236,27 +247,27 @@ TEST_F(RangeDelAggregatorTest, CoverSameSeqNo) {
 // larger one when VerifyRangeDels() runs them in reverse
 TEST_F(RangeDelAggregatorTest, CoverMultipleFromLeft) {
   VerifyRangeDels(
-      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "f", 20}},
+      {{{{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "f", 20}}}},
       {{" ", 0}, {"a", 20}, {"f", 15}, {"g", 0}},
       {{"a", "f", 20}, {"f", "g", 15}});
 }
 
 TEST_F(RangeDelAggregatorTest, CoverMultipleFromRight) {
   VerifyRangeDels(
-      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"c", "h", 20}},
+      {{{{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"c", "h", 20}}}},
       {{" ", 0}, {"b", 5}, {"c", 20}, {"h", 0}},
       {{"b", "c", 5}, {"c", "h", 20}});
 }
 
 TEST_F(RangeDelAggregatorTest, CoverMultipleFully) {
   VerifyRangeDels(
-      {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "h", 20}},
+      {{{{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "h", 20}}}},
       {{" ", 0}, {"a", 20}, {"h", 0}}, {{"a", "h", 20}});
 }
 
 TEST_F(RangeDelAggregatorTest, AlternateMultipleAboveBelow) {
   VerifyRangeDels(
-      {{"b", "d", 15}, {"c", "f", 10}, {"e", "g", 20}, {"a", "h", 5}},
+      {{{{"b", "d", 15}, {"c", "f", 10}, {"e", "g", 20}, {"a", "h", 5}}}},
       {{" ", 0}, {"a", 5}, {"b", 15}, {"d", 10}, {"e", 20}, {"g", 5}, {"h", 0}},
       {{"a", "b", 5},
        {"b", "d", 15},
@@ -324,13 +335,12 @@ TEST_F(RangeDelAggregatorTest, TruncateTombstones) {
   const InternalKey smallest("b", 1, kTypeRangeDeletion);
   const InternalKey largest("e", kMaxSequenceNumber, kTypeRangeDeletion);
   VerifyRangeDels(
-      {{"a", "c", 10}, {"d", "f", 10}},
+      {{{{"a", "c", 10}, {"d", "f", 10}}, &smallest, &largest}},
       {{"a", 10, true},  // truncated
        {"b", 10, false}, // not truncated
        {"d", 10, false}, // not truncated
        {"e", 10, false}}, // not truncated
-      {{"b", "c", 10}, {"d", "e", 10}},
-      &smallest, &largest);
+      {{"b", "c", 10}, {"d", "e", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlappingLargestKeyTruncateTombstones) {
@@ -339,13 +349,66 @@ TEST_F(RangeDelAggregatorTest, OverlappingLargestKeyTruncateTombstones) {
       "e", 3,  // could happen if "e" is in consecutive sstables
       kTypeValue);
   VerifyRangeDels(
-      {{"a", "c", 10}, {"d", "f", 10}},
+      {{{{"a", "c", 10}, {"d", "f", 10}}, &smallest, &largest}},
       {{"a", 10, true},  // truncated
        {"b", 10, false}, // not truncated
        {"d", 10, false}, // not truncated
        {"e", 10, false}}, // not truncated
-      {{"b", "c", 10}, {"d", "e", 10}},
-      &smallest, &largest);
+      {{"b", "c", 10}, {"d", "e", 10}});
+}
+
+TEST_F(RangeDelAggregatorTest, TruncatedEndKeyCoversStartKey) {
+  const InternalKey smallest1("a", 1, kTypeRangeDeletion);
+  const InternalKey largest1("b", kMaxSequenceNumber, kTypeRangeDeletion);
+  const InternalKey smallest2("b", 1, kTypeRangeDeletion);
+  const InternalKey largest2("f", 1, kTypeRangeDeletion);
+  VerifyRangeDels(
+      {{{{"a", "c", 10}}, &smallest1, &largest1},
+       {{{"b", "c", 5}}, &smallest2, &largest2}},
+      {{"a", 10, false},
+       {"b", 10, false}},
+      {{"a", "b", 10}, {"b", "c", 5}});
+}
+
+TEST_F(RangeDelAggregatorTest, TruncatedEndKeyOverlapsTombstone) {
+  const InternalKey smallest1("a", 1, kTypeRangeDeletion);
+  const InternalKey largest1("c", kMaxSequenceNumber, kTypeRangeDeletion);
+  const InternalKey smallest2("b", 1, kTypeRangeDeletion);
+  const InternalKey largest2("e", kMaxSequenceNumber, kTypeRangeDeletion);
+  VerifyRangeDels(
+      {{{{"a", "d", 10}}, &smallest1, &largest1},
+       {{{"b", "d", 5}}, &smallest2, &largest2}},
+      {{"a", 10, false},
+       {"b", 10, false},
+       {"c", 10, false}},
+      {{"a", "c", 10}, {"c", "d", 5}});
+}
+
+TEST_F(RangeDelAggregatorTest, TruncatedEndKeyCoversNonTruncatedEndKey) {
+  const InternalKey smallest("a", 1, kTypeRangeDeletion);
+  const InternalKey largest("c", kMaxSequenceNumber, kTypeRangeDeletion);
+  VerifyRangeDels(
+      {{{{"a", "d", 10}, {"b", "c", 5}}, &smallest, &largest}},
+      {{"a", 10, false},
+       {"b", 10, false},
+       {"c", 10, false}},
+      {{"a", "c", 10}});
+}
+
+TEST_F(RangeDelAggregatorTest, OverlappingSameSeqNoWithTruncatedTombstone) {
+  const InternalKey smallest("a", 1, kTypeRangeDeletion);
+  const InternalKey largest("c", kMaxSequenceNumber, kTypeRangeDeletion);
+  VerifyRangeDels({{{{"a", "d", 5}}, &smallest, &largest}, {{{"b", "d", 5}}}},
+                  {{" ", 0}, {"a", 5}, {"b", 5}, {"c", 5}, {"d", 0}},
+                  {{"a", "d", 5}});
+}
+
+TEST_F(RangeDelAggregatorTest, CoverSameSeqNoWithTruncatedTombstone) {
+  const InternalKey smallest("b", 1, kTypeRangeDeletion);
+  const InternalKey largest("c", kMaxSequenceNumber, kTypeRangeDeletion);
+  VerifyRangeDels({{{{"a", "d", 5}}}, {{{"b", "d", 5}}, &smallest, &largest}},
+                  {{" ", 0}, {"a", 5}, {"b", 5}, {"c", 5}, {"d", 0}},
+                  {{"a", "d", 5}});
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -96,6 +96,9 @@ void VerifyRangeDels(
           if (expected_point.expectAlive) {
             ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key, mode));
           } else {
+            if (!range_del_agg.ShouldDelete(parsed_key, mode)) {
+              assert(false);
+            }
             ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key, mode));
           }
         }
@@ -328,7 +331,7 @@ TEST_F(RangeDelAggregatorTest, TruncateTombstones) {
       {{"a", 10, true},  // truncated
        {"b", 10, false}, // not truncated
        {"d", 10, false}, // not truncated
-       {"e", 10, true}}, // truncated
+       {"e", 10, false}}, // not truncated
       {{"b", "c", 10}, {"d", "e", 10}},
       &smallest, &largest);
 }
@@ -344,7 +347,7 @@ TEST_F(RangeDelAggregatorTest, OverlappingLargestKeyTruncateTombstones) {
        {"b", 10, false}, // not truncated
        {"d", 10, false}, // not truncated
        {"e", 10, false}}, // not truncated
-      {{"b", "c", 10}, {"d", "f", 10}},
+      {{"b", "c", 10}, {"d", "e", 10}},
       &smallest, &largest);
 }
 


### PR DESCRIPTION
Summary: Previously, range tombstones were truncated to the boundaries
of their parent SST files, if applicable. However, in cases where SSTs
had overlapping keys due to snapshots, the right-exclusive semantics
of range tombstones prevented us from truncating the tombstone without
incurring correctness issues from reading the largest key in the SST.

This change extends range tombstone semantics in the RangeDelAggregator
to treat truncated tombstones as left- and right-inclusive, which allows
us to safely truncate the tombstones.

Test Plan: make range_del_aggregator_test && ./range_del_aggregator_test

=======

This PR is somewhat incomplete; it still needs to handle the case of adjacent tombstones with the same seqnum, and the comments need to be updated. However, at least we no longer need to consider cases of overlapping tombstones with the same seqnum.

cc @benesch @petermattis 