### PR TITLE
2pc log rolling unit test

### DIFF
--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -206,6 +206,8 @@ Status PessimisticTransaction::Prepare() {
     if (s.ok()) {
       assert(log_number_ != 0);
       if (!wal_already_marked) {
+        TEST_SYNC_POINT("PessimisticTransaction::Prepare:BeforeMark1");
+        TEST_SYNC_POINT("PessimisticTransaction::Prepare:BeforeMark2");
         dbimpl_->logs_with_prep_tracker()->MarkLogAsContainingPrepSection(
             log_number_);
       }


### PR DESCRIPTION
In 2PC transaction, after we write a prepare entry into WAL, we call a Flush before `MarkLogAsContainingPrepSection`, the log file containing the prepare entry will be deleted.