### PR TITLE
Call Snapshot::GetSequenceNumber in DBImpl::Get instead of casting to SnapshotImpl

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1246,8 +1246,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
     // In WriteUnprepared, we cannot set snapshot in the lookup key because we
     // may skip uncommitted data that should be visible to the transaction for
     // reading own writes.
-    snapshot =
-        reinterpret_cast<const SnapshotImpl*>(read_options.snapshot)->number_;
+    snapshot = read_options.snapshot->GetSequenceNumber();
     if (callback) {
       snapshot = std::max(snapshot, callback->MaxUnpreparedSequenceNumber());
     }
@@ -1352,8 +1351,7 @@ std::vector<Status> DBImpl::MultiGet(
 
   mutex_.Lock();
   if (read_options.snapshot != nullptr) {
-    snapshot =
-        reinterpret_cast<const SnapshotImpl*>(read_options.snapshot)->number_;
+    snapshot = read_options.snapshot->GetSequenceNumber();
   } else {
     snapshot = last_seq_same_as_publish_seq_
                    ? versions_->LastSequence()

--- a/db/db_impl_readonly.cc
+++ b/db/db_impl_readonly.cc
@@ -74,8 +74,7 @@ Iterator* DBImplReadOnly::NewIterator(const ReadOptions& read_options,
   SequenceNumber latest_snapshot = versions_->LastSequence();
   SequenceNumber read_seq =
       read_options.snapshot != nullptr
-          ? reinterpret_cast<const SnapshotImpl*>(read_options.snapshot)
-                ->number_
+          ? read_options.snapshot->GetSequenceNumber()
           : latest_snapshot;
   ReadCallback* read_callback = nullptr;  // No read callback provided.
   auto db_iter = NewArenaWrappedDbIterator(
@@ -103,8 +102,7 @@ Status DBImplReadOnly::NewIterators(
   SequenceNumber latest_snapshot = versions_->LastSequence();
   SequenceNumber read_seq =
       read_options.snapshot != nullptr
-          ? reinterpret_cast<const SnapshotImpl*>(read_options.snapshot)
-                ->number_
+          ? read_options.snapshot->GetSequenceNumber()
           : latest_snapshot;
 
   for (auto cfh : column_families) {


### PR DESCRIPTION
The original implementation get sequence number by casting `Snapshot` to `SnapshotImpl`. If one extends the class to use a different implementation of the snapshot class they would have to reimplement the ::GetImpl, which seems avoidable by using the Snapshot::GetSequenceNumber API.