### PR TITLE
[BlobDB] Correct the comment about inlined blob option

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -76,7 +76,7 @@ void BlobDBOptions::Dump(Logger* log) const {
       log, "                               BlobDBOptions.max_db_size: %" PRIu64,
       max_db_size);
   ROCKS_LOG_HEADER(
-      log, "                            BlobDBOptions.ttl_range_secs: %" PRIu32,
+      log, "                            BlobDBOptions.ttl_range_secs: %" PRIu64,
       ttl_range_secs);
   ROCKS_LOG_HEADER(
       log, "                             BlobDBOptions.min_blob_size: %" PRIu64,

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -52,7 +52,7 @@ struct BlobDBOptions {
   // and so on
   uint64_t ttl_range_secs = 3600;
 
-  // The smallest value to store in blob log. Value larger than this threshold
+  // The smallest value to store in blob log. Values smaller than this threshold
   // will be inlined in base DB together with the key.
   uint64_t min_blob_size = 0;
 


### PR DESCRIPTION
- Corrected a comment asserting that the values "smaller" than a min_blob_size will be inlined in the base db. 
- Also fixed the type of ttl_range_secs while dumping blobdb options. 