### PR TITLE
Blob index single delete should not be treated as a mismatch

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -407,7 +407,8 @@ void CompactionIterator::NextFromInput() {
             // is an unexpected Merge or Delete.  We will compact it out
             // either way. We will maintain counts of how many mismatches
             // happened
-            if (next_ikey.type != kTypeValue) {
+            if (next_ikey.type != kTypeValue &&
+                next_ikey.type != kTypeBlobIndex) {
               ++iter_stats_.num_single_del_mismatch;
             }
 


### PR DESCRIPTION
Summary:
In compaction iterator, if the next value of single delete is a blob value, it should not treated as mismatch. This is only a minor fix and doesn't affect correctness.

Test Plan:
`make all`