### PR TITLE
Fix RocksDB auto-recovery from SpaceLimit err

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -629,8 +629,6 @@ TEST_F(DBSSTTest, DBWithMaxSpaceAllowed) {
   std::shared_ptr<SstFileManager> sst_file_manager(NewSstFileManager(env_));
   auto sfm = static_cast<SstFileManagerImpl*>(sst_file_manager.get());
 
-  SyncPoint::GetInstance()->DisableProcessing();
-
   Options options = CurrentOptions();
   options.sst_file_manager = sst_file_manager;
   options.disable_auto_compactions = true;

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -629,6 +629,8 @@ TEST_F(DBSSTTest, DBWithMaxSpaceAllowed) {
   std::shared_ptr<SstFileManager> sst_file_manager(NewSstFileManager(env_));
   auto sfm = static_cast<SstFileManagerImpl*>(sst_file_manager.get());
 
+  SyncPoint::GetInstance()->DisableProcessing();
+
   Options options = CurrentOptions();
   options.sst_file_manager = sst_file_manager;
   options.disable_auto_compactions = true;

--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -266,6 +266,9 @@ void SstFileManagerImpl::ClearError() {
 
     uint64_t free_space;
     Status s = env_->GetFreeSpace(path_, &free_space);
+    free_space = max_allowed_space_ > 0
+                     ? std::min(max_allowed_space_, free_space)
+                     : free_space;
     if (s.ok()) {
       // In case of multi-DB instances, some of them may have experienced a
       // soft error and some a hard error. In the SstFileManagerImpl, a hard


### PR DESCRIPTION
Summary:
If RocksDB is configured with a positive max_allowed_space (via sst file manager),
then the sst file manager should use this value instead of total free disk
space to determine whether to clear the background error of space limit
reached.

In DBSSTTest.DBWithMaxSpaceAllowed, we configure a low space limit that is very
likely lower than the free disk space of the test machine. Therefore, once the
test db encounters a Status::SpaceLimit, error handler will call into sst file
manager to start error recovery which may clear the bg error since disk free
space is larger than reserved_disk_buffer_.

Test Plan:
```
TEST_TMPDIR=/dev/shm ~/gtest-parallel/gtest-parallel ./db_sst_test --gtest_filter=DBSSTTest.DBWithMaxSpaceAllowed --repeat=1000
```