### PR TITLE
Fix `compression_zstd_max_train_bytes` coverage in stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -26,6 +26,7 @@ default_params = {
     "block_size": 16384,
     "cache_size": 1048576,
     "checkpoint_one_in": 1000000,
+    "compression_type": "snappy",
     "compression_max_dict_bytes": lambda: 16384 * random.randint(0, 1),
     "compression_zstd_max_train_bytes": lambda: 65536 * random.randint(0, 1),
     "clear_column_family_one_in": 0,


### PR DESCRIPTION
Previously `finalize_and_sanitize` function was always zeroing out `compression_zstd_max_train_bytes`. It was only supposed to do that when non-ZSTD compression was used. But since `--compression_type` was an unknown argument (i.e., one that `db_crashtest.py` does not recognize and blindly forwards to `db_stress`), `finalize_and_sanitize` could not tell whether ZSTD was used. This PR fixes it simply by making `--compression_type` a known argument with snappy as default (same as `db_stress`).

Test Plan:

- tried it out, verified `--compression_zstd_max_train_bytes=16384` is passed to `db_stress`

```
$ python tools/db_crashtest.py blackbox --simple --write_buffer_size=1048576 --target_file_size_base=1048576 --target_file_size_multiplier=1 --max_bytes_for_level_base=4194304 --compression_type=zstd --duration=120 --max_key=10000000 --interval=30 --compression_zstd_max_train_bytes=524288 --compression_max_dict_bytes=16384 --compression_zstd_max_train_bytes=16384 --value_size_mult=33
```