### PR TITLE
Use BUILD_SHARED_LIBS to set lib type in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -743,12 +743,13 @@ if (ARTIFACT_SUFFIX)
     PROPERTIES OUTPUT_NAME rocksdb${ARTIFACT_SUFFIX})
 endif ()
 target_link_libraries(rocksdb
-  "$<IF:$<BOOL:${WIN32}>,shlwapi;rpcrt4,${CMAKE_THREAD_LIBS_INIT}>")
+  "$<IF:$<BOOL:${WIN32}>,shlwapi;rpcrt4$<$<BOOL:${WITH_XPRESS}>:;cabinet.lib>,${CMAKE_THREAD_LIBS_INIT}>")
 if (BUILD_SHARED_LIBS)
   if (WIN32)
     target_compile_definitions (rocksdb
       PUBLIC
         ROCKSDB_DLL
+        $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${WITH_XPRESS}>>:XPRESS>
       PRIVATE
         ROCKSDB_LIBRARY_EXPORTS
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,10 +721,6 @@ else()
     env/io_posix.cc)
 endif()
 
-set(ROCKSDB_STATIC_LIB rocksdb${ARTIFACT_SUFFIX})
-set(ROCKSDB_SHARED_LIB rocksdb-shared${ARTIFACT_SUFFIX})
-set(ROCKSDB_IMPORT_LIB ${ROCKSDB_SHARED_LIB})
-
 option(WITH_LIBRADOS "Build with librados" OFF)
 if(WITH_LIBRADOS)
   list(APPEND SOURCES
@@ -732,41 +728,39 @@ if(WITH_LIBRADOS)
   list(APPEND THIRDPARTY_LIBS rados)
 endif()
 
-if(WIN32)
-  set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
-  set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-else()
-  set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
-  set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+#[===================================================================[
+  declare a library target.
+  type is based on BUILD_SHARED_LIBS setting
+#]===================================================================]
 
-  add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
-  target_link_libraries(${ROCKSDB_SHARED_LIB}
-    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-  set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
-                        LINKER_LANGUAGE CXX
-                        VERSION ${ROCKSDB_VERSION}
-                        SOVERSION ${ROCKSDB_VERSION_MAJOR}
-                        CXX_STANDARD 11
-                        OUTPUT_NAME "rocksdb")
+option(BUILD_SHARED_LIBS "Build a shared library" OFF)
+add_library(rocksdb ${SOURCES})
+if(NOT MSVC)
+  set_property(TARGET rocksdb PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
-
-add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES})
-target_link_libraries(${ROCKSDB_STATIC_LIB}
-  ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-
-if(WIN32)
-  add_library(${ROCKSDB_IMPORT_LIB} SHARED ${SOURCES})
-  target_link_libraries(${ROCKSDB_IMPORT_LIB}
-    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-  set_target_properties(${ROCKSDB_IMPORT_LIB} PROPERTIES
-    COMPILE_DEFINITIONS "ROCKSDB_DLL;ROCKSDB_LIBRARY_EXPORTS")
-  if(MSVC)
-    set_target_properties(${ROCKSDB_STATIC_LIB} PROPERTIES
-      COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/${ROCKSDB_STATIC_LIB}.pdb")
-    set_target_properties(${ROCKSDB_IMPORT_LIB} PROPERTIES
-      COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/${ROCKSDB_IMPORT_LIB}.pdb")
-  endif()
-endif()
+if (ARTIFACT_SUFFIX)
+  set_target_properties(rocksdb
+    PROPERTIES OUTPUT_NAME rocksdb${ARTIFACT_SUFFIX})
+endif ()
+target_link_libraries(rocksdb
+  "$<IF:$<BOOL:${WIN32}>,shlwapi;rpcrt4,${CMAKE_THREAD_LIBS_INIT}>")
+if (BUILD_SHARED_LIBS)
+  if (WIN32)
+    target_compile_definitions (rocksdb
+      PUBLIC
+        ROCKSDB_DLL
+      PRIVATE
+        ROCKSDB_LIBRARY_EXPORTS
+    )
+  else ()
+    set_target_properties(rocksdb
+      PROPERTIES
+        LINKER_LANGUAGE CXX
+        VERSION ${ROCKSDB_VERSION}
+        SOVERSION ${ROCKSDB_VERSION_MAJOR}
+        CXX_STANDARD 11)
+  endif ()
+endif ()
 
 option(WITH_JNI "build with JNI" OFF)
 if(WITH_JNI OR JNI)
@@ -807,15 +801,7 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
   install(DIRECTORY include/rocksdb COMPONENT devel DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
   install(
-    TARGETS ${ROCKSDB_STATIC_LIB}
-    EXPORT RocksDBTargets
-    COMPONENT devel
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-  )
-
-  install(
-    TARGETS ${ROCKSDB_SHARED_LIB}
+    TARGETS rocksdb
     EXPORT RocksDBTargets
     COMPONENT runtime
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -997,7 +983,7 @@ if(WITH_TESTS)
     get_filename_component(exename ${sourcefile} NAME_WE)
     add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile}
       $<TARGET_OBJECTS:testharness>)
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} gtest ${LIBS})
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} gtest rocksdb)
   endforeach(sourcefile ${BENCHMARKS})
 
   # For test util library that is build only in DEBUG mode
