### PR TITLE
Stats should be logged in INFO level

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -613,7 +613,7 @@ const Status DBImpl::CreateArchivalDirectory() {
 void DBImpl::PrintStatistics() {
   auto dbstats = immutable_db_options_.statistics.get();
   if (dbstats) {
-    ROCKS_LOG_WARN(immutable_db_options_.info_log, "STATISTICS:\n %s",
+    ROCKS_LOG_INFO(immutable_db_options_.info_log, "STATISTICS:\n %s",
                    dbstats->ToString().c_str());
   }
 }
@@ -665,16 +665,16 @@ void DBImpl::DumpStats() {
     }
   }
   TEST_SYNC_POINT("DBImpl::DumpStats:2");
-  ROCKS_LOG_WARN(immutable_db_options_.info_log,
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "------- DUMPING STATS -------");
-  ROCKS_LOG_WARN(immutable_db_options_.info_log, "%s", stats.c_str());
+  ROCKS_LOG_INFO(immutable_db_options_.info_log, "%s", stats.c_str());
   if (immutable_db_options_.dump_malloc_stats) {
     stats.clear();
     DumpMallocStats(&stats);
     if (!stats.empty()) {
-      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "------- Malloc STATS -------");
-      ROCKS_LOG_WARN(immutable_db_options_.info_log, "%s", stats.c_str());
+      ROCKS_LOG_INFO(immutable_db_options_.info_log, "%s", stats.c_str());
     }
   }
 #endif  // !ROCKSDB_LITE


### PR DESCRIPTION
Summary: Previously, stats were logged in warning level. This was done in that way because
people reported that it wasn't logged in MyRocks. However, later we learned that it turns
out to be due to a bug in MyRocks, which is fixed in
https://github.com/facebook/mysql-5.6/commit/79bb705e74b239d7030b724ea6bbd635eceec531

Now we revert the stats logging to INFO level, so that it doesn't pollute the warning
level logging.

Test Plan: Run it and observe the log file.