### PR TITLE
optimized the performance of autovector::emplace_back.

### DIFF
--- a/util/autovector.h
+++ b/util/autovector.h
@@ -271,7 +271,12 @@ class autovector {
 
   template <class... Args>
   void emplace_back(Args&&... args) {
-    push_back(value_type(args...));
+    if (num_stack_items_ < kSize) {
+      values_[num_stack_items_++] =
+          std::move(value_type(std::forward<Args>(args)...));
+    } else {
+      vect_.emplace_back(std::forward<Args>(args)...);
+    }
   }
 
   void pop_back() {


### PR DESCRIPTION
It called the autovector::push_back simply in autovector::emplace_back.
This was not efficient, and then optimazed this function through the
perfect forwarding.

This was the src and result of the benchmark(using the google'benchmark library, the type of elem in
autovector was std::string, and call emplace_back with the "char *" type):

https://gist.github.com/monadbobo/93448b89a42737b08cbada81de75c5cd

