### PR TITLE
Option string/map/file can set env from object registry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,12 +2,11 @@
 ## Unreleased
 ### New Features
 * Add an option `strict_bytes_per_sync` that causes a file-writing thread to block rather than exceed the limit on bytes pending writeback specified by `bytes_per_sync` or `wal_bytes_per_sync`.
-
-## Unreleased
-### New Features
 * Improve range scan performance by avoiding per-key upper bound check in BlockBasedTableIterator.
 * Introduce Periodic Compaction for Level style compaction. Files are re-compacted periodically and put in the same level.
 * Block-based table index now contains exact highest key in the file, rather than an upper bound. This may improve Get() and iterator Seek() performance in some situations, especially when direct IO is enabled and block cache is disabled. A setting BlockBasedTableOptions::index_shortening is introduced to control this behavior. Set it to kShortenSeparatorsAndSuccessor to get the old behavior.
+* When reading from option file/string/map, customized envs can be filled according to object registry.
+
 ### Public API Change
 * Change the behavior of OptimizeForPointLookup(): move away from hash-based block-based-table index, and use whole key memtable filtering.
 * Change the behavior of OptimizeForSmallDb(): use a 16MB block cache, put index and filter blocks into it, and cost the memtable size to it. DBOptions.OptimizeForSmallDb() and ColumnFamilyOptions.OptimizeForSmallDb() start to take an optional cache object.

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -150,6 +150,10 @@ class Env {
   // The result of Default() belongs to rocksdb and must never be deleted.
   static Env* Default();
 
+  // The name of the `Env`. Recorded in options file. Can be deserialized into
+  // an `Env` object if the name is registered with object registry.
+  virtual const char* Name() const { return "UnregisteredEnv"; }
+
   // Create a brand new sequentially-readable file with the specified name.
   // On success, stores a pointer to the new file in *result and returns OK.
   // On failure stores nullptr in *result and returns non-OK.  If the file does

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -150,10 +150,6 @@ class Env {
   // The result of Default() belongs to rocksdb and must never be deleted.
   static Env* Default();
 
-  // The name of the `Env`. Recorded in options file. Can be deserialized into
-  // an `Env` object if the name is registered with object registry.
-  virtual const char* Name() const { return "UnregisteredEnv"; }
-
   // Create a brand new sequentially-readable file with the specified name.
   // On success, stores a pointer to the new file in *result and returns OK.
   // On failure stores nullptr in *result and returns non-OK.  If the file does

--- a/include/rocksdb/utilities/options_util.h
+++ b/include/rocksdb/utilities/options_util.h
@@ -33,9 +33,10 @@ namespace rocksdb {
 // * merge_operator
 // * compaction_filter
 //
-// User can also choose to load customized comparator and/or merge_operator
-// through object registry:
+// User can also choose to load customized comparator, env, and/or
+// merge_operator through object registry:
 // * comparator needs to be registered through Registrar<const Comparator>
+// * env needs to be registered through Registrar<Env>
 // * merge operator needs to be registered through
 //     Registrar<std::shared_ptr<MergeOperator>>.
 //

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -765,13 +765,6 @@ bool SerializeSingleOptionHelper(const char* opt_address,
       return SerializeEnum<CompactionStopStyle>(
           compaction_stop_style_string_map,
           *reinterpret_cast<const CompactionStopStyle*>(opt_address), value);
-    case OptionType::kEnv: {
-      // `opt_address` is a const pointer to the `DBOptions::env` field. That
-      // field itself holds a non-const pointer to an `Env` object.
-      Env* env_ptr = *reinterpret_cast<Env* const*>(opt_address);
-      *value = env_ptr ? env_ptr->Name() : kNullptrString;
-      break;
-    }
     default:
       return false;
   }

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -247,6 +247,7 @@ std::unordered_map<std::string, CompressionType>
 #ifndef ROCKSDB_LITE
 
 const std::string kNameComparator = "comparator";
+const std::string kNameEnv = "env";
 const std::string kNameMergeOperator = "merge_operator";
 
 template <typename T>
@@ -764,6 +765,13 @@ bool SerializeSingleOptionHelper(const char* opt_address,
       return SerializeEnum<CompactionStopStyle>(
           compaction_stop_style_string_map,
           *reinterpret_cast<const CompactionStopStyle*>(opt_address), value);
+    case OptionType::kEnv: {
+      // `opt_address` is a const pointer to the `DBOptions::env` field. That
+      // field itself holds a non-const pointer to an `Env` object.
+      Env* env_ptr = *reinterpret_cast<Env* const*>(opt_address);
+      *value = env_ptr ? env_ptr->Name() : kNullptrString;
+      break;
+    }
     default:
       return false;
   }
@@ -1179,6 +1187,14 @@ Status ParseDBOption(const std::string& name,
     if (name == "rate_limiter_bytes_per_sec") {
       new_options->rate_limiter.reset(
           NewGenericRateLimiter(static_cast<int64_t>(ParseUint64(value))));
+    } else if (name == kNameEnv) {
+      // Currently `Env` can be deserialized from object registry only.
+      std::unique_ptr<Env> env_guard;
+      Env* env = NewCustomObject<Env>(value, &env_guard);
+      // Only support static env for now.
+      if (env != nullptr && !env_guard) {
+        new_options->env = env;
+      }
     } else {
       auto iter = db_options_type_info.find(name);
       if (iter == db_options_type_info.end()) {
@@ -1388,7 +1404,6 @@ std::unordered_map<std::string, OptionTypeInfo>
     OptionsHelper::db_options_type_info = {
         /*
          // not yet supported
-          Env* env;
           std::shared_ptr<Cache> row_cache;
           std::shared_ptr<DeleteScheduler> delete_scheduler;
           std::shared_ptr<Logger> info_log;
@@ -1553,8 +1568,8 @@ std::unordered_map<std::string, OptionTypeInfo>
           OptionVerificationType::kNormal, true,
           offsetof(struct MutableDBOptions, wal_bytes_per_sync)}},
         {"strict_bytes_per_sync",
-         {offsetof(struct DBOptions, strict_bytes_per_sync), OptionType::kBoolean,
-          OptionVerificationType::kNormal, true,
+         {offsetof(struct DBOptions, strict_bytes_per_sync),
+          OptionType::kBoolean, OptionVerificationType::kNormal, true,
           offsetof(struct MutableDBOptions, strict_bytes_per_sync)}},
         {"stats_dump_period_sec",
          {offsetof(struct DBOptions, stats_dump_period_sec), OptionType::kUInt,
@@ -1639,8 +1654,8 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"avoid_unnecessary_blocking_io",
          {offsetof(struct DBOptions, avoid_unnecessary_blocking_io),
           OptionType::kBoolean, OptionVerificationType::kNormal, false,
-          offsetof(struct ImmutableDBOptions, avoid_unnecessary_blocking_io)}}
-      };
+          offsetof(struct ImmutableDBOptions, avoid_unnecessary_blocking_io)}},
+};
 
 std::unordered_map<std::string, BlockBasedTableOptions::IndexType>
     OptionsHelper::block_base_table_index_type_string_map = {

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -81,7 +81,8 @@ enum class OptionType {
   kAccessHint,
   kInfoLogLevel,
   kLRUCacheOptions,
-  kUnknown
+  kEnv,
+  kUnknown,
 };
 
 enum class OptionVerificationType {

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -764,7 +764,7 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   const static char* kCustomEnvName = "CustomEnv";
   class CustomEnv : public EnvWrapper {
    public:
-    explicit CustomEnv(Env* target) : EnvWrapper(target) {}
+    explicit CustomEnv(Env* _target) : EnvWrapper(_target) {}
 
     virtual const char* Name() const override { return kCustomEnvName; }
   };

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -759,6 +759,22 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   block_based_table_options.cache_index_and_filter_blocks = true;
   base_options.table_factory.reset(
       NewBlockBasedTableFactory(block_based_table_options));
+
+  // Register an Env with object registry.
+  const static char* kCustomEnvName = "CustomEnv";
+  class CustomEnv : public EnvWrapper {
+   public:
+    explicit CustomEnv(Env* target) : EnvWrapper(target) {}
+
+    virtual const char* Name() const override { return kCustomEnvName; }
+  };
+  static Registrar<Env> test_reg_env(
+      kCustomEnvName,
+      [](const std::string& /*name*/, std::unique_ptr<Env>* /*env_guard*/) {
+        static CustomEnv env(Env::Default());
+        return &env;
+      });
+
   ASSERT_OK(GetOptionsFromString(
       base_options,
       "write_buffer_size=10;max_write_buffer_number=16;"
@@ -766,7 +782,7 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
       "compression_opts=4:5:6;create_if_missing=true;max_open_files=1;"
       "bottommost_compression_opts=5:6:7;create_if_missing=true;max_open_files="
       "1;"
-      "rate_limiter_bytes_per_sec=1024",
+      "rate_limiter_bytes_per_sec=1024;env=CustomEnv",
       &new_options));
 
   ASSERT_EQ(new_options.compression_opts.window_bits, 4);
@@ -795,6 +811,7 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   ASSERT_EQ(new_options.create_if_missing, true);
   ASSERT_EQ(new_options.max_open_files, 1);
   ASSERT_TRUE(new_options.rate_limiter.get() != nullptr);
+  ASSERT_EQ(kCustomEnvName, std::string(new_options.env->Name()));
 }
 
 TEST_F(OptionsTest, DBOptionsSerialization) {

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -765,9 +765,8 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   class CustomEnv : public EnvWrapper {
    public:
     explicit CustomEnv(Env* _target) : EnvWrapper(_target) {}
-
-    virtual const char* Name() const override { return kCustomEnvName; }
   };
+
   static Registrar<Env> test_reg_env(
       kCustomEnvName,
       [](const std::string& /*name*/, std::unique_ptr<Env>* /*env_guard*/) {
@@ -811,7 +810,8 @@ TEST_F(OptionsTest, GetOptionsFromStringTest) {
   ASSERT_EQ(new_options.create_if_missing, true);
   ASSERT_EQ(new_options.max_open_files, 1);
   ASSERT_TRUE(new_options.rate_limiter.get() != nullptr);
-  ASSERT_EQ(kCustomEnvName, std::string(new_options.env->Name()));
+  std::unique_ptr<Env> env_guard;
+  ASSERT_EQ(NewCustomObject<Env>(kCustomEnvName, &env_guard), new_options.env);
 }
 
 TEST_F(OptionsTest, DBOptionsSerialization) {


### PR DESCRIPTION
- By providing the "env" field in any text-based options (i.e., string, map, or file), we can use `NewCustomObject` to deserialize the text value into an actual `Env` object.
- Currently factory functions for `Env` registered with object registry should only return pointer to static `Env` objects. That's because `DBOptions::env` is a raw pointer so we cannot easily delegate cleanup.
- Note I did not add `env` to `db_option_type_info`. It wasn't needed for (de)serialization, and I believe we don't want to do verification on `env`, even by checking name. That's because the user should be able to copy their DB from Linux to Windows, change envs, and not see an option verification error.

Test Plan:
- updated unit test to cover deserializing a custom env from string
- manually verified downgrade compatibility. User needs to provide ignore_unknown_options for it to work. Somebody remind ZippyDB :).