### PR TITLE
Fix dangling partition filters in block cache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 ### New Features
 * When reading from option file/string/map, customized comparators and/or merge operators can be filled according to object registry.
 * Introduce Periodic Compaction for Level style compaction. Files are re-compacted periodically and put in the same level.
+### Bug Fixes
+* Fix partition filters not being removed from the block cache when the table is closed.
 
 ### Public API Change
 * Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -255,7 +255,8 @@ class ClockCacheShard final : public CacheShard {
   // Not necessary to hold mutex_ before being called.
   bool Ref(Cache::Handle* handle) override;
   bool Release(Cache::Handle* handle, bool force_erase = false) override;
-  void Erase(const Slice& key, uint32_t hash) override;
+  // expect_last_ref is ignored in ClockCache::Erase
+  void Erase(const Slice& key, uint32_t hash, const bool) override;
   bool EraseAndConfirm(const Slice& key, uint32_t hash,
                        CleanupContext* context);
   size_t GetUsage() const override;
@@ -641,7 +642,7 @@ bool ClockCacheShard::Release(Cache::Handle* h, bool force_erase) {
   return erased;
 }
 
-void ClockCacheShard::Erase(const Slice& key, uint32_t hash) {
+void ClockCacheShard::Erase(const Slice& key, uint32_t hash, const bool) {
   CleanupContext context;
   EraseAndConfirm(key, hash, &context);
   Cleanup(context);

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -415,7 +415,7 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   return s;
 }
 
-void LRUCacheShard::Erase(const Slice& key, uint32_t hash) {
+void LRUCacheShard::Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) {
   LRUHandle* e;
   bool last_reference = false;
   {
@@ -423,6 +423,7 @@ void LRUCacheShard::Erase(const Slice& key, uint32_t hash) {
     e = table_.Remove(key, hash);
     if (e != nullptr) {
       last_reference = Unref(e);
+      assert(last_reference || !expect_last_ref);
       if (last_reference) {
         usage_ -= e->charge;
       }

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -415,7 +415,8 @@ Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
   return s;
 }
 
-void LRUCacheShard::Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) {
+void LRUCacheShard::Erase(const Slice& key, uint32_t hash,
+                          const bool expect_last_ref) {
   LRUHandle* e;
   bool last_reference = false;
   {

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -192,7 +192,8 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   virtual bool Ref(Cache::Handle* handle) override;
   virtual bool Release(Cache::Handle* handle,
                        bool force_erase = false) override;
-  virtual void Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) override;
+  virtual void Erase(const Slice& key, uint32_t hash,
+                     const bool expect_last_ref) override;
 
   // Although in some platforms the update of size_t is atomic, to make sure
   // GetUsage() and GetPinnedUsage() work correctly under any platform, we'll

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -192,7 +192,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   virtual bool Ref(Cache::Handle* handle) override;
   virtual bool Release(Cache::Handle* handle,
                        bool force_erase = false) override;
-  virtual void Erase(const Slice& key, uint32_t hash) override;
+  virtual void Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) override;
 
   // Although in some platforms the update of size_t is atomic, to make sure
   // GetUsage() and GetPinnedUsage() work correctly under any platform, we'll

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -55,7 +55,7 @@ class LRUCacheTest : public testing::Test {
 
   bool Lookup(char key) { return Lookup(std::string(1, key)); }
 
-  void Erase(const std::string& key) { cache_->Erase(key, 0 /*hash*/); }
+  void Erase(const std::string& key) { cache_->Erase(key, 0 /*hash*/, false /*expect_last_ref*/); }
 
   void ValidateLRUList(std::vector<std::string> keys,
                        size_t num_high_pri_pool_keys = 0) {

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -55,7 +55,9 @@ class LRUCacheTest : public testing::Test {
 
   bool Lookup(char key) { return Lookup(std::string(1, key)); }
 
-  void Erase(const std::string& key) { cache_->Erase(key, 0 /*hash*/, false /*expect_last_ref*/); }
+  void Erase(const std::string& key) {
+    cache_->Erase(key, 0 /*hash*/, false /*expect_last_ref*/);
+  }
 
   void ValidateLRUList(std::vector<std::string> keys,
                        size_t num_high_pri_pool_keys = 0) {

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -70,9 +70,9 @@ bool ShardedCache::Release(Handle* handle, bool force_erase) {
   return GetShard(Shard(hash))->Release(handle, force_erase);
 }
 
-void ShardedCache::Erase(const Slice& key) {
+void ShardedCache::Erase(const Slice& key, const bool expect_last_ref) {
   uint32_t hash = HashSlice(key);
-  GetShard(Shard(hash))->Erase(key, hash);
+  GetShard(Shard(hash))->Erase(key, hash, expect_last_ref);
 }
 
 uint64_t ShardedCache::NewId() {

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -31,7 +31,7 @@ class CacheShard {
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) = 0;
   virtual bool Ref(Cache::Handle* handle) = 0;
   virtual bool Release(Cache::Handle* handle, bool force_erase = false) = 0;
-  virtual void Erase(const Slice& key, uint32_t hash) = 0;
+  virtual void Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) = 0;
   virtual void SetCapacity(size_t capacity) = 0;
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) = 0;
   virtual size_t GetUsage() const = 0;
@@ -67,7 +67,7 @@ class ShardedCache : public Cache {
   virtual Handle* Lookup(const Slice& key, Statistics* stats) override;
   virtual bool Ref(Handle* handle) override;
   virtual bool Release(Handle* handle, bool force_erase = false) override;
-  virtual void Erase(const Slice& key) override;
+  virtual void Erase(const Slice& key, const bool expect_last_ref) override;
   virtual uint64_t NewId() override;
   virtual size_t GetCapacity() const override;
   virtual bool HasStrictCapacityLimit() const override;

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -31,7 +31,8 @@ class CacheShard {
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) = 0;
   virtual bool Ref(Cache::Handle* handle) = 0;
   virtual bool Release(Cache::Handle* handle, bool force_erase = false) = 0;
-  virtual void Erase(const Slice& key, uint32_t hash, const bool expect_last_ref) = 0;
+  virtual void Erase(const Slice& key, uint32_t hash,
+                     const bool expect_last_ref) = 0;
   virtual void SetCapacity(size_t capacity) = 0;
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) = 0;
   virtual size_t GetUsage() const = 0;

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -193,7 +193,7 @@ class Cache {
   // If the cache contains entry for key, erase it.  Note that the
   // underlying entry will be kept around until all existing handles
   // to it have been released.
-  virtual void Erase(const Slice& key) = 0;
+  virtual void Erase(const Slice& key, const bool expect_last_ref = false) = 0;
   // Return a new numeric id.  May be used by multiple clients who are
   // sharding the same cache to partition the key space.  Typically the
   // client will allocate a new id at startup and prepend the id to

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -3289,19 +3289,19 @@ void BlockBasedTable::Close() {
     // Get the filter block key
     auto key = GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
                            rep_->filter_handle, cache_key);
-    cache->Erase(key);
-
+    const bool kExpectLastRef = true;
+    cache->Erase(key, kExpectLastRef);
     // Get the index block key
     key = GetCacheKeyFromOffset(rep_->cache_key_prefix,
                                 rep_->cache_key_prefix_size,
                                 rep_->dummy_index_reader_offset, cache_key);
-    cache->Erase(key);
+    cache->Erase(key, kExpectLastRef);
 
     if (!rep_->compression_dict_handle.IsNull()) {
       // Get the compression dictionary block key
       key = GetCacheKey(rep_->cache_key_prefix, rep_->cache_key_prefix_size,
                         rep_->compression_dict_handle, cache_key);
-      cache->Erase(key);
+      cache->Erase(key, kExpectLastRef);
     }
   }
 

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -211,9 +211,9 @@ class SimCacheImpl : public SimCache {
     return cache_->Release(handle, force_erase);
   }
 
-  void Erase(const Slice& key) override {
-    cache_->Erase(key);
-    key_only_cache_->Erase(key);
+  void Erase(const Slice& key, const bool expect_last_ref) override {
+    cache_->Erase(key, expect_last_ref);
+    key_only_cache_->Erase(key, expect_last_ref);
   }
 
   void* Value(Handle* handle) override { return cache_->Value(handle); }


### PR DESCRIPTION
Partition filters should be removed from the block cache upon table close. The ::Erase function that is being used currently is ineffective since the PartitionedFilterBlockReader has not released the handle yet when ::Erase is called. The patch fixes that and also extends ::Erase signature with a bool to allow the caller specify their expectation of having no more references to the block cache.