### PR TITLE
Extend Level based TTL compaction to bottommost level

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ### Unreleased
 ### New Features
 * When reading from option file/string/map, customized comparators and/or merge operators can be filled according to object registry.
+* Bottommost level files are also eligible for Level based TTL compactions by setting `bottommost_level_ttl` option.
+
 ### Public API Change
 ### Bug Fixes
 * Fix a bug in 2PC where a sequence of txn prepare, memtable flush, and crash could result in losing the prepared transaction.

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1180,9 +1180,12 @@ void LevelCompactionBuilder::PickExpiredTtlFiles() {
     start_level_ = level_file.first;
     output_level_ =
         (start_level_ == 0) ? vstorage_->base_level() : start_level_ + 1;
+    output_level_ = output_level_ <= (vstorage_->num_levels() - 1)
+                        ? output_level_
+                        : (vstorage_->num_levels() - 1);
 
     if ((start_level_ == 0 &&
-        !compaction_picker_->level0_compactions_in_progress()->empty())) {
+         !compaction_picker_->level0_compactions_in_progress()->empty())) {
       return false;
     }
 

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1181,9 +1181,8 @@ void LevelCompactionBuilder::PickExpiredTtlFiles() {
     output_level_ =
         (start_level_ == 0) ? vstorage_->base_level() : start_level_ + 1;
 
-    if ((start_level_ == vstorage_->num_non_empty_levels() - 1) ||
-        (start_level_ == 0 &&
-         !compaction_picker_->level0_compactions_in_progress()->empty())) {
+    if ((start_level_ == 0 &&
+        !compaction_picker_->level0_compactions_in_progress()->empty())) {
       return false;
     }
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3517,6 +3517,51 @@ TEST_F(DBCompactionTest, LevelCompactExpiredTtlFiles) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
+// TEST_F(DBCompactionTest, LevelCompactBottommostExpiredTtlFiles) {
+//   const int kNumKeysPerFile = 32;
+//   const int kNumLevelFiles = 2;
+//   const int kValueSize = 1024;
+//
+//   Options options = CurrentOptions();
+//   options.compression = kNoCompression;
+//   options.ttl = 24 * 60 * 60;  // 24 hours
+//   options.bottommost_level_ttl = 48 * 60 * 60;  // 24 hours
+//   options.max_open_files = -1;
+//   env_->time_elapse_only_sleep_ = false;
+//   options.env = env_;
+//
+//   env_->addon_time_.store(0);
+//   DestroyAndReopen(options);
+//
+//   Random rnd(301);
+//   for (int i = 0; i < kNumLevelFiles; ++i) {
+//     for (int j = 0; j < kNumKeysPerFile; ++j) {
+//       ASSERT_OK(
+//           Put(Key(i * kNumKeysPerFile + j), RandomString(&rnd, kValueSize)));
+//     }
+//     Flush();
+//   }
+//   dbfull()->TEST_WaitForCompact();
+//   MoveFilesToLevel(6);
+//   ASSERT_EQ("0,0,0,0,0,0,2", FilesPerLevel());
+//
+//   env_->addon_time_.fetch_add(50 * 60 * 60);
+//   ASSERT_OK(Put("a", "1"));
+//   Flush();
+//
+//   // ASSERT_EQ("1,0,0,0,0,0,2", FilesPerLevel());
+//   // rocksdb::SyncPoint::GetInstance()->SetCallBack(
+//   //     "LevelCompactionPicker::PickCompaction:Return", [&](void* arg) {
+//   //       Compaction* compaction = reinterpret_cast<Compaction*>(arg);
+//   //       ASSERT_TRUE(compaction->compaction_reason() == CompactionReason::kFlush);
+//   //     });
+//   // rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+//   // dbfull()->TEST_WaitForCompact();
+//   // ASSERT_EQ("1,0,0,0,0,0,2", FilesPerLevel());
+//   // rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+//
+// }
+
 TEST_F(DBCompactionTest, CompactRangeDelayedByL0FileCount) {
   // Verify that, when `CompactRangeOptions::allow_write_stall == false`, manual
   // compaction only triggers flush after it's sure stall won't be triggered for

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -188,6 +188,11 @@ static Status ValidateOptions(
             "TTL is only supported in Block-Based Table format. ");
       }
     }
+
+    if (cfd.options.bottommost_level_ttl > 0 && cfd.options.ttl == 0) {
+      return Status::NotSupported(
+        "Bottommost Level TTL can be set only when TTL is set. ");
+    }
   }
 
   if (db_options.db_paths.size() > 4) {

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -191,7 +191,7 @@ static Status ValidateOptions(
 
     if (cfd.options.bottommost_level_ttl > 0 && cfd.options.ttl == 0) {
       return Status::NotSupported(
-        "Bottommost Level TTL can be set only when TTL is set. ");
+          "Bottommost Level TTL can be set only when TTL is set. ");
     }
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1704,7 +1704,7 @@ void VersionStorageInfo::ComputeCompactionScore(
   ComputeBottommostFilesMarkedForCompaction();
   if (mutable_cf_options.ttl > 0) {
     ComputeExpiredTtlFiles(immutable_cf_options, mutable_cf_options.ttl,
-        mutable_cf_options.bottommost_level_ttl);
+                           mutable_cf_options.bottommost_level_ttl);
   }
   EstimateCompactionBytesNeeded(mutable_cf_options);
 }
