### PR TITLE
Fix swallowing of exception in Java RocksDB when loading native library 

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -64,8 +64,8 @@ public class RocksDB extends RocksObject {
         NativeLibraryLoader.getInstance().loadLibrary(tmpDir);
       } catch (IOException e) {
         libraryLoaded.set(LibraryState.NOT_LOADED);
-        throw new RuntimeException("Unable to load the RocksDB shared library"
-            + e);
+        throw new RuntimeException("Unable to load the RocksDB shared library",
+            e);
       }
 
       libraryLoaded.set(LibraryState.LOADED);


### PR DESCRIPTION
This PR fixes #4721. When an exception is caught and thrown as a different exception, then the original exception should be  inserted as a cause of the new exception. This bug in RocksDB was swallowing the underlying exception from `NativeLibraryLoader` and throwing the following exception 
```
...
Caused by: java.lang.RuntimeException: Unable to load the RocksDB shared libraryjava.nio.channels.ClosedByInterruptException
  at org.rocksdb.RocksDB.loadLibrary(RocksDB.java:67)
  at org.rocksdb.RocksDB.<clinit>(RocksDB.java:35)
  ... 73 more
```

The fix is simple and self-explanatory.