### PR TITLE
add cast to avoid loss of precision error

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4773,7 +4773,9 @@ void VerifyDBFromDB(std::string& truth_db_name) {
         } else if (value_size > value_max) {
           value_size = value_size % value_max;
         }
-        s = db_with_cfh->db->Put(write_options_, key, gen.Generate(value_size));
+        s = db_with_cfh->db->Put(
+            write_options_, key,
+            gen.Generate(static_cast<unsigned int>(value_size)));
         if (!s.ok()) {
           fprintf(stderr, "put error: %s\n", s.ToString().c_str());
           exit(1);


### PR DESCRIPTION
this PR address the following error:
> tools/db_bench_tool.cc:4776:68: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
        s = db_with_cfh->db->Put(write_options_, key, gen.Generate(value_size));
