### PR TITLE
WriteBufferManager JNI fixes

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -180,7 +180,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Also, a larger write buffer will result in a longer recovery time
   // the next time the database is opened.
   //
-  // Note that write_buffer_size is enforced per column family.
+  // Note that block_cache_data_addwrite_buffer_size is enforced per column family.
   // See db_write_buffer_size for sharing memory across column families.
   //
   // Default: 64MB

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -669,7 +669,7 @@ struct DBOptions {
   // is issued.
   //
   // If the object is only passed to on DB, the behavior is the same as
-  // db_write_buffer_size. When write_buffer_manager is set, the value set will
+  // db_write_buffer_size. When write_buffer_managerrocksdb_max_memtables is set, the value set will
   // override db_write_buffer_size.
   //
   // This feature is disabled by default. Specify a non-zero value

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -669,7 +669,7 @@ struct DBOptions {
   // is issued.
   //
   // If the object is only passed to on DB, the behavior is the same as
-  // db_write_buffer_size. When write_buffer_managerrocksdb_max_memtables is set, the value set will
+  // db_write_buffer_size. When write_buffer_manager is set, the value set will
   // override db_write_buffer_size.
   //
   // This feature is disabled by default. Specify a non-zero value

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -180,7 +180,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Also, a larger write buffer will result in a longer recovery time
   // the next time the database is opened.
   //
-  // Note that block_cache_data_addwrite_buffer_size is enforced per column family.
+  // Note that write_buffer_size is enforced per column family.
   // See db_write_buffer_size for sharing memory across column families.
   //
   // Default: 64MB

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -5534,6 +5534,20 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
 
 /*
  * Class:     org_rocksdb_DBOptions
+ * Method:    setWriteBufferManager
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_DBOptions_setWriteBufferManager(JNIEnv* /*env*/, jobject /*jobj*/,
+                                                      jlong joptions_handle,
+                                                      jlong jwrite_buffer_manager_handle) {
+auto* write_buffer_manager =
+        reinterpret_cast<std::shared_ptr<rocksdb::WriteBufferManager> *>(jwrite_buffer_manager_handle);
+reinterpret_cast<rocksdb::DBOptions*>(joptions_handle)->write_buffer_manager =
+        *write_buffer_manager;
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
  * Method:    dbWriteBufferSize
  * Signature: (J)J
  */

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -5538,11 +5538,11 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
  * Signature: (JJ)V
  */
 void Java_org_rocksdb_DBOptions_setWriteBufferManager(JNIEnv* /*env*/, jobject /*jobj*/,
-                                                      jlong joptions_handle,
+                                                      jlong jdb_options_handle,
                                                       jlong jwrite_buffer_manager_handle) {
 auto* write_buffer_manager =
         reinterpret_cast<std::shared_ptr<rocksdb::WriteBufferManager> *>(jwrite_buffer_manager_handle);
-reinterpret_cast<rocksdb::DBOptions*>(joptions_handle)->write_buffer_manager =
+reinterpret_cast<rocksdb::DBOptions*>(jdb_options_handle)->write_buffer_manager =
         *write_buffer_manager;
 }
 

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -5540,10 +5540,10 @@ void Java_org_rocksdb_DBOptions_setDbWriteBufferSize(
 void Java_org_rocksdb_DBOptions_setWriteBufferManager(JNIEnv* /*env*/, jobject /*jobj*/,
                                                       jlong jdb_options_handle,
                                                       jlong jwrite_buffer_manager_handle) {
-auto* write_buffer_manager =
-        reinterpret_cast<std::shared_ptr<rocksdb::WriteBufferManager> *>(jwrite_buffer_manager_handle);
-reinterpret_cast<rocksdb::DBOptions*>(jdb_options_handle)->write_buffer_manager =
-        *write_buffer_manager;
+  auto* write_buffer_manager =
+      reinterpret_cast<std::shared_ptr<rocksdb::WriteBufferManager> *>(jwrite_buffer_manager_handle);
+  reinterpret_cast<rocksdb::DBOptions*>(jdb_options_handle)->write_buffer_manager =
+      *write_buffer_manager;
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -677,7 +677,7 @@ public class DBOptions
   }
 
   @Override
-  public WriteBufferManager getWriteBufferManager() {
+  public WriteBufferManager writeBufferManager() {
     assert(isOwningHandle());
     return this.writeBufferManager_;
   }

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -677,6 +677,12 @@ public class DBOptions
   }
 
   @Override
+  public WriteBufferManager getWriteBufferManager() {
+    assert(isOwningHandle());
+    return this.writeBufferManager_;
+  }
+
+    @Override
   public long dbWriteBufferSize() {
     assert(isOwningHandle());
     return dbWriteBufferSize(nativeHandle_);

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -46,6 +46,7 @@ public class DBOptions
     this.numShardBits_ = other.numShardBits_;
     this.rateLimiter_ = other.rateLimiter_;
     this.rowCache_ = other.rowCache_;
+    this.writeBufferManager_ = other.writeBufferManager_;
   }
 
   /**
@@ -671,6 +672,7 @@ public class DBOptions
   public DBOptions setWriteBufferManager(final WriteBufferManager writeBufferManager) {
     assert(isOwningHandle());
     setWriteBufferManager(nativeHandle_, writeBufferManager.nativeHandle_);
+    this.writeBufferManager_ = writeBufferManager;
     return this;
   }
 
@@ -1167,4 +1169,5 @@ public class DBOptions
   private int numShardBits_;
   private RateLimiter rateLimiter_;
   private Cache rowCache_;
+  private WriteBufferManager writeBufferManager_;
 }

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1011,7 +1011,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    *
    * @return a reference to WriteBufferManager
    */
-  WriteBufferManager getWriteBufferManager();
+  WriteBufferManager writeBufferManager();
 
   /**
    * Amount of data to build up in memtables across all column

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1005,7 +1005,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
   T setWriteBufferManager(final WriteBufferManager writeBufferManager);
 
   /**
-   * Reference to WriteBufferManager used by it. <br>
+   * Reference to {@link WriteBufferManager} used by it. <br>
    *
    * Default: null (Disabled)
    *

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1005,6 +1005,15 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
   T setWriteBufferManager(final WriteBufferManager writeBufferManager);
 
   /**
+   * Reference to WriteBufferManager used by it. <br>
+   *
+   * Default: null (Disabled)
+   *
+   * @return a reference to WriteBufferManager
+   */
+  WriteBufferManager getWriteBufferManager();
+
+  /**
    * Amount of data to build up in memtables across all column
    * families before writing to disk.
    *

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -733,7 +733,7 @@ public class Options extends RocksObject
   }
 
   @Override
-  public WriteBufferManager getWriteBufferManager() {
+  public WriteBufferManager writeBufferManager() {
     assert(isOwningHandle());
     return this.writeBufferManager_;
   }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -70,6 +70,7 @@ public class Options extends RocksObject
     this.compactionOptionsFIFO_ = other.compactionOptionsFIFO_;
     this.compressionOptions_ = other.compressionOptions_;
     this.rowCache_ = other.rowCache_;
+    this.writeBufferManager_ = other.writeBufferManager_;
   }
 
   @Override
@@ -727,6 +728,7 @@ public class Options extends RocksObject
   public Options setWriteBufferManager(final WriteBufferManager writeBufferManager) {
     assert(isOwningHandle());
     setWriteBufferManager(nativeHandle_, writeBufferManager.nativeHandle_);
+    this.writeBufferManager_ = writeBufferManager;
     return this;
   }
 
@@ -1918,4 +1920,5 @@ public class Options extends RocksObject
   private CompactionOptionsFIFO compactionOptionsFIFO_;
   private CompressionOptions compressionOptions_;
   private Cache rowCache_;
+  private WriteBufferManager writeBufferManager_;
 }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -733,6 +733,12 @@ public class Options extends RocksObject
   }
 
   @Override
+  public WriteBufferManager getWriteBufferManager() {
+    assert(isOwningHandle());
+    return this.writeBufferManager_;
+  }
+
+    @Override
   public long dbWriteBufferSize() {
     assert(isOwningHandle());
     return dbWriteBufferSize(nativeHandle_);

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -430,6 +430,7 @@ public class DBOptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
+      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -426,7 +426,7 @@ public class DBOptionsTest {
 
   @Test
   public void setWriteBufferManager() throws RocksDBException {
-    try (final Options opt = new Options();
+    try (final DBOptions opt = new DBOptions();
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
@@ -435,7 +435,7 @@ public class DBOptionsTest {
 
   @Test
   public void setWriteBufferManagerWithZeroBufferSize() throws RocksDBException {
-    try (final Options opt = new Options();
+    try (final DBOptions opt = new DBOptions();
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -430,7 +430,7 @@ public class DBOptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
-      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
+      assertThat(opt.writeBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 
@@ -440,7 +440,7 @@ public class DBOptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
-      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
+      assertThat(opt.writeBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -440,6 +440,7 @@ public class DBOptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
+      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -651,7 +651,7 @@ public class OptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
-      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
+      assertThat(opt.writeBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 
@@ -661,7 +661,7 @@ public class OptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
-      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
+      assertThat(opt.writeBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -661,6 +661,7 @@ public class OptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(0l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
+      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -651,6 +651,7 @@ public class OptionsTest {
          final Cache cache = new LRUCache(1 * 1024 * 1024);
          final WriteBufferManager writeBufferManager = new WriteBufferManager(2000l, cache)) {
       opt.setWriteBufferManager(writeBufferManager);
+      assertThat(opt.getWriteBufferManager()).isEqualTo(writeBufferManager);
     }
   }
 


### PR DESCRIPTION
1. `WriteBufferManager` should have a reference alive in Java side through `Options`/`DBOptions` otherwise, if it's GC'ed at java side, native side can seg fault.
2. native method `setWriteBufferManager()` in `DBOptions.java` doesn't have it's jni method invocation in rocksdbjni which is added in this PR
3. `DBOptionsTest.java` is referencing object of `Options`. Instead it should be testing against `DBOptions`. Seems like a copy paste error. 
4. Add a getter for WriteBufferManager.