### PR TITLE
Add a missing define to monitoring/iostats_context_imp.h

### DIFF
--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -55,5 +55,6 @@ extern __thread IOStatsContext iostats_context;
 #define IOSTATS(metric) 0
 
 #define IOSTATS_TIMER_GUARD(metric)
+#define IOSTATS_CPU_TIMER_GUARD(metric, env)
 
 #endif  // ROCKSDB_SUPPORT_THREAD_LOCAL


### PR DESCRIPTION
I think when PR https://github.com/facebook/rocksdb/pull/4889 added the `IOSTATS_CPU_TIMER_GUARD` define to this header file, the noop version in the `#else` branch was forgotten.

Not sure if this is common, but on my MacOS machine it breaks my build