### PR TITLE
add locking around calls to RecalculateWriteStallConditions in column_family_test

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -513,6 +513,13 @@ class ColumnFamilyTestBase : public testing::Test {
     return static_cast<int>(files.size());
   }
 
+  void RecalculateWriteStallConditions(ColumnFamilyData* cfd,
+      const MutableCFOptions& mutable_cf_options)  {
+    dbfull()->TEST_LockMutex();
+    cfd->RecalculateWriteStallConditions(mutable_cf_options);
+    dbfull()-> TEST_UnlockMutex();
+  }
+
   std::vector<ColumnFamilyHandle*> handles_;
   std::vector<std::string> names_;
   std::vector<std::set<std::string>> keys_;
@@ -2500,185 +2507,139 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
   mutable_cf_options.disable_auto_compactions = false;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(201);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(400);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(450);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(205);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(202);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(201);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(198);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(399);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(599);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(2001);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(3001);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(390);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(100);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->set_l0_delay_trigger_count(100);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(101);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(0);
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(101);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(200);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(0);
   vstorage->TEST_set_estimated_compaction_needed_bytes(0);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   mutable_cf_options.disable_auto_compactions = true;
   dbfull()->TEST_write_controler().set_delayed_write_rate(kBaseRate);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->set_l0_delay_trigger_count(50);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(0, GetDbDelayedWriteRate());
@@ -2686,9 +2647,7 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
 
   vstorage->set_l0_delay_trigger_count(60);
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(0, GetDbDelayedWriteRate());
@@ -2697,18 +2656,14 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
   mutable_cf_options.disable_auto_compactions = false;
   vstorage->set_l0_delay_trigger_count(70);
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(71);
   vstorage->TEST_set_estimated_compaction_needed_bytes(501);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
@@ -2733,45 +2688,31 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupSingleColumnFamily) {
   mutable_cf_options.hard_pending_compaction_bytes_limit = 2000;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(40);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(45);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(7);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(9);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(6);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   // Speed up threshold = min(4 * 2, 4 + (12 - 4)/4) = 6
@@ -2780,21 +2721,15 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupSingleColumnFamily) {
   mutable_cf_options.level0_stop_writes_trigger = 30;
 
   vstorage->set_l0_delay_trigger_count(5);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(7);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(3);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 }
 
@@ -2821,71 +2756,53 @@ TEST_P(ColumnFamilyTest, WriteStallTwoColumnFamilies) {
   mutable_cf_options1.soft_pending_compaction_bytes_limit = 500;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(201);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(600);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(70);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(800);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(700);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(600);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
@@ -2918,61 +2835,41 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupTwoColumnFamilies) {
   mutable_cf_options1.level0_slowdown_writes_trigger = 16;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(40);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(60);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(30);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(70);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(20);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(3);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(9);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->set_l0_delay_trigger_count(2);
-  dbfull()->TEST_LockMutex();
-  cfd1->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd1, mutable_cf_options);
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(0);
-  dbfull()->TEST_LockMutex();
-  cfd->RecalculateWriteStallConditions(mutable_cf_options);
-  dbfull()->TEST_UnlockMutex();
+  RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 }
 

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2500,139 +2500,185 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
   mutable_cf_options.disable_auto_compactions = false;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(201);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(400);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(450);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(205);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(202);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(201);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(198);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(399);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(599);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(2001);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(3001);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(390);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(100);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->set_l0_delay_trigger_count(100);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(101);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(0);
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(101);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(200);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(0);
   vstorage->TEST_set_estimated_compaction_needed_bytes(0);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   mutable_cf_options.disable_auto_compactions = true;
   dbfull()->TEST_write_controler().set_delayed_write_rate(kBaseRate);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage->set_l0_delay_trigger_count(50);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(0, GetDbDelayedWriteRate());
