### PR TITLE
Avoid memtable cut when active memtable is empty

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1165,6 +1165,9 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
   }
 
   for (const auto cfd : cfds) {
+    if (cfd->mem()->IsEmpty()) {
+      continue;
+    }
     cfd->Ref();
     status = SwitchMemtable(cfd, write_context);
     cfd->Unref();
@@ -1318,7 +1321,9 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
   }
   Status status;
   for (auto& cfd : cfds) {
-    status = SwitchMemtable(cfd, context);
+    if (!cfd->mem()->IsEmpty()) {
+      status = SwitchMemtable(cfd, context);
+    }
     if (cfd->Unref()) {
       delete cfd;
       cfd = nullptr;


### PR DESCRIPTION
For flush triggered by RocksDB due to memory usage approaching certain
threshold (WriteBufferManager or Memtable full), we should cut the memtable
only when the current active memtable is not empty, i.e. contains data. This is
what we do for non-atomic flush. If we always cut memtable even when the active
memtable is empty, we will generate extra, empty immutable memtable.
This is not ideal since it may cause write stall. It also causes some
DBAtomicFlushTest to fail because cfd->imm()->NumNotFlushed() is different from
expectation.

Test plan
```
$make clean && make J=1 -j32 all check
$make clean && OPT="-DROCKSDB_LITE -g" make J=1 -j32 all check
$make clean && TEST_TMPDIR=/dev/shm/rocksdb OPT=-g make J=1 -j32 valgrind_test
```