### PR TITLE
Compaction limiter miscs

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -4053,7 +4053,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
     dbfull()->TEST_WaitForFlushMemTable(handles_[cf]);
   }
 
-  dbfull()->TEST_WaitForCompact();
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 
   // Max outstanding compact tasks reached limit
   for (auto& ls : limiter_settings) {
@@ -4076,8 +4076,7 @@ TEST_F(DBCompactionTest, CompactionLimiter) {
   ASSERT_EQ(1, NumTableFilesAtLevel(0, cf_test));
 
   Compact(cf_test, Key(0), Key(keyIndex));
-  dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(0, unique_limiter->GetOutstandingTask());
+  ASSERT_OK(dbfull()->TEST_WaitForCompact());
 }
 
 INSTANTIATE_TEST_CASE_P(DBCompactionTestWithParam, DBCompactionTestWithParam,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1114,9 +1114,6 @@ class DBImpl : public DB {
   // Schedule background tasks
   void StartTimedTasks();
 
-  void SubtractCompactionTask(const std::string& device_name,
-                              LogBuffer* log_buffer);
-
   void PrintStatistics();
 
   // dump rocksdb.stats to LOG

--- a/util/concurrent_task_limiter_impl.cc
+++ b/util/concurrent_task_limiter_impl.cc
@@ -21,6 +21,7 @@ ConcurrentTaskLimiterImpl::ConcurrentTaskLimiterImpl(
 }
 
 ConcurrentTaskLimiterImpl::~ConcurrentTaskLimiterImpl() {
+  assert(outstanding_tasks_ == 0);
 }
 
 const std::string& ConcurrentTaskLimiterImpl::GetName() const {


### PR DESCRIPTION
1. Remove unused API SubtractCompactionTask().
2. Assert outstanding tasks drop to zero in ConcurrentTaskLimiterImpl destructor.
3. Remove GetOutstandingTask() check from manual compaction test, as TEST_WaitForCompact() doesn't synced with 'delete prepicked_compaction' in DBImpl::BGWorkCompaction(), which may make the test flaky.