### PR TITLE
Escape '.' by adding a '\' to avoid matching any char

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ include make_config.mk
 CLEAN_FILES += make_config.mk
 
 missing_make_config_paths := $(shell				\
-	grep "./\S*\|/\S*" -o $(CURDIR)/make_config.mk | 	\
+	grep "\./\S*\|/\S*" -o $(CURDIR)/make_config.mk | 	\
 	while read path;					\
 		do [ -e $$path ] || echo $$path; 		\
 	done | sort | uniq)


### PR DESCRIPTION
Test plan:
```
$make clean
```
The output should not contain the following.
```
Makefile:156: Warning: Compiling in debug mode. Don't use the resulting binary in production
Makefile:206: Warning: B/mnt/gvfs/third-party2/binutils/55031de95a2b46c82948743419a603b3d6aefe28/2.29.1/centos7-native/da39a3e/bin/gold dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/gcc/112ec378fec7002ad3e09afde022e656049f7191/5.x/centos7-native/c447969/bin/g++ dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/gcc/112ec378fec7002ad3e09afde022e656049f7191/5.x/centos7-native/c447969/bin/gcc dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/llvm-fb/04999bdb3ce81a11073535dcb00b5e13dc1cbaf5/stable/centos7-native/c9f9104/bin/clang++ dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/llvm-fb/04999bdb3ce81a11073535dcb00b5e13dc1cbaf5/stable/centos7-native/c9f9104/../../src/llvm/tools/clang/tools/scan-build/bin/scan-build dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/lua/f0cd714433206d5139df61659eb7b28b1dea6683/5.2.3/gcc-5-glibc-2.23/65372bd dont exist
Makefile:206: Warning: =/mnt/gvfs/third-party2/valgrind/f3f697a28122e6bcd513273dd9c1ff23852fc59f/3.13.0/gcc-5-glibc-2.23/9bc6787/bin/ dont exist
Makefile:206: Warning: =/usr/local/fbcode/gcc-5-glibc-2.23/lib dont exist
Makefile:206: Warning: ,/usr/local/fbcode/gcc-5-glibc-2.23/lib/ld.so dont exist
```