### PR TITLE
Fix Clang static analyzer warning in db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4647,6 +4647,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
       if (rand_num < 0) {
         rand_num = rand_num * (-1);
       }
+      assert(range_ != 0);
       int pos = static_cast<int>(rand_num % range_);
       for (int i = 0; i < static_cast<int>(type_.size()); i++) {
         if (pos < type_[i]) {


### PR DESCRIPTION
Fixed clang static analyzer warning about division by 0. 
```
ar: creating librocksdb_debug.a
tools/db_bench_tool.cc:4650:43: warning: Division by zero
      int pos = static_cast<int>(rand_num % range_);
                                 ~~~~~~~~~^~~~~~~~
1 warning generated.
make: *** [analyze] Error 1
```

This is from the new code I recently merged in ce8e88d2d7a62e2a08c4109aac84cb9e95ed359b.

Test Plan:
`USE_CLANG=1 make analyze`