### PR TITLE
WritePrepared: Report released snapshots in IsInSnapshot

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1515,7 +1515,8 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   snap_seq = snap1->GetSequenceNumber();
   // Invaid snapshot lower than max
   ASSERT_LE(snap_seq + 1, wp_db->max_evicted_seq_);
-  ASSERT_TRUE(wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(
+      wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
 
   db->ReleaseSnapshot(snap1);
@@ -1528,11 +1529,13 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
 
   released = false;
   // Invaid snapshot lower than max
-  ASSERT_TRUE(wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(
+      wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
-  
+
   // This make the snapshot release to reflect in txn db structures
-  wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_, wp_db->max_evicted_seq_ + 1);
+  wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_,
+                              wp_db->max_evicted_seq_ + 1);
 
   released = false;
   // Released snapshot lower than max
@@ -1541,9 +1544,10 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
 
   released = false;
   // Invaid snapshot lower than max
-  ASSERT_TRUE(wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(
+      wp_db->IsInSnapshot(seq, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
-  
+
   snap_seq = snap2->GetSequenceNumber();
 
   released = false;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1484,6 +1484,65 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotEmptyMapTest) {
   }
 }
 
+TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
+  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  WriteOptions woptions;
+  ASSERT_OK(db->Put(woptions, "key", "value"));
+  // snap seq = 1
+  const Snapshot* snap1 = db->GetSnapshot();
+  ASSERT_OK(db->Put(woptions, "key", "value"));
+  ASSERT_OK(db->Put(woptions, "key", "value"));
+  // snap seq = 3
+  const Snapshot* snap2 = db->GetSnapshot();
+  size_t overwrite_seq = wp_db->COMMIT_CACHE_SIZE + 1;
+  wp_db->AddCommitted(overwrite_seq, overwrite_seq);
+  SequenceNumber snap_seq;
+  uint64_t min_uncommitted = 0;
+  bool released;
+
+  released = false;
+  snap_seq = snap1->GetSequenceNumber();
+  ASSERT_LE(1, snap_seq);
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
+  ASSERT_FALSE(released);
+
+  released = false;
+  snap_seq = snap1->GetSequenceNumber();
+  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(released);
+
+  snap_seq = snap1->GetSequenceNumber();
+  db->ReleaseSnapshot(snap1);
+
+  released = false;
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
+  ASSERT_FALSE(released);
+
+  released = false;
+  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(released);
+  
+  wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_, wp_db->max_evicted_seq_ + 1);
+
+  released = false;
+  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
+  ASSERT_TRUE(released);
+
+  released = false;
+  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(released);
+  
+  snap_seq = snap2->GetSequenceNumber();
+
+  released = false;
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
+  ASSERT_FALSE(released);
+
+  released = false;
+  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(released);
+}
+
 // Test WritePreparedTxnDB's IsInSnapshot against different ordering of
 // snapshot, max_committed_seq_, prepared, and commit entries.
 TEST_P(WritePreparedTransactionTest, IsInSnapshotTest) {

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1550,6 +1550,8 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   // Unreleased snapshot lower than max
   ASSERT_TRUE(wp_db->IsInSnapshot(seq, snap_seq, min_uncommitted, &released));
   ASSERT_FALSE(released);
+
+  db->ReleaseSnapshot(snap2);
 }
 
 // Test WritePreparedTxnDB's IsInSnapshot against different ordering of

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1508,7 +1508,7 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
 
   released = false;
   snap_seq = snap1->GetSequenceNumber();
-  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
 
   snap_seq = snap1->GetSequenceNumber();
@@ -1519,17 +1519,17 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   ASSERT_FALSE(released);
 
   released = false;
-  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
   
   wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_, wp_db->max_evicted_seq_ + 1);
 
   released = false;
-  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq, min_uncommitted, &released));
   ASSERT_TRUE(released);
 
   released = false;
-  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
   
   snap_seq = snap2->GetSequenceNumber();
@@ -1539,7 +1539,7 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   ASSERT_FALSE(released);
 
   released = false;
