### PR TITLE
SetBytesPerSecond should do like GenericRateLimiter constructor does 

### DIFF
--- a/util/rate_limiter.cc
+++ b/util/rate_limiter.cc
@@ -92,7 +92,12 @@ GenericRateLimiter::~GenericRateLimiter() {
 // This API allows user to dynamically change rate limiter's bytes per second.
 void GenericRateLimiter::SetBytesPerSecond(int64_t bytes_per_second) {
   assert(bytes_per_second > 0);
-  rate_bytes_per_sec_ = bytes_per_second;
+  if (auto_tuned_) {
+    rate_bytes_per_sec_ = bytes_per_second/2;
+  } else {
+    rate_bytes_per_sec_ = bytes_per_second;
+  }
+  
   refill_bytes_per_period_.store(
       CalculateRefillBytesPerPeriod(bytes_per_second),
       std::memory_order_relaxed);


### PR DESCRIPTION
If auto_tuned_ is true rate_bytes_per_sec_ should be set bytes_per_second/2 like  GenericRateLimiter constructor does.
https://github.com/facebook/rocksdb/blob/e1de88c8c74bbfbbfc80a8992bd6bb489bdfd194/util/rate_limiter.cc#L52