### PR TITLE
RocksJava: Add the missing FIFO compaction options

### DIFF
--- a/java/rocksjni/compaction_options_fifo.cc
+++ b/java/rocksjni/compaction_options_fifo.cc
@@ -48,6 +48,53 @@ jlong Java_org_rocksdb_CompactionOptionsFIFO_maxTableFilesSize(JNIEnv* /*env*/,
 
 /*
  * Class:     org_rocksdb_CompactionOptionsFIFO
+ * Method:    setTtl
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_CompactionOptionsFIFO_setTtl(JNIEnv* /*env*/,
+                                                   jobject /*jobj*/,
+                                                   jlong jhandle, jlong ttl) {
+  auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
+  opt->ttl = static_cast<uint64_t>(ttl);
+}
+
+/*
+ * Class:     org_rocksdb_CompactionOptionsFIFO
+ * Method:    ttl
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_CompactionOptionsFIFO_ttl(JNIEnv* /*env*/,
+                                                 jobject /*jobj*/,
+                                                 jlong jhandle) {
+  auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
+  return static_cast<jlong>(opt->ttl);
+}
+
+/*
+ * Class:     org_rocksdb_CompactionOptionsFIFO
+ * Method:    setAllowCompaction
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_CompactionOptionsFIFO_setAllowCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle,
+    jboolean allow_compaction) {
+  auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
+  opt->allow_compaction = static_cast<bool>(allow_compaction);
+}
+
+/*
+ * Class:     org_rocksdb_CompactionOptionsFIFO
+ * Method:    allowCompaction
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_CompactionOptionsFIFO_allowCompaction(
+    JNIEnv* /*env*/, jobject /*jobj*/, jlong jhandle) {
+  auto* opt = reinterpret_cast<rocksdb::CompactionOptionsFIFO*>(jhandle);
+  return static_cast<jboolean>(opt->allow_compaction);
+}
+
+/*
+ * Class:     org_rocksdb_CompactionOptionsFIFO
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/CompactionOptionsFIFO.java
+++ b/java/src/main/java/org/rocksdb/CompactionOptionsFIFO.java
@@ -42,8 +42,77 @@ public class CompactionOptionsFIFO extends RocksObject {
     return maxTableFilesSize(nativeHandle_);
   }
 
+  /**
+   * Drop files older than TTL. TTL based deletion will take precedence over
+   * size based deletion if ttl &gt; 0.
+   * delete if sst_file_creation_time &lt; (current_time - ttl).
+   * unit: seconds. Ex: 1 day = 1 * 24 * 60 * 60
+   *
+   * Default: 0 (disabled)
+   *
+   * @param ttl The ttl for the table files in seconds
+   *
+   * @return the reference to the current options.
+   */
+  public CompactionOptionsFIFO setTtl(final long ttl) {
+    setTtl(nativeHandle_, ttl);
+    return this;
+  }
+
+  /**
+   * The current ttl value.
+   * Drop files older than TTL. TTL based deletion will take precedence over
+   * size based deletion if ttl &gt; 0.
+   * delete if sst_file_creation_time &lt; (current_time - ttl).
+   *
+   * Default: 0 (disabled)
+   *
+   * @return the ttl in seconds
+   */
+  public long ttl() {
+    return ttl(nativeHandle_);
+  }
+
+  /**
+   * If true, try to do compaction to compact smaller files into larger ones.
+   * Minimum files to compact follows options.level0_file_num_compaction_trigger
+   * and compaction won't trigger if average compact bytes per del file is
+   * larger than options.write_buffer_size. This is to protect large files
+   * from being compacted again.
+   *
+   * Default: false
+   *
+   * @param allowCompaction should allow intra-L0 compaction?
+   *
+   * @return the reference to the current options.
+   */
+  public CompactionOptionsFIFO setAllowCompaction(final boolean allowCompaction) {
+    setAllowCompaction(nativeHandle_, allowCompaction);
+    return this;
+  }
+
+  /**
+   * Check if intra-L0 compaction is enabled.
+   * If true, try to do compaction to compact smaller files into larger ones.
+   * Minimum files to compact follows options.level0_file_num_compaction_trigger
+   * and compaction won't trigger if average compact bytes per del file is
+   * larger than options.write_buffer_size. This is to protect large files
+   * from being compacted again.
+   *
+   * Default: false
+   *
+   * @return a boolean value indicating whether intra-L0 compaction is enabled
+   */
+  public boolean allowCompaction() {
+    return allowCompaction(nativeHandle_);
+  }
+
   private native void setMaxTableFilesSize(long handle, long maxTableFilesSize);
   private native long maxTableFilesSize(long handle);
+  private native void setTtl(long handle, long ttl);
+  private native long ttl(long handle);
+  private native void setAllowCompaction(long handle, boolean allowCompaction);
+  private native boolean allowCompaction(long handle);
 
   private native static long newCompactionOptionsFIFO();
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/test/java/org/rocksdb/CompactionOptionsFIFOTest.java
+++ b/java/src/test/java/org/rocksdb/CompactionOptionsFIFOTest.java
@@ -18,9 +18,27 @@ public class CompactionOptionsFIFOTest {
   @Test
   public void maxTableFilesSize() {
     final long size = 500 * 1024 * 1026;
-    try(final CompactionOptionsFIFO opt = new CompactionOptionsFIFO()) {
+    try (final CompactionOptionsFIFO opt = new CompactionOptionsFIFO()) {
       opt.setMaxTableFilesSize(size);
       assertThat(opt.maxTableFilesSize()).isEqualTo(size);
+    }
+  }
+
+  @Test
+  public void ttl() {
+    final long ttl = 7 * 24 * 60 * 60; // 7 days
+    try (final CompactionOptionsFIFO opt = new CompactionOptionsFIFO()) {
+      opt.setTtl(ttl);
+      assertThat(opt.ttl()).isEqualTo(ttl);
+    }
+  }
+
+  @Test
+  public void allowCompaction() {
+    final boolean allowCompaction = true;
+    try (final CompactionOptionsFIFO opt = new CompactionOptionsFIFO()) {
+      opt.setAllowCompaction(allowCompaction);
+      assertThat(opt.allowCompaction()).isEqualTo(allowCompaction);
     }
   }
 }


### PR DESCRIPTION
Make CompactionOptionsFIFO's ttl and allow_compaction options to be available in RocksJava.

Test Plan:
New tests.