### PR TITLE
5.18: Add ShouldDelete fast path

### DIFF
--- a/db/range_del_aggregator_v2.cc
+++ b/db/range_del_aggregator_v2.cc
@@ -239,6 +239,9 @@ bool RangeDelAggregatorV2::ShouldDelete(const ParsedInternalKey& parsed,
   if (wrapped_range_del_agg != nullptr) {
     return wrapped_range_del_agg->ShouldDelete(parsed, mode);
   }
+  if (IsEmpty()) {
+    return false;
+  }
 
   switch (mode) {
     case RangeDelPositioningMode::kForwardTraversal:


### PR DESCRIPTION
Summary: In the common case with no range tombstones, checking range
deletions should take as little time as possible. This commit adds a
fast path for that case to ensure that as little time is spent
processing range deletions as possible.

This is a lightweight version of part of a commit that landed on master,
modified to be safely backportable to 5.18.

Test Plan: make check