### PR TITLE
Reuse data block iterator in BlockBasedTableReader::MultiGet()

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2958,7 +2958,7 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
           offset = iiter->value().offset();
           biter.Invalidate(Status::OK());
           NewDataBlockIterator<DataBlockIter>(
-              read_options, iiter->value(), &biter, false,
+              read_options, iiter->value(), &biter, BlockType::kData, false,
               true /* key_includes_seq */, get_context);
           reusing_block = false;
         }

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2934,7 +2934,7 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
     }
 
     DataBlockIter biter;
-    BlockHandle bhandle;
+    BlockHandle bhandle = BlockHandle::NullBlockHandle();
     for (auto miter = sst_file_range.begin(); miter != sst_file_range.end();
          ++miter) {
       Status s;
@@ -2943,7 +2943,8 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
       bool matched = false;  // if such user key matched a key in SST
       bool done = false;
       for (iiter->Seek(key); iiter->Valid() && !done; iiter->Next()) {
-        if (iiter->value().offset() != bhandle.offset()) {
+        if (iiter->value().offset() != bhandle.offset() ||
+            iiter->value().size() != bhandle.size()) {
           bhandle = iiter->value();
           biter.Invalidate(Status::OK());
           NewDataBlockIterator<DataBlockIter>(

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2933,7 +2933,7 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
       iiter_unique_ptr.reset(iiter);
     }
 
-    std::unique_ptr<DataBlockIter> biter(new DataBlockIter());;
+    DataBlockIter biter;
     BlockHandle bhandle;
     for (auto miter = sst_file_range.begin(); miter != sst_file_range.end();
          ++miter) {
@@ -2945,26 +2945,26 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
       for (iiter->Seek(key); iiter->Valid() && !done; iiter->Next()) {
         if (iiter->value().offset() != bhandle.offset()) {
           bhandle = iiter->value();
-          biter.reset(new DataBlockIter());
+          biter.Invalidate(Status::OK());
           NewDataBlockIterator<DataBlockIter>(
-              rep_, read_options, bhandle, biter.get(), false,
+              rep_, read_options, bhandle, &biter, false,
               true /* key_includes_seq */, get_context);
         }
 
         if (read_options.read_tier == kBlockCacheTier &&
-            biter->status().IsIncomplete()) {
+            biter.status().IsIncomplete()) {
           // couldn't get block from block_cache
           // Update Saver.state to Found because we are only looking for
           // whether we can guarantee the key is not there when "no_io" is set
           get_context->MarkKeyMayExist();
           break;
         }
-        if (!biter->status().ok()) {
-          s = biter->status();
+        if (!biter.status().ok()) {
+          s = biter.status();
           break;
         }
 
-        bool may_exist = biter->SeekForGet(key);
+        bool may_exist = biter.SeekForGet(key);
         if (!may_exist) {
           // HashSeek cannot find the key this block and the the iter is not
           // the end of the block, i.e. cannot be in the following blocks
@@ -2974,20 +2974,20 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
         }
 
         // Call the *saver function on each entry/block until it returns false
-        for (; biter->Valid(); biter->Next()) {
+        for (; biter.Valid(); biter.Next()) {
           ParsedInternalKey parsed_key;
-          if (!ParseInternalKey(biter->key(), &parsed_key)) {
+          if (!ParseInternalKey(biter.key(), &parsed_key)) {
             s = Status::Corruption(Slice());
           }
 
           if (!get_context->SaveValue(
-                  parsed_key, biter->value(), &matched,
-                  biter->IsValuePinned() ? biter.get() : nullptr)) {
+                  parsed_key, biter.value(), &matched,
+                  biter.IsValuePinned() ? &biter : nullptr)) {
             done = true;
             break;
           }
         }
-        s = biter->status();
+        s = biter.status();
         if (done) {
           // Avoid the extra Next which is expensive in two-level indexes
           break;


### PR DESCRIPTION
Instead of creating a new DataBlockIterator for every key in a MultiGet batch, reuse it if the next key is in the same block. This results in a small 1-2% cpu improvement.

TEST_TMPDIR=/dev/shm/multiget numactl -C 10  ./db_bench.tmp -use_existing_db=true -benchmarks="readseq,multireadrandom" -write_buffer_size=4194304 -target_file_size_base=4194304 -max_bytes_for_level_base=16777216 -num=12000000 -reads=12000000 -duration=90 -threads=1 -compression_type=none -cache_size=4194304000 -batch_size=32 -disable_auto_compactions=true -bloom_bits=10 -cache_index_and_filter_blocks=true -pin_l0_filter_and_index_blocks_in_cache=true -multiread_batched=true -multiread_stride=4

Without the change -
multireadrandom :       3.066 micros/op 326122 ops/sec; (29375968 of 29375968 found)

With the change -
multireadrandom :       3.003 micros/op 332945 ops/sec; (29983968 of 29983968 found)

Test:
make check
asan_crash
asan_check