### PR TITLE
Extend Transaction::GetForUpdate with do_validate

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ### New Features
 
 ### Public API Change
-* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similar ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_exclusive_tracked with default value of false. It true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
+* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similar ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. It true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### New Features
 
 ### Public API Change
+* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similar ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_exclusive_tracked with default value of false. It true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ### New Features
 
 ### Public API Change
-* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similarly ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. If true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
+* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similarly ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. If true it indicates that call is assumed to be after a ::GetForUpdate.
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ### New Features
 
 ### Public API Change
-* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similar ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. It true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
+* Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similarly ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. If true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -293,7 +293,8 @@ class Transaction {
   // keys being written.
   //
   // assume_exclusive_tracked=false expects the key already tracked with an
-  // exclusive lock. If valid then it skips ValidateSnapshot. Returns error otherwise.
+  // exclusive lock. If valid then it skips ValidateSnapshot. Returns error
+  // otherwise.
   //
   // If this Transaction was created on an OptimisticTransactionDB, these
   // functions should always return Status::OK().
@@ -307,28 +308,34 @@ class Transaction {
   //  (See max_write_buffer_number_to_maintain)
   // or other errors on unexpected failures.
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value, const bool assume_exclusive_tracked=false) = 0;
+                     const Slice& value,
+                     const bool assume_exclusive_tracked = false) = 0;
   virtual Status Put(const Slice& key, const Slice& value) = 0;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value, const bool assume_exclusive_tracked=false) = 0;
+                     const SliceParts& value,
+                     const bool assume_exclusive_tracked = false) = 0;
   virtual Status Put(const SliceParts& key, const SliceParts& value) = 0;
 
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value, const bool assume_exclusive_tracked=false) = 0;
+                       const Slice& value,
+                       const bool assume_exclusive_tracked = false) = 0;
   virtual Status Merge(const Slice& key, const Slice& value) = 0;
 
-  virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const Slice& key, const bool assume_exclusive_tracked=false) = 0;
+  virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
+                        const bool assume_exclusive_tracked = false) = 0;
   virtual Status Delete(const Slice& key) = 0;
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const SliceParts& key, const bool assume_exclusive_tracked=false) = 0;
+                        const SliceParts& key,
+                        const bool assume_exclusive_tracked = false) = 0;
   virtual Status Delete(const SliceParts& key) = 0;
 
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const Slice& key, const bool assume_exclusive_tracked=false) = 0;
+                              const Slice& key,
+                              const bool assume_exclusive_tracked = false) = 0;
   virtual Status SingleDelete(const Slice& key) = 0;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const SliceParts& key, const bool assume_exclusive_tracked=false) = 0;
+                              const SliceParts& key,
+                              const bool assume_exclusive_tracked = false) = 0;
   virtual Status SingleDelete(const SliceParts& key) = 0;
 
   // PutUntracked() will write a Put to the batch of operations to be committed

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -293,7 +293,7 @@ class Transaction {
   // functions in WriteBatch, but will also do conflict checking on the
   // keys being written.
   //
-  // assume_tracked=false expects the key already tracked. If valid then it
+  // assume_tracked=false expects the key be already tracked. If valid then it
   // skips ValidateSnapshot. Returns error otherwise.
   //
   // If this Transaction was created on an OptimisticTransactionDB, these

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -243,20 +243,23 @@ class Transaction {
   virtual Status GetForUpdate(const ReadOptions& options,
                               ColumnFamilyHandle* column_family,
                               const Slice& key, PinnableSlice* pinnable_val,
-                              bool exclusive = true) {
+                              bool exclusive = true,
+                              bool skip_validate = false) {
     if (pinnable_val == nullptr) {
       std::string* null_str = nullptr;
-      return GetForUpdate(options, column_family, key, null_str, exclusive);
+      return GetForUpdate(options, column_family, key, null_str, exclusive,
+                          skip_validate);
     } else {
       auto s = GetForUpdate(options, column_family, key,
-                            pinnable_val->GetSelf(), exclusive);
+                            pinnable_val->GetSelf(), exclusive, skip_validate);
       pinnable_val->PinSelf();
       return s;
     }
   }
 
   virtual Status GetForUpdate(const ReadOptions& options, const Slice& key,
-                              std::string* value, bool exclusive = true) = 0;
+                              std::string* value, bool exclusive = true,
+                              bool skip_validate = false) = 0;
 
   virtual std::vector<Status> MultiGetForUpdate(
       const ReadOptions& options,

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -292,6 +292,9 @@ class Transaction {
   // functions in WriteBatch, but will also do conflict checking on the
   // keys being written.
   //
+  // assume_exclusive_tracked=false expects the key already tracked with an
+  // exclusive lock. If valid then it skips ValidateSnapshot. Returns error otherwise.
+  //
   // If this Transaction was created on an OptimisticTransactionDB, these
   // functions should always return Status::OK().
   //
@@ -304,28 +307,28 @@ class Transaction {
   //  (See max_write_buffer_number_to_maintain)
   // or other errors on unexpected failures.
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value) = 0;
+                     const Slice& value, const bool assume_exclusive_tracked=false) = 0;
   virtual Status Put(const Slice& key, const Slice& value) = 0;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value) = 0;
+                     const SliceParts& value, const bool assume_exclusive_tracked=false) = 0;
   virtual Status Put(const SliceParts& key, const SliceParts& value) = 0;
 
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) = 0;
+                       const Slice& value, const bool assume_exclusive_tracked=false) = 0;
   virtual Status Merge(const Slice& key, const Slice& value) = 0;
 
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const Slice& key) = 0;
+                        const Slice& key, const bool assume_exclusive_tracked=false) = 0;
   virtual Status Delete(const Slice& key) = 0;
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const SliceParts& key) = 0;
+                        const SliceParts& key, const bool assume_exclusive_tracked=false) = 0;
   virtual Status Delete(const SliceParts& key) = 0;
 
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const Slice& key) = 0;
+                              const Slice& key, const bool assume_exclusive_tracked=false) = 0;
   virtual Status SingleDelete(const Slice& key) = 0;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const SliceParts& key) = 0;
+                              const SliceParts& key, const bool assume_exclusive_tracked=false) = 0;
   virtual Status SingleDelete(const SliceParts& key) = 0;
 
   // PutUntracked() will write a Put to the batch of operations to be committed

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -208,8 +208,9 @@ class Transaction {
   // Read this key and ensure that this transaction will only
   // be able to be committed if this key is not written outside this
   // transaction after it has first been read (or after the snapshot if a
-  // snapshot is set in this transaction).  The transaction behavior is the
-  // same regardless of whether the key exists or not.
+  // snapshot is set in this transaction and skip_validate is false).  The
+  // transaction behavior is the same regardless of whether the key exists or
+  // not.
   //
   // Note: Currently, this function will return Status::MergeInProgress
   // if the most recent write to the queried key in this batch is a Merge.
@@ -234,7 +235,8 @@ class Transaction {
   virtual Status GetForUpdate(const ReadOptions& options,
                               ColumnFamilyHandle* column_family,
                               const Slice& key, std::string* value,
-                              bool exclusive = true) = 0;
+                              bool exclusive = true,
+                              bool skip_validate = false) = 0;
 
   // An overload of the above method that receives a PinnableSlice
   // For backward compatibility a default implementation is provided

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -293,9 +293,8 @@ class Transaction {
   // functions in WriteBatch, but will also do conflict checking on the
   // keys being written.
   //
-  // assume_exclusive_tracked=false expects the key already tracked with an
-  // exclusive lock. If valid then it skips ValidateSnapshot. Returns error
-  // otherwise.
+  // assume_tracked=false expects the key already tracked. If valid then it
+  // skips ValidateSnapshot. Returns error otherwise.
   //
   // If this Transaction was created on an OptimisticTransactionDB, these
   // functions should always return Status::OK().
@@ -309,34 +308,33 @@ class Transaction {
   //  (See max_write_buffer_number_to_maintain)
   // or other errors on unexpected failures.
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value,
-                     const bool assume_exclusive_tracked = false) = 0;
+                     const Slice& value, const bool assume_tracked = false) = 0;
   virtual Status Put(const Slice& key, const Slice& value) = 0;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value,
-                     const bool assume_exclusive_tracked = false) = 0;
+                     const bool assume_tracked = false) = 0;
   virtual Status Put(const SliceParts& key, const SliceParts& value) = 0;
 
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
                        const Slice& value,
-                       const bool assume_exclusive_tracked = false) = 0;
+                       const bool assume_tracked = false) = 0;
   virtual Status Merge(const Slice& key, const Slice& value) = 0;
 
   virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                        const bool assume_exclusive_tracked = false) = 0;
+                        const bool assume_tracked = false) = 0;
   virtual Status Delete(const Slice& key) = 0;
   virtual Status Delete(ColumnFamilyHandle* column_family,
                         const SliceParts& key,
-                        const bool assume_exclusive_tracked = false) = 0;
+                        const bool assume_tracked = false) = 0;
   virtual Status Delete(const SliceParts& key) = 0;
 
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const Slice& key,
-                              const bool assume_exclusive_tracked = false) = 0;
+                              const bool assume_tracked = false) = 0;
   virtual Status SingleDelete(const Slice& key) = 0;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const SliceParts& key,
