### PR TITLE
Extend MultiGet batching to Transactions

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -208,15 +208,21 @@ class Transaction {
   // Batched version of MultiGet - see DBImpl::MultiGet(). Sub-classes are
   // expected to override this with an implementation that calls
   // DBImpl::MultiGet()
-  virtual void MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys, PinnableSlice* values,
-      Status* statuses) {
+  virtual void MultiGet(const ReadOptions& options,
+                        ColumnFamilyHandle* column_family,
+                        const size_t num_keys, const Slice* keys,
+                        PinnableSlice* values, Status* statuses,
+                        const bool /*sorted_input*/ = false) {
     std::vector<Status> status;
     std::vector<std::string> vals;
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    std::vector<Slice> user_keys;
 
-    status = MultiGet(options, column_family, keys, &vals);
+    for (size_t i = 0; i < num_keys; ++i) {
+      user_keys.emplace_back(keys[i]);
+    }
+
+    status = MultiGet(options, column_families, user_keys, &vals);
     std::copy(status.begin(), status.end(), statuses);
     for (auto& value : vals) {
       values->PinSelf(value);
@@ -292,15 +298,23 @@ class Transaction {
 
   // Batched version of MultiGetForUpdate. Sub-classes are expected to
   // override this with an implementation that calls DBImpl::MultiGet()
-  virtual void MultiGetForUpdate(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys, PinnableSlice* values,
-      Status* statuses) {
+  // It accepts keys from a single column family, to match the capabilities
+  // of DBImpl::MultiGet(). If an attempt to lock any of the keys fails,
+  // the entire call will be returned with Status::Busy().
+  virtual void MultiGetSingleCFForUpdate(
+      const ReadOptions& options, ColumnFamilyHandle* column_family,
+      const size_t num_keys, const Slice* keys, PinnableSlice* values,
+      Status* statuses, const bool /*sorted_input*/ = false) {
     std::vector<Status> status;
     std::vector<std::string> vals;
+    std::vector<ColumnFamilyHandle*> column_families(num_keys, column_family);
+    std::vector<Slice> user_keys;
 
-    status = MultiGet(options, column_family, keys, &vals);
+    for (size_t i = 0; i < num_keys; ++i) {
+      user_keys.emplace_back(keys[i]);
+    }
+
+    status = MultiGet(options, column_families, user_keys, &vals);
     std::copy(status.begin(), status.end(), statuses);
     for (auto& value : vals) {
       values->PinSelf(value);

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -205,6 +205,25 @@ class Transaction {
                                        const std::vector<Slice>& keys,
                                        std::vector<std::string>* values) = 0;
 
+  // Batched version of MultiGet - see DBImpl::MultiGet(). Sub-classes are
+  // expected to override this with an implementation that calls
+  // DBImpl::MultiGet()
+  virtual void MultiGet(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys, PinnableSlice* values,
+      Status* statuses) {
+    std::vector<Status> status;
+    std::vector<std::string> vals;
+
+    status = MultiGet(options, column_family, keys, &vals);
+    std::copy(status.begin(), status.end(), statuses);
+    for (auto& value : vals) {
+      values->PinSelf(value);
+      values++;
+    }
+  }
+
   // Read this key and ensure that this transaction will only
   // be able to be committed if this key is not written outside this
   // transaction after it has first been read (or after the snapshot if a
@@ -270,6 +289,24 @@ class Transaction {
   virtual std::vector<Status> MultiGetForUpdate(
       const ReadOptions& options, const std::vector<Slice>& keys,
       std::vector<std::string>* values) = 0;
+
+  // Batched version of MultiGetForUpdate. Sub-classes are expected to
+  // override this with an implementation that calls DBImpl::MultiGet()
+  virtual void MultiGetForUpdate(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys, PinnableSlice* values,
+      Status* statuses) {
+    std::vector<Status> status;
+    std::vector<std::string> vals;
+
+    status = MultiGet(options, column_family, keys, &vals);
+    std::copy(status.begin(), status.end(), statuses);
+    for (auto& value : vals) {
+      values->PinSelf(value);
+      values++;
+    }
+  }
 
   // Returns an iterator that will iterate on all keys in the default
   // column family including both keys in the DB and uncommitted keys in this

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -209,10 +209,10 @@ class WriteBatchWithIndex : public WriteBatchBase {
                            PinnableSlice* value);
 
   void MultiGetFromBatchAndDB(DB* db, const ReadOptions& read_options,
-                           const std::vector<ColumnFamilyHandle*>&
-                                                        column_family,
-                           const std::vector<Slice>& key,
-                           PinnableSlice* values, Status* statuses);
+                              ColumnFamilyHandle* column_family,
+                              const size_t num_keys, const Slice* keys,
+                              PinnableSlice* values, Status* statuses,
+                              bool sorted_input);
 
   // Records the state of the batch for future calls to RollbackToSavePoint().
   // May be called multiple times to set multiple save points.
@@ -254,11 +254,10 @@ class WriteBatchWithIndex : public WriteBatchBase {
                            ColumnFamilyHandle* column_family, const Slice& key,
                            PinnableSlice* value, ReadCallback* callback);
   void MultiGetFromBatchAndDB(DB* db, const ReadOptions& read_options,
-                           const std::vector<ColumnFamilyHandle*>&
-                                                        column_family,
-                           const std::vector<Slice>& key,
-                           PinnableSlice* values, Status* statuses,
-                           ReadCallback* callback);
+                              ColumnFamilyHandle* column_family,
+                              const size_t num_keys, const Slice* keys,
+                              PinnableSlice* values, Status* statuses,
+                              bool sorted_input, ReadCallback* callback);
   struct Rep;
   std::unique_ptr<Rep> rep;
 };

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rocksdb/comparator.h"
 #include "rocksdb/iterator.h"
@@ -207,6 +208,12 @@ class WriteBatchWithIndex : public WriteBatchBase {
                            ColumnFamilyHandle* column_family, const Slice& key,
                            PinnableSlice* value);
 
+  void MultiGetFromBatchAndDB(DB* db, const ReadOptions& read_options,
+                           const std::vector<ColumnFamilyHandle*>&
+                                                        column_family,
+                           const std::vector<Slice>& key,
+                           PinnableSlice* values, Status* statuses);
+
   // Records the state of the batch for future calls to RollbackToSavePoint().
   // May be called multiple times to set multiple save points.
   void SetSavePoint() override;
@@ -246,6 +253,12 @@ class WriteBatchWithIndex : public WriteBatchBase {
   Status GetFromBatchAndDB(DB* db, const ReadOptions& read_options,
                            ColumnFamilyHandle* column_family, const Slice& key,
                            PinnableSlice* value, ReadCallback* callback);
+  void MultiGetFromBatchAndDB(DB* db, const ReadOptions& read_options,
+                           const std::vector<ColumnFamilyHandle*>&
+                                                        column_family,
+                           const std::vector<Slice>& key,
+                           PinnableSlice* values, Status* statuses,
+                           ReadCallback* callback);
   struct Rep;
   std::unique_ptr<Rep> rep;
 };

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -319,29 +319,6 @@ std::vector<Status> TransactionBaseImpl::MultiGetForUpdate(
   return stat_list;
 }
 
-void TransactionBaseImpl::MultiGetSingleCFForUpdate(
-    const ReadOptions& read_options, ColumnFamilyHandle* column_family,
-    const size_t num_keys, const Slice* keys, PinnableSlice* values,
-    Status* statuses, bool sorted_input) {
-  // Regardless of whether the MultiGet succeeded, track these keys.
-  // Lock all keys
-  for (size_t i = 0; i < num_keys; ++i) {
-    Status s = TryLock(column_family, keys[i], true /* read_only */,
-                       true /* exclusive */);
-    if (!s.ok()) {
-      // Fail entire multiget if we cannot lock all keys
-      for (size_t j = 0; j < num_keys; ++j) {
-        statuses[j] = s;
-      }
-      return;
-    }
-  }
-
-  write_batch_.MultiGetFromBatchAndDB(db_, read_options, column_family,
-                                      num_keys, keys, values, statuses,
-                                      sorted_input);
-}
-
 Iterator* TransactionBaseImpl::GetIterator(const ReadOptions& read_options) {
   Iterator* db_iter = db_->NewIterator(read_options);
   assert(db_iter);

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -94,11 +94,9 @@ class TransactionBaseImpl : public Transaction {
                     keys, values);
   }
 
-  void MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      PinnableSlice* values, Status* statuses) override;
+  void MultiGet(const ReadOptions& options, ColumnFamilyHandle* column_family,
+                const size_t num_keys, const Slice* keys, PinnableSlice* values,
+                Status* statuses, bool sorted_input = false) override;
 
   using Transaction::MultiGetForUpdate;
   std::vector<Status> MultiGetForUpdate(
@@ -116,11 +114,11 @@ class TransactionBaseImpl : public Transaction {
                              keys, values);
   }
 
-  void MultiGetForUpdate(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      PinnableSlice* values, Status* statuses) override;
+  void MultiGetSingleCFForUpdate(const ReadOptions& options,
+                                 ColumnFamilyHandle* column_family,
+                                 const size_t num_keys, const Slice* keys,
+                                 PinnableSlice* values, Status* statuses,
+                                 bool sorted_input = false) override;
 
   Iterator* GetIterator(const ReadOptions& read_options) override;
   Iterator* GetIterator(const ReadOptions& read_options,

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -114,12 +114,6 @@ class TransactionBaseImpl : public Transaction {
                              keys, values);
   }
 
-  void MultiGetSingleCFForUpdate(const ReadOptions& options,
-                                 ColumnFamilyHandle* column_family,
-                                 const size_t num_keys, const Slice* keys,
-                                 PinnableSlice* values, Status* statuses,
-                                 bool sorted_input = false) override;
-
   Iterator* GetIterator(const ReadOptions& read_options) override;
   Iterator* GetIterator(const ReadOptions& read_options,
                         ColumnFamilyHandle* column_family) override;

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -46,7 +46,7 @@ class TransactionBaseImpl : public Transaction {
   void SetSavePoint() override;
 
   Status RollbackToSavePoint() override;
-  
+
   Status PopSavePoint() override;
 
   using Transaction::Get;
@@ -79,6 +79,7 @@ class TransactionBaseImpl : public Transaction {
                         exclusive, do_validate);
   }
 
+  using Transaction::MultiGet;
   std::vector<Status> MultiGet(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
@@ -93,6 +94,13 @@ class TransactionBaseImpl : public Transaction {
                     keys, values);
   }
 
+  void MultiGet(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys,
+      PinnableSlice* values, Status* statuses) override;
+
+  using Transaction::MultiGetForUpdate;
   std::vector<Status> MultiGetForUpdate(
       const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_family,
@@ -107,6 +115,12 @@ class TransactionBaseImpl : public Transaction {
                                  keys.size(), db_->DefaultColumnFamily()),
                              keys, values);
   }
+
+  void MultiGetForUpdate(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys,
+      PinnableSlice* values, Status* statuses) override;
 
   Iterator* GetIterator(const ReadOptions& read_options) override;
   Iterator* GetIterator(const ReadOptions& read_options,

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -435,38 +435,6 @@ class TransactionTestBase : public ::testing::Test {
       ASSERT_EQ(kv.second, value);
     }
   }
-
-  Status MultiGetForUpdateOne(Transaction* txn, const ReadOptions& ro,
-                              ColumnFamilyHandle* column_family,
-                              const Slice& key, std::string* value) {
-    std::vector<Slice> keys(1);
-    std::vector<PinnableSlice> values(1);
-    std::vector<Status> statuses(1);
-
-    keys[0] = key;
-    txn->MultiGetSingleCFForUpdate(ro, column_family, 1, keys.data(),
-                                   values.data(), statuses.data());
-    if (statuses[0].ok()) {
-      value->assign(values[0].data(), values[0].size());
-    }
-    return statuses[0];
-  }
-
-  Status MultiGetOne(Transaction* txn, const ReadOptions& ro,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     std::string* value) {
-    std::vector<Slice> keys(1);
-    std::vector<PinnableSlice> values(1);
-    std::vector<Status> statuses(1);
-
-    keys[0] = key;
-    txn->MultiGet(ro, column_family, 1, keys.data(), values.data(),
-                  statuses.data());
-    if (statuses[0].ok()) {
-      value->assign(values[0].data(), values[0].size());
-    }
-    return statuses[0];
-  }
 };
 
 class TransactionTest : public TransactionTestBase,

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -435,6 +435,38 @@ class TransactionTestBase : public ::testing::Test {
       ASSERT_EQ(kv.second, value);
     }
   }
+
+  Status MultiGetForUpdateOne(Transaction* txn, const ReadOptions& ro,
+                              ColumnFamilyHandle* column_family,
+                              const Slice& key, std::string* value) {
+    std::vector<Slice> keys(1);
+    std::vector<PinnableSlice> values(1);
+    std::vector<Status> statuses(1);
+
+    keys[0] = key;
+    txn->MultiGetSingleCFForUpdate(ro, column_family, 1, keys.data(),
+                                   values.data(), statuses.data());
+    if (statuses[0].ok()) {
+      value->assign(values[0].data(), values[0].size());
+    }
+    return statuses[0];
+  }
+
+  Status MultiGetOne(Transaction* txn, const ReadOptions& ro,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     std::string* value) {
+    std::vector<Slice> keys(1);
+    std::vector<PinnableSlice> values(1);
+    std::vector<Status> statuses(1);
+
+    keys[0] = key;
+    txn->MultiGet(ro, column_family, 1, keys.data(), values.data(),
+                  statuses.data());
+    if (statuses[0].ok()) {
+      value->assign(values[0].data(), values[0].size());
+    }
+    return statuses[0];
+  }
 };
 
 class TransactionTest : public TransactionTestBase,

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -923,40 +923,38 @@ Status WriteBatchWithIndex::GetFromBatchAndDB(
 }
 
 void WriteBatchWithIndex::MultiGetFromBatchAndDB(
-    DB* db, const ReadOptions& read_options,
-    const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, PinnableSlice* values, Status* statuses) {
-  MultiGetFromBatchAndDB(db, read_options, column_family, keys, values,
-      statuses, nullptr);
+    DB* db, const ReadOptions& read_options, ColumnFamilyHandle* column_family,
+    const size_t num_keys, const Slice* keys, PinnableSlice* values,
+    Status* statuses, bool sorted_input) {
+  MultiGetFromBatchAndDB(db, read_options, column_family, num_keys, keys,
+                         values, statuses, sorted_input, nullptr);
 }
 
 void WriteBatchWithIndex::MultiGetFromBatchAndDB(
-    DB* db, const ReadOptions& read_options,
-    const std::vector<ColumnFamilyHandle*>& column_family,
-    const std::vector<Slice>& keys, PinnableSlice* values, Status* statuses,
-    ReadCallback* callback) {
+    DB* db, const ReadOptions& read_options, ColumnFamilyHandle* column_family,
+    const size_t num_keys, const Slice* keys, PinnableSlice* values,
+    Status* statuses, bool sorted_input, ReadCallback* callback) {
   const ImmutableDBOptions& immuable_db_options =
       static_cast_with_check<DBImpl, DB>(db->GetRootDB())
           ->immutable_db_options();
 
-  autovector<KeyContext, MultiGetContext::MAX_KEYS_ON_STACK> key_context;
+  autovector<KeyContext, MultiGetContext::MAX_BATCH_SIZE> key_context;
   // To hold merges from the write batch
-  autovector<std::pair<WriteBatchWithIndexInternal::Result,
-    MergeContext>, MultiGetContext::MAX_KEYS_ON_STACK> merges;
+  autovector<std::pair<WriteBatchWithIndexInternal::Result, MergeContext>,
+             MultiGetContext::MAX_BATCH_SIZE>
+      merges;
   // Since the lifetime of the WriteBatch is the same as that of the transaction
   // we cannot pin it as otherwise the returned value will not be available
   // after the transaction finishes.
-  for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
-    auto index = iter - keys.begin();
+  for (size_t i = 0; i < num_keys; ++i) {
     MergeContext merge_context;
-    PinnableSlice* pinnable_val = &values[index];
+    PinnableSlice* pinnable_val = &values[i];
     std::string& batch_value = *pinnable_val->GetSelf();
-    Status* s = &statuses[index];
+    Status* s = &statuses[i];
     WriteBatchWithIndexInternal::Result result =
         WriteBatchWithIndexInternal::GetFromBatch(
-            immuable_db_options, this, column_family[index], *iter,
-            &merge_context, &rep->comparator, &batch_value, rep->overwrite_key,
-            s);
+            immuable_db_options, this, column_family, keys[i], &merge_context,
+            &rep->comparator, &batch_value, rep->overwrite_key, s);
 
     if (result == WriteBatchWithIndexInternal::Result::kFound) {
       pinnable_val->PinSelf();
@@ -980,27 +978,27 @@ void WriteBatchWithIndex::MultiGetFromBatchAndDB(
 
     assert(result == WriteBatchWithIndexInternal::Result::kMergeInProgress ||
            result == WriteBatchWithIndexInternal::Result::kNotFound);
-    key_context.emplace_back(*iter, column_family[index], &values[index],
-        &statuses[index]);
+    key_context.emplace_back(keys[i], &values[i], &statuses[i]);
     merges.emplace_back(result, std::move(merge_context));
   }
 
   // Did not find key in batch OR could not resolve Merges.  Try DB.
   static_cast_with_check<DBImpl, DB>(db->GetRootDB())
-      ->MultiGetImpl(read_options, key_context, callback);
+      ->MultiGetImpl(read_options, column_family, key_context, sorted_input,
+                     callback);
 
+  ColumnFamilyHandleImpl* cfh =
+      reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
+  const MergeOperator* merge_operator = cfh->cfd()->ioptions()->merge_operator;
   for (auto iter = key_context.begin(); iter != key_context.end(); ++iter) {
     KeyContext& key = *iter;
     if (key.s->ok() || key.s->IsNotFound()) {  // DB Get Succeeded
-      auto index = iter - key_context.begin();
-      auto& merge_result = merges[index];
+      size_t index = iter - key_context.begin();
+      std::pair<WriteBatchWithIndexInternal::Result, MergeContext>&
+          merge_result = merges[index];
       if (merge_result.first ==
           WriteBatchWithIndexInternal::Result::kMergeInProgress) {
         // Merge result from DB with merges in Batch
-        auto cfh =
-          reinterpret_cast<ColumnFamilyHandleImpl*>(iter->column_family);
-        const MergeOperator* merge_operator =
-            cfh->cfd()->ioptions()->merge_operator;
         Statistics* statistics = immuable_db_options.statistics.get();
         Env* env = immuable_db_options.env;
         Logger* logger = immuable_db_options.info_log.get();
@@ -1015,12 +1013,12 @@ void WriteBatchWithIndex::MultiGetFromBatchAndDB(
         if (merge_operator) {
           *key.s = MergeHelper::TimedFullMerge(
               merge_operator, *key.key, merge_data,
-              merge_result.second.GetOperands(), key.value->GetSelf(),
-              logger, statistics, env);
+              merge_result.second.GetOperands(), key.value->GetSelf(), logger,
+              statistics, env);
           key.value->PinSelf();
         } else {
-          *key.s = Status::InvalidArgument(
-              "Options::merge_operator must be set");
+          *key.s =
+              Status::InvalidArgument("Options::merge_operator must be set");
         }
       }
     }


### PR DESCRIPTION
MultiGet batching was implemented in #5011 in order to reduce CPU utilization when looking up multiple keys at once. This PR implements corresponding ```MultiGet``` and ```MultiGetSingleCFForUpdate``` in ```rocksdb::Transaction``` that call the underlying batching implementation.

Test:
Added new unit tests
make check