### PR TITLE
Test mapping of Histograms and HistogramsNameMap

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -563,7 +563,7 @@ enum Histograms : uint32_t {
   // Time spent flushing memtable to disk
   FLUSH_TIME,
 
-  HISTOGRAM_ENUM_MAX,  // TODO(ldemailly): enforce HistogramsNameMap match
+  HISTOGRAM_ENUM_MAX,
 };
 
 const std::vector<std::pair<Histograms, std::string>> HistogramsNameMap = {

--- a/monitoring/statistics_test.cc
+++ b/monitoring/statistics_test.cc
@@ -16,13 +16,25 @@ class StatisticsTest : public testing::Test {};
 
 // Sanity check to make sure that contents and order of TickersNameMap
 // match Tickers enum
-TEST_F(StatisticsTest, Sanity) {
+TEST_F(StatisticsTest, SanityTickers) {
   EXPECT_EQ(static_cast<size_t>(Tickers::TICKER_ENUM_MAX),
             TickersNameMap.size());
 
   for (uint32_t t = 0; t < Tickers::TICKER_ENUM_MAX; t++) {
     auto pair = TickersNameMap[static_cast<size_t>(t)];
     ASSERT_EQ(pair.first, t) << "Miss match at " << pair.second;
+  }
+}
+
+// Sanity check to make sure that contents and order of HistogramsNameMap
+// match Tickers enum
+TEST_F(StatisticsTest, SanityHistograms) {
+  EXPECT_EQ(static_cast<size_t>(Histograms::HISTOGRAM_ENUM_MAX),
+            HistogramsNameMap.size());
+
+  for (uint32_t h = 0; h < Histograms::HISTOGRAM_ENUM_MAX; h++) {
+    auto pair = HistogramsNameMap[static_cast<size_t>(h)];
+    ASSERT_EQ(pair.first, h) << "Miss match at " << pair.second;
   }
 }
 


### PR DESCRIPTION
Adding sanity check test for mapping of `Histograms` and `HistogramsNameMap`

```
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from StatisticsTest
[ RUN      ] StatisticsTest.SanityTickers
[       OK ] StatisticsTest.SanityTickers (0 ms)
[ RUN      ] StatisticsTest.SanityHistograms
[       OK ] StatisticsTest.SanityHistograms (0 ms)
[----------] 2 tests from StatisticsTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (0 ms total)
[  PASSED  ] 2 tests.
```