### PR TITLE
Fix failure of sst_file_reader_test in LITE mode regression test

### DIFF
--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -95,4 +95,12 @@ int main(int argc, char** argv) {
   return RUN_ALL_TESTS();
 }
 
+#else
+#include <stdio.h>
+
+int main(int /*argc*/, char** /*argv*/) {
+  fprintf(stderr, "SKIPPED as SstFileReader is not supported in ROCKSDB_LITE\n");
+  return 0;
+}
+
 #endif  // ROCKSDB_LITE


### PR DESCRIPTION
Add a dummy main() in sst_file_reader_test for ROCKSDB_LITE to fix link failure in regression