### PR TITLE
[RocksJava] Fix DefaultEnvTest.incBackgroundThreadsIfNeeded test

### DIFF
--- a/java/src/test/java/org/rocksdb/DefaultEnvTest.java
+++ b/java/src/test/java/org/rocksdb/DefaultEnvTest.java
@@ -54,13 +54,13 @@ public class DefaultEnvTest {
   public void incBackgroundThreadsIfNeeded() {
     try (final Env defaultEnv = RocksEnv.getDefault()) {
       defaultEnv.incBackgroundThreadsIfNeeded(20, Priority.BOTTOM);
-      assertThat(defaultEnv.getBackgroundThreads(Priority.BOTTOM)).isEqualTo(20);
+      assertThat(defaultEnv.getBackgroundThreads(Priority.BOTTOM)).isGreaterThanOrEqualTo(20);
 
       defaultEnv.incBackgroundThreadsIfNeeded(20, Priority.LOW);
-      assertThat(defaultEnv.getBackgroundThreads(Priority.LOW)).isEqualTo(20);
+      assertThat(defaultEnv.getBackgroundThreads(Priority.LOW)).isGreaterThanOrEqualTo(20);
 
       defaultEnv.incBackgroundThreadsIfNeeded(20, Priority.HIGH);
-      assertThat(defaultEnv.getBackgroundThreads(Priority.HIGH)).isEqualTo(20);
+      assertThat(defaultEnv.getBackgroundThreads(Priority.HIGH)).isGreaterThanOrEqualTo(20);
     }
   }
 


### PR DESCRIPTION
`DefaultEnvTest.incBackgroundThreadsIfNeeded` jtest should assert that the number of threads is greater than or equal to the minimum number of threads. 

Test Plan:
This test is failing on my system with an error like:
```
Expected: 20
Actual: 48
```
All tests now pass with this fix. 