### PR TITLE
WritePrepared: commit of delayed prepared entries

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2565,8 +2565,7 @@ TEST_P(WritePreparedTransactionTest, CommitOfOldPrepared) {
   for (const size_t commit_cache_bits : {0, 2, 3}) {
     for (const size_t sub_batch_cnt : {1, 2, 3}) {
       DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
-      std::atomic<const Snapshot*> snap;
-      snap.store(nullptr);
+      std::atomic<const Snapshot*> snap = {nullptr};
       std::atomic<SequenceNumber> exp_prepare = {0};
       // Value is synchronized via snap
       PinnableSlice value;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2574,7 +2574,7 @@ TEST_P(WritePreparedTransactionTest, CommitOfOldPrepared) {
       // Take a snapshot after publish and before RemovePrepared:Start
       auto callback = [&](void* param) {
         SequenceNumber prep_seq = *((SequenceNumber*)param);
-        if (prep_seq == exp_prepare) {  // only for write_thread
+        if (prep_seq == exp_prepare.load()) {  // only for write_thread
           ASSERT_EQ(nullptr, snap.load());
           snap.store(db->GetSnapshot());
           ReadOptions roptions;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1199,7 +1199,6 @@ TEST_P(WritePreparedTransactionTest, MaxCatchupWithNewSnapshot) {
   const size_t commit_cache_bits = 0;    // only 1 entry => frequent eviction
   DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
   WriteOptions woptions;
-  TransactionOptions txn_options;
   WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
 
   const int writes = 50;
@@ -2568,7 +2567,7 @@ TEST_P(WritePreparedTransactionTest, CommitOfOldPrepared) {
       DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
       std::atomic<const Snapshot*> snap;
       snap.store(nullptr);
-      std::atomic<const SequenceNumber> exp_prepare = {0};
+      std::atomic<SequenceNumber> exp_prepare = {0};
       // Value is synchronized via snap
       PinnableSlice value;
       // Take a snapshot after publish and before RemovePrepared:Start

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2563,70 +2563,70 @@ TEST_P(WritePreparedTransactionTest, IteratorRefreshNotSupported) {
 // stresses such cacese.
 TEST_P(WritePreparedTransactionTest, CommitOfOldPrepared) {
   const size_t snapshot_cache_bits = 7;  // same as default
-  for (const size_t commit_cache_bits: {0, 2, 3}) {
-  for (const size_t sub_batch_cnt: {1, 2, 3}) {
-  DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
-  std::atomic<const Snapshot*> snap;
-  snap.store(nullptr);
-  std::atomic<const SequenceNumber> exp_prepare = {0};
-  // Value is synchronized via snap
-  PinnableSlice value;
-  // Take a snapshot after publish and before RemovePrepared:Start
-  auto callback = [&](void* param) {
-    SequenceNumber prep_seq = *((SequenceNumber*)param);
-    if (prep_seq == exp_prepare) {  // only for write_thread
-      ASSERT_EQ(nullptr, snap.load());
-      snap.store(db->GetSnapshot());
-      ReadOptions roptions;
-      roptions.snapshot = snap.load();
-      auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
-      ASSERT_OK(s);
-    }
-  };
-  SyncPoint::GetInstance()->SetCallBack("RemovePrepared:Start", callback);
-  SyncPoint::GetInstance()->EnableProcessing();
-  // Thread to cause frequent evictions
-  rocksdb::port::Thread eviction_thread([&]() {
-    for (int i = 0; i < 100; i++) {
-      db->Put(WriteOptions(), Slice("key1"), Slice("value1"));
-    }
-  });
-  rocksdb::port::Thread write_thread([&]() {
-    for (int i = 0; i < 100; i++) {
-      Transaction* txn =
-          db->BeginTransaction(WriteOptions(), TransactionOptions());
-      ASSERT_OK(txn->SetName("xid"));
-      std::string val_str = "value" + ToString(i);
-      for (size_t b = 0; b < sub_batch_cnt; b++) {
-      ASSERT_OK(txn->Put(Slice("key"), val_str));
-      }
-      ASSERT_OK(txn->Prepare());
-      // Let an eviction to kick in
-      std::this_thread::yield();
-
-      exp_prepare.store(txn->GetId());
-      ASSERT_OK(txn->Commit());
-      delete txn;
-
-      // Read with the snapshot taken before delayed_prepared_ cleanup
-      ReadOptions roptions;
-      roptions.snapshot = snap.load();
-      ASSERT_NE(nullptr, roptions.snapshot);
-      PinnableSlice value2;
-      auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value2);
-      ASSERT_OK(s);
-      // It should see its own write
-      ASSERT_TRUE(val_str == value2);
-      // The value read by snapshot should not change
-      ASSERT_STREQ(value2.ToString().c_str(), value.ToString().c_str());
-
-      db->ReleaseSnapshot(roptions.snapshot);
+  for (const size_t commit_cache_bits : {0, 2, 3}) {
+    for (const size_t sub_batch_cnt : {1, 2, 3}) {
+      DestroyAndReopenWithExtraOptions(snapshot_cache_bits, commit_cache_bits);
+      std::atomic<const Snapshot*> snap;
       snap.store(nullptr);
+      std::atomic<const SequenceNumber> exp_prepare = {0};
+      // Value is synchronized via snap
+      PinnableSlice value;
+      // Take a snapshot after publish and before RemovePrepared:Start
+      auto callback = [&](void* param) {
+        SequenceNumber prep_seq = *((SequenceNumber*)param);
+        if (prep_seq == exp_prepare) {  // only for write_thread
+          ASSERT_EQ(nullptr, snap.load());
+          snap.store(db->GetSnapshot());
+          ReadOptions roptions;
+          roptions.snapshot = snap.load();
+          auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
+          ASSERT_OK(s);
+        }
+      };
+      SyncPoint::GetInstance()->SetCallBack("RemovePrepared:Start", callback);
+      SyncPoint::GetInstance()->EnableProcessing();
+      // Thread to cause frequent evictions
+      rocksdb::port::Thread eviction_thread([&]() {
+        for (int i = 0; i < 100; i++) {
+          db->Put(WriteOptions(), Slice("key1"), Slice("value1"));
+        }
+      });
+      rocksdb::port::Thread write_thread([&]() {
+        for (int i = 0; i < 100; i++) {
+          Transaction* txn =
+              db->BeginTransaction(WriteOptions(), TransactionOptions());
+          ASSERT_OK(txn->SetName("xid"));
+          std::string val_str = "value" + ToString(i);
+          for (size_t b = 0; b < sub_batch_cnt; b++) {
+            ASSERT_OK(txn->Put(Slice("key"), val_str));
+          }
+          ASSERT_OK(txn->Prepare());
+          // Let an eviction to kick in
+          std::this_thread::yield();
+
+          exp_prepare.store(txn->GetId());
+          ASSERT_OK(txn->Commit());
+          delete txn;
+
+          // Read with the snapshot taken before delayed_prepared_ cleanup
+          ReadOptions roptions;
+          roptions.snapshot = snap.load();
+          ASSERT_NE(nullptr, roptions.snapshot);
+          PinnableSlice value2;
+          auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value2);
+          ASSERT_OK(s);
+          // It should see its own write
+          ASSERT_TRUE(val_str == value2);
+          // The value read by snapshot should not change
+          ASSERT_STREQ(value2.ToString().c_str(), value.ToString().c_str());
+
+          db->ReleaseSnapshot(roptions.snapshot);
+          snap.store(nullptr);
+        }
+      });
+      write_thread.join();
+      eviction_thread.join();
     }
-  });
-  write_thread.join();
-  eviction_thread.join();
-  }
     rocksdb::SyncPoint::GetInstance()->DisableProcessing();
     rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
   }

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -443,21 +443,21 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
     // After each eviction from commit cache, check if the commit entry should
     // be kept around because it overlaps with a live snapshot.
     CheckAgainstSnapshots(evicted);
-  if (UNLIKELY(!delayed_prepared_empty_.load(std::memory_order_acquire))) {
-    WriteLock wl(&prepared_mutex_);
-    for (auto dp: delayed_prepared_) {
-      if (dp == evicted.prep_seq) {
-        // This is a rare case that txn is committed but prepared_txns_ is not
-        // cleaned up yet. Refer to delayed_prepared_commits_ definition for why
-        // it should be kept updated.
-        delayed_prepared_commits_[evicted.prep_seq] = evicted.commit_seq;
-        ROCKS_LOG_DEBUG(info_log_,
-                        "delayed_prepared_commits_[%" PRIu64 "]=%" PRIu64,
-                        evicted.prep_seq, evicted.commit_seq);
-        break;
+    if (UNLIKELY(!delayed_prepared_empty_.load(std::memory_order_acquire))) {
+      WriteLock wl(&prepared_mutex_);
+      for (auto dp : delayed_prepared_) {
+        if (dp == evicted.prep_seq) {
+          // This is a rare case that txn is committed but prepared_txns_ is not
+          // cleaned up yet. Refer to delayed_prepared_commits_ definition for
+          // why it should be kept updated.
+          delayed_prepared_commits_[evicted.prep_seq] = evicted.commit_seq;
+          ROCKS_LOG_DEBUG(info_log_,
+                          "delayed_prepared_commits_[%" PRIu64 "]=%" PRIu64,
+                          evicted.prep_seq, evicted.commit_seq);
+          break;
+        }
       }
     }
-  }
   }
   bool succ =
       ExchangeCommitEntry(indexed_seq, evicted_64b, {prepare_seq, commit_seq});

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -465,7 +465,9 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
 
 void WritePreparedTxnDB::RemovePrepared(const uint64_t prepare_seq,
                                         const size_t batch_cnt) {
-  TEST_SYNC_POINT_CALLBACK("RemovePrepared:Start", const_cast<void*>(reinterpret_cast<const void*>(&prepare_seq)));
+  TEST_SYNC_POINT_CALLBACK(
+      "RemovePrepared:Start",
+      const_cast<void*>(reinterpret_cast<const void*>(&prepare_seq)));
   WriteLock wl(&prepared_mutex_);
   for (size_t i = 0; i < batch_cnt; i++) {
     prepared_txns_.erase(prepare_seq + i);
@@ -474,9 +476,8 @@ void WritePreparedTxnDB::RemovePrepared(const uint64_t prepare_seq,
       delayed_prepared_.erase(prepare_seq + i);
       auto it = delayed_prepared_commits_.find(prepare_seq + i);
       if (it != delayed_prepared_commits_.end()) {
-      ROCKS_LOG_DETAILS(info_log_,
-                        "delayed_prepared_commits_.erase %" PRIu64,
-                        prepare_seq + i);
+        ROCKS_LOG_DETAILS(info_log_, "delayed_prepared_commits_.erase %" PRIu64,
+                          prepare_seq + i);
         delayed_prepared_commits_.erase(it);
       }
       bool is_empty = delayed_prepared_.empty();
@@ -499,12 +500,10 @@ void WritePreparedTxnDB::MarkDelayedPreparedCommitted(
                         "MarkDelayedPreparedCommitted %" PRIu64 " -> %" PRIu64,
                         prepare_seq, commit_seq);
     } else {
-      ROCKS_LOG_DETAILS(info_log_,
-                        "MarkDelayedPreparedCommitted not found");
+      ROCKS_LOG_DETAILS(info_log_, "MarkDelayedPreparedCommitted not found");
     }
   } else {
-      ROCKS_LOG_DETAILS(info_log_,
-                        "MarkDelayedPreparedCommitted empty");
+    ROCKS_LOG_DETAILS(info_log_, "MarkDelayedPreparedCommitted empty");
   }
 }
 
@@ -641,7 +640,8 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
     // last published seq. This case is not likely in real-world setup so we
     // handle it with a few retries.
     size_t retry = 0;
-    while (snap_impl->GetSequenceNumber() <= future_max_evicted_seq_ && retry < 100) {
+    while (snap_impl->GetSequenceNumber() <= future_max_evicted_seq_ &&
+           retry < 100) {
       ROCKS_LOG_WARN(info_log_, "GetSnapshot retry %" PRIu64,
                      snap_impl->GetSequenceNumber());
       ReleaseSnapshot(snap_impl);
@@ -654,11 +654,11 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
     }
     assert(snap_impl->GetSequenceNumber() > future_max_evicted_seq_);
     if (snap_impl->GetSequenceNumber() <= future_max_evicted_seq_) {
-      throw std::runtime_error("Snapshot seq " +
-                               ToString(snap_impl->GetSequenceNumber()) +
-                               " after " + ToString(retry) +
-                               " retries is still less than futre_max_evicted_seq_" +
-                               ToString(future_max_evicted_seq_.load()));
+      throw std::runtime_error(
+          "Snapshot seq " + ToString(snap_impl->GetSequenceNumber()) +
+          " after " + ToString(retry) +
+          " retries is still less than futre_max_evicted_seq_" +
+          ToString(future_max_evicted_seq_.load()));
     }
   }
   EnhanceSnapshot(snap_impl, min_uncommitted);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -668,8 +668,10 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
     SequenceNumber max;
     while ((max = future_max_evicted_seq_.load()) &&
            snap_impl->GetSequenceNumber() <= max && retry < 100) {
-      ROCKS_LOG_WARN(info_log_, "GetSnapshot retry %" PRIu64,
-                     snap_impl->GetSequenceNumber());
+      ROCKS_LOG_WARN(info_log_,
+                     "GetSnapshot snap: %" PRIu64 " max: %" PRIu64
+                     " retry %" ROCKSDB_PRIszt,
+                     snap_impl->GetSequenceNumber(), max, retry);
       ReleaseSnapshot(snap_impl);
       // Wait for last visible seq to catch up with max, and also go beyond it
       // by one.

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -444,7 +444,7 @@ void WritePreparedTxnDB::AddCommitted(uint64_t prepare_seq, uint64_t commit_seq,
                         " => %lu",
                         prepare_seq, evicted.prep_seq, evicted.commit_seq,
                         prev_max, max_evicted_seq);
-      AdvanceMaxEvictedSeq(prev_max, max_evicted_seq, evicted);
+      AdvanceMaxEvictedSeq(prev_max, max_evicted_seq);
     }
     // After each eviction from commit cache, check if the commit entry should
     // be kept around because it overlaps with a live snapshot.
@@ -563,12 +563,11 @@ bool WritePreparedTxnDB::ExchangeCommitEntry(const uint64_t indexed_seq,
 }
 
 void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
-                                              const SequenceNumber& new_max,
-                                              const CommitEntry& evicted) {
+                                              const SequenceNumber& new_max) {
   ROCKS_LOG_DETAILS(info_log_,
-                    "AdvanceMaxEvictedSeq overhead %" PRIu64 " => %" PRIu64
-                    " evicted: %" PRIu64,
-                    prev_max, new_max, evicted.prep_seq);
+                    "AdvanceMaxEvictedSeq overhead %" PRIu64
+                    " => %" PRIu64 prev_max,
+                    new_max);
   // Declare the intention before getting snapshot from the DB. This helps a
   // concurrent GetSnapshot to wait to catch up with future_max_evicted_seq_ if
   // it has not already. Otherwise the new snapshot is when we ask DB for

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -645,7 +645,7 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
     // handle it with a few retries.
     size_t retry = 0;
     SequenceNumber max;
-    while ((max = future_max_evicted_seq_.load()) &&
+    while ((max = future_max_evicted_seq_.load()) != 0 &&
            snap_impl->GetSequenceNumber() <= max && retry < 100) {
       ROCKS_LOG_WARN(info_log_,
                      "GetSnapshot snap: %" PRIu64 " max: %" PRIu64

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -512,27 +512,6 @@ void WritePreparedTxnDB::RemovePrepared(const uint64_t prepare_seq,
   }
 }
 
-void WritePreparedTxnDB::MarkDelayedPreparedCommitted(
-    const uint64_t prepare_seq, const uint64_t commit_seq) {
-  WriteLock wl(&prepared_mutex_);
-  bool was_empty = delayed_prepared_.empty();
-  if (!was_empty) {
-    assert(!delayed_prepared_empty_);
-    if (delayed_prepared_.find(prepare_seq) != delayed_prepared_.end()) {
-      delayed_prepared_commits_[prepare_seq] = commit_seq;
-      ROCKS_LOG_DETAILS(info_log_,
-                        "MarkDelayedPreparedCommitted %" PRIu64 " -> %" PRIu64,
-                        prepare_seq, commit_seq);
-    } else {
-      ROCKS_LOG_DETAILS(info_log_,
-                        "MarkDelayedPreparedCommitted %" PRIu64 " not found");
-    }
-  } else {
-    ROCKS_LOG_DETAILS(info_log_,
-                      "MarkDelayedPreparedCommitted %" PRIu64 " empty");
-  }
-}
-
 bool WritePreparedTxnDB::GetCommitEntry(const uint64_t indexed_seq,
                                         CommitEntry64b* entry_64b,
                                         CommitEntry* entry) const {

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -492,6 +492,7 @@ void WritePreparedTxnDB::MarkDelayedPreparedCommitted(
   WriteLock wl(&prepared_mutex_);
   bool was_empty = delayed_prepared_.empty();
   if (!was_empty) {
+    assert(!delayed_prepared_empty_);
     if (delayed_prepared_.find(prepare_seq) != delayed_prepared_.end()) {
       delayed_prepared_commits_[prepare_seq] = commit_seq;
       ROCKS_LOG_DETAILS(info_log_,

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -188,19 +188,20 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
         // This is the order: 1) delayed_prepared_commits_ update, 2) publish 3)
         // delayed_prepared_ clean up. So check if it is the case of a late
         // clenaup.
-        auto it =delayed_prepared_commits_.find(prep_seq);
+        auto it = delayed_prepared_commits_.find(prep_seq);
         if (it == delayed_prepared_commits_.end()) {
-        // Then it is not committed yet
-        ROCKS_LOG_DETAILS(info_log_,
-                          "IsInSnapshot %" PRIu64 " in %" PRIu64
-                          " returns %" PRId32,
-                          prep_seq, snapshot_seq, 0);
-        return false;
+          // Then it is not committed yet
+          ROCKS_LOG_DETAILS(info_log_,
+                            "IsInSnapshot %" PRIu64 " in %" PRIu64
+                            " returns %" PRId32,
+                            prep_seq, snapshot_seq, 0);
+          return false;
         } else {
-        ROCKS_LOG_DETAILS(info_log_,
-                          "IsInSnapshot %" PRIu64 " in %" PRIu64
-                          " commit: %" PRIu64 " returns %" PRId32,
-                          prep_seq, snapshot_seq, it->second, snapshot_seq <= it->second);
+          ROCKS_LOG_DETAILS(info_log_,
+                            "IsInSnapshot %" PRIu64 " in %" PRIu64
+                            " commit: %" PRIu64 " returns %" PRId32,
+                            prep_seq, snapshot_seq, it->second,
+                            snapshot_seq <= it->second);
           return it->second <= snapshot_seq;
         }
       }

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -517,8 +517,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   // a serial invocation in which the last invocation is the one with the
   // largest new_max value.
   void AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
-                            const SequenceNumber& new_max,
-                            const CommitEntry& evicted = {});
+                            const SequenceNumber& new_max);
 
   inline SequenceNumber SmallestUnCommittedSeq() {
     // Since we update the prepare_heap always from the main write queue via


### PR DESCRIPTION
Here is the order of ops in a commit: 1) update commit cache 2) publish seq, 3) RemovePrepared. In case of a delayed prepared, there will be a gap between when the commit is visible to snapshots until delayed_prepared_ is cleaned up. To tell apart this case from a delayed uncommitted txn from, the commit entry of a delayed prepared is also stored in delayed_prepared_commits_, which is updated before publishing the commit.
Also logic in GetSnapshotInternal that ensures that each new snapshot is always larger than max_evicted_seq_ is updated to check against the upcoming value of max_evicted_seq_ rather than its current one. This is because AdvanceMaxEvictedSeq gets the list of snapshots lower than the new max, before updating max_evicted_seq_.