### PR TITLE
Fix buck dev mode fbcode builds

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -73,7 +73,7 @@ sanitizer = read_config("fbcode", "sanitizer")
 
 # Let RocksDB aware of jemalloc existence.
 # Do not enable it if sanitizer presents.
-if default_allocator.startswith("jemalloc") and sanitizer == "":
+if is_opt_mode and default_allocator.startswith("jemalloc") and sanitizer == "":
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
     rocksdb_external_deps.append(("jemalloc", None, "headers"))
 
@@ -991,6 +991,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "sst_file_reader_test",
+        "table/sst_file_reader_test.cc",
+        "serial",
+    ],
+    [
         "statistics_test",
         "monitoring/statistics_test.cc",
         "serial",
@@ -1099,11 +1104,6 @@ ROCKS_TESTS = [
         "write_unprepared_transaction_test",
         "utilities/transactions/write_unprepared_transaction_test.cc",
         "parallel",
-    ],
-    [
-        "sst_file_reader_test",
-        "table/sst_file_reader_test.cc",
-        "serial",
     ],
 ]
 

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -77,7 +77,7 @@ sanitizer = read_config("fbcode", "sanitizer")
 
 # Let RocksDB aware of jemalloc existence.
 # Do not enable it if sanitizer presents.
-if default_allocator.startswith("jemalloc") and sanitizer == "":
+if is_opt_mode and default_allocator.startswith("jemalloc") and sanitizer == "":
     rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
     rocksdb_external_deps.append(("jemalloc", None, "headers"))
 """


### PR DESCRIPTION
Summary:
Don't enable ROCKSDB_JEMALLOC unless the build mode is opt and default
allocator is jemalloc. In dev mode, this is causing compile/link errors such as -
```
stderr: buck-out/dev/gen/rocksdb/src/rocksdb_lib#compile-pic-malloc_stats.cc.o4768b59e,gcc-5-glibc-2.23-clang/db/malloc_stats.cc.o:malloc_stats.cc:function rocksdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*): error: undefined reference to 'malloc_stats_print'
clang-7.0: error: linker command failed with exit code 1
```