### PR TITLE
Improve error message when opening file for truncation

### DIFF
--- a/util/fault_injection_test_env.cc
+++ b/util/fault_injection_test_env.cc
@@ -33,7 +33,7 @@ Status Truncate(Env* env, const std::string& filename, uint64_t length) {
   const EnvOptions options;
   Status s = env->NewSequentialFile(filename, &orig_file, options);
   if (!s.ok()) {
-    fprintf(stderr, "Cannot truncate file %s: %s\n", filename.c_str(),
+    fprintf(stderr, "Cannot open file %s for truncation: %s\n", filename.c_str(),
             s.ToString().c_str());
     return s;
   }

--- a/util/fault_injection_test_env.cc
+++ b/util/fault_injection_test_env.cc
@@ -33,8 +33,8 @@ Status Truncate(Env* env, const std::string& filename, uint64_t length) {
   const EnvOptions options;
   Status s = env->NewSequentialFile(filename, &orig_file, options);
   if (!s.ok()) {
-    fprintf(stderr, "Cannot open file %s for truncation: %s\n", filename.c_str(),
-            s.ToString().c_str());
+    fprintf(stderr, "Cannot open file %s for truncation: %s\n",
+            filename.c_str(), s.ToString().c_str());
     return s;
   }
 


### PR DESCRIPTION
The old error message was misleading because it led people to believe the truncation operation failed.