-                              const bool assume_exclusive_tracked = false) = 0;
+                              const bool assume_tracked = false) = 0;
   virtual Status SingleDelete(const SliceParts& key) = 0;
 
   // PutUntracked() will write a Put to the batch of operations to be committed

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -570,19 +570,20 @@ void txn_write_kv_helper(JNIEnv* env, const FnWriteKV& fn_write_kv,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    put
- * Signature: (J[BI[BIJ)V
+ * Signature: (J[BI[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3BI_3BIJ(
+void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle) {
+    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKV fn_put = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
-      const rocksdb::Slice&)>(&rocksdb::Transaction::Put, txn,
-                              column_family_handle, _1, _2);
+      const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Put, txn,
+                                    column_family_handle, _1, _2,
+                                    jassume_exclusive_tracked);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -708,20 +709,21 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    put
- * Signature: (J[[BI[[BIJ)V
+ * Signature: (J[[BI[[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJ(
+void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
-    jlong jcolumn_family_handle) {
+    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKVParts fn_put_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
-          const rocksdb::SliceParts&)>(&rocksdb::Transaction::Put, txn,
-                                       column_family_handle, _1, _2);
+          const rocksdb::SliceParts&, bool)>(&rocksdb::Transaction::Put, txn,
+                                             column_family_handle, _1, _2,
+                                             jassume_exclusive_tracked);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
                             jvalue_parts, jvalue_parts_len);
 }
@@ -746,19 +748,20 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    merge
- * Signature: (J[BI[BIJ)V
+ * Signature: (J[BI[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJ(
+void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle) {
+    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKV fn_merge = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
-      const rocksdb::Slice&)>(&rocksdb::Transaction::Merge, txn,
-                              column_family_handle, _1, _2);
+      const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Merge, txn,
+                                    column_family_handle, _1, _2,
+                                    jassume_exclusive_tracked);
   txn_write_kv_helper(env, fn_merge, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -805,18 +808,19 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    delete
- * Signature: (J[BIJ)V
+ * Signature: (J[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3BIJ(JNIEnv* env, jobject /*jobj*/,
-                                                 jlong jhandle, jbyteArray jkey,
-                                                 jint jkey_part_len,
-                                                 jlong jcolumn_family_handle) {
+void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
+    JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
+    jint jkey_part_len, jlong jcolumn_family_handle,
+    jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
-      &rocksdb::Transaction::Delete, txn, column_family_handle, _1);
+      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
+      &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
+      jassume_exclusive_tracked);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
 }
 
@@ -894,18 +898,20 @@ void txn_write_k_parts_helper(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    delete
- * Signature: (J[[BIJ)V
+ * Signature: (J[[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3_3BIJ(
+void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
-    jint jkey_parts_len, jlong jcolumn_family_handle) {
+    jint jkey_parts_len, jlong jcolumn_family_handle,
+    jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_delete_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::Delete, txn, column_family_handle, _1);
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
+          &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
+          jassume_exclusive_tracked);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
 }
 
@@ -928,18 +934,20 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    singleDelete
- * Signature: (J[BIJ)V
+ * Signature: (J[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3BIJ(
+void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle) {
+    jint jkey_part_len, jlong jcolumn_family_handle,
+    jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_single_delete =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&)>(
-          &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1);
+          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
+          &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
+          jassume_exclusive_tracked);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
 }
 
@@ -963,18 +971,20 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    singleDelete
- * Signature: (J[[BIJ)V
+ * Signature: (J[[BIJZ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJ(
+void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
-    jint jkey_parts_len, jlong jcolumn_family_handle) {
+    jint jkey_parts_len, jlong jcolumn_family_handle,
+    jboolean jassume_exclusive_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_single_delete_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&)>(
-          &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1);
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
+          &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
+          jassume_exclusive_tracked);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,
                            jkey_parts_len);
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -423,7 +423,7 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
 jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_part_len, jlong jcolumn_family_handle,
-    jboolean jexclusive, jboolean jskip_validate) {
+    jboolean jexclusive, jboolean jdo_validate) {
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
@@ -431,7 +431,7 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZZ(
       const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*,
       const rocksdb::Slice&, std::string*, bool, bool)>(
       &rocksdb::Transaction::GetForUpdate, txn, _1, column_family_handle, _2,
-      _3, jexclusive, jskip_validate);
+      _3, jexclusive, jdo_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
                         jkey_part_len);
 }
@@ -444,12 +444,12 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZZ(
 jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_part_len, jboolean jexclusive,
-    jboolean jskip_validate) {
+    jboolean jdo_validate) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnGet fn_get_for_update = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*, bool,
       bool)>(&rocksdb::Transaction::GetForUpdate, txn, _1, _2, _3, jexclusive,
-             jskip_validate);
+             jdo_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
                         jkey_part_len);
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -575,7 +575,7 @@ void txn_write_kv_helper(JNIEnv* env, const FnWriteKV& fn_write_kv,
 void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -583,7 +583,7 @@ void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
       const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Put, txn,
                                     column_family_handle, _1, _2,
-                                    jassume_exclusive_tracked);
+                                    jassume_tracked);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -714,7 +714,7 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
-    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -723,7 +723,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
           const rocksdb::SliceParts&, bool)>(&rocksdb::Transaction::Put, txn,
                                              column_family_handle, _1, _2,
-                                             jassume_exclusive_tracked);
+                                             jassume_tracked);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
                             jvalue_parts, jvalue_parts_len);
 }
@@ -753,7 +753,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BI(
 void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle, jboolean jassume_exclusive_tracked) {
+    jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -761,7 +761,7 @@ void Java_org_rocksdb_Transaction_merge__J_3BI_3BIJZ(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
       const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Merge, txn,
                                     column_family_handle, _1, _2,
-                                    jassume_exclusive_tracked);
+                                    jassume_tracked);
   txn_write_kv_helper(env, fn_merge, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -812,15 +812,14 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
  */
 void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle,
-    jboolean jassume_exclusive_tracked) {
+    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
       &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
-      jassume_exclusive_tracked);
+      jassume_tracked);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
 }
 
@@ -903,7 +902,7 @@ void txn_write_k_parts_helper(JNIEnv* env,
 void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
-    jboolean jassume_exclusive_tracked) {
+    jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -911,7 +910,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
           &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
-          jassume_exclusive_tracked);
+          jassume_tracked);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
 }
 
@@ -938,8 +937,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle,
-    jboolean jassume_exclusive_tracked) {
+    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -947,7 +945,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
-          jassume_exclusive_tracked);
+          jassume_tracked);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
 }
 
@@ -976,7 +974,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
 void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
-    jboolean jassume_exclusive_tracked) {
+    jboolean jassume_tracked) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -984,7 +982,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
-          jassume_exclusive_tracked);
+          jassume_tracked);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,
                            jkey_parts_len);
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -418,20 +418,20 @@ jobjectArray Java_org_rocksdb_Transaction_multiGet__JJ_3_3B(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    getForUpdate
- * Signature: (JJ[BIJZ)[B
+ * Signature: (JJ[BIJZZ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZ(
+jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
     jbyteArray jkey, jint jkey_part_len, jlong jcolumn_family_handle,
-    jboolean jexclusive) {
+    jboolean jexclusive, jboolean jskip_validate) {
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnGet fn_get_for_update = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       const rocksdb::ReadOptions&, rocksdb::ColumnFamilyHandle*,
-      const rocksdb::Slice&, std::string*, bool)>(
+      const rocksdb::Slice&, std::string*, bool, bool)>(
       &rocksdb::Transaction::GetForUpdate, txn, _1, column_family_handle, _2,
-      _3, jexclusive);
+      _3, jexclusive, jskip_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
                         jkey_part_len);
 }
@@ -439,15 +439,17 @@ jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIJZ(
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    getForUpdate
- * Signature: (JJ[BIZ)[B
+ * Signature: (JJ[BIZZ)[B
  */
-jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZ(
+jbyteArray Java_org_rocksdb_Transaction_getForUpdate__JJ_3BIZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jlong jread_options_handle,
-    jbyteArray jkey, jint jkey_part_len, jboolean jexclusive) {
+    jbyteArray jkey, jint jkey_part_len, jboolean jexclusive,
+    jboolean jskip_validate) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   FnGet fn_get_for_update = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-      const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*, bool)>(
-      &rocksdb::Transaction::GetForUpdate, txn, _1, _2, _3, jexclusive);
+      const rocksdb::ReadOptions&, const rocksdb::Slice&, std::string*, bool,
+      bool)>(&rocksdb::Transaction::GetForUpdate, txn, _1, _2, _3, jexclusive,
+             jskip_validate);
   return txn_get_helper(env, fn_get_for_update, jread_options_handle, jkey,
                         jkey_part_len);
 }

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -663,22 +663,22 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final byte[] value,
-      final boolean assume_exclusive_tracked) throws RocksDBException {
+      final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
     put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        assume_exclusive_tracked);
+        assume_tracked);
   }
 
   /*
    * Same as
    * {@link #put(ColumnFamilyHandle, byte[], byte[], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
     put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   /**
@@ -723,23 +723,23 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final byte[][] valueParts, final boolean assume_exclusive_tracked) throws RocksDBException {
+      final byte[][] valueParts, final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
-        columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+        columnFamilyHandle.nativeHandle_, assume_tracked);
   }
 
   /*
    * Same as
    * {@link #put(ColumnFamilyHandle, byte[][], byte[][], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts, final byte[][] valueParts)
       throws RocksDBException {
     assert(isOwningHandle());
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
-        columnFamilyHandle.nativeHandle_, /*assume_exclusive_tracked*/ false);
+        columnFamilyHandle.nativeHandle_, /*assume_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -785,22 +785,22 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void merge(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
-      final byte[] value, final boolean assume_exclusive_tracked) throws RocksDBException {
+      final byte[] value, final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
     merge(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        assume_exclusive_tracked);
+        assume_tracked);
   }
 
   /*
    * Same as
    * {@link #merge(ColumnFamilyHandle, byte[], byte[], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   public void merge(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
     merge(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   /**
@@ -854,22 +854,21 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
-      final boolean assume_exclusive_tracked) throws RocksDBException {
+      final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
-    delete(
-        nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+    delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_tracked);
   }
 
   /*
    * Same as
    * {@link #delete(ColumnFamilyHandle, byte[], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key) throws RocksDBException {
     assert(isOwningHandle());
     delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   /**
@@ -911,22 +910,22 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final boolean assume_exclusive_tracked) throws RocksDBException {
+      final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
-    delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        assume_exclusive_tracked);
+    delete(
+        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_, assume_tracked);
   }
 
   /*
    * Same as
    * {@link #delete(ColumnFamilyHandle, byte[][], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts) throws RocksDBException {
     assert(isOwningHandle());
     delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -969,23 +968,22 @@ public class Transaction extends RocksObject {
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
-      final boolean assume_exclusive_tracked) throws RocksDBException {
+      final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
-    singleDelete(
-        nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+    singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_tracked);
   }
 
   /*
    * Same as
    * {@link #singleDelete(ColumnFamilyHandle, byte[], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key)
       throws RocksDBException {
     assert(isOwningHandle());
     singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   /**
@@ -1029,23 +1027,23 @@ public class Transaction extends RocksObject {
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final boolean assume_exclusive_tracked) throws RocksDBException {
+      final boolean assume_tracked) throws RocksDBException {
     assert (isOwningHandle());
-    singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        assume_exclusive_tracked);
+    singleDelete(
+        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_, assume_tracked);
   }
 
   /*
    * Same as
    * {@link #singleDelete(ColumnFamilyHandle, byte[][], boolean)}
-   * with assume_exclusive_tracked=false.
+   * with assume_tracked=false.
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts)
       throws RocksDBException {
     assert(isOwningHandle());
     singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        /*assume_exclusive_tracked*/ false);
+        /*assume_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -1774,40 +1772,36 @@ public class Transaction extends RocksObject {
       final long readOptionsHandle, final long columnFamilyHandle);
   private native void put(final long handle, final byte[] key, final int keyLength,
       final byte[] value, final int valueLength, final long columnFamilyHandle,
-      final boolean assume_exclusive_tracked) throws RocksDBException;
+      final boolean assume_tracked) throws RocksDBException;
   private native void put(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
   private native void put(final long handle, final byte[][] keys, final int keysLength,
       final byte[][] values, final int valuesLength, final long columnFamilyHandle,
-      final boolean assume_exclusive_tracked) throws RocksDBException;
+      final boolean assume_tracked) throws RocksDBException;
   private native void put(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength)
       throws RocksDBException;
   private native void merge(final long handle, final byte[] key, final int keyLength,
       final byte[] value, final int valueLength, final long columnFamilyHandle,
-      final boolean assume_exclusive_tracked) throws RocksDBException;
+      final boolean assume_tracked) throws RocksDBException;
   private native void merge(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
   private native void delete(final long handle, final byte[] key, final int keyLength,
-      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
-      throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
   private native void delete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
   private native void delete(final long handle, final byte[][] keys, final int keysLength,
-      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
-      throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
   private native void delete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[] key, final int keyLength,
-      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
-      throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
-      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
-      throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
   private native void putUntracked(final long handle, final byte[] key,

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -433,6 +433,33 @@ public class Transaction extends RocksObject {
    * @param key the key to retrieve the value for.
    * @param exclusive true if the transaction should have exclusive access to
    *     the key, otherwise false for shared access.
+   * @param skip_validate true if it should skip validating the snapshot before doing the read
+   *
+   * @return a byte array storing the value associated with the input key if
+   *     any.  null if it does not find the specified key.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public byte[] getForUpdate(final ReadOptions readOptions,
+      final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final boolean exclusive,
+      final boolean skip_validate) throws RocksDBException {
+    assert (isOwningHandle());
+    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length,
+        columnFamilyHandle.nativeHandle_, exclusive, skip_validate);
+  }
+
+  /**
+   * Same as
+   * {@link #getForUpdate(ReadOptions, ColumnFamilyHandle, byte[], boolean, boolean)}
+   * without skip_validate option.
+   *
+   * @param readOptions Read options.
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param key the key to retrieve the value for.
+   * @param exclusive true if the transaction should have exclusive access to
+   *     the key, otherwise false for shared access.
    *
    * @return a byte array storing the value associated with the input key if
    *     any.  null if it does not find the specified key.
@@ -444,8 +471,8 @@ public class Transaction extends RocksObject {
       final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final boolean exclusive) throws RocksDBException {
     assert(isOwningHandle());
-    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key,
-        key.length, columnFamilyHandle.nativeHandle_, exclusive);
+    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length,
+        columnFamilyHandle.nativeHandle_, exclusive, false /*skip_validate*/);
   }
 
   /**
@@ -495,8 +522,8 @@ public class Transaction extends RocksObject {
   public byte[] getForUpdate(final ReadOptions readOptions, final byte[] key,
       final boolean exclusive) throws RocksDBException {
     assert(isOwningHandle());
-    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key,
-        key.length, exclusive);
+    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length, exclusive,
+        false /*skip_validate*/);
   }
 
   /**
@@ -1642,13 +1669,12 @@ public class Transaction extends RocksObject {
   private native byte[][] multiGet(final long handle,
       final long readOptionsHandle, final byte[][] keys)
       throws RocksDBException;
-  private native byte[] getForUpdate(final long handle,
-      final long readOptionsHandle, final byte key[], final int keyLength,
-      final long columnFamilyHandle, final boolean exclusive)
+  private native byte[] getForUpdate(final long handle, final long readOptionsHandle,
+      final byte key[], final int keyLength, final long columnFamilyHandle, final boolean exclusive,
+      final boolean skip_validate) throws RocksDBException;
+  private native byte[] getForUpdate(final long handle, final long readOptionsHandle,
+      final byte key[], final int keyLen, final boolean exclusive, final boolean skip_validate)
       throws RocksDBException;
-  private native byte[] getForUpdate(final long handle,
-      final long readOptionsHandle, final byte key[], final int keyLen,
-      final boolean exclusive) throws RocksDBException;
   private native byte[][] multiGetForUpdate(final long handle,
       final long readOptionsHandle, final byte[][] keys,
       final long[] columnFamilyHandles) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -452,7 +452,7 @@ public class Transaction extends RocksObject {
   /**
    * Same as
    * {@link #getForUpdate(ReadOptions, ColumnFamilyHandle, byte[], boolean, boolean)}
-   * without do_validate option.
+   * with do_validate=true.
    *
    * @param readOptions Read options.
    * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
@@ -668,6 +668,12 @@ public class Transaction extends RocksObject {
     put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
         assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #put(ColumnFamilyHandle, byte[], byte[], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
@@ -722,6 +728,12 @@ public class Transaction extends RocksObject {
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
         columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #put(ColumnFamilyHandle, byte[][], byte[][], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   public void put(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts, final byte[][] valueParts)
       throws RocksDBException {
@@ -778,6 +790,12 @@ public class Transaction extends RocksObject {
     merge(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
         assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #merge(ColumnFamilyHandle, byte[], byte[], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   public void merge(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
@@ -841,6 +859,12 @@ public class Transaction extends RocksObject {
     delete(
         nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #delete(ColumnFamilyHandle, byte[], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key) throws RocksDBException {
     assert(isOwningHandle());
@@ -892,6 +916,12 @@ public class Transaction extends RocksObject {
     delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
         assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #delete(ColumnFamilyHandle, byte[][], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts) throws RocksDBException {
     assert(isOwningHandle());
@@ -944,6 +974,12 @@ public class Transaction extends RocksObject {
     singleDelete(
         nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #singleDelete(ColumnFamilyHandle, byte[], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key)
       throws RocksDBException {
@@ -998,6 +1034,12 @@ public class Transaction extends RocksObject {
     singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
         assume_exclusive_tracked);
   }
+
+  /*
+   * Same as
+   * {@link #singleDelete(ColumnFamilyHandle, byte[][], boolean)}
+   * with assume_exclusive_tracked=false.
+   */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts)
       throws RocksDBException {

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -662,11 +662,17 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
+  public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final byte[] value,
+      final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
+        assume_exclusive_tracked);
+  }
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
-    put(nativeHandle_, key, key.length, value, value.length,
-        columnFamilyHandle.nativeHandle_);
+    put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   /**
@@ -710,12 +716,18 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
+  public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
+      final byte[][] valueParts, final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
+        columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+  }
   public void put(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts, final byte[][] valueParts)
       throws RocksDBException {
     assert(isOwningHandle());
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
-        columnFamilyHandle.nativeHandle_);
+        columnFamilyHandle.nativeHandle_, /*assume_exclusive_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -760,11 +772,17 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
+  public void merge(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
+      final byte[] value, final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    merge(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
+        assume_exclusive_tracked);
+  }
   public void merge(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key, final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
-    merge(nativeHandle_, key, key.length, value, value.length,
-        columnFamilyHandle.nativeHandle_);
+    merge(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   /**
@@ -817,10 +835,17 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
+  public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
+      final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    delete(
+        nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+  }
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key) throws RocksDBException {
     assert(isOwningHandle());
-    delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_);
+    delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   /**
@@ -861,11 +886,17 @@ public class Transaction extends RocksObject {
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
    */
