### PR TITLE
Add back NewEmptyIterator

### DIFF
--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -157,6 +157,8 @@ class EmptyInternalIterator : public InternalIteratorBase<TValue> {
 };
 }  // namespace
 
+Iterator* NewEmptyIterator() { return new EmptyIterator(Status::OK()); }
+
 Iterator* NewErrorIterator(const Status& status) {
   return new EmptyIterator(status);
 }


### PR DESCRIPTION
Summary: #4905 removed the implementation of `NewEmptyIterator` but kept its
declaration in the public header. This breaks some systems that depend on
RocksDB if the systems use `NewEmptyIterator`. Therefore, add it back to fix. 

Test Plan:
```
$make clean && make -j32 all && sleep 1 && make check
```