### PR TITLE
Non-initial file preloading should always prefetch index and filter

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3022,9 +3022,7 @@ Status VersionSet::ProcessManifestWrites(
         ColumnFamilyData* cfd = versions[i]->cfd_;
         builder_guards[i]->version_builder()->LoadTableHandlers(
             cfd->internal_stats(), cfd->ioptions()->optimize_filters_for_hits,
-            this->GetColumnFamilySet()->get_table_cache()->GetCapacity() ==
-                TableCache::
-                    kInfiniteCapacity /* prefetch_index_and_filter_in_cache */,
+            true /* prefetch_index_and_filter_in_cache */,
             false /* is_initial_load */,
             mutable_cf_options_ptrs[i]->prefix_extractor.get());
       }


### PR DESCRIPTION
Summary: https://github.com/facebook/rocksdb/pull/3340 introduces preloading when max_open_files != -1.
It doesn't preload index and filter in non-initial file loading case. This is a little bit too
complicated to understand. We observed in one MyRocks use case where the filter is expected to be
preloaded but is not. To simplify the use case, we simply always prefetch the index and filter.
They anyway is expected to be loaded in the file verification phase anyway.

Test Plan: Add a unit test to cover this code path. The test passes before and after the change, but
it verifies the expected behavior anyway.