### PR TITLE
Lazily initialize RangeDelAggregator stripe map entries

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -598,8 +598,7 @@ RangeDelMap* RangeDelAggregator::GetRangeDelMapIfExists(SequenceNumber seq) {
   }
   StripeMap::iterator iter;
   if (seq > 0) {
-    // upper_bound() checks strict inequality so need to subtract one
-    iter = rep_->stripe_map_.upper_bound(seq - 1);
+    iter = rep_->stripe_map_.lower_bound(seq);
   } else {
     iter = rep_->stripe_map_.begin();
   }
@@ -619,9 +618,8 @@ RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
   // the snapshot below.
   std::vector<SequenceNumber>::iterator iter;
   if (seq > 0) {
-    // upper_bound() checks strict inequality so need to subtract one
-    iter = std::upper_bound(rep_->snapshots_.begin(), rep_->snapshots_.end(),
-                            seq - 1);
+    iter = std::lower_bound(rep_->snapshots_.begin(), rep_->snapshots_.end(),
+                            seq);
   } else {
     iter = rep_->snapshots_.begin();
   }

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -596,12 +596,7 @@ RangeDelMap* RangeDelAggregator::GetRangeDelMapIfExists(SequenceNumber seq) {
   if (rep_->stripe_map_.empty()) {
     return nullptr;
   }
-  StripeMap::iterator iter;
-  if (seq > 0) {
-    iter = rep_->stripe_map_.lower_bound(seq);
-  } else {
-    iter = rep_->stripe_map_.begin();
-  }
+  StripeMap::iterator iter = rep_->stripe_map_.lower_bound(seq);
   if (iter == rep_->stripe_map_.end()) {
     return nullptr;
   }
@@ -616,13 +611,8 @@ RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
   assert(rep_ != nullptr);
   // The stripe includes seqnum for the snapshot above and excludes seqnum for
   // the snapshot below.
-  std::vector<SequenceNumber>::iterator iter;
-  if (seq > 0) {
-    iter = std::lower_bound(rep_->snapshots_.begin(), rep_->snapshots_.end(),
-                            seq);
-  } else {
-    iter = rep_->snapshots_.begin();
-  }
+  std::vector<SequenceNumber>::iterator iter =
+      std::lower_bound(rep_->snapshots_.begin(), rep_->snapshots_.end(), seq);
   // catch-all stripe justifies this assertion in either of above cases
   assert(iter != rep_->snapshots_.end());
   if (rep_->stripe_map_.find(*iter) == rep_->stripe_map_.end()) {

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -441,11 +441,9 @@ RangeDelAggregator::RangeDelAggregator(const InternalKeyComparator& icmp,
 void RangeDelAggregator::InitRep(const std::vector<SequenceNumber>& snapshots) {
   assert(rep_ == nullptr);
   rep_.reset(new Rep());
-  for (auto snapshot : snapshots) {
-    rep_->stripe_map_.emplace(snapshot, NewRangeDelMap());
-  }
+  rep_->snapshots_ = snapshots;
   // Data newer than any snapshot falls in this catch-all stripe
-  rep_->stripe_map_.emplace(kMaxSequenceNumber, NewRangeDelMap());
+  rep_->snapshots_.emplace_back(kMaxSequenceNumber);
   rep_->pinned_iters_mgr_.StartPinning();
 }
 
@@ -474,11 +472,11 @@ bool RangeDelAggregator::ShouldDeleteImpl(const ParsedInternalKey& parsed,
                                           RangeDelPositioningMode mode) {
   assert(IsValueType(parsed.type));
   assert(rep_ != nullptr);
-  auto& tombstone_map = GetRangeDelMap(parsed.sequence);
-  if (tombstone_map.IsEmpty()) {
+  auto* tombstone_map = GetRangeDelMapIfExists(parsed.sequence);
+  if (tombstone_map == nullptr || tombstone_map->IsEmpty()) {
     return false;
   }
-  return tombstone_map.ShouldDelete(parsed, mode);
+  return tombstone_map->ShouldDelete(parsed, mode);
 }
 
 bool RangeDelAggregator::IsRangeOverlapped(const Slice& start,
@@ -591,10 +589,13 @@ void RangeDelAggregator::InvalidateRangeDelMapPositions() {
   }
 }
 
-RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
+RangeDelMap* RangeDelAggregator::GetRangeDelMapIfExists(SequenceNumber seq) {
   assert(rep_ != nullptr);
   // The stripe includes seqnum for the snapshot above and excludes seqnum for
   // the snapshot below.
+  if (rep_->stripe_map_.empty()) {
+    return nullptr;
+  }
   StripeMap::iterator iter;
   if (seq > 0) {
     // upper_bound() checks strict inequality so need to subtract one
@@ -602,9 +603,30 @@ RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
   } else {
     iter = rep_->stripe_map_.begin();
   }
+  if (iter != rep_->stripe_map_.end()) {
+    return iter->second.get();
+  }
+  return nullptr;
+}
+
+RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
+  assert(rep_ != nullptr);
+  // The stripe includes seqnum for the snapshot above and excludes seqnum for
+  // the snapshot below.
+  std::vector<SequenceNumber>::iterator iter;
+  if (seq > 0) {
+    // upper_bound() checks strict inequality so need to subtract one
+    iter = std::upper_bound(rep_->snapshots_.begin(), rep_->snapshots_.end(),
+                            seq - 1);
+  } else {
+    iter = rep_->snapshots_.begin();
+  }
   // catch-all stripe justifies this assertion in either of above cases
-  assert(iter != rep_->stripe_map_.end());
-  return *iter->second;
+  assert(iter != rep_->snapshots_.end());
+  if (rep_->stripe_map_.find(*iter) == rep_->stripe_map_.end()) {
+    rep_->stripe_map_.emplace(*iter, NewRangeDelMap());
+  }
+  return *rep_->stripe_map_[*iter];
 }
 
 bool RangeDelAggregator::IsEmpty() {

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -200,9 +200,12 @@ class RangeDelAggregator {
 
  private:
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
-  // their seqnums are greater than the next smaller snapshot's seqnum. Each
-  // entry is lazily initialized.
-  typedef std::map<SequenceNumber, std::unique_ptr<RangeDelMap>> StripeMap;
+  // their seqnums are greater than the next smaller snapshot's seqnum, and the
+  // corresponding index into the list of snapshots. Each entry is lazily
+  // initialized.
+  typedef std::map<SequenceNumber,
+                   std::pair<std::unique_ptr<RangeDelMap>, size_t>>
+      StripeMap;
 
   struct Rep {
     std::vector<SequenceNumber> snapshots_;

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -200,10 +200,12 @@ class RangeDelAggregator {
 
  private:
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
-  // their seqnums are greater than the next smaller snapshot's seqnum.
+  // their seqnums are greater than the next smaller snapshot's seqnum. Each
+  // entry is lazily initialized.
   typedef std::map<SequenceNumber, std::unique_ptr<RangeDelMap>> StripeMap;
 
   struct Rep {
+    std::vector<SequenceNumber> snapshots_;
     StripeMap stripe_map_;
     PinnedIteratorsManager pinned_iters_mgr_;
     std::list<std::string> pinned_slices_;
@@ -215,6 +217,7 @@ class RangeDelAggregator {
   void InitRep(const std::vector<SequenceNumber>& snapshots);
 
   std::unique_ptr<RangeDelMap> NewRangeDelMap();
+  RangeDelMap* GetRangeDelMapIfExists(SequenceNumber seq);
   RangeDelMap& GetRangeDelMap(SequenceNumber seq);
 
   SequenceNumber upper_bound_;


### PR DESCRIPTION
When there are no range deletions, flush and compaction perform a binary search
on an effectively empty map every time they call ShouldDelete. This PR lazily
initializes each stripe map entry so that the binary search can be elided in
these cases.

After this PR, the total amount of time spent in compactions is 52.541331s, and the total amount of time spent in flush is 5.532608s, the former of which is a significant improvement from the results after #4495.

Test Plan:
- `make check`
- `TEST_TMPDIR=/dev/shm ./db_stress -writepercent=100 -readpercent=0 -iterpercent=0 -prefixpercent=0 -delpercent=0 -reopen=0 -column_families=1 -clear_column_family_one_in=0 -max_background_flushes=4 -max_background_compactions=8 -compression_type=none -value_size_mult=33 -memtablerep=skiplist -statistics=1 -threads=1 -ops_per_thread=10000000 -max_key=10000000 -write_buffer_size=4194304 -target_file_size_base=4194304 -max_bytes_for_level_base=16777216 -acquire_snapshot_one_in=100 -snapshot_hold_ops=1000000`
- from results of the above command, look at `rocksdb.db.flush.micros` and `rocksdb.compaction.times.micros`.