### PR TITLE
remove incorrect assert in `GetUniqueIdFromFile`

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -188,14 +188,6 @@ class PosixEnv : public Env {
       }
     }
     result->reset(new PosixSequentialFile(fname, file, fd, options));
-    {
-      struct stat buf;
-      int fstat_result = fstat(fd, &buf);
-      if (fstat_result == -1) {
-        return IOError("While fstat the sequential file just created",
-                       fname, fstat_result);
-      }
-    }
     return Status::OK();
   }
 
@@ -252,14 +244,6 @@ class PosixEnv : public Env {
 #endif
       }
       result->reset(new PosixRandomAccessFile(fname, fd, options));
-    }
-    if (s.ok()) {
-      struct stat buf;
-      int fstat_result = fstat(fd, &buf);
-      if (fstat_result == -1) {
-        return IOError("While fstat the random access file just created",
-                       fname, fstat_result);
-      }
     }
     return s;
   }

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -191,7 +191,6 @@ class PosixEnv : public Env {
     {
       struct stat buf;
       int fstat_result = fstat(fd, &buf);
-      assert(fstat_result != -1);
       if (fstat_result == -1) {
         return IOError("While fstat the sequential file just created",
                        fname, fstat_result);
@@ -257,7 +256,6 @@ class PosixEnv : public Env {
     if (s.ok()) {
       struct stat buf;
       int fstat_result = fstat(fd, &buf);
-      assert(fstat_result != -1);
       if (fstat_result == -1) {
         return IOError("While fstat the random access file just created",
                        fname, fstat_result);

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -188,6 +188,15 @@ class PosixEnv : public Env {
       }
     }
     result->reset(new PosixSequentialFile(fname, file, fd, options));
+    {
+      struct stat buf;
+      int fstat_result = fstat(fd, &buf);
+      assert(fstat_result != -1);
+      if (fstat_result == -1) {
+        return IOError("While fstat the sequential file just created",
+                       fname, fstat_result);
+      }
+    }
     return Status::OK();
   }
 
@@ -244,6 +253,15 @@ class PosixEnv : public Env {
 #endif
       }
       result->reset(new PosixRandomAccessFile(fname, fd, options));
+    }
+    if (s.ok()) {
+      struct stat buf;
+      int fstat_result = fstat(fd, &buf);
+      assert(fstat_result != -1);
+      if (fstat_result == -1) {
+        return IOError("While fstat the random access file just created",
+                       fname, fstat_result);
+      }
     }
     return s;
   }

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -265,7 +265,6 @@ size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
 
   struct stat buf;
   int result = fstat(fd, &buf);
-  assert(result != -1);
   if (result == -1) {
     return 0;
   }


### PR DESCRIPTION
User report has shown that sometimes `BlockBasedTable::SetupCacheKeyPrefix` would assert when trying to generate an id from the file. The actual cause seems to be hardware related but we might be better off without the incorrect assertion 
See T42178927 for more information