### PR TITLE
Fix BlockBasedTable not always using memory allocator if available

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 # Rocksdb Change Log
 ## Unreleased
 ### New Features
-* Introduced `Memoryllocator`, which lets the user specify custom allocator for memory in block cache.
 * Improved `DeleteRange` to prevent read performance degradation. The feature is no longer marked as experimental.
+
 ### Public API Change
 * `NO_ITERATORS` is divided into two counters `NO_ITERATOR_CREATED` and `NO_ITERATOR_DELETE`. Both of them are only increasing now, just as other counters.
 ### Bug Fixes
@@ -11,6 +11,8 @@
 
 ## 5.18.0 (11/12/2018)
 ### New Features
+* Introduced `Memoryllocator` interface, which lets the user specify custom allocator for memory in block cache.
+* Introduced `JemallocNodumpAllocator` memory allocator. When being use, block cache will be excluded from core dump.
 * Introduced `PerfContextByLevel` as part of `PerfContext` which allows storing perf context at each level. Also replaced `__thread` with `thread_local` keyword for perf_context. Added per-level perf context for bloom filter and `Get` query.
 * With level_compaction_dynamic_level_bytes = true, level multiplier may be adjusted automatically when Level 0 to 1 compaction is lagged behind.
 * Introduced DB option `atomic_flush`. If true, RocksDB supports flushing multiple column families and atomically committing the result to MANIFEST. Useful when WAL is disabled.

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -955,7 +955,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
         rep->file.get(), prefetch_buffer.get(), rep->footer, read_options,
         compression_dict_handle, compression_dict_cont.get(), rep->ioptions,
         false /* decompress */, Slice() /*compression dict*/, cache_options,
-        GetMemoryAllocator(table_options));
+        nullptr /*memory_allocator*/);
     s = compression_block_fetcher.ReadBlockContents();
 
     if (!s.ok()) {

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -322,9 +322,9 @@ class BlockBasedTable : public TableReader {
       CachableEntry<Block>* block, BlockContents* raw_block_contents,
       CompressionType raw_block_comp_type, uint32_t format_version,
       const Slice& compression_dict, SequenceNumber seq_no,
-      size_t read_amp_bytes_per_bit, bool is_index = false,
-      Cache::Priority pri = Cache::Priority::LOW,
-      GetContext* get_context = nullptr, MemoryAllocator* allocator = nullptr);
+      size_t read_amp_bytes_per_bit, MemoryAllocator* memory_allocator,
+      bool is_index = false, Cache::Priority pri = Cache::Priority::LOW,
+      GetContext* get_context = nullptr);
 
   // Calls (*handle_result)(arg, ...) repeatedly, starting with the entry found
   // after a call to Seek(key), until handle_result returns false.

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -141,7 +141,8 @@ void BlockFetcher::PrepareBufferForBlockFromFile() {
     // trivially allocated stack buffer instead of needing a full malloc()
     used_buf_ = &stack_buf_[0];
   } else {
-    heap_buf_ = AllocateBlock(block_size_ + kBlockTrailerSize, allocator_);
+    heap_buf_ =
+        AllocateBlock(block_size_ + kBlockTrailerSize, memory_allocator_);
     used_buf_ = heap_buf_.get();
   }
 }
@@ -178,7 +179,8 @@ void BlockFetcher::GetBlockContents() {
     // or heap provided. Refer to https://github.com/facebook/rocksdb/pull/4096
     if (got_from_prefetch_buffer_ || used_buf_ == &stack_buf_[0]) {
       assert(used_buf_ != heap_buf_.get());
-      heap_buf_ = AllocateBlock(block_size_ + kBlockTrailerSize, allocator_);
+      heap_buf_ =
+          AllocateBlock(block_size_ + kBlockTrailerSize, memory_allocator_);
       memcpy(heap_buf_.get(), used_buf_, block_size_ + kBlockTrailerSize);
     }
     *contents_ = BlockContents(std::move(heap_buf_), block_size_);
@@ -244,7 +246,7 @@ Status BlockFetcher::ReadBlockContents() {
                                            compression_dict_);
     status_ = UncompressBlockContents(uncompression_ctx, slice_.data(),
                                       block_size_, contents_, footer_.version(),
-                                      ioptions_, allocator_);
+                                      ioptions_, memory_allocator_);
     compression_type_ = kNoCompression;
   } else {
     GetBlockContents();

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -25,9 +25,11 @@ class BlockFetcher {
                FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                const ReadOptions& read_options, const BlockHandle& handle,
                BlockContents* contents, const ImmutableCFOptions& ioptions,
-               bool do_uncompress, const Slice& compression_dict,
+               bool do_uncompress, bool maybe_compressed,
+               const Slice& compression_dict,
                const PersistentCacheOptions& cache_options,
-               MemoryAllocator* memory_allocator)
+               MemoryAllocator* memory_allocator = nullptr,
+               MemoryAllocator* memory_allocator_compressed = nullptr)
       : file_(file),
         prefetch_buffer_(prefetch_buffer),
         footer_(footer),
