### PR TITLE
Avoid double-compacting data in bottom level in manual compactions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 ## 6.1.0 (3/27/2019)
 ### New Features
 * Introduce two more stats levels, kExceptHistogramOrTimers and kExceptTimers.
+* Added BottommostLevelCompaction::kForceOptimized to avoid double compacting newly compacted files in bottom level compaction of manual compaction.
 * Added a feature to perform data-block sampling for compressibility, and report stats to user.
 * Add support for trace filtering.
 * Add DBOptions.avoid_unnecessary_blocking_io. If true, we avoid file deletion when destorying ColumnFamilyHandle and Iterator. Instead, a job is scheduled to delete the files in background.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 ### Public API Change
 * Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.
 * Change the behavior of OptimizeForSmallDb(): use a 16MB block cache, put index and filter blocks into it, and cost the memtable size to it. DBOptions.OptimizeForSmallDb() and ColumnFamilyOptions.OptimizeForSmallDb() start to take an optional cache object.
+* Added BottommostLevelCompaction::kForceOptimized to avoid double compacting newly compacted files in bottom level compaction of manual compaction.
 
 ### Bug Fixes
 * Fix a bug in 2PC where a sequence of txn prepare, memtable flush, and crash could result in losing the prepared transaction.
@@ -18,7 +19,6 @@
 ## 6.1.0 (3/27/2019)
 ### New Features
 * Introduce two more stats levels, kExceptHistogramOrTimers and kExceptTimers.
