### PR TITLE
Fix trace_analyzer potential huge memory wasting due to no valid query analyzed

### DIFF
--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -276,6 +276,7 @@ TraceAnalyzer::TraceAnalyzer(std::string& trace_path, std::string& output_path,
   total_access_keys_ = 0;
   total_gets_ = 0;
   total_writes_ = 0;
+  trace_create_time_ = 0;
   begin_time_ = 0;
   end_time_ = 0;
   time_series_start_ = 0;
@@ -422,6 +423,7 @@ Status TraceAnalyzer::StartProcessing() {
     fprintf(stderr, "Cannot read the header\n");
     return s;
   }
+  trace_create_time_ = header.ts;
   if (FLAGS_output_time_series) {
     time_series_start_ = header.ts;
   }
@@ -740,13 +742,13 @@ Status TraceAnalyzer::MakeStatisticCorrelation(TraceStats& stats,
 
 // Process the statistics of QPS
 Status TraceAnalyzer::MakeStatisticQPS() {
+  if(begin_time_ == 0) {
+    begin_time_ = trace_create_time_;
+  }
   uint32_t duration =
       static_cast<uint32_t>((end_time_ - begin_time_) / 1000000);
   int ret;
   Status s;
-  if(begin_time_ == 0) {
-    duration = 1;
-  }
   std::vector<std::vector<uint32_t>> type_qps(
       duration, std::vector<uint32_t>(kTaTypeNum + 1, 0));
   std::vector<uint64_t> qps_sum(kTaTypeNum + 1, 0);

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -744,6 +744,9 @@ Status TraceAnalyzer::MakeStatisticQPS() {
       static_cast<uint32_t>((end_time_ - begin_time_) / 1000000);
   int ret;
   Status s;
+  if(begin_time_ == 0) {
+    duration = 1;
+  }
   std::vector<std::vector<uint32_t>> type_qps(
       duration, std::vector<uint32_t>(kTaTypeNum + 1, 0));
   std::vector<uint64_t> qps_sum(kTaTypeNum + 1, 0);

--- a/tools/trace_analyzer_tool.h
+++ b/tools/trace_analyzer_tool.h
@@ -204,6 +204,7 @@ class TraceAnalyzer {
   uint64_t total_access_keys_;
   uint64_t total_gets_;
   uint64_t total_writes_;
+  uint64_t trace_create_time_;
   uint64_t begin_time_;
   uint64_t end_time_;
   uint64_t time_series_start_;


### PR DESCRIPTION
If the query types being analyzed do not appear in the trace, the current trace_analyzer will use 0 as the begin time, which create the time duration from 1970/01/01 to the now time. It will waste huge memory. Fixed by adding the trace_create_time to limit the duration.

test plan: 
tested by the trace_analyzer_test and make asan_check