### PR TITLE
add bytes append merge operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,6 +654,7 @@ set(SOURCES
         utilities/merge_operators/string_append/stringappend.cc
         utilities/merge_operators/string_append/stringappend2.cc
         utilities/merge_operators/uint64add.cc
+        utilities/merge_operators/bytesappend.cc
         utilities/option_change_migration/option_change_migration.cc
         utilities/options/options_util.cc
         utilities/persistent_cache/block_cache_tier.cc
@@ -967,6 +968,7 @@ if(WITH_TESTS)
         utilities/checkpoint/checkpoint_test.cc
         utilities/memory/memory_test.cc
         utilities/merge_operators/string_append/stringappend_test.cc
+        utilities/merge_operators/bytesappend_test.cc
         utilities/object_registry_test.cc
         utilities/option_change_migration/option_change_migration_test.cc
         utilities/options/options_util_test.cc

--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,7 @@ TESTS = \
 	skiplist_test \
 	write_buffer_manager_test \
 	stringappend_test \
+	bytesappend_test \
 	cassandra_format_test \
 	cassandra_functional_test \
 	cassandra_row_merge_test \
@@ -1162,6 +1163,8 @@ option_change_migration_test: utilities/option_change_migration/option_change_mi
 
 stringappend_test: utilities/merge_operators/string_append/stringappend_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
+
+bytesappend_test: utilities/merge_operators/bytesappend_test.o $(LIBOBJECTS) $(TESTHARNESS)
 
 cassandra_format_test: utilities/cassandra/cassandra_format_test.o utilities/cassandra/test_utils.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)