-* Added BottommostLevelCompaction::kForceOptimized to avoid double compacting newly compacted files in bottom level compaction of manual compaction.
 * Added a feature to perform data-block sampling for compressibility, and report stats to user.
 * Add support for trace filtering.
 * Add DBOptions.avoid_unnecessary_blocking_io. If true, we avoid file deletion when destorying ColumnFamilyHandle and Iterator. Instead, a job is scheduled to delete the files in background.

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -991,11 +991,12 @@ Compaction* ColumnFamilyData::CompactRange(
     const MutableCFOptions& mutable_cf_options, int input_level,
     int output_level, uint32_t output_path_id, uint32_t max_subcompactions,
     const InternalKey* begin, const InternalKey* end,
-    InternalKey** compaction_end, bool* conflict) {
+    InternalKey** compaction_end, bool* conflict,
+    uint64_t max_sst_file_number) {
   auto* result = compaction_picker_->CompactRange(
       GetName(), mutable_cf_options, current_->storage_info(), input_level,
       output_level, output_path_id, max_subcompactions, begin, end,
-      compaction_end, conflict);
+      compaction_end, conflict, max_sst_file_number);
   if (result != nullptr) {
     result->SetInputVersion(current_);
   }

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -990,12 +990,14 @@ const int ColumnFamilyData::kCompactToBaseLevel = -2;
 Compaction* ColumnFamilyData::CompactRange(
     const MutableCFOptions& mutable_cf_options, int input_level,
     int output_level, uint32_t output_path_id, uint32_t max_subcompactions,
+    BottommostLevelCompaction bottommost_level_compaction,
     const InternalKey* begin, const InternalKey* end,
     InternalKey** compaction_end, bool* conflict,
     uint64_t max_file_num_to_ignore) {
   auto* result = compaction_picker_->CompactRange(
       GetName(), mutable_cf_options, current_->storage_info(), input_level,
-      output_level, output_path_id, max_subcompactions, begin, end,
+      output_level, output_path_id, max_subcompactions,
+      bottommost_level_compaction, begin, end,
       compaction_end, conflict, max_file_num_to_ignore);
   if (result != nullptr) {
     result->SetInputVersion(current_);

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -989,16 +989,14 @@ const int ColumnFamilyData::kCompactToBaseLevel = -2;
 
 Compaction* ColumnFamilyData::CompactRange(
     const MutableCFOptions& mutable_cf_options, int input_level,
-    int output_level, uint32_t output_path_id, uint32_t max_subcompactions,
-    BottommostLevelCompaction bottommost_level_compaction,
+    int output_level, const CompactRangeOptions& compact_range_options,
     const InternalKey* begin, const InternalKey* end,
     InternalKey** compaction_end, bool* conflict,
     uint64_t max_file_num_to_ignore) {
   auto* result = compaction_picker_->CompactRange(
       GetName(), mutable_cf_options, current_->storage_info(), input_level,
-      output_level, output_path_id, max_subcompactions,
-      bottommost_level_compaction, begin, end,
-      compaction_end, conflict, max_file_num_to_ignore);
+      output_level, compact_range_options, begin, end, compaction_end, conflict,
+      max_file_num_to_ignore);
   if (result != nullptr) {
     result->SetInputVersion(current_);
   }

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -992,11 +992,11 @@ Compaction* ColumnFamilyData::CompactRange(
     int output_level, uint32_t output_path_id, uint32_t max_subcompactions,
     const InternalKey* begin, const InternalKey* end,
     InternalKey** compaction_end, bool* conflict,
-    uint64_t max_sst_file_number) {
+    uint64_t max_file_num_to_ignore) {
   auto* result = compaction_picker_->CompactRange(
       GetName(), mutable_cf_options, current_->storage_info(), input_level,
       output_level, output_path_id, max_subcompactions, begin, end,
-      compaction_end, conflict, max_sst_file_number);
+      compaction_end, conflict, max_file_num_to_ignore);
   if (result != nullptr) {
     result->SetInputVersion(current_);
   }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -299,7 +299,7 @@ class ColumnFamilyData {
                            uint32_t output_path_id, uint32_t max_subcompactions,
                            const InternalKey* begin, const InternalKey* end,
                            InternalKey** compaction_end, bool* manual_conflict,
-                           uint64_t max_sst_file_number);
+                           uint64_t max_file_num_to_ignore);
 
   CompactionPicker* compaction_picker() { return compaction_picker_.get(); }
   // thread-safe

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -296,8 +296,7 @@ class ColumnFamilyData {
   // REQUIRES: DB mutex held
   Compaction* CompactRange(const MutableCFOptions& mutable_cf_options,
                            int input_level, int output_level,
-                           uint32_t output_path_id, uint32_t max_subcompactions,
-                           BottommostLevelCompaction bottommost_level_compaction,
+                           const CompactRangeOptions& compact_range_options,
                            const InternalKey* begin, const InternalKey* end,
                            InternalKey** compaction_end, bool* manual_conflict,
                            uint64_t max_file_num_to_ignore);

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -297,6 +297,7 @@ class ColumnFamilyData {
   Compaction* CompactRange(const MutableCFOptions& mutable_cf_options,
                            int input_level, int output_level,
                            uint32_t output_path_id, uint32_t max_subcompactions,
+                           BottommostLevelCompaction bottommost_level_compaction,
                            const InternalKey* begin, const InternalKey* end,
                            InternalKey** compaction_end, bool* manual_conflict,
                            uint64_t max_file_num_to_ignore);

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -298,7 +298,8 @@ class ColumnFamilyData {
                            int input_level, int output_level,
                            uint32_t output_path_id, uint32_t max_subcompactions,
                            const InternalKey* begin, const InternalKey* end,
-                           InternalKey** compaction_end, bool* manual_conflict);
+                           InternalKey** compaction_end, bool* manual_conflict,
+                           uint64_t max_sst_file_number);
 
   CompactionPicker* compaction_picker() { return compaction_picker_.get(); }
   // thread-safe

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -661,7 +661,7 @@ Compaction* CompactionPicker::CompactRange(
   }
   assert(output_path_id < static_cast<uint32_t>(ioptions_.cf_paths.size()));
 
-  // for bottom level compaction, skip files that are created during the
+  // for BOTTOM LEVEL compaction, skip files that are created during the
   // current compaction
   if (max_sst_file_number > 0) {
     assert(input_level == output_level);
@@ -669,6 +669,16 @@ Compaction* CompactionPicker::CompactRange(
     for (size_t i = 0; i < inputs.size(); ++i) {
       if (inputs[i]->fd.GetNumber() <= max_sst_file_number) {
         inputs_shrinked.emplace_back(inputs[i]);
+      } else {
+        // inputs[i] was created during the current manual compaction and
+        // need to be skipped
+        if (inputs_shrinked.empty()) {
+          // haven't found anything to compact, keep looking
+          continue;
+        } else {
+          // already found something to compact, skip the rest files
+          break;
+        }
       }
     }
     if (inputs_shrinked.empty()) {

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -60,7 +60,8 @@ class CompactionPicker {
       VersionStorageInfo* vstorage, int input_level, int output_level,
       uint32_t output_path_id, uint32_t max_subcompactions,
       const InternalKey* begin, const InternalKey* end,
-      InternalKey** compaction_end, bool* manual_conflict);
+      InternalKey** compaction_end, bool* manual_conflict,
+      uint64_t max_sst_file_number);
 
   // The maximum allowed output level.  Default value is NumberLevels() - 1.
   virtual int MaxOutputLevel() const { return NumberLevels() - 1; }
@@ -260,7 +261,8 @@ class NullCompactionPicker : public CompactionPicker {
                            const InternalKey* /*begin*/,
                            const InternalKey* /*end*/,
                            InternalKey** /*compaction_end*/,
-                           bool* /*manual_conflict*/) override {
+                           bool* /*manual_conflict*/,
+                           uint64_t /*max_sst_file_number*/) override {
     return nullptr;
   }
 

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -61,7 +61,7 @@ class CompactionPicker {
       uint32_t output_path_id, uint32_t max_subcompactions,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
-      uint64_t max_sst_file_number);
+      uint64_t max_file_num_to_ignore);
 
   // The maximum allowed output level.  Default value is NumberLevels() - 1.
   virtual int MaxOutputLevel() const { return NumberLevels() - 1; }
@@ -262,7 +262,7 @@ class NullCompactionPicker : public CompactionPicker {
                            const InternalKey* /*end*/,
                            InternalKey** /*compaction_end*/,
                            bool* /*manual_conflict*/,
-                           uint64_t /*max_sst_file_number*/) override {
+                           uint64_t /*max_file_num_to_ignore*/) override {
     return nullptr;
   }
 

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -59,6 +59,7 @@ class CompactionPicker {
       const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
       VersionStorageInfo* vstorage, int input_level, int output_level,
       uint32_t output_path_id, uint32_t max_subcompactions,
+      BottommostLevelCompaction bottommost_level_compaction,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
       uint64_t max_file_num_to_ignore);
@@ -258,6 +259,7 @@ class NullCompactionPicker : public CompactionPicker {
                            int /*input_level*/, int /*output_level*/,
                            uint32_t /*output_path_id*/,
                            uint32_t /*max_subcompactions*/,
+                           BottommostLevelCompaction /*bottommost_level_compaction*/,
                            const InternalKey* /*begin*/,
                            const InternalKey* /*end*/,
                            InternalKey** /*compaction_end*/,

--- a/db/compaction_picker.h
+++ b/db/compaction_picker.h
@@ -58,8 +58,7 @@ class CompactionPicker {
   virtual Compaction* CompactRange(
       const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
       VersionStorageInfo* vstorage, int input_level, int output_level,
-      uint32_t output_path_id, uint32_t max_subcompactions,
-      BottommostLevelCompaction bottommost_level_compaction,
+      const CompactRangeOptions& compact_range_options,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
       uint64_t max_file_num_to_ignore);
@@ -257,9 +256,7 @@ class NullCompactionPicker : public CompactionPicker {
                            const MutableCFOptions& /*mutable_cf_options*/,
                            VersionStorageInfo* /*vstorage*/,
                            int /*input_level*/, int /*output_level*/,
-                           uint32_t /*output_path_id*/,
-                           uint32_t /*max_subcompactions*/,
-                           BottommostLevelCompaction /*bottommost_level_compaction*/,
+                           const CompactRangeOptions& /*compact_range_options*/,
                            const InternalKey* /*begin*/,
                            const InternalKey* /*end*/,
                            InternalKey** /*compaction_end*/,

--- a/db/compaction_picker_fifo.cc
+++ b/db/compaction_picker_fifo.cc
@@ -214,6 +214,7 @@ Compaction* FIFOCompactionPicker::CompactRange(
     const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
     VersionStorageInfo* vstorage, int input_level, int output_level,
     uint32_t /*output_path_id*/, uint32_t /*max_subcompactions*/,
+    BottommostLevelCompaction /*bottommost_level_compaction*/,
     const InternalKey* /*begin*/, const InternalKey* /*end*/,
     InternalKey** compaction_end, bool* /*manual_conflict*/,
     uint64_t /*max_file_num_to_ignore*/) {

--- a/db/compaction_picker_fifo.cc
+++ b/db/compaction_picker_fifo.cc
@@ -216,7 +216,7 @@ Compaction* FIFOCompactionPicker::CompactRange(
     uint32_t /*output_path_id*/, uint32_t /*max_subcompactions*/,
     const InternalKey* /*begin*/, const InternalKey* /*end*/,
     InternalKey** compaction_end, bool* /*manual_conflict*/,
-    uint64_t /*max_sst_file_number*/) {
+    uint64_t /*max_file_num_to_ignore*/) {
 #ifdef NDEBUG
   (void)input_level;
   (void)output_level;

--- a/db/compaction_picker_fifo.cc
+++ b/db/compaction_picker_fifo.cc
@@ -213,8 +213,7 @@ Compaction* FIFOCompactionPicker::PickCompaction(
 Compaction* FIFOCompactionPicker::CompactRange(
     const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
     VersionStorageInfo* vstorage, int input_level, int output_level,
-    uint32_t /*output_path_id*/, uint32_t /*max_subcompactions*/,
-    BottommostLevelCompaction /*bottommost_level_compaction*/,
+    const CompactRangeOptions& /*compact_range_options*/,
     const InternalKey* /*begin*/, const InternalKey* /*end*/,
     InternalKey** compaction_end, bool* /*manual_conflict*/,
     uint64_t /*max_file_num_to_ignore*/) {

--- a/db/compaction_picker_fifo.cc
+++ b/db/compaction_picker_fifo.cc
@@ -215,7 +215,8 @@ Compaction* FIFOCompactionPicker::CompactRange(
     VersionStorageInfo* vstorage, int input_level, int output_level,
     uint32_t /*output_path_id*/, uint32_t /*max_subcompactions*/,
     const InternalKey* /*begin*/, const InternalKey* /*end*/,
-    InternalKey** compaction_end, bool* /*manual_conflict*/) {
+    InternalKey** compaction_end, bool* /*manual_conflict*/,
+    uint64_t /*max_sst_file_number*/) {
 #ifdef NDEBUG
   (void)input_level;
   (void)output_level;

--- a/db/compaction_picker_fifo.h
+++ b/db/compaction_picker_fifo.h
@@ -30,7 +30,7 @@ class FIFOCompactionPicker : public CompactionPicker {
       uint32_t output_path_id, uint32_t max_subcompactions,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
-      uint64_t max_sst_file_number) override;
+      uint64_t max_file_num_to_ignore) override;
 
   // The maximum allowed output level.  Always returns 0.
   virtual int MaxOutputLevel() const override { return 0; }

--- a/db/compaction_picker_fifo.h
+++ b/db/compaction_picker_fifo.h
@@ -28,6 +28,7 @@ class FIFOCompactionPicker : public CompactionPicker {
       const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
       VersionStorageInfo* vstorage, int input_level, int output_level,
       uint32_t output_path_id, uint32_t max_subcompactions,
+      BottommostLevelCompaction bottommost_level_compaction,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
       uint64_t max_file_num_to_ignore) override;

--- a/db/compaction_picker_fifo.h
+++ b/db/compaction_picker_fifo.h
@@ -27,8 +27,7 @@ class FIFOCompactionPicker : public CompactionPicker {
   virtual Compaction* CompactRange(
       const std::string& cf_name, const MutableCFOptions& mutable_cf_options,
       VersionStorageInfo* vstorage, int input_level, int output_level,
-      uint32_t output_path_id, uint32_t max_subcompactions,
-      BottommostLevelCompaction bottommost_level_compaction,
+      const CompactRangeOptions& compact_range_options,
       const InternalKey* begin, const InternalKey* end,
       InternalKey** compaction_end, bool* manual_conflict,
       uint64_t max_file_num_to_ignore) override;

--- a/db/compaction_picker_fifo.h
+++ b/db/compaction_picker_fifo.h
@@ -29,7 +29,8 @@ class FIFOCompactionPicker : public CompactionPicker {
       VersionStorageInfo* vstorage, int input_level, int output_level,
       uint32_t output_path_id, uint32_t max_subcompactions,
       const InternalKey* begin, const InternalKey* end,
-      InternalKey** compaction_end, bool* manual_conflict) override;
+      InternalKey** compaction_end, bool* manual_conflict,
+      uint64_t max_sst_file_number) override;
 
   // The maximum allowed output level.  Always returns 0.
   virtual int MaxOutputLevel() const override { return 0; }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -353,7 +353,7 @@ TEST_P(DBCompactionTestWithParam, CompactionsPreserveDeletes) {
     CompactRangeOptions cro;
     cro.change_level = true;
     cro.target_level = 2;
-    cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+    cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
 
     dbfull()->TEST_WaitForFlushMemTable();
     dbfull()->CompactRange(cro, nullptr, nullptr);
@@ -511,7 +511,7 @@ TEST_F(DBCompactionTest, TestTableReaderForCompaction) {
   CompactRangeOptions cro;
   cro.change_level = true;
   cro.target_level = 2;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   db_->CompactRange(cro, nullptr, nullptr);
   // Only verifying compaction outputs issues one table cache lookup
   // for both data block and range deletion block).
@@ -2260,6 +2260,8 @@ TEST_P(DBCompactionTestWithParam, ConvertCompactionStyle) {
   CompactRangeOptions compact_options;
   compact_options.change_level = true;
   compact_options.target_level = 0;
+  // cannot use kForceOptimized here because the compaction here is expected
+  // to generate one output file
   compact_options.bottommost_level_compaction =
       BottommostLevelCompaction::kForce;
   compact_options.exclusive_manual_compaction = exclusive_manual_compaction_;
@@ -3039,7 +3041,7 @@ TEST_P(DBCompactionTestWithParam, ForceBottommostLevelCompaction) {
   // then compacte the bottommost level L3=>L3 (non trivial move)
   compact_options = CompactRangeOptions();
   compact_options.bottommost_level_compaction =
-      BottommostLevelCompaction::kForce;
+      BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
   ASSERT_EQ("0,0,0,1", FilesPerLevel(0));
   ASSERT_EQ(trivial_move, 4);
@@ -4378,7 +4380,7 @@ TEST_F(DBCompactionTest, PartialManualCompaction) {
       {{"max_compaction_bytes", std::to_string(max_compaction_bytes)}}));
 
   CompactRangeOptions cro;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   dbfull()->CompactRange(cro, nullptr, nullptr);
 }
 
@@ -4425,7 +4427,7 @@ TEST_F(DBCompactionTest, ManualCompactionFailsInReadOnlyMode) {
 // ManualCompactionBottomLevelOptimization tests the bottom level manual
 // compaction optimization to skip recompacting files created by Ln-1 to Ln
 // compaction
-TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimization) {
+TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimized) {
   Options opts = CurrentOptions();
   opts.num_levels = 3;
   opts.level0_file_num_compaction_trigger = 5;
@@ -4463,7 +4465,7 @@ TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimization) {
   ASSERT_EQ(num, 0);
 
   CompactRangeOptions cro;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   dbfull()->CompactRange(cro, nullptr, nullptr);
 
   const std::vector<InternalStats::CompactionStats>& comp_stats2 =

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -353,7 +353,8 @@ TEST_P(DBCompactionTestWithParam, CompactionsPreserveDeletes) {
     CompactRangeOptions cro;
     cro.change_level = true;
     cro.target_level = 2;
-    cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
+    cro.bottommost_level_compaction =
+        BottommostLevelCompaction::kForceOptimized;
 
     dbfull()->TEST_WaitForFlushMemTable();
     dbfull()->CompactRange(cro, nullptr, nullptr);
@@ -4446,7 +4447,8 @@ TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimized) {
   Random rnd(301);
   for (auto i = 0; i < 8; ++i) {
     for (auto j = 0; j < 10; ++j) {
-      ASSERT_OK(Put("foo" + std::to_string(i*10+j), RandomString(&rnd, 1024)));
+      ASSERT_OK(
+          Put("foo" + std::to_string(i * 10 + j), RandomString(&rnd, 1024)));
     }
     Flush();
   }
@@ -4455,7 +4457,8 @@ TEST_F(DBCompactionTest, ManualCompactionBottomLevelOptimized) {
 
   for (auto i = 0; i < 8; ++i) {
     for (auto j = 0; j < 10; ++j) {
-      ASSERT_OK(Put("bar" + std::to_string(i*10+j), RandomString(&rnd, 1024)));
+      ASSERT_OK(
+          Put("bar" + std::to_string(i * 10 + j), RandomString(&rnd, 1024)));
     }
     Flush();
   }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -383,6 +383,11 @@ class DBImpl : public DB {
   Status TraceIteratorSeekForPrev(const uint32_t& cf_id, const Slice& key);
 #endif  // ROCKSDB_LITE
 
+
+  // Collect the largest sst file number under the db directory
+  // REQUIRES: mutex locked
+  uint64_t GetMaxSSTFileNumber() const;
+
   // Similar to GetSnapshot(), but also lets the db know that this snapshot
   // will be used for transaction write-conflict checking.  The DB can then
   // make sure not to compact any keys that would prevent a write-conflict from
@@ -395,11 +400,14 @@ class DBImpl : public DB {
 
   virtual Status GetDbIdentity(std::string& identity) const override;
 
+  // pass non-zero max_sst_file_number to allow bottom level compaction to
+  // skip newly created sst files
   Status RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                              int output_level, uint32_t output_path_id,
                              uint32_t max_subcompactions, const Slice* begin,
                              const Slice* end, bool exclusive,
-                             bool disallow_trivial_move = false);
+                             bool disallow_trivial_move,
+                             uint64_t max_sst_file_number);
 
   // Return an internal iterator over the current state of the database.
   // The keys of this iterator are internal keys (see format.h).

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -399,12 +399,10 @@ class DBImpl : public DB {
   // compacted SST files. Setting max_file_num_to_ignore to kMaxUint64 will
   // disable the filtering
   Status RunManualCompaction(ColumnFamilyData* cfd, int input_level,
-                             int output_level, uint32_t output_path_id,
-                             uint32_t max_subcompactions,
-                             BottommostLevelCompaction bottommost_level_compaction,
-                             const Slice* begin,
-                             const Slice* end, bool exclusive,
-                             bool disallow_trivial_move,
+                             int output_level,
+                             const CompactRangeOptions& compact_range_options,
+                             const Slice* begin, const Slice* end,
+                             bool exclusive, bool disallow_trivial_move,
                              uint64_t max_file_num_to_ignore);
 
   // Return an internal iterator over the current state of the database.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -400,7 +400,9 @@ class DBImpl : public DB {
   // disable the filtering
   Status RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                              int output_level, uint32_t output_path_id,
-                             uint32_t max_subcompactions, const Slice* begin,
+                             uint32_t max_subcompactions,
+                             BottommostLevelCompaction bottommost_level_compaction,
+                             const Slice* begin,
                              const Slice* end, bool exclusive,
                              bool disallow_trivial_move,
                              uint64_t max_file_num_to_ignore);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -383,11 +383,6 @@ class DBImpl : public DB {
   Status TraceIteratorSeekForPrev(const uint32_t& cf_id, const Slice& key);
 #endif  // ROCKSDB_LITE
 
-
-  // Collect the largest sst file number under the db directory
-  // REQUIRES: mutex locked
-  uint64_t GetMaxSSTFileNumber() const;
-
   // Similar to GetSnapshot(), but also lets the db know that this snapshot
   // will be used for transaction write-conflict checking.  The DB can then
   // make sure not to compact any keys that would prevent a write-conflict from
@@ -400,14 +395,15 @@ class DBImpl : public DB {
 
   virtual Status GetDbIdentity(std::string& identity) const override;
 
-  // pass non-zero max_sst_file_number to allow bottom level compaction to
-  // skip newly created sst files
+  // max_file_num_to_ignore allows bottom level compaction to filter out newly
+  // compacted SST files. Setting max_file_num_to_ignore to kMaxUint64 will
+  // disable the filtering
   Status RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                              int output_level, uint32_t output_path_id,
                              uint32_t max_subcompactions, const Slice* begin,
                              const Slice* end, bool exclusive,
                              bool disallow_trivial_move,
-                             uint64_t max_sst_file_number);
+                             uint64_t max_file_num_to_ignore);
 
   // Return an internal iterator over the current state of the database.
   // The keys of this iterator are internal keys (see format.h).

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -712,8 +712,9 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
     }
     s = RunManualCompaction(cfd, ColumnFamilyData::kCompactAllLevels,
                             final_output_level, options.target_path_id,
-                            options.max_subcompactions, begin, end, exclusive,
-                            false, max_file_num_to_ignore);
+                            options.max_subcompactions,
+                            options.bottommost_level_compaction, begin, end,
+                            exclusive, false, max_file_num_to_ignore);
   } else {
     for (int level = 0; level <= max_level_with_files; level++) {
       int output_level;
@@ -751,7 +752,8 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
         }
       }
       s = RunManualCompaction(cfd, level, output_level, options.target_path_id,
-                              options.max_subcompactions, begin, end,
+                              options.max_subcompactions,
+                              options.bottommost_level_compaction, begin, end,
                               exclusive, false, max_file_num_to_ignore);
       if (!s.ok()) {
         break;
@@ -1338,6 +1340,7 @@ Status DBImpl::Flush(const FlushOptions& flush_options,
 Status DBImpl::RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                                    int output_level, uint32_t output_path_id,
                                    uint32_t max_subcompactions,
+                                   BottommostLevelCompaction bottommost_level_compaction,
                                    const Slice* begin, const Slice* end,
                                    bool exclusive, bool disallow_trivial_move,
                                    uint64_t max_file_num_to_ignore) {
@@ -1429,6 +1432,7 @@ Status DBImpl::RunManualCompaction(ColumnFamilyData* cfd, int input_level,
          ((compaction = manual.cfd->CompactRange(
                *manual.cfd->GetLatestMutableCFOptions(), manual.input_level,
                manual.output_level, manual.output_path_id, max_subcompactions,
+               bottommost_level_compaction,
                manual.begin, manual.end, &manual.manual_end,
                &manual_conflict, max_file_num_to_ignore)) == nullptr &&
           manual_conflict))) {

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -639,25 +639,6 @@ void DBImpl::NotifyOnFlushCompleted(ColumnFamilyData* cfd,
 #endif  // ROCKSDB_LITE
 }
 
-
-uint64_t DBImpl::GetMaxSSTFileNumber() const {
-  std::vector<std::string> files;
-  uint64_t largest_file_number = 0;
-  env_->GetChildren(dbname_, &files);
-
-  uint64_t number;
-  FileType type;
-  for (size_t i = 0; i < files.size(); ++i) {
-    if (ParseFileName(files[i], &number, &type)) {
-      if (type == kTableFile && number > largest_file_number) {
-        largest_file_number = number;
-      }
-    }
-  }
-  return largest_file_number;
-}
-
-
 Status DBImpl::CompactRange(const CompactRangeOptions& options,
                             ColumnFamilyHandle* column_family,
                             const Slice* begin, const Slice* end) {
@@ -703,9 +684,10 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
   }
 
   int max_level_with_files = 0;
-  // largest sst file number before compaction starts, possibly skip any
-  // files with number > max_sst_file_number
-  uint64_t max_sst_file_number = 0;
+  // max_file_num_to_ignore can be used to filter out newly created SST files, useful
+  // for bottom level compaction in a manual compaction
+  uint64_t max_file_num_to_ignore = port::kMaxUint64;
+  uint64_t next_file_number = port::kMaxUint64;
   {
     InstrumentedMutexLock l(&mutex_);
     Version* base = cfd->current();
@@ -715,11 +697,11 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
         max_level_with_files = level;
       }
     }
-    max_sst_file_number = GetMaxSSTFileNumber();
+    next_file_number = versions_->current_next_file_number();
   }
 
   int final_output_level = 0;
-  uint64_t max_sst_file_number_to_use = 0;
+
   if (cfd->ioptions()->compaction_style == kCompactionStyleUniversal &&
       cfd->NumberLevels() > 1) {
     // Always compact all files together.
@@ -731,7 +713,7 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
     s = RunManualCompaction(cfd, ColumnFamilyData::kCompactAllLevels,
                             final_output_level, options.target_path_id,
                             options.max_subcompactions, begin, end, exclusive,
-                            false, 0);
+                            false, max_file_num_to_ignore);
   } else {
     for (int level = 0; level <= max_level_with_files; level++) {
       int output_level;
@@ -756,8 +738,10 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
           continue;
         }
         output_level = level;
-        // only use max_sst_file_number for bottom level compaction
-        max_sst_file_number_to_use = max_sst_file_number;
+        // update max_file_num_to_ignore only for bottom level compaction because
+        // data in newly compacted files in middle levels may still need to
+        // be pushed down
+        max_file_num_to_ignore = next_file_number;
       } else {
         output_level = level + 1;
         if (cfd->ioptions()->compaction_style == kCompactionStyleLevel &&
@@ -766,10 +750,9 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
           output_level = ColumnFamilyData::kCompactToBaseLevel;
         }
       }
-      // max_sst_file_number should only be non-zero for bottom level
       s = RunManualCompaction(cfd, level, output_level, options.target_path_id,
                               options.max_subcompactions, begin, end,
-                              exclusive, false, max_sst_file_number_to_use);
+                              exclusive, false, max_file_num_to_ignore);
       if (!s.ok()) {
         break;
       }
@@ -1357,7 +1340,7 @@ Status DBImpl::RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                                    uint32_t max_subcompactions,
                                    const Slice* begin, const Slice* end,
                                    bool exclusive, bool disallow_trivial_move,
-                                   uint64_t max_sst_file_number) {
+                                   uint64_t max_file_num_to_ignore) {
   assert(input_level == ColumnFamilyData::kCompactAllLevels ||
          input_level >= 0);
 
@@ -1447,7 +1430,7 @@ Status DBImpl::RunManualCompaction(ColumnFamilyData* cfd, int input_level,
                *manual.cfd->GetLatestMutableCFOptions(), manual.input_level,
                manual.output_level, manual.output_path_id, max_subcompactions,
                manual.begin, manual.end, &manual.manual_end,
-               &manual_conflict, max_sst_file_number)) == nullptr &&
+               &manual_conflict, max_file_num_to_ignore)) == nullptr &&
           manual_conflict))) {
       // exclusive manual compactions should not see a conflict during
       // CompactRange

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -93,11 +93,8 @@ Status DBImpl::TEST_CompactRange(int level, const Slice* begin,
        cfd->ioptions()->compaction_style == kCompactionStyleFIFO)
           ? level
           : level + 1;
-  return RunManualCompaction(cfd, level, output_level, 0 /*output_path_id*/,
-                             0 /*max_subcompactions*/,
-                             BottommostLevelCompaction::kIfHaveCompactionFilter,
-                             begin, end, true,
-                             disallow_trivial_move,
+  return RunManualCompaction(cfd, level, output_level, CompactRangeOptions(),
+                             begin, end, true, disallow_trivial_move,
                              port::kMaxUint64 /*max_file_num_to_ignore*/);
 }
 

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -94,7 +94,8 @@ Status DBImpl::TEST_CompactRange(int level, const Slice* begin,
           ? level
           : level + 1;
   return RunManualCompaction(cfd, level, output_level, 0, 0, begin, end, true,
-                             disallow_trivial_move, 0 /*max_sst_file_number*/);
+                             disallow_trivial_move,
+                             port::kMaxUint64 /*max_file_num_to_ignore*/);
 }
 
 Status DBImpl::TEST_SwitchMemtable(ColumnFamilyData* cfd) {

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -94,7 +94,7 @@ Status DBImpl::TEST_CompactRange(int level, const Slice* begin,
           ? level
           : level + 1;
   return RunManualCompaction(cfd, level, output_level, 0, 0, begin, end, true,
-                             disallow_trivial_move);
+                             disallow_trivial_move, 0 /*max_sst_file_number*/);
 }
 
 Status DBImpl::TEST_SwitchMemtable(ColumnFamilyData* cfd) {

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -93,7 +93,10 @@ Status DBImpl::TEST_CompactRange(int level, const Slice* begin,
        cfd->ioptions()->compaction_style == kCompactionStyleFIFO)
           ? level
           : level + 1;
-  return RunManualCompaction(cfd, level, output_level, 0, 0, begin, end, true,
+  return RunManualCompaction(cfd, level, output_level, 0 /*output_path_id*/,
+                             0 /*max_subcompactions*/,
+                             BottommostLevelCompaction::kIfHaveCompactionFilter,
+                             begin, end, true,
                              disallow_trivial_move,
                              port::kMaxUint64 /*max_file_num_to_ignore*/);
 }

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -440,7 +440,8 @@ TEST_F(DBRangeDelTest, ValidUniversalSubcompactionBoundaries) {
           ->cfd(),
       1 /* input_level */, 2 /* output_level */, 0 /* output_path_id */,
       0 /* max_subcompactions */, nullptr /* begin */, nullptr /* end */,
-      true /* exclusive */, true /* disallow_trivial_move */));
+      true /* exclusive */, true /* disallow_trivial_move */,
+      0 /* max_sst_file_number */));
 }
 #endif  // ROCKSDB_LITE
 

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -438,10 +438,9 @@ TEST_F(DBRangeDelTest, ValidUniversalSubcompactionBoundaries) {
   ASSERT_OK(dbfull()->RunManualCompaction(
       reinterpret_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily())
           ->cfd(),
-      1 /* input_level */, 2 /* output_level */, 0 /* output_path_id */,
-      0 /* max_subcompactions */,
-      BottommostLevelCompaction::kIfHaveCompactionFilter, nullptr /* begin */,
-      nullptr /* end */, true /* exclusive */, true /* disallow_trivial_move */,
+      1 /* input_level */, 2 /* output_level */, CompactRangeOptions(),
+      nullptr /* begin */, nullptr /* end */, true /* exclusive */,
+      true /* disallow_trivial_move */,
       port::kMaxUint64 /* max_file_num_to_ignore */));
 }
 #endif  // ROCKSDB_LITE

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -441,7 +441,7 @@ TEST_F(DBRangeDelTest, ValidUniversalSubcompactionBoundaries) {
       1 /* input_level */, 2 /* output_level */, 0 /* output_path_id */,
       0 /* max_subcompactions */, nullptr /* begin */, nullptr /* end */,
       true /* exclusive */, true /* disallow_trivial_move */,
-      0 /* max_sst_file_number */));
+      port::kMaxUint64 /* max_file_num_to_ignore */));
 }
 #endif  // ROCKSDB_LITE
 

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -439,8 +439,9 @@ TEST_F(DBRangeDelTest, ValidUniversalSubcompactionBoundaries) {
       reinterpret_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily())
           ->cfd(),
       1 /* input_level */, 2 /* output_level */, 0 /* output_path_id */,
