### PR TITLE
Improve transaction lock details

### DIFF
--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -449,7 +449,7 @@ bool TransactionLockMgr::IncrementWaiters(
   std::lock_guard<std::mutex> lock(wait_txn_map_mutex_);
   assert(!wait_txn_map_.Contains(id));
 
-  wait_txn_map_.Insert(id, {wait_ids, cf_id, key, exclusive});
+  wait_txn_map_.Insert(id, {wait_ids, cf_id, exclusive, key});
 
   for (auto wait_id : wait_ids) {
     if (rev_wait_txn_map_.Contains(wait_id)) {

--- a/utilities/transactions/transaction_lock_mgr.cc
+++ b/utilities/transactions/transaction_lock_mgr.cc
@@ -192,8 +192,7 @@ void TransactionLockMgr::AddColumnFamily(uint32_t column_family_id) {
 
   if (lock_maps_.find(column_family_id) == lock_maps_.end()) {
     lock_maps_.emplace(column_family_id,
-                       std::shared_ptr<LockMap>(
-                           new LockMap(default_num_stripes_, mutex_factory_)));
+                       std::make_shared<LockMap>(default_num_stripes_, mutex_factory_));
   } else {
     // column_family already exists in lock map
     assert(false);

--- a/utilities/transactions/transaction_lock_mgr.h
+++ b/utilities/transactions/transaction_lock_mgr.h
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <string>
 #include <unordered_map>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/utilities/transactions/transaction_lock_mgr.h
+++ b/utilities/transactions/transaction_lock_mgr.h
@@ -45,8 +45,8 @@ struct DeadlockInfoBuffer {
 struct TrackedTrxInfo {
   autovector<TransactionID> m_neighbors;
   uint32_t m_cf_id;
-  std::string m_waiting_key;
   bool m_exclusive;
+  std::string m_waiting_key;
 };
 
 class Slice;


### PR DESCRIPTION
This branch contains two small improvements:
* Create `LockMap` entries using `std::make_shared`. This saves one heap allocation per LockMap entry but also locates the control block and the LockMap object closely together in memory, which can help with caching
* Reorder the members of `TrackedTrxInfo`, so that the resulting struct uses less memory (at least on 64bit systems)

