### PR TITLE
Fix a bug in GetOverlappingInputsRangeBinarySearch

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2832,7 +2832,7 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
   // If there were no overlapping files, return immediately.
   if (!foundOverlap) {
     if (next_smallest) {
-      next_smallest = nullptr;
+      *next_smallest = nullptr;
     }
     return;
   }


### PR DESCRIPTION
As title.

Test Plan:
```
$make clean && COMPILE_WITH_ASAN=1 make -j32 all && sleep 1 && make check
```