### PR TITLE
Make ReadRangeDelAggregator::ShouldDelete() more inline friendly

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -322,8 +322,8 @@ void ReadRangeDelAggregator::AddTombstones(
           std::move(input_iter), icmp_, smallest, largest)));
 }
 
-bool ReadRangeDelAggregator::ShouldDelete(const ParsedInternalKey& parsed,
-                                          RangeDelPositioningMode mode) {
+bool ReadRangeDelAggregator::ShouldDeleteImpl(const ParsedInternalKey& parsed,
+                                              RangeDelPositioningMode mode) {
   return rep_.ShouldDelete(parsed, mode);
 }
 


### PR DESCRIPTION
Summary:
Reorganize the code so that no function call into ReadRangeDelAggregator is needed if there is no tomb range stone.

Test Plan: Run all existing tests.
Run db_bench readseq and see the code is inlined.