### PR TITLE
Prepare FragmentedRangeTombstoneIterator for use in compaction

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -428,7 +428,7 @@ FragmentedRangeTombstoneIterator* MemTable::NewRangeTombstoneIterator(
           comparator_.comparator);
 
   auto* fragmented_iter = new FragmentedRangeTombstoneIterator(
-      fragmented_tombstone_list, read_seq, comparator_.comparator);
+      fragmented_tombstone_list, comparator_.comparator, read_seq);
   return fragmented_iter;
 }
 

--- a/db/range_del_aggregator_bench.cc
+++ b/db/range_del_aggregator_bench.cc
@@ -220,8 +220,8 @@ int main(int argc, char** argv) {
       std::unique_ptr<rocksdb::FragmentedRangeTombstoneIterator>
           fragmented_range_del_iter(
               new rocksdb::FragmentedRangeTombstoneIterator(
-                  fragmented_range_tombstone_lists.back().get(),
-                  rocksdb::kMaxSequenceNumber, icmp));
+                  fragmented_range_tombstone_lists.back().get(), icmp,
+                  rocksdb::kMaxSequenceNumber));
 
       if (FLAGS_use_v2_aggregator) {
         rocksdb::StopWatchNano stop_watch_add_tombstones(

--- a/db/range_del_aggregator_v2_test.cc
+++ b/db/range_del_aggregator_v2_test.cc
@@ -173,8 +173,8 @@ TEST_F(RangeDelAggregatorV2Test, EmptyTruncatedIter) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list, kMaxSequenceNumber,
-                                           bytewise_icmp));
+      new FragmentedRangeTombstoneIterator(&fragment_list, bytewise_icmp,
+                                           kMaxSequenceNumber));
 
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp, nullptr,
                                  nullptr);
@@ -192,8 +192,8 @@ TEST_F(RangeDelAggregatorV2Test, UntruncatedIter) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list, kMaxSequenceNumber,
-                                           bytewise_icmp));
+      new FragmentedRangeTombstoneIterator(&fragment_list,
+                                           bytewise_icmp, kMaxSequenceNumber));
 
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp, nullptr,
                                  nullptr);
@@ -226,8 +226,8 @@ TEST_F(RangeDelAggregatorV2Test, UntruncatedIterWithSnapshot) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list, 9 /* snapshot */,
-                                           bytewise_icmp));
+      new FragmentedRangeTombstoneIterator(&fragment_list,
+                                           bytewise_icmp, 9 /* snapshot */));
 
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp, nullptr,
                                  nullptr);
@@ -259,8 +259,8 @@ TEST_F(RangeDelAggregatorV2Test, TruncatedIter) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list, kMaxSequenceNumber,
-                                           bytewise_icmp));
+      new FragmentedRangeTombstoneIterator(&fragment_list,
+                                           bytewise_icmp, kMaxSequenceNumber));
 
   InternalKey smallest("d", 7, kTypeValue);
   InternalKey largest("m", 9, kTypeValue);
@@ -294,8 +294,8 @@ TEST_F(RangeDelAggregatorV2Test, SingleIterInAggregator) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list, kMaxSequenceNumber,
-                                           bytewise_icmp));
+      new FragmentedRangeTombstoneIterator(&fragment_list,
+                                           bytewise_icmp, kMaxSequenceNumber));
 
   RangeDelAggregatorV2 range_del_agg(&bytewise_icmp, kMaxSequenceNumber);
   range_del_agg.AddTombstones(std::move(input_iter));
@@ -322,7 +322,7 @@ TEST_F(RangeDelAggregatorV2Test, MultipleItersInAggregator) {
   for (const auto& fragment_list : fragment_lists) {
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
         new FragmentedRangeTombstoneIterator(
-            fragment_list.get(), kMaxSequenceNumber, bytewise_icmp));
+            fragment_list.get(), bytewise_icmp, kMaxSequenceNumber));
     range_del_agg.AddTombstones(std::move(input_iter));
   }
 
@@ -354,7 +354,7 @@ TEST_F(RangeDelAggregatorV2Test, MultipleItersInAggregatorWithUpperBound) {
   for (const auto& fragment_list : fragment_lists) {
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
         new FragmentedRangeTombstoneIterator(fragment_list.get(),
-                                             19 /* snapshot */, bytewise_icmp));
+                                             bytewise_icmp, 19 /* snapshot */));
     range_del_agg.AddTombstones(std::move(input_iter));
   }
 
@@ -393,7 +393,7 @@ TEST_F(RangeDelAggregatorV2Test, MultipleTruncatedItersInAggregator) {
     const auto& bounds = iter_bounds[i];
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
         new FragmentedRangeTombstoneIterator(fragment_list.get(),
-                                             19 /* snapshot */, bytewise_icmp));
+                                             bytewise_icmp, 19 /* snapshot */));
     range_del_agg.AddTombstones(std::move(input_iter), &bounds.first,
                                 &bounds.second);
   }
