### PR TITLE
Disallow customized hash function in DynamicBloom

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -110,10 +110,10 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
   assert(!ShouldScheduleFlush());
 
   if (prefix_extractor_ && moptions_.memtable_prefix_bloom_bits > 0) {
-    prefix_bloom_.reset(new DynamicBloom(
-        &arena_, moptions_.memtable_prefix_bloom_bits, ioptions.bloom_locality,
-        6 /* hard coded 6 probes */, nullptr, moptions_.memtable_huge_page_size,
-        ioptions.info_log));
+    prefix_bloom_.reset(
+        new DynamicBloom(&arena_, moptions_.memtable_prefix_bloom_bits,
+                         ioptions.bloom_locality, 6 /* hard coded 6 probes */,
+                         moptions_.memtable_huge_page_size, ioptions.info_log));
   }
 }
 

--- a/table/bloom_block.h
+++ b/table/bloom_block.h
@@ -15,8 +15,7 @@ class BloomBlockBuilder {
  public:
   static const std::string kBloomBlock;
 
-  explicit BloomBlockBuilder(uint32_t num_probes = 6)
-      : bloom_(num_probes, nullptr) {}
+  explicit BloomBlockBuilder(uint32_t num_probes = 6) : bloom_(num_probes) {}
 
   void SetTotalBits(Allocator* allocator, uint32_t total_bits,
                     uint32_t locality, size_t huge_page_tlb_size,

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -104,7 +104,7 @@ PlainTableReader::PlainTableReader(
       user_key_len_(static_cast<uint32_t>(table_properties->fixed_key_len)),
       prefix_extractor_(prefix_extractor),
       enable_bloom_(false),
-      bloom_(6, nullptr),
+      bloom_(6),
       file_info_(std::move(file), storage_options,
                  static_cast<uint32_t>(table_properties->data_size)),
       ioptions_(ioptions),

--- a/util/dynamic_bloom.cc
+++ b/util/dynamic_bloom.cc
@@ -32,20 +32,13 @@ uint32_t GetTotalBitsForLocality(uint32_t total_bits) {
 
 DynamicBloom::DynamicBloom(Allocator* allocator, uint32_t total_bits,
                            uint32_t locality, uint32_t num_probes,
-                           uint32_t (*hash_func)(const Slice& key),
-                           size_t huge_page_tlb_size,
-                           Logger* logger)
-    : DynamicBloom(num_probes, hash_func) {
+                           size_t huge_page_tlb_size, Logger* logger)
+    : DynamicBloom(num_probes) {
   SetTotalBits(allocator, total_bits, locality, huge_page_tlb_size, logger);
 }
 
-DynamicBloom::DynamicBloom(uint32_t num_probes,
-                           uint32_t (*hash_func)(const Slice& key))
-    : kTotalBits(0),
-      kNumBlocks(0),
-      kNumProbes(num_probes),
-      hash_func_(hash_func == nullptr ? &BloomHash : hash_func),
-      data_(nullptr) {}
+DynamicBloom::DynamicBloom(uint32_t num_probes)
+    : kTotalBits(0), kNumBlocks(0), kNumProbes(num_probes), data_(nullptr) {}
 
 void DynamicBloom::SetRawData(unsigned char* raw_data, uint32_t total_bits,
                               uint32_t num_blocks) {


### PR DESCRIPTION
Summary: I didn't find where customized hash function is used in DynamicBloom. This can only reduce performance. Remove it.

Test Plan: Run all existing tests