### PR TITLE
fix DeleteRange memory leak for mmap and block cache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,8 @@
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.
+* Fix a memory leak when files with range tombstones are read in mmap mode and block cache is enabled
+* Fix handling of corrupt range tombstone blocks such that corruptions cannot cause deleted keys to reappear
 
 ## 5.18.0 (11/30/2018)
 ### New Features

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -492,7 +492,7 @@ TEST_F(CorruptionTest, RangeDeletionCorrupted) {
       ImmutableCFOptions(options_), kRangeDelBlock, &range_del_handle));
 
   ASSERT_OK(TryReopen());
-  CorruptFile(filename, range_del_handle.offset(), 1);
+  CorruptFile(filename, static_cast<int>(range_del_handle.offset()), 1);
   // The test case does not fail on TryReopen because failure to preload table
   // handlers is not considered critical.
   ASSERT_OK(TryReopen());

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -24,6 +24,8 @@
 #include "rocksdb/env.h"
 #include "rocksdb/table.h"
 #include "rocksdb/write_batch.h"
+#include "table/block_based_table_builder.h"
+#include "table/meta_blocks.h"
 #include "util/filename.h"
 #include "util/string_util.h"
 #include "util/testharness.h"
@@ -465,6 +467,37 @@ TEST_F(CorruptionTest, UnrelatedKeys) {
   dbi->TEST_FlushMemTable();
   ASSERT_OK(db_->Get(ReadOptions(), Key(1000, &tmp1), &v));
   ASSERT_EQ(Value(1000, &tmp2).ToString(), v);
+}
+
+TEST_F(CorruptionTest, RangeDeletionCorrupted) {
+  ASSERT_OK(
+      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "a", "b"));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  std::vector<LiveFileMetaData> metadata;
+  db_->GetLiveFilesMetaData(&metadata);
+  ASSERT_EQ(static_cast<size_t>(1), metadata.size());
+  std::string filename = dbname_ + metadata[0].name;
+
+  std::unique_ptr<RandomAccessFile> file;
+  ASSERT_OK(options_.env->NewRandomAccessFile(filename, &file, EnvOptions()));
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(std::move(file), filename));
+
+  uint64_t file_size;
+  ASSERT_OK(options_.env->GetFileSize(filename, &file_size));
+
+  BlockHandle range_del_handle;
+  ASSERT_OK(FindMetaBlock(
+      file_reader.get(), file_size, kBlockBasedTableMagicNumber,
+      ImmutableCFOptions(options_), kRangeDelBlock, &range_del_handle));
+
+  ASSERT_OK(TryReopen());
+  CorruptFile(filename, range_del_handle.offset(), 20);
+  // make sure the block isn't in cache
+  tiny_cache_ = NewLRUCache(100, 4);
+  ASSERT_OK(TryReopen());
+  std::string val;
+  ASSERT_TRUE(db_->Get(ReadOptions(), "a", &val).IsCorruption());
 }
 
 TEST_F(CorruptionTest, FileSystemStateCorrupted) {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -492,11 +492,13 @@ TEST_F(CorruptionTest, RangeDeletionCorrupted) {
       ImmutableCFOptions(options_), kRangeDelBlock, &range_del_handle));
 
   ASSERT_OK(TryReopen());
-  CorruptFile(filename, range_del_handle.offset(), 20);
-  // make sure the block isn't in cache
-  tiny_cache_ = NewLRUCache(100, 4);
+  CorruptFile(filename, range_del_handle.offset(), 1);
+  // The test case does not fail on TryReopen because failure to preload table
+  // handlers is not considered critical.
   ASSERT_OK(TryReopen());
   std::string val;
