### PR TITLE
Consolidating WAL creation which currently has duplicate logic in db_impl_write.cc and db_impl_open.cc

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1679,7 +1679,7 @@ class DBImpl : public DB {
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
   Status CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
-                   const size_t preallocate_block_size, log::Writer** new_log);
+                   const size_t write_buffer_size, log::Writer** new_log);
 
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1678,10 +1678,9 @@ class DBImpl : public DB {
   size_t GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
-  Status CreateWAL(DBImpl* impl, const EnvOptions& env_options,
-                          uint64_t log_file_num, uint64_t recycle_log_number,
-                          const size_t preallocate_block_size,
-                          log::Writer** new_log);
+  Status CreateWAL(const EnvOptions& env_options, uint64_t log_file_num,
+                   uint64_t recycle_log_number,
+                   const size_t preallocate_block_size, log::Writer** new_log);
 
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1678,9 +1678,8 @@ class DBImpl : public DB {
   size_t GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
-  static Status CreateWAL(DBImpl* impl, const EnvOptions& env_options,
+  Status CreateWAL(DBImpl* impl, const EnvOptions& env_options,
                           uint64_t log_file_num, uint64_t recycle_log_number,
-                          bool create_new_log, bool called_from_open,
                           const size_t preallocate_block_size,
                           log::Writer** new_log);
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1679,7 +1679,7 @@ class DBImpl : public DB {
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
   Status CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
-                   const size_t preallocate_block_size, log::Writer** new_log);
+                   size_t preallocate_block_size, log::Writer** new_log);
 
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1678,8 +1678,7 @@ class DBImpl : public DB {
   size_t GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
-  Status CreateWAL(const EnvOptions& env_options, uint64_t log_file_num,
-                   uint64_t recycle_log_number,
+  Status CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
                    const size_t preallocate_block_size, log::Writer** new_log);
 
   // When set, we use a separate queue for writes that dont write to memtable.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1679,7 +1679,7 @@ class DBImpl : public DB {
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
   Status CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
-                   const size_t write_buffer_size, log::Writer** new_log);
+                   const size_t preallocate_block_size, log::Writer** new_log);
 
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1678,6 +1678,12 @@ class DBImpl : public DB {
   size_t GetWalPreallocateBlockSize(uint64_t write_buffer_size) const;
   Env::WriteLifeTimeHint CalculateWALWriteHint() { return Env::WLTH_SHORT; }
 
+  static Status CreateWAL(DBImpl* impl, const EnvOptions& env_options,
+                          uint64_t log_file_num, uint64_t recycle_log_number,
+                          bool create_new_log, bool called_from_open,
+                          const size_t preallocate_block_size,
+                          log::Writer** new_log);
+
   // When set, we use a separate queue for writes that dont write to memtable.
   // In 2PC these are the writes at Prepare phase.
   const bool two_write_queues_;

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1106,6 +1106,63 @@ Status DB::Open(const DBOptions& db_options, const std::string& dbname,
                       !kSeqPerBatch, kBatchPerTxn);
 }
 
+Status DBImpl::CreateWAL(DBImpl* impl, const EnvOptions& env_options,
+                         uint64_t log_file_num, uint64_t recycle_log_number,
+                         bool create_new_log, bool called_from_open,
+                         const size_t preallocate_block_size,
+                         log::Writer** new_log) {
+  assert(impl != nullptr);
+  Status s;
+  std::unique_ptr<WritableFile> lfile;
+
+  DBOptions db_options =
+      BuildDBOptions(impl->immutable_db_options_, impl->mutable_db_options_);
+  EnvOptions opt_env_options =
+      impl->env_->OptimizeForLogWrite(env_options, db_options);
+  std::string log_fname =
+      LogFileName(impl->immutable_db_options_.wal_dir, log_file_num);
+
+  if (create_new_log) {
+    if (recycle_log_number) {
+      ROCKS_LOG_INFO(impl->immutable_db_options_.info_log,
+                     "reusing log %" PRIu64 " from recycle list\n",
+                     recycle_log_number);
+      std::string old_log_fname =
+          LogFileName(impl->immutable_db_options_.wal_dir, recycle_log_number);
+      s = impl->env_->ReuseWritableFile(log_fname, old_log_fname, &lfile,
+                                        opt_env_options);
+    } else {
+      if (called_from_open) {
+        s = NewWritableFile(impl->immutable_db_options_.env, log_fname, &lfile,
+                            opt_env_options);
+      } else {
+        s = NewWritableFile(impl->env_, log_fname, &lfile, opt_env_options);
+      }
+    }
+
+    if (s.ok()) {
+      lfile->SetWriteLifeTimeHint(impl->CalculateWALWriteHint());
+      lfile->SetPreallocationBlockSize(preallocate_block_size);
+
+      const auto& listeners = impl->immutable_db_options_.listeners;
+      std::unique_ptr<WritableFileWriter> file_writer(
+          new WritableFileWriter(std::move(lfile), log_fname, opt_env_options,
+                                 impl->env_, nullptr /* stats */, listeners));
+      *new_log =
+          new log::Writer(std::move(file_writer), log_file_num,
+                          impl->immutable_db_options_.recycle_log_file_num > 0,
+                          impl->immutable_db_options_.manual_wal_flush);
+
+      if (called_from_open) {
+        InstrumentedMutexLock wl(&impl->log_write_mutex_);
+        impl->logfile_number_ = log_file_num;
+        impl->logs_.emplace_back(log_file_num, *new_log);
+      }
+    }
+  }
+  return s;
+}
+
 Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
                     const std::vector<ColumnFamilyDescriptor>& column_families,
                     std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
@@ -1166,40 +1223,20 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     return s;
   }
   impl->mutex_.Lock();
