### PR TITLE
Improve Error Message When wal_dir doesn't exist

### DIFF
--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -422,8 +422,12 @@ Status DBImpl::Recover(
     std::vector<std::string> filenames;
     s = env_->GetChildren(immutable_db_options_.wal_dir, &filenames);
     if (!s.ok()) {
-      return Status::InvalidArgument("wal_dir not found",
-                                     immutable_db_options_.wal_dir);
+      if (s.IsNotFound()) {
+        return Status::InvalidArgument("wal_dir not found",
+                                       immutable_db_options_.wal_dir);
+      } else {
+        return s;
+      }
     }
 
     std::vector<uint64_t> logs;

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -422,7 +422,8 @@ Status DBImpl::Recover(
     std::vector<std::string> filenames;
     s = env_->GetChildren(immutable_db_options_.wal_dir, &filenames);
     if (!s.ok()) {
-      return s;
+      return Status::InvalidArgument("wal_dir not found",
+                                     immutable_db_options_.wal_dir);
     }
 
     std::vector<uint64_t> logs;

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -421,13 +421,11 @@ Status DBImpl::Recover(
     // produced by an older version of rocksdb.
     std::vector<std::string> filenames;
     s = env_->GetChildren(immutable_db_options_.wal_dir, &filenames);
-    if (!s.ok()) {
-      if (s.IsNotFound()) {
-        return Status::InvalidArgument("wal_dir not found",
-                                       immutable_db_options_.wal_dir);
-      } else {
-        return s;
-      }
+    if (s.IsNotFound()) {
+      return Status::InvalidArgument("wal_dir not found",
+                                     immutable_db_options_.wal_dir);
+    } else if (!s.ok()) {
+      return s;
     }
 
     std::vector<uint64_t> logs;


### PR DESCRIPTION
Summary: Right now the error mesage when options.wal_dir doesn't exist is not helpful to users. Be more specific

Test Plan: Manually test the wal_dir doesn't exist case and observe the error message.