### PR TITLE
Set -DROCKSDB_JEMALLOC for buck build if jemalloc presents

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -69,7 +69,11 @@ if is_opt_mode:
 
 default_allocator = read_config("fbcode", "default_allocator")
 
-if default_allocator.startswith("jemalloc"):
+sanitizer = read_config("fbcode", "sanitizer")
+
+# Let RocksDB aware of jemalloc existence.
+# Do not enable it if sanitizer presents.
+if default_allocator.startswith("jemalloc") and sanitizer == "":
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
     rocksdb_external_deps.append(("jemalloc", None, "headers"))
 

--- a/TARGETS
+++ b/TARGETS
@@ -59,6 +59,7 @@ rocksdb_arch_preprocessor_flags = {
 }
 
 build_mode = read_config("fbcode", "build_mode")
+
 is_opt_mode = build_mode.startswith("opt")
 
 # -DNDEBUG is added by default in opt mode in fbcode. But adding it twice
@@ -68,10 +69,9 @@ if is_opt_mode:
 
 default_allocator = read_config("fbcode", "default_allocator")
 
-if default_allocator in ["jemalloc", "jemalloc_debug"]:
+if default_allocator.startswith("jemalloc"):
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
-    rocksdb_external_deps.append(("jemalloc", None, "jemalloc"))
-
+    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 
 cpp_library(
     name = "rocksdb_lib",

--- a/TARGETS
+++ b/TARGETS
@@ -59,13 +59,19 @@ rocksdb_arch_preprocessor_flags = {
 }
 
 build_mode = read_config("fbcode", "build_mode")
-
 is_opt_mode = build_mode.startswith("opt")
 
 # -DNDEBUG is added by default in opt mode in fbcode. But adding it twice
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
+
+default_allocator = read_config("fbcode", "default_allocator")
+
+if default_allocator in ["jemalloc", "jemalloc_debug"]:
+    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
+    rocksdb_external_deps.append(("jemalloc", None, "jemalloc"))
+
 
 cpp_library(
     name = "rocksdb_lib",

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -63,13 +63,19 @@ rocksdb_arch_preprocessor_flags = {
 }
 
 build_mode = read_config("fbcode", "build_mode")
-
 is_opt_mode = build_mode.startswith("opt")
 
 # -DNDEBUG is added by default in opt mode in fbcode. But adding it twice
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
+
+default_allocator = read_config("fbcode", "default_allocator")
+
+if default_allocator in ["jemalloc", "jemalloc_debug"]:
+    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
+    rocksdb_external_deps.append(("jemalloc", None, "jemalloc"))
+
 """
 
 

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -73,7 +73,11 @@ if is_opt_mode:
 
 default_allocator = read_config("fbcode", "default_allocator")
 
-if default_allocator.startswith("jemalloc"):
+sanitizer = read_config("fbcode", "sanitizer")
+
+# Let RocksDB aware of jemalloc existence.
+# Do not enable it if sanitizer presents.
+if default_allocator.startswith("jemalloc") and sanitizer == "":
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
     rocksdb_external_deps.append(("jemalloc", None, "headers"))
 """

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -63,6 +63,7 @@ rocksdb_arch_preprocessor_flags = {
 }
 
 build_mode = read_config("fbcode", "build_mode")
+
 is_opt_mode = build_mode.startswith("opt")
 
 # -DNDEBUG is added by default in opt mode in fbcode. But adding it twice
@@ -72,10 +73,9 @@ if is_opt_mode:
 
 default_allocator = read_config("fbcode", "default_allocator")
 
-if default_allocator in ["jemalloc", "jemalloc_debug"]:
+if default_allocator.startswith("jemalloc"):
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
-    rocksdb_external_deps.append(("jemalloc", None, "jemalloc"))
-
+    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 """
 
 


### PR DESCRIPTION
Summary:
Set the macro if default allocator is jemalloc. It doesn't handle the case when allocator is specified, e.g.
```
cpp_binary(
    name="xxx"
    allocator="jemalloc", # or "malloc" or something else
    deps=["//rocksdb:rocksdb"],
)
```

Test Plan:
See if sandcastle build passes.