### PR TITLE
Use chrono::time_point instead of time_t

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * `TableProperties::num_entries` and `TableProperties::num_deletions` now also account for number of range tombstones.
 * Remove geodb, spatial_db, document_db, json_document, date_tiered_db, and redis_lists.
 * With "ldb ----try_load_options", when wal_dir specified by the option file doesn't exist, ignore it.
+* Change time resolution in FileOperationInfo.
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -905,6 +905,7 @@ class TestFileOperationListener : public EventListener {
     if (info.status.ok()) {
       ++file_reads_success_;
     }
+    ReportDuration(info);
   }
 
   void OnFileWriteFinish(const FileOperationInfo& info) override {
@@ -912,6 +913,7 @@ class TestFileOperationListener : public EventListener {
     if (info.status.ok()) {
       ++file_writes_success_;
     }
+    ReportDuration(info);
   }
 
   bool ShouldBeNotifiedOnFileIO() override { return true; }
@@ -920,6 +922,13 @@ class TestFileOperationListener : public EventListener {
   std::atomic<size_t> file_reads_success_;
   std::atomic<size_t> file_writes_;
   std::atomic<size_t> file_writes_success_;
+
+ private:
+  void ReportDuration(const FileOperationInfo& info) const {
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        info.finish_timestamp - info.start_timestamp);
+    ASSERT_GT(duration.count(), 0);
+  }
 };
 
 TEST_F(EventListenerTest, OnFileOperationTest) {

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -145,13 +145,18 @@ struct TableFileDeletionInfo {
 };
 
 struct FileOperationInfo {
+  using TimePoint = std::chrono::time_point<std::chrono::system_clock,
+                                            std::chrono::nanoseconds>;
+
   const std::string& path;
   uint64_t offset;
   size_t length;
-  std::chrono::system_clock::time_point start_timestamp;
-  std::chrono::system_clock::time_point finish_timestamp;
+  const TimePoint& start_timestamp;
+  const TimePoint& finish_timestamp;
   Status status;
-  FileOperationInfo(const std::string& _path) : path(_path) {}
+  FileOperationInfo(const std::string& _path, const TimePoint& start,
+                    const TimePoint& finish)
+      : path(_path), start_timestamp(start), finish_timestamp(finish) {}
 };
 
 struct FlushJobInfo {

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -147,8 +148,8 @@ struct FileOperationInfo {
   const std::string& path;
   uint64_t offset;
   size_t length;
-  time_t start_timestamp;
-  time_t finish_timestamp;
+  std::chrono::system_clock::time_point start_timestamp;
+  std::chrono::system_clock::time_point finish_timestamp;
   Status status;
   FileOperationInfo(const std::string& _path) : path(_path) {}
 };

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -99,11 +99,10 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
         }
         Slice tmp;
 
-        time_t start_ts = 0;
+        std::chrono::system_clock::time_point start_ts;
         uint64_t orig_offset = 0;
         if (ShouldNotifyListeners()) {
-          start_ts = std::chrono::system_clock::to_time_t(
-              std::chrono::system_clock::now());
+          start_ts = std::chrono::system_clock::now();
           orig_offset = aligned_offset + buf.CurrentSize();
         }
         s = file_->Read(aligned_offset + buf.CurrentSize(), allowed, &tmp,
@@ -145,10 +144,9 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
         Slice tmp_result;
 
 #ifndef ROCKSDB_LITE
-        time_t start_ts = 0;
+        std::chrono::system_clock::time_point start_ts;
         if (ShouldNotifyListeners()) {
-          start_ts = std::chrono::system_clock::to_time_t(
-              std::chrono::system_clock::now());
+          start_ts = std::chrono::system_clock::now();
         }
 #endif
         s = file_->Read(offset + pos, allowed, &tmp_result, scratch + pos);
@@ -444,11 +442,10 @@ Status WritableFileWriter::WriteBuffered(const char* data, size_t size) {
       TEST_SYNC_POINT("WritableFileWriter::Flush:BeforeAppend");
 
 #ifndef ROCKSDB_LITE
-      time_t start_ts = 0;
+      std::chrono::system_clock::time_point start_ts;
       uint64_t old_size = writable_file_->GetFileSize();
       if (ShouldNotifyListeners()) {
-        start_ts = std::chrono::system_clock::to_time_t(
-            std::chrono::system_clock::now());
+        start_ts = std::chrono::system_clock::now();
         old_size = next_write_offset_;
       }
 #endif
@@ -520,10 +517,9 @@ Status WritableFileWriter::WriteDirect() {
     {
       IOSTATS_TIMER_GUARD(write_nanos);
       TEST_SYNC_POINT("WritableFileWriter::Flush:BeforeAppend");
-      time_t start_ts(0);
+      std::chrono::system_clock::time_point start_ts;
       if (ShouldNotifyListeners()) {
-        start_ts = std::chrono::system_clock::to_time_t(
-            std::chrono::system_clock::now());
+        start_ts = std::chrono::system_clock::now();
       }
       // direct writes must be positional
       s = writable_file_->PositionedAppend(Slice(src, size), write_offset);

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -64,15 +64,13 @@ class SequentialFileReader {
 class RandomAccessFileReader {
  private:
 #ifndef ROCKSDB_LITE
-  void NotifyOnFileReadFinish(
-      uint64_t offset, size_t length,
-      const std::chrono::system_clock::time_point& start_ts,
-      const Status& status) const {
-    FileOperationInfo info(file_name_);
+  void NotifyOnFileReadFinish(uint64_t offset, size_t length,
+                              const FileOperationInfo::TimePoint& start_ts,
+                              const FileOperationInfo::TimePoint& finish_ts,
+                              const Status& status) const {
+    FileOperationInfo info(file_name_, start_ts, finish_ts);
     info.offset = offset;
     info.length = length;
-    info.start_timestamp = start_ts;
-    info.finish_timestamp = std::chrono::system_clock::now();
     info.status = status;
 
     for (auto& listener : listeners_) {
@@ -157,15 +155,13 @@ class RandomAccessFileReader {
 class WritableFileWriter {
  private:
 #ifndef ROCKSDB_LITE
-  void NotifyOnFileWriteFinish(
-      uint64_t offset, size_t length,
-      const std::chrono::system_clock::time_point& start_ts,
-      const Status& status) {
-    FileOperationInfo info(file_name_);
+  void NotifyOnFileWriteFinish(uint64_t offset, size_t length,
+                               const FileOperationInfo::TimePoint& start_ts,
+                               const FileOperationInfo::TimePoint& finish_ts,
+                               const Status& status) {
+    FileOperationInfo info(file_name_, start_ts, finish_ts);
     info.offset = offset;
     info.length = length;
-    info.start_timestamp = start_ts;
-    info.finish_timestamp = std::chrono::system_clock::now();
     info.status = status;
 
     for (auto& listener : listeners_) {

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -64,15 +64,15 @@ class SequentialFileReader {
 class RandomAccessFileReader {
  private:
 #ifndef ROCKSDB_LITE
-  void NotifyOnFileReadFinish(uint64_t offset, size_t length, time_t start_ts,
-                              const Status& status) const {
+  void NotifyOnFileReadFinish(
+      uint64_t offset, size_t length,
+      const std::chrono::system_clock::time_point& start_ts,
+      const Status& status) const {
     FileOperationInfo info(file_name_);
     info.offset = offset;
     info.length = length;
     info.start_timestamp = start_ts;
-    time_t finish_ts =
-        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    info.finish_timestamp = finish_ts;
+    info.finish_timestamp = std::chrono::system_clock::now();
     info.status = status;
 
     for (auto& listener : listeners_) {
@@ -157,15 +157,15 @@ class RandomAccessFileReader {
 class WritableFileWriter {
  private:
 #ifndef ROCKSDB_LITE
-  void NotifyOnFileWriteFinish(uint64_t offset, size_t length, time_t start_ts,
-                               const Status& status) {
+  void NotifyOnFileWriteFinish(
+      uint64_t offset, size_t length,
+      const std::chrono::system_clock::time_point& start_ts,
+      const Status& status) {
     FileOperationInfo info(file_name_);
     info.offset = offset;
     info.length = length;
     info.start_timestamp = start_ts;
-    time_t finish_ts =
-        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    info.finish_timestamp = finish_ts;
+    info.finish_timestamp = std::chrono::system_clock::now();
     info.status = status;
 
     for (auto& listener : listeners_) {


### PR DESCRIPTION
Summary:
By convention, time_t almost always stores the integral number of seconds since
00:00 hours, Jan 1, 1970 UTC, according to http://www.cplusplus.com/reference/ctime/time_t/.
We surely want more precision than seconds.

Test Plan:
```
$make clean && make -j32 all check
$./listener_test
```