### PR TITLE
Fix Windows broken build error due to non-const override

### DIFF
--- a/db/range_del_aggregator_bench.cc
+++ b/db/range_del_aggregator_bench.cc
@@ -197,7 +197,8 @@ int main(int argc, char** argv) {
       // real workloads.
       for (int j = 0; j < FLAGS_num_range_tombstones; j++) {
         uint64_t start = rnd.Uniform(FLAGS_tombstone_start_upper_bound);
-        uint64_t end = start + std::max(1.0, normal_dist(random_gen));
+        uint64_t end = static_cast<uint64_t>(
+            std::round(start + std::max(1.0, normal_dist(random_gen))));
         persistent_range_tombstones[j] = rocksdb::PersistentRangeTombstone(
             rocksdb::Key(start), rocksdb::Key(end), j);
       }

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -237,7 +237,7 @@ class Transaction {
                               ColumnFamilyHandle* column_family,
                               const Slice& key, std::string* value,
                               bool exclusive = true,
-                              bool do_validate = true) = 0;
+                              const bool do_validate = true) = 0;
 
   // An overload of the above method that receives a PinnableSlice
   // For backward compatibility a default implementation is provided


### PR DESCRIPTION
1) `transaction_base.h` overrides from `transaction.h` with a `const boolean do_validate`.
The non-const base declaration, which I cannot see the need for, causes a compilation error on Microsoft Windows.

2) Implicit cast from `double` to `uint64_t` causes a compilation error on Microsoft Windows.