### PR TITLE
Prevent users from creating own PerfContext obj

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -213,6 +213,12 @@ struct PerfContext {
 
   std::map<uint32_t, PerfContextByLevel>* level_to_perf_context;
   bool per_level_perf_context_enabled;
+
+ private:
+  PerfContext() {}
+  PerfContext(const PerfContext&) = delete;
+  PerfContext(PerfContext&&) = delete;
+  friend PerfContext* get_perf_context();
 };
 
 // Get Thread-local PerfContext object pointer

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -9,23 +9,16 @@
 
 namespace rocksdb {
 
-#if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
-PerfContext perf_context;
-#else
-#if defined(OS_SOLARIS)
-__thread PerfContext perf_context_;
-#else
-thread_local PerfContext perf_context;
-#endif
-#endif
-
 PerfContext* get_perf_context() {
 #if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
+  static PerfContext perf_context;
   return &perf_context;
 #else
 #if defined(OS_SOLARIS)
+  static __thread PerfContext perf_context_;
   return &perf_context_;
 #else
+  static thread_local PerfContext perf_context;
   return &perf_context;
 #endif
 #endif

--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -9,16 +9,6 @@
 #include "util/stop_watch.h"
 
 namespace rocksdb {
-#if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
-extern PerfContext perf_context;
-#else
-#if defined(OS_SOLARIS)
-extern __thread PerfContext perf_context_;
-#define perf_context (*get_perf_context())
-#else
-extern thread_local PerfContext perf_context;
-#endif
-#endif
 
 #if defined(NPERF_CONTEXT)
 
@@ -37,29 +27,29 @@ extern thread_local PerfContext perf_context;
 #define PERF_TIMER_START(metric) perf_step_timer_##metric.Start();
 
 // Declare and set start time of the timer
-#define PERF_TIMER_GUARD(metric)                                  \
-  PerfStepTimer perf_step_timer_##metric(&(perf_context.metric)); \
+#define PERF_TIMER_GUARD(metric)                                         \
+  PerfStepTimer perf_step_timer_##metric(&(get_perf_context()->metric)); \
   perf_step_timer_##metric.Start();
 
 // Declare and set start time of the timer
-#define PERF_TIMER_GUARD_WITH_ENV(metric, env)                         \
-  PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), env); \
+#define PERF_TIMER_GUARD_WITH_ENV(metric, env)                                \
+  PerfStepTimer perf_step_timer_##metric(&(get_perf_context()->metric), env); \
   perf_step_timer_##metric.Start();
 
 // Declare and set start time of the timer
 #define PERF_CPU_TIMER_GUARD(metric, env)              \
   PerfStepTimer perf_step_timer_##metric(              \
-      &(perf_context.metric), env, true,               \
+      &(get_perf_context()->metric), env, true,        \
       PerfLevel::kEnableTimeAndCPUTimeExceptForMutex); \
   perf_step_timer_##metric.Start();
 
-#define PERF_CONDITIONAL_TIMER_FOR_MUTEX_GUARD(metric, condition, stats,       \
-                                               ticker_type)                    \
-  PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), nullptr,      \
-                                         false, PerfLevel::kEnableTime, stats, \
-                                         ticker_type);                         \
-  if (condition) {                                                             \
-    perf_step_timer_##metric.Start();                                          \
+#define PERF_CONDITIONAL_TIMER_FOR_MUTEX_GUARD(metric, condition, stats,     \
+                                               ticker_type)                  \
+  PerfStepTimer perf_step_timer_##metric(                                    \
+      &(get_perf_context()->metric), nullptr, false, PerfLevel::kEnableTime, \
+      stats, ticker_type);                                                   \
+  if (condition) {                                                           \
+    perf_step_timer_##metric.Start();                                        \
   }
 
 // Update metric with time elapsed since last START. start time is reset
@@ -69,24 +59,23 @@ extern thread_local PerfContext perf_context;
 // Increase metric value
 #define PERF_COUNTER_ADD(metric, value)        \
   if (perf_level >= PerfLevel::kEnableCount) { \
-    perf_context.metric += value;              \
+    get_perf_context()->metric += value;       \
   }
 
 // Increase metric value
 #define PERF_COUNTER_BY_LEVEL_ADD(metric, value, level)                      \
   if (perf_level >= PerfLevel::kEnableCount &&                               \
-      perf_context.per_level_perf_context_enabled &&                         \
-      perf_context.level_to_perf_context) {                                  \
-    if ((*(perf_context.level_to_perf_context)).find(level) !=               \
-        (*(perf_context.level_to_perf_context)).end()) {                     \
-      (*(perf_context.level_to_perf_context))[level].metric += value;        \
-    }                                                                        \
-    else {                                                                   \
+      get_perf_context()->per_level_perf_context_enabled &&                  \
+      get_perf_context()->level_to_perf_context) {                           \
+    if ((*(get_perf_context()->level_to_perf_context)).find(level) !=        \
+        (*(get_perf_context()->level_to_perf_context)).end()) {              \
+      (*(get_perf_context()->level_to_perf_context))[level].metric += value; \
+    } else {                                                                 \
       PerfContextByLevel empty_context;                                      \
-      (*(perf_context.level_to_perf_context))[level] = empty_context;        \
-      (*(perf_context.level_to_perf_context))[level].metric += value;       \
+      (*(get_perf_context()->level_to_perf_context))[level] = empty_context; \
+      (*(get_perf_context()->level_to_perf_context))[level].metric += value; \
     }                                                                        \
-  }                                                                          \
+  }
 
 #endif
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2864,7 +2864,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     }
 
     SetPerfLevel(static_cast<PerfLevel> (shared->perf_level));
-    perf_context.EnablePerLevelPerfContext();
+    get_perf_context()->EnablePerLevelPerfContext();
     thread->stats.Start(thread->tid);
     (arg->bm->*(arg->method))(thread);
     thread->stats.Stop();


### PR DESCRIPTION
Summary:
This is an API-breaking change.
PerfContext objects should be created only by RocksDB and exposed to users only
for read. We should probably prevent applications from creating their own
PerfContext objects. If we do NOT disable this feature, users can copy/move
PerfContext objects, making resource reclamation more complex in its
destructor.

Test Plan:
```
$make clean && make -j32 all check
```
All tests must pass.