### PR TITLE
Thread.sleep() in StatisticsCollector

### DIFF
--- a/java/src/main/java/org/rocksdb/StatisticsCollector.java
+++ b/java/src/main/java/org/rocksdb/StatisticsCollector.java
@@ -93,9 +93,9 @@ public class StatisticsCollector {
                   statsCallback.histogramCallback(histogramType, histogramData);
                 }
               }
-
-              Thread.sleep(_statsCollectionInterval);
             }
+
+            Thread.sleep(_statsCollectionInterval);
           }
           catch (final InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
In  'StatisticsCollector', the call of Thread.sleep() might be better outside the loop?