### PR TITLE
Reset size_ to 0 in PinnableSlice::Reset

### DIFF
--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -202,6 +202,7 @@ class PinnableSlice : public Slice, public Cleanable {
   void Reset() {
     Cleanable::Reset();
     pinned_ = false;
+    size_ = 0;
   }
 
   inline std::string* GetSelf() { return buf_; }


### PR DESCRIPTION
It would avoid bugs if the reused PinnableSlice is not actually reassigned and yet the programmer makes conclusions based on the size of the Slice.