### PR TITLE
Add some "inline" annotation to DBIter functions

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -231,12 +231,12 @@ class DBIter final: public Iterator {
     return Status::InvalidArgument("Unidentified property.");
   }
 
-  void Next() final override;
-  void Prev() override;
-  void Seek(const Slice& target) override;
-  void SeekForPrev(const Slice& target) override;
-  void SeekToFirst() override;
-  void SeekToLast() override;
+  inline void Next() final override;
+  inline void Prev() final override;
+  inline void Seek(const Slice& target) final override;
+  inline void SeekForPrev(const Slice& target) final override;
+  inline void SeekToFirst() final override;
+  inline void SeekToLast() final override;
   Env* env() { return env_; }
   void set_sequence(uint64_t s) {
     sequence_ = s;


### PR DESCRIPTION
Summary: My compiler doesn't inline DBIter::Next() to arena wrapped iterator, even if it is a direct forward. Adding this annotation makes it inlined. It might not always work but inlinging this function to arena wrapped iterator always feels like the right decision.

Test Plan: run all existing tests