### PR TITLE
Add support to let Env::Default return custom env

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -339,6 +339,17 @@ cpp_library(
 )
 
 cpp_library(
+    name = "db_basic_test_lib",
+    srcs = ["db/db_basic_test.cc"],
+    auto_headers = AutoHeaders.RECURSIVE_GLOB,
+    arch_preprocessor_flags = rocksdb_arch_preprocessor_flags,
+    compiler_flags = rocksdb_compiler_flags,
+    preprocessor_flags = rocksdb_preprocessor_flags,
+    deps = [":rocksdb_test_lib"],
+    external_deps = rocksdb_external_deps,
+)
+
+cpp_library(
     name = "env_basic_test_lib",
     srcs = ["env/env_basic_test.cc"],
     auto_headers = AutoHeaders.RECURSIVE_GLOB,

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -10,7 +10,10 @@ import sys
 from util import ColorString
 
 # tests to export as libraries for inclusion in other projects
-_EXPORTED_TEST_LIBS = ["env_basic_test"]
+_EXPORTED_TEST_LIBS = [
+    "env_basic_test",
+    "db_basic_test",
+]
 
 # Parse src.mk files as a Dictionary of
 # VAR_NAME => list of files
@@ -81,7 +84,7 @@ def get_tests(repo_path):
             else:
                 # we consumed all the parallel tests
                 break
-    
+
     return tests
 
 

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -2939,7 +2939,7 @@ TEST_P(ColumnFamilyTest, FlushCloseWALFiles) {
   wo.sync = true;
   ASSERT_OK(db_->Put(wo, handles_[1], "fodor", "mirko"));
 
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
 
   sleeping_task.WakeUp();
   sleeping_task.WaitUntilDone();
@@ -2984,7 +2984,7 @@ TEST_P(ColumnFamilyTest, IteratorCloseWALFile1) {
   wo.sync = true;
   ASSERT_OK(db_->Put(wo, handles_[1], "fodor", "mirko"));
 
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
   // Deleting the iterator will clear its super version, triggering
   // closing all files
   delete it;
@@ -3035,11 +3035,11 @@ TEST_P(ColumnFamilyTest, IteratorCloseWALFile2) {
   wo.sync = true;
   ASSERT_OK(db_->Put(wo, handles_[1], "fodor", "mirko"));
 
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
   // Deleting the iterator will clear its super version, triggering
   // closing all files
   delete it;
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
 
   TEST_SYNC_POINT("ColumnFamilyTest::IteratorCloseWALFile2:0");
   TEST_SYNC_POINT("ColumnFamilyTest::IteratorCloseWALFile2:1");
@@ -3105,11 +3105,11 @@ TEST_P(ColumnFamilyTest, ForwardIteratorCloseWALFile) {
   ASSERT_OK(db_->Put(wo, handles_[1], "fodor", "mirko"));
 
   env.delete_count_.store(0);
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
   // Deleting the iterator will clear its super version, triggering
   // closing all files
   it->Seek("");
-  ASSERT_EQ(2, env.num_open_wal_file_.load());
+  ASSERT_EQ(1, env.num_open_wal_file_.load());
   ASSERT_EQ(0, env.delete_count_.load());
 
   TEST_SYNC_POINT("ColumnFamilyTest::IteratorCloseWALFile2:0");

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1284,6 +1284,7 @@ class DBImpl : public DB {
 
     log::Writer* ReleaseWriter() {
       auto* w = writer;
+      writer->Close();
       writer = nullptr;
       return w;
     }

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -31,9 +31,19 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
   }
 }
 
-Writer::~Writer() { WriteBuffer(); }
+Writer::~Writer() {
+  if (dest_) {
+    WriteBuffer();
+  }
+}
 
 Status Writer::WriteBuffer() { return dest_->Flush(); }
+
+Status Writer::Close() {
+  Status s = dest_->Close();
+  dest_.reset();
+  return s;
+}
 
 Status Writer::AddRecord(const Slice& slice) {
   const char* ptr = slice.data();

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -84,6 +84,8 @@ class Writer {
 
   Status WriteBuffer();
 
+  Status Close();
+
   bool TEST_BufferIsEmpty();
 
  private:

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -102,13 +102,14 @@ namespace {
 // ValuesIn() will skip running tests when given an empty collection.
 std::vector<Env*> GetCustomEnvs() {
   static Env* custom_env;
-  static std::unique_ptr<Env> custom_env_guard;
   static bool init = false;
   if (!init) {
     init = true;
     const char* uri = getenv("TEST_ENV_URI");
     if (uri != nullptr) {
-      custom_env = NewCustomObject<Env>(uri, &custom_env_guard);
+      custom_env = Env::Default();
+    } else {
+      custom_env = nullptr;
     }
   }
 

--- a/env/env_hdfs.cc
+++ b/env/env_hdfs.cc
@@ -602,7 +602,8 @@ Status HdfsEnv::NewLogger(const std::string& fname,
 
 // The factory method for creating an HDFS Env
 Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname) {
-  *hdfs_env = new HdfsEnv(fsname);
+  (void)fsname;
+  *hdfs_env = Env::Default();
   return Status::OK();
 }
 }  // namespace rocksdb

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -1140,7 +1140,7 @@ Env* Env::Default() {
                                    const Env* target = reinterpret_cast<const Env*>(arg);
                                    assert(env_guard != nullptr);
                                    env_guard->reset(new HdfsEnv(const_cast<Env*>(target), fs_name));
-                                   return env_guard.get();
+                                   return env_guard->get();
                                  });
 
   PosixEnv* default_env = PosixEnv::Default();

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -1135,16 +1135,6 @@ PosixEnv* PosixEnv::Default() {
 Env* Env::Default() {
   PosixEnv* default_env = PosixEnv::Default();
 #ifndef ROCKSDB_LITE
-  static Registrar<Env> hdfs_reg("hdfs://.*",
-                                 [](const std::string& fs_name,
-                                    const void* arg,
-                                    std::unique_ptr<Env>* env_guard) {
-                                   const Env* target = reinterpret_cast<const Env*>(arg);
-                                   assert(env_guard != nullptr);
-                                   env_guard->reset(new HdfsEnv(const_cast<Env*>(target), fs_name));
-                                   return env_guard->get();
-                                 });
-
   const char* uri_pattern = getenv("ROCKS_ENV_URI_PATTERN");
   if (uri_pattern != nullptr) {
     static Env* custom_env = nullptr;

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -1133,6 +1133,8 @@ PosixEnv* PosixEnv::Default() {
 // Default Env
 //
 Env* Env::Default() {
+  PosixEnv* default_env = PosixEnv::Default();
+#ifndef ROCKSDB_LITE
   static Registrar<Env> hdfs_reg("hdfs://.*",
                                  [](const std::string& fs_name,
                                     const void* arg,
@@ -1143,8 +1145,6 @@ Env* Env::Default() {
                                    return env_guard->get();
                                  });
 
-  PosixEnv* default_env = PosixEnv::Default();
-#ifndef ROCKSDB_LITE
   const char* uri_pattern = getenv("ROCKS_ENV_URI_PATTERN");
   if (uri_pattern != nullptr) {
     static Env* custom_env = nullptr;

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -45,7 +45,7 @@ class HdfsEnv : public Env {
 
  public:
   explicit HdfsEnv(const std::string& fsname) : fsname_(fsname) {
-    posixEnv = Env::Default();
+    posixEnv = Env::BaseDefault();
     fileSys_ = connectToPath(fsname_);
   }
 

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -112,15 +112,14 @@ class HdfsEnv : public EnvWrapper {
   std::string fsname_;  // string of the form "hdfs://hostname:port/"
   hdfsFS fileSys_;      //  a single FileSystem object for all files
 
-  static const std::string kProto;
-  static const std::string pathsep;
-
   /**
    * If the URI is specified of the form hdfs://server:port/path,
    * then connect to the specified cluster
    * else connect to default.
    */
   hdfsFS connectToPath(const std::string& uri) {
+    const std::string kProto = "hdfs://";
+    const std::string kPathSep = "/";
     if (uri.empty()) {
       return nullptr;
     }
@@ -140,7 +139,7 @@ class HdfsEnv : public EnvWrapper {
     std::string host(parts[0]);
     std::string remaining(parts[1]);
 
-    int rem = static_cast<int>(remaining.find(pathsep));
+    int rem = static_cast<int>(remaining.find(kPathSep));
     std::string portStr = (rem == 0 ? remaining :
                            remaining.substr(0, rem));
 

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -43,9 +43,9 @@ private:
 //
 class HdfsEnv : public EnvWrapper {
  public:
-  explicit HdfsEnv(Env* target, const std::string& fsname)
-      : EnvWrapper(target), fsname_(fsname) {
-    assert(nullptr != target);
+  explicit HdfsEnv(Env* _target, const std::string& fsname)
+      : EnvWrapper(_target), fsname_(fsname) {
+    assert(nullptr != _target);
     fileSys_ = connectToPath(fsname_);
   }
 
@@ -178,7 +178,8 @@ static const Status notsup;
 
 class HdfsEnv : public EnvWrapper {
  public:
-  explicit HdfsEnv(const std::string& /*fsname*/) {
+  explicit HdfsEnv(Env* _target, const std::string& /*fsname*/)
+      : EnvWrapper(_target) {
     fprintf(stderr, "You have not build rocksdb with HDFS support\n");
     fprintf(stderr, "Please see hdfs/README for details\n");
     abort();

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -43,8 +43,9 @@ private:
 //
 class HdfsEnv : public EnvWrapper {
  public:
-  explicit HdfsEnv(const std::string& fsname)
-      : EnvWrapper(Env::Default()), fsname_(fsname) {
+  explicit HdfsEnv(Env* target, const std::string& fsname)
+      : EnvWrapper(target), fsname_(fsname) {
+    assert(nullptr != target);
     fileSys_ = connectToPath(fsname_);
   }
 
@@ -175,8 +176,7 @@ namespace rocksdb {
 
 static const Status notsup;
 
-class HdfsEnv : public Env {
-
+class HdfsEnv : public EnvWrapper {
  public:
   explicit HdfsEnv(const std::string& /*fsname*/) {
     fprintf(stderr, "You have not build rocksdb with HDFS support\n");
@@ -264,56 +264,6 @@ class HdfsEnv : public Env {
   virtual Status NewLogger(const std::string& /*fname*/,
                            std::shared_ptr<Logger>* /*result*/) override {
     return notsup;
-  }
-
-  virtual void Schedule(void (* /*function*/)(void* arg), void* /*arg*/,
-                        Priority /*pri*/ = LOW, void* /*tag*/ = nullptr,
-                        void (* /*unschedFunction*/)(void* arg) = 0) override {}
-
-  virtual int UnSchedule(void* /*tag*/, Priority /*pri*/) override { return 0; }
-
-  virtual void StartThread(void (* /*function*/)(void* arg),
-                           void* /*arg*/) override {}
-
-  virtual void WaitForJoin() override {}
-
-  virtual unsigned int GetThreadPoolQueueLen(
-      Priority /*pri*/ = LOW) const override {
-    return 0;
-  }
-
-  virtual Status GetTestDirectory(std::string* /*path*/) override {
-    return notsup;
-  }
-
-  virtual uint64_t NowMicros() override { return 0; }
-
-  virtual void SleepForMicroseconds(int /*micros*/) override {}
-
-  virtual Status GetHostName(char* /*name*/, uint64_t /*len*/) override {
-    return notsup;
-  }
-
-  virtual Status GetCurrentTime(int64_t* /*unix_time*/) override {
-    return notsup;
-  }
-
-  virtual Status GetAbsolutePath(const std::string& /*db_path*/,
-                                 std::string* /*outputpath*/) override {
-    return notsup;
-  }
-
-  virtual void SetBackgroundThreads(int /*number*/,
-                                    Priority /*pri*/ = LOW) override {}
-  virtual int GetBackgroundThreads(Priority /*pri*/ = LOW) override {
-    return 0;
-  }
-  virtual void IncBackgroundThreadsIfNeeded(int /*number*/,
-                                            Priority /*pri*/) override {}
-  virtual std::string TimeToString(uint64_t /*number*/) override { return ""; }
-
-  virtual uint64_t GetThreadID() const override {
-    return 0;
   }
 };
 }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -482,8 +482,6 @@ class Env {
   // status of each thread.
   ThreadStatusUpdater* thread_status_updater_;
 
-  static Env* BaseDefault();
-
  private:
   // No copying allowed
   Env(const Env&);

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -482,6 +482,8 @@ class Env {
   // status of each thread.
   ThreadStatusUpdater* thread_status_updater_;
 
+  static Env* BaseDefault();
+
  private:
   // No copying allowed
   Env(const Env&);

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1020,8 +1020,8 @@ Status ParseColumnFamilyOption(const std::string& name,
       if (name == kNameComparator) {
         // Try to get comparator from object registry first.
         std::unique_ptr<const Comparator> comp_guard;
-        const Comparator* comp =
-            NewCustomObject<const Comparator>(value, &comp_guard);
+        const Comparator* comp = NewCustomObject<const Comparator>(
+            value, nullptr /*arg*/, &comp_guard);
         // Only support static comparator for now.
         if (comp != nullptr && !comp_guard) {
           new_options->comparator = comp;
@@ -1030,7 +1030,8 @@ Status ParseColumnFamilyOption(const std::string& name,
         // Try to get merge operator from object registry first.
         std::unique_ptr<std::shared_ptr<MergeOperator>> mo_guard;
         std::shared_ptr<MergeOperator>* mo =
-            NewCustomObject<std::shared_ptr<MergeOperator>>(value, &mo_guard);
+            NewCustomObject<std::shared_ptr<MergeOperator>>(
+                value, nullptr /*arg*/, &mo_guard);
         // Only support static comparator for now.
         if (mo != nullptr) {
           new_options->merge_operator = *mo;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -340,7 +340,7 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
   // Comparator from object registry
   std::string kCompName = "reverse_comp";
   static Registrar<const Comparator> test_reg_a(
-      kCompName, [](const std::string& /*name*/,
+      kCompName, [](const std::string& /*name*/, const void* /*arg*/,
                     std::unique_ptr<const Comparator>* /*comparator_guard*/) {
         return ReverseBytewiseComparator();
       });
@@ -353,7 +353,7 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
   std::unique_ptr<BytesXOROperator> bxo(new BytesXOROperator());
   std::string kMoName = bxo->Name();
   static Registrar<std::shared_ptr<MergeOperator>> test_reg_b(
-      kMoName, [](const std::string& /*name*/,
+      kMoName, [](const std::string& /*name*/, const void* /*arg*/,
                   std::unique_ptr<std::shared_ptr<MergeOperator>>*
                       merge_operator_guard) {
         merge_operator_guard->reset(

--- a/port/win/env_default.cc
+++ b/port/win/env_default.cc
@@ -29,7 +29,7 @@ namespace {
 };
 }
 
-Env* Env::Default() {
+Env* Env::BaseDefault() {
   using namespace port;
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
@@ -38,4 +38,5 @@ Env* Env::Default() {
   return envptr;
 }
 
+Env* Env::Default() { return Env::BaseDefault(); }
 }

--- a/port/win/env_default.cc
+++ b/port/win/env_default.cc
@@ -29,7 +29,7 @@ namespace {
 };
 }
 
-Env* Env::BaseDefault() {
+WinEnv* WinEnv::Default() {
   using namespace port;
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
@@ -38,5 +38,5 @@ Env* Env::BaseDefault() {
   return envptr;
 }
 
-Env* Env::Default() { return Env::BaseDefault(); }
+Env* Env::Default() { return WinEnv::Default(); }
 }

--- a/port/win/env_default.cc
+++ b/port/win/env_default.cc
@@ -25,11 +25,11 @@ namespace port {
 //    in this manner any remaining threads are terminated OK.
 namespace {
   std::once_flag winenv_once_flag;
-  Env* envptr;
+  WinEnv* envptr;
 };
 }
 
-WinEnv* WinEnv::Default() {
+port::WinEnv* port::WinEnv::Default() {
   using namespace port;
   ThreadLocalPtr::InitSingletons();
   CompressionContextCache::InitSingleton();
@@ -38,5 +38,5 @@ WinEnv* WinEnv::Default() {
   return envptr;
 }
 
-Env* Env::Default() { return WinEnv::Default(); }
+Env* Env::Default() { return port::WinEnv::Default(); }
 }

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -199,131 +199,129 @@ private:
 
 class WinEnv : public Env {
 public:
-  WinEnv();
+ static WinEnv* Default();
 
-  ~WinEnv();
+ WinEnv();
 
-  Status DeleteFile(const std::string& fname) override;
+ ~WinEnv();
 
-  Status Truncate(const std::string& fname, size_t size) override;
+ Status DeleteFile(const std::string& fname) override;
 
-  Status GetCurrentTime(int64_t* unix_time) override;
+ Status Truncate(const std::string& fname, size_t size) override;
 
-  Status NewSequentialFile(const std::string& fname,
-                           std::unique_ptr<SequentialFile>* result,
-                           const EnvOptions& options) override;
+ Status GetCurrentTime(int64_t* unix_time) override;
 
-  Status NewRandomAccessFile(const std::string& fname,
-                             std::unique_ptr<RandomAccessFile>* result,
-                             const EnvOptions& options) override;
+ Status NewSequentialFile(const std::string& fname,
+                          std::unique_ptr<SequentialFile>* result,
+                          const EnvOptions& options) override;
 
-  Status NewWritableFile(const std::string& fname,
-                         std::unique_ptr<WritableFile>* result,
-                         const EnvOptions& options) override;
-
-  // Create an object that writes to a new file with the specified
-  // name.  Deletes any existing file with the same name and creates a
-  // new file.  On success, stores a pointer to the new file in
-  // *result and returns OK.  On failure stores nullptr in *result and
-  // returns non-OK.
-  //
-  // The returned file will only be accessed by one thread at a time.
-  Status ReopenWritableFile(const std::string& fname,
-                            std::unique_ptr<WritableFile>* result,
+ Status NewRandomAccessFile(const std::string& fname,
+                            std::unique_ptr<RandomAccessFile>* result,
                             const EnvOptions& options) override;
 
-  // The returned file will only be accessed by one thread at a time.
-  Status NewRandomRWFile(const std::string& fname,
-                         std::unique_ptr<RandomRWFile>* result,
-                         const EnvOptions& options) override;
+ Status NewWritableFile(const std::string& fname,
+                        std::unique_ptr<WritableFile>* result,
+                        const EnvOptions& options) override;
 
-  Status NewMemoryMappedFileBuffer(
-      const std::string& fname,
-      std::unique_ptr<MemoryMappedFileBuffer>* result) override;
+ // Create an object that writes to a new file with the specified
+ // name.  Deletes any existing file with the same name and creates a
+ // new file.  On success, stores a pointer to the new file in
+ // *result and returns OK.  On failure stores nullptr in *result and
+ // returns non-OK.
+ //
+ // The returned file will only be accessed by one thread at a time.
+ Status ReopenWritableFile(const std::string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           const EnvOptions& options) override;
 
-  Status NewDirectory(const std::string& name,
-                      std::unique_ptr<Directory>* result) override;
+ // The returned file will only be accessed by one thread at a time.
+ Status NewRandomRWFile(const std::string& fname,
+                        std::unique_ptr<RandomRWFile>* result,
+                        const EnvOptions& options) override;
 
-  Status FileExists(const std::string& fname) override;
+ Status NewMemoryMappedFileBuffer(
+     const std::string& fname,
+     std::unique_ptr<MemoryMappedFileBuffer>* result) override;
 
-  Status GetChildren(const std::string& dir,
-                     std::vector<std::string>* result) override;
+ Status NewDirectory(const std::string& name,
+                     std::unique_ptr<Directory>* result) override;
 
-  Status CreateDir(const std::string& name) override;
+ Status FileExists(const std::string& fname) override;
 
-  Status CreateDirIfMissing(const std::string& name) override;
+ Status GetChildren(const std::string& dir,
+                    std::vector<std::string>* result) override;
 
-  Status DeleteDir(const std::string& name) override;
+ Status CreateDir(const std::string& name) override;
 
-  Status GetFileSize(const std::string& fname,
-                     uint64_t* size) override;
+ Status CreateDirIfMissing(const std::string& name) override;
 
-  Status GetFileModificationTime(const std::string& fname,
-                                 uint64_t* file_mtime) override;
+ Status DeleteDir(const std::string& name) override;
 
-  Status RenameFile(const std::string& src,
-                    const std::string& target) override;
+ Status GetFileSize(const std::string& fname, uint64_t* size) override;
 
-  Status LinkFile(const std::string& src,
-                  const std::string& target) override;
+ Status GetFileModificationTime(const std::string& fname,
+                                uint64_t* file_mtime) override;
 
-  Status NumFileLinks(const std::string& fname, uint64_t* count) override;
+ Status RenameFile(const std::string& src, const std::string& target) override;
 
-  Status AreFilesSame(const std::string& first,
-                      const std::string& second, bool* res) override;
+ Status LinkFile(const std::string& src, const std::string& target) override;
 
-  Status LockFile(const std::string& lockFname, FileLock** lock) override;
+ Status NumFileLinks(const std::string& fname, uint64_t* count) override;
 
-  Status UnlockFile(FileLock* lock) override;
+ Status AreFilesSame(const std::string& first, const std::string& second,
+                     bool* res) override;
 
-  Status GetTestDirectory(std::string* result) override;
+ Status LockFile(const std::string& lockFname, FileLock** lock) override;
 
-  Status NewLogger(const std::string& fname,
-                   std::shared_ptr<Logger>* result) override;
+ Status UnlockFile(FileLock* lock) override;
 
-  uint64_t NowMicros() override;
+ Status GetTestDirectory(std::string* result) override;
 
-  uint64_t NowNanos() override;
+ Status NewLogger(const std::string& fname,
+                  std::shared_ptr<Logger>* result) override;
 
-  Status GetHostName(char* name, uint64_t len) override;
+ uint64_t NowMicros() override;
 
-  Status GetAbsolutePath(const std::string& db_path,
-                         std::string* output_path) override;
+ uint64_t NowNanos() override;
 
-  std::string TimeToString(uint64_t secondsSince1970) override;
+ Status GetHostName(char* name, uint64_t len) override;
 
-  Status GetThreadList(std::vector<ThreadStatus>* thread_list) override;
+ Status GetAbsolutePath(const std::string& db_path,
+                        std::string* output_path) override;
 
-  void Schedule(void(*function)(void*), void* arg, Env::Priority pri,
-                void* tag, void(*unschedFunction)(void* arg)) override;
+ std::string TimeToString(uint64_t secondsSince1970) override;
 
-  int UnSchedule(void* arg, Env::Priority pri) override;
+ Status GetThreadList(std::vector<ThreadStatus>* thread_list) override;
 
-  void StartThread(void(*function)(void* arg), void* arg) override;
+ void Schedule(void (*function)(void*), void* arg, Env::Priority pri, void* tag,
+               void (*unschedFunction)(void* arg)) override;
 
-  void WaitForJoin();
+ int UnSchedule(void* arg, Env::Priority pri) override;
 
-  unsigned int GetThreadPoolQueueLen(Env::Priority pri) const override;
+ void StartThread(void (*function)(void* arg), void* arg) override;
 
-  uint64_t GetThreadID() const override;
+ void WaitForJoin();
 
-  void SleepForMicroseconds(int micros) override;
+ unsigned int GetThreadPoolQueueLen(Env::Priority pri) const override;
 
-  // Allow increasing the number of worker threads.
-  void SetBackgroundThreads(int num, Env::Priority pri) override;
-  int GetBackgroundThreads(Env::Priority pri) override;
+ uint64_t GetThreadID() const override;
 
-  void IncBackgroundThreadsIfNeeded(int num, Env::Priority pri) override;
+ void SleepForMicroseconds(int micros) override;
 
-  EnvOptions OptimizeForManifestRead(
-      const EnvOptions& env_options) const override;
+ // Allow increasing the number of worker threads.
+ void SetBackgroundThreads(int num, Env::Priority pri) override;
+ int GetBackgroundThreads(Env::Priority pri) override;
 
-  EnvOptions OptimizeForLogWrite(const EnvOptions& env_options,
-                                 const DBOptions& db_options) const override;
+ void IncBackgroundThreadsIfNeeded(int num, Env::Priority pri) override;
 
-  EnvOptions OptimizeForManifestWrite(
-      const EnvOptions& env_options) const override;
+ EnvOptions OptimizeForManifestRead(
+     const EnvOptions& env_options) const override;
 
+ EnvOptions OptimizeForLogWrite(const EnvOptions& env_options,
+                                const DBOptions& db_options) const override;
+
+ EnvOptions OptimizeForManifestWrite(
+     const EnvOptions& env_options) const override;
 
 private:
 

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -199,129 +199,129 @@ private:
 
 class WinEnv : public Env {
 public:
- static WinEnv* Default();
+  static WinEnv* Default();
 
- WinEnv();
+  WinEnv();
 
- ~WinEnv();
+  ~WinEnv();
 
- Status DeleteFile(const std::string& fname) override;
+  Status DeleteFile(const std::string& fname) override;
 
- Status Truncate(const std::string& fname, size_t size) override;
+  Status Truncate(const std::string& fname, size_t size) override;
 
- Status GetCurrentTime(int64_t* unix_time) override;
+  Status GetCurrentTime(int64_t* unix_time) override;
 
- Status NewSequentialFile(const std::string& fname,
-                          std::unique_ptr<SequentialFile>* result,
-                          const EnvOptions& options) override;
-
- Status NewRandomAccessFile(const std::string& fname,
-                            std::unique_ptr<RandomAccessFile>* result,
-                            const EnvOptions& options) override;
-
- Status NewWritableFile(const std::string& fname,
-                        std::unique_ptr<WritableFile>* result,
-                        const EnvOptions& options) override;
-
- // Create an object that writes to a new file with the specified
- // name.  Deletes any existing file with the same name and creates a
- // new file.  On success, stores a pointer to the new file in
- // *result and returns OK.  On failure stores nullptr in *result and
- // returns non-OK.
- //
- // The returned file will only be accessed by one thread at a time.
- Status ReopenWritableFile(const std::string& fname,
-                           std::unique_ptr<WritableFile>* result,
+  Status NewSequentialFile(const std::string& fname,
+                           std::unique_ptr<SequentialFile>* result,
                            const EnvOptions& options) override;
 
- // The returned file will only be accessed by one thread at a time.
- Status NewRandomRWFile(const std::string& fname,
-                        std::unique_ptr<RandomRWFile>* result,
-                        const EnvOptions& options) override;
+  Status NewRandomAccessFile(const std::string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             const EnvOptions& options) override;
 
- Status NewMemoryMappedFileBuffer(
-     const std::string& fname,
-     std::unique_ptr<MemoryMappedFileBuffer>* result) override;
+  Status NewWritableFile(const std::string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         const EnvOptions& options) override;
 
- Status NewDirectory(const std::string& name,
-                     std::unique_ptr<Directory>* result) override;
+  // Create an object that writes to a new file with the specified
+  // name.  Deletes any existing file with the same name and creates a
+  // new file.  On success, stores a pointer to the new file in
+  // *result and returns OK.  On failure stores nullptr in *result and
+  // returns non-OK.
+  //
+  // The returned file will only be accessed by one thread at a time.
+  Status ReopenWritableFile(const std::string& fname,
+                            std::unique_ptr<WritableFile>* result,
+                            const EnvOptions& options) override;
 
- Status FileExists(const std::string& fname) override;
+  // The returned file will only be accessed by one thread at a time.
+  Status NewRandomRWFile(const std::string& fname,
+                         std::unique_ptr<RandomRWFile>* result,
+                         const EnvOptions& options) override;
 
- Status GetChildren(const std::string& dir,
-                    std::vector<std::string>* result) override;
+  Status NewMemoryMappedFileBuffer(
+      const std::string& fname,
+      std::unique_ptr<MemoryMappedFileBuffer>* result) override;
 
- Status CreateDir(const std::string& name) override;
+  Status NewDirectory(const std::string& name,
+                      std::unique_ptr<Directory>* result) override;
 
- Status CreateDirIfMissing(const std::string& name) override;
+  Status FileExists(const std::string& fname) override;
 
- Status DeleteDir(const std::string& name) override;
+  Status GetChildren(const std::string& dir,
+                     std::vector<std::string>* result) override;
 
- Status GetFileSize(const std::string& fname, uint64_t* size) override;
+  Status CreateDir(const std::string& name) override;
 
- Status GetFileModificationTime(const std::string& fname,
-                                uint64_t* file_mtime) override;
+  Status CreateDirIfMissing(const std::string& name) override;
 
- Status RenameFile(const std::string& src, const std::string& target) override;
+  Status DeleteDir(const std::string& name) override;
 
- Status LinkFile(const std::string& src, const std::string& target) override;
+  Status GetFileSize(const std::string& fname, uint64_t* size) override;
 
- Status NumFileLinks(const std::string& fname, uint64_t* count) override;
+  Status GetFileModificationTime(const std::string& fname,
+                                 uint64_t* file_mtime) override;
 
- Status AreFilesSame(const std::string& first, const std::string& second,
-                     bool* res) override;
+  Status RenameFile(const std::string& src, const std::string& target) override;
 
- Status LockFile(const std::string& lockFname, FileLock** lock) override;
+  Status LinkFile(const std::string& src, const std::string& target) override;
 
- Status UnlockFile(FileLock* lock) override;
+  Status NumFileLinks(const std::string& fname, uint64_t* count) override;
 
- Status GetTestDirectory(std::string* result) override;
+  Status AreFilesSame(const std::string& first, const std::string& second,
+                      bool* res) override;
 
- Status NewLogger(const std::string& fname,
-                  std::shared_ptr<Logger>* result) override;
+  Status LockFile(const std::string& lockFname, FileLock** lock) override;
 
- uint64_t NowMicros() override;
+  Status UnlockFile(FileLock* lock) override;
 
- uint64_t NowNanos() override;
+  Status GetTestDirectory(std::string* result) override;
 
- Status GetHostName(char* name, uint64_t len) override;
+  Status NewLogger(const std::string& fname,
+                   std::shared_ptr<Logger>* result) override;
 
- Status GetAbsolutePath(const std::string& db_path,
-                        std::string* output_path) override;
+  uint64_t NowMicros() override;
 
- std::string TimeToString(uint64_t secondsSince1970) override;
+  uint64_t NowNanos() override;
 
- Status GetThreadList(std::vector<ThreadStatus>* thread_list) override;
+  Status GetHostName(char* name, uint64_t len) override;
 
- void Schedule(void (*function)(void*), void* arg, Env::Priority pri, void* tag,
-               void (*unschedFunction)(void* arg)) override;
+  Status GetAbsolutePath(const std::string& db_path,
+                         std::string* output_path) override;
 
- int UnSchedule(void* arg, Env::Priority pri) override;
+  std::string TimeToString(uint64_t secondsSince1970) override;
 
- void StartThread(void (*function)(void* arg), void* arg) override;
+  Status GetThreadList(std::vector<ThreadStatus>* thread_list) override;
 
- void WaitForJoin();
+  void Schedule(void (*function)(void*), void* arg, Env::Priority pri, void* tag,
+                void (*unschedFunction)(void* arg)) override;
 
- unsigned int GetThreadPoolQueueLen(Env::Priority pri) const override;
+  int UnSchedule(void* arg, Env::Priority pri) override;
 
- uint64_t GetThreadID() const override;
+  void StartThread(void (*function)(void* arg), void* arg) override;
 
- void SleepForMicroseconds(int micros) override;
+  void WaitForJoin();
 
- // Allow increasing the number of worker threads.
- void SetBackgroundThreads(int num, Env::Priority pri) override;
- int GetBackgroundThreads(Env::Priority pri) override;
+  unsigned int GetThreadPoolQueueLen(Env::Priority pri) const override;
 
- void IncBackgroundThreadsIfNeeded(int num, Env::Priority pri) override;
+  uint64_t GetThreadID() const override;
 
- EnvOptions OptimizeForManifestRead(
-     const EnvOptions& env_options) const override;
+  void SleepForMicroseconds(int micros) override;
 
- EnvOptions OptimizeForLogWrite(const EnvOptions& env_options,
-                                const DBOptions& db_options) const override;
+  // Allow increasing the number of worker threads.
+  void SetBackgroundThreads(int num, Env::Priority pri) override;
+  int GetBackgroundThreads(Env::Priority pri) override;
 
- EnvOptions OptimizeForManifestWrite(
-     const EnvOptions& env_options) const override;
+  void IncBackgroundThreadsIfNeeded(int num, Env::Priority pri) override;
+
+  EnvOptions OptimizeForManifestRead(
+      const EnvOptions& env_options) const override;
+
+  EnvOptions OptimizeForLogWrite(const EnvOptions& env_options,
+                                 const DBOptions& db_options) const override;
+
+  EnvOptions OptimizeForManifestWrite(
+      const EnvOptions& env_options) const override;
 
 private:
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -3960,9 +3960,6 @@ int main(int argc, char** argv) {
   FLAGS_compression_type_e =
     StringToCompressionType(FLAGS_compression_type.c_str());
   FLAGS_checksum_type_e = StringToChecksumType(FLAGS_checksum_type.c_str());
-  if (!FLAGS_hdfs.empty()) {
-    FLAGS_env  = new rocksdb::HdfsEnv(FLAGS_hdfs);
-  }
   FLAGS_rep_factory = StringToRepFactory(FLAGS_memtablerep.c_str());
 
   // The number of background threads should be at least as much the

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2787,8 +2787,7 @@ void BackupCommand::DoCommand() {
     return;
   }
   printf("open db OK\n");
-  std::unique_ptr<Env> custom_env_guard;
-  Env* custom_env = NewCustomObject<Env>(backup_env_uri_, &custom_env_guard);
+  Env* custom_env = Env::Default();
   BackupableDBOptions backup_options =
       BackupableDBOptions(backup_dir_, custom_env);
   backup_options.info_log = logger_.get();
@@ -2822,8 +2821,7 @@ void RestoreCommand::Help(std::string& ret) {
 }
 
 void RestoreCommand::DoCommand() {
-  std::unique_ptr<Env> custom_env_guard;
-  Env* custom_env = NewCustomObject<Env>(backup_env_uri_, &custom_env_guard);
+  Env* custom_env = Env::Default();
   std::unique_ptr<BackupEngineReadOnly> restore_engine;
   Status status;
   {

--- a/utilities/env_librados.cc
+++ b/utilities/env_librados.cc
@@ -1486,4 +1486,4 @@ EnvLibrados* EnvLibrados::Default() {
   return &default_env;
 }
 // @lint-ignore TXT4 T25377293 Grandfathered in
-}
+}  // namespace rocksdb

--- a/utilities/env_librados.cc
+++ b/utilities/env_librados.cc
@@ -580,18 +580,11 @@ public:
  * @param db_name unique database name
  * @param config_path the configure file path for rados
  */
-EnvLibrados::EnvLibrados(const std::string& db_name,
+EnvLibrados::EnvLibrados(Env* target, const std::string& db_name,
                          const std::string& config_path,
                          const std::string& db_pool)
-  : EnvLibrados("client.admin",
-                "ceph",
-                0,
-                db_name,
-                config_path,
-                db_pool,
-                "/wal",
-                db_pool,
-                1 << 20) {}
+    : EnvLibrados(target, "client.admin", "ceph", 0, db_name, config_path,
+                  db_pool, "/wal", db_pool, 1 << 20) {}
 
 /**
  * @brief EnvLibrados ctor
@@ -606,25 +599,23 @@ EnvLibrados::EnvLibrados(const std::string& db_name,
  * @param wal_pool the pool for WAL data
  * @param write_buffer_size WritableFile buffer max size
  */
-EnvLibrados::EnvLibrados(const std::string& client_name,
-                         const std::string& cluster_name,
-                         const uint64_t flags,
+EnvLibrados::EnvLibrados(Env* target, const std::string& client_name,
+                         const std::string& cluster_name, const uint64_t flags,
                          const std::string& db_name,
                          const std::string& config_path,
-                         const std::string& db_pool,
-                         const std::string& wal_dir,
+                         const std::string& db_pool, const std::string& wal_dir,
                          const std::string& wal_pool,
                          const uint64_t write_buffer_size)
-  : EnvWrapper(Env::Default()),
-    _client_name(client_name),
-    _cluster_name(cluster_name),
-    _flags(flags),
-    _db_name(db_name),
-    _config_path(config_path),
-    _db_pool_name(db_pool),
-    _wal_dir(wal_dir),
-    _wal_pool_name(wal_pool),
-    _write_buffer_size(write_buffer_size) {
+    : EnvWrapper(target),
+      _client_name(client_name),
+      _cluster_name(cluster_name),
+      _flags(flags),
+      _db_name(db_name),
+      _config_path(config_path),
+      _db_pool_name(db_pool),
+      _wal_dir(wal_dir),
+      _wal_pool_name(wal_pool),
+      _write_buffer_size(write_buffer_size) {
   int ret = 0;
 
   // 1. create a Rados object and initialize it

--- a/utilities/object_registry_test.cc
+++ b/utilities/object_registry_test.cc
@@ -20,12 +20,14 @@ int EnvRegistryTest::num_b = 0;
 
 static Registrar<Env> test_reg_a("a://.*",
                                  [](const std::string& /*uri*/,
+                                    const void* /*arg*/,
                                     std::unique_ptr<Env>* /*env_guard*/) {
                                    ++EnvRegistryTest::num_a;
                                    return Env::Default();
                                  });
 
 static Registrar<Env> test_reg_b("b://.*", [](const std::string& /*uri*/,
+                                              const void* /*arg*/,
                                               std::unique_ptr<Env>* env_guard) {
   ++EnvRegistryTest::num_b;
   // Env::Default() is a singleton so we can't grant ownership directly to the
@@ -36,19 +38,19 @@ static Registrar<Env> test_reg_b("b://.*", [](const std::string& /*uri*/,
 
 TEST_F(EnvRegistryTest, Basics) {
   std::unique_ptr<Env> env_guard;
-  auto res = NewCustomObject<Env>("a://test", &env_guard);
+  auto res = NewCustomObject<Env>("a://test", nullptr, &env_guard);
   ASSERT_NE(res, nullptr);
   ASSERT_EQ(env_guard, nullptr);
   ASSERT_EQ(1, num_a);
   ASSERT_EQ(0, num_b);
 
-  res = NewCustomObject<Env>("b://test", &env_guard);
+  res = NewCustomObject<Env>("b://test", nullptr, &env_guard);
   ASSERT_NE(res, nullptr);
   ASSERT_NE(env_guard, nullptr);
   ASSERT_EQ(1, num_a);
   ASSERT_EQ(1, num_b);
 
-  res = NewCustomObject<Env>("c://test", &env_guard);
+  res = NewCustomObject<Env>("c://test", nullptr, &env_guard);
   ASSERT_EQ(res, nullptr);
   ASSERT_EQ(env_guard, nullptr);
   ASSERT_EQ(1, num_a);


### PR DESCRIPTION
Summary:
Existing RocksDB uses `Env::Default` to return the underlying default OS
environment on which the tests are being run. We have more and more requests to
support running all the tests communicating with custom data storage, e.g.
HDFS, NFS, etc. Therefore, we extend `Env::Default` so that a custom Env will
be handed to caller, e.g. unit tests.

Also update buckifier script.

Test Plan:
```
$make clean && make -j32 all
$make check
```

It's also possible to set up a test HDFS. Then
```
$export ROCKS_ENV_URI_PATTERN=hdfs://.*
$make -j32 all check #tests should run on HDFS.
```

Note that custom env, e.g. HdfsEnv needs to implement the GetTestDirectory
method, etc.