### PR TITLE
Fix BlockBasedTableIterator construction missing index_key_is_full  parameter

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2557,7 +2557,7 @@ InternalIterator* BlockBasedTable::NewIterator(
         !skip_filters && !read_options.total_order_seek &&
             prefix_extractor != nullptr,
         need_upper_bound_check, prefix_extractor, kIsNotIndex,
-        true /*key_includes_seq*/, for_compaction);
+        true /*key_includes_seq*/, true /*index_key_is_full*/, for_compaction);
   } else {
     auto* mem =
         arena->AllocateAligned(sizeof(BlockBasedTableIterator<DataBlockIter>));
@@ -2567,7 +2567,7 @@ InternalIterator* BlockBasedTable::NewIterator(
         !skip_filters && !read_options.total_order_seek &&
             prefix_extractor != nullptr,
         need_upper_bound_check, prefix_extractor, kIsNotIndex,
-        true /*key_includes_seq*/, for_compaction);
+        true /*key_includes_seq*/, true /*index_key_is_full*/, for_compaction);
   }
 }
 


### PR DESCRIPTION
Summary:
#3983 adds index_key_is_full param to `BlockBasedTableIterator` constructor, but failed to update `BlockBasedTable::NewIterator` accordingly. Fixing it.

Test Plan:
existing tests

Signed-off-by: Yi Wu <yiwu@pingcap.com>