+  public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
+      final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        assume_exclusive_tracked);
+  }
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts) throws RocksDBException {
     assert(isOwningHandle());
-    delete(nativeHandle_, keyParts, keyParts.length,
-        columnFamilyHandle.nativeHandle_);
+    delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -907,11 +938,18 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   @Experimental("Performance optimization for a very specific workload")
-  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle,
-      final byte[] key) throws RocksDBException {
+  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
+      final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    singleDelete(
+        nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_exclusive_tracked);
+  }
+  @Experimental("Performance optimization for a very specific workload")
+  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key)
+      throws RocksDBException {
     assert(isOwningHandle());
-    singleDelete(nativeHandle_, key, key.length,
-        columnFamilyHandle.nativeHandle_);
+    singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   /**
@@ -954,11 +992,18 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   @Experimental("Performance optimization for a very specific workload")
-  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle,
-      final byte[][] keyParts) throws RocksDBException {
+  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
+      final boolean assume_exclusive_tracked) throws RocksDBException {
+    assert (isOwningHandle());
+    singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        assume_exclusive_tracked);
+  }
+  @Experimental("Performance optimization for a very specific workload")
+  public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts)
+      throws RocksDBException {
     assert(isOwningHandle());
-    singleDelete(nativeHandle_, keyParts, keyParts.length,
-        columnFamilyHandle.nativeHandle_);
+    singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        /*assume_exclusive_tracked*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -1685,41 +1730,41 @@ public class Transaction extends RocksObject {
       final long readOptionsHandle);
   private native long getIterator(final long handle,
       final long readOptionsHandle, final long columnFamilyHandle);
-  private native void put(final long handle, final byte[] key,
-      final int keyLength, final byte[] value, final int valueLength,
-      final long columnFamilyHandle) throws RocksDBException;
+  private native void put(final long handle, final byte[] key, final int keyLength,
+      final byte[] value, final int valueLength, final long columnFamilyHandle,
+      final boolean assume_exclusive_tracked) throws RocksDBException;
   private native void put(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
-  private native void put(final long handle, final byte[][] keys,
-      final int keysLength, final byte[][] values, final int valuesLength,
-      final long columnFamilyHandle) throws RocksDBException;
+  private native void put(final long handle, final byte[][] keys, final int keysLength,
+      final byte[][] values, final int valuesLength, final long columnFamilyHandle,
+      final boolean assume_exclusive_tracked) throws RocksDBException;
   private native void put(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength)
       throws RocksDBException;
-  private native void merge(final long handle, final byte[] key,
-      final int keyLength, final byte[] value, final int valueLength,
-      final long columnFamilyHandle) throws RocksDBException;
+  private native void merge(final long handle, final byte[] key, final int keyLength,
+      final byte[] value, final int valueLength, final long columnFamilyHandle,
+      final boolean assume_exclusive_tracked) throws RocksDBException;
   private native void merge(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
-  private native void delete(final long handle, final byte[] key,
-      final int keyLength, final long columnFamilyHandle)
+  private native void delete(final long handle, final byte[] key, final int keyLength,
+      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
       throws RocksDBException;
   private native void delete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
-  private native void delete(final long handle, final byte[][] keys,
-      final int keysLength, final long columnFamilyHandle)
+  private native void delete(final long handle, final byte[][] keys, final int keysLength,
+      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
       throws RocksDBException;
   private native void delete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[] key,
-      final int keyLength, final long columnFamilyHandle)
+  private native void singleDelete(final long handle, final byte[] key, final int keyLength,
+      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
       throws RocksDBException;
   private native void singleDelete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
-  private native void singleDelete(final long handle, final byte[][] keys,
-      final int keysLength, final long columnFamilyHandle)
+  private native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
+      final long columnFamilyHandle, final boolean assume_exclusive_tracked)
       throws RocksDBException;
   private native void singleDelete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -433,7 +433,7 @@ public class Transaction extends RocksObject {
    * @param key the key to retrieve the value for.
    * @param exclusive true if the transaction should have exclusive access to
    *     the key, otherwise false for shared access.
-   * @param skip_validate true if it should skip validating the snapshot before doing the read
+   * @param do_validate true if it should validate the snapshot before doing the read
    *
    * @return a byte array storing the value associated with the input key if
    *     any.  null if it does not find the specified key.
@@ -443,16 +443,16 @@ public class Transaction extends RocksObject {
    */
   public byte[] getForUpdate(final ReadOptions readOptions,
       final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final boolean exclusive,
-      final boolean skip_validate) throws RocksDBException {
+      final boolean do_validate) throws RocksDBException {
     assert (isOwningHandle());
     return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length,
-        columnFamilyHandle.nativeHandle_, exclusive, skip_validate);
+        columnFamilyHandle.nativeHandle_, exclusive, do_validate);
   }
 
   /**
    * Same as
    * {@link #getForUpdate(ReadOptions, ColumnFamilyHandle, byte[], boolean, boolean)}
-   * without skip_validate option.
+   * without do_validate option.
    *
    * @param readOptions Read options.
    * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
@@ -472,7 +472,7 @@ public class Transaction extends RocksObject {
       final boolean exclusive) throws RocksDBException {
     assert(isOwningHandle());
     return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length,
-        columnFamilyHandle.nativeHandle_, exclusive, false /*skip_validate*/);
+        columnFamilyHandle.nativeHandle_, exclusive, true /*do_validate*/);
   }
 
   /**
@@ -522,8 +522,8 @@ public class Transaction extends RocksObject {
   public byte[] getForUpdate(final ReadOptions readOptions, final byte[] key,
       final boolean exclusive) throws RocksDBException {
     assert(isOwningHandle());
-    return getForUpdate(nativeHandle_, readOptions.nativeHandle_, key, key.length, exclusive,
-        false /*skip_validate*/);
+    return getForUpdate(
+        nativeHandle_, readOptions.nativeHandle_, key, key.length, exclusive, true /*do_validate*/);
   }
 
   /**
@@ -1716,9 +1716,9 @@ public class Transaction extends RocksObject {
       throws RocksDBException;
   private native byte[] getForUpdate(final long handle, final long readOptionsHandle,
       final byte key[], final int keyLength, final long columnFamilyHandle, final boolean exclusive,
-      final boolean skip_validate) throws RocksDBException;
+      final boolean do_validate) throws RocksDBException;
   private native byte[] getForUpdate(final long handle, final long readOptionsHandle,
-      final byte key[], final int keyLen, final boolean exclusive, final boolean skip_validate)
+      final byte key[], final int keyLen, final boolean exclusive, final boolean do_validate)
       throws RocksDBException;
   private native byte[][] multiGetForUpdate(final long handle,
       final long readOptionsHandle, final byte[][] keys,

--- a/util/jemalloc_nodump_allocator.cc
+++ b/util/jemalloc_nodump_allocator.cc
@@ -134,7 +134,7 @@ Status NewJemallocNodumpAllocator(
     std::shared_ptr<MemoryAllocator>* memory_allocator) {
   *memory_allocator = nullptr;
 #ifndef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
-  (void) options;
+  (void)options;
   return Status::NotSupported(
       "JemallocNodumpAllocator only available with jemalloc version >= 5 "
       "and MADV_DONTDUMP is available.");

--- a/utilities/transactions/optimistic_transaction.cc
+++ b/utilities/transactions/optimistic_transaction.cc
@@ -80,9 +80,10 @@ Status OptimisticTransaction::Rollback() {
 // 'exclusive' is unused for OptimisticTransaction.
 Status OptimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
                                       const Slice& key, bool read_only,
-                                      bool exclusive, bool untracked, const bool assume_exclusive_tracked) {
-  assert(!assume_exclusive_tracked); // not supported
-  (void) assume_exclusive_tracked;
+                                      bool exclusive, bool untracked,
+                                      const bool assume_exclusive_tracked) {
+  assert(!assume_exclusive_tracked);  // not supported
+  (void)assume_exclusive_tracked;
   if (untracked) {
     return Status::OK();
   }

--- a/utilities/transactions/optimistic_transaction.cc
+++ b/utilities/transactions/optimistic_transaction.cc
@@ -80,7 +80,9 @@ Status OptimisticTransaction::Rollback() {
 // 'exclusive' is unused for OptimisticTransaction.
 Status OptimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
                                       const Slice& key, bool read_only,
-                                      bool exclusive, bool untracked) {
+                                      bool exclusive, bool untracked, const bool assume_exclusive_tracked) {
+  assert(!assume_exclusive_tracked); // not supported
+  (void) assume_exclusive_tracked;
   if (untracked) {
     return Status::OK();
   }

--- a/utilities/transactions/optimistic_transaction.cc
+++ b/utilities/transactions/optimistic_transaction.cc
@@ -81,9 +81,9 @@ Status OptimisticTransaction::Rollback() {
 Status OptimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
                                       const Slice& key, bool read_only,
                                       bool exclusive, const bool do_validate,
-                                      const bool assume_exclusive_tracked) {
-  assert(!assume_exclusive_tracked);  // not supported
-  (void)assume_exclusive_tracked;
+                                      const bool assume_tracked) {
+  assert(!assume_tracked);  // not supported
+  (void)assume_tracked;
   if (!do_validate) {
     return Status::OK();
   }

--- a/utilities/transactions/optimistic_transaction.cc
+++ b/utilities/transactions/optimistic_transaction.cc
@@ -80,11 +80,11 @@ Status OptimisticTransaction::Rollback() {
 // 'exclusive' is unused for OptimisticTransaction.
 Status OptimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
                                       const Slice& key, bool read_only,
-                                      bool exclusive, bool untracked,
+                                      bool exclusive, const bool do_validate,
                                       const bool assume_exclusive_tracked) {
   assert(!assume_exclusive_tracked);  // not supported
   (void)assume_exclusive_tracked;
-  if (untracked) {
+  if (!do_validate) {
     return Status::OK();
   }
   uint32_t cfh_id = GetColumnFamilyID(column_family);

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -49,7 +49,7 @@ class OptimisticTransaction : public TransactionBaseImpl {
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                  bool read_only, bool exclusive,
-                 bool untracked = false) override;
+                 bool untracked = false, const bool assume_exclusive_tracked=false) override;
 
  private:
   OptimisticTransactionDB* const txn_db_;

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -49,7 +49,7 @@ class OptimisticTransaction : public TransactionBaseImpl {
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                  bool read_only, bool exclusive, const bool do_validate = true,
-                 const bool assume_exclusive_tracked = false) override;
+                 const bool assume_tracked = false) override;
 
  private:
   OptimisticTransactionDB* const txn_db_;

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -48,7 +48,7 @@ class OptimisticTransaction : public TransactionBaseImpl {
 
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                 bool read_only, bool exclusive, bool untracked = false,
+                 bool read_only, bool exclusive, const bool do_validate = true,
                  const bool assume_exclusive_tracked = false) override;
 
  private:

--- a/utilities/transactions/optimistic_transaction.h
+++ b/utilities/transactions/optimistic_transaction.h
@@ -48,8 +48,8 @@ class OptimisticTransaction : public TransactionBaseImpl {
 
  protected:
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                 bool read_only, bool exclusive,
-                 bool untracked = false, const bool assume_exclusive_tracked=false) override;
+                 bool read_only, bool exclusive, bool untracked = false,
+                 const bool assume_exclusive_tracked = false) override;
 
  private:
   OptimisticTransactionDB* const txn_db_;

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -562,7 +562,6 @@ Status PessimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
   // TODO(agiardullo): could optimize by supporting shared txn locks in the
   // future
   if (!do_validate || snapshot_ == nullptr) {
-    assert(!assume_tracked || previously_locked);
     if (assume_tracked && !previously_locked) {
       s = Status::InvalidArgument(
           "assume_tracked is set but it is not tracked yet");

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -563,11 +563,9 @@ Status PessimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
   // future
   if (!do_validate || snapshot_ == nullptr) {
     assert(!assume_tracked || previously_locked);
-    if (assume_tracked) {
-      if (!previously_locked) {
-        s = Status::InvalidArgument(
-            "assume_tracked is set but it is not tracked yet");
-      }
+    if (assume_tracked && !previously_locked) {
+      s = Status::InvalidArgument(
+          "assume_tracked is set but it is not tracked yet");
     }
     // Need to remember the earliest sequence number that we know that this
     // key has not been modified after.  This is useful if this same

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -515,7 +515,8 @@ Status PessimisticTransaction::LockBatch(WriteBatch* batch,
 // the snapshot time.
 Status PessimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
                                        const Slice& key, bool read_only,
-                                       bool exclusive, bool skip_validate, const bool assume_exclusive_tracked) {
+                                       bool exclusive, bool skip_validate,
+                                       const bool assume_exclusive_tracked) {
   assert(!assume_exclusive_tracked || (skip_validate && exclusive));
   Status s;
   if (UNLIKELY(skip_concurrency_control_)) {
@@ -568,7 +569,8 @@ Status PessimisticTransaction::TryLock(ColumnFamilyHandle* column_family,
             "assume_exclusive_tracked is set but it is not tracked yet");
       } else if (lock_upgrade) {
         s = Status::InvalidArgument(
-            "assume_exclusive_tracked is set but it is not tracked exclusively");
+            "assume_exclusive_tracked is set but it is not tracked "
+            "exclusively");
       }
     }
     // Need to remember the earliest sequence number that we know that this

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -135,7 +135,7 @@ class PessimisticTransaction : public TransactionBaseImpl {
   Status LockBatch(WriteBatch* batch, TransactionKeyMap* keys_to_unlock);
 
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                 bool read_only, bool exclusive, bool skip_validate = false,
+                 bool read_only, bool exclusive, const bool do_validate = true,
                  const bool assume_exclusive_tracked = false) override;
 
   void Clear() override;

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -136,7 +136,7 @@ class PessimisticTransaction : public TransactionBaseImpl {
 
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                  bool read_only, bool exclusive, const bool do_validate = true,
-                 const bool assume_exclusive_tracked = false) override;
+                 const bool assume_tracked = false) override;
 
   void Clear() override;
 

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -135,8 +135,8 @@ class PessimisticTransaction : public TransactionBaseImpl {
   Status LockBatch(WriteBatch* batch, TransactionKeyMap* keys_to_unlock);
 
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
-                 bool read_only, bool exclusive,
-                 bool skip_validate = false, const bool assume_exclusive_tracked=false) override;
+                 bool read_only, bool exclusive, bool skip_validate = false,
+                 const bool assume_exclusive_tracked = false) override;
 
   void Clear() override;
 

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -136,7 +136,7 @@ class PessimisticTransaction : public TransactionBaseImpl {
 
   Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                  bool read_only, bool exclusive,
-                 bool skip_validate = false) override;
+                 bool skip_validate = false, const bool assume_exclusive_tracked=false) override;
 
   void Clear() override;
 

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -223,11 +223,13 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
     assert(value != nullptr);
     PinnableSlice pinnable_val(value);
     assert(!pinnable_val.IsPinned());
-    ReadOptions ro(read_options);
-    if (skip_validate) {
+    if (skip_validate && read_options.snaoshot != nullptr) {
+      ReadOptions ro(read_options);
       ro.snapshot = nullptr;
+      s = Get(ro, column_family, key, &pinnable_val);
+    } else {
+      s = Get(read_options, column_family, key, &pinnable_val);
     }
-    s = Get(read_options, column_family, key, &pinnable_val);
     if (s.ok() && pinnable_val.IsPinned()) {
       value->assign(pinnable_val.data(), pinnable_val.size());
     }  // else value is already assigned
@@ -244,11 +246,13 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                      skip_validate);
 
   if (s.ok() && pinnable_val != nullptr) {
-    ReadOptions ro(read_options);
-    if (skip_validate) {
+    if (skip_validate && read_options.snaoshot != nullptr) {
+      ReadOptions ro(read_options);
       ro.snapshot = nullptr;
+      s = Get(ro, column_family, key, pinnable_val);
+    } else {
+      s = Get(read_options, column_family, key, pinnable_val);
     }
-    s = Get(read_options, column_family, key, pinnable_val);
   }
   return s;
 }

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -236,10 +236,11 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          const Slice& key,
                                          PinnableSlice* pinnable_val,
                                          bool exclusive, bool skip_validate) {
-  Status s = TryLock(column_family, key, true /* read_only */, exclusive);
+  Status s = TryLock(column_family, key, true /* read_only */, exclusive,
+                     skip_validate);
 
   if (s.ok() && pinnable_val != nullptr) {
-    s = Get(read_options, column_family, key, pinnable_val, skip_validate);
+    s = Get(read_options, column_family, key, pinnable_val);
   }
   return s;
 }

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -245,7 +245,7 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          PinnableSlice* pinnable_val,
                                          bool exclusive,
                                          const bool do_validate) {
-  if (UNLIKELY(!do_validate && read_options.snapshot != nullptr)) {
+  if (!do_validate && read_options.snapshot != nullptr) {
     return Status::InvalidArgument(
         "If do_validate is false then GetForUpdate with snapshot is not "
         "defined.");

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -220,7 +220,7 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          bool exclusive,
                                          const bool do_validate) {
   assert(do_validate || read_options.snapshot == nullptr);
-  if (UNLIKELY(!do_validate && read_options.snapshot != nullptr)) {
+  if (!do_validate && read_options.snapshot != nullptr) {
     return Status::InvalidArgument(
         "If do_validate is false then GetForUpdate with snapshot is not "
         "defined.");

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -97,7 +97,8 @@ void TransactionBaseImpl::SetSnapshotIfNeeded() {
 
 Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
                                     const SliceParts& key, bool read_only,
-                                    bool exclusive, bool skip_validate, const bool assume_exclusive_tracked) {
+                                    bool exclusive, bool skip_validate,
+                                    const bool assume_exclusive_tracked) {
   size_t key_size = 0;
   for (int i = 0; i < key.num_parts; ++i) {
     key_size += key.parts[i].size();
@@ -110,7 +111,8 @@ Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
     str.append(key.parts[i].data(), key.parts[i].size());
   }
 
-  return TryLock(column_family, str, read_only, exclusive, skip_validate, assume_exclusive_tracked);
+  return TryLock(column_family, str, read_only, exclusive, skip_validate,
+                 assume_exclusive_tracked);
 }
 
 void TransactionBaseImpl::SetSavePoint() {
@@ -317,10 +319,12 @@ Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options,
 }
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
-                                const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
+                                const Slice& key, const Slice& value,
+                                const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);
@@ -333,11 +337,12 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
-                                const SliceParts& key,
-                                const SliceParts& value, const bool assume_exclusive_tracked) {
+                                const SliceParts& key, const SliceParts& value,
+                                const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);
@@ -350,10 +355,12 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
-                                  const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
+                                  const Slice& key, const Slice& value,
+                                  const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Merge(column_family, key, value);
@@ -366,10 +373,12 @@ Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
-                                   const Slice& key, const bool assume_exclusive_tracked) {
+                                   const Slice& key,
+                                   const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);
@@ -382,10 +391,12 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
-                                   const SliceParts& key, const bool assume_exclusive_tracked) {
+                                   const SliceParts& key,
+                                   const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);
@@ -398,10 +409,12 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
-                                         const Slice& key, const bool assume_exclusive_tracked) {
+                                         const Slice& key,
+                                         const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);
@@ -414,10 +427,12 @@ Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
 }
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
-                                         const SliceParts& key, const bool assume_exclusive_tracked) {
+                                         const SliceParts& key,
+                                         const bool assume_exclusive_tracked) {
   const bool skip_validate = assume_exclusive_tracked;
   Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */, skip_validate, assume_exclusive_tracked);