+  // However, it does fail on any read involving that file since that file
+  // cannot be opened with a corrupt range deletion meta-block.
   ASSERT_TRUE(db_->Get(ReadOptions(), "a", &val).IsCorruption());
 }
 

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -365,7 +365,7 @@ class BlockBasedTable : public TableReader {
                                     const SequenceNumber largest_seqno);
   static Status ReadRangeDelBlock(
       Rep* rep, FilePrefetchBuffer* prefetch_buffer,
-      InternalIterator* meta_iter, BlockBasedTable* new_table,
+      InternalIterator* meta_iter,
       const InternalKeyComparator& internal_comparator);
   static Status ReadCompressionDictBlock(Rep* rep,
                                          FilePrefetchBuffer* prefetch_buffer,
@@ -406,9 +406,6 @@ class BlockBasedTable : public TableReader {
 
   friend class PartitionedFilterBlockReader;
   friend class PartitionedFilterBlockTest;
-
-  InternalIterator* NewUnfragmentedRangeTombstoneIterator(
-      const ReadOptions& read_options);
 };
 
 // Maitaning state of a two-level iteration on a partitioned index structure
@@ -468,7 +465,6 @@ struct BlockBasedTable::Rep {
         hash_index_allow_collision(false),
         whole_key_filtering(_table_opt.whole_key_filtering),
         prefix_filtering(true),
-        range_del_handle(BlockHandle::NullBlockHandle()),
         global_seqno(kDisableGlobalSequenceNumber),
         level(_level),
         immortal_table(_immortal_table) {}
@@ -532,10 +528,6 @@ struct BlockBasedTable::Rep {
   // push flush them out, hence they're pinned
   CachableEntry<FilterBlockReader> filter_entry;
   CachableEntry<IndexReader> index_entry;
-  // range deletion meta-block is pinned through reader's lifetime when LRU
-  // cache is enabled.
-  CachableEntry<Block> range_del_entry;
-  BlockHandle range_del_handle;
   std::shared_ptr<const FragmentedRangeTombstoneList> fragmented_range_dels;
 
   // If global_seqno is used, all Keys in this file will have the same


### PR DESCRIPTION
Previously we were cleaning up range tombstone meta-block by calling `ReleaseCachedEntry`, which wouldn't work if `value != nullptr && cache_handle == nullptr`. This happened at least in the case with mmap reads and block cache both enabled. I noticed `NewDataBlockIterator` intends to handle all these cases, so migrated to that instead of `NewUnfragmentedRangeTombstoneIterator`.

Also changed the table-opening logic to fail on `ReadRangeDelBlock` failure, since that can cause data corruption. Added a test case to verify this behavior. Note the test case does not fail on `TryReopen` because failure to preload table handlers is not considered critical. However, it does fail on any read involving that file since it cannot return correct data.

Test Plan:

- `python tools/db_crashtest.py whitebox`
- example command that failed before and passes now:
```
$ COMPILE_WITH_ASAN=1 make -j64 db_stress
$ TEST_TMPDIR=/dev/shm ./db_stress --snapshot_hold_ops=100000 --format_version=2 --memtablerep=skip_list --max_write_buffer_number=3 --value_size_mult=33 --reopen=0 --acquire_snapshot_one_in=10000 --delpercent=4 --log2_keys_per_lock=10 --block_size=16384 --use_direct_reads=0 --allow_concurrent_memtable_write=1 --compact_files_one_in=1000000 --target_file_size_multiplier=1 --clear_column_family_one_in=0 --use_full_merge_v1=1 --progress_reports=0 --checkpoint_one_in=1000000 --mmap_read=1 --writepercent=59 --readpercent=25 --subcompactions=3 --use_merge=1 --write_buffer_size=1048576 --test_batches_snapshots=0 --column_families=1 --max_bytes_for_level_base=67108864 --compact_range_one_in=1000000 --open_files=500000 --destroy_db_initially=1 --max_background_compactions=1 --target_file_size_base=16777216 --compression_zstd_max_train_bytes=0 --enable_pipelined_write=0 --nooverwritepercent=1 --compression_max_dict_bytes=16384 --max_key=1000000 --prefixpercent=1 --flush_one_in=1000000 --ops_per_thread=2000 --index_block_restart_interval=15 --cache_size=1048576 --compaction_style=1 --verify_checksum=1 --delrangepercent=1 --use_direct_io_for_flush_and_compaction=0 --compression_type=zstd
```
- new unit test