### PR TITLE
fix typo in error message, twice

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -232,7 +232,7 @@ class DBIter final: public Iterator {
       *prop = saved_key_.GetUserKey().ToString();
       return Status::OK();
     }
-    return Status::InvalidArgument("Undentified property.");
+    return Status::InvalidArgument("Unidentified property.");
   }
 
   virtual void Next() override;

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -103,7 +103,7 @@ Status Iterator::GetProperty(std::string prop_name, std::string* prop) {
     *prop = "0";
     return Status::OK();
   }
-  return Status::InvalidArgument("Undentified property.");
+  return Status::InvalidArgument("Unidentified property.");
 }
 
 namespace {


### PR DESCRIPTION
Fixes a typo in error messages returned by Iterator::GetProperty(...)