### PR TITLE
Avoid to go through every CF for every ReleaseSnapshot()

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2147,14 +2147,7 @@ void DBImpl::ReleaseSnapshot(const Snapshot* s) {
       // mutex might be unlocked during the loop, making the result inaccurate.
       SequenceNumber new_bottommost_files_mark_threshold = kMaxSequenceNumber;
       for (auto* cfd : *versions_->GetColumnFamilySet()) {
-        bool scheduled = false;
-        for (auto* cfs : cf_scheduled) {
-          if (cfd == cfs) {
-            scheduled = true;
-            break;
-          }
-        }
-        if (scheduled) {
+        if (cf_scheduled.contains(cfd)) {
           continue;
         }
         new_bottommost_files_mark_threshold = std::min(

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -865,6 +865,7 @@ class DBImpl : public DB {
   friend class CompactedDBImpl;
   friend class DBTest_ConcurrentFlushWAL_Test;
   friend class DBTest_MixedSlowdownOptionsStop_Test;
+  friend class DBCompactionTest_CompactBottomLevelFilesWithDeletions_Test;
 #ifndef NDEBUG
   friend class DBTest2_ReadCallbackTest_Test;
   friend class WriteCallbackTest_WriteWithCallbackTest_Test;
@@ -1561,6 +1562,10 @@ class DBImpl : public DB {
 
   // Indicate DB was opened successfully
   bool opened_successfully_;
+
+  // The min threshold to triggere bottommost compaction for removing
+  // garbages, among all column families.
+  SequenceNumber bottommost_files_mark_threshold_ = kMaxSequenceNumber;
 
   LogsWithPrepTracker logs_with_prep_tracker_;
 

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -2861,6 +2861,17 @@ void DBImpl::InstallSuperVersionAndScheduleWork(
   }
   cfd->InstallSuperVersion(sv_context, &mutex_, mutable_cf_options);
 
+  // There may be a small data race here. The snapshot tricking bottommost
+  // compaction may already be released here. But assuming there will always be
+  // newer snapshot created and released frequently, the compaction will be
+  // triggered soon anyway.
+  bottommost_files_mark_threshold_ = kMaxSequenceNumber;
+  for (auto* my_cfd : *versions_->GetColumnFamilySet()) {
+    bottommost_files_mark_threshold_ = std::min(
+        bottommost_files_mark_threshold_,
+        my_cfd->current()->storage_info()->bottommost_files_mark_threshold());
+  }
+
   // Whenever we install new SuperVersion, we might need to issue new flushes or
   // compactions.
   SchedulePendingCompaction(cfd);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -402,6 +402,10 @@ class VersionStorageInfo {
 
   bool force_consistency_checks() const { return force_consistency_checks_; }
 
+  SequenceNumber bottommost_files_mark_threshold() const {
+    return bottommost_files_mark_threshold_;
+  }
+
   // Returns whether any key in [`smallest_key`, `largest_key`] could appear in
   // an older L0 file than `last_l0_idx` or in a greater level than `last_level`
   //

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -288,6 +288,15 @@ class autovector {
     }
   }
 
+  bool contains(const T& item) {
+    for (const T& t : *this) {
+      if (t == item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   void clear() {
     num_stack_items_ = 0;
     vect_.clear();

--- a/util/autovector.h
+++ b/util/autovector.h
@@ -288,15 +288,6 @@ class autovector {
     }
   }
 
-  bool contains(const T& item) {
-    for (const T& t : *this) {
-      if (t == item) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   void clear() {
     num_stack_items_ = 0;
     vect_.clear();


### PR DESCRIPTION
Summary: With https://github.com/facebook/rocksdb/pull/3009 we go through every CF
to check whether a bottommost compaction is needed to be triggered. This is done
within DB mutex. What we do within DB mutex may heavily influece the write throughput
we can achieve, so we always want to minimize work there.

Here we try to avoid this for-loop by first check a global threshold. In most of
the time, the CF loop can be avoided.

Test Plan: Run all existing tests.