@@ -432,7 +432,7 @@ TEST_F(RangeDelAggregatorV2Test, MultipleTruncatedItersInAggregatorSameLevel) {
   auto add_iter_to_agg = [&](size_t i) {
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
         new FragmentedRangeTombstoneIterator(fragment_lists[i].get(),
-                                             19 /* snapshot */, bytewise_icmp));
+                                             bytewise_icmp, 19 /* snapshot */));
     range_del_agg.AddTombstones(std::move(input_iter), &iter_bounds[i].first,
                                 &iter_bounds[i].second);
   };

--- a/db/range_del_aggregator_v2_test.cc
+++ b/db/range_del_aggregator_v2_test.cc
@@ -192,8 +192,8 @@ TEST_F(RangeDelAggregatorV2Test, UntruncatedIter) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list,
-                                           bytewise_icmp, kMaxSequenceNumber));
+      new FragmentedRangeTombstoneIterator(&fragment_list, bytewise_icmp,
+                                           kMaxSequenceNumber));
 
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp, nullptr,
                                  nullptr);
@@ -226,8 +226,8 @@ TEST_F(RangeDelAggregatorV2Test, UntruncatedIterWithSnapshot) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list,
-                                           bytewise_icmp, 9 /* snapshot */));
+      new FragmentedRangeTombstoneIterator(&fragment_list, bytewise_icmp,
+                                           9 /* snapshot */));
 
   TruncatedRangeDelIterator iter(std::move(input_iter), &bytewise_icmp, nullptr,
                                  nullptr);
@@ -259,8 +259,8 @@ TEST_F(RangeDelAggregatorV2Test, TruncatedIter) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list,
-                                           bytewise_icmp, kMaxSequenceNumber));
+      new FragmentedRangeTombstoneIterator(&fragment_list, bytewise_icmp,
+                                           kMaxSequenceNumber));
 
   InternalKey smallest("d", 7, kTypeValue);
   InternalKey largest("m", 9, kTypeValue);
@@ -294,8 +294,8 @@ TEST_F(RangeDelAggregatorV2Test, SingleIterInAggregator) {
   FragmentedRangeTombstoneList fragment_list(std::move(range_del_iter),
                                              bytewise_icmp);
   std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-      new FragmentedRangeTombstoneIterator(&fragment_list,
-                                           bytewise_icmp, kMaxSequenceNumber));
+      new FragmentedRangeTombstoneIterator(&fragment_list, bytewise_icmp,
+                                           kMaxSequenceNumber));
 
   RangeDelAggregatorV2 range_del_agg(&bytewise_icmp, kMaxSequenceNumber);
   range_del_agg.AddTombstones(std::move(input_iter));
@@ -321,8 +321,8 @@ TEST_F(RangeDelAggregatorV2Test, MultipleItersInAggregator) {
   RangeDelAggregatorV2 range_del_agg(&bytewise_icmp, kMaxSequenceNumber);
   for (const auto& fragment_list : fragment_lists) {
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-        new FragmentedRangeTombstoneIterator(
-            fragment_list.get(), bytewise_icmp, kMaxSequenceNumber));
+        new FragmentedRangeTombstoneIterator(fragment_list.get(), bytewise_icmp,
+                                             kMaxSequenceNumber));
     range_del_agg.AddTombstones(std::move(input_iter));
   }
 
@@ -353,8 +353,8 @@ TEST_F(RangeDelAggregatorV2Test, MultipleItersInAggregatorWithUpperBound) {
   RangeDelAggregatorV2 range_del_agg(&bytewise_icmp, 19);
   for (const auto& fragment_list : fragment_lists) {
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-        new FragmentedRangeTombstoneIterator(fragment_list.get(),
-                                             bytewise_icmp, 19 /* snapshot */));
+        new FragmentedRangeTombstoneIterator(fragment_list.get(), bytewise_icmp,
+                                             19 /* snapshot */));
     range_del_agg.AddTombstones(std::move(input_iter));
   }
 
@@ -392,8 +392,8 @@ TEST_F(RangeDelAggregatorV2Test, MultipleTruncatedItersInAggregator) {
     const auto& fragment_list = fragment_lists[i];
     const auto& bounds = iter_bounds[i];
     std::unique_ptr<FragmentedRangeTombstoneIterator> input_iter(
-        new FragmentedRangeTombstoneIterator(fragment_list.get(),
-                                             bytewise_icmp, 19 /* snapshot */));
+        new FragmentedRangeTombstoneIterator(fragment_list.get(), bytewise_icmp,
+                                             19 /* snapshot */));
     range_del_agg.AddTombstones(std::move(input_iter), &bounds.first,
                                 &bounds.second);
   }

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -20,7 +20,8 @@ namespace rocksdb {
 
 FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
     std::unique_ptr<InternalIterator> unfragmented_tombstones,
-    const InternalKeyComparator& icmp) {
+    const InternalKeyComparator& icmp, bool for_compaction,
+    const std::vector<SequenceNumber>& snapshots) {
   if (unfragmented_tombstones == nullptr) {
     return;
   }
@@ -43,7 +44,8 @@ FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
     }
   }
   if (is_sorted) {
-    FragmentTombstones(std::move(unfragmented_tombstones), icmp);
+    FragmentTombstones(std::move(unfragmented_tombstones), icmp, for_compaction,
+                       snapshots);
     return;
   }
 
