### PR TITLE
Reorder DBIter fields to reduce memory usage

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -117,29 +117,29 @@ class DBIter final: public Iterator {
          uint64_t max_sequential_skip_in_iterations,
          ReadCallback* read_callback, DBImpl* db_impl, ColumnFamilyData* cfd,
          bool allow_blob)
-      : arena_mode_(arena_mode),
-        env_(_env),
+      : env_(_env),
         logger_(cf_options.info_log),
         user_comparator_(cmp),
         merge_operator_(cf_options.merge_operator),
         iter_(iter),
         sequence_(s),
-        direction_(kForward),
-        valid_(false),
-        current_entry_is_merged_(false),
         statistics_(cf_options.statistics),
         num_internal_keys_skipped_(0),
         iterate_lower_bound_(read_options.iterate_lower_bound),
         iterate_upper_bound_(read_options.iterate_upper_bound),
+        direction_(kForward),
+        arena_mode_(arena_mode),
+        valid_(false),
+        current_entry_is_merged_(false),
         prefix_same_as_start_(read_options.prefix_same_as_start),
         pin_thru_lifetime_(read_options.pin_data),
         total_order_seek_(read_options.total_order_seek),
+        allow_blob_(allow_blob),
+        is_blob_(false),
         range_del_agg_(&cf_options.internal_comparator, s),
         read_callback_(read_callback),
         db_impl_(db_impl),
         cfd_(cfd),
