### PR TITLE
Replace 'string' with 'const string&' in FileOperationInfo

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -144,12 +144,13 @@ struct TableFileDeletionInfo {
 };
 
 struct FileOperationInfo {
-  std::string path;
+  const std::string& path;
   uint64_t offset;
   size_t length;
   time_t start_timestamp;
   time_t finish_timestamp;
   Status status;
+  FileOperationInfo(const std::string& _path) : path(_path) {}
 };
 
 struct FlushJobInfo {

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -66,8 +66,7 @@ class RandomAccessFileReader {
 #ifndef ROCKSDB_LITE
   void NotifyOnFileReadFinish(uint64_t offset, size_t length, time_t start_ts,
                               const Status& status) const {
-    FileOperationInfo info;
-    info.path = file_name_;
+    FileOperationInfo info(file_name_);
     info.offset = offset;
     info.length = length;
     info.start_timestamp = start_ts;
@@ -160,8 +159,7 @@ class WritableFileWriter {
 #ifndef ROCKSDB_LITE
   void NotifyOnFileWriteFinish(uint64_t offset, size_t length, time_t start_ts,
                                const Status& status) {
-    FileOperationInfo info;
-    info.path = file_name_;
+    FileOperationInfo info(file_name_);
     info.offset = offset;
     info.length = length;
     info.start_timestamp = start_ts;


### PR DESCRIPTION
Summary:
Using const string& can avoid one extra string copy. This PR addresses a recent comment made by @siying  on #3933. 

Test plan:
```
$make clean && make -j32 all check
```