### PR TITLE
BlobDB::Open() should put all existing trash files to delete scheduler

### DIFF
--- a/util/delete_scheduler.cc
+++ b/util/delete_scheduler.cc
@@ -221,6 +221,7 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       // Delete file from trash and update total_penlty value
       Status s =
           DeleteTrashFile(path_in_trash, fad.dir, &deleted_bytes, &is_complete);
+
       total_deleted_bytes += deleted_bytes;
       mu_.Lock();
       if (is_complete) {

--- a/util/delete_scheduler.cc
+++ b/util/delete_scheduler.cc
@@ -221,7 +221,6 @@ void DeleteScheduler::BackgroundEmptyTrash() {
       // Delete file from trash and update total_penlty value
       Status s =
           DeleteTrashFile(path_in_trash, fad.dir, &deleted_bytes, &is_complete);
-
       total_deleted_bytes += deleted_bytes;
       mu_.Lock();
       if (is_complete) {

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -197,6 +197,8 @@ class BlobDBImpl : public BlobDB {
   void TEST_DeleteObsoleteFiles();
 
   uint64_t TEST_live_sst_size();
+
+  const std::string& TEST_blob_dir() const { return blob_dir_; }
 #endif  //  !NDEBUG
 
  private:

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -817,17 +817,6 @@ TEST_F(BlobDBTest, SstFileManager) {
 }
 
 TEST_F(BlobDBTest, SstFileManagerRestart) {
-  // run the same test for Get(), MultiGet() and Iterator each.
-  std::shared_ptr<SstFileManager> sst_file_manager(
-      NewSstFileManager(mock_env_.get()));
-  sst_file_manager->SetDeleteRateBytesPerSecond(1);
-  SstFileManagerImpl *sfm =
-      static_cast<SstFileManagerImpl *>(sst_file_manager.get());
-
-  BlobDBOptions bdb_options;
-  bdb_options.min_blob_size = 0;
-  Options db_options;
-
   int files_deleted_directly = 0;
   int files_scheduled_to_delete = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
@@ -840,6 +829,18 @@ TEST_F(BlobDBTest, SstFileManagerRestart) {
       {"BlobDBTest.SstFileManagerRestart:1",
        "DeleteScheduler::BackgroundEmptyTrash"},
   });
+
+  // run the same test for Get(), MultiGet() and Iterator each.
+  std::shared_ptr<SstFileManager> sst_file_manager(
+      NewSstFileManager(mock_env_.get()));
+  sst_file_manager->SetDeleteRateBytesPerSecond(1);
+  SstFileManagerImpl *sfm =
+      static_cast<SstFileManagerImpl *>(sst_file_manager.get());
+
+  BlobDBOptions bdb_options;
+  bdb_options.min_blob_size = 0;
+  Options db_options;
+
 
   SyncPoint::GetInstance()->EnableProcessing();
   db_options.sst_file_manager = sst_file_manager;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -810,8 +810,62 @@ TEST_F(BlobDBTest, SstFileManager) {
   ASSERT_EQ(0, files_deleted_directly);
   Destroy();
   // Make sure that DestroyBlobDB() also goes through delete scheduler.
-  ASSERT_GE(2, files_scheduled_to_delete);
+  ASSERT_GE(files_scheduled_to_delete, 2);
   ASSERT_EQ(0, files_deleted_directly);
+  SyncPoint::GetInstance()->DisableProcessing();
+  sfm->WaitForEmptyTrash();
+}
+
+TEST_F(BlobDBTest, SstFileManagerRestart) {
+  // run the same test for Get(), MultiGet() and Iterator each.
+  std::shared_ptr<SstFileManager> sst_file_manager(
+      NewSstFileManager(mock_env_.get()));
+  sst_file_manager->SetDeleteRateBytesPerSecond(1);
+  SstFileManagerImpl *sfm =
+      static_cast<SstFileManagerImpl *>(sst_file_manager.get());
+
+  BlobDBOptions bdb_options;
+  bdb_options.min_blob_size = 0;
+  Options db_options;
+
+  int files_deleted_directly = 0;
+  int files_scheduled_to_delete = 0;
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "SstFileManagerImpl::ScheduleFileDeletion",
+      [&](void * /*arg*/) { files_scheduled_to_delete++; });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "DeleteScheduler::DeleteFile",
+      [&](void * /*arg*/) { files_deleted_directly++; });
+  rocksdb::SyncPoint::GetInstance()->LoadDependency({
+      {"BlobDBTest.SstFileManagerRestart:1",
+       "DeleteScheduler::BackgroundEmptyTrash"},
+  });
+
+  SyncPoint::GetInstance()->EnableProcessing();
+  db_options.sst_file_manager = sst_file_manager;
+
+  Open(bdb_options, db_options);
+
+  // Create one obselete file and clean it.
+  blob_db_->Put(WriteOptions(), "foo", "bar");
+  auto blob_files = blob_db_impl()->TEST_GetBlobFiles();
+  ASSERT_EQ(1, blob_files.size());
+  std::shared_ptr<BlobFile> bfile = blob_files[0];
+  ASSERT_OK(blob_db_impl()->TEST_CloseBlobFile(bfile));
+  GCStats gc_stats;
+  ASSERT_OK(blob_db_impl()->TEST_GCFileAndUpdateLSM(bfile, &gc_stats));
+  blob_db_impl()->TEST_DeleteObsoleteFiles();
+
+  // Even if SSTFileManager is not set, DB is creating a dummy one.
+  ASSERT_EQ(1, files_scheduled_to_delete);
+  ASSERT_EQ(0, files_deleted_directly);
+
+  // Make sure that reopening the DB rescan the existing trash files
+  Reopen(bdb_options, db_options);
+  ASSERT_GE(files_scheduled_to_delete, 2);
+  ASSERT_EQ(0, files_deleted_directly);
+  TEST_SYNC_POINT("BlobDBTest.SstFileManagerRestart:1");
+
   SyncPoint::GetInstance()->DisableProcessing();
   sfm->WaitForEmptyTrash();
 }


### PR DESCRIPTION
Summary:
Right now, BlobDB::Open() fails to put all trash files to delete scheduler,
which causes some trash files permanently untracked.

Test Plan: Add a unit test, which fails without the fix.