@@ -2640,7 +2686,9 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
 
   vstorage->set_l0_delay_trigger_count(60);
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(0, GetDbDelayedWriteRate());
@@ -2649,14 +2697,18 @@ TEST_P(ColumnFamilyTest, WriteStallSingleColumnFamily) {
   mutable_cf_options.disable_auto_compactions = false;
   vstorage->set_l0_delay_trigger_count(70);
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->set_l0_delay_trigger_count(71);
   vstorage->TEST_set_estimated_compaction_needed_bytes(501);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
@@ -2681,31 +2733,45 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupSingleColumnFamily) {
   mutable_cf_options.hard_pending_compaction_bytes_limit = 2000;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(40);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(45);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(7);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(9);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(6);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   // Speed up threshold = min(4 * 2, 4 + (12 - 4)/4) = 6
@@ -2714,15 +2780,21 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupSingleColumnFamily) {
   mutable_cf_options.level0_stop_writes_trigger = 30;
 
   vstorage->set_l0_delay_trigger_count(5);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(7);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(3);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 }
 
@@ -2749,53 +2821,71 @@ TEST_P(ColumnFamilyTest, WriteStallTwoColumnFamilies) {
   mutable_cf_options1.soft_pending_compaction_bytes_limit = 500;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(50);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(201);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(600);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(70);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(800);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(300);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(700);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(500);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25 / 1.25, GetDbDelayedWriteRate());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(600);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_TRUE(!IsDbWriteStopped());
   ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
   ASSERT_EQ(kBaseRate / 1.25, GetDbDelayedWriteRate());
@@ -2828,41 +2918,61 @@ TEST_P(ColumnFamilyTest, CompactionSpeedupTwoColumnFamilies) {
   mutable_cf_options1.level0_slowdown_writes_trigger = 16;
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(40);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(60);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(30);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(70);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->TEST_set_estimated_compaction_needed_bytes(20);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->TEST_set_estimated_compaction_needed_bytes(3);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(9);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage1->set_l0_delay_trigger_count(2);
+  dbfull()->TEST_LockMutex();
   cfd1->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(6, dbfull()->TEST_BGCompactionsAllowed());
 
   vstorage->set_l0_delay_trigger_count(0);
+  dbfull()->TEST_LockMutex();
   cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbfull()->TEST_UnlockMutex();
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 }
 

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -515,6 +515,9 @@ class ColumnFamilyTestBase : public testing::Test {
 
   void RecalculateWriteStallConditions(ColumnFamilyData* cfd,
       const MutableCFOptions& mutable_cf_options)  {
+    // add lock to avoid race condition between
+    // `RecalculateWriteStallConditions` which writes to CFStats and
+    // background `DBImpl::DumpStats()` threads which read CFStats
     dbfull()->TEST_LockMutex();
     cfd->RecalculateWriteStallConditions(mutable_cf_options);
     dbfull()-> TEST_UnlockMutex();


### PR DESCRIPTION
this should fix the current failing TSAN jobs:
The callstack for TSAN:
> WARNING: ThreadSanitizer: data race (pid=87440)
  Read of size 8 at 0x7d580000fce0 by thread T22 (mutexes: write M548703):
    #0 rocksdb::InternalStats::DumpCFStatsNoFileHistogram(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) db/internal_stats.cc:1204 (column_family_test+0x00000080eca7)
    #1 rocksdb::InternalStats::DumpCFStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) db/internal_stats.cc:1169 (column_family_test+0x0000008106d0)
    #2 rocksdb::InternalStats::HandleCFStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, rocksdb::Slice) db/internal_stats.cc:578 (column_family_test+0x000000810720)
    #3 rocksdb::InternalStats::GetStringProperty(rocksdb::DBPropertyInfo const&, rocksdb::Slice const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) db/internal_stats.cc:488 (column_family_test+0x00000080670c)
    #4 rocksdb::DBImpl::DumpStats() db/db_impl.cc:625 (column_family_test+0x00000070ce9a)

>  Previous write of size 8 at 0x7d580000fce0 by main thread:
    #0 rocksdb::InternalStats::AddCFStats(rocksdb::InternalStats::InternalCFStatsType, unsigned long) db/internal_stats.h:324 (column_family_test+0x000000693bbf)
    #1 rocksdb::ColumnFamilyData::RecalculateWriteStallConditions(rocksdb::MutableCFOptions const&) db/column_family.cc:818 (column_family_test+0x000000693bbf)
    #2 rocksdb::ColumnFamilyTest_WriteStallSingleColumnFamily_Test::TestBody() db/column_family_test.cc:2563 (column_family_test+0x0000005e5a49)