### PR TITLE
Checksum properties block for block-based table

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 * Add support for block checksums verification for external SST files before ingestion.
 * Add a place holder in manifest which indicate a record from future that can be safely ignored.
 * Add support for trace sampling.
+* Enable properties block checksum verification for block-based tables.
 
 ### Public API Change
 * Disallow CompactionFilter::IgnoreSnapshots() = false, because it is not very useful and the behavior is confusing. The filter will filter everything if there is no snapshot declared by the time the compaction starts. However, users can define a snapshot after the compaction starts and before it finishes and this new snapshot won't be repeatable, because after the compaction finishes, some keys may be dropped. 

--- a/table/block.cc
+++ b/table/block.cc
@@ -63,6 +63,35 @@ struct DecodeEntry {
   }
 };
 
+struct DecodeEntrySlow {
+  inline const char* operator()(const char* p, const char* limit,
+                                uint32_t* shared, uint32_t* non_shared,
+                                uint32_t* value_length) {
+    // We need 2 bytes for shared and non_shared size. We also need one more
+    // byte either for value size or the actual value in case of value delta
+    // encoding.
+    assert(limit - p >= 3);
+    *shared = reinterpret_cast<const unsigned char*>(p)[0];
+    *non_shared = reinterpret_cast<const unsigned char*>(p)[1];
+    *value_length = reinterpret_cast<const unsigned char*>(p)[2];
+    if ((*shared | *non_shared | *value_length) < 128) {
+      // Fast path: all three values are encoded in one byte each
+      p += 3;
+    } else {
+      if ((p = GetVarint32Ptr(p, limit, shared)) == nullptr) return nullptr;
+      if ((p = GetVarint32Ptr(p, limit, non_shared)) == nullptr) return nullptr;
+      if ((p = GetVarint32Ptr(p, limit, value_length)) == nullptr) {
+        return nullptr;
+      }
+    }
+
+    if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+      return nullptr;
+    }
+    return p;
+  }
+};
+
 struct DecodeKey {
   inline const char* operator()(const char* p, const char* limit,
                                 uint32_t* shared, uint32_t* non_shared) {
@@ -96,7 +125,12 @@ struct DecodeKeyV4 {
 
 void DataBlockIter::Next() {
   assert(Valid());
-  ParseNextDataKey();
+  ParseNextDataKey<DecodeEntry>();
+}
+
+void DataBlockIter::SlowNext() {
+  assert(Valid());
+  ParseNextDataKey<DecodeEntrySlow>();
 }
 
 void IndexBlockIter::Next() {
@@ -179,7 +213,7 @@ void DataBlockIter::Prev() {
   SeekToRestartPoint(restart_index_);
 
   do {
-    if (!ParseNextDataKey()) {
+    if (!ParseNextDataKey<DecodeEntry>()) {
       break;
     }
     Slice current_key = key();
@@ -218,7 +252,7 @@ void DataBlockIter::Seek(const Slice& target) {
   // Linear search (within restart block) for first key >= target
 
   while (true) {
-    if (!ParseNextDataKey() || Compare(key_, seek_key) >= 0) {
+    if (!ParseNextDataKey<DecodeEntry>() || Compare(key_, seek_key) >= 0) {
       return;
     }
   }
@@ -297,7 +331,7 @@ bool DataBlockIter::SeekForGetImpl(const Slice& target) {
     //
     // TODO(fwu): check the left and write boundary of the restart interval
     // to avoid linear seek a target key that is out of range.
-    if (!ParseNextDataKey(limit) || Compare(key_, target) >= 0) {
+    if (!ParseNextDataKey<DecodeEntry>(limit) || Compare(key_, target) >= 0) {
       // we stop at the first potential matching user key.
       break;
     }
@@ -391,7 +425,7 @@ void DataBlockIter::SeekForPrev(const Slice& target) {
   SeekToRestartPoint(index);
   // Linear search (within restart block) for first key >= seek_key
 
-  while (ParseNextDataKey() && Compare(key_, seek_key) < 0) {
+  while (ParseNextDataKey<DecodeEntry>() && Compare(key_, seek_key) < 0) {
   }
   if (!Valid()) {
     SeekToLast();
@@ -407,7 +441,15 @@ void DataBlockIter::SeekToFirst() {
     return;
   }
   SeekToRestartPoint(0);
-  ParseNextDataKey();
+  ParseNextDataKey<DecodeEntry>();
+}
+
+void DataBlockIter::SlowSeekToFirst() {
+  if (data_ == nullptr) {  // Not init yet
+    return;
+  }
+  SeekToRestartPoint(0);
+  ParseNextDataKey<DecodeEntrySlow>();
 }
 
 void IndexBlockIter::SeekToFirst() {
@@ -423,7 +465,7 @@ void DataBlockIter::SeekToLast() {
     return;
   }
   SeekToRestartPoint(num_restarts_ - 1);
-  while (ParseNextDataKey() && NextEntryOffset() < restarts_) {
+  while (ParseNextDataKey<DecodeEntry>() && NextEntryOffset() < restarts_) {
     // Keep skipping
   }
 }
@@ -447,6 +489,7 @@ void BlockIter<TValue>::CorruptionError() {
   value_.clear();
 }
 
+template <typename DecodeEntryFunc>
 bool DataBlockIter::ParseNextDataKey(const char* limit) {
   current_ = NextEntryOffset();
   const char* p = data_ + current_;
@@ -463,7 +506,7 @@ bool DataBlockIter::ParseNextDataKey(const char* limit) {
 
   // Decode next entry
   uint32_t shared, non_shared, value_length;
-  p = DecodeEntry()(p, limit, &shared, &non_shared, &value_length);
+  p = DecodeEntryFunc()(p, limit, &shared, &non_shared, &value_length);
   if (p == nullptr || key_.Size() < shared) {
     CorruptionError();
     return false;

--- a/table/block.h
+++ b/table/block.h
@@ -395,7 +395,11 @@ class DataBlockIter final : public BlockIter<Slice> {
 
   virtual void Next() override;
 
+  void SlowNext();
+
   virtual void SeekToFirst() override;
+
+  void SlowSeekToFirst();
 
   virtual void SeekToLast() override;
 
@@ -439,6 +443,7 @@ class DataBlockIter final : public BlockIter<Slice> {
   DataBlockHashIndex* data_block_hash_index_;
   const Comparator* user_comparator_;
 
+  template <typename DecodeEntryFunc>
   inline bool ParseNextDataKey(const char* limit = nullptr);
 
   inline int Compare(const IterKey& ikey, const Slice& b) const {

--- a/table/block.h
+++ b/table/block.h
@@ -395,11 +395,17 @@ class DataBlockIter final : public BlockIter<Slice> {
 
   virtual void Next() override;
 
-  void SlowNext();
+  // Try to advance to the next entry in the block. If there is data corruption
+  // or error, report it to the caller instead of aborting the process. May
+  // incur higher CPU overhead because we need to perform check on every entry.
+  void NextOrReport();
 
   virtual void SeekToFirst() override;
 
-  void SlowSeekToFirst();
+  // Try to seek to the first entry in the block. If there is data corruption
+  // or error, report it to caller instead of aborting the process. May incur
+  // higher CPU overhead because we need to perform check on every entry.
+  void SeekToFirstOrReport();
 
   virtual void SeekToLast() override;
 

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -853,6 +853,18 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
                   &properties_block_handle);
   }
   if (ok()) {
+#ifndef NDEBUG
+    {
+      uint64_t props_block_offset = properties_block_handle.offset();
+      uint64_t props_block_size = properties_block_handle.size();
+      TEST_SYNC_POINT_CALLBACK(
+          "BlockBasedTableBuilder::WritePropertiesBlock:GetPropsBlockOffset",
+          &props_block_offset);
+      TEST_SYNC_POINT_CALLBACK(
+          "BlockBasedTableBuilder::WritePropertiesBlock:GetPropsBlockSize",
+          &props_block_size);
+    }
+#endif  // !NDEBUG
     meta_index_builder->Add(kPropertiesBlock, properties_block_handle);
   }
 }

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -992,10 +992,11 @@ Status BlockBasedTable::ReadPropertiesBlock(
                  props_block_contents.data.size() + kBlockTrailerSize);
           const auto seqno_pos_iter = table_properties->properties_offsets.find(
               ExternalSstFilePropertyNames::kGlobalSeqno);
-          assert(seqno_pos_iter != table_properties->properties_offsets.end());
-          uint64_t global_seqno_offset = seqno_pos_iter->second;
-          EncodeFixed64(
-              tmp_buf + global_seqno_offset - props_block_handle.offset(), 0);
+          if (seqno_pos_iter != table_properties->properties_offsets.end()) {
+            uint64_t global_seqno_offset = seqno_pos_iter->second;
+            EncodeFixed64(
+                tmp_buf + global_seqno_offset - props_block_handle.offset(), 0);
+          }
           uint32_t value = DecodeFixed32(tmp_buf + block_size + 1);
           s = rocksdb::VerifyChecksum(rep->footer.checksum(), tmp_buf,
                                       block_size + 1, value);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -46,10 +46,12 @@
 
 #include "monitoring/perf_context_imp.h"
 #include "util/coding.h"
+#include "util/crc32c.h"
 #include "util/file_reader_writer.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 #include "util/sync_point.h"
+#include "util/xxhash.h"
 
 namespace rocksdb {
 
@@ -919,6 +921,33 @@ Status BlockBasedTable::PrefetchTail(
   return s;
 }
 
+Status VerifyChecksum(const ChecksumType type, const char* buf, size_t len,
+                      uint32_t expected) {
+  Status s;
+  uint32_t actual = 0;
+  switch (type) {
+    case kNoChecksum:
+      break;
+    case kCRC32c:
+      expected = crc32c::Unmask(expected);
+      actual = crc32c::Value(buf, len);
+      break;
+    case kxxHash:
+      actual = XXH32(buf, static_cast<int>(len), 0);
+      break;
+    case kxxHash64:
+      actual = static_cast<uint32_t>(XXH64(buf, static_cast<int>(len), 0) &
+                                     uint64_t{0xffffffff});
+      break;
+    default:
+      s = Status::Corruption("unknown checksum type");
+  }
+  if (s.ok() && actual != expected) {
+    s = Status::Corruption("properties block checksum mismatched");
+  }
+  return s;
+}
+
 Status BlockBasedTable::ReadPropertiesBlock(
     Rep* rep, FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
     const SequenceNumber largest_seqno) {
@@ -934,10 +963,46 @@ Status BlockBasedTable::ReadPropertiesBlock(
     s = meta_iter->status();
     TableProperties* table_properties = nullptr;
     if (s.ok()) {
-      s = ReadProperties(meta_iter->value(), rep->file.get(), prefetch_buffer,
-                         rep->footer, rep->ioptions, &table_properties,
-                         false /* compression_type_missing */,
-                         nullptr /* memory_allocator */);
+      s = ReadProperties(
+          meta_iter->value(), rep->file.get(), prefetch_buffer, rep->footer,
+          rep->ioptions, &table_properties, true /* verify_checksum */,
+          nullptr /* ret_block_handle */, nullptr /* ret_block_contents */,
+          false /* compression_type_missing */, nullptr /* memory_allocator */);
+    }
+
+    if (s.IsCorruption()) {
+      // If this is an external SST file ingested with write_global_seqno set to
+      // true, then we expect the checksum mismatch because checksum was written
+      // by SstFileWriter, but its global seqno in the properties block may have
+      // been changed during ingestion. In this case, we read the properties
+      // block, copy it to a memory buffer, change the global seqno to its
+      // original value, i.e. 0, and verify the checksum again.
+      BlockHandle props_block_handle;
+      BlockContents props_block_contents;
+      s = ReadProperties(
+          meta_iter->value(), rep->file.get(), prefetch_buffer, rep->footer,
+          rep->ioptions, &table_properties, false /* verify_checksum */,
+          &props_block_handle, &props_block_contents,
+          false /* compression_type_missing */, nullptr /* memory_allocator */);
+      if (s.ok()) {
+        size_t block_size = props_block_handle.size();
+        char* tmp_buf = new char[block_size + kBlockTrailerSize];
+        if (tmp_buf) {
+          memcpy(tmp_buf, props_block_contents.data.data(),
+                 props_block_contents.data.size() + kBlockTrailerSize);
+          const auto seqno_pos_iter = table_properties->properties_offsets.find(
+              ExternalSstFilePropertyNames::kGlobalSeqno);
+          assert(seqno_pos_iter != table_properties->properties_offsets.end());
+          uint64_t global_seqno_offset = seqno_pos_iter->second;
+          EncodeFixed64(
+              tmp_buf + global_seqno_offset - props_block_handle.offset(), 0);
+          uint32_t value = DecodeFixed32(tmp_buf + block_size + 1);
+          s = rocksdb::VerifyChecksum(rep->footer.checksum(), tmp_buf,
+                                      block_size + 1, value);
+          delete[] tmp_buf;
+          tmp_buf = nullptr;
+        }
+      }
     }
 
     if (!s.ok()) {

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -250,7 +250,7 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
   };
 
   std::string last_key;
-  for (iter.SlowSeekToFirst(); iter.Valid(); iter.SlowNext()) {
+  for (iter.SeekToFirstOrReport(); iter.Valid(); iter.NextOrReport()) {
     s = iter.status();
     if (!s.ok()) {
       break;

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -250,7 +250,7 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
   };
 
   std::string last_key;
-  for (iter.SeekToFirst(); iter.Valid(); iter.Next()) {
+  for (iter.SlowSeekToFirst(); iter.Valid(); iter.SlowNext()) {
     s = iter.status();
     if (!s.ok()) {
       break;

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -96,7 +96,8 @@ bool NotifyCollectTableCollectorsOnFinish(
 Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
                       FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                       const ImmutableCFOptions& ioptions,
-                      TableProperties** table_properties,
+                      TableProperties** table_properties, bool verify_checksum,
+                      BlockHandle* block_handle, BlockContents* block_contents,
                       bool compression_type_missing = false,
                       MemoryAllocator* memory_allocator = nullptr);
 

--- a/table/meta_blocks.h
+++ b/table/meta_blocks.h
@@ -97,7 +97,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
                       FilePrefetchBuffer* prefetch_buffer, const Footer& footer,
                       const ImmutableCFOptions& ioptions,
                       TableProperties** table_properties, bool verify_checksum,
-                      BlockHandle* block_handle, BlockContents* block_contents,
+                      BlockHandle* block_handle,
+                      CacheAllocationPtr* verification_buf,
                       bool compression_type_missing = false,
                       MemoryAllocator* memory_allocator = nullptr);
 


### PR DESCRIPTION
Summary:
Always enable properties block checksum verification for block-based table. For external SST file ingested with 'write_global_seqno==true', we use 'DecodeEntrySlow' to parse its blocks' contents so that the process will not die upon failing the assertion possibly caused by corruption.

Test Plan:
```
$make clean && COMPILE_WITH_ASAN=1 make -j32 all
$./external_sst_file_basic_test
$./external_sst_file_test
$make check
```

To verify there is no performance regression, run the following.
```
$git checkout checksum_props_blk
$make clean && make -j32 db_bench
$./db_bench -benchmarks filluniquerandomdeterministic,readtocache -disable_auto_compactions=true -num=10000000 -block_size=16384 -num_levels=3
```
Got the following result
```
...
Level[0]: /000060.sst(size: 6968789 bytes)
Level[1]: /000071.sst - /000071.sst(total size: 60083320 bytes)
Level[2]: /000061.sst - /000070.sst(total size: 632136432 bytes)
filluniquerandomdeterministic :       8.844 micros/op 113074 ops/sec;   12.5 MB/s
DB path: [/tmp/rocksdbtest-148062/dbbench]
readtocache  :       0.328 micros/op 3052135 ops/sec;  337.6 MB/s
```

Then try the baseline.
```
$git checkout 1a761e6a6cfdab685eb48c1606668094147f3631
$make clean && make -j32 db_bench
$./db_bench -benchmarks filluniquerandomdeterministic,readtocache -disable_auto_compactions=true -num=10000000 -block_size=16384 -num_levels=3
```
The results are as follows
```
...
Level[0]: /000060.sst(size: 6969634 bytes)
Level[1]: /000071.sst - /000071.sst(total size: 60080378 bytes)
Level[2]: /000061.sst - /000070.sst(total size: 632136432 bytes)
filluniquerandomdeterministic :       8.933 micros/op 111942 ops/sec;   12.4 MB/s
DB path: [/tmp/rocksdbtest-148062/dbbench]
readtocache  :       0.328 micros/op 3050842 ops/sec;  337.5 MB/s
```

This is expected as c++ function template instantiation mostly incurs no runtime overhead (sometimes binary size may affect CPU cache friendliness).