### PR TITLE
[Minor] Bug in Regular Expression in Makefile (#3446)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ include make_config.mk
 CLEAN_FILES += make_config.mk
 
 missing_make_config_paths := $(shell				\
-	grep "\/\S*" -o $(CURDIR)/make_config.mk | 		\
+	grep "./\S*\|/\S*" -o $(CURDIR)/make_config.mk | 		\
 	while read path;					\
 		do [ -e $$path ] || echo $$path; 		\
 	done | sort | uniq)


### PR DESCRIPTION
Summary:
False-negative about path not existing. The regex is ignoring the "." in front of a path.
Example: "./path/to/file"