### PR TITLE
Refresh snapshot list during long compactions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Introduce Periodic Compaction for Level style compaction. Files are re-compacted periodically and put in the same level.
 * Block-based table index now contains exact highest key in the file, rather than an upper bound. This may improve Get() and iterator Seek() performance in some situations, especially when direct IO is enabled and block cache is disabled. A setting BlockBasedTableOptions::index_shortening is introduced to control this behavior. Set it to kShortenSeparatorsAndSuccessor to get the old behavior.
 * When reading from option file/string/map, customized envs can be filled according to object registry.
+* Add an option `snap_refresh_nanos` (default to 0.5s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.
 
 ### Public API Change
 * Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.

--- a/db/c.cc
+++ b/db/c.cc
@@ -2214,8 +2214,8 @@ void rocksdb_options_set_max_bytes_for_level_base(
   opt->rep.max_bytes_for_level_base = n;
 }
 
-void rocksdb_options_set_snap_refresh_nanos(
-    rocksdb_options_t* opt, uint64_t n) {
+void rocksdb_options_set_snap_refresh_nanos(rocksdb_options_t* opt,
+                                            uint64_t n) {
   opt->rep.snap_refresh_nanos = n;
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -2214,6 +2214,11 @@ void rocksdb_options_set_max_bytes_for_level_base(
   opt->rep.max_bytes_for_level_base = n;
 }
 
+void rocksdb_options_set_snap_refresh_nanos(
+    rocksdb_options_t* opt, uint64_t n) {
+  opt->rep.snap_refresh_nanos = n;
+}
+
 void rocksdb_options_set_level_compaction_dynamic_level_bytes(
     rocksdb_options_t* opt, unsigned char v) {
   opt->rep.level_compaction_dynamic_level_bytes = v;

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -39,8 +39,7 @@ CompactionIterator::CompactionIterator(
     const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
     const SequenceNumber preserve_deletes_seqnum,
-    SnapshotListFetchCallback* snap_list_callback
-    )
+    SnapshotListFetchCallback* snap_list_callback)
     : CompactionIterator(
           input, cmp, merge_helper, last_sequence, snapshots,
           earliest_write_conflict_snapshot, snapshot_checker, env,
@@ -61,8 +60,7 @@ CompactionIterator::CompactionIterator(
     const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
     const SequenceNumber preserve_deletes_seqnum,
-    SnapshotListFetchCallback* snap_list_callback
-    )
+    SnapshotListFetchCallback* snap_list_callback)
     : input_(input),
       cmp_(cmp),
       merge_helper_(merge_helper),
@@ -82,8 +80,7 @@ CompactionIterator::CompactionIterator(
       merge_out_iter_(merge_helper_),
       current_key_committed_(false),
       snap_list_callback_(snap_list_callback),
-      timer_(env_, true)
-  {
+      timer_(env_, true) {
   assert(compaction_filter_ == nullptr || compaction_ != nullptr);
   assert(snapshots_ != nullptr);
   bottommost_level_ =
@@ -289,7 +286,7 @@ void CompactionIterator::NextFromInput() {
         // inc next refresh period exponentially (by x4)
         auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);
         const uint64_t elapsed = timer_.ElapsedNanos();
-        if (elapsed > next_refresh_threshold) {  
+        if (elapsed > next_refresh_threshold) {
           snap_list_callback_->Refresh(snapshots_, latest_snapshot_);
           snap_refresh_cnt_++;
           ProcessSnapshotList();

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -282,16 +282,11 @@ void CompactionIterator::NextFromInput() {
       num_keys_++;
       // Use num_keys_ to reduce the overhead of reading current time
       if (snap_list_callback_ && snapshots_->size() &&
-          snap_list_callback_->skip_key(num_keys_)) {
-        const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
-        // inc next refresh period exponentially (by x4)
-        auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);
-        const uint64_t elapsed = timer_.ElapsedNanos();
-        if (elapsed > next_refresh_threshold) {
-          snap_list_callback_->Refresh(snapshots_, latest_snapshot_);
-          snap_refresh_cnt_++;
-          ProcessSnapshotList();
-        }
+          snap_list_callback_->TimeToRefresh(timer_, num_keys_,
+                                             snap_refresh_cnt_)) {
+        snap_list_callback_->Refresh(snapshots_, latest_snapshot_);
+        snap_refresh_cnt_++;
+        ProcessSnapshotList();
       }
       // First occurrence of this user key
       // Copy key for output

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -279,10 +279,10 @@ void CompactionIterator::NextFromInput() {
     // compaction filter). ikey_.user_key is pointing to the copy.
     if (!has_current_user_key_ ||
         !cmp_->Equal(ikey_.user_key, current_user_key_)) {
-      key_cnt_++;
-      // Use key_cnt_ to reduce the overhead of reading current time
+      num_keys_++;
+      // Use num_keys_ to reduce the overhead of reading current time
       if (snap_list_callback_ && snapshots_->size() &&
-          key_cnt_ % snap_list_callback_->key_skip() == 0) {
+          snap_list_callback_->skip_key(num_keys_)) {
         const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
         // inc next refresh period exponentially (by x4)
         auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -281,7 +281,7 @@ void CompactionIterator::NextFromInput() {
         !cmp_->Equal(ikey_.user_key, current_user_key_)) {
       key_cnt_++;
       // Use key_cnt_ to reduce the overhead of reading current time
-      if (snap_list_callback_ && snapshots_->size() && key_cnt_ % 1024 == 0) {
+      if (snap_list_callback_ && snapshots_->size() && key_cnt_ % snap_list_callback_->key_skip() == 0) {
         const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
         // inc next refresh period exponentially (by x4)
         auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -79,8 +79,7 @@ CompactionIterator::CompactionIterator(
       current_user_key_snapshot_(0),
       merge_out_iter_(merge_helper_),
       current_key_committed_(false),
-      snap_list_callback_(snap_list_callback),
-      timer_(env_, true) {
+      snap_list_callback_(snap_list_callback) {
   assert(compaction_filter_ == nullptr || compaction_ != nullptr);
   assert(snapshots_ != nullptr);
   bottommost_level_ =
@@ -282,8 +281,7 @@ void CompactionIterator::NextFromInput() {
       num_keys_++;
       // Use num_keys_ to reduce the overhead of reading current time
       if (snap_list_callback_ && snapshots_->size() &&
-          snap_list_callback_->TimeToRefresh(timer_, num_keys_,
-                                             snap_refresh_cnt_)) {
+          snap_list_callback_->TimeToRefresh(num_keys_, snap_refresh_cnt_)) {
         snap_list_callback_->Refresh(snapshots_, latest_snapshot_);
         snap_refresh_cnt_++;
         ProcessSnapshotList();

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -38,14 +38,17 @@ CompactionIterator::CompactionIterator(
     CompactionRangeDelAggregator* range_del_agg, const Compaction* compaction,
     const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
-    const SequenceNumber preserve_deletes_seqnum)
+    const SequenceNumber preserve_deletes_seqnum,
+    SnapshotListFetchCallback* snap_list_callback
+    )
     : CompactionIterator(
           input, cmp, merge_helper, last_sequence, snapshots,
           earliest_write_conflict_snapshot, snapshot_checker, env,
           report_detailed_time, expect_valid_internal_key, range_del_agg,
           std::unique_ptr<CompactionProxy>(
               compaction ? new CompactionProxy(compaction) : nullptr),
-          compaction_filter, shutting_down, preserve_deletes_seqnum) {}
+          compaction_filter, shutting_down, preserve_deletes_seqnum,
+          snap_list_callback) {}
 
 CompactionIterator::CompactionIterator(
     InternalIterator* input, const Comparator* cmp, MergeHelper* merge_helper,
@@ -57,7 +60,9 @@ CompactionIterator::CompactionIterator(
     std::unique_ptr<CompactionProxy> compaction,
     const CompactionFilter* compaction_filter,
     const std::atomic<bool>* shutting_down,
-    const SequenceNumber preserve_deletes_seqnum)
+    const SequenceNumber preserve_deletes_seqnum,
+    SnapshotListFetchCallback* snap_list_callback
+    )
     : input_(input),
       cmp_(cmp),
       merge_helper_(merge_helper),
@@ -75,7 +80,10 @@ CompactionIterator::CompactionIterator(
       current_user_key_sequence_(0),
       current_user_key_snapshot_(0),
       merge_out_iter_(merge_helper_),
-      current_key_committed_(false) {
+      current_key_committed_(false),
+      snap_list_callback_(snap_list_callback),
+      timer_(env_, true)
+  {
   assert(compaction_filter_ == nullptr || compaction_ != nullptr);
   assert(snapshots_ != nullptr);
   bottommost_level_ =
@@ -83,24 +91,7 @@ CompactionIterator::CompactionIterator(
   if (compaction_ != nullptr) {
     level_ptrs_ = std::vector<size_t>(compaction_->number_levels(), 0);
   }
-  if (snapshots_->size() == 0) {
-    // optimize for fast path if there are no snapshots
-    visible_at_tip_ = true;
-    earliest_snapshot_iter_ = snapshots_->end();
-    earliest_snapshot_ = kMaxSequenceNumber;
-    latest_snapshot_ = 0;
-  } else {
-    visible_at_tip_ = false;
-    earliest_snapshot_iter_ = snapshots_->begin();
-    earliest_snapshot_ = snapshots_->at(0);
-    latest_snapshot_ = snapshots_->back();
-  }
-#ifndef NDEBUG
-  // findEarliestVisibleSnapshot assumes this ordering.
-  for (size_t i = 1; i < snapshots_->size(); ++i) {
-    assert(snapshots_->at(i - 1) < snapshots_->at(i));
-  }
-#endif
+  ProcessSnapshotList();
   input_->SetPinnedItersMgr(&pinned_iters_mgr_);
   TEST_SYNC_POINT_CALLBACK("CompactionIterator:AfterInit", compaction_.get());
 }
@@ -222,6 +213,28 @@ void CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
   }
 }
 
+void CompactionIterator::ProcessSnapshotList() {
+#ifndef NDEBUG
+  // findEarliestVisibleSnapshot assumes this ordering.
+  for (size_t i = 1; i < snapshots_->size(); ++i) {
+    assert(snapshots_->at(i - 1) < snapshots_->at(i));
+  }
+#endif
+  if (snapshots_->size() == 0) {
+    // optimize for fast path if there are no snapshots
+    visible_at_tip_ = true;
+    earliest_snapshot_iter_ = snapshots_->end();
+    earliest_snapshot_ = kMaxSequenceNumber;
+    latest_snapshot_ = 0;
+  } else {
+    visible_at_tip_ = false;
+    earliest_snapshot_iter_ = snapshots_->begin();
+    earliest_snapshot_ = snapshots_->at(0);
+    latest_snapshot_ = snapshots_->back();
+  }
+  released_snapshots_.clear();
+}
+
 void CompactionIterator::NextFromInput() {
   at_next_ = false;
   valid_ = false;
@@ -269,6 +282,19 @@ void CompactionIterator::NextFromInput() {
     // compaction filter). ikey_.user_key is pointing to the copy.
     if (!has_current_user_key_ ||
         !cmp_->Equal(ikey_.user_key, current_user_key_)) {
+      key_cnt_++;
+      // Use key_cnt_ to reduce the overhead of reading current time
+      if (snap_list_callback_ && key_cnt_ % 1024 == 0 && snapshots_->size()) {
+        const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
+        // inc next refresh period exponentially (by x4)
+        auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);
+        const uint64_t elapsed = timer_.ElapsedNanos();
+        if (elapsed > next_refresh_threshold) {  
+          snap_list_callback_->Refresh(snapshots_, latest_snapshot_);
+          snap_refresh_cnt_++;
+          ProcessSnapshotList();
+        }
+      }
       // First occurrence of this user key
       // Copy key for output
       key_ = current_key_.SetInternalKey(key_, &ikey_);

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -281,7 +281,8 @@ void CompactionIterator::NextFromInput() {
         !cmp_->Equal(ikey_.user_key, current_user_key_)) {
       key_cnt_++;
       // Use key_cnt_ to reduce the overhead of reading current time
-      if (snap_list_callback_ && snapshots_->size() && key_cnt_ % snap_list_callback_->key_skip() == 0) {
+      if (snap_list_callback_ && snapshots_->size() &&
+          key_cnt_ % snap_list_callback_->key_skip() == 0) {
         const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
         // inc next refresh period exponentially (by x4)
         auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -284,7 +284,7 @@ void CompactionIterator::NextFromInput() {
         !cmp_->Equal(ikey_.user_key, current_user_key_)) {
       key_cnt_++;
       // Use key_cnt_ to reduce the overhead of reading current time
-      if (snap_list_callback_ && key_cnt_ % 1024 == 0 && snapshots_->size()) {
+      if (snap_list_callback_ && snapshots_->size() && key_cnt_ % 1024 == 0) {
         const uint64_t nanos = snap_list_callback_->snap_refresh_nanos();
         // inc next refresh period exponentially (by x4)
         auto next_refresh_threshold = nanos << (snap_refresh_cnt_ * 2);

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -23,7 +23,8 @@ namespace rocksdb {
 
 class SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallback(uint64_t snap_refresh_nanos, size_t _key_skip = 1024)
+  SnapshotListFetchCallback(uint64_t snap_refresh_nanos,
+                            size_t _key_skip = 1024)
       : snap_refresh_nanos_(snap_refresh_nanos), key_skip_(_key_skip) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
                        SequenceNumber max) = 0;

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -31,6 +31,7 @@ class SnapshotListFetchCallback {
   static constexpr SnapshotListFetchCallback* kDisabled = nullptr;
 
   virtual ~SnapshotListFetchCallback() {}
+
  private:
   const uint64_t snap_refresh_nanos_;
 };
@@ -84,7 +85,7 @@ class CompactionIterator {
                      const CompactionFilter* compaction_filter = nullptr,
                      const std::atomic<bool>* shutting_down = nullptr,
                      const SequenceNumber preserve_deletes_seqnum = 0,
-    SnapshotListFetchCallback* snap_list_callback = nullptr);
+                     SnapshotListFetchCallback* snap_list_callback = nullptr);
 
   // Constructor with custom CompactionProxy, used for tests.
   CompactionIterator(InternalIterator* input, const Comparator* cmp,
@@ -98,7 +99,7 @@ class CompactionIterator {
                      const CompactionFilter* compaction_filter = nullptr,
                      const std::atomic<bool>* shutting_down = nullptr,
                      const SequenceNumber preserve_deletes_seqnum = 0,
-    SnapshotListFetchCallback* snap_list_callback = nullptr);
+                     SnapshotListFetchCallback* snap_list_callback = nullptr);
 
   ~CompactionIterator();
 

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -23,9 +23,9 @@ namespace rocksdb {
 
 class SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallback(uint64_t snap_refresh_nanos,
+  SnapshotListFetchCallback(uint64_t _snap_refresh_nanos,
                             size_t _key_skip = 1024)
-      : snap_refresh_nanos_(snap_refresh_nanos), key_skip_(_key_skip) {}
+      : snap_refresh_nanos_(_snap_refresh_nanos), key_skip_(_key_skip) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
                        SequenceNumber max) = 0;
   inline uint64_t snap_refresh_nanos() { return snap_refresh_nanos_; }

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -28,6 +28,7 @@ class SnapshotListFetchCallback {
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
                        SequenceNumber max) = 0;
   uint64_t snap_refresh_nanos() { return snap_refresh_nanos_; }
+  static constexpr SnapshotListFetchCallback* kDisabled = nullptr;
 
   virtual ~SnapshotListFetchCallback() {}
  private:

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -23,8 +23,6 @@ namespace rocksdb {
 
 class SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallback()
-      : snap_refresh_nanos_(500 * 1000 * 1000) {} // 0.5s
   SnapshotListFetchCallback(uint64_t snap_refresh_nanos)
       : snap_refresh_nanos_(snap_refresh_nanos) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,

--- a/db/compaction_iterator.h
+++ b/db/compaction_iterator.h
@@ -23,17 +23,19 @@ namespace rocksdb {
 
 class SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallback(uint64_t snap_refresh_nanos)
-      : snap_refresh_nanos_(snap_refresh_nanos) {}
+  SnapshotListFetchCallback(uint64_t snap_refresh_nanos, size_t _key_skip = 1024)
+      : snap_refresh_nanos_(snap_refresh_nanos), key_skip_(_key_skip) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
                        SequenceNumber max) = 0;
-  uint64_t snap_refresh_nanos() { return snap_refresh_nanos_; }
+  inline uint64_t snap_refresh_nanos() { return snap_refresh_nanos_; }
+  inline uint64_t key_skip() { return key_skip_; }
   static constexpr SnapshotListFetchCallback* kDisabled = nullptr;
 
   virtual ~SnapshotListFetchCallback() {}
 
  private:
   const uint64_t snap_refresh_nanos_;
+  const uint64_t key_skip_;
 };
 
 class CompactionIterator {

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -315,7 +315,9 @@ CompactionJob::CompactionJob(
     const SnapshotChecker* snapshot_checker, std::shared_ptr<Cache> table_cache,
     EventLogger* event_logger, bool paranoid_file_checks, bool measure_io_stats,
     const std::string& dbname, CompactionJobStats* compaction_job_stats,
-    Env::Priority thread_pri)
+    Env::Priority thread_pri,
+                SnapshotListFetchCallback* snap_list_callback
+    )
     : job_id_(job_id),
       compact_(new CompactionState(compaction)),
       compaction_job_stats_(compaction_job_stats),
@@ -336,6 +338,7 @@ CompactionJob::CompactionJob(
       db_mutex_(db_mutex),
       db_error_handler_(db_error_handler),
       existing_snapshots_(std::move(existing_snapshots)),
+      snap_list_callback_(snap_list_callback),
       earliest_write_conflict_snapshot_(earliest_write_conflict_snapshot),
       snapshot_checker_(snapshot_checker),
       table_cache_(std::move(table_cache)),
@@ -892,7 +895,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
       &existing_snapshots_, earliest_write_conflict_snapshot_,
       snapshot_checker_, env_, ShouldReportDetailedTime(env_, stats_), false,
       &range_del_agg, sub_compact->compaction, compaction_filter,
-      shutting_down_, preserve_deletes_seqnum_));
+      shutting_down_, preserve_deletes_seqnum_, snap_list_callback_));
   auto c_iter = sub_compact->c_iter.get();
   c_iter->SeekToFirst();
   if (c_iter->Valid() && sub_compact->compaction->output_level() != 0) {

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -315,9 +315,7 @@ CompactionJob::CompactionJob(
     const SnapshotChecker* snapshot_checker, std::shared_ptr<Cache> table_cache,
     EventLogger* event_logger, bool paranoid_file_checks, bool measure_io_stats,
     const std::string& dbname, CompactionJobStats* compaction_job_stats,
-    Env::Priority thread_pri,
-                SnapshotListFetchCallback* snap_list_callback
-    )
+    Env::Priority thread_pri, SnapshotListFetchCallback* snap_list_callback)
     : job_id_(job_id),
       compact_(new CompactionState(compaction)),
       compaction_job_stats_(compaction_job_stats),

--- a/db/compaction_job.h
+++ b/db/compaction_job.h
@@ -72,7 +72,9 @@ class CompactionJob {
                 bool paranoid_file_checks, bool measure_io_stats,
                 const std::string& dbname,
                 CompactionJobStats* compaction_job_stats,
-                Env::Priority thread_pri);
+                Env::Priority thread_pri,
+                SnapshotListFetchCallback* snap_list_callback = nullptr
+                );
 
   ~CompactionJob();
 
@@ -152,6 +154,7 @@ class CompactionJob {
   // entirely within s1 and s2, then the earlier version of k1 can be safely
   // deleted because that version is not visible in any snapshot.
   std::vector<SequenceNumber> existing_snapshots_;
+  SnapshotListFetchCallback* snap_list_callback_;
 
   // This is the earliest snapshot that could be used for write-conflict
   // checking by a transaction.  For any user-key newer than this snapshot, we

--- a/db/compaction_job.h
+++ b/db/compaction_job.h
@@ -73,7 +73,7 @@ class CompactionJob {
                 const std::string& dbname,
                 CompactionJobStats* compaction_job_stats,
                 Env::Priority thread_pri,
-                SnapshotListFetchCallback* snap_list_callback = nullptr
+                SnapshotListFetchCallback* snap_list_callback
                 );
 
   ~CompactionJob();

--- a/db/compaction_job.h
+++ b/db/compaction_job.h
@@ -57,24 +57,20 @@ class VersionSet;
 
 class CompactionJob {
  public:
-  CompactionJob(int job_id, Compaction* compaction,
-                const ImmutableDBOptions& db_options,
-                const EnvOptions env_options, VersionSet* versions,
-                const std::atomic<bool>* shutting_down,
-                const SequenceNumber preserve_deletes_seqnum,
-                LogBuffer* log_buffer, Directory* db_directory,
-                Directory* output_directory, Statistics* stats,
-                InstrumentedMutex* db_mutex, ErrorHandler* db_error_handler,
-                std::vector<SequenceNumber> existing_snapshots,
-                SequenceNumber earliest_write_conflict_snapshot,
-                const SnapshotChecker* snapshot_checker,
-                std::shared_ptr<Cache> table_cache, EventLogger* event_logger,
-                bool paranoid_file_checks, bool measure_io_stats,
-                const std::string& dbname,
-                CompactionJobStats* compaction_job_stats,
-                Env::Priority thread_pri,
-                SnapshotListFetchCallback* snap_list_callback
-                );
+  CompactionJob(
+      int job_id, Compaction* compaction, const ImmutableDBOptions& db_options,
+      const EnvOptions env_options, VersionSet* versions,
+      const std::atomic<bool>* shutting_down,
+      const SequenceNumber preserve_deletes_seqnum, LogBuffer* log_buffer,
+      Directory* db_directory, Directory* output_directory, Statistics* stats,
+      InstrumentedMutex* db_mutex, ErrorHandler* db_error_handler,
+      std::vector<SequenceNumber> existing_snapshots,
+      SequenceNumber earliest_write_conflict_snapshot,
+      const SnapshotChecker* snapshot_checker,
+      std::shared_ptr<Cache> table_cache, EventLogger* event_logger,
+      bool paranoid_file_checks, bool measure_io_stats,
+      const std::string& dbname, CompactionJobStats* compaction_job_stats,
+      Env::Priority thread_pri, SnapshotListFetchCallback* snap_list_callback);
 
   ~CompactionJob();
 

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -5,7 +5,12 @@
 
 #ifndef ROCKSDB_LITE
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <algorithm>
+#include <inttypes.h>
 #include <map>
 #include <string>
 #include <tuple>
@@ -194,6 +199,13 @@ class CompactionJobTest : public testing::Test {
   }
 
   void NewDB() {
+    DestroyDB(dbname_, Options());
+    EXPECT_OK(env_->CreateDirIfMissing(dbname_));
+    versions_.reset(new VersionSet(dbname_, &db_options_, env_options_,
+                                   table_cache_.get(), &write_buffer_manager_,
+                                   &write_controller_));
+    compaction_job_stats_.Reset();
+
     VersionEdit new_db;
     new_db.SetLogNumber(0);
     new_db.SetNextFile(2);
@@ -230,7 +242,7 @@ class CompactionJobTest : public testing::Test {
       const std::vector<std::vector<FileMetaData*>>& input_files,
       const stl_wrappers::KVMap& expected_results,
       const std::vector<SequenceNumber>& snapshots = {},
-      SequenceNumber earliest_write_conflict_snapshot = kMaxSequenceNumber) {
+      SequenceNumber earliest_write_conflict_snapshot = kMaxSequenceNumber, int output_level = 1, bool verify = true, SnapshotListFetchCallback* snapshot_fetcher = SnapshotListFetchCallback::kDisabled) {
     auto cfd = versions_->GetColumnFamilySet()->GetDefault();
 
     size_t num_input_files = 0;
@@ -247,7 +259,7 @@ class CompactionJobTest : public testing::Test {
 
     Compaction compaction(cfd->current()->storage_info(), *cfd->ioptions(),
                           *cfd->GetLatestMutableCFOptions(),
-                          compaction_input_files, 1, 1024 * 1024,
+                          compaction_input_files, output_level, 1024 * 1024,
                           10 * 1024 * 1024, 0, kNoCompression,
                           cfd->ioptions()->compression_opts, 0, {}, true);
     compaction.SetInputVersion(cfd->current());
@@ -263,7 +275,7 @@ class CompactionJobTest : public testing::Test {
         nullptr, nullptr, &mutex_, &error_handler_, snapshots,
         earliest_write_conflict_snapshot, snapshot_checker, table_cache_,
         &event_logger, false, false, dbname_, &compaction_job_stats_,
-        Env::Priority::USER, SnapshotListFetchCallback::kDisabled);
+        Env::Priority::USER, snapshot_fetcher);
     VerifyInitializationOfCompactionJobStats(compaction_job_stats_);
 
     compaction_job.Prepare();
@@ -275,6 +287,7 @@ class CompactionJobTest : public testing::Test {
     ASSERT_OK(compaction_job.Install(*cfd->GetLatestMutableCFOptions()));
     mutex_.Unlock();
 
+    if (verify) {
     if (expected_results.size() == 0) {
       ASSERT_GE(compaction_job_stats_.elapsed_micros, 0U);
       ASSERT_EQ(compaction_job_stats_.num_input_files, num_input_files);
@@ -284,6 +297,7 @@ class CompactionJobTest : public testing::Test {
       ASSERT_EQ(compaction_job_stats_.num_input_files, num_input_files);
       ASSERT_EQ(compaction_job_stats_.num_output_files, 1U);
       mock_table_factory_->AssertLatestFile(expected_results);
+    }
     }
   }
 
@@ -936,6 +950,64 @@ TEST_F(CompactionJobTest, CorruptionAfterDeletion) {
   SetLastSequence(6U);
   auto files = cfd_->current()->storage_info()->LevelFiles(0);
   RunCompaction({files}, expected_results);
+}
+
+// Test the snapshot fetcher in compaction
+TEST_F(CompactionJobTest, SnapshotRefresh) {
+  uint64_t time_seed = env_->NowMicros();
+  printf("time_seed is %" PRIu64 "\n", time_seed);  // would help to reproduce
+  Random64 rand(time_seed);
+  std::vector<SequenceNumber> db_snapshots = {3U, 5U};
+  class SnapshotListFetchCallbackTest : public SnapshotListFetchCallback {
+   public:
+    SnapshotListFetchCallbackTest(Random64& rand,
+                                  std::vector<SequenceNumber>* snapshots)
+        : SnapshotListFetchCallback(0 /*no time delay*/, 1 /*fetch after each key*/), rand_(rand), snapshots_(snapshots) {}
+    virtual void Refresh(std::vector<SequenceNumber>* snapshots,
+                         SequenceNumber) override {
+      assert(snapshots->size());
+      assert(snapshots_->size());
+      assert(snapshots_->size() == snapshots->size());
+      uint64_t release_index = rand_.Uniform(snapshots_->size());
+      snapshots_->erase(snapshots_->begin() + release_index);
+      *snapshots = *snapshots_;
+    }
+
+   private:
+    Random64 rand_;
+    std::vector<SequenceNumber>* snapshots_;
+  } snapshot_fetcher(rand, &db_snapshots);
+
+  auto file1 =
+      mock::MakeMockFile({{test::KeyStr("A", 6U, kTypeValue), "val3"},
+                          {test::KeyStr("a", 5U, kTypeDeletion), ""},
+                          {test::KeyStr("a", 4U, kTypeValue, true), "val"}});
+  auto file2 =
+      mock::MakeMockFile({{test::KeyStr("b", 3U, kTypeSingleDeletion), ""},
+                          {test::KeyStr("b", 2U, kTypeValue, true), "val"},
+                          {test::KeyStr("c", 1U, kTypeValue), "val2"}});
+
+  const bool kVerify = true;
+  const int output_level_0 = 0;
+  NewDB();
+  AddMockFile(file1);
+  AddMockFile(file2);
+  SetLastSequence(6U);
+  auto files = cfd_->current()->storage_info()->LevelFiles(0);
+  RunCompaction({files}, file1, db_snapshots, kMaxSequenceNumber, output_level_0, !kVerify, &snapshot_fetcher);
+  // Now db_snapshots are changed. Run the compaction again without snapshot fetcher but with the updated snapshot list.
+  compaction_job_stats_.Reset();
+  files = cfd_->current()->storage_info()->LevelFiles(0);
+  RunCompaction({files}, file1, db_snapshots, kMaxSequenceNumber, output_level_0 + 1, !kVerify);
+  // The result should be what we get if we run compaction without snapshot fetcher on the updated list of snapshots
+  auto expected = mock_table_factory_->output();
+
+  NewDB();
+  AddMockFile(file1);
+  AddMockFile(file2);
+  SetLastSequence(6U);
+  files = cfd_->current()->storage_info()->LevelFiles(0);
+  RunCompaction({files}, expected, db_snapshots, kMaxSequenceNumber);
 }
 
 }  // namespace rocksdb

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -11,6 +11,7 @@
 
 #include <inttypes.h>
 #include <algorithm>
+#include <array>
 #include <map>
 #include <string>
 #include <tuple>

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -263,7 +263,7 @@ class CompactionJobTest : public testing::Test {
         nullptr, nullptr, &mutex_, &error_handler_, snapshots,
         earliest_write_conflict_snapshot, snapshot_checker, table_cache_,
         &event_logger, false, false, dbname_, &compaction_job_stats_,
-        Env::Priority::USER);
+        Env::Priority::USER, SnapshotListFetchCallback::kDisabled);
     VerifyInitializationOfCompactionJobStats(compaction_job_stats_);
 
     compaction_job.Prepare();

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -964,9 +964,9 @@ TEST_F(CompactionJobTest, SnapshotRefresh) {
   std::vector<SequenceNumber> db_snapshots;
   class SnapshotListFetchCallbackTest : public SnapshotListFetchCallback {
    public:
-    SnapshotListFetchCallbackTest(Random64& rand,
+    SnapshotListFetchCallbackTest(Env* env, Random64& rand,
                                   std::vector<SequenceNumber>* snapshots)
-        : SnapshotListFetchCallback(0 /*no time delay*/,
+        : SnapshotListFetchCallback(env, 0 /*no time delay*/,
                                     1 /*fetch after each key*/),
           rand_(rand),
           snapshots_(snapshots) {}
@@ -985,7 +985,7 @@ TEST_F(CompactionJobTest, SnapshotRefresh) {
    private:
     Random64 rand_;
     std::vector<SequenceNumber>* snapshots_;
-  } snapshot_fetcher(rand, &db_snapshots);
+  } snapshot_fetcher(env_, rand, &db_snapshots);
 
   std::vector<std::pair<const std::string, std::string>> file1_kvs, file2_kvs;
   std::array<ValueType, 4> types = {kTypeValue, kTypeDeletion,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -562,8 +562,8 @@ class DBImpl : public DB {
   const SnapshotList& snapshots() const { return snapshots_; }
 
   const std::vector<SequenceNumber> CopySnapshots(
-      SequenceNumber* oldest_write_conflict_snapshot = nullptr,
-      const SequenceNumber& max_seq = kMaxSequenceNumber) const {
+      SequenceNumber* oldest_write_conflict_snapshot,
+      const SequenceNumber& max_seq) const {
     InstrumentedMutexLock l(mutex());
     return snapshots().GetAll(oldest_write_conflict_snapshot, max_seq);
   }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -561,6 +561,13 @@ class DBImpl : public DB {
 
   const SnapshotList& snapshots() const { return snapshots_; }
 
+  const std::vector<SequenceNumber> CopySnapshots(
+      SequenceNumber* oldest_write_conflict_snapshot = nullptr,
+      const SequenceNumber& max_seq = kMaxSequenceNumber) const {
+    InstrumentedMutexLock l(mutex());
+    return snapshots().GetAll(oldest_write_conflict_snapshot, max_seq);
+  }
+
   const ImmutableDBOptions& immutable_db_options() const {
     return immutable_db_options_;
   }
@@ -739,7 +746,7 @@ class DBImpl : public DB {
   // Not thread-safe.
   void SetRecoverableStatePreReleaseCallback(PreReleaseCallback* callback);
 
-  InstrumentedMutex* mutex() { return &mutex_; }
+  InstrumentedMutex* mutex() const { return &mutex_; }
 
   Status NewDB();
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -561,11 +561,11 @@ class DBImpl : public DB {
 
   const SnapshotList& snapshots() const { return snapshots_; }
 
-  const std::vector<SequenceNumber> CopySnapshots(
-      SequenceNumber* oldest_write_conflict_snapshot,
-      const SequenceNumber& max_seq) const {
+  void LoadSnapshots(std::vector<SequenceNumber>* snap_vector,
+                     SequenceNumber* oldest_write_conflict_snapshot,
+                     const SequenceNumber& max_seq) const {
     InstrumentedMutexLock l(mutex());
-    return snapshots().GetAll(oldest_write_conflict_snapshot, max_seq);
+    snapshots().GetAll(snap_vector, oldest_write_conflict_snapshot, max_seq);
   }
 
   const ImmutableDBOptions& immutable_db_options() const {

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -988,7 +988,9 @@ Status DBImpl::CompactFilesImpl(
 
   assert(is_snapshot_supported_ || snapshots_.empty());
   CompactionJobStats compaction_job_stats;
-  SnapshotListFetchCallbackImpl fetch_callback(&mutex_, &snapshots_, c->mutable_cf_options()->snap_refresh_nanos, immutable_db_options_.info_log.get());
+  SnapshotListFetchCallbackImpl fetch_callback(
+      &mutex_, &snapshots_, c->mutable_cf_options()->snap_refresh_nanos,
+      immutable_db_options_.info_log.get());
   CompactionJob compaction_job(
       job_context->job_id, c.get(), immutable_db_options_,
       env_options_for_compaction_, versions_.get(), &shutting_down_,
@@ -999,7 +1001,8 @@ Status DBImpl::CompactFilesImpl(
       c->mutable_cf_options()->paranoid_file_checks,
       c->mutable_cf_options()->report_bg_io_stats, dbname_,
       &compaction_job_stats, Env::Priority::USER,
-      immutable_db_options_.max_subcompactions <=1 ? &fetch_callback : nullptr);
+      immutable_db_options_.max_subcompactions <= 1 ? &fetch_callback
+                                                    : nullptr);
 
   // Creating a compaction influences the compaction score because the score
   // takes running compactions into account (by skipping files that are already
@@ -2643,7 +2646,9 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
     GetSnapshotContext(job_context, &snapshot_seqs,
                        &earliest_write_conflict_snapshot, &snapshot_checker);
     assert(is_snapshot_supported_ || snapshots_.empty());
-    SnapshotListFetchCallbackImpl fetch_callback(&mutex_, &snapshots_, c->mutable_cf_options()->snap_refresh_nanos, immutable_db_options_.info_log.get());
+    SnapshotListFetchCallbackImpl fetch_callback(
+        &mutex_, &snapshots_, c->mutable_cf_options()->snap_refresh_nanos,
+        immutable_db_options_.info_log.get());
     CompactionJob compaction_job(
         job_context->job_id, c.get(), immutable_db_options_,
         env_options_for_compaction_, versions_.get(), &shutting_down_,
@@ -2654,7 +2659,8 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
         &event_logger_, c->mutable_cf_options()->paranoid_file_checks,
         c->mutable_cf_options()->report_bg_io_stats, dbname_,
         &compaction_job_stats, thread_pri,
-      immutable_db_options_.max_subcompactions <=1 ? &fetch_callback : nullptr);
+        immutable_db_options_.max_subcompactions <= 1 ? &fetch_callback
+                                                      : nullptr);
     compaction_job.Prepare();
 
     NotifyOnCompactionBegin(c->column_family_data(), c.get(), status,

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -791,9 +791,9 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
 
 class SnapshotListFetchCallbackImpl : public SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallbackImpl(DBImpl* db_impl, uint64_t _snap_refresh_nanos,
-                                Logger* info_log)
-      : SnapshotListFetchCallback(_snap_refresh_nanos),
+  SnapshotListFetchCallbackImpl(DBImpl* db_impl, Env* env,
+                                uint64_t snap_refresh_nanos, Logger* info_log)
+      : SnapshotListFetchCallback(env, snap_refresh_nanos),
         db_impl_(db_impl),
         info_log_(info_log) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
@@ -983,7 +983,7 @@ Status DBImpl::CompactFilesImpl(
   assert(is_snapshot_supported_ || snapshots_.empty());
   CompactionJobStats compaction_job_stats;
   SnapshotListFetchCallbackImpl fetch_callback(
-      this, c->mutable_cf_options()->snap_refresh_nanos,
+      this, env_, c->mutable_cf_options()->snap_refresh_nanos,
       immutable_db_options_.info_log.get());
   CompactionJob compaction_job(
       job_context->job_id, c.get(), immutable_db_options_,
@@ -2641,7 +2641,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
                        &earliest_write_conflict_snapshot, &snapshot_checker);
     assert(is_snapshot_supported_ || snapshots_.empty());
     SnapshotListFetchCallbackImpl fetch_callback(
-        this, c->mutable_cf_options()->snap_refresh_nanos,
+        this, env_, c->mutable_cf_options()->snap_refresh_nanos,
         immutable_db_options_.info_log.get());
     CompactionJob compaction_job(
         job_context->job_id, c.get(), immutable_db_options_,

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -791,9 +791,9 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
 
 class SnapshotListFetchCallbackImpl : public SnapshotListFetchCallback {
  public:
-  SnapshotListFetchCallbackImpl(DBImpl* db_impl, uint64_t snap_refresh_nanos,
+  SnapshotListFetchCallbackImpl(DBImpl* db_impl, uint64_t _snap_refresh_nanos,
                                 Logger* info_log)
-      : SnapshotListFetchCallback(snap_refresh_nanos),
+      : SnapshotListFetchCallback(_snap_refresh_nanos),
         db_impl_(db_impl),
         info_log_(info_log) {}
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -799,7 +799,8 @@ class SnapshotListFetchCallbackImpl : public SnapshotListFetchCallback {
   virtual void Refresh(std::vector<SequenceNumber>* snapshots,
                        SequenceNumber max) override {
     size_t prev = snapshots->size();
-    *snapshots = db_impl_->CopySnapshots(nullptr, max);
+    snapshots->clear();
+    db_impl_->LoadSnapshots(snapshots, nullptr, max);
     size_t now = snapshots->size();
     ROCKS_LOG_DEBUG(info_log_,
                     "Compaction snapshot count refreshed from %zu to %zu", prev,

--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -91,13 +91,23 @@ class SnapshotList {
       SequenceNumber* oldest_write_conflict_snapshot = nullptr,
       const SequenceNumber& max_seq = kMaxSequenceNumber) const {
     std::vector<SequenceNumber> ret;
+    GetAll(&ret, oldest_write_conflict_snapshot, max_seq);
+    return ret;
+  }
+
+  void GetAll(std::vector<SequenceNumber>* snap_vector,
+              SequenceNumber* oldest_write_conflict_snapshot = nullptr,
+              const SequenceNumber& max_seq = kMaxSequenceNumber) const {
+    std::vector<SequenceNumber>& ret = *snap_vector;
+    // So far we have no use case that would pass a non-empty vector
+    assert(ret.size() == 0);
 
     if (oldest_write_conflict_snapshot != nullptr) {
       *oldest_write_conflict_snapshot = kMaxSequenceNumber;
     }
 
     if (empty()) {
-      return ret;
+      return;
     }
     const SnapshotImpl* s = &list_;
     while (s->next_ != &list_) {
@@ -119,7 +129,7 @@ class SnapshotList {
 
       s = s->next_;
     }
-    return ret;
+    return;
   }
 
   // get the sequence number of the most recent snapshot

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -811,7 +811,7 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_target_file_size_multiplier(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_bytes_for_level_base(
     rocksdb_options_t*, uint64_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_bytes_for_level_base(
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_snap_refresh_nanos(
     rocksdb_options_t*, uint64_t);
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_level_compaction_dynamic_level_bytes(rocksdb_options_t*,

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -811,6 +811,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_target_file_size_multiplier(
     rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_bytes_for_level_base(
     rocksdb_options_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_bytes_for_level_base(
+    rocksdb_options_t*, uint64_t);
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_set_level_compaction_dynamic_level_bytes(rocksdb_options_t*,
                                                          unsigned char);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -269,6 +269,17 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   uint64_t max_bytes_for_level_base = 256 * 1048576;
 
+  // If non-zero, compactions will periodically refresh the snapshot list. The
+  // delay for the first refresh is snap_refresh_nanos nano seconds and
+  // exponentially increases afterwards. When having many short-lived snapshots,
+  // this option helps reducing the cpu usage of long-running compactions. The
+  // feature is disabled when max_subcompactions is greater than one.
+  //
+  // Default: 0.5s
+  //
+  // Dynamically changeable through SetOptions() API
+  uint64_t snap_refresh_nanos  = 500 * 1000 * 1000; // 0.5s
+
   // Disable automatic compactions. Manual compactions can still
   // be issued on this column family
   //

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -278,7 +278,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: 0.5s
   //
   // Dynamically changeable through SetOptions() API
-  uint64_t snap_refresh_nanos  = 500 * 1000 * 1000; // 0.5s
+  uint64_t snap_refresh_nanos = 500 * 1000 * 1000;  // 0.5s
 
   // Disable automatic compactions. Manual compactions can still
   // be issued on this column family

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -169,6 +169,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  target_file_size_multiplier);
   ROCKS_LOG_INFO(log, "                 max_bytes_for_level_base: %" PRIu64,
                  max_bytes_for_level_base);
+  ROCKS_LOG_INFO(log, "                       snap_refresh_nanos: %" PRIu64,
+                 snap_refresh_nanos);
   ROCKS_LOG_INFO(log, "           max_bytes_for_level_multiplier: %f",
                  max_bytes_for_level_multiplier);
   ROCKS_LOG_INFO(log, "                                      ttl: %" PRIu64,

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -149,6 +149,7 @@ struct MutableCFOptions {
         target_file_size_base(options.target_file_size_base),
         target_file_size_multiplier(options.target_file_size_multiplier),
         max_bytes_for_level_base(options.max_bytes_for_level_base),
+        snap_refresh_nanos(options.snap_refresh_nanos),
         max_bytes_for_level_multiplier(options.max_bytes_for_level_multiplier),
         ttl(options.ttl),
         periodic_compaction_seconds(options.periodic_compaction_seconds),
@@ -185,6 +186,7 @@ struct MutableCFOptions {
         target_file_size_base(0),
         target_file_size_multiplier(0),
         max_bytes_for_level_base(0),
+        snap_refresh_nanos(0),
         max_bytes_for_level_multiplier(0),
         ttl(0),
         periodic_compaction_seconds(0),
@@ -236,6 +238,7 @@ struct MutableCFOptions {
   uint64_t target_file_size_base;
   int target_file_size_multiplier;
   uint64_t max_bytes_for_level_base;
+  uint64_t snap_refresh_nanos;
   double max_bytes_for_level_multiplier;
   uint64_t ttl;
   uint64_t periodic_compaction_seconds;

--- a/options/options.cc
+++ b/options/options.cc
@@ -215,6 +215,9 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(
         log, "               Options.max_bytes_for_level_base: %" PRIu64,
         max_bytes_for_level_base);
+    ROCKS_LOG_HEADER(
+        log, "                     Options.snap_refresh_nanos: %" PRIu64,
+        snap_refresh_nanos);
     ROCKS_LOG_HEADER(log, "Options.level_compaction_dynamic_level_bytes: %d",
                      level_compaction_dynamic_level_bytes);
     ROCKS_LOG_HEADER(log, "         Options.max_bytes_for_level_multiplier: %f",
@@ -490,6 +493,7 @@ ColumnFamilyOptions* ColumnFamilyOptions::OptimizeForSmallDb(
   write_buffer_size = 2 << 20;
   target_file_size_base = 2 * 1048576;
   max_bytes_for_level_base = 10 * 1048576;
+  snap_refresh_nanos = 0;
   soft_pending_compaction_bytes_limit = 256 * 1048576;
   hard_pending_compaction_bytes_limit = 1073741824ul;
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -177,6 +177,8 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
       mutable_cf_options.target_file_size_multiplier;
   cf_opts.max_bytes_for_level_base =
       mutable_cf_options.max_bytes_for_level_base;
+  cf_opts.snap_refresh_nanos =
+      mutable_cf_options.snap_refresh_nanos;
   cf_opts.max_bytes_for_level_multiplier =
       mutable_cf_options.max_bytes_for_level_multiplier;
   cf_opts.ttl = mutable_cf_options.ttl;
@@ -1910,6 +1912,10 @@ std::unordered_map<std::string, OptionTypeInfo>
          {offset_of(&ColumnFamilyOptions::max_bytes_for_level_base),
           OptionType::kUInt64T, OptionVerificationType::kNormal, true,
           offsetof(struct MutableCFOptions, max_bytes_for_level_base)}},
+        {"snap_refresh_nanos",
+         {offset_of(&ColumnFamilyOptions::snap_refresh_nanos),
+          OptionType::kUInt64T, OptionVerificationType::kNormal, true,
+          offsetof(struct MutableCFOptions, snap_refresh_nanos)}},
         {"max_bytes_for_level_multiplier",
          {offset_of(&ColumnFamilyOptions::max_bytes_for_level_multiplier),
           OptionType::kDouble, OptionVerificationType::kNormal, true,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -177,8 +177,7 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
       mutable_cf_options.target_file_size_multiplier;
   cf_opts.max_bytes_for_level_base =
       mutable_cf_options.max_bytes_for_level_base;
-  cf_opts.snap_refresh_nanos =
-      mutable_cf_options.snap_refresh_nanos;
+  cf_opts.snap_refresh_nanos = mutable_cf_options.snap_refresh_nanos;
   cf_opts.max_bytes_for_level_multiplier =
       mutable_cf_options.max_bytes_for_level_multiplier;
   cf_opts.ttl = mutable_cf_options.ttl;
@@ -528,9 +527,9 @@ bool ParseOptionHelper(char* opt_address, const OptionType& opt_type,
               opt_address));
     case OptionType::kBlockBasedTableIndexShorteningMode:
       return ParseEnum<BlockBasedTableOptions::IndexShorteningMode>(
-        block_base_table_index_shortening_mode_string_map, value,
-        reinterpret_cast<BlockBasedTableOptions::IndexShorteningMode*>(
-            opt_address));
+          block_base_table_index_shortening_mode_string_map, value,
+          reinterpret_cast<BlockBasedTableOptions::IndexShorteningMode*>(
+              opt_address));
     case OptionType::kEncodingType:
       return ParseEnum<EncodingType>(
           encoding_type_string_map, value,
@@ -1668,13 +1667,13 @@ std::unordered_map<std::string, BlockBasedTableOptions::DataBlockIndexType>
 
 std::unordered_map<std::string, BlockBasedTableOptions::IndexShorteningMode>
     OptionsHelper::block_base_table_index_shortening_mode_string_map = {
-      {"kNoShortening",
-       BlockBasedTableOptions::IndexShorteningMode::kNoShortening},
-      {"kShortenSeparators",
-       BlockBasedTableOptions::IndexShorteningMode::kShortenSeparators},
-      {"kShortenSeparatorsAndSuccessor",
-       BlockBasedTableOptions::IndexShorteningMode::
-           kShortenSeparatorsAndSuccessor}};
+        {"kNoShortening",
+         BlockBasedTableOptions::IndexShorteningMode::kNoShortening},
+        {"kShortenSeparators",
+         BlockBasedTableOptions::IndexShorteningMode::kShortenSeparators},
+        {"kShortenSeparatorsAndSuccessor",
+         BlockBasedTableOptions::IndexShorteningMode::
+             kShortenSeparatorsAndSuccessor}};
 
 std::unordered_map<std::string, EncodingType>
     OptionsHelper::encoding_type_string_map = {{"kPlain", kPlain},

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -415,6 +415,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "kBZip2Compression:kNoCompression:kZlibCompression:kBZip2Compression:"
       "kSnappyCompression;"
       "max_bytes_for_level_base=986;"
+      "snap_refresh_nanos=1000000000;"
       "bloom_locality=8016;"
       "target_file_size_base=4294976376;"
       "memtable_huge_page_size=2557;"

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -74,6 +74,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"target_file_size_base", "12"},
       {"target_file_size_multiplier", "13"},
       {"max_bytes_for_level_base", "14"},
+      {"snap_refresh_nanos", "1000000000"},
       {"level_compaction_dynamic_level_bytes", "true"},
       {"max_bytes_for_level_multiplier", "15.0"},
       {"max_bytes_for_level_multiplier_additional", "16:17:18"},
@@ -183,6 +184,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.target_file_size_base, static_cast<uint64_t>(12));
   ASSERT_EQ(new_cf_opt.target_file_size_multiplier, 13);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_base, 14U);
+  ASSERT_EQ(new_cf_opt.snap_refresh_nanos, 1000000000U);
   ASSERT_EQ(new_cf_opt.level_compaction_dynamic_level_bytes, true);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_multiplier, 15.0);
   ASSERT_EQ(new_cf_opt.max_bytes_for_level_multiplier_additional.size(), 3U);

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -23,7 +23,8 @@ const InternalKeyComparator icmp_(BytewiseComparator());
 
 stl_wrappers::KVMap MakeMockFile(
     std::vector<std::pair<const std::string, std::string>> l) {
-  return stl_wrappers::KVMap(l.begin(), l.end(), stl_wrappers::LessOfComparator(&icmp_));
+  return stl_wrappers::KVMap(l.begin(), l.end(),
+                             stl_wrappers::LessOfComparator(&icmp_));
 }
 
 stl_wrappers::KVMap MakeMockFile(

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -22,6 +22,11 @@ const InternalKeyComparator icmp_(BytewiseComparator());
 }  // namespace
 
 stl_wrappers::KVMap MakeMockFile(
+    std::vector<std::pair<const std::string, std::string>> l) {
+  return stl_wrappers::KVMap(l.begin(), l.end(), stl_wrappers::LessOfComparator(&icmp_));
+}
+
+stl_wrappers::KVMap MakeMockFile(
     std::initializer_list<std::pair<const std::string, std::string>> l) {
   return stl_wrappers::KVMap(l, stl_wrappers::LessOfComparator(&icmp_));
 }

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -143,6 +143,14 @@ void MockTableFactory::AssertLatestFile(
       ParseInternalKey(Slice(key), &ikey);
       std::cout << ikey.DebugString(false) << " -> " << value << std::endl;
     }
+    std::cout << "Expected:" << std::endl;
+    for (const auto& kv : file_contents) {
+      ParsedInternalKey ikey;
+      std::string key, value;
+      std::tie(key, value) = kv;
+      ParseInternalKey(Slice(key), &ikey);
+      std::cout << ikey.DebugString(false) << " -> " << value << std::endl;
+    }
     FAIL();
   }
 }

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -28,6 +28,8 @@ namespace mock {
 
 stl_wrappers::KVMap MakeMockFile(
     std::initializer_list<std::pair<const std::string, std::string>> l = {});
+stl_wrappers::KVMap MakeMockFile(
+    std::vector<std::pair<const std::string, std::string>> l);
 
 struct MockTableFileSystem {
   port::Mutex mutex;

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -184,6 +184,12 @@ class MockTableFactory : public TableFactory {
   // contents are equal to file_contents
   void AssertSingleFile(const stl_wrappers::KVMap& file_contents);
   void AssertLatestFile(const stl_wrappers::KVMap& file_contents);
+  stl_wrappers::KVMap output() {
+    assert(!file_system_.files.empty());
+    auto latest = file_system_.files.end();
+    --latest;
+    return latest->second;
+  }
 
  private:
   uint32_t GetAndWriteNextID(WritableFileWriter* file) const;

--- a/util/compaction_job_stats_impl.cc
+++ b/util/compaction_job_stats_impl.cc
@@ -40,6 +40,9 @@ void CompactionJobStats::Reset() {
   file_fsync_nanos = 0;
   file_prepare_write_nanos = 0;
 
+  smallest_output_key_prefix.clear();
+  largest_output_key_prefix.clear();
+
   num_single_del_fallthru = 0;
   num_single_del_mismatch = 0;
 }


### PR DESCRIPTION
Part of compaction cpu goes to processing snapshot list, the larger the list the bigger the overhead. Although the lifetime of most of the snapshots is much shorter than the lifetime of compactions, the compaction conservatively operates on the list of snapshots that it initially obtained. This patch allows the snapshot list to be updated via a callback if the compaction is taking long. This should let the compaction to continue more efficiently with much smaller snapshot list.