### PR TITLE
Add PerfContext counters for index/filter block cache stats

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -60,6 +60,10 @@ struct PerfContext {
   uint64_t block_read_count;          // total number of block reads (with IO)
   uint64_t block_read_byte;           // total number of bytes from block reads
   uint64_t block_read_time;           // total nanos spent on block reads
+  uint64_t block_cache_index_hit_count; // total number of index block hits
+  uint64_t index_block_read_count;      // total number of index block reads
+  uint64_t block_cache_filter_hit_count; // total number of filter block hits
+  uint64_t filter_block_read_count;     // total number of filter block reads
   uint64_t block_checksum_time;       // total nanos spent on block checksum
   uint64_t block_decompress_time;  // total nanos spent on block decompression
 

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -44,6 +44,10 @@ void PerfContext::Reset() {
   block_read_count = 0;
   block_read_byte = 0;
   block_read_time = 0;
+  block_cache_index_hit_count = 0;
+  index_block_read_count = 0;
+  block_cache_filter_hit_count = 0;
+  filter_block_read_count = 0;
   block_checksum_time = 0;
   block_decompress_time = 0;
   get_read_bytes = 0;
@@ -152,6 +156,10 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(block_read_count);
   PERF_CONTEXT_OUTPUT(block_read_byte);
   PERF_CONTEXT_OUTPUT(block_read_time);
+  PERF_CONTEXT_OUTPUT(block_cache_index_hit_count);
+  PERF_CONTEXT_OUTPUT(index_block_read_count);
+  PERF_CONTEXT_OUTPUT(block_cache_filter_hit_count);
+  PERF_CONTEXT_OUTPUT(filter_block_read_count);
   PERF_CONTEXT_OUTPUT(block_checksum_time);
   PERF_CONTEXT_OUTPUT(block_decompress_time);
   PERF_CONTEXT_OUTPUT(get_read_bytes);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1557,6 +1557,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
   FilterBlockReader* filter = nullptr;
   if (cache_handle != nullptr) {
+    PERF_COUNTER_ADD(block_cache_filter_hit_count, 1);
     filter = reinterpret_cast<FilterBlockReader*>(
         block_cache->Value(cache_handle));
   } else if (no_io) {
@@ -1573,6 +1574,7 @@ BlockBasedTable::CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
               ? Cache::Priority::HIGH
               : Cache::Priority::LOW);
       if (s.ok()) {
+        PERF_COUNTER_ADD(filter_block_read_count, 1);
         if (get_context != nullptr) {
           get_context->get_context_stats_.num_cache_add++;
           get_context->get_context_stats_.num_cache_bytes_write += usage;
@@ -1648,6 +1650,7 @@ InternalIteratorBase<BlockHandle>* BlockBasedTable::NewIndexIterator(
 
   IndexReader* index_reader = nullptr;
   if (cache_handle != nullptr) {
+    PERF_COUNTER_ADD(block_cache_index_hit_count, 1);
     index_reader =
         reinterpret_cast<IndexReader*>(block_cache->Value(cache_handle));
   } else {
@@ -1677,6 +1680,7 @@ InternalIteratorBase<BlockHandle>* BlockBasedTable::NewIndexIterator(
         RecordTick(statistics, BLOCK_CACHE_ADD);
         RecordTick(statistics, BLOCK_CACHE_BYTES_WRITE, charge);
       }
+      PERF_COUNTER_ADD(index_block_read_count, 1);
       RecordTick(statistics, BLOCK_CACHE_INDEX_ADD);
       RecordTick(statistics, BLOCK_CACHE_INDEX_BYTES_INSERT, charge);
     } else {


### PR DESCRIPTION
Add counters to track block cache index/filter hits and misses. We currently count aggregate hits and misses, which includes index/filter/data blocks.