### PR TITLE
WriteBatch::Iterate wrongly returns Status::Corruption 

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -414,9 +414,10 @@ Status WriteBatch::Iterate(Handler* handler) const {
   char tag = 0;
   uint32_t column_family = 0;  // default
   bool last_was_try_again = false;
-  bool handlerContinue = true;
+  bool handler_continue = true;
   while (((s.ok() && !input.empty()) || UNLIKELY(s.IsTryAgain()))) {
-    if (!(handlerContinue = handler->Continue())) {
+    handler_continue = handler->Continue();
+    if (!handler_continue) {
       break;
     }
     
@@ -587,7 +588,7 @@ Status WriteBatch::Iterate(Handler* handler) const {
   if (!s.ok()) {
     return s;
   }
-  if (handlerContinue && found != WriteBatchInternal::Count(this)) {
+  if (handler_continue && found != WriteBatchInternal::Count(this)) {
     return Status::Corruption("WriteBatch has wrong count");
   } else {
     return Status::OK();

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -420,7 +420,7 @@ Status WriteBatch::Iterate(Handler* handler) const {
     if (!handler_continue) {
       break;
     }
-    
+
     if (LIKELY(!s.IsTryAgain())) {
       last_was_try_again = false;
       tag = 0;


### PR DESCRIPTION
Wrong I overwrite `WriteBatch::Handler::Continue` to return _false_ at some point, I always get the `Status::Corruption` error. 
I don't think this check is used correctly here: The counter in `found` cannot reflect all entries in the WriteBatch when we exit the loop early.