### PR TITLE
Set IngestExternalFileOptions.write_global_seqno to false by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * For users of dictionary compression with ZSTD v0.7.0+, we now reuse the same digested dictionary when compressing each of an SST file's data blocks for faster compression speeds.
 * For all users of dictionary compression who set `cache_index_and_filter_blocks == true`, we now store dictionary data used for decompression in the block cache for better control over memory usage. For users of ZSTD v1.1.4+ who compile with -DZSTD_STATIC_LINKING_ONLY, this includes a digested dictionary, which is used to increase decompression speed.
 * Add support for block checksums verification for external SST files before ingestion.
+* Stop writing global sequence number for external SST files unless the user explicitly says otherwise. Database with bulkloaded SST files not writing global sequence number cannot be opened by RocksDB 5.15 and older.
 
 ### Public API Change
 * CompactionPri = kMinOverlappingRatio also uses compensated file size, which boosts file with lots of tombstones to be compacted first.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1342,8 +1342,7 @@ struct IngestExternalFileOptions {
   // you set this option to false, which brings two benefits:
   // 1. No extra random write for global_seqno during ingestion.
   // 2. Without writing external SST file, it's possible to do checksum.
-  // We have a plan to set this option to false by default in the future.
-  bool write_global_seqno = true;
+  bool write_global_seqno = false;
   // Set to true if you would like to verify the checksums of each block of the
   // external SST file before ingestion.
   // Warning: setting this to true causes slowdown in file ingestion because


### PR DESCRIPTION
Summary: set IngestExternalFileOptions.write_global_seqno to false by default. External
SST files ingested without writing global_seqno cannot be used by older
versions of RocksDB (5.15 and prior).

**RocksDB 6.0**

Test Plan:
```
$make clean && COMPILE_WITH_ASAN=1 make -j32 all
$make check
```