### PR TITLE
sst_dump recompress show #blocks compressed and not compressed

### DIFF
--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -202,7 +202,7 @@ int SstFileDumper::ShowAllCompressionSizes(
   ReadOptions read_options;
   Options opts;
   opts.statistics = rocksdb::CreateDBStatistics();
-  opts.statistics->stats_level_ = StatsLevel::kAll;
+  opts.statistics->set_stats_level(StatsLevel::kAll);
   const ImmutableCFOptions imoptions(opts);
   const ColumnFamilyOptions cfo(opts);
   const MutableCFOptions moptions(cfo);

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -222,7 +222,7 @@ int SstFileDumper::ShowAllCompressionSizes(
           false /* skip_filters */, column_family_name, unknown_level);
       uint64_t num_data_blocks = 0;
       uint64_t file_size = CalculateCompressedTableSize(tb_opts, block_size,
-                                                        num_data_blocks);
+                                                        &num_data_blocks);
       fprintf(stdout, "Compression: %-24s", i.second);
       fprintf(stdout, " Size: %10" PRIu64, file_size);
       fprintf(stdout, " Blocks: %6" PRIu64, num_data_blocks);

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -189,6 +189,7 @@ uint64_t SstFileDumper::CalculateCompressedTableSize(
     exit(1);
   }
   uint64_t size = table_builder->FileSize();
+  assert(num_data_blocks != nullptr);
   *num_data_blocks = table_builder->GetTableProperties().num_data_blocks;
   env->DeleteFile(testFileName);
   return size;

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -231,6 +231,8 @@ int SstFileDumper::ShowAllCompressionSizes(
         opts.statistics->getAndResetTickerCount(NUMBER_BLOCK_COMPRESSED);
       const uint64_t not_compressed_blocks =
         opts.statistics->getAndResetTickerCount(NUMBER_BLOCK_NOT_COMPRESSED);
+      // When the option enable_index_compression is true,
+      // NUMBER_BLOCK_COMPRESSED is incremented for index block(s).
       if( (compressed_blocks + not_compressed_blocks) > num_data_blocks ){
         num_data_blocks = compressed_blocks + not_compressed_blocks;
       }

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -159,7 +159,7 @@ Status SstFileDumper::DumpTable(const std::string& out_filename) {
 
 uint64_t SstFileDumper::CalculateCompressedTableSize(
     const TableBuilderOptions& tb_options, size_t block_size,
-    uint64_t& num_data_blocks) {
+    uint64_t* num_data_blocks) {
   std::unique_ptr<WritableFile> out_file;
   std::unique_ptr<Env> env(NewMemEnv(Env::Default()));
   env->NewWritableFile(testFileName, &out_file, soptions_);
@@ -189,7 +189,7 @@ uint64_t SstFileDumper::CalculateCompressedTableSize(
     exit(1);
   }
   uint64_t size = table_builder->FileSize();
-  num_data_blocks = table_builder->GetTableProperties().num_data_blocks;
+  *num_data_blocks = table_builder->GetTableProperties().num_data_blocks;
   env->DeleteFile(testFileName);
   return size;
 }

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -46,7 +46,8 @@ class SstFileDumper {
                              RandomAccessFileReader* file, uint64_t file_size);
 
   uint64_t CalculateCompressedTableSize(const TableBuilderOptions& tb_options,
-                                        size_t block_size);
+                                        size_t block_size,
+                                        uint64_t& num_data_blocks);
 
   Status SetTableOptionsByMagicNumber(uint64_t table_magic_number);
   Status SetOldTableOptions();

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -47,7 +47,7 @@ class SstFileDumper {
 
   uint64_t CalculateCompressedTableSize(const TableBuilderOptions& tb_options,
                                         size_t block_size,
-                                        uint64_t& num_data_blocks);
+                                        uint64_t* num_data_blocks);
 
   Status SetTableOptionsByMagicNumber(uint64_t table_magic_number);
   Status SetOldTableOptions();


### PR DESCRIPTION
Closes #1474
Helps show when the 12.5% threshold for GoodCompressionRatio (originally from ldb) is hit.

Example output:

```
> ./sst_dump --file=/tmp/test.sst --command=recompress
from [] to []
Process /tmp/test.sst
Sst file format: block-based
Block Size: 16384
Compression: kNoCompression           Size:  122579836 Blocks:   2300 Compressed:      0 (  0.0%) Not compressed (ratio):   2300 (100.0%) Not compressed (abort):      0 (  0.0%)
Compression: kSnappyCompression       Size:   46289962 Blocks:   2300 Compressed:   2119 ( 92.1%) Not compressed (ratio):    181 (  7.9%) Not compressed (abort):      0 (  0.0%)
Compression: kZlibCompression         Size:   29689825 Blocks:   2300 Compressed:   2301 (100.0%) Not compressed (ratio):      0 (  0.0%) Not compressed (abort):      0 (  0.0%)
Unsupported compression type: kBZip2Compression.
Compression: kLZ4Compression          Size:   44785490 Blocks:   2300 Compressed:   1950 ( 84.8%) Not compressed (ratio):    350 ( 15.2%) Not compressed (abort):      0 (  0.0%)
Compression: kLZ4HCCompression        Size:   37498895 Blocks:   2300 Compressed:   2301 (100.0%) Not compressed (ratio):      0 (  0.0%) Not compressed (abort):      0 (  0.0%)
Unsupported compression type: kXpressCompression.
Compression: kZSTD                    Size:   32208707 Blocks:   2300 Compressed:   2301 (100.0%) Not compressed (ratio):      0 (  0.0%) Not compressed (abort):      0 (  0.0%)
```