@@ -61,12 +63,13 @@ FragmentedRangeTombstoneList::FragmentedRangeTombstoneList(
   // VectorIterator implicitly sorts by key during construction.
   auto iter = std::unique_ptr<VectorIterator>(
       new VectorIterator(std::move(keys), std::move(values), &icmp));
-  FragmentTombstones(std::move(iter), icmp);
+  FragmentTombstones(std::move(iter), icmp, for_compaction, snapshots);
 }
 
 void FragmentedRangeTombstoneList::FragmentTombstones(
     std::unique_ptr<InternalIterator> unfragmented_tombstones,
-    const InternalKeyComparator& icmp) {
+    const InternalKeyComparator& icmp, bool for_compaction,
+    const std::vector<SequenceNumber>& snapshots) {
   Slice cur_start_key(nullptr, 0);
   auto cmp = ParsedInternalKeyComparator(&icmp);
 
@@ -117,11 +120,41 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
       }
       std::sort(seqnums_to_flush.begin(), seqnums_to_flush.end(),
                 std::greater<SequenceNumber>());
+
       size_t start_idx = tombstone_seqs_.size();
       size_t end_idx = start_idx + seqnums_to_flush.size();
-      tombstone_seqs_.insert(tombstone_seqs_.end(), seqnums_to_flush.begin(),
-                             seqnums_to_flush.end());
-      tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx, end_idx);
+
+      if (for_compaction) {
+        // Drop all tombstone seqnums that are not preserved by a snapshot.
+        SequenceNumber next_snapshot = kMaxSequenceNumber;
+        for (auto seq : seqnums_to_flush) {
+          if (seq <= next_snapshot) {
+            // This seqnum is visible by a lower snapshot.
+            tombstone_seqs_.push_back(seq);
+            seq_set_.insert(seq);
+            auto upper_bound_it =
+                std::lower_bound(snapshots.begin(), snapshots.end(), seq);
+            if (upper_bound_it == snapshots.begin()) {
+              // This seqnum is the topmost one visible by the earliest
+              // snapshot. None of the seqnums below it will be visible, so we
+              // can skip them.
+              break;
+            }
+            next_snapshot = *std::prev(upper_bound_it);
+          }
+        }
+        end_idx = tombstone_seqs_.size();
+      } else {
+        // The fragmentation is being done for reads, so preserve all seqnums.
+        tombstone_seqs_.insert(tombstone_seqs_.end(), seqnums_to_flush.begin(),
+                               seqnums_to_flush.end());
+        seq_set_.insert(seqnums_to_flush.begin(), seqnums_to_flush.end());
+      }
+
+      if (start_idx != end_idx) {
+        tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx,
+                                 end_idx);
+      }
 
       cur_start_key = cur_end_key;
     }
@@ -178,33 +211,41 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
   }
 }
 
+bool FragmentedRangeTombstoneList::ContainsRange(SequenceNumber lower,
+                                                 SequenceNumber upper) const {
+  auto seq_it = seq_set_.lower_bound(lower);
+  return seq_it != seq_set_.end() && *seq_it <= upper;
+}
+
 FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
-    const FragmentedRangeTombstoneList* tombstones, SequenceNumber snapshot,
-    const InternalKeyComparator& icmp)
+    const FragmentedRangeTombstoneList* tombstones,
+    const InternalKeyComparator& icmp, SequenceNumber upper_bound,
+    SequenceNumber lower_bound)
     : tombstone_start_cmp_(icmp.user_comparator()),
       tombstone_end_cmp_(icmp.user_comparator()),
+      icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_(tombstones),
-      snapshot_(snapshot) {
+      upper_bound_(upper_bound),
+      lower_bound_(lower_bound) {
   assert(tombstones_ != nullptr);
-  pos_ = tombstones_->end();
-  pinned_pos_ = tombstones_->end();
+  Invalidate();
 }
 
 FragmentedRangeTombstoneIterator::FragmentedRangeTombstoneIterator(
     const std::shared_ptr<const FragmentedRangeTombstoneList>& tombstones,
-    SequenceNumber snapshot, const InternalKeyComparator& icmp)
+    const InternalKeyComparator& icmp, SequenceNumber upper_bound,
+    SequenceNumber lower_bound)
     : tombstone_start_cmp_(icmp.user_comparator()),
       tombstone_end_cmp_(icmp.user_comparator()),
+      icmp_(&icmp),
       ucmp_(icmp.user_comparator()),
       tombstones_ref_(tombstones),
       tombstones_(tombstones_ref_.get()),
