### PR TITLE
apply ReadOptions.iterate_upper_bound to transaction iterator

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1772,34 +1772,37 @@ rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator) {
   rocksdb_readoptions_t options;
-  return rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(&options, wbwi, base_iterator);
+  return rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
+      &options, wbwi, base_iterator);
 }
 
 rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
-    rocksdb_writebatch_wi_t* wbwi,
-    rocksdb_iterator_t* base_iterator,
+    rocksdb_writebatch_wi_t* wbwi, rocksdb_iterator_t* base_iterator,
     rocksdb_column_family_handle_t* column_family) {
   rocksdb_readoptions_t options;
-  return rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(&options, wbwi, base_iterator, column_family);
+  return rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
+      &options, wbwi, base_iterator, column_family);
 }
 
-rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
-    const rocksdb_readoptions_t* options,
-    rocksdb_writebatch_wi_t* wbwi,
+rocksdb_iterator_t*
+rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
+    const rocksdb_readoptions_t* options, rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator) {
   rocksdb_iterator_t* result = new rocksdb_iterator_t;
-  result->rep = wbwi->rep->NewIteratorWithBase(options->rep, base_iterator->rep);
+  result->rep =
+      wbwi->rep->NewIteratorWithBase(options->rep, base_iterator->rep);
   delete base_iterator;
   return result;
 }
 
-rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
-    const rocksdb_readoptions_t* options,
-    rocksdb_writebatch_wi_t* wbwi,
+rocksdb_iterator_t*
+rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
+    const rocksdb_readoptions_t* options, rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,
     rocksdb_column_family_handle_t* column_family) {
   rocksdb_iterator_t* result = new rocksdb_iterator_t;
-  result->rep = wbwi->rep->NewIteratorWithBase(options->rep, column_family->rep, base_iterator->rep);
+  result->rep = wbwi->rep->NewIteratorWithBase(options->rep, column_family->rep,
+                                               base_iterator->rep);
   delete base_iterator;
   return result;
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -1769,20 +1769,22 @@ void rocksdb_writebatch_wi_rollback_to_save_point(rocksdb_writebatch_wi_t* b,
 }
 
 rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
+    const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator) {
   rocksdb_iterator_t* result = new rocksdb_iterator_t;
-  result->rep = wbwi->rep->NewIteratorWithBase(base_iterator->rep);
+  result->rep = wbwi->rep->NewIteratorWithBase(options->rep, base_iterator->rep);
   delete base_iterator;
   return result;
 }
 
 rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
+    const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,
     rocksdb_column_family_handle_t* column_family) {
   rocksdb_iterator_t* result = new rocksdb_iterator_t;
-  result->rep = wbwi->rep->NewIteratorWithBase(column_family->rep, base_iterator->rep);
+  result->rep = wbwi->rep->NewIteratorWithBase(options->rep, column_family->rep, base_iterator->rep);
   delete base_iterator;
   return result;
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -1769,6 +1769,21 @@ void rocksdb_writebatch_wi_rollback_to_save_point(rocksdb_writebatch_wi_t* b,
 }
 
 rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
+    rocksdb_writebatch_wi_t* wbwi,
+    rocksdb_iterator_t* base_iterator) {
+  rocksdb_readoptions_t options;
+  return rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(&options, wbwi, base_iterator);
+}
+
+rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
+    rocksdb_writebatch_wi_t* wbwi,
+    rocksdb_iterator_t* base_iterator,
+    rocksdb_column_family_handle_t* column_family) {
+  rocksdb_readoptions_t options;
+  return rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(&options, wbwi, base_iterator, column_family);
+}
+
+rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
     const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator) {
@@ -1778,7 +1793,7 @@ rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
   return result;
 }
 
-rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
+rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
     const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -917,7 +917,7 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_wi_t* wbi = rocksdb_writebatch_wi_create(0, 1);
     rocksdb_writebatch_wi_put(wbi, "bar", 3, "b", 1);
     rocksdb_writebatch_wi_delete(wbi, "foo", 3);
-    rocksdb_iterator_t* iter = rocksdb_writebatch_wi_create_iterator_with_base(wbi, base_iter);
+    rocksdb_iterator_t* iter = rocksdb_writebatch_wi_create_iterator_with_base(roptions, wbi, base_iter);
     CheckCondition(!rocksdb_iter_valid(iter));
     rocksdb_iter_seek_to_first(iter);
     CheckCondition(rocksdb_iter_valid(iter));
