### PR TITLE
Add variations of BytewiseComparator that fix performance issues in some use cases

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Unreleased
 ### New Features
 * When reading from option file/string/map, customized comparators and/or merge operators can be filled according to object registry.
+* Add some flavors of BytewiseComparator(): BytewiseComparatorWithoutSuccessorShortening() and BytewiseComparatorWithoutAnyShortening(). They can improve iterator seek performance in some situations, especially when direct IO is enabled and block cache is disabled, but may increase sst index size. The cost and benefit is very dependent on the use case and requires some understanding of rocksdb internals. See comparator.h for more details.
 ### Public API Change
 ### Bug Fixes
 * Fix a bug in 2PC where a sequence of txn prepare, memtable flush, and crash could result in losing the prepared transaction.


### PR DESCRIPTION
I ran into some really bad iterator performance with enabled direct IO and disabled block cache. This should fix it. See long comments.

We could do it using a custom Comparator outside rocksdb instead, but (a) it may be useful for other users too, and (b) a custom Comparator might break in future in subtle ways if more methods are added to rocksdb::Comparator.

Will try it out and confirm that it helps before landing.