### PR TITLE
[BlobDB] Remove an unused option

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -97,9 +97,6 @@ void BlobDBOptions::Dump(Logger* log) const {
       log, "          BlobDBOptions.garbage_collection_interval_secs: %" PRIu64,
       garbage_collection_interval_secs);
   ROCKS_LOG_HEADER(
-      log, "BlobDBOptions.garbage_collection_deletion_size_threshold: %lf",
-      garbage_collection_deletion_size_threshold);
-  ROCKS_LOG_HEADER(
       log, "                  BlobDBOptions.disable_background_tasks: %d",
       disable_background_tasks);
 }

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -76,10 +76,6 @@ struct BlobDBOptions {
   // Time interval to trigger garbage collection, in seconds.
   uint64_t garbage_collection_interval_secs = 60;
 
-  // If garbage collection is enabled, blob files with deleted size no less
-  // than this ratio will become candidates to be cleanup.
-  double garbage_collection_deletion_size_threshold = 0.75;
-
   // Disable all background job. Used for test only.
   bool disable_background_tasks = false;
 


### PR DESCRIPTION
Remove `garbage_collection_deletion_size_threshold` as it is not used anywhere. 

Test Plan:
`make check` and monitor other internal tests.