### PR TITLE
fix the JNI CF handle leak

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1707,6 +1707,7 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject /*jdb*/,
   }
 }
 
+
 /*
  * Class:     org_rocksdb_RocksDB
  * Method:    destroyColumnFamilyHandle

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1707,7 +1707,6 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject /*jdb*/,
   }
 }
 
-
 /*
  * Class:     org_rocksdb_RocksDB
  * Method:    destroyColumnFamilyHandle

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1708,6 +1708,23 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject /*jdb*/,
 }
 
 /*
+ * Class:     org_rocksdb_RocksDB
+ * Method:    destroyColumnFamilyHandle
+ * Signature: (JJ)V;
+ */
+void Java_org_rocksdb_RocksDB_destroyColumnFamilyHandle(JNIEnv* env,
+                                                        jobject /*jdb*/,
+                                               jlong jdb_handle,
+                                               jlong jcf_handle) {
+  auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
+  auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
+  rocksdb::Status s = db_handle->DestroyColumnFamilyHandle(cf_handle);
+  if (!s.ok()) {
+    rocksdb::RocksDBExceptionJni::ThrowNew(env, s);
+  }
+}
+
+/*
  * Method:    getSnapshot
  * Signature: (J)J
  */

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1714,8 +1714,8 @@ void Java_org_rocksdb_RocksDB_dropColumnFamily(JNIEnv* env, jobject /*jdb*/,
  */
 void Java_org_rocksdb_RocksDB_destroyColumnFamilyHandle(JNIEnv* env,
                                                         jobject /*jdb*/,
-                                               jlong jdb_handle,
-                                               jlong jcf_handle) {
+                                                        jlong jdb_handle,
+                                                        jlong jcf_handle) {
   auto* cf_handle = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcf_handle);
   auto* db_handle = reinterpret_cast<rocksdb::DB*>(jdb_handle);
   rocksdb::Status s = db_handle->DestroyColumnFamilyHandle(cf_handle);


### PR DESCRIPTION
I got the memory leak now. It is 100% precise. 

Actually `dropColumnFamily` method will not free `ColumnFamily` at all. In C++ world, RocksDB provide one method below.

```C++
Status DB::DestroyColumnFamilyHandle(ColumnFamilyHandle* column_family) {
  delete column_family;
  return Status::OK();
}
```

But in java world JNI did not expose it at all!~~~
