### PR TITLE
Don't call FindObsoleteFiles() in ~ColumnFamilyHandleImpl() if CF is not dropped

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -63,9 +63,14 @@ ColumnFamilyHandleImpl::~ColumnFamilyHandleImpl() {
     JobContext job_context(0);
     mutex_->Lock();
     if (cfd_->Unref()) {
+      bool dropped = cfd_->IsDropped();
+
       delete cfd_;
+
+      if (dropped) {
+        db_->FindObsoleteFiles(&job_context, false, true);
+      }
     }
-    db_->FindObsoleteFiles(&job_context, false, true);
     mutex_->Unlock();
     if (job_context.HaveSomethingToDelete()) {
       bool defer_purge =


### PR DESCRIPTION
We have a DB with ~4k column families and ~70k files. On shutdown, destroying the 4k ColumnFamilyHandle-s takes over 2 minutes. Most of this time is spent in VersionSet::AddLiveFiles() called from FindObsoleteFiles() from ~ColumnFamilyHandleImpl(). It's just iterating over the list of files in memory. This seems completely unnecessary as no obsolete files are actually found since the CFs are not even dropped. This PR fixes that, the shutdown now takes 2 seconds.