### PR TITLE
Add the sampling option to trace_analyzer

### DIFF
--- a/tools/trace_analyzer_tool.h
+++ b/tools/trace_analyzer_tool.h
@@ -140,6 +140,7 @@ struct TypeUnit {
   uint64_t total_keys;
   uint64_t total_access;
   uint64_t total_succ_access;
+  uint32_t sample_count;
   std::map<uint32_t, TraceStats> stats;
   TypeUnit() = default;
   ~TypeUnit() = default;
@@ -208,6 +209,7 @@ class TraceAnalyzer {
   uint64_t begin_time_;
   uint64_t end_time_;
   uint64_t time_series_start_;
+  uint32_t sample_max_;
   std::unique_ptr<rocksdb::WritableFile> trace_sequence_f_;  // readable trace
   std::unique_ptr<rocksdb::WritableFile> qps_f_;             // overall qps
   std::unique_ptr<rocksdb::SequentialFile> wkey_input_f_;


### PR DESCRIPTION
If the trace is very large or user want to sample the trace first based on the sampling ratio, user can set the sample_ratio to partially analyze the trace. It is based on every X query of one type, analyze one query. X = <int>(1.0/sample_ratio).

Test plan: tested through the trace analyzing and test