--- a/TARGETS
+++ b/TARGETS
@@ -269,6 +269,7 @@ cpp_library(
         "utilities/merge_operators/string_append/stringappend.cc",
         "utilities/merge_operators/string_append/stringappend2.cc",
         "utilities/merge_operators/uint64add.cc",
+        "utilities/merge_operators/bytesappend.cc"
         "utilities/option_change_migration/option_change_migration.cc",
         "utilities/options/options_util.cc",
         "utilities/persistent_cache/block_cache_tier.cc",
@@ -959,6 +960,11 @@ ROCKS_TESTS = [
     [
         "stringappend_test",
         "utilities/merge_operators/string_append/stringappend_test.cc",
+        "serial",
+    ],
+    [
+        "bytesappend_test",
+        "utilities/merge_operators/bytesappend_test.cc",
         "serial",
     ],
     [

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -145,6 +145,7 @@ set(NATIVE_JAVA_CLASSES
         org.rocksdb.SstFileWriter
         org.rocksdb.Statistics
         org.rocksdb.StringAppendOperator
+        org.rocksdb.BytesAppendOperator
         org.rocksdb.TableFormatConfig
         org.rocksdb.ThreadStatus
         org.rocksdb.TimedEnv
@@ -314,6 +315,7 @@ add_jar(
   src/main/java/org/rocksdb/StatsLevel.java
   src/main/java/org/rocksdb/Status.java
   src/main/java/org/rocksdb/StringAppendOperator.java
+  src/main/java/org/rocksdb/BytsAppendOperator.java
   src/main/java/org/rocksdb/TableFilter.java
   src/main/java/org/rocksdb/TableProperties.java
   src/main/java/org/rocksdb/TableFormatConfig.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -73,6 +73,7 @@ NATIVE_JAVA_CLASSES = org.rocksdb.AbstractCompactionFilter\
 	org.rocksdb.Snapshot\
 	org.rocksdb.StringAppendOperator\
 	org.rocksdb.UInt64AddOperator\
+	ort.rocksdb.BytesAppendOperator\
 	org.rocksdb.WriteBatch\
 	org.rocksdb.WriteBatch.Handler\
 	org.rocksdb.WriteOptions\

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -15,7 +15,7 @@
 
 #include "include/org_rocksdb_StringAppendOperator.h"
 #include "include/org_rocksdb_UInt64AddOperator.h"
-#include "include/org_rocksdb_BytesAppend.h"
+#include "include/org_rocksdb_BytesAppendOperator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"

--- a/java/rocksjni/merge_operator.cc
+++ b/java/rocksjni/merge_operator.cc
@@ -15,6 +15,7 @@
 
 #include "include/org_rocksdb_StringAppendOperator.h"
 #include "include/org_rocksdb_UInt64AddOperator.h"
+#include "include/org_rocksdb_BytesAppend.h"
 #include "rocksdb/db.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
@@ -73,4 +74,29 @@ void Java_org_rocksdb_UInt64AddOperator_disposeInternal(JNIEnv* /*env*/,
   auto* sptr_uint64_add_op =
       reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
   delete sptr_uint64_add_op;  // delete std::shared_ptr
+}
+
+/*
+ * Class:     org_rocksdb_BytesAppendOperator
+ * Method:    newSharedBytesAppendOperator
+ * Signature: (C)J
+ */
+jlong Java_org_rocksdb_BytesAppendOperator_newSharedBytesAppendOperator(
+  JNIEnv* /*env*/, jclass /*jclazz*/) {
+  auto* sptr_bytes_append_op = new std::shared_ptr<rocksdb::MergeOperator>(
+    rocksdb::MergeOperators::CreateBytesAppendOperator());
+  return reinterpret_cast<jlong>(sptr_bytes_append_op);
+}
+
+/*
+ * Class:     org_rocksdb_BytesAppendOperator
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_BytesAppendOperator_disposeInternal(JNIEnv* /*env*/,
+                                                           jobject /*jobj*/,
+                                                           jlong jhandle) {
+  auto* sptr_bytes_append_op =
+    reinterpret_cast<std::shared_ptr<rocksdb::MergeOperator>*>(jhandle);
+  delete sptr_bytes_append_op;  // delete std::shared_ptr
 }

--- a/java/src/main/java/org/rocksdb/BytesAppendOperator.java
+++ b/java/src/main/java/org/rocksdb/BytesAppendOperator.java
@@ -1,0 +1,19 @@
+/**
+*  Created by Jesse Ma on 2019-05-23.
+*  for bytes append operator
+*/
+
+package org.rocksdb;
+
+/**
+ * BytesAppendOperator is a merge operator that concatenates
+ * two strings.
+ */
+public class BytesAppendOperator extends MergeOperator {
+    public BytesAppendOperator() {
+        super(newSharedBytesAppendOperator());
+    }
+
+    private native static long newSharedBytesAppendOperator();
+    @Override protected final native void disposeInternal(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -386,7 +386,7 @@ public class MergeTest {
           // Test also with createColumnFamily
           try (final ColumnFamilyOptions cfHandleOpts =
                        new ColumnFamilyOptions()
-                               .setMergeOperator(stringAppendOperator);
+                               .setMergeOperator(bytesAppendOperator);
                final ColumnFamilyHandle cfHandle =
                        db.createColumnFamily(
                                new ColumnFamilyDescriptor("new_cf2".getBytes(),

--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -78,6 +78,25 @@ public class MergeTest {
   }
 
   @Test
+  public void BytesOption()
+          throws InterruptedException, RocksDBException {
+    try (final Options opt = new Options()
+            .setCreateIfMissing(true)
+            .setMergeOperatorName("bytesappend");
+         final RocksDB db = RocksDB.open(opt,
+                 dbFolder.getRoot().getAbsolutePath())) {
+      // writing aa under key
+      db.put("key".getBytes(), "aa".getBytes());
+      // merge bb under key
+      db.merge("key".getBytes(), "bb".getBytes());
+
+      final byte[] value = db.get("key".getBytes());
+      final String strValue = new String(value);
+      assertThat(strValue).isEqualTo("aabb");
+    }
+  }
+
+  @Test
   public void cFStringOption()
       throws InterruptedException, RocksDBException {
 
@@ -110,6 +129,48 @@ public class MergeTest {
               "cfkey".getBytes());
           String strValue = new String(value);
           assertThat(strValue).isEqualTo("aa,bb");
+        } finally {
+          for (final ColumnFamilyHandle handle : columnFamilyHandleList) {
+            handle.close();
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void cFBytesOption()
+          throws InterruptedException, RocksDBException {
+
+    try (final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
+            .setMergeOperatorName("bytesappend");
+         final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
+                 .setMergeOperatorName("bytesappend")
+    ) {
+      final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+              new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+              new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt2)
+      );
+
+      final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+      try (final DBOptions opt = new DBOptions()
+              .setCreateIfMissing(true)
+              .setCreateMissingColumnFamilies(true);
+           final RocksDB db = RocksDB.open(opt,
+                   dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
+                   columnFamilyHandleList)) {
+        try {
+          // writing aa under key
+          db.put(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes(), "aa".getBytes());
+          // merge bb under key
+          db.merge(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes(), "bb".getBytes());
+
+          byte[] value = db.get(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes());
+          String strValue = new String(value);
+          assertThat(strValue).isEqualTo("aabb");
         } finally {
           for (final ColumnFamilyHandle handle : columnFamilyHandleList) {
             handle.close();
@@ -180,6 +241,28 @@ public class MergeTest {
       final String strValue = new String(value);
 
       assertThat(strValue).isEqualTo("aa,bb");
+    }
+  }
+
+  @Test
+  public void bytesAppendOperatorOption()
+          throws InterruptedException, RocksDBException {
+    try (final BytesAppendOperator bytesAppendOperator = new BytesAppendOperator();
+         final Options opt = new Options()
+                 .setCreateIfMissing(true)
+                 .setMergeOperator(bytesAppendOperator);
+         final RocksDB db = RocksDB.open(opt,
+                 dbFolder.getRoot().getAbsolutePath())) {
+      // Writing aa under key
+      db.put("key".getBytes(), "aa".getBytes());
+
+      // Writing bb under key
+      db.merge("key".getBytes(), "bb".getBytes());
+
+      final byte[] value = db.get("key".getBytes());
+      final String strValue = new String(value);
+
+      assertThat(strValue).isEqualTo("aabb");
     }
   }
 
@@ -266,6 +349,70 @@ public class MergeTest {
       }
     }
   }
+
+
+  @Test
+  public void cFBytesAppendOperatorOption()
+          throws InterruptedException, RocksDBException {
+    try (final BytesAppendOperator bytesAppendOperator = new BytesAppendOperator();
+         final ColumnFamilyOptions cfOpt1 = new ColumnFamilyOptions()
+                 .setMergeOperator(bytesAppendOperator);
+         final ColumnFamilyOptions cfOpt2 = new ColumnFamilyOptions()
+                 .setMergeOperator(bytesAppendOperator)
+    ) {
+      final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+              new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpt1),
+              new ColumnFamilyDescriptor("new_cf".getBytes(), cfOpt2)
+      );
+      final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
+      try (final DBOptions opt = new DBOptions()
+              .setCreateIfMissing(true)
+              .setCreateMissingColumnFamilies(true);
+           final RocksDB db = RocksDB.open(opt,
+                   dbFolder.getRoot().getAbsolutePath(), cfDescriptors,
+                   columnFamilyHandleList)
+      ) {
+        try {
+          // writing aa under key
+          db.put(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes(), "aa".getBytes());
+          // merge bb under key
+          db.merge(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes(), "bb".getBytes());
+          byte[] value = db.get(columnFamilyHandleList.get(1),
+                  "cfkey".getBytes());
+          String strValue = new String(value);
+
+          // Test also with createColumnFamily
+          try (final ColumnFamilyOptions cfHandleOpts =
+                       new ColumnFamilyOptions()
+                               .setMergeOperator(stringAppendOperator);
+               final ColumnFamilyHandle cfHandle =
+                       db.createColumnFamily(
+                               new ColumnFamilyDescriptor("new_cf2".getBytes(),
+                                       cfHandleOpts))
+          ) {
+            // writing xx under cfkey2
+            db.put(cfHandle, "cfkey2".getBytes(), "xx".getBytes());
+            // merge yy under cfkey2
+            db.merge(cfHandle, new WriteOptions(), "cfkey2".getBytes(),
+                    "yy".getBytes());
+            value = db.get(cfHandle, "cfkey2".getBytes());
+            String strValueTmpCf = new String(value);
+
+            assertThat(strValue).isEqualTo("aabb");
+            assertThat(strValueTmpCf).isEqualTo("xxyy");
+          }
+        } finally {
+          for (final ColumnFamilyHandle columnFamilyHandle :
+                  columnFamilyHandleList) {
+            columnFamilyHandle.close();
+          }
+        }
+      }
+    }
+  }
+
 
   @Test
   public void cFUInt64AddOperatorOption()
@@ -370,6 +517,49 @@ public class MergeTest {
       }
     }
   }
+
+  @Test
+  public void bytesAppendOperatorGcBehaviour()
+          throws RocksDBException {
+    try (final BytesAppendOperator bytesAppendOperator = new BytesAppendOperator()) {
+      try (final Options opt = new Options()
+              .setCreateIfMissing(true)
+              .setMergeOperator(bytesAppendOperator);
+           final RocksDB db = RocksDB.open(opt,
+                   dbFolder.getRoot().getAbsolutePath())) {
+        //no-op
+      }
+
+      // test reuse
+      try (final Options opt = new Options()
+              .setMergeOperator(bytesAppendOperator);
+           final RocksDB db = RocksDB.open(opt,
+                   dbFolder.getRoot().getAbsolutePath())) {
+        //no-op
+      }
+
+      // test param init
+      try (final BytesAppendOperator bytesAppendOperator2 = new BytesAppendOperator();
+           final Options opt = new Options()
+                   .setMergeOperator(bytesAppendOperator2);
+           final RocksDB db = RocksDB.open(opt,
+                   dbFolder.getRoot().getAbsolutePath())) {
+        //no-op
+      }
+
+      // test replace one with another merge operator instance
+      try (final Options opt = new Options()
+              .setMergeOperator(bytesAppendOperator);
+           final BytesAppendOperator newBytesAppendOperator = new BytesAppendOperator()) {
+        opt.setMergeOperator(newBytesAppendOperator);
+        try (final RocksDB db = RocksDB.open(opt,
+                dbFolder.getRoot().getAbsolutePath())) {
+          //no-op
+        }
+      }
+    }
+  }
+
 
   @Test
   public void uint64AddOperatorGcBehaviour()

--- a/src.mk
+++ b/src.mk
@@ -189,6 +189,7 @@ LIB_SOURCES =                                                   \
   utilities/merge_operators/string_append/stringappend2.cc      \
   utilities/merge_operators/uint64add.cc                        \
   utilities/merge_operators/bytesxor.cc                         \
+  utilities/merge_operators/bytesappend.cc                      \
   utilities/option_change_migration/option_change_migration.cc  \
   utilities/options/options_util.cc                             \
   utilities/persistent_cache/block_cache_tier.cc                \

--- a/src.mk
+++ b/src.mk
@@ -393,6 +393,7 @@ MAIN_SOURCES =                                                          \
   utilities/checkpoint/checkpoint_test.cc                               \
   utilities/memory/memory_test.cc                                       \
   utilities/merge_operators/string_append/stringappend_test.cc          \
+  utilities/merge_operators/bytesappend_test.cc                         \
   utilities/object_registry_test.cc                                     \
   utilities/option_change_migration/option_change_migration_test.cc     \
   utilities/options/options_util_test.cc                                \

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -3178,7 +3178,7 @@ BlockBasedTableOptions::IndexType BlockBasedTable::UpdateIndexType() {
 Status BlockBasedTable::CreateIndexReader(
     FilePrefetchBuffer* prefetch_buffer, IndexReader** index_reader,
     InternalIterator* preloaded_meta_index_iter, int level) {
-  auto index_type_on_file = UpdateIndexType();
+  auto index_type_on_file = rep_->index_type;
 
   auto file = rep_->file.get();
   const InternalKeyComparator* icomparator = &rep_->internal_comparator;

--- a/utilities/merge_operators.h
+++ b/utilities/merge_operators.h
@@ -23,6 +23,7 @@ class MergeOperators {
   static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator();
   static std::shared_ptr<MergeOperator> CreateMaxOperator();
   static std::shared_ptr<MergeOperator> CreateBytesXOROperator();
+  static std::shared_ptr<MergeOperator> CreateBytesAppendOperator();
 
   // Will return a different merge operator depending on the string.
   // TODO: Hook the "name" up to the actual Name() of the MergeOperators?
@@ -42,6 +43,8 @@ class MergeOperators {
       return CreateMaxOperator();
     } else if (name == "bytesxor") {
       return CreateBytesXOROperator();
+    } else if (name == "bytesappend") {
+        return CreateBytesAppendOperator();
     } else {
       // Empty or unknown, just return nullptr
       return nullptr;

--- a/utilities/merge_operators/bytesappend.cc
+++ b/utilities/merge_operators/bytesappend.cc
@@ -33,7 +33,7 @@ namespace rocksdb {
         return true;
     }
 
-    const char *Name() {
+    const char *BytesAppendOperator::Name() const {
         return "BytesAppendOperator";
     }
 

--- a/utilities/merge_operators/bytesappend.cc
+++ b/utilities/merge_operators/bytesappend.cc
@@ -1,0 +1,44 @@
+/**
+*  Created by Jesse Ma on 2019-05-22.
+*  for bytes append operator
+*/
+
+#include "bytesappend.h"
+
+#include <memory>
+#include <assert.h>
+#include "utilities/merge_operators.h"
+
+namespace rocksdb {
+// Implementation for the merge operation (concatenates two strings)
+    bool BytesAppendOperator::Merge(const Slice & /*key*/,
+                                    const Slice *existing_value,
+                                    const Slice &value,
+                                    std::string *new_value,
+                                    Logger * /*logger*/) const {
+        // Clear the *new_value for writing.
+        assert(new_value);
+        new_value->clear();
+
+        if (!existing_value) {
+            // No existing_value. Set *new_value = value
+            new_value->assign(value.data(), value.size());
+        } else {
+            // Generic append (existing_value != null).
+            // Reserve *new_value to correct size, and apply concatenation.
+            new_value->reserve(existing_value->size() + value.size());
+            new_value->assign(existing_value->data(), existing_value->size());
+            new_value->append(value.data(), value.size());
+        }
+        return true;
+    }
+
+    const char *Name() {
+        return "BytesAppendOperator";
+    }
+
+    std::shared_ptr <MergeOperator> MergeOperators::CreateBytesAppendOperator() {
+        return std::make_shared<BytesAppendOperator>();
+    }
+
+}

--- a/utilities/merge_operators/bytesappend.cc
+++ b/utilities/merge_operators/bytesappend.cc
@@ -11,34 +11,34 @@
 
 namespace rocksdb {
 // Implementation for the merge operation (concatenates two strings)
-    bool BytesAppendOperator::Merge(const Slice & /*key*/,
-                                    const Slice *existing_value,
-                                    const Slice &value,
-                                    std::string *new_value,
-                                    Logger * /*logger*/) const {
-        // Clear the *new_value for writing.
-        assert(new_value);
-        new_value->clear();
+bool BytesAppendOperator::Merge(const Slice & /*key*/,
+                                const Slice *existing_value,
+                                const Slice &value,
+                                std::string *new_value,
+                                Logger * /*logger*/) const {
+  // Clear the *new_value for writing.
+  assert(new_value);
+  new_value->clear();
 
-        if (!existing_value) {
-            // No existing_value. Set *new_value = value
-            new_value->assign(value.data(), value.size());
-        } else {
-            // Generic append (existing_value != null).
-            // Reserve *new_value to correct size, and apply concatenation.
-            new_value->reserve(existing_value->size() + value.size());
-            new_value->assign(existing_value->data(), existing_value->size());
-            new_value->append(value.data(), value.size());
-        }
-        return true;
-    }
+  if (!existing_value) {
+    // No existing_value. Set *new_value = value
+    new_value->assign(value.data(), value.size());
+  } else {
+    // Generic append (existing_value != null).
+    // Reserve *new_value to correct size, and apply concatenation.
+    new_value->reserve(existing_value->size() + value.size());
+    new_value->assign(existing_value->data(), existing_value->size());
+    new_value->append(value.data(), value.size());
+  }
+  return true;
+}
 
-    const char *BytesAppendOperator::Name() const {
-        return "BytesAppendOperator";
-    }
+const char *BytesAppendOperator::Name() const {
+  return "BytesAppendOperator";
+}
 
-    std::shared_ptr <MergeOperator> MergeOperators::CreateBytesAppendOperator() {
-        return std::make_shared<BytesAppendOperator>();
-    }
+std::shared_ptr<MergeOperator> MergeOperators::CreateBytesAppendOperator() {
+  return std::make_shared<BytesAppendOperator>();
+}
 
 }

--- a/utilities/merge_operators/bytesappend.h
+++ b/utilities/merge_operators/bytesappend.h
@@ -1,0 +1,27 @@
+/**
+*  Created by Jesse Ma on 2019-05-22.
+*  for bytes append operator
+*/
+
+#pragma once
+
+#include <string>
+#include "rocksdb/slice.h"
+#include "rocksdb/merge_operator.h"
+
+namespace rocksdb {
+
+// BytesAppend merge operator appends the bytes to the end of the original value.
+    class BytesAppendOperator : public AssociativeMergeOperator {
+    public:
+        virtual bool Merge(const Slice &key,
+                           const Slice *existing_value,
+                           const Slice &value,
+                           std::string *new_value,
+                           Logger *logger) const override;
+
+        virtual const char *Name() const override;
+    };
+
+}  // namespace rocksdb
+

--- a/utilities/merge_operators/bytesappend.h
+++ b/utilities/merge_operators/bytesappend.h
@@ -13,14 +13,14 @@ namespace rocksdb {
 
 // BytesAppend merge operator appends the bytes to the end of the original value.
 class BytesAppendOperator : public AssociativeMergeOperator {
-  public:
-    virtual bool Merge(const Slice &key,
-                       const Slice *existing_value,
-                       const Slice &value,
-                       std::string *new_value,
-                       Logger *logger) const override;
+ public:
+  virtual bool Merge(const Slice &key,
+                     const Slice *existing_value,
+                     const Slice &value,
+                     std::string *new_value,
+                     Logger *logger) const override;
 
-    virtual const char *Name() const override;
+  virtual const char *Name() const override;
 };
 
 }  // namespace rocksdb

--- a/utilities/merge_operators/bytesappend.h
+++ b/utilities/merge_operators/bytesappend.h
@@ -12,16 +12,16 @@
 namespace rocksdb {
 
 // BytesAppend merge operator appends the bytes to the end of the original value.
-    class BytesAppendOperator : public AssociativeMergeOperator {
-    public:
-        virtual bool Merge(const Slice &key,
-                           const Slice *existing_value,
-                           const Slice &value,
-                           std::string *new_value,
-                           Logger *logger) const override;
+class BytesAppendOperator : public AssociativeMergeOperator {
+  public:
+    virtual bool Merge(const Slice &key,
+                       const Slice *existing_value,
+                       const Slice &value,
+                       std::string *new_value,
+                       Logger *logger) const override;
 
-        virtual const char *Name() const override;
-    };
+    virtual const char *Name() const override;
+};
 
 }  // namespace rocksdb
 

--- a/utilities/merge_operators/bytesappend_test.cc
+++ b/utilities/merge_operators/bytesappend_test.cc
@@ -1,0 +1,96 @@
+//
+// Created by Jesse Ma on 2019-05-23.
+//
+
+#include "util/testharness.h"
+#include "utilities/merge_operators.h"
+
+
+namespace rocksdb {
+
+  class UtilBytesAppendMergeOperatorTest : public testing::Test {
+  public:
+    UtilBytesAppendMergeOperatorTest() {
+    }
+
+    std::string FullMergeV2(std::string existing_value,
+                            std::vector<std::string> operands,
+                            std::string key = "") {
+      std::string result;
+      Slice result_operand(nullptr, 0);
+
+      Slice existing_value_slice(existing_value);
+      std::vector<Slice> operands_slice(operands.begin(), operands.end());
+
+      const MergeOperator::MergeOperationInput merge_in(
+        key, &existing_value_slice, operands_slice, nullptr);
+      MergeOperator::MergeOperationOutput merge_out(result, result_operand);
+      merge_operator_->FullMergeV2(merge_in, &merge_out);
+
+      if (result_operand.data()) {
+        result.assign(result_operand.data(), result_operand.size());
+      }
+      return result;
+    }
+
+    std::string FullMergeV2(std::vector<std::string> operands,
+                            std::string key = "") {
+      std::string result;
+      Slice result_operand(nullptr, 0);
+
+      std::vector<Slice> operands_slice(operands.begin(), operands.end());
+
+      const MergeOperator::MergeOperationInput merge_in(key, nullptr,
+                                                        operands_slice, nullptr);
+      MergeOperator::MergeOperationOutput merge_out(result, result_operand);
+      merge_operator_->FullMergeV2(merge_in, &merge_out);
+
+      if (result_operand.data()) {
+        result.assign(result_operand.data(), result_operand.size());
+      }
+      return result;
+    }
+
+    std::string PartialMerge(std::string left, std::string right,
+                             std::string key = "") {
+      std::string result;
+
+      merge_operator_->PartialMerge(key, left, right, &result, nullptr);
+      return result;
+    }
+
+    std::string PartialMergeMulti(std::deque<std::string> operands,
+                                  std::string key = "") {
+      std::string result;
+      std::deque<Slice> operands_slice(operands.begin(), operands.end());
+
+      merge_operator_->PartialMergeMulti(key, operands_slice, &result, nullptr);
+      return result;
+    }
+
+  protected:
+    std::shared_ptr<MergeOperator> merge_operator_;
+  };
+  TEST_F(UtilBytesAppendMergeOperatorTest, SubTest1) {
+    merge_operator_ = MergeOperators::CreateBytesAppendOperator();
+
+    EXPECT_EQ("BA", FullMergeV2("B", {"A"}));
+    EXPECT_EQ("AB", FullMergeV2("A", {"B"}));
+    EXPECT_EQ("", FullMergeV2({"", "", ""}));
+    EXPECT_EQ("A", FullMergeV2({"A"}));
+    EXPECT_EQ("ABC", FullMergeV2({"ABC"}));
+    EXPECT_EQ("ABCZCAXX", FullMergeV2({"ABC", "Z", "C", "AXX"}));
+    EXPECT_EQ("ABCCCZZZZ", FullMergeV2({"ABC", "CC", "Z", "ZZZ"}));
+    EXPECT_EQ("aABCCCZZZZ", FullMergeV2("a", {"ABC", "CC", "Z", "ZZZ"}));
+
+    EXPECT_EQ("azefqfqwgwewaazhhhhh", PartialMergeMulti({"a", "z", "efqfqwgwew", "aaz", "hhhhh"}));
+    EXPECT_EQ("ab", PartialMerge("a", "b"));
+    EXPECT_EQ("zazzz", PartialMerge("z", "azzz"));
+    EXPECT_EQ("a",PartialMerge("a", ""));
+  }
+}  // namespace rocksdb
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/merge_operators/bytesappend_test.cc
+++ b/utilities/merge_operators/bytesappend_test.cc
@@ -1,6 +1,7 @@
-//
-// Created by Jesse Ma on 2019-05-23.
-//
+/**
+*  Created by Jesse Ma on 2019-05-22.
+*  for bytes append operator unit test
+*/
 
 #include "util/testharness.h"
 #include "utilities/merge_operators.h"
@@ -8,86 +9,88 @@
 
 namespace rocksdb {
 
-  class UtilBytesAppendMergeOperatorTest : public testing::Test {
-  public:
-    UtilBytesAppendMergeOperatorTest() {
+class UtilBytesAppendMergeOperatorTest : public testing::Test {
+ public:
+  UtilBytesAppendMergeOperatorTest() {}
+
+  std::string FullMergeV2(std::string existing_value,
+                          std::vector<std::string> operands,
+                          std::string key = "") {
+    std::string result;
+    Slice result_operand(nullptr, 0);
+
+    Slice existing_value_slice(existing_value);
+    std::vector<Slice> operands_slice(operands.begin(), operands.end());
+
+    const MergeOperator::MergeOperationInput merge_in(
+      key, &existing_value_slice, operands_slice, nullptr);
+    MergeOperator::MergeOperationOutput merge_out(result, result_operand);
+    merge_operator_->FullMergeV2(merge_in, &merge_out);
+
+    if (result_operand.data()) {
+      result.assign(result_operand.data(), result_operand.size());
     }
-
-    std::string FullMergeV2(std::string existing_value,
-                            std::vector<std::string> operands,
-                            std::string key = "") {
-      std::string result;
-      Slice result_operand(nullptr, 0);
-
-      Slice existing_value_slice(existing_value);
-      std::vector<Slice> operands_slice(operands.begin(), operands.end());
-
-      const MergeOperator::MergeOperationInput merge_in(
-        key, &existing_value_slice, operands_slice, nullptr);
-      MergeOperator::MergeOperationOutput merge_out(result, result_operand);
-      merge_operator_->FullMergeV2(merge_in, &merge_out);
-
-      if (result_operand.data()) {
-        result.assign(result_operand.data(), result_operand.size());
-      }
-      return result;
-    }
-
-    std::string FullMergeV2(std::vector<std::string> operands,
-                            std::string key = "") {
-      std::string result;
-      Slice result_operand(nullptr, 0);
-
-      std::vector<Slice> operands_slice(operands.begin(), operands.end());
-
-      const MergeOperator::MergeOperationInput merge_in(key, nullptr,
-                                                        operands_slice, nullptr);
-      MergeOperator::MergeOperationOutput merge_out(result, result_operand);
-      merge_operator_->FullMergeV2(merge_in, &merge_out);
-
-      if (result_operand.data()) {
-        result.assign(result_operand.data(), result_operand.size());
-      }
-      return result;
-    }
-
-    std::string PartialMerge(std::string left, std::string right,
-                             std::string key = "") {
-      std::string result;
-
-      merge_operator_->PartialMerge(key, left, right, &result, nullptr);
-      return result;
-    }
-
-    std::string PartialMergeMulti(std::deque<std::string> operands,
-                                  std::string key = "") {
-      std::string result;
-      std::deque<Slice> operands_slice(operands.begin(), operands.end());
-
-      merge_operator_->PartialMergeMulti(key, operands_slice, &result, nullptr);
-      return result;
-    }
-
-  protected:
-    std::shared_ptr<MergeOperator> merge_operator_;
-  };
-  TEST_F(UtilBytesAppendMergeOperatorTest, SubTest1) {
-    merge_operator_ = MergeOperators::CreateBytesAppendOperator();
-
-    EXPECT_EQ("BA", FullMergeV2("B", {"A"}));
-    EXPECT_EQ("AB", FullMergeV2("A", {"B"}));
-    EXPECT_EQ("", FullMergeV2({"", "", ""}));
-    EXPECT_EQ("A", FullMergeV2({"A"}));
-    EXPECT_EQ("ABC", FullMergeV2({"ABC"}));
-    EXPECT_EQ("ABCZCAXX", FullMergeV2({"ABC", "Z", "C", "AXX"}));
-    EXPECT_EQ("ABCCCZZZZ", FullMergeV2({"ABC", "CC", "Z", "ZZZ"}));
-    EXPECT_EQ("aABCCCZZZZ", FullMergeV2("a", {"ABC", "CC", "Z", "ZZZ"}));
-
-    EXPECT_EQ("azefqfqwgwewaazhhhhh", PartialMergeMulti({"a", "z", "efqfqwgwew", "aaz", "hhhhh"}));
-    EXPECT_EQ("ab", PartialMerge("a", "b"));
-    EXPECT_EQ("zazzz", PartialMerge("z", "azzz"));
-    EXPECT_EQ("a",PartialMerge("a", ""));
+    return result;
   }
+
+  std::string FullMergeV2(std::vector<std::string> operands,
+                          std::string key = "") {
+    std::string result;
+    Slice result_operand(nullptr, 0);
+
+    std::vector<Slice> operands_slice(operands.begin(), operands.end());
+
+    const MergeOperator::MergeOperationInput merge_in(key, nullptr,
+                                                      operands_slice, nullptr);
+    MergeOperator::MergeOperationOutput merge_out(result, result_operand);
+    merge_operator_->FullMergeV2(merge_in, &merge_out);
+
+    if (result_operand.data()) {
+      result.assign(result_operand.data(), result_operand.size());
+    }
+    return result;
+  }
+
+  std::string PartialMerge(std::string left, std::string right,
+                           std::string key = "") {
+    std::string result;
+
+    merge_operator_->PartialMerge(key, left, right, &result, nullptr);
+    return result;
+  }
+
+  std::string PartialMergeMulti(std::deque<std::string> operands,
+                                std::string key = "") {
+    std::string result;
+    std::deque<Slice> operands_slice(operands.begin(), operands.end());
+
+    merge_operator_->PartialMergeMulti(key, operands_slice, &result, nullptr);
+    return result;
+  }
+
+ protected:
+  std::shared_ptr<MergeOperator> merge_operator_;
+};
+
+// test case
+TEST_F(UtilBytesAppendMergeOperatorTest, SubTest1) {
+  merge_operator_ = MergeOperators::CreateBytesAppendOperator();
+
+  EXPECT_EQ("BA", FullMergeV2("B", {"A"}));
+  EXPECT_EQ("AB", FullMergeV2("A", {"B"}));
+  EXPECT_EQ("", FullMergeV2({"", "", ""}));
+  EXPECT_EQ("A", FullMergeV2({"A"}));
+  EXPECT_EQ("ABC", FullMergeV2({"ABC"}));
+  EXPECT_EQ("ABCZCAXX", FullMergeV2({"ABC", "Z", "C", "AXX"}));
+  EXPECT_EQ("ABCCCZZZZ", FullMergeV2({"ABC", "CC", "Z", "ZZZ"}));
+  EXPECT_EQ("aABCCCZZZZ", FullMergeV2("a", {"ABC", "CC", "Z", "ZZZ"}));
+
+  EXPECT_EQ("azefqfqwgwewaazhhhhh", PartialMergeMulti({"a", "z", "efqfqwgwew", "aaz", "hhhhh"}));
+  EXPECT_EQ("ab", PartialMerge("a", "b"));
+  EXPECT_EQ("zazzz", PartialMerge("z", "azzz"));
+  EXPECT_EQ("a",PartialMerge("a", ""));
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This pull request adds a merge operator for bytes append operation, append the bytes in the end of the value. If the value is empty, the merge operation just like put. 
motivation: if we want add some bytes in the end of the value which is a fixed length element ( e.x uint32)array, there's no need separator, because you know the size of the element. 
when we use the bytes append merge operator, it's same as adding an elements to the end of the value. When we want to get the elements, no need to convert the elements step by step, you can convert the pointer directly. 
More over, we may want to add the bytes just in the end of the value with no separator, it's also very efficient.