### PR TITLE
WritePrepared: handle adding prepare before max_evicted_seq_

### DIFF
--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -392,36 +392,47 @@ void WritePreparedTxnDB::Init(const TransactionDBOptions& /* unused */) {
       new std::atomic<CommitEntry64b>[COMMIT_CACHE_SIZE] {});
 }
 
+void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max) {
+  prepared_mutex_.AssertHeld();
+  // When max_evicted_seq_ advances, move older entries from prepared_txns_
+  // to delayed_prepared_. This guarantees that if a seq is lower than max,
+  // then it is not in prepared_txns_ and save an expensive, synchronized
+  // lookup from a shared set. delayed_prepared_ is expected to be empty in
+  // normal cases.
+  ROCKS_LOG_DETAILS(
+      info_log_,
+      "CheckPreparedAgainstMax prepared_txns_.empty() %d top: %" PRIu64,
+      prepared_txns_.empty(),
+      prepared_txns_.empty() ? 0 : prepared_txns_.top());
+  while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
+    auto to_be_popped = prepared_txns_.top();
+    delayed_prepared_.insert(to_be_popped);
+    ROCKS_LOG_WARN(info_log_,
+                   "prepared_mutex_ overhead %" PRIu64 " (prep=%" PRIu64
+                   " new_max=%" PRIu64,
+                   static_cast<uint64_t>(delayed_prepared_.size()),
+                   to_be_popped, new_max);
+    prepared_txns_.pop();
+    delayed_prepared_empty_.store(false, std::memory_order_release);
+  }
+}
+
 void WritePreparedTxnDB::AddPrepared(uint64_t seq) {
   ROCKS_LOG_DETAILS(info_log_, "Txn %" PRIu64 " Preparing with max %" PRIu64,
                     seq, max_evicted_seq_.load());
   TEST_SYNC_POINT("AddPrepared::begin:pause");
   TEST_SYNC_POINT("AddPrepared::begin:resume");
   WriteLock wl(&prepared_mutex_);
-  if (UNLIKELY(seq <= max_evicted_seq_)) {
+  prepared_txns_.push(seq);
+  auto new_max = future_max_evicted_seq_.load();
+  if (UNLIKELY(seq <= new_max)) {
     // This should not happen in normal case
     ROCKS_LOG_ERROR(
         info_log_,
         "Added prepare_seq is not larger than max_evicted_seq_: %" PRIu64
         " <= %" PRIu64,
-        seq, max_evicted_seq_.load());
-    delayed_prepared_.insert(seq);
-    delayed_prepared_empty_.store(false, std::memory_order_release);
-  } else {
-    prepared_txns_.push(seq);
-  }
-  auto new_max = future_max_evicted_seq_.load();
-  if (UNLIKELY(seq <= new_max)) {
-    while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
-      auto to_be_popped = prepared_txns_.top();
-      delayed_prepared_.insert(to_be_popped);
-      ROCKS_LOG_WARN(info_log_,
-                     "Prepare before max (prep=%" PRIu64
-                     " new_max=%" PRIu64,
-                     to_be_popped, new_max);
-      prepared_txns_.pop();
-      delayed_prepared_empty_.store(false, std::memory_order_release);
-    }
+        seq, new_max);
+    CheckPreparedAgainstMax(new_max);
   }
   TEST_SYNC_POINT("AddPrepared::end");
 }
@@ -573,31 +584,11 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
              updated_future_max, new_max, std::memory_order_acq_rel,
              std::memory_order_relaxed)) {
   };
-  // When max_evicted_seq_ advances, move older entries from prepared_txns_
-  // to delayed_prepared_. This guarantees that if a seq is lower than max,
-  // then it is not in prepared_txns_ ans save an expensive, synchronized
-  // lookup from a shared set. delayed_prepared_ is expected to be empty in
-  // normal cases.
+
   {
     WriteLock wl(&prepared_mutex_);
-    ROCKS_LOG_DETAILS(
-        info_log_,
-        "AdvanceMaxEvictedSeq prepared_txns_.empty() %d top: %" PRIu64,
-        prepared_txns_.empty(),
-        prepared_txns_.empty() ? 0 : prepared_txns_.top());
-    while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
-      auto to_be_popped = prepared_txns_.top();
-      delayed_prepared_.insert(to_be_popped);
-      ROCKS_LOG_WARN(info_log_,
-                     "prepared_mutex_ overhead %" PRIu64 " (prep=%" PRIu64
-                     " new_max=%" PRIu64 " oldmax=%" PRIu64,
-                     static_cast<uint64_t>(delayed_prepared_.size()),
-                     to_be_popped, new_max, prev_max);
-      prepared_txns_.pop();
-      delayed_prepared_empty_.store(false, std::memory_order_release);
-    }
+    CheckPreparedAgainstMax(new_max);
   }
