### PR TITLE
Introduce CPU timers for iterator seek and next

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -732,6 +732,8 @@ bool DBIter::MergeValuesNewToOld() {
 void DBIter::Prev() {
   assert(valid_);
   assert(status_.ok());
+
+  PERF_CPU_TIMER_GUARD(iter_prev_cpu_nanos, env_);
   ReleaseTempPinnedData();
   ResetInternalKeysSkippedCounter();
   bool ok = true;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -374,6 +374,7 @@ void DBIter::Next() {
   assert(valid_);
   assert(status_.ok());
 
+  PERF_CPU_TIMER_GUARD(iter_next_cpu_nanos, env_);
   // Release temporarily pinned blocks from last operation
   ReleaseTempPinnedData();
   ResetInternalKeysSkippedCounter();
@@ -1261,6 +1262,7 @@ SequenceNumber DBIter::MaxVisibleSequenceNumber() {
 }
 
 void DBIter::Seek(const Slice& target) {
+  PERF_CPU_TIMER_GUARD(iter_seek_cpu_nanos, env_);
   StopWatch sw(env_, statistics_, DB_SEEK);
   status_ = Status::OK();
   ReleaseTempPinnedData();
@@ -1318,6 +1320,7 @@ void DBIter::Seek(const Slice& target) {
 }
 
 void DBIter::SeekForPrev(const Slice& target) {
+  PERF_CPU_TIMER_GUARD(iter_seek_cpu_nanos, env_);
   StopWatch sw(env_, statistics_, DB_SEEK);
   status_ = Status::OK();
   ReleaseTempPinnedData();
@@ -1378,6 +1381,7 @@ void DBIter::SeekToFirst() {
     Seek(*iterate_lower_bound_);
     return;
   }
+  PERF_CPU_TIMER_GUARD(iter_seek_cpu_nanos, env_);
   // Don't use iter_::Seek() if we set a prefix extractor
   // because prefix seek will be used.
   if (prefix_extractor_ != nullptr && !total_order_seek_) {
@@ -1429,6 +1433,7 @@ void DBIter::SeekToLast() {
     return;
   }
 
+  PERF_CPU_TIMER_GUARD(iter_seek_cpu_nanos, env_);
   // Don't use iter_::Seek() if we set a prefix extractor
   // because prefix seek will be used.
   if (prefix_extractor_ != nullptr && !total_order_seek_) {

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1869,16 +1869,16 @@ TEST_F(DBTest2, TestPerfContextIterCpuTime) {
   iter->SeekToFirst();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v0", iter->value().ToString());
+  ASSERT_EQ(0, get_perf_context()->iter_seek_cpu_nanos);
   iter->Next();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v1", iter->value().ToString());
+  ASSERT_EQ(0, get_perf_context()->iter_next_cpu_nanos);
   iter->Prev();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v0", iter->value().ToString());
-  ASSERT_EQ(0, env_->now_cpu_count_.load());
-  ASSERT_EQ(0, get_perf_context()->iter_next_cpu_nanos);
   ASSERT_EQ(0, get_perf_context()->iter_prev_cpu_nanos);
-  ASSERT_EQ(0, get_perf_context()->iter_seek_cpu_nanos);
+  ASSERT_EQ(0, env_->now_cpu_count_.load());
   delete iter;
 
   uint64_t kDummyAddonTime = uint64_t{1000000000000};
@@ -1902,20 +1902,19 @@ TEST_F(DBTest2, TestPerfContextIterCpuTime) {
   iter->SeekToFirst();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v0", iter->value().ToString());
+  ASSERT_GT(get_perf_context()->iter_seek_cpu_nanos, 0);
+  ASSERT_LT(get_perf_context()->iter_seek_cpu_nanos, kDummyAddonTime);
   iter->Next();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v1", iter->value().ToString());
+  ASSERT_GT(get_perf_context()->iter_next_cpu_nanos, 0);
+  ASSERT_LT(get_perf_context()->iter_next_cpu_nanos, kDummyAddonTime);
   iter->Prev();
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ("v0", iter->value().ToString());
-  ASSERT_GE(env_->now_cpu_count_.load(), 12);
-  ASSERT_GT(get_perf_context()->iter_next_cpu_nanos, 0);
-  ASSERT_LT(get_perf_context()->iter_next_cpu_nanos, kDummyAddonTime);
   ASSERT_GT(get_perf_context()->iter_prev_cpu_nanos, 0);
   ASSERT_LT(get_perf_context()->iter_prev_cpu_nanos, kDummyAddonTime);
-  ASSERT_GT(get_perf_context()->iter_seek_cpu_nanos, 0);
-  ASSERT_LT(get_perf_context()->iter_seek_cpu_nanos, kDummyAddonTime);
-  ASSERT_LT(get_perf_context()->get_cpu_nanos, kDummyAddonTime);
+  ASSERT_GE(env_->now_cpu_count_.load(), 12);
   ASSERT_GT(get_perf_context()->find_table_nanos, kDummyAddonTime);
 
   SetPerfLevel(PerfLevel::kDisable);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1805,7 +1805,7 @@ class MockPersistentCache : public PersistentCache {
 #ifdef OS_LINUX
 // Make sure that in CPU time perf context counters, Env::NowCPUNanos()
 // is used, rather than Env::CPUNanos();
-TEST_F(DBTest2, TestPerfContextCpuTime) {
+TEST_F(DBTest2, TestPerfContextGetCpuTime) {
   // force resizing table cache so table handle is not preloaded so that
   // we can measure find_table_nanos during Get().
   dbfull()->TEST_table_cache()->SetCapacity(0);
@@ -1835,6 +1835,92 @@ TEST_F(DBTest2, TestPerfContextCpuTime) {
 
   SetPerfLevel(PerfLevel::kDisable);
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(DBTest2, TestPerfContextIterCpuTime) {
+  DestroyAndReopen(CurrentOptions());
+  // force resizing table cache so table handle is not preloaded so that
+  // we can measure find_table_nanos during iteration
+  dbfull()->TEST_table_cache()->SetCapacity(0);
+
+  const size_t kNumEntries = 10;
+  for (size_t i = 0; i < kNumEntries; ++i) {
+    ASSERT_OK(Put("k" + ToString(i), "v" + ToString(i)));
+  }
+  ASSERT_OK(Flush());
+  for (size_t i = 0; i < kNumEntries; ++i) {
+    ASSERT_EQ("v" + ToString(i), Get("k" + ToString(i)));
+  }
+  std::string last_key = "k" + ToString(kNumEntries - 1);
+  std::string last_value = "v" + ToString(kNumEntries - 1);
+  env_->now_cpu_count_.store(0);
+
+  // CPU timing is not enabled with kEnableTimeExceptForMutex
+  SetPerfLevel(PerfLevel::kEnableTimeExceptForMutex);
+  Iterator* iter = db_->NewIterator(ReadOptions());
+  iter->Seek("k0");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  iter->SeekForPrev(last_key);
+  ASSERT_TRUE(iter->Valid());
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(last_value, iter->value().ToString());
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v1", iter->value().ToString());
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  ASSERT_EQ(0, env_->now_cpu_count_.load());
+  ASSERT_EQ(0, get_perf_context()->iter_next_cpu_nanos);
+  ASSERT_EQ(0, get_perf_context()->iter_prev_cpu_nanos);
+  ASSERT_EQ(0, get_perf_context()->iter_seek_cpu_nanos);
+  delete iter;
+
+  uint64_t kDummyAddonTime = uint64_t{1000000000000};
+
+  // Add time to NowNanos() reading.
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "TableCache::FindTable:0",
+      [&](void* /*arg*/) { env_->addon_time_.fetch_add(kDummyAddonTime); });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  SetPerfLevel(PerfLevel::kEnableTimeAndCPUTimeExceptForMutex);
+  iter = db_->NewIterator(ReadOptions());
+  iter->Seek("k0");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  iter->SeekForPrev(last_key);
+  ASSERT_TRUE(iter->Valid());
+  iter->SeekToLast();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(last_value, iter->value().ToString());
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  iter->Next();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v1", iter->value().ToString());
+  iter->Prev();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("v0", iter->value().ToString());
+  ASSERT_GE(env_->now_cpu_count_.load(), 12);
+  ASSERT_GT(get_perf_context()->iter_next_cpu_nanos, 0);
+  ASSERT_LT(get_perf_context()->iter_next_cpu_nanos, kDummyAddonTime);
+  ASSERT_GT(get_perf_context()->iter_prev_cpu_nanos, 0);
+  ASSERT_LT(get_perf_context()->iter_prev_cpu_nanos, kDummyAddonTime);
+  ASSERT_GT(get_perf_context()->iter_seek_cpu_nanos, 0);
+  ASSERT_LT(get_perf_context()->iter_seek_cpu_nanos, kDummyAddonTime);
+  ASSERT_LT(get_perf_context()->get_cpu_nanos, kDummyAddonTime);
+  ASSERT_GT(get_perf_context()->find_table_nanos, kDummyAddonTime);
+
+  SetPerfLevel(PerfLevel::kDisable);
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  delete iter;
 }
 #endif  // OS_LINUX
 

--- a/db/perf_context_test.cc
+++ b/db/perf_context_test.cc
@@ -836,7 +836,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     ASSERT_EQ(value, "v0");
 
     if (FLAGS_verbose) {
-      std::cout << "Get CPU time nanos: " << get_perf_context()->get_cpu_nanos << "ns\n";
+      std::cout << "Get CPU time nanos: "
+                << get_perf_context()->get_cpu_nanos << "ns\n";
     }
 
     // Iter
@@ -848,7 +849,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->Seek(key);
 
     if (FLAGS_verbose) {
-      std::cout << "Iter Seek CPU time nanos: " << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
+      std::cout << "Iter Seek CPU time nanos: "
+                << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
     }
 
     // SeekForPrev
@@ -856,7 +858,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->SeekForPrev(key);
 
     if (FLAGS_verbose) {
-      std::cout << "Iter SeekForPrev CPU time nanos: " << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
+      std::cout << "Iter SeekForPrev CPU time nanos: "
+                << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
     }
 
     // SeekToLast
@@ -864,7 +867,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->SeekToLast();
 
     if (FLAGS_verbose) {
-      std::cout << "Iter SeekToLast CPU time nanos: " << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
+      std::cout << "Iter SeekToLast CPU time nanos: "
+                << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
     }
 
     // SeekToFirst
@@ -872,7 +876,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->SeekToFirst();
 
     if (FLAGS_verbose) {
-      std::cout << "Iter SeekToFirst CPU time nanos: " << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
+      std::cout << "Iter SeekToFirst CPU time nanos: "
+                << get_perf_context()->iter_seek_cpu_nanos << "ns\n";
     }
 
     // Next
@@ -880,7 +885,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->Next();
 
     if (FLAGS_verbose) {
-      std::cout << "Iter Next CPU time nanos: " << get_perf_context()->iter_next_cpu_nanos << "ns\n";
+      std::cout << "Iter Next CPU time nanos: "
+                << get_perf_context()->iter_next_cpu_nanos << "ns\n";
     }
 
     // Prev
@@ -888,7 +894,8 @@ TEST_F(PerfContextTest, CPUTimer) {
     iter->Prev();
 
     if (FLAGS_verbose) {
-      std::cout << "Iter Prev CPU time nanos: " << get_perf_context()->iter_prev_cpu_nanos << "ns\n";
+      std::cout << "Iter Prev CPU time nanos: "
+                << get_perf_context()->iter_prev_cpu_nanos << "ns\n";
     }
 
     // monotonically increasing

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -218,6 +218,8 @@ struct PerfContext {
   uint64_t env_new_logger_nanos;
 
   uint64_t get_cpu_nanos;
+  uint64_t iter_seek_cpu_nanos;
+  uint64_t iter_next_cpu_nanos;
 
   std::map<uint32_t, PerfContextByLevel>* level_to_perf_context = nullptr;
   bool per_level_perf_context_enabled = false;

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -218,8 +218,9 @@ struct PerfContext {
   uint64_t env_new_logger_nanos;
 
   uint64_t get_cpu_nanos;
-  uint64_t iter_seek_cpu_nanos;
   uint64_t iter_next_cpu_nanos;
+  uint64_t iter_prev_cpu_nanos;
+  uint64_t iter_seek_cpu_nanos;
 
   std::map<uint32_t, PerfContextByLevel>* level_to_perf_context = nullptr;
   bool per_level_perf_context_enabled = false;

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -118,6 +118,8 @@ PerfContext::PerfContext(const PerfContext& other) {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
+  iter_next_cpu_nanos = other.iter_next_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -210,6 +212,8 @@ PerfContext::PerfContext(PerfContext&& other) noexcept {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
+  iter_next_cpu_nanos = other.iter_next_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -304,6 +308,8 @@ PerfContext& PerfContext::operator=(const PerfContext& other) {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
+  iter_next_cpu_nanos = other.iter_next_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -395,6 +401,8 @@ void PerfContext::Reset() {
   env_unlock_file_nanos = 0;
   env_new_logger_nanos = 0;
   get_cpu_nanos = 0;
+  iter_seek_cpu_nanos = 0;
+  iter_next_cpu_nanos = 0;
   if (per_level_perf_context_enabled && level_to_perf_context) {
     for (auto& kv : *level_to_perf_context) {
       kv.second.Reset();
@@ -509,6 +517,8 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(env_unlock_file_nanos);
   PERF_CONTEXT_OUTPUT(env_new_logger_nanos);
   PERF_CONTEXT_OUTPUT(get_cpu_nanos);
+  PERF_CONTEXT_OUTPUT(iter_seek_cpu_nanos);
+  PERF_CONTEXT_OUTPUT(iter_next_cpu_nanos);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_useful);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_full_positive);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_full_true_positive);

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -118,8 +118,9 @@ PerfContext::PerfContext(const PerfContext& other) {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
-  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   iter_next_cpu_nanos = other.iter_next_cpu_nanos;
+  iter_prev_cpu_nanos = other.iter_prev_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -212,8 +213,9 @@ PerfContext::PerfContext(PerfContext&& other) noexcept {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
-  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   iter_next_cpu_nanos = other.iter_next_cpu_nanos;
+  iter_prev_cpu_nanos = other.iter_prev_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -308,8 +310,9 @@ PerfContext& PerfContext::operator=(const PerfContext& other) {
   env_unlock_file_nanos = other.env_unlock_file_nanos;
   env_new_logger_nanos = other.env_new_logger_nanos;
   get_cpu_nanos = other.get_cpu_nanos;
-  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   iter_next_cpu_nanos = other.iter_next_cpu_nanos;
+  iter_prev_cpu_nanos = other.iter_prev_cpu_nanos;
+  iter_seek_cpu_nanos = other.iter_seek_cpu_nanos;
   if (per_level_perf_context_enabled && level_to_perf_context != nullptr) {
     ClearPerLevelPerfContext();
   }
@@ -401,8 +404,9 @@ void PerfContext::Reset() {
   env_unlock_file_nanos = 0;
   env_new_logger_nanos = 0;
   get_cpu_nanos = 0;
-  iter_seek_cpu_nanos = 0;
   iter_next_cpu_nanos = 0;
+  iter_prev_cpu_nanos = 0;
+  iter_seek_cpu_nanos = 0;
   if (per_level_perf_context_enabled && level_to_perf_context) {
     for (auto& kv : *level_to_perf_context) {
       kv.second.Reset();
@@ -517,8 +521,9 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(env_unlock_file_nanos);
   PERF_CONTEXT_OUTPUT(env_new_logger_nanos);
   PERF_CONTEXT_OUTPUT(get_cpu_nanos);
-  PERF_CONTEXT_OUTPUT(iter_seek_cpu_nanos);
   PERF_CONTEXT_OUTPUT(iter_next_cpu_nanos);
+  PERF_CONTEXT_OUTPUT(iter_prev_cpu_nanos);
+  PERF_CONTEXT_OUTPUT(iter_seek_cpu_nanos);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_useful);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_full_positive);
   PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(bloom_filter_full_true_positive);


### PR DESCRIPTION
Introduce CPU timers for iterator seek and next operations. Seek
counter includes SeekToFirst, SeekToLast and SeekForPrev, w/ the
caveat that SeekToLast timer doesn't include some post processing
time if upper bound is defined.