### PR TITLE
Fix bugs detected by clang analyzer

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1174,6 +1174,7 @@ TEST_F(DBBasicTest, MultiGetBatchedMultiLevel) {
     Flush();
     num_keys = 0;
   }
+  ASSERT_EQ(0, num_keys);
 
   for (int i = 0; i < 128; i += 9) {
     ASSERT_OK(Put("key_" + std::to_string(i), "val_mem_" + std::to_string(i)));

--- a/table/full_filter_block.cc
+++ b/table/full_filter_block.cc
@@ -196,7 +196,7 @@ void FullFilterBlockReader::MayMatch(MultiGetRange* range) {
   // declare both keys and may_match as arrays, which is also slightly less
   // expensive compared to autovector
   Slice* keys[MultiGetContext::MAX_BATCH_SIZE];
-  bool may_match[MultiGetContext::MAX_BATCH_SIZE];
+  bool may_match[MultiGetContext::MAX_BATCH_SIZE] = {false};
   int num_keys = 0;
   for (auto iter = range->begin(); iter != range->end(); ++iter) {
     keys[num_keys++] = &iter->ukey;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4618,7 +4618,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     std::vector<std::unique_ptr<const char[]> > key_guards;
     std::vector<std::string> values(entries_per_batch_);
     PinnableSlice* pin_values = new PinnableSlice[entries_per_batch_];
-    std::unique_ptr<PinnableSlice> pin_values_guard(pin_values);
+    std::unique_ptr<PinnableSlice[]> pin_values_guard(pin_values);
     std::vector<Status> stat_list(entries_per_batch_);
     while (static_cast<int64_t>(keys.size()) < entries_per_batch_) {
       key_guards.push_back(std::unique_ptr<const char[]>());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4618,6 +4618,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     std::vector<std::unique_ptr<const char[]> > key_guards;
     std::vector<std::string> values(entries_per_batch_);
     PinnableSlice* pin_values = new PinnableSlice[entries_per_batch_];
+    std::unique_ptr<PinnableSlice> pin_values_guard(pin_values);
     std::vector<Status> stat_list(entries_per_batch_);
     while (static_cast<int64_t>(keys.size()) < entries_per_batch_) {
       key_guards.push_back(std::unique_ptr<const char[]>());


### PR DESCRIPTION
Summary: as titled. False positive included, fixed anyway to make the check
pass.

Test Plan:
```
$make clean && USE_CLANG=1 make -j32 analyze
$make clean && COMPILE_WITH_ASAN=1 make -j32 all && sleep 1 && make check
```
All tests must pass.