-      snapshot_(snapshot) {
+      upper_bound_(upper_bound),
+      lower_bound_(lower_bound) {
   assert(tombstones_ != nullptr);
-  pos_ = tombstones_->end();
-  seq_pos_ = tombstones_->seq_end();
-  pinned_pos_ = tombstones_->end();
-  pinned_seq_pos_ = tombstones_->seq_end();
+  Invalidate();
 }
 
 void FragmentedRangeTombstoneIterator::SeekToFirst() {
@@ -220,7 +261,7 @@ void FragmentedRangeTombstoneIterator::SeekToTopFirst() {
   pos_ = tombstones_->begin();
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
   ScanForwardToVisibleTombstone();
 }
 
@@ -237,7 +278,7 @@ void FragmentedRangeTombstoneIterator::SeekToTopLast() {
   pos_ = std::prev(tombstones_->end());
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
   ScanBackwardToVisibleTombstone();
 }
 
@@ -270,7 +311,7 @@ void FragmentedRangeTombstoneIterator::SeekToCoveringTombstone(
   }
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
 }
 
 void FragmentedRangeTombstoneIterator::SeekForPrevToCoveringTombstone(
@@ -289,25 +330,27 @@ void FragmentedRangeTombstoneIterator::SeekForPrevToCoveringTombstone(
   --pos_;
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
 }
 
 void FragmentedRangeTombstoneIterator::ScanForwardToVisibleTombstone() {
   while (pos_ != tombstones_->end() &&
-         seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx)) {
+         (seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx) ||
+          *seq_pos_ < lower_bound_)) {
     ++pos_;
     if (pos_ == tombstones_->end()) {
       return;
     }
     seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                                 tombstones_->seq_iter(pos_->seq_end_idx),
-                                snapshot_, std::greater<SequenceNumber>());
+                                upper_bound_, std::greater<SequenceNumber>());
   }
 }
 
 void FragmentedRangeTombstoneIterator::ScanBackwardToVisibleTombstone() {
   while (pos_ != tombstones_->end() &&
-         seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx)) {
+         (seq_pos_ == tombstones_->seq_iter(pos_->seq_end_idx) ||
+          *seq_pos_ < lower_bound_)) {
     if (pos_ == tombstones_->begin()) {
       Invalidate();
       return;
@@ -315,7 +358,7 @@ void FragmentedRangeTombstoneIterator::ScanBackwardToVisibleTombstone() {
     --pos_;
     seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                                 tombstones_->seq_iter(pos_->seq_end_idx),
-                                snapshot_, std::greater<SequenceNumber>());
+                                upper_bound_, std::greater<SequenceNumber>());
   }
 }
 
@@ -333,7 +376,7 @@ void FragmentedRangeTombstoneIterator::TopNext() {
   }
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
   ScanForwardToVisibleTombstone();
 }
 
@@ -358,7 +401,7 @@ void FragmentedRangeTombstoneIterator::TopPrev() {
   --pos_;
   seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
                               tombstones_->seq_iter(pos_->seq_end_idx),
-                              snapshot_, std::greater<SequenceNumber>());
+                              upper_bound_, std::greater<SequenceNumber>());
   ScanBackwardToVisibleTombstone();
 }
 
@@ -370,6 +413,29 @@ SequenceNumber FragmentedRangeTombstoneIterator::MaxCoveringTombstoneSeqnum(
     const Slice& user_key) {
   SeekToCoveringTombstone(user_key);
   return ValidPos() && ucmp_->Compare(start_key(), user_key) <= 0 ? seq() : 0;
+}
+
+std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
+FragmentedRangeTombstoneIterator::SplitBySnapshot(
+    const std::vector<SequenceNumber>& snapshots) {
+  std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>> splits;
+  SequenceNumber lower_bound = 0;
+  SequenceNumber upper_bound;
+  for (size_t i = 0; i <= snapshots.size(); i++) {
+    if (i >= snapshots.size()) {
+      upper_bound = kMaxSequenceNumber;
+    } else {
+      upper_bound = snapshots[i];
+    }
+    if (tombstones_->ContainsRange(lower_bound, upper_bound)) {
+      splits.emplace_back(new FragmentedRangeTombstoneIterator(
+          tombstones_, *icmp_, upper_bound, lower_bound));
+    } else {
+      splits.emplace_back(nullptr);
+    }
+    lower_bound = upper_bound + 1;
+  }
+  return splits;
 }
 
 }  // namespace rocksdb

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -151,10 +151,8 @@ void FragmentedRangeTombstoneList::FragmentTombstones(
         seq_set_.insert(seqnums_to_flush.begin(), seqnums_to_flush.end());
       }
 
