### PR TITLE
Remove two variables from BlockContents class and don't use class Block for compressed block

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -138,7 +138,7 @@ struct BlockBasedTableOptions {
 
   // If non-NULL use the specified cache for compressed blocks.
   // If NULL, rocksdb will not use a compressed block cache.
-  // Note: though it looks similar too `block_cache`, RocksDB doesn't put the
+  // Note: though it looks similar to `block_cache`, RocksDB doesn't put the
   //       same type of object there.
   std::shared_ptr<Cache> block_cache_compressed = nullptr;
 

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -138,6 +138,8 @@ struct BlockBasedTableOptions {
 
   // If non-NULL use the specified cache for compressed blocks.
   // If NULL, rocksdb will not use a compressed block cache.
+  // Note: though it looks similar too `block_cache`, RocksDB doesn't put the
+  //       same type of object there.
   std::shared_ptr<Cache> block_cache_compressed = nullptr;
 
   // Approximate size of user data packed per block.  Note that the

--- a/table/block.h
+++ b/table/block.h
@@ -153,14 +153,12 @@ class Block {
 
   size_t size() const { return size_; }
   const char* data() const { return data_; }
-  bool cachable() const { return contents_.cachable; }
   // The additional memory space taken by the block data.
   size_t usable_size() const { return contents_.usable_size(); }
   uint32_t NumRestarts() const;
+  bool own_bytes() const { return contents_.allocation.get() != nullptr; }
+
   BlockBasedTableOptions::DataBlockIndexType IndexType() const;
-  CompressionType compression_type() const {
-    return contents_.compression_type;
-  }
 
   // If comparator is InternalKeyComparator, user_comparator is its user
   // comparator; they are equal otherwise.
@@ -180,6 +178,14 @@ class Block {
   // If `prefix_index` is not nullptr this block will do hash lookup for the key
   // prefix. If total_order_seek is true, prefix_index_ is ignored.
   //
+  // If `block_contents_pinned` is true, the caller will guarantee that when
+  // the cleanup functions are transferred from the iterator to other
+  // classes, e.g. PinnableSlice, the pointer to the bytes will still be
+  // valid. Either the iterator holds cache handle or ownership of some resource
+  // and release them in a release function, or caller is sure that the data
+  // will not go away (for example, it's from mmapped file which will not be
+  // closed).
+  //
   // NOTE: for the hash based lookup, if a key prefix doesn't match any key,
   // the iterator will simply be set as "invalid", rather than returning
   // the key that is just pass the target key.
@@ -188,7 +194,8 @@ class Block {
       const Comparator* comparator, const Comparator* user_comparator,
       TBlockIter* iter = nullptr, Statistics* stats = nullptr,
       bool total_order_seek = true, bool key_includes_seq = true,
-      bool value_is_full = true, BlockPrefixIndex* prefix_index = nullptr);
+      bool value_is_full = true, bool block_contents_pinned = false,
+      BlockPrefixIndex* prefix_index = nullptr);
 
   // Report an approximation of how much memory has been used.
   size_t ApproximateMemoryUsage() const;
@@ -295,7 +302,9 @@ class BlockIter : public InternalIteratorBase<TValue> {
   Slice value_;
   Status status_;
   bool key_pinned_;
-  // whether the block data is guaranteed to outlive this iterator
+  // whether the block data is guaranteed to outlive this iterator, and
+  // when the cleanup functions are transferred from to other classes,
+  // e.g. PinnableSlice, the pointer to the bytes will still be valid.
   bool block_contents_pinned_;
   SequenceNumber global_seqno_;
 

--- a/table/block.h
+++ b/table/block.h
@@ -156,7 +156,7 @@ class Block {
   // The additional memory space taken by the block data.
   size_t usable_size() const { return contents_.usable_size(); }
   uint32_t NumRestarts() const;
-  bool own_bytes() const { return contents_.allocation.get() != nullptr; }
+  bool own_bytes() const { return contents_.own_bytes(); }
 
   BlockBasedTableOptions::DataBlockIndexType IndexType() const;
 

--- a/table/block.h
+++ b/table/block.h
@@ -302,8 +302,8 @@ class BlockIter : public InternalIteratorBase<TValue> {
   Slice value_;
   Status status_;
   bool key_pinned_;
-  // whether the block data is guaranteed to outlive this iterator, and
-  // when the cleanup functions are transferred from to other classes,
+  // Whether the block data is guaranteed to outlive this iterator, and
+  // as long as the cleanup functions are transferred to another class,
   // e.g. PinnableSlice, the pointer to the bytes will still be valid.
   bool block_contents_pinned_;
   SequenceNumber global_seqno_;

--- a/table/block_based_filter_block_test.cc
+++ b/table/block_based_filter_block_test.cc
@@ -55,7 +55,7 @@ class FilterBlockTest : public testing::Test {
 
 TEST_F(FilterBlockTest, EmptyBuilder) {
   BlockBasedFilterBlockBuilder builder(nullptr, table_options_);
-  BlockContents block(builder.Finish(), false, kNoCompression);
+  BlockContents block(builder.Finish());
   ASSERT_EQ("\\x00\\x00\\x00\\x00\\x0b", EscapeString(block.data));
   BlockBasedFilterBlockReader reader(nullptr, table_options_, true,
                                      std::move(block), nullptr);
@@ -75,7 +75,7 @@ TEST_F(FilterBlockTest, SingleChunk) {
   builder.StartBlock(300);
   builder.Add("hello");
   ASSERT_EQ(5, builder.NumAdded());
-  BlockContents block(builder.Finish(), false, kNoCompression);
+  BlockContents block(builder.Finish());
   BlockBasedFilterBlockReader reader(nullptr, table_options_, true,
                                      std::move(block), nullptr);
   ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, 100));
@@ -107,7 +107,7 @@ TEST_F(FilterBlockTest, MultiChunk) {
   builder.Add("box");
   builder.Add("hello");
 
-  BlockContents block(builder.Finish(), false, kNoCompression);
+  BlockContents block(builder.Finish());
   BlockBasedFilterBlockReader reader(nullptr, table_options_, true,
                                      std::move(block), nullptr);
 
@@ -152,7 +152,7 @@ class BlockBasedFilterBlockTest : public testing::Test {
 TEST_F(BlockBasedFilterBlockTest, BlockBasedEmptyBuilder) {
   FilterBlockBuilder* builder = new BlockBasedFilterBlockBuilder(
       nullptr, table_options_);
-  BlockContents block(builder->Finish(), false, kNoCompression);
+  BlockContents block(builder->Finish());
   ASSERT_EQ("\\x00\\x00\\x00\\x00\\x0b", EscapeString(block.data));
   FilterBlockReader* reader = new BlockBasedFilterBlockReader(
       nullptr, table_options_, true, std::move(block), nullptr);
@@ -174,7 +174,7 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedSingleChunk) {
   builder->Add("box");
   builder->StartBlock(300);
   builder->Add("hello");
-  BlockContents block(builder->Finish(), false, kNoCompression);
+  BlockContents block(builder->Finish());
   FilterBlockReader* reader = new BlockBasedFilterBlockReader(
       nullptr, table_options_, true, std::move(block), nullptr);
   ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, 100));
@@ -210,7 +210,7 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedMultiChunk) {
   builder->Add("box");
   builder->Add("hello");
 
-  BlockContents block(builder->Finish(), false, kNoCompression);
+  BlockContents block(builder->Finish());
   FilterBlockReader* reader = new BlockBasedFilterBlockReader(
       nullptr, table_options_, true, std::move(block), nullptr);
 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -677,7 +677,7 @@ Status BlockBasedTableBuilder::InsertBlockInCache(const Slice& block_contents,
     memcpy(ubuf.get(), block_contents.data(), size);
     ubuf[size] = type;
 
-    BlockContents results(std::move(ubuf), size, true, type);
+    BlockContents results(std::move(ubuf), size);
 
     Block* block = new Block(std::move(results), kDisableGlobalSequenceNumber);
 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -654,9 +654,9 @@ Status BlockBasedTableBuilder::status() const {
   return rep_->status;
 }
 
-static void DeleteCachedBlock(const Slice& /*key*/, void* value) {
-  Block* block = reinterpret_cast<Block*>(value);
-  delete block;
+static void DeleteCachedBlockContents(const Slice& /*key*/, void* value) {
+  BlockContents* bc = reinterpret_cast<BlockContents*>(value);
+  delete bc;
 }
 
 //
@@ -677,9 +677,11 @@ Status BlockBasedTableBuilder::InsertBlockInCache(const Slice& block_contents,
     memcpy(ubuf.get(), block_contents.data(), size);
     ubuf[size] = type;
 
-    BlockContents results(std::move(ubuf), size);
-
-    Block* block = new Block(std::move(results), kDisableGlobalSequenceNumber);
+    BlockContents* block_contents_to_cache =
+        new BlockContents(std::move(ubuf), size);
+#ifndef NDEBUG
+    block_contents_to_cache->is_raw_block = true;
+#endif  // NDEBUG
 
     // make cache key by appending the file offset to the cache prefix id
     char* end = EncodeVarint64(
@@ -690,8 +692,10 @@ Status BlockBasedTableBuilder::InsertBlockInCache(const Slice& block_contents,
               (end - r->compressed_cache_key_prefix));
 
     // Insert into compressed block cache.
-    block_cache_compressed->Insert(key, block, block->ApproximateMemoryUsage(),
-                                   &DeleteCachedBlock);
+    block_cache_compressed->Insert(
+        key, block_contents_to_cache,
+        block_contents_to_cache->ApproximateMemoryUsage(),
+        &DeleteCachedBlockContents);
 
     // Invalidate OS cache.
     r->file->InvalidateCache(static_cast<size_t>(r->offset), size);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -254,8 +254,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
               index_value_is_full_),
           index_block_->NewIterator<IndexBlockIter>(
               icomparator_, icomparator_->user_comparator(), nullptr,
-              kNullStats, true, index_key_includes_seq_, index_value_is_full_,
-              false /* block_contents_pinned */));
+              kNullStats, true, index_key_includes_seq_, index_value_is_full_));
     } else {
       auto ro = ReadOptions();
       ro.fill_cache = fill_cache;
@@ -266,8 +265,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
           table_, ro, *icomparator_,
           index_block_->NewIterator<IndexBlockIter>(
               icomparator_, icomparator_->user_comparator(), nullptr,
-              kNullStats, true, index_key_includes_seq_, index_value_is_full_,
-              false /* block_contents_pinned */),
+              kNullStats, true, index_key_includes_seq_, index_value_is_full_),
           false, true, /* prefix_extractor */ nullptr, kIsIndex,
           index_key_includes_seq_, index_value_is_full_);
     }
@@ -287,8 +285,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     // to set `block_contents_pinned`.
     index_block_->NewIterator<IndexBlockIter>(
         icomparator_, icomparator_->user_comparator(), &biter, kNullStats, true,
-        index_key_includes_seq_, index_value_is_full_,
-        false /* block_contents_pinned */);
+        index_key_includes_seq_, index_value_is_full_);
     // Index partitions are assumed to be consecuitive. Prefetch them all.
     // Read the first block offset
     biter.SeekToFirst();
@@ -1359,12 +1356,11 @@ Status BlockBasedTable::PutDataBlockToCache(
         &DeleteCachedEntry<BlockContents>);
     if (s.ok()) {
       // Avoid the following code to delete this cached block.
-      block_cont_for_comp_cache = nullptr;
       RecordTick(statistics, BLOCK_CACHE_COMPRESSED_ADD);
     } else {
       RecordTick(statistics, BLOCK_CACHE_COMPRESSED_ADD_FAILURES);
+      delete block_cont_for_comp_cache;
     }
-    delete block_cont_for_comp_cache;
   }
 
   // insert into uncompressed block cache
@@ -1910,8 +1906,7 @@ BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
     // to set `block_contents_pinned`.
     return block->second.value->NewIterator<IndexBlockIter>(
         &rep->internal_comparator, rep->internal_comparator.user_comparator(),
-        nullptr, kNullStats, true, index_key_includes_seq_, index_key_is_full_,
-        false /* block_contents_pinned */);
+        nullptr, kNullStats, true, index_key_includes_seq_, index_key_is_full_);
   }
   // Create an empty iterator
   return new IndexBlockIter();

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1348,6 +1348,10 @@ Status BlockBasedTable::PutDataBlockToCache(
   if (block_cache_compressed != nullptr &&
       raw_block_comp_type != kNoCompression && raw_block_contents != nullptr &&
       raw_block_contents->own_bytes()) {
+#ifndef NDEBUG
+    assert(raw_block_contents->is_raw_block);
+#endif  // NDEBUG
+
     // We cannot directly put raw_block_contents because this could point to
     // an object in the stack.
     BlockContents* block_cont_for_comp_cache =

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -325,7 +325,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
       const bool is_index = true;
       // TODO: Support counter batch update for partitioned index and
       // filter blocks
-      s = table_->ReadBlockAndMaybeLoadToCache(
+      s = table_->MaybeReadBlockAndLoadToCache(
           prefetch_buffer.get(), rep, ro, handle, compression_dict, &block,
           is_index, nullptr /* get_context */);
 
@@ -982,7 +982,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         s.ToString().c_str());
   } else if (found_range_del_block && !rep->range_del_handle.IsNull()) {
     ReadOptions read_options;
-    s = ReadBlockAndMaybeLoadToCache(
+    s = MaybeReadBlockAndLoadToCache(
         prefetch_buffer.get(), rep, read_options, rep->range_del_handle,
         Slice() /* compression_dict */, &rep->range_del_entry,
         false /* is_index */, nullptr /* get_context */);
@@ -1712,7 +1712,7 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     if (rep->compression_dict_block) {
       compression_dict = rep->compression_dict_block->data;
     }
-    s = ReadBlockAndMaybeLoadToCache(prefetch_buffer, rep, ro, handle,
+    s = MaybeReadBlockAndLoadToCache(prefetch_buffer, rep, ro, handle,
                                      compression_dict, &block, is_index,
                                      get_context);
   }
@@ -1772,7 +1772,7 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
         // insert a dummy record to block cache to track the memory usage
         Cache::Handle* cache_handle;
         // There are two other types of cache keys: 1) SST cache key added in
-        // `ReadBlockAndMaybeLoadToCache` 2) dummy cache key added in
+        // `MaybeReadBlockAndLoadToCache` 2) dummy cache key added in
         // `write_buffer_manager`. Use longer prefix (41 bytes) to differentiate
         // from SST cache key(31 bytes), and use non-zero prefix to
         // differentiate from `write_buffer_manager`
@@ -1808,7 +1808,7 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
   return iter;
 }
 
-Status BlockBasedTable::ReadBlockAndMaybeLoadToCache(
+Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
     FilePrefetchBuffer* prefetch_buffer, Rep* rep, const ReadOptions& ro,
     const BlockHandle& handle, Slice compression_dict,
     CachableEntry<Block>* block_entry, bool is_index, GetContext* get_context) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1753,9 +1753,6 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
     // 2. it's pointing to immortable source. If own_bytes is true then we are
     //    not reading data from the original source, weather immortal or not.
     //    Otherwise, the block is pinned iff the source is immortal.
-    //    We can determine this case by
-    //    checking: (1) the block doesn't own bytes itself (outside source,
-    //    usually mmapped bytes) (2) the source is immortable
     bool block_contents_pinned =
         (block.cache_handle != nullptr ||
          (!block.value->own_bytes() && rep->immortal_table));

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1717,7 +1717,7 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
   } else {
     iter = new TBlockIter;
   }
-  // Didn't get any data and there isn't any error. Must be no_io = true
+  // Didn't get any data from block caches.
   if (s.ok() && block.value == nullptr) {
     if (no_io) {
       // Could not read from block_cache and can't do IO

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -300,12 +300,11 @@ class BlockBasedTable : public TableReader {
   //    dictionary.
   static Status GetDataBlockFromCache(
       const Slice& block_cache_key, const Slice& compressed_block_cache_key,
-      Cache* block_cache, Cache* block_cache_compressed,
-      const ImmutableCFOptions& ioptions, const ReadOptions& read_options,
-      BlockBasedTable::CachableEntry<Block>* block, uint32_t format_version,
+      Cache* block_cache, Cache* block_cache_compressed, Rep* rep,
+      const ReadOptions& read_options,
+      BlockBasedTable::CachableEntry<Block>* block,
       const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-      bool is_index = false, GetContext* get_context = nullptr,
-      MemoryAllocator* allocator = nullptr);
+      bool is_index = false, GetContext* get_context = nullptr);
 
   // Put a raw block (maybe compressed) to the corresponding block caches.
   // This method will perform decompression against raw_block if needed and then
@@ -536,6 +535,10 @@ struct BlockBasedTable::Rep {
 
   bool closed = false;
   const bool immortal_table;
+
+  SequenceNumber get_global_seqno(bool is_index) const {
+    return is_index ? kDisableGlobalSequenceNumber : global_seqno;
+  }
 };
 
 template <class TBlockIter, typename TValue = Slice>

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -310,8 +310,8 @@ class BlockBasedTable : public TableReader {
   // On success, Status::OK will be returned; also @block will be populated with
   // uncompressed block and its cache handle.
   //
-  // REQUIRES: raw_block is heap-allocated. PutDataBlockToCache() will be
-  // responsible for releasing its memory if error occurs.
+  // Allocated memory managed by raw_block_contents will be transferred to
+  // PutDataBlockToCache(). After the call, the class will be invalid.
   // @param compression_dict Data for presetting the compression library's
   //    dictionary.
   static Status PutDataBlockToCache(

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -256,7 +256,7 @@ class BlockBasedTable : public TableReader {
   // @param block_entry value is set to the uncompressed block if found. If
   //    in uncompressed block cache, also sets cache_handle to reference that
   //    block.
-  static Status ReadBlockAndMaybeLoadToCache(
+  static Status MaybeReadBlockAndLoadToCache(
       FilePrefetchBuffer* prefetch_buffer, Rep* rep, const ReadOptions& ro,
       const BlockHandle& handle, Slice compression_dict,
       CachableEntry<Block>* block_entry, bool is_index = false,

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -256,13 +256,13 @@ class BlockBasedTable : public TableReader {
   // @param block_entry value is set to the uncompressed block if found. If
   //    in uncompressed block cache, also sets cache_handle to reference that
   //    block.
-  static Status MaybeLoadDataBlockToCache(FilePrefetchBuffer* prefetch_buffer,
-                                          Rep* rep, const ReadOptions& ro,
-                                          const BlockHandle& handle,
-                                          Slice compression_dict,
-                                          CachableEntry<Block>* block_entry,
-                                          bool is_index = false,
-                                          GetContext* get_context = nullptr);
+  static Status LoadBlockFromCacheOrFile(FilePrefetchBuffer* prefetch_buffer,
+                                         Rep* rep, const ReadOptions& ro,
+                                         const BlockHandle& handle,
+                                         Slice compression_dict,
+                                         CachableEntry<Block>* block_entry,
+                                         bool is_index = false,
+                                         GetContext* get_context = nullptr);
 
   // For the following two functions:
   // if `no_io == true`, we will not try to read filter/index from sst file
@@ -321,9 +321,11 @@ class BlockBasedTable : public TableReader {
       const Slice& block_cache_key, const Slice& compressed_block_cache_key,
       Cache* block_cache, Cache* block_cache_compressed,
       const ReadOptions& read_options, const ImmutableCFOptions& ioptions,
-      CachableEntry<Block>* block, Block* raw_block, uint32_t format_version,
-      const Slice& compression_dict, size_t read_amp_bytes_per_bit,
-      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW,
+      CachableEntry<Block>* block, BlockContents* raw_block_contents,
+      CompressionType raw_block_comp_type, uint32_t format_version,
+      const Slice& compression_dict, SequenceNumber seq_no,
+      size_t read_amp_bytes_per_bit, bool is_index = false,
+      Cache::Priority pri = Cache::Priority::LOW,
       GetContext* get_context = nullptr, MemoryAllocator* allocator = nullptr);
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -256,13 +256,11 @@ class BlockBasedTable : public TableReader {
   // @param block_entry value is set to the uncompressed block if found. If
   //    in uncompressed block cache, also sets cache_handle to reference that
   //    block.
-  static Status LoadBlockFromCacheOrFile(FilePrefetchBuffer* prefetch_buffer,
-                                         Rep* rep, const ReadOptions& ro,
-                                         const BlockHandle& handle,
-                                         Slice compression_dict,
-                                         CachableEntry<Block>* block_entry,
-                                         bool is_index = false,
-                                         GetContext* get_context = nullptr);
+  static Status ReadBlockAndMaybeLoadToCache(
+      FilePrefetchBuffer* prefetch_buffer, Rep* rep, const ReadOptions& ro,
+      const BlockHandle& handle, Slice compression_dict,
+      CachableEntry<Block>* block_entry, bool is_index = false,
+      GetContext* get_context = nullptr);
 
   // For the following two functions:
   // if `no_io == true`, we will not try to read filter/index from sst file

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -311,7 +311,7 @@ class BlockBasedTable : public TableReader {
   // uncompressed block and its cache handle.
   //
   // Allocated memory managed by raw_block_contents will be transferred to
-  // PutDataBlockToCache(). After the call, the class will be invalid.
+  // PutDataBlockToCache(). After the call, the object will be invalid.
   // @param compression_dict Data for presetting the compression library's
   //    dictionary.
   static Status PutDataBlockToCache(

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -183,6 +183,9 @@ void BlockFetcher::GetBlockContents() {
     }
     *contents_ = BlockContents(std::move(heap_buf_), block_size_);
   }
+#ifdef NDEBUG
+  contents_->is_raw_block = true;
+#endif
 }
 
 Status BlockFetcher::ReadBlockContents() {

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -172,8 +172,7 @@ inline
 void BlockFetcher::GetBlockContents() {
   if (slice_.data() != used_buf_) {
     // the slice content is not the buffer provided
-    *contents_ = BlockContents(Slice(slice_.data(), block_size_),
-                               immortal_source_, compression_type);
+    *contents_ = BlockContents(Slice(slice_.data(), block_size_));
   } else {
     // page can be either uncompressed or compressed, the buffer either stack
     // or heap provided. Refer to https://github.com/facebook/rocksdb/pull/4096
@@ -182,8 +181,7 @@ void BlockFetcher::GetBlockContents() {
       heap_buf_ = AllocateBlock(block_size_ + kBlockTrailerSize, allocator_);
       memcpy(heap_buf_.get(), used_buf_, block_size_ + kBlockTrailerSize);
     }
-    *contents_ = BlockContents(std::move(heap_buf_), block_size_, true,
-                               compression_type);
+    *contents_ = BlockContents(std::move(heap_buf_), block_size_);
   }
 }
 
@@ -191,6 +189,7 @@ Status BlockFetcher::ReadBlockContents() {
   block_size_ = static_cast<size_t>(handle_.size());
 
   if (TryGetUncompressBlockFromPersistentCache()) {
+    compression_type_ = kNoCompression;
     return Status::OK();
   }
   if (TryGetFromPrefetchBuffer()) {
@@ -231,15 +230,17 @@ Status BlockFetcher::ReadBlockContents() {
 
   PERF_TIMER_GUARD(block_decompress_time);
 
-  compression_type =
+  compression_type_ =
       static_cast<rocksdb::CompressionType>(slice_.data()[block_size_]);
 
-  if (do_uncompress_ && compression_type != kNoCompression) {
+  if (do_uncompress_ && compression_type_ != kNoCompression) {
     // compressed page, uncompress, update cache
-    UncompressionContext uncompression_ctx(compression_type, compression_dict_);
+    UncompressionContext uncompression_ctx(compression_type_,
+                                           compression_dict_);
     status_ = UncompressBlockContents(uncompression_ctx, slice_.data(),
                                       block_size_, contents_, footer_.version(),
                                       ioptions_, allocator_);
+    compression_type_ = kNoCompression;
   } else {
     GetBlockContents();
   }

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -183,7 +183,7 @@ void BlockFetcher::GetBlockContents() {
     }
     *contents_ = BlockContents(std::move(heap_buf_), block_size_);
   }
-#ifdef NDEBUG
+#ifndef NDEBUG
   contents_->is_raw_block = true;
 #endif
 }

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -233,8 +233,7 @@ Status BlockFetcher::ReadBlockContents() {
 
   PERF_TIMER_GUARD(block_decompress_time);
 
-  compression_type_ =
-      static_cast<rocksdb::CompressionType>(slice_.data()[block_size_]);
+  compression_type_ = get_block_compression_type(slice_.data(), block_size_);
 
   if (do_uncompress_ && compression_type_ != kNoCompression) {
     // compressed page, uncompress, update cache

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -193,6 +193,9 @@ Status BlockFetcher::ReadBlockContents() {
 
   if (TryGetUncompressBlockFromPersistentCache()) {
     compression_type_ = kNoCompression;
+#ifndef NDEBUG
+    contents_->is_raw_block = true;
+#endif  // NDEBUG
     return Status::OK();
   }
   if (TryGetFromPrefetchBuffer()) {

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -28,8 +28,7 @@ class BlockFetcher {
                BlockContents* contents, const ImmutableCFOptions& ioptions,
                bool do_uncompress, const Slice& compression_dict,
                const PersistentCacheOptions& cache_options,
-               MemoryAllocator* allocator = nullptr,
-               const bool immortal_source = false)
+               MemoryAllocator* allocator = nullptr)
       : file_(file),
         prefetch_buffer_(prefetch_buffer),
         footer_(footer),
@@ -38,7 +37,6 @@ class BlockFetcher {
         contents_(contents),
         ioptions_(ioptions),
         do_uncompress_(do_uncompress),
-        immortal_source_(immortal_source),
         compression_dict_(compression_dict),
         cache_options_(cache_options),
         allocator_(allocator) {}
@@ -56,7 +54,6 @@ class BlockFetcher {
   BlockContents* contents_;
   const ImmutableCFOptions& ioptions_;
   bool do_uncompress_;
-  const bool immortal_source_;
   const Slice& compression_dict_;
   const PersistentCacheOptions& cache_options_;
   MemoryAllocator* allocator_;

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -43,6 +43,7 @@ class BlockFetcher {
         cache_options_(cache_options),
         allocator_(allocator) {}
   Status ReadBlockContents();
+  CompressionType get_compression_type() const { return compression_type_; }
 
  private:
   static const uint32_t kDefaultStackBufferSize = 5000;
@@ -66,7 +67,7 @@ class BlockFetcher {
   CacheAllocationPtr heap_buf_;
   char stack_buf_[kDefaultStackBufferSize];
   bool got_from_prefetch_buffer_ = false;
-  rocksdb::CompressionType compression_type;
+  rocksdb::CompressionType compression_type_;
 
   // return true if found
   bool TryGetUncompressBlockFromPersistentCache();

--- a/table/block_test.cc
+++ b/table/block_test.cc
@@ -117,7 +117,6 @@ TEST_F(BlockTest, SimpleTest) {
   // create block reader
   BlockContents contents;
   contents.data = rawblock;
-  contents.cachable = false;
   Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
   // read contents of block sequentially
@@ -188,7 +187,6 @@ TEST_F(BlockTest, ValueDeltaEncodingTest) {
   // create block reader
   BlockContents contents;
   contents.data = rawblock;
-  contents.cachable = false;
   Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
   const bool kTotalOrderSeek = true;
@@ -247,7 +245,6 @@ BlockContents GetBlockContents(std::unique_ptr<BlockBuilder> *builder,
 
   BlockContents contents;
   contents.data = rawblock;
-  contents.cachable = false;
 
   return contents;
 }
@@ -257,8 +254,7 @@ void CheckBlockContents(BlockContents contents, const int max_key,
                         const std::vector<std::string> &values) {
   const size_t prefix_size = 6;
   // create block reader
-  BlockContents contents_ref(contents.data, contents.cachable,
-                             contents.compression_type);
+  BlockContents contents_ref(contents.data);
   Block reader1(std::move(contents), kDisableGlobalSequenceNumber);
   Block reader2(std::move(contents_ref), kDisableGlobalSequenceNumber);
 
@@ -486,7 +482,6 @@ TEST_F(BlockTest, BlockWithReadAmpBitmap) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = true;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber,
                  kBytesPerBit, stats.get());
 
@@ -521,7 +516,6 @@ TEST_F(BlockTest, BlockWithReadAmpBitmap) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = true;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber,
                  kBytesPerBit, stats.get());
 
@@ -558,7 +552,6 @@ TEST_F(BlockTest, BlockWithReadAmpBitmap) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = true;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber,
                  kBytesPerBit, stats.get());
 

--- a/table/data_block_hash_index_test.cc
+++ b/table/data_block_hash_index_test.cc
@@ -284,7 +284,6 @@ TEST(DataBlockHashIndex, BlockRestartIndexExceedMax) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = false;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
     ASSERT_EQ(reader.IndexType(),
@@ -307,7 +306,6 @@ TEST(DataBlockHashIndex, BlockRestartIndexExceedMax) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = false;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
     ASSERT_EQ(reader.IndexType(),
@@ -339,7 +337,6 @@ TEST(DataBlockHashIndex, BlockSizeExceedMax) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = false;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
     ASSERT_EQ(reader.IndexType(),
@@ -364,7 +361,6 @@ TEST(DataBlockHashIndex, BlockSizeExceedMax) {
     // create block reader
     BlockContents contents;
     contents.data = rawblock;
-    contents.cachable = false;
     Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
     // the index type have fallen back to binary when build finish.
@@ -392,7 +388,6 @@ TEST(DataBlockHashIndex, BlockTestSingleKey) {
   // create block reader
   BlockContents contents;
   contents.data = rawblock;
-  contents.cachable = false;
   Block reader(std::move(contents), kDisableGlobalSequenceNumber);
 
   const InternalKeyComparator icmp(BytewiseComparator());
@@ -474,7 +469,6 @@ TEST(DataBlockHashIndex, BlockTestLarge) {
   // create block reader
   BlockContents contents;
   contents.data = rawblock;
-  contents.cachable = false;
   Block reader(std::move(contents), kDisableGlobalSequenceNumber);
   const InternalKeyComparator icmp(BytewiseComparator());
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -301,7 +301,7 @@ Status UncompressBlockContentsForCompressionType(
       if (!Snappy_Uncompress(data, n, ubuf.get())) {
         return Status::Corruption(snappy_corrupt_msg);
       }
-      *contents = BlockContents(std::move(ubuf), ulength, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), ulength);
       break;
     }
     case kZlibCompression:
@@ -314,8 +314,7 @@ Status UncompressBlockContentsForCompressionType(
           "Zlib not supported or corrupted Zlib compressed block contents";
         return Status::Corruption(zlib_corrupt_msg);
       }
-      *contents =
-          BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     case kBZip2Compression:
       ubuf = BZip2_Uncompress(
@@ -327,8 +326,7 @@ Status UncompressBlockContentsForCompressionType(
           "Bzip2 not supported or corrupted Bzip2 compressed block contents";
         return Status::Corruption(bzip2_corrupt_msg);
       }
-      *contents =
-          BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     case kLZ4Compression:
       ubuf = LZ4_Uncompress(
@@ -340,8 +338,7 @@ Status UncompressBlockContentsForCompressionType(
           "LZ4 not supported or corrupted LZ4 compressed block contents";
         return Status::Corruption(lz4_corrupt_msg);
       }
-      *contents =
-          BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     case kLZ4HCCompression:
       ubuf = LZ4_Uncompress(
@@ -353,8 +350,7 @@ Status UncompressBlockContentsForCompressionType(
           "LZ4HC not supported or corrupted LZ4HC compressed block contents";
         return Status::Corruption(lz4hc_corrupt_msg);
       }
-      *contents =
-          BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     case kXpressCompression:
       // XPRESS allocates memory internally, thus no support for custom
@@ -365,8 +361,7 @@ Status UncompressBlockContentsForCompressionType(
           "XPRESS not supported or corrupted XPRESS compressed block contents";
         return Status::Corruption(xpress_corrupt_msg);
       }
-      *contents =
-        BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     case kZSTD:
     case kZSTDNotFinalCompression:
@@ -377,8 +372,7 @@ Status UncompressBlockContentsForCompressionType(
             "ZSTD not supported or corrupted ZSTD compressed block contents";
         return Status::Corruption(zstd_corrupt_msg);
       }
-      *contents =
-          BlockContents(std::move(ubuf), decompress_size, true, kNoCompression);
+      *contents = BlockContents(std::move(ubuf), decompress_size);
       break;
     default:
       return Status::Corruption("bad block type");

--- a/table/format.h
+++ b/table/format.h
@@ -189,6 +189,11 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
 // 1-byte type + 32-bit crc
 static const size_t kBlockTrailerSize = 5;
 
+inline CompressionType get_block_compression_type(const char* block_data,
+                                                  size_t block_size) {
+  return static_cast<CompressionType>(block_data[block_size]);
+}
+
 struct BlockContents {
   Slice data;     // Actual contents of data
   CacheAllocationPtr allocation;
@@ -216,7 +221,7 @@ struct BlockContents {
   // byte in the end.
   CompressionType get_compression_type() const {
     assert(is_raw_block);
-    return static_cast<CompressionType>(data.data()[data.size()]);
+    return get_block_compression_type(data.data(), data.size());
   }
 
   // The additional memory space taken by the block data.

--- a/table/format.h
+++ b/table/format.h
@@ -193,7 +193,7 @@ struct BlockContents {
   Slice data;     // Actual contents of data
   CacheAllocationPtr allocation;
 
-#ifdef NDEBUG
+#ifndef NDEBUG
   bool is_raw_block = false;
 #endif  // NDEBUG
 
@@ -247,7 +247,7 @@ struct BlockContents {
   BlockContents& operator=(BlockContents&& other) {
     data = std::move(other.data);
     allocation = std::move(other.allocation);
-#ifdef NDEBUG
+#ifndef NDEBUG
     is_raw_block = other.is_raw_block;
 #endif  // NDEBUG
     return *this;

--- a/table/format.h
+++ b/table/format.h
@@ -199,6 +199,8 @@ struct BlockContents {
   CacheAllocationPtr allocation;
 
 #ifndef NDEBUG
+  // Whether the block is a raw block, which contains compression type
+  // byte. It is only used for assertion.
   bool is_raw_block = false;
 #endif  // NDEBUG
 

--- a/table/format.h
+++ b/table/format.h
@@ -224,6 +224,10 @@ struct BlockContents {
     }
   }
 
+  size_t ApproximateMemoryUsage() const {
+    return usable_size() + sizeof(*this);
+  }
+
   BlockContents(BlockContents&& other) ROCKSDB_NOEXCEPT {
     *this = std::move(other);
   }

--- a/table/format.h
+++ b/table/format.h
@@ -191,30 +191,21 @@ static const size_t kBlockTrailerSize = 5;
 
 struct BlockContents {
   Slice data;     // Actual contents of data
-  bool cachable;  // True iff data can be cached
-  CompressionType compression_type;
   CacheAllocationPtr allocation;
 
-  BlockContents() : cachable(false), compression_type(kNoCompression) {}
+  BlockContents() {}
 
-  BlockContents(const Slice& _data, bool _cachable,
-                CompressionType _compression_type)
-      : data(_data), cachable(_cachable), compression_type(_compression_type) {}
+  BlockContents(const Slice& _data) : data(_data) {}
 
-  BlockContents(CacheAllocationPtr&& _data, size_t _size, bool _cachable,
-                CompressionType _compression_type)
-      : data(_data.get(), _size),
-        cachable(_cachable),
-        compression_type(_compression_type),
-        allocation(std::move(_data)) {}
+  BlockContents(CacheAllocationPtr&& _data, size_t _size)
+      : data(_data.get(), _size), allocation(std::move(_data)) {}
 
-  BlockContents(std::unique_ptr<char[]>&& _data, size_t _size, bool _cachable,
-                CompressionType _compression_type)
-      : data(_data.get(), _size),
-        cachable(_cachable),
-        compression_type(_compression_type) {
+  BlockContents(std::unique_ptr<char[]>&& _data, size_t _size)
+      : data(_data.get(), _size) {
     allocation.reset(_data.release());
   }
+
+  bool own_bytes() const { return allocation.get() != nullptr; }
 
   // The additional memory space taken by the block data.
   size_t usable_size() const {
@@ -239,8 +230,6 @@ struct BlockContents {
 
   BlockContents& operator=(BlockContents&& other) {
     data = std::move(other.data);
-    cachable = other.cachable;
-    compression_type = other.compression_type;
     allocation = std::move(other.allocation);
     return *this;
   }

--- a/table/partitioned_filter_block_test.cc
+++ b/table/partitioned_filter_block_test.cc
@@ -33,7 +33,7 @@ class MockedBlockBasedTable : public BlockBasedTable {
       const SliceTransform* prefix_extractor) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(
-        prefix_extractor, true, BlockContents(slice, false, kNoCompression),
+        prefix_extractor, true, BlockContents(slice),
         rep_->table_options.filter_policy->GetFilterBitsReader(slice), nullptr);
     return {obj, nullptr};
   }
@@ -44,7 +44,7 @@ class MockedBlockBasedTable : public BlockBasedTable {
       const SliceTransform* prefix_extractor) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(
-        prefix_extractor, true, BlockContents(slice, false, kNoCompression),
+        prefix_extractor, true, BlockContents(slice),
         rep_->table_options.filter_policy->GetFilterBitsReader(slice), nullptr);
     return obj;
   }
@@ -149,8 +149,8 @@ class PartitionedFilterBlockTest
         new BlockBasedTable::Rep(ioptions, env_options, table_options_, icomp,
                                  !kSkipFilters, 0, !kImmortal)));
     auto reader = new PartitionedFilterBlockReader(
-        prefix_extractor, true, BlockContents(slice, false, kNoCompression),
-        nullptr, nullptr, icomp, table.get(), pib->seperator_is_key_plus_seq(),
+        prefix_extractor, true, BlockContents(slice), nullptr, nullptr, icomp,
+        table.get(), pib->seperator_is_key_plus_seq(),
         !pib->get_use_value_delta_encoding());
     return reader;
   }

--- a/table/persistent_cache_helper.cc
+++ b/table/persistent_cache_helper.cc
@@ -29,12 +29,9 @@ void PersistentCacheHelper::InsertUncompressedPage(
     const BlockContents& contents) {
   assert(cache_options.persistent_cache);
   assert(!cache_options.persistent_cache->IsCompressed());
-  if (!contents.cachable || contents.compression_type != kNoCompression) {
-    // We shouldn't cache this. Either
-    // (1) content is not cacheable
-    // (2) content is compressed
-    return;
-  }
+  // Precondition:
+  // (1) content is cacheable
+  // (2) content is not compressed
 
   // construct the page key
   char cache_key[BlockBasedTable::kMaxCacheKeyPrefixSize + kMaxVarint64Length];
@@ -109,8 +106,7 @@ Status PersistentCacheHelper::LookupUncompressedPage(
   // update stats
   RecordTick(cache_options.statistics, PERSISTENT_CACHE_HIT);
   // construct result and return
-  *contents =
-      BlockContents(std::move(data), size, false /*cacheable*/, kNoCompression);
+  *contents = BlockContents(std::move(data), size);
   return Status::OK();
 }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -232,7 +232,6 @@ class BlockConstructor: public Constructor {
     data_ = builder.Finish().ToString();
     BlockContents contents;
     contents.data = data_;
-    contents.cachable = false;
     block_ = new Block(std::move(contents), kDisableGlobalSequenceNumber);
     return Status::OK();
   }


### PR DESCRIPTION
Summary: We carry compression type and "cachable" variables for every block in the block cache, while they take well-known values. 8-byte is wasted for each block (2-byte for useful information but it takes 8 bytes because of padding). With this change, these two variables are removed.

The cachable information is only useful in the process of reading the block. We use other information to infer from it. For compressed blocks, the compression type is a part of the block content itself so we can get it from there.

Some code is slightly refactored so that the cachable information can flow better.

Another change is to only use class BlockContents for compressed block, and narrow the class Block to only be used for uncompressed blocks. This can make the Block class less confusing. It also saves tens of bytes for each block in compressed block cache.

Test Plan: Run tests with ASAN