@@ -1036,7 +1022,7 @@ if(WITH_TESTS)
         EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
         OUTPUT_NAME ${exename}${ARTIFACT_SUFFIX}
         )
-      target_link_libraries(${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} gtest ${LIBS})
+      target_link_libraries(${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} gtest rocksdb)
       if(NOT "${exename}" MATCHES "db_sanity_test")
         add_test(NAME ${exename} COMMAND ${exename}${ARTIFACT_SUFFIX})
         add_dependencies(check ${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX})
@@ -1056,7 +1042,7 @@ if(WITH_TESTS)
         EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
         EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
         )
-      target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${ROCKSDB_IMPORT_LIB} testutillib${ARTIFACT_SUFFIX})
+      target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb testutillib${ARTIFACT_SUFFIX})
       add_test(NAME ${exename} COMMAND ${exename}${ARTIFACT_SUFFIX})
       add_dependencies(check ${exename}${ARTIFACT_SUFFIX})
   endforeach(sourcefile ${C_TEST_EXES})

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -377,20 +377,16 @@ create_javah(
   OUTPUT_DIR ${JNI_OUTPUT_DIR}
 )
 
-if(NOT MSVC)
-  set_property(TARGET ${ROCKSDB_STATIC_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
-endif()
-
 set(ROCKSDBJNI_STATIC_LIB rocksdbjni${ARTIFACT_SUFFIX})
 add_library(${ROCKSDBJNI_STATIC_LIB} ${JNI_NATIVE_SOURCES})
 add_dependencies(${ROCKSDBJNI_STATIC_LIB} rocksdbjni_headers)
-target_link_libraries(${ROCKSDBJNI_STATIC_LIB} ${ROCKSDB_STATIC_LIB} ${LIBS})
+target_link_libraries(${ROCKSDBJNI_STATIC_LIB} rocksdb)
 
 if(NOT MINGW)
   set(ROCKSDBJNI_SHARED_LIB rocksdbjni-shared${ARTIFACT_SUFFIX})
   add_library(${ROCKSDBJNI_SHARED_LIB} SHARED ${JNI_NATIVE_SOURCES})
   add_dependencies(${ROCKSDBJNI_SHARED_LIB} rocksdbjni_headers)
-  target_link_libraries(${ROCKSDBJNI_SHARED_LIB} ${ROCKSDB_STATIC_LIB} ${LIBS})
+  target_link_libraries(${ROCKSDBJNI_SHARED_LIB} rocksdb)
 
   set_target_properties(
     ${ROCKSDBJNI_SHARED_LIB}

--- a/thirdparty.inc
+++ b/thirdparty.inc
@@ -24,11 +24,11 @@ endif ()
 
 if (WITH_GFLAGS)
   message(STATUS "GFLAGS library is enabled")
-  
+
   if(DEFINED ENV{GFLAGS_INCLUDE})
     set(GFLAGS_INCLUDE $ENV{GFLAGS_INCLUDE})
   endif()
-  
+
   if(DEFINED ENV{GFLAGS_LIB_DEBUG})
     set(GFLAGS_LIB_DEBUG $ENV{GFLAGS_LIB_DEBUG})
   endif()
@@ -36,7 +36,7 @@ if (WITH_GFLAGS)
   if(DEFINED ENV{GFLAGS_LIB_RELEASE})
     set(GFLAGS_LIB_RELEASE $ENV{GFLAGS_LIB_RELEASE})
   endif()
-  
+
   set(GFLAGS_CXX_FLAGS -DGFLAGS=gflags)
   set(GFLAGS_LIBS debug ${GFLAGS_LIB_DEBUG} optimized ${GFLAGS_LIB_RELEASE})
 
@@ -103,11 +103,11 @@ endif ()
 
 if (WITH_LZ4)
   message(STATUS "LZ4 library is enabled")
-  
+
   if(DEFINED ENV{LZ4_INCLUDE})
     set(LZ4_INCLUDE $ENV{LZ4_INCLUDE})
   endif()
-  
+
   if(DEFINED ENV{LZ4_LIB_DEBUG})
     set(LZ4_LIB_DEBUG $ENV{LZ4_LIB_DEBUG})
   endif()
@@ -115,7 +115,7 @@ if (WITH_LZ4)
   if(DEFINED ENV{LZ4_LIB_RELEASE})
     set(LZ4_LIB_RELEASE $ENV{LZ4_LIB_RELEASE})
   endif()
-  
+
   set(LZ4_CXX_FLAGS -DLZ4)
   set(LZ4_LIBS debug ${LZ4_LIB_DEBUG} optimized ${LZ4_LIB_RELEASE})
 
@@ -146,7 +146,7 @@ if (WITH_ZLIB)
   if(DEFINED ENV{ZLIB_INCLUDE})
     set(ZLIB_INCLUDE $ENV{ZLIB_INCLUDE})
   endif()
-  
+
   if(DEFINED ENV{ZLIB_LIB_DEBUG})
     set(ZLIB_LIB_DEBUG $ENV{ZLIB_LIB_DEBUG})
   endif()
@@ -154,7 +154,7 @@ if (WITH_ZLIB)
   if(DEFINED ENV{ZLIB_LIB_RELEASE})
     set(ZLIB_LIB_RELEASE $ENV{ZLIB_LIB_RELEASE})
   endif()
-  
+
   set(ZLIB_CXX_FLAGS -DZLIB)
   set(ZLIB_LIBS debug ${ZLIB_LIB_DEBUG} optimized ${ZLIB_LIB_RELEASE})
 
@@ -175,11 +175,6 @@ endif ()
 
 if (WITH_XPRESS)
   message(STATUS "XPRESS is enabled")
-
-  add_definitions(-DXPRESS)
-  
-  # We are using the implementation provided by the system
-  set (SYSTEM_LIBS ${SYSTEM_LIBS} Cabinet.lib)
 else ()
   message(STATUS "XPRESS is disabled")
 endif ()
@@ -205,7 +200,7 @@ if (WITH_ZSTD)
   if(DEFINED ENV{ZSTD_INCLUDE})
     set(ZSTD_INCLUDE $ENV{ZSTD_INCLUDE})
   endif()
-  
+
   if(DEFINED ENV{ZSTD_LIB_DEBUG})
     set(ZSTD_LIB_DEBUG $ENV{ZSTD_LIB_DEBUG})
   endif()
@@ -241,11 +236,11 @@ endif()
 if (WITH_JEMALLOC)
   message(STATUS "JEMALLOC library is enabled")
   set(JEMALLOC_CXX_FLAGS "-DROCKSDB_JEMALLOC -DJEMALLOC_EXPORT= ")
-  
+
   if(DEFINED ENV{JEMALLOC_INCLUDE})
     set(JEMALLOC_INCLUDE $ENV{JEMALLOC_INCLUDE})
   endif()
-  
+
   if(DEFINED ENV{JEMALLOC_LIB_DEBUG})
     set(JEMALLOC_LIB_DEBUG $ENV{JEMALLOC_LIB_DEBUG})
   endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach(src ${TOOLS})
   get_filename_component(exename ${src} NAME_WE)
   add_executable(${exename}${ARTIFACT_SUFFIX}
     ${src})
-  target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
+  target_link_libraries(${exename}${ARTIFACT_SUFFIX} rocksdb)
   list(APPEND tool_deps ${exename})
 endforeach()
 add_custom_target(tools


### PR DESCRIPTION
Modify CMake file to make use of standard BUILD_SHARED_LIBS option. Remove redundant targets.

FIXES: https://github.com/facebook/rocksdb/issues/4484