### PR TITLE
Enable DeleteRange in stress/crash tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -31,7 +31,8 @@ default_params = {
     "clear_column_family_one_in": 0,
     "compact_files_one_in": 1000000,
     "compact_range_one_in": 1000000,
-    "delpercent": 5,
+    "delpercent": 4,
+    "delrangepercent": 1,
     "destroy_db_initially": 0,
     "enable_pipelined_write": lambda: random.randint(0, 1),
     "expected_values_path": expected_values_file.name,
@@ -107,8 +108,6 @@ whitebox_default_params = {
 simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
-    "delpercent": 4,
-    "delrangepercent": 1,
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
     "memtablerep": "skip_list",
@@ -149,6 +148,9 @@ def finalize_and_sanitize(src_params):
             dest_params["db"]):
         dest_params["use_direct_io_for_flush_and_compaction"] = 0
         dest_params["use_direct_reads"] = 0
+    if dest_params.get("test_batches_snapshots") == 1:
+        dest_params["delpercent"] += dest_params["delrangepercent"]
+        dest_params["delrangepercent"] = 0
     return dest_params
 
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -107,6 +107,8 @@ whitebox_default_params = {
 simple_default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     "column_families": 1,
+    "delpercent": 4,
+    "delrangepercent": 1,
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
     "memtablerep": "skip_list",


### PR DESCRIPTION
Set `delrangepercent=1` when `test_batches_snapshots=false`.

Test Plan:

Verified abbreviated runs pass for all four combinations of the crash test:

```
$ TEST_TMPDIR=/dev/shm python tools/db_crashtest.py whitebox --simple --max_key=1000000 --value_size_mult=33 --write_buffer_size=1048576 --max_bytes_for_level_base=4194304 --target_file_size_base=1048576 --interval=10 --duration=120
$ TEST_TMPDIR=/dev/shm python tools/db_crashtest.py whitebox --max_key=1000000 --value_size_mult=33 --write_buffer_size=1048576 --max_bytes_for_level_base=4194304 --target_file_size_base=1048576 --interval=10 --duration=120
$ TEST_TMPDIR=/dev/shm python tools/db_crashtest.py blackbox --simple --max_key=1000000 --value_size_mult=33 --write_buffer_size=1048576 --max_bytes_for_level_base=4194304 --target_file_size_base=1048576 --interval=10 --duration=120
$ TEST_TMPDIR=/dev/shm python tools/db_crashtest.py blackbox --max_key=1000000 --value_size_mult=33 --write_buffer_size=1048576 --max_bytes_for_level_base=4194304 --target_file_size_base=1048576 --interval=10 --duration=120
```
