### PR TITLE
Refactor atomic flush result installation to MANIFEST

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -220,7 +220,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       preserve_deletes_(options.preserve_deletes),
       closed_(false),
       error_handler_(this, immutable_db_options_, &mutex_),
-      atomic_flush_commit_in_progress_(false) {
+      atomic_flush_install_cv_(&mutex_) {
   // !batch_per_trx_ implies seq_per_batch_ because it is only unset for
   // WriteUnprepared, which should use seq_per_batch_.
   assert(batch_per_txn_ || seq_per_batch_);

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -404,34 +404,57 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         }
       }
     }
+  }
 
-    if (s.ok()) {
-      autovector<const autovector<MemTable*>*> mems_list;
-      for (int i = 0; i != num_cfs; ++i) {
+  if (s.ok()) {
+    auto wait_to_install_func = [&]() {
+      bool ready = true;
+      for (size_t i = 0; i != cfds.size(); ++i) {
+        const auto& mems = jobs[i].GetMemTables();
         if (cfds[i]->IsDropped()) {
           continue;
+        } else if (!mems.empty() &&
+                   cfds[i]->imm()->GetEarliestMemTableID() < mems[0]->GetID()) {
+          ready = false;
+          break;
+        } else if (mems.empty() && cfds[i]->imm()->GetEarliestMemTableID() <=
+                                       bg_flush_args[i].max_memtable_id_) {
+          ready = false;
+          break;
         }
-        const auto& mems = jobs[i].GetMemTables();
-        mems_list.emplace_back(&mems);
       }
-      autovector<ColumnFamilyData*> all_cfds;
-      autovector<MemTableList*> imm_lists;
-      autovector<const MutableCFOptions*> mutable_cf_options_list;
-      for (auto cfd : *versions_->GetColumnFamilySet()) {
-        if (cfd->IsDropped()) {
-          continue;
-        }
-        all_cfds.emplace_back(cfd);
-        imm_lists.emplace_back(cfd->imm());
-        mutable_cf_options_list.emplace_back(cfd->GetLatestMutableCFOptions());
-      }
+      return ready;
+    };
 
-      s = MemTableList::TryInstallMemtableFlushResults(
-          imm_lists, all_cfds, mutable_cf_options_list, mems_list,
-          &atomic_flush_commit_in_progress_, &logs_with_prep_tracker_,
-          versions_.get(), &mutex_, file_meta, &job_context->memtables_to_free,
-          directories_.GetDbDir(), log_buffer);
+    bool resuming_from_bg_err = error_handler_.IsDBStopped();
+    while ((!error_handler_.IsDBStopped() ||
+            error_handler_.GetRecoveryError().ok()) &&
+           !wait_to_install_func()) {
+      atomic_flush_install_cv_.Wait();
     }
+
+    s = resuming_from_bg_err ? error_handler_.GetRecoveryError()
+                             : error_handler_.GetBGError();
+  }
+
+  if (s.ok()) {
+    autovector<ColumnFamilyData*> tmp_cfds;
+    autovector<const autovector<MemTable*>*> mems_list;
+    autovector<const MutableCFOptions*> mutable_cf_options_list;
+    for (int i = 0; i != num_cfs; ++i) {
+      const auto& mems = jobs[i].GetMemTables();
+      if (!cfds[i]->IsDropped() && !mems.empty()) {
+        tmp_cfds.emplace_back(cfds[i]);
+        mems_list.emplace_back(&mems);
+        mutable_cf_options_list.emplace_back(
+            cfds[i]->GetLatestMutableCFOptions());
+      }
+    }
+
+    s = InstallMemtableAtomicFlushResults(
+        nullptr /* imm_lists */, tmp_cfds, mutable_cf_options_list, mems_list,
+        versions_.get(), &mutex_, file_meta, &job_context->memtables_to_free,
+        directories_.GetDbDir(), log_buffer);
   }
 
   if (s.ok() || s.IsShutdownInProgress()) {
@@ -2104,6 +2127,7 @@ void DBImpl::BackgroundCallFlush() {
     bg_flush_scheduled_--;
     // See if there's more work to be done
     MaybeScheduleFlushOrCompaction();
+    atomic_flush_install_cv_.SignalAll();
     bg_cv_.SignalAll();
     // IMPORTANT: there should be no code after calling SignalAll. This call may
     // signal the DB destructor that it's OK to proceed with destruction. In

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -279,7 +279,6 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
           *cfd->GetLatestMutableCFOptions(), kMaxSequenceNumber);
       mem->SetID(i);
       mem->Ref();
-      mem->TEST_AtomicFlushSequenceNumber() = 123;
 
       for (size_t j = 0; j != num_keys_per_memtable; ++j) {
         std::string key(ToString(j + i * num_keys_per_memtable));
@@ -325,17 +324,13 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
     const auto& mems = flush_jobs[i].GetMemTables();
     mems_list.push_back(&mems);
   }
-  autovector<MemTableList*> imm_lists;
   autovector<const MutableCFOptions*> mutable_cf_options_list;
   for (auto cfd : all_cfds) {
-    imm_lists.push_back(cfd->imm());
     mutable_cf_options_list.push_back(cfd->GetLatestMutableCFOptions());
   }
 
-  bool atomic_flush_commit_in_progress = false;
-  Status s = MemTableList::TryInstallMemtableFlushResults(
-      imm_lists, all_cfds, mutable_cf_options_list, mems_list,
-      &atomic_flush_commit_in_progress, nullptr /* logs_prep_tracker */,
+  Status s = InstallMemtableAtomicFlushResults(
+      nullptr /* imm_lists */, all_cfds, mutable_cf_options_list, mems_list,
       versions_.get(), &mutex_, file_metas, &job_context.memtables_to_free,
       nullptr /* db_directory */, nullptr /* log_buffer */);
   ASSERT_OK(s);

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -386,13 +386,15 @@ class MemTable {
 
   uint64_t GetID() const { return id_; }
 
-  SequenceNumber& TEST_AtomicFlushSequenceNumber() {
-    return atomic_flush_seqno_;
+  void SetFlushCompleted(bool completed) { flush_completed_ = completed; }
+
+  uint64_t GetFileNumber() const { return file_number_; }
+
+  void SetFileNumber(uint64_t file_num) { file_number_ = file_num; }
+
+  void SetFlushInProgress(bool in_progress) {
+    flush_in_progress_ = in_progress;
   }
-
-  void TEST_SetFlushCompleted(bool completed) { flush_completed_ = completed; }
-
-  void TEST_SetFileNumber(uint64_t file_num) { file_number_ = file_num; }
 
  private:
   enum FlushStateEnum { FLUSH_NOT_REQUESTED, FLUSH_REQUESTED, FLUSH_SCHEDULED };

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -562,7 +562,6 @@ Status InstallMemtableAtomicFlushResults(
 
   Status s;
 
-  assert(num == cfds.size());
   autovector<autovector<VersionEdit*>> edit_lists;
   uint32_t num_entries = 0;
   for (const auto mems : mems_list) {

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -260,228 +260,6 @@ void MemTableListVersion::TrimHistory(autovector<MemTable*>* to_delete) {
   }
 }
 
-// Try to record multiple successful flush to the MANIFEST as an atomic unit.
-// This function may just return Status::OK if there has already been
-// a concurrent thread performing actual recording.
-Status MemTableList::TryInstallMemtableFlushResults(
-    autovector<MemTableList*>& imm_lists,
-    const autovector<ColumnFamilyData*>& cfds,
-    const autovector<const MutableCFOptions*>& mutable_cf_options_list,
-    const autovector<const autovector<MemTable*>*>& mems_list,
-    bool* atomic_flush_commit_in_progress, LogsWithPrepTracker* prep_tracker,
-    VersionSet* vset, InstrumentedMutex* mu,
-    const autovector<FileMetaData>& file_metas,
-    autovector<MemTable*>* to_delete, Directory* db_directory,
-    LogBuffer* log_buffer) {
-  AutoThreadOperationStageUpdater stage_updater(
-      ThreadStatus::STAGE_MEMTABLE_INSTALL_FLUSH_RESULTS);
-  mu->AssertHeld();
-
-  for (size_t k = 0; k != mems_list.size(); ++k) {
-    for (size_t i = 0; i != mems_list[k]->size(); ++i) {
-      assert(i == 0 || (*mems_list[k])[i]->GetEdits()->NumEntries() == 0);
-      (*mems_list[k])[i]->flush_completed_ = true;
-      (*mems_list[k])[i]->file_number_ = file_metas[k].fd.GetNumber();
-    }
-  }
-
-  assert(atomic_flush_commit_in_progress != nullptr);
-  Status s;
-  if (*atomic_flush_commit_in_progress) {
-    // If the function reaches here, there must be a concurrent thread that
-    // have already started recording to MANIFEST. Therefore we should just
-    // return Status::OK and let the othe thread finish writing to MANIFEST on
-    // our behalf.
-    return s;
-  }
-
-  // If the function reaches here, the current thread will start writing to
-  // MANIFEST. It may record to MANIFEST the flush results of other flushes.
-  *atomic_flush_commit_in_progress = true;
-
-  auto comp = [&imm_lists](size_t lh, size_t rh) {
-    const auto& memlist1 = imm_lists[lh]->current_->memlist_;
-    const auto& memlist2 = imm_lists[rh]->current_->memlist_;
-    auto it1 = memlist1.rbegin();
-    auto it2 = memlist2.rbegin();
-    return (*it1)->atomic_flush_seqno_ > (*it2)->atomic_flush_seqno_;
-  };
-  // The top of the heap is the memtable with smallest atomic_flush_seqno_.
-  std::priority_queue<size_t, std::vector<size_t>, decltype(comp)> heap(comp);
-  // Sequence number of the oldest unfinished atomic flush.
-  SequenceNumber min_unfinished_seqno = kMaxSequenceNumber;
-  // Populate the heap with first element of each imm iff. it has been
-  // flushed to storage, i.e. flush_completed_ is true.
-  size_t num = imm_lists.size();
-  assert(num == cfds.size());
-  for (size_t i = 0; i != num; ++i) {
-    std::list<MemTable*>& memlist = imm_lists[i]->current_->memlist_;
-    if (memlist.empty()) {
-      continue;
-    }
-    auto it = memlist.rbegin();
-    if ((*it)->flush_completed_) {
-      heap.emplace(i);
-    } else if (min_unfinished_seqno > (*it)->atomic_flush_seqno_) {
-      min_unfinished_seqno = (*it)->atomic_flush_seqno_;
-    }
-  }
-
-  while (s.ok() && !heap.empty()) {
-    autovector<size_t> batch;
-    SequenceNumber seqno = kMaxSequenceNumber;
-    // Pop from the heap the memtables that belong to the same atomic flush,
-    // namely their atomic_flush_seqno_ are equal.
-    do {
-      size_t pos = heap.top();
-      const auto& memlist = imm_lists[pos]->current_->memlist_;
-      MemTable* mem = *(memlist.rbegin());
-      if (seqno == kMaxSequenceNumber) {
-        // First mem in this batch.
-        seqno = mem->atomic_flush_seqno_;
-        batch.emplace_back(pos);
-        heap.pop();
-      } else if (mem->atomic_flush_seqno_ == seqno) {
-        // mem has the same atomic_flush_seqno_, thus in the same atomic flush.
-        batch.emplace_back(pos);
-        heap.pop();
-      } else if (mem->atomic_flush_seqno_ > seqno) {
-        // mem belongs to another atomic flush with higher seqno, break the
-        // loop.
-        break;
-      }
-    } while (!heap.empty());
-    if (seqno >= min_unfinished_seqno) {
-      // If there is an older, unfinished atomic flush, then we should not
-      // proceed.
-      TEST_SYNC_POINT_CALLBACK(
-          "MemTableList::TryInstallMemtableFlushResults:"
-          "HasOlderUnfinishedAtomicFlush:0",
-          nullptr);
-      break;
-    }
-
-    // Found the earliest, complete atomic flush. No earlier atomic flush is
-    // pending. Therefore ready to record it to the MANIFEST.
-    uint32_t num_entries = 0;
-    autovector<ColumnFamilyData*> tmp_cfds;
-    autovector<const MutableCFOptions*> tmp_mutable_cf_options_list;
-    std::vector<autovector<MemTable*>> memtables_to_flush;
-    autovector<autovector<VersionEdit*>> edit_lists;
-    for (auto pos : batch) {
-      tmp_cfds.emplace_back(cfds[pos]);
-      tmp_mutable_cf_options_list.emplace_back(mutable_cf_options_list[pos]);
-      const auto& memlist = imm_lists[pos]->current_->memlist_;
-      uint64_t batch_file_number = 0;
-      autovector<MemTable*> tmp_mems;
-      autovector<VersionEdit*> edits;
-      for (auto it = memlist.rbegin(); it != memlist.rend(); ++it) {
-        MemTable* m = *it;
-        if (!m->flush_completed_ ||
-            (it != memlist.rbegin() && m->file_number_ != batch_file_number)) {
-          break;
-        }
-        if (it == memlist.rbegin()) {
-          batch_file_number = m->file_number_;
-          edits.push_back(m->GetEdits());
-          ++num_entries;
-        }
-        tmp_mems.push_back(m);
-      }
-      edit_lists.push_back(edits);
-      memtables_to_flush.push_back(tmp_mems);
-    }
-    TEST_SYNC_POINT_CALLBACK(
-        "MemTableList::TryInstallMemtableFlushResults:FoundBatchToCommit:0",
-        &num_entries);
-
-    // Mark the version edits as an atomic group
-    uint32_t remaining = num_entries;
-    for (auto& edit_list : edit_lists) {
-      assert(edit_list.size() == 1);
-      edit_list[0]->MarkAtomicGroup(--remaining);
-    }
-    assert(remaining == 0);
-
-    size_t batch_sz = batch.size();
-    assert(batch_sz > 0);
-    assert(batch_sz == memtables_to_flush.size());
-    assert(batch_sz == tmp_cfds.size());
-    assert(batch_sz == edit_lists.size());
-
-    if (vset->db_options()->allow_2pc) {
-      for (size_t i = 0; i != batch_sz; ++i) {
-        auto& edit_list = edit_lists[i];
-        assert(!edit_list.empty());
-        edit_list.back()->SetMinLogNumberToKeep(
-            PrecomputeMinLogNumberToKeep(vset, *tmp_cfds[i], edit_list,
-                                         memtables_to_flush[i], prep_tracker));
-      }
-    }
-    // this can release and reacquire the mutex.
-    s = vset->LogAndApply(tmp_cfds, tmp_mutable_cf_options_list, edit_lists, mu,
-                          db_directory);
-
-    for (const auto pos : batch) {
-      imm_lists[pos]->InstallNewVersion();
-    }
-
-    if (s.ok() || s.IsShutdownInProgress()) {
-      for (size_t i = 0; i != batch_sz; ++i) {
-        if (tmp_cfds[i]->IsDropped()) {
-          continue;
-        }
-        size_t pos = batch[i];
-        for (auto m : memtables_to_flush[i]) {
-          assert(m->file_number_ > 0);
-          uint64_t mem_id = m->GetID();
-          ROCKS_LOG_BUFFER(log_buffer,
-                           "[%s] Level-0 commit table #%" PRIu64
-                           ": memtable #%" PRIu64 " done",
-                           tmp_cfds[i]->GetName().c_str(), m->file_number_,
-                           mem_id);
-          imm_lists[pos]->current_->Remove(m, to_delete);
-        }
-      }
-    } else {
-      for (size_t i = 0; i != batch_sz; ++i) {
-        size_t pos = batch[i];
-        for (auto m : memtables_to_flush[i]) {
-          uint64_t mem_id = m->GetID();
-          ROCKS_LOG_BUFFER(log_buffer,
-                           "[%s] Level-0 commit table #%" PRIu64
-                           ": memtable #%" PRIu64 " failed",
-                           tmp_cfds[i]->GetName().c_str(), m->file_number_,
-                           mem_id);
-          m->flush_completed_ = false;
-          m->flush_in_progress_ = false;
-          m->edit_.Clear();
-          m->file_number_ = 0;
-          imm_lists[pos]->num_flush_not_started_++;
-        }
-        imm_lists[pos]->imm_flush_needed.store(true, std::memory_order_release);
-      }
-    }
-    // Adjust the heap AFTER installing new MemTableListVersions because the
-    // compare function 'comp' needs to capture the most up-to-date state of
-    // imm_lists.
-    for (auto pos : batch) {
-      const auto& memlist = imm_lists[pos]->current_->memlist_;
-      if (!memlist.empty()) {
-        MemTable* mem = *(memlist.rbegin());
-        if (mem->flush_completed_) {
-          heap.emplace(pos);
-        } else if (min_unfinished_seqno > mem->atomic_flush_seqno_) {
-          min_unfinished_seqno = mem->atomic_flush_seqno_;
-        }
-      }
-    }
-  }
-
-  *atomic_flush_commit_in_progress = false;
-  return s;
-}
-
 // Returns true if there is at least one memtable on which flush has
 // not yet started.
 bool MemTableList::IsFlushPending() const {
@@ -747,6 +525,108 @@ uint64_t MemTableList::PrecomputeMinLogContainingPrepSection(
   }
 
   return min_log;
+}
+
+// Commit a successful atomic flush in the manifest file.
+Status InstallMemtableAtomicFlushResults(
+    const autovector<MemTableList*>* imm_lists,
+    const autovector<ColumnFamilyData*>& cfds,
+    const autovector<const MutableCFOptions*>& mutable_cf_options_list,
+    const autovector<const autovector<MemTable*>*>& mems_list, VersionSet* vset,
+    InstrumentedMutex* mu, const autovector<FileMetaData>& file_metas,
+    autovector<MemTable*>* to_delete, Directory* db_directory,
+    LogBuffer* log_buffer) {
+  AutoThreadOperationStageUpdater stage_updater(
+      ThreadStatus::STAGE_MEMTABLE_INSTALL_FLUSH_RESULTS);
+  mu->AssertHeld();
+
+  size_t num = mems_list.size();
+  assert(cfds.size() == num);
+  if (imm_lists != nullptr) {
+    assert(imm_lists->size() == num);
+  }
+  for (size_t k = 0; k != num; ++k) {
+#ifndef NDEBUG
+    const auto* imm =
+        (imm_lists == nullptr) ? cfds[k]->imm() : imm_lists->at(k);
+    if (!mems_list[k]->empty()) {
+      assert((*mems_list[k])[0]->GetID() == imm->GetEarliestMemTableID());
+    }
+#endif
+    for (size_t i = 0; i != mems_list[k]->size(); ++i) {
+      assert(i == 0 || (*mems_list[k])[i]->GetEdits()->NumEntries() == 0);
+      (*mems_list[k])[i]->SetFlushCompleted(true);
+      (*mems_list[k])[i]->SetFileNumber(file_metas[k].fd.GetNumber());
+    }
+  }
+
+  Status s;
+
+  assert(num == cfds.size());
+  autovector<autovector<VersionEdit*>> edit_lists;
+  uint32_t num_entries = 0;
+  for (const auto mems : mems_list) {
+    assert(mems != nullptr);
+    autovector<VersionEdit*> edits;
+    assert(!mems->empty());
+    edits.emplace_back((*mems)[0]->GetEdits());
+    ++num_entries;
+    edit_lists.emplace_back(edits);
+  }
+  // Mark the version edits as an atomic group
+  for (auto& edits : edit_lists) {
+    assert(edits.size() == 1);
+    edits[0]->MarkAtomicGroup(--num_entries);
+  }
+  assert(0 == num_entries);
+
+  // this can release and reacquire the mutex.
+  s = vset->LogAndApply(cfds, mutable_cf_options_list, edit_lists, mu,
+                        db_directory);
+
+  for (size_t k = 0; k != cfds.size(); ++k) {
+    auto* imm = (imm_lists == nullptr) ? cfds[k]->imm() : imm_lists->at(k);
+    imm->InstallNewVersion();
+  }
+
+  if (s.ok() || s.IsShutdownInProgress()) {
+    for (size_t i = 0; i != cfds.size(); ++i) {
+      if (cfds[i]->IsDropped()) {
+        continue;
+      }
+      auto* imm = (imm_lists == nullptr) ? cfds[i]->imm() : imm_lists->at(i);
+      for (auto m : *mems_list[i]) {
+        assert(m->GetFileNumber() > 0);
+        uint64_t mem_id = m->GetID();
+        ROCKS_LOG_BUFFER(log_buffer,
+                         "[%s] Level-0 commit table #%" PRIu64
+                         ": memtable #%" PRIu64 " done",
+                         cfds[i]->GetName().c_str(), m->GetFileNumber(),
+                         mem_id);
+        imm->current_->Remove(m, to_delete);
+      }
+    }
+  } else {
+    for (size_t i = 0; i != cfds.size(); ++i) {
+      auto* imm = (imm_lists == nullptr) ? cfds[i]->imm() : imm_lists->at(i);
+      for (auto m : *mems_list[i]) {
+        uint64_t mem_id = m->GetID();
+        ROCKS_LOG_BUFFER(log_buffer,
+                         "[%s] Level-0 commit table #%" PRIu64
+                         ": memtable #%" PRIu64 " failed",
+                         cfds[i]->GetName().c_str(), m->GetFileNumber(),
+                         mem_id);
+        m->SetFlushCompleted(false);
+        m->SetFlushInProgress(false);
+        m->GetEdits()->Clear();
+        m->SetFileNumber(0);
+        imm->num_flush_not_started_++;
+      }
+      imm->imm_flush_needed.store(true, std::memory_order_release);
+    }
+  }
+
+  return s;
 }
 
 }  // namespace rocksdb

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1019,7 +1019,9 @@ TEST_P(VersionSetTestDropOneCF, HandleDroppedColumnFamilyInAtomicGroup) {
   auto cfd_to_drop =
       versions_->GetColumnFamilySet()->GetColumnFamily(cf_to_drop_name);
   ASSERT_NE(nullptr, cfd_to_drop);
-  cfd_to_drop->Ref(); // Increase its refcount because cfd_to_drop is used later
+  // Increase its refcount because cfd_to_drop is used later, and we need to
+  // prevent it from being deleted.
+  cfd_to_drop->Ref();
   drop_cf_edit.SetColumnFamily(cfd_to_drop->GetID());
   mutex_.Lock();
   s = versions_->LogAndApply(cfd_to_drop,


### PR DESCRIPTION
Summary: as titled.
Since different bg flush threads can flush different sets of column families
(due to column family creation and drop), we decide not to let one thread
perform atomic flush result installation for other threads. Bg flush threads
will install their atomic flush results sequentially to MANIFEST, using
a conditional variable, i.e. atomic_flush_install_cv_ to coordinate.

Test Plan:
```
$make clean && make -j32 all check
$./db_stress -atomic_flush=true
$./db_stress -atomic_flush=true -disable_wal=1 -reopen=0
$rm -f /dev/shm/dbstress.tmp && rm -rf /dev/shm/dbstress/ && touch /dev/shm/dbstress.tmp && for i in $(seq 100); do TEST_TMPDIR=/dev/shm ./db_stress -atomic_flush=true -reopen=0 -expected_values_path=/dev/shm/dbstress.tmp -destroy_db_initially=false -clear_column_family_one_in=0 -max_key=1000000 -value_size_mult=33 -write_buffer_size=1048576 -max_bytes_for_level_base=4194304 -target_file_size_base=1048576 -max_background_compactions=1 -allow_concurrent_memtable_write=false -flush_one_in=100 -ops_per_thread=50000 -disable_wal=true -threads=6 ; done
```

All tests must pass.