### PR TITLE
Silence clang-analyzer error in DeleteFileTest.BackgroundPurgeCFDropTest

### DIFF
--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -288,6 +288,7 @@ TEST_F(DeleteFileTest, BackgroundPurgeCFDropTest) {
     FlushOptions fo;
     ColumnFamilyHandle* cfh = nullptr;
 
+    assert(db_); // silence a weird clang-analyzer error
     ASSERT_OK(db_->CreateColumnFamily(co, "dropme", &cfh));
 
     ASSERT_OK(db_->Put(wo, cfh, "pika", "chu"));


### PR DESCRIPTION
The error says that db_ can be null. It indeed can, if DB::Open() fails in DeleteFileTest's constructor. But (a) adding an `if (!db_) std::abort()` in constructor doesn't help, (b) why doesn't it raise the same error for all the other test cases in that file? Maybe it gets confused by the lambda? I couldn't figure it out, so this PR just suppresses the warning.