### PR TITLE
Disable GroupCommitTest in Appveyor

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2313,6 +2313,9 @@ INSTANTIATE_TEST_CASE_P(
 #endif  // ROCKSDB_LITE
 
 // Group commit test:
+#if !defined(TRAVIS) && !defined(OS_WIN)
+// Disable this test temporarily on Travis and appveyor as it fails
+// intermittently. Github issue: #4151
 namespace {
 
 static const int kGCNumThreads = 4;
@@ -2339,9 +2342,6 @@ static void GCThreadBody(void* arg) {
 
 }  // namespace
 
-#if !defined(TRAVIS) && !defined(OS_WIN)
-// Disable this test temporarily on Travis and appveyor as it fails
-// intermittently. Github issue: #4151
 TEST_F(DBTest, GroupCommitTest) {
   do {
     Options options = CurrentOptions();


### PR DESCRIPTION
We have already disabled it on Travis since it has been too flaky. The same problem arises in Appveyor as well.