### PR TITLE
fixes compilation if BZIP2 define is not set

### DIFF
--- a/util/compression.h
+++ b/util/compression.h
@@ -661,7 +661,13 @@ inline bool BZip2_Compress(const CompressionContext& /*ctx*/,
 // header in varint32 format
 inline CacheAllocationPtr BZip2_Uncompress(
     const char* input_data, size_t input_length, int* decompress_size,
-    uint32_t compress_format_version, CacheAllocator* allocator = nullptr) {
+    uint32_t compress_format_version, 
+#ifdef BZIP2
+    CacheAllocator* allocator = nullptr) {
+#else
+    CacheAllocator* /*allocator*/ = nullptr) {
+#endif
+
 #ifdef BZIP2
   uint32_t output_len = 0;
   if (compress_format_version == 2) {


### PR DESCRIPTION
the problem is that if the `BZIP2` define is not set, the `allocator`
function parameter is not used inside BZip2_Uncompress, and this
may trigger a compiler warning (the one triggered by -Wunused-parameter).
And as compiler warnings are upgraded to errors by the default Makefile,
this makes the compilation process abort.

The fix is to unname the unused parameter in case the `BZIP2` define
is not set and the parameter is not used inside the function.