### PR TITLE
Universal Compaction with TTL

### DIFF
--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -181,6 +181,11 @@ class CompactionPicker {
                                     int* start_level, int* output_level,
                                     CompactionInputFiles* start_level_inputs);
 
+  void PickExpiredTtlFiles(const std::string& cf_name,
+                           VersionStorageInfo* vstorage, int* start_level,
+                           int* output_level,
+                           CompactionInputFiles* start_level_inputs);
+
   bool GetOverlappingL0Files(VersionStorageInfo* vstorage,
                              CompactionInputFiles* start_level_inputs,
                              int output_level, int* parent_index);

--- a/db/compaction_picker_universal.h
+++ b/db/compaction_picker_universal.h
@@ -73,10 +73,19 @@ class UniversalCompactionPicker : public CompactionPicker {
       VersionStorageInfo* vstorage, double score,
       const std::vector<SortedRun>& sorted_runs, LogBuffer* log_buffer);
 
-  Compaction* PickDeleteTriggeredCompaction(
+  enum TriggerStrategy {
+    // Pick files marked for compaction. Typically, files are marked by
+    // CompactOnDeletionCollector due to the presence of tombstones.
+    MARKED_FILES,
+    // Pick ttl expired files.
+    TTL
+  };
+
+  Compaction* PickSomeTriggeredCompaction(
       const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
       VersionStorageInfo* vstorage, double score,
-      const std::vector<SortedRun>& sorted_runs, LogBuffer* log_buffer);
+      const std::vector<SortedRun>& sorted_runs, LogBuffer* log_buffer,
+      const TriggerStrategy strategy);
 
   // Used in universal compaction when the enabled_trivial_move
   // option is set. Checks whether there are any overlapping files


### PR DESCRIPTION
Extend the ttl option to work with Universal compaction as well. This is an extension of the Level compaction+TTL work done in #3591. This would allow to reduce space and read amplification at the cost of more write amplification. 
All compaction styles (fifo, level and universal) now work with a ttl option.


Implementation Details:
- Re-used the code from PickDeleteTriggeredCompaction, and changed the method name to be more generic.

Still Todo:
- Write more TTL-triggered tests
- Change name of `PickSomeTriggeredCompaction`

For later: Deprecate CompactionOptionsFIFO.ttl and instead make use of ColumnFamilyOptions.ttl for FIFO
