### PR TITLE
Refactor SstFileReader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,6 +577,7 @@ set(SOURCES
         table/plain_table_index.cc
         table/plain_table_key_coding.cc
         table/plain_table_reader.cc
+				table/sst_file_reader.cc
         table/sst_file_writer.cc
         table/table_properties.cc
         table/two_level_iterator.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ set(SOURCES
         table/plain_table_index.cc
         table/plain_table_key_coding.cc
         table/plain_table_reader.cc
-				table/sst_file_reader.cc
+        table/sst_file_reader.cc
         table/sst_file_writer.cc
         table/table_properties.cc
         table/two_level_iterator.cc

--- a/TARGETS
+++ b/TARGETS
@@ -201,6 +201,7 @@ cpp_library(
         "table/plain_table_index.cc",
         "table/plain_table_key_coding.cc",
         "table/plain_table_reader.cc",
+        "table/sst_file_reader.cc",
         "table/sst_file_writer.cc",
         "table/table_properties.cc",
         "table/two_level_iterator.cc",

--- a/include/rocksdb/sst_file_reader.h
+++ b/include/rocksdb/sst_file_reader.h
@@ -1,0 +1,83 @@
+//  Copyright (c) 2018-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#ifndef ROCKSDB_LITE
+
+#include <string>
+
+#include "rocksdb/iterator.h"
+#include "rocksdb/table.h"
+
+namespace rocksdb {
+
+class SstKVIterator : public Iterator {
+ public:
+  SstKVIterator() {}
+  virtual ~SstKVIterator() {}
+  // If `sequence` is not nullptr, it will be set as the SequenceNumber of
+  // current entry. If `type` is not nullptr, it will be set as the ValueType of
+  // current entry.
+  virtual Slice key(SequenceNumber* sequence, int* type) const = 0;
+  // key() will be implemented by key(nullptr, nullptr).
+  virtual Slice key() const = 0;
+};
+
+// SstFileReader is used to read sst files.
+// SstFileReader may be safely accessed from multiple threads
+// without external synchronization.
+class SstFileReader {
+ public:
+  // `file_name` specifies path of the read-only sst file to be accessed.
+  // `options` to control the behavior of TableReader.
+  // `comparator` provides a total order across slices that are used as keys in
+  // sstable.
+  SstFileReader(const std::string& file_name, Options options = Options(),
+                const Comparator* comparator = BytewiseComparator());
+
+  ~SstFileReader();
+
+  // Returns an iterator over this sst file.
+  // The result of NewIterator() is initially invalid (caller must
+  // call one of the Seek methods on the iterator before using it).
+  //
+  // Caller should delete the iterator when it is no longer needed.
+  // The returned iterator should be deleted before this SstFileReader is
+  // deleted.
+  SstKVIterator* NewIterator(const ReadOptions& read_options,
+                             const SliceTransform* prefix_extractor,
+                             Arena* arena = nullptr, bool skip_filters = false,
+                             bool for_compaction = false);
+  // If `verify_checksum` is true, all data read from underlying storage will be
+  // verified against corresponding checksums.
+  // If `cache` is true, the "data block"/"index block"" read for this iteration
+  // be placed in block cache. Both parameters will be used to create
+  // ReadOptions.
+  SstKVIterator* NewIterator(bool cksum, bool cache,
+                             const SliceTransform* prefix_extractor);
+
+  // If `prefix_extractor` is not specified, then will use prefix_extractor of
+  // `options` in constructor.
+  SstKVIterator* NewIterator(bool cksum, bool cache = false);
+
+  // Get table properties.
+  Status ReadTableProperties(
+      std::shared_ptr<const TableProperties>* table_properties);
+
+  // Returns init result of SstFileReader.
+  // It can be invoked after constructor to tell whether is ready to use.
+  Status getStatus();
+
+  // Check whether there is corruption in this file.
+  Status VerifyChecksum();
+
+ private:
+  struct Rep;
+  std::unique_ptr<Rep> rep_;
+};
+}  // namespace rocksdb
+
+#endif  // !ROCKSDB_LITE

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -457,9 +457,10 @@ class TableFactory {
   // NewTableReader() is called in three places:
   // (1) TableCache::FindTable() calls the function when table cache miss
   //     and cache the table object returned.
-  // (2) SstFileReader (for SST Dump) opens the table and dump the table
+  // (2) SstFileDumper (for SST Dump) opens the table and dump the table
   //     contents using the iterator of the table.
-  // (3) DBImpl::IngestExternalFile() calls this function to read the contents of
+  // (3) DBImpl::IngestExternalFile() calls this function to read the contents
+  // of
   //     the sst file it's attempting to add
   //
   // table_reader_options is a TableReaderOptions which contain all the

--- a/src.mk
+++ b/src.mk
@@ -121,6 +121,7 @@ LIB_SOURCES =                                                   \
   table/plain_table_index.cc                                    \
   table/plain_table_key_coding.cc                               \
   table/plain_table_reader.cc                                   \
+  table/sst_file_reader.cc                                      \
   table/sst_file_writer.cc                                      \
   table/table_properties.cc                                     \
   table/two_level_iterator.cc                                   \

--- a/table/internal_sst_file_reader.h
+++ b/table/internal_sst_file_reader.h
@@ -20,9 +20,6 @@ class InternalSstFileReader {
 
   virtual ~InternalSstFileReader() {}
 
-  InternalIterator* NewIterator(bool cksum, bool cache,
-                                const SliceTransform* prefix_extractor);
-  InternalIterator* NewIterator(bool cksum, bool cache);
   InternalIterator* NewIterator(const ReadOptions& read_options,
                                 const SliceTransform* prefix_extractor,
                                 Arena* arena = nullptr,

--- a/table/internal_sst_file_reader.h
+++ b/table/internal_sst_file_reader.h
@@ -1,0 +1,91 @@
+//  Copyright (c) 2018-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#ifndef ROCKSDB_LITE
+
+#include <string>
+#include "rocksdb/options.h"
+#include "table/table_reader.h"
+
+namespace rocksdb {
+
+class InternalSstFileReader {
+ public:
+  InternalSstFileReader(const std::string& file_name, Options options,
+                        const Comparator* comparator);
+
+  virtual ~InternalSstFileReader() {}
+
+  InternalIterator* NewIterator(bool cksum, bool cache,
+                                const SliceTransform* prefix_extractor);
+  InternalIterator* NewIterator(bool cksum, bool cache);
+  InternalIterator* NewIterator(const ReadOptions& read_options,
+                                const SliceTransform* prefix_extractor,
+                                Arena* arena = nullptr,
+                                bool skip_filters = false,
+                                bool for_compaction = false);
+
+  Status ReadTableProperties(
+      std::shared_ptr<const TableProperties>* table_properties);
+
+  Status getStatus() { return init_result_; }
+
+  Status VerifyChecksum();
+
+ protected:
+  enum SstFileFormat {
+    BlockBased,
+    PlainTable,
+    Unsupported,
+  };
+
+  InternalSstFileReader(Options options = Options(),
+                        const Comparator* comparator = BytewiseComparator());
+
+  Status Open(const std::string& file_name);
+
+  // Get the TableReader implementation for the sst file
+  Status GetTableReader(const std::string& file_path);
+
+  // Helper function to call the factory with settings specific to the
+  // factory implementation
+  Status NewTableReader(const ImmutableCFOptions& ioptions,
+                        const EnvOptions& soptions,
+                        const InternalKeyComparator& internal_comparator,
+                        uint64_t file_size,
+                        std::unique_ptr<TableReader>* table_reader);
+
+  virtual Status ReadTableProperties(uint64_t table_magic_number,
+                                     RandomAccessFileReader* file,
+                                     uint64_t file_size);
+
+  virtual Status SetTableOptionsByMagicNumber(uint64_t table_magic_number);
+  void SetBlockBasedTableOptionsByMagicNumber();
+  void SetPlainTableOptionsByMagicNumber();
+  virtual Status SetOldTableOptions();
+
+  SstFileFormat GetSstFileFormat(uint64_t table_magic_number);
+
+  std::string file_name_;
+  EnvOptions soptions_;
+
+  // options_ and internal_comparator_ will also be used in NewIterator,
+  // ReadSequential internally (specifically, seek-related operations)
+  Options options_;
+  const ImmutableCFOptions ioptions_;
+  const MutableCFOptions moptions_;
+
+  Status init_result_ = Status::Incomplete();
+  std::unique_ptr<TableReader> table_reader_;
+  std::unique_ptr<RandomAccessFileReader> file_;
+
+  InternalKeyComparator internal_comparator_;
+  std::unique_ptr<TableProperties> table_properties_;
+};
+}  // namespace rocksdb
+
+#endif  // !ROCKSDB_LITE

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -1,0 +1,345 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "table/block_based_table_builder.h"
+#include "table/block_based_table_factory.h"
+#include "table/get_context.h"
+#include "table/internal_sst_file_reader.h"
+
+#include "rocksdb/sst_file_reader.h"
+
+namespace rocksdb {
+
+#ifndef ROCKSDB_LITE
+
+InternalSstFileReader::InternalSstFileReader(const std::string& file_name,
+                                             Options options,
+                                             const Comparator* comparator)
+    : InternalSstFileReader(options, comparator) {
+  Open(file_name);
+}
+
+InternalSstFileReader::InternalSstFileReader(Options options,
+                                             const Comparator* comparator)
+    : options_(options),
+      ioptions_(options_),
+      moptions_(ColumnFamilyOptions(options_)),
+      internal_comparator_(comparator) {}
+
+extern const uint64_t kBlockBasedTableMagicNumber;
+extern const uint64_t kLegacyBlockBasedTableMagicNumber;
+extern const uint64_t kPlainTableMagicNumber;
+extern const uint64_t kLegacyPlainTableMagicNumber;
+
+Status InternalSstFileReader::Open(const std::string& file_path) {
+  file_name_ = file_path;
+  init_result_ = GetTableReader(file_name_);
+  return init_result_;
+}
+
+Status InternalSstFileReader::VerifyChecksum() {
+  if (!table_reader_) {
+    return init_result_;
+  }
+  return table_reader_->VerifyChecksum();
+}
+
+Status InternalSstFileReader::GetTableReader(const std::string& file_path) {
+  // Warning about 'magic_number' being uninitialized shows up only in UBsan
+  // builds. Though access is guarded by 's.ok()' checks, fix the issue to
+  // avoid any warnings.
+  uint64_t magic_number = Footer::kInvalidTableMagicNumber;
+
+  // read table magic number
+  Footer footer;
+
+  std::unique_ptr<RandomAccessFile> file;
+  uint64_t file_size = 0;
+  Status s = options_.env->NewRandomAccessFile(file_path, &file, soptions_);
+  if (s.ok()) {
+    s = options_.env->GetFileSize(file_path, &file_size);
+  }
+
+  file_.reset(new RandomAccessFileReader(std::move(file), file_path));
+
+  if (s.ok()) {
+    s = ReadFooterFromFile(file_.get(), nullptr /* prefetch_buffer */,
+                           file_size, &footer);
+  }
+  if (s.ok()) {
+    magic_number = footer.table_magic_number();
+  }
+
+  if (s.ok()) {
+    if (magic_number == kPlainTableMagicNumber ||
+        magic_number == kLegacyPlainTableMagicNumber) {
+      soptions_.use_mmap_reads = true;
+      options_.env->NewRandomAccessFile(file_path, &file, soptions_);
+      file_.reset(new RandomAccessFileReader(std::move(file), file_path));
+    }
+    options_.comparator = &internal_comparator_;
+    // For old sst format, ReadTableProperties might fail but file can be read
+    if (ReadTableProperties(magic_number, file_.get(), file_size).ok()) {
+      SetTableOptionsByMagicNumber(magic_number);
+    } else {
+      SetOldTableOptions();
+    }
+  }
+
+  if (s.ok()) {
+    s = NewTableReader(ioptions_, soptions_, internal_comparator_, file_size,
+                       &table_reader_);
+  }
+  return s;
+}
+
+Status InternalSstFileReader::SetOldTableOptions() {
+  assert(table_properties_ == nullptr);
+  options_.table_factory = std::make_shared<BlockBasedTableFactory>();
+  return Status::OK();
+}
+
+InternalSstFileReader::SstFileFormat InternalSstFileReader::GetSstFileFormat(
+    uint64_t table_magic_number) {
+  assert(table_properties_);
+  if (table_magic_number == kBlockBasedTableMagicNumber ||
+      table_magic_number == kLegacyBlockBasedTableMagicNumber) {
+    return SstFileFormat::BlockBased;
+  } else if (table_magic_number == kPlainTableMagicNumber ||
+             table_magic_number == kLegacyPlainTableMagicNumber) {
+    return SstFileFormat::PlainTable;
+  } else {
+    return SstFileFormat::Unsupported;
+  }
+}
+
+InternalIterator* InternalSstFileReader::NewIterator(
+    const ReadOptions& read_options, const SliceTransform* prefix_extractor,
+    Arena* arena, bool skip_filters, bool for_compaction) {
+  if (!table_reader_) {
+    return nullptr;
+  }
+  return table_reader_->NewIterator(read_options, prefix_extractor, arena,
+                                    skip_filters, for_compaction);
+}
+
+InternalIterator* InternalSstFileReader::NewIterator(
+    bool cksum, bool cache, const SliceTransform* prefix_extractor) {
+  return NewIterator(ReadOptions(cksum, cache), prefix_extractor);
+}
+
+InternalIterator* InternalSstFileReader::NewIterator(bool cksum, bool cache) {
+  return NewIterator(ReadOptions(cksum, cache),
+                     moptions_.prefix_extractor.get());
+}
+
+void InternalSstFileReader::SetBlockBasedTableOptionsByMagicNumber() {
+  options_.table_factory = std::make_shared<BlockBasedTableFactory>();
+  auto& props = table_properties_->user_collected_properties;
+  auto pos = props.find(BlockBasedTablePropertyNames::kIndexType);
+  if (pos != props.end()) {
+    auto index_type_on_file = static_cast<BlockBasedTableOptions::IndexType>(
+        DecodeFixed32(pos->second.c_str()));
+    if (index_type_on_file == BlockBasedTableOptions::IndexType::kHashSearch) {
+      options_.prefix_extractor.reset(NewNoopTransform());
+    }
+  }
+}
+
+void InternalSstFileReader::SetPlainTableOptionsByMagicNumber() {
+  options_.allow_mmap_reads = true;
+  PlainTableOptions plain_table_options;
+  plain_table_options.user_key_len = kPlainTableVariableLength;
+  plain_table_options.bloom_bits_per_key = 0;
+  plain_table_options.hash_table_ratio = 0;
+  plain_table_options.index_sparseness = 1;
+  plain_table_options.huge_page_tlb_size = 0;
+  plain_table_options.encoding_type = kPlain;
+  plain_table_options.full_scan_mode = true;
+  options_.table_factory.reset(NewPlainTableFactory(plain_table_options));
+}
+
+Status InternalSstFileReader::SetTableOptionsByMagicNumber(
+    uint64_t table_magic_number) {
+  switch (GetSstFileFormat(table_magic_number)) {
+    case SstFileFormat::BlockBased: {
+      SetBlockBasedTableOptionsByMagicNumber();
+      break;
+    }
+    case SstFileFormat::PlainTable: {
+      SetPlainTableOptionsByMagicNumber();
+      break;
+    }
+    case SstFileFormat::Unsupported: {
+      return Status::NotSupported("Unsupported");
+      break;
+    }
+  }
+  return Status::OK();
+}
+
+Status InternalSstFileReader::ReadTableProperties(uint64_t table_magic_number,
+                                                  RandomAccessFileReader* file,
+                                                  uint64_t file_size) {
+  TableProperties* table_properties = nullptr;
+  Status s = rocksdb::ReadTableProperties(file, file_size, table_magic_number,
+                                          ioptions_, &table_properties);
+  if (s.ok()) {
+    table_properties_.reset(table_properties);
+  }
+  return s;
+}
+
+Status InternalSstFileReader::NewTableReader(
+    const ImmutableCFOptions& /*ioptions*/, const EnvOptions& /*soptions*/,
+    const InternalKeyComparator& /*internal_comparator*/, uint64_t file_size,
+    std::unique_ptr<TableReader>* /*table_reader*/) {
+  // We need to turn off pre-fetching of index and filter nodes for
+  // BlockBasedTable
+  if (BlockBasedTableFactory::kName == options_.table_factory->Name()) {
+    return options_.table_factory->NewTableReader(
+        TableReaderOptions(ioptions_, moptions_.prefix_extractor.get(),
+                           soptions_, internal_comparator_),
+        std::move(file_), file_size, &table_reader_, /*enable_prefetch=*/false);
+  }
+
+  // For all other factory implementation
+  return options_.table_factory->NewTableReader(
+      TableReaderOptions(ioptions_, moptions_.prefix_extractor.get(), soptions_,
+                         internal_comparator_),
+      std::move(file_), file_size, &table_reader_);
+}
+
+Status InternalSstFileReader::ReadTableProperties(
+    std::shared_ptr<const TableProperties>* table_properties) {
+  if (!table_reader_) {
+    return init_result_;
+  }
+
+  *table_properties = table_reader_->GetTableProperties();
+  return init_result_;
+}
+
+class SstKVIteratorImpl : public SstKVIterator {
+ public:
+  explicit SstKVIteratorImpl(InternalIterator* iter) : iter_(iter) {}
+
+  virtual bool Valid() const override { return iter_->Valid(); }
+  virtual void SeekToFirst() override { iter_->SeekToFirst(); }
+  virtual void SeekToLast() override { iter_->SeekToLast(); }
+  virtual void Seek(const Slice& k) override {
+    InternalKey ikey;
+    ikey.SetMinPossibleForUserKey(k);
+    iter_->Seek(ikey.Encode());
+  }
+  virtual void SeekForPrev(const Slice& k) override {
+    InternalKey ikey;
+    ikey.SetMinPossibleForUserKey(k);
+    iter_->SeekForPrev(ikey.Encode());
+  }
+  virtual void Next() override { iter_->Next(); }
+  virtual void Prev() override { iter_->Prev(); }
+
+  virtual Slice value() const override { return iter_->value(); }
+
+  Slice key() const override { return key(nullptr, nullptr); }
+
+  Slice key(SequenceNumber* sequence, int* type) const override {
+    ParsedInternalKey ikey;
+    ikey.type = kTypeDeletion;
+    ParseInternalKey(iter_->key(), &ikey);
+
+    if (sequence != nullptr) {
+      *sequence = ikey.sequence;
+    }
+    if (type != nullptr) {
+      *type = static_cast<int>(ikey.type);
+    }
+    return ikey.user_key;
+  }
+
+  virtual Status status() const override { return iter_->status(); }
+
+  virtual Status GetProperty(std::string prop_name,
+                             std::string* prop) override {
+    return iter_->GetProperty(prop_name, prop);
+  }
+
+  virtual ~SstKVIteratorImpl() { delete iter_; }
+
+ private:
+  InternalIterator* iter_;
+};
+
+struct SstFileReader::Rep : public InternalSstFileReader {
+  Rep(const std::string& file_name, Options options,
+      const Comparator* comparator)
+      : InternalSstFileReader(file_name, options, comparator) {}
+
+  SstKVIteratorImpl* NewIterator(const ReadOptions& read_options,
+                                 const SliceTransform* prefix_extractor,
+                                 Arena* arena, bool skip_filters,
+                                 bool for_compaction) {
+    InternalIterator* iter = InternalSstFileReader::NewIterator(
+        read_options, prefix_extractor, arena, skip_filters, for_compaction);
+    if (iter == nullptr) {
+      return nullptr;
+    }
+    return new SstKVIteratorImpl(iter);
+  }
+
+  SstKVIteratorImpl* NewIterator(bool cksum, bool cache) {
+    InternalIterator* iter = InternalSstFileReader::NewIterator(cksum, cache);
+    if (iter == nullptr) {
+      return nullptr;
+    }
+    return new SstKVIteratorImpl(iter);
+  }
+
+  SstKVIteratorImpl* NewIterator(bool cksum, bool cache,
+                                 const SliceTransform* prefix_extractor) {
+    InternalIterator* iter =
+        InternalSstFileReader::NewIterator(cksum, cache, prefix_extractor);
+    if (iter == nullptr) {
+      return nullptr;
+    }
+    return new SstKVIteratorImpl(iter);
+  }
+};
+
+SstFileReader::SstFileReader(const std::string& file_name, Options options,
+                             const Comparator* comparator)
+    : rep_(new Rep(file_name, options, comparator)) {}
+
+SstFileReader::~SstFileReader() {}
+
+SstKVIterator* SstFileReader::NewIterator(
+    const ReadOptions& read_options, const SliceTransform* prefix_extractor,
+    Arena* arena, bool skip_filters, bool for_compaction) {
+  return rep_->NewIterator(read_options, prefix_extractor, arena, skip_filters,
+                           for_compaction);
+}
+
+SstKVIterator* SstFileReader::NewIterator(bool cksum, bool cache) {
+  return rep_->NewIterator(cksum, cache);
+}
+
+SstKVIterator* SstFileReader::NewIterator(
+    bool cksum, bool cache, const SliceTransform* prefix_extractor) {
+  return rep_->NewIterator(cksum, cache, prefix_extractor);
+}
+
+Status SstFileReader::ReadTableProperties(
+    std::shared_ptr<const TableProperties>* table_properties) {
+  return rep_->ReadTableProperties(table_properties);
+}
+
+Status SstFileReader::getStatus() { return rep_->getStatus(); }
+
+Status SstFileReader::VerifyChecksum() { return rep_->VerifyChecksum(); }
+
+#endif  // !ROCKSDB_LITE
+
+}  // namespace rocksdb

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2845,8 +2845,9 @@ void DumpSstFile(std::string filename, bool output_hex, bool show_properties) {
     return;
   }
   // no verification
-  rocksdb::SstFileReader reader(filename, false, output_hex);
-  Status st = reader.ReadSequential(true, std::numeric_limits<uint64_t>::max(), false,  // has_from
+  rocksdb::SstFileDumper dumper(filename, false, output_hex);
+  Status st = dumper.ReadSequential(true, std::numeric_limits<uint64_t>::max(),
+                                    false,            // has_from
                                     from_key, false,  // has_to
                                     to_key);
   if (!st.ok()) {
@@ -2860,11 +2861,11 @@ void DumpSstFile(std::string filename, bool output_hex, bool show_properties) {
 
     std::shared_ptr<const rocksdb::TableProperties>
         table_properties_from_reader;
-    st = reader.ReadTableProperties(&table_properties_from_reader);
+    st = dumper.ReadTableProperties(&table_properties_from_reader);
     if (!st.ok()) {
       std::cerr << filename << ": " << st.ToString()
                 << ". Try to use initial table properties" << std::endl;
-      table_properties = reader.GetInitTableProperties();
+      table_properties = dumper.GetInitTableProperties();
     } else {
       table_properties = table_properties_from_reader.get();
     }

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -201,7 +201,8 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
     return init_result_;
   }
 
-  InternalIterator* iter = NewIterator(verify_checksum_, false);
+  InternalIterator* iter = NewIterator(ReadOptions(verify_checksum_, false),
+                                       moptions_.prefix_extractor.get());
   uint64_t i = 0;
   if (has_from) {
     InternalKey ikey;


### PR DESCRIPTION
* Rename original `SstFileReader` to `SstFileDumper` because it is located in file `sst_dump_tool_imp.h` and does implement function `DumpTable`.
* Extract and refactor new `SstFileReader`:
  - Implement `NewIterator` to get/scan key-value of sst file.
  - Move functions and member variables like `ReadTableProperties`, `getStatus`, `VerifyChecksum`, etc. , from SstFileDumper into `SstFileReader`.
  - Make `SstFileDumper` inherit from `SstFileReader`.
  - Originally, some methods, such as `SetTableOptionsByMagicNumber` used `fprintf`, which should not exist in lib. So, I split it into some smaller functions and use `virtual` methods to implement same function as the original one.
  - Add unit test case.