### PR TITLE
Add rocksdb_property_int_cf

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1070,6 +1070,18 @@ int rocksdb_property_int(
   }
 }
 
+int rocksdb_property_int_cf(
+    rocksdb_t* db,
+    rocksdb_column_family_handle_t* column_family,
+    const char* propname,
+    uint64_t *out_val) {
+  if (db->rep->GetIntProperty(column_family->rep, (propname), out_val)) {
+    return 0;
+  } else {
+    return -1;
+  }
+}
+
 char* rocksdb_property_value_cf(
     rocksdb_t* db,
     rocksdb_column_family_handle_t* column_family,

--- a/db/c.cc
+++ b/db/c.cc
@@ -1075,7 +1075,7 @@ int rocksdb_property_int_cf(
     rocksdb_column_family_handle_t* column_family,
     const char* propname,
     uint64_t *out_val) {
-  if (db->rep->GetIntProperty(column_family->rep, (propname), out_val)) {
+  if (db->rep->GetIntProperty(column_family->rep, Slice(propname), out_val)) {
     return 0;
   } else {
     return -1;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -336,6 +336,11 @@ int rocksdb_property_int(
     rocksdb_t* db,
     const char* propname, uint64_t *out_val);
 
+/* returns 0 on success, -1 otherwise */
+int rocksdb_property_int_cf(
+    rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
+    const char* propname, uint64_t *out_val);
+
 extern ROCKSDB_LIBRARY_API char* rocksdb_property_value_cf(
     rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
     const char* propname);


### PR DESCRIPTION
Adds the missing `rocksdb_property_int_cf` function to the C API to let consuming libraries avoid parsing strings.
Fixes https://github.com/facebook/rocksdb/issues/5249