### PR TITLE
C++17 support

### DIFF
--- a/util/transaction_test_util.cc
+++ b/util/transaction_test_util.cc
@@ -13,6 +13,7 @@
 #include <inttypes.h>
 #include <algorithm>
 #include <numeric>
+#include <random>
 #include <string>
 #include <thread>
 
@@ -134,9 +135,8 @@ bool RandomTransactionInserter::DoInsert(DB* db, Transaction* txn,
   bool unexpected_error = false;
 
   std::vector<uint16_t> set_vec(num_sets_);
-  std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0));
-  std::random_shuffle(set_vec.begin(), set_vec.end(),
-                      [&](uint64_t r) { return rand_->Uniform(r); });
+  std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0)); 
+  std::shuffle(set_vec.begin(), set_vec.end(), std::random_device{});
 
   // For each set, pick a key at random and increment it
   for (uint16_t set_i : set_vec) {
@@ -258,10 +258,8 @@ Status RandomTransactionInserter::Verify(DB* db, uint16_t num_sets,
 
   std::vector<uint16_t> set_vec(num_sets);
   std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0));
-  if (rand) {
-    std::random_shuffle(set_vec.begin(), set_vec.end(),
-                        [&](uint64_t r) { return rand->Uniform(r); });
-  }
+  std::shuffle(set_vec.begin(), set_vec.end(), std::random_device{});
+    
   // For each set of keys with the same prefix, sum all the values
   for (uint16_t set_i : set_vec) {
     // Five digits (since the largest uint16_t is 65535) plus the NUL

--- a/util/transaction_test_util.cc
+++ b/util/transaction_test_util.cc
@@ -135,7 +135,7 @@ bool RandomTransactionInserter::DoInsert(DB* db, Transaction* txn,
   bool unexpected_error = false;
 
   std::vector<uint16_t> set_vec(num_sets_);
-  std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0)); 
+  std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0));
   std::shuffle(set_vec.begin(), set_vec.end(), std::random_device{});
 
   // For each set, pick a key at random and increment it
@@ -259,7 +259,7 @@ Status RandomTransactionInserter::Verify(DB* db, uint16_t num_sets,
   std::vector<uint16_t> set_vec(num_sets);
   std::iota(set_vec.begin(), set_vec.end(), static_cast<uint16_t>(0));
   std::shuffle(set_vec.begin(), set_vec.end(), std::random_device{});
-    
+
   // For each set of keys with the same prefix, sum all the values
   for (uint16_t set_i : set_vec) {
     // Five digits (since the largest uint16_t is 65535) plus the NUL


### PR DESCRIPTION
Closes https://github.com/facebook/rocksdb/issues/4462

I'm not sure if you'll be happy with `std::random_device{}`, perhaps you would want to use your rand instance instead. I didn't test to see if your rand instance supports the requirements that `std::shuffle` takes.