### PR TITLE
Extend StringAppendTESTOperator to use string delimiter of variable length

### DIFF
--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -38,6 +38,28 @@ jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendOperator(
 
 /*
  * Class:     org_rocksdb_StringAppendOperator
+ * Method:    newSharedStringAppendTESTOperator
+ * Signature: ([B)J
+ */
+jlong Java_org_rocksdb_StringAppendOperator_newSharedStringAppendTESTOperator(
+        JNIEnv* env, jclass /*jclazz*/, jbyteArray jdelim) {
+  jboolean has_exception = JNI_FALSE;
+  std::string delim = rocksdb::JniUtil::byteString<std::string>(
+          env, jdelim,
+          [](const char* str, const size_t len) { return std::string(str, len); },
+          &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  auto* sptr_string_append_test_op = new std::shared_ptr<rocksdb::MergeOperator>(
+          rocksdb::MergeOperators::CreateStringAppendTESTOperator(delim));
+  return reinterpret_cast<jlong>(sptr_string_append_test_op);
+}
+
+/*
+ * Class:     org_rocksdb_StringAppendOperator
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/StringAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/StringAppendOperator.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import java.nio.charset.Charset;
+
 /**
  * StringAppendOperator is a merge operator that concatenates
  * two strings.
@@ -18,6 +20,19 @@ public class StringAppendOperator extends MergeOperator {
         super(newSharedStringAppendOperator(delim));
     }
 
+    public StringAppendOperator(byte[] delim) {
+        super(newSharedStringAppendTESTOperator(delim));
+    }
+
+    public StringAppendOperator(String delim) {
+        this(delim.getBytes());
+    }
+
+    public StringAppendOperator(String delim, Charset charset) {
+        this(delim.getBytes(charset));
+    }
+
     private native static long newSharedStringAppendOperator(final char delim);
+    private native static long newSharedStringAppendTESTOperator(final byte[] delim);
     @Override protected final native void disposeInternal(final long handle);
 }

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -184,6 +184,31 @@ public class MergeTest {
   }
 
   @Test
+  public void stringDelimiter() throws RocksDBException {
+    stringDelimiter("DELIM");
+    stringDelimiter("");
+  }
+
+  private void stringDelimiter(String delim) throws RocksDBException {
+    try (final StringAppendOperator stringAppendOperator = new StringAppendOperator(delim.getBytes());
+         final Options opt = new Options()
+                 .setCreateIfMissing(true)
+                 .setMergeOperator(stringAppendOperator);
+         final RocksDB db = RocksDB.open(opt, dbFolder.getRoot().getAbsolutePath())) {
+      // Writing aa under key
+      db.put("key".getBytes(), "aa".getBytes());
+
+      // Writing bb under key
+      db.merge("key".getBytes(), "bb".getBytes());
+
+      final byte[] value = db.get("key".getBytes());
+      final String strValue = new String(value);
+
+      assertThat(strValue).isEqualTo("aa" + delim + "bb");
+    }
+  }
+
+  @Test
   public void uint64AddOperatorOption()
       throws InterruptedException, RocksDBException {
     try (final UInt64AddOperator uint64AddOperator = new UInt64AddOperator();

--- a/utilities/merge_operators.h
+++ b/utilities/merge_operators.h
@@ -21,6 +21,7 @@ class MergeOperators {
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator();
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator(char delim_char);
   static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator();
+  static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator(std::string delim);
   static std::shared_ptr<MergeOperator> CreateMaxOperator();
   static std::shared_ptr<MergeOperator> CreateBytesXOROperator();
 

--- a/utilities/merge_operators/string_append/stringappend2.h
+++ b/utilities/merge_operators/string_append/stringappend2.h
@@ -13,7 +13,7 @@
 #pragma once
 #include <deque>
 #include <string>
-
+#include <utility>
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/slice.h"
 
@@ -21,18 +21,20 @@ namespace rocksdb {
 
 class StringAppendTESTOperator : public MergeOperator {
  public:
-  // Constructor with delimiter
-  explicit StringAppendTESTOperator(char delim_char);
+  // Constructor with string delimiter
+  explicit StringAppendTESTOperator(std::string delim_str) : delim_(std::move(delim_str)) {};
 
-  virtual bool FullMergeV2(const MergeOperationInput& merge_in,
-                           MergeOperationOutput* merge_out) const override;
+  // Constructor with char delimiter
+  explicit StringAppendTESTOperator(char delim_char) : delim_(std::string(1, delim_char)) {};
 
-  virtual bool PartialMergeMulti(const Slice& key,
-                                 const std::deque<Slice>& operand_list,
-                                 std::string* new_value, Logger* logger) const
-      override;
+  bool FullMergeV2(const MergeOperationInput& merge_in,
+                   MergeOperationOutput* merge_out) const override;
 
-  virtual const char* Name() const override;
+  bool PartialMergeMulti(const Slice& key,
+                         const std::deque<Slice>& operand_list,
+                         std::string* new_value, Logger* logger) const override;
+
+  const char* Name() const override;
 
  private:
   // A version of PartialMerge that actually performs "partial merging".
@@ -41,7 +43,7 @@ class StringAppendTESTOperator : public MergeOperator {
                                const std::deque<Slice>& operand_list,
                                std::string* new_value, Logger* logger) const;
 
-  char delim_;         // The delimiter is inserted between elements
+  std::string delim_;         // The delimiter is inserted between elements
 
 };
 


### PR DESCRIPTION
This PR extend StringAppendTESTOperator class to use `std::string` delimiter instead of `char`. `char` becomes then a custom case of `std::string`. This allows for delimiter of variable length, including zero length if delimiter is not needed at all and space can be saved. The PR also extends `StringAppendOperator` in Java API.