### PR TITLE
Add an option to skip calling TryLock for Txn Put/Delete

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,7 @@
 * Files written by `SstFileWriter` will now use dictionary compression if it is configured in the file writer's `CompressionOptions`.
 
 ### Public API Change
-* Disallow CompactionFilter::IgnoreSnapshots() = false, because it is not very useful and the behavior is confusing. The filter will filter everything if there is no snapshot declared by the time the compaction starts. However, users can define a snapshot after the compaction starts and before it finishes and this new snapshot won't be repeatable, because after the compaction finishes, some keys may be dropped. 
+* Disallow CompactionFilter::IgnoreSnapshots() = false, because it is not very useful and the behavior is confusing. The filter will filter everything if there is no snapshot declared by the time the compaction starts. However, users can define a snapshot after the compaction starts and before it finishes and this new snapshot won't be repeatable, because after the compaction finishes, some keys may be dropped.
 * CompactionPri = kMinOverlappingRatio also uses compensated file size, which boosts file with lots of tombstones to be compacted first.
 * Transaction::GetForUpdate is extended with a do_validate parameter with default value of true. If false it skips validating the snapshot before doing the read. Similarly ::Merge, ::Put, ::Delete, and ::SingleDelete are extended with assume_tracked with default value of false. If true it indicates that call is assumed to be after a ::GetForUpdate.
 * `TableProperties::num_entries` and `TableProperties::num_deletions` now also account for number of range tombstones.
@@ -25,6 +25,7 @@
 * Remove PlainTable's store_index_in_file feature. When opening an existing DB with index in SST files, the index and bloom filter will still be rebuild while SST files are opened, in the same way as there is no index in the file.
 * Remove CuckooHash memtable.
 * The counter stat `number.block.not_compressed` now also counts blocks not compressed due to poor compression ratio.
+* Transaction::Put and Transaction::Delete are extended with skip_lock with default value of false. If true it indicates caller's intent to skip calling TryLock in the code path.
 * Support SST file ingestion across multiple column families via DB::IngestExternalFiles. See the function's comment about atomicity.
 * Remove Lua compaction filter.
 

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -323,11 +323,13 @@ class Transaction {
   virtual Status Merge(const Slice& key, const Slice& value) = 0;
 
   virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                        const bool assume_tracked = false) = 0;
+                        const bool assume_tracked = false,
+                        const bool skip_lock = false) = 0;
   virtual Status Delete(const Slice& key) = 0;
   virtual Status Delete(ColumnFamilyHandle* column_family,
                         const SliceParts& key,
-                        const bool assume_tracked = false) = 0;
+                        const bool assume_tracked = false,
+                        const bool skip_lock = false) = 0;
   virtual Status Delete(const SliceParts& key) = 0;
 
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -308,11 +308,13 @@ class Transaction {
   //  (See max_write_buffer_number_to_maintain)
   // or other errors on unexpected failures.
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-                     const Slice& value, const bool assume_tracked = false) = 0;
+                     const Slice& value, const bool assume_tracked = false,
+                     const bool skip_lock = false) = 0;
   virtual Status Put(const Slice& key, const Slice& value) = 0;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value,
-                     const bool assume_tracked = false) = 0;
+                     const bool assume_tracked = false,
+                     const bool skip_lock = false) = 0;
   virtual Status Put(const SliceParts& key, const SliceParts& value) = 0;
 
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -334,11 +334,13 @@ class Transaction {
 
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const Slice& key,
-                              const bool assume_tracked = false) = 0;
+                              const bool assume_tracked = false,
+                              const bool skip_lock = false) = 0;
   virtual Status SingleDelete(const Slice& key) = 0;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const SliceParts& key,
