### PR TITLE
WritePrepared: relax assert in compaction iterator

### DIFF
--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -482,11 +482,14 @@ void CompactionIterator::NextFromInput() {
       // this value, and findEarliestVisibleSnapshot returns the next snapshot
       // as current_user_key_snapshot. In this case last value and current
       // value are both in current_user_key_snapshot currently.
+      // Although last_snapshot is released we might still get a definitive
+      // response when key sequence number changes, e.g., when seq is determined
+      // too old and visible in all snapshots.
       assert(last_snapshot == current_user_key_snapshot_ ||
              (snapshot_checker_ != nullptr &&
               snapshot_checker_->CheckInSnapshot(current_user_key_sequence_,
-                                                 last_snapshot) ==
-                  SnapshotCheckerResult::kSnapshotReleased));
+                                                 last_snapshot) !=
+                  SnapshotCheckerResult::kNotInSnapshot));
 
       ++iter_stats_.num_record_drop_hidden;  // (A)
       input_->Next();


### PR DESCRIPTION
If IsInSnapshot(seq2, snapshot) determines that the snapshot is released, the future queries IsInSnapshot(seq1, snapshot) could still return a definitive answer of true if for example seq1 is too old that is determined visible in all snapshots. This violates a recently added assert statement to compaction iterator. The patch relaxes the assert.