### PR TITLE
Update RepeatableThreadTest with MockTimeEnv

### DIFF
--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -527,6 +527,16 @@ TEST_F(DBOptionsTest, RunStatsDumpPeriodSec) {
   mock_env->set_current_time(0); // in seconds
   options.env = mock_env.get();
   int counter = 0;
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+    if (time_us < mock_env->RealNowMicros()) {
+      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+    }
+  });
+#endif  // OS_MACOSX && !NDEBUG
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DumpStats:1", [&](void* /*arg*/) {
         counter++;
@@ -556,6 +566,16 @@ TEST_F(DBOptionsTest, StatsPersistScheduling) {
   mock_env.reset(new rocksdb::MockTimeEnv(env_));
   mock_env->set_current_time(0);  // in seconds
   options.env = mock_env.get();
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+    if (time_us < mock_env->RealNowMicros()) {
+      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+    }
+  });
+#endif  // OS_MACOSX && !NDEBUG
   int counter = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::PersistStats:Entry", [&](void* /*arg*/) { counter++; });
@@ -581,6 +601,16 @@ TEST_F(DBOptionsTest, PersistentStatsFreshInstall) {
   mock_env.reset(new rocksdb::MockTimeEnv(env_));
   mock_env->set_current_time(0);  // in seconds
   options.env = mock_env.get();
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+    if (time_us < mock_env->RealNowMicros()) {
+      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+    }
+  });
+#endif  // OS_MACOSX && !NDEBUG
   int counter = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::PersistStats:Entry", [&](void* /*arg*/) { counter++; });
@@ -616,6 +646,18 @@ TEST_F(DBOptionsTest, GetStatsHistory) {
   mock_env.reset(new rocksdb::MockTimeEnv(env_));
   mock_env->set_current_time(0);  // in seconds
   options.env = mock_env.get();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+    if (time_us < mock_env->RealNowMicros()) {
+      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+    }
+  });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+#endif  // OS_MACOSX && !NDEBUG
+
   CreateColumnFamilies({"pikachu"}, options);
   ASSERT_OK(Put("foo", "bar"));
   ReopenWithColumnFamilies({"default", "pikachu"}, options);
@@ -658,6 +700,18 @@ TEST_F(DBOptionsTest, InMemoryStatsHistoryPurging) {
   mock_env.reset(new rocksdb::MockTimeEnv(env_));
   mock_env->set_current_time(0);  // in seconds
   options.env = mock_env.get();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
+  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+    if (time_us < mock_env->RealNowMicros()) {
+      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+    }
+  });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+#endif  // OS_MACOSX && !NDEBUG
+
   CreateColumnFamilies({"pikachu"}, options);
   ASSERT_OK(Put("foo", "bar"));
   ReopenWithColumnFamilies({"default", "pikachu"}, options);

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -530,12 +530,13 @@ TEST_F(DBOptionsTest, RunStatsDumpPeriodSec) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
 #if defined(OS_MACOSX) && !defined(NDEBUG)
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+        }
+      });
 #endif  // OS_MACOSX && !NDEBUG
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DumpStats:1", [&](void* /*arg*/) {
@@ -569,12 +570,13 @@ TEST_F(DBOptionsTest, StatsPersistScheduling) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
 #if defined(OS_MACOSX) && !defined(NDEBUG)
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+        }
+      });
 #endif  // OS_MACOSX && !NDEBUG
   int counter = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
@@ -604,12 +606,13 @@ TEST_F(DBOptionsTest, PersistentStatsFreshInstall) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
 #if defined(OS_MACOSX) && !defined(NDEBUG)
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+        }
+      });
 #endif  // OS_MACOSX && !NDEBUG
   int counter = 0;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
@@ -649,12 +652,13 @@ TEST_F(DBOptionsTest, GetStatsHistory) {
 #if defined(OS_MACOSX) && !defined(NDEBUG)
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+        }
+      });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 #endif  // OS_MACOSX && !NDEBUG
 
@@ -703,12 +707,13 @@ TEST_F(DBOptionsTest, InMemoryStatsHistoryPurging) {
 #if defined(OS_MACOSX) && !defined(NDEBUG)
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env->RealNowMicros() + 1000;
+        }
+      });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 #endif  // OS_MACOSX && !NDEBUG
 

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -356,6 +356,14 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
   env_->time_elapse_only_sleep_ = true;
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
+  // Need to disable stats dumping and persisting which also use
+  // RepeatableThread, one of whose member variables is of type
+  // InstrumentedCondVar. The callback for
+  // InstrumentedCondVar::TimedWaitInternal can be triggered by stats dumping
+  // and persisting threads and cause time_spent_deleting measurement to become
+  // incorrect.
+  options.stats_dump_period_sec = 0;
+  options.stats_persist_period_sec = 0;
   options.env = env_;
 
   int64_t rate_bytes_per_sec = 1024 * 10;  // 10 Kbs / Sec