+      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
+              skip_validate, assume_exclusive_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -223,6 +223,10 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
     assert(value != nullptr);
     PinnableSlice pinnable_val(value);
     assert(!pinnable_val.IsPinned());
+    ReadOptions ro(read_options);
+    if (skip_validate) {
+      ro.snapshot = nullptr;
+    }
     s = Get(read_options, column_family, key, &pinnable_val);
     if (s.ok() && pinnable_val.IsPinned()) {
       value->assign(pinnable_val.data(), pinnable_val.size());
@@ -240,6 +244,10 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                      skip_validate);
 
   if (s.ok() && pinnable_val != nullptr) {
+    ReadOptions ro(read_options);
+    if (skip_validate) {
+      ro.snapshot = nullptr;
+    }
     s = Get(read_options, column_family, key, pinnable_val);
   }
   return s;

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -98,7 +98,7 @@ void TransactionBaseImpl::SetSnapshotIfNeeded() {
 Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
                                     const SliceParts& key, bool read_only,
                                     bool exclusive, const bool do_validate,
-                                    const bool assume_exclusive_tracked) {
+                                    const bool assume_tracked) {
   size_t key_size = 0;
   for (int i = 0; i < key.num_parts; ++i) {
     key_size += key.parts[i].size();
@@ -112,7 +112,7 @@ Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
   }
 
   return TryLock(column_family, str, read_only, exclusive, do_validate,
-                 assume_exclusive_tracked);
+                 assume_tracked);
 }
 
 void TransactionBaseImpl::SetSavePoint() {
@@ -320,11 +320,10 @@ Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options,
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
                                 const Slice& key, const Slice& value,
-                                const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);
@@ -338,11 +337,10 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
                                 const SliceParts& key, const SliceParts& value,
