### PR TITLE
Atomic ingest

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@
 * Remove PlainTable's store_index_in_file feature. When opening an existing DB with index in SST files, the index and bloom filter will still be rebuild while SST files are opened, in the same way as there is no index in the file.
 * Remove CuckooHash memtable.
 * The counter stat `number.block.not_compressed` now also counts blocks not compressed due to poor compression ratio.
+* Support atomic SST file ingestion across multiple column families via DB::IngestExternalFiles.
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,7 +24,7 @@
 * Remove PlainTable's store_index_in_file feature. When opening an existing DB with index in SST files, the index and bloom filter will still be rebuild while SST files are opened, in the same way as there is no index in the file.
 * Remove CuckooHash memtable.
 * The counter stat `number.block.not_compressed` now also counts blocks not compressed due to poor compression ratio.
-* Support atomic SST file ingestion across multiple column families via DB::IngestExternalFiles.
+* Support SST file ingestion across multiple column families via DB::IngestExternalFiles. See the function's comment about atomicity.
 
 ### Bug Fixes
 * Fix a deadlock caused by compaction and file ingestion waiting for each other in the event of write stalls.

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3128,13 +3128,12 @@ Status DBImpl::IngestExternalFiles(
   for (size_t i = 0; i != num_cfs; ++i) {
     if (args[i].external_files.empty()) {
       char err_msg[128] = {0};
-      snprintf(err_msg, 128, "external_files[%d] is empty",
-               static_cast<int>(i));
+      snprintf(err_msg, 128, "external_files[%zu] is empty", i);
       return Status::InvalidArgument(err_msg);
     }
   }
   for (const auto& arg : args) {
-    const auto& ingest_opts = arg.options;
+    const IngestExternalFileOptions& ingest_opts = arg.options;
     if (ingest_opts.ingest_behind &&
         !immutable_db_options_.allow_ingest_behind) {
       return Status::InvalidArgument(

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3334,6 +3334,14 @@ Status DBImpl::IngestExternalFiles(
         if (!cfd->IsDropped()) {
           InstallSuperVersionAndScheduleWork(cfd, &sv_ctxs[i],
                                              *cfd->GetLatestMutableCFOptions());
+#ifndef NDEBUG
+          if (0 == i && num_cfs > 1) {
+            TEST_SYNC_POINT(
+                "DBImpl::IngestExternalFiles:InstallSVForFirstCF:0");
+            TEST_SYNC_POINT(
+                "DBImpl::IngestExternalFiles:InstallSVForFirstCF:1");
+          }
+#endif  // !NDEBUG
         }
       }
     }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3121,7 +3121,17 @@ Status DBImpl::IngestExternalFile(
 Status DBImpl::IngestExternalFiles(
     const std::vector<IngestExternalFileArg>& args) {
   if (args.empty()) {
-    return Status::InvalidArgument("column_families is empty");
+    return Status::InvalidArgument("ingestion arg list is empty");
+  }
+  {
+    std::unordered_set<ColumnFamilyHandle*> unique_cfhs;
+    for (const auto& arg : args) {
+      if (unique_cfhs.count(arg.column_family) > 0) {
+        return Status::InvalidArgument(
+            "ingestion args have duplicate column families");
+      }
+      unique_cfhs.insert(arg.column_family);
+    }
   }
   // Ingest multiple external SST files atomically.
   size_t num_cfs = args.size();

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -348,10 +348,7 @@ class DBImpl : public DB {
 
   using DB::IngestExternalFiles;
   virtual Status IngestExternalFiles(
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      const std::vector<std::vector<std::string>>& external_files,
-      const std::vector<IngestExternalFileOptions>& ingestion_options_list)
-      override;
+      const std::vector<IngestExternalFileArg>& args) override;
 
   virtual Status VerifyChecksum() override;
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1595,7 +1595,14 @@ class DBImpl : public DB {
                               const CompactionJobStats& compaction_job_stats,
                               const int job_id, const Version* current,
                               CompactionJobInfo* compaction_job_info) const;
-#endif
+  // Reserve the next 'num' file numbers for to-be-ingested external SST files,
+  // and return the current file_number in 'next_file_number'.
+  // Write a version edit to the MANIFEST.
+  Status ReserveFileNumbersBeforeIngestion(
+      ColumnFamilyData* cfd, uint64_t num,
+      std::list<uint64_t>::iterator* pending_output_elem,
+      uint64_t* next_file_number);
+#endif  //! ROCKSDB_LITE
 
   bool ShouldPurge(uint64_t file_number) const;
   void MarkAsGrabbedForPurge(uint64_t file_number);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -346,6 +346,13 @@ class DBImpl : public DB {
       const std::vector<std::string>& external_files,
       const IngestExternalFileOptions& ingestion_options) override;
 
+  using DB::IngestExternalFiles;
+  virtual Status IngestExternalFiles(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<std::vector<std::string>>& external_files,
+      const std::vector<IngestExternalFileOptions>& ingestion_options_list)
+      override;
+
   virtual Status VerifyChecksum() override;
 
   using DB::StartTrace;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2462,6 +2462,15 @@ class ModelDB : public DB {
     return Status::NotSupported("Not implemented.");
   }
 
+  using DB::IngestExternalFiles;
+  virtual Status IngestExternalFiles(
+      const std::vector<ColumnFamilyHandle*>& /*column_families*/,
+      const std::vector<std::vector<std::string>>& /*external_files*/,
+      const std::vector<IngestExternalFileOptions>& /*ingestion_options_list*/)
+      override {
+    return Status::NotSupported("Not implemented");
+  }
+
   virtual Status VerifyChecksum() override {
     return Status::NotSupported("Not implemented.");
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2464,10 +2464,7 @@ class ModelDB : public DB {
 
   using DB::IngestExternalFiles;
   virtual Status IngestExternalFiles(
-      const std::vector<ColumnFamilyHandle*>& /*column_families*/,
-      const std::vector<std::vector<std::string>>& /*external_files*/,
-      const std::vector<IngestExternalFileOptions>& /*ingestion_options_list*/)
-      override {
+      const std::vector<IngestExternalFileArg>& /*args*/) override {
     return Status::NotSupported("Not implemented");
   }
 

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -85,7 +85,8 @@ class ExternalSstFileIngestionJob {
         env_options_(env_options),
         db_snapshots_(db_snapshots),
         ingestion_options_(ingestion_options),
-        job_start_time_(env_->NowMicros()) {}
+        job_start_time_(env_->NowMicros()),
+        consumed_seqno_(false) {}
 
   // Prepare the job by copying external files into the DB.
   Status Prepare(const std::vector<std::string>& external_files_paths,
@@ -117,6 +118,9 @@ class ExternalSstFileIngestionJob {
   const autovector<IngestedFileInfo>& files_to_ingest() const {
     return files_to_ingest_;
   }
+
+  // Whether to increment VersionSet's seqno after this job runs
+  bool ShouldIncrementLastSequence() const { return consumed_seqno_; }
 
  private:
   // Open the external file and populate `file_to_ingest` with all the
@@ -159,6 +163,7 @@ class ExternalSstFileIngestionJob {
   const IngestExternalFileOptions& ingestion_options_;
   VersionEdit edit_;
   uint64_t job_start_time_;
+  bool consumed_seqno_;
 };
 
 }  // namespace rocksdb

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2329,7 +2329,10 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_Success) {
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
     ifo.allow_global_seqno = true;        // Always allow global_seqno
-    ifo.write_global_seqno = GetParam();  // May or may not write global_seqno
+    // May or may not write global_seqno
+    ifo.write_global_seqno = std::get<0>(GetParam());
+    // Whether to verify checksums before ingestion
+    ifo.verify_checksums_before_ingest = std::get<1>(GetParam());
   }
   std::vector<std::vector<std::pair<std::string, std::string>>> data;
   data.push_back(
@@ -2381,7 +2384,10 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_PrepareFail) {
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
     ifo.allow_global_seqno = true;        // Always allow global_seqno
-    ifo.write_global_seqno = GetParam();  // May or may not write global_seqno
+    // May or may not write global_seqno
+    ifo.write_global_seqno = std::get<0>(GetParam());
+    // Whether to verify block checksums before ingest
+    ifo.verify_checksums_before_ingest = std::get<1>(GetParam());
   }
   std::vector<std::vector<std::pair<std::string, std::string>>> data;
   data.push_back(
@@ -2444,7 +2450,10 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_CommitFail) {
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
     ifo.allow_global_seqno = true;        // Always allow global_seqno
-    ifo.write_global_seqno = GetParam();  // May or may not write global_seqno
+    // May or may not write global_seqno
+    ifo.write_global_seqno = std::get<0>(GetParam());
+    // Whether to verify block checksums before ingestion
+    ifo.verify_checksums_before_ingest = std::get<1>(GetParam());
   }
   std::vector<std::vector<std::pair<std::string, std::string>>> data;
   data.push_back(
@@ -2512,7 +2521,10 @@ TEST_P(ExternalSSTFileTest,
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
     ifo.allow_global_seqno = true;        // Always allow global_seqno
-    ifo.write_global_seqno = GetParam();  // May or may not write global_seqno
+    // May or may not write global_seqno
+    ifo.write_global_seqno = std::get<0>(GetParam());
+    // Whether to verify block checksums before ingestion
+    ifo.verify_checksums_before_ingest = std::get<1>(GetParam());
   }
   std::vector<std::vector<std::pair<std::string, std::string>>> data;
   data.push_back(

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -219,7 +219,7 @@ class ExternalSSTFileTest
     assert(ifos.size() == num_cfs);
     assert(data.size() == num_cfs);
     Status s;
-    std::vector<std::vector<std::string>> external_files;
+    std::vector<IngestExternalFileArg> args;
     for (size_t i = 0; i != num_cfs; ++i) {
       std::string external_file_path;
       s = GenerateOneExternalFile(
@@ -230,9 +230,11 @@ class ExternalSSTFileTest
         return s;
       }
       ++file_id;
-      external_files.push_back({external_file_path});
+      args.emplace_back(column_families[i],
+                        std::vector<std::string>(1, external_file_path),
+                        ifos[i]);
     }
-    s = db_->IngestExternalFiles(column_families, external_files, ifos);
+    s = db_->IngestExternalFiles(args);
     return s;
   }
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -219,7 +219,7 @@ class ExternalSSTFileTest
     assert(ifos.size() == num_cfs);
     assert(data.size() == num_cfs);
     Status s;
-    std::vector<IngestExternalFileArg> args;
+    std::vector<IngestExternalFileArg> args(num_cfs);
     for (size_t i = 0; i != num_cfs; ++i) {
       std::string external_file_path;
       s = GenerateOneExternalFile(
@@ -230,9 +230,10 @@ class ExternalSSTFileTest
         return s;
       }
       ++file_id;
-      args.emplace_back(column_families[i],
-                        std::vector<std::string>(1, external_file_path),
-                        ifos[i]);
+
+      args[i].column_family = column_families[i];
+      args[i].external_files.push_back(external_file_path);
+      args[i].options = ifos[i];
     }
     s = db_->IngestExternalFiles(args);
     return s;

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2328,7 +2328,7 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_Success) {
   column_families.push_back(handles_[1]);
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
-    ifo.allow_global_seqno = true;        // Always allow global_seqno
+    ifo.allow_global_seqno = true;  // Always allow global_seqno
     // May or may not write global_seqno
     ifo.write_global_seqno = std::get<0>(GetParam());
     // Whether to verify checksums before ingestion
@@ -2500,7 +2500,7 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_PrepareFail) {
   column_families.push_back(handles_[1]);
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
-    ifo.allow_global_seqno = true;        // Always allow global_seqno
+    ifo.allow_global_seqno = true;  // Always allow global_seqno
     // May or may not write global_seqno
     ifo.write_global_seqno = std::get<0>(GetParam());
     // Whether to verify block checksums before ingest
@@ -2566,7 +2566,7 @@ TEST_P(ExternalSSTFileTest, IngestFilesIntoMultipleColumnFamilies_CommitFail) {
   column_families.push_back(handles_[1]);
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
-    ifo.allow_global_seqno = true;        // Always allow global_seqno
+    ifo.allow_global_seqno = true;  // Always allow global_seqno
     // May or may not write global_seqno
     ifo.write_global_seqno = std::get<0>(GetParam());
     // Whether to verify block checksums before ingestion
@@ -2637,7 +2637,7 @@ TEST_P(ExternalSSTFileTest,
   column_families.push_back(handles_[1]);
   std::vector<IngestExternalFileOptions> ifos(column_families.size());
   for (auto& ifo : ifos) {
-    ifo.allow_global_seqno = true;        // Always allow global_seqno
+    ifo.allow_global_seqno = true;  // Always allow global_seqno
     // May or may not write global_seqno
     ifo.write_global_seqno = std::get<0>(GetParam());
     // Whether to verify block checksums before ingestion

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3060,6 +3060,9 @@ Status VersionSet::ProcessManifestWrites(
 
     // Write new records to MANIFEST log
     if (s.ok()) {
+#ifndef NDEBUG
+      size_t idx = 0;
+#endif
       for (auto& e : batch_edits) {
         std::string record;
         if (!e->EncodeTo(&record)) {
@@ -3069,6 +3072,15 @@ Status VersionSet::ProcessManifestWrites(
         }
         TEST_KILL_RANDOM("VersionSet::LogAndApply:BeforeAddRecord",
                          rocksdb_kill_odds * REDUCE_ODDS2);
+#ifndef NDEBUG
+        if (batch_edits.size() > 1 && batch_edits.size() - 1 == idx) {
+          TEST_SYNC_POINT(
+              "VersionSet::ProcessManifestWrites:BeforeWriteLastVersionEdit:0");
+          TEST_SYNC_POINT(
+              "VersionSet::ProcessManifestWrites:BeforeWriteLastVersionEdit:1");
+        }
+        ++idx;
+#endif /* !NDEBUG */
         s = descriptor_log_->AddRecord(record);
         if (!s.ok()) {
           break;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1051,6 +1051,11 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
+  virtual Status IngestExternalFiles(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<std::vector<std::string>>& external_files,
+      const std::vector<IngestExternalFileOptions>& ingestion_options_list) = 0;
+
   virtual Status VerifyChecksum() = 0;
 
   // AddFile() is deprecated, please use IngestExternalFile()

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1067,10 +1067,10 @@ class DB {
   // If this function returns NOK, or the process crashes, then non-of the
   // files will be ingested into the database after recovery.
   // Note that it is possible for application to observe a mixed state during
-  // the execution of this function. If a user issues two consecutive Get calls
-  // to two different column families, one of the Get calls may return ingested
-  // data, while the other may return data before ingestion.
-  // In this sense, it's not strictly 'atomic'.
+  // the execution of this function. If the user performs range scan over the
+  // column families with iterators, iterator on one column family may return
+  // ingested data, while iterator on other column family returns old data.
+  // Users can use snapshot for a consistent view of data.
   virtual Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) = 0;
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1063,6 +1063,14 @@ class DB {
 
   // IngestExternalFiles() will ingest files for multiple column families, and
   // record the result atomically to the MANIFEST.
+  // If this function returns OK, all column families' ingestion must succeed.
+  // If this function returns NOK, or the process crashes, then non-of the
+  // files will be ingested into the database after recovery.
+  // Note that it is possible for application to observe a mixed state during
+  // the execution of this function. If a user issues two consecutive Get calls
+  // to two different column families, one of the Get calls may return ingested
+  // data, while the other may return data before ingestion.
+  // In this sense, it's not strictly 'atomic'.
   virtual Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) = 0;
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -111,13 +111,9 @@ struct RangePtr {
 };
 
 struct IngestExternalFileArg {
-  ColumnFamilyHandle* column_family;
+  ColumnFamilyHandle* column_family = nullptr;
   std::vector<std::string> external_files;
   IngestExternalFileOptions options;
-  IngestExternalFileArg(ColumnFamilyHandle* cfh,
-                        const std::vector<std::string>& files,
-                        const IngestExternalFileOptions& ingest_options)
-      : column_family(cfh), external_files(files), options(ingest_options) {}
 };
 
 // A collections of table properties objects, where

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -112,8 +112,8 @@ struct RangePtr {
 
 struct IngestExternalFileArg {
   ColumnFamilyHandle* column_family;
-  const std::vector<std::string> external_files;
-  const IngestExternalFileOptions options;
+  std::vector<std::string> external_files;
+  IngestExternalFileOptions options;
   IngestExternalFileArg(ColumnFamilyHandle* cfh,
                         const std::vector<std::string>& files,
                         const IngestExternalFileOptions& ingest_options)
@@ -1071,6 +1071,9 @@ class DB {
   // column families with iterators, iterator on one column family may return
   // ingested data, while iterator on other column family returns old data.
   // Users can use snapshot for a consistent view of data.
+  //
+  // REQUIRES: each arg corresponds to a different column family: namely, for
+  // 0 <= i < j < len(args), args[i].column_family != args[j].column_family.
   virtual Status IngestExternalFiles(
       const std::vector<IngestExternalFileArg>& args) = 0;
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -110,6 +110,16 @@ struct RangePtr {
   RangePtr(const Slice* s, const Slice* l) : start(s), limit(l) { }
 };
 
+struct IngestExternalFileArg {
+  ColumnFamilyHandle* column_family;
+  const std::vector<std::string> external_files;
+  const IngestExternalFileOptions options;
+  IngestExternalFileArg(ColumnFamilyHandle* cfh,
+                        const std::vector<std::string>& files,
+                        const IngestExternalFileOptions& ingest_options)
+      : column_family(cfh), external_files(files), options(ingest_options) {}
+};
+
 // A collections of table properties objects, where
 //  key: is the table's file name.
 //  value: the table properties object of the given table.
@@ -1051,10 +1061,10 @@ class DB {
     return IngestExternalFile(DefaultColumnFamily(), external_files, options);
   }
 
+  // IngestExternalFiles() will ingest files for multiple column families, and
+  // record the result atomically to the MANIFEST.
   virtual Status IngestExternalFiles(
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      const std::vector<std::vector<std::string>>& external_files,
-      const std::vector<IngestExternalFileOptions>& ingestion_options_list) = 0;
+      const std::vector<IngestExternalFileArg>& args) = 0;
 
   virtual Status VerifyChecksum() = 0;
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -107,6 +107,15 @@ class StackableDB : public DB {
     return db_->IngestExternalFile(column_family, external_files, options);
   }
 
+  using DB::IngestExternalFiles;
+  virtual Status IngestExternalFiles(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      const std::vector<std::vector<std::string>>& external_files,
+      const std::vector<IngestExternalFileOptions>& ingestion_options_list) {
+    return db_->IngestExternalFiles(column_families, external_files,
+                                    ingestion_options_list);
+  }
+
   virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }
 
   using DB::KeyMayExist;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -111,7 +111,8 @@ class StackableDB : public DB {
   virtual Status IngestExternalFiles(
       const std::vector<ColumnFamilyHandle*>& column_families,
       const std::vector<std::vector<std::string>>& external_files,
-      const std::vector<IngestExternalFileOptions>& ingestion_options_list) {
+      const std::vector<IngestExternalFileOptions>& ingestion_options_list)
+      override {
     return db_->IngestExternalFiles(column_families, external_files,
                                     ingestion_options_list);
   }

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -109,12 +109,8 @@ class StackableDB : public DB {
 
   using DB::IngestExternalFiles;
   virtual Status IngestExternalFiles(
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      const std::vector<std::vector<std::string>>& external_files,
-      const std::vector<IngestExternalFileOptions>& ingestion_options_list)
-      override {
-    return db_->IngestExternalFiles(column_families, external_files,
-                                    ingestion_options_list);
+      const std::vector<IngestExternalFileArg>& args) override {
+    return db_->IngestExternalFiles(args);
   }
 
   virtual Status VerifyChecksum() override { return db_->VerifyChecksum(); }

--- a/util/fault_injection_test_env.h
+++ b/util/fault_injection_test_env.h
@@ -135,6 +135,10 @@ class FaultInjectionTestEnv : public EnvWrapper {
 
   void WritableFileClosed(const FileState& state);
 
+  void WritableFileSynced(const FileState& state);
+
+  void WritableFileAppended(const FileState& state);
+
   // For every file that is not fully synced, make a call to `func` with
   // FileState of the file as the parameter.
   Status DropFileData(std::function<Status(Env*, FileState)> func);


### PR DESCRIPTION
Make file ingestion atomic.

Summary: as title.
Ingesting external SST files into multiple column families should be atomic. If
a crash occurs and db reopens, either all column families have successfully
ingested the files before the crash, or non of the ingestions have any effect
on the state of the db.

Also add unit tests for atomic ingestion.

Note that the unit test here does not cover the case of incomplete atomic group
in the MANIFEST, which is covered in VersionSetTest already.

Test Plan:
```
$make clean && make -j32
$./external_sst_file_test --gtest_filter=ExternalSSTFileTest/ExternalSSTFileTest.IngestFilesIntoMultipleColumnFamilies*/*
$make -j32 all check
```