### PR TITLE
Modify FragmentedRangeTombstoneList member layout

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -741,12 +741,11 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              comparator_.comparator,
                                              true /* one_time_use */, snapshot);
-  FragmentedRangeTombstoneIterator fragment_iter(&fragment_list,
+  FragmentedRangeTombstoneIterator fragment_iter(&fragment_list, snapshot,
                                                  comparator_.comparator);
-  *max_covering_tombstone_seq = std::max(
-      *max_covering_tombstone_seq,
-      MaxCoveringTombstoneSeqnum(&fragment_iter, key.internal_key(),
-                                 comparator_.comparator.user_comparator()));
+  *max_covering_tombstone_seq =
+      std::max(*max_covering_tombstone_seq,
+               fragment_iter.MaxCoveringTombstoneSeqnum(key.user_key()));
 
   Slice user_key = key.user_key();
   bool found_final_value = false;

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -202,7 +202,6 @@ FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     const InternalKeyComparator& icmp)
     : tombstone_start_cmp_(icmp.user_comparator()),
       tombstone_end_cmp_(icmp.user_comparator()),
-      icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_(tombstones) {
   assert(tombstones_ != nullptr);
@@ -215,7 +214,6 @@ FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     const InternalKeyComparator& icmp)
     : tombstone_start_cmp_(icmp.user_comparator()),
       tombstone_end_cmp_(icmp.user_comparator()),
-      icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_ref_(tombstones),
       tombstones_(tombstones_ref_.get()) {

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -109,7 +109,7 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
       // Flush a range tombstone fragment [cur_start_key, cur_end_key), which
       // should not overlap with the last-flushed tombstone fragment.
       assert(tombstones_.empty() ||
-             icmp.user_comparator()->Compare(tombstones_.back().end_key_,
+             icmp.user_comparator()->Compare(tombstones_.back().end_key,
                                                cur_start_key) <= 0);
 
       if (one_time_use) {
@@ -118,9 +118,10 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
           max_seqnum = std::max(max_seqnum, flush_it->sequence);
         }
 
-        // Flush only the tombstone fragment with the highest sequence number.
-        tombstones_.push_back(
-            RangeTombstone(cur_start_key, cur_end_key, max_seqnum));
+        size_t start_idx = tombstone_seqs_.size();
+        tombstone_seqs_.push_back(max_seqnum);
+        tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx,
+                                 start_idx + 1);
       } else {
         // Sort the sequence numbers of the tombstones being fragmented in
         // descending order, and then flush them in that order.
@@ -130,10 +131,12 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
         }
         std::sort(seqnums_to_flush.begin(), seqnums_to_flush.end(),
                   std::greater<SequenceNumber>());
-        for (const auto seq : seqnums_to_flush) {
-          tombstones_.push_back(
-              RangeTombstone(cur_start_key, cur_end_key, seq));
-        }
+        size_t start_idx = tombstone_seqs_.size();
+        size_t end_idx = start_idx + seqnums_to_flush.size();
+        tombstone_seqs_.insert(tombstone_seqs_.end(), seqnums_to_flush.begin(),
+                               seqnums_to_flush.end());
+        tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx,
+                                 end_idx);
       }
       cur_start_key = cur_end_key;
     }
@@ -197,7 +200,8 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
 FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     const FragmentedRangeTombstoneList* tombstones,
     const InternalKeyComparator& icmp)
-    : tombstone_cmp_(icmp.user_comparator()),
+    : tombstone_start_cmp_(icmp.user_comparator()),
+      tombstone_end_cmp_(icmp.user_comparator()),
       icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_(tombstones) {
@@ -209,22 +213,27 @@ FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
 FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     const std::shared_ptr<const FragmentedRangeTombstoneList>& tombstones,
     const InternalKeyComparator& icmp)
-    : tombstone_cmp_(icmp.user_comparator()),
+    : tombstone_start_cmp_(icmp.user_comparator()),
+      tombstone_end_cmp_(icmp.user_comparator()),
       icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_ref_(tombstones),
       tombstones_(tombstones_ref_.get()) {
   assert(tombstones_ != nullptr);
   pos_ = tombstones_->end();
+  seq_pos_ = tombstones_->seq_end();
   pinned_pos_ = tombstones_->end();
+  pinned_seq_pos_ = tombstones_->seq_end();
 }
 
 void FragmentedRangeTombstoneIterator::SeekToFirst() {
   pos_ = tombstones_->begin();
+  seq_pos_ = tombstones_->seq_begin();
 }
 
 void FragmentedRangeTombstoneIterator::SeekToLast() {
   pos_ = tombstones_->end();
+  seq_pos_ = tombstones_->seq_end();
   Prev();
 }
 
@@ -233,37 +242,67 @@ void FragmentedRangeTombstoneIterator::Seek(const Slice& target) {
     pos_ = tombstones_->end();
     return;
   }
