### PR TITLE
WriteUnPrepared: fix ubsan complaint

### DIFF
--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -42,14 +42,15 @@ class WriteUnpreparedTxnReadCallback : public ReadCallback {
 
   // TODO(myabandeh): override Refresh when Iterator::Refresh is supported
  private:
-  SequenceNumber CalcMaxVisibleSeq(WriteUnpreparedTxn* txn,
-                                   SequenceNumber snapshot_seq) {
+  static SequenceNumber CalcMaxVisibleSeq(WriteUnpreparedTxn* txn,
+                                          SequenceNumber snapshot_seq) {
     SequenceNumber max_unprepared = CalcMaxUnpreparedSequenceNumber(txn);
     assert(snapshot_seq < max_unprepared || max_unprepared == 0 ||
            snapshot_seq == kMaxSequenceNumber);
     return std::max(max_unprepared, snapshot_seq);
   }
-  SequenceNumber CalcMaxUnpreparedSequenceNumber(WriteUnpreparedTxn* txn);
+  static SequenceNumber CalcMaxUnpreparedSequenceNumber(
+      WriteUnpreparedTxn* txn);
   WritePreparedTxnDB* db_;
   WriteUnpreparedTxn* txn_;
   SequenceNumber wup_snapshot_;


### PR DESCRIPTION
Ubsan complains that in initialization of WriteUnpreparedTxnReadCallback the method of the child class is used before the parent class is constructed. The patch fixes that by making the aforementioned method static.