### PR TITLE
MOD: add wait_for_background_work option

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -445,7 +445,7 @@ Status DBImpl::CloseHelper() {
   // CancelAllBackgroundWork called with false means we just set the shutdown
   // marker. After this we do a variant of the waiting and unschedule work
   // (to consider: moving all the waiting into CancelAllBackgroundWork(true))
-  CancelAllBackgroundWork(false);
+  CancelAllBackgroundWork(initial_db_options_.wait_for_background_work);
   int bottom_compactions_unscheduled =
       env_->UnSchedule(this, Env::Priority::BOTTOM);
   int compactions_unscheduled = env_->UnSchedule(this, Env::Priority::LOW);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1047,6 +1047,10 @@ struct DBOptions {
   // If set to true, takes precedence over
   // ReadOptions::background_purge_on_iterator_cleanup.
   bool avoid_unnecessary_blocking_io = false;
+
+  // If true, RocksDB would wait for all background work finished when close.
+  // Set wait_for_background_work as false means we just set the shutdown.
+  bool wait_for_background_work = false;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1649,6 +1649,10 @@ std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct DBOptions, avoid_unnecessary_blocking_io),
           OptionType::kBoolean, OptionVerificationType::kNormal, false,
           offsetof(struct ImmutableDBOptions, avoid_unnecessary_blocking_io)}},
+        {"wait_for_background_work",
+         {offsetof(struct DBOptions, wait_for_background_work),
+          OptionType::kBoolean, OptionVerificationType::kNormal, false,
+          0}},
 };
 
 std::unordered_map<std::string, BlockBasedTableOptions::IndexType>

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -297,7 +297,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;"
                              "atomic_flush=false;"
-                             "avoid_unnecessary_blocking_io=false",
+                             "avoid_unnecessary_blocking_io=false;"
+                             "wait_for_background_work=false",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),


### PR DESCRIPTION
RocksDB wouldn't wait for all background work when close the DB and may cause some problems when we use DB's member in the compact filter(like column family). So add the `wait_for_background_worker` option to determine whether wait for background work.

Thanks~