### PR TITLE
Force read existing data during db repair

### DIFF
--- a/db/repair.cc
+++ b/db/repair.cc
@@ -517,8 +517,10 @@ class Repairer {
       }
     }
     if (status.ok()) {
+      ReadOptions ropts;
+      ropts.total_order_seek = true;
       InternalIterator* iter = table_cache_->NewIterator(
-          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta,
+          ropts, env_options_, cfd->internal_comparator(), t->meta,
           nullptr /* range_del_agg */,
           cfd->GetLatestMutableCFOptions()->prefix_extractor.get());
       bool empty = true;


### PR DESCRIPTION
Summary:
Setting read_opts.total_order_seek achieves this, even with a different prefix
extractor.

Test Plan:
Use existing tests.
Optionally, manually repair a db and check.