### PR TITLE
Provide an option so that SST ingestion won't fall back to copy after hard linking fails

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.
 * Add an option `unordered_write` which trades snapshot guarantees with higher write throughput. When used with WRITE_PREPARED transactions with two_write_queues=true, it offers higher throughput with however no compromise on guarantees.
 * Allow DBImplSecondary to remove memtables with obsolete data after replaying MANIFEST and WAL.
+* Add an option `failed_move_fall_back_to_copy` (default is true) for external SST ingestion. When `move_files` is true and hard link fails, ingestion falls back to copy if `failed_move_fall_back_to_copy` is true. Otherwise, ingestion reports an error.
 
 ### Performance Improvements
 * Reduce binary search when iterator reseek into the same data block.
@@ -20,7 +21,7 @@
 
 ### Bug Fixes
 
-	
+
 ## 6.2.0 (4/30/2019)
 ### New Features
 * Add an option `strict_bytes_per_sync` that causes a file-writing thread to block rather than exceed the limit on bytes pending writeback specified by `bytes_per_sync` or `wal_bytes_per_sync`.

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -509,7 +509,6 @@ class DBImpl : public DB {
   void TEST_WaitForPersistStatsRun(std::function<void()> callback) const;
   bool TEST_IsPersistentStatsEnabled() const;
   size_t TEST_EstiamteStatsHistorySize() const;
-  VersionSet* Test_GetVersionSet() const { return versions_.get(); }
 
 #endif  // NDEBUG
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -509,6 +509,8 @@ class DBImpl : public DB {
   void TEST_WaitForPersistStatsRun(std::function<void()> callback) const;
   bool TEST_IsPersistentStatsEnabled() const;
   size_t TEST_EstiamteStatsHistorySize() const;
+  VersionSet* Test_GetVersionSet() const { return versions_.get(); };
+  EnvOptions Test_GetEnvOptions() const { return env_options_; };
 
 #endif  // NDEBUG
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -510,7 +510,6 @@ class DBImpl : public DB {
   bool TEST_IsPersistentStatsEnabled() const;
   size_t TEST_EstiamteStatsHistorySize() const;
   VersionSet* Test_GetVersionSet() const { return versions_.get(); }
-  EnvOptions Test_GetEnvOptions() const { return env_options_; }
 
 #endif  // NDEBUG
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -509,8 +509,8 @@ class DBImpl : public DB {
   void TEST_WaitForPersistStatsRun(std::function<void()> callback) const;
   bool TEST_IsPersistentStatsEnabled() const;
   size_t TEST_EstiamteStatsHistorySize() const;
-  VersionSet* Test_GetVersionSet() const { return versions_.get(); };
-  EnvOptions Test_GetEnvOptions() const { return env_options_; };
+  VersionSet* Test_GetVersionSet() const { return versions_.get(); }
+  EnvOptions Test_GetEnvOptions() const { return env_options_; }
 
 #endif  // NDEBUG
 

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -109,7 +109,8 @@ Status ExternalSstFileIngestionJob::Prepare(
     }
 
     if (f.copy_file) {
-      TEST_SYNC_POINT("ExternalSstFileIngestionJob::Prepare:CopyFile");
+      TEST_SYNC_POINT_CALLBACK("ExternalSstFileIngestionJob::Prepare:CopyFile",
+                               nullptr);
       status = CopyFile(env_, path_outside_db, path_inside_db, 0,
                         db_options_.use_fsync);
     }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -92,26 +92,25 @@ Status ExternalSstFileIngestionJob::Prepare(
   // Copy/Move external files into DB
   for (IngestedFileInfo& f : files_to_ingest_) {
     f.fd = FileDescriptor(next_file_number++, 0, f.file_size);
-
+    f.copy_file = false;
     const std::string path_outside_db = f.external_file_path;
     const std::string path_inside_db =
         TableFileName(cfd_->ioptions()->cf_paths, f.fd.GetNumber(),
                       f.fd.GetPathId());
-
     if (ingestion_options_.move_files) {
       status = env_->LinkFile(path_outside_db, path_inside_db);
-      if (status.IsNotSupported()) {
-        // Original file is on a different FS, use copy instead of hard linking
-        status = CopyFile(env_, path_outside_db, path_inside_db, 0,
-                          db_options_.use_fsync);
+      if (status.IsNotSupported() &&
+          ingestion_options_.failed_move_fall_back_to_copy) {
+        // Original file is on a different FS, use copy instead of hard linking.
         f.copy_file = true;
-      } else {
-        f.copy_file = false;
       }
     } else {
+      f.copy_file = true;
+    }
+
+    if (f.copy_file) {
       status = CopyFile(env_, path_outside_db, path_inside_db, 0,
                         db_options_.use_fsync);
-      f.copy_file = true;
     }
     TEST_SYNC_POINT("ExternalSstFileIngestionJob::Prepare:FileAdded");
     if (!status.ok()) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -109,6 +109,7 @@ Status ExternalSstFileIngestionJob::Prepare(
     }
 
     if (f.copy_file) {
+      TEST_SYNC_POINT("ExternalSstFileIngestionJob::Prepare:CopyFile");
       status = CopyFile(env_, path_outside_db, path_inside_db, 0,
                         db_options_.use_fsync);
     }

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -35,7 +35,7 @@ class ExternalSSTTestEnv : public EnvWrapper {
 
 class ExternSSTFileLinkFailFallbackTest
     : public DBTestBase,
-      public ::testing::WithParamInterface<bool> {
+      public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
   ExternSSTFileLinkFailFallbackTest() : DBTestBase("/external_sst_file_test") {
     sst_files_dir_ = dbname_ + "/sst_files/";
@@ -2045,17 +2045,26 @@ TEST_F(ExternalSSTFileTest, FileWithCFInfo) {
 }
 
 /*
- * Test and verify the functionality of ingestion_options.move_files.
+ * Test and verify the functionality of ingestion_options.move_files and
+ * ingestion_options.failed_move_fall_back_to_copy
  */
-TEST_F(ExternalSSTFileTest, LinkExternalSst) {
+TEST_P(ExternSSTFileLinkFailFallbackTest, LinkFailFallBackExternalSst) {
+  const bool fail_link = std::get<0>(GetParam());
+  const bool failed_move_fall_back_to_copy = std::get<1>(GetParam());
+  ExternalSSTTestEnv* test_env = new ExternalSSTTestEnv(env_, fail_link);
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
+  options.env = test_env;
+  const EnvOptions env_options;
   DestroyAndReopen(options);
   const int kNumKeys = 10000;
+  IngestExternalFileOptions ifo;
+  ifo.move_files = true;
+  ifo.failed_move_fall_back_to_copy = failed_move_fall_back_to_copy;
 
   std::string file_path = sst_files_dir_ + "file1.sst";
   // Create SstFileWriter for default column family
-  SstFileWriter sst_file_writer(EnvOptions(), options);
+  SstFileWriter sst_file_writer(env_options, options);
   ASSERT_OK(sst_file_writer.Open(file_path));
   for (int i = 0; i < kNumKeys; i++) {
     ASSERT_OK(sst_file_writer.Put(Key(i), Key(i) + "_value"));
@@ -2064,9 +2073,13 @@ TEST_F(ExternalSSTFileTest, LinkExternalSst) {
   uint64_t file_size = 0;
   ASSERT_OK(env_->GetFileSize(file_path, &file_size));
 
-  IngestExternalFileOptions ifo;
-  ifo.move_files = true;
-  ASSERT_OK(db_->IngestExternalFile({file_path}, ifo));
+  bool copyfile = false;
+  rocksdb::SyncPoint::GetInstance()->SetCallBack(
+      "ExternalSstFileIngestionJob::Prepare:CopyFile",
+      [&](void* /* arg */) { copyfile = true; });
+  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
+
+  const Status s = db_->IngestExternalFile({file_path}, ifo);
 
   ColumnFamilyHandleImpl* cfh =
       static_cast<ColumnFamilyHandleImpl*>(dbfull()->DefaultColumnFamily());
@@ -2080,76 +2093,30 @@ TEST_F(ExternalSSTFileTest, LinkExternalSst) {
     bytes_copied += stats.bytes_written;
     bytes_moved += stats.bytes_moved;
   }
-  // If bytes_moved > 0, it means external sst resides on the same FS
-  // supporting hard link operation. Therefore,
-  // 0 bytes should be copied, and the bytes_moved == file_size.
-  // Otherwise, FS does not support hard link, or external sst file resides on
-  // a different file system, then the bytes_copied should be equal to
-  // file_size.
-  if (bytes_moved > 0) {
+
+  if (!fail_link) {
+    // Link operation succeeds. External SST should be moved.
+    ASSERT_OK(s);
     ASSERT_EQ(0, bytes_copied);
     ASSERT_EQ(file_size, bytes_moved);
-  } else {
-    ASSERT_EQ(file_size, bytes_copied);
-  }
-}
-
-/*
- * Test and verify the functionality of ingestion_options.move_files and
- * ingestion_options.failed_move_fall_back_to_copy
- */
-TEST_P(ExternSSTFileLinkFailFallbackTest, LinkFailFallBackExternalSst) {
-  Options options = CurrentOptions();
-  options.disable_auto_compactions = true;
-  const EnvOptions env_options;
-  DestroyAndReopen(options);
-  const int kNumKeys = 10000;
-  IngestExternalFileOptions ifo;
-  ifo.move_files = true;
-  ifo.failed_move_fall_back_to_copy = GetParam();
-
-  std::string file_path = sst_files_dir_ + "file1.sst";
-  // Create SstFileWriter for default column family
-  SstFileWriter sst_file_writer(env_options, options);
-  ASSERT_OK(sst_file_writer.Open(file_path));
-  for (int i = 0; i < kNumKeys; i++) {
-    ASSERT_OK(sst_file_writer.Put(Key(i), Key(i) + "_value"));
-  }
-  ASSERT_OK(sst_file_writer.Finish());
-  uint64_t file_size = 0;
-  ASSERT_OK(env_->GetFileSize(file_path, &file_size));
-
-  ExternalSSTTestEnv test_env(options.env, true);
-  InstrumentedMutex mutex_;
-  const uint64_t next_file_number =
-      dbfull()->Test_GetVersionSet()->FetchAddFileNumber(1);
-  ColumnFamilyData* cfd =
-      static_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily())->cfd();
-  ExternalSstFileIngestionJob job(&test_env, dbfull()->Test_GetVersionSet(),
-                                  cfd, dbfull()->immutable_db_options(),
-                                  env_options, nullptr, ifo);
-  SuperVersion* super_version = cfd->GetReferencedSuperVersion(&mutex_);
-  bool copyfile = false;
-  rocksdb::SyncPoint::GetInstance()->SetCallBack(
-      "ExternalSstFileIngestionJob::Prepare:CopyFile",
-      [&](void* /* arg */) { copyfile = true; });
-  rocksdb::SyncPoint::GetInstance()->EnableProcessing();
-
-  const Status s =
-      job.Prepare({file_path}, next_file_number + 1, super_version);
-  dbfull()->CleanupSuperVersion(super_version);
-  if (ifo.failed_move_fall_back_to_copy) {
-    ASSERT_OK(s);
-    // Copy file is true since a failed link falls back to copy file.
-    ASSERT_TRUE(job.files_to_ingest()[0].copy_file);
-    ASSERT_TRUE(copyfile);
-  } else {
-    ASSERT_TRUE(s.IsNotSupported());
-    // Copy file is false since a failed link does not fall back to copy file.
-    ASSERT_FALSE(job.files_to_ingest()[0].copy_file);
     ASSERT_FALSE(copyfile);
+  } else {
+    // Link operation fails.
+    ASSERT_EQ(0, bytes_moved);
+    if (failed_move_fall_back_to_copy) {
+      ASSERT_OK(s);
+      // Copy file is true since a failed link falls back to copy file.
+      ASSERT_TRUE(copyfile);
+      ASSERT_EQ(file_size, bytes_copied);
+    } else {
+      ASSERT_TRUE(s.IsNotSupported());
+      // Copy file is false since a failed link does not fall back to copy file.
+      ASSERT_FALSE(copyfile);
+      ASSERT_EQ(0, bytes_copied);
+    }
   }
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
+  delete test_env;
 }
 
 class TestIngestExternalFileListener : public EventListener {
@@ -2757,7 +2724,9 @@ INSTANTIATE_TEST_CASE_P(ExternalSSTFileTest, ExternalSSTFileTest,
 
 INSTANTIATE_TEST_CASE_P(ExternSSTFileLinkFailFallbackTest,
                         ExternSSTFileLinkFailFallbackTest,
-                        testing::Values(true, false));
+                        testing::Values(std::make_tuple(false, false),
+                                        std::make_tuple(false, true),
+                                        std::make_tuple(true, false)));
 
 }  // namespace rocksdb
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2117,7 +2117,6 @@ TEST_P(ExternSSTFileLinkFailFallbackTest, LinkFailFallBackExternalSst) {
     }
   }
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
-  delete test_env;
 }
 
 class TestIngestExternalFileListener : public EventListener {

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -42,7 +42,7 @@ class ExternSSTFileLinkFailFallbackTest
       public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
   ExternSSTFileLinkFailFallbackTest() : DBTestBase("/external_sst_file_test"),
-  test_env_(new ExternalSSTTestEnv(env_, true)) {
+  test_env_(std::make_shared<ExternalSSTTestEnv>(env_, true)) {
     sst_files_dir_ = dbname_ + "/sst_files/";
     test::DestroyDir(env_, sst_files_dir_);
     env_->CreateDir(sst_files_dir_);

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -2121,7 +2121,6 @@ TEST_P(ExternSSTFileLinkFailFallbackTest, LinkFailFallBackExternalSst) {
 
   ExternalSSTTestEnv test_env(options.env, true);
   InstrumentedMutex mutex_;
-  std::list<uint64_t>::iterator pending_output_elem;
   const uint64_t next_file_number =
       dbfull()->Test_GetVersionSet()->FetchAddFileNumber(1);
   ColumnFamilyData* cfd =

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -7,8 +7,8 @@
 
 #include <functional>
 #include "db/db_test_util.h"
-#include "port/stack_trace.h"
 #include "port/port.h"
+#include "port/stack_trace.h"
 #include "rocksdb/sst_file_writer.h"
 #include "util/fault_injection_test_env.h"
 #include "util/filename.h"
@@ -16,7 +16,7 @@
 
 namespace rocksdb {
 
-// A test environment that can configured to fail the Link operation.
+// A test environment that can be configured to fail the Link operation.
 class ExternalSSTTestEnv : public EnvWrapper {
  public:
   ExternalSSTTestEnv(Env* t, bool fail_link)
@@ -2100,7 +2100,7 @@ TEST_F(ExternalSSTFileTest, LinkFailExternalSst) {
   uint64_t file_size = 0;
   ASSERT_OK(env_->GetFileSize(file_path, &file_size));
 
-  // Failed move fall back to copy.
+  // Failed move falls back to copy.
   {
     IngestExternalFileOptions ifo;
     ifo.move_files = true;

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -42,7 +42,7 @@ class ExternSSTFileLinkFailFallbackTest
       public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
   ExternSSTFileLinkFailFallbackTest() : DBTestBase("/external_sst_file_test"),
-  test_env_(std::make_shared<ExternalSSTTestEnv>(env_, true)) {
+  test_env_(new ExternalSSTTestEnv(env_, true)) {
     sst_files_dir_ = dbname_ + "/sst_files/";
     test::DestroyDir(env_, sst_files_dir_);
     env_->CreateDir(sst_files_dir_);
@@ -50,7 +50,7 @@ class ExternSSTFileLinkFailFallbackTest
 
  protected:
   std::string sst_files_dir_;
-  std::shared_ptr<ExternalSSTTestEnv> test_env_;
+  ExternalSSTTestEnv* test_env_;
 };
 
 class ExternalSSTFileTest
@@ -2060,7 +2060,7 @@ TEST_P(ExternSSTFileLinkFailFallbackTest, LinkFailFallBackExternalSst) {
   test_env_->set_fail_link(fail_link);
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
-  options.env = test_env_.get();
+  options.env = test_env_;
   const EnvOptions env_options;
   DestroyAndReopen(options);
   const int kNumKeys = 10000;

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -29,9 +29,7 @@ class ExternalSSTTestEnv : public EnvWrapper {
     return target()->LinkFile(s, t);
   }
 
-  void set_fail_link(bool fail_link) {
-    fail_link_ = fail_link;
-  }
+  void set_fail_link(bool fail_link) { fail_link_ = fail_link; }
 
  private:
   bool fail_link_;
@@ -41,8 +39,9 @@ class ExternSSTFileLinkFailFallbackTest
     : public DBTestBase,
       public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
-  ExternSSTFileLinkFailFallbackTest() : DBTestBase("/external_sst_file_test"),
-  test_env_(new ExternalSSTTestEnv(env_, true)) {
+  ExternSSTFileLinkFailFallbackTest()
+      : DBTestBase("/external_sst_file_test"),
+        test_env_(new ExternalSSTTestEnv(env_, true)) {
     sst_files_dir_ = dbname_ + "/sst_files/";
     test::DestroyDir(env_, sst_files_dir_);
     env_->CreateDir(sst_files_dir_);

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1398,6 +1398,8 @@ struct CompactRangeOptions {
 struct IngestExternalFileOptions {
   // Can be set to true to move the files instead of copying them.
   bool move_files = false;
+  // If set to true, ingestion falls back to copy when move fails.
+  bool failed_move_fall_back_to_copy = true;
   // If set to false, an ingested file keys could appear in existing snapshots
   // that where created before the file was ingested.
   bool snapshot_consistency = true;


### PR DESCRIPTION
RocksDB always tries to perform a hard link operation on the external SST file to ingest. This operation can fail if the external SST resides on a different device/FS, or the underlying FS does not support hard link. Currently RocksDB assumes that if the link fails, the user is willing to perform file copy, which is not true according to the post. This commit provides an option named  'failed_move_fall_back_to_copy' for users to choose which behavior they want.