### PR TITLE
RocksJava must compile on JDK7

### DIFF
--- a/java/src/main/java/org/rocksdb/MemoryUsageType.java
+++ b/java/src/main/java/org/rocksdb/MemoryUsageType.java
@@ -54,9 +54,9 @@ public enum MemoryUsageType {
    *     cannot be found
    */
   public static MemoryUsageType getMemoryUsageType(final byte byteIdentifier) {
-    for (final MemoryUsageType MemoryUsageType : MemoryUsageType.values()) {
-      if (MemoryUsageType.getValue() == byteIdentifier) {
-        return MemoryUsageType;
+    for (final MemoryUsageType memoryUsageType : MemoryUsageType.values()) {
+      if (memoryUsageType.getValue() == byteIdentifier) {
+        return memoryUsageType;
       }
     }
 
@@ -64,7 +64,7 @@ public enum MemoryUsageType {
         "Illegal value provided for MemoryUsageType.");
   }
 
-  private MemoryUsageType(byte value) {
+  MemoryUsageType(byte value) {
     value_ = value;
   }
 

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -46,13 +46,13 @@ public class MergeTest {
   }
 
   private byte[] longToByteArray(long l) {
-    ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
+    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
     buf.putLong(l);
     return buf.array();
   }
 
   private long longFromByteArray(byte[] a) {
-    ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
+    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
     buf.put(a);
     buf.flip();
     return buf.getLong();


### PR DESCRIPTION
Fixes some RocksJava regressions recently introduced, whereby RocksJava would not build on JDK 7.
These should have been visible on Travis-CI!