### PR TITLE
xxhash.h: move define before namespace rocksdb

### DIFF
--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -59,6 +59,12 @@ It depends on successfully passing SMHasher test set.
 
 #pragma once
 #include <stdlib.h>
+#if !defined(__VMS) &&       \
+    (defined(__cplusplus) || \
+     (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */))
+#include <stdint.h>
+#endif
+
 #if defined (__cplusplus)
 namespace rocksdb {
 #endif
@@ -196,7 +202,6 @@ XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
 #if !defined(__VMS) &&       \
     (defined(__cplusplus) || \
      (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */))
-#include <stdint.h>
 
 struct XXH64_state_s {
   uint64_t total_len;


### PR DESCRIPTION
Summary: I saw compiler error:
In file included from util/xxhash.cc:133:
util/xxhash.h:199:1: fatal error: import of module '_Builtin_stdint' appears within namespace 'rocksdb'
^
util/xxhash.h:63:1: note: namespace 'rocksdb' begins here
namespace rocksdb {
^
1 error generated.

Move the header out of namespace `rocksdb`.