### PR TITLE
[rocksandra] fix TombstoneCollectable test

### DIFF
--- a/utilities/cassandra/cassandra_format_test.cc
+++ b/utilities/cassandra/cassandra_format_test.cc
@@ -125,13 +125,14 @@ TEST(ExpiringColumnTest, ExpiringColumn) {
 TEST(TombstoneTest, TombstoneCollectable) {
   int32_t now = (int32_t)time(nullptr);
   int32_t gc_grace_seconds = 16440;
+  int32_t time_delta_seconds = 10;
   EXPECT_TRUE(Tombstone(ColumnTypeMask::DELETION_MASK, 0,
-                        now - gc_grace_seconds,
-                        ToMicroSeconds(now - gc_grace_seconds))
+                        now - gc_grace_seconds - time_delta_seconds,
+                        ToMicroSeconds(now - gc_grace_seconds - time_delta_seconds))
                   .Collectable(gc_grace_seconds));
   EXPECT_FALSE(Tombstone(ColumnTypeMask::DELETION_MASK, 0,
-                         now - gc_grace_seconds + 1,
-                         ToMicroSeconds(now - gc_grace_seconds + 1))
+                         now - gc_grace_seconds + time_delta_seconds,
+                         ToMicroSeconds(now - gc_grace_seconds + time_delta_seconds))
                    .Collectable(gc_grace_seconds));
 }
 


### PR DESCRIPTION
the original test does not give enough time difference between tombstone write time and the expire time point, which make test flaky.