### PR TITLE
Remove enable_internal_stats

### DIFF
--- a/java/rocksjni/statisticsjni.cc
+++ b/java/rocksjni/statisticsjni.cc
@@ -11,11 +11,11 @@
 namespace rocksdb {
 
   StatisticsJni::StatisticsJni(std::shared_ptr<Statistics> stats)
-      : StatisticsImpl(stats, false), m_ignore_histograms() {
+      : StatisticsImpl(stats), m_ignore_histograms() {
   }
 
   StatisticsJni::StatisticsJni(std::shared_ptr<Statistics> stats,
-      const std::set<uint32_t> ignore_histograms) : StatisticsImpl(stats, false),
+      const std::set<uint32_t> ignore_histograms) : StatisticsImpl(stats),
       m_ignore_histograms(ignore_histograms) {
   }
 

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -18,12 +18,11 @@
 namespace rocksdb {
 
 std::shared_ptr<Statistics> CreateDBStatistics() {
-  return std::make_shared<StatisticsImpl>(nullptr, false);
+  return std::make_shared<StatisticsImpl>(nullptr);
 }
 
-StatisticsImpl::StatisticsImpl(std::shared_ptr<Statistics> stats,
-                               bool enable_internal_stats)
-    : stats_(std::move(stats)), enable_internal_stats_(enable_internal_stats) {}
+StatisticsImpl::StatisticsImpl(std::shared_ptr<Statistics> stats)
+    : stats_(std::move(stats)) {}
 
 StatisticsImpl::~StatisticsImpl() {}
 
@@ -33,10 +32,7 @@ uint64_t StatisticsImpl::getTickerCount(uint32_t tickerType) const {
 }
 
 uint64_t StatisticsImpl::getTickerCountLocked(uint32_t tickerType) const {
-  assert(
-    enable_internal_stats_ ?
-      tickerType < INTERNAL_TICKER_ENUM_MAX :
-      tickerType < TICKER_ENUM_MAX);
+  assert(tickerType < TICKER_ENUM_MAX);
   uint64_t res = 0;
   for (size_t core_idx = 0; core_idx < per_core_stats_.Size(); ++core_idx) {
     res += per_core_stats_.AccessAtCore(core_idx)->tickers_[tickerType];
@@ -52,10 +48,7 @@ void StatisticsImpl::histogramData(uint32_t histogramType,
 
 std::unique_ptr<HistogramImpl> StatisticsImpl::getHistogramImplLocked(
     uint32_t histogramType) const {
-  assert(
-    enable_internal_stats_ ?
-      histogramType < INTERNAL_HISTOGRAM_ENUM_MAX :
-      histogramType < HISTOGRAM_ENUM_MAX);
+  assert(histogramType < HISTOGRAM_ENUM_MAX);
   std::unique_ptr<HistogramImpl> res_hist(new HistogramImpl());
   for (size_t core_idx = 0; core_idx < per_core_stats_.Size(); ++core_idx) {
     res_hist->Merge(
@@ -80,8 +73,7 @@ void StatisticsImpl::setTickerCount(uint32_t tickerType, uint64_t count) {
 }
 
 void StatisticsImpl::setTickerCountLocked(uint32_t tickerType, uint64_t count) {
-  assert(enable_internal_stats_ ? tickerType < INTERNAL_TICKER_ENUM_MAX
-                                : tickerType < TICKER_ENUM_MAX);
+  assert(tickerType < TICKER_ENUM_MAX);
   for (size_t core_idx = 0; core_idx < per_core_stats_.Size(); ++core_idx) {
     if (core_idx == 0) {
       per_core_stats_.AccessAtCore(core_idx)->tickers_[tickerType] = count;
@@ -95,8 +87,7 @@ uint64_t StatisticsImpl::getAndResetTickerCount(uint32_t tickerType) {
   uint64_t sum = 0;
   {
     MutexLock lock(&aggregate_lock_);
-    assert(enable_internal_stats_ ? tickerType < INTERNAL_TICKER_ENUM_MAX
-                                  : tickerType < TICKER_ENUM_MAX);
+    assert(tickerType < TICKER_ENUM_MAX);
     for (size_t core_idx = 0; core_idx < per_core_stats_.Size(); ++core_idx) {
       sum +=
           per_core_stats_.AccessAtCore(core_idx)->tickers_[tickerType].exchange(
@@ -110,10 +101,7 @@ uint64_t StatisticsImpl::getAndResetTickerCount(uint32_t tickerType) {
 }
 
 void StatisticsImpl::recordTick(uint32_t tickerType, uint64_t count) {
-  assert(
-    enable_internal_stats_ ?
-      tickerType < INTERNAL_TICKER_ENUM_MAX :
-      tickerType < TICKER_ENUM_MAX);
+  assert(tickerType < TICKER_ENUM_MAX);
   per_core_stats_.Access()->tickers_[tickerType].fetch_add(
       count, std::memory_order_relaxed);
   if (stats_ && tickerType < TICKER_ENUM_MAX) {
@@ -122,10 +110,7 @@ void StatisticsImpl::recordTick(uint32_t tickerType, uint64_t count) {
 }
 
 void StatisticsImpl::measureTime(uint32_t histogramType, uint64_t value) {
-  assert(
-    enable_internal_stats_ ?
-      histogramType < INTERNAL_HISTOGRAM_ENUM_MAX :
-      histogramType < HISTOGRAM_ENUM_MAX);
+  assert(histogramType < HISTOGRAM_ENUM_MAX);
   per_core_stats_.Access()->histograms_[histogramType].Add(value);
   if (stats_ && histogramType < HISTOGRAM_ENUM_MAX) {
     stats_->measureTime(histogramType, value);
@@ -157,7 +142,7 @@ std::string StatisticsImpl::ToString() const {
   std::string res;
   res.reserve(20000);
   for (const auto& t : TickersNameMap) {
-    if (t.first < TICKER_ENUM_MAX || enable_internal_stats_) {
+    if (t.first < TICKER_ENUM_MAX) {
       char buffer[kTmpStrBufferSize];
       snprintf(buffer, kTmpStrBufferSize, "%s COUNT : %" PRIu64 "\n",
                t.second.c_str(), getTickerCountLocked(t.first));
@@ -165,7 +150,7 @@ std::string StatisticsImpl::ToString() const {
     }
   }
   for (const auto& h : HistogramsNameMap) {
-    if (h.first < HISTOGRAM_ENUM_MAX || enable_internal_stats_) {
+    if (h.first < HISTOGRAM_ENUM_MAX) {
       char buffer[kTmpStrBufferSize];
       HistogramData hData;
       getHistogramImplLocked(h.first)->Data(&hData);
@@ -188,10 +173,7 @@ std::string StatisticsImpl::ToString() const {
 }
 
 bool StatisticsImpl::HistEnabledForType(uint32_t type) const {
-  if (LIKELY(!enable_internal_stats_)) {
-    return type < HISTOGRAM_ENUM_MAX;
-  }
-  return true;
+  return type < HISTOGRAM_ENUM_MAX;
 }
 
 } // namespace rocksdb

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -142,31 +142,29 @@ std::string StatisticsImpl::ToString() const {
   std::string res;
   res.reserve(20000);
   for (const auto& t : TickersNameMap) {
-    if (t.first < TICKER_ENUM_MAX) {
-      char buffer[kTmpStrBufferSize];
-      snprintf(buffer, kTmpStrBufferSize, "%s COUNT : %" PRIu64 "\n",
-               t.second.c_str(), getTickerCountLocked(t.first));
-      res.append(buffer);
-    }
+    assert(t.first < TICKER_ENUM_MAX);
+    char buffer[kTmpStrBufferSize];
+    snprintf(buffer, kTmpStrBufferSize, "%s COUNT : %" PRIu64 "\n",
+             t.second.c_str(), getTickerCountLocked(t.first));
+    res.append(buffer);
   }
   for (const auto& h : HistogramsNameMap) {
-    if (h.first < HISTOGRAM_ENUM_MAX) {
-      char buffer[kTmpStrBufferSize];
-      HistogramData hData;
-      getHistogramImplLocked(h.first)->Data(&hData);
-      // don't handle failures - buffer should always be big enough and arguments
-      // should be provided correctly
-      int ret = snprintf(
-          buffer, kTmpStrBufferSize,
-          "%s P50 : %f P95 : %f P99 : %f P100 : %f COUNT : %" PRIu64 " SUM : %"
-          PRIu64 "\n", h.second.c_str(), hData.median, hData.percentile95,
-          hData.percentile99, hData.max, hData.count, hData.sum);
-      if (ret < 0 || ret >= kTmpStrBufferSize) {
-        assert(false);
-        continue;
-      }
-      res.append(buffer);
+    assert(h.first < HISTOGRAM_ENUM_MAX);
+    char buffer[kTmpStrBufferSize];
+    HistogramData hData;
+    getHistogramImplLocked(h.first)->Data(&hData);
+    // don't handle failures - buffer should always be big enough and arguments
+    // should be provided correctly
+    int ret = snprintf(
+        buffer, kTmpStrBufferSize,
+        "%s P50 : %f P95 : %f P99 : %f P100 : %f COUNT : %" PRIu64 " SUM : %"
+        PRIu64 "\n", h.second.c_str(), hData.median, hData.percentile95,
+        hData.percentile99, hData.max, hData.count, hData.sum);
+    if (ret < 0 || ret >= kTmpStrBufferSize) {
+      assert(false);
+      continue;
     }
+    res.append(buffer);
   }
   res.shrink_to_fit();
   return res;

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -41,8 +41,7 @@ enum HistogramsInternal : uint32_t {
 
 class StatisticsImpl : public Statistics {
  public:
-  StatisticsImpl(std::shared_ptr<Statistics> stats,
-                 bool enable_internal_stats);
+  StatisticsImpl(std::shared_ptr<Statistics> stats);
   virtual ~StatisticsImpl();
 
   virtual uint64_t getTickerCount(uint32_t ticker_type) const override;
@@ -62,8 +61,6 @@ class StatisticsImpl : public Statistics {
  private:
   // If non-nullptr, forwards updates to the object pointed to by `stats_`.
   std::shared_ptr<Statistics> stats_;
-  // TODO(ajkr): clean this up since there are no internal stats anymore
-  bool enable_internal_stats_;
   // Synchronizes anything that operates across other cores' local data,
   // such that operations like Reset() can be performed atomically.
   mutable port::Mutex aggregate_lock_;


### PR DESCRIPTION
Simple patch to address comments in [statistics.h#L65](https://github.com/facebook/rocksdb/blob/master/monitoring/statistics.h#L65|statistics.h#L65)  `TODO(ajkr): clean this up since there are no internal stats anymore`

