### PR TITLE
ldb command parsing: allow option values to contain equals signs

### DIFF
--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -96,6 +96,14 @@ class LDBCommand {
     ldb_options_ = ldb_options;
   }
 
+  const std::map<std::string, std::string>& TEST_GetOptionMap() {
+    return option_map_;
+  }
+
+  const std::vector<std::string>& TEST_GetFlags() {
+    return flags_;
+  }
+
   virtual bool NoDBOpen() { return false; }
 
   virtual ~LDBCommand() { CloseDB(); }

--- a/include/rocksdb/utilities/ldb_cmd.h
+++ b/include/rocksdb/utilities/ldb_cmd.h
@@ -100,9 +100,7 @@ class LDBCommand {
     return option_map_;
   }
 
-  const std::vector<std::string>& TEST_GetFlags() {
-    return flags_;
-  }
+  const std::vector<std::string>& TEST_GetFlags() { return flags_; }
 
   virtual bool NoDBOpen() { return false; }
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -132,12 +132,19 @@ LDBCommand* LDBCommand::InitFromCmdLineArgs(
   for (const auto& arg : args) {
     if (arg[0] == '-' && arg[1] == '-'){
       std::vector<std::string> splits = StringSplit(arg, '=');
+      // --option_name=option_value
       if (splits.size() == 2) {
         std::string optionKey = splits[0].substr(OPTION_PREFIX.size());
         parsed_params.option_map[optionKey] = splits[1];
-      } else {
+      } else if (splits.size() == 1) {
+        // --flag_name
         std::string optionKey = splits[0].substr(OPTION_PREFIX.size());
         parsed_params.flags.push_back(optionKey);
+      } else {
+        // --option_name=option_value, option_value contains '='
+        std::string optionKey = splits[0].substr(OPTION_PREFIX.size());
+        parsed_params.option_map[optionKey] =
+            arg.substr(splits[0].length() + 1);
       }
     } else {
       cmdTokens.push_back(arg);

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -88,9 +88,8 @@ TEST_F(LdbCmdTest, OptionParsing) {
     args.push_back("scan");
     args.push_back("--ttl");
     args.push_back("--timestamp");
-    LDBCommand* command =
-        rocksdb::LDBCommand::InitFromCmdLineArgs(args, Options(), LDBOptions(),
-                                                 nullptr);
+    LDBCommand* command = rocksdb::LDBCommand::InitFromCmdLineArgs(
+        args, Options(), LDBOptions(), nullptr);
     const std::vector<std::string> flags = command->TEST_GetFlags();
     EXPECT_EQ(flags.size(), 2);
     EXPECT_EQ(flags[0], "ttl");
@@ -102,14 +101,19 @@ TEST_F(LdbCmdTest, OptionParsing) {
     std::vector<std::string> args;
     args.push_back("scan");
     args.push_back("--db=/dev/shm/ldbtest/");
-    args.push_back("--from='abcd/efg/hijk/lmn/opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz=a&bcd_ef=gh.ijk'");
-    LDBCommand* command =
-        rocksdb::LDBCommand::InitFromCmdLineArgs(args, Options(), LDBOptions(),
-                                                 nullptr);
+    args.push_back(
+        "--from='abcd/efg/hijk/lmn/"
+        "opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz=a&bcd_"
+        "ef=gh.ijk'");
+    LDBCommand* command = rocksdb::LDBCommand::InitFromCmdLineArgs(
+        args, Options(), LDBOptions(), nullptr);
     const std::map<std::string, std::string> option_map =
         command->TEST_GetOptionMap();
     EXPECT_EQ(option_map.at("db"), "/dev/shm/ldbtest/");
-    EXPECT_EQ(option_map.at("from"), "'abcd/efg/hijk/lmn/opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz=a&bcd_ef=gh.ijk'");
+    EXPECT_EQ(option_map.at("from"),
+              "'abcd/efg/hijk/lmn/"
+              "opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz="
+              "a&bcd_ef=gh.ijk'");
     delete command;
   }
 }

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -81,6 +81,39 @@ TEST_F(LdbCmdTest, MemEnv) {
   tool.Run(3, argv, opts);
 }
 
+TEST_F(LdbCmdTest, OptionParsing) {
+  // test parsing flags
+  {
+    std::vector<std::string> args;
+    args.push_back("scan");
+    args.push_back("--ttl");
+    args.push_back("--timestamp");
+    LDBCommand* command =
+        rocksdb::LDBCommand::InitFromCmdLineArgs(args, Options(), LDBOptions(),
+                                                 nullptr);
+    const std::vector<std::string> flags = command->TEST_GetFlags();
+    EXPECT_EQ(flags.size(), 2);
+    EXPECT_EQ(flags[0], "ttl");
+    EXPECT_EQ(flags[1], "timestamp");
+    delete command;
+  }
+  // test parsing options which contains equal sign in the option value
+  {
+    std::vector<std::string> args;
+    args.push_back("scan");
+    args.push_back("--db=/dev/shm/ldbtest/");
+    args.push_back("--from='abcd/efg/hijk/lmn/opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz=a&bcd_ef=gh.ijk'");
+    LDBCommand* command =
+        rocksdb::LDBCommand::InitFromCmdLineArgs(args, Options(), LDBOptions(),
+                                                 nullptr);
+    const std::map<std::string, std::string> option_map =
+        command->TEST_GetOptionMap();
+    EXPECT_EQ(option_map.at("db"), "/dev/shm/ldbtest/");
+    EXPECT_EQ(option_map.at("from"), "'abcd/efg/hijk/lmn/opq:__rst.uvw.xyz?a=3+4+bcd+efghi&jk=lm_no&pq=rst-0&uv=wx-8&yz=a&bcd_ef=gh.ijk'");
+    delete command;
+  }
+}
+
 } // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Right now ldb command doesn't allow cases where option values contain equals sign. For example, 
```
ldb --db=/tmp/test scan --from='q=3' --max_keys=1 
```
after parsing, ldb will have one option 'db', 'max_keys' and one flag 'from'.
This PR updates the parsing logic so that it now supports the above mentioned cases