### PR TITLE
Initialize two members in PerfContext

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -211,8 +211,8 @@ struct PerfContext {
 
   uint64_t get_cpu_nanos;
 
-  std::map<uint32_t, PerfContextByLevel>* level_to_perf_context;
-  bool per_level_perf_context_enabled;
+  std::map<uint32_t, PerfContextByLevel>* level_to_perf_context = nullptr;
+  bool per_level_perf_context_enabled = false;
 };
 
 // Get Thread-local PerfContext object pointer


### PR DESCRIPTION
Summary: as titled.
Currently it's possible to create a local object of type PerfContext since it's
part of public API. Then it's safe to initialize the two members to 0.
If PerfContext is created as thread-local object, then all members are
zero-initialized according to C++ standard.

Test Plan:
```
$make clean && make -j32 all check
```
All tests must pass.