-      if (start_idx != end_idx) {
-        tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx,
-                                 end_idx);
-      }
+      assert(start_idx < end_idx);
+      tombstones_.emplace_back(cur_start_key, cur_end_key, start_idx, end_idx);
 
       cur_start_key = cur_end_key;
     }

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -339,6 +339,7 @@ void FragmentedRangeTombstoneIterator::ScanForwardToVisibleTombstone() {
           *seq_pos_ < lower_bound_)) {
     ++pos_;
     if (pos_ == tombstones_->end()) {
+      Invalidate();
       return;
     }
     seq_pos_ = std::lower_bound(tombstones_->seq_iter(pos_->seq_start_idx),
@@ -382,8 +383,7 @@ void FragmentedRangeTombstoneIterator::TopNext() {
 
 void FragmentedRangeTombstoneIterator::Prev() {
   if (seq_pos_ == tombstones_->seq_begin()) {
-    pos_ = tombstones_->end();
-    seq_pos_ = tombstones_->seq_end();
+    Invalidate();
     return;
   }
   --seq_pos_;

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -7,6 +7,7 @@
 
 #include <list>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,8 @@ struct FragmentedRangeTombstoneList {
   };
   FragmentedRangeTombstoneList(
       std::unique_ptr<InternalIterator> unfragmented_tombstones,
-      const InternalKeyComparator& icmp);
+      const InternalKeyComparator& icmp, bool for_compaction = false,
+      const std::vector<SequenceNumber>& snapshots = {});
 
   std::vector<RangeTombstoneStack>::const_iterator begin() const {
     return tombstones_.begin();
@@ -60,7 +62,11 @@ struct FragmentedRangeTombstoneList {
     return tombstone_seqs_.end();
   }
 
-  bool empty() const { return tombstones_.size() == 0; }
+  bool empty() const { return tombstones_.empty(); }
+
+  // Returns true if the stored tombstones contain with one with a sequence
+  // number in [lower, upper].
+  bool ContainsRange(SequenceNumber lower, SequenceNumber upper) const;
 
  private:
   // Given an ordered range tombstone iterator unfragmented_tombstones,
@@ -68,10 +74,12 @@ struct FragmentedRangeTombstoneList {
   // tombstones_ and tombstone_seqs_.
   void FragmentTombstones(
       std::unique_ptr<InternalIterator> unfragmented_tombstones,
-      const InternalKeyComparator& icmp);
+      const InternalKeyComparator& icmp, bool for_compaction,
+      const std::vector<SequenceNumber>& snapshots);
 
   std::vector<RangeTombstoneStack> tombstones_;
   std::vector<SequenceNumber> tombstone_seqs_;
+  std::set<SequenceNumber> seq_set_;
   std::list<std::string> pinned_slices_;
   PinnedIteratorsManager pinned_iters_mgr_;
 };
@@ -88,11 +96,13 @@ struct FragmentedRangeTombstoneList {
 class FragmentedRangeTombstoneIterator : public InternalIterator {
  public:
   FragmentedRangeTombstoneIterator(
-      const FragmentedRangeTombstoneList* tombstones, SequenceNumber snapshot,
-      const InternalKeyComparator& icmp);
+      const FragmentedRangeTombstoneList* tombstones,
+      const InternalKeyComparator& icmp, SequenceNumber upper_bound,
+      SequenceNumber lower_bound = 0);
   FragmentedRangeTombstoneIterator(
       const std::shared_ptr<const FragmentedRangeTombstoneList>& tombstones,
-      SequenceNumber snapshot, const InternalKeyComparator& icmp);
+      const InternalKeyComparator& icmp, SequenceNumber upper_bound,
+      SequenceNumber lower_bound = 0);
 
   void SeekToFirst() override;
   void SeekToLast() override;
@@ -136,10 +146,6 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
     seq_pos_ = tombstones_->seq_end();
   }
 
-  // TODO: implement properly
-  RangeTombstone tombstone() const {
-    return RangeTombstone(start_key(), end_key(), seq());
-  }
   Slice start_key() const { return pos_->start_key; }
   Slice end_key() const { return pos_->end_key; }
   SequenceNumber seq() const { return *seq_pos_; }
@@ -151,11 +157,21 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
     return ParsedInternalKey(pos_->end_key, kMaxSequenceNumber,
                              kTypeRangeDeletion);
   }
-  ParsedInternalKey internal_key() const {
-    return ParsedInternalKey(pos_->start_key, *seq_pos_, kTypeRangeDeletion);
-  }
 
   SequenceNumber MaxCoveringTombstoneSeqnum(const Slice& user_key);
+
+  // Splits the iterator into n+1 iterators (where n is the number of
+  // snapshots), each providing a view over a "stripe" of sequence numbers. The
+  // iterators are ordered by the range of sequence numbers they cover, in
+  // ascending order (same as the input snapshots). Also, if the range an
+  // iterator covers is empty, it will be represented as nullptr.
+  //
+  // NOTE: the iterators in the returned vector are no longer valid if their
+  // parent iterator is deleted, since they do not modify the refcount of the
+  // underlying tombstone list. Therefore, this vector should be deleted before
+  // the parent iterator.
+  std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
+  SplitBySnapshot(const std::vector<SequenceNumber>& snapshots);
 
  private:
   using RangeTombstoneStack = FragmentedRangeTombstoneList::RangeTombstoneStack;
@@ -217,10 +233,12 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
 
   const RangeTombstoneStackStartComparator tombstone_start_cmp_;
   const RangeTombstoneStackEndComparator tombstone_end_cmp_;
+  const InternalKeyComparator* icmp_;
   const Comparator* ucmp_;
   std::shared_ptr<const FragmentedRangeTombstoneList> tombstones_ref_;
   const FragmentedRangeTombstoneList* tombstones_;
-  SequenceNumber snapshot_;
+  SequenceNumber upper_bound_;
+  SequenceNumber lower_bound_;
   std::vector<RangeTombstoneStack>::const_iterator pos_;
   std::vector<SequenceNumber>::const_iterator seq_pos_;
   mutable std::vector<RangeTombstoneStack>::const_iterator pinned_pos_;

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -172,6 +172,9 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
   std::map<SequenceNumber, std::unique_ptr<FragmentedRangeTombstoneIterator>>
   SplitBySnapshot(const std::vector<SequenceNumber>& snapshots);
 