@@ -1527,7 +1527,7 @@ int main(int argc, char** argv) {
     const rocksdb_snapshot_t* snapshot;
     snapshot = rocksdb_transactiondb_create_snapshot(txn_db);
     rocksdb_readoptions_set_snapshot(roptions, snapshot);
-  
+
     rocksdb_transactiondb_put(txn_db, woptions, "foo", 3, "hey", 3,  &err);
     CheckNoError(err);
 
@@ -1643,6 +1643,7 @@ int main(int argc, char** argv) {
     // Check iterator with column family
     rocksdb_transaction_put_cf(txn, cfh1, "key1_cf", 7, "val1_cf", 7, &err);
     CheckNoError(err);
+    rocksdb_readoptions_set_iterate_upper_bound(roptions, "key2", 4);
     rocksdb_iterator_t* iter =
         rocksdb_transaction_create_iterator_cf(txn, roptions, cfh1);
     CheckCondition(!rocksdb_iter_valid(iter));

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -917,7 +917,7 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_wi_t* wbi = rocksdb_writebatch_wi_create(0, 1);
     rocksdb_writebatch_wi_put(wbi, "bar", 3, "b", 1);
     rocksdb_writebatch_wi_delete(wbi, "foo", 3);
-    rocksdb_iterator_t* iter = rocksdb_writebatch_wi_create_iterator_with_base(roptions, wbi, base_iter);
+    rocksdb_iterator_t* iter = rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(roptions, wbi, base_iter);
     CheckCondition(!rocksdb_iter_valid(iter));
     rocksdb_iter_seek_to_first(iter);
     CheckCondition(rocksdb_iter_valid(iter));

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -917,7 +917,9 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_wi_t* wbi = rocksdb_writebatch_wi_create(0, 1);
     rocksdb_writebatch_wi_put(wbi, "bar", 3, "b", 1);
     rocksdb_writebatch_wi_delete(wbi, "foo", 3);
-    rocksdb_iterator_t* iter = rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(roptions, wbi, base_iter);
+    rocksdb_iterator_t* iter =
+        rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
+            roptions, wbi, base_iter);
     CheckCondition(!rocksdb_iter_valid(iter));
     rocksdb_iter_seek_to_first(iter);
     CheckCondition(rocksdb_iter_valid(iter));

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -636,16 +636,14 @@ extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iter
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,
     rocksdb_column_family_handle_t* cf);
-extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
-    const rocksdb_readoptions_t* options,
-    rocksdb_writebatch_wi_t* wbwi,
+extern ROCKSDB_LIBRARY_API rocksdb_iterator_t*
+rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
+    const rocksdb_readoptions_t* options, rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator);
-extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
-    const rocksdb_readoptions_t* options,
-    rocksdb_writebatch_wi_t* wbwi,
-    rocksdb_iterator_t* base_iterator,
-    rocksdb_column_family_handle_t* cf);
-
+extern ROCKSDB_LIBRARY_API rocksdb_iterator_t*
+rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
+    const rocksdb_readoptions_t* options, rocksdb_writebatch_wi_t* wbwi,
+    rocksdb_iterator_t* base_iterator, rocksdb_column_family_handle_t* cf);
 
 /* Block based table options */
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -630,9 +630,11 @@ extern ROCKSDB_LIBRARY_API void rocksdb_write_writebatch_wi(
     rocksdb_writebatch_wi_t* wbwi,
     char** errptr);
 extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
+    const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator);
 extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
