### PR TITLE
refactor SavePoints

### DIFF
--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -52,6 +52,7 @@
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"
 #include "rocksdb/merge_operator.h"
+#include "util/autovector.h"
 #include "util/coding.h"
 #include "util/duplicate_detector.h"
 #include "util/string_util.h"
@@ -137,7 +138,7 @@ struct BatchContentClassifier : public WriteBatch::Handler {
 }  // anon namespace
 
 struct SavePoints {
-  std::stack<SavePoint, std::vector<SavePoint>> stack;
+  std::stack<SavePoint, autovector<SavePoint>> stack;
 };
 
 WriteBatch::WriteBatch(size_t reserved_bytes, size_t max_bytes)

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -27,7 +27,6 @@
 #include <stdint.h>
 #include <atomic>
 #include <memory>
-#include <stack>
 #include <string>
 #include "rocksdb/status.h"
 #include "rocksdb/write_batch_base.h"

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <atomic>
+#include <memory>
 #include <stack>
 #include <string>
 #include "rocksdb/status.h"
@@ -337,7 +338,7 @@ class WriteBatch : public WriteBatchBase {
   // remove duplicate keys. Remove it when the hack is replaced with a proper
   // solution.
   friend class WriteBatchWithIndex;
-  SavePoints* save_points_;
+  std::unique_ptr<SavePoints> save_points_;
 
   // When sending a WriteBatch through WriteImpl we might want to
   // specify that only the first x records of the batch be written to

--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <mutex>
 #include <sstream>
 #include <thread>

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -123,7 +123,7 @@ Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
 
 void TransactionBaseImpl::SetSavePoint() {
   if (save_points_ == nullptr) {
-    save_points_.reset(new std::stack<TransactionBaseImpl::SavePoint, std::vector<TransactionBaseImpl::SavePoint>>());
+    save_points_.reset(new std::stack<TransactionBaseImpl::SavePoint, autovector<TransactionBaseImpl::SavePoint>>());
   }
   save_points_->emplace(snapshot_, snapshot_needed_, snapshot_notifier_,
                         num_puts_, num_deletes_, num_merges_);

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -123,80 +123,81 @@ Status TransactionBaseImpl::TryLock(ColumnFamilyHandle* column_family,
 
 void TransactionBaseImpl::SetSavePoint() {
   if (save_points_ == nullptr) {
-    save_points_.reset(new std::stack<TransactionBaseImpl::SavePoint>());
+    save_points_.reset(new std::vector<TransactionBaseImpl::SavePoint>());
   }
-  save_points_->emplace(snapshot_, snapshot_needed_, snapshot_notifier_,
-                        num_puts_, num_deletes_, num_merges_);
+  save_points_->emplace_back(snapshot_, snapshot_needed_, snapshot_notifier_,
+                             num_puts_, num_deletes_, num_merges_);
   write_batch_.SetSavePoint();
 }
 
 Status TransactionBaseImpl::RollbackToSavePoint() {
-  if (save_points_ != nullptr && save_points_->size() > 0) {
-    // Restore saved SavePoint
-    TransactionBaseImpl::SavePoint& save_point = save_points_->top();
-    snapshot_ = save_point.snapshot_;
-    snapshot_needed_ = save_point.snapshot_needed_;
-    snapshot_notifier_ = save_point.snapshot_notifier_;
-    num_puts_ = save_point.num_puts_;
-    num_deletes_ = save_point.num_deletes_;
-    num_merges_ = save_point.num_merges_;
-
-    // Rollback batch
-    Status s = write_batch_.RollbackToSavePoint();
-    assert(s.ok());
-
-    // Rollback any keys that were tracked since the last savepoint
-    const TransactionKeyMap& key_map = save_point.new_keys_;
-    for (const auto& key_map_iter : key_map) {
-      uint32_t column_family_id = key_map_iter.first;
-      auto& keys = key_map_iter.second;
-
-      auto& cf_tracked_keys = tracked_keys_[column_family_id];
-
-      for (const auto& key_iter : keys) {
-        const std::string& key = key_iter.first;
-        uint32_t num_reads = key_iter.second.num_reads;
-        uint32_t num_writes = key_iter.second.num_writes;
-
-        auto tracked_keys_iter = cf_tracked_keys.find(key);
-        assert(tracked_keys_iter != cf_tracked_keys.end());
-
-        // Decrement the total reads/writes of this key by the number of
-        // reads/writes done since the last SavePoint.
-        if (num_reads > 0) {
-          assert(tracked_keys_iter->second.num_reads >= num_reads);
-          tracked_keys_iter->second.num_reads -= num_reads;
-        }
-        if (num_writes > 0) {
-          assert(tracked_keys_iter->second.num_writes >= num_writes);
-          tracked_keys_iter->second.num_writes -= num_writes;
-        }
-        if (tracked_keys_iter->second.num_reads == 0 &&
-            tracked_keys_iter->second.num_writes == 0) {
-          tracked_keys_[column_family_id].erase(tracked_keys_iter);
-        }
-      }
-    }
-
-    save_points_->pop();
-
-    return s;
-  } else {
+  if (save_points_ == nullptr || save_points_->empty()) {
     assert(write_batch_.RollbackToSavePoint().IsNotFound());
     return Status::NotFound();
   }
+
+  // Restore saved SavePoint
+  TransactionBaseImpl::SavePoint& save_point = save_points_->back();
+  // It is ok to move data out of the SavePoint, as we are going to
+  // pop it off the stack anyway
+  snapshot_ = std::move(save_point.snapshot_);
+  snapshot_needed_ = save_point.snapshot_needed_;
+  snapshot_notifier_ = std::move(save_point.snapshot_notifier_);
+  num_puts_ = save_point.num_puts_;
+  num_deletes_ = save_point.num_deletes_;
+  num_merges_ = save_point.num_merges_;
+
+  // Rollback batch
+  Status s = write_batch_.RollbackToSavePoint();
+  assert(s.ok());
+
+  // Rollback any keys that were tracked since the last savepoint
+  const TransactionKeyMap& key_map = save_point.new_keys_;
+  for (const auto& key_map_iter : key_map) {
+    uint32_t column_family_id = key_map_iter.first;
+    auto& keys = key_map_iter.second;
+
+    auto& cf_tracked_keys = tracked_keys_[column_family_id];
+
+    for (const auto& key_iter : keys) {
+      const std::string& key = key_iter.first;
+      uint32_t num_reads = key_iter.second.num_reads;
+      uint32_t num_writes = key_iter.second.num_writes;
+
+      auto tracked_keys_iter = cf_tracked_keys.find(key);
+      assert(tracked_keys_iter != cf_tracked_keys.end());
+
+      // Decrement the total reads/writes of this key by the number of
+      // reads/writes done since the last SavePoint.
+      if (num_reads > 0) {
+        assert(tracked_keys_iter->second.num_reads >= num_reads);
+        tracked_keys_iter->second.num_reads -= num_reads;
+      }
+      if (num_writes > 0) {
+        assert(tracked_keys_iter->second.num_writes >= num_writes);
+        tracked_keys_iter->second.num_writes -= num_writes;
+      }
+      if (tracked_keys_iter->second.num_reads == 0 &&
+          tracked_keys_iter->second.num_writes == 0) {
+        tracked_keys_[column_family_id].erase(tracked_keys_iter);
+      }
+    }
+  }
+
+  save_points_->pop_back();
+
+  return s;
 }
 
 Status TransactionBaseImpl::PopSavePoint() {
-  if (save_points_ == nullptr ||
-      save_points_->empty()) {
+  if (save_points_ == nullptr || save_points_->empty()) {
     // No SavePoint yet.
     assert(write_batch_.PopSavePoint().IsNotFound());
     return Status::NotFound();
   }
 
   assert(!save_points_->empty());
-  save_points_->pop();
+  save_points_->pop_back();
   return write_batch_.PopSavePoint();
 }
 
@@ -573,7 +574,7 @@ void TransactionBaseImpl::TrackKey(uint32_t cfh_id, const std::string& key,
 
   if (save_points_ != nullptr && !save_points_->empty()) {
     // Update map of tracked keys in this SavePoint
-    TrackKey(&save_points_->top().new_keys_, cfh_id, key, seq, read_only,
+    TrackKey(&save_points_->back().new_keys_, cfh_id, key, seq, read_only,
              exclusive);
   }
 }
@@ -612,8 +613,8 @@ TransactionBaseImpl::GetTrackedKeysSinceSavePoint() {
     // Examine the number of reads/writes performed on all keys written
     // since the last SavePoint and compare to the total number of reads/writes
     // for each key.
-    TransactionKeyMap* result = new TransactionKeyMap();
-    for (const auto& key_map_iter : save_points_->top().new_keys_) {
+    std::unique_ptr<TransactionKeyMap> result(new TransactionKeyMap());
+    for (const auto& key_map_iter : save_points_->back().new_keys_) {
       uint32_t column_family_id = key_map_iter.first;
       auto& keys = key_map_iter.second;
 
@@ -633,12 +634,12 @@ TransactionBaseImpl::GetTrackedKeysSinceSavePoint() {
             total_key_info->second.num_writes == num_writes) {
           // All the reads/writes to this key were done in the last savepoint.
           bool read_only = (num_writes == 0);
-          TrackKey(result, column_family_id, key, key_iter.second.seq,
+          TrackKey(result.get(), column_family_id, key, key_iter.second.seq,
                    read_only, key_iter.second.exclusive);
         }
       }
     }
-    return std::unique_ptr<TransactionKeyMap>(result);
+    return result;
   }
 
   // No SavePoint
@@ -678,7 +679,7 @@ void TransactionBaseImpl::UndoGetForUpdate(ColumnFamilyHandle* column_family,
 
   if (save_points_ != nullptr && !save_points_->empty()) {
     // Check if this key was fetched ForUpdate in this SavePoint
-    auto& cf_savepoint_keys = save_points_->top().new_keys_[column_family_id];
+    auto& cf_savepoint_keys = save_points_->back().new_keys_[column_family_id];
 
     auto savepoint_iter = cf_savepoint_keys.find(key_str);
     if (savepoint_iter != cf_savepoint_keys.end()) {

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -19,6 +19,7 @@
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
+#include "util/autovector.h"
 #include "utilities/transactions/transaction_util.h"
 
 namespace rocksdb {
@@ -318,7 +319,7 @@ class TransactionBaseImpl : public Transaction {
 
   // Stack of the Snapshot saved at each save point.  Saved snapshots may be
   // nullptr if there was no snapshot at the time SetSavePoint() was called.
-  std::unique_ptr<std::stack<TransactionBaseImpl::SavePoint, std::vector<TransactionBaseImpl::SavePoint>>> save_points_;
+  std::unique_ptr<std::stack<TransactionBaseImpl::SavePoint, autovector<TransactionBaseImpl::SavePoint>>> save_points_;
 
   // Map from column_family_id to map of keys that are involved in this
   // transaction.

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -7,7 +7,6 @@
 
 #ifndef ROCKSDB_LITE
 
-#include <stack>
 #include <string>
 #include <vector>
 
@@ -223,7 +222,7 @@ class TransactionBaseImpl : public Transaction {
                         const Slice& key) override;
   void UndoGetForUpdate(const Slice& key) override {
     return UndoGetForUpdate(nullptr, key);
-  };
+  }
 
   // Get list of keys in this transaction that must not have any conflicts
   // with writes in other transactions.
@@ -318,7 +317,7 @@ class TransactionBaseImpl : public Transaction {
 
   // Stack of the Snapshot saved at each save point.  Saved snapshots may be
   // nullptr if there was no snapshot at the time SetSavePoint() was called.
-  std::unique_ptr<std::stack<TransactionBaseImpl::SavePoint>> save_points_;
+  std::unique_ptr<std::vector<TransactionBaseImpl::SavePoint>> save_points_;
 
   // Map from column_family_id to map of keys that are involved in this
   // transaction.

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -7,6 +7,7 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <stack>
 #include <string>
 #include <vector>
 
@@ -222,7 +223,7 @@ class TransactionBaseImpl : public Transaction {
                         const Slice& key) override;
   void UndoGetForUpdate(const Slice& key) override {
     return UndoGetForUpdate(nullptr, key);
-  }
+  };
 
   // Get list of keys in this transaction that must not have any conflicts
   // with writes in other transactions.
@@ -317,7 +318,7 @@ class TransactionBaseImpl : public Transaction {
 
   // Stack of the Snapshot saved at each save point.  Saved snapshots may be
   // nullptr if there was no snapshot at the time SetSavePoint() was called.
-  std::unique_ptr<std::vector<TransactionBaseImpl::SavePoint>> save_points_;
+  std::unique_ptr<std::stack<TransactionBaseImpl::SavePoint, std::vector<TransactionBaseImpl::SavePoint>>> save_points_;
 
   // Map from column_family_id to map of keys that are involved in this
   // transaction.


### PR DESCRIPTION
Savepoints are assumed to be used in a stack-wise fashion (only
the top element should be used), so they were stored by `WriteBatch`
in a member variable `save_points` using an std::stack.

Conceptually this is fine, but the implementation had a few issues:
- the `save_points_` instance variable was a plain pointer to a heap-
  allocated `SavePoints` struct. The destructor of `WriteBatch` simply
  deletes this pointer. However, the copy constructor of WriteBatch
  just copied that pointer, meaning that copying a WriteBatch with
  active savepoints will very likely have crashed before. Now a proper
  copy of the savepoints is made in the copy constructor, and not just
  a copy of the pointer
- `save_points_` was an std::stack, which defaults to `std::deque` for
  the underlying container. A deque is a bit over the top here, as we
  only need access to the most recent savepoint (i.e. stack.top()) but
  never any elements at the front. std::deque is rather expensive to
  initialize in common environments. For example, the STL implementation
  shipped with GNU g++ will perform a heap allocation of more than 500
  bytes to create an empty deque object. Although the `save_points_`
  container is created lazily by RocksDB, moving from a deque to a plain
  `std::vector` is much more memory-efficient. So `save_points_` is now
  a vector.
- `save_points_` was changed from a plain pointer to an `std::unique_ptr`,
  making ownership more explicit.