### PR TITLE
Change directory where ExternalSSTFileBasicTest runs

### DIFF
--- a/db/external_sst_file_basic_test.cc
+++ b/db/external_sst_file_basic_test.cc
@@ -17,7 +17,7 @@ namespace rocksdb {
 class ExternalSSTFileBasicTest : public DBTestBase,
                                  public ::testing::WithParamInterface<bool> {
  public:
-  ExternalSSTFileBasicTest() : DBTestBase("/external_sst_file_test") {
+  ExternalSSTFileBasicTest() : DBTestBase("/external_sst_file_basic_test") {
     sst_files_dir_ = dbname_ + "/sst_files/";
     DestroyAndRecreateExternalSSTFilesDir();
   }


### PR DESCRIPTION
Change the directory where ExternalSSTFileBasicTest* tests run.

**Problem:**
Without this change, I spent considerable time chasing around a non-existent issue as ExternalSSTFileTest.* and ExternalSSTFileBasicTest.* create similar directories. 

Test Plan:
Before:
```
 TEST_TMPDIR=/dev/shm KEEP_DB=1 ./external_sst_file_basic_test --gtest_filter=ExternalSSTFileBasicTest.Basic
Note: Google Test filter = ExternalSSTFileBasicTest.Basic
[ RUN      ] ExternalSSTFileBasicTest.Basic
DB is still at /dev/shm//external_sst_file_test_<some-random-number>
[       OK ] ExternalSSTFileBasicTest.Basic (7 ms)
[  PASSED  ] 1 test.
```
Now:
```
 TEST_TMPDIR=/dev/shm KEEP_DB=1 ./external_sst_file_basic_test --gtest_filter=ExternalSSTFileBasicTest.Basic
Note: Google Test filter = ExternalSSTFileBasicTest.Basic
[ RUN      ] ExternalSSTFileBasicTest.Basic
DB is still at /dev/shm//external_sst_file_basic_test_<some-random-number>
[       OK ] ExternalSSTFileBasicTest.Basic (7 ms)
[  PASSED  ] 1 test.
```