### PR TITLE
BlobDB: Remove GC interval option

### DIFF
--- a/utilities/blob_db/blob_db.cc
+++ b/utilities/blob_db/blob_db.cc
@@ -94,9 +94,6 @@ void BlobDBOptions::Dump(Logger* log) const {
       log, "                 BlobDBOptions.enable_garbage_collection: %d",
       enable_garbage_collection);
   ROCKS_LOG_HEADER(
-      log, "          BlobDBOptions.garbage_collection_interval_secs: %" PRIu64,
-      garbage_collection_interval_secs);
-  ROCKS_LOG_HEADER(
       log, "                  BlobDBOptions.disable_background_tasks: %d",
       disable_background_tasks);
 }

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -73,9 +73,6 @@ struct BlobDBOptions {
   // blob files will be cleanup based on TTL.
   bool enable_garbage_collection = false;
 
-  // Time interval to trigger garbage collection, in seconds.
-  uint64_t garbage_collection_interval_secs = 60;
-
   // Disable all background job. Used for test only.
   bool disable_background_tasks = false;
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -198,9 +198,6 @@ void BlobDBImpl::StartBackgroundTasks() {
   tqueue_.add(
       kReclaimOpenFilesPeriodMillisecs,
       std::bind(&BlobDBImpl::ReclaimOpenFiles, this, std::placeholders::_1));
-  tqueue_.add(static_cast<int64_t>(
-                  bdb_options_.garbage_collection_interval_secs * 1000),
-              std::bind(&BlobDBImpl::RunGC, this, std::placeholders::_1));
   tqueue_.add(
       kDeleteObsoleteFilesPeriodMillisecs,
       std::bind(&BlobDBImpl::DeleteObsoleteFiles, this, std::placeholders::_1));


### PR DESCRIPTION
Summary:
Remove BlobDBOptions.garbage_collection_interval_secs for now, since
garbage collection is not yet implemented in BlobDB.