### PR TITLE
Fix compilation errors for 32bits/LITE/ios build.

### DIFF
--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -55,6 +55,6 @@ extern __thread IOStatsContext iostats_context;
 #define IOSTATS(metric) 0
 
 #define IOSTATS_TIMER_GUARD(metric)
-#define IOSTATS_CPU_TIMER_GUARD(metric, env)
+#define IOSTATS_CPU_TIMER_GUARD(metric, env)   (void)env
 
 #endif  // ROCKSDB_SUPPORT_THREAD_LOCAL

--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -55,6 +55,6 @@ extern __thread IOStatsContext iostats_context;
 #define IOSTATS(metric) 0
 
 #define IOSTATS_TIMER_GUARD(metric)
-#define IOSTATS_CPU_TIMER_GUARD(metric, env)   (void)env
+#define IOSTATS_CPU_TIMER_GUARD(metric, env)   static_cast<void>(env)
 
 #endif  // ROCKSDB_SUPPORT_THREAD_LOCAL

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -1064,7 +1064,8 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
   if (!r->data_block_and_keys_buffers.empty()) {
     while (compression_dict_samples.size() < kSampleBytes) {
       size_t rand_idx =
-          static_cast<size_t>(generator.Uniform(r->data_block_and_keys_buffers.size()));
+          static_cast<size_t>(
+              generator.Uniform(r->data_block_and_keys_buffers.size()));
       size_t copy_len =
           std::min(kSampleBytes - compression_dict_samples.size(),
                    r->data_block_and_keys_buffers[rand_idx].first.size());

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -1064,7 +1064,7 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
   if (!r->data_block_and_keys_buffers.empty()) {
     while (compression_dict_samples.size() < kSampleBytes) {
       size_t rand_idx =
-          generator.Uniform(r->data_block_and_keys_buffers.size());
+          (size_t)generator.Uniform(r->data_block_and_keys_buffers.size());
       size_t copy_len =
           std::min(kSampleBytes - compression_dict_samples.size(),
                    r->data_block_and_keys_buffers[rand_idx].first.size());

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -1064,7 +1064,7 @@ void BlockBasedTableBuilder::EnterUnbuffered() {
   if (!r->data_block_and_keys_buffers.empty()) {
     while (compression_dict_samples.size() < kSampleBytes) {
       size_t rand_idx =
-          (size_t)generator.Uniform(r->data_block_and_keys_buffers.size());
+          static_cast<size_t>(generator.Uniform(r->data_block_and_keys_buffers.size()));
       size_t copy_len =
           std::min(kSampleBytes - compression_dict_samples.size(),
                    r->data_block_and_keys_buffers[rand_idx].first.size());

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -968,7 +968,7 @@ Status BlockBasedTable::TryReadPropertiesWithGlobalSeqno(
         (*table_properties)
             ->properties_offsets.find(
                 ExternalSstFilePropertyNames::kGlobalSeqno);
-    size_t block_size = props_block_handle.size();
+    size_t block_size = (size_t)props_block_handle.size();
     if (seqno_pos_iter != (*table_properties)->properties_offsets.end()) {
       uint64_t global_seqno_offset = seqno_pos_iter->second;
       EncodeFixed64(

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -968,7 +968,7 @@ Status BlockBasedTable::TryReadPropertiesWithGlobalSeqno(
         (*table_properties)
             ->properties_offsets.find(
                 ExternalSstFilePropertyNames::kGlobalSeqno);
-    size_t block_size = (size_t)props_block_handle.size();
+    size_t block_size = static_cast<size_t>(props_block_handle.size());
     if (seqno_pos_iter != (*table_properties)->properties_offsets.end()) {
       uint64_t global_seqno_offset = seqno_pos_iter->second;
       EncodeFixed64(

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -335,7 +335,7 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
       *ret_block_handle = handle;
     }
     if (verification_buf != nullptr) {
-      size_t len = (size_t)(handle.size() + kBlockTrailerSize);
+      size_t len = static_cast<size_t>(handle.size() + kBlockTrailerSize);
       *verification_buf = rocksdb::AllocateBlock(len, memory_allocator);
       if (verification_buf->get() != nullptr) {
         memcpy(verification_buf->get(), block_contents.data.data(), len);

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -335,7 +335,7 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
       *ret_block_handle = handle;
     }
     if (verification_buf != nullptr) {
-      size_t len = handle.size() + kBlockTrailerSize;
+      size_t len = (size_t)(handle.size() + kBlockTrailerSize);
       *verification_buf = rocksdb::AllocateBlock(len, memory_allocator);
       if (verification_buf->get() != nullptr) {
         memcpy(verification_buf->get(), block_contents.data.data(), len);


### PR DESCRIPTION
When I build RocksDB for 32bits/LITE/iOS environment, some errors like the following.

`
table/block_based_table_reader.cc:971:44: error: implicit conversion loses integer precision: 'uint64_t'
      (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]
    size_t block_size = props_block_handle.size();
           ~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~^~~~~~


./util/file_reader_writer.h:177:8: error: private field 'env_' is not used [-Werror,-Wunused-private-field]
  Env* env_;
       ^
`
