### PR TITLE
utilities: Fix build failure with -Werror=maybe-uninitialized

### DIFF
--- a/utilities/blob_db/blob_log_format.cc
+++ b/utilities/blob_db/blob_log_format.cc
@@ -82,7 +82,7 @@ Status BlobLogFooter::DecodeFrom(Slice src) {
   uint32_t src_crc = 0;
   src_crc = crc32c::Value(src.data(), BlobLogFooter::kSize - sizeof(uint32_t));
   src_crc = crc32c::Mask(src_crc);
-  uint32_t magic_number;
+  uint32_t magic_number = 0;
   if (!GetFixed32(&src, &magic_number) || !GetFixed64(&src, &blob_count) ||
       !GetFixed64(&src, &expiration_range.first) ||
       !GetFixed64(&src, &expiration_range.second) || !GetFixed32(&src, &crc)) {


### PR DESCRIPTION
Summary:
Initialize magic_number to zero to avoid such failure.
utilities/blob_db/blob_log_format.cc:91:3: error: 'magic_number' may be used
uninitialized in this function [-Werror=maybe-uninitialized]
   if (magic_number != kMagicNumber) {
   ^~

Signed-off-by: He Zhe <zhe.he@windriver.com>