### PR TITLE
revert the incorrectly added override to please ROCKSDB_LITE

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2050,17 +2050,17 @@ class Benchmark {
           no_auto_recovery_(false),
           recovery_complete_(false) {}
 
-    ~ErrorHandlerListener() override {}
+    ~ErrorHandlerListener() {}
 
     void OnErrorRecoveryBegin(BackgroundErrorReason /*reason*/,
                               Status /*bg_error*/,
-                              bool* auto_recovery) override {
+                              bool* auto_recovery) {
       if (*auto_recovery && no_auto_recovery_) {
         *auto_recovery = false;
       }
     }
 
-    void OnErrorRecoveryCompleted(Status /*old_bg_error*/) override {
+    void OnErrorRecoveryCompleted(Status /*old_bg_error*/) {
       InstrumentedMutexLock l(&mutex_);
       recovery_complete_ = true;
       cv_.SignalAll();


### PR DESCRIPTION
commit https://github.com/facebook/rocksdb/commit/ca89ac2ba997dfa0e135bd75d4ccf6f5774a7eff tries to "modernize" the codebase without realizing our use of macro ROCKSDB_LITE which resulted in a broken build for ROCKSDB_LITE. This PR reverts the incorrect changes to keep ROCKSDB_LITE happy.