### PR TITLE
Fix compilation on db_bench_tool.cc on Windows

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4816,10 +4816,10 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     // the limit of qps initiation
     if (FLAGS_sine_a != 0 || FLAGS_sine_d != 0) {
       thread->shared->read_rate_limiter.reset(NewGenericRateLimiter(
-          read_rate, 100000 /* refill_period_us */, 10 /* fairness */,
+          static_cast<int64_t>(read_rate), 100000 /* refill_period_us */, 10 /* fairness */,
           RateLimiter::Mode::kReadsOnly));
       thread->shared->write_rate_limiter.reset(
-          NewGenericRateLimiter(write_rate));
+          NewGenericRateLimiter(static_cast<int64_t>(write_rate)));
     }
 
     Duration duration(FLAGS_duration, reads_);
@@ -4855,9 +4855,9 @@ void VerifyDBFromDB(std::string& truth_db_name) {
             mix_rate_with_noise * query.ratio_[1] * FLAGS_mix_ave_kv_size;
 
         thread->shared->write_rate_limiter.reset(
-            NewGenericRateLimiter(write_rate));
+            NewGenericRateLimiter(static_cast<int64_t>(write_rate)));
         thread->shared->read_rate_limiter.reset(NewGenericRateLimiter(
-            read_rate,
+            static_cast<int64_t>(read_rate),
             FLAGS_sine_mix_rate_interval_milliseconds * uint64_t{1000}, 10,
             RateLimiter::Mode::kReadsOnly));
       }


### PR DESCRIPTION
I needed this change to be able to build the v6.0.1 release on Windows.