### PR TITLE
Fix uninitialized fields in file metadata

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -916,6 +916,8 @@ void Version::GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta) {
           file->largest.user_key().ToString(),
           file->stats.num_reads_sampled.load(std::memory_order_relaxed),
           file->being_compacted});
+      files.back().num_entries = file->num_entries;
+      files.back().num_deletions = file->num_deletions;
       level_size += file->fd.GetFileSize();
     }
     cf_meta->levels.emplace_back(
@@ -4406,6 +4408,9 @@ void VersionSet::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
         filemetadata.largestkey = file->largest.user_key().ToString();
         filemetadata.smallest_seqno = file->fd.smallest_seqno;
         filemetadata.largest_seqno = file->fd.largest_seqno;
+        filemetadata.num_reads_sampled = file->stats.num_reads_sampled.load(
+            std::memory_order_relaxed);
+        filemetadata.being_compacted = file->being_compacted;
         filemetadata.num_entries = file->num_entries;
         filemetadata.num_deletions = file->num_deletions;
         metadata->push_back(filemetadata);

--- a/include/rocksdb/metadata.h
+++ b/include/rocksdb/metadata.h
@@ -63,7 +63,10 @@ struct SstFileMetaData {
         smallestkey(""),
         largestkey(""),
         num_reads_sampled(0),
-        being_compacted(false) {}
+        being_compacted(false),
+        num_entries(0),
+        num_deletions(0) {}
+
   SstFileMetaData(const std::string& _file_name, const std::string& _path,
                   size_t _size, SequenceNumber _smallest_seqno,
                   SequenceNumber _largest_seqno,
@@ -78,7 +81,9 @@ struct SstFileMetaData {
         smallestkey(_smallestkey),
         largestkey(_largestkey),
         num_reads_sampled(_num_reads_sampled),
-        being_compacted(_being_compacted) {}
+        being_compacted(_being_compacted),
+        num_entries(0),
+        num_deletions(0) {}
 
   // File size in bytes.
   size_t size;
@@ -102,5 +107,6 @@ struct SstFileMetaData {
 struct LiveFileMetaData : SstFileMetaData {
   std::string column_family_name;  // Name of the column family
   int level;               // Level at which this file resides.
+  LiveFileMetaData() : column_family_name(), level(0) {}
 };
 }  // namespace rocksdb


### PR DESCRIPTION
This is a quick fix for the uninitialized bugs in `LiveFileMetaData` and `SstFileMetaData` that were uncovered in #4686.

Test Plan:

- `make check -j64`
- manual testing for read counts since the behavior is non-deterministic

```
In [23]: lookup_key = next(filter(lambda file: file['name'] == '/000973.sst', db.get_live_files_metadata()))['smallestkey']

In [24]: for i in range(100000):
    ...:     db.get(lookup_key)
    ...:

In [25]: next(filter(lambda file: file['name'] == '/000973.sst', db.get_live_files_metadata()))['num_reads_sampled']
Out[25]: 109568
```