### PR TITLE
Fix LITE Build

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2086,9 +2086,10 @@ class Benchmark {
     InstrumentedCondVar cv_;
     bool no_auto_recovery_;
     bool recovery_complete_;
-#endif  // ROCKSDB_LITE
+#else   // ROCKSDB_LITE
     bool WaitForRecovery(uint64_t /*abs_time_us*/) { return true; }
     void EnableAutoRecovery(bool /*enable*/) {}
+#endif  // ROCKSDB_LITE
   };
 
   std::shared_ptr<ErrorHandlerListener> listener_;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2044,6 +2044,7 @@ class Benchmark {
 
   class ErrorHandlerListener : public EventListener {
    public:
+#ifndef ROCKSDB_LITE
     ErrorHandlerListener()
         : mutex_(),
           cv_(&mutex_),
@@ -2085,6 +2086,9 @@ class Benchmark {
     InstrumentedCondVar cv_;
     bool no_auto_recovery_;
     bool recovery_complete_;
+#endif  // ROCKSDB_LITE
+    bool WaitForRecovery(uint64_t /*abs_time_us*/) { return true; }
+    void EnableAutoRecovery(bool /*enable*/) {}
   };
 
   std::shared_ptr<ErrorHandlerListener> listener_;


### PR DESCRIPTION
Summary: LITE mode has EventListener to be an empty class. However in db_bench,
it is used. When "override" is added to the functions, the build breaks. Fix it
by keeping the listener empty in LITE mode.

Test Plan: make check and release in LITE mode.