### PR TITLE
add compression options to table properties

### DIFF
--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -53,6 +53,7 @@ struct TablePropertiesNames {
   static const std::string kPrefixExtractorName;
   static const std::string kPropertyCollectors;
   static const std::string kCompression;
+  static const std::string kCompressionOptions;
   static const std::string kCreationTime;
   static const std::string kOldestKeyTime;
 };
@@ -200,6 +201,9 @@ struct TableProperties {
 
   // The compression algo used to compress the SST files.
   std::string compression_name;
+
+  // Compression options used to compress the SST files.
+  std::string compression_options;
 
   // user collected properties
   UserCollectedProperties user_collected_properties;

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -879,6 +879,8 @@ void BlockBasedTableBuilder::WritePropertiesBlock(
             : "nullptr";
     rep_->props.compression_name =
         CompressionTypeToString(rep_->compression_type);
+    rep_->props.compression_options =
+        CompressionOptionsToString(rep_->compression_opts);
     rep_->props.prefix_extractor_name =
         rep_->moptions.prefix_extractor != nullptr
             ? rep_->moptions.prefix_extractor->Name()

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -115,6 +115,9 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
   if (!props.compression_name.empty()) {
     Add(TablePropertiesNames::kCompression, props.compression_name);
   }
+  if (!props.compression_options.empty()) {
+    Add(TablePropertiesNames::kCompressionOptions, props.compression_options);
+  }
 }
 
 Slice PropertyBlockBuilder::Finish() {
@@ -303,6 +306,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
       new_table_properties->property_collectors_names = raw_val.ToString();
     } else if (key == TablePropertiesNames::kCompression) {
       new_table_properties->compression_name = raw_val.ToString();
+    } else if (key == TablePropertiesNames::kCompressionOptions) {
+      new_table_properties->compression_options = raw_val.ToString();
     } else {
       // handle user-collected properties
       new_table_properties->user_collected_properties.insert(

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -153,6 +153,11 @@ std::string TableProperties::ToString(
       compression_name.empty() ? std::string("N/A") : compression_name,
       prop_delim, kv_delim);
 
+  AppendProperty(
+      result, "SST file compression options",
+      compression_options.empty() ? std::string("N/A") : compression_options,
+      prop_delim, kv_delim);
+
   AppendProperty(result, "creation time", creation_time, prop_delim, kv_delim);
 
   AppendProperty(result, "time stamp of earliest key", oldest_key_time,
@@ -223,6 +228,8 @@ const std::string TablePropertiesNames::kPrefixExtractorName =
 const std::string TablePropertiesNames::kPropertyCollectors =
     "rocksdb.property.collectors";
 const std::string TablePropertiesNames::kCompression = "rocksdb.compression";
+const std::string TablePropertiesNames::kCompressionOptions =
+    "rocksdb.compression_options";
 const std::string TablePropertiesNames::kCreationTime = "rocksdb.creation.time";
 const std::string TablePropertiesNames::kOldestKeyTime =
     "rocksdb.oldest.key.time";

--- a/util/compression.h
+++ b/util/compression.h
@@ -25,6 +25,7 @@
 #include "util/coding.h"
 #include "util/compression_context_cache.h"
 #include "util/memory_allocator.h"
+#include "util/string_util.h"
 
 #ifdef SNAPPY
 #include <snappy.h>
@@ -499,6 +500,31 @@ inline std::string CompressionTypeToString(CompressionType compression_type) {
       assert(false);
       return "";
   }
+}
+
+inline std::string CompressionOptionsToString(
+    CompressionOptions compression_options) {
+  std::string result;
+  result.reserve(512);
+  result.append("window_bits=")
+      .append(ToString(compression_options.window_bits))
+      .append("; ");
+  result.append("level=")
+      .append(ToString(compression_options.level))
+      .append("; ");
+  result.append("strategy=")
+      .append(ToString(compression_options.strategy))
+      .append("; ");
+  result.append("max_dict_bytes=")
+      .append(ToString(compression_options.max_dict_bytes))
+      .append("; ");
+  result.append("zstd_max_train_bytes=")
+      .append(ToString(compression_options.zstd_max_train_bytes))
+      .append("; ");
+  result.append("enabled=")
+      .append(ToString(compression_options.enabled))
+      .append("; ");
+  return result;
 }
 
 // compress_format_version can have two values:

--- a/util/compression.h
+++ b/util/compression.h
@@ -503,7 +503,7 @@ inline std::string CompressionTypeToString(CompressionType compression_type) {
 }
 
 inline std::string CompressionOptionsToString(
-    CompressionOptions compression_options) {
+    CompressionOptions& compression_options) {
   std::string result;
   result.reserve(512);
   result.append("window_bits=")


### PR DESCRIPTION
Since we are planning to use dictionary compression and to use different compression level, it is quite useful to add compression options to TableProperties. For example, in MyRocks, if the feature is available, we can query from information_schema.rocksdb_sst_props to see if all sst files are converted to ZSTD dictionary compressions. Resolves https://github.com/facebook/rocksdb/issues/4992

With this PR, user can query table properties through `GetPropertiesOfAllTables` API and get compression options as std::string:
`window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0;`
or table_properties->ToString() will also contain it
`# data blocks=1; # entries=13; # deletions=0; # merge operands=0; # range deletions=0; raw key size=143; raw average key size=11.000000; raw value size=39; raw average value size=3.000000; data block size=120; index block size (user-key? 0, delta-value? 0)=27; filter block size=0; (estimated) table size=147; filter policy name=N/A; prefix extractor name=nullptr; column family ID=0; column family name=default; comparator name=leveldb.BytewiseComparator; merge operator name=nullptr; property collectors names=[]; SST file compression algo=Snappy; SST file compression options=window_bits=-14; level=32767; strategy=0; max_dict_bytes=0; zstd_max_train_bytes=0; enabled=0; ; creation time=1552946632; time stamp of earliest key=1552946632;`