### PR TITLE
BYTES_READ stats miscount for NotFound cases

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1319,10 +1319,13 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
     ReturnAndCleanupSuperVersion(cfd, sv);
 
     RecordTick(stats_, NUMBER_KEYS_READ);
-    size_t size = pinnable_val->size();
-    RecordTick(stats_, BYTES_READ, size);
+    size_t size = 0;
+    if (s.ok()) {
+      size = pinnable_val->size();
+      RecordTick(stats_, BYTES_READ, size);
+      PERF_COUNTER_ADD(get_read_bytes, size);
+    }
     MeasureTime(stats_, BYTES_PER_READ, size);
-    PERF_COUNTER_ADD(get_read_bytes, size);
   }
   return s;
 }


### PR DESCRIPTION
Summary: In NotFound cases, stats BYTES_READ and perf_context.get_read_bytes is still increased. The amount increased will be whatever size of the string or PinnableSlice that users passed in as the output data structure. This is wrong. Fix this by not increasing these two counters.

Test Plan: Run all existing tests