### PR TITLE
TransactionUtil::CheckKey() to skip unnecessary history

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3419,9 +3419,9 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
     return Status::OK();
   }
 
-  SequenceNumber min_seq_in_mem = sv->mem->GetEarliestSequenceNumber();
-  if (min_seq_in_mem != kMaxSequenceNumber &&
-      min_seq_in_mem < lower_bound_seq) {
+  SequenceNumber lower_bound_in_mem = sv->mem->GetEarliestSequenceNumber();
+  if (lower_bound_in_mem != kMaxSequenceNumber &&
+      lower_bound_in_mem < lower_bound_seq) {
     *found_record_for_key = false;
     return Status::OK();
   }
@@ -3445,9 +3445,9 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
     return Status::OK();
   }
 
-  SequenceNumber min_seq_in_imm = sv->imm->GetEarliestSequenceNumber();
-  if (min_seq_in_imm != kMaxSequenceNumber &&
-      min_seq_in_imm < lower_bound_seq) {
+  SequenceNumber lower_bound_in_imm = sv->imm->GetEarliestSequenceNumber();
+  if (lower_bound_in_imm != kMaxSequenceNumber &&
+      lower_bound_in_imm < lower_bound_seq) {
     *found_record_for_key = false;
     return Status::OK();
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3421,7 +3421,7 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
 
   SequenceNumber min_seq_in_mem = sv->mem->GetEarliestSequenceNumber();
   if (min_seq_in_mem != kMaxSequenceNumber &&
-      min_seq_in_mem <= lower_bound_seq) {
+      min_seq_in_mem < lower_bound_seq) {
     *found_record_for_key = false;
     return Status::OK();
   }
@@ -3447,7 +3447,7 @@ Status DBImpl::GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
 
   SequenceNumber min_seq_in_imm = sv->imm->GetEarliestSequenceNumber();
   if (min_seq_in_imm != kMaxSequenceNumber &&
-      min_seq_in_imm <= lower_bound_seq) {
+      min_seq_in_imm < lower_bound_seq) {
     *found_record_for_key = false;
     return Status::OK();
   }

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -413,11 +413,17 @@ class DBImpl : public DB {
   // snapshot, we know that no key could have existing after this snapshot
   // (since we do not compact keys that have an earlier snapshot).
   //
+  // Only records newer than or at `lower_bound_seq` are guaranteed to be
+  // returned. Memtables and files may not be checked if it only contains data
+  // older than `lower_bound_seq`.
+  //
   // Returns OK or NotFound on success,
   // other status on unexpected error.
   // TODO(andrewkr): this API need to be aware of range deletion operations
   Status GetLatestSequenceForKey(SuperVersion* sv, const Slice& key,
-                                 bool cache_only, SequenceNumber* seq,
+                                 bool cache_only,
+                                 SequenceNumber lower_bound_seq,
+                                 SequenceNumber* seq,
                                  bool* found_record_for_key,
                                  bool* is_blob_index = nullptr);
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1426,8 +1426,8 @@ class BlobDBImpl::GarbageCollectionWriteCallback : public WriteCallback {
     bool found_record_for_key = false;
     bool is_blob_index = false;
     Status s = db_impl->GetLatestSequenceForKey(
-        sv, key_, false /*cache_only*/, &latest_seq, &found_record_for_key,
-        &is_blob_index);
+        sv, key_, false /*cache_only*/, 0 /*lower_bound_seq*/, &latest_seq,
+        &found_record_for_key, &is_blob_index);
     db_impl->ReturnAndCleanupSuperVersion(cfd_, sv);
     if (!s.ok() && !s.IsNotFound()) {
       // Error.

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -348,12 +348,14 @@ TEST_F(OptimisticTransactionTest, CheckKeySkipOldMemtable) {
     ASSERT_EQ(value, "bar");
     ASSERT_OK(txn2->Put(Slice("foo2"), Slice("bar2")));
 
-    // txn updates "foo" and tx2 updates "foo2", and now a write is
+    // txn updates "foo" and tnx2 updates "foo2", and now a write is
     // issued for "foo", which conflicts with txn but not txn2
     ASSERT_OK(txn_db->Put(write_options, "foo", "bar"));
 
     if (attempt == kAttemptImmMemTable) {
-      // For the second attempt, hold the flush from happening
+      // For the second attempt, hold flush from beginning. The memtable
+      // will be switched to immutable after calling TEST_SwitchMemtable()
+      // while CheckKey() is called.
       rocksdb::SyncPoint::GetInstance()->LoadDependency(
           {{"OptimisticTransactionTest.CheckKeySkipOldMemtable",
             "FlushJob::Start"}});
@@ -388,7 +390,7 @@ TEST_F(OptimisticTransactionTest, CheckKeySkipOldMemtable) {
     ASSERT_TRUE(txn3 != nullptr);
 
     // Commit both of txn and txn2. txn will conflict but txn2 will
-    // pass. In both ways, both memtables are queries.
+    // pass. In both ways, both memtables are queried.
     SetPerfLevel(PerfLevel::kEnableCount);
 
     get_perf_context()->Reset();

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -348,7 +348,7 @@ TEST_F(OptimisticTransactionTest, CheckKeySkipOldMemtable) {
     ASSERT_EQ(value, "bar");
     ASSERT_OK(txn2->Put(Slice("foo2"), Slice("bar2")));
 
-    // txn updates "foo" and tnx2 updates "foo2", and now a write is
+    // txn updates "foo" and txn2 updates "foo2", and now a write is
     // issued for "foo", which conflicts with txn but not txn2
     ASSERT_OK(txn_db->Put(write_options, "foo", "bar"));
 

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -9,11 +9,15 @@
 #include <string>
 #include <thread>
 
+
+#include "db/db_impl/db_impl.h"
 #include "logging/logging.h"
 #include "port/port.h"
 #include "rocksdb/db.h"
+#include "rocksdb/perf_context.h"
 #include "rocksdb/utilities/optimistic_transaction_db.h"
 #include "rocksdb/utilities/transaction.h"
+#include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "test_util/transaction_test_util.h"
 #include "util/crc32c.h"
@@ -306,6 +310,205 @@ TEST_F(OptimisticTransactionTest, FlushTest2) {
   ASSERT_EQ(value, "bar");
 
   delete txn;
+}
+
+// Trigger the condition where some old memtables are skipped when doing
+// TransactionUtil::CheckKey(), and make sure the result is still correct.
+TEST_F(OptimisticTransactionTest, CheckKeySkipHistoryMemtable) {
+  options.max_write_buffer_number_to_maintain = 3;
+  Reopen();
+
+  WriteOptions write_options;
+  ReadOptions read_options;
+  ReadOptions snapshot_read_options;
+  ReadOptions snapshot_read_options2;
+  string value;
+  Status s;
+
+  txn_db->Put(write_options, Slice("foo"), Slice("bar"));
+  txn_db->Put(write_options, Slice("foo2"), Slice("bar"));
+
+  Transaction* txn = txn_db->BeginTransaction(write_options);
+  ASSERT_TRUE(txn);
+
+  Transaction* txn2 = txn_db->BeginTransaction(write_options);
+  ASSERT_TRUE(txn);
+
+  snapshot_read_options.snapshot = txn->GetSnapshot();
+  txn->GetForUpdate(snapshot_read_options, "foo", &value);
+  ASSERT_EQ(value, "bar");
+  txn->Put(Slice("foo"), Slice("bar2"));
+
+  snapshot_read_options2.snapshot = txn2->GetSnapshot();
+  txn2->GetForUpdate(snapshot_read_options2, "foo2", &value);
+  ASSERT_EQ(value, "bar");
+  txn2->Put(Slice("foo2"), Slice("bar2"));
+
+  // txn updates "foo" and tx2 updates "foo2", and now a write is
+  // issued for "foo", which conflicts with txn but not txn2
+  s = txn_db->Put(write_options, "foo", "bar");
+  ASSERT_OK(s);
+
+  // force a memtable flush. The memtable should still be kept
+  FlushOptions flush_ops;
+  txn_db->Flush(flush_ops);
+  uint64_t num_imm_mems;
+  ASSERT_TRUE(txn_db->GetIntProperty(DB::Properties::kNumImmutableMemTable,
+                                     &num_imm_mems));
+  ASSERT_EQ(0, num_imm_mems);
+
+  // Put something in active memtable
+  txn_db->Put(write_options, Slice("foo3"), Slice("bar"));
+
+  // Create txn3 after flushing, when this transaction is commited,
+  // only need to check the active memtable
+  Transaction* txn3 = txn_db->BeginTransaction(write_options);
+  ASSERT_TRUE(txn);
+
+  // Commit both of txn and txn2. txn will conflict but txn2 will
+  // pass. In both ways, both memtables are queries.
+  SetPerfLevel(PerfLevel::kEnableCount);
+
+  get_perf_context()->Reset();
+  s = txn->Commit();
+  // We should have checked two memtables
+  ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+  // txn should fail because of conflict, even if the memtable
+  // has flushed, because it is still preserved in history.
+  ASSERT_TRUE(s.IsBusy());
+
+  get_perf_context()->Reset();
+  s = txn2->Commit();
+  // We should have checked two memtables
+  ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+  ASSERT_TRUE(s.ok());
+
+  txn3->Put(Slice("foo2"), Slice("bar2"));
+  get_perf_context()->Reset();
+  s = txn3->Commit();
+  // txn3 is created after the active memtable is created, so that is the only
+  // memtable to check.
+  ASSERT_EQ(1, get_perf_context()->get_from_memtable_count);
+  ASSERT_TRUE(s.ok());
+
+  SetPerfLevel(PerfLevel::kDisable);
+
+  delete txn;
+  delete txn2;
+  delete txn3;
+}
+
+// Trigger the condition where some old memtables are skipped when doing
+// TransactionUtil::CheckKey(), and make sure the result is still correct.
+TEST_F(OptimisticTransactionTest, CheckKeySkipOldMemtable) {
+  const int kAttemptHistoryMemtable = 0;
+  const int kAttemptImmMemTable = 1;
+  for (int attempt = kAttemptHistoryMemtable; attempt <= kAttemptImmMemTable;
+       attempt++) {
+    options.max_write_buffer_number_to_maintain = 3;
+    Reopen();
+
+    WriteOptions write_options;
+    ReadOptions read_options;
+    ReadOptions snapshot_read_options;
+    ReadOptions snapshot_read_options2;
+    string value;
+    Status s;
+
+    txn_db->Put(write_options, Slice("foo"), Slice("bar"));
+    txn_db->Put(write_options, Slice("foo2"), Slice("bar"));
+
+    Transaction* txn = txn_db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn);
+
+    Transaction* txn2 = txn_db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn);
+
+    snapshot_read_options.snapshot = txn->GetSnapshot();
+    txn->GetForUpdate(snapshot_read_options, "foo", &value);
+    ASSERT_EQ(value, "bar");
+    txn->Put(Slice("foo"), Slice("bar2"));
+
+    snapshot_read_options2.snapshot = txn2->GetSnapshot();
+    txn2->GetForUpdate(snapshot_read_options2, "foo2", &value);
+    ASSERT_EQ(value, "bar");
+    txn2->Put(Slice("foo2"), Slice("bar2"));
+
+    // txn updates "foo" and tx2 updates "foo2", and now a write is
+    // issued for "foo", which conflicts with txn but not txn2
+    s = txn_db->Put(write_options, "foo", "bar");
+    ASSERT_OK(s);
+
+    if (attempt == kAttemptImmMemTable) {
+      // For the second attempt, hold the flush from happening
+      rocksdb::SyncPoint::GetInstance()->LoadDependency(
+          {{"OptimisticTransactionTest.CheckKeySkipOldMemtable",
+            "FlushJob::Start"}});
+      rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+    }
+
+    // force a memtable flush. The memtable should still be kept
+    FlushOptions flush_ops;
+    if (attempt == kAttemptHistoryMemtable) {
+      txn_db->Flush(flush_ops);
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      DBImpl* db_impl = static_cast<DBImpl*>(txn_db->GetRootDB());
+      db_impl->TEST_SwitchMemtable();
+    }
+    uint64_t num_imm_mems;
+    ASSERT_TRUE(txn_db->GetIntProperty(DB::Properties::kNumImmutableMemTable,
+                                       &num_imm_mems));
+    if (attempt == kAttemptHistoryMemtable) {
+      ASSERT_EQ(0, num_imm_mems);
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      ASSERT_EQ(1, num_imm_mems);
+    }
+
+    // Put something in active memtable
+    txn_db->Put(write_options, Slice("foo3"), Slice("bar"));
+
+    // Create txn3 after flushing, when this transaction is commited,
+    // only need to check the active memtable
+    Transaction* txn3 = txn_db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn);
+
+    // Commit both of txn and txn2. txn will conflict but txn2 will
+    // pass. In both ways, both memtables are queries.
+    SetPerfLevel(PerfLevel::kEnableCount);
+
+    get_perf_context()->Reset();
+    s = txn->Commit();
+    // We should have checked two memtables
+    ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+    // txn should fail because of conflict, even if the memtable
+    // has flushed, because it is still preserved in history.
+    ASSERT_TRUE(s.IsBusy());
+
+    get_perf_context()->Reset();
+    s = txn2->Commit();
+    // We should have checked two memtables
+    ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+    ASSERT_TRUE(s.ok());
+
+    txn3->Put(Slice("foo2"), Slice("bar2"));
+    get_perf_context()->Reset();
+    s = txn3->Commit();
+    // txn3 is created after the active memtable is created, so that is the only
+    // memtable to check.
+    ASSERT_EQ(1, get_perf_context()->get_from_memtable_count);
+    ASSERT_TRUE(s.ok());
+
+    TEST_SYNC_POINT("OptimisticTransactionTest.CheckKeySkipOldMemtable");
+    rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+
+    SetPerfLevel(PerfLevel::kDisable);
+
+    delete txn;
+    delete txn2;
+    delete txn3;
+  }
 }
 
 TEST_F(OptimisticTransactionTest, NoSnapshotTest) {

--- a/utilities/transactions/transaction_util.cc
+++ b/utilities/transactions/transaction_util.cc
@@ -56,6 +56,12 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
                                  const std::string& key, bool cache_only,
                                  ReadCallback* snap_checker,
                                  SequenceNumber min_uncommitted) {
+  // When `min_uncommitted` is provided, keys are not always committed
+  // in sequence number order, and`snap_checker` is used to check whether
+  // specific sequence number is in the database is visible to the transaction.
+  // So `snapchecker` must be provided.
+  assert(min_uncommitted == kMaxSequenceNumber || snap_checker != nullptr);
+
   Status result;
   bool need_to_read_sst = false;
 
@@ -83,7 +89,7 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
     need_to_read_sst = true;
 
     if (cache_only) {
-      // The age of this memtable is too new to use to check for recent
+      // The age of this memtable is too new to use to check for recentOP
       // writes.
       char msg[300];
       snprintf(msg, sizeof(msg),
@@ -104,8 +110,19 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
     SequenceNumber seq = kMaxSequenceNumber;
     bool found_record_for_key = false;
 
+    // When min_uncommitted == kMaxSequenceNumber, writes are committed in
+    // sequence number order, so only keys larger than `snap_seq` can cause
+    // conflict.
+    // When min_uncommitted != kMaxSequenceNumber, keys lower than
+    // min_uncommitted will not triggered conflicts, while keys between
+    // min_uncommitted and snap_seq might create conflicts, so we need
+    // to read them out from the DB, and call callback to snap_checker
+    // to determine. So only keys lower than min_uncommitted can be skipped.
+    SequenceNumber lower_bound_seq =
+        (min_uncommitted == kMaxSequenceNumber) ? snap_seq : min_uncommitted;
     Status s = db_impl->GetLatestSequenceForKey(sv, key, !need_to_read_sst,
-                                                &seq, &found_record_for_key);
+                                                lower_bound_seq, &seq,
+                                                &found_record_for_key);
 
     if (!(s.ok() || s.IsNotFound() || s.IsMergeInProgress())) {
       result = s;

--- a/utilities/transactions/transaction_util.cc
+++ b/utilities/transactions/transaction_util.cc
@@ -57,9 +57,9 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
                                  ReadCallback* snap_checker,
                                  SequenceNumber min_uncommitted) {
   // When `min_uncommitted` is provided, keys are not always committed
-  // in sequence number order, and`snap_checker` is used to check whether
+  // in sequence number order, and `snap_checker` is used to check whether
   // specific sequence number is in the database is visible to the transaction.
-  // So `snapchecker` must be provided.
+  // So `snap_checker` must be provided.
   assert(min_uncommitted == kMaxSequenceNumber || snap_checker != nullptr);
 
   Status result;
@@ -89,7 +89,7 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
     need_to_read_sst = true;
 
     if (cache_only) {
-      // The age of this memtable is too new to use to check for recentOP
+      // The age of this memtable is too new to use to check for recent
       // writes.
       char msg[300];
       snprintf(msg, sizeof(msg),
@@ -114,10 +114,10 @@ Status TransactionUtil::CheckKey(DBImpl* db_impl, SuperVersion* sv,
     // sequence number order, so only keys larger than `snap_seq` can cause
     // conflict.
     // When min_uncommitted != kMaxSequenceNumber, keys lower than
-    // min_uncommitted will not triggered conflicts, while keys between
-    // min_uncommitted and snap_seq might create conflicts, so we need
-    // to read them out from the DB, and call callback to snap_checker
-    // to determine. So only keys lower than min_uncommitted can be skipped.
+    // min_uncommitted will not triggered conflicts, while keys larger than
+    // min_uncommitted might create conflicts, so we need  to read them out
+    // from the DB, and call callback to snap_checker to determine. So only
+    // keys lower than min_uncommitted can be skipped.
     SequenceNumber lower_bound_seq =
         (min_uncommitted == kMaxSequenceNumber) ? snap_seq : min_uncommitted;
     Status s = db_impl->GetLatestSequenceForKey(sv, key, !need_to_read_sst,

--- a/utilities/transactions/transaction_util.h
+++ b/utilities/transactions/transaction_util.h
@@ -50,6 +50,9 @@ class TransactionUtil {
   // SST files.  This will make it more likely this function will
   // return an error if it is unable to determine if there are any conflicts.
   //
+  // See comment of CheckKey() for explanation of `snap_seq`, `snap_checker`
+  // and `min_uncommitted`.
+  //
   // Returns OK on success, BUSY if there is a conflicting write, or other error
   // status for any unexpected errors.
   static Status CheckKeyForConflicts(
@@ -72,6 +75,14 @@ class TransactionUtil {
                                       bool cache_only);
 
  private:
+  // If `snap_checker` == nullptr, writes are always commited in sequence number
+  // order. All sequence number <= `snap_seq` will not conflict with any
+  // write, and all keys > `snap_seq` of `key` will trigger conflict.
+  // If `snap_checker` != nullptr, writes may not commit in sequence number
+  // order. In this case `min_uncommitted` is a lower bound.
+  //  seq < `min_uncommitted`: no conflict
+  //  seq > `snap_seq`: applicable to conflict
+  //  `min_uncommitted` <= seq <= `snap_seq` : call `snap_checker` to determine.
   static Status CheckKey(DBImpl* db_impl, SuperVersion* sv,
                          SequenceNumber earliest_seq, SequenceNumber snap_seq,
                          const std::string& key, bool cache_only,

--- a/utilities/transactions/transaction_util.h
+++ b/utilities/transactions/transaction_util.h
@@ -82,7 +82,7 @@ class TransactionUtil {
   // order. In this case `min_uncommitted` is a lower bound.
   //  seq < `min_uncommitted`: no conflict
   //  seq > `snap_seq`: applicable to conflict
-  //  `min_uncommitted` <= seq <= `snap_seq` : call `snap_checker` to determine.
+  //  `min_uncommitted` <= seq <= `snap_seq`: call `snap_checker` to determine.
   static Status CheckKey(DBImpl* db_impl, SuperVersion* sv,
                          SequenceNumber earliest_seq, SequenceNumber snap_seq,
                          const std::string& key, bool cache_only,

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -773,6 +773,154 @@ TEST_P(WritePreparedTransactionTest, MaybeUpdateOldCommitMap) {
   MaybeUpdateOldCommitMapTestWithNext(p, c, s, ns, false);
 }
 
+// Trigger the condition where some old memtables are skipped when doing
+// TransactionUtil::CheckKey(), and make sure the result is still correct.
+TEST_P(WritePreparedTransactionTest, CheckKeySkipOldMemtable) {
+  const int kAttemptHistoryMemtable = 0;
+  const int kAttemptImmMemTable = 1;
+  for (int attempt = kAttemptHistoryMemtable; attempt <= kAttemptImmMemTable;
+       attempt++) {
+    options.max_write_buffer_number_to_maintain = 3;
+    ReOpen();
+
+    WriteOptions write_options;
+    ReadOptions read_options;
+    string value;
+    Status s;
+
+    ASSERT_OK(db->Put(write_options, Slice("foo"), Slice("bar")));
+    ASSERT_OK(db->Put(write_options, Slice("foo2"), Slice("bar")));
+
+    Transaction* txn = db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn != nullptr);
+    ASSERT_OK(txn->SetName("txn"));
+
+    Transaction* txn2 = db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn2 != nullptr);
+    ASSERT_OK(txn2->SetName("txn2"));
+
+    // This transaction is created to cause potential conflict.
+    Transaction* txn_x = db->BeginTransaction(write_options);
+    ASSERT_OK(txn_x->SetName("txn_x"));
+    ASSERT_OK(txn_x->Put(Slice("foo"), Slice("bar3")));
+    ASSERT_OK(txn_x->Prepare());
+    
+    // Create snapshots after the prepare, but there should still
+    // be a conflict when trying to read "foo".
+
+    // Write to the transaction just to ankor a snapshot.
+    txn->SetSnapshotOnNextOperation();
+    ASSERT_OK(txn->Put("foofoo1", "bar")); 
+    txn2->SetSnapshotOnNextOperation();
+    ASSERT_OK(txn2->Put("foofoo2", "bar"));
+
+    if (attempt == kAttemptImmMemTable) {
+      // For the second attempt, hold flush from beginning. The memtable
+      // will be switched to immutable after calling TEST_SwitchMemtable()
+      // while CheckKey() is called.
+      rocksdb::SyncPoint::GetInstance()->LoadDependency(
+          {{"WritePreparedTransactionTest.CheckKeySkipOldMemtable",
+            "FlushJob::Start"}});
+      rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+    }
+
+    // force a memtable flush. The memtable should still be kept
+    FlushOptions flush_ops;
+    if (attempt == kAttemptHistoryMemtable) {
+      ASSERT_OK(db->Flush(flush_ops));
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      DBImpl* db_impl = static_cast<DBImpl*>(db->GetRootDB());
+      db_impl->TEST_SwitchMemtable();
+    }
+    uint64_t num_imm_mems;
+    ASSERT_TRUE(db->GetIntProperty(DB::Properties::kNumImmutableMemTable,
+                                       &num_imm_mems));
+    if (attempt == kAttemptHistoryMemtable) {
+      ASSERT_EQ(0, num_imm_mems);
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      ASSERT_EQ(1, num_imm_mems);
+    }
+    
+    // Put something in active memtable
+    ASSERT_OK(db->Put(write_options, Slice("foo3"), Slice("bar")));
+
+    // Create txn3 after flushing, but this transaction also needs to
+    // check all memtables because of they contains uncommitted data.
+    Transaction* txn3 = db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn3 != nullptr);
+    ASSERT_OK(txn3->SetName("txn3"));
+    // Write to the transaction just to ankor a snapshot.
+    txn3->SetSnapshotOnNextOperation();
+    ASSERT_OK(txn3->Put("foofoo3", "bar"));
+
+    // Commit the pending write
+    ASSERT_OK(txn_x->Commit());    
+
+    // Commit txn, txn2 and tx3. txn and tx3 will conflict but txn2 will
+    // pass. In all cases, both memtables are queried.
+    SetPerfLevel(PerfLevel::kEnableCount);
+    get_perf_context()->Reset();
+    ASSERT_TRUE(txn3->GetForUpdate(read_options, "foo", &value).IsBusy());
+    // We should have checked two memtables
+    ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+    
+    get_perf_context()->Reset();
+    ASSERT_TRUE(txn->GetForUpdate(read_options, "foo", &value).IsBusy());
+    // We should have checked two memtables
+    ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+
+    get_perf_context()->Reset();
+    ASSERT_OK(txn2->GetForUpdate(read_options, "foo2", &value));
+    ASSERT_EQ(value, "bar"); 
+    // We should have checked two memtables, and since there is not
+    // conflict, another Get() will be made and fetch the data from
+    // DB. If it is in immutable memtable, two extra memtable reads
+    // will be issued. If it is not (in history), only one will
+    // be made.
+    if (attempt == kAttemptHistoryMemtable) {
+      ASSERT_EQ(3, get_perf_context()->get_from_memtable_count);
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      ASSERT_EQ(4, get_perf_context()->get_from_memtable_count);
+    }
+
+    Transaction* txn4 = db->BeginTransaction(write_options);
+    ASSERT_TRUE(txn4 != nullptr);
+    txn4->SetSnapshotOnNextOperation();
+    ASSERT_OK(txn4->SetName("txn4"));
+    // Write to the transaction just to ankor a snapshot.
+    ASSERT_OK(txn4->Put("foofoo4", "bar"));
+    get_perf_context()->Reset();
+    ASSERT_OK(txn4->GetForUpdate(read_options, "foo", &value));
+    // Only active memtable should be checked, and extra read(s)
+    // will be made to fetch the value.
+    if (attempt == kAttemptHistoryMemtable) {
+      ASSERT_EQ(2, get_perf_context()->get_from_memtable_count);
+    } else {
+      assert(attempt == kAttemptImmMemTable);
+      ASSERT_EQ(3, get_perf_context()->get_from_memtable_count);
+    }
+    
+    ASSERT_OK(txn2->Prepare());
+    ASSERT_OK(txn2->Commit());
+    ASSERT_OK(txn4->Prepare());
+    ASSERT_OK(txn4->Commit());
+
+    TEST_SYNC_POINT("WritePreparedTransactionTest.CheckKeySkipOldMemtable");
+    rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+
+    SetPerfLevel(PerfLevel::kDisable);
+
+    delete txn;
+    delete txn2;
+    delete txn3;
+    delete txn4;
+    delete txn_x;
+  }
+}
+
 // Reproduce the bug with two snapshots with the same seuqence number and test
 // that the release of the first snapshot will not affect the reads by the other
 // snapshot


### PR DESCRIPTION
Summary: If a memtable definitely covers a key, there isn't a need to check older memtables.
We can skip them by checking the earliest sequence number.

Test Plan: Make sure existing tests pass and add a test to make sure older snapshot doesn't
filter a history memtable covering it.