-  TEST_SYNC_POINT("AdvanceMaxEvictedSeq::prepared:after");
 
   // With each change to max_evicted_seq_ fetch the live snapshots behind it.
   // We use max as the version of snapshots to identify how fresh are the

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -441,30 +441,29 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       const ColumnFamilyOptions& cf_options) override;
 
  private:
-  friend class WritePreparedCommitEntryPreReleaseCallback;
-  friend class WritePreparedCommitEntryPreReleaseCallback;
-  friend class WritePreparedTransactionTest_IsInSnapshotTest_Test;
-  friend class WritePreparedTransactionTest_PreReleaseCallback_Test;
-  friend class WritePreparedTransactionTest_CheckAgainstSnapshotsTest_Test;
-  friend class WritePreparedTransactionTest_CommitMapTest_Test;
-  friend class
-      WritePreparedTransactionTest_ConflictDetectionAfterRecoveryTest_Test;
-  friend class SnapshotConcurrentAccessTest_SnapshotConcurrentAccessTest_Test;
-  friend class WritePreparedTransactionTestBase;
   friend class PreparedHeap_BasicsTest_Test;
-  friend class PreparedHeap_EmptyAtTheEnd_Test;
   friend class PreparedHeap_Concurrent_Test;
+  friend class PreparedHeap_EmptyAtTheEnd_Test;
+  friend class SnapshotConcurrentAccessTest_SnapshotConcurrentAccessTest_Test;
+  friend class WritePreparedCommitEntryPreReleaseCallback;
+  friend class WritePreparedTransactionTestBase;
   friend class WritePreparedTxn;
   friend class WritePreparedTxnDBMock;
+  friend class WritePreparedTransactionTest_AddPreparedBeforeMax_Test;
   friend class WritePreparedTransactionTest_AdvanceMaxEvictedSeqBasicTest_Test;
   friend class
       WritePreparedTransactionTest_AdvanceMaxEvictedSeqWithDuplicatesTest_Test;
   friend class WritePreparedTransactionTest_AdvanceSeqByOne_Test;
   friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;
+  friend class WritePreparedTransactionTest_CheckAgainstSnapshotsTest_Test;
   friend class WritePreparedTransactionTest_CleanupSnapshotEqualToMax_Test;
+  friend class
+      WritePreparedTransactionTest_ConflictDetectionAfterRecoveryTest_Test;
+  friend class WritePreparedTransactionTest_CommitMapTest_Test;
   friend class WritePreparedTransactionTest_DoubleSnapshot_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotReleased_Test;
+  friend class WritePreparedTransactionTest_IsInSnapshotTest_Test;
   friend class WritePreparedTransactionTest_NewSnapshotLargerThanMax_Test;
   friend class WritePreparedTransactionTest_MaxCatchupWithNewSnapshot_Test;
   friend class

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -442,7 +442,9 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
 
  private:
   friend class WritePreparedCommitEntryPreReleaseCallback;
+  friend class WritePreparedCommitEntryPreReleaseCallback;
   friend class WritePreparedTransactionTest_IsInSnapshotTest_Test;
+  friend class WritePreparedTransactionTest_PreReleaseCallback_Test;
   friend class WritePreparedTransactionTest_CheckAgainstSnapshotsTest_Test;
   friend class WritePreparedTransactionTest_CommitMapTest_Test;
   friend class
@@ -755,6 +757,8 @@ class AddPreparedCallback : public PreReleaseCallback {
     (void)is_mem_disabled;
 #endif
     assert(!two_write_queues_ || !is_mem_disabled);  // implies the 1st queue
+    TEST_SYNC_POINT("AddPreparedCallback::Callback:pause");
+    TEST_SYNC_POINT("AddPreparedCallback::Callback:resume");
     for (size_t i = 0; i < sub_batch_cnt_; i++) {
       db_->AddPrepared(prepare_seq + i);
     }


### PR DESCRIPTION
The patch fixes an improbable race condition between AddPrepared from one write queue and AdvanceMaxEvictedSeq from another queue. In this scenario AddPrepared finds prepare_seq lower than max and adding to PrepareHeap as usual while AdvanceMaxEvictedSeq has finished checking PrepareHeap against the future max. Thus when AdvanceMaxEvictedSeq finishes off by updating the max_evicted_seq_, PrepareHeap ends up with a prepared_seq lower than it which breaks the PrepareHeap contract. The fix is that in AddPrepared we check against the future_max_evicted_seq_ instead, which is update before AdvanceMaxEvictedSeq acquire prepare_mutex_ and looks into PrepareHeap.
A unit test added to test for the failure scenario. The code is also refactored a bit to remove the duplicate code between AdvanceMaxEvictedSeq and AddPrepared.