### PR TITLE
Fix the potential DB crash caused by call EndTrace before StartTrace

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3655,7 +3655,7 @@ Status DBImpl::StartTrace(const TraceOptions& trace_options,
 Status DBImpl::EndTrace() {
   InstrumentedMutexLock lock(&trace_mutex_);
   Status s;
-  if (tracer_.get() != nullptr) {
+  if (tracer_ != nullptr) {
     s = tracer_->Close();
     tracer_.reset();
   } else {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3654,8 +3654,13 @@ Status DBImpl::StartTrace(const TraceOptions& trace_options,
 
 Status DBImpl::EndTrace() {
   InstrumentedMutexLock lock(&trace_mutex_);
-  Status s = tracer_->Close();
-  tracer_.reset();
+  Status s;
+  if (tracer_.get() != nullptr) {
+    s = tracer_->Close();
+    tracer_.reset();
+  } else {
+    return Status::IOError("No trace file to close");
+  }
   return s;
 }
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2874,6 +2874,8 @@ TEST_F(DBTest2, TraceAndReplay) {
   Random rnd(301);
   Iterator* single_iter = nullptr;
 
+  ASSERT_TRUE(db_->EndTrace().IsIOError());
+
   std::string trace_filename = dbname_ + "/rocksdb.trace";
   std::unique_ptr<TraceWriter> trace_writer;
   ASSERT_OK(NewFileTraceWriter(env_, env_opts, trace_filename, &trace_writer));


### PR DESCRIPTION
Although user should first call StartTrace to begin the RocksDB tracing function and call EndTrace to stop the tracing process, user can accidentally call EndTrace first. It will cause segment fault and crash the DB instance. The issue is fixed by checking the pointer first.

Test case added in db_test2.

Test plan:
Pass the make and make asan_check.