### PR TITLE
util: fix log_write_bench

### DIFF
--- a/util/log_write_bench.cc
+++ b/util/log_write_bench.cc
@@ -40,7 +40,8 @@ void RunBenchmark() {
   env->NewWritableFile(file_name, &file, env_options);
   std::unique_ptr<WritableFileWriter> writer;
   writer.reset(new WritableFileWriter(std::move(file), file_name, env_options,
-    env, nullptr/* stats */, options.listeners));
+                                      env, nullptr /* stats */,
+                                      options.listeners));
 
   std::string record;
   record.assign(FLAGS_record_size, 'X');

--- a/util/log_write_bench.cc
+++ b/util/log_write_bench.cc
@@ -32,13 +32,15 @@ DEFINE_bool(enable_sync, false, "sync after each write.");
 namespace rocksdb {
 void RunBenchmark() {
   std::string file_name = test::PerThreadDBPath("log_write_benchmark.log");
+  DBOptions options;
   Env* env = Env::Default();
-  EnvOptions env_options = env->OptimizeForLogWrite(EnvOptions());
+  EnvOptions env_options = env->OptimizeForLogWrite(EnvOptions(), options);
   env_options.bytes_per_sync = FLAGS_bytes_per_sync;
   std::unique_ptr<WritableFile> file;
   env->NewWritableFile(file_name, &file, env_options);
   std::unique_ptr<WritableFileWriter> writer;
-  writer.reset(new WritableFileWriter(std::move(file), env_options));
+  writer.reset(new WritableFileWriter(std::move(file), file_name, env_options,
+    env, nullptr/* stats */, options.listeners));
 
   std::string record;
   record.assign(FLAGS_record_size, 'X');


### PR DESCRIPTION
log_write_bench doesn't compile due to some recent API changes.
This patch fixes the compile by adding the missing params for
OptimizeForLogWrite() and WritableFileWriter().

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>