### PR TITLE
WritePrepared: fix issue with snapshot released during compaction

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -669,13 +669,13 @@ bool CompactionIterator::IsInEarliestSnapshot(SequenceNumber sequence) {
     earliest_snapshot_iter_++;
     if (earliest_snapshot_iter_ == snapshots_->end()) {
       earliest_snapshot_ = kMaxSequenceNumber;
-      return true;
     } else {
       earliest_snapshot_ = *earliest_snapshot_iter_;
-      in_snapshot =
-          snapshot_checker_->CheckInSnapshot(sequence, earliest_snapshot_);
     }
+    in_snapshot =
+        snapshot_checker_->CheckInSnapshot(sequence, earliest_snapshot_);
   }
+  assert(in_snapshot != SnapshotCheckerResult::kSnapshotReleased);
   return in_snapshot == SnapshotCheckerResult::kInSnapshot;
 }
 

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -9,6 +9,7 @@
 #include "port/likely.h"
 #include "rocksdb/listener.h"
 #include "table/internal_iterator.h"
+#include "util/sync_point.h"
 
 #define DEFINITELY_IN_SNAPSHOT(seq, snapshot)                       \
   ((seq) <= (snapshot) &&                                           \

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -132,6 +132,14 @@ class CompactionIterator {
   // or seqnum be zero-ed out even if all other conditions for it are met.
   inline bool ikeyNotNeededForIncrementalSnapshot();
 
+  inline bool KeyCommitted(SequenceNumber sequence) {
+    return snapshot_checker_ == nullptr ||
+           snapshot_checker_->CheckInSnapshot(sequence, kMaxSequenceNumber) ==
+               SnapshotCheckerResult::kInSnapshot;
+  }
+
+  bool IsInEarliestSnapshot(SequenceNumber sequence);
+
   InternalIterator* input_;
   const Comparator* cmp_;
   MergeHelper* merge_helper_;

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -144,6 +144,7 @@ class CompactionIterator {
   const Comparator* cmp_;
   MergeHelper* merge_helper_;
   const std::vector<SequenceNumber>* snapshots_;
+  std::vector<SequenceNumber>::const_iterator earliest_snapshot_iter_;
   const SequenceNumber earliest_write_conflict_snapshot_;
   const SnapshotChecker* const snapshot_checker_;
   Env* env_;
@@ -159,6 +160,7 @@ class CompactionIterator {
   bool visible_at_tip_;
   SequenceNumber earliest_snapshot_;
   SequenceNumber latest_snapshot_;
+
   bool ignore_snapshots_;
 
   // State

--- a/db/compaction_iterator_test.cc
+++ b/db/compaction_iterator_test.cc
@@ -190,13 +190,17 @@ class TestSnapshotChecker : public SnapshotChecker {
       : last_committed_sequence_(last_committed_sequence),
         snapshots_(snapshots) {}
 
-  bool IsInSnapshot(SequenceNumber seq,
-                    SequenceNumber snapshot_seq) const override {
+  SnapshotCheckerResult CheckInSnapshot(
+      SequenceNumber seq, SequenceNumber snapshot_seq) const override {
     if (snapshot_seq == kMaxSequenceNumber) {
-      return seq <= last_committed_sequence_;
+      return seq <= last_committed_sequence_
+                 ? SnapshotCheckerResult::kInSnapshot
+                 : SnapshotCheckerResult::kNotInSnapshot;
     }
     assert(snapshots_.count(snapshot_seq) > 0);
-    return seq <= snapshots_.at(snapshot_seq);
+    return seq <= snapshots_.at(snapshot_seq)
+               ? SnapshotCheckerResult::kInSnapshot
+               : SnapshotCheckerResult::kNotInSnapshot;
   }
 
  private:

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -166,9 +166,11 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       break;
     } else if (stop_before > 0 && ikey.sequence <= stop_before &&
                LIKELY(snapshot_checker_ == nullptr ||
-                      snapshot_checker_->IsInSnapshot(ikey.sequence,
-                                                      stop_before))) {
-      // hit an entry that's visible by the previous snapshot, can't touch that
+                      snapshot_checker_->CheckInSnapshot(ikey.sequence,
+                                                         stop_before) !=
+                          SnapshotCheckerResult::kNotInSnapshot)) {
+      // hit an entry that's possibly visible by the previous snapshot, can't
+      // touch that
       break;
     }
 

--- a/db/snapshot_checker.h
+++ b/db/snapshot_checker.h
@@ -8,22 +8,30 @@
 
 namespace rocksdb {
 
-// Callback class that control GC of duplicate keys in flush/compaction
+enum class SnapshotCheckerResult : int {
+  kInSnapshot = 0,
+  kNotInSnapshot = 1,
+  // In case snapshot is released and the checker has no clue whether
+  // the given sequence is visible to the snapshot.
+  kSnapshotReleased = 2,
+};
+
+// Callback class that control GC of duplicate keys in flush/compaction.
 class SnapshotChecker {
  public:
   virtual ~SnapshotChecker() {}
-  virtual bool IsInSnapshot(SequenceNumber sequence,
-                            SequenceNumber snapshot_sequence) const = 0;
+  virtual SnapshotCheckerResult CheckInSnapshot(
+      SequenceNumber sequence, SequenceNumber snapshot_sequence) const = 0;
 };
 
 class DisableGCSnapshotChecker : public SnapshotChecker {
  public:
   virtual ~DisableGCSnapshotChecker() {}
-  virtual bool IsInSnapshot(
+  virtual SnapshotCheckerResult CheckInSnapshot(
       SequenceNumber /*sequence*/,
       SequenceNumber /*snapshot_sequence*/) const override {
-    // By returning false, we prevent all the values from being GCed
-    return false;
+    // By returning kNotInSnapshot, we prevent all the values from being GCed
+    return SnapshotCheckerResult::kNotInSnapshot;
   }
   static DisableGCSnapshotChecker* Instance() { return &instance_; }
 
@@ -41,8 +49,8 @@ class WritePreparedSnapshotChecker : public SnapshotChecker {
   explicit WritePreparedSnapshotChecker(WritePreparedTxnDB* txn_db);
   virtual ~WritePreparedSnapshotChecker() {}
 
-  virtual bool IsInSnapshot(SequenceNumber sequence,
-                            SequenceNumber snapshot_sequence) const override;
+  virtual SnapshotCheckerResult CheckInSnapshot(
+      SequenceNumber sequence, SequenceNumber snapshot_sequence) const override;
 
  private:
 #ifndef ROCKSDB_LITE

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -33,6 +33,7 @@ WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
 SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber sequence, SequenceNumber snapshot_sequence) const {
   bool snapshot_released = false;
+  // TODO(myabandeh): set min_uncommitted
   bool in_snapshot = txn_db_->IsInSnapshot(
       sequence, snapshot_sequence, 0 /*min_uncommitted*/, &snapshot_released);
   if (snapshot_released) {

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -9,7 +9,6 @@
 #include <assert.h>
 #endif  // ROCKSDB_LITE
 
-#include "db/snapshot_checker.h"
 #include "utilities/transactions/write_prepared_txn_db.h"
 
 namespace rocksdb {

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -32,7 +32,7 @@ WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
 
 SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber sequence, SequenceNumber snapshot_sequence) const {
-  bool snapshot_released;
+  bool snapshot_released = false;
   bool in_snapshot = txn_db_->IsInSnapshot(
       sequence, snapshot_sequence, 0 /*min_uncommitted*/, &snapshot_released);
   if (snapshot_released) {

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -17,11 +17,11 @@ namespace rocksdb {
 WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
     WritePreparedTxnDB* /*txn_db*/) {}
 
-bool WritePreparedSnapshotChecker::IsInSnapshot(
+SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber /*sequence*/, SequenceNumber /*snapshot_sequence*/) const {
   // Should never be called in LITE mode.
   assert(false);
-  return true;
+  return SnapshotChecker::kInSnapshot;
 }
 
 #else
@@ -30,9 +30,16 @@ WritePreparedSnapshotChecker::WritePreparedSnapshotChecker(
     WritePreparedTxnDB* txn_db)
     : txn_db_(txn_db){};
 
-bool WritePreparedSnapshotChecker::IsInSnapshot(
+SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber sequence, SequenceNumber snapshot_sequence) const {
-  return txn_db_->IsInSnapshot(sequence, snapshot_sequence);
+  bool snapshot_released;
+  bool in_snapshot = txn_db_->IsInSnapshot(
+      sequence, snapshot_sequence, 0 /*min_uncommitted*/, &snapshot_released);
+  if (snapshot_released) {
+    return SnapshotCheckerResult::kSnapshotReleased;
+  }
+  return in_snapshot ? SnapshotCheckerResult::kInSnapshot
+                     : SnapshotCheckerResult::kNotInSnapshot;
 }
 
 #endif  // ROCKSDB_LITE

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -9,6 +9,7 @@
 #include <assert.h>
 #endif  // ROCKSDB_LITE
 
+#include "db/snapshot_checker.h"
 #include "utilities/transactions/write_prepared_txn_db.h"
 
 namespace rocksdb {

--- a/utilities/transactions/snapshot_checker.cc
+++ b/utilities/transactions/snapshot_checker.cc
@@ -22,7 +22,7 @@ SnapshotCheckerResult WritePreparedSnapshotChecker::CheckInSnapshot(
     SequenceNumber /*sequence*/, SequenceNumber /*snapshot_sequence*/) const {
   // Should never be called in LITE mode.
   assert(false);
-  return SnapshotChecker::kInSnapshot;
+  return SnapshotCheckerResult::kInSnapshot;
 }
 
 #else

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2283,6 +2283,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   VerifyKeys({{"key1", "value1_2"}});
   VerifyKeys({{"key1", "value1_1"}}, snapshot2);
   db->ReleaseSnapshot(snapshot2);
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
@@ -2313,7 +2314,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
     // CompactionIterator need to double check and find out snapshot2 is now
     // the earliest existing snapshot.
     if (compaction != nullptr) {
-      db->ReleaseSnapshot(snapshot1);
+      // db->ReleaseSnapshot(snapshot1);
       // Add some keys to advance max_evicted_seq.
       ASSERT_OK(db->Put(WriteOptions(), "key3", "value3"));
       ASSERT_OK(db->Put(WriteOptions(), "key4", "value4"));
@@ -2334,6 +2335,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
   VerifyInternalKeys({{"key1", "", del_seq, kTypeDeletion},
                       {"key1", "value1", 0, kTypeValue}});
   db->ReleaseSnapshot(snapshot2);
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 // A more complex test to verify compaction/flush should keep keys visible

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2243,6 +2243,95 @@ TEST_P(WritePreparedTransactionTest, SmallestUncommittedOptimization) {
   }
 }
 
+TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
+  const size_t snapshot_cache_bits = 7;  // same as default
+  const size_t commit_cache_bits = 0;    // minimum commit cache
+  DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
+
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1_1"));
+  auto* transaction =
+      db->BeginTransaction(WriteOptions(), TransactionOptions(), nullptr);
+  ASSERT_OK(transaction->SetName("txn"));
+  ASSERT_OK(transaction->Put("key1", "value1_2"));
+  ASSERT_OK(transaction->Prepare());
+  auto snapshot1 = db->GetSnapshot();
+  // Increment sequence number.
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
+  auto snapshot2 = db->GetSnapshot();
+  ASSERT_OK(transaction->Commit());
+  VerifyKeys({{"key1", "value1_2"}});
+  VerifyKeys({{"key1", "value1_1"}}, snapshot1);
+  VerifyKeys({{"key1", "value1_1"}}, snapshot2);
+  // Add a flush to avoid compaction to fallback to trivial move.
+
+  auto callback = [&](void*) {
+    // Release snapshot1 after CompactionIterator init.
+    // CompactionIterator need to figure out the earliest snapshot
+    // that can see key1:value1_2 is kMaxSequenceNumber, not
+    // snapshot1 or snapshot2.
+    db->ReleaseSnapshot(snapshot1);
+    // Add some keys to advance max_evicted_seq.
+    ASSERT_OK(db->Put(WriteOptions(), "key3", "value3"));
+    ASSERT_OK(db->Put(WriteOptions(), "key4", "value4"));
+  };
+  SyncPoint::GetInstance()->SetCallBack("CompactionIterator:AfterInit",
+                                        callback);
+  SyncPoint::GetInstance()->EnableProcessing();
+  
+  ASSERT_OK(db->Flush(FlushOptions()));
+  VerifyKeys({{"key1", "value1_2"}});
+  VerifyKeys({{"key1", "value1_1"}}, snapshot2);
+}
+
+TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
+  const size_t snapshot_cache_bits = 7;  // same as default
+  const size_t commit_cache_bits = 0;    // minimum commit cache
+  DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
+
+  ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
+  auto* transaction =
+      db->BeginTransaction(WriteOptions(), TransactionOptions(), nullptr);
+  ASSERT_OK(transaction->SetName("txn"));
+  ASSERT_OK(transaction->Delete("key1"));
+  ASSERT_OK(transaction->Prepare());
+  SequenceNumber del_seq = db->GetLatestSequenceNumber();
+  auto snapshot1 = db->GetSnapshot();
+  // Increment sequence number.
+  ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
+  auto snapshot2 = db->GetSnapshot();
+  ASSERT_OK(transaction->Commit());
+  VerifyKeys({{"key1", "NOT_FOUND"}});
+  VerifyKeys({{"key1", "value1"}}, snapshot1);
+  VerifyKeys({{"key1", "value1"}}, snapshot2);
+  ASSERT_OK(db->Flush(FlushOptions()));
+
+  auto callback = [&](void* compaction) {
+    // Release snapshot1 after CompactionIterator init.
+    // CompactionIterator need to double check and find out snapshot2 is now
+    // the earliest existing snapshot.
+    if (compaction != nullptr) {
+      db->ReleaseSnapshot(snapshot1);
+      // Add some keys to advance max_evicted_seq.
+      ASSERT_OK(db->Put(WriteOptions(), "key3", "value3"));
+      ASSERT_OK(db->Put(WriteOptions(), "key4", "value4"));
+    }
+  };
+  SyncPoint::GetInstance()->SetCallBack("CompactionIterator:AfterInit",
+                                        callback);
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Dummy keys to avoid compaction trivially move files and get around actual
+  // compaction logic.
+  ASSERT_OK(db->Put(WriteOptions(), "a", "dummy"));
+  ASSERT_OK(db->Put(WriteOptions(), "z", "dummy"));
+  ASSERT_OK(db->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  // Only verify for key1. Both the put and delete for the key should be kept.
+  // Since the delete tombstone is not visible to snapshot2, we need to keep
+  // at least one version of the key, for write-conflict check.
+  VerifyInternalKeys({{"key1", "", del_seq, kTypeDeletion},
+                      {"key1", "value1", 0, kTypeValue}});
+}
+
 // A more complex test to verify compaction/flush should keep keys visible
 // to snapshots.
 TEST_P(WritePreparedTransactionTest,

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2314,7 +2314,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
     // CompactionIterator need to double check and find out snapshot2 is now
     // the earliest existing snapshot.
     if (compaction != nullptr) {
-      // db->ReleaseSnapshot(snapshot1);
+      db->ReleaseSnapshot(snapshot1);
       // Add some keys to advance max_evicted_seq.
       ASSERT_OK(db->Put(WriteOptions(), "key3", "value3"));
       ASSERT_OK(db->Put(WriteOptions(), "key4", "value4"));

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2259,6 +2259,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
   auto snapshot2 = db->GetSnapshot();
   ASSERT_OK(transaction->Commit());
+  delete transaction;
   VerifyKeys({{"key1", "value1_2"}});
   VerifyKeys({{"key1", "value1_1"}}, snapshot1);
   VerifyKeys({{"key1", "value1_1"}}, snapshot2);
@@ -2281,6 +2282,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   ASSERT_OK(db->Flush(FlushOptions()));
   VerifyKeys({{"key1", "value1_2"}});
   VerifyKeys({{"key1", "value1_1"}}, snapshot2);
+  db->ReleaseSnapshot(snapshot2);
 }
 
 TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
@@ -2300,6 +2302,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
   ASSERT_OK(db->Put(WriteOptions(), "key2", "value2"));
   auto snapshot2 = db->GetSnapshot();
   ASSERT_OK(transaction->Commit());
+  delete transaction;
   VerifyKeys({{"key1", "NOT_FOUND"}});
   VerifyKeys({{"key1", "value1"}}, snapshot1);
   VerifyKeys({{"key1", "value1"}}, snapshot2);
@@ -2330,6 +2333,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
   // at least one version of the key, for write-conflict check.
   VerifyInternalKeys({{"key1", "", del_seq, kTypeDeletion},
                       {"key1", "value1", 0, kTypeValue}});
+  db->ReleaseSnapshot(snapshot2);
 }
 
 // A more complex test to verify compaction/flush should keep keys visible

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2278,7 +2278,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   SyncPoint::GetInstance()->SetCallBack("CompactionIterator:AfterInit",
                                         callback);
   SyncPoint::GetInstance()->EnableProcessing();
-  
+
   ASSERT_OK(db->Flush(FlushOptions()));
   VerifyKeys({{"key1", "value1_2"}});
   VerifyKeys({{"key1", "value1_1"}}, snapshot2);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -124,6 +124,9 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                       "IsInSnapshot %" PRIu64 " in %" PRIu64
                       " min_uncommitted %" PRIu64,
                       prep_seq, snapshot_seq, min_uncommitted);
+    if (snap_released != nullptr) {
+      *snap_released = false;
+    }
     // Here we try to infer the return value without looking into prepare list.
     // This would help avoiding synchronization over a shared map.
     // TODO(myabandeh): optimize this. This sequence of checks must be correct

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -520,10 +520,6 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       return *delayed_prepared_.begin();
     }
     if (prepared_txns_.empty()) {
-      if (!delayed_prepared_.empty()) {
-        assert(!delayed_prepared_empty_.load());
-        return *delayed_prepared_.begin();
-      }
       return db_impl_->GetLatestSequenceNumber() + 1;
     } else {
       return std::min(prepared_txns_.top(),

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -124,9 +124,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                       "IsInSnapshot %" PRIu64 " in %" PRIu64
                       " min_uncommitted %" PRIu64,
                       prep_seq, snapshot_seq, min_uncommitted);
-    if (snap_released != nullptr) {
-      *snap_released = false;
-    }
+    // Caller is responsible to initialize snap_released.
+    assert(snap_released == nullptr || *snap_released == false);
     // Here we try to infer the return value without looking into prepare list.
     // This would help avoiding synchronization over a shared map.
     // TODO(myabandeh): optimize this. This sequence of checks must be correct

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -520,6 +520,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       return *delayed_prepared_.begin();
     }
     if (prepared_txns_.empty()) {
+      if (!delayed_prepared_.empty()) {
+        assert(!delayed_prepared_empty_.load());
+        return *delayed_prepared_.begin();
+      }
       return db_impl_->GetLatestSequenceNumber() + 1;
     } else {
       return std::min(prepared_txns_.top(),


### PR DESCRIPTION
Summary:
Compaction iterator keep a copy of list of live snapshots at the beginning of compaction, and then query snapshot checker to verify if values of a sequence number is visible to these snapshots. However when the snapshot is released in the middle of compaction, the snapshot checker implementation (i.e. WritePreparedSnapshotChecker) may remove info with the snapshot and may report incorrect result, which lead to values being compacted out when it shouldn't. This patch conservatively keep the values if snapshot checker determines that the snapshots is released.

Test Plan:
Current tests. Future PRs will add new specific tests.