### PR TITLE
Free memory after use

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -3802,6 +3802,14 @@ class AtomicFlushStressTest : public StressTest {
                                 &cf_handles, &checkpoint_db);
       }
     }
+    if (checkpoint_db != nullptr) {
+      for (auto cfh : cf_handles) {
+        delete cfh;
+      }
+      cf_handles.clear();
+      delete checkpoint_db;
+      checkpoint_db = nullptr;
+    }
     DestroyDB(checkpoint_dir, Options());
     if (!s.ok()) {
       fprintf(stderr, "A checkpoint operation failed with: %s\n",


### PR DESCRIPTION
Test plan:
```
$make clean && COMPILE_WITH_ASAN=1 make -j32 db_stress
$./db_stress --test_atomic_flush=1 --max_background_compactions=20 --compact_range_one_in=1000000 --format_version=4 --memtablerep=skip_list --max_write_buffer_number=3 --reopen=0 --acquire_snapshot_one_in=10000 --delpercent=4 --log2_keys_per_lock=10 --block_size=16384 --use_direct_reads=0 --compact_files_one_in=1000000 --target_file_size_multiplier=2 --clear_column_family_one_in=0 --use_full_merge_v1=1 --progress_reports=0 --checkpoint_one_in=1000 --mmap_read=1 --writepercent=35 --readpercent=45 --subcompactions=3 --use_merge=0 --write_buffer_size=1048576 --test_batches_snapshots=0 --max_bytes_for_level_base=10485760 --disable_wal=1 --open_files=500000 --destroy_db_initially=0 --target_file_size_base=2097152 --compression_zstd_max_train_bytes=0 --snapshot_hold_ops=100000 --enable_pipelined_write=0 --nooverwritepercent=1 --compression_max_dict_bytes=16384 --max_key=100000000 --prefixpercent=5 --flush_one_in=1000000 --ops_per_thread=20000 --index_block_restart_interval=8 --cache_size=1048576 --compaction_style=1 --verify_checksum=1 --delrangepercent=1 --use_direct_io_for_flush_and_compaction=0 --compression_type=zstd
```
The test process must exit successfully.