### PR TITLE
Fix SstFileReader not able to open ingested file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 * Fix JEMALLOC_CXX_THROW macro missing from older Jemalloc versions, causing build failures on some platforms.
+* Fix SstFileReader not able to open file ingested with write_glbal_seqno=true.
 
 
 ## Unreleased

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2883,7 +2883,7 @@ Status BlockBasedTable::VerifyChecksumInMetaBlocks(
         false /* decompress */, false /*maybe_compressed*/,
         UncompressionDict::GetEmptyDict(), rep_->persistent_cache_options);
     s = block_fetcher.ReadBlockContents();
-    if (!s.ok() && index_iter->key() == kPropertiesBlock) {
+    if (s.IsCorruption() && index_iter->key() == kPropertiesBlock) {
       TableProperties* table_properties;
       s = TryReadPropertiesWithGlobalSeqno(rep_, nullptr /* prefetch_buffer */,
                                            index_iter->value(),

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -949,6 +949,41 @@ Status VerifyChecksum(const ChecksumType type, const char* buf, size_t len,
   return s;
 }
 
+Status BlockBasedTable::TryReadPropertiesWithGlobalSeqno(
+    Rep* rep, FilePrefetchBuffer* prefetch_buffer, const Slice& handle_value,
+    TableProperties** table_properties) {
+  assert(table_properties != nullptr);
+  // If this is an external SST file ingested with write_global_seqno set to
+  // true, then we expect the checksum mismatch because checksum was written
+  // by SstFileWriter, but its global seqno in the properties block may have
+  // been changed during ingestion. In this case, we read the properties
+  // block, copy it to a memory buffer, change the global seqno to its
+  // original value, i.e. 0, and verify the checksum again.
+  BlockHandle props_block_handle;
+  CacheAllocationPtr tmp_buf;
+  Status s = ReadProperties(handle_value, rep->file.get(), prefetch_buffer,
+                            rep->footer, rep->ioptions, table_properties,
+                            false /* verify_checksum */, &props_block_handle,
+                            &tmp_buf, false /* compression_type_missing */,
+                            nullptr /* memory_allocator */);
+  if (s.ok() && tmp_buf) {
+    const auto seqno_pos_iter =
+        (*table_properties)
+            ->properties_offsets.find(
+                ExternalSstFilePropertyNames::kGlobalSeqno);
+    size_t block_size = props_block_handle.size();
+    if (seqno_pos_iter != (*table_properties)->properties_offsets.end()) {
+      uint64_t global_seqno_offset = seqno_pos_iter->second;
+      EncodeFixed64(
+          tmp_buf.get() + global_seqno_offset - props_block_handle.offset(), 0);
+    }
+    uint32_t value = DecodeFixed32(tmp_buf.get() + block_size + 1);
+    s = rocksdb::VerifyChecksum(rep->footer.checksum(), tmp_buf.get(),
+                                block_size + 1, value);
+  }
+  return s;
+}
+
 Status BlockBasedTable::ReadPropertiesBlock(
     Rep* rep, FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
     const SequenceNumber largest_seqno) {
@@ -972,33 +1007,8 @@ Status BlockBasedTable::ReadPropertiesBlock(
     }
 
     if (s.IsCorruption()) {
-      // If this is an external SST file ingested with write_global_seqno set to
-      // true, then we expect the checksum mismatch because checksum was written
-      // by SstFileWriter, but its global seqno in the properties block may have
-      // been changed during ingestion. In this case, we read the properties
-      // block, copy it to a memory buffer, change the global seqno to its
-      // original value, i.e. 0, and verify the checksum again.
-      BlockHandle props_block_handle;
-      CacheAllocationPtr tmp_buf;
-      s = ReadProperties(meta_iter->value(), rep->file.get(), prefetch_buffer,
-                         rep->footer, rep->ioptions, &table_properties,
-                         false /* verify_checksum */, &props_block_handle,
-                         &tmp_buf, false /* compression_type_missing */,
-                         nullptr /* memory_allocator */);
-      if (s.ok() && tmp_buf) {
-        const auto seqno_pos_iter = table_properties->properties_offsets.find(
-            ExternalSstFilePropertyNames::kGlobalSeqno);
-        size_t block_size = props_block_handle.size();
-        if (seqno_pos_iter != table_properties->properties_offsets.end()) {
-          uint64_t global_seqno_offset = seqno_pos_iter->second;
-          EncodeFixed64(
-              tmp_buf.get() + global_seqno_offset - props_block_handle.offset(),
-              0);
-        }
-        uint32_t value = DecodeFixed32(tmp_buf.get() + block_size + 1);
-        s = rocksdb::VerifyChecksum(rep->footer.checksum(), tmp_buf.get(),
-                                    block_size + 1, value);
-      }
+      s = TryReadPropertiesWithGlobalSeqno(
+          rep, prefetch_buffer, meta_iter->value(), &table_properties);
     }
     std::unique_ptr<TableProperties> props_guard;
     if (table_properties != nullptr) {
@@ -2808,8 +2818,7 @@ Status BlockBasedTable::VerifyChecksum() {
   std::unique_ptr<InternalIterator> meta_iter;
   s = ReadMetaBlock(rep_, nullptr /* prefetch buffer */, &meta, &meta_iter);
   if (s.ok()) {
-    s = VerifyChecksumInBlocks(meta_iter.get());
-    printf("verify meta %s\n", s.ToString().c_str());
+    s = VerifyChecksumInMetaBlocks(meta_iter.get());
     if (!s.ok()) {
       return s;
     }
@@ -2856,7 +2865,7 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
   return s;
 }
 
-Status BlockBasedTable::VerifyChecksumInBlocks(
+Status BlockBasedTable::VerifyChecksumInMetaBlocks(
     InternalIteratorBase<Slice>* index_iter) {
   Status s;
   for (index_iter->SeekToFirst(); index_iter->Valid(); index_iter->Next()) {
@@ -2874,6 +2883,13 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
         false /* decompress */, false /*maybe_compressed*/,
         UncompressionDict::GetEmptyDict(), rep_->persistent_cache_options);
     s = block_fetcher.ReadBlockContents();
+    if (!s.ok() && index_iter->key() == kPropertiesBlock) {
+      TableProperties* table_properties;
+      s = TryReadPropertiesWithGlobalSeqno(rep_, nullptr /* prefetch_buffer */,
+                                           index_iter->value(),
+                                           &table_properties);
+      delete table_properties;
+    }
     if (!s.ok()) {
       break;
     }

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -364,6 +364,9 @@ class BlockBasedTable : public TableReader {
   static Status ReadMetaBlock(Rep* rep, FilePrefetchBuffer* prefetch_buffer,
                               std::unique_ptr<Block>* meta_block,
                               std::unique_ptr<InternalIterator>* iter);
+  static Status TryReadPropertiesWithGlobalSeqno(
+      Rep* rep, FilePrefetchBuffer* prefetch_buffer, const Slice& handle_value,
+      TableProperties** table_properties);
   static Status ReadPropertiesBlock(Rep* rep,
                                     FilePrefetchBuffer* prefetch_buffer,
                                     InternalIterator* meta_iter,
@@ -382,7 +385,7 @@ class BlockBasedTable : public TableReader {
       const BlockBasedTableOptions& table_options, const int level,
       const bool prefetch_index_and_filter_in_cache);
 
-  Status VerifyChecksumInBlocks(InternalIteratorBase<Slice>* index_iter);
+  Status VerifyChecksumInMetaBlocks(InternalIteratorBase<Slice>* index_iter);
   Status VerifyChecksumInBlocks(InternalIteratorBase<BlockHandle>* index_iter);
 
   // Create the filter from the filter block.

--- a/table/sst_file_writer_collectors.h
+++ b/table/sst_file_writer_collectors.h
@@ -5,6 +5,8 @@
 
 #pragma once
 #include <string>
+#include "db/dbformat.h"
+#include "db/table_properties_collector.h"
 #include "rocksdb/types.h"
 #include "util/string_util.h"
 

--- a/table/sst_file_writer_collectors.h
+++ b/table/sst_file_writer_collectors.h
@@ -5,8 +5,6 @@
 
 #pragma once
 #include <string>
-#include "db/dbformat.h"
-#include "db/table_properties_collector.h"
 #include "rocksdb/types.h"
 #include "util/string_util.h"
 

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -63,7 +63,7 @@ struct TableReaderOptions {
   bool immortal;
   // what level this table/file is on, -1 for "not set, don't know"
   int level;
-  // largest seqno in the table.
+  // largest seqno in the table
   SequenceNumber largest_seqno;
 };
 

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -63,7 +63,7 @@ struct TableReaderOptions {
   bool immortal;
   // what level this table/file is on, -1 for "not set, don't know"
   int level;
-  // largest seqno in the table
+  // largest seqno in the table.
   SequenceNumber largest_seqno;
 };
 


### PR DESCRIPTION
Summary:
Since `SstFileReader` don't know largest seqno of a file, it will fail this check when it open a file with global seqno: https://github.com/facebook/rocksdb/blob/ca89ac2ba997dfa0e135bd75d4ccf6f5774a7eff/table/block_based_table_reader.cc#L730
Changes:
* Pass largest_seqno=kMaxSequenceNumber from `SstFileReader` and allow it to bypass the above check.
* `BlockBasedTable::VerifyChecksum` also double check if checksum will match when excluding global seqno (this is to make the new test in sst_table_reader_test pass).

Test Plan:
Added a new test.