### PR TITLE
fix unused param `allocator` in compression.h

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -16,12 +16,12 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <algorithm>
+#include <list>
 #include <map>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <list>
 #include "db/compaction.h"
 #include "db/internal_stats.h"
 #include "db/log_reader.h"
@@ -2069,7 +2069,8 @@ void VersionStorageInfo::GetOverlappingInputs(
       if (begin != nullptr && user_cmp->Compare(file_limit, user_begin) < 0) {
         // "f" is completely before specified range; skip it
         iter++;
-      } else if (end != nullptr && user_cmp->Compare(file_start, user_end) > 0) {
+      } else if (end != nullptr &&
+                 user_cmp->Compare(file_start, user_end) > 0) {
         // "f" is completely after specified range; skip it
         iter++;
       } else {
@@ -2087,8 +2088,7 @@ void VersionStorageInfo::GetOverlappingInputs(
               user_cmp->Compare(file_start, user_begin) < 0) {
             user_begin = file_start;
           }
-          if (end != nullptr &&
-              user_cmp->Compare(file_limit, user_end) > 0) {
+          if (end != nullptr && user_cmp->Compare(file_limit, user_end) > 0) {
             user_end = file_limit;
           }
         }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -99,7 +99,6 @@ extern std::shared_ptr<Cache> NewClockCache(size_t capacity,
                                             int num_shard_bits = -1,
                                             bool strict_capacity_limit = false);
 
-
 class Cache {
  public:
   // Depending on implementation, cache entries with high priority could be less

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1158,8 +1158,7 @@ Status BlockBasedTable::ReadMetaBlock(Rep* rep,
       rep->footer.metaindex_handle(), &meta, rep->ioptions,
       true /* decompress */, Slice() /*compression dict*/,
       rep->persistent_cache_options, kDisableGlobalSequenceNumber,
-      0 /* read_amp_bytes_per_bit */,
-      GetCacheAllocator(rep->table_options));
+      0 /* read_amp_bytes_per_bit */, GetCacheAllocator(rep->table_options));
 
   if (!s.ok()) {
     ROCKS_LOG_ERROR(rep->ioptions.info_log,
@@ -1712,8 +1711,7 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
           compression_dict, rep->persistent_cache_options,
           is_index ? kDisableGlobalSequenceNumber : rep->global_seqno,
           rep->table_options.read_amp_bytes_per_bit,
-          GetCacheAllocator(rep->table_options),
-          rep->immortal_table);
+          GetCacheAllocator(rep->table_options), rep->immortal_table);
     }
     if (s.ok()) {
       block.value = block_value.release();
@@ -1819,8 +1817,7 @@ Status BlockBasedTable::MaybeLoadDataBlockToCache(
             compression_dict, rep->persistent_cache_options,
             is_index ? kDisableGlobalSequenceNumber : rep->global_seqno,
             rep->table_options.read_amp_bytes_per_bit,
-            GetCacheAllocator(rep->table_options),
-            rep->immortal_table);
+            GetCacheAllocator(rep->table_options), rep->immortal_table);
       }
 
       if (s.ok()) {
@@ -2544,8 +2541,7 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
         rep_->file.get(), nullptr /* prefetch buffer */, rep_->footer,
         ReadOptions(), handle, &contents, rep_->ioptions,
         false /* decompress */, dummy_comp_dict /*compression dict*/,
-        rep_->persistent_cache_options,
-        GetCacheAllocator(rep_->table_options));
+        rep_->persistent_cache_options, GetCacheAllocator(rep_->table_options));
     s = block_fetcher.ReadBlockContents();
     if (!s.ok()) {
       break;
@@ -2571,8 +2567,7 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
         rep_->file.get(), nullptr /* prefetch buffer */, rep_->footer,
         ReadOptions(), handle, &contents, rep_->ioptions,
         false /* decompress */, dummy_comp_dict /*compression dict*/,
-        rep_->persistent_cache_options,
-        GetCacheAllocator(rep_->table_options));
+        rep_->persistent_cache_options, GetCacheAllocator(rep_->table_options));
     s = block_fetcher.ReadBlockContents();
     if (!s.ok()) {
       break;

--- a/table/format.cc
+++ b/table/format.cc
@@ -280,8 +280,7 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
 Status UncompressBlockContentsForCompressionType(
     const UncompressionContext& uncompression_ctx, const char* data, size_t n,
     BlockContents* contents, uint32_t format_version,
-    const ImmutableCFOptions& ioptions,
-    CacheAllocator* allocator) {
+    const ImmutableCFOptions& ioptions, CacheAllocator* allocator) {
   CacheAllocationPtr ubuf;
 
   assert(uncompression_ctx.type() != kNoCompression &&

--- a/table/format.h
+++ b/table/format.h
@@ -25,8 +25,8 @@
 #include "options/cf_options.h"
 #include "port/port.h"  // noexcept
 #include "table/persistent_cache_options.h"
-#include "util/file_reader_writer.h"
 #include "util/cache_allocator.h"
+#include "util/file_reader_writer.h"
 
 namespace rocksdb {
 

--- a/util/compression.h
+++ b/util/compression.h
@@ -589,6 +589,7 @@ inline CacheAllocationPtr Zlib_Uncompress(
   (void)input_length;
   (void)decompress_size;
   (void)compress_format_version;
+  (void)allocator;
   (void)windowBits;
   return nullptr;
 #endif
@@ -733,6 +734,7 @@ inline CacheAllocationPtr BZip2_Uncompress(
   (void)input_length;
   (void)decompress_size;
   (void)compress_format_version;
+  (void)allocator;
   return nullptr;
 #endif
 }


### PR DESCRIPTION
this should fix currently failing contrun test: rocksdb-contrun-no_compression, rocksdb-contrun-tsan, rocksdb-contrun-tsan_crash 

