### PR TITLE
Add `getMin`, `getMax`, `getCount`, `getSum` to `HistogramData` class object.

### DIFF
--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -430,6 +430,7 @@ struct HistogramData {
   double max = 0.0;
   uint64_t count = 0;
   uint64_t sum = 0;
+  double min = 0.0;
 };
 
 enum StatsLevel {

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -1612,7 +1612,7 @@ class HistogramDataJni : public JavaClass {
       return nullptr;
     }
 
-    static jmethodID mid = env->GetMethodID(jclazz, "<init>", "(DDDDD)V");
+    static jmethodID mid = env->GetMethodID(jclazz, "<init>", "(DDDDDDJJD)V");
     assert(mid != nullptr);
     return mid;
   }

--- a/java/rocksjni/statistics.cc
+++ b/java/rocksjni/statistics.cc
@@ -202,7 +202,8 @@ jobject Java_org_rocksdb_Statistics_getHistogramData(JNIEnv* env,
 
   return env->NewObject(jclazz, mid, data.median, data.percentile95,
                         data.percentile99, data.average,
-                        data.standard_deviation);
+                        data.standard_deviation, data.max, data.count,
+                        data.sum, data.min);
 }
 
 /*

--- a/java/src/main/java/org/rocksdb/HistogramData.java
+++ b/java/src/main/java/org/rocksdb/HistogramData.java
@@ -53,7 +53,7 @@ public class HistogramData {
   }
 
   public double getMax() {
-    return max_;'
+    return max_;
   }
 
   public long getCount() {

--- a/java/src/main/java/org/rocksdb/HistogramData.java
+++ b/java/src/main/java/org/rocksdb/HistogramData.java
@@ -11,15 +11,25 @@ public class HistogramData {
   private final double percentile99_;
   private final double average_;
   private final double standardDeviation_;
+  private final double max_;
+  private final long count_;
+  private final long sum_;
+  private final double min_;
+
 
   public HistogramData(final double median, final double percentile95,
       final double percentile99, final double average,
-      final double standardDeviation) {
+      final double standardDeviation, final double max, final long count,
+      final long sum, final double min) {
     median_ = median;
     percentile95_ = percentile95;
     percentile99_ = percentile99;
     average_ = average;
     standardDeviation_ = standardDeviation;
+    max_ = max;
+    count_ = count;
+    sum_ = sum;
+    min_ = min;
   }
 
   public double getMedian() {
@@ -40,5 +50,21 @@ public class HistogramData {
 
   public double getStandardDeviation() {
     return standardDeviation_;
+  }
+
+  public double getMax() {
+    return max_;'
+  }
+
+  public long getCount() {
+    return count_;
+  }
+
+  public long getSum() {
+    return sum_;
+  }
+
+  public double getMin() {
+    return min_;
   }
 }

--- a/java/src/test/java/org/rocksdb/StatisticsTest.java
+++ b/java/src/test/java/org/rocksdb/StatisticsTest.java
@@ -96,6 +96,14 @@ public class StatisticsTest {
       final HistogramData histogramData = statistics.getHistogramData(HistogramType.BYTES_PER_READ);
       assertThat(histogramData).isNotNull();
       assertThat(histogramData.getAverage()).isGreaterThan(0);
+      assertThat(histogramData.getMedian()).isGreaterThan(0);
+      assertThat(histogramData.getPercentile95()).isGreaterThan(0);
+      assertThat(histogramData.getPercentile99()).isGreaterThan(0);
+      assertThat(histogramData.getStandardDeviation()).isEqualTo(0.00);
+      assertThat(histogramData.getMax()).isGreaterThan(0);
+      assertThat(histogramData.getCount()).isGreaterThan(0);
+      assertThat(histogramData.getSum()).isGreaterThan(0);
+      assertThat(histogramData.getMin()).isGreaterThan(0);
     }
   }
 

--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -237,6 +237,7 @@ void HistogramStat::Data(HistogramData * const data) const {
   data->standard_deviation = StandardDeviation();
   data->count = num();
   data->sum = sum();
+  data->min = static_cast<double>(min());
 }
 
 void HistogramImpl::Clear() {


### PR DESCRIPTION
Expose common stats min,max,count,sum via statistics JNI. These stats are not fully exposed on the Java side as is, but are available on the native side.