### PR TITLE
WritePrepared: followup fix for snapshot double release issue

### DIFF
--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -592,8 +592,13 @@ void WritePreparedTxnDB::CleanupReleasedSnapshots(
   for (; newi != new_snapshots.end() && oldi != old_snapshots.end();) {
     assert(*newi >= *oldi);  // cannot have new snapshots with lower seq
     if (*newi == *oldi) {    // still not released
-      newi++;
-      oldi++;
+      auto value = *newi;
+      while (newi != old_snapshots.end() && *newi == value) {
+        newi++;
+      }
+      while (oldi != old_snapshots.end() && *oldi == value) {
+        oldi++;
+      }
     } else {
       assert(*newi > *oldi);  // *oldi is released
       ReleaseSnapshotInternal(*oldi);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -593,7 +593,7 @@ void WritePreparedTxnDB::CleanupReleasedSnapshots(
     assert(*newi >= *oldi);  // cannot have new snapshots with lower seq
     if (*newi == *oldi) {    // still not released
       auto value = *newi;
-      while (newi != old_snapshots.end() && *newi == value) {
+      while (newi != new_snapshots.end() && *newi == value) {
         newi++;
       }
       while (oldi != old_snapshots.end() && *oldi == value) {


### PR DESCRIPTION
The fix in #4727 for double snapshot release was incomplete since it does not properly remove the duplicate entires in the snapshot list after finding that a snapshot is still valid. The patch does that and also improves the unit test to show the issue.