### PR TITLE
Enable crash-recovery stress test for atomic flush

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -881,6 +881,7 @@ crash_test: whitebox_crash_test blackbox_crash_test
 
 blackbox_crash_test: db_stress
 	python -u tools/db_crashtest.py --simple blackbox $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py --enable_atomic_flush blackbox $(CRASH_TEST_EXT_ARGS)
 	python -u tools/db_crashtest.py blackbox $(CRASH_TEST_EXT_ARGS)
 
 ifeq ($(CRASH_TEST_KILL_ODD),)
@@ -889,6 +890,8 @@ endif
 
 whitebox_crash_test: db_stress
 	python -u tools/db_crashtest.py --simple whitebox --random_kill_odd \
+      $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py --enable_atomic_flush whitebox  --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
 	python -u tools/db_crashtest.py whitebox  --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -15,6 +15,9 @@ import argparse
 #       default_params < {blackbox,whitebox}_default_params <
 #       simple_default_params <
 #       {blackbox,whitebox}_simple_default_params < args
+#   for enable_atomic_flush:
+#       default_params < {blackbox,whitebox}_default_params <
+#       atomic_flush_params < args
 
 expected_values_file = tempfile.NamedTemporaryFile()
 
@@ -122,6 +125,15 @@ blackbox_simple_default_params = {
 
 whitebox_simple_default_params = {}
 
+atomic_flush_params = {
+    "atomic_flush": 1,
+    "disable_wal": 1,
+    "reopen": 0,
+    # use small value for write_buffer_size so that RocksDB triggers flush
+    # more frequently
+    "write_buffer_size": 1024 * 1024,
+}
+
 
 def finalize_and_sanitize(src_params):
     dest_params = dict([(k,  v() if callable(v) else v)
@@ -152,6 +164,8 @@ def gen_cmd_params(args):
             params.update(blackbox_simple_default_params)
         if args.test_type == 'whitebox':
             params.update(whitebox_simple_default_params)
+    if args.enable_atomic_flush:
+        params.update(atomic_flush_params)
 
     for k, v in vars(args).items():
         if v is not None:
@@ -164,7 +178,7 @@ def gen_cmd(params, unknown_params):
         '--{0}={1}'.format(k, v)
         for k, v in finalize_and_sanitize(params).items()
         if k not in set(['test_type', 'simple', 'duration', 'interval',
-                         'random_kill_odd'])
+                         'random_kill_odd', 'enable_atomic_flush'])
         and v is not None] + unknown_params
     return cmd
 
@@ -356,6 +370,7 @@ def main():
         db_stress multiple times")
     parser.add_argument("test_type", choices=["blackbox", "whitebox"])
     parser.add_argument("--simple", action="store_true")
+    parser.add_argument("--enable_atomic_flush", action='store_true')
 
     all_params = dict(default_params.items()
                       + blackbox_default_params.items()


### PR DESCRIPTION
This PR adds test of atomic flush to our continuous stress tests.

Test plan:
```
$make clean && make -j32 db_stress
$python tools/db_crashtest.py --enable_atomic_flush blackbox
$python tools/db_crashtest.py --enable_atomic_flush whitebox
```