### PR TITLE
Use creation_time or mtime when file_creation_time=0

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3611,6 +3611,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithOldDB) {
 
   int periodic_compactions = 0;
   bool set_file_creation_time_to_zero = true;
+  bool set_creation_time_to_zero = true;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "LevelCompactionPicker::PickCompaction:Return", [&](void* arg) {
         Compaction* compaction = reinterpret_cast<Compaction*>(arg);
@@ -3625,6 +3626,9 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithOldDB) {
         if (set_file_creation_time_to_zero) {
           props->file_creation_time = 0;
         }
+        if (set_creation_time_to_zero) {
+          props->creation_time = 0;
+        }
       });
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
@@ -3638,6 +3642,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithOldDB) {
     // Move the first two files to L2.
     if (i == 1) {
       MoveFilesToLevel(2);
+      set_creation_time_to_zero = false;
     }
   }
   ASSERT_OK(dbfull()->TEST_WaitForCompact());

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3592,6 +3592,75 @@ TEST_F(DBCompactionTest, LevelPeriodicCompaction) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
+TEST_F(DBCompactionTest, LevelPeriodicCompactionWithOldDB) {
+  // This test makes sure that periodic compactions are working with an old DB
+  // where file_creation_time of files is 0.
+  // After compactions the new files are created with a valid file_creation_time
+
+  const int kNumKeysPerFile = 32;
+  const int kNumFiles = 4;
+  const int kValueSize = 100;
+
+  Options options = CurrentOptions();
+  options.max_open_files = -1;  // needed for ttl compaction
+  env_->time_elapse_only_sleep_ = false;
+  options.env = env_;
+
+  env_->addon_time_.store(0);
+  DestroyAndReopen(options);
+
+  int periodic_compactions = 0;
+  bool set_file_creation_time_to_zero = true;
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "LevelCompactionPicker::PickCompaction:Return", [&](void* arg) {
+        Compaction* compaction = reinterpret_cast<Compaction*>(arg);
+        auto compaction_reason = compaction->compaction_reason();
+        if (compaction_reason == CompactionReason::kPeriodicCompaction) {
+          periodic_compactions++;
+          set_file_creation_time_to_zero = false;
+        }
+      });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "FlushJob::WriteLevel0Table", [&](void* /*arg*/) {
+        // set file_creation_time to 0 on flushes.
+        set_file_creation_time_to_zero = true;
+      });
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "PropertyBlockBuilder::AddTableProperty:Start", [&](void* arg) {
+        TableProperties* props = reinterpret_cast<TableProperties*>(arg);
+        if (set_file_creation_time_to_zero) {
+          props->file_creation_time = 0;
+          set_file_creation_time_to_zero = false;
+        }
+      });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  Random rnd(301);
+  for (int i = 0; i < kNumFiles; ++i) {
+    for (int j = 0; j < kNumKeysPerFile; ++j) {
+      ASSERT_OK(
+          Put(Key(i * kNumKeysPerFile + j), RandomString(&rnd, kValueSize)));
+    }
+    Flush();
+    // Move the first two files to L2.
+    if (i == 1) {
+      MoveFilesToLevel(2);
+    }
+  }
+  dbfull()->TEST_WaitForCompact();
+
+  ASSERT_EQ("2,0,2", FilesPerLevel());
+  ASSERT_EQ(0, periodic_compactions);
+
+  ASSERT_OK(dbfull()->SetOptions({{"periodic_compaction_seconds", "86400"}}));
+  dbfull()->TEST_WaitForCompact();
+  ASSERT_EQ("2,0,2", FilesPerLevel());
+  // Make sure that all files go through periodic compaction.
+  ASSERT_EQ(kNumFiles, periodic_compactions);
+
+  rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+}
+
 TEST_F(DBCompactionTest, LevelPeriodicAndTtlCompaction) {
   const int kNumKeysPerFile = 32;
   const int kNumLevelFiles = 2;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2360,7 +2360,7 @@ void VersionStorageInfo::ComputeFilesMarkedForPeriodicCompaction(
           f->fd.table_reader->GetTableProperties() != nullptr) {
         auto file_creation_time =
             f->fd.table_reader->GetTableProperties()->file_creation_time;
-        if (file_creation_time > 0 && file_creation_time < allowed_time_limit) {
+        if (file_creation_time < allowed_time_limit) {
           files_marked_for_periodic_compaction_.emplace_back(level, f);
         }
       }

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -646,6 +646,12 @@ struct AdvancedColumnFamilyOptions {
 
   // Files older than this value will be picked up for compaction, and
   // re-written to the same level as they were before.
+  //
+  // A file's age is computed by looking at file_creation_time or creation_time
+  // table properties in order, if they have valid non-zero values; if not, the
+  // age is based on the file's last modified time (given by the underlying
+  // Env).
+  //
   // Only supported in Level compaction.
   // Pre-req: max_open_file == -1.
   // unit: seconds. Ex: 7 days = 7 * 24 * 60 * 60

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -18,6 +18,7 @@
 #include "table/table_properties_internal.h"
 #include "util/coding.h"
 #include "util/file_reader_writer.h"
+#include "util/sync_point.h"
 
 namespace rocksdb {
 
@@ -67,6 +68,9 @@ void PropertyBlockBuilder::Add(
 }
 
 void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
+  TEST_SYNC_POINT_CALLBACK("PropertyBlockBuilder::AddTableProperty:Start",
+                           const_cast<TableProperties*>(&props));
+
   Add(TablePropertiesNames::kRawKeySize, props.raw_key_size);
   Add(TablePropertiesNames::kRawValueSize, props.raw_value_size);
   Add(TablePropertiesNames::kDataSize, props.data_size);


### PR DESCRIPTION
We found an issue in Periodic Compactions (introduced in #5166) where files were not being picked up for compactions as all the SST files created with older versions of RocksDB have `file_creation_time` as 0. (Note that `file_creation_time` is a new table property introduced in #5166).

To address this, Periodic compactions now fall back to looking at the `creation_time` table property or the file's modification time (as given by the Env) when `file_creation_time` table property is found to be 0.

Here how the file's modification time (and, in turn, the file age) is computed now: 
1. Use `file_creation_time` table property if it is > 0.
1. If not, then use `creation_time` table property if it is > 0.
1. If not, then use file's mtime stat metadata given by the underlying Env. 
Don't consider the file at all for compaction if the modification time cannot be correctly determined based on the above conditions.

Test Plan:
- Added a new test to simulate this behavior: `DBCompactionTest.LevelPeriodicCompactionWithOldDB`