### PR TITLE
Remove some "using std::..." from header files.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,9 @@
 * statistics.stats_level_ becomes atomic. It is preferred to use statistics.set_stats_level() and statistics.get_stats_level() to access it.
 * Introduce a new IOError subcode, PathNotFound, to indicate trying to open a nonexistent file or directory for read.
 * Add initial support for multiple db instances sharing the same data in single-writer, multi-reader mode.
+* Removed some "using std::xxx" from public headers.
+
+>>>>>>> b61281cd9... Remove some "using std::..." from header files.
 ### Bug Fixes
 * Fix JEMALLOC_CXX_THROW macro missing from older Jemalloc versions, causing build failures on some platforms.
 * Fix SstFileReader not able to open file ingested with write_glbal_seqno=true.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,6 @@
 * Add initial support for multiple db instances sharing the same data in single-writer, multi-reader mode.
 * Removed some "using std::xxx" from public headers.
 
->>>>>>> b61281cd9... Remove some "using std::..." from header files.
 ### Bug Fixes
 * Fix JEMALLOC_CXX_THROW macro missing from older Jemalloc versions, causing build failures on some platforms.
 * Fix SstFileReader not able to open file ingested with write_glbal_seqno=true.

--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -98,7 +98,7 @@ class CacheTest : public testing::TestWithParam<std::string> {
     return nullptr;
   }
 