-                              const bool assume_tracked = false) = 0;
+                              const bool assume_tracked = false,
+                              const bool skip_lock = false) = 0;
   virtual Status SingleDelete(const SliceParts& key) = 0;
 
   // PutUntracked() will write a Put to the batch of operations to be committed

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -575,7 +575,8 @@ void txn_write_kv_helper(JNIEnv* env, const FnWriteKV& fn_write_kv,
 void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
-    jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jlong jcolumn_family_handle, jboolean jassume_tracked,
+    jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -583,7 +584,7 @@ void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
       const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Put, txn,
                                     column_family_handle, _1, _2,
-                                    jassume_tracked);
+                                    jassume_tracked, jskip_lock);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
 }
 
@@ -714,7 +715,8 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
-    jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jlong jcolumn_family_handle, jboolean jassume_tracked,
+    jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -723,7 +725,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
           const rocksdb::SliceParts&, bool)>(&rocksdb::Transaction::Put, txn,
                                              column_family_handle, _1, _2,
-                                             jassume_tracked);
+                                             jassume_tracked, jskip_lock);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
                             jvalue_parts, jvalue_parts_len);
 }
@@ -812,14 +814,15 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
  */
 void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked,
+    jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
       &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
-      jassume_tracked);
+      jassume_tracked, jskip_lock);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
 }
 
@@ -902,7 +905,7 @@ void txn_write_k_parts_helper(JNIEnv* env,
 void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
-    jboolean jassume_tracked) {
+    jboolean jassume_tracked, jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -910,7 +913,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
           &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
-          jassume_tracked);
+          jassume_tracked, jskip_lock);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
 }
 
@@ -937,7 +940,8 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
  */
 void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
-    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked) {
+    jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked,
+    jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -945,7 +949,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
-          jassume_tracked);
+          jassume_tracked, jskip_lock);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
 }
 
@@ -974,7 +978,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
 void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
