### PR TITLE
Updated the CentOS 6 Docker build for RocksJava to a newer GCC toolchain

### DIFF
--- a/java/crossbuild/docker-build-linux-centos.sh
+++ b/java/crossbuild/docker-build-linux-centos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+#set -x
 
 rm -rf /rocksdb-local
 cp -r /rocksdb-host /rocksdb-local
@@ -8,11 +9,19 @@ cd /rocksdb-local
 
 # Use scl devtoolset if available (i.e. CentOS <7)
 if hash scl 2>/dev/null; then
-	scl enable devtoolset-2 'make jclean clean'
-	scl enable devtoolset-2 'PORTABLE=1 make -j8 rocksdbjavastatic'
+	if scl --list | grep -q 'devtoolset-7'; then
+		scl enable devtoolset-7 'make jclean clean'
+		scl enable devtoolset-7 'PORTABLE=1 make -j6 rocksdbjavastatic'
+	elif scl --list | grep -q 'devtoolset-2'; then
+		scl enable devtoolset-2 'make jclean clean'
+		scl enable devtoolset-2 'PORTABLE=1 make -j6 rocksdbjavastatic'
+	else
+		echo "Could not find devtoolset"
+		exit 1;
+	fi
 else
 	make jclean clean
-        PORTABLE=1 make -j8 rocksdbjavastatic
+        PORTABLE=1 make -j6 rocksdbjavastatic
 fi
 
 cp java/target/librocksdbjni-linux*.so java/target/rocksdbjni-*-linux*.jar /rocksdb-host/java/target


### PR DESCRIPTION
Uses a newer build toolchain but the same old GLIBC when building releases of RocksJava for Linux x64 in the Docker Container.