### PR TITLE
db_bench: fix "micros/op" reporting

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1831,7 +1831,7 @@ class Stats {
 
     fprintf(stdout, "%-12s : %11.3f micros/op %ld ops/sec;%s%s\n",
             name.ToString().c_str(),
-            elapsed * 1e6 / done_,
+            seconds_ * 1e6 / done_,
             (long)throughput,
             (extra.empty() ? "" : " "),
             extra.c_str());


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/commit/4985a9f73b9fb8a0323fbbb06222ae1f758a6b1d#diff-e5276985b26a0551957144f4420a594bR511
changes the meaning of latency reporting from running time per query, to elapse_time / #ops, without providing a reason why.
Considering that this is a counter-intuitive reporting, Reverting the change.

Test Plan: Run db_bench and observe the number reported