### PR TITLE
Fix compatibility of public ticker stats

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -155,7 +155,8 @@ enum Tickers : uint32_t {
   // Disabled by default. To enable it set stats level to kAll
   DB_MUTEX_WAIT_MICROS,
   RATE_LIMIT_DELAY_MILLIS,
-  NO_ITERATOR_CREATED,  // number of iterators created
+  // DEPRECATED number of iterators currently open
+  NO_ITERATORS,
 
   // Number of MultiGet calls, keys read, and bytes read
   NUMBER_MULTIGET_CALLS,
@@ -323,6 +324,7 @@ enum Tickers : uint32_t {
   // NUMBER_MULTIGET_KEYS_READ gives the number requested by caller
   NUMBER_MULTIGET_KEYS_FOUND,
 
+  NO_ITERATOR_CREATED,  // number of iterators created
   NO_ITERATOR_DELETED,  // number of iterators deleted
   TICKER_ENUM_MAX
 };
@@ -394,7 +396,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {STALL_MICROS, "rocksdb.stall.micros"},
     {DB_MUTEX_WAIT_MICROS, "rocksdb.db.mutex.wait.micros"},
     {RATE_LIMIT_DELAY_MILLIS, "rocksdb.rate.limit.delay.millis"},
-    {NO_ITERATOR_CREATED, "rocksdb.num.iterator.created"},
+    {NO_ITERATORS, "rocksdb.num.iterators"},
     {NUMBER_MULTIGET_CALLS, "rocksdb.number.multiget.get"},
     {NUMBER_MULTIGET_KEYS_READ, "rocksdb.number.multiget.keys.read"},
     {NUMBER_MULTIGET_BYTES_READ, "rocksdb.number.multiget.bytes.read"},
@@ -476,6 +478,7 @@ const std::vector<std::pair<Tickers, std::string>> TickersNameMap = {
     {TXN_DUPLICATE_KEY_OVERHEAD, "rocksdb.txn.overhead.duplicate.key"},
     {TXN_SNAPSHOT_MUTEX_OVERHEAD, "rocksdb.txn.overhead.mutex.snapshot"},
     {NUMBER_MULTIGET_KEYS_FOUND, "rocksdb.number.multiget.keys.found"},
+    {NO_ITERATOR_CREATED, "rocksdb.num.iterator.created"},
     {NO_ITERATOR_DELETED, "rocksdb.num.iterator.deleted"},
 };
 

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -3301,7 +3301,7 @@ class TickerTypeJni {
         return 0x36;
       case rocksdb::Tickers::RATE_LIMIT_DELAY_MILLIS:
         return 0x37;
-      case rocksdb::Tickers::NO_ITERATOR_CREATED:
+      case rocksdb::Tickers::NO_ITERATORS:
         return 0x38;
       case rocksdb::Tickers::NUMBER_MULTIGET_CALLS:
         return 0x39;
@@ -3379,10 +3379,12 @@ class TickerTypeJni {
         return 0x5D;
       case rocksdb::Tickers::NUMBER_MULTIGET_KEYS_FOUND:
         return 0x5E;
-      case rocksdb::Tickers::NO_ITERATOR_DELETED:
+      case rocksdb::Tickers::NO_ITERATOR_CREATED:
         return 0x5F;
-      case rocksdb::Tickers::TICKER_ENUM_MAX:
+      case rocksdb::Tickers::NO_ITERATOR_DELETED:
         return 0x60;
+      case rocksdb::Tickers::TICKER_ENUM_MAX:
+        return 0x61;
 
       default:
         // undefined/default


### PR DESCRIPTION
- Added back the `NO_ITERATORS` that was removed in 5945e16dfc6e99522c607841cfd387eebed256fc.
- Marked it as deprecated since it is no longer populated, but kept for API compatibility.
- Made sure the new tickers, `NO_ITERATOR_CREATED` and `NO_ITERATOR_DELETED`, are appended at the end of the enum, in case people are relying on the int values.

The change where `NO_ITERATOR_CREATED` and `NO_ITERATOR_DELETED` were introduced is unreleased so I believe it is ok to change their ordering.

Test Plan:

- `make check -j64`