### PR TITLE
Change is_range_del_table_empty_ flag to atomic

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -414,7 +414,8 @@ InternalIterator* MemTable::NewIterator(const ReadOptions& read_options,
 
 FragmentedRangeTombstoneIterator* MemTable::NewRangeTombstoneIterator(
     const ReadOptions& read_options, SequenceNumber read_seq) {
-  if (read_options.ignore_range_deletions || is_range_del_table_empty_) {
+  if (read_options.ignore_range_deletions ||
+      is_range_del_table_empty_.load(std::memory_order_acquire)) {
     return nullptr;
   }
   auto* unfragmented_iter = new MemTableIterator(
@@ -563,8 +564,8 @@ bool MemTable::Add(SequenceNumber s, ValueType type,
         !first_seqno_.compare_exchange_weak(cur_earliest_seqno, s)) {
     }
   }
-  if (is_range_del_table_empty_ && type == kTypeRangeDeletion) {
-    is_range_del_table_empty_ = false;
+  if (type == kTypeRangeDeletion) {
+    is_range_del_table_empty_.store(false, std::memory_order_release);
   }
   UpdateOldestKeyTime();
   return true;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -415,7 +415,7 @@ InternalIterator* MemTable::NewIterator(const ReadOptions& read_options,
 FragmentedRangeTombstoneIterator* MemTable::NewRangeTombstoneIterator(
     const ReadOptions& read_options, SequenceNumber read_seq) {
   if (read_options.ignore_range_deletions ||
-      is_range_del_table_empty_.load(std::memory_order_acquire)) {
+      is_range_del_table_empty_.load(std::memory_order_relaxed)) {
     return nullptr;
   }
   auto* unfragmented_iter = new MemTableIterator(
@@ -565,7 +565,7 @@ bool MemTable::Add(SequenceNumber s, ValueType type,
     }
   }
   if (type == kTypeRangeDeletion) {
-    is_range_del_table_empty_.store(false, std::memory_order_release);
+    is_range_del_table_empty_.store(false, std::memory_order_relaxed);
   }
   UpdateOldestKeyTime();
   return true;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -409,7 +409,7 @@ class MemTable {
   ConcurrentArena arena_;
   std::unique_ptr<MemTableRep> table_;
   std::unique_ptr<MemTableRep> range_del_table_;
-  bool is_range_del_table_empty_;
+  std::atomic_bool is_range_del_table_empty_;
 
   // Total data size of all data inserted
   std::atomic<uint64_t> data_size_;


### PR DESCRIPTION
Summary: To avoid a race on the flag, make it an atomic_bool. This
doesn't seem to significantly affect benchmarks.

Test Plan:
- run readwhilewriting benchmark with db_bench on a DB with
range tombstones
- run crashtests with tsan enabled