### PR TITLE
Ensure delete[] and not delete is used on buffer_

### DIFF
--- a/utilities/blob_db/blob_dump_tool.h
+++ b/utilities/blob_db/blob_dump_tool.h
@@ -33,7 +33,7 @@ class BlobDumpTool {
 
  private:
   std::unique_ptr<RandomAccessFileReader> reader_;
-  std::unique_ptr<char> buffer_;
+  std::unique_ptr<char[]> buffer_;
   size_t buffer_size_;
 
   Status Read(uint64_t offset, size_t size, Slice* result);


### PR DESCRIPTION
Ensure delete[] and not delete is called on buffer_, as it is reset with new char[buffer_size_].