### PR TITLE
Add DeleteRangeCF for two WriteBatch::Handler subclass

### DIFF
--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -364,7 +364,7 @@ Status WriteCommittedTxn::CommitInternal() {
   auto s =
       db_impl_->WriteImpl(write_options_, working_batch, /*callback*/ nullptr,
                           /*log_used*/ nullptr, /*log_ref*/ log_number_,
-                          /*disable_memtable*/ false, &seq_used);  
+                          /*disable_memtable*/ false, &seq_used);
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
   if (s.ok()) {
     SetId(seq_used);
@@ -472,6 +472,12 @@ Status PessimisticTransaction::LockBatch(WriteBatch* batch,
       RecordKey(column_family_id, key);
       return Status::OK();
     }
+    virtual Status DeleteRangeCF(uint32_t /*column_family_id*/,
+                              const Slice& /*begin_key*/,
+                              const Slice& /*end_key*/) {
+      // TODO: Add range lock support
+      return Status::OK();
+   }
   };
 
   // Iterating on this handler will add all keys in this batch into keys

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -473,11 +473,11 @@ Status PessimisticTransaction::LockBatch(WriteBatch* batch,
       return Status::OK();
     }
     virtual Status DeleteRangeCF(uint32_t /*column_family_id*/,
-                              const Slice& /*begin_key*/,
-                              const Slice& /*end_key*/) {
+                                 const Slice& /*begin_key*/,
+                                 const Slice& /*end_key*/) override {
       // TODO: Add range lock support
       return Status::OK();
-   }
+    }
   };
 
   // Iterating on this handler will add all keys in this batch into keys

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -786,6 +786,13 @@ struct SubBatchCounter : public WriteBatch::Handler {
     AddKey(cf, key);
     return Status::OK();
   }
+
+  Status DeleteRangeCF(uint32_t /*column_family_id*/,
+                            const Slice& /*begin_key*/,
+                            const Slice& /*end_key*/) {
+    // TODO: Add range lock support
+    return Status::OK();
+ }
   Status MarkBeginPrepare(bool) override { return Status::OK(); }
   Status MarkRollback(const Slice&) override { return Status::OK(); }
   bool WriteAfterCommit() const override { return false; }


### PR DESCRIPTION
Background: We try to use DeleteRange to improve performance for myrocks' truncate table.

During testing, found out there are WriteBatch::Handler subclass don't implement DeleteRangeCF correctly.

This PR is to unblock myself first --- Currently I only need the following two subclasses and don't need range lock no due to the table itself is locked during truncate table

In future, Hope someone can add full support for the following WriteBatch::Handler subclass.

TODO:
1. Range lock support:
- pessimistic_transaction.cc:   class Handler : public WriteBatch::Handler
- write_prepared_txn_db.h: struct SubBatchCounter : public WriteBatch::Handler

2. Transaction support:
- transaction_base.cc:  struct IndexedWriteBatchBuilder : public WriteBatch::Handler 
- write_prepared_txn.cc:  struct RollbackWriteBatchBuilder : public WriteBatch::Handler 
- write_unprepared_txn_db.h: struct KeySetBuilder : public WriteBatch::Handler 
- write_unprepared_txn_db.cc:   struct RollbackWriteBatchBuilder : public WriteBatch::Handler 


Thanks Manuel and Andrew's help.