-      0 /* max_subcompactions */, nullptr /* begin */, nullptr /* end */,
-      true /* exclusive */, true /* disallow_trivial_move */,
+      0 /* max_subcompactions */,
+      BottommostLevelCompaction::kIfHaveCompactionFilter, nullptr /* begin */,
+      nullptr /* end */, true /* exclusive */, true /* disallow_trivial_move */,
       port::kMaxUint64 /* max_file_num_to_ignore */));
 }
 #endif  // ROCKSDB_LITE

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -457,7 +457,9 @@ TEST_F(DBSSTTest, RateLimitedWALDelete) {
   ASSERT_EQ("4", FilesPerLevel(0));
 
   // Compaction will move the 4 files in L0 to trash and create 1 L1 file
-  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  CompactRangeOptions cro;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
   ASSERT_OK(dbfull()->TEST_WaitForCompact(true));
   ASSERT_EQ("0,1", FilesPerLevel(0));
 
@@ -563,7 +565,7 @@ TEST_F(DBSSTTest, DeleteSchedulerMultipleDBPaths) {
   // Compaction will delete both files and regenerate a file in L1 in second
   // db path. The deleted files should still be cleaned up via delete scheduler.
   compact_options.bottommost_level_compaction =
-      BottommostLevelCompaction::kForce;
+      BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(compact_options, nullptr, nullptr));
   ASSERT_EQ("0,1", FilesPerLevel(0));
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1194,7 +1194,7 @@ TEST_F(DBTest2, PresetCompressionDictLocality) {
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   CompactRangeOptions compact_range_opts;
   compact_range_opts.bottommost_level_compaction =
-      BottommostLevelCompaction::kForce;
+      BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(compact_range_opts, nullptr, nullptr));
 
   // Dictionary compression should not be so good as to compress four totally
@@ -1712,7 +1712,7 @@ TEST_F(DBTest2, MaxCompactionBytesTest) {
     GenerateNewRandomFile(&rnd);
   }
   CompactRangeOptions cro;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
   ASSERT_EQ("0,0,8", FilesPerLevel(0));
 
@@ -2303,7 +2303,7 @@ TEST_F(DBTest2, AutomaticCompactionOverlapManualCompaction) {
   // Run a manual compaction that will compact the 2 files in L2
   // into 1 file in L2
   cro.exclusive_manual_compaction = false;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
 
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
@@ -2377,7 +2377,7 @@ TEST_F(DBTest2, ManualCompactionOverlapManualCompaction) {
   // into 1 file in L1
   CompactRangeOptions cro;
   cro.exclusive_manual_compaction = false;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
   bg_thread.join();
 

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -492,7 +492,7 @@ TEST_F(EventListenerTest, CompactionReasonLevel) {
 
   Put("key", "value");
   CompactRangeOptions cro;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
   ASSERT_OK(db_->CompactRange(cro, nullptr, nullptr));
   ASSERT_GT(listener->compaction_reasons_.size(), 0);
   for (auto compaction_reason : listener->compaction_reasons_) {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1301,6 +1301,9 @@ enum class BottommostLevelCompaction {
   kIfHaveCompactionFilter,
   // Always compact bottommost level
   kForce,
+  // Always compact bottommost level but in bottommost level avoid
+  // double-compacting files created in the same compaction
+  kForceOptimized,
 };
 
 // CompactRangeOptions is used by CompactRange() call.

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -1360,9 +1360,9 @@ class JniUtil {
  public:
     /**
      * Detect if jlong overflows size_t
-     * 
+     *
      * @param jvalue the jlong value
-     * 
+     *
      * @return
      */
     inline static Status check_if_jlong_fits_size_t(const jlong& jvalue) {
@@ -1588,8 +1588,8 @@ class JniUtil {
      * @param bytes The bytes to copy
      *
      * @return the Java byte[], or nullptr if an exception occurs
-     * 
-     * @throws RocksDBException thrown 
+     *
+     * @throws RocksDBException thrown
      *   if memory size to copy exceeds general java specific array size limitation.
      */
     static jbyteArray copyBytes(JNIEnv* env, std::string bytes) {
@@ -1827,7 +1827,7 @@ class JniUtil {
 
       return env->NewStringUTF(string->c_str());
     }
-    
+
     /**
       * Copies bytes to a new jByteArray with the check of java array size limitation.
       *
@@ -1835,29 +1835,29 @@ class JniUtil {
       * @param size number of bytes to copy
       *
       * @return the Java byte[], or nullptr if an exception occurs
-      * 
-      * @throws RocksDBException thrown 
+      *
+      * @throws RocksDBException thrown
       *   if memory size to copy exceeds general java array size limitation to avoid overflow.
       */
     static jbyteArray createJavaByteArrayWithSizeCheck(JNIEnv* env, const char* bytes, const size_t size) {
       // Limitation for java array size is vm specific
       // In general it cannot exceed Integer.MAX_VALUE (2^31 - 1)
       // Current HotSpot VM limitation for array size is Integer.MAX_VALUE - 5 (2^31 - 1 - 5)
-      // It means that the next call to env->NewByteArray can still end with 
+      // It means that the next call to env->NewByteArray can still end with
       // OutOfMemoryError("Requested array size exceeds VM limit") coming from VM
       static const size_t MAX_JARRAY_SIZE = (static_cast<size_t>(1)) << 31;
       if(size > MAX_JARRAY_SIZE) {
         rocksdb::RocksDBExceptionJni::ThrowNew(env, "Requested array size exceeds VM limit");
         return nullptr;
       }
-      
+
       const jsize jlen = static_cast<jsize>(size);
       jbyteArray jbytes = env->NewByteArray(jlen);
       if(jbytes == nullptr) {
-        // exception thrown: OutOfMemoryError	
+        // exception thrown: OutOfMemoryError
         return nullptr;
       }
-      
+
       env->SetByteArrayRegion(jbytes, 0, jlen,
         const_cast<jbyte*>(reinterpret_cast<const jbyte*>(bytes)));
       if(env->ExceptionCheck()) {
@@ -1876,8 +1876,8 @@ class JniUtil {
      * @param bytes The bytes to copy
      *
      * @return the Java byte[] or nullptr if an exception occurs
-     * 
-     * @throws RocksDBException thrown 
+     *
+     * @throws RocksDBException thrown
      *   if memory size to copy exceeds general java specific array size limitation.
      */
     static jbyteArray copyBytes(JNIEnv* env, const Slice& bytes) {
@@ -2007,13 +2007,13 @@ class JniUtil {
     /**
      * Creates a vector<T*> of C++ pointers from
      *     a Java array of C++ pointer addresses.
-     * 
+     *
      * @param env (IN) A pointer to the java environment
      * @param pointers (IN) A Java array of C++ pointer addresses
      * @param has_exception (OUT) will be set to JNI_TRUE
      *     if an ArrayIndexOutOfBoundsException or OutOfMemoryError
      *     exception occurs.
-     * 
+     *
      * @return A vector of C++ pointers.
      */
     template<typename T> static std::vector<T*> fromJPointers(
@@ -2037,13 +2037,13 @@ class JniUtil {
     /**
      * Creates a Java array of C++ pointer addresses
      *     from a vector of C++ pointers.
-     * 
+     *
      * @param env (IN) A pointer to the java environment
      * @param pointers (IN) A vector of C++ pointers
      * @param has_exception (OUT) will be set to JNI_TRUE
      *     if an ArrayIndexOutOfBoundsException or OutOfMemoryError
      *     exception occurs
-     * 
+     *
      * @return Java array of C++ pointer addresses.
      */
     template<typename T> static jlongArray toJPointers(JNIEnv* env,
@@ -4084,6 +4084,8 @@ class BottommostLevelCompactionJni {
         return 0x1;
       case rocksdb::BottommostLevelCompaction::kForce:
         return 0x2;
+      case rocksdb::BottommostLevelCompaction::kForceOptimized:
+        return 0x3;
       default:
         return 0x7F;  // undefined
     }
@@ -4100,6 +4102,8 @@ class BottommostLevelCompactionJni {
         return rocksdb::BottommostLevelCompaction::kIfHaveCompactionFilter;
       case 0x2:
         return rocksdb::BottommostLevelCompaction::kForce;
+      case 0x3:
+        return rocksdb::BottommostLevelCompaction::kForceOptimized;
       default:
         // undefined/default
         return rocksdb::BottommostLevelCompaction::kIfHaveCompactionFilter;
@@ -5670,7 +5674,7 @@ class TablePropertiesJni : public JavaClass {
       env->DeleteLocalRef(jmerge_operator_name);
       return nullptr;
     }
-  
+
     jstring jproperty_collectors_names = rocksdb::JniUtil::toJavaString(env, &table_properties.property_collectors_names, true);
     if (env->ExceptionCheck()) {
       // exception occurred creating java string

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6070,7 +6070,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
   void Compact(ThreadState* thread) {
     DB* db = SelectDB(thread);
     CompactRangeOptions cro;
-    cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
+    cro.bottommost_level_compaction =
+        BottommostLevelCompaction::kForceOptimized;
     db->CompactRange(cro, nullptr, nullptr);
   }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6070,7 +6070,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
   void Compact(ThreadState* thread) {
     DB* db = SelectDB(thread);
     CompactRangeOptions cro;
-    cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+    cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
     db->CompactRange(cro, nullptr, nullptr);
   }
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -849,7 +849,7 @@ void CompactorCommand::DoCommand() {
   }
 
   CompactRangeOptions cro;
-  cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
+  cro.bottommost_level_compaction = BottommostLevelCompaction::kForceOptimized;
 
   db_->CompactRange(cro, GetCfHandle(), begin, end);
   exec_state_ = LDBCommandExecuteResult::Succeed("");

--- a/utilities/option_change_migration/option_change_migration.cc
+++ b/utilities/option_change_migration/option_change_migration.cc
@@ -56,6 +56,8 @@ Status CompactToLevel(const Options& options, const std::string& dbname,
   cro.change_level = true;
   cro.target_level = dest_level;
   if (dest_level == 0) {
+    // cannot use kForceOptimized because the compaction is expected to
+    // generate one output file
     cro.bottommost_level_compaction = BottommostLevelCompaction::kForce;
   }
   db->CompactRange(cro, nullptr, nullptr);


### PR DESCRIPTION
Depending on the config, manual compaction (leveled compaction style) does following compactions:
L0->L1
L1->L2
...
Ln-1 -> Ln
Ln -> Ln
The final Ln -> Ln compaction is partly unnecessary as it recompacts all the files that were just generated by the Ln-1 -> Ln. We should avoid recompacting such files. This rule should be applied to Lmax only.
Resolves issue https://github.com/facebook/rocksdb/issues/4995