### PR TITLE
Correct the code comment in Compaction::KeyNotExistsBeyondOutputLevel

### DIFF
--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -373,8 +373,8 @@ bool Compaction::KeyNotExistsBeyondOutputLevel(
         if (user_cmp->Compare(user_key, f->largest.user_key()) <= 0) {
           // We've advanced far enough
           if (user_cmp->Compare(user_key, f->smallest.user_key()) >= 0) {
-            // Key falls in this file's range, so definitely
-            // exists beyond output level
+            // Key falls in this file's range, so it may
+            // exist beyond output level
             return false;
           }
           break;


### PR DESCRIPTION
Even one key falls in a file's range, we can not infer it definitely exists in this file.