### PR TITLE
Fix crash in BlockBasedTableIterator::Seek()

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2335,7 +2335,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::Seek(const Slice& target) {
   }
 
   bool need_seek_index = true;
-  if (block_iter_points_to_real_block_) {
+  if (block_iter_points_to_real_block_ && block_iter_.Valid()) {
     // Reseek.
     prev_index_value_ = index_iter_->value();
     // We can avoid an index seek if:


### PR DESCRIPTION
https://github.com/facebook/rocksdb/pull/5256 broke it: `block_iter_.user_key()` may not be valid even if `block_iter_points_to_real_block_` is true. E.g. if there was an IO error or Status::Incomplete.