### PR TITLE
DBWriteImpl: remove redundant code

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -338,8 +338,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
           }
         }
         write_group.last_sequence = last_sequence;
-        write_group.running.store(static_cast<uint32_t>(write_group.size),
-                                  std::memory_order_relaxed);
         write_thread_.LaunchParallelMemTableWriters(&write_group);
         in_parallel_group = true;
 

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -507,7 +507,7 @@ void WriteThread::ExitAsMemTableWriter(Writer* /*self*/,
 
 void WriteThread::LaunchParallelMemTableWriters(WriteGroup* write_group) {
   assert(write_group != nullptr);
-  write_group->running.store(write_group->size, std::memory_order_release);
+  write_group->running.store(write_group->size);
   for (auto w : *write_group) {
     SetState(w, STATE_PARALLEL_MEMTABLE_WRITER);
   }

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -507,7 +507,7 @@ void WriteThread::ExitAsMemTableWriter(Writer* /*self*/,
 
 void WriteThread::LaunchParallelMemTableWriters(WriteGroup* write_group) {
   assert(write_group != nullptr);
-  write_group->running.store(write_group->size, std::memory_order_relaxed);
+  write_group->running.store(write_group->size);
   for (auto w : *write_group) {
     SetState(w, STATE_PARALLEL_MEMTABLE_WRITER);
   }

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -507,7 +507,7 @@ void WriteThread::ExitAsMemTableWriter(Writer* /*self*/,
 
 void WriteThread::LaunchParallelMemTableWriters(WriteGroup* write_group) {
   assert(write_group != nullptr);
-  write_group->running.store(write_group->size);
+  write_group->running.store(write_group->size, std::memory_order_relaxed);
   for (auto w : *write_group) {
     SetState(w, STATE_PARALLEL_MEMTABLE_WRITER);
   }

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -507,7 +507,7 @@ void WriteThread::ExitAsMemTableWriter(Writer* /*self*/,
 
 void WriteThread::LaunchParallelMemTableWriters(WriteGroup* write_group) {
   assert(write_group != nullptr);
-  write_group->running.store(write_group->size);
+  write_group->running.store(write_group->size, std::memory_order_release);
   for (auto w : *write_group) {
     SetState(w, STATE_PARALLEL_MEMTABLE_WRITER);
   }


### PR DESCRIPTION
in `WriteThread::LaunchParallelMemTableWriters`, there is `  write_group->running.store(write_group->size);
`
https://github.com/facebook/rocksdb/blob/master/db/write_thread.cc#L510