### PR TITLE
Expose trx commit sequence number

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -437,6 +437,12 @@ class Transaction {
   virtual void SetLogNumber(uint64_t log) { log_number_ = log; }
 
   virtual uint64_t GetLogNumber() const { return log_number_; }
+  
+  // Sequence number in WAL where operations start, only valid after
+  // a successfull commit with the WRITE_COMMITTED db txn policy
+  virtual SequenceNumber GetCommitedSeqNumber() const {
+    return 0;
+  }
 
   virtual Status SetName(const TransactionName& name) = 0;
 

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -127,7 +127,8 @@ bool PessimisticTransaction::IsExpired() const {
 WriteCommittedTxn::WriteCommittedTxn(TransactionDB* txn_db,
                                      const WriteOptions& write_options,
                                      const TransactionOptions& txn_options)
-    : PessimisticTransaction(txn_db, write_options, txn_options){};
+    : PessimisticTransaction(txn_db, write_options, txn_options),
+      commited_seq_nr_(0) {};
 
 Status PessimisticTransaction::CommitBatch(WriteBatch* batch) {
   TransactionKeyMap keys_to_unlock;
@@ -230,10 +231,15 @@ Status WriteCommittedTxn::PrepareInternal() {
   WriteOptions write_options = write_options_;
   write_options.disableWAL = false;
   WriteBatchInternal::MarkEndPrepare(GetWriteBatch()->GetWriteBatch(), name_);
+  uint64_t seq_used = kMaxSequenceNumber;
   Status s =
       db_impl_->WriteImpl(write_options, GetWriteBatch()->GetWriteBatch(),
-                          /*callback*/ nullptr, &log_number_, /*log ref*/ 0,
-                          /* disable_memtable*/ true);
+                      /*callback*/ nullptr, &log_number_, /*log ref*/ 0,
+                      /*disable_memtable*/ true, &seq_used);
+  assert(!s.ok() || seq_used != kMaxSequenceNumber);
+  if (s.ok()) {
+    commited_seq_nr_ = seq_used;
+  }
   return s;
 }
 
@@ -322,7 +328,14 @@ Status PessimisticTransaction::Commit() {
 }
 
 Status WriteCommittedTxn::CommitWithoutPrepareInternal() {
-  Status s = db_->Write(write_options_, GetWriteBatch()->GetWriteBatch());
+  uint64_t seq_used = kMaxSequenceNumber;
+  auto s = db_impl_->WriteImpl(write_options_, GetWriteBatch()->GetWriteBatch(),
+                               /*callback*/ nullptr, /*log nr*/ nullptr,
+                               /*log ref*/ 0, /*disable_memtable*/ false, &seq_used);
+  assert(!s.ok() || seq_used != kMaxSequenceNumber);
+  if (s.ok()) {
+    commited_seq_nr_ = seq_used;
+  }
   return s;
 }
 

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -204,6 +204,11 @@ class WriteCommittedTxn : public PessimisticTransaction {
                     const TransactionOptions& txn_options);
 
   virtual ~WriteCommittedTxn() {}
+  
+  SequenceNumber GetCommitedSeqNumber() const override {
+    assert(txn_state_ == COMMITED);
+    return commited_seq_nr_;
+  }
 
  private:
   Status PrepareInternal() override;
@@ -219,6 +224,10 @@ class WriteCommittedTxn : public PessimisticTransaction {
   // No copying allowed
   WriteCommittedTxn(const WriteCommittedTxn&);
   void operator=(const WriteCommittedTxn&);
+  
+ protected:
+  // seq_nr of WriteBatch in WAL
+  SequenceNumber commited_seq_nr_;
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
I would like to be able see the WAL sequence number at which a transaction was committed.
This small change would allow us to later find the transaction in the log again. We use this in out application to efficiently keep track of the total number of keys stored in the database, without having to perform a full scan of all keys after a crash.

I only added it to the `WriteCommittedTxn` implementation since I do not know enough about the other write policies that are still in development.

