### PR TITLE
Fix range tombstone covering short-circuit logic

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
 ### New Features
 * Introduced `Memoryllocator`, which lets the user specify custom memory allocator for block based table.
 
+### Bug Fixes
+* Fixed Get correctness bug in the presence of range tombstones where merge operands covered by a range tombstone always result in NotFound.
+
 ## 5.18.0 (11/12/2018)
 ### New Features
 * Introduced `PerfContextByLevel` as part of `PerfContext` which allows storing perf context at each level. Also replaced `__thread` with `thread_local` keyword for perf_context. Added per-level perf context for bloom filter and `Get` query.

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -729,10 +729,6 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
     // Avoiding recording stats for speed.
     return false;
   }
-  if (*max_covering_tombstone_seq > 0) {
-    *s = Status::NotFound();
-    return true;
-  }
   PERF_TIMER_GUARD(get_from_memtable_time);
 
   std::unique_ptr<InternalIterator> range_del_iter(

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1210,9 +1210,9 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
   while (f != nullptr) {
     if (*max_covering_tombstone_seq > 0) {
-      // Use empty error message for speed
-      *status = Status::NotFound();
-      return;
+      // The remaining files we look at will only contain covered keys, so we
+      // stop here.
+      break;
     }
     if (get_context.sample()) {
       sample_file_read_inc(f->file_metadata);


### PR DESCRIPTION
Summary: Since a range tombstone seen at one level will cover all keys
in the range at lower levels, there was a short-circuiting check in Get
that reported a key was not found at most one file after the range
tombstone was discovered. However, this was incorrect for merge
operands, since a deletion might only cover some merge operands,
which implies that the key should be found. This PR fixes this logic in
the Version portion of Get, and removes the logic from the MemTable
portion of Get, since the perforamnce benefit provided there is minimal.

Test Plan: TEST_TMPDIR=/dev/shm python tools/db_crashtest.py
blackbox --simple --delrangepercent=1 --delpercent=4
--write_buffer_size=1048576 --max_bytes_for_level_base=4194304
--target_file_size_base=1048576 --value_size_mult=33
--max_background_compactions=12 --max_key=10000000 --interval=30