### PR TITLE
Not adding RangeDelete start key to memtable bloom filter

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -518,11 +518,13 @@ bool MemTable::Add(SequenceNumber s, ValueType type,
                          std::memory_order_relaxed);
     }
 
-    if (bloom_filter_ && prefix_extractor_) {
-      bloom_filter_->Add(prefix_extractor_->Transform(key));
-    }
-    if (bloom_filter_ && moptions_.memtable_whole_key_filtering) {
-      bloom_filter_->Add(key);
+    if (type != kTypeRangeDeletion) {
+      if (bloom_filter_ && prefix_extractor_) {
+        bloom_filter_->Add(prefix_extractor_->Transform(key));
+      }
+      if (bloom_filter_ && moptions_.memtable_whole_key_filtering) {
+        bloom_filter_->Add(key);
+      }
     }
 
     // The first sequence number inserted into the memtable

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -518,11 +518,11 @@ bool MemTable::Add(SequenceNumber s, ValueType type,
                          std::memory_order_relaxed);
     }
 
-    if (type != kTypeRangeDeletion) {
-      if (bloom_filter_ && prefix_extractor_) {
+    if (bloom_filter_ && type != kTypeRangeDeletion) {
+      if (prefix_extractor_) {
         bloom_filter_->Add(prefix_extractor_->Transform(key));
       }
-      if (bloom_filter_ && moptions_.memtable_whole_key_filtering) {
+      if (moptions_.memtable_whole_key_filtering) {
         bloom_filter_->Add(key);
       }
     }


### PR DESCRIPTION
Summary:
It is not useful to add `DeleteRange` start key to memtable bloom filter. We don't lookup delete range tombstone using bloom filters.

Test Plan:
existing test