### PR TITLE
Fix index block cache eviction metric with partitioned indexes

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1354,8 +1354,8 @@ Status BlockBasedTable::PutDataBlockToCache(
   if (block_cache != nullptr && block->value->cachable()) {
     size_t charge = block->value->ApproximateMemoryUsage();
     s = block_cache->Insert(block_cache_key, block->value, charge,
-                            &DeleteCachedEntry<Block>, &(block->cache_handle),
-                            priority);
+                            is_index ? &DeleteCachedIndexEntry : &DeleteCachedEntry<Block>,
+                            &(block->cache_handle), priority);
     block_cache->TEST_mark_as_data_block(block_cache_key, charge);
     if (s.ok()) {
       assert(block->cache_handle != nullptr);


### PR DESCRIPTION
We are seeing that using:
* `kTwoLevelIndexSearch` and 
* `cache_index_and_filter_blocks` = false

is leaving the `BLOCK_CACHE_INDEX_BYTES_EVICT` metric at zero, while `BLOCK_CACHE_INDEX_BYTES_INSERT` keeps climbing.  I believe this is because `PutDataBlockToCache()` is called for the lower-level index blocks, but the deletion callback is always bound to the naive `DeleteCachedEntry<Block>()` data deletion callback.

@maysamyabandeh can you confirm this reasoning?

I will see about adding a unit test for this specifically - I didn't see any currently testing eviction metrics, just insertion.