### PR TITLE
Don't rebuild fragmented tombstones on every read.

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -8,8 +8,6 @@
 #include "port/port.h"
 #include "util/testutil.h"
 #include "utilities/merge_operators.h"
-#include <iostream>
-#include <bitset>
 
 namespace rocksdb {
 
@@ -1533,13 +1531,11 @@ TEST_F(DBRangeDelTest, RangeDelConcurrent) {
   std::string value;
   for (int i = 0; i < 137; i++) {
     bool res = db_->Get(ReadOptions(), keys[i], &value).IsNotFound();
-    std::cout << "i: " << i << " result: " << res << std::endl;
     ASSERT_TRUE(res);
   }
 
   for (int i = 137; i < 200; i++) {
     bool res = db_->Get(ReadOptions(), keys[i], &value).IsNotFound();
-    std::cout << "i: " << i << " result: " << res << std::endl;
     ASSERT_FALSE(res);
   }
 }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #pragma once
+#include <iostream>
 #include <atomic>
 #include <deque>
 #include <functional>
@@ -65,12 +66,15 @@ struct MemTablePostProcessInfo {
 
 struct FragmentedTombstones {
 public:
-  std::shared_ptr<FragmentedRangeTombstoneList> fragmented_tombstones_list = nullptr;
-  std::atomic_bool initiate_flag = {0};
+  std::shared_ptr<FragmentedRangeTombstoneList> fragmented_tombstones_list;
+  std::atomic_bool initiate_flag;
 
-  FragmentedTombstones() {}
+  FragmentedTombstones():
+    fragmented_tombstones_list(nullptr),
+    initiate_flag(false) {}
+
   FragmentedTombstones(FragmentedTombstones *f) noexcept {
-    initiate_flag = {f->initiate_flag.load()};
+    initiate_flag = f->initiate_flag.load();
     fragmented_tombstones_list = f->fragmented_tombstones_list; // how to deep copy here?
   }
 };

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -495,8 +495,8 @@ class MemTable {
   // writes with sequence number smaller than seq are flushed.
   SequenceNumber atomic_flush_seqno_;
 
-  std::shared_ptr<FragmentedTombstones> fragmented_tombstones;
-  std::atomic<uint64_t> range_tombstone_count;
+  std::shared_ptr<FragmentedTombstones> fragmented_tombstones_;
+  std::atomic<uint64_t> range_tombstone_count_;
 
   void InvalidateFragmentedTombstones();
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -75,7 +75,7 @@ public:
 
   FragmentedTombstones(FragmentedTombstones *f) noexcept {
     initiate_flag = f->initiate_flag.load();
-    fragmented_tombstones_list = f->fragmented_tombstones_list; // how to deep copy here?
+    fragmented_tombstones_list = f->fragmented_tombstones_list;
   }
 };
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -8,7 +8,6 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #pragma once
-#include <iostream>
 #include <atomic>
 #include <deque>
 #include <functional>


### PR DESCRIPTION
Instead, store them upon first read and rebuild when a `DeleteRange` is received.  Related: https://github.com/facebook/rocksdb/issues/4808