### PR TITLE
Added trace replay fast forward function

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -762,6 +762,8 @@ DEFINE_bool(use_stderr_info_logger, false,
 
 DEFINE_string(trace_file, "", "Trace workload to a file. ");
 
+DEFINE_uint32(trace_replay_fast_forward, 1, "Fast forward trace replay. ");
+
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
 
@@ -6159,6 +6161,7 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     }
     Replayer replayer(db_with_cfh->db, db_with_cfh->cfh,
                       std::move(trace_reader));
+    replayer.SetFastForward(FLAGS_trace_replay_fast_forward);
     s = replayer.Replay();
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -762,7 +762,8 @@ DEFINE_bool(use_stderr_info_logger, false,
 
 DEFINE_string(trace_file, "", "Trace workload to a file. ");
 
-DEFINE_uint32(trace_replay_fast_forward, 1, "Fast forward trace replay. ");
+DEFINE_int32(trace_replay_fast_forward, 1,
+             "Fast forward trace replay, must >= 1. ");
 
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
@@ -6161,7 +6162,8 @@ void VerifyDBFromDB(std::string& truth_db_name) {
     }
     Replayer replayer(db_with_cfh->db, db_with_cfh->cfh,
                       std::move(trace_reader));
-    replayer.SetFastForward(FLAGS_trace_replay_fast_forward);
+    replayer.SetFastForward(
+        static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
     s = replayer.Replay();
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",

--- a/util/trace_replay.h
+++ b/util/trace_replay.h
@@ -88,6 +88,7 @@ class Replayer {
   ~Replayer();
 
   Status Replay();
+  Status SetFastForward(uint32_t fast_forward);
 
  private:
   Status ReadHeader(Trace* header);
@@ -97,6 +98,7 @@ class Replayer {
   DBImpl* db_;
   std::unique_ptr<TraceReader> trace_reader_;
   std::unordered_map<uint32_t, ColumnFamilyHandle*> cf_map_;
+  uint32_t fast_forward_;
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
In the current db_bench trace replay, the replay process strictly follows the timestamp to issue the queries. In some cases, user does not care about the time. Therefore, fast forward is needed for users to speed up the replay process. 

Test plan:
Tested with real trace and pass the make asan_check