### PR TITLE
exclude test CompactFilesShouldTriggerAutoCompaction from ROCKSDB_LITE

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5440,6 +5440,7 @@ TEST_F(DBTest, AutomaticConflictsWithManualCompaction) {
   dbfull()->TEST_WaitForCompact();
 }
 
+#ifndef ROCKSDB_LITE
 TEST_F(DBTest, CompactFilesShouldTriggerAutoCompaction) {
   Options options = CurrentOptions();
   options.max_background_compactions = 1;
@@ -5500,6 +5501,7 @@ TEST_F(DBTest, CompactFilesShouldTriggerAutoCompaction) {
   ASSERT_LE(cf_meta_data.levels[0].files.size(),
       options.level0_file_num_compaction_trigger);
 }
+#endif  // ROCKSDB_LITE
 
 // Github issue #595
 // Large write batch with column families


### PR DESCRIPTION
This will fix the following build error:

> db/db_test.cc: In member function ‘virtual void rocksdb::DBTest_CompactFilesShouldTriggerAutoCompaction_Test::TestBody()’:
> db/db_test.cc:5462:8: error: ‘class rocksdb::DB’ has no member named ‘GetColumnFamilyMetaData’
>    db_->GetColumnFamilyMetaData(db_->DefaultColumnFamily(), &cf_meta_data);
> db/db_test.cc:5490:8: error: ‘class rocksdb::DB’ has no member named ‘GetColumnFamilyMetaData’
>    db_->GetColumnFamilyMetaData(db_->DefaultColumnFamily(), &cf_meta_data);
> db/db_test.cc:5499:8: error: ‘class rocksdb::DB’ has no member named ‘GetColumnFamilyMetaData’
>    db_->GetColumnFamilyMetaData(db_->DefaultColumnFamily(), &cf_meta_data);
