### PR TITLE
Try to fix DBSSTTest.RateLimitedDelete flakiness

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -385,6 +385,7 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
 
   // Compaction will move the 4 files in L0 to trash and create 1 L1 file
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
   ASSERT_EQ("0,1", FilesPerLevel(0));
 
   uint64_t delete_start_time = env_->NowMicros();


### PR DESCRIPTION
Summary: DBSSTTest.RateLimitedDelete is flakey. The root cause is not completely identified, but
the compaction waiting in the test doesn't strictly wait for compaction cleaning to finish, which
may cause test flakiness. Fix it first and see whether the failures still happen.

Test Plan: Run the test and make sure it still passes.