+  SequenceNumber upper_bound() const { return upper_bound_; }
+  SequenceNumber lower_bound() const { return lower_bound_; }
+
  private:
   using RangeTombstoneStack = FragmentedRangeTombstoneList::RangeTombstoneStack;
 

--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -162,15 +162,14 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
 
   // Splits the iterator into n+1 iterators (where n is the number of
   // snapshots), each providing a view over a "stripe" of sequence numbers. The
-  // iterators are ordered by the range of sequence numbers they cover, in
-  // ascending order (same as the input snapshots). Also, if the range an
-  // iterator covers is empty, it will be represented as nullptr.
+  // iterators are keyed by the upper bound of their ranges (the provided
+  // snapshots + kMaxSequenceNumber).
   //
-  // NOTE: the iterators in the returned vector are no longer valid if their
+  // NOTE: the iterators in the returned map are no longer valid if their
   // parent iterator is deleted, since they do not modify the refcount of the
-  // underlying tombstone list. Therefore, this vector should be deleted before
+  // underlying tombstone list. Therefore, this map should be deleted before
   // the parent iterator.
-  std::vector<std::unique_ptr<FragmentedRangeTombstoneIterator>>
+  std::map<SequenceNumber, std::unique_ptr<FragmentedRangeTombstoneIterator>>
   SplitBySnapshot(const std::vector<SequenceNumber>& snapshots);
 
  private:

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -355,7 +355,7 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitNoSnapshots) {
   auto split_iters = iter.SplitBySnapshot({} /* snapshots */);
   ASSERT_EQ(1, split_iters.size());
 
-  auto* split_iter = split_iters[0].get();
+  auto* split_iter = split_iters[kMaxSequenceNumber].get();
   VerifyVisibleTombstones(split_iter, {{"a", "c", 10},
                                        {"c", "e", 10},
                                        {"e", "g", 8},
@@ -379,27 +379,27 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitWithSnapshots) {
   auto split_iters = iter.SplitBySnapshot({3, 5, 7, 9} /* snapshots */);
   ASSERT_EQ(5, split_iters.size());
 
-  auto* split_iter1 = split_iters[0].get();
+  auto* split_iter1 = split_iters[3].get();
   VerifyVisibleTombstones(split_iter1, {{"j", "l", 2}});
 
-  auto* split_iter2 = split_iters[1].get();
+  auto* split_iter2 = split_iters[5].get();
   VerifyVisibleTombstones(split_iter2, {{"j", "l", 4}, {"l", "n", 4}});
 
-  auto* split_iter3 = split_iters[2].get();
+  auto* split_iter3 = split_iters[7].get();
   VerifyVisibleTombstones(split_iter3, {{"c", "e", 6},
                                         {"e", "g", 6},
                                         {"g", "i", 6},
                                         {"j", "l", 4},
                                         {"l", "n", 4}});
 
-  auto* split_iter4 = split_iters[3].get();
+  auto* split_iter4 = split_iters[9].get();
   VerifyVisibleTombstones(split_iter4, {{"c", "e", 8},
                                         {"e", "g", 8},
                                         {"g", "i", 6},
                                         {"j", "l", 4},
                                         {"l", "n", 4}});
 
-  auto* split_iter5 = split_iters[4].get();
+  auto* split_iter5 = split_iters[kMaxSequenceNumber].get();
   VerifyVisibleTombstones(split_iter5, {{"a", "c", 10},
                                         {"c", "e", 10},
                                         {"e", "g", 8},

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -119,6 +119,8 @@ TEST_F(RangeTombstoneFragmenterTest, NonOverlappingTombstones) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(&iter, {{"a", "b", 10}, {"c", "d", 5}});
   VerifyMaxCoveringTombstoneSeqnum(&iter,
                                    {{"", 0}, {"a", 10}, {"b", 0}, {"c", 5}});
@@ -131,6 +133,8 @@ TEST_F(RangeTombstoneFragmenterTest, OverlappingTombstones) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(
       &iter, {{"a", "c", 10}, {"c", "e", 15}, {"c", "e", 10}, {"e", "g", 15}});
   VerifyMaxCoveringTombstoneSeqnum(&iter,
@@ -145,6 +149,8 @@ TEST_F(RangeTombstoneFragmenterTest, ContiguousTombstones) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(
       &iter, {{"a", "c", 10}, {"c", "e", 20}, {"c", "e", 5}, {"e", "g", 15}});
   VerifyMaxCoveringTombstoneSeqnum(&iter,
@@ -159,6 +165,8 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartAndEndKey) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(&iter,
                             {{"a", "c", 10}, {"a", "c", 7}, {"a", "c", 3}});
   VerifyMaxCoveringTombstoneSeqnum(&iter, {{"a", 10}, {"b", 10}, {"c", 0}});
@@ -172,6 +180,8 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyDifferentEndKeys) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10},
                                     {"a", "c", 7},
                                     {"a", "c", 3},
@@ -193,6 +203,8 @@ TEST_F(RangeTombstoneFragmenterTest, RepeatedStartKeyMixedEndKeys) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter.upper_bound());
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 30},
                                     {"a", "c", 20},
                                     {"a", "c", 10},
@@ -239,6 +251,8 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
                                      {"l", "n", 4}});
   }
 