+    const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,
     rocksdb_column_family_handle_t* cf);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -630,10 +630,17 @@ extern ROCKSDB_LIBRARY_API void rocksdb_write_writebatch_wi(
     rocksdb_writebatch_wi_t* wbwi,
     char** errptr);
 extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base(
-    const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator);
 extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf(
+    rocksdb_writebatch_wi_t* wbwi,
+    rocksdb_iterator_t* base_iterator,
+    rocksdb_column_family_handle_t* cf);
+extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_and_readoptions(
+    const rocksdb_readoptions_t* options,
+    rocksdb_writebatch_wi_t* wbwi,
+    rocksdb_iterator_t* base_iterator);
+extern ROCKSDB_LIBRARY_API rocksdb_iterator_t* rocksdb_writebatch_wi_create_iterator_with_base_cf_and_readoptions(
     const rocksdb_readoptions_t* options,
     rocksdb_writebatch_wi_t* wbwi,
     rocksdb_iterator_t* base_iterator,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -161,10 +161,12 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // key() and value() of the iterator. This invalidation happens even before
   // the write batch update finishes. The state may recover after Next() is
   // called.
-  Iterator* NewIteratorWithBase(ColumnFamilyHandle* column_family,
+  Iterator* NewIteratorWithBase(const ReadOptions& read_options,
+                                ColumnFamilyHandle* column_family,
                                 Iterator* base_iterator);
   // default column family
-  Iterator* NewIteratorWithBase(Iterator* base_iterator);
+  Iterator* NewIteratorWithBase(const ReadOptions& read_options,
+                                Iterator* base_iterator);
 
   // Similar to DB::Get() but will only read the key from this batch.
   // If the batch does not have enough data to resolve Merge operations,

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -164,9 +164,13 @@ class WriteBatchWithIndex : public WriteBatchBase {
   Iterator* NewIteratorWithBase(const ReadOptions& read_options,
                                 ColumnFamilyHandle* column_family,
                                 Iterator* base_iterator);
+
+  Iterator* NewIteratorWithBase(ColumnFamilyHandle* column_family,
+                                Iterator* base_iterator);
   // default column family
   Iterator* NewIteratorWithBase(const ReadOptions& read_options,
                                 Iterator* base_iterator);
+  Iterator* NewIteratorWithBase(Iterator* base_iterator);
 
   // Similar to DB::Get() but will only read the key from this batch.
   // If the batch does not have enough data to resolve Merge operations,

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -457,11 +457,13 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(JNIEnv* /*env*/,
                                                             jobject /*jobj*/,
                                                             jlong jwbwi_handle,
                                                             jlong jcf_handle,
-                                                            jlong jbi_handle) {
+                                                            jlong jbi_handle,
+                                                            jlong jreadopt_handle) {
   auto* wbwi = reinterpret_cast<rocksdb::WriteBatchWithIndex*>(jwbwi_handle);
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* base_iterator = reinterpret_cast<rocksdb::Iterator*>(jbi_handle);
-  auto* iterator = wbwi->NewIteratorWithBase(cf_handle, base_iterator);
+  auto* readopt = reinterpret_cast<rocksdb::ReadOptions*>(jreadopt_handle);
+  auto* iterator = wbwi->NewIteratorWithBase(*readopt, cf_handle, base_iterator);
   return reinterpret_cast<jlong>(iterator);
 }
 

--- a/java/rocksjni/write_batch_with_index.cc
+++ b/java/rocksjni/write_batch_with_index.cc
@@ -463,7 +463,8 @@ jlong Java_org_rocksdb_WriteBatchWithIndex_iteratorWithBase(JNIEnv* /*env*/,
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* base_iterator = reinterpret_cast<rocksdb::Iterator*>(jbi_handle);
   auto* readopt = reinterpret_cast<rocksdb::ReadOptions*>(jreadopt_handle);
-  auto* iterator = wbwi->NewIteratorWithBase(*readopt, cf_handle, base_iterator);
+  auto* iterator =
+      wbwi->NewIteratorWithBase(*readopt, cf_handle, base_iterator);
   return reinterpret_cast<jlong>(iterator);
 }
 

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -15,7 +15,8 @@ package org.rocksdb;
  * A user can call {@link org.rocksdb.WriteBatchWithIndex#newIterator()} to
  * create an iterator over the write batch or
  * {@link org.rocksdb.WriteBatchWithIndex#newIteratorWithBase(org.rocksdb.ReadOptions, org.rocksdb.RocksIterator)}
- * to get an iterator for the database with Read-Your-Own-Writes like capability
+ * to get an iterator for the database with Read-Your-Own-Writes like
+ * capability
  */
 public class WriteBatchWithIndex extends AbstractWriteBatch {
   /**
@@ -127,19 +128,38 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
    * @return An iterator which shows a view comprised of both the database
    * point-in-time from baseIterator and modifications made in this write batch.
    */
-  public RocksIterator newIteratorWithBase(
-      final ReadOptions read_opts,
-      final ColumnFamilyHandle columnFamilyHandle,
-      final RocksIterator baseIterator) {
-    RocksIterator iterator = new RocksIterator(
-        baseIterator.parent_,
-        iteratorWithBase(nativeHandle_,
-                columnFamilyHandle.nativeHandle_,
-                baseIterator.nativeHandle_,
-                read_opts.nativeHandle_));
+  public RocksIterator newIteratorWithBase(final ReadOptions read_opts,
+      final ColumnFamilyHandle columnFamilyHandle, final RocksIterator baseIterator) {
+    RocksIterator iterator = new RocksIterator(baseIterator.parent_,
+        iteratorWithBase(nativeHandle_, columnFamilyHandle.nativeHandle_,
+            baseIterator.nativeHandle_, read_opts.nativeHandle_));
     //when the iterator is deleted it will also delete the baseIterator
     baseIterator.disOwnNativeHandle();
     return iterator;
+  }
+
+  /**
+   * Provides Read-Your-Own-Writes like functionality by
+   * creating a new Iterator that will use {@link org.rocksdb.WBWIRocksIterator}
+   * as a delta and baseIterator as a base
+   *
+   * Updating write batch with the current key of the iterator is not safe.
+   * We strongly recommand users not to do it. It will invalidate the current
+   * key() and value() of the iterator. This invalidation happens even before
+   * the write batch update finishes. The state may recover after Next() is
+   * called.
+   *
+   * @param columnFamilyHandle The column family to iterate over
+   * @param baseIterator The base iterator,
+   *   e.g. {@link org.rocksdb.RocksDB#newIterator()}
+   * @return An iterator which shows a view comprised of both the database
+   * point-in-time from baseIterator and modifications made in this write batch.
+   */
+  public RocksIterator newIteratorWithBase(
+      final ColumnFamilyHandle columnFamilyHandle,
+      final RocksIterator baseIterator) {
+    ReadOptions read_opts = new ReadOptions();
+    return newIteratorWithBase(read_opts, columnFamilyHandle, baseIterator);
   }
 
   /**
@@ -154,10 +174,26 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
    * @return An iterator which shows a view comprised of both the database
    * point-in-timefrom baseIterator and modifications made in this write batch.
    */
-  public RocksIterator newIteratorWithBase(final ReadOptions read_opts,
-      final RocksIterator baseIterator) {
-    return newIteratorWithBase(read_opts,
-        baseIterator.parent_.getDefaultColumnFamily(), baseIterator);
+  public RocksIterator newIteratorWithBase(
+      final ReadOptions read_opts, final RocksIterator baseIterator) {
+    return newIteratorWithBase(
+        read_opts, baseIterator.parent_.getDefaultColumnFamily(), baseIterator);
+  }
+
+  /**
+   * Provides Read-Your-Own-Writes like functionality by
+   * creating a new Iterator that will use {@link org.rocksdb.WBWIRocksIterator}
+   * as a delta and baseIterator as a base. Operates on the default column
+   * family.
+   *
+   * @param baseIterator The base iterator,
+   *   e.g. {@link org.rocksdb.RocksDB#newIterator()}
+   * @return An iterator which shows a view comprised of both the database
+   * point-in-timefrom baseIterator and modifications made in this write batch.
+   */
+  public RocksIterator newIteratorWithBase(final RocksIterator baseIterator) {
+    ReadOptions read_opts = new ReadOptions();
+    return newIteratorWithBase(read_opts, baseIterator);
   }
 
   /**
@@ -300,8 +336,8 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
       final boolean overwriteKey);
   private native long iterator0(final long handle);
   private native long iterator1(final long handle, final long cfHandle);
-  private native long iteratorWithBase(final long handle,
-      final long baseIteratorHandle, final long cfHandle, final long jreadopt_handle);
+  private native long iteratorWithBase(final long handle, final long baseIteratorHandle,
+      final long cfHandle, final long jreadopt_handle);
   private native byte[] getFromBatch(final long handle, final long optHandle,
       final byte[] key, final int keyLen);
   private native byte[] getFromBatch(final long handle, final long optHandle,

--- a/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
+++ b/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
@@ -46,7 +46,8 @@ public class WriteBatchWithIndexTest {
 
       try (final WriteBatchWithIndex wbwi = new WriteBatchWithIndex(true);
            final RocksIterator base = db.newIterator();
-           final RocksIterator it = wbwi.newIteratorWithBase(base)) {
+           final ReadOptions readOptions = new ReadOptions();
+           final RocksIterator it = wbwi.newIteratorWithBase(readOptions, base)) {
 
         it.seek(k1);
         assertThat(it.isValid()).isTrue();
@@ -422,7 +423,7 @@ public class WriteBatchWithIndexTest {
       final String skey) {
     final byte[] key = skey.getBytes();
     try(final RocksIterator baseIterator = db.newIterator(readOptions);
-        final RocksIterator iterator = wbwi.newIteratorWithBase(baseIterator)) {
+        final RocksIterator iterator = wbwi.newIteratorWithBase(readOptions, baseIterator)) {
       iterator.seek(key);
 
       // Arrays.equals(key, iterator.key()) ensures an exact match in Rocks,

--- a/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
+++ b/java/src/test/java/org/rocksdb/WriteBatchWithIndexTest.java
@@ -46,9 +46,7 @@ public class WriteBatchWithIndexTest {
 
       try (final WriteBatchWithIndex wbwi = new WriteBatchWithIndex(true);
            final RocksIterator base = db.newIterator();
-           final ReadOptions readOptions = new ReadOptions();
-           final RocksIterator it = wbwi.newIteratorWithBase(readOptions, base)) {
-
+           final RocksIterator it = wbwi.newIteratorWithBase(base)) {
         it.seek(k1);
         assertThat(it.isValid()).isTrue();
         assertThat(it.key()).isEqualTo(k1);
@@ -422,8 +420,8 @@ public class WriteBatchWithIndexTest {
       final ReadOptions readOptions, final WriteBatchWithIndex wbwi,
       final String skey) {
     final byte[] key = skey.getBytes();
-    try(final RocksIterator baseIterator = db.newIterator(readOptions);
-        final RocksIterator iterator = wbwi.newIteratorWithBase(readOptions, baseIterator)) {
+    try (final RocksIterator baseIterator = db.newIterator(readOptions);
+         final RocksIterator iterator = wbwi.newIteratorWithBase(baseIterator)) {
       iterator.seek(key);
 
       // Arrays.equals(key, iterator.key()) ensures an exact match in Rocks,

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -883,6 +883,13 @@ TEST_F(OptimisticTransactionTest, IteratorUpperBoundTest) {
     key_count++;
   }
   ASSERT_EQ(key_count, 1);
+  // Test Seek to a key equal or over upper bound
+  it->Seek("a2");
+  ASSERT_FALSE(it->Valid());
+  it->Seek("a3");
+  ASSERT_FALSE(it->Valid());
+  it->Seek("a1");
+  ASSERT_TRUE(it->Valid());
   it.reset();
 
   s = txn->Commit();

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -876,6 +876,12 @@ TEST_F(OptimisticTransactionTest, IteratorUpperBoundTest) {
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     EXPECT_LT(it->key().ToString(), ubKey);
   }
+  int key_count = 0;
+  for (it->SeekToFirst(); it->Valid(); it->Next()) {
+    EXPECT_LT(it->key().ToString(), ubKey);
+    key_count++;
+  }
+  ASSERT_EQ(key_count, 1);
   it.reset();
 
   s = txn->Commit();

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -876,6 +876,7 @@ TEST_F(OptimisticTransactionTest, IteratorUpperBoundTest) {
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     EXPECT_LT(it->key().ToString(), ubKey);
   }
+  EXPECT_GE(it->key().ToString(), ubKey);
   int key_count = 0;
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     EXPECT_LT(it->key().ToString(), ubKey);

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -852,6 +852,37 @@ TEST_F(OptimisticTransactionTest, UntrackedWrites) {
   delete txn;
 }
 
+TEST_F(OptimisticTransactionTest, IteratorUpperBoundTest) {
+  WriteOptions write_options;
+  ReadOptions read_options;
+  auto txn = unique_ptr<Transaction>(txn_db->BeginTransaction(write_options));
+
+  string key1 = "a1";
+  string key2 = "a3";
+  string key3 = "b1";
+  string val = "123";
+  txn->Put(key1, val);
+  txn->Put(key2, val);
+
+  Status s = txn->Commit();
+  ASSERT_OK(s);
+  txn = unique_ptr<Transaction>(txn_db->BeginTransaction(write_options));
+  txn->Put(key3, val);
+
+  string ubKey("a2");
+  Slice upperbound(ubKey);
+  read_options.iterate_upper_bound = &upperbound;
+  auto it = unique_ptr<Iterator>(txn->GetIterator(read_options));
+  for (it->SeekToFirst(); it->Valid(); it->Next()) {
+    EXPECT_LT(it->key().ToString(), ubKey);
+  }
+  it.reset();
+
+  s = txn->Commit();
+  ASSERT_OK(s);
+  txn.reset();
+}
+
 TEST_F(OptimisticTransactionTest, IteratorTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -178,7 +178,7 @@ Status TransactionBaseImpl::RollbackToSavePoint() {
     return Status::NotFound();
   }
 }
-  
+
 Status TransactionBaseImpl::PopSavePoint() {
   if (save_points_ == nullptr ||
       save_points_->empty()) {
@@ -187,7 +187,7 @@ Status TransactionBaseImpl::PopSavePoint() {
     return Status::NotFound();
   }
 
-  assert(!save_points_->empty()); 
+  assert(!save_points_->empty());
   save_points_->pop();
   return write_batch_.PopSavePoint();
 }
@@ -291,7 +291,7 @@ Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options) {
   Iterator* db_iter = db_->NewIterator(read_options);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(db_iter);
+  return write_batch_.NewIteratorWithBase(read_options, db_iter);
 }
 
 Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options,
@@ -299,7 +299,7 @@ Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options,
   Iterator* db_iter = db_->NewIterator(read_options, column_family);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(column_family, db_iter);
+  return write_batch_.NewIteratorWithBase(read_options, column_family, db_iter);
 }
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -62,7 +62,7 @@ Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options) {
   Iterator* db_iter = wpt_db_->NewIterator(options);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(db_iter);
+  return write_batch_.NewIteratorWithBase(options, db_iter);
 }
 
 Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options,
@@ -71,7 +71,7 @@ Iterator* WritePreparedTxn::GetIterator(const ReadOptions& options,
   Iterator* db_iter = wpt_db_->NewIterator(options, column_family);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(column_family, db_iter);
+  return write_batch_.NewIteratorWithBase(options, column_family, db_iter);
 }
 
 Status WritePreparedTxn::PrepareInternal() {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -506,7 +506,7 @@ Iterator* WriteUnpreparedTxn::GetIterator(const ReadOptions& options,
   Iterator* db_iter = wupt_db_->NewIterator(options, column_family, this);
   assert(db_iter);
 
-  return write_batch_.NewIteratorWithBase(column_family, db_iter);
+  return write_batch_.NewIteratorWithBase(options, column_family, db_iter);
 }
 
 const std::map<SequenceNumber, size_t>&

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -47,7 +47,9 @@ class BaseDeltaIterator : public Iterator {
   virtual ~BaseDeltaIterator() {}
 
   bool Valid() const override {
-    return current_over_upper_bound_ ? false : (current_at_base_ ? BaseValid() : DeltaValid());
+    return current_over_upper_bound_
+               ? false
+               : (current_at_base_ ? BaseValid() : DeltaValid());
   }
 
   void SeekToFirst() override {
@@ -224,8 +226,7 @@ class BaseDeltaIterator : public Iterator {
 
   bool IsOverUpperBound() {
     return read_options_.iterate_upper_bound != nullptr &&
-         comparator_->Compare(key(),
-                              *read_options_.iterate_upper_bound) >= 0;
+           comparator_->Compare(key(), *read_options_.iterate_upper_bound) >= 0;
   }
 
   void Advance() {
@@ -669,6 +670,12 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(
+    ColumnFamilyHandle* column_family, Iterator* base_iterator) {
+  ReadOptions read_options;
+  return NewIteratorWithBase(read_options, column_family, base_iterator);
+}
+
+Iterator* WriteBatchWithIndex::NewIteratorWithBase(
     const ReadOptions& read_options, Iterator* base_iterator) {
   if (rep->overwrite_key == false) {
     assert(false);
@@ -677,6 +684,11 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
   // default column family's comparator
   return new BaseDeltaIterator(read_options, base_iterator, NewIterator(),
                                rep->comparator.default_comparator());
+}
+
+Iterator* WriteBatchWithIndex::NewIteratorWithBase(Iterator* base_iterator) {
+  ReadOptions read_options;
+  return NewIteratorWithBase(read_options, base_iterator);
 }
 
 Status WriteBatchWithIndex::Put(ColumnFamilyHandle* column_family,

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -222,13 +222,10 @@ class BaseDeltaIterator : public Iterator {
 #endif
   }
 
-  void IsOverUpperBound() {
-    if ((read_options_.iterate_upper_bound != nullptr &&
+  bool IsOverUpperBound() {
+    return read_options_.iterate_upper_bound != nullptr &&
          comparator_->Compare(key(),
-                              *read_options_.iterate_upper_bound) >= 0)) {
-      current_over_upper_bound_ = true;
-      return;
-    }
+                              *read_options_.iterate_upper_bound) >= 0;
   }
 
   void Advance() {
@@ -327,7 +324,7 @@ class BaseDeltaIterator : public Iterator {
       }
     }
 
-    IsOverUpperBound();
+    current_over_upper_bound_ = IsOverUpperBound();
     // AssertInvariants();
 #endif  // __clang_analyzer__
   }

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -322,10 +322,13 @@ class BaseDeltaIterator : public Iterator {
           break;
         }
       }
+      current_over_upper_bound_ = IsOverUpperBound();
+      if (current_over_upper_bound_) {
+        break;
+      }
     }
 
     current_over_upper_bound_ = IsOverUpperBound();
-    // AssertInvariants();
 #endif  // __clang_analyzer__
   }
 

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -32,11 +32,13 @@ namespace rocksdb {
 // * equal_keys_ <=> base_iterator == delta_iterator
 class BaseDeltaIterator : public Iterator {
  public:
-  BaseDeltaIterator(Iterator* base_iterator, WBWIIterator* delta_iterator,
-                    const Comparator* comparator)
-      : forward_(true),
+  BaseDeltaIterator(const ReadOptions& read_options, Iterator* base_iterator,
+                    WBWIIterator* delta_iterator, const Comparator* comparator)
+      : read_options_(read_options),
+        forward_(true),
         current_at_base_(true),
         equal_keys_(false),
+        current_over_upper_bound_(false),
         status_(Status::OK()),
         base_iterator_(base_iterator),
         delta_iterator_(delta_iterator),
@@ -45,7 +47,7 @@ class BaseDeltaIterator : public Iterator {
   virtual ~BaseDeltaIterator() {}
 
   bool Valid() const override {
-    return current_at_base_ ? BaseValid() : DeltaValid();
+    return current_over_upper_bound_ ? false : (current_at_base_ ? BaseValid() : DeltaValid());
   }
 
   void SeekToFirst() override {
@@ -216,7 +218,17 @@ class BaseDeltaIterator : public Iterator {
     }
     // equal_keys_ <=> compare == 0
     assert((equal_keys_ || compare != 0) && (!equal_keys_ || compare == 0));
+
 #endif
+  }
+
+  void IsOverUpperBound() {
+    if ((read_options_.iterate_upper_bound != nullptr &&
+         comparator_->Compare(key(),
+                              *read_options_.iterate_upper_bound) >= 0)) {
+      current_over_upper_bound_ = true;
+      return;
+    }
   }
 
   void Advance() {
@@ -264,32 +276,32 @@ class BaseDeltaIterator : public Iterator {
       } else if (!delta_iterator_->status().ok()) {
         // Expose the error status and stop.
         current_at_base_ = false;
-        return;
+        break;
       }
       equal_keys_ = false;
       if (!BaseValid()) {
         if (!base_iterator_->status().ok()) {
           // Expose the error status and stop.
           current_at_base_ = true;
-          return;
+          break;
         }
 
         // Base has finished.
         if (!DeltaValid()) {
           // Finished
-          return;
+          break;
         }
         if (delta_entry.type == kDeleteRecord ||
             delta_entry.type == kSingleDeleteRecord) {
           AdvanceDelta();
         } else {
           current_at_base_ = false;
-          return;
+          break;
         }
       } else if (!DeltaValid()) {
         // Delta has finished.
         current_at_base_ = true;
-        return;
+        break;
       } else {
         int compare =
             (forward_ ? 1 : -1) *
@@ -301,7 +313,7 @@ class BaseDeltaIterator : public Iterator {
           if (delta_entry.type != kDeleteRecord &&
               delta_entry.type != kSingleDeleteRecord) {
             current_at_base_ = false;
-            return;
+            break;
           }
           // Delta is less advanced and is delete.
           AdvanceDelta();
@@ -310,18 +322,21 @@ class BaseDeltaIterator : public Iterator {
           }
         } else {
           current_at_base_ = true;
-          return;
+          break;
         }
       }
     }
 
-    AssertInvariants();
+    IsOverUpperBound();
+    // AssertInvariants();
 #endif  // __clang_analyzer__
   }
 
+  ReadOptions read_options_;
   bool forward_;
   bool current_at_base_;
   bool equal_keys_;
+  bool current_over_upper_bound_;
   Status status_;
   std::unique_ptr<Iterator> base_iterator_;
   std::unique_ptr<WBWIIterator> delta_iterator_;
@@ -642,22 +657,25 @@ WBWIIterator* WriteBatchWithIndex::NewIterator(
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(
-    ColumnFamilyHandle* column_family, Iterator* base_iterator) {
+    const ReadOptions& read_options, ColumnFamilyHandle* column_family,
+    Iterator* base_iterator) {
   if (rep->overwrite_key == false) {
     assert(false);
     return nullptr;
   }
-  return new BaseDeltaIterator(base_iterator, NewIterator(column_family),
+  return new BaseDeltaIterator(read_options, base_iterator,
+                               NewIterator(column_family),
                                GetColumnFamilyUserComparator(column_family));
 }
 
-Iterator* WriteBatchWithIndex::NewIteratorWithBase(Iterator* base_iterator) {
+Iterator* WriteBatchWithIndex::NewIteratorWithBase(
+    const ReadOptions& read_options, Iterator* base_iterator) {
   if (rep->overwrite_key == false) {
     assert(false);
     return nullptr;
   }
   // default column family's comparator
-  return new BaseDeltaIterator(base_iterator, NewIterator(),
+  return new BaseDeltaIterator(read_options, base_iterator, NewIterator(),
                                rep->comparator.default_comparator());
 }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -613,9 +613,8 @@ TEST_F(WriteBatchWithIndexTest, TestRandomIteraratorWithBase) {
       }
     }
 
-    ReadOptions read_options;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
     std::unique_ptr<Iterator> result_iter(new KVIter(&merged_map));
 
     bool is_valid = false;
@@ -681,7 +680,6 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 20, true);
-  ReadOptions read_options;
 
   {
     KVMap map;
@@ -689,7 +687,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["c"] = "cc";
     map["e"] = "ee";
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -727,7 +725,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -747,7 +745,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["cc"] = "cccc";
     map["f"] = "ff";
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -805,7 +803,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -845,7 +843,6 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 20, true);
-  ReadOptions read_options;
 
   // Test the case that there is one element in the write batch
   batch.Put(&cf2, "zoo", "bar");
@@ -853,7 +850,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -866,7 +863,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "c", "cc");
@@ -899,8 +896,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap map;
     map["b"] = "";
-    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(read_options,
-        new KVIter(&map)));
+    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "b");
@@ -1376,14 +1372,13 @@ TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseCorrectnessTest) {
   }
 
   KVMap map;
-  ReadOptions read_options;
   map["aa"] = "aa";
   map["cc"] = "cc";
   map["ee"] = "ee";
   map["em"] = "me";
 
   std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(read_options, new KVIter(&map)));
+      batch.NewIteratorWithBase(new KVIter(&map)));
   iter->Seek("k");
   AssertIterKey("k", iter.get());
   iter->Next();
@@ -1445,13 +1440,12 @@ TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseStressTest) {
   }
 
   KVMap map;
-  ReadOptions read_options;
   for (char c = 'a'; c <= 'z'; ++c) {
     map[std::string(2, c)] = std::string(2, c);
   }
 
   std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(read_options, new KVIter(&map)));
+      batch.NewIteratorWithBase(new KVIter(&map)));
 
   Random rnd(301);
   for (int i = 0; i < 1000000; ++i) {
@@ -1541,11 +1535,10 @@ static std::string PrintContents(WriteBatchWithIndex* batch, KVMap* base_map,
   std::string result;
 
   Iterator* iter;
-  ReadOptions read_options;
   if (column_family == nullptr) {
-    iter = batch->NewIteratorWithBase(read_options, new KVIter(base_map));
+    iter = batch->NewIteratorWithBase(new KVIter(base_map));
   } else {
-    iter = batch->NewIteratorWithBase(read_options, column_family, new KVIter(base_map));
+    iter = batch->NewIteratorWithBase(column_family, new KVIter(base_map));
   }
 
   iter->SeekToFirst();

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -613,8 +613,9 @@ TEST_F(WriteBatchWithIndexTest, TestRandomIteraratorWithBase) {
       }
     }
 
+    ReadOptions read_options;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
     std::unique_ptr<Iterator> result_iter(new KVIter(&merged_map));
 
     bool is_valid = false;
@@ -680,6 +681,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 20, true);
+  ReadOptions read_options;
 
   {
     KVMap map;
@@ -687,7 +689,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["c"] = "cc";
     map["e"] = "ee";
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -725,7 +727,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -745,7 +747,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["cc"] = "cccc";
     map["f"] = "ff";
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -803,7 +805,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -843,6 +845,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 20, true);
+  ReadOptions read_options;
 
   // Test the case that there is one element in the write batch
   batch.Put(&cf2, "zoo", "bar");
@@ -850,7 +853,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&empty_map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -863,7 +866,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap map;
     std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+        batch.NewIteratorWithBase(read_options, &cf1, new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "c", "cc");
@@ -896,7 +899,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   {
     KVMap map;
     map["b"] = "";
-    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
+    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(read_options,
+        new KVIter(&map)));
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "b");
@@ -1372,13 +1376,14 @@ TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseCorrectnessTest) {
   }
 
   KVMap map;
+  ReadOptions read_options;
   map["aa"] = "aa";
   map["cc"] = "cc";
   map["ee"] = "ee";
   map["em"] = "me";
 
   std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(new KVIter(&map)));
+      batch.NewIteratorWithBase(read_options, new KVIter(&map)));
   iter->Seek("k");
   AssertIterKey("k", iter.get());
   iter->Next();
@@ -1440,12 +1445,13 @@ TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseStressTest) {
   }
 
   KVMap map;
+  ReadOptions read_options;
   for (char c = 'a'; c <= 'z'; ++c) {
     map[std::string(2, c)] = std::string(2, c);
   }
 
   std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(new KVIter(&map)));
+      batch.NewIteratorWithBase(read_options, new KVIter(&map)));
 
   Random rnd(301);
   for (int i = 0; i < 1000000; ++i) {
@@ -1535,10 +1541,11 @@ static std::string PrintContents(WriteBatchWithIndex* batch, KVMap* base_map,
   std::string result;
 
   Iterator* iter;
+  ReadOptions read_options;
   if (column_family == nullptr) {
-    iter = batch->NewIteratorWithBase(new KVIter(base_map));
+    iter = batch->NewIteratorWithBase(read_options, new KVIter(base_map));
   } else {
-    iter = batch->NewIteratorWithBase(column_family, new KVIter(base_map));
+    iter = batch->NewIteratorWithBase(read_options, column_family, new KVIter(base_map));
   }
 
   iter->SeekToFirst();


### PR DESCRIPTION
Currently transaction iterator does not apply `ReadOptions.iterate_upper_bound` when iterating. This PR attempts to fix the problem by having `BaseDeltaIterator` enforcing the upper bound check when iterator state is changed.