### PR TITLE
db_bench: fix hang on IO error

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2102,10 +2102,10 @@ class Benchmark {
       cv_.SignalAll();
     }
 
-    bool WaitForRecovery(uint64_t /*abs_time_us*/) {
+    bool WaitForRecovery(uint64_t abs_time_us) {
       InstrumentedMutexLock l(&mutex_);
       if (!recovery_complete_) {
-        cv_.Wait(/*abs_time_us*/);
+        cv_.TimedWait(abs_time_us);
       }
       if (recovery_complete_) {
         recovery_complete_ = false;


### PR DESCRIPTION
Summary:
db_bench will wait indefinitely if there's background error. Fix by pass `abs_time_us` to cond var.

Test Plan:
Didn't actually test. Only did `make db_bench`.