### PR TITLE
make the memory usage stats for lru cache more precise

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -351,7 +351,7 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
 
   e->value = value;
   e->deleter = deleter;
-  e->charge = charge;
+  e->charge = charge + sizeof(LRUHandle) - 1;
   e->key_length = key.size();
   e->flags = 0;
   e->hash = hash;


### PR DESCRIPTION
The original version doesn't take the size of `LRUHandle` into account. Although it's neglectable in block cache(since the charge itself is big enough), it shouldn't be ignored when using LRU cache to store key value pairs, like row cache.