### PR TITLE
Fixed the potential stack overflow of MixGraph in db_bench

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4709,7 +4709,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     int64_t seek = 0;
     int64_t seek_found = 0;
     int64_t bytes = 0;
-    const int64_t default_value_max = 64 * 1024 * 1024;
+    const int64_t default_value_max = 1 * 1024 * 1024;
     int64_t value_max = default_value_max;
     int64_t scan_len_max = FLAGS_mix_max_scan_len;
     double write_rate = 1000000.0;
@@ -4807,7 +4807,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
               256, Env::IO_HIGH, nullptr /* stats */,
               RateLimiter::OpType::kRead);
         }
-
+        thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db, 1, kRead);
       } else if (query_type == 1) {
         // the Put query
         puts++;
@@ -4831,7 +4831,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
               key.size() + value_size, Env::IO_HIGH, nullptr /*stats*/,
               RateLimiter::OpType::kWrite);
         }
-
+        thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db, 1, kWrite);
       } else if (query_type == 2) {
         // Seek query
         if (db_with_cfh->db != nullptr) {
@@ -4859,6 +4859,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
           }
           delete single_iter;
         }
+        thread->stats.FinishedOps(db_with_cfh, db_with_cfh->db, 1, kSeek);
       }
     }
     char msg[256];


### PR DESCRIPTION
In the MixGraph benchmark of db_bench, The max buffer size used for value of KV-pair might be extremely large (64MB), which might cause function stack overflow in some platforms, reduced to 1MB.

Added the finished ops printing in MixGraph benchmark.

Test plan: tested with make check