### PR TITLE
exclude get db property calls from rocksdb_lite 

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -246,12 +246,12 @@ TEST_F(DBFlushTest, ManualFlushFailsInReadOnlyMode) {
   fault_injection_env->SetFilesystemActive(false);
   ASSERT_OK(db_->ContinueBackgroundWork());
   dbfull()->TEST_WaitForFlushMemTable();
-  uint64_t num_bg_errors;
 #ifndef ROCKSDB_LITE
+  uint64_t num_bg_errors;
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kBackgroundErrors,
                                   &num_bg_errors));
-#endif  // ROCKSDB_LITE
   ASSERT_GT(num_bg_errors, 0);
+#endif  // ROCKSDB_LITE
 
   // In the bug scenario, triggering another flush would cause the second flush
   // to hang forever. After the fix we expect it to return an error.

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -247,8 +247,10 @@ TEST_F(DBFlushTest, ManualFlushFailsInReadOnlyMode) {
   ASSERT_OK(db_->ContinueBackgroundWork());
   dbfull()->TEST_WaitForFlushMemTable();
   uint64_t num_bg_errors;
+#ifndef ROCKSDB_LITE
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kBackgroundErrors,
                                   &num_bg_errors));
+#endif  // ROCKSDB_LITE
   ASSERT_GT(num_bg_errors, 0);
 
   // In the bug scenario, triggering another flush would cause the second flush


### PR DESCRIPTION
fix current failing lite test:
> In file included from ./util/testharness.h:15:0,
                 from ./table/mock_table.h:23,
                 from ./db/db_test_util.h:44,
                 from db/db_flush_test.cc:10:
db/db_flush_test.cc: In member function ‘virtual void rocksdb::DBFlushTest_ManualFlushFailsInReadOnlyMode_Test::TestBody()’:
db/db_flush_test.cc:250:35: error: ‘Properties’ is not a member of ‘rocksdb::DB’
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kBackgroundErrors,
                                   ^
make: *** [db/db_flush_test.o] Error 1