### PR TITLE
add method Cache::Clear() to clear the block cache

### DIFF
--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -117,7 +117,6 @@ class CacheTest : public testing::TestWithParam<std::string> {
     cache->Erase(EncodeKey(key));
   }
 
-
   int Lookup(int key) {
     return Lookup(cache_, key);
   }
@@ -656,7 +655,7 @@ void callback(void* entry, size_t charge) {
 }
 };
 
-TEST_P(CacheTest, ApplyToAllCacheEntiresTest) {
+TEST_P(CacheTest, ApplyToAllCacheEntriesTest) {
   std::vector<std::pair<int, int>> inserted;
   callback_state.clear();
 

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -28,7 +28,7 @@ std::shared_ptr<Cache> NewClockCache(size_t /*capacity*/, int /*num_shard_bits*/
 #include <deque>
 
 // "tbb/concurrent_hash_map.h" requires RTTI if exception is enabled.
-// Disable it so users can chooose to disable RTTI.
+// Disable it so users can choose to disable RTTI.
 #ifndef ROCKSDB_USE_RTTI
 #define TBB_USE_EXCEPTIONS 0
 #endif
@@ -710,6 +710,8 @@ class ClockCache : public ShardedCache {
   }
 
   virtual void DisownData() override { shards_ = nullptr; }
+
+  virtual Status Clear() override { return Status::NotSupported(); }
 
  private:
   ClockCacheShard* shards_;

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -185,6 +185,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard : public CacheShard {
   virtual bool Release(Cache::Handle* handle,
                        bool force_erase = false) override;
   virtual void Erase(const Slice& key, uint32_t hash) override;
+  virtual Status Clear() override;
 
   // Although in some platforms the update of size_t is atomic, to make sure
   // GetUsage() and GetPinnedUsage() work correctly under any platform, we'll

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -75,6 +75,18 @@ void ShardedCache::Erase(const Slice& key) {
   GetShard(Shard(hash))->Erase(key, hash);
 }
 
+Status ShardedCache::Clear() {
+  Status status;
+  int num_shards = 1 << num_shard_bits_;
+  for (int s = 0; s < num_shards; s++) {
+    status = GetShard(s)->Clear();
+    if (!status.ok()) {
+      break;
+    }
+  }
+  return status;
+}
+
 uint64_t ShardedCache::NewId() {
   return last_id_.fetch_add(1, std::memory_order_relaxed);
 }

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -32,6 +32,8 @@ class CacheShard {
   virtual bool Ref(Cache::Handle* handle) = 0;
   virtual bool Release(Cache::Handle* handle, bool force_erase = false) = 0;
   virtual void Erase(const Slice& key, uint32_t hash) = 0;
+  // Clear() is only implemented in some derived classes
+  virtual Status Clear() { return Status::NotSupported(); }
   virtual void SetCapacity(size_t capacity) = 0;
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) = 0;
   virtual size_t GetUsage() const = 0;
@@ -68,6 +70,10 @@ class ShardedCache : public Cache {
   virtual bool Ref(Handle* handle) override;
   virtual bool Release(Handle* handle, bool force_erase = false) override;
   virtual void Erase(const Slice& key) override;
+  // Iterate over all shards, and clear them seperately.
+  // This is a best-effort deletion, but does not guarantee
+  // a consistent deletion across all shards
+  virtual Status Clear() override;
   virtual uint64_t NewId() override;
   virtual size_t GetCapacity() const override;
   virtual bool HasStrictCapacityLimit() const override;

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -183,6 +183,16 @@ class Cache {
   // underlying entry will be kept around until all existing handles
   // to it have been released.
   virtual void Erase(const Slice& key) = 0;
+
+  // Clear all non-referenced entries from the cache. This tries to achieve
+  // a best-effort deletion of cache entries, but it does not guarantee 
+  // consistent deletion of entries, e.g. across multiple shards.
+  virtual Status Clear() {
+    // there is no default implementation for Clear(), only some derived 
+    // classes implement it
+    return Status::NotSupported();
+  }
+
   // Return a new numeric id.  May be used by multiple clients who are
   // sharding the same cache to partition the key space.  Typically the
   // client will allocate a new id at startup and prepend the id to
@@ -220,9 +230,9 @@ class Cache {
   // memory - call this only if you're shutting down the process.
   // Any attempts of using cache after this call will fail terribly.
   // Always delete the DB object before calling this method!
-  virtual void DisownData(){
-      // default implementation is noop
-  };
+  virtual void DisownData() {
+    // default implementation is noop
+  }
 
   // Apply callback to all entries in the cache
   // If thread_safe is true, it will also lock the accesses. Otherwise, it will


### PR DESCRIPTION
As `Cache` is just an interface and users may have subclassed it,
the default implementation of Clear() will simply return
`Status::NotSupported`.

Cache clearing is implemented for the LRU cache however. The
implementation will clear all unreferenced entries in the block cache.
It will visit the shards sequentially, acquiring only the per-shard
mutex while cleaning the shard's entries. This means the overall
cleaning procedure may be "inconsistent", but it should be good
enough for real-world use cases.