### PR TITLE
Log file_creation_time table property

### DIFF
--- a/db/event_helpers.cc
+++ b/db/event_helpers.cc
@@ -120,7 +120,8 @@ void EventHelpers::LogAndNotifyTableFileCreationFinished(
               << table_properties.compression_name << "compression_options"
               << table_properties.compression_options << "creation_time"
               << table_properties.creation_time << "oldest_key_time"
-              << table_properties.oldest_key_time;
+              << table_properties.oldest_key_time << "file_creation_time"
+              << table_properties.file_creation_time;
 
       // user collected properties
       for (const auto& prop : table_properties.readable_properties) {


### PR DESCRIPTION
Log file_creation_time table property when a new table file is created.

Test Plan:
- `make check`
- Verified that the property gets logged correctly:
`TEST_TMPDIR=/dev/shm KEEP_DB=1 ./db_compaction_test --gtest_filter=DBCompactionTest.LevelPeriodicCompactionWithOldDB`