### PR TITLE
fix SstFileMetaData member initialization

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -871,9 +871,11 @@ Status CompactionPicker::SanitizeCompactionInputFilesForAllLevels(
       }
     }
 
-    SstFileMetaData aggregated_file_meta;
-    aggregated_file_meta.smallestkey = smallestkey;
-    aggregated_file_meta.largestkey = largestkey;
+    const SstFileMetaData aggregated_file_meta(
+        "" /* file_name */, "" /* path */, 0 /* size */, 0 /* smallest_seqno */,
+        0 /* largest_seqno */, smallestkey, largestkey,
+        0 /* num_reads_sampled */, false /* being_compacted */,
+        0 /* num_entries */, 0 /* num_deletions */);
 
     // For all lower levels, include all overlapping files.
     // We need to add overlapping files from the current level too because even

--- a/utilities/blob_db/blob_db_impl_filesnapshot.cc
+++ b/utilities/blob_db/blob_db_impl_filesnapshot.cc
@@ -92,14 +92,18 @@ void BlobDBImpl::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
   db_->GetLiveFilesMetaData(metadata);
   for (auto bfile_pair : blob_files_) {
     auto blob_file = bfile_pair.second;
-    LiveFileMetaData filemetadata;
-    filemetadata.size = static_cast<size_t>(blob_file->GetFileSize());
     // Path should be relative to db_name, but begin with slash.
-    filemetadata.name =
+    std::string file_name =
         BlobFileName("", bdb_options_.blob_dir, blob_file->BlobFileNumber());
     auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(DefaultColumnFamily());
-    filemetadata.column_family_name = cfh->GetName();
-    metadata->emplace_back(filemetadata);
+    LiveFileMetaData filemetadata(
+        std::move(file_name), "" /* path */,
+        static_cast<size_t>(blob_file->GetFileSize()) /* size */,
+        0 /* smallest_seqno */, 0 /* largest_seqno */, "" /* smallest_key */,
+        "" /* largest_key */, 0 /* num_reads_sampled */,
+        false /* being_compacted */, 0 /* num_entries */, 0 /* num_deletions */,
+        cfh->GetName(), 0 /* level */);
+    metadata->emplace_back(std::move(filemetadata));
   }
 }
 


### PR DESCRIPTION
The problem is we have an internal structure `FileMetaData` as well as a public-facing structure `SstFileMetaData`. The latter is usually created by copying fields from the former. Until now there has been no mechanism ensuring all the fields of `SstFileMetaData` are initialized, either by copying from `FileMetaData` or by setting default values. For example, `GetLiveFilesMetaData` completely forgot to copy `num_reads_sampled` to the result, so users were told that all their files were read zero times.

This proposed solution makes the only constructor available in `SstFileMetaData` (and its subclass `LiveFileMetaData`) a full constructor, i.e., one that initializes every member. I made it private because we will need to add parameters to it every time a member variable is added, and we don't want to be burdened by public API compatibility concerns. Then, to make it available internally, I had to add internal clients as friend classes.