-  int Lookup(shared_ptr<Cache> cache, int key) {
+  int Lookup(std::shared_ptr<Cache> cache, int key) {
     Cache::Handle* handle = cache->Lookup(EncodeKey(key));
     const int r = (handle == nullptr) ? -1 : DecodeValue(cache->Value(handle));
     if (handle != nullptr) {
@@ -107,15 +107,15 @@ class CacheTest : public testing::TestWithParam<std::string> {
     return r;
   }
 
-  void Insert(shared_ptr<Cache> cache, int key, int value, int charge = 1) {
+  void Insert(std::shared_ptr<Cache> cache, int key, int value,
+              int charge = 1) {
     cache->Insert(EncodeKey(key), EncodeValue(value), charge,
                   &CacheTest::Deleter);
   }
 
-  void Erase(shared_ptr<Cache> cache, int key) {
+  void Erase(std::shared_ptr<Cache> cache, int key) {
     cache->Erase(EncodeKey(key));
   }
-
 
   int Lookup(int key) {
     return Lookup(cache_, key);
@@ -687,7 +687,8 @@ TEST_P(CacheTest, DefaultShardBits) {
 }
 
 #ifdef SUPPORT_CLOCK_CACHE
-shared_ptr<Cache> (*new_clock_cache_func)(size_t, int, bool) = NewClockCache;
+std::shared_ptr<Cache> (*new_clock_cache_func)(size_t, int,
+                                               bool) = NewClockCache;
 INSTANTIATE_TEST_CASE_P(CacheTestInstance, CacheTest,
                         testing::Values(kLRU, kClock));
 #else

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -2836,7 +2836,7 @@ void DBImpl::BuildCompactionJobInfo(
                               fmd->fd.GetNumber(), fmd->fd.GetPathId());
       compaction_job_info->input_files.push_back(fn);
       if (compaction_job_info->table_properties.count(fn) == 0) {
-        shared_ptr<const TableProperties> tp;
+        std::shared_ptr<const TableProperties> tp;
         auto s = current->GetTableProperties(&tp, fmd, &fn);
         if (s.ok()) {
           compaction_job_info->table_properties[fn] = tp;

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -20,7 +20,6 @@ namespace rocksdb {
 
 class SequentialFileReader;
 class Logger;
-using std::unique_ptr;
 
 namespace log {
 

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -18,7 +18,7 @@
 namespace rocksdb {
 namespace log {
 
-Writer::Writer(unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
+Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
                bool recycle_log_files, bool manual_flush)
     : dest_(std::move(dest)),
       block_offset_(0),

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -20,8 +20,6 @@ namespace rocksdb {
 
 class WritableFileWriter;
 
-using std::unique_ptr;
-
 namespace log {
 
 /**
@@ -72,8 +70,9 @@ class Writer {
   // Create a writer that will append data to "*dest".
   // "*dest" must be initially empty.
   // "*dest" must remain live while this Writer is in use.
-  explicit Writer(unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
-                  bool recycle_log_files, bool manual_flush = false);
+  explicit Writer(std::unique_ptr<WritableFileWriter>&& dest,
+                  uint64_t log_number, bool recycle_log_files,
+                  bool manual_flush = false);
   ~Writer();
 
   Status AddRecord(const Slice& slice);

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -58,8 +58,6 @@ class TraceWriter;
 class CompactionJobInfo;
 #endif
 
-using std::unique_ptr;
-
 extern const std::string kDefaultColumnFamilyName;
 struct ColumnFamilyDescriptor {
   std::string name;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -50,9 +50,6 @@ class RateLimiter;
 class ThreadStatusUpdater;
 struct ThreadStatus;
 
-using std::unique_ptr;
-using std::shared_ptr;
-
 const size_t kDefaultPageSize = 4 * 1024;
 
 // Options while opening a file to read/write

--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -41,8 +41,6 @@ class WritableFileWriter;
 struct EnvOptions;
 struct Options;
 
-using std::unique_ptr;
-
 enum ChecksumType : char {
   kNoChecksum = 0x0,
   kCRC32c = 0x1,

--- a/table/adaptive_table_factory.h
+++ b/table/adaptive_table_factory.h
@@ -14,7 +14,6 @@ namespace rocksdb {
 
 struct EnvOptions;
 
-using std::unique_ptr;
 class Status;
 class RandomAccessFile;
 class WritableFile;

--- a/table/block_based_table_factory.h
+++ b/table/block_based_table_factory.h
@@ -23,7 +23,6 @@ namespace rocksdb {
 
 struct EnvOptions;
 
-using std::unique_ptr;
 class BlockBasedTableBuilder;
 
 // A class used to track actual bytes written from the tail in the recent SST

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -58,7 +58,6 @@ namespace rocksdb {
 extern const uint64_t kBlockBasedTableMagicNumber;
 extern const std::string kHashIndexPrefixesBlock;
 extern const std::string kHashIndexPrefixesMetadataBlock;
-using std::unique_ptr;
 
 typedef BlockBasedTable::IndexReader IndexReader;
 

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -53,8 +53,6 @@ struct EnvOptions;
 struct ReadOptions;
 class GetContext;
 
-using std::unique_ptr;
-
 typedef std::vector<std::pair<std::string, std::string>> KVPairBlock;
 
 // A Table is a sorted map from strings to strings.  Tables are

--- a/table/plain_table_factory.h
+++ b/table/plain_table_factory.h
@@ -17,7 +17,6 @@ namespace rocksdb {
 
 struct EnvOptions;
 
-using std::unique_ptr;
 class Status;
 class RandomAccessFile;
 class WritableFile;

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -206,7 +206,8 @@ InternalIterator* PlainTableReader::NewIterator(
 }
 
 Status PlainTableReader::PopulateIndexRecordList(
-    PlainTableIndexBuilder* index_builder, vector<uint32_t>* prefix_hashes) {
+    PlainTableIndexBuilder* index_builder,
+    std::vector<uint32_t>* prefix_hashes) {
   Slice prev_key_prefix_slice;
   std::string prev_key_prefix_buf;
   uint32_t pos = data_start_offset_;
@@ -256,10 +257,9 @@ Status PlainTableReader::PopulateIndexRecordList(
   return s;
 }
 
-void PlainTableReader::AllocateAndFillBloom(int bloom_bits_per_key,
-                                            int num_prefixes,
-                                            size_t huge_page_tlb_size,
-                                            vector<uint32_t>* prefix_hashes) {
+void PlainTableReader::AllocateAndFillBloom(
+    int bloom_bits_per_key, int num_prefixes, size_t huge_page_tlb_size,
+    std::vector<uint32_t>* prefix_hashes) {
   if (!IsTotalOrderMode()) {
     uint32_t bloom_total_bits = num_prefixes * bloom_bits_per_key;
     if (bloom_total_bits > 0) {
@@ -271,7 +271,7 @@ void PlainTableReader::AllocateAndFillBloom(int bloom_bits_per_key,
   }
 }
 
-void PlainTableReader::FillBloom(vector<uint32_t>* prefix_hashes) {
+void PlainTableReader::FillBloom(std::vector<uint32_t>* prefix_hashes) {
   assert(bloom_.IsInitialized());
   for (auto prefix_hash : *prefix_hashes) {
     bloom_.AddHash(prefix_hash);

--- a/table/plain_table_reader.h
+++ b/table/plain_table_reader.h
@@ -39,9 +39,6 @@ class InternalKeyComparator;
 class PlainTableKeyDecoder;
 class GetContext;
 
-using std::unique_ptr;
-using std::unordered_map;
-using std::vector;
 extern const uint32_t kPlainTableVariableLength;
 
 struct PlainTableReaderFileInfo {
@@ -50,7 +47,7 @@ struct PlainTableReaderFileInfo {
   uint32_t data_end_offset;
   std::unique_ptr<RandomAccessFileReader> file;
 
-  PlainTableReaderFileInfo(unique_ptr<RandomAccessFileReader>&& _file,
+  PlainTableReaderFileInfo(std::unique_ptr<RandomAccessFileReader>&& _file,
                            const EnvOptions& storage_options,
                            uint32_t _data_size_offset)
       : is_mmap_mode(storage_options.use_mmap_reads),
@@ -202,14 +199,14 @@ class PlainTableReader: public TableReader {
   // If bloom_ is not null, all the keys' full-key hash will be added to the
   // bloom filter.
   Status PopulateIndexRecordList(PlainTableIndexBuilder* index_builder,
-                                 vector<uint32_t>* prefix_hashes);
+                                 std::vector<uint32_t>* prefix_hashes);
 
   // Internal helper function to allocate memory for bloom filter and fill it
   void AllocateAndFillBloom(int bloom_bits_per_key, int num_prefixes,
                             size_t huge_page_tlb_size,
-                            vector<uint32_t>* prefix_hashes);
+                            std::vector<uint32_t>* prefix_hashes);
 
-  void FillBloom(vector<uint32_t>* prefix_hashes);
+  void FillBloom(std::vector<uint32_t>* prefix_hashes);
 
   // Read the key and value at `offset` to parameters for keys, the and
   // `seekable`.

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1222,7 +1222,7 @@ class ReportFileOpEnv : public EnvWrapper {
       ReportFileOpCounters* counters_;
 
      public:
-      CountingFile(unique_ptr<SequentialFile>&& target,
+      CountingFile(std::unique_ptr<SequentialFile>&& target,
                    ReportFileOpCounters* counters)
           : target_(std::move(target)), counters_(counters) {}
 
@@ -1254,7 +1254,7 @@ class ReportFileOpEnv : public EnvWrapper {
       ReportFileOpCounters* counters_;
 
      public:
-      CountingFile(unique_ptr<RandomAccessFile>&& target,
+      CountingFile(std::unique_ptr<RandomAccessFile>&& target,
                    ReportFileOpCounters* counters)
           : target_(std::move(target)), counters_(counters) {}
       Status Read(uint64_t offset, size_t n, Slice* result,
@@ -1283,7 +1283,7 @@ class ReportFileOpEnv : public EnvWrapper {
       ReportFileOpCounters* counters_;
 
      public:
-      CountingFile(unique_ptr<WritableFile>&& target,
+      CountingFile(std::unique_ptr<WritableFile>&& target,
                    ReportFileOpCounters* counters)
           : target_(std::move(target)), counters_(counters) {}
 

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -35,8 +35,6 @@ namespace rocksdb {
 
 namespace {
 
-using std::unique_ptr;
-
 class DummyDB : public StackableDB {
  public:
   /* implicit */
@@ -206,7 +204,7 @@ class TestEnv : public EnvWrapper {
   }
 
   Status NewRandomAccessFile(const std::string& fname,
-                             unique_ptr<RandomAccessFile>* result,
+                             std::unique_ptr<RandomAccessFile>* result,
                              const EnvOptions& options) override {
     MutexLock l(&mutex_);
     Status s = EnvWrapper::NewRandomAccessFile(fname, result, options);

--- a/utilities/blob_db/blob_log_reader.cc
+++ b/utilities/blob_db/blob_log_reader.cc
@@ -16,7 +16,7 @@
 namespace rocksdb {
 namespace blob_db {
 
-Reader::Reader(unique_ptr<RandomAccessFileReader>&& file_reader, Env* env,
+Reader::Reader(std::unique_ptr<RandomAccessFileReader>&& file_reader, Env* env,
                Statistics* statistics)
     : file_(std::move(file_reader)),
       env_(env),

--- a/utilities/blob_db/blob_log_writer.cc
+++ b/utilities/blob_db/blob_log_writer.cc
@@ -19,7 +19,7 @@
 namespace rocksdb {
 namespace blob_db {
 
-Writer::Writer(unique_ptr<WritableFileWriter>&& dest, Env* env,
+Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, Env* env,
                Statistics* statistics, uint64_t log_number, uint64_t bpsync,
                bool use_fs, uint64_t boffset)
     : dest_(std::move(dest)),


### PR DESCRIPTION
Summary: The code convention we are following, Google C++ Style, discourage
alias in header files, especially public headers:
https://google.github.io/styleguide/cppguide.html#Aliases
Remove some of them. Might removed some from .cc files as well to be consistent.

Test Plan: Build the project.