@@ -36,9 +38,11 @@ class BlockFetcher {
         contents_(contents),
         ioptions_(ioptions),
         do_uncompress_(do_uncompress),
+        maybe_compressed_(maybe_compressed),
         compression_dict_(compression_dict),
         cache_options_(cache_options),
-        memory_allocator_(memory_allocator) {}
+        memory_allocator_(memory_allocator),
+        memory_allocator_compressed_(memory_allocator_compressed) {}
   Status ReadBlockContents();
   CompressionType get_compression_type() const { return compression_type_; }
 
@@ -53,14 +57,17 @@ class BlockFetcher {
   BlockContents* contents_;
   const ImmutableCFOptions& ioptions_;
   bool do_uncompress_;
+  bool maybe_compressed_;
   const Slice& compression_dict_;
   const PersistentCacheOptions& cache_options_;
   MemoryAllocator* memory_allocator_;
+  MemoryAllocator* memory_allocator_compressed_;
   Status status_;
   Slice slice_;
   char* used_buf_ = nullptr;
   size_t block_size_;
   CacheAllocationPtr heap_buf_;
+  CacheAllocationPtr compressed_buf_;
   char stack_buf_[kDefaultStackBufferSize];
   bool got_from_prefetch_buffer_ = false;
   rocksdb::CompressionType compression_type_;
@@ -71,6 +78,8 @@ class BlockFetcher {
   bool TryGetFromPrefetchBuffer();
   bool TryGetCompressedBlockFromPersistentCache();
   void PrepareBufferForBlockFromFile();
+  // Copy content from used_buf_ to new heap buffer.
+  void CopyBuffer();
   void GetBlockContents();
   void InsertCompressedBlockToPersistentCacheIfNeeded();
   void InsertUncompressedBlockToPersistentCacheIfNeeded();

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -10,7 +10,6 @@
 #pragma once
 #include "table/block.h"
 #include "table/format.h"
-
 #include "util/memory_allocator.h"
 
 namespace rocksdb {
@@ -28,7 +27,7 @@ class BlockFetcher {
                BlockContents* contents, const ImmutableCFOptions& ioptions,
                bool do_uncompress, const Slice& compression_dict,
                const PersistentCacheOptions& cache_options,
-               MemoryAllocator* allocator = nullptr)
+               MemoryAllocator* memory_allocator)
       : file_(file),
         prefetch_buffer_(prefetch_buffer),
         footer_(footer),
@@ -39,7 +38,7 @@ class BlockFetcher {
         do_uncompress_(do_uncompress),
         compression_dict_(compression_dict),
         cache_options_(cache_options),
-        allocator_(allocator) {}
+        memory_allocator_(memory_allocator) {}
   Status ReadBlockContents();
   CompressionType get_compression_type() const { return compression_type_; }
 
@@ -56,7 +55,7 @@ class BlockFetcher {
   bool do_uncompress_;
   const Slice& compression_dict_;
   const PersistentCacheOptions& cache_options_;
-  MemoryAllocator* allocator_;
+  MemoryAllocator* memory_allocator_;
   Status status_;
   Slice slice_;
   char* used_buf_ = nullptr;

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -79,7 +79,7 @@ class BlockFetcher {
   bool TryGetCompressedBlockFromPersistentCache();
   void PrepareBufferForBlockFromFile();
   // Copy content from used_buf_ to new heap buffer.
-  void CopyBuffer();
+  void CopyBufferToHeap();
   void GetBlockContents();
   void InsertCompressedBlockToPersistentCacheIfNeeded();
   void InsertUncompressedBlockToPersistentCacheIfNeeded();

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -175,7 +175,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
                       FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                       const ImmutableCFOptions& ioptions,
                       TableProperties** table_properties,
-                      bool /*compression_type_missing*/) {
+                      bool /*compression_type_missing*/,
+                      MemoryAllocator* memory_allocator) {
   assert(table_properties);
 
   Slice v = handle_value;
@@ -191,9 +192,10 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
   Slice compression_dict;
   PersistentCacheOptions cache_options;
 
-  BlockFetcher block_fetcher(
-      file, prefetch_buffer, footer, read_options, handle, &block_contents,
-      ioptions, false /* decompress */, compression_dict, cache_options);
+  BlockFetcher block_fetcher(file, prefetch_buffer, footer, read_options,
+                             handle, &block_contents, ioptions,
+                             false /* decompress */, compression_dict,
+                             cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   // property block is never compressed. Need to add uncompress logic if we are
   // to compress it..
@@ -314,9 +316,10 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
 
 Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
                            uint64_t table_magic_number,
-                           const ImmutableCFOptions &ioptions,
+                           const ImmutableCFOptions& ioptions,
                            TableProperties** properties,
-                           bool compression_type_missing) {
+                           bool compression_type_missing,
+                           MemoryAllocator* memory_allocator) {
   // -- Read metaindex block
   Footer footer;
   auto s = ReadFooterFromFile(file, nullptr /* prefetch_buffer */, file_size,
@@ -335,7 +338,7 @@ Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
   BlockFetcher block_fetcher(
       file, nullptr /* prefetch_buffer */, footer, read_options,
       metaindex_handle, &metaindex_contents, ioptions, false /* decompress */,
-      compression_dict, cache_options);
+      compression_dict, cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   if (!s.ok()) {
     return s;
@@ -358,7 +361,8 @@ Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
   TableProperties table_properties;
   if (found_properties_block == true) {
     s = ReadProperties(meta_iter->value(), file, nullptr /* prefetch_buffer */,
-                       footer, ioptions, properties, compression_type_missing);
+                       footer, ioptions, properties, compression_type_missing,
+                       memory_allocator);
   } else {
     s = Status::NotFound();
   }
@@ -384,7 +388,8 @@ Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
                      const ImmutableCFOptions& ioptions,
                      const std::string& meta_block_name,
                      BlockHandle* block_handle,
-                     bool /*compression_type_missing*/) {
+                     bool /*compression_type_missing*/,
+                     MemoryAllocator* memory_allocator) {
   Footer footer;
   auto s = ReadFooterFromFile(file, nullptr /* prefetch_buffer */, file_size,
                               &footer, table_magic_number);
@@ -398,10 +403,11 @@ Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
   read_options.verify_checksums = false;
   Slice compression_dict;
   PersistentCacheOptions cache_options;
-  BlockFetcher block_fetcher(
-      file, nullptr /* prefetch_buffer */, footer, read_options,
-      metaindex_handle, &metaindex_contents, ioptions,
-      false /* do decompression */, compression_dict, cache_options);
+  BlockFetcher block_fetcher(file, nullptr /* prefetch_buffer */, footer,
+                             read_options, metaindex_handle,
+                             &metaindex_contents, ioptions,
+                             false /* do decompression */, compression_dict,
+                             cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   if (!s.ok()) {
     return s;
@@ -423,8 +429,8 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
                      uint64_t table_magic_number,
                      const ImmutableCFOptions& ioptions,
                      const std::string& meta_block_name,
-                     BlockContents* contents,
-                     bool /*compression_type_missing*/) {
+                     BlockContents* contents, bool /*compression_type_missing*/,
+                     MemoryAllocator* memory_allocator) {
   Status status;
   Footer footer;
   status = ReadFooterFromFile(file, prefetch_buffer, file_size, &footer,
@@ -444,7 +450,7 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
   BlockFetcher block_fetcher(file, prefetch_buffer, footer, read_options,
                              metaindex_handle, &metaindex_contents, ioptions,
                              false /* decompress */, compression_dict,
-                             cache_options);
+                             cache_options, memory_allocator);
   status = block_fetcher.ReadBlockContents();
   if (!status.ok()) {
     return status;
@@ -468,9 +474,10 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
   }
 
   // Reading metablock
-  BlockFetcher block_fetcher2(
-      file, prefetch_buffer, footer, read_options, block_handle, contents,
-      ioptions, false /* decompress */, compression_dict, cache_options);
+  BlockFetcher block_fetcher2(file, prefetch_buffer, footer, read_options,
+                              block_handle, contents, ioptions,
+                              false /* decompress */, compression_dict,
+                              cache_options, memory_allocator);
   return block_fetcher2.ReadBlockContents();
 }
 

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -194,8 +194,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
 
   BlockFetcher block_fetcher(file, prefetch_buffer, footer, read_options,
                              handle, &block_contents, ioptions,
-                             false /* decompress */, compression_dict,
-                             cache_options, memory_allocator);
+                             false /* decompress */, false /*maybe_compressed*/,
+                             compression_dict, cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   // property block is never compressed. Need to add uncompress logic if we are
   // to compress it..
@@ -335,10 +335,11 @@ Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
   Slice compression_dict;
   PersistentCacheOptions cache_options;
 
-  BlockFetcher block_fetcher(
-      file, nullptr /* prefetch_buffer */, footer, read_options,
-      metaindex_handle, &metaindex_contents, ioptions, false /* decompress */,
-      compression_dict, cache_options, memory_allocator);
+  BlockFetcher block_fetcher(file, nullptr /* prefetch_buffer */, footer,
+                             read_options, metaindex_handle,
+                             &metaindex_contents, ioptions,
+                             false /* decompress */, false /*maybe_compressed*/,
+                             compression_dict, cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   if (!s.ok()) {
     return s;
@@ -403,11 +404,11 @@ Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
   read_options.verify_checksums = false;
   Slice compression_dict;
   PersistentCacheOptions cache_options;
-  BlockFetcher block_fetcher(file, nullptr /* prefetch_buffer */, footer,
-                             read_options, metaindex_handle,
-                             &metaindex_contents, ioptions,
-                             false /* do decompression */, compression_dict,
-                             cache_options, memory_allocator);
+  BlockFetcher block_fetcher(
+      file, nullptr /* prefetch_buffer */, footer, read_options,
+      metaindex_handle, &metaindex_contents, ioptions,
+      false /* do decompression */, false /*maybe_compressed*/,
+      compression_dict, cache_options, memory_allocator);
   s = block_fetcher.ReadBlockContents();
   if (!s.ok()) {
     return s;
@@ -449,8 +450,8 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
 
   BlockFetcher block_fetcher(file, prefetch_buffer, footer, read_options,
                              metaindex_handle, &metaindex_contents, ioptions,
-                             false /* decompress */, compression_dict,
-                             cache_options, memory_allocator);
+                             false /* decompress */, false /*maybe_compressed*/,
+                             compression_dict, cache_options, memory_allocator);
   status = block_fetcher.ReadBlockContents();
   if (!status.ok()) {
     return status;
@@ -474,10 +475,10 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
   }
 
   // Reading metablock
-  BlockFetcher block_fetcher2(file, prefetch_buffer, footer, read_options,
-                              block_handle, contents, ioptions,
-                              false /* decompress */, compression_dict,
-                              cache_options, memory_allocator);
+  BlockFetcher block_fetcher2(
+      file, prefetch_buffer, footer, read_options, block_handle, contents,
+      ioptions, false /* decompress */, false /*maybe_compressed*/,
+      compression_dict, cache_options, memory_allocator);
   return block_fetcher2.ReadBlockContents();
 }
 

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -11,12 +11,13 @@
 
 #include "db/builder.h"
 #include "db/table_properties_collector.h"
-#include "util/kv_map.h"
 #include "rocksdb/comparator.h"
+#include "rocksdb/memory_allocator.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "table/block_builder.h"
 #include "table/format.h"
+#include "util/kv_map.h"
 
 namespace rocksdb {
 
@@ -96,7 +97,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
                       FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                       const ImmutableCFOptions& ioptions,
                       TableProperties** table_properties,
-                      bool compression_type_missing = false);
+                      bool compression_type_missing = false,
+                      MemoryAllocator* memory_allocator = nullptr);
 
 // Directly read the properties from the properties block of a plain table.
 // @returns a status to indicate if the operation succeeded. On success,
@@ -108,9 +110,10 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
 // `ReadProperties`, `FindMetaBlock`, and `ReadMetaBlock`
 Status ReadTableProperties(RandomAccessFileReader* file, uint64_t file_size,
                            uint64_t table_magic_number,
-                           const ImmutableCFOptions &ioptions,
+                           const ImmutableCFOptions& ioptions,
                            TableProperties** properties,
-                           bool compression_type_missing = false);
+                           bool compression_type_missing = false,
+                           MemoryAllocator* memory_allocator = nullptr);
 
 // Find the meta block from the meta index block.
 Status FindMetaBlock(InternalIterator* meta_index_iter,
@@ -120,10 +123,11 @@ Status FindMetaBlock(InternalIterator* meta_index_iter,
 // Find the meta block
 Status FindMetaBlock(RandomAccessFileReader* file, uint64_t file_size,
                      uint64_t table_magic_number,
-                     const ImmutableCFOptions &ioptions,
+                     const ImmutableCFOptions& ioptions,
                      const std::string& meta_block_name,
                      BlockHandle* block_handle,
-                     bool compression_type_missing = false);
+                     bool compression_type_missing = false,
+                     MemoryAllocator* memory_allocator = nullptr);
 
 // Read the specified meta block with name meta_block_name
 // from `file` and initialize `contents` with contents of this block.
@@ -134,6 +138,7 @@ Status ReadMetaBlock(RandomAccessFileReader* file,
                      const ImmutableCFOptions& ioptions,
                      const std::string& meta_block_name,
                      BlockContents* contents,
-                     bool compression_type_missing = false);
+                     bool compression_type_missing = false,
+                     MemoryAllocator* memory_allocator = nullptr);
 
 }  // namespace rocksdb

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3578,10 +3578,10 @@ TEST_P(BlockBasedTableTest, PropertiesBlockRestartPointTest) {
       Slice compression_dict;
       PersistentCacheOptions cache_options;
 
-      BlockFetcher block_fetcher(file, nullptr /* prefetch_buffer */, footer,
-                                 read_options, handle, contents, ioptions,
-                                 false /* decompress */, compression_dict,
-                                 cache_options, nullptr /*memory_allocator*/);
+      BlockFetcher block_fetcher(
+          file, nullptr /* prefetch_buffer */, footer, read_options, handle,
+          contents, ioptions, false /* decompress */,
+          false /*maybe_compressed*/, compression_dict, cache_options);
 
       ASSERT_OK(block_fetcher.ReadBlockContents());
     };
@@ -3667,7 +3667,8 @@ TEST_P(BlockBasedTableTest, PropertiesMetaBlockLast) {
   BlockFetcher block_fetcher(
       table_reader.get(), nullptr /* prefetch_buffer */, footer, ReadOptions(),
       metaindex_handle, &metaindex_contents, ioptions, false /* decompress */,
-      compression_dict, pcache_opts, nullptr /*memory_allocator*/);
+      false /*maybe_compressed*/, compression_dict, pcache_opts,
+      nullptr /*memory_allocator*/);
   ASSERT_OK(block_fetcher.ReadBlockContents());
   Block metaindex_block(std::move(metaindex_contents),
                         kDisableGlobalSequenceNumber);

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3581,7 +3581,7 @@ TEST_P(BlockBasedTableTest, PropertiesBlockRestartPointTest) {
       BlockFetcher block_fetcher(file, nullptr /* prefetch_buffer */, footer,
                                  read_options, handle, contents, ioptions,
                                  false /* decompress */, compression_dict,
-                                 cache_options);
+                                 cache_options, nullptr /*memory_allocator*/);
 
       ASSERT_OK(block_fetcher.ReadBlockContents());
     };
@@ -3667,7 +3667,7 @@ TEST_P(BlockBasedTableTest, PropertiesMetaBlockLast) {
   BlockFetcher block_fetcher(
       table_reader.get(), nullptr /* prefetch_buffer */, footer, ReadOptions(),
       metaindex_handle, &metaindex_contents, ioptions, false /* decompress */,
-      compression_dict, pcache_opts);
+      compression_dict, pcache_opts, nullptr /*memory_allocator*/);
   ASSERT_OK(block_fetcher.ReadBlockContents());
   Block metaindex_block(std::move(metaindex_contents),
                         kDisableGlobalSequenceNumber);


### PR DESCRIPTION
Summary:
Fix block based table reader not using memory_allocator when allocating index blocks and compression dictionary blocks.

Test Plan:
Use the following patch to force using memory allocator, and run all tests.
```
diff --git a/cache/lru_cache.cc b/cache/lru_cache.cc
index e11ac6ddb..5a6ea7cd4 100644
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -554,6 +554,9 @@ std::shared_ptr<Cache> NewLRUCache(
     // invalid high_pri_pool_ratio
     return nullptr;
   }
+  if (memory_allocator == nullptr) {
+    NewJemallocNodumpAllocator(&memory_allocator);
+  }
   if (num_shard_bits < 0) {
     num_shard_bits = GetDefaultCacheShardBits(capacity);
   }
```

Will add memory allocator specific tests in another patch.