### PR TITLE
Refactor memtable iterator Seek and SeekForPrev

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -319,7 +319,7 @@ class LookupKey {
  private:
   // We construct a char array of the form:
   //    klength  varint32               <-- start_
-  //    userkey  char[klength]          <-- kstart_
+  //    userkey  char[klength-8]        <-- kstart_
   //    tag      uint64
   //                                    <-- end_
   // The array is a suitable MemTable key.

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -202,11 +202,13 @@ class MemTableRep {
     virtual void Prev() = 0;
 
     // Advance to the first entry with a key >= target
-    virtual void Seek(const Slice& internal_key, const char* memtable_key) = 0;
+    virtual void Seek(const char* memtable_key) = 0;
+
+    // Advance to the first entry with a key >= ENCODE(target)
+    virtual void SeekInternal(const Slice& internal_key);
 
     // retreat to the first entry with a key <= target
-    virtual void SeekForPrev(const Slice& internal_key,
-                             const char* memtable_key) = 0;
+    virtual void SeekForPrev(const char* memtable_key) = 0;
 
     // Position at the first entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.
@@ -215,6 +217,9 @@ class MemTableRep {
     // Position at the last entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.
     virtual void SeekToLast() = 0;
+
+  protected:
+    std::string tmp_;       // For passing to EncodeKey
   };
 
   // Return an iterator over the keys in this representation.

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -202,13 +202,10 @@ class MemTableRep {
     virtual void Prev() = 0;
 
     // Advance to the first entry with a key >= target
-    virtual void Seek(const char* memtable_key) = 0;
-
-    // Advance to the first entry with a key >= ENCODE(target)
-    virtual void SeekInternal(const Slice& internal_key);
+    virtual void Seek(const Slice& internal_key) = 0;
 
     // retreat to the first entry with a key <= target
-    virtual void SeekForPrev(const char* memtable_key) = 0;
+    virtual void SeekForPrev(const Slice& internal_key) = 0;
 
     // Position at the first entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.
@@ -217,9 +214,6 @@ class MemTableRep {
     // Position at the last entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.
     virtual void SeekToLast() = 0;
-
-  protected:
-    std::string tmp_;       // For passing to EncodeKey
   };
 
   // Return an iterator over the keys in this representation.

--- a/memtable/hash_linklist_rep.cc
+++ b/memtable/hash_linklist_rep.cc
@@ -291,13 +291,13 @@ class HashLinkListRep : public MemTableRep {
     }
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override {
-      iter_.Seek(memtable_key);
+    void Seek(const Slice& internal_key) override {
+      iter_.Seek(EncodeKey(&tmp_, internal_key));
     }
 
     // Retreat to the last entry with a key <= target
-    void SeekForPrev(const char* memtable_key) override {
-      iter_.SeekForPrev(memtable_key);
+    void SeekForPrev(const Slice& internal_key) override {
+      iter_.SeekForPrev(EncodeKey(&tmp_, internal_key));
     }
 
     // Position at the first entry in collection.
@@ -313,6 +313,7 @@ class HashLinkListRep : public MemTableRep {
     // To destruct with the iterator.
     std::unique_ptr<MemtableSkipList> full_list_;
     std::unique_ptr<Allocator> allocator_;
+    std::string tmp_;       // For passing to EncodeKey
   };
 
   class LinkListIterator : public MemTableRep::Iterator {
@@ -351,18 +352,13 @@ class HashLinkListRep : public MemTableRep {
     }
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override {
-      SeekInternal(GetLengthPrefixedSlice(memtable_key));
-    }
-
-    // Advance to the first entry with a key >= ENCODE(target)
-    void SeekInternal(const Slice& internal_key) override {
+    void Seek(const Slice& internal_key) override {
       node_ = hash_link_list_rep_->FindGreaterOrEqualInBucket(head_,
                                                               internal_key);
     }
 
     // Retreat to the last entry with a key <= target
-    void SeekForPrev(const char* /*memtable_key*/) override {
+    void SeekForPrev(const Slice& /*internal_key*/) override {
       // Since we do not support Prev()
       // We simply do not support SeekForPrev
       Reset(nullptr);
@@ -407,13 +403,27 @@ class HashLinkListRep : public MemTableRep {
           memtable_rep_(memtable_rep) {}
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override {
-      SeekImpl(GetLengthPrefixedSlice(memtable_key), memtable_key);
-    }
+    void Seek(const Slice& k) override {
+      auto transformed = memtable_rep_.GetPrefix(k);
+      auto* bucket = memtable_rep_.GetBucket(transformed);
 
-    // Advance to the first entry with a key >= ENCODE(target)
-    void SeekInternal(const Slice& k) override {
-      SeekImpl(k, EncodeKey(&tmp_, k));
+      SkipListBucketHeader* skip_list_header =
+          memtable_rep_.GetSkipListBucketHeader(bucket);
+      if (skip_list_header != nullptr) {
+        // The bucket is organized as a skip list
+        if (!skip_list_iter_) {
+          skip_list_iter_.reset(
+              new MemtableSkipList::Iterator(&skip_list_header->skip_list));
+        } else {
+          skip_list_iter_->SetList(&skip_list_header->skip_list);
+        }
+        skip_list_iter_->Seek(EncodeKey(&tmp_, k));
+      } else {
+        // The bucket is organized as a linked list
+        skip_list_iter_.reset();
+        Reset(memtable_rep_.GetLinkListFirstNode(bucket));
+        HashLinkListRep::LinkListIterator::Seek(k);
+      }
     }
 
     bool Valid() const override {
@@ -439,32 +449,10 @@ class HashLinkListRep : public MemTableRep {
     }
 
    private:
-    void SeekImpl(const Slice& k, const char* memtable_key) {
-      auto transformed = memtable_rep_.GetPrefix(k);
-      auto* bucket = memtable_rep_.GetBucket(transformed);
-
-      SkipListBucketHeader* skip_list_header =
-          memtable_rep_.GetSkipListBucketHeader(bucket);
-      if (skip_list_header != nullptr) {
-        // The bucket is organized as a skip list
-        if (!skip_list_iter_) {
-          skip_list_iter_.reset(
-              new MemtableSkipList::Iterator(&skip_list_header->skip_list));
-        } else {
-          skip_list_iter_->SetList(&skip_list_header->skip_list);
-        }
-        skip_list_iter_->Seek(memtable_key);
-      } else {
-        // The bucket is organized as a linked list
-        skip_list_iter_.reset();
-        Reset(memtable_rep_.GetLinkListFirstNode(bucket));
-        HashLinkListRep::LinkListIterator::SeekInternal(k);
-      }
-    }
-
     // the underlying memtable
     const HashLinkListRep& memtable_rep_;
     std::unique_ptr<MemtableSkipList::Iterator> skip_list_iter_;
+    std::string tmp_;       // For passing to EncodeKey
   };
 
   class EmptyIterator : public MemTableRep::Iterator {
@@ -479,9 +467,8 @@ class HashLinkListRep : public MemTableRep {
     }
     void Next() override {}
     void Prev() override {}
-    void Seek(const char* /*memtable_key*/) override {}
-    void SeekInternal(const Slice& /*internal_key*/) override {}
-    void SeekForPrev(const char* /*memtable_key*/) override {}
+    void Seek(const Slice& /*internal_key*/) override {}
+    void SeekForPrev(const Slice& /*internal_key*/) override {}
     void SeekToFirst() override {}
     void SeekToLast() override {}
 
@@ -727,7 +714,7 @@ void HashLinkListRep::Get(const LookupKey& k, void* callback_args,
     auto* link_list_head = GetLinkListFirstNode(bucket);
     if (link_list_head != nullptr) {
       LinkListIterator iter(this, link_list_head);
-      for (iter.SeekInternal(k.internal_key());
+      for (iter.Seek(k.internal_key());
            iter.Valid() && callback_func(callback_args, iter.key());
            iter.Next()) {
       }

--- a/memtable/hash_skiplist_rep.cc
+++ b/memtable/hash_skiplist_rep.cc
@@ -117,14 +117,14 @@ class HashSkipListRep : public MemTableRep {
     }
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override {
+    void Seek(const Slice& internal_key) override {
       if (list_ != nullptr) {
-        iter_.Seek(memtable_key);
+        iter_.Seek(EncodeKey(&tmp_, internal_key));
       }
     }
 
     // Retreat to the last entry with a key <= target
-    void SeekForPrev(const char* /*memtable_key*/) override {
+    void SeekForPrev(const Slice& /*internal_key*/) override {
       // not supported
       assert(false);
     }
@@ -164,6 +164,7 @@ class HashSkipListRep : public MemTableRep {
     // responsible for it's cleaning. This is a poor man's std::shared_ptr
     bool own_list_;
     std::unique_ptr<Arena> arena_;
+    std::string tmp_;       // For passing to EncodeKey
   };
 
   class DynamicIterator : public HashSkipListRep::Iterator {
@@ -173,13 +174,10 @@ class HashSkipListRep : public MemTableRep {
         memtable_rep_(memtable_rep) {}
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override {
-      SeekImpl(GetLengthPrefixedSlice(memtable_key), memtable_key);
-    }
-
-    // Advance to the first entry with a key >= ENCODE(target)
-    void SeekInternal(const Slice& k) override {
-      SeekImpl(k, EncodeKey(&tmp_, k));
+    void Seek(const Slice& k) override {
+      auto transformed = memtable_rep_.transform_->Transform(ExtractUserKey(k));
+      Reset(memtable_rep_.GetBucket(transformed));
+      HashSkipListRep::Iterator::Seek(k);
     }
 
     // Position at the first entry in collection.
@@ -199,12 +197,6 @@ class HashSkipListRep : public MemTableRep {
     }
 
    private:
-    void SeekImpl(const Slice& k, const char* memtable_key) {
-      auto transformed = memtable_rep_.transform_->Transform(ExtractUserKey(k));
-      Reset(memtable_rep_.GetBucket(transformed));
-      HashSkipListRep::Iterator::Seek(memtable_key);
-    }
-
     // the underlying memtable
     const HashSkipListRep& memtable_rep_;
   };
@@ -221,9 +213,8 @@ class HashSkipListRep : public MemTableRep {
     }
     void Next() override {}
     void Prev() override {}
-    void Seek(const char* /*memtable_key*/) override {}
-    void SeekInternal(const Slice& /*internal_key*/) override {}
-    void SeekForPrev(const char* /*memtable_key*/) override {}
+    void Seek(const Slice& /*internal_key*/) override {}
+    void SeekForPrev(const Slice& /*internal_key*/) override {}
     void SeekToFirst() override {}
     void SeekToLast() override {}
 

--- a/memtable/inlineskiplist_test.cc
+++ b/memtable/inlineskiplist_test.cc
@@ -88,7 +88,7 @@ class InlineSkipTest : public testing::Test {
     TestInlineSkipList::Iterator iter(list);
     ASSERT_FALSE(iter.Valid());
     Key zero = 0;
-    iter.Seek(Encode(&zero));
+    iter.Seek(zero);
     for (Key key : keys_) {
       ASSERT_TRUE(iter.Valid());
       ASSERT_EQ(key, Decode(iter.key()));
@@ -115,9 +115,9 @@ TEST_F(InlineSkipTest, Empty) {
   iter.SeekToFirst();
   ASSERT_TRUE(!iter.Valid());
   key = 100;
-  iter.Seek(Encode(&key));
+  iter.Seek(key);
   ASSERT_TRUE(!iter.Valid());
-  iter.SeekForPrev(Encode(&key));
+  iter.SeekForPrev(key);
   ASSERT_TRUE(!iter.Valid());
   iter.SeekToLast();
   ASSERT_TRUE(!iter.Valid());
@@ -154,12 +154,12 @@ TEST_F(InlineSkipTest, InsertAndLookup) {
     ASSERT_TRUE(!iter.Valid());
 
     uint64_t zero = 0;
-    iter.Seek(Encode(&zero));
+    iter.Seek(zero);
     ASSERT_TRUE(iter.Valid());
     ASSERT_EQ(*(keys.begin()), Decode(iter.key()));
 
     uint64_t max_key = R - 1;
-    iter.SeekForPrev(Encode(&max_key));
+    iter.SeekForPrev(max_key);
     ASSERT_TRUE(iter.Valid());
     ASSERT_EQ(*(keys.rbegin()), Decode(iter.key()));
 
@@ -175,7 +175,7 @@ TEST_F(InlineSkipTest, InsertAndLookup) {
   // Forward iteration test
   for (Key i = 0; i < R; i++) {
     InlineSkipList<TestComparator>::Iterator iter(&list);
-    iter.Seek(Encode(&i));
+    iter.Seek(i);
 
     // Compare against model iterator
     std::set<Key>::iterator model_iter = keys.lower_bound(i);
@@ -195,7 +195,7 @@ TEST_F(InlineSkipTest, InsertAndLookup) {
   // Backward iteration test
   for (Key i = 0; i < R; i++) {
     InlineSkipList<TestComparator>::Iterator iter(&list);
-    iter.SeekForPrev(Encode(&i));
+    iter.SeekForPrev(i);
 
     // Compare against model iterator
     std::set<Key>::iterator model_iter = keys.upper_bound(i);
@@ -431,7 +431,7 @@ class ConcurrentTest {
 
     Key pos = RandomTarget(rnd);
     InlineSkipList<TestComparator>::Iterator iter(&list_);
-    iter.Seek(Encode(&pos));
+    iter.Seek(pos);
     while (true) {
       Key current;
       if (!iter.Valid()) {
@@ -474,7 +474,7 @@ class ConcurrentTest {
         Key new_target = RandomTarget(rnd);
         if (new_target > pos) {
           pos = new_target;
-          iter.Seek(Encode(&new_target));
+          iter.Seek(new_target);
         }
       }
     }

--- a/memtable/vectorrep.cc
+++ b/memtable/vectorrep.cc
@@ -50,6 +50,7 @@ class VectorRep : public MemTableRep {
     std::shared_ptr<std::vector<const char*>> bucket_;
     std::vector<const char*>::const_iterator mutable cit_;
     const KeyComparator& compare_;
+    std::string tmp_;       // For passing to EncodeKey
     bool mutable sorted_;
     void DoSort() const;
    public:
@@ -78,10 +79,10 @@ class VectorRep : public MemTableRep {
     void Prev() override;
 
     // Advance to the first entry with a key >= target
-    void Seek(const char* memtable_key) override;
+    void Seek(const Slice& internal_key) override;
 
     // Advance to the first entry with a key <= target
-    void SeekForPrev(const char* memtable_key) override;
+    void SeekForPrev(const Slice& internal_key) override;
 
     // Position at the first entry in collection.
     // Final state of iterator is Valid() iff collection is not empty.
@@ -209,19 +210,19 @@ void VectorRep::Iterator::Prev() {
 }
 
 // Advance to the first entry with a key >= target
-void VectorRep::Iterator::Seek(const char* memtable_key) {
+void VectorRep::Iterator::Seek(const Slice& internal_key) {
   DoSort();
   // Do binary search to find first value not less than the target
   cit_ = std::equal_range(bucket_->begin(),
                           bucket_->end(),
-                          memtable_key,
+                          EncodeKey(&tmp_, internal_key),
                           [this] (const char* a, const char* b) {
                             return compare_(a, b) < 0;
                           }).first;
 }
 
 // Advance to the first entry with a key <= target
-void VectorRep::Iterator::SeekForPrev(const char* /*memtable_key*/) {
+void VectorRep::Iterator::SeekForPrev(const Slice& /*internal_key*/) {
   assert(false);
 }
 
@@ -256,7 +257,7 @@ void VectorRep::Get(const LookupKey& k, void* callback_args,
   VectorRep::Iterator iter(vector_rep, immutable_ ? bucket_ : bucket, compare_);
   rwlock_.ReadUnlock();
 
-  for (iter.Seek(k.memtable_key().data());
+  for (iter.Seek(k.internal_key());
        iter.Valid() && callback_func(callback_args, iter.key()); iter.Next()) {
   }
 }


### PR DESCRIPTION
Right now Seek/SeekForPrev takes two args: the second is length prefixed
version of the first. As they can be converted to each other hence only
one is needed. For DynamicIterator SeekImpl is added to avoid unnecessary
back-and-forth convertion.