### PR TITLE
Change OptimizeForPointLookup() and OptimizeForSmallDb()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 * When reading from option file/string/map, customized comparators and/or merge operators can be filled according to object registry.
 ### Public API Change
 * Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.
-* Change the behavior of OptimizeForSmallDb(): use a 16MB block cache, put index and filter blocks into it, and cost the memtable size to it.
+* Change the behavior of OptimizeForSmallDb(): use a 16MB block cache, put index and filter blocks into it, and cost the memtable size to it. DBOptions.OptimizeForSmallDb() and ColumnFamilyOptions.OptimizeForSmallDb() start to take an optional cache object.
 ### Bug Fixes
 * Fix a bug in 2PC where a sequence of txn prepare, memtable flush, and crash could result in losing the prepared transaction.
 * Fix a bug in Encryption Env which could cause encrypted files to be read beyond file boundaries.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 ### New Features
 * When reading from option file/string/map, customized comparators and/or merge operators can be filled according to object registry.
 ### Public API Change
+* Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.
+* Change the behavior of OptimizeForSmallDb(): use a 16MB block cache, put index and filter blocks into it, and cost the memtable size to it.
 ### Bug Fixes
 * Fix a bug in 2PC where a sequence of txn prepare, memtable flush, and crash could result in losing the prepared transaction.
 * Fix a bug in Encryption Env which could cause encrypted files to be read beyond file boundaries.

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2416,15 +2416,19 @@ TEST_F(DBTest2, OptimizeForSmallDB) {
 
   // memtable size is costed to the block cache
   ASSERT_NE(0, cache->GetUsage());
-  ASSERT_EQ("v1", Get("foo"));
 
+  ASSERT_EQ("v1", Get("foo"));
   Flush();
 
   size_t prev_size = cache->GetUsage();
   // Remember block cache size, so that we can find that
   // it is filled after Get().
-  ASSERT_EQ("v1", Get("foo"));
+  // Use pinnable slice so that it can ping the block so that
+  // when we check the size it is not evicted.
+  PinnableSlice value;
+  ASSERT_OK(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), "foo", &value));
   ASSERT_GT(cache->GetUsage(), prev_size);
+  value.Reset();
 }
 
 #endif  // ROCKSDB_LITE

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2396,6 +2396,37 @@ TEST_F(DBTest2, OptimizeForPointLookup) {
   ASSERT_EQ("v1", Get("foo"));
 }
 
+TEST_F(DBTest2, OptimizeForSmallDB) {
+  Options options = CurrentOptions();
+  Close();
+  options.OptimizeForSmallDb();
+
+  // Find the cache object
+  ASSERT_EQ(std::string(BlockBasedTableFactory::kName),
+            std::string(options.table_factory->Name()));
+  BlockBasedTableOptions* table_options =
+      reinterpret_cast<BlockBasedTableOptions*>(
+          options.table_factory->GetOptions());
+  ASSERT_TRUE(table_options != nullptr);
+  std::shared_ptr<Cache> cache = table_options->block_cache;
+
+  ASSERT_EQ(0, cache->GetUsage());
+  ASSERT_OK(DB::Open(options, dbname_, &db_));
+  ASSERT_OK(Put("foo", "v1"));
+
+  // memtable size is costed to the block cache
+  ASSERT_NE(0, cache->GetUsage());
+  ASSERT_EQ("v1", Get("foo"));
+
+  Flush();
+
+  size_t prev_size = cache->GetUsage();
+  // Remember block cache size, so that we can find that
+  // it is filled after Get().
+  ASSERT_EQ("v1", Get("foo"));
+  ASSERT_GT(cache->GetUsage(), prev_size);
+}
+
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBTest2, GetRaceFlush1) {

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -6,9 +6,9 @@
 #ifndef ROCKSDB_LITE
 
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <iostream>
-#include <cassert>
 
 #include "rocksdb/env_encryption.h"
 #include "util/aligned_buffer.h"
@@ -897,7 +897,8 @@ Status CTREncryptionProvider::CreateCipherStream(
   // very large chunk of the file (and very likely read over the bounds)
   assert(prefix.size() >= 2 * blockSize);
   if (prefix.size() < 2 * blockSize) {
-    return Status::Corruption("Unable to read from file " + fname + ": read attempt would read beyond file bounds");
+    return Status::Corruption("Unable to read from file " + fname +
+                              ": read attempt would read beyond file bounds");
   }
 
   // Decrypt the encrypted part of the prefix, starting from block 2 (block 0, 1 with initial counter & IV are unencrypted)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -88,6 +88,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Some functions that make it easier to optimize RocksDB
   // Use this if your DB is very small (like under 1GB) and you don't want to
   // spend lots of memory for memtables.
+  // An optional cache object is passed in to be used as the block cache
   ColumnFamilyOptions* OptimizeForSmallDb(
       std::shared_ptr<Cache>* cache = nullptr);
 
@@ -1047,7 +1048,6 @@ struct Options : public DBOptions, public ColumnFamilyOptions {
 
   // Use this if your DB is very small (like under 1GB) and you don't want to
   // spend lots of memory for memtables.
-  // An optional cache object is passed in to be used as the block cache
   Options* OptimizeForSmallDb();
 };
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -88,7 +88,8 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Some functions that make it easier to optimize RocksDB
   // Use this if your DB is very small (like under 1GB) and you don't want to
   // spend lots of memory for memtables.
-  ColumnFamilyOptions* OptimizeForSmallDb();
+  ColumnFamilyOptions* OptimizeForSmallDb(
+      std::shared_ptr<Cache>* cache = nullptr);
 
   // Use this if you don't need to keep the data sorted, i.e. you'll never use
   // an iterator, only Put() and Get() API calls
@@ -349,7 +350,9 @@ struct DBOptions {
 
   // Use this if your DB is very small (like under 1GB) and you don't want to
   // spend lots of memory for memtables.
-  DBOptions* OptimizeForSmallDb();
+  // An optional cache object is passed in for the memory of the
+  // memtable to cost to
+  DBOptions* OptimizeForSmallDb(std::shared_ptr<Cache>* cache = nullptr);
 
 #ifndef ROCKSDB_LITE
   // By default, RocksDB uses only one background thread for flush and
@@ -1044,6 +1047,7 @@ struct Options : public DBOptions, public ColumnFamilyOptions {
 
   // Use this if your DB is very small (like under 1GB) and you don't want to
   // spend lots of memory for memtables.
+  // An optional cache object is passed in to be used as the block cache
   Options* OptimizeForSmallDb();
 };
 

--- a/options/options.cc
+++ b/options/options.cc
@@ -507,7 +507,8 @@ ColumnFamilyOptions* ColumnFamilyOptions::OptimizeForPointLookup(
   block_based_options.block_cache =
       NewLRUCache(static_cast<size_t>(block_cache_size_mb * 1024 * 1024));
   table_factory.reset(new BlockBasedTableFactory(block_based_options));
-  memtable_whole_key_filtering = 0.02;
+  memtable_prefix_bloom_size_ratio = 0.02;
+  memtable_whole_key_filtering = true;
   return this;
 }
 


### PR DESCRIPTION
Summary:
Change the behavior of OptimizeForSmallDb() so that it is less likely to go out of memory.
Change the behavior of OptimizeForPointLookup() to take advantage of the new memtable whole key filter, and move away from prefix extractor as well as hash-based indexing, as they are prone to misuse.

Test Plan: Run all tests.