### PR TITLE
Add the -try_process_corrupted_trace option to trace_analyzer

### DIFF
--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -78,6 +78,11 @@ DEFINE_bool(output_time_series, false,
             "such that we can have the time series data of the queries \n"
             "File name: <prefix>-<query_type>-<cf_id>-time_series.txt\n"
             "Format:[type_id time_in_sec access_keyid].");
+DEFINE_bool(try_process_corrupted_trace, false,
+            "In default, trace_analyzer will exist if the trace file is "
+            "corrupted due to the unexpected tracing cases. If this option "
+            "is enabled, trace_analyzer will stop reading the trace file, "
+            "and start analyzing the read-in data.");
 DEFINE_int32(output_prefix_cut, 0,
              "The number of bytes as prefix to cut the keys.\n"
              "If it is enabled, it will generate the following:\n"
@@ -1943,7 +1948,7 @@ int trace_analyzer_tool(int argc, char** argv) {
   }
 
   s = analyzer->StartProcessing();
-  if (!s.ok()) {
+  if (!s.ok() && !FLAGS_try_process_corrupted_trace) {
     fprintf(stderr, "%s\n", s.getState());
     fprintf(stderr, "Cannot processing the trace\n");
     exit(1);

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -79,7 +79,7 @@ DEFINE_bool(output_time_series, false,
             "File name: <prefix>-<query_type>-<cf_id>-time_series.txt\n"
             "Format:[type_id time_in_sec access_keyid].");
 DEFINE_bool(try_process_corrupted_trace, false,
-            "In default, trace_analyzer will exist if the trace file is "
+            "In default, trace_analyzer will exit if the trace file is "
             "corrupted due to the unexpected tracing cases. If this option "
             "is enabled, trace_analyzer will stop reading the trace file, "
             "and start analyzing the read-in data.");


### PR DESCRIPTION
In the current trace_analyzer implementation, once the trace file has corrupted content, which can be caused by unexpected tracing operations or other reasons, trace_analyzer will print the error and stop analyzing.

By adding the -try_process_corrupted_trace option, user can try to process the corrupted trace file and get the analyzing results of the trace records from the beginning to the the first corrupted point in the trace file. Analyzing might fail even this option is enabled.

Test:
Test tested with make check and with correct trace file and corrupted trace file.