+  ASSERT_EQ(0, iter1.lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, iter1.upper_bound());
   VerifyVisibleTombstones(&iter1, {{"a", "c", 10},
                                    {"c", "e", 10},
                                    {"e", "g", 8},
@@ -248,6 +262,8 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
   VerifyMaxCoveringTombstoneSeqnum(
       &iter1, {{"a", 10}, {"c", 10}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
 
+  ASSERT_EQ(0, iter2.lower_bound());
+  ASSERT_EQ(9, iter2.upper_bound());
   VerifyVisibleTombstones(&iter2, {{"c", "e", 8},
                                    {"e", "g", 8},
                                    {"g", "i", 6},
@@ -256,6 +272,8 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
   VerifyMaxCoveringTombstoneSeqnum(
       &iter2, {{"a", 0}, {"c", 8}, {"e", 8}, {"i", 0}, {"j", 4}, {"m", 4}});
 
+  ASSERT_EQ(0, iter3.lower_bound());
+  ASSERT_EQ(7, iter3.upper_bound());
   VerifyVisibleTombstones(&iter3, {{"c", "e", 6},
                                    {"e", "g", 6},
                                    {"g", "i", 6},
@@ -264,10 +282,14 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKey) {
   VerifyMaxCoveringTombstoneSeqnum(
       &iter3, {{"a", 0}, {"c", 6}, {"e", 6}, {"i", 0}, {"j", 4}, {"m", 4}});
 
+  ASSERT_EQ(0, iter4.lower_bound());
+  ASSERT_EQ(5, iter4.upper_bound());
   VerifyVisibleTombstones(&iter4, {{"j", "l", 4}, {"l", "n", 4}});
   VerifyMaxCoveringTombstoneSeqnum(
       &iter4, {{"a", 0}, {"c", 0}, {"e", 0}, {"i", 0}, {"j", 4}, {"m", 4}});
 
+  ASSERT_EQ(0, iter5.lower_bound());
+  ASSERT_EQ(3, iter5.upper_bound());
   VerifyVisibleTombstones(&iter5, {{"j", "l", 2}});
   VerifyMaxCoveringTombstoneSeqnum(
       &iter5, {{"a", 0}, {"c", 0}, {"e", 0}, {"i", 0}, {"j", 2}, {"m", 0}});
@@ -284,6 +306,8 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyUnordered) {
                                              bytewise_icmp);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         9 /* upper_bound */);
+  ASSERT_EQ(0, iter.lower_bound());
+  ASSERT_EQ(9, iter.upper_bound());
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10},
                                     {"c", "e", 10},
                                     {"c", "e", 8},
@@ -307,7 +331,7 @@ TEST_F(RangeTombstoneFragmenterTest, OverlapAndRepeatedStartKeyForCompaction) {
 
   FragmentedRangeTombstoneList fragment_list(
       std::move(range_del_iter), bytewise_icmp, true /* for_compaction */,
-      {} /* upper_bounds */);
+      {} /* snapshots */);
   FragmentedRangeTombstoneIterator iter(&fragment_list, bytewise_icmp,
                                         kMaxSequenceNumber /* upper_bound */);
   VerifyFragmentedRangeDels(&iter, {{"a", "c", 10},
@@ -356,6 +380,8 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitNoSnapshots) {
   ASSERT_EQ(1, split_iters.size());
 
   auto* split_iter = split_iters[kMaxSequenceNumber].get();
+  ASSERT_EQ(0, split_iter->lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, split_iter->upper_bound());
   VerifyVisibleTombstones(split_iter, {{"a", "c", 10},
                                        {"c", "e", 10},
                                        {"e", "g", 8},
@@ -380,19 +406,29 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitWithSnapshots) {
   ASSERT_EQ(5, split_iters.size());
 
   auto* split_iter1 = split_iters[3].get();
+  ASSERT_EQ(0, split_iter1->lower_bound());
+  ASSERT_EQ(3, split_iter1->upper_bound());
   VerifyVisibleTombstones(split_iter1, {{"j", "l", 2}});
 
   auto* split_iter2 = split_iters[5].get();
+  ASSERT_EQ(4, split_iter2->lower_bound());
+  ASSERT_EQ(5, split_iter2->upper_bound());
   VerifyVisibleTombstones(split_iter2, {{"j", "l", 4}, {"l", "n", 4}});
 
   auto* split_iter3 = split_iters[7].get();
+  ASSERT_EQ(6, split_iter3->lower_bound());
+  ASSERT_EQ(7, split_iter3->upper_bound());
   VerifyVisibleTombstones(split_iter3,
                           {{"c", "e", 6}, {"e", "g", 6}, {"g", "i", 6}});
 
   auto* split_iter4 = split_iters[9].get();
+  ASSERT_EQ(8, split_iter4->lower_bound());
+  ASSERT_EQ(9, split_iter4->upper_bound());
   VerifyVisibleTombstones(split_iter4, {{"c", "e", 8}, {"e", "g", 8}});
 
   auto* split_iter5 = split_iters[kMaxSequenceNumber].get();
+  ASSERT_EQ(10, split_iter5->lower_bound());
+  ASSERT_EQ(kMaxSequenceNumber, split_iter5->upper_bound());
   VerifyVisibleTombstones(split_iter5, {{"a", "c", 10}, {"c", "e", 10}});
 }
 

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -46,8 +46,8 @@ void VerifyFragmentedRangeDels(
     FragmentedRangeTombstoneIterator* iter,
     const std::vector<RangeTombstone>& expected_tombstones) {
   iter->SeekToFirst();
-  for (size_t i = 0; i < expected_tombstones.size() && iter->Valid();
-       i++, iter->Next()) {
+  for (size_t i = 0; i < expected_tombstones.size(); i++, iter->Next()) {
+    ASSERT_TRUE(iter->Valid());
     CheckIterPosition(expected_tombstones[i], iter);
   }
   EXPECT_FALSE(iter->Valid());
@@ -57,8 +57,8 @@ void VerifyVisibleTombstones(
     FragmentedRangeTombstoneIterator* iter,
     const std::vector<RangeTombstone>& expected_tombstones) {
   iter->SeekToTopFirst();
-  for (size_t i = 0; i < expected_tombstones.size() && iter->Valid();
-       i++, iter->TopNext()) {
+  for (size_t i = 0; i < expected_tombstones.size(); i++, iter->TopNext()) {
+    ASSERT_TRUE(iter->Valid());
     CheckIterPosition(expected_tombstones[i], iter);
   }
   EXPECT_FALSE(iter->Valid());
@@ -388,24 +388,15 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitWithSnapshots) {
   auto* split_iter3 = split_iters[7].get();
   VerifyVisibleTombstones(split_iter3, {{"c", "e", 6},
                                         {"e", "g", 6},
-                                        {"g", "i", 6},
-                                        {"j", "l", 4},
-                                        {"l", "n", 4}});
+                                        {"g", "i", 6}});
 
   auto* split_iter4 = split_iters[9].get();
   VerifyVisibleTombstones(split_iter4, {{"c", "e", 8},
-                                        {"e", "g", 8},
-                                        {"g", "i", 6},
-                                        {"j", "l", 4},
-                                        {"l", "n", 4}});
+                                        {"e", "g", 8}});
 
   auto* split_iter5 = split_iters[kMaxSequenceNumber].get();
   VerifyVisibleTombstones(split_iter5, {{"a", "c", 10},
-                                        {"c", "e", 10},
-                                        {"e", "g", 8},
-                                        {"g", "i", 6},
-                                        {"j", "l", 4},
-                                        {"l", "n", 4}});
+                                        {"c", "e", 10}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekStartKey) {

--- a/db/range_tombstone_fragmenter_test.cc
+++ b/db/range_tombstone_fragmenter_test.cc
@@ -386,17 +386,14 @@ TEST_F(RangeTombstoneFragmenterTest, IteratorSplitWithSnapshots) {
   VerifyVisibleTombstones(split_iter2, {{"j", "l", 4}, {"l", "n", 4}});
 
   auto* split_iter3 = split_iters[7].get();
-  VerifyVisibleTombstones(split_iter3, {{"c", "e", 6},
-                                        {"e", "g", 6},
-                                        {"g", "i", 6}});
+  VerifyVisibleTombstones(split_iter3,
+                          {{"c", "e", 6}, {"e", "g", 6}, {"g", "i", 6}});
 
   auto* split_iter4 = split_iters[9].get();
-  VerifyVisibleTombstones(split_iter4, {{"c", "e", 8},
-                                        {"e", "g", 8}});
+  VerifyVisibleTombstones(split_iter4, {{"c", "e", 8}, {"e", "g", 8}});
 
   auto* split_iter5 = split_iters[kMaxSequenceNumber].get();
-  VerifyVisibleTombstones(split_iter5, {{"a", "c", 10},
-                                        {"c", "e", 10}});
+  VerifyVisibleTombstones(split_iter5, {{"a", "c", 10}, {"c", "e", 10}});
 }
 
 TEST_F(RangeTombstoneFragmenterTest, SeekStartKey) {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2412,7 +2412,7 @@ FragmentedRangeTombstoneIterator* BlockBasedTable::NewRangeTombstoneIterator(
     snapshot = read_options.snapshot->GetSequenceNumber();
   }
   return new FragmentedRangeTombstoneIterator(
-      rep_->fragmented_range_dels, snapshot, rep_->internal_comparator);
+      rep_->fragmented_range_dels, rep_->internal_comparator, snapshot);
 }
 
 InternalIterator* BlockBasedTable::NewUnfragmentedRangeTombstoneIterator(


### PR DESCRIPTION
Summary: To support the flush/compaction use cases of RangeDelAggregator
in v2, FragmentedRangeTombstoneIterator now supports dropping tombstones
that cannot be read in the compaction output file. Furthermore,
FragmentedRangeTombstoneIterator supports the "snapshot striping" use
case by allowing an iterator to be split by a list of snapshots.
RangeDelAggregatorV2 will use these changes in a follow-up change.

In the process of making these changes, other miscellaneous cleanups
were also done in these files.

Test Plan: make check