### PR TITLE
Shrink "make crash_test" duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -895,20 +895,24 @@ ldb_tests: ldb
 crash_test: whitebox_crash_test blackbox_crash_test
 
 blackbox_crash_test: db_stress
-	python -u tools/db_crashtest.py --simple blackbox $(CRASH_TEST_EXT_ARGS)
-	python -u tools/db_crashtest.py --enable_atomic_flush blackbox $(CRASH_TEST_EXT_ARGS)
-	python -u tools/db_crashtest.py blackbox $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py --simple blackbox --duration 3000 \
+      $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py --enable_atomic_flush blackbox \
+      --duration 1000 $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py blackbox --duration 3000 \
+      $(CRASH_TEST_EXT_ARGS)
 
 ifeq ($(CRASH_TEST_KILL_ODD),)
   CRASH_TEST_KILL_ODD=888887
 endif
 
 whitebox_crash_test: db_stress
-	python -u tools/db_crashtest.py --simple whitebox --random_kill_odd \
-      $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
-	python -u tools/db_crashtest.py --enable_atomic_flush whitebox  --random_kill_odd \
-      $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
-	python -u tools/db_crashtest.py whitebox  --random_kill_odd \
+	python -u tools/db_crashtest.py --simple whitebox --duration 5000 \
+      --random_kill_odd $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py --enable_atomic_flush whitebox \
+      --duration 2000  --random_kill_odd $(CRASH_TEST_KILL_ODD) \
+      $(CRASH_TEST_EXT_ARGS)
+	python -u tools/db_crashtest.py whitebox --duration 5000 --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
 
 asan_check:


### PR DESCRIPTION
Summary: We add more options in crash_test, so it runs longer. We adjust duration of each
test so the run time of crash_test is under control.