### PR TITLE
WritePrepared: snapshot should be larger than max_evicted_seq_

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -238,6 +238,13 @@ class DBImpl : public DB {
   virtual Status SyncWAL() override;
 
   virtual SequenceNumber GetLatestSequenceNumber() const override;
+  virtual SequenceNumber GetLastPublishedSequence() const {
+    if (last_seq_same_as_publish_seq_) {
+      return versions_->LastSequence();
+    } else {
+      return versions_->LastPublishedSequence();
+    }
+  }
   // REQUIRES: joined the main write queue if two_write_queues is disabled, and
   // the second write queue otherwise.
   virtual void SetLastPublishedSequence(SequenceNumber seq);

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -37,7 +37,7 @@ TransactionID PessimisticTransaction::GenTxnID() {
 
 PessimisticTransaction::PessimisticTransaction(
     TransactionDB* txn_db, const WriteOptions& write_options,
-    const TransactionOptions& txn_options)
+    const TransactionOptions& txn_options, const bool init)
     : TransactionBaseImpl(txn_db->GetRootDB(), write_options),
       txn_db_impl_(nullptr),
       expiration_time_(0),
@@ -51,7 +51,9 @@ PessimisticTransaction::PessimisticTransaction(
   txn_db_impl_ =
       static_cast_with_check<PessimisticTransactionDB, TransactionDB>(txn_db);
   db_impl_ = static_cast_with_check<DBImpl, DB>(db_);
-  Initialize(txn_options);
+  if (init) {
+    Initialize(txn_options);
+  }
 }
 
 void PessimisticTransaction::Initialize(const TransactionOptions& txn_options) {

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -38,7 +38,8 @@ class PessimisticTransactionDB;
 class PessimisticTransaction : public TransactionBaseImpl {
  public:
   PessimisticTransaction(TransactionDB* db, const WriteOptions& write_options,
-                         const TransactionOptions& txn_options, const bool init = true);
+                         const TransactionOptions& txn_options,
+                         const bool init = true);
 
   virtual ~PessimisticTransaction();
 

--- a/utilities/transactions/pessimistic_transaction.h
+++ b/utilities/transactions/pessimistic_transaction.h
@@ -38,7 +38,7 @@ class PessimisticTransactionDB;
 class PessimisticTransaction : public TransactionBaseImpl {
  public:
   PessimisticTransaction(TransactionDB* db, const WriteOptions& write_options,
-                         const TransactionOptions& txn_options);
+                         const TransactionOptions& txn_options, const bool init = true);
 
   virtual ~PessimisticTransaction();
 

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1223,7 +1223,9 @@ TEST_P(WritePreparedTransactionTest, MaxCatchupWithNewSnapshot) {
     }
     for (int i = 0; i < 10; i++) {
       auto snap = db->GetSnapshot();
-      ASSERT_LT(wp_db->max_evicted_seq_, snap->GetSequenceNumber());
+      if (snap->GetSequenceNumber() != 0) {
+        ASSERT_LT(wp_db->max_evicted_seq_, snap->GetSequenceNumber());
+      }  // seq 0 is ok to be less than max since nothing is visible to it
       db->ReleaseSnapshot(snap);
     }
   });
@@ -1258,6 +1260,8 @@ TEST_P(WritePreparedTransactionTest, TxnInitialize) {
 
   txn0->Rollback();
   txn1->Rollback();
+  delete txn0;
+  delete txn1;
 }
 
 // This tests that transactions with duplicate keys perform correctly after max

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -831,6 +831,13 @@ TEST_P(WritePreparedTransactionTest, DoubleSnapshot) {
   wp_db->ReleaseSnapshot(snapshot3);
 }
 
