### PR TITLE
Fix build failures due to missing JEMALLOC_CXX_THROW macro

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@
 ### Public API Change
 * statistics.stats_level_ becomes atomic. It is preferred to use statistics.set_stats_level() and statistics.get_stats_level() to access it.
 
+### Bug Fixes
+* Fix JEMALLOC_CXX_THROW macro missing from older Jemalloc versions, causing build failures on some platforms.
+
+
 ## 6.0.0 (2/19/2019)
 ### New Features
 * Enabled checkpoint on readonly db (DBImplReadOnly).

--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -12,6 +12,10 @@
 #include <jemalloc/jemalloc.h>
 #endif
 
+#ifndef JEMALLOC_CXX_THROW
+#define JEMALLOC_CXX_THROW
+#endif
+
 // Declare non-standard jemalloc APIs as weak symbols. We can null-check these
 // symbols to detect whether jemalloc is linked with the binary.
 extern "C" void* mallocx(size_t, int) __attribute__((__weak__));


### PR DESCRIPTION
Summary:
JEMALLOC_CXX_THROW is not defined for earlier versions of jemalloc (e.g. 3.6), causing builds to fail on some platforms. Fixing it. Closes #4869 

Test Plan:
On both ubuntu 18.04 (with jemalloc-3.6) and ubuntu 18.10 (with jemalloc-5.1.0), run `make util/jemalloc_nodump_allocator.o`