### PR TITLE
Call the OnFlushCompleted handler unconditionally

### DIFF
--- a/db/compact_files_test.cc
+++ b/db/compact_files_test.cc
@@ -38,6 +38,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() override {}
 
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -58,6 +58,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() override {}
 
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }
@@ -103,7 +106,10 @@ public:
     compaction_completed_[k]++;
   }
 
-  void OnFlushCompleted(DB* /* db */, const FlushJobInfo& /* info */) override {
+  void OnFlushCompleted(DB* /* db */, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     int k = static_cast<int>(CompactionReason::kFlush);
     compaction_completed_[k]++;
   }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -817,7 +817,8 @@ class DBImpl : public DB {
 
   void NotifyOnFlushCompleted(ColumnFamilyData* cfd, FileMetaData* file_meta,
                               const MutableCFOptions& mutable_cf_options,
-                              int job_id, TableProperties prop);
+                              const Status& st, int job_id,
+                              TableProperties prop);
 
   void NotifyOnCompactionBegin(ColumnFamilyData* cfd, Compaction* c,
                                const Status& st,

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -28,6 +28,9 @@ class FlushedFileCollector : public EventListener {
   ~FlushedFileCollector() override {}
 
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     flushed_files_.push_back(info.file_path);
   }

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -197,6 +197,9 @@ class TestFlushListener : public EventListener {
 
   void OnFlushCompleted(
       DB* db, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     flushed_dbs_.push_back(db);
     flushed_column_family_names_.push_back(info.cf_name);
     if (info.triggered_writes_slowdown) {
@@ -743,6 +746,9 @@ public:
 
   void OnFlushCompleted(DB* /*db*/,
     const FlushJobInfo& flush_job_info) override {
+    if (!flush_job_info.status.ok()) {
+      return;
+    }
     ASSERT_LE(flush_job_info.smallest_seqno, latest_seq_number_);
   }
 };

--- a/examples/compact_files_example.cc
+++ b/examples/compact_files_example.cc
@@ -72,6 +72,9 @@ class FullCompactor : public Compactor {
   // compaction-task to true.
   void OnFlushCompleted(
       DB* db, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     CompactionTask* task = PickCompaction(db, info.cf_name);
     if (task != nullptr) {
       if (info.triggered_writes_stop) {

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -190,6 +190,8 @@ struct FlushJobInfo {
   TableProperties table_properties;
 
   FlushReason flush_reason;
+  // the status indicating whether the flush was successful or not.
+  Status status;
 };
 
 struct CompactionJobInfo {

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1261,6 +1261,9 @@ class DbStressListener : public EventListener {
   }
 #ifndef ROCKSDB_LITE
   virtual void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     assert(IsValidColumnFamilyName(info.cf_name));
     VerifyFilePath(info.file_path);
     // pretending doing some work here

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -26,7 +26,10 @@ class BlobDBListener : public EventListener {
     blob_db_impl_->SyncBlobFiles();
   }
 
-  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& /*info*/) override {
+  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (!info.status.ok()) {
+      return;
+    }
     assert(blob_db_impl_ != nullptr);
     blob_db_impl_->UpdateLiveSSTSize();
   }


### PR DESCRIPTION
https://github.com/facebook/rocksdb/issues/5206

In the case of a shutdown or other reasons in which a flush may
not complete, OnFlushCompleted is not called because the Status is
not OK. Instead, pass the status through to the event listener via the
FlushJobInfo and allow the listener to deal with any failure as they
see fit.