### PR TITLE
Fix `WriteBatchBase::DeleteRange` API comment

### DIFF
--- a/include/rocksdb/write_batch_base.h
+++ b/include/rocksdb/write_batch_base.h
@@ -69,7 +69,7 @@ class WriteBatchBase {
                               const SliceParts& key);
   virtual Status SingleDelete(const SliceParts& key);
 
-  // If the database contains mappings in the range ["begin_key", "end_key"],
+  // If the database contains mappings in the range ["begin_key", "end_key"),
   // erase them. Else do nothing.
   virtual Status DeleteRange(ColumnFamilyHandle* column_family,
                              const Slice& begin_key, const Slice& end_key) = 0;


### PR DESCRIPTION
The `DeleteRange` end key is exclusive, not inclusive. Updated API comment accordingly.