### PR TITLE
Augment BackupInfo with BackupFileInfo

### DIFF
--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -160,6 +160,19 @@ struct RestoreOptions {
 
 typedef uint32_t BackupID;
 
+struct BackupFileInfo {
+  std::string path;
+  uint64_t size;
+  uint32_t checksum;
+
+  BackupFileInfo() {}
+
+  BackupFileInfo(const std::string& _path, uint64_t _size, uint32_t _checksum)
+      : path(_path),
+        size(_size),
+        checksum(_checksum) {}
+};
+
 struct BackupInfo {
   BackupID backup_id;
   int64_t timestamp;
@@ -167,16 +180,19 @@ struct BackupInfo {
 
   uint32_t number_files;
   std::string app_metadata;
+  std::vector<BackupFileInfo> backup_files_info;
 
   BackupInfo() {}
 
   BackupInfo(BackupID _backup_id, int64_t _timestamp, uint64_t _size,
-             uint32_t _number_files, const std::string& _app_metadata)
+             uint32_t _number_files, const std::string& _app_metadata,
+             const std::vector<BackupFileInfo>& _backup_files_info)
       : backup_id(_backup_id),
         timestamp(_timestamp),
         size(_size),
         number_files(_number_files),
-        app_metadata(_app_metadata) {}
+        app_metadata(_app_metadata),
+        backup_files_info(_backup_files_info) {}
 };
 
 class BackupStatistics {

--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -24,6 +24,7 @@
 
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
+#include "rocksdb/table.h"
 
 namespace rocksdb {
 
@@ -160,14 +161,29 @@ struct RestoreOptions {
 
 typedef uint32_t BackupID;
 
+struct Checksum {
+  // Encapsulate values for multiple types of supported checksum algorithms.
+  // Only one checksum value at a time will be populated, depending on the
+  // checksum_type. Currently only ChecksumType.kCRC32c is supported (the value
+  // for that is found in Checksum::crc32_value).
+  ChecksumType checksum_type;
+  uint32_t crc32_value;
+
+  Checksum() {}
+
+  Checksum(ChecksumType _checksum_type, uint32_t _crc32_value=0)
+      : checksum_type(_checksum_type),
+        crc32_value(_crc32_value) {}
+};
+
 struct BackupFileInfo {
   std::string path;
   uint64_t size;
-  uint32_t checksum;
+  Checksum checksum;
 
   BackupFileInfo() {}
 
-  BackupFileInfo(const std::string& _path, uint64_t _size, uint32_t _checksum)
+  BackupFileInfo(const std::string& _path, uint64_t _size, Checksum _checksum)
       : path(_path),
         size(_size),
         checksum(_checksum) {}

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1040,7 +1040,8 @@ void BackupEngineImpl::GetBackupInfo(std::vector<BackupInfo>* backup_info) {
       auto backup_files_info = std::vector<BackupFileInfo>();
       for (const auto& file_meta: backup_files_meta) {
         backup_files_info.push_back(BackupFileInfo(
-            file_meta->filename, file_meta->size, file_meta->checksum_value));
+            file_meta->filename, file_meta->size,
+            Checksum(ChecksumType::kCRC32c, file_meta->checksum_value)));
       }
       backup_info->push_back(BackupInfo(
           backup.first, backup.second->GetTimestamp(), backup.second->GetSize(),

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -1761,6 +1761,7 @@ TEST_F(BackupableDBTest, BackupFilesInfoConsistent) {
   uint64_t total_size = 0;
   for (const auto& file_meta: backup_info[0].backup_files_info) {
     total_size += file_meta.size;
+    ASSERT_EQ(ChecksumType::kCRC32c, file_meta.checksum.checksum_type);
   }
   ASSERT_EQ(backup_info[0].size, total_size);
   CloseDBAndBackupEngine();


### PR DESCRIPTION
Currently the BackupInfo object exposes limited, aggregated information about
the content of a backup. We extend the information currently available by
exposing a set of metadata for each file in the backup that includes:
 - filename;
 - file size;
 - checksum.

For consistency, I have renamed FileInfo to FileMeta. BackupMeta and the
newly renamed FileMeta class are internal implementation details, whereas
BackupInfo and the newly created BackupFileInfo are part of the public interface
(this way, *Meta is consistently used in the private implementation, and *Info
is part of the public interface).

In previous conversations with @ajkr we discussed exposing the extra information conditionally, subject the value of a new GetBackupInfo parameter. I eventually decided to make the file-level information always available because they are fetched at BackupEngine initialization time anyway, so they can be exposed at no extra cost (save for the additional memory).