--- a/util/mock_time_env.h
+++ b/util/mock_time_env.h
@@ -31,6 +31,8 @@ class MockTimeEnv : public EnvWrapper {
     return current_time_ * 1000000000;
   }
 
+  uint64_t RealNowMicros() { return target()->NowMicros(); }
+
   void set_current_time(uint64_t time) {
     assert(time >= current_time_);
     current_time_ = time;

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -25,6 +25,7 @@ class RepeatableThread {
         env_(env),
         delay_us_(delay_us),
         initial_delay_us_(initial_delay_us),
+        mutex_(env),
         cond_var_(&mutex_),
         running_(true),
 #ifndef NDEBUG

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -87,7 +87,8 @@ class RepeatableThread {
         if (dynamic_cast<MockTimeEnv*>(env_) != nullptr) {
           // MockTimeEnv is used. Since it is not easy to mock TimedWait,
           // we wait without timeout to wait for TEST_WaitForRun to wake us up.
-          cond_var_.Wait();
+          //cond_var_.Wait();
+          cond_var_.TimedWait(wait_until);
         } else {
           cond_var_.TimedWait(wait_until);
         }

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -36,7 +36,7 @@ class RepeatableThread {
 
   void cancel() {
     {
-      MutexLock l(&mutex_);
+      InstrumentedMutexLock l(&mutex_);
       if (!running_) {
         return;
       }
@@ -58,7 +58,7 @@ class RepeatableThread {
   //
   // Note: only support one caller of this method.
   void TEST_WaitForRun(std::function<void()> callback = nullptr) {
-    MutexLock l(&mutex_);
+    InstrumentedMutexLock l(&mutex_);
     while (!waiting_) {
       cond_var_.Wait();
     }
@@ -75,7 +75,7 @@ class RepeatableThread {
 
  private:
   bool wait(uint64_t delay) {
-    MutexLock l(&mutex_);
+    InstrumentedMutexLock l(&mutex_);
     if (running_ && delay > 0) {
       uint64_t wait_until = env_->NowMicros() + delay;
 #ifndef NDEBUG
@@ -114,7 +114,7 @@ class RepeatableThread {
       function_();
 #ifndef NDEBUG
       {
-        MutexLock l(&mutex_);
+        InstrumentedMutexLock l(&mutex_);
         run_count_++;
         cond_var_.SignalAll();
       }
@@ -130,8 +130,8 @@ class RepeatableThread {
 
   // Mutex lock should be held when accessing running_, waiting_
   // and run_count_.
-  port::Mutex mutex_;
-  port::CondVar cond_var_;
+  InstrumentedMutex mutex_;
+  InstrumentedCondVar cond_var_;
   bool running_;
 #ifndef NDEBUG
   // RepeatableThread waiting for timeout.

--- a/util/repeatable_thread.h
+++ b/util/repeatable_thread.h
@@ -83,18 +83,7 @@ class RepeatableThread {
       cond_var_.SignalAll();
 #endif
       while (running_) {
-#ifndef NDEBUG
-        if (dynamic_cast<MockTimeEnv*>(env_) != nullptr) {
-          // MockTimeEnv is used. Since it is not easy to mock TimedWait,
-          // we wait without timeout to wait for TEST_WaitForRun to wake us up.
-          //cond_var_.Wait();
-          cond_var_.TimedWait(wait_until);
-        } else {
-          cond_var_.TimedWait(wait_until);
-        }
-#else
         cond_var_.TimedWait(wait_until);
-#endif
         if (env_->NowMicros() >= wait_until) {
           break;
         }

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -55,29 +55,27 @@ TEST_F(RepeatableThreadTest, TimedTest) {
 TEST_F(RepeatableThreadTest, MockEnvTest) {
   constexpr uint64_t kSecond = 1000000;  // 1s = 1000000us
   constexpr int kIteration = 3;
-  rocksdb::Env* env = rocksdb::Env::Default();
-  // Obtain the current (real) time in seconds and add 1000 extra seconds to
-  // ensure that RepeatableThread::wait invokes TimedWait with a time greater
-  // than (real) current time. This is to prevent the TimedWait function from
-  // returning immediately without sleeping and releasing the mutex on certain
-  // platforms, e.g. OS X. If TimedWait returns immediately, the mutex will not
-  // be released, and RepeatableThread::TEST_WaitForRun never has a chance to
-  // execute the callback which, in this case, updates the result returned by
-  // mock_env->NowMicros. Consequently, RepeatableThread::wait cannot break out
-  // of the loop, causing test to hang.
-  // The extra 1000 seconds is a best-effort approach because there seems no
-  // reliable and deterministic way to provide the aforementioned guarantee. By
-  // the time RepeatableThread::wait is called, it is no guarantee that the
-  // delay + mock_env->NowMicros will be greater than the current real time.
-  // However, 1000 seconds should be sufficient in most cases.
-  uint64_t now_seconds = env->NowMicros() / kSecond + 1000;
-  mock_env_->set_current_time(now_seconds);  // in seconds
+  mock_env_->set_current_time(0);  // in seconds
   std::atomic<int> count{0};
 
 #if defined(OS_MACOSX) && !defined(NDEBUG)
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
   rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+    // Obtain the current (real) time in seconds and add 1000 extra seconds to
+    // ensure that RepeatableThread::wait invokes TimedWait with a time greater
+    // than (real) current time. This is to prevent the TimedWait function from
+    // returning immediately without sleeping and releasing the mutex on certain
+    // platforms, e.g. OS X. If TimedWait returns immediately, the mutex will not
+    // be released, and RepeatableThread::TEST_WaitForRun never has a chance to
+    // execute the callback which, in this case, updates the result returned by
+    // mock_env->NowMicros. Consequently, RepeatableThread::wait cannot break out
+    // of the loop, causing test to hang.
+    // The extra 1000 seconds is a best-effort approach because there seems no
+    // reliable and deterministic way to provide the aforementioned guarantee. By
+    // the time RepeatableThread::wait is called, it is no guarantee that the
+    // delay + mock_env->NowMicros will be greater than the current real time.
+    // However, 1000 seconds should be sufficient in most cases.
     uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
     if (time_us < mock_env_->RealNowMicros()) {
       *reinterpret_cast<uint64_t*>(arg) = mock_env_->RealNowMicros() + 1000;
@@ -90,8 +88,7 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
                                    1 * kSecond, 1 * kSecond);
   for (int i = 1; i <= kIteration; i++) {
     // Bump current time
-    thread.TEST_WaitForRun(
-        [&] { mock_env_->set_current_time(now_seconds + i); });
+    thread.TEST_WaitForRun([&] { mock_env_->set_current_time(i); });
   }
   // Test function should be exectued exactly kIteraion times.
   ASSERT_EQ(kIteration, count.load());

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -61,26 +61,28 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
 #if defined(OS_MACOSX) && !defined(NDEBUG)
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
-  rocksdb::SyncPoint::GetInstance()->SetCallBack("InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
-    // Obtain the current (real) time in seconds and add 1000 extra seconds to
-    // ensure that RepeatableThread::wait invokes TimedWait with a time greater
-    // than (real) current time. This is to prevent the TimedWait function from
-    // returning immediately without sleeping and releasing the mutex on certain
-    // platforms, e.g. OS X. If TimedWait returns immediately, the mutex will not
-    // be released, and RepeatableThread::TEST_WaitForRun never has a chance to
-    // execute the callback which, in this case, updates the result returned by
-    // mock_env->NowMicros. Consequently, RepeatableThread::wait cannot break out
-    // of the loop, causing test to hang.
-    // The extra 1000 seconds is a best-effort approach because there seems no
-    // reliable and deterministic way to provide the aforementioned guarantee. By
-    // the time RepeatableThread::wait is called, it is no guarantee that the
-    // delay + mock_env->NowMicros will be greater than the current real time.
-    // However, 1000 seconds should be sufficient in most cases.
-    uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
-    if (time_us < mock_env_->RealNowMicros()) {
-      *reinterpret_cast<uint64_t*>(arg) = mock_env_->RealNowMicros() + 1000;
-    }
-  });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        // Obtain the current (real) time in seconds and add 1000 extra seconds
+        // to ensure that RepeatableThread::wait invokes TimedWait with a time
+        // greater than (real) current time. This is to prevent the TimedWait
+        // function from returning immediately without sleeping and releasing
+        // the mutex on certain platforms, e.g. OS X. If TimedWait returns
+        // immediately, the mutex will not be released, and
+        // RepeatableThread::TEST_WaitForRun never has a chance to execute the
+        // callback which, in this case, updates the result returned by
+        // mock_env->NowMicros. Consequently, RepeatableThread::wait cannot
+        // break out of the loop, causing test to hang. The extra 1000 seconds
+        // is a best-effort approach because there seems no reliable and
+        // deterministic way to provide the aforementioned guarantee. By the
+        // time RepeatableThread::wait is called, it is no guarantee that the
+        // delay + mock_env->NowMicros will be greater than the current real
+        // time. However, 1000 seconds should be sufficient in most cases.
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < mock_env_->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = mock_env_->RealNowMicros() + 1000;
+        }
+      });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 #endif  // OS_MACOSX && !NDEBUG
 

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -62,7 +62,8 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
                                    1 * kSecond, 1 * kSecond);
   for (int i = 1; i <= kIteration; i++) {
     // Bump current time
-    thread.TEST_WaitForRun([&] { mock_env_->set_current_time(now_seconds + i); });
+    thread.TEST_WaitForRun(
+        [&] { mock_env_->set_current_time(now_seconds + i); });
   }
   // Test function should be exectued exactly kIteraion times.
   ASSERT_EQ(kIteration, count.load());

--- a/util/repeatable_thread_test.cc
+++ b/util/repeatable_thread_test.cc
@@ -55,7 +55,7 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
   constexpr uint64_t kSecond = 1000000;  // 1s = 1000000us
   constexpr int kIteration = 3;
   rocksdb::Env* env = rocksdb::Env::Default();
-  // Obtain the current (real) time in seconds and add 10 extra seconds to
+  // Obtain the current (real) time in seconds and add 1000 extra seconds to
   // ensure that RepeatableThread::wait invokes TimedWait with a time greater
   // than (real) current time. This is to prevent the TimedWait function from
   // returning immediately without sleeping and releasing the mutex on certain
@@ -64,12 +64,12 @@ TEST_F(RepeatableThreadTest, MockEnvTest) {
   // execute the callback which, in this case, updates the result returned by
   // mock_env->NowMicros. Consequently, RepeatableThread::wait cannot break out
   // of the loop, causing test to hang.
-  // The extra 10 seconds is a best-effort approach because there seems no
+  // The extra 1000 seconds is a best-effort approach because there seems no
   // reliable and deterministic way to provide the aforementioned guarantee. By
   // the time RepeatableThread::wait is called, it is no guarantee that the
   // delay + mock_env->NowMicros will be greater than the current real time.
-  // However, 10 seconds should be sufficient in most cases.
-  uint64_t now_seconds = env->NowMicros() / kSecond + 10;
+  // However, 1000 seconds should be sufficient in most cases.
+  uint64_t now_seconds = env->NowMicros() / kSecond + 1000;
   mock_env_->set_current_time(now_seconds);  // in seconds
   std::atomic<int> count{0};
   rocksdb::RepeatableThread thread([&] { count++; }, "rt_test", mock_env_.get(),


### PR DESCRIPTION
`RepeatableThreadTest.MockEnvTest` uses `MockTimeEnv` and `RepeatableThread`. If `RepeatableThread::wait` calls `TimedWait` with a time smaller than or equal to the current (real) time, `TimedWait` returns immediately on certain platforms, e.g. OS X. #4560 addresses this issue by replacing `TimedWait` with `Wait` in test. This fixes the test but makes test/production code diverge, which is not optimal for test coverage. This PR proposes an alternative fix which unifies test and production code path for `RepeatableThread::wait`. We obtain the current (real) time in seconds and add 10 extra seconds to ensure that `RepeatableThread::wait` invokes `TimedWait` with a time greater than (real) current time. This is to prevent the `TimedWait` function from returning immediately without sleeping and releasing the mutex. If `TimedWait` returns immediately, the mutex will not be released, and `RepeatableThread::TEST_WaitForRun` never has a chance to execute the callback which, in this case, updates the result returned by `mock_env->NowMicros()`. Consequently, `RepeatableThread::wait` cannot break out of the loop, causing test to hang. The extra 10 seconds is a best-effort approach because there seems no reliable and deterministic way to provide the aforementioned guarantee. By the time `RepeatableThread::wait` is called, there is no guarantee that the `delay + mock_env->NowMicros()` will be greater than the current real time. However, 10 seconds should be sufficient in most cases. We will keep an eye for possible flakiness of this test.

Test plan
```
$make -j32 repeatable_thread_test
$./repeatable_thread_test
./db_options_test --gtest_filter=-DBOptionsTest.DeleteObsoleteFilesPeriodChange
```

`MockTimeEnv` is also used in quite many other places. These tests also seem to hang on OS X. It is going to take a while to understand exactly why they hang on OS X (very likely due to similar reason but with different execution sequence, e.g. DBOptionsTest.DeleteObsoleteFilesPeriodChange, etc.). Therefore, I prefer not to rashly apply the technique of this PR to other tests. Instead, we can identify the failing tests, understand the interleaving, and fix one by one.