### PR TITLE
Detect if Jemalloc is linked with the binary

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -11,7 +11,6 @@ rocksdb_compiler_flags = [
     "-DROCKSDB_PLATFORM_POSIX",
     "-DROCKSDB_LIB_IO_POSIX",
     "-DROCKSDB_FALLOCATE_PRESENT",
-    "-DROCKSDB_JEMALLOC",
     "-DROCKSDB_MALLOC_USABLE_SIZE",
     "-DROCKSDB_RANGESYNC_PRESENT",
     "-DROCKSDB_SCHED_GETCPU_PRESENT",
@@ -44,7 +43,6 @@ rocksdb_external_deps = [
     ("tbb", None),
     ("numa", None, "numa"),
     ("googletest", None, "gtest"),
-    ("jemalloc", None, "headers"),
 ]
 
 rocksdb_preprocessor_flags = [
@@ -68,6 +66,14 @@ is_opt_mode = build_mode.startswith("opt")
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
+
+sanitizer = read_config("fbcode", "sanitizer")
+
+# Do not enable jemalloc if sanitizer presents. RocksDB will further detect
+# whether the binary is linked with jemalloc at runtime.
+if sanitizer == "":
+    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
+    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 
 cpp_library(
     name = "rocksdb_lib",

--- a/TARGETS
+++ b/TARGETS
@@ -11,6 +11,7 @@ rocksdb_compiler_flags = [
     "-DROCKSDB_PLATFORM_POSIX",
     "-DROCKSDB_LIB_IO_POSIX",
     "-DROCKSDB_FALLOCATE_PRESENT",
+    "-DROCKSDB_JEMALLOC",
     "-DROCKSDB_MALLOC_USABLE_SIZE",
     "-DROCKSDB_RANGESYNC_PRESENT",
     "-DROCKSDB_SCHED_GETCPU_PRESENT",
@@ -43,6 +44,7 @@ rocksdb_external_deps = [
     ("tbb", None),
     ("numa", None, "numa"),
     ("googletest", None, "gtest"),
+    ("jemalloc", None, "headers"),
 ]
 
 rocksdb_preprocessor_flags = [
@@ -66,16 +68,6 @@ is_opt_mode = build_mode.startswith("opt")
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
-
-default_allocator = read_config("fbcode", "default_allocator")
-
-sanitizer = read_config("fbcode", "sanitizer")
-
-# Let RocksDB aware of jemalloc existence.
-# Do not enable it if sanitizer presents.
-if is_opt_mode and default_allocator.startswith("jemalloc") and sanitizer == "":
-    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
-    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 
 cpp_library(
     name = "rocksdb_lib",

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -15,7 +15,6 @@ rocksdb_compiler_flags = [
     "-DROCKSDB_PLATFORM_POSIX",
     "-DROCKSDB_LIB_IO_POSIX",
     "-DROCKSDB_FALLOCATE_PRESENT",
-    "-DROCKSDB_JEMALLOC",
     "-DROCKSDB_MALLOC_USABLE_SIZE",
     "-DROCKSDB_RANGESYNC_PRESENT",
     "-DROCKSDB_SCHED_GETCPU_PRESENT",
@@ -48,7 +47,6 @@ rocksdb_external_deps = [
     ("tbb", None),
     ("numa", None, "numa"),
     ("googletest", None, "gtest"),
-    ("jemalloc", None, "headers"),
 ]
 
 rocksdb_preprocessor_flags = [
@@ -72,6 +70,14 @@ is_opt_mode = build_mode.startswith("opt")
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
+
+sanitizer = read_config("fbcode", "sanitizer")
+
+# Do not enable jemalloc if sanitizer presents. RocksDB will further detect
+# whether the binary is linked with jemalloc at runtime.
+if sanitizer == "":
+    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
+    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 """
 
 

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -15,6 +15,7 @@ rocksdb_compiler_flags = [
     "-DROCKSDB_PLATFORM_POSIX",
     "-DROCKSDB_LIB_IO_POSIX",
     "-DROCKSDB_FALLOCATE_PRESENT",
+    "-DROCKSDB_JEMALLOC",
     "-DROCKSDB_MALLOC_USABLE_SIZE",
     "-DROCKSDB_RANGESYNC_PRESENT",
     "-DROCKSDB_SCHED_GETCPU_PRESENT",
@@ -47,6 +48,7 @@ rocksdb_external_deps = [
     ("tbb", None),
     ("numa", None, "numa"),
     ("googletest", None, "gtest"),
+    ("jemalloc", None, "headers"),
 ]
 
 rocksdb_preprocessor_flags = [
@@ -70,16 +72,6 @@ is_opt_mode = build_mode.startswith("opt")
 # doesn't harm and avoid forgetting to add it.
 if is_opt_mode:
     rocksdb_compiler_flags.append("-DNDEBUG")
-
-default_allocator = read_config("fbcode", "default_allocator")
-
-sanitizer = read_config("fbcode", "sanitizer")
-
-# Let RocksDB aware of jemalloc existence.
-# Do not enable it if sanitizer presents.
-if is_opt_mode and default_allocator.startswith("jemalloc") and sanitizer == "":
-    rocksdb_compiler_flags.append("-DROCKSDB_JEMALLOC")
-    rocksdb_external_deps.append(("jemalloc", None, "headers"))
 """
 
 

--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -15,13 +15,15 @@
 
 #include "port/jemalloc_helper.h"
 
-#ifdef JEMALLOC_NO_RENAME
-#define malloc_stats_print je_malloc_stats_print
-#endif
 
 namespace rocksdb {
 
 #ifdef ROCKSDB_JEMALLOC
+
+#ifdef JEMALLOC_NO_RENAME
+#define malloc_stats_print je_malloc_stats_print
+#endif
+
 typedef struct {
   char* cur;
   char* end;

--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -13,18 +13,15 @@
 #include <memory>
 #include <string.h>
 
-namespace rocksdb {
+#include "port/jemalloc.h"
 
-#ifdef ROCKSDB_JEMALLOC
-#ifdef __FreeBSD__
-#include <malloc_np.h>
-#else
-#include "jemalloc/jemalloc.h"
 #ifdef JEMALLOC_NO_RENAME
 #define malloc_stats_print je_malloc_stats_print
 #endif
-#endif
 
+namespace rocksdb {
+
+#ifdef ROCKSDB_JEMALLOC
 typedef struct {
   char* cur;
   char* end;
@@ -41,10 +38,10 @@ static void GetJemallocStatus(void* mstat_arg, const char* status) {
   snprintf(mstat->cur, buf_size, "%s", status);
   mstat->cur += status_len;
 }
-#endif  // ROCKSDB_JEMALLOC
-
-#ifdef ROCKSDB_JEMALLOC
 void DumpMallocStats(std::string* stats) {
+  if (!HasJemalloc()) {
+    return;
+  }
   MallocStatus mstat;
   const unsigned int kMallocStatusLen = 1000000;
   std::unique_ptr<char[]> buf{new char[kMallocStatusLen + 1]};
@@ -56,5 +53,5 @@ void DumpMallocStats(std::string* stats) {
 #else
 void DumpMallocStats(std::string*) {}
 #endif  // ROCKSDB_JEMALLOC
-}
+}  // namespace rocksdb
 #endif  // !ROCKSDB_LITE

--- a/db/malloc_stats.cc
+++ b/db/malloc_stats.cc
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string.h>
 
-#include "port/jemalloc.h"
+#include "port/jemalloc_helper.h"
 
 #ifdef JEMALLOC_NO_RENAME
 #define malloc_stats_print je_malloc_stats_print

--- a/port/jemalloc.h
+++ b/port/jemalloc.h
@@ -29,8 +29,8 @@ extern "C" int mallctlbymib(const size_t*, size_t, void*, size_t*, void*,
                             size_t) __attribute__((__weak__));
 extern "C" void malloc_stats_print(void (*)(void*, const char*), void*,
                                    const char*) __attribute__((__weak__));
-extern "C" size_t malloc_usable_size(void*) JEMALLOC_CXX_THROW
-    __attribute__((__weak__));
+extern "C" size_t malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void*)
+    JEMALLOC_CXX_THROW __attribute__((__weak__));
 
 // Check if Jemalloc is linked with the binary. Note the main program might be
 // using a different memory allocator even this method return true.

--- a/port/jemalloc.h
+++ b/port/jemalloc.h
@@ -1,0 +1,45 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#ifdef ROCKSDB_JEMALLOC
+#ifdef __FreeBSD__
+#include <malloc_np.h>
+#else
+#include <jemalloc/jemalloc.h>
+#endif
+
+// Declare non-standard jemalloc APIs as weak symbols. We can null-check these
+// symbols to detect whether jemalloc is linked with the binary.
+extern "C" void* mallocx(size_t, int) __attribute__((__weak__));
+extern "C" void* rallocx(void*, size_t, int) __attribute__((__weak__));
+extern "C" size_t xallocx(void*, size_t, size_t, int) __attribute__((__weak__));
+extern "C" size_t sallocx(const void*, int) __attribute__((__weak__));
+extern "C" void dallocx(void*, int) __attribute__((__weak__));
+extern "C" void sdallocx(void*, size_t, int) __attribute__((__weak__));
+extern "C" size_t nallocx(size_t, int) __attribute__((__weak__));
+extern "C" int mallctl(const char*, void*, size_t*, void*, size_t)
+    __attribute__((__weak__));
+extern "C" int mallctlnametomib(const char*, size_t*, size_t*)
+    __attribute__((__weak__));
+extern "C" int mallctlbymib(const size_t*, size_t, void*, size_t*, void*,
+                            size_t) __attribute__((__weak__));
+extern "C" void malloc_stats_print(void (*)(void*, const char*), void*,
+                                   const char*) __attribute__((__weak__));
+extern "C" size_t malloc_usable_size(void*) JEMALLOC_CXX_THROW
+    __attribute__((__weak__));
+
+// Check if Jemalloc is linked with the binary. Note the main program might be
+// using a different memory allocator even this method return true.
+static inline bool HasJemalloc() {
+  return mallocx != nullptr && rallocx != nullptr && xallocx != nullptr &&
+         sallocx != nullptr && dallocx != nullptr && sdallocx != nullptr &&
+         nallocx != nullptr && mallctl != nullptr &&
+         mallctlnametomib != nullptr && mallctlbymib != nullptr &&
+         malloc_stats_print != nullptr && malloc_usable_size != nullptr;
+}
+
+#endif  // ROCKSDB_JEMALLOC

--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -34,6 +34,10 @@ extern "C" size_t malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void*)
 
 // Check if Jemalloc is linked with the binary. Note the main program might be
 // using a different memory allocator even this method return true.
+// It is loosely based on folly::usingJEMalloc(), minus the check the actually
+// allocate memory and see if it is through jemalloc, to handle the dlopen()
+// case:
+// https://github.com/facebook/folly/blob/76cf8b5841fb33137cfbf8b224f0226437c855bc/folly/memory/Malloc.h#L147
 static inline bool HasJemalloc() {
   return mallocx != nullptr && rallocx != nullptr && xallocx != nullptr &&
          sallocx != nullptr && dallocx != nullptr && sdallocx != nullptr &&

--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -34,7 +34,7 @@ extern "C" size_t malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void*)
 
 // Check if Jemalloc is linked with the binary. Note the main program might be
 // using a different memory allocator even this method return true.
-// It is loosely based on folly::usingJEMalloc(), minus the check the actually
+// It is loosely based on folly::usingJEMalloc(), minus the check that actually
 // allocate memory and see if it is through jemalloc, to handle the dlopen()
 // case:
 // https://github.com/facebook/folly/blob/76cf8b5841fb33137cfbf8b224f0226437c855bc/folly/memory/Malloc.h#L147

--- a/util/jemalloc_nodump_allocator.cc
+++ b/util/jemalloc_nodump_allocator.cc
@@ -135,10 +135,16 @@ Status NewJemallocNodumpAllocator(
   *memory_allocator = nullptr;
 #ifndef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   (void)options;
-  return Status::NotSupported(
-      "JemallocNodumpAllocator only available with jemalloc version >= 5 "
-      "and MADV_DONTDUMP is available.");
+  bool supported = false;
 #else
+  bool supported = HasJemalloc();
+#endif
+  if (!supported) {
+    return Status::NotSupported(
+        "JemallocNodumpAllocator only available with jemalloc version >= 5 "
+        "and MADV_DONTDUMP is available.");
+  }
+#ifdef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   if (memory_allocator == nullptr) {
     return Status::InvalidArgument("memory_allocator must be non-null.");
   }

--- a/util/jemalloc_nodump_allocator.cc
+++ b/util/jemalloc_nodump_allocator.cc
@@ -133,18 +133,16 @@ Status NewJemallocNodumpAllocator(
     JemallocAllocatorOptions& options,
     std::shared_ptr<MemoryAllocator>* memory_allocator) {
   *memory_allocator = nullptr;
+  Status unsupported = Status::NotSupported(
+      "JemallocNodumpAllocator only available with jemalloc version >= 5 "
+      "and MADV_DONTDUMP is available.");
 #ifndef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   (void)options;
-  bool supported = false;
+  return unsupported;
 #else
-  bool supported = HasJemalloc();
-#endif
-  if (!supported) {
-    return Status::NotSupported(
-        "JemallocNodumpAllocator only available with jemalloc version >= 5 "
-        "and MADV_DONTDUMP is available.");
+  if (!HasJemalloc()) {
+    return unsupported;
   }
-#ifdef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   if (memory_allocator == nullptr) {
     return Status::InvalidArgument("memory_allocator must be non-null.");
   }

--- a/util/jemalloc_nodump_allocator.h
+++ b/util/jemalloc_nodump_allocator.h
@@ -8,7 +8,7 @@
 #include <atomic>
 #include <vector>
 
-#include "port/jemalloc.h"
+#include "port/jemalloc_helper.h"
 #include "port/port.h"
 #include "rocksdb/memory_allocator.h"
 #include "util/core_local.h"

--- a/util/jemalloc_nodump_allocator.h
+++ b/util/jemalloc_nodump_allocator.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <vector>
 
+#include "port/jemalloc.h"
 #include "port/port.h"
 #include "rocksdb/memory_allocator.h"
 #include "util/core_local.h"
@@ -15,7 +16,6 @@
 
 #if defined(ROCKSDB_JEMALLOC) && defined(ROCKSDB_PLATFORM_POSIX)
 
-#include <jemalloc/jemalloc.h>
 #include <sys/mman.h>
 
 #if (JEMALLOC_VERSION_MAJOR >= 5) && defined(MADV_DONTDUMP)


### PR DESCRIPTION
Summary:
Declare Jemalloc non-standard APIs as weak symbols, so that if Jemalloc is linked with the binary, these symbols will be replaced by Jemalloc's, otherwise they will be nullptr. This is similar to how folly detect jemalloc, but we assume the main program use jemalloc as long as jemalloc is linked: https://github.com/facebook/folly/blob/master/folly/memory/Malloc.h#L147

Test Plan:
Tested fbcode build with D13563724. Also tested with local MyRocks build and MacOS build.
