### PR TITLE
When closing BlobDB, should first wait for all background tasks

### DIFF
--- a/util/timer_queue.h
+++ b/util/timer_queue.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "port/port.h"
-
 #include <assert.h>
 #include <chrono>
 #include <condition_variable>
@@ -32,6 +30,9 @@
 #include <thread>
 #include <utility>
 #include <vector>
+
+#include "port/port.h"
+#include "util/sync_point.h"
 
 // Allows execution of handlers at a specified time in the future
 // Guarantees:

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -94,6 +94,7 @@ BlobDBImpl::BlobDBImpl(const std::string& dbname,
 }
 
 BlobDBImpl::~BlobDBImpl() {
+  tqueue_.shutdown();
   // CancelAllBackgroundWork(db_, true);
   Status s __attribute__((__unused__)) = Close();
   assert(s.ok());
@@ -1308,6 +1309,9 @@ std::pair<bool, int64_t> BlobDBImpl::EvictExpiredFiles(bool aborted) {
     return std::make_pair(false, -1);
   }
 
+  TEST_SYNC_POINT("BlobDBImpl::EvictExpiredFiles:0");
+  TEST_SYNC_POINT("BlobDBImpl::EvictExpiredFiles:1");
+
   std::vector<std::shared_ptr<BlobFile>> process_files;
   uint64_t now = EpochNow();
   {
@@ -1321,6 +1325,10 @@ std::pair<bool, int64_t> BlobDBImpl::EvictExpiredFiles(bool aborted) {
       }
     }
   }
+
+  TEST_SYNC_POINT("BlobDBImpl::EvictExpiredFiles:2");
+  TEST_SYNC_POINT("BlobDBImpl::EvictExpiredFiles:3");
+  TEST_SYNC_POINT_CALLBACK("BlobDBImpl::EvictExpiredFiles:cb", nullptr);
 
   SequenceNumber seq = GetLatestSequenceNumber();
   {


### PR DESCRIPTION
Summary: When closing a BlobDB, it only waits for background tasks
to finish as the last thing, but the background task may access
some variables that are destroyed. The fix is to introduce a
shutdown function in the timer queue and call the function as
the first thing when destorying BlobDB.

Test Plan: Add a new unit test and make sure it passes TSAN.
The test fails TSAN test without the fix.