### PR TITLE
avoid copying when iterating using range-based for

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -937,8 +937,8 @@ Status CompactionPicker::SanitizeCompactionInputFiles(
   // any currently-existing files.
   for (auto file_num : *input_files) {
     bool found = false;
-    for (auto level_meta : cf_meta.levels) {
-      for (auto file_meta : level_meta.files) {
+    for (const auto& level_meta : cf_meta.levels) {
+      for (const auto& file_meta : level_meta.files) {
         if (file_num == TableFileNameToNumber(file_meta.name)) {
           if (file_meta.being_compacted) {
             return Status::Aborted("Specified compaction input file " +

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -126,7 +126,7 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
 
   // create names of the live files. The names are not absolute
   // paths, instead they are relative to dbname_;
-  for (auto live_file : live) {
+  for (const auto& live_file : live) {
     ret.push_back(MakeTableFileName("", live_file.GetNumber()));
   }
 

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -547,7 +547,7 @@ Status DBImpl::CompactFilesImpl(
   }
 
   std::unordered_set<uint64_t> input_set;
-  for (auto file_name : input_file_names) {
+  for (const auto& file_name : input_file_names) {
     input_set.insert(TableFileNameToNumber(file_name));
   }
 
@@ -579,7 +579,7 @@ Status DBImpl::CompactFilesImpl(
     return s;
   }
 
-  for (auto inputs : input_files) {
+  for (const auto& inputs : input_files) {
     if (cfd->compaction_picker()->AreFilesInCompaction(inputs.files)) {
       return Status::Aborted(
           "Some of the necessary compaction input "

--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -42,7 +42,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
           "Error when reading %s dir\n", dbname.c_str());
   }
   std::sort(files.begin(), files.end());
-  for (std::string file : files) {
+  for (const std::string& file : files) {
     if (!ParseFileName(file, &number, &type)) {
       continue;
     }
@@ -85,7 +85,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
         continue;
       }
       std::sort(files.begin(), files.end());
-      for (std::string file : files) {
+      for (const std::string& file : files) {
         if (ParseFileName(file, &number, &type)) {
           if (type == kTableFile && ++file_num < 10) {
             file_info.append(file).append(" ");
@@ -109,7 +109,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
       return;
     }
     wal_info.clear();
-    for (std::string file : files) {
+    for (const std::string& file : files) {
       if (ParseFileName(file, &number, &type)) {
         if (type == kLogFile) {
           env->GetFileSize(options.wal_dir + "/" + file, &file_size);

--- a/utilities/geodb/geodb_impl.cc
+++ b/utilities/geodb/geodb_impl.cc
@@ -222,7 +222,7 @@ GeoIterator* GeoDBImpl::SearchRadial(const GeoPosition& pos,
   Iterator* iter = db_->NewIterator(ReadOptions());
 
   // Process each prospective quadkey
-  for (std::string qid : qids) {
+  for (const std::string& qid : qids) {
     // The user is interested in only these many objects.
     if (number_of_values == 0) {
       break;


### PR DESCRIPTION
this avoids a few copies of std::string and other structs
in the context of range-based for loops. instead of copying
the values for each iteration, use a const reference to avoid
copying.