### PR TITLE
Log replay integration for secondary instance

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 ### New Features
 * Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.
 * Add an option `unordered_write` which trades snapshot guarantees with higher write throughput. When used with WRITE_PREPARED transactions, it offers higher throughput with however no compromise on guarantees.
+* Allow DBImplSecondary to remove memtables with obsolete data after replaying MANIFEST and WAL.
 
 ### Performance Improvements
 * Reduce binary search when iterator reseek into the same data block.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1078,8 +1078,8 @@ class DBImpl : public DB {
       JobContext* job_context, LogBuffer* log_buffer, Env::Priority thread_pri);
 
   // REQUIRES: log_numbers are sorted in ascending order
-  virtual Status RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
-                                 SequenceNumber* next_sequence, bool read_only);
+  Status RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
+                         SequenceNumber* next_sequence, bool read_only);
 
   // The following two methods are used to flush a memtable to
   // storage. The first one is used at database RecoveryTime (when the

--- a/db/db_impl_secondary.cc
+++ b/db/db_impl_secondary.cc
@@ -22,26 +22,44 @@ namespace rocksdb {
 class ColumnFamilyCollector : public WriteBatch::Handler {
   std::unordered_set<uint32_t> column_family_ids_;
 
+  Status AddColumnFamilyId(uint32_t column_family_id) {
+    if (column_family_ids_.find(column_family_id) == column_family_ids_.end()) {
+      column_family_ids_.insert(column_family_id);
+    }
+    return Status::OK();
+  }
+
  public:
   explicit ColumnFamilyCollector() {}
 
   ~ColumnFamilyCollector() override {}
 
   Status PutCF(uint32_t column_family_id, const Slice&, const Slice&) override {
-    if (column_family_ids_.find(column_family_id) == column_family_ids_.end()) {
-      column_family_ids_.insert(column_family_id);
-    }
-    return Status::OK();
+    return AddColumnFamilyId(column_family_id);
   }
 
   Status DeleteCF(uint32_t column_family_id, const Slice&) override {
-    if (column_family_ids_.find(column_family_id) == column_family_ids_.end()) {
-      column_family_ids_.insert(column_family_id);
-    }
-    return Status::OK();
+    return AddColumnFamilyId(column_family_id);
   }
 
-  // TODO(yanqin): handle other operations
+  Status SingleDeleteCF(uint32_t column_family_id, const Slice&) override {
+    return AddColumnFamilyId(column_family_id);
+  }
+
+  Status DeleteRangeCF(uint32_t column_family_id, const Slice&,
+                       const Slice&) override {
+    return AddColumnFamilyId(column_family_id);
+  }
+
+  Status MergeCF(uint32_t column_family_id, const Slice&,
+                 const Slice&) override {
+    return AddColumnFamilyId(column_family_id);
+  }
+
+  Status PutBlobIndexCF(uint32_t column_family_id, const Slice&,
+                        const Slice&) override {
+    return AddColumnFamilyId(column_family_id);
+  }
 
   const std::unordered_set<uint32_t>& column_families() const {
     return column_family_ids_;

--- a/db/db_impl_secondary.cc
+++ b/db/db_impl_secondary.cc
@@ -18,68 +18,6 @@
 namespace rocksdb {
 
 #ifndef ROCKSDB_LITE
-
-class ColumnFamilyCollector : public WriteBatch::Handler {
-  std::unordered_set<uint32_t> column_family_ids_;
-
-  Status AddColumnFamilyId(uint32_t column_family_id) {
-    if (column_family_ids_.find(column_family_id) == column_family_ids_.end()) {
-      column_family_ids_.insert(column_family_id);
-    }
-    return Status::OK();
-  }
-
- public:
-  explicit ColumnFamilyCollector() {}
-
-  ~ColumnFamilyCollector() override {}
-
-  Status PutCF(uint32_t column_family_id, const Slice&, const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  Status DeleteCF(uint32_t column_family_id, const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  Status SingleDeleteCF(uint32_t column_family_id, const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  Status DeleteRangeCF(uint32_t column_family_id, const Slice&,
-                       const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  Status MergeCF(uint32_t column_family_id, const Slice&,
-                 const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  Status PutBlobIndexCF(uint32_t column_family_id, const Slice&,
-                        const Slice&) override {
-    return AddColumnFamilyId(column_family_id);
-  }
-
-  const std::unordered_set<uint32_t>& column_families() const {
-    return column_family_ids_;
-  }
-};
-
-Status CollectColumnFamilyIdsFromWriteBatch(
-    const WriteBatch& batch, std::vector<uint32_t>* column_family_ids) {
-  assert(column_family_ids != nullptr);
-  column_family_ids->clear();
-  ColumnFamilyCollector handler;
-  Status s = batch.Iterate(&handler);
-  if (s.ok()) {
-    for (const auto& cf : handler.column_families()) {
-      column_family_ids->push_back(cf);
-    }
-  }
-  return s;
-}
-
 DBImplSecondary::DBImplSecondary(const DBOptions& db_options,
                                  const std::string& dbname)
     : DBImpl(db_options, dbname) {

--- a/db/db_impl_secondary.h
+++ b/db/db_impl_secondary.h
@@ -194,11 +194,14 @@ class DBImplSecondary : public DBImpl {
 
   using DBImpl::Recover;
 
-  Status FindAndRecoverLogFiles();
+  Status FindAndRecoverLogFiles(
+      std::unordered_set<ColumnFamilyData*>* cfds_changed,
+      JobContext* job_context);
   Status FindNewLogNumbers(std::vector<uint64_t>* logs);
   Status RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
                          SequenceNumber* next_sequence,
-                         bool read_only) override;
+                         std::unordered_set<ColumnFamilyData*>* cfds_changed,
+                         JobContext* job_context);
 
   std::unique_ptr<log::FragmentBufferedReader> manifest_reader_;
   std::unique_ptr<log::Reader::Reporter> manifest_reporter_;
@@ -207,6 +210,8 @@ class DBImplSecondary : public DBImpl {
   // cache log readers for each log number, used for continue WAL replay
   // after recovery
   std::map<uint64_t, std::unique_ptr<LogReaderContainer>> log_readers_;
+
+  std::unordered_map<ColumnFamilyData*, uint64_t> current_log_;
 };
 
 }  // namespace rocksdb

--- a/db/db_impl_secondary.h
+++ b/db/db_impl_secondary.h
@@ -207,10 +207,11 @@ class DBImplSecondary : public DBImpl {
   std::unique_ptr<log::Reader::Reporter> manifest_reporter_;
   std::unique_ptr<Status> manifest_reader_status_;
 
-  // cache log readers for each log number, used for continue WAL replay
+  // Cache log readers for each log number, used for continue WAL replay
   // after recovery
   std::map<uint64_t, std::unique_ptr<LogReaderContainer>> log_readers_;
 
+  // Current WAL number replayed for each column family.
   std::unordered_map<ColumnFamilyData*, uint64_t> current_log_;
 };
 

--- a/db/db_impl_secondary.h
+++ b/db/db_impl_secondary.h
@@ -212,7 +212,7 @@ class DBImplSecondary : public DBImpl {
   std::map<uint64_t, std::unique_ptr<LogReaderContainer>> log_readers_;
 
   // Current WAL number replayed for each column family.
-  std::unordered_map<ColumnFamilyData*, uint64_t> current_log_;
+  std::unordered_map<ColumnFamilyData*, uint64_t> cfd_to_current_log_;
 };
 
 }  // namespace rocksdb

--- a/db/db_impl_secondary.h
+++ b/db/db_impl_secondary.h
@@ -96,40 +96,40 @@ class DBImplSecondary : public DBImpl {
   Status Put(const WriteOptions& /*options*/,
              ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
              const Slice& /*value*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::Merge;
   Status Merge(const WriteOptions& /*options*/,
                ColumnFamilyHandle* /*column_family*/, const Slice& /*key*/,
                const Slice& /*value*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::Delete;
   Status Delete(const WriteOptions& /*options*/,
                 ColumnFamilyHandle* /*column_family*/,
                 const Slice& /*key*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::SingleDelete;
   Status SingleDelete(const WriteOptions& /*options*/,
                       ColumnFamilyHandle* /*column_family*/,
                       const Slice& /*key*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   Status Write(const WriteOptions& /*options*/,
                WriteBatch* /*updates*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::CompactRange;
   Status CompactRange(const CompactRangeOptions& /*options*/,
                       ColumnFamilyHandle* /*column_family*/,
                       const Slice* /*begin*/, const Slice* /*end*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::CompactFiles;
@@ -140,32 +140,32 @@ class DBImplSecondary : public DBImpl {
       const int /*output_level*/, const int /*output_path_id*/ = -1,
       std::vector<std::string>* const /*output_file_names*/ = nullptr,
       CompactionJobInfo* /*compaction_job_info*/ = nullptr) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   Status DisableFileDeletions() override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   Status EnableFileDeletions(bool /*force*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   Status GetLiveFiles(std::vector<std::string>&,
                       uint64_t* /*manifest_file_size*/,
                       bool /*flush_memtable*/ = true) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::Flush;
   Status Flush(const FlushOptions& /*options*/,
                ColumnFamilyHandle* /*column_family*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DBImpl::SyncWAL;
   Status SyncWAL() override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   using DB::IngestExternalFile;
@@ -173,7 +173,7 @@ class DBImplSecondary : public DBImpl {
       ColumnFamilyHandle* /*column_family*/,
       const std::vector<std::string>& /*external_files*/,
       const IngestExternalFileOptions& /*ingestion_options*/) override {
-    return Status::NotSupported("Not supported operation in read only mode.");
+    return Status::NotSupported("Not supported operation in secondary mode.");
   }
 
   // Try to catch up with the primary by reading as much as possible from the

--- a/db/db_impl_secondary.h
+++ b/db/db_impl_secondary.h
@@ -185,6 +185,70 @@ class DBImplSecondary : public DBImpl {
   Status MaybeInitLogReader(uint64_t log_number,
                             log::FragmentBufferedReader** log_reader);
 
+ protected:
+  class ColumnFamilyCollector : public WriteBatch::Handler {
+    std::unordered_set<uint32_t> column_family_ids_;
+
+    Status AddColumnFamilyId(uint32_t column_family_id) {
+      if (column_family_ids_.find(column_family_id) ==
+          column_family_ids_.end()) {
+        column_family_ids_.insert(column_family_id);
+      }
+      return Status::OK();
+    }
+
+   public:
+    explicit ColumnFamilyCollector() {}
+
+    ~ColumnFamilyCollector() override {}
+
+    Status PutCF(uint32_t column_family_id, const Slice&,
+                 const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    Status DeleteCF(uint32_t column_family_id, const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    Status SingleDeleteCF(uint32_t column_family_id, const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    Status DeleteRangeCF(uint32_t column_family_id, const Slice&,
+                         const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    Status MergeCF(uint32_t column_family_id, const Slice&,
+                   const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    Status PutBlobIndexCF(uint32_t column_family_id, const Slice&,
+                          const Slice&) override {
+      return AddColumnFamilyId(column_family_id);
+    }
+
+    const std::unordered_set<uint32_t>& column_families() const {
+      return column_family_ids_;
+    }
+  };
+
+  Status CollectColumnFamilyIdsFromWriteBatch(
+      const WriteBatch& batch, std::vector<uint32_t>* column_family_ids) {
+    assert(column_family_ids != nullptr);
+    column_family_ids->clear();
+    ColumnFamilyCollector handler;
+    Status s = batch.Iterate(&handler);
+    if (s.ok()) {
+      for (const auto& cf : handler.column_families()) {
+        column_family_ids->push_back(cf);
+      }
+    }
+    return s;
+  }
+
  private:
   friend class DB;
 

--- a/db/db_secondary_test.cc
+++ b/db/db_secondary_test.cc
@@ -243,6 +243,11 @@ TEST_F(DBSecondaryTest, OpenAsSecondaryWALTailing) {
 
   ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
   verify_db_func("new_foo_value", "new_bar_value");
+
+  ASSERT_OK(Flush());
+  ASSERT_OK(Put("foo", "new_foo_value_1"));
+  ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
+  verify_db_func("new_foo_value_1", "new_bar_value");
 }
 
 TEST_F(DBSecondaryTest, OpenWithNonExistColumnFamily) {

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -294,6 +294,10 @@ class MemTableList {
     }
   }
 
+  // Used only by DBImplSecondary during log replay.
+  // Remove memtables whose data were written before the WAL with log_number
+  // was created, i.e. mem->GetNextLogNumber() <= log_number. The memtables are
+  // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
 

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -294,6 +294,9 @@ class MemTableList {
     }
   }
 
+  void RemoveOldMemTables(uint64_t log_number,
+                          autovector<MemTable*>* to_delete);
+
  private:
   friend Status InstallMemtableAtomicFlushResults(
       const autovector<MemTableList*>* imm_lists,


### PR DESCRIPTION
RocksDB secondary can replay both MANIFEST and WAL now.
On the one hand, the memory usage by memtables will grow after replaying WAL for sometime. On the other hand, replaying the MANIFEST can bring the database persistent data to a more recent point in time, giving us the opportunity to discard some memtables containing out-dated data.
This PR coordinates the MANIFEST and WAL replay, using the updates from MANIFEST replay to update the active memtable and immutable memtable list of each column family.

Test plan
```
$make clean && COMPILE_WITH_ASAN=1 make -j20 all
$./db_secondary_test
$make check
```