### PR TITLE
Interface to customize compaction output file boundary

### DIFF
--- a/db/compaction_job.h
+++ b/db/compaction_job.h
@@ -122,6 +122,8 @@ class CompactionJob {
 
   void LogCompaction();
 
+  std::unique_ptr<CompactionPolicy> GetCompactionPolicy();
+
   int job_id_;
 
   // CompactionJob state

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1083,35 +1083,7 @@ void DBImpl::NotifyOnCompactionBegin(ColumnFamilyData* cfd, Compaction* c,
   TEST_SYNC_POINT("DBImpl::NotifyOnCompactionBegin::UnlockMutex");
   {
     CompactionJobInfo info;
-    info.cf_name = cfd->GetName();
-    info.status = st;
-    info.thread_id = env_->GetThreadID();
-    info.job_id = job_id;
-    info.base_input_level = c->start_level();
-    info.output_level = c->output_level();
-    info.stats = job_stats;
-    info.table_properties = c->GetOutputTableProperties();
-    info.compaction_reason = c->compaction_reason();
-    info.compression = c->output_compression();
-    for (size_t i = 0; i < c->num_input_levels(); ++i) {
-      for (const auto fmd : *c->inputs(i)) {
-        auto fn = TableFileName(c->immutable_cf_options()->cf_paths,
-                                fmd->fd.GetNumber(), fmd->fd.GetPathId());
-        info.input_files.push_back(fn);
-        if (info.table_properties.count(fn) == 0) {
-          std::shared_ptr<const TableProperties> tp;
-          auto s = current->GetTableProperties(&tp, fmd, &fn);
-          if (s.ok()) {
-            info.table_properties[fn] = tp;
-          }
-        }
-      }
-    }
-    for (const auto newf : c->edit()->GetNewFiles()) {
-      info.output_files.push_back(TableFileName(
-          c->immutable_cf_options()->cf_paths, newf.second.fd.GetNumber(),
-          newf.second.fd.GetPathId()));
-    }
+    BuildCompactionJobInfo(cfd, c, st, job_stats, job_id, current, &info);
     for (auto listener : immutable_db_options_.listeners) {
       listener->OnCompactionBegin(this, info);
     }

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "rocksdb/compaction_policy.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/universal_compaction.h"
 
@@ -689,6 +690,13 @@ struct AdvancedColumnFamilyOptions {
   // NOT SUPPORTED ANYMORE
   // Does not have any effect.
   bool purge_redundant_kvs_while_flush = true;
+
+  // The compaction policy interface provide a way for application to customize
+  // the way compaction runs. If it is non-null, it overrides the following
+  // options:
+  //   * target_file_size_base
+  //   * target_file_size_multiplier
+  std::shared_ptr<CompactionPolicyFactory> compaction_policy_factory;
 };
 
 }  // namespace rocksdb

--- a/include/rocksdb/compaction_policy.h
+++ b/include/rocksdb/compaction_policy.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <memory>
+
+#include "rocksdb/listener.h"
+
+namespace rocksdb {
+
+struct CompactionOutputInfo {
+  Slice next_key;
+  uint64_t current_output_file_size;
+};
+
+class CompactionPolicy {
+ public:
+  virtual ~CompactionPolicy() = default;
+
+  virtual void NotifyKeyAdded(const Slice& key) = 0;
+
+  virtual bool ShouldEndCurrentOutputFile(const CompactionOutputInfo& info) = 0;
+};
+
+class CompactionPolicyFactory {
+ public:
+  virtual ~CompactionPolicyFactory() = default;
+
+  virtual const char* Name() const = 0;
+
+  virtual std::unique_ptr<CompactionPolicy> NewCompactionPolicy(
+      const CompactionJobInfo& info) = 0;
+};
+
+}  // namespace rocksdb

--- a/include/rocksdb/compaction_policy.h
+++ b/include/rocksdb/compaction_policy.h
@@ -24,7 +24,8 @@ class CompactionPolicy {
  public:
   virtual ~CompactionPolicy() = default;
 
-  virtual void NotifyKeyAdded(const Slice& key) = 0;
+  // TODO: shall the key be user key or internal key?
+  virtual void Add(const Slice& key, const Slice& value) = 0;
 
   virtual bool ShouldEndCurrentOutputFile(const CompactionOutputInfo& info) = 0;
 };

--- a/include/rocksdb/compaction_policy.h
+++ b/include/rocksdb/compaction_policy.h
@@ -11,6 +11,10 @@
 
 namespace rocksdb {
 
+struct CompactionInfo {
+  int output_level;
+};
+
 struct CompactionOutputInfo {
   Slice next_key;
   uint64_t current_output_file_size;
@@ -32,7 +36,7 @@ class CompactionPolicyFactory {
   virtual const char* Name() const = 0;
 
   virtual std::unique_ptr<CompactionPolicy> NewCompactionPolicy(
-      const CompactionJobInfo& info) = 0;
+      const CompactionInfo& info) = 0;
 };
 
 }  // namespace rocksdb

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -222,6 +222,9 @@ void MutableCFOptions::Dump(Logger* log) const {
                  compaction_options_fifo.max_table_files_size);
   ROCKS_LOG_INFO(log, "compaction_options_fifo.allow_compaction : %d",
                  compaction_options_fifo.allow_compaction);
+  ROCKS_LOG_INFO(
+      log, "                compaction_policy_factory: %s",
+      compaction_policy_factory ? compaction_policy_factory->Name() : "None");
 }
 
 MutableCFOptions::MutableCFOptions(const Options& options)

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -156,6 +156,7 @@ struct MutableCFOptions {
             options.max_bytes_for_level_multiplier_additional),
         compaction_options_fifo(options.compaction_options_fifo),
         compaction_options_universal(options.compaction_options_universal),
+        compaction_policy_factory(options.compaction_policy_factory),
         max_sequential_skip_in_iterations(
             options.max_sequential_skip_in_iterations),
         paranoid_file_checks(options.paranoid_file_checks),
@@ -242,6 +243,7 @@ struct MutableCFOptions {
   std::vector<int> max_bytes_for_level_multiplier_additional;
   CompactionOptionsFIFO compaction_options_fifo;
   CompactionOptionsUniversal compaction_options_universal;
+  std::shared_ptr<CompactionPolicyFactory> compaction_policy_factory;
 
   // Misc options
   uint64_t max_sequential_skip_in_iterations;

--- a/options/options.cc
+++ b/options/options.cc
@@ -89,7 +89,8 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       report_bg_io_stats(options.report_bg_io_stats),
       ttl(options.ttl),
       periodic_compaction_seconds(options.periodic_compaction_seconds),
-      sample_for_compression(options.sample_for_compression) {
+      sample_for_compression(options.sample_for_compression),
+      compaction_policy_factory(options.compaction_policy_factory) {
   assert(memtable_factory.get() != nullptr);
   if (max_bytes_for_level_multiplier_additional.size() <
       static_cast<unsigned int>(num_levels)) {
@@ -356,6 +357,10 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(log,
                      "         Options.periodic_compaction_seconds: %" PRIu64,
                      periodic_compaction_seconds);
+    ROCKS_LOG_HEADER(
+        log, "           Options.compaction_policy_factory: %s",
+        compaction_policy_factory ? compaction_policy_factory->Name() : "None");
+
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {


### PR DESCRIPTION
Summary:
Introduce an interface to customize how compaction cuts output file. Currently compaction output is cut based on size only, controlled by `target_file_size_base` and `target_file_size_multipler`. Potential use case of the interface include:
1. application can choose to fine-tune file boundaries between different levels, reducing non-overlapping potion between input level and output level for a compaction job, to reduce compaction IO. An example would be the "guards" described in this paper: http://www.cs.utexas.edu/~vijay/papers/sosp17-pebblesdb.pdf
2. some application shard its data and store multiple shards in a single rocksdb instance. Such application can choose to cut SST by shard boundary. When it want to drop a shard and reclaim space with `DeleteFilesInRange`, it can drop data more precisely. Without cutting files at shard boundary, some files can overlap with two adjacent shards, and cannot reclaim by `DeleteFilesInRange`.

Other potential use of the interface:
1. It can be used as a callback for each output key from a compaction.
2. It may be further extend to customize other aspect of the compaction algorithm.

Test Plan:
Pending. Will add test if the interface look okay.