-  RangeTombstone search(ExtractUserKey(target), ExtractUserKey(target),
-                        GetInternalKeySeqno(target));
-  pos_ = std::lower_bound(tombstones_->begin(), tombstones_->end(), search,
-                          tombstone_cmp_);
+  pos_ = std::upper_bound(tombstones_->begin(), tombstones_->end(),
+                          ExtractUserKey(target), tombstone_end_cmp_);
+  if (pos_ == tombstones_->end()) {
+    seq_pos_ = tombstones_->seq_end();
+    return;
+  }
+  seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
+                              tombstones_->seq_iter(pos_->seq_end_idx),
+                              GetInternalKeySeqno(target),
+                              std::greater<SequenceNumber>());
+  if (seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx)) {
+    ++pos_;
+  }
 }
 
 void FragmentedRangeTombstoneIterator::SeekForPrev(const Slice& target) {
-  Seek(target);
-  if (!Valid()) {
-    SeekToLast();
-  }
-  ParsedInternalKey parsed_target;
-  if (!ParseInternalKey(target, &parsed_target)) {
-    assert(false);
-  }
-  ParsedInternalKey parsed_start_key;
-  ParseKey(&parsed_start_key);
-  while (Valid() && icmp_->Compare(parsed_target, parsed_start_key) < 0) {
-    Prev();
-    ParseKey(&parsed_start_key);
-  }
-}
-
-void FragmentedRangeTombstoneIterator::Next() { ++pos_; }
-
-void FragmentedRangeTombstoneIterator::Prev() {
-  if (pos_ == tombstones_->begin()) {
+  if (tombstones_->empty()) {
     pos_ = tombstones_->end();
     return;
   }
+  pos_ = std::upper_bound(tombstones_->begin(), tombstones_->end(),
+                          ExtractUserKey(target), tombstone_start_cmp_);
+  if (pos_ == tombstones_->begin()) {
+    pos_ = tombstones_->end();
+    seq_pos_ = tombstones_->seq_end();
+    return;
+  }
   --pos_;
+  seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
+                              tombstones_->seq_iter(pos_->seq_end_idx),
+                              GetInternalKeySeqno(target),
+                              std::greater<SequenceNumber>());
+  if (seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx)) {
+    if (pos_ == tombstones_->begin()) {
+      pos_ = tombstones_->end();
+      seq_pos_ = tombstones_->seq_end();
+      return;
+    }
+    --pos_;
+    seq_pos_ = tombstones_->seq_iter(pos_->seq_start_idx);
+  }
+}
+
+void FragmentedRangeTombstoneIterator::Next() {
+  ++seq_pos_;
+  if (seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx)) {
+    ++pos_;
+  }
+}
+
+void FragmentedRangeTombstoneIterator::Prev() {
+  if (seq_pos_ == tombstones_->seq_begin()) {
+    pos_ = tombstones_->end();
+    seq_pos_ = tombstones_->seq_end();
+    return;
+  }
+  --seq_pos_;
+  if (pos_ == tombstones_->end() ||
+      seq_pos_ == tombstones_->seq_iter(pos_->seq_start_idx - 1)) {
+    --pos_;
+  }
 }
 
 bool FragmentedRangeTombstoneIterator::Valid() const {
@@ -277,25 +316,12 @@ SequenceNumber MaxCoveringTombstoneSeqnum(
     return 0;
   }
 
-  SequenceNumber snapshot = GetInternalKeySeqno(lookup_key);
-  Slice user_key = ExtractUserKey(lookup_key);
-
   tombstone_iter->Seek(lookup_key);
-  SequenceNumber highest_covering_seqnum = 0;
-  if (!tombstone_iter->Valid()) {
-    // Seeked past the last tombstone
-    tombstone_iter->Prev();
-  }
-  while (tombstone_iter->Valid() &&
-         ucmp->Compare(user_key, tombstone_iter->value()) < 0) {
-    if (tombstone_iter->seq() <= snapshot &&
-        ucmp->Compare(tombstone_iter->user_key(), user_key) <= 0) {
-      highest_covering_seqnum =
-          std::max(highest_covering_seqnum, tombstone_iter->seq());
-    }
-    tombstone_iter->Prev();
-  }
-  return highest_covering_seqnum;
+  return tombstone_iter->Valid() &&
+                 ucmp->Compare(tombstone_iter->start_key(),
+                               ExtractUserKey(lookup_key)) <= 0
+             ? tombstone_iter->seq()
+             : 0;
 }
 
 }  // namespace rocksdb

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -166,8 +166,8 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
   };
 
   void MaybePinKey() const {
-    if (pos_ != tombstones_->end() && pinned_pos_ != pos_ &&
-        seq_pos_ != tombstones_->seq_end() && pinned_seq_pos_ != seq_pos_) {
+    if (pos_ != tombstones_->end() && seq_pos_ != tombstones_->seq_end() &&
+        (pinned_pos_ != pos_ || pinned_seq_pos_ != seq_pos_)) {
       current_start_key_.Set(pos_->start_key, *seq_pos_, kTypeRangeDeletion);
       pinned_pos_ = pos_;
       pinned_seq_pos_ = seq_pos_;

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -19,17 +19,47 @@ namespace rocksdb {
 
 struct FragmentedRangeTombstoneList {
  public:
+  // A compact representation of a "stack" of range tombstone fragments, which
+  // start and end at the same user keys but have different sequence numbers.
+  // The members seq_start_idx and seq_end_idx are intended to be parameters to
+  // seq_iter().
+  struct RangeTombstoneStack {
+    RangeTombstoneStack(const Slice& start, const Slice& end, int start_idx,
+                        int end_idx)
+        : start_key(start),
+          end_key(end),
+          seq_start_idx(start_idx),
+          seq_end_idx(end_idx) {}
+
+    Slice start_key;
+    Slice end_key;
+    size_t seq_start_idx;
+    // TODO: see if seq_end_idx can be removed
+    size_t seq_end_idx;
+  };
   FragmentedRangeTombstoneList(
       std::unique_ptr<InternalIterator> unfragmented_tombstones,
       const InternalKeyComparator& icmp, bool one_time_use,
       SequenceNumber snapshot = kMaxSequenceNumber);
 
-  std::vector<RangeTombstone>::const_iterator begin() const {
+  std::vector<RangeTombstoneStack>::const_iterator begin() const {
     return tombstones_.begin();
   }
 
-  std::vector<RangeTombstone>::const_iterator end() const {
+  std::vector<RangeTombstoneStack>::const_iterator end() const {
     return tombstones_.end();
+  }
+
+  std::vector<SequenceNumber>::const_iterator seq_iter(size_t idx) const {
+    return std::next(tombstone_seqs_.begin(), idx);
+  }
+
+  std::vector<SequenceNumber>::const_iterator seq_begin() const {
+    return tombstone_seqs_.begin();
+  }
+
+  std::vector<SequenceNumber>::const_iterator seq_end() const {
+    return tombstone_seqs_.end();
   }
 
   bool empty() const { return tombstones_.size() == 0; }
@@ -37,13 +67,14 @@ struct FragmentedRangeTombstoneList {
  private:
   // Given an ordered range tombstone iterator unfragmented_tombstones,
   // "fragment" the tombstones into non-overlapping pieces, and store them in
-  // tombstones_.
+  // tombstones_ and tombstone_seqs_.
   void FragmentTombstones(
       std::unique_ptr<InternalIterator> unfragmented_tombstones,
       const InternalKeyComparator& icmp, bool one_time_use,
       SequenceNumber snapshot = kMaxSequenceNumber);
 
-  std::vector<RangeTombstone> tombstones_;
+  std::vector<RangeTombstoneStack> tombstones_;
+  std::vector<SequenceNumber> tombstone_seqs_;
   std::list<std::string> pinned_slices_;
   PinnedIteratorsManager pinned_iters_mgr_;
 };
@@ -67,8 +98,16 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
       const InternalKeyComparator& icmp);
   void SeekToFirst() override;
   void SeekToLast() override;
+
+  // Seeks to the range tombstone that covers target's user key at a seqnum
+  // at most target's seqnum. If no such tombstone exists, seek to the earliest
+  // tombstone that ends after target (regardless of its seqnum).
   void Seek(const Slice& target) override;
+  // Seeks to the range tombstone that covers target's user key at a seqnum
+  // at most target's seqnum. If no such tombstone exists, seek to the latest
+  // tombstone that starts before target (regardless of its seqnum).
   void SeekForPrev(const Slice& target) override;
+
   void Next() override;
   void Prev() override;
   bool Valid() const override;
@@ -76,49 +115,75 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
     MaybePinKey();
     return current_start_key_.Encode();
   }
-  Slice value() const override { return pos_->end_key_; }
+  Slice value() const override { return pos_->end_key; }
   bool IsKeyPinned() const override { return false; }
   bool IsValuePinned() const override { return true; }
   Status status() const override { return Status::OK(); }
 
-  Slice user_key() const { return pos_->start_key_; }
-  SequenceNumber seq() const { return pos_->seq_; }
+  Slice start_key() const { return pos_->start_key; }
+  Slice end_key() const { return pos_->end_key; }
+  SequenceNumber seq() const { return *seq_pos_; }
 
  private:
-  struct FragmentedRangeTombstoneComparator {
-    explicit FragmentedRangeTombstoneComparator(const Comparator* c) : cmp(c) {}
+  using RangeTombstoneStack = FragmentedRangeTombstoneList::RangeTombstoneStack;
 
-    bool operator()(const RangeTombstone& a, const RangeTombstone& b) const {
-      int user_key_cmp = cmp->Compare(a.start_key_, b.start_key_);
-      if (user_key_cmp != 0) {
-        return user_key_cmp < 0;
-      }
-      return a.seq_ > b.seq_;
+  struct RangeTombstoneStackStartComparator {
+    explicit RangeTombstoneStackStartComparator(const Comparator* c) : cmp(c) {}
+
+    bool operator()(const RangeTombstoneStack& a,
+                    const RangeTombstoneStack& b) const {
+      return cmp->Compare(a.start_key, b.start_key) < 0;
+    }
+
+    bool operator()(const RangeTombstoneStack& a, const Slice& b) const {
+      return cmp->Compare(a.start_key, b) < 0;
+    }
+
+    bool operator()(const Slice& a, const RangeTombstoneStack& b) const {
+      return cmp->Compare(a, b.start_key) < 0;
+    }
+
+    const Comparator* cmp;
+  };
+
+  struct RangeTombstoneStackEndComparator {
+    explicit RangeTombstoneStackEndComparator(const Comparator* c) : cmp(c) {}
+
+    bool operator()(const RangeTombstoneStack& a,
+                    const RangeTombstoneStack& b) const {
+      return cmp->Compare(a.end_key, b.end_key) < 0;
+    }
+
+    bool operator()(const RangeTombstoneStack& a, const Slice& b) const {
+      return cmp->Compare(a.end_key, b) < 0;
+    }
+
+    bool operator()(const Slice& a, const RangeTombstoneStack& b) const {
+      return cmp->Compare(a, b.end_key) < 0;
     }
 
     const Comparator* cmp;
   };
 
   void MaybePinKey() const {
-    if (pos_ != tombstones_->end() && pinned_pos_ != pos_) {
-      current_start_key_.Set(pos_->start_key_, pos_->seq_, kTypeRangeDeletion);
+    if (pos_ != tombstones_->end() && pinned_pos_ != pos_ &&
+        seq_pos_ != tombstones_->seq_end() && pinned_seq_pos_ != seq_pos_) {
+      current_start_key_.Set(pos_->start_key, *seq_pos_, kTypeRangeDeletion);
       pinned_pos_ = pos_;
+      pinned_seq_pos_ = seq_pos_;
     }
   }
 
-  void ParseKey(ParsedInternalKey* parsed) const {
-    parsed->user_key = pos_->start_key_;
-    parsed->sequence = pos_->seq_;
-    parsed->type = kTypeRangeDeletion;
-  }
-
-  const FragmentedRangeTombstoneComparator tombstone_cmp_;
+  const RangeTombstoneStackStartComparator tombstone_start_cmp_;
+  const RangeTombstoneStackEndComparator tombstone_end_cmp_;
   const InternalKeyComparator* icmp_;
   const Comparator* ucmp_;
   std::shared_ptr<const FragmentedRangeTombstoneList> tombstones_ref_;
   const FragmentedRangeTombstoneList* tombstones_;
-  std::vector<RangeTombstone>::const_iterator pos_;
-  mutable std::vector<RangeTombstone>::const_iterator pinned_pos_;
+  std::vector<RangeTombstoneStack>::const_iterator pos_;
+  std::vector<SequenceNumber>::const_iterator seq_pos_;
+  mutable std::vector<RangeTombstoneStack>::const_iterator pinned_pos_;
+  mutable std::vector<SequenceNumber>::const_iterator pinned_seq_pos_;
   mutable InternalKey current_start_key_;
   PinnedIteratorsManager pinned_iters_mgr_;
 };

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -176,7 +176,6 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
 
   const RangeTombstoneStackStartComparator tombstone_start_cmp_;
   const RangeTombstoneStackEndComparator tombstone_end_cmp_;
-  const InternalKeyComparator* icmp_;
   const Comparator* ucmp_;
   std::shared_ptr<const FragmentedRangeTombstoneList> tombstones_ref_;
   const FragmentedRangeTombstoneList* tombstones_;

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -24,8 +24,8 @@ struct FragmentedRangeTombstoneList {
   // The members seq_start_idx and seq_end_idx are intended to be parameters to
   // seq_iter().
   struct RangeTombstoneStack {
-    RangeTombstoneStack(const Slice& start, const Slice& end, int start_idx,
-                        int end_idx)
+    RangeTombstoneStack(const Slice& start, const Slice& end, size_t start_idx,
+                        size_t end_idx)
         : start_key(start),
           end_key(end),
           seq_start_idx(start_idx),

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -35,47 +35,65 @@ void VerifyFragmentedRangeDels(
   iter->SeekToFirst();
   for (size_t i = 0; i < expected_tombstones.size() && iter->Valid();
        i++, iter->Next()) {
-    EXPECT_EQ(ExtractUserKey(iter->key()), expected_tombstones[i].start_key_);
+    EXPECT_EQ(iter->start_key(), expected_tombstones[i].start_key_);
     EXPECT_EQ(iter->value(), expected_tombstones[i].end_key_);
-    EXPECT_EQ(GetInternalKeySeqno(iter->key()), expected_tombstones[i].seq_);
+    EXPECT_EQ(iter->seq(), expected_tombstones[i].seq_);
   }
   EXPECT_FALSE(iter->Valid());
 }
 
-struct SeekForPrevTestCase {
+struct SeekTestCase {
   Slice seek_target;
+  SequenceNumber target_seq;
   RangeTombstone expected_position;
   bool out_of_range;
 };
 
-void VerifySeekForPrev(FragmentedRangeTombstoneIterator* iter,
-                       const std::vector<SeekForPrevTestCase>& cases) {
+void VerifySeek(FragmentedRangeTombstoneIterator* iter,
+                const std::vector<SeekTestCase>& cases) {
   for (const auto& testcase : cases) {
-    InternalKey ikey_seek_target(testcase.seek_target, 0, kTypeRangeDeletion);
+    InternalKey ikey_seek_target(testcase.seek_target, testcase.target_seq,
+                                 kTypeRangeDeletion);
+    iter->Seek(ikey_seek_target.Encode());
+    if (testcase.out_of_range) {
+      ASSERT_FALSE(iter->Valid());
+    } else {
+      ASSERT_TRUE(iter->Valid());
+      EXPECT_EQ(testcase.expected_position.start_key_, iter->start_key());
+      EXPECT_EQ(testcase.expected_position.end_key_, iter->value());
+      EXPECT_EQ(testcase.expected_position.seq_, iter->seq());
+    }
+  }
+}
+
+void VerifySeekForPrev(FragmentedRangeTombstoneIterator* iter,
+                       const std::vector<SeekTestCase>& cases) {
+  for (const auto& testcase : cases) {
+    InternalKey ikey_seek_target(testcase.seek_target, testcase.target_seq,
+                                 kTypeRangeDeletion);
     iter->SeekForPrev(ikey_seek_target.Encode());
     if (testcase.out_of_range) {
       ASSERT_FALSE(iter->Valid());
     } else {
       ASSERT_TRUE(iter->Valid());
-      EXPECT_EQ(ExtractUserKey(iter->key()),
-                testcase.expected_position.start_key_);
-      EXPECT_EQ(iter->value(), testcase.expected_position.end_key_);
-      EXPECT_EQ(GetInternalKeySeqno(iter->key()),
-                testcase.expected_position.seq_);
+      EXPECT_EQ(testcase.expected_position.start_key_, iter->start_key());
+      EXPECT_EQ(testcase.expected_position.end_key_, iter->value());
+      EXPECT_EQ(testcase.expected_position.seq_, iter->seq());
     }
   }
 }
 
 struct MaxCoveringTombstoneSeqnumTestCase {
   Slice user_key;
-  int result;
+  SequenceNumber snapshot;
+  SequenceNumber result;
 };
 
 void VerifyMaxCoveringTombstoneSeqnum(
     FragmentedRangeTombstoneIterator* iter, const Comparator* ucmp,
     const std::vector<MaxCoveringTombstoneSeqnumTestCase>& cases) {
   for (const auto& testcase : cases) {
-    InternalKey key_and_snapshot(testcase.user_key, kMaxSequenceNumber,
+    InternalKey key_and_snapshot(testcase.user_key, testcase.snapshot,
                                  kTypeValue);
     EXPECT_EQ(testcase.result, MaxCoveringTombstoneSeqnum(
                                    iter, key_and_snapshot.Encode(), ucmp));
@@ -92,7 +110,10 @@ TEST_F(RangeTombstoneFragmenterTest, NonOverlappingTombstones) {
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
   VerifyFragmentedRangeDels(&iter, {{"a", "b", 10}, {"c", "d", 5}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"", 0}, {"a", 10}, {"b", 0}, {"c", 5}});
+                                   {{"", kMaxSequenceNumber, 0},
+                                    {"a", kMaxSequenceNumber, 10},
+                                    {"b", kMaxSequenceNumber, 0},
+                                    {"c", kMaxSequenceNumber, 5}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlappingTombstones) {
@@ -104,7 +125,10 @@ TEST_F(RangeTombstoneFragmenterTest, OverlappingTombstones) {
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 15}, {"e", "g", 15}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 10}, {"c", 15}, {"e", 15}, {"g", 0}});
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"c", kMaxSequenceNumber, 15},
+                                    {"e", kMaxSequenceNumber, 15},
+                                    {"g", kMaxSequenceNumber, 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, ContiguousTombstones) {
@@ -117,7 +141,10 @@ TEST_F(RangeTombstoneFragmenterTest, ContiguousTombstones) {
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 20}, {"e", "g", 15}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 10}, {"c", 20}, {"e", 15}, {"g", 0}});
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"c", kMaxSequenceNumber, 20},
+                                    {"e", kMaxSequenceNumber, 15},
+                                    {"g", kMaxSequenceNumber, 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartAndEndKey) {
@@ -129,7 +156,9 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartAndEndKey) {
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 10}, {"b", 10}, {"c", 0}});
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"b", kMaxSequenceNumber, 10},
+                                    {"c", kMaxSequenceNumber, 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyDifferentEndKeys) {
@@ -142,7 +171,10 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyDifferentEndKeys) {
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 10}, {"e", "g", 7}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 10}, {"c", 10}, {"e", 7}, {"g", 0}});
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"c", kMaxSequenceNumber, 10},
+                                    {"e", kMaxSequenceNumber, 7},
+                                    {"g", kMaxSequenceNumber, 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyMixedEndKeys) {
@@ -158,7 +190,10 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyMixedEndKeys) {
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 30}, {"c", "e", 20}, {"e", "g", 20}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 30}, {"c", 20}, {"e", 20}, {"g", 0}});
+                                   {{"a", kMaxSequenceNumber, 30},
+                                    {"c", kMaxSequenceNumber, 20},
+                                    {"e", kMaxSequenceNumber, 20},
+                                    {"g", kMaxSequenceNumber, 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
@@ -177,9 +212,13 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
                                     {"g", "i", 6},
                                     {"j", "l", 4},
                                     {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(
-      &iter, bytewise_icmp.user_comparator(),
-      {{"a", 10}, {"c", 10}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"c", kMaxSequenceNumber, 10},
+                                    {"e", kMaxSequenceNumber, 8},
+                                    {"i", kMaxSequenceNumber, 0},
+                                    {"j", kMaxSequenceNumber, 4},
+                                    {"m", kMaxSequenceNumber, 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyWithSnapshot) {
@@ -194,9 +233,13 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyWithSnapshot) {
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
   VerifyFragmentedRangeDels(
       &iter, {{"c", "g", 8}, {"g", "i", 6}, {"j", "l", 4}, {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(
-      &iter, bytewise_icmp.user_comparator(),
-      {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
+                                   {{"a", 9, 0},
+                                    {"c", 9, 8},
+                                    {"e", 9, 8},
+                                    {"i", 9, 0},
+                                    {"j", 9, 4},
+                                    {"m", 9, 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyUnordered) {
@@ -211,9 +254,13 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyUnordered) {
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
   VerifyFragmentedRangeDels(
       &iter, {{"c", "g", 8}, {"g", "i", 6}, {"j", "l", 4}, {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(
-      &iter, bytewise_icmp.user_comparator(),
-      {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
+                                   {{"a", 9, 0},
+                                    {"c", 9, 8},
+                                    {"e", 9, 8},
+                                    {"i", 9, 0},
+                                    {"j", 9, 4},
+                                    {"m", 9, 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyMultiUse) {
@@ -236,12 +283,23 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyMultiUse) {
                                     {"j", "l", 4},
                                     {"j", "l", 2},
                                     {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(
-      &iter, bytewise_icmp.user_comparator(),
-      {{"a", 10}, {"c", 10}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
+                                   {{"a", kMaxSequenceNumber, 10},
+                                    {"a", 9, 0},
+                                    {"c", kMaxSequenceNumber, 10},
+                                    {"c", 9, 8},
+                                    {"c", 7, 6},
+                                    {"c", 5, 0},
+                                    {"e", kMaxSequenceNumber, 8},
+                                    {"e", 7, 6},
+                                    {"e", 5, 0},
+                                    {"i", kMaxSequenceNumber, 0},
+                                    {"j", kMaxSequenceNumber, 4},
+                                    {"j", 3, 2},
+                                    {"m", kMaxSequenceNumber, 4}});
 }
 
-TEST_F(RangeTombstoneFragmenterTest, SeekForPrevStartKey) {
+TEST_F(RangeTombstoneFragmenterTest, SeekStartKey) {
   // Same tombstones as OverlapAndRepeatedStartKey.
   auto range_del_iter = MakeRangeDelIter({{"a", "e", 10},
                                           {"c", "g", 8},
@@ -250,14 +308,23 @@ TEST_F(RangeTombstoneFragmenterTest, SeekForPrevStartKey) {
                                           {"j", "l", 2}});
 
   FragmentedRangeTombstoneList fragment_list(
-      std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
+      std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeekForPrev(
-      &iter,
-      {{"a", {"a", "c", 10}}, {"e", {"e", "g", 8}}, {"l", {"l", "n", 4}}});
+  VerifySeek(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
+                     {"a", 8, {"c", "e", 10}},
+                     {"e", kMaxSequenceNumber, {"e", "g", 8}},
+                     {"e", 6, {"e", "g", 6}},
+                     {"l", kMaxSequenceNumber, {"l", "n", 4}},
+                     {"l", 3, {}, true /* out of range */}});
+  VerifySeekForPrev(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
+                            {"a", 8, {}, true /* out of range */},
+                            {"e", kMaxSequenceNumber, {"e", "g", 8}},
+                            {"e", 6, {"e", "g", 6}},
+                            {"l", kMaxSequenceNumber, {"l", "n", 4}},
+                            {"l", 3, {"j", "l", 4}}});
 }
 
-TEST_F(RangeTombstoneFragmenterTest, SeekForPrevCovered) {
+TEST_F(RangeTombstoneFragmenterTest, SeekCovered) {
   // Same tombstones as OverlapAndRepeatedStartKey.
   auto range_del_iter = MakeRangeDelIter({{"a", "e", 10},
                                           {"c", "g", 8},
@@ -266,14 +333,23 @@ TEST_F(RangeTombstoneFragmenterTest, SeekForPrevCovered) {
                                           {"j", "l", 2}});
 
   FragmentedRangeTombstoneList fragment_list(
-      std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
+      std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeekForPrev(
-      &iter,
-      {{"b", {"a", "c", 10}}, {"f", {"e", "g", 8}}, {"m", {"l", "n", 4}}});
+  VerifySeek(&iter, {{"b", kMaxSequenceNumber, {"a", "c", 10}},
+                     {"b", 8, {"c", "e", 10}},
+                     {"f", kMaxSequenceNumber, {"e", "g", 8}},
+                     {"f", 6, {"e", "g", 6}},
+                     {"m", kMaxSequenceNumber, {"l", "n", 4}},
+                     {"m", 3, {}, true /* out of range */}});
+  VerifySeekForPrev(&iter, {{"b", kMaxSequenceNumber, {"a", "c", 10}},
+                            {"b", 8, {}, true /* out of range */},
+                            {"f", kMaxSequenceNumber, {"e", "g", 8}},
+                            {"f", 6, {"e", "g", 6}},
+                            {"m", kMaxSequenceNumber, {"l", "n", 4}},
+                            {"m", 3, {"j", "l", 4}}});
 }
 
-TEST_F(RangeTombstoneFragmenterTest, SeekForPrevEndKey) {
+TEST_F(RangeTombstoneFragmenterTest, SeekEndKey) {
   // Same tombstones as OverlapAndRepeatedStartKey.
   auto range_del_iter = MakeRangeDelIter({{"a", "e", 10},
                                           {"c", "g", 8},
@@ -282,15 +358,23 @@ TEST_F(RangeTombstoneFragmenterTest, SeekForPrevEndKey) {
                                           {"j", "l", 2}});
 
   FragmentedRangeTombstoneList fragment_list(
-      std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
+      std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeekForPrev(&iter, {{"c", {"c", "e", 10}},
-                            {"g", {"g", "i", 6}},
-                            {"i", {"g", "i", 6}},
-                            {"n", {"l", "n", 4}}});
+  VerifySeek(&iter, {{"c", kMaxSequenceNumber, {"c", "e", 10}},
+                     {"c", 9, {"c", "e", 8}},
+                     {"g", kMaxSequenceNumber, {"g", "i", 6}},
+                     {"g", 4, {"j", "l", 4}},
+                     {"i", kMaxSequenceNumber, {"j", "l", 4}},
+                     {"n", kMaxSequenceNumber, {}, true /* out of range */}});
+  VerifySeekForPrev(&iter, {{"c", kMaxSequenceNumber, {"c", "e", 10}},
+                            {"c", 9, {"c", "e", 8}},
+                            {"g", kMaxSequenceNumber, {"g", "i", 6}},
+                            {"g", 4, {"e", "g", 8}},
+                            {"i", kMaxSequenceNumber, {"g", "i", 6}},
+                            {"n", kMaxSequenceNumber, {"l", "n", 4}}});
 }
 
-TEST_F(RangeTombstoneFragmenterTest, SeekForPrevOutOfBounds) {
+TEST_F(RangeTombstoneFragmenterTest, SeekOutOfBounds) {
   // Same tombstones as OverlapAndRepeatedStartKey.
   auto range_del_iter = MakeRangeDelIter({{"a", "e", 10},
                                           {"c", "g", 8},
@@ -299,10 +383,37 @@ TEST_F(RangeTombstoneFragmenterTest, SeekForPrevOutOfBounds) {
                                           {"j", "l", 2}});
 
   FragmentedRangeTombstoneList fragment_list(
-      std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
+      std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  VerifySeek(&iter, {{"", kMaxSequenceNumber, {"a", "c", 10}},
+                     {"z", kMaxSequenceNumber, {}, true /* out of range */}});
   VerifySeekForPrev(&iter,
-                    {{"", {}, true /* out of range */}, {"z", {"l", "n", 4}}});
+                    {{"", kMaxSequenceNumber, {}, true /* out of range */},
+                     {"z", kMaxSequenceNumber, {"l", "n", 4}}});
+}
+
+TEST_F(RangeTombstoneFragmenterTest, SeekOneTimeUse) {
+  // Same tombstones as OverlapAndRepeatedStartKey.
+  auto range_del_iter = MakeRangeDelIter({{"a", "e", 10},
+                                          {"c", "g", 8},
+                                          {"c", "i", 6},
+                                          {"j", "n", 4},
+                                          {"j", "l", 2}});
+
+  FragmentedRangeTombstoneList fragment_list(
+      std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  VerifySeek(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
+                     {"e", kMaxSequenceNumber, {"e", "g", 8}},
+                     {"e", 6, {"g", "i", 6}},
+                     {"l", kMaxSequenceNumber, {"l", "n", 4}},
+                     {"l", 3, {}, true /* out of range */}});
+  VerifySeekForPrev(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
+                            {"a", 8, {}, true /* out of range */},
+                            {"e", kMaxSequenceNumber, {"e", "g", 8}},
+                            {"e", 6, {"c", "e", 10}},
+                            {"l", kMaxSequenceNumber, {"l", "n", 4}},
+                            {"l", 3, {"j", "l", 4}}});
 }
 
 }  // namespace rocksdb

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -44,7 +44,6 @@ void VerifyFragmentedRangeDels(
 
 struct SeekTestCase {
   Slice seek_target;
-  SequenceNumber target_seq;
   RangeTombstone expected_position;
   bool out_of_range;
 };
@@ -52,9 +51,7 @@ struct SeekTestCase {
 void VerifySeek(FragmentedRangeTombstoneIterator* iter,
                 const std::vector<SeekTestCase>& cases) {
   for (const auto& testcase : cases) {
-    InternalKey ikey_seek_target(testcase.seek_target, testcase.target_seq,
-                                 kTypeRangeDeletion);
-    iter->Seek(ikey_seek_target.Encode());
+    iter->Seek(testcase.seek_target);
     if (testcase.out_of_range) {
       ASSERT_FALSE(iter->Valid());
     } else {
@@ -69,9 +66,7 @@ void VerifySeek(FragmentedRangeTombstoneIterator* iter,
 void VerifySeekForPrev(FragmentedRangeTombstoneIterator* iter,
                        const std::vector<SeekTestCase>& cases) {
   for (const auto& testcase : cases) {
-    InternalKey ikey_seek_target(testcase.seek_target, testcase.target_seq,
-                                 kTypeRangeDeletion);
-    iter->SeekForPrev(ikey_seek_target.Encode());
+    iter->SeekForPrev(testcase.seek_target);
     if (testcase.out_of_range) {
       ASSERT_FALSE(iter->Valid());
     } else {
@@ -85,18 +80,15 @@ void VerifySeekForPrev(FragmentedRangeTombstoneIterator* iter,
 
 struct MaxCoveringTombstoneSeqnumTestCase {
   Slice user_key;
-  SequenceNumber snapshot;
   SequenceNumber result;
 };
 
 void VerifyMaxCoveringTombstoneSeqnum(
-    FragmentedRangeTombstoneIterator* iter, const Comparator* ucmp,
+    FragmentedRangeTombstoneIterator* iter,
     const std::vector<MaxCoveringTombstoneSeqnumTestCase>& cases) {
   for (const auto& testcase : cases) {
-    InternalKey key_and_snapshot(testcase.user_key, testcase.snapshot,
-                                 kTypeValue);
-    EXPECT_EQ(testcase.result, MaxCoveringTombstoneSeqnum(
-                                   iter, key_and_snapshot.Encode(), ucmp));
+    EXPECT_EQ(testcase.result,
+              iter->MaxCoveringTombstoneSeqnum(testcase.user_key));
   }
 }
 
@@ -107,13 +99,11 @@ TEST_F(RangeTombstoneFragmenterTest, NonOverlappingTombstones) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter, {{"a", "b", 10}, {"c", "d", 5}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"", kMaxSequenceNumber, 0},
-                                    {"a", kMaxSequenceNumber, 10},
-                                    {"b", kMaxSequenceNumber, 0},
-                                    {"c", kMaxSequenceNumber, 5}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter,
+                                   {{"", 0}, {"a", 10}, {"b", 0}, {"c", 5}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlappingTombstones) {
@@ -121,14 +111,12 @@ TEST_F(RangeTombstoneFragmenterTest, OverlappingTombstones) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 15}, {"e", "g", 15}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"c", kMaxSequenceNumber, 15},
-                                    {"e", kMaxSequenceNumber, 15},
-                                    {"g", kMaxSequenceNumber, 0}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter,
+                                   {{"a", 10}, {"c", 15}, {"e", 15}, {"g", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, ContiguousTombstones) {
@@ -137,14 +125,12 @@ TEST_F(RangeTombstoneFragmenterTest, ContiguousTombstones) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 20}, {"e", "g", 15}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"c", kMaxSequenceNumber, 20},
-                                    {"e", kMaxSequenceNumber, 15},
-                                    {"g", kMaxSequenceNumber, 0}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter,
+                                   {{"a", 10}, {"c", 20}, {"e", 15}, {"g", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartAndEndKey) {
@@ -153,12 +139,10 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartAndEndKey) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"b", kMaxSequenceNumber, 10},
-                                    {"c", kMaxSequenceNumber, 0}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter, {{"a", 10}, {"b", 10}, {"c", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyDifferentEndKeys) {
@@ -167,14 +151,12 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyDifferentEndKeys) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"c", "e", 10}, {"e", "g", 7}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"c", kMaxSequenceNumber, 10},
-                                    {"e", kMaxSequenceNumber, 7},
-                                    {"g", kMaxSequenceNumber, 0}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter,
+                                   {{"a", 10}, {"c", 10}, {"e", 7}, {"g", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyMixedEndKeys) {
@@ -186,14 +168,12 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyMixedEndKeys) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 30}, {"c", "e", 20}, {"e", "g", 20}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 30},
-                                    {"c", kMaxSequenceNumber, 20},
-                                    {"e", kMaxSequenceNumber, 20},
-                                    {"g", kMaxSequenceNumber, 0}});
+  VerifyMaxCoveringTombstoneSeqnum(&iter,
+                                   {{"a", 30}, {"c", 20}, {"e", 20}, {"g", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
@@ -205,20 +185,16 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10},
                                     {"c", "e", 10},
                                     {"e", "g", 8},
                                     {"g", "i", 6},
                                     {"j", "l", 4},
                                     {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"c", kMaxSequenceNumber, 10},
-                                    {"e", kMaxSequenceNumber, 8},
-                                    {"i", kMaxSequenceNumber, 0},
-                                    {"j", kMaxSequenceNumber, 4},
-                                    {"m", kMaxSequenceNumber, 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter, {{"a", 10}, {"c", 10}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyWithSnapshot) {
@@ -230,16 +206,12 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyWithSnapshot) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */, 9);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, 9 /* snapshot */,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(
       &iter, {{"c", "g", 8}, {"g", "i", 6}, {"j", "l", 4}, {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 9, 0},
-                                    {"c", 9, 8},
-                                    {"e", 9, 8},
-                                    {"i", 9, 0},
-                                    {"j", 9, 4},
-                                    {"m", 9, 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter, {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyUnordered) {
@@ -251,16 +223,12 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyUnordered) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */, 9);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter(&fragment_list, 9 /* snapshot */,
+                                        bytewise_icmp);
   VerifyFragmentedRangeDels(
       &iter, {{"c", "g", 8}, {"g", "i", 6}, {"j", "l", 4}, {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", 9, 0},
-                                    {"c", 9, 8},
-                                    {"e", 9, 8},
-                                    {"i", 9, 0},
-                                    {"j", 9, 4},
-                                    {"m", 9, 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter, {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyMultiUse) {
@@ -272,31 +240,38 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyMultiUse) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifyFragmentedRangeDels(&iter, {{"a", "c", 10},
-                                    {"c", "e", 10},
-                                    {"c", "e", 8},
-                                    {"c", "e", 6},
-                                    {"e", "g", 8},
-                                    {"e", "g", 6},
-                                    {"g", "i", 6},
-                                    {"j", "l", 4},
-                                    {"j", "l", 2},
-                                    {"l", "n", 4}});
-  VerifyMaxCoveringTombstoneSeqnum(&iter, bytewise_icmp.user_comparator(),
-                                   {{"a", kMaxSequenceNumber, 10},
-                                    {"a", 9, 0},
-                                    {"c", kMaxSequenceNumber, 10},
-                                    {"c", 9, 8},
-                                    {"c", 7, 6},
-                                    {"c", 5, 0},
-                                    {"e", kMaxSequenceNumber, 8},
-                                    {"e", 7, 6},
-                                    {"e", 5, 0},
-                                    {"i", kMaxSequenceNumber, 0},
-                                    {"j", kMaxSequenceNumber, 4},
-                                    {"j", 3, 2},
-                                    {"m", kMaxSequenceNumber, 4}});
+  FragmentedRangeTombstoneIterator iter1(&fragment_list, kMaxSequenceNumber,
+                                         bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter2(&fragment_list, 9 /* snapshot */,
+                                         bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter3(&fragment_list, 7 /* snapshot */,
+                                         bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter4(&fragment_list, 5 /* snapshot */,
+                                         bytewise_icmp);
+  FragmentedRangeTombstoneIterator iter5(&fragment_list, 3 /* snapshot */,
+                                         bytewise_icmp);
+  for (auto* iter : {&iter1, &iter2, &iter3, &iter4, &iter5}) {
+    VerifyFragmentedRangeDels(iter, {{"a", "c", 10},
+                                     {"c", "e", 10},
+                                     {"c", "e", 8},
+                                     {"c", "e", 6},
+                                     {"e", "g", 8},
+                                     {"e", "g", 6},
+                                     {"g", "i", 6},
+                                     {"j", "l", 4},
+                                     {"j", "l", 2},
+                                     {"l", "n", 4}});
+  }
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter1, {{"a", 10}, {"c", 10}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter2, {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter3, {{"a", 0}, {"c", 6}, {"e", 6}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter4, {{"a", 0}, {"c", 0}, {"e", 0}, {"i", 0}, {"j", 4}, {"m", 4}});
+  VerifyMaxCoveringTombstoneSeqnum(
+      &iter5, {{"a", 0}, {"c", 0}, {"e", 0}, {"i", 0}, {"j", 2}, {"m", 0}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekStartKey) {
@@ -309,19 +284,24 @@ TEST_F(RangeTombstoneFragmenterTest, SeekStartKey) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeek(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
-                     {"a", 8, {"c", "e", 10}},
-                     {"e", kMaxSequenceNumber, {"e", "g", 8}},
-                     {"e", 6, {"e", "g", 6}},
-                     {"l", kMaxSequenceNumber, {"l", "n", 4}},
-                     {"l", 3, {}, true /* out of range */}});
-  VerifySeekForPrev(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
-                            {"a", 8, {}, true /* out of range */},
-                            {"e", kMaxSequenceNumber, {"e", "g", 8}},
-                            {"e", 6, {"e", "g", 6}},
-                            {"l", kMaxSequenceNumber, {"l", "n", 4}},
-                            {"l", 3, {"j", "l", 4}}});
+
+  FragmentedRangeTombstoneIterator iter1(&fragment_list, kMaxSequenceNumber,
+                                         bytewise_icmp);
+  VerifySeek(
+      &iter1,
+      {{"a", {"a", "c", 10}}, {"e", {"e", "g", 8}}, {"l", {"l", "n", 4}}});
+  VerifySeekForPrev(
+      &iter1,
+      {{"a", {"a", "c", 10}}, {"e", {"e", "g", 8}}, {"l", {"l", "n", 4}}});
+
+  FragmentedRangeTombstoneIterator iter2(&fragment_list, 3 /* snapshot */,
+                                         bytewise_icmp);
+  VerifySeek(&iter2, {{"a", {"j", "l", 2}},
+                      {"e", {"j", "l", 2}},
+                      {"l", {}, true /* out of range */}});
+  VerifySeekForPrev(&iter2, {{"a", {}, true /* out of range */},
+                             {"e", {}, true /* out of range */},
+                             {"l", {"j", "l", 2}}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekCovered) {
@@ -334,19 +314,24 @@ TEST_F(RangeTombstoneFragmenterTest, SeekCovered) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeek(&iter, {{"b", kMaxSequenceNumber, {"a", "c", 10}},
-                     {"b", 8, {"c", "e", 10}},
-                     {"f", kMaxSequenceNumber, {"e", "g", 8}},
-                     {"f", 6, {"e", "g", 6}},
-                     {"m", kMaxSequenceNumber, {"l", "n", 4}},
-                     {"m", 3, {}, true /* out of range */}});
-  VerifySeekForPrev(&iter, {{"b", kMaxSequenceNumber, {"a", "c", 10}},
-                            {"b", 8, {}, true /* out of range */},
-                            {"f", kMaxSequenceNumber, {"e", "g", 8}},
-                            {"f", 6, {"e", "g", 6}},
-                            {"m", kMaxSequenceNumber, {"l", "n", 4}},
-                            {"m", 3, {"j", "l", 4}}});
+
+  FragmentedRangeTombstoneIterator iter1(&fragment_list, kMaxSequenceNumber,
+                                         bytewise_icmp);
+  VerifySeek(
+      &iter1,
+      {{"b", {"a", "c", 10}}, {"f", {"e", "g", 8}}, {"m", {"l", "n", 4}}});
+  VerifySeekForPrev(
+      &iter1,
+      {{"b", {"a", "c", 10}}, {"f", {"e", "g", 8}}, {"m", {"l", "n", 4}}});
+
+  FragmentedRangeTombstoneIterator iter2(&fragment_list, 3 /* snapshot */,
+                                         bytewise_icmp);
+  VerifySeek(&iter2, {{"b", {"j", "l", 2}},
+                      {"f", {"j", "l", 2}},
+                      {"m", {}, true /* out of range */}});
+  VerifySeekForPrev(&iter2, {{"b", {}, true /* out of range */},
+                             {"f", {}, true /* out of range */},
+                             {"m", {"j", "l", 2}}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekEndKey) {
@@ -359,19 +344,28 @@ TEST_F(RangeTombstoneFragmenterTest, SeekEndKey) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeek(&iter, {{"c", kMaxSequenceNumber, {"c", "e", 10}},
-                     {"c", 9, {"c", "e", 8}},
-                     {"g", kMaxSequenceNumber, {"g", "i", 6}},
-                     {"g", 4, {"j", "l", 4}},
-                     {"i", kMaxSequenceNumber, {"j", "l", 4}},
-                     {"n", kMaxSequenceNumber, {}, true /* out of range */}});
-  VerifySeekForPrev(&iter, {{"c", kMaxSequenceNumber, {"c", "e", 10}},
-                            {"c", 9, {"c", "e", 8}},
-                            {"g", kMaxSequenceNumber, {"g", "i", 6}},
-                            {"g", 4, {"e", "g", 8}},
-                            {"i", kMaxSequenceNumber, {"g", "i", 6}},
-                            {"n", kMaxSequenceNumber, {"l", "n", 4}}});
+
+  FragmentedRangeTombstoneIterator iter1(&fragment_list, kMaxSequenceNumber,
+                                         bytewise_icmp);
+  VerifySeek(&iter1, {{"c", {"c", "e", 10}},
+                      {"g", {"g", "i", 6}},
+                      {"i", {"j", "l", 4}},
+                      {"n", {}, true /* out of range */}});
+  VerifySeekForPrev(&iter1, {{"c", {"c", "e", 10}},
+                             {"g", {"g", "i", 6}},
+                             {"i", {"g", "i", 6}},
+                             {"n", {"l", "n", 4}}});
+
+  FragmentedRangeTombstoneIterator iter2(&fragment_list, 3 /* snapshot */,
+                                         bytewise_icmp);
+  VerifySeek(&iter2, {{"c", {"j", "l", 2}},
+                      {"g", {"j", "l", 2}},
+                      {"i", {"j", "l", 2}},
+                      {"n", {}, true /* out of range */}});
+  VerifySeekForPrev(&iter2, {{"c", {}, true /* out of range */},
+                             {"g", {}, true /* out of range */},
+                             {"i", {}, true /* out of range */},
+                             {"n", {"j", "l", 2}}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekOutOfBounds) {
@@ -384,12 +378,12 @@ TEST_F(RangeTombstoneFragmenterTest, SeekOutOfBounds) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, false /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeek(&iter, {{"", kMaxSequenceNumber, {"a", "c", 10}},
-                     {"z", kMaxSequenceNumber, {}, true /* out of range */}});
+
+  FragmentedRangeTombstoneIterator iter(&fragment_list, kMaxSequenceNumber,
+                                        bytewise_icmp);
+  VerifySeek(&iter, {{"", {"a", "c", 10}}, {"z", {}, true /* out of range */}});
   VerifySeekForPrev(&iter,
-                    {{"", kMaxSequenceNumber, {}, true /* out of range */},
-                     {"z", kMaxSequenceNumber, {"l", "n", 4}}});
+                    {{"", {}, true /* out of range */}, {"z", {"l", "n", 4}}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekOneTimeUse) {
@@ -402,18 +396,26 @@ TEST_F(RangeTombstoneFragmenterTest, SeekOneTimeUse) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* one_time_use */);
-  FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp);
-  VerifySeek(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
-                     {"e", kMaxSequenceNumber, {"e", "g", 8}},
-                     {"e", 6, {"g", "i", 6}},
-                     {"l", kMaxSequenceNumber, {"l", "n", 4}},
-                     {"l", 3, {}, true /* out of range */}});
-  VerifySeekForPrev(&iter, {{"a", kMaxSequenceNumber, {"a", "c", 10}},
-                            {"a", 8, {}, true /* out of range */},
-                            {"e", kMaxSequenceNumber, {"e", "g", 8}},
-                            {"e", 6, {"c", "e", 10}},
-                            {"l", kMaxSequenceNumber, {"l", "n", 4}},
-                            {"l", 3, {"j", "l", 4}}});
+
+  FragmentedRangeTombstoneIterator iter1(&fragment_list, kMaxSequenceNumber,
+                                         bytewise_icmp);
+  VerifySeek(
+      &iter1,
+      {{"a", {"a", "c", 10}}, {"e", {"e", "g", 8}}, {"l", {"l", "n", 4}}});
+  VerifySeekForPrev(
+      &iter1,
+      {{"a", {"a", "c", 10}}, {"e", {"e", "g", 8}}, {"l", {"l", "n", 4}}});
+
+  // No tombstone fragments exist at this snapshot because they were dropped
+  // when the list was created.
+  FragmentedRangeTombstoneIterator iter2(&fragment_list, 3 /* snapshot */,
+                                         bytewise_icmp);
+  VerifySeek(&iter2, {{"a", {}, true /* out of range */},
+                      {"e", {}, true /* out of range */},
+                      {"l", {}, true /* out of range */}});
+  VerifySeekForPrev(&iter2, {{"a", {}, true /* out of range */},
+                             {"e", {}, true /* out of range */},
+                             {"l", {}, true /* out of range */}});
 }
 
 }  // namespace rocksdb

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -377,14 +377,12 @@ Status TableCache::Get(const ReadOptions& options,
         get_context->max_covering_tombstone_seq();
     if (s.ok() && max_covering_tombstone_seq != nullptr &&
         !options.ignore_range_deletions) {
-      std::unique_ptr<InternalIterator> range_del_iter(
-          t->NewRangeTombstoneIterator(options));
-      *max_covering_tombstone_seq =
-          std::max(*max_covering_tombstone_seq,
-                   MaxCoveringTombstoneSeqnum(
-                       static_cast<FragmentedRangeTombstoneIterator*>(
-                           range_del_iter.get()),
-                       k, internal_comparator.user_comparator()));
+      std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+          static_cast<FragmentedRangeTombstoneIterator*>(
+              t->NewRangeTombstoneIterator(options)));
+      *max_covering_tombstone_seq = std::max(
+          *max_covering_tombstone_seq,
+          range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k)));
     }
     if (s.ok()) {
       get_context->SetReplayLog(row_cache_entry);  // nullptr if no cache.

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -380,9 +380,11 @@ Status TableCache::Get(const ReadOptions& options,
       std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
           static_cast<FragmentedRangeTombstoneIterator*>(
               t->NewRangeTombstoneIterator(options)));
-      *max_covering_tombstone_seq = std::max(
-          *max_covering_tombstone_seq,
-          range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k)));
+      if (range_del_iter != nullptr) {
+        *max_covering_tombstone_seq = std::max(
+            *max_covering_tombstone_seq,
+            range_del_iter->MaxCoveringTombstoneSeqnum(ExtractUserKey(k)));
+      }
     }
     if (s.ok()) {
       get_context->SetReplayLog(row_cache_entry);  // nullptr if no cache.

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2314,12 +2314,16 @@ InternalIterator* BlockBasedTable::NewIterator(
 }
 
 InternalIterator* BlockBasedTable::NewRangeTombstoneIterator(
-    const ReadOptions& /* read_options */) {
+    const ReadOptions& read_options) {
   if (rep_->fragmented_range_dels == nullptr) {
     return nullptr;
   }
-  return new FragmentedRangeTombstoneIterator(rep_->fragmented_range_dels,
-                                              rep_->internal_comparator);
+  SequenceNumber snapshot = kMaxSequenceNumber;
+  if (read_options.snapshot != nullptr) {
+    snapshot = read_options.snapshot->GetSequenceNumber();
+  }
+  return new FragmentedRangeTombstoneIterator(
+      rep_->fragmented_range_dels, snapshot, rep_->internal_comparator);
 }
 
 InternalIterator* BlockBasedTable::NewUnfragmentedRangeTombstoneIterator(


### PR DESCRIPTION
Summary:
Rather than storing a `vector<RangeTombstone>`, we now store a
`vector<RangeTombstoneStack>` and a `vector<SequenceNumber>`. A
`RangeTombstoneStack` contains the start and end keys of a range tombstone
fragment, and indices into the seqnum vector to indicate which sequence
numbers the fragment is located at. The diagram below illustrates an
example:

```
tombstones_:     [a, b) [c, e) [h, k)
                   | \   /  \   /  |
                   |  \ /    \ /   |
                   v   v      v    v
tombstone_seqs_: [ 5 3 10 7 2 8 6  ]
```

This format allows binary searching the tombstone list to use less key
comparisons, which helps in cases where there are many overlapping
tombstones. Also, this format makes it easier to add DBIter-like
semantics to `FragmentedRangeTombstoneIterator` in the future.

Test Plan:
make check