-  ASSERT_FALSE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
+  ASSERT_TRUE(wp_db->IsInSnapshot(1, snap_seq + 1, min_uncommitted, &released));
   ASSERT_TRUE(released);
 }
 

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -535,6 +535,13 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
   }
   if (update_snapshots) {
     UpdateSnapshots(snapshots, new_snapshots_version);
+    if (!snapshots.empty()) {
+      WriteLock wl(&old_commit_map_mutex_);
+      for (auto snap: snapshots) {
+        old_commit_map_[snap];
+      }
+      old_commit_map_empty_.store(false, std::memory_order_release);
+    }
   }
   auto updated_prev_max = prev_max;
   while (updated_prev_max < new_max &&

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -538,6 +538,8 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
     if (!snapshots.empty()) {
       WriteLock wl(&old_commit_map_mutex_);
       for (auto snap: snapshots) {
+        // This allows IsInSnapshot to tell apart the reads from in valid
+        // snapshots from the reads from committed values in valid snapshots.
         old_commit_map_[snap];
       }
       old_commit_map_empty_.store(false, std::memory_order_release);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -537,7 +537,7 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
     UpdateSnapshots(snapshots, new_snapshots_version);
     if (!snapshots.empty()) {
       WriteLock wl(&old_commit_map_mutex_);
-      for (auto snap: snapshots) {
+      for (auto snap : snapshots) {
         // This allows IsInSnapshot to tell apart the reads from in valid
         // snapshots from the reads from committed values in valid snapshots.
         old_commit_map_[snap];

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -116,10 +116,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   // is visible to the snapshot with sequence number snapshot_seq.
   // Returns true if commit_seq <= snapshot_seq
   // If the snapshot_seq is already released and snapshot_seq <= max, sets
-  // *released to true and returns true as well.
+  // *snap_released to true and returns true as well.
   inline bool IsInSnapshot(uint64_t prep_seq, uint64_t snapshot_seq,
                            uint64_t min_uncommitted = 0,
-                           bool* released = nullptr) const {
+                           bool* snap_released = nullptr) const {
     ROCKS_LOG_DETAILS(info_log_,
                       "IsInSnapshot %" PRIu64 " in %" PRIu64
                       " min_uncommitted %" PRIu64,
@@ -217,11 +217,11 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                         "IsInSnapshot %" PRIu64 " in %" PRIu64
                         " returns %" PRId32 " released=1",
                         prep_seq, snapshot_seq, 0);
-      assert(released);
+      assert(snap_released);
       // This snapshot is not valid anymore. We cannot tell if prep_seq is
       // committed before or after the snapshot. Return true but also set
-      // released to true.
-      *released = true;
+      // snap_released to true.
+      *snap_released = true;
       return true;
     }
     {
@@ -243,9 +243,9 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                           prep_seq, snapshot_seq, 0);
         // This snapshot is not valid anymore. We cannot tell if prep_seq is
         // committed before or after the snapshot. Return true but also set
-        // released to true.
-        assert(released);
-        *released = true;
+        // snap_released to true.
+        assert(snap_released);
+        *snap_released = true;
         return true;
       }
 

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -218,7 +218,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       // snapshot might be released.
       assert(released);
       *released = true;
-      return false;
+      return true;
     }
     {
       // We should not normally reach here unless sapshot_seq is old. This is a
@@ -241,7 +241,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
         // snapshot might be released.
         assert(released);
         *released = true;
-        return false;
+        return true;
       }
 
       if (!found) {

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -35,8 +35,8 @@
 namespace rocksdb {
 
 #define ROCKS_LOG_DETAILS(LGR, FMT, ...) \
- ROCKS_LOG_DEBUG(LGR, FMT, ##__VA_ARGS__)
-//  ;  // due to overhead by default skip such lines
+  ;  // due to overhead by default skip such lines
+// ROCKS_LOG_DEBUG(LGR, FMT, ##__VA_ARGS__)
 
 // A PessimisticTransactionDB that writes data to DB after prepare phase of 2PC.
 // In this way some data in the DB might not be committed. The DB provides
@@ -214,9 +214,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       ROCKS_LOG_DETAILS(
           info_log_, "IsInSnapshot %" PRIu64 " in %" PRIu64 " returns %" PRId32" released=1",
           prep_seq, snapshot_seq, 0);
-      // This could be used to ensure that the caller is expecting the
-      // snapshot might be released.
       assert(released);
+      // This snapshot is not valid anymore. We cannot tell if prep_seq is
+      // committed before or after the snapshot. Return true but also set
+      // released to true.
       *released = true;
       return true;
     }
@@ -237,8 +238,9 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                           "IsInSnapshot %" PRIu64 " in %" PRIu64
                           " returns %" PRId32" released=1",
                           prep_seq, snapshot_seq, 0);
-        // This could be used to ensure that the caller is expecting the
-        // snapshot might be released.
+        // This snapshot is not valid anymore. We cannot tell if prep_seq is
+        // committed before or after the snapshot. Return true but also set
+        // released to true.
         assert(released);
         *released = true;
         return true;

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -213,9 +213,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // snapshot. If there was no overlapping commit entry, then it is committed
     // with a commit_seq lower than any live snapshot, including snapshot_seq.
     if (old_commit_map_empty_.load(std::memory_order_acquire)) {
-      ROCKS_LOG_DETAILS(
-          info_log_, "IsInSnapshot %" PRIu64 " in %" PRIu64 " returns %" PRId32" released=1",
-          prep_seq, snapshot_seq, 0);
+      ROCKS_LOG_DETAILS(info_log_,
+                        "IsInSnapshot %" PRIu64 " in %" PRIu64
+                        " returns %" PRId32 " released=1",
+                        prep_seq, snapshot_seq, 0);
       assert(released);
       // This snapshot is not valid anymore. We cannot tell if prep_seq is
       // committed before or after the snapshot. Return true but also set
@@ -238,7 +239,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
         // coming from compaction
         ROCKS_LOG_DETAILS(info_log_,
                           "IsInSnapshot %" PRIu64 " in %" PRIu64
-                          " returns %" PRId32" released=1",
+                          " returns %" PRId32 " released=1",
                           prep_seq, snapshot_seq, 0);
         // This snapshot is not valid anymore. We cannot tell if prep_seq is
         // committed before or after the snapshot. Return true but also set

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -115,6 +115,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   // Check whether the transaction that wrote the value with sequence number seq
   // is visible to the snapshot with sequence number snapshot_seq.
   // Returns true if commit_seq <= snapshot_seq
+  // If the snapshot_seq is already released and snapshot_seq <= max, sets
+  // *released to true and returns true as well.
   inline bool IsInSnapshot(uint64_t prep_seq, uint64_t snapshot_seq,
                            uint64_t min_uncommitted = 0,
                            bool* released = nullptr) const {

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -372,15 +372,14 @@ Status WriteUnpreparedTxn::RollbackInternal() {
   assert(GetId() != kMaxSequenceNumber);
   assert(GetId() > 0);
   const auto& cf_map = *wupt_db_->GetCFHandleMap();
-  // In WritePrepared, the txn is is the same as prepare seq
-  auto last_visible_txn = GetId() - 1;
+  auto read_at_seq = kMaxSequenceNumber;
   Status s;
 
   ReadOptions roptions;
   // Note that we do not use WriteUnpreparedTxnReadCallback because we do not
   // need to read our own writes when reading prior versions of the key for
   // rollback.
-  WritePreparedTxnReadCallback callback(wpt_db_, last_visible_txn, 0);
+  WritePreparedTxnReadCallback callback(wpt_db_, read_at_seq, 0);
   for (const auto& cfkey : write_set_keys_) {
     const auto cfid = cfkey.first;
     const auto& keys = cfkey.second;


### PR DESCRIPTION
Previously IsInSnapshot assumed that the snapshot is valid at the time that the function is called. However there are cases where that might not be valid. Example is background compactions where the compaction algorithm operates with a list of snapshots some of which might be released by the time they are being passed to IsInSnapshot. The patch make two changes to enable the caller to tell difference: i) any live snapshot below max is added to max_committed_seq_, which allows IsInSnapshot to confidently tell whether the passed snapshot is invalid if it below max, ii) extends IsInSnapshot API with a "released" variable that is set true when IsInSnapshot find no such snapshot below max and also find no other way to give a certain return value. In such cases the return value is true but the caller should also check the "released" boolean after the call.
In short here is the changes in the API:
i) If the snapshot is valid, no change is required.
ii) If the snapshot might be invalid, a reference to "released" boolean must be passed to IsInSnapshot.
ii-a) If snapshot is above max, IsInSnapshot can figure the return valid using the commit cache.
ii-b) otherwise if snapshot is in old_commit_map_, IsInSnapshot can use that to tell if value was visible to the snapshot.
ii-c) otherwise it sets "released" to true and returns true as well.