### PR TITLE
DB::Close() to fail when there are unreleased snapshots

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Public API Change
+* Now DB::Close() will return Aborted() error when there is unreleased snapshot. Users can retry after all snapshots are released.
 
 ## 6.2.0 (4/30/2019)
 ### New Features

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -432,9 +432,9 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
 }
 
 Status DBImpl::CloseHelper() {
-  mutex_.Lock();
   // Guarantee that there is no background error recovery in progress before
   // continuing with the shutdown
+  mutex_.Lock();
   shutdown_initiated_ = true;
   error_handler_.CancelErrorRecovery();
   while (error_handler_.IsRecoveryInProgress()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -582,12 +582,11 @@ Status DBImpl::CloseHelper() {
       ret = s;
     }
   }
-  closed_ = true;
   if (ret.IsAborted()) {
     // Reserve IsAborted() error for those where users didn't release
     // certain resource and they can release them and come back and
     // retry. In this case, we wrap this exception to something else.
-    return Status::Incomplete(ret);
+    return Status::Incomplete(ret.ToString());
   }
   return ret;
 }
@@ -3051,7 +3050,7 @@ Status DBImpl::Close() {
       }
     }
 
-    close_ = true;
+    closed_ = true;
     return CloseImpl();
   }
   return Status::OK();

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -911,8 +911,6 @@ class DBImpl : public DB {
   Status WriteRecoverableState();
 
   // Actual implementation of Close()
-  // The function will set closed_ if CloseImpl() should not be called
-  // again. And keep it if the Close() can be called again.
   Status CloseImpl();
 
   // Recover the descriptor from persistent storage.  May do a significant

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1268,6 +1268,7 @@ class DBImpl : public DB {
   uint64_t GetMaxTotalWalSize() const;
 
   Directory* GetDataDir(ColumnFamilyData* cfd, size_t path_id) const;
+
   Status CloseHelper();
 
   void WaitForBackgroundWork();

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -911,6 +911,8 @@ class DBImpl : public DB {
   Status WriteRecoverableState();
 
   // Actual implementation of Close()
+  // The function will set closed_ if CloseImpl() should not be called
+  // again. And keep it if the Close() can be called again.
   Status CloseImpl();
 
   // Recover the descriptor from persistent storage.  May do a significant
@@ -1268,7 +1270,6 @@ class DBImpl : public DB {
   uint64_t GetMaxTotalWalSize() const;
 
   Directory* GetDataDir(ColumnFamilyData* cfd, size_t path_id) const;
-
   Status CloseHelper();
 
   void WaitForBackgroundWork();

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -3738,6 +3738,21 @@ TEST_F(DBTest2, OldStatsInterface) {
   ASSERT_GT(dos->num_rt, 0);
   ASSERT_GT(dos->num_mt, 0);
 }
+
+TEST_F(DBTest2, CloseWithUnreleasedSnapshot) {
+  const Snapshot* ss = db_->GetSnapshot();
+
+  for (auto h : handles_) {
+    db_->DestroyColumnFamilyHandle(h);
+  }
+  handles_.clear();
+
+  ASSERT_NOK(db_->Close());
+  db_->ReleaseSnapshot(ss);
+  ASSERT_OK(db_->Close());
+  delete db_;
+  db_ = nullptr;
+}
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -232,9 +232,13 @@ class DB {
   // status in case there are any errors. This will not fsync the WAL files.
   // If syncing is required, the caller must first call SyncWAL(), or Write()
   // using an empty write batch with WriteOptions.sync=true.
-  // Regardless of the return status, the DB must be freed. If the return
-  // status is NotSupported(), then the DB implementation does cleanup in the
-  // destructor
+  // Regardless of the return status, the DB must be freed.
+  // If the return status is Aborted(), closing fails because there is
+  // unreleased snapshot in the system. In this case, users can release
+  // the unreleased snapshots and try again and expect it to succeed. For
+  // other status, recalling Close() will be no-op.
+  // If the return status is NotSupported(), then the DB implementation does
+  // cleanup in the destructor
   virtual Status Close() { return Status::NotSupported(); }
 
   // ListColumnFamilies will open the DB specified by argument name


### PR DESCRIPTION
Summary: Sometimes, users might make mistake of not releasing snapshots before closing the DB. This is undocumented use of RocksDB and the behavior is unknown. We return DB::Close() to provide a way to check it for the users. Aborted() will be returned to users when they call DB::Close().

Test Plan: Add a unit test; run all existing tests.