### PR TITLE
Add a placeholder in manifest indicating ignorable record

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * For users of dictionary compression with ZSTD v0.7.0+, we now reuse the same digested dictionary when compressing each of an SST file's data blocks for faster compression speeds.
 * For all users of dictionary compression who set `cache_index_and_filter_blocks == true`, we now store dictionary data used for decompression in the block cache for better control over memory usage. For users of ZSTD v1.1.4+ who compile with -DZSTD_STATIC_LINKING_ONLY, this includes a digested dictionary, which is used to increase decompression speed.
 * Add support for block checksums verification for external SST files before ingestion.
+* Add a place holder in manifest which indicate a record from future that can be safely ignored.
 
 ### Public API Change
 * CompactionPri = kMinOverlappingRatio also uses compensated file size, which boosts file with lots of tombstones to be compacted first.

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -513,8 +513,9 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
             if (!msg) {
               msg = "safely ignorrable form future length error";
             }
+          } else {
+            input.remove_prefix(static_cast<size_t>(field_len));
           }
-          input.remove_prefix(static_cast<size_t>(field_len));
         } else {
           msg = "unknown tag";
         }

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -511,7 +511,7 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
           if (!GetVarint32(&input, &field_len) ||
               static_cast<size_t>(field_len) > input.size()) {
             if (!msg) {
-              msg = "safely ignorrable form future length error";
+              msg = "safely ignoreable tag length error";
             }
           } else {
             input.remove_prefix(static_cast<size_t>(field_len));

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -44,6 +44,9 @@ enum Tag : uint32_t {
   kInAtomicGroup = 300,
 };
 
+// Mask for an identified tag from the future which can be safely ignored.
+uint32_t kTagSafeIgnoreMask = 1 << 13;
+
 enum CustomTag : uint32_t {
   kTerminate = 1,  // The end of customized fields
   kNeedCompaction = 2,
@@ -501,7 +504,20 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         break;
 
       default:
-        msg = "unknown tag";
+        if (tag & kTagSafeIgnoreMask) {
+          // Tag from future which can be safely ignored.
+          // The next field must be the length of the entry.
+          uint32_t field_len;
+          if (!GetVarint32(&input, &field_len) ||
+              static_cast<size_t>(field_len) > input.size()) {
+            if (!msg) {
+              msg = "safely ignorrable form future length error";
+            }
+          }
+          input.remove_prefix(static_cast<size_t>(field_len));
+        } else {
+          msg = "unknown tag";
+        }
         break;
     }
   }


### PR DESCRIPTION
Summary: We want to reserve some right that some extra information added manifest
in the future can be forward compatible by previous versions. Now we create a
place holder for that. A bit in tag is added to indicate that a field can be
safely ignored.

Test Plan: Manually created some DB with corrupted record, safely ignored records
and observe that they are read correctly.