@@ -1748,7 +1748,6 @@ void VersionStorageInfo::ComputeExpiredTtlFiles(
 
   uint64_t current_ttl = ttl;
   for (int level = 0; level < num_levels(); level++) {
-
     if (level == (num_levels() - 1)) {
       // bottommost level
       if (bottommost_level_ttl == 0) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -137,7 +137,8 @@ class VersionStorageInfo {
   // This computes ttl_expired_files_ and is called by
   // ComputeCompactionScore()
   void ComputeExpiredTtlFiles(const ImmutableCFOptions& ioptions,
-                              const uint64_t ttl);
+                              const uint64_t ttl,
+                              const uint64_t bottommost_level_ttl);
 
   // This computes bottommost_files_marked_for_compaction_ and is called by
   // ComputeCompactionScore() or UpdateOldestSnapshot().

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -644,6 +644,13 @@ struct AdvancedColumnFamilyOptions {
   // Dynamically changeable through SetOptions() API
   uint64_t ttl = 0;
 
+  // Bottommost level files older than this TTL will be picked up for
+  // compaction. Supported only in Level compaction.
+  // Default: 0 (disabled)
+  //
+  // Dynamically changeable through SetOptions() API
+  uint64_t bottommost_level_ttl = 0;
+
   // If this option is set then 1 in N blocks are compressed
   // using a fast (lz4) and slow (zstd) compression algorithm.
   // The compressibility is reported as stats and the stored

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -645,7 +645,12 @@ struct AdvancedColumnFamilyOptions {
   uint64_t ttl = 0;
 
   // Bottommost level files older than this TTL will be picked up for
-  // compaction. Supported only in Level compaction.
+  // compaction. The data in the L_max level might be needed around for a much
+  // longer time before requring a cleanup in some use cases. And hence the need
+  // for introducing a separate ttl option for bottommost level.
+  // Supported only in Level compaction.
+  // Pre-req: ttl > 0 && max_open_file == -1.
+  // unit: seconds. Ex: 7 days = 7 * 24 * 60 * 60
   // Default: 0 (disabled)
   //
   // Dynamically changeable through SetOptions() API

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -173,6 +173,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  max_bytes_for_level_multiplier);
   ROCKS_LOG_INFO(log, "                                      ttl: %" PRIu64,
                  ttl);
+  ROCKS_LOG_INFO(log, "                     bottommost_level_ttl: %" PRIu64,
+                 bottommost_level_ttl);
   std::string result;
   char buf[10];
   for (const auto m : max_bytes_for_level_multiplier_additional) {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -151,6 +151,7 @@ struct MutableCFOptions {
         max_bytes_for_level_base(options.max_bytes_for_level_base),
         max_bytes_for_level_multiplier(options.max_bytes_for_level_multiplier),
         ttl(options.ttl),
+        bottommost_level_ttl(options.bottommost_level_ttl),
         max_bytes_for_level_multiplier_additional(
             options.max_bytes_for_level_multiplier_additional),
         compaction_options_fifo(options.compaction_options_fifo),
@@ -186,6 +187,7 @@ struct MutableCFOptions {
         max_bytes_for_level_base(0),
         max_bytes_for_level_multiplier(0),
         ttl(0),
+        bottommost_level_ttl(0),
         compaction_options_fifo(),
         max_sequential_skip_in_iterations(0),
         paranoid_file_checks(false),
@@ -236,6 +238,7 @@ struct MutableCFOptions {
   uint64_t max_bytes_for_level_base;
   double max_bytes_for_level_multiplier;
   uint64_t ttl;
+  uint64_t bottommost_level_ttl;
   std::vector<int> max_bytes_for_level_multiplier_additional;
   CompactionOptionsFIFO compaction_options_fifo;
   CompactionOptionsUniversal compaction_options_universal;

--- a/options/options.cc
+++ b/options/options.cc
@@ -88,6 +88,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       force_consistency_checks(options.force_consistency_checks),
       report_bg_io_stats(options.report_bg_io_stats),
       ttl(options.ttl),
+      bottommost_level_ttl(options.bottommost_level_ttl),
       sample_for_compression(options.sample_for_compression) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
@@ -352,6 +353,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      report_bg_io_stats);
     ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
                      ttl);
+    ROCKS_LOG_HEADER(log, "             Options.bottommost_level_ttl: %d",
+                     bottommost_level_ttl);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options.cc
+++ b/options/options.cc
@@ -353,7 +353,7 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      report_bg_io_stats);
     ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,
                      ttl);
-    ROCKS_LOG_HEADER(log, "             Options.bottommost_level_ttl: %d",
+    ROCKS_LOG_HEADER(log, "             Options.bottommost_level_ttl: %" PRIu64,
                      bottommost_level_ttl);
 }  // ColumnFamilyOptions::Dump
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -179,6 +179,7 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
   cf_opts.max_bytes_for_level_multiplier =
       mutable_cf_options.max_bytes_for_level_multiplier;
   cf_opts.ttl = mutable_cf_options.ttl;
+  cf_opts.bottommost_level_ttl = mutable_cf_options.bottommost_level_ttl;
 
   cf_opts.max_bytes_for_level_multiplier_additional.clear();
   for (auto value :
@@ -1960,6 +1961,11 @@ std::unordered_map<std::string, OptionTypeInfo>
          {offset_of(&ColumnFamilyOptions::ttl), OptionType::kUInt64T,
           OptionVerificationType::kNormal, true,
           offsetof(struct MutableCFOptions, ttl)}},
+        {"bottommost_level_ttl",
+         {offset_of(&ColumnFamilyOptions::bottommost_level_ttl),
+          OptionType::kUInt64T,
+          OptionVerificationType::kNormal, true,
+          offsetof(struct MutableCFOptions, bottommost_level_ttl)}},
         {"sample_for_compression",
          {offset_of(&ColumnFamilyOptions::sample_for_compression),
           OptionType::kUInt64T, OptionVerificationType::kNormal, true,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -452,6 +452,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "disable_auto_compactions=false;"
       "report_bg_io_stats=true;"
       "ttl=60;"
+      "bottommost_level_ttl=3600;"
       "sample_for_compression=0;"
       "compaction_options_fifo={max_table_files_size=3;allow_"
       "compaction=false;};",

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -346,6 +346,7 @@ void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, Random* rnd) {
   // uint64_t options
   static const uint64_t uint_max = static_cast<uint64_t>(UINT_MAX);
   cf_opt->ttl = uint_max + rnd->Uniform(10000);
+  cf_opt->bottommost_level_ttl = uint_max + rnd->Uniform(10000);
   cf_opt->max_sequential_skip_in_iterations = uint_max + rnd->Uniform(10000);
   cf_opt->target_file_size_base = uint_max + rnd->Uniform(10000);
   cf_opt->max_compaction_bytes =


### PR DESCRIPTION
Extend Level based TTL compaction to bottommost level.

We previously introduced Level compaction with TTL in #3591 to periodically clean up data for 0 -- L_max -1 levels. This PR extends the TTL compactions to also look at L_max (bottommost) level files as well. 

- Introduced a new option, `bottommost_level_ttl` (default: 0 -- disabled), to gate this feature.
- Users can set different ttls for `ttl` and `bottommost_level_ttl` options. This especially helps use cases where bottommost level data needs to be retained for a much longer period than the other levels.
- `bottommost_level_ttl` can be set dynamically.

Test Plan:
Add a new unit test: `DBCompactionTest.LevelCompactBottommostExpiredTtlFiles`
Can test with: 
```
make db_compaction_test -j100
TEST_TMPDIR=/dev/shm ./db_compaction_test --gtest_filter=DBCompactionTest.LevelCompactBottommostExpiredTtlFiles
```