### PR TITLE
Reduce javadoc warnings

### DIFF
--- a/java/src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
+++ b/java/src/main/java/org/rocksdb/AbstractCompactionFilterFactory.java
@@ -57,6 +57,8 @@ public abstract class AbstractCompactionFilterFactory<T extends AbstractCompacti
    * A name which identifies this compaction filter
    *
    * The name will be printed to the LOG file on start up for diagnosis
+   *
+   * @return name which identifies this compaction filter.
    */
   public abstract String name();
 

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptions.java
@@ -200,6 +200,9 @@ public class ColumnFamilyOptions extends RocksObject
    * {@link #setCompactionFilter(AbstractCompactionFilter)} takes precedence
    * over {@link #setCompactionFilterFactory(AbstractCompactionFilterFactory)}
    * if the client specifies both.
+   *
+   * @param compactionFilter The compaction filter called during compaction.
+   * @return the reference to {@link org.rocksdb.ColumnFamilyOptions instance}.
    */
   //TODO(AR) need to set a note on the concurrency of the compaction filter used from this method
   public ColumnFamilyOptions setCompactionFilter(
@@ -218,6 +221,9 @@ public class ColumnFamilyOptions extends RocksObject
    * A new filter will be created on each compaction run.  If multithreaded
    * compaction is being used, each created CompactionFilter will only be used
    * from a single thread and so does not need to be thread-safe.
+   *
+   * @param compactionFilterFactory The factory used for creating a new filter on each compaction run.
+   * @return the reference to {@link org.rocksdb.ColumnFamilyOptions instance}.
    */
   public ColumnFamilyOptions setCompactionFilterFactory(final AbstractCompactionFilterFactory<? extends AbstractCompactionFilter<?>> compactionFilterFactory) {
     assert (isOwningHandle());

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -174,6 +174,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface> {
    *    first db_path (db_name if db_paths is empty).
    *
    * @param sstFileManager The SST File Manager for the db.
+   * @return the instance of the current object.
    */
   T setSstFileManager(SstFileManager sstFileManager);
 

--- a/java/src/main/java/org/rocksdb/SstFileManager.java
+++ b/java/src/main/java/org/rocksdb/SstFileManager.java
@@ -28,6 +28,8 @@ public final class SstFileManager extends RocksObject {
    * instances to track SST file and control there deletion rate.
    *
    * @param env the environment.
+   *
+   * @throws RocksDBException thrown if error happens in underlying native library.
    */
   public SstFileManager(final Env env) throws RocksDBException {
     this(env, null);
@@ -39,6 +41,8 @@ public final class SstFileManager extends RocksObject {
    *
    * @param env the environment.
    * @param logger if not null, the logger will be used to log errors.
+   *
+   * @throws RocksDBException thrown if error happens in underlying native library.
    */
   public SstFileManager(final Env env, /*@Nullable*/  final Logger logger)
       throws RocksDBException {
@@ -57,6 +61,8 @@ public final class SstFileManager extends RocksObject {
    *     this value is set to 1024 (1 Kb / sec) and we deleted a file of size
    *     4 Kb in 1 second, we will wait for another 3 seconds before we delete
    *     other files, Set to 0 to disable deletion rate limiting.
+   *
+   * @throws RocksDBException thrown if error happens in underlying native library.
    */
   public SstFileManager(final Env env, /*@Nullable*/  final Logger logger,
       final long rateBytesPerSec) throws RocksDBException {
@@ -78,6 +84,8 @@ public final class SstFileManager extends RocksObject {
    * @param maxTrashDbRatio if the trash size constitutes for more than this
    *     fraction of the total DB size we will start deleting new files passed
    *     to DeleteScheduler immediately.
+   *
+   *  @throws RocksDBException thrown if error happens in underlying native library.
    */
   public SstFileManager(final Env env, /*@Nullable*/ final Logger logger,
       final long rateBytesPerSec, final double maxTrashDbRatio)
@@ -104,6 +112,8 @@ public final class SstFileManager extends RocksObject {
    * @param bytesMaxDeleteChunk if a single file is larger than delete chunk,
    *     ftruncate the file by this size each time, rather than dropping the whole
    *     file. 0 means to always delete the whole file.
+   *
+   * @throws RocksDBException thrown if error happens in underlying native library.
    */
   public SstFileManager(final Env env, /*@Nullable*/final Logger logger,
       final long rateBytesPerSec, final double maxTrashDbRatio,

--- a/java/src/main/java/org/rocksdb/WriteBatchInterface.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchInterface.java
@@ -23,6 +23,7 @@ public interface WriteBatchInterface {
      *
      * @param key the specified key to be inserted.
      * @param value the value associated with the specified key.
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void put(byte[] key, byte[] value) throws RocksDBException;
 
@@ -34,6 +35,7 @@ public interface WriteBatchInterface {
      *     instance
      * @param key the specified key to be inserted.
      * @param value the value associated with the specified key.
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void put(ColumnFamilyHandle columnFamilyHandle,
                     byte[] key, byte[] value) throws RocksDBException;
@@ -45,6 +47,7 @@ public interface WriteBatchInterface {
      * @param key the specified key to be merged.
      * @param value the value to be merged with the current value for
      * the specified key.
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void merge(byte[] key, byte[] value) throws RocksDBException;
 
@@ -56,6 +59,7 @@ public interface WriteBatchInterface {
      * @param key the specified key to be merged.
      * @param value the value to be merged with the current value for
      * the specified key.
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void merge(ColumnFamilyHandle columnFamilyHandle,
                       byte[] key, byte[] value) throws RocksDBException;
@@ -66,6 +70,7 @@ public interface WriteBatchInterface {
      * @param key Key to delete within database
      *
      * @deprecated Use {@link #delete(byte[])}
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     @Deprecated
     void remove(byte[] key) throws RocksDBException;
@@ -77,6 +82,7 @@ public interface WriteBatchInterface {
      * @param key Key to delete within database
      *
      * @deprecated Use {@link #delete(ColumnFamilyHandle, byte[])}
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     @Deprecated
     void remove(ColumnFamilyHandle columnFamilyHandle, byte[] key)
@@ -86,6 +92,7 @@ public interface WriteBatchInterface {
      * <p>If the database contains a mapping for "key", erase it.  Else do nothing.</p>
      *
      * @param key Key to delete within database
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void delete(byte[] key) throws RocksDBException;
 
@@ -94,6 +101,7 @@ public interface WriteBatchInterface {
      *
      * @param columnFamilyHandle {@link ColumnFamilyHandle} instance
      * @param key Key to delete within database
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void delete(ColumnFamilyHandle columnFamilyHandle, byte[] key)
         throws RocksDBException;
@@ -161,6 +169,7 @@ public interface WriteBatchInterface {
      *          First key to delete within database (included)
      * @param endKey
      *          Last key to delete within database (excluded)
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void deleteRange(byte[] beginKey, byte[] endKey) throws RocksDBException;
 
@@ -178,6 +187,7 @@ public interface WriteBatchInterface {
      *          First key to delete within database (included)
      * @param endKey
      *          Last key to delete within database (excluded)
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void deleteRange(ColumnFamilyHandle columnFamilyHandle, byte[] beginKey,
             byte[] endKey) throws RocksDBException;
@@ -195,6 +205,7 @@ public interface WriteBatchInterface {
      * replication.
      *
      * @param blob binary object to be inserted
+     * @throws RocksDBException thrown if error happens in underlying native library.
      */
     void putLogData(byte[] blob) throws RocksDBException;
 


### PR DESCRIPTION
Compile logs have a bit of noise due to missing javadoc annotations. Updating docs to reduce. 