### PR TITLE
WritePrepared: fix race condition on GetSnapshotListFromDB

### DIFF
--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -567,7 +567,7 @@ const Snapshot* WritePreparedTxnDB::GetSnapshot() {
 const std::vector<SequenceNumber> WritePreparedTxnDB::GetSnapshotListFromDB(
     SequenceNumber max) {
   ROCKS_LOG_DETAILS(info_log_, "GetSnapshotListFromDB with max %" PRIu64, max);
-  InstrumentedMutex(db_impl_->mutex());
+  InstrumentedMutexLock(db_impl_->mutex());
   return db_impl_->snapshots().GetAll(nullptr, max);
 }
 

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -567,7 +567,8 @@ const Snapshot* WritePreparedTxnDB::GetSnapshot() {
 const std::vector<SequenceNumber> WritePreparedTxnDB::GetSnapshotListFromDB(
     SequenceNumber max) {
   ROCKS_LOG_DETAILS(info_log_, "GetSnapshotListFromDB with max %" PRIu64, max);
-  InstrumentedMutexLock(db_impl_->mutex());
+  InstrumentedMutexLock dblock(db_impl_->mutex());
+  db_impl_->mutex()->AssertHeld();
   return db_impl_->snapshots().GetAll(nullptr, max);
 }
 


### PR DESCRIPTION
Fixes a typo that made mutex_ to remain unlocked when GetSnapshotListFromDB called from WritePreparedTxnDB.