### PR TITLE
Use -Os flag even when invoked with OPT="-DROCKSDB_LITE"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,16 @@ endif
 
 # Lite build flag.
 LITE ?= 0
-ifneq ($(LITE), 0)
+ifeq ($(LITE), 0)
+ifneq ($(filter -DROCKSDB_LITE,$(OPT)),)
+  # Be backward compatible and support older format where OPT=-DROCKSDB_LITE is
+  # specified instead of LITE=1 on the command line.
+  LITE=1
+endif
+else ifeq ($(LITE), 1)
+ifeq ($(filter -DROCKSDB_LITE,$(OPT)),)
 	OPT += -DROCKSDB_LITE
+endif
 endif
 
 # Figure out optimize level.


### PR DESCRIPTION
We were setting -Os for lite builds only when LITE=1 is specified. But currently almost all the users invoke lite build via OPT="-DROCKSDB_LITE=1". So this diff tries to set LITE=1 when users already pass in -DROCKSDB_LITE=1 via the command line. 

Test Plan:
Tried these commands, and made sure the builds are using -Os:
`V=1 LITE=1 make static_lib`
`V=1 OPT="-DROCKSDB_LITE" make static_lib`