-        allow_blob_(allow_blob),
-        is_blob_(false),
         start_seqnum_(read_options.iter_start_seqnum) {
     RecordTick(statistics_, NO_ITERATOR_CREATED);
     prefix_extractor_ = mutable_cf_options.prefix_extractor.get();
@@ -304,7 +304,6 @@ class DBIter final: public Iterator {
   }
 
   const SliceTransform* prefix_extractor_;
-  bool arena_mode_;
   Env* const env_;
   Logger* logger_;
   const Comparator* const user_comparator_;
@@ -312,7 +311,6 @@ class DBIter final: public Iterator {
   InternalIterator* iter_;
   SequenceNumber sequence_;
 
-  Status status_;
   IterKey saved_key_;
   // Reusable internal key data structure. This is only used inside one function
   // and should not be used across functions. Reusing this object can reduce
@@ -320,9 +318,6 @@ class DBIter final: public Iterator {
   ParsedInternalKey ikey_;
   std::string saved_value_;
   Slice pinned_value_;
-  Direction direction_;
-  bool valid_;
-  bool current_entry_is_merged_;
   // for prefix seek mode to support prev()
   Statistics* statistics_;
   uint64_t max_skip_;
@@ -330,13 +325,22 @@ class DBIter final: public Iterator {
   uint64_t num_internal_keys_skipped_;
   const Slice* iterate_lower_bound_;
   const Slice* iterate_upper_bound_;
+
   IterKey prefix_start_buf_;
+
+  Status status_;
   Slice prefix_start_key_;
+  Direction direction_;
+  bool arena_mode_;
+  bool valid_;
+  bool current_entry_is_merged_;
   const bool prefix_same_as_start_;
   // Means that we will pin all data blocks we read as long the Iterator
   // is not deleted, will be true if ReadOptions::pin_data is true
   const bool pin_thru_lifetime_;
   const bool total_order_seek_;
+  bool allow_blob_;
+  bool is_blob_;
   // List of operands for merge operator.
   MergeContext merge_context_;
   ReadRangeDelAggregator range_del_agg_;
@@ -345,8 +349,6 @@ class DBIter final: public Iterator {
   ReadCallback* read_callback_;
   DBImpl* db_impl_;
   ColumnFamilyData* cfd_;
-  bool allow_blob_;
-  bool is_blob_;
   // for diff snapshots we want the lower bound on the seqnum;
   // if this value > 0 iterator will return internal keys
   SequenceNumber start_seqnum_;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -122,6 +122,7 @@ class DBIter final: public Iterator {
         user_comparator_(cmp),
         merge_operator_(cf_options.merge_operator),
         iter_(iter),
+        read_callback_(read_callback),
         sequence_(s),
         statistics_(cf_options.statistics),
         num_internal_keys_skipped_(0),
@@ -137,7 +138,6 @@ class DBIter final: public Iterator {
         is_blob_(false),
         arena_mode_(arena_mode),
         range_del_agg_(&cf_options.internal_comparator, s),
-        read_callback_(read_callback),
         db_impl_(db_impl),
         cfd_(cfd),
         start_seqnum_(read_options.iter_start_seqnum) {
@@ -309,6 +309,7 @@ class DBIter final: public Iterator {
   const Comparator* const user_comparator_;
   const MergeOperator* const merge_operator_;
   InternalIterator* iter_;
+  ReadCallback* read_callback_;
   SequenceNumber sequence_;
 
   IterKey saved_key_;
@@ -346,7 +347,6 @@ class DBIter final: public Iterator {
   ReadRangeDelAggregator range_del_agg_;
   LocalStatistics local_stats_;
   PinnedIteratorsManager pinned_iters_mgr_;
-  ReadCallback* read_callback_;
   DBImpl* db_impl_;
   ColumnFamilyData* cfd_;
   // for diff snapshots we want the lower bound on the seqnum;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -128,7 +128,6 @@ class DBIter final: public Iterator {
         iterate_lower_bound_(read_options.iterate_lower_bound),
         iterate_upper_bound_(read_options.iterate_upper_bound),
         direction_(kForward),
-        arena_mode_(arena_mode),
         valid_(false),
         current_entry_is_merged_(false),
         prefix_same_as_start_(read_options.prefix_same_as_start),
@@ -136,6 +135,7 @@ class DBIter final: public Iterator {
         total_order_seek_(read_options.total_order_seek),
         allow_blob_(allow_blob),
         is_blob_(false),
+        arena_mode_(arena_mode),
         range_del_agg_(&cf_options.internal_comparator, s),
         read_callback_(read_callback),
         db_impl_(db_impl),
@@ -331,7 +331,6 @@ class DBIter final: public Iterator {
   Status status_;
   Slice prefix_start_key_;
   Direction direction_;
-  bool arena_mode_;
   bool valid_;
   bool current_entry_is_merged_;
   const bool prefix_same_as_start_;
@@ -341,6 +340,7 @@ class DBIter final: public Iterator {
   const bool total_order_seek_;
   bool allow_blob_;
   bool is_blob_;
+  bool arena_mode_;
   // List of operands for merge operator.
   MergeContext merge_context_;
   ReadRangeDelAggregator range_del_agg_;

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -339,9 +339,9 @@ class IterKey {
  public:
   IterKey()
       : buf_(space_),
-        buf_size_(sizeof(space_)),
         key_(buf_),
         key_size_(0),
+        buf_size_(sizeof(space_)),
         is_user_key_(true) {}
 
   ~IterKey() { ResetBuffer(); }
@@ -496,9 +496,9 @@ class IterKey {
 
  private:
   char* buf_;
-  size_t buf_size_;
   const char* key_;
   size_t key_size_;
+  size_t buf_size_;
   char space_[32];  // Avoid allocation for short keys
   bool is_user_key_;
 


### PR DESCRIPTION
The patch reorders DBIter fields to put 1-byte fields together and let the compiler optimize the memory usage by using less 64-bit allocations for bools and enums. 

This might have a negative side effect of putting the variables that are accessed together into different cache lines and hence increasing the cache misses. Not sure what benchmark would verify that thought. I ran simple, single-threaded seekrandom benchmarks but the variance in the results is too much to be conclusive.

./db_bench --benchmarks=fillrandom --use_existing_db=0 --num=1000000 --db=/dev/shm/dbbench
./db_bench --benchmarks=seekrandom[X10] --use_existing_db=1 --db=/dev/shm/dbbench --num=1000000 --duration=60 --seek_nexts=100