-    jboolean jassume_tracked) {
+    jboolean jassume_tracked, jboolean jskip_lock) {
   auto* txn = reinterpret_cast<rocksdb::Transaction*>(jhandle);
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
@@ -982,7 +986,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
-          jassume_tracked);
+          jassume_tracked, jskip_lock);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,
                            jkey_parts_len);
 }

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -570,9 +570,9 @@ void txn_write_kv_helper(JNIEnv* env, const FnWriteKV& fn_write_kv,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    put
- * Signature: (J[BI[BIJZ)V
+ * Signature: (J[BI[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
+void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jbyteArray jval, jint jval_len,
     jlong jcolumn_family_handle, jboolean jassume_tracked,
@@ -582,7 +582,7 @@ void Java_org_rocksdb_Transaction_put__J_3BI_3BIJZ(
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKV fn_put = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
       rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&,
-      const rocksdb::Slice&, bool)>(&rocksdb::Transaction::Put, txn,
+      const rocksdb::Slice&, bool, bool)>(&rocksdb::Transaction::Put, txn,
                                     column_family_handle, _1, _2,
                                     jassume_tracked, jskip_lock);
   txn_write_kv_helper(env, fn_put, jkey, jkey_part_len, jval, jval_len);
@@ -710,9 +710,9 @@ void txn_write_kv_parts_helper(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    put
- * Signature: (J[[BI[[BIJZ)V
+ * Signature: (J[[BI[[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
+void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jobjectArray jvalue_parts, jint jvalue_parts_len,
     jlong jcolumn_family_handle, jboolean jassume_tracked,
@@ -723,7 +723,7 @@ void Java_org_rocksdb_Transaction_put__J_3_3BI_3_3BIJZ(
   FnWriteKVParts fn_put_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
           rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&,
-          const rocksdb::SliceParts&, bool)>(&rocksdb::Transaction::Put, txn,
+          const rocksdb::SliceParts&, bool, bool)>(&rocksdb::Transaction::Put, txn,
                                              column_family_handle, _1, _2,
                                              jassume_tracked, jskip_lock);
   txn_write_kv_parts_helper(env, fn_put_parts, jkey_parts, jkey_parts_len,
@@ -810,9 +810,9 @@ void txn_write_k_helper(JNIEnv* env, const FnWriteK& fn_write_k,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    delete
- * Signature: (J[BIJZ)V
+ * Signature: (J[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
+void Java_org_rocksdb_Transaction_delete__J_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked,
     jboolean jskip_lock) {
@@ -820,7 +820,7 @@ void Java_org_rocksdb_Transaction_delete__J_3BIJZ(
   auto* column_family_handle =
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_delete = std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
+      rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool, bool)>(
       &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
       jassume_tracked, jskip_lock);
   txn_write_k_helper(env, fn_delete, jkey, jkey_part_len);
@@ -900,9 +900,9 @@ void txn_write_k_parts_helper(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    delete
- * Signature: (J[[BIJZ)V
+ * Signature: (J[[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
+void Java_org_rocksdb_Transaction_delete__J_3_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
     jboolean jassume_tracked, jboolean jskip_lock) {
@@ -911,7 +911,7 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BIJZ(
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_delete_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool, bool)>(
           &rocksdb::Transaction::Delete, txn, column_family_handle, _1,
           jassume_tracked, jskip_lock);
   txn_write_k_parts_helper(env, fn_delete_parts, jkey_parts, jkey_parts_len);
@@ -936,9 +936,9 @@ void Java_org_rocksdb_Transaction_delete__J_3_3BI(JNIEnv* env, jobject /*jobj*/,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    singleDelete
- * Signature: (J[BIJZ)V
+ * Signature: (J[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
+void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jbyteArray jkey,
     jint jkey_part_len, jlong jcolumn_family_handle, jboolean jassume_tracked,
     jboolean jskip_lock) {
@@ -947,7 +947,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BIJZ(
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteK fn_single_delete =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool)>(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::Slice&, bool, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
           jassume_tracked, jskip_lock);
   txn_write_k_helper(env, fn_single_delete, jkey, jkey_part_len);
@@ -973,9 +973,9 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3BI(JNIEnv* env,
 /*
  * Class:     org_rocksdb_Transaction
  * Method:    singleDelete
- * Signature: (J[[BIJZ)V
+ * Signature: (J[[BIJZZ)V
  */
-void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
+void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZZ(
     JNIEnv* env, jobject /*jobj*/, jlong jhandle, jobjectArray jkey_parts,
     jint jkey_parts_len, jlong jcolumn_family_handle,
     jboolean jassume_tracked, jboolean jskip_lock) {
@@ -984,7 +984,7 @@ void Java_org_rocksdb_Transaction_singleDelete__J_3_3BIJZ(
       reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jcolumn_family_handle);
   FnWriteKParts fn_single_delete_parts =
       std::bind<rocksdb::Status (rocksdb::Transaction::*)(
-          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool)>(
+          rocksdb::ColumnFamilyHandle*, const rocksdb::SliceParts&, bool, bool)>(
           &rocksdb::Transaction::SingleDelete, txn, column_family_handle, _1,
           jassume_tracked, jskip_lock);
   txn_write_k_parts_helper(env, fn_single_delete_parts, jkey_parts,

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -658,6 +658,8 @@ public class Transaction extends RocksObject {
    * @param columnFamilyHandle The column family to put the key/value into
    * @param key the specified key to be inserted.
    * @param value the value associated with the specified key.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -672,7 +674,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #put(ColumnFamilyHandle, byte[], byte[], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
       final byte[] value) throws RocksDBException {
@@ -718,6 +720,8 @@ public class Transaction extends RocksObject {
    * @param columnFamilyHandle The column family to put the key/value into
    * @param keyParts the specified key to be inserted.
    * @param valueParts the value associated with the specified key.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -733,7 +737,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #put(ColumnFamilyHandle, byte[][], byte[][], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts, final byte[][] valueParts)
@@ -782,6 +786,7 @@ public class Transaction extends RocksObject {
    * @param columnFamilyHandle The column family to merge the key/value into
    * @param key the specified key to be merged.
    * @param value the value associated with the specified key.
+   * @param assume_tracked whether to expect the key be already tracked.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -851,6 +856,8 @@ public class Transaction extends RocksObject {
    *
    * @param columnFamilyHandle The column family to delete the key/value from
    * @param key the specified key to be deleted.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -865,7 +872,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #delete(ColumnFamilyHandle, byte[], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[] key) throws RocksDBException {
@@ -908,6 +915,8 @@ public class Transaction extends RocksObject {
    *
    * @param columnFamilyHandle The column family to delete the key/value from
    * @param keyParts the specified key to be deleted.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -923,7 +932,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #delete(ColumnFamilyHandle, byte[][], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle,
       final byte[][] keyParts) throws RocksDBException {
@@ -966,6 +975,8 @@ public class Transaction extends RocksObject {
    *
    * @param columnFamilyHandle The column family to delete the key/value from
    * @param key the specified key to be deleted.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -981,7 +992,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #singleDelete(ColumnFamilyHandle, byte[], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key)
@@ -1026,6 +1037,8 @@ public class Transaction extends RocksObject {
    *
    * @param columnFamilyHandle The column family to delete the key/value from
    * @param keyParts the specified key to be deleted.
+   * @param assume_tracked whether to expect the key be already tracked.
+   * @param skip_lock whether to skip calling TryLock in the code path.
    *
    * @throws RocksDBException when one of the TransactionalDB conditions
    *     described above occurs, or in the case of an unexpected error
@@ -1042,7 +1055,7 @@ public class Transaction extends RocksObject {
   /*
    * Same as
    * {@link #singleDelete(ColumnFamilyHandle, byte[][], boolean)}
-   * with assume_tracked=false.
+   * with assume_tracked=false and skip_lock=false.
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts)

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -663,10 +663,10 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[] key, final byte[] value,
-      final boolean assume_tracked) throws RocksDBException {
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
     put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        assume_tracked);
+        assume_tracked, skip_lock);
   }
 
   /*
@@ -678,7 +678,7 @@ public class Transaction extends RocksObject {
       final byte[] value) throws RocksDBException {
     assert(isOwningHandle());
     put(nativeHandle_, key, key.length, value, value.length, columnFamilyHandle.nativeHandle_,
-        /*assume_tracked*/ false);
+        /*assume_tracked*/ false, /*skip_lock*/ false);
   }
 
   /**
@@ -723,10 +723,11 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void put(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final byte[][] valueParts, final boolean assume_tracked) throws RocksDBException {
+      final byte[][] valueParts, final boolean assume_tracked,
+      final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
-        columnFamilyHandle.nativeHandle_, assume_tracked);
+        columnFamilyHandle.nativeHandle_, assume_tracked, skip_lock);
   }
 
   /*
@@ -739,7 +740,8 @@ public class Transaction extends RocksObject {
       throws RocksDBException {
     assert(isOwningHandle());
     put(nativeHandle_, keyParts, keyParts.length, valueParts, valueParts.length,
-        columnFamilyHandle.nativeHandle_, /*assume_tracked*/ false);
+        columnFamilyHandle.nativeHandle_, /*assume_tracked*/ false,
+        /*skip_lock*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -854,9 +856,10 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
-      final boolean assume_tracked) throws RocksDBException {
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
-    delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_tracked);
+    delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
+           assume_tracked, skip_lock);
   }
 
   /*
@@ -868,7 +871,7 @@ public class Transaction extends RocksObject {
       final byte[] key) throws RocksDBException {
     assert(isOwningHandle());
     delete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
-        /*assume_tracked*/ false);
+        /*assume_tracked*/ false, /*skip_lock*/ false);
   }
 
   /**
@@ -910,10 +913,11 @@ public class Transaction extends RocksObject {
    *     described above occurs, or in the case of an unexpected error
    */
   public void delete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final boolean assume_tracked) throws RocksDBException {
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
     delete(
-        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_, assume_tracked);
+        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        assume_tracked, skip_lock);
   }
 
   /*
@@ -925,7 +929,7 @@ public class Transaction extends RocksObject {
       final byte[][] keyParts) throws RocksDBException {
     assert(isOwningHandle());
     delete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        /*assume_tracked*/ false);
+        /*assume_tracked*/ false, /*skip_lock*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -968,9 +972,10 @@ public class Transaction extends RocksObject {
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[] key,
-      final boolean assume_tracked) throws RocksDBException {
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
-    singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_, assume_tracked);
+    singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
+    assume_tracked, skip_lock);
   }
 
   /*
@@ -983,7 +988,7 @@ public class Transaction extends RocksObject {
       throws RocksDBException {
     assert(isOwningHandle());
     singleDelete(nativeHandle_, key, key.length, columnFamilyHandle.nativeHandle_,
-        /*assume_tracked*/ false);
+        /*assume_tracked*/ false, /*skip_lock*/ false);
   }
 
   /**
@@ -1027,10 +1032,11 @@ public class Transaction extends RocksObject {
    */
   @Experimental("Performance optimization for a very specific workload")
   public void singleDelete(final ColumnFamilyHandle columnFamilyHandle, final byte[][] keyParts,
-      final boolean assume_tracked) throws RocksDBException {
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException {
     assert (isOwningHandle());
     singleDelete(
-        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_, assume_tracked);
+        nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
+        assume_tracked, skip_lock);
   }
 
   /*
@@ -1043,7 +1049,7 @@ public class Transaction extends RocksObject {
       throws RocksDBException {
     assert(isOwningHandle());
     singleDelete(nativeHandle_, keyParts, keyParts.length, columnFamilyHandle.nativeHandle_,
-        /*assume_tracked*/ false);
+        /*assume_tracked*/ false, /*skip_lock*/ false);
   }
 
   //TODO(AR) refactor if we implement org.rocksdb.SliceParts in future
@@ -1772,13 +1778,13 @@ public class Transaction extends RocksObject {
       final long readOptionsHandle, final long columnFamilyHandle);
   private native void put(final long handle, final byte[] key, final int keyLength,
       final byte[] value, final int valueLength, final long columnFamilyHandle,
-      final boolean assume_tracked) throws RocksDBException;
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException;
   private native void put(final long handle, final byte[] key,
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
   private native void put(final long handle, final byte[][] keys, final int keysLength,
       final byte[][] values, final int valuesLength, final long columnFamilyHandle,
-      final boolean assume_tracked) throws RocksDBException;
+      final boolean assume_tracked, final boolean skip_lock) throws RocksDBException;
   private native void put(final long handle, final byte[][] keys,
       final int keysLength, final byte[][] values, final int valuesLength)
       throws RocksDBException;
@@ -1789,19 +1795,23 @@ public class Transaction extends RocksObject {
       final int keyLength, final byte[] value, final int valueLength)
       throws RocksDBException;
   private native void delete(final long handle, final byte[] key, final int keyLength,
-      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked,
+      final boolean skip_lock) throws RocksDBException;
   private native void delete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
   private native void delete(final long handle, final byte[][] keys, final int keysLength,
-      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked,
+      final boolean skip_lock) throws RocksDBException;
   private native void delete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[] key, final int keyLength,
-      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked,
+      final boolean skip_lock) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[] key,
       final int keyLength) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[][] keys, final int keysLength,
-      final long columnFamilyHandle, final boolean assume_tracked) throws RocksDBException;
+      final long columnFamilyHandle, final boolean assume_tracked,
+      final boolean skip_lock) throws RocksDBException;
   private native void singleDelete(final long handle, final byte[][] keys,
       final int keysLength) throws RocksDBException;
   private native void putUntracked(final long handle, final byte[] key,

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -320,10 +320,14 @@ Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options,
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
                                 const Slice& key, const Slice& value,
-                                const bool assume_tracked) {
+                                const bool assume_tracked,
+                                const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);
@@ -337,10 +341,14 @@ Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Put(ColumnFamilyHandle* column_family,
                                 const SliceParts& key, const SliceParts& value,
-                                const bool assume_tracked) {
+                                const bool assume_tracked,
+                                const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->Put(column_family, key, value);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -379,10 +379,14 @@ Status TransactionBaseImpl::Merge(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
                                    const Slice& key,
-                                   const bool assume_tracked) {
+                                   const bool assume_tracked,
+                                   const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);
@@ -396,10 +400,14 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
                                    const SliceParts& key,
-                                   const bool assume_tracked) {
+                                   const bool assume_tracked,
+                                   const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->Delete(column_family, key);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -421,10 +421,14 @@ Status TransactionBaseImpl::Delete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
                                          const Slice& key,
-                                         const bool assume_tracked) {
+                                         const bool assume_tracked,
+                                         const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);
@@ -438,10 +442,14 @@ Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
 
 Status TransactionBaseImpl::SingleDelete(ColumnFamilyHandle* column_family,
                                          const SliceParts& key,
-                                         const bool assume_tracked) {
+                                         const bool assume_tracked,
+                                         const bool skip_lock) {
   const bool do_validate = !assume_tracked;
-  Status s = TryLock(column_family, key, false /* read_only */,
-                     true /* exclusive */, do_validate, assume_tracked);
+  Status s = Status::OK();
+  if (!skip_lock) {
+    s = TryLock(column_family, key, false /* read_only */,
+                true /* exclusive */, do_validate, assume_tracked);
+  }
 
   if (s.ok()) {
     s = GetBatchForWrite()->SingleDelete(column_family, key);

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -143,12 +143,14 @@ class TransactionBaseImpl : public Transaction {
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
 
   Status SingleDelete(ColumnFamilyHandle* column_family, const Slice& key,
-                      const bool assume_tracked = false) override;
+                      const bool assume_tracked = false,
+                      const bool skip_lock = false) override;
   Status SingleDelete(const Slice& key) override {
     return SingleDelete(nullptr, key);
   }
   Status SingleDelete(ColumnFamilyHandle* column_family, const SliceParts& key,
-                      const bool assume_tracked = false) override;
+                      const bool assume_tracked = false,
+                      const bool skip_lock = false) override;
   Status SingleDelete(const SliceParts& key) override {
     return SingleDelete(nullptr, key);
   }

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -46,7 +46,7 @@ class TransactionBaseImpl : public Transaction {
   void SetSavePoint() override;
 
   Status RollbackToSavePoint() override;
-  
+
   Status PopSavePoint() override;
 
   using Transaction::Get;
@@ -113,14 +113,16 @@ class TransactionBaseImpl : public Transaction {
                         ColumnFamilyHandle* column_family) override;
 
   Status Put(ColumnFamilyHandle* column_family, const Slice& key,
-             const Slice& value, const bool assume_tracked = false) override;
+             const Slice& value, const bool assume_tracked = false,
+             const bool skip_lock = false) override;
   Status Put(const Slice& key, const Slice& value) override {
     return Put(nullptr, key, value);
   }
 
   Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
              const SliceParts& value,
-             const bool assume_tracked = false) override;
+             const bool assume_tracked = false,
+             const bool skip_lock = false) override;
   Status Put(const SliceParts& key, const SliceParts& value) override {
     return Put(nullptr, key, value);
   }

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -134,10 +134,12 @@ class TransactionBaseImpl : public Transaction {
   }
 
   Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                const bool assume_tracked = false) override;
+                const bool assume_tracked = false,
+                const bool skip_lock = false) override;
   Status Delete(const Slice& key) override { return Delete(nullptr, key); }
   Status Delete(ColumnFamilyHandle* column_family, const SliceParts& key,
-                const bool assume_tracked = false) override;
+                const bool assume_tracked = false,
+                const bool skip_lock = false) override;
   Status Delete(const SliceParts& key) override { return Delete(nullptr, key); }
 
   Status SingleDelete(ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -85,7 +85,8 @@ void WriteUnpreparedTxn::Initialize(const TransactionOptions& txn_options) {
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const Slice& key, const Slice& value,
-                               const bool assume_tracked) {
+                               const bool assume_tracked,
+                               const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
@@ -95,7 +96,8 @@ Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const SliceParts& key, const SliceParts& value,
-                               const bool assume_tracked) {
+                               const bool assume_tracked,
+                               const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -116,7 +116,8 @@ Status WriteUnpreparedTxn::Merge(ColumnFamilyHandle* column_family,
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
-                                  const Slice& key, const bool assume_tracked) {
+                                  const Slice& key, const bool assume_tracked,
+                                  const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
@@ -126,7 +127,8 @@ Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
                                   const SliceParts& key,
-                                  const bool assume_tracked) {
+                                  const bool assume_tracked,
+                                  const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -138,7 +138,8 @@ Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const Slice& key,
-                                        const bool assume_tracked) {
+                                        const bool assume_tracked,
+                                        const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;
@@ -148,7 +149,8 @@ Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const SliceParts& key,
-                                        const bool assume_tracked) {
+                                        const bool assume_tracked,
+                                        const bool /*skip_lock*/) {
   Status s = MaybeFlushWriteBatchToDB();
   if (!s.ok()) {
     return s;

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -49,10 +49,12 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   using TransactionBaseImpl::Put;
   virtual Status Put(ColumnFamilyHandle* column_family, const Slice& key,
                      const Slice& value,
-                     const bool assume_tracked = false) override;
+                     const bool assume_tracked = false,
+                     const bool skip_lock = false) override;
   virtual Status Put(ColumnFamilyHandle* column_family, const SliceParts& key,
                      const SliceParts& value,
-                     const bool assume_tracked = false) override;
+                     const bool assume_tracked = false,
+                     const bool skip_lock = false) override;
 
   using TransactionBaseImpl::Merge;
   virtual Status Merge(ColumnFamilyHandle* column_family, const Slice& key,

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -73,10 +73,12 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   using TransactionBaseImpl::SingleDelete;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const Slice& key,
-                              const bool assume_tracked = false) override;
+                              const bool assume_tracked = false,
+                              const bool skip_lock = false) override;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,
                               const SliceParts& key,
-                              const bool assume_tracked = false) override;
+                              const bool assume_tracked = false,
+                              const bool skip_lock = false) override;
 
   virtual Status RebuildFromWriteBatch(WriteBatch*) override {
     // This function was only useful for recovering prepared transactions, but

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -63,10 +63,12 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
   using TransactionBaseImpl::Delete;
   virtual Status Delete(ColumnFamilyHandle* column_family, const Slice& key,
-                        const bool assume_tracked = false) override;
+                        const bool assume_tracked = false,
+                        const bool skip_lock = false) override;
   virtual Status Delete(ColumnFamilyHandle* column_family,
                         const SliceParts& key,
-                        const bool assume_tracked = false) override;
+                        const bool assume_tracked = false,
+                        const bool skip_lock = false) override;
 
   using TransactionBaseImpl::SingleDelete;
   virtual Status SingleDelete(ColumnFamilyHandle* column_family,


### PR DESCRIPTION
MyRocks INSERT call path is first calling `GetForUpdate(key=i)`, then if the key does not exist, call `Put(key=i)`.
Both `GetForUpdate` and `Put` both call `rocksdb::PessimisticTransaction::TryLock` (and `rocksdb::TransactionBaseImpl::TrackKey`) for the same key.
it is unnecessary to call TryLock for the same key multiple times. However, a way to avoid repeated TryLock calls is missing. 
This PR introduces a new argument `const bool skip_lock` which allows MyRocks to skip locks as needed, regardless of the txn isolation level. 