### PR TITLE
Expose JavaAPI for getting the filter policy of a BlockBasedTableConfig

### DIFF
--- a/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
+++ b/java/src/main/java/org/rocksdb/BlockBasedTableConfig.java
@@ -480,6 +480,15 @@ public class BlockBasedTableConfig extends TableFormatConfig {
   }
 
   /**
+   * Get the filter policy.
+   *
+   * @return the current filter policy.
+   */
+  public Filter filterPolicy() {
+    return filterPolicy;
+  }
+
+  /**
    * Use the specified filter policy to reduce disk reads.
    *
    * {@link org.rocksdb.Filter} should not be disposed before options instances


### PR DESCRIPTION
I would like to be able to read out the current Filter that has been set (or not) for a BlockBasedTableConfig. Added one public method to BlockBasedTableConfig:

public Filter filterPolicy() {
    return filterPolicy;
}
