### PR TITLE
Fix potential DB hang while using CompactFiles

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1023,6 +1023,7 @@ Status DBImpl::CompactFilesImpl(
   if (bg_compaction_scheduled_ == 0) {
     bg_cv_.SignalAll();
   }
+  MaybeScheduleFlushOrCompaction();
   TEST_SYNC_POINT("CompactFilesImpl:End");
 
   return status;


### PR DESCRIPTION
CompactFiles() may block auto compaction which could cuase DB hang when it
reachs level0_stop_writes_trigger.