### PR TITLE
Introduce InternalIteratorBase::NextAndGetResult()

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -231,7 +231,7 @@ class DBIter final: public Iterator {
     return Status::InvalidArgument("Unidentified property.");
   }
 
-  void Next() override;
+  void Next() final override;
   void Prev() override;
   void Seek(const Slice& target) override;
   void SeekForPrev(const Slice& target) override;

--- a/table/block.h
+++ b/table/block.h
@@ -392,7 +392,7 @@ class DataBlockIter final : public BlockIter<Slice> {
 
   virtual void Prev() override;
 
-  virtual void Next() override;
+  virtual void Next() final override;
 
   // Try to advance to the next entry in the block. If there is data corruption
   // or error, report it to the caller instead of aborting the process. May

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2436,6 +2436,17 @@ void BlockBasedTableIterator<TBlockIter, TValue>::Next() {
 }
 
 template <class TBlockIter, typename TValue>
+bool BlockBasedTableIterator<TBlockIter, TValue>::NextAndGetResult(
+    Slice* ret_key) {
+  Next();
+  bool is_valid = Valid();
+  if (is_valid) {
+    *ret_key = key();
+  }
+  return is_valid;
+}
+
+template <class TBlockIter, typename TValue>
 void BlockBasedTableIterator<TBlockIter, TValue>::Prev() {
   assert(block_iter_points_to_real_block_);
   block_iter_.Prev();
@@ -2493,10 +2504,10 @@ void BlockBasedTableIterator<TBlockIter, TValue>::InitDataBlock() {
 }
 
 template <class TBlockIter, typename TValue>
-void BlockBasedTableIterator<TBlockIter, TValue>::FindKeyForward() {
+void BlockBasedTableIterator<TBlockIter, TValue>::FindBlockForward() {
   // TODO the while loop inherits from two-level-iterator. We don't know
   // whether a block can be empty so it can be replaced by an "if".
-  while (!block_iter_.Valid()) {
+  do {
     if (!block_iter_.status().ok()) {
       return;
     }
@@ -2528,6 +2539,15 @@ void BlockBasedTableIterator<TBlockIter, TValue>::FindKeyForward() {
     } else {
       return;
     }
+  } while (!block_iter_.Valid());
+}
+
+template <class TBlockIter, typename TValue>
+void BlockBasedTableIterator<TBlockIter, TValue>::FindKeyForward() {
+  assert(!is_out_of_bound_);
+
+  if (!block_iter_.Valid()) {
+    FindBlockForward();
   }
 }
 

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -611,7 +611,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<TValue> {
   void SeekForPrev(const Slice& target) override;
   void SeekToFirst() override;
   void SeekToLast() override;
-  void Next() override;
+  void Next() final override;
+  bool NextAndGetResult(Slice* ret_key) override;
   void Prev() override;
   bool Valid() const override {
     return !is_out_of_bound_ && block_iter_points_to_real_block_ &&
@@ -688,7 +689,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<TValue> {
   }
 
   void InitDataBlock();
-  void FindKeyForward();
+  inline void FindKeyForward();
+  void FindBlockForward();
   void FindKeyBackward();
   void CheckOutOfBound();
 

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -54,6 +54,15 @@ class InternalIteratorBase : public Cleanable {
   // REQUIRES: Valid()
   virtual void Next() = 0;
 
+  virtual bool NextAndGetResult(Slice* ret_key) {
+    Next();
+    bool is_valid = Valid();
+    if (is_valid) {
+      *ret_key = key();
+    }
+    return is_valid;
+  }
+
   // Moves to the previous entry in the source.  After this call, Valid() is
   // true iff the iterator was not positioned at the first entry in source.
   // REQUIRES: Valid()

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -63,7 +63,11 @@ class IteratorWrapperBase {
   }
   // Methods below require iter() != nullptr
   Status status() const     { assert(iter_); return iter_->status(); }
-  void Next()               { assert(iter_); iter_->Next();        Update(); }
+  void Next() {
+    assert(iter_);
+    valid_ = iter_->NextAndGetResult(&key_);
+    assert(!valid_ || iter_->status().ok());
+  }
   void Prev()               { assert(iter_); iter_->Prev();        Update(); }
   void Seek(const Slice& k) { assert(iter_); iter_->Seek(k);       Update(); }
   void SeekForPrev(const Slice& k) {


### PR DESCRIPTION
Summary: In long scans, virtual function calls of Next(), Valid(), key() and value() are not trivial. By introducing NextAndGetResult(), Some of the Next(), Valid() and key() calls are consolidated into one virtual function call to reduce CPU.
Also did some inline tricks and add some "final" randomly in some functions. Even without the "final" annotation, most Next() calls are inlined with -O3, but sometimes with a final it is inlined by O2 too. It doesn't hurt to add those final annotations.

Test Plan: Run all tests
After filling data with fillseq, run
./db_bench --benchmarks=readseq --num=100000000 -use_existing_db
With the change, it improves scan speed by about 8%, for -O3. Even more gain with -O2.