### PR TITLE
Header logger should call LogHeader()

### DIFF
--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1316,7 +1316,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
 #endif  // !ROCKSDB_LITE
 
   if (s.ok()) {
-    ROCKS_LOG_INFO(impl->immutable_db_options_.info_log, "DB pointer %p", impl);
+    ROCKS_LOG_HEADER(impl->immutable_db_options_.info_log, "DB pointer %p",
+                     impl);
     LogFlush(impl->immutable_db_options_.info_log);
     assert(impl->TEST_WALBufferIsEmpty());
     // If the assert above fails then we need to FlushWAL before returning

--- a/env/env.cc
+++ b/env/env.cc
@@ -138,6 +138,8 @@ void Logger::Logv(const InfoLogLevel log_level, const char* format, va_list ap) 
     // are INFO level. We don't want to add extra costs to those existing
     // logging.
     Logv(format, ap);
+  } else if (log_level == InfoLogLevel::HEADER_LEVEL) {
+    LogHeader(format, ap);
   } else {
     char new_format[500];
     snprintf(new_format, sizeof(new_format) - 1, "[%s] %s",

--- a/java/src/test/java/org/rocksdb/InfoLogLevelTest.java
+++ b/java/src/test/java/org/rocksdb/InfoLogLevelTest.java
@@ -93,7 +93,7 @@ public class InfoLogLevelTest {
     int first_non_header = lines.length;
     // Identify the last line of the header
     for (int i = lines.length - 1; i >= 0; --i) {
-      if (lines[i].indexOf("Options.") >= 0 && lines[i].indexOf(':') >= 0) {
+      if (lines[i].indexOf(" DB pointer ") >= 0) {
         first_non_header = i + 1;
         break;
       }

--- a/java/src/test/java/org/rocksdb/InfoLogLevelTest.java
+++ b/java/src/test/java/org/rocksdb/InfoLogLevelTest.java
@@ -27,6 +27,7 @@ public class InfoLogLevelTest {
     try (final RocksDB db =
              RocksDB.open(dbFolder.getRoot().getAbsolutePath())) {
       db.put("key".getBytes(), "value".getBytes());
+      db.flush(new FlushOptions().setWaitForFlush(true));
       assertThat(getLogContentsWithoutHeader()).isNotEmpty();
     }
   }
@@ -93,7 +94,7 @@ public class InfoLogLevelTest {
     int first_non_header = lines.length;
     // Identify the last line of the header
     for (int i = lines.length - 1; i >= 0; --i) {
-      if (lines[i].indexOf(" DB pointer ") >= 0) {
+      if (lines[i].indexOf("DB pointer") >= 0) {
         first_non_header = i + 1;
         break;
       }


### PR DESCRIPTION
Summary: The info log header feature never worked well, because log level Header was not
translated to Logger::LogHeader() call. Fix it.

Test Plan: Observe rolled log files have headers.