### PR TITLE
Fix Java to C++ ticker conversions

### DIFF
--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -3509,7 +3509,7 @@ class TickerTypeJni {
       case 0x37:
         return rocksdb::Tickers::RATE_LIMIT_DELAY_MILLIS;
       case 0x38:
-        return rocksdb::Tickers::NO_ITERATOR_CREATED;
+        return rocksdb::Tickers::NO_ITERATORS;
       case 0x39:
         return rocksdb::Tickers::NUMBER_MULTIGET_CALLS;
       case 0x3A:
@@ -3587,8 +3587,10 @@ class TickerTypeJni {
       case 0x5E:
         return rocksdb::Tickers::NUMBER_MULTIGET_KEYS_FOUND;
       case 0x5F:
-        return rocksdb::Tickers::NO_ITERATOR_DELETED;
+        return rocksdb::Tickers::NO_ITERATOR_CREATED;
       case 0x60:
+        return rocksdb::Tickers::NO_ITERATOR_DELETED;
+      case 0x61:
         return rocksdb::Tickers::TICKER_ENUM_MAX;
 
       default:


### PR DESCRIPTION
Added back `NO_ITERATORS` and moved `NO_ITERATOR_CREATED` to the end of `toCppTickers`.

This is a leftover fix which is needed in addition to a138e351bcc017667560c7ecbb295800b30881c2 to correctly convert java tickers to c++ tickers. a138e351bcc017667560c7ecbb295800b30881c2 only updated `toJavaTickerType` but both `toJavaTickerType` and `toCppTickers` need to be changed.