### PR TITLE
Fix cmake script zlib package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
   endif()
 
   if(WITH_ZLIB)
-    find_package(zlib REQUIRED)
+    find_package(ZLIB REQUIRED)
     add_definitions(-DZLIB)
     if(ZLIB_INCLUDE_DIRS)
       # CMake 3


### PR DESCRIPTION
Summary:
#4823 remove Findzlib.cmake and rely on the FindZLIB.cmake module come with cmake itself. But it seems the package name is case-sensitive (at least on Ubuntu 18.10). With the lower-case "zlib" as package name, cmake return the following error: https://gist.github.com/yiwu-arbug/1f50ebacb6433a702ac6b9178347c3c8

Test Plan:
`cmake . -DWITH_ZLIB=ON; make`