### PR TITLE
Fix two contrun job failures

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -674,5 +674,17 @@ int InternalKeyComparator::CompareKeySeq(const Slice& akey,
   return r;
 }
 
+struct ParsedInternalKeyComparator {
+  explicit ParsedInternalKeyComparator(const InternalKeyComparator* c)
+      : cmp(c) {}
+
+  bool operator()(const ParsedInternalKey& a,
+                  const ParsedInternalKey& b) const {
+    return cmp->Compare(a, b) < 0;
+  }
+
+  const InternalKeyComparator* cmp;
+};
+
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -22,18 +22,6 @@ struct TombstoneStartKeyComparator {
   const InternalKeyComparator* cmp;
 };
 
-struct ParsedInternalKeyComparator {
-  explicit ParsedInternalKeyComparator(const InternalKeyComparator* c)
-      : cmp(c) {}
-
-  bool operator()(const ParsedInternalKey& a,
-                  const ParsedInternalKey& b) const {
-    return cmp->Compare(a, b) < 0;
-  }
-
-  const InternalKeyComparator* cmp;
-};
-
 // An UncollapsedRangeDelMap is quick to create but slow to answer ShouldDelete
 // queries.
 class UncollapsedRangeDelMap : public RangeDelMap {

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -17,22 +17,6 @@
 
 namespace rocksdb {
 
-namespace {
-
-struct ParsedInternalKeyComparator {
-  explicit ParsedInternalKeyComparator(const InternalKeyComparator* c)
-      : cmp(c) {}
-
-  bool operator()(const ParsedInternalKey& a,
-                  const ParsedInternalKey& b) const {
-    return cmp->Compare(a, b) < 0;
-  }
-
-  const InternalKeyComparator* cmp;
-};
-
-}  // anonymous namespace
-
 FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     std::unique_ptr<InternalIterator> unfragmented_tombstones,
     const InternalKeyComparator& icmp, SequenceNumber snapshot)

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -938,6 +938,9 @@ DEFINE_uint64(max_compaction_bytes, rocksdb::Options().max_compaction_bytes,
 
 #ifndef ROCKSDB_LITE
 DEFINE_bool(readonly, false, "Run read only benchmarks.");
+
+DEFINE_bool(print_malloc_stats, false,
+            "Print malloc stats to stdout after benchmarks finish.");
 #endif  // ROCKSDB_LITE
 
 DEFINE_bool(disable_auto_compactions, false, "Do not auto trigger compactions");
@@ -1038,9 +1041,6 @@ DEFINE_bool(identity_as_first_hash, false, "the first hash function of cuckoo "
 DEFINE_bool(dump_malloc_stats, true, "Dump malloc stats in LOG ");
 DEFINE_uint64(stats_dump_period_sec, rocksdb::Options().stats_dump_period_sec,
               "Gap between printing stats to log in seconds");
-
-DEFINE_bool(print_malloc_stats, false,
-            "Print malloc stats to stdout after benchmarks finish.");
 
 enum RepFactory {
   kSkipList,
@@ -5809,11 +5809,13 @@ int db_bench_tool(int argc, char** argv) {
   rocksdb::Benchmark benchmark;
   benchmark.Run();
 
+#ifndef ROCKSDB_LITE
   if (FLAGS_print_malloc_stats) {
     std::string stats_string;
     rocksdb::DumpMallocStats(&stats_string);
     fprintf(stdout, "Malloc stats:\n%s\n", stats_string.c_str());
   }
+#endif  // ROCKSDB_LITE
 
   return 0;
 }


### PR DESCRIPTION
Currently there are two contrun test failures:
* rocksdb-contrun-lite: 
> tools/db_bench_tool.cc: In function ‘int rocksdb::db_bench_tool(int, char**)’:
tools/db_bench_tool.cc:5814:5: error: ‘DumpMallocStats’ is not a member of ‘rocksdb’
     rocksdb::DumpMallocStats(&stats_string);
     ^
make: *** [tools/db_bench_tool.o] Error 1
* rocksdb-contrun-unity:
> In file included from unity.cc:44:0:
db/range_tombstone_fragmenter.cc: In member function ‘void rocksdb::FragmentedRangeTombstoneIterator::FragmentTombstones(std::unique_ptr<rocksdb::InternalIteratorBase<rocksdb::Slice> >, rocksdb::SequenceNumber)’:
db/range_tombstone_fragmenter.cc:90:14: error: reference to ‘ParsedInternalKeyComparator’ is ambiguous
   auto cmp = ParsedInternalKeyComparator(icmp_);

This PR will fix them