+size_t UniqueCnt(std::vector<SequenceNumber> vec) {
+  std::set<SequenceNumber> aset;
+  for (auto i : vec) {
+    aset.insert(i);
+  }
+  return aset.size();
+}
 // Test that the entries in old_commit_map_ get garbage collected properly
 TEST_P(WritePreparedTransactionTest, OldCommitMapGC) {
   const size_t snapshot_cache_bits = 0;
@@ -879,9 +886,9 @@ TEST_P(WritePreparedTransactionTest, OldCommitMapGC) {
     ASSERT_FALSE(wp_db->old_commit_map_empty_.load());
     ReadLock rl(&wp_db->old_commit_map_mutex_);
     ASSERT_EQ(3, wp_db->old_commit_map_.size());
-    ASSERT_EQ(2, wp_db->old_commit_map_[snap_seq1].size());
-    ASSERT_EQ(1, wp_db->old_commit_map_[snap_seq2].size());
-    ASSERT_EQ(1, wp_db->old_commit_map_[snap_seq3].size());
+    ASSERT_EQ(2, UniqueCnt(wp_db->old_commit_map_[snap_seq1]));
+    ASSERT_EQ(1, UniqueCnt(wp_db->old_commit_map_[snap_seq2]));
+    ASSERT_EQ(1, UniqueCnt(wp_db->old_commit_map_[snap_seq3]));
   }
 
   // Verify that the 2nd snapshot is cleaned up after the release
@@ -890,8 +897,8 @@ TEST_P(WritePreparedTransactionTest, OldCommitMapGC) {
     ASSERT_FALSE(wp_db->old_commit_map_empty_.load());
     ReadLock rl(&wp_db->old_commit_map_mutex_);
     ASSERT_EQ(2, wp_db->old_commit_map_.size());
-    ASSERT_EQ(2, wp_db->old_commit_map_[snap_seq1].size());
-    ASSERT_EQ(1, wp_db->old_commit_map_[snap_seq3].size());
+    ASSERT_EQ(2, UniqueCnt(wp_db->old_commit_map_[snap_seq1]));
+    ASSERT_EQ(1, UniqueCnt(wp_db->old_commit_map_[snap_seq3]));
   }
 
   // Verify that the 1st snapshot is cleaned up after the release
@@ -900,7 +907,7 @@ TEST_P(WritePreparedTransactionTest, OldCommitMapGC) {
     ASSERT_FALSE(wp_db->old_commit_map_empty_.load());
     ReadLock rl(&wp_db->old_commit_map_mutex_);
     ASSERT_EQ(1, wp_db->old_commit_map_.size());
-    ASSERT_EQ(1, wp_db->old_commit_map_[snap_seq3].size());
+    ASSERT_EQ(1, UniqueCnt(wp_db->old_commit_map_[snap_seq3]));
   }
 
   // Verify that the 3rd snapshot is cleaned up after the release

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1240,6 +1240,21 @@ TEST_P(WritePreparedTransactionTest, MaxCatchupWithNewSnapshot) {
   db->ReleaseSnapshot(snap);
 }
 
+TEST_P(WritePreparedTransactionTest, AdvanceSeqByOne) {
+  auto snap = db->GetSnapshot();
+  auto seq1 = snap->GetSequenceNumber();
+  db->ReleaseSnapshot(snap);
+
+  WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
+  wp_db->AdvanceSeqByOne();
+
+  snap = db->GetSnapshot();
+  auto seq2 = snap->GetSequenceNumber();
+  db->ReleaseSnapshot(snap);
+
+  ASSERT_LT(seq1, seq2);
+}
+
 // Test that the txn Initilize calls the overridden functions
 TEST_P(WritePreparedTransactionTest, TxnInitialize) {
   TransactionOptions txn_options;

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -634,10 +634,14 @@ void WritePreparedTxnDB::AdvanceSeqByOne() {
   assert(strlen(name) < 64 - 1);
   Status s = txn0->SetName(name);
   assert(s.ok());
-  // Without prepare it would simply skip the commit
-  s = txn0->Prepare();
+  if (s.ok()) {
+    // Without prepare it would simply skip the commit
+    s = txn0->Prepare();
+  }
   assert(s.ok());
-  s = txn0->Commit();
+  if (s.ok()) {
+    s = txn0->Commit();
+  }
   assert(s.ok());
   delete txn0;
 }

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -612,6 +612,7 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
       // Without prepare it would simply skip the commit
       txn0->Prepare();
       txn0->Commit();
+      delete txn0;
       snap_impl = db_impl_->GetSnapshotImpl(for_ww_conflict_check);
       assert(snap_impl);
       retry++;

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -608,10 +608,13 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
       snprintf(name, 64, "txn%" ROCKSDB_PRIszt,
                hasher(std::this_thread::get_id()));
       assert(strlen(name) < 64 - 1);
-      txn0->SetName(name);
+      Status s = txn0->SetName(name);
+      assert(s.ok());
       // Without prepare it would simply skip the commit
-      txn0->Prepare();
-      txn0->Commit();
+      s = txn0->Prepare();
+      assert(s.ok());
+      s = txn0->Commit();
+      assert(s.ok());
       delete txn0;
       snap_impl = db_impl_->GetSnapshotImpl(for_ww_conflict_check);
       assert(snap_impl);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -422,19 +422,22 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
                       "Evicting %" PRIu64 ",%" PRIu64 " with max %" PRIu64,
                       evicted.prep_seq, evicted.commit_seq, prev_max);
     if (prev_max < evicted.commit_seq) {
-      auto last = db_impl_->GetLastPublishedSequence() - 1;
+      auto last = db_impl_->GetLastPublishedSequence();  // could be 0
       SequenceNumber max_evicted_seq;
-      if (LIKELY(evicted.commit_seq <= last)) {
+      if (LIKELY(evicted.commit_seq < last)) {
+        assert(last > 0);
         // Inc max in larger steps to avoid frequent updates
         max_evicted_seq =
-            std::min(evicted.commit_seq + INC_STEP_FOR_MAX_EVICTED, last);
+            std::min(evicted.commit_seq + INC_STEP_FOR_MAX_EVICTED, last - 1);
       } else {
         // legit when a commit entry in a write batch overwrite the previous one
         max_evicted_seq = evicted.commit_seq;
       }
-    ROCKS_LOG_DETAILS(info_log_,
-                      "%lu Evicting %" PRIu64 ",%" PRIu64 " with max %" PRIu64 " => %lu",
-                      prepare_seq, evicted.prep_seq, evicted.commit_seq, prev_max, max_evicted_seq);
+      ROCKS_LOG_DETAILS(info_log_,
+                        "%lu Evicting %" PRIu64 ",%" PRIu64 " with max %" PRIu64
+                        " => %lu",
+                        prepare_seq, evicted.prep_seq, evicted.commit_seq,
+                        prev_max, max_evicted_seq);
       AdvanceMaxEvictedSeq(prev_max, max_evicted_seq);
     }
     // After each eviction from commit cache, check if the commit entry should
@@ -569,7 +572,8 @@ const Snapshot* WritePreparedTxnDB::GetSnapshot() {
   return GetSnapshotInternal(!kForWWConflictCheck);
 }
 
-SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(bool for_ww_conflict_check) {
+SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
+    bool for_ww_conflict_check) {
   // Note: for this optimization setting the last sequence number and obtaining
   // the smallest uncommitted seq should be done atomically. However to avoid
   // the mutex overhead, we call SmallestUnCommittedSeq BEFORE taking the
@@ -584,16 +588,30 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(bool for_ww_conflict_check
   assert(snap_impl);
   SequenceNumber snap_seq = snap_impl->GetSequenceNumber();
   if (UNLIKELY(snap_seq != 0 && snap_seq <= max_evicted_seq_)) {
-    // There is a very rare case in which the commit entry evict another commit
+    // There is a very rare case in which the commit entry evicts another commit
     // entry that is not published yet thus advancing max evicted seq beyond the
     // last published seq. This case is not likely in real-world setup so we
-    // handle it with a few retires.
+    // handle it with a few retries.
     size_t retry = 0;
     while (snap_impl->GetSequenceNumber() <= max_evicted_seq_ && retry < 100) {
       ROCKS_LOG_WARN(info_log_, "GetSnapshot retry %" PRIu64,
-                        snap_impl->GetSequenceNumber());
+                     snap_impl->GetSequenceNumber());
       ReleaseSnapshot(snap_impl);
-      std::this_thread::yield();
+      // Inserting an empty value will i) let the max evicted entry to be
+      // published, i.e., max == last_published, increase the last published to
+      // be one beyond max, i.e., max < last_published.
+      WriteOptions woptions;
+      TransactionOptions txn_options;
+      Transaction* txn0 = BeginTransaction(woptions, txn_options, nullptr);
+      std::hash<std::thread::id> hasher;
+      char name[64];
+      snprintf(name, 64, "txn%" ROCKSDB_PRIszt,
+               hasher(std::this_thread::get_id()));
+      assert(strlen(name) < 64 - 1);
+      txn0->SetName(name);
+      // Without prepare it would simply skip the commit
+      txn0->Prepare();
+      txn0->Commit();
       snap_impl = db_impl_->GetSnapshotImpl(for_ww_conflict_check);
       assert(snap_impl);
       retry++;
@@ -611,7 +629,7 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(bool for_ww_conflict_check
   ROCKS_LOG_DETAILS(
       db_impl_->immutable_db_options().info_log,
       "GetSnapshot %" PRIu64 " ww:%" PRIi32 " min_uncommitted: %" PRIu64,
-      for_ww_conflict_check, snapshot->GetSequenceNumber(), min_uncommitted);
+      for_ww_conflict_check, snap_impl->GetSequenceNumber(), min_uncommitted);
   return snap_impl;
 }
 

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -399,6 +399,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   friend class WritePreparedTransactionTest_DoubleSnapshot_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotReleased_Test;
+  friend class WritePreparedTransactionTest_NewSnapshotLargerThanMax_Test;
   friend class WritePreparedTransactionTest_OldCommitMapGC_Test;
   friend class WritePreparedTransactionTest_RollbackTest_Test;
   friend class WriteUnpreparedTxnDB;

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -396,6 +396,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   friend class WritePreparedTransactionTest_AdvanceMaxEvictedSeqBasicTest_Test;
   friend class
       WritePreparedTransactionTest_AdvanceMaxEvictedSeqWithDuplicatesTest_Test;
+  friend class WritePreparedTransactionTest_AdvanceSeqByOne_Test;
   friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;
   friend class WritePreparedTransactionTest_DoubleSnapshot_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
@@ -566,6 +567,10 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
                                const uint64_t& commit_seq,
                                const uint64_t& snapshot_seq,
                                const bool next_is_larger);
+
+  // A trick to increase the last visible sequence number by one and also wait
+  // for the in-flight commits to be visible.
+  void AdvanceSeqByOne();
 
   // The list of live snapshots at the last time that max_evicted_seq_ advanced.
   // The list stored into two data structures: in snapshot_cache_ that is

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -401,6 +401,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotReleased_Test;
   friend class WritePreparedTransactionTest_NewSnapshotLargerThanMax_Test;
+  friend class WritePreparedTransactionTest_MaxCatchupWithNewSnapshot_Test;
   friend class WritePreparedTransactionTest_OldCommitMapGC_Test;
   friend class WritePreparedTransactionTest_RollbackTest_Test;
   friend class WriteUnpreparedTxnDB;

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -374,6 +374,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   void UpdateCFComparatorMap(ColumnFamilyHandle* handle) override;
 
   virtual const Snapshot* GetSnapshot() override;
+  SnapshotImpl* GetSnapshotInternal(bool for_ww_conflict_check);
 
  protected:
   virtual Status VerifyCFOptions(


### PR DESCRIPTION
The AdvanceMaxEvictedSeq algorithm assumes that new snapshots always have sequence number larger than the last max_evicted_seq_. To enforce this assumption we make two changes:
i) max is not advanced beyond the last published seq, with the exception that the evicted commit entry itself is not published yet, which is quite rare.
ii) When obtaining the snapshot if the max_evicted_seq_ is not published yet, commit a dummy entry so that it waits for it to be published and also increased the latest published seq by one above the max.
To test these non-realistic corner cases we create a commit cache with size 1 so that every single commit results into eviction.