### PR TITLE
[BlobDB] Remove unused Blob WAL filter

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -45,13 +45,6 @@ int kBlockBasedTableVersionFormat = 2;
 namespace rocksdb {
 namespace blob_db {
 
-WalFilter::WalProcessingOption BlobReconcileWalFilter::LogRecordFound(
-    unsigned long long /*log_number*/, const std::string& /*log_file_name*/,
-    const WriteBatch& /*batch*/, WriteBatch* /*new_batch*/,
-    bool* /*batch_changed*/) {
-  return WalFilter::WalProcessingOption::kContinueProcessing;
-}
-
 bool BlobFileComparator::operator()(
     const std::shared_ptr<BlobFile>& lhs,
     const std::shared_ptr<BlobFile>& rhs) const {

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -47,21 +47,6 @@ struct BlobCompactionContext;
 class BlobDBImpl;
 class BlobFile;
 
-// this implements the callback from the WAL which ensures that the
-// blob record is present in the blob log. If fsync/fdatasync in not
-// happening on every write, there is the probability that keys in the
-// blob log can lag the keys in blobs
-// TODO(yiwu): implement the WAL filter.
-class BlobReconcileWalFilter : public WalFilter {
- public:
-  virtual WalFilter::WalProcessingOption LogRecordFound(
-      unsigned long long log_number, const std::string& log_file_name,
-      const WriteBatch& batch, WriteBatch* new_batch,
-      bool* batch_changed) override;
-
-  virtual const char* Name() const override { return "BlobDBWalReconciler"; }
-};
-
 // Comparator to sort "TTL" aware Blob files based on the lower value of
 // TTL range.
 struct BlobFileComparatorTTL {


### PR DESCRIPTION
Remove unused blob WAL filter so that users are not confused.
I was initially under the impression that we have WAL Filter support in BlobDB. 

Test Plan:
`make check`