-                                const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);
@@ -356,11 +354,10 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
                                   const Slice& key, const Slice& value,
-                                  const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                  const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Merge(column_family, key, value);
@@ -374,11 +371,10 @@ Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
                                    const Slice& key,
-                                   const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                   const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);
@@ -392,11 +388,10 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
                                    const SliceParts& key,
-                                   const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                   const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);
@@ -410,11 +405,10 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
                                          const Slice& key,
-                                         const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                         const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);
@@ -428,11 +422,10 @@ Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
                                          const SliceParts& key,
-                                         const bool assume_exclusive_tracked) {
-  const bool do_validate = !assume_exclusive_tracked;
-  Status s =
-      TryLock(column_family, key, false /* read_only */, true /* exclusive */,
-              do_validate, assume_exclusive_tracked);
+                                         const bool assume_tracked) {
+  const bool do_validate = !assume_tracked;
+  Status s = TryLock(column_family, key, false /* read_only */,
+                     true /* exclusive */, do_validate, assume_tracked);
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -219,7 +219,6 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          const Slice& key, std::string* value,
                                          bool exclusive,
                                          const bool do_validate) {
-  assert(do_validate || read_options.snapshot == nullptr);
   if (!do_validate && read_options.snapshot != nullptr) {
     return Status::InvalidArgument(
         "If do_validate is false then GetForUpdate with snapshot is not "
@@ -246,7 +245,6 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          PinnableSlice* pinnable_val,
                                          bool exclusive,
                                          const bool do_validate) {
-  assert(do_validate || read_options.snapshot == nullptr);
   if (UNLIKELY(!do_validate && read_options.snapshot != nullptr)) {
     return Status::InvalidArgument(
         "If do_validate is false then GetForUpdate with snapshot is not "

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -215,8 +215,9 @@ Status TransactionBaseImpl::Get(const ReadOptions& read_options,
 Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          ColumnFamilyHandle* column_family,
                                          const Slice& key, std::string* value,
-                                         bool exclusive) {
-  Status s = TryLock(column_family, key, true /* read_only */, exclusive);
+                                         bool exclusive, bool skip_validate) {
+  Status s = TryLock(column_family, key, true /* read_only */, exclusive,
+                     skip_validate);
 
   if (s.ok() && value != nullptr) {
     assert(value != nullptr);
@@ -234,11 +235,11 @@ Status TransactionBaseImpl::GetForUpdate(const ReadOptions& read_options,
                                          ColumnFamilyHandle* column_family,
                                          const Slice& key,
                                          PinnableSlice* pinnable_val,
-                                         bool exclusive) {
+                                         bool exclusive, bool skip_validate) {
   Status s = TryLock(column_family, key, true /* read_only */, exclusive);
 
   if (s.ok() && pinnable_val != nullptr) {
-    s = Get(read_options, column_family, key, pinnable_val);
+    s = Get(read_options, column_family, key, pinnable_val, skip_validate);
   }
   return s;
 }

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -36,11 +36,11 @@ class TransactionBaseImpl : public Transaction {
 
   // Called before executing Put, Merge, Delete, and GetForUpdate.  If TryLock
   // returns non-OK, the Put/Merge/Delete/GetForUpdate will be failed.
-  // skip_validate will be true if called from PutUntracked, DeleteUntracked,
-  // MergeUntracked, or GetForUpdate(skip_validate=true)
+  // do_validate will be false if called from PutUntracked, DeleteUntracked,
+  // MergeUntracked, or GetForUpdate(do_validate=false)
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
-                         bool skip_validate = false,
+                         const bool do_validate = true,
                          const bool assume_exclusive_tracked = false) = 0;
 
   void SetSavePoint() override;
@@ -65,18 +65,18 @@ class TransactionBaseImpl : public Transaction {
   Status GetForUpdate(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const Slice& key,
                       std::string* value, bool exclusive,
-                      bool skip_validate) override;
+                      const bool do_validate) override;
 
   Status GetForUpdate(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const Slice& key,
                       PinnableSlice* pinnable_val, bool exclusive,
-                      bool skip_validate) override;
+                      const bool do_validate) override;
 
   Status GetForUpdate(const ReadOptions& options, const Slice& key,
                       std::string* value, bool exclusive,
-                      bool skip_validate) override {
+                      const bool do_validate) override {
     return GetForUpdate(options, db_->DefaultColumnFamily(), key, value,
-                        exclusive, skip_validate);
+                        exclusive, do_validate);
   }
 
   std::vector<Status> MultiGet(
@@ -343,7 +343,7 @@ class TransactionBaseImpl : public Transaction {
   std::shared_ptr<TransactionNotifier> snapshot_notifier_ = nullptr;
 
   Status TryLock(ColumnFamilyHandle* column_family, const SliceParts& key,
-                 bool read_only, bool exclusive, bool skip_validate = false,
+                 bool read_only, bool exclusive, const bool do_validate = true,
                  const bool assume_exclusive_tracked = false);
 
   WriteBatchBase* GetBatchForWrite();

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -40,7 +40,8 @@ class TransactionBaseImpl : public Transaction {
   // MergeUntracked, or GetForUpdate(skip_validate=true)
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
-                         bool skip_validate = false, const bool assume_exclusive_tracked=false) = 0;
+                         bool skip_validate = false,
+                         const bool assume_exclusive_tracked = false) = 0;
 
   void SetSavePoint() override;
 
@@ -112,36 +113,40 @@ class TransactionBaseImpl : public Transaction {
                         ColumnFamilyHandle* column_family) override;
 
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-             const Slice& value, const bool assume_exclusive_tracked=false) override;
+             const Slice& value,
+             const bool assume_exclusive_tracked = false) override;
   Status Put(const Slice& key, const Slice& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-             const SliceParts& value, const bool assume_exclusive_tracked=false) override;
+             const SliceParts& value,
+             const bool assume_exclusive_tracked = false) override;
   Status Put(const SliceParts& key, const SliceParts& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-               const Slice& value, const bool assume_exclusive_tracked=false) override;
+               const Slice& value,
+               const bool assume_exclusive_tracked = false) override;
   Status Merge(const Slice& key, const Slice& value) override {
     return Merge(nullptr, key, value);
   }
 
-  Status Delete(ColumnFamilyHandle* column_family, const Slice& key, const bool assume_exclusive_tracked=false) override;
+  Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
+                const bool assume_exclusive_tracked = false) override;
   Status Delete(const Slice& key) override { return Delete(nullptr, key); }
-  Status Delete(ColumnFamilyHandle* column_family,
-                const SliceParts& key, const bool assume_exclusive_tracked=false) override;
+  Status Delete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                const bool assume_exclusive_tracked = false) override;
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
 
-  Status SingleDelete(ColumnFamilyHandle* column_family,
-                      const Slice& key, const bool assume_exclusive_tracked=false) override;
+  Status SingleDelete(ColumnFamilyHandle* column_family, const Slice& key,
+                      const bool assume_exclusive_tracked = false) override;
   Status SingleDelete(const Slice& key) override {
     return SingleDelete(nullptr, key);
   }
-  Status SingleDelete(ColumnFamilyHandle* column_family,
-                      const SliceParts& key, const bool assume_exclusive_tracked=false) override;
+  Status SingleDelete(ColumnFamilyHandle* column_family, const SliceParts& key,
+                      const bool assume_exclusive_tracked = false) override;
   Status SingleDelete(const SliceParts& key) override {
     return SingleDelete(nullptr, key);
   }
@@ -338,7 +343,8 @@ class TransactionBaseImpl : public Transaction {
   std::shared_ptr<TransactionNotifier> snapshot_notifier_ = nullptr;
 
   Status TryLock(ColumnFamilyHandle* column_family, const SliceParts& key,
-                 bool read_only, bool exclusive, bool skip_validate = false, const bool assume_exclusive_tracked=false);
+                 bool read_only, bool exclusive, bool skip_validate = false,
+                 const bool assume_exclusive_tracked = false);
 
   WriteBatchBase* GetBatchForWrite();
   void SetSnapshotInternal(const Snapshot* snapshot);

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -36,8 +36,8 @@ class TransactionBaseImpl : public Transaction {
 
   // Called before executing Put, Merge, Delete, and GetForUpdate.  If TryLock
   // returns non-OK, the Put/Merge/Delete/GetForUpdate will be failed.
-  // skip_validate will be true if called from PutUntracked, DeleteUntracked, or
-  // MergeUntracked.
+  // skip_validate will be true if called from PutUntracked, DeleteUntracked,
+  // MergeUntracked, or GetForUpdate(skip_validate=true)
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
                          bool skip_validate = false) = 0;
@@ -63,16 +63,19 @@ class TransactionBaseImpl : public Transaction {
   using Transaction::GetForUpdate;
   Status GetForUpdate(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const Slice& key,
-                      std::string* value, bool exclusive) override;
+                      std::string* value, bool exclusive,
+                      bool skip_validate) override;
 
   Status GetForUpdate(const ReadOptions& options,
                       ColumnFamilyHandle* column_family, const Slice& key,
-                      PinnableSlice* pinnable_val, bool exclusive) override;
+                      PinnableSlice* pinnable_val, bool exclusive,
+                      bool skip_validate) override;
 
   Status GetForUpdate(const ReadOptions& options, const Slice& key,
-                      std::string* value, bool exclusive) override {
+                      std::string* value, bool exclusive,
+                      bool skip_validate) override {
     return GetForUpdate(options, db_->DefaultColumnFamily(), key, value,
-                        exclusive);
+                        exclusive, skip_validate);
   }
 
   std::vector<Status> MultiGet(

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -40,7 +40,7 @@ class TransactionBaseImpl : public Transaction {
   // MergeUntracked, or GetForUpdate(skip_validate=true)
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
-                         bool skip_validate = false) = 0;
+                         bool skip_validate = false, const bool assume_exclusive_tracked=false) = 0;
 
   void SetSavePoint() override;
 
@@ -112,36 +112,36 @@ class TransactionBaseImpl : public Transaction {
                         ColumnFamilyHandle* column_family) override;
 
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-             const Slice& value) override;
+             const Slice& value, const bool assume_exclusive_tracked=false) override;
   Status Put(const Slice& key, const Slice& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-             const SliceParts& value) override;
+             const SliceParts& value, const bool assume_exclusive_tracked=false) override;
   Status Put(const SliceParts& key, const SliceParts& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-               const Slice& value) override;
+               const Slice& value, const bool assume_exclusive_tracked=false) override;
   Status Merge(const Slice& key, const Slice& value) override {
     return Merge(nullptr, key, value);
   }
 
-  Status Delete(ColumnFamilyHandle* column_family, const Slice& key) override;
+  Status Delete(ColumnFamilyHandle* column_family, const Slice& key, const bool assume_exclusive_tracked=false) override;
   Status Delete(const Slice& key) override { return Delete(nullptr, key); }
   Status Delete(ColumnFamilyHandle* column_family,
-                const SliceParts& key) override;
+                const SliceParts& key, const bool assume_exclusive_tracked=false) override;
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
 
   Status SingleDelete(ColumnFamilyHandle* column_family,
-                      const Slice& key) override;
+                      const Slice& key, const bool assume_exclusive_tracked=false) override;
   Status SingleDelete(const Slice& key) override {
     return SingleDelete(nullptr, key);
   }
   Status SingleDelete(ColumnFamilyHandle* column_family,
-                      const SliceParts& key) override;
+                      const SliceParts& key, const bool assume_exclusive_tracked=false) override;
   Status SingleDelete(const SliceParts& key) override {
     return SingleDelete(nullptr, key);
   }
@@ -338,7 +338,7 @@ class TransactionBaseImpl : public Transaction {
   std::shared_ptr<TransactionNotifier> snapshot_notifier_ = nullptr;
 
   Status TryLock(ColumnFamilyHandle* column_family, const SliceParts& key,
-                 bool read_only, bool exclusive, bool skip_validate = false);
+                 bool read_only, bool exclusive, bool skip_validate = false, const bool assume_exclusive_tracked=false);
 
   WriteBatchBase* GetBatchForWrite();
   void SetSnapshotInternal(const Snapshot* snapshot);

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -41,7 +41,7 @@ class TransactionBaseImpl : public Transaction {
   virtual Status TryLock(ColumnFamilyHandle* column_family, const Slice& key,
                          bool read_only, bool exclusive,
                          const bool do_validate = true,
-                         const bool assume_exclusive_tracked = false) = 0;
+                         const bool assume_tracked = false) = 0;
 
   void SetSavePoint() override;
 
@@ -113,40 +113,38 @@ class TransactionBaseImpl : public Transaction {
                         ColumnFamilyHandle* column_family) override;
 
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-             const Slice& value,
-             const bool assume_exclusive_tracked = false) override;
+             const Slice& value, const bool assume_tracked = false) override;
   Status Put(const Slice& key, const Slice& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
              const SliceParts& value,
-             const bool assume_exclusive_tracked = false) override;
+             const bool assume_tracked = false) override;
   Status Put(const SliceParts& key, const SliceParts& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-               const Slice& value,
-               const bool assume_exclusive_tracked = false) override;
+               const Slice& value, const bool assume_tracked = false) override;
   Status Merge(const Slice& key, const Slice& value) override {
     return Merge(nullptr, key, value);
   }
 
   Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                const bool assume_exclusive_tracked = false) override;
+                const bool assume_tracked = false) override;
   Status Delete(const Slice& key) override { return Delete(nullptr, key); }
   Status Delete(ColumnFamilyHandle* column_family, const SliceParts& key,
-                const bool assume_exclusive_tracked = false) override;
+                const bool assume_tracked = false) override;
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
 
   Status SingleDelete(ColumnFamilyHandle* column_family, const Slice& key,
-                      const bool assume_exclusive_tracked = false) override;
+                      const bool assume_tracked = false) override;
   Status SingleDelete(const Slice& key) override {
     return SingleDelete(nullptr, key);
   }
   Status SingleDelete(ColumnFamilyHandle* column_family, const SliceParts& key,
-                      const bool assume_exclusive_tracked = false) override;
+                      const bool assume_tracked = false) override;
   Status SingleDelete(const SliceParts& key) override {
     return SingleDelete(nullptr, key);
   }
@@ -344,7 +342,7 @@ class TransactionBaseImpl : public Transaction {
 
   Status TryLock(ColumnFamilyHandle* column_family, const SliceParts& key,
                  bool read_only, bool exclusive, const bool do_validate = true,
-                 const bool assume_exclusive_tracked = false);
+                 const bool assume_tracked = false);
 
   WriteBatchBase* GetBatchForWrite();
   void SetSnapshotInternal(const Snapshot* snapshot);

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -140,6 +140,61 @@ TEST_P(TransactionTest, SuccessTest) {
   delete txn;
 }
 
+// The test clarifies the contract of skip_validate and assume_exclusive_tracked
+// in GetForUpdate and Put/Merge/Delete
+TEST_P(TransactionTest, AssumeExclusiveTracked) {
+  WriteOptions write_options;
+  ReadOptions read_options;
+  std::string value;
+  Status s;
+  TransactionOptions txn_options;
+  txn_options.lock_timeout = 1;
+  const bool EXCLUSIVE = true;
+  const bool SKIP_VALIDATE = true;
+  const bool ASSUME_EXC_LOCKED = true;
+
+  Transaction* txn = db->BeginTransaction(write_options, txn_options);
+  ASSERT_TRUE(txn);
+  txn->SetSnapshot();
+
+  // commit a value after the snapshot is taken
+  ASSERT_OK(db->Put(write_options, Slice("foo"), Slice("bar")));
+
+  // By default write should fail to the commit after our snapshot
+  s = txn->GetForUpdate(read_options, "foo", &value, EXCLUSIVE);
+  ASSERT_TRUE(s.IsBusy());
+  // But the user could direct the db to skip validating the snapshot. The read
+  // value then should be the most recently committed
+  ASSERT_OK(
+      txn->GetForUpdate(read_options, "foo", &value, EXCLUSIVE, SKIP_VALIDATE));
+  ASSERT_EQ(value, "bar");
+
+  // Although ValidateSnapshot is skipped the key must have still got locked
+  s = db->Put(write_options, Slice("foo"), Slice("bar"));
+  ASSERT_TRUE(s.IsTimedOut());
+
+  // By default the write operations should fail due to the commit after the
+  // snapshot
+  s = txn->Put(Slice("foo"), Slice("bar1"));
+  ASSERT_TRUE(s.IsBusy());
+  s = txn->Put(db->DefaultColumnFamily(), Slice("foo"), Slice("bar1"),
+               !ASSUME_EXC_LOCKED);
+  ASSERT_TRUE(s.IsBusy());
+  // But the user could direct the db that it already assumes exclusive lock on
+  // the key due to the previous GetForUpdate call.
+  ASSERT_OK(txn->Put(db->DefaultColumnFamily(), Slice("foo"), Slice("bar1"),
+                     ASSUME_EXC_LOCKED));
+  ASSERT_OK(txn->Merge(db->DefaultColumnFamily(), Slice("foo"), Slice("bar2"),
+                       ASSUME_EXC_LOCKED));
+  ASSERT_OK(
+      txn->Delete(db->DefaultColumnFamily(), Slice("foo"), ASSUME_EXC_LOCKED));
+  ASSERT_OK(txn->SingleDelete(db->DefaultColumnFamily(), Slice("foo"),
+                              ASSUME_EXC_LOCKED));
+
+  txn->Rollback();
+  delete txn;
+}
+
 // This test clarifies the contract of ValidateSnapshot
 TEST_P(TransactionTest, ValidateSnapshotTest) {
   for (bool with_2pc : {true, false}) {

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -140,7 +140,7 @@ TEST_P(TransactionTest, SuccessTest) {
   delete txn;
 }
 
-// The test clarifies the contract of skip_validate and assume_exclusive_tracked
+// The test clarifies the contract of do_validate and assume_exclusive_tracked
 // in GetForUpdate and Put/Merge/Delete
 TEST_P(TransactionTest, AssumeExclusiveTracked) {
   WriteOptions write_options;
@@ -150,7 +150,7 @@ TEST_P(TransactionTest, AssumeExclusiveTracked) {
   TransactionOptions txn_options;
   txn_options.lock_timeout = 1;
   const bool EXCLUSIVE = true;
-  const bool SKIP_VALIDATE = true;
+  const bool DO_VALIDATE = true;
   const bool ASSUME_EXC_LOCKED = true;
 
   Transaction* txn = db->BeginTransaction(write_options, txn_options);
@@ -166,7 +166,7 @@ TEST_P(TransactionTest, AssumeExclusiveTracked) {
   // But the user could direct the db to skip validating the snapshot. The read
   // value then should be the most recently committed
   ASSERT_OK(
-      txn->GetForUpdate(read_options, "foo", &value, EXCLUSIVE, SKIP_VALIDATE));
+      txn->GetForUpdate(read_options, "foo", &value, EXCLUSIVE, !DO_VALIDATE));
   ASSERT_EQ(value, "bar");
 
   // Although ValidateSnapshot is skipped the key must have still got locked

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -140,7 +140,7 @@ TEST_P(TransactionTest, SuccessTest) {
   delete txn;
 }
 
-// The test clarifies the contract of do_validate and assume_exclusive_tracked
+// The test clarifies the contract of do_validate and assume_tracked
 // in GetForUpdate and Put/Merge/Delete
 TEST_P(TransactionTest, AssumeExclusiveTracked) {
   WriteOptions write_options;
@@ -151,7 +151,7 @@ TEST_P(TransactionTest, AssumeExclusiveTracked) {
   txn_options.lock_timeout = 1;
   const bool EXCLUSIVE = true;
   const bool DO_VALIDATE = true;
-  const bool ASSUME_EXC_LOCKED = true;
+  const bool ASSUME_LOCKED = true;
 
   Transaction* txn = db->BeginTransaction(write_options, txn_options);
   ASSERT_TRUE(txn);
@@ -178,18 +178,18 @@ TEST_P(TransactionTest, AssumeExclusiveTracked) {
   s = txn->Put(Slice("foo"), Slice("bar1"));
   ASSERT_TRUE(s.IsBusy());
   s = txn->Put(db->DefaultColumnFamily(), Slice("foo"), Slice("bar1"),
-               !ASSUME_EXC_LOCKED);
+               !ASSUME_LOCKED);
   ASSERT_TRUE(s.IsBusy());
   // But the user could direct the db that it already assumes exclusive lock on
   // the key due to the previous GetForUpdate call.
   ASSERT_OK(txn->Put(db->DefaultColumnFamily(), Slice("foo"), Slice("bar1"),
-                     ASSUME_EXC_LOCKED));
+                     ASSUME_LOCKED));
   ASSERT_OK(txn->Merge(db->DefaultColumnFamily(), Slice("foo"), Slice("bar2"),
-                       ASSUME_EXC_LOCKED));
+                       ASSUME_LOCKED));
   ASSERT_OK(
-      txn->Delete(db->DefaultColumnFamily(), Slice("foo"), ASSUME_EXC_LOCKED));
+      txn->Delete(db->DefaultColumnFamily(), Slice("foo"), ASSUME_LOCKED));
   ASSERT_OK(txn->SingleDelete(db->DefaultColumnFamily(), Slice("foo"),
-                              ASSUME_EXC_LOCKED));
+                              ASSUME_LOCKED));
 
   txn->Rollback();
   delete txn;

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -85,79 +85,71 @@ void WriteUnpreparedTxn::Initialize(const TransactionOptions& txn_options) {
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const Slice& key, const Slice& value,
-                               const bool assume_exclusive_tracked) {
+                               const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value,
-                                  assume_exclusive_tracked);
+  return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const SliceParts& key, const SliceParts& value,
-                               const bool assume_exclusive_tracked) {
+                               const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value,
-                                  assume_exclusive_tracked);
+  return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::Merge(ColumnFamilyHandle* column_family,
                                  const Slice& key, const Slice& value,
-                                 const bool assume_exclusive_tracked) {
+                                 const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Merge(column_family, key, value,
-                                    assume_exclusive_tracked);
+  return TransactionBaseImpl::Merge(column_family, key, value, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const Slice& key,
-                                  const bool assume_exclusive_tracked) {
+                                  const Slice& key, const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key,
-                                     assume_exclusive_tracked);
+  return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
                                   const SliceParts& key,
-                                  const bool assume_exclusive_tracked) {
+                                  const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key,
-                                     assume_exclusive_tracked);
+  return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const Slice& key,
-                                        const bool assume_exclusive_tracked) {
+                                        const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key,
-                                           assume_exclusive_tracked);
+  return TransactionBaseImpl::SingleDelete(column_family, key, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const SliceParts& key,
-                                        const bool assume_exclusive_tracked) {
+                                        const bool assume_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key,
-                                           assume_exclusive_tracked);
+  return TransactionBaseImpl::SingleDelete(column_family, key, assume_tracked);
 }
 
 Status WriteUnpreparedTxn::MaybeFlushWriteBatchToDB() {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -84,66 +84,66 @@ void WriteUnpreparedTxn::Initialize(const TransactionOptions& txn_options) {
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
-                               const Slice& key, const Slice& value) {
+                               const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value);
+  return TransactionBaseImpl::Put(column_family, key, value, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
-                               const SliceParts& key, const SliceParts& value) {
+                               const SliceParts& key, const SliceParts& value, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value);
+  return TransactionBaseImpl::Put(column_family, key, value, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Merge(ColumnFamilyHandle* column_family,
-                                 const Slice& key, const Slice& value) {
+                                 const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Merge(column_family, key, value);
+  return TransactionBaseImpl::Merge(column_family, key, value, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const Slice& key) {
+                                  const Slice& key, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key);
+  return TransactionBaseImpl::Delete(column_family, key, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const SliceParts& key) {
+                                  const SliceParts& key, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key);
+  return TransactionBaseImpl::Delete(column_family, key, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
-                                        const Slice& key) {
+                                        const Slice& key, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key);
+  return TransactionBaseImpl::SingleDelete(column_family, key, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
-                                        const SliceParts& key) {
+                                        const SliceParts& key, const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key);
+  return TransactionBaseImpl::SingleDelete(column_family, key, assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::MaybeFlushWriteBatchToDB() {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -84,66 +84,80 @@ void WriteUnpreparedTxn::Initialize(const TransactionOptions& txn_options) {
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
-                               const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
+                               const Slice& key, const Slice& value,
+                               const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value, assume_exclusive_tracked);
+  return TransactionBaseImpl::Put(column_family, key, value,
+                                  assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
-                               const SliceParts& key, const SliceParts& value, const bool assume_exclusive_tracked) {
+                               const SliceParts& key, const SliceParts& value,
+                               const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Put(column_family, key, value, assume_exclusive_tracked);
+  return TransactionBaseImpl::Put(column_family, key, value,
+                                  assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Merge(ColumnFamilyHandle* column_family,
-                                 const Slice& key, const Slice& value, const bool assume_exclusive_tracked) {
+                                 const Slice& key, const Slice& value,
+                                 const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Merge(column_family, key, value, assume_exclusive_tracked);
+  return TransactionBaseImpl::Merge(column_family, key, value,
+                                    assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const Slice& key, const bool assume_exclusive_tracked) {
+                                  const Slice& key,
+                                  const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key, assume_exclusive_tracked);
+  return TransactionBaseImpl::Delete(column_family, key,
+                                     assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const SliceParts& key, const bool assume_exclusive_tracked) {
+                                  const SliceParts& key,
+                                  const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::Delete(column_family, key, assume_exclusive_tracked);
+  return TransactionBaseImpl::Delete(column_family, key,
+                                     assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
-                                        const Slice& key, const bool assume_exclusive_tracked) {
+                                        const Slice& key,
+                                        const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key, assume_exclusive_tracked);
+  return TransactionBaseImpl::SingleDelete(column_family, key,
+                                           assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
-                                        const SliceParts& key, const bool assume_exclusive_tracked) {
+                                        const SliceParts& key,
+                                        const bool assume_exclusive_tracked) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
   }
-  return TransactionBaseImpl::SingleDelete(column_family, key, assume_exclusive_tracked);
+  return TransactionBaseImpl::SingleDelete(column_family, key,
+                                           assume_exclusive_tracked);
 }
 
 Status WriteUnpreparedTxn::MaybeFlushWriteBatchToDB() {

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -48,25 +48,25 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
   using TransactionBaseImpl::Put;
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value) override;
+                     const Slice& value, const bool assume_exclusive_tracked=false) override;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value) override;
+                     const SliceParts& value, const bool assume_exclusive_tracked=false) override;
 
   using TransactionBaseImpl::Merge;
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value) override;
+                       const Slice& value, const bool assume_exclusive_tracked=false) override;
 
   using TransactionBaseImpl::Delete;
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const Slice& key) override;
+                        const Slice& key, const bool assume_exclusive_tracked=false) override;
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const SliceParts& key) override;
+                        const SliceParts& key, const bool assume_exclusive_tracked=false) override;
 
   using TransactionBaseImpl::SingleDelete;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const Slice& key) override;
+                              const Slice& key, const bool assume_exclusive_tracked=false) override;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const SliceParts& key) override;
+                              const SliceParts& key, const bool assume_exclusive_tracked=false) override;
 
   virtual Status RebuildFromWriteBatch(WriteBatch*) override {
     // This function was only useful for recovering prepared transactions, but

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -48,25 +48,31 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
   using TransactionBaseImpl::Put;
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value, const bool assume_exclusive_tracked=false) override;
+                     const Slice& value,
+                     const bool assume_exclusive_tracked = false) override;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
-                     const SliceParts& value, const bool assume_exclusive_tracked=false) override;
+                     const SliceParts& value,
+                     const bool assume_exclusive_tracked = false) override;
 
   using TransactionBaseImpl::Merge;
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
-                       const Slice& value, const bool assume_exclusive_tracked=false) override;
+                       const Slice& value,
+                       const bool assume_exclusive_tracked = false) override;
 
   using TransactionBaseImpl::Delete;
+  virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
+                        const bool assume_exclusive_tracked = false) override;
   virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const Slice& key, const bool assume_exclusive_tracked=false) override;
-  virtual Status Delete(ColumnFamilyHandle* column_family,
-                        const SliceParts& key, const bool assume_exclusive_tracked=false) override;
+                        const SliceParts& key,
+                        const bool assume_exclusive_tracked = false) override;
 
   using TransactionBaseImpl::SingleDelete;
-  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const Slice& key, const bool assume_exclusive_tracked=false) override;
-  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
-                              const SliceParts& key, const bool assume_exclusive_tracked=false) override;
+  virtual Status SingleDelete(
+      ColumnFamilyHandle* column_family, const Slice& key,
+      const bool assume_exclusive_tracked = false) override;
+  virtual Status SingleDelete(
+      ColumnFamilyHandle* column_family, const SliceParts& key,
+      const bool assume_exclusive_tracked = false) override;
 
   virtual Status RebuildFromWriteBatch(WriteBatch*) override {
     // This function was only useful for recovering prepared transactions, but

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -49,30 +49,30 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   using TransactionBaseImpl::Put;
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
                      const Slice& value,
-                     const bool assume_exclusive_tracked = false) override;
+                     const bool assume_tracked = false) override;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value,
-                     const bool assume_exclusive_tracked = false) override;
+                     const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::Merge;
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,
                        const Slice& value,
-                       const bool assume_exclusive_tracked = false) override;
+                       const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::Delete;
   virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                        const bool assume_exclusive_tracked = false) override;
+                        const bool assume_tracked = false) override;
   virtual Status Delete(ColumnFamilyHandle* column_family,
                         const SliceParts& key,
-                        const bool assume_exclusive_tracked = false) override;
+                        const bool assume_tracked = false) override;
 
   using TransactionBaseImpl::SingleDelete;
-  virtual Status SingleDelete(
-      ColumnFamilyHandle* column_family, const Slice& key,
-      const bool assume_exclusive_tracked = false) override;
-  virtual Status SingleDelete(
-      ColumnFamilyHandle* column_family, const SliceParts& key,
-      const bool assume_exclusive_tracked = false) override;
+  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
+                              const Slice& key,
+                              const bool assume_tracked = false) override;
+  virtual Status SingleDelete(ColumnFamilyHandle* column_family,
+                              const SliceParts& key,
+                              const bool assume_tracked = false) override;
 
   virtual Status RebuildFromWriteBatch(WriteBatch*) override {
     // This function was only useful for recovering prepared transactions, but


### PR DESCRIPTION
Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot (if there is any) before doing the read. After the read it also returns the latest value (expects the ReadOptions::snapshot to be nullptr). This allows RocksDB applications to use GetForUpdate similarly to how InnoDB does. Similarly ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_exclusive_tracked with default value of false. It true it indicates that call is assumed to be after a ::GetForUpdate(do_validate=false).
The Java APIs are accordingly updated.