-  auto write_hint = impl->CalculateWALWriteHint();
+  // auto write_hint = impl->CalculateWALWriteHint();
   // Handles create_if_missing, error_if_exists
   s = impl->Recover(column_families);
   if (s.ok()) {
+    EnvOptions env_options(db_options);
     uint64_t new_log_number = impl->versions_->NewFileNumber();
-    std::unique_ptr<WritableFile> lfile;
-    EnvOptions soptions(db_options);
-    EnvOptions opt_env_options =
-        impl->immutable_db_options_.env->OptimizeForLogWrite(
-            soptions, BuildDBOptions(impl->immutable_db_options_,
-                                     impl->mutable_db_options_));
-    std::string log_fname =
-        LogFileName(impl->immutable_db_options_.wal_dir, new_log_number);
-    s = NewWritableFile(impl->immutable_db_options_.env, log_fname, &lfile,
-                        opt_env_options);
-    if (s.ok()) {
-      lfile->SetWriteLifeTimeHint(write_hint);
-      lfile->SetPreallocationBlockSize(
-          impl->GetWalPreallocateBlockSize(max_write_buffer_size));
-      {
-        InstrumentedMutexLock wl(&impl->log_write_mutex_);
-        impl->logfile_number_ = new_log_number;
-        const auto& listeners = impl->immutable_db_options_.listeners;
-        std::unique_ptr<WritableFileWriter> file_writer(
-            new WritableFileWriter(std::move(lfile), log_fname, opt_env_options,
-                                   impl->env_, nullptr /* stats */, listeners));
-        impl->logs_.emplace_back(
-            new_log_number,
-            new log::Writer(
-                std::move(file_writer), new_log_number,
-                impl->immutable_db_options_.recycle_log_file_num > 0,
-                impl->immutable_db_options_.manual_wal_flush));
-      }
+    log::Writer* new_log = nullptr;
+    const size_t preallocate_block_size =
+        impl->GetWalPreallocateBlockSize(max_write_buffer_size);
+    s = CreateWAL(impl, env_options, new_log_number, 0 /*recycle_log_number*/,
+                  true /*creating_new_log*/, true /* called_from_open*/,
+                  preallocate_block_size, &new_log);
 
+    if (s.ok()) {
       // set column family handles
       for (auto cf : column_families) {
         auto cfd =

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1107,11 +1107,12 @@ Status DB::Open(const DBOptions& db_options, const std::string& dbname,
 }
 
 Status DBImpl::CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
-                         const size_t preallocate_block_size,
+                         const size_t write_buffer_size,
                          log::Writer** new_log) {
   Status s;
   std::unique_ptr<WritableFile> lfile;
-
+  const auto preallocate_block_size =
+      GetWalPreallocateBlockSize(write_buffer_size);
   DBOptions db_options =
       BuildDBOptions(immutable_db_options_, mutable_db_options_);
   EnvOptions opt_env_options =
@@ -1212,11 +1213,9 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   if (s.ok()) {
     uint64_t new_log_number = impl->versions_->NewFileNumber();
     log::Writer* new_log = nullptr;
-    const size_t preallocate_block_size =
-        impl->GetWalPreallocateBlockSize(max_write_buffer_size);
     s = impl->CreateWAL(new_log_number, 0 /*recycle_log_number*/,
-                        preallocate_block_size, &new_log);
-    {
+                        max_write_buffer_size, &new_log);
+    if (s.ok()) {
       InstrumentedMutexLock wl(&impl->log_write_mutex_);
       impl->logfile_number_ = new_log_number;
       impl->logs_.emplace_back(new_log_number, new_log);

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1217,6 +1217,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     if (s.ok()) {
       InstrumentedMutexLock wl(&impl->log_write_mutex_);
       impl->logfile_number_ = new_log_number;
+      assert(new_log != nullptr);
       impl->logs_.emplace_back(new_log_number, new_log);
     }
 

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1210,10 +1210,12 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   // Handles create_if_missing, error_if_exists
   s = impl->Recover(column_families);
   if (s.ok()) {
+    EnvOptions env_options(db_options);
     uint64_t new_log_number = impl->versions_->NewFileNumber();
     log::Writer* new_log = nullptr;
     const size_t preallocate_block_size =
         impl->GetWalPreallocateBlockSize(max_write_buffer_size);
+<<<<<<< HEAD
     s = impl->CreateWAL(new_log_number, 0 /*recycle_log_number*/,
                         preallocate_block_size, &new_log);
     {
@@ -1221,6 +1223,11 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       impl->logfile_number_ = new_log_number;
       impl->logs_.emplace_back(new_log_number, new_log);
     }
+=======
+    s = CreateWAL(impl, env_options, new_log_number, 0 /*recycle_log_number*/,
+                  true /*creating_new_log*/, true /* called_from_open*/,
+                  preallocate_block_size, &new_log);
+>>>>>>> Consolidating wal creation
 
     if (s.ok()) {
       // set column family handles

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1215,27 +1215,13 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     log::Writer* new_log = nullptr;
     const size_t preallocate_block_size =
         impl->GetWalPreallocateBlockSize(max_write_buffer_size);
-<<<<<<< HEAD
-<<<<<<< HEAD
     s = impl->CreateWAL(new_log_number, 0 /*recycle_log_number*/,
                         preallocate_block_size, &new_log);
-=======
-    s = impl->CreateWAL(impl, env_options, new_log_number,
-                0 /*recycle_log_number*/, preallocate_block_size, &new_log);
->>>>>>> Changes based on comments
     {
       InstrumentedMutexLock wl(&impl->log_write_mutex_);
       impl->logfile_number_ = new_log_number;
       impl->logs_.emplace_back(new_log_number, new_log);
     }
-<<<<<<< HEAD
-=======
-    s = CreateWAL(impl, env_options, new_log_number, 0 /*recycle_log_number*/,
-                  true /*creating_new_log*/, true /* called_from_open*/,
-                  preallocate_block_size, &new_log);
->>>>>>> Consolidating wal creation
-=======
->>>>>>> Changes based on comments
 
     if (s.ok()) {
       // set column family handles

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1216,18 +1216,26 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     const size_t preallocate_block_size =
         impl->GetWalPreallocateBlockSize(max_write_buffer_size);
 <<<<<<< HEAD
+<<<<<<< HEAD
     s = impl->CreateWAL(new_log_number, 0 /*recycle_log_number*/,
                         preallocate_block_size, &new_log);
+=======
+    s = impl->CreateWAL(impl, env_options, new_log_number,
+                0 /*recycle_log_number*/, preallocate_block_size, &new_log);
+>>>>>>> Changes based on comments
     {
       InstrumentedMutexLock wl(&impl->log_write_mutex_);
       impl->logfile_number_ = new_log_number;
       impl->logs_.emplace_back(new_log_number, new_log);
     }
+<<<<<<< HEAD
 =======
     s = CreateWAL(impl, env_options, new_log_number, 0 /*recycle_log_number*/,
                   true /*creating_new_log*/, true /* called_from_open*/,
                   preallocate_block_size, &new_log);
 >>>>>>> Consolidating wal creation
+=======
+>>>>>>> Changes based on comments
 
     if (s.ok()) {
       // set column family handles

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1108,9 +1108,7 @@ Status DB::Open(const DBOptions& db_options, const std::string& dbname,
 
 Status DBImpl::CreateWAL(DBImpl* impl, const EnvOptions& env_options,
                          uint64_t log_file_num, uint64_t recycle_log_number,
-                         bool create_new_log, bool called_from_open,
-                         const size_t preallocate_block_size,
-                         log::Writer** new_log) {
+                         const size_t preallocate_block_size, log::Writer** new_log) {
   assert(impl != nullptr);
   Status s;
   std::unique_ptr<WritableFile> lfile;
@@ -1122,43 +1120,30 @@ Status DBImpl::CreateWAL(DBImpl* impl, const EnvOptions& env_options,
   std::string log_fname =
       LogFileName(impl->immutable_db_options_.wal_dir, log_file_num);
 
-  if (create_new_log) {
-    if (recycle_log_number) {
-      ROCKS_LOG_INFO(impl->immutable_db_options_.info_log,
-                     "reusing log %" PRIu64 " from recycle list\n",
-                     recycle_log_number);
-      std::string old_log_fname =
-          LogFileName(impl->immutable_db_options_.wal_dir, recycle_log_number);
-      s = impl->env_->ReuseWritableFile(log_fname, old_log_fname, &lfile,
-                                        opt_env_options);
-    } else {
-      if (called_from_open) {
-        s = NewWritableFile(impl->immutable_db_options_.env, log_fname, &lfile,
-                            opt_env_options);
-      } else {
-        s = NewWritableFile(impl->env_, log_fname, &lfile, opt_env_options);
-      }
-    }
+  if (recycle_log_number) {
+    ROCKS_LOG_INFO(impl->immutable_db_options_.info_log,
+                   "reusing log %" PRIu64 " from recycle list\n",
+                   recycle_log_number);
+    std::string old_log_fname =
+        LogFileName(impl->immutable_db_options_.wal_dir, recycle_log_number);
+    s = impl->env_->ReuseWritableFile(log_fname, old_log_fname, &lfile,
+                                      opt_env_options);
+  } else {
+    s = NewWritableFile(impl->env_, log_fname, &lfile, opt_env_options);
+  }
 
-    if (s.ok()) {
-      lfile->SetWriteLifeTimeHint(impl->CalculateWALWriteHint());
-      lfile->SetPreallocationBlockSize(preallocate_block_size);
+  if (s.ok()) {
+    lfile->SetWriteLifeTimeHint(impl->CalculateWALWriteHint());
+    lfile->SetPreallocationBlockSize(preallocate_block_size);
 
-      const auto& listeners = impl->immutable_db_options_.listeners;
-      std::unique_ptr<WritableFileWriter> file_writer(
-          new WritableFileWriter(std::move(lfile), log_fname, opt_env_options,
-                                 impl->env_, nullptr /* stats */, listeners));
-      *new_log =
-          new log::Writer(std::move(file_writer), log_file_num,
-                          impl->immutable_db_options_.recycle_log_file_num > 0,
-                          impl->immutable_db_options_.manual_wal_flush);
-
-      if (called_from_open) {
-        InstrumentedMutexLock wl(&impl->log_write_mutex_);
-        impl->logfile_number_ = log_file_num;
-        impl->logs_.emplace_back(log_file_num, *new_log);
-      }
-    }
+    const auto& listeners = impl->immutable_db_options_.listeners;
+    std::unique_ptr<WritableFileWriter> file_writer(
+        new WritableFileWriter(std::move(lfile), log_fname, opt_env_options,
+                               impl->env_, nullptr /* stats */, listeners));
+    *new_log =
+        new log::Writer(std::move(file_writer), log_file_num,
+                        impl->immutable_db_options_.recycle_log_file_num > 0,
+                        impl->immutable_db_options_.manual_wal_flush);
   }
   return s;
 }
@@ -1232,9 +1217,13 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
     log::Writer* new_log = nullptr;
     const size_t preallocate_block_size =
         impl->GetWalPreallocateBlockSize(max_write_buffer_size);
-    s = CreateWAL(impl, env_options, new_log_number, 0 /*recycle_log_number*/,
-                  true /*creating_new_log*/, true /* called_from_open*/,
-                  preallocate_block_size, &new_log);
+    s = impl->CreateWAL(impl, env_options, new_log_number,
+                0 /*recycle_log_number*/, preallocate_block_size, &new_log);
+    {
+      InstrumentedMutexLock wl(&impl->log_write_mutex_);
+      impl->logfile_number_ = new_log_number;
+      impl->logs_.emplace_back(new_log_number, new_log);
+    }
 
     if (s.ok()) {
       // set column family handles

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1210,7 +1210,6 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   // Handles create_if_missing, error_if_exists
   s = impl->Recover(column_families);
   if (s.ok()) {
-    EnvOptions env_options(db_options);
     uint64_t new_log_number = impl->versions_->NewFileNumber();
     log::Writer* new_log = nullptr;
     const size_t preallocate_block_size =

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1107,8 +1107,7 @@ Status DB::Open(const DBOptions& db_options, const std::string& dbname,
 }
 
 Status DBImpl::CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
-                         const size_t preallocate_block_size,
-                         log::Writer** new_log) {
+                         size_t preallocate_block_size, log::Writer** new_log) {
   Status s;
   std::unique_ptr<WritableFile> lfile;
 

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1418,45 +1418,13 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   // Log this later after lock release. It may be outdated, e.g., if background
   // flush happens before logging, but that should be ok.
   int num_imm_unflushed = cfd->imm()->NumNotFlushed();
-  DBOptions db_options =
-      BuildDBOptions(immutable_db_options_, mutable_db_options_);
   const auto preallocate_block_size =
       GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
-  auto write_hint = CalculateWALWriteHint();
   mutex_.Unlock();
   {
-    std::string log_fname =
-        LogFileName(immutable_db_options_.wal_dir, new_log_number);
-    if (creating_new_log) {
-      EnvOptions opt_env_opt =
-          env_->OptimizeForLogWrite(env_options_, db_options);
-      if (recycle_log_number) {
-        ROCKS_LOG_INFO(immutable_db_options_.info_log,
-                       "reusing log %" PRIu64 " from recycle list\n",
-                       recycle_log_number);
-        std::string old_log_fname =
-            LogFileName(immutable_db_options_.wal_dir, recycle_log_number);
-        s = env_->ReuseWritableFile(log_fname, old_log_fname, &lfile,
-                                    opt_env_opt);
-      } else {
-        s = NewWritableFile(env_, log_fname, &lfile, opt_env_opt);
-      }
-      if (s.ok()) {
-        // Our final size should be less than write_buffer_size
-        // (compression, etc) but err on the side of caution.
-
-        // use preallocate_block_size instead
-        // of calling GetWalPreallocateBlockSize()
-        lfile->SetPreallocationBlockSize(preallocate_block_size);
-        lfile->SetWriteLifeTimeHint(write_hint);
-        std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-            std::move(lfile), log_fname, opt_env_opt, env_, nullptr /* stats */,
-            immutable_db_options_.listeners));
-        new_log = new log::Writer(
-            std::move(file_writer), new_log_number,
-            immutable_db_options_.recycle_log_file_num > 0, manual_wal_flush_);
-      }
-    }
+    s = CreateWAL(this, env_options_, new_log_number, recycle_log_number,
+                  creating_new_log, false /*called_from_open*/,
+                  preallocate_block_size, &new_log);
 
     if (s.ok()) {
       SequenceNumber seq = versions_->LastSequence();

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1422,7 +1422,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
       GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
   mutex_.Unlock();
   if (creating_new_log) {
-    s = CreateWAL(this, env_options_, new_log_number, recycle_log_number,
+    s = CreateWAL(env_options_, new_log_number, recycle_log_number,
                   preallocate_block_size, &new_log);
   }
   if (s.ok()) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1422,8 +1422,8 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
       GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
   mutex_.Unlock();
   if (creating_new_log) {
-    s = CreateWAL(env_options_, new_log_number, recycle_log_number,
-                  preallocate_block_size, &new_log);
+    s = CreateWAL(new_log_number, recycle_log_number, preallocate_block_size,
+                  &new_log);
   }
   if (s.ok()) {
     SequenceNumber seq = versions_->LastSequence();

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1418,12 +1418,12 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   // Log this later after lock release. It may be outdated, e.g., if background
   // flush happens before logging, but that should be ok.
   int num_imm_unflushed = cfd->imm()->NumNotFlushed();
-  const auto preallocate_block_size =
-      GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
   mutex_.Unlock();
   if (creating_new_log) {
-    s = CreateWAL(new_log_number, recycle_log_number, preallocate_block_size,
-                  &new_log);
+    // TODO: Write buffer size passed in should be max of all CF's instead
+    // of mutable_cf_options.write_buffer_size.
+    s = CreateWAL(new_log_number, recycle_log_number,
+                  mutable_cf_options.write_buffer_size, &new_log);
   }
   if (s.ok()) {
     SequenceNumber seq = versions_->LastSequence();

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1418,12 +1418,14 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   // Log this later after lock release. It may be outdated, e.g., if background
   // flush happens before logging, but that should be ok.
   int num_imm_unflushed = cfd->imm()->NumNotFlushed();
+  const auto preallocate_block_size =
+      GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
   mutex_.Unlock();
   if (creating_new_log) {
     // TODO: Write buffer size passed in should be max of all CF's instead
     // of mutable_cf_options.write_buffer_size.
-    s = CreateWAL(new_log_number, recycle_log_number,
-                  mutable_cf_options.write_buffer_size, &new_log);
+    s = CreateWAL(new_log_number, recycle_log_number, preallocate_block_size,
+                  &new_log);
   }
   if (s.ok()) {
     SequenceNumber seq = versions_->LastSequence();

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1421,16 +1421,14 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   const auto preallocate_block_size =
       GetWalPreallocateBlockSize(mutable_cf_options.write_buffer_size);
   mutex_.Unlock();
-  {
+  if (creating_new_log) {
     s = CreateWAL(this, env_options_, new_log_number, recycle_log_number,
-                  creating_new_log, false /*called_from_open*/,
                   preallocate_block_size, &new_log);
-
-    if (s.ok()) {
-      SequenceNumber seq = versions_->LastSequence();
-      new_mem = cfd->ConstructNewMemtable(mutable_cf_options, seq);
-      context->superversion_context.NewSuperVersion();
-    }
+  }
+  if (s.ok()) {
+    SequenceNumber seq = versions_->LastSequence();
+    new_mem = cfd->ConstructNewMemtable(mutable_cf_options, seq);
+    context->superversion_context.NewSuperVersion();
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "[%s] New memtable created with log file: #%" PRIu64


### PR DESCRIPTION
Right now, two separate pieces of code are used to create WAL files in DBImpl::Open function of db_impl_open.cc and DBImpl::SwitchMemtable function of db_impl_write.cc. This code change simply creates 1 function called DBImpl::CreateWAL in db_impl_open.cc which is used to replace existing WAL creation logic in DBImpl::Open and DBImpl::SwitchMemtable. 