### PR TITLE
Fix stats update batching by correcting function call argument order

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2518,7 +2518,8 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         DataBlockIter biter;
         NewDataBlockIterator<DataBlockIter>(
             rep_, read_options, iiter->value(), &biter, false,
-            true /* key_includes_seq */, get_context);
+            true /* key_includes_seq */, true /* index_key_is_full */,
+            get_context);
 
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {


### PR DESCRIPTION
The pointer `get_context` was passed as the value for the boolean argument `index_key_is_full`. Luckily the pointer was always non-null so evaluated to true which is the correct value for the boolean argument. But we were missing out on batch updates to stats since we were not passing anything for the `GetContext*` argument and it defaults to `nullptr`.

Test Plan: `make check -j64`