### PR TITLE
Add a MultiRead() method to Env

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1107,6 +1107,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
     file->MultiRead(&reqs);
     for (size_t i = 0; i < reqs.size(); ++i) {
       auto buf = NewAligned(kSectorSize * 8, i*2 + 1);
+      ASSERT_OK(reqs[i].status);
       ASSERT_EQ(memcmp(reqs[i].scratch, buf.get(), kSectorSize), 0);
     }
   }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1081,7 +1081,6 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
       Slice slice(data.get(), kSectorSize);
       ASSERT_OK(wfile->Append(slice));
     }
-    ASSERT_OK(wfile->InvalidateCache(0, 0));
     ASSERT_OK(wfile->Close());
   }
 
@@ -1104,7 +1103,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
     }
 #endif
     ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    file->MultiRead(reqs.data(), reqs.size());
+    ASSERT_OK(file->MultiRead(reqs.data(), reqs.size()));
     for (size_t i = 0; i < reqs.size(); ++i) {
       auto buf = NewAligned(kSectorSize * 8, static_cast<const char>(i*2 + 1));
       ASSERT_OK(reqs[i].status);

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1059,6 +1059,59 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDDeletes) {
   }
 }
 
+TEST_P(EnvPosixTestWithParam, MultiRead) {
+  EnvOptions soptions;
+  soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+  std::string fname = test::PerThreadDBPath(env_, "testfile");
+
+  const size_t kSectorSize = 4096;
+  const size_t kNumSectors = 8;
+
+  // Create file.
+  {
+    std::unique_ptr<WritableFile> wfile;
+#if !defined(OS_MACOSX) && !defined(OS_WIN) && !defined(OS_SOLARIS) && !defined(OS_AIX)
+    if (soptions.use_direct_writes) {
+      soptions.use_direct_writes = false;
+    }
+#endif
+    ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
+    for (size_t i = 0; i < kNumSectors; ++i) {
+      auto data = NewAligned(kSectorSize * 8, i + 1);
+      Slice slice(data.get(), kSectorSize);
+      ASSERT_OK(wfile->Append(slice));
+    }
+    ASSERT_OK(wfile->InvalidateCache(0, 0));
+    ASSERT_OK(wfile->Close());
+  }
+
+  // Random Read
+  {
+    std::unique_ptr<RandomAccessFile> file;
+    std::vector<ReadRequest> reqs(3);
+    std::vector<std::unique_ptr<char, Deleter>> data;
+    uint64_t offset = 0;
+    for (size_t i = 0; i < reqs.size(); ++i) {
+      reqs[i].offset = offset;
+      offset += 2 * kSectorSize;
+      reqs[i].len = kSectorSize;
+      data.emplace_back(NewAligned(kSectorSize, 0));
+      reqs[i].scratch = data.back().get();
+    }
+#if !defined(OS_MACOSX) && !defined(OS_WIN) && !defined(OS_SOLARIS) && !defined(OS_AIX)
+    if (soptions.use_direct_reads) {
+      soptions.use_direct_reads = false;
+    }
+#endif
+    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+    file->MultiRead(&reqs);
+    for (size_t i = 0; i < reqs.size(); ++i) {
+      auto buf = NewAligned(kSectorSize * 8, i*2 + 1);
+      ASSERT_EQ(memcmp(reqs[i].scratch, buf.get(), kSectorSize), 0);
+    }
+  }
+}
+
 // Only works in linux platforms
 #ifdef OS_WIN
 TEST_P(EnvPosixTestWithParam, DISABLED_InvalidateCache) {

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1077,7 +1077,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
 #endif
     ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
     for (size_t i = 0; i < kNumSectors; ++i) {
-      auto data = NewAligned(kSectorSize * 8, i + 1);
+      auto data = NewAligned(kSectorSize * 8, static_cast<const char>(i + 1));
       Slice slice(data.get(), kSectorSize);
       ASSERT_OK(wfile->Append(slice));
     }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1104,9 +1104,9 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
     }
 #endif
     ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    file->MultiRead(&reqs);
+    file->MultiRead(reqs.data(), reqs.size());
     for (size_t i = 0; i < reqs.size(); ++i) {
-      auto buf = NewAligned(kSectorSize * 8, i*2 + 1);
+      auto buf = NewAligned(kSectorSize * 8, static_cast<const char>(i*2 + 1));
       ASSERT_OK(reqs[i].status);
       ASSERT_EQ(memcmp(reqs[i].scratch, buf.get(), kSectorSize), 0);
     }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -619,6 +619,7 @@ class RandomAccessFile {
   // should return after all reads have completed. The reads will be
   // non-overlapping
   virtual void MultiRead(std::vector<ReadRequest>* reqs) {
+    assert(reqs != nullptr);
     for (size_t i = 0; i < reqs->size(); ++i) {
       ReadRequest& req = (*reqs)[i];
       req.status = Read(req.offset, req.len, &req.result, req.scratch);
@@ -1345,6 +1346,9 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override {
     return target_->Read(offset, n, result, scratch);
+  }
+  void MultiRead(std::vector<ReadRequest>* reqs) override {
+    target_->MultiRead(reqs);
   }
   Status Prefetch(uint64_t offset, size_t n) override {
     return target_->Prefetch(offset, n);

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -618,10 +618,10 @@ class RandomAccessFile {
   // optionally be read in parallel. This is a synchronous call, i.e it
   // should return after all reads have completed. The reads will be
   // non-overlapping
-  virtual void MultiRead(std::vector<ReadRequest>* reqs) {
+  virtual void MultiRead(ReadRequest* reqs, size_t num_reqs) {
     assert(reqs != nullptr);
-    for (size_t i = 0; i < reqs->size(); ++i) {
-      ReadRequest& req = (*reqs)[i];
+    for (size_t i = 0; i < num_reqs; ++i) {
+      ReadRequest& req = reqs[i];
       req.status = Read(req.offset, req.len, &req.result, req.scratch);
     }
   }
@@ -1347,8 +1347,8 @@ class RandomAccessFileWrapper : public RandomAccessFile {
               char* scratch) const override {
     return target_->Read(offset, n, result, scratch);
   }
-  void MultiRead(std::vector<ReadRequest>* reqs) override {
-    target_->MultiRead(reqs);
+  void MultiRead(ReadRequest* reqs, size_t num_reqs) override {
+    target_->MultiRead(reqs, num_reqs);
   }
   Status Prefetch(uint64_t offset, size_t n) override {
     return target_->Prefetch(offset, n);


### PR DESCRIPTION
Define the Env:: MultiRead() method to allow callers to request multiple block reads in one shot. The underlying Env implementation can parallelize it if it chooses to in order to reduce the overall IO latency.