### PR TITLE
Create a Configurable base class for use in get/set values from properties and INI files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,6 +580,7 @@ set(SOURCES
         monitoring/thread_status_util.cc
         monitoring/thread_status_util_debug.cc
         options/cf_options.cc
+        options/configurable.cc
         options/db_options.cc
         options/options.cc
         options/options_helper.cc
@@ -963,6 +964,7 @@ if(WITH_TESTS)
         monitoring/iostats_context_test.cc
         monitoring/statistics_test.cc
         monitoring/stats_history_test.cc
+        options/configurable_test.cc
         options/options_settable_test.cc
         options/options_test.cc
         table/block_based/block_based_filter_block_test.cc

--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,7 @@ TESTS = \
 	fault_injection_test \
 	filelock_test \
 	filename_test \
+	file_reader_writer_test \
 	block_based_filter_block_test \
 	full_filter_block_test \
 	partitioned_filter_block_test \
@@ -524,6 +525,7 @@ TESTS = \
 	obsolete_files_test \
 	table_test \
 	delete_scheduler_test \
+	configurable_test \
 	options_test \
 	options_settable_test \
 	options_util_test \
@@ -579,7 +581,6 @@ PARALLEL_TEST = \
 	external_sst_file_test \
 	import_column_family_test \
 	fault_injection_test \
-	file_reader_writer_test \
 	inlineskiplist_test \
 	manual_compaction_test \
 	persistent_cache_test \
@@ -1501,6 +1502,9 @@ compact_files_test: db/compact_files_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 options_test: options/options_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+configurable_test: options/configurable_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 options_settable_test: options/options_settable_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -38,7 +38,7 @@ class DBOptionsTest : public DBTestBase {
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
     for (const auto opt : db_options_type_info) {
-      if (opt.second.is_mutable &&
+      if (opt.second.IsMutable() &&
           opt.second.verification != OptionVerificationType::kDeprecated) {
         mutable_map[opt.first] = options_map[opt.first];
       }
@@ -54,7 +54,7 @@ class DBOptionsTest : public DBTestBase {
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
     for (const auto opt : cf_options_type_info) {
-      if (opt.second.is_mutable &&
+      if (opt.second.IsMutable() &&
           opt.second.verification != OptionVerificationType::kDeprecated) {
         mutable_map[opt.first] = options_map[opt.first];
       }

--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -1,0 +1,495 @@
+
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "rocksdb/status.h"
+#include "rocksdb/utilities/options_type.h"
+
+namespace rocksdb {
+struct DBOptions;
+struct ColumnFamilyOptions;
+class Logger;
+struct OptionTypeInfo;
+typedef std::unordered_map<std::string, OptionTypeInfo> OptionTypeMap;
+
+/**
+ * Configurable is an is an base class used by the rocksdb that describes a
+ * standard way of configuring objects.  A Configurable object can:
+ *   -> Populate itself given:
+ *        - One or more "name/value" pair strings
+ *        - A string repesenting the set of name=value properties
+ *        - A map of name/value properties.
+ *   -> Convert itself into its string representation
+ *   -> Dump itself to a Logger
+ *   -> Compare itself to another Configurable object to see if the two objects
+ * are equivalent
+ *
+ * If a derived class calls RegisterOptionsMap to register (by name) how its
+ * options objects are to be processed, this functionality can typically be
+ * handled by this class without additional overrides. Otherwise, the derived
+ * class will need to implement the methods for handling the corresponding
+ * functionality.
+ *
+ * The Configurable class also provides hooks to validate the option values
+ * associated with it
+ *   - The SanitizeOptions method can be used to check and change any options
+ * required for validity
+ *   - The ValidateOptions method can be used to check (but not change the
+ * values) of the options. These two methods must be overridden by derived
+ * classes to implement class-specific validation.
+ */
+class Configurable {
+ protected:
+  static const std::string kDefaultPrefix /*  = "rocksdb." */;
+
+ private:
+#ifndef ROCKSDB_LITE
+  std::unordered_map<std::string, std::pair<void*, OptionTypeMap>> options_;
+#else
+  std::unordered_map<std::string, void*> options_;
+#endif  // ROCKSDB_LITE
+  bool is_mutable_;
+
+ protected:
+#ifndef ROCKSDB_LITE
+  Status DoConfigureFromMap(const DBOptions&,
+                            const std::unordered_map<std::string, std::string>&,
+                            bool input_strings_escaped,
+                            bool ignore_used_options,
+                            std::unordered_set<std::string>* unused);
+#endif  // ROCKSDB_LITE
+  /**
+   * To disambiguate options from different Configurable objects,configurations
+   * may specify a prefix. It is strongly recommended that derived classes
+   * override this method to some unique representative value.
+   */
+  virtual const std::string& GetOptionsPrefix() const { return kDefaultPrefix; }
+
+ public:
+  Configurable(bool is_mutable = false) : is_mutable_(is_mutable) {}
+  Configurable(const std::string& name, void* options,
+               const OptionTypeMap& opt_map, bool is_mutable = false)
+      : is_mutable_(is_mutable) {
+    RegisterOptionsMap(name, options, opt_map);
+  }
+  virtual ~Configurable() {}
+
+ public:  // Public API methods exposed by Configurable
+  /**
+   *  Attempts to make the local options valid for the specified DB Options
+   * and ColumnFamilyOptions. If necessary, this method can change values of
+   * itself or the DBOptions or the ColumnFamilyOptions (unlike
+   * ValidateOptions). After calling this method, the
+   * DBOptions/ColumnFamilyOptions should be valid. a non-ok Status will be
+   * returned.
+   */
+  Status SanitizeOptions();
+  Status SanitizeOptions(DBOptions& db_opts);
+  Status SanitizeOptions(DBOptions& db_opts, ColumnFamilyOptions& cf_opts);
+
+  /**
+   *  Validates the local options are valid for the specified DB Options
+   * and ColumnFamilyOptions. If the options are not valid,
+   * a non-ok Status will be returned.  This method cannot change its input
+   * arguments or the object itself.
+   */
+  Status ValidateOptions() const;
+  Status ValidateOptions(const DBOptions&) const;
+  Status ValidateOptions(const DBOptions& db_opts,
+                         const ColumnFamilyOptions& cf_opts) const;
+
+  /**
+   *  Prints the configuration object settings to the input Logger
+   */
+  void Dump(Logger* log, const std::string& indent,
+            uint32_t mode = OptionStringMode::kOptionNone) const {
+    DumpOptions(log, indent, mode);
+  }
+  void Dump(Logger* log, uint32_t mode = OptionStringMode::kOptionNone) const {
+    Dump(log, "              ", mode);
+  }
+
+  /**
+   *  Returns the raw pointer of the named options that is used by this
+   * object, or nullptr if this function is not supported.
+   * Since the return value is a raw pointer, the object owns the
+   * pointer and the caller should not delete the pointer.
+   *
+   * Note that changing the underlying options while the object
+   * is currently used by any open DB is undefined behavior.
+   * Developers should use DB::SetOption() instead to dynamically change
+   * options while the DB is open.
+   */
+  template <typename T>
+  const T* GetOptions(const std::string& name) const {
+    return reinterpret_cast<const T*>(GetOptionsPtr(name));
+  }
+  template <typename T>
+  T* GetOptions(const std::string& name) {
+    return reinterpret_cast<T*>(const_cast<void*>(GetOptionsPtr(name)));
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Configures the options for this extension based on the input parameters.
+   * Returns an OK status if configuration was successful.
+   * Parameters:
+   *   opt_map                 The name/value pair map of the options to set
+   *   opt_str                 String of name/value pairs of the options to set
+   *   input_strings_escaped   True if the strings are escaped (old-style?)
+   *   ignore_unusued_options  If true and there are any unused options,
+   *                           they will be ignored and OK will be returned
+   *   unused_opts             The set of any unused option names from the map
+   */
+  Status ConfigureFromMap(const DBOptions&,
+                          const std::unordered_map<std::string, std::string>&,
+                          bool input_strings_escaped = false,
+                          bool ignore_unused_options = false);
+  Status ConfigureFromMap(const DBOptions&,
+                          const std::unordered_map<std::string, std::string>&,
+                          bool input_strings_escaped,
+                          std::unordered_set<std::string>* unused);
+
+  Status ConfigureFromString(const DBOptions&, const std::string& opts,
+                             bool input_strings_escaped,
+                             std::unordered_set<std::string>* unused);
+#endif  // ROCKSDB_LITE
+
+  Status ConfigureFromString(const DBOptions&, const std::string& opts,
+                             bool input_strings_escaped = false,
+                             bool ignore_unused_options = false);
+
+  /**
+   *  Updates the named option to the input value, returning OK if successful.
+   * Parameters:
+   *     name                  The name of the option to update
+   *     value                 The value to set for the named option
+   * Returns:  OK              on success
+   *           NotFound        if the name is not a valid option
+   *           InvalidArgument if the value is valid for the named option
+   *           NotSupported    If the name/value is not supported
+   */
+  Status ConfigureOption(const DBOptions& db_opts, const std::string& name,
+                         const std::string& value,
+                         bool input_strings_escaped = false);
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Fills in result with the string representation of the configuration options
+   * Parameters:
+   *   result:                The returned string representation of the options
+   *   delimiter:             Separator between options in the string
+   *   mode:                  OR-ed together string mode options controlling how
+   * the options are returned
+   */
+  Status GetOptionString(std::string* result,
+                         const std::string& delimiter) const {
+    return GetOptionString(OptionStringMode::kOptionNone, result, delimiter);
+  }
+  Status GetOptionString(uint32_t mode, std::string* result,
+                         const std::string& delimiter) const;
+
+  // Returns the list of option names associated with this configurable
+  Status GetOptionNames(std::unordered_set<std::string>* result) const {
+    return GetOptionNames(OptionStringMode::kOptionShallow, result);
+  }
+
+  Status GetOptionNames(uint32_t mode,
+                        std::unordered_set<std::string>* result) const;
+  // Converts this object to a delimited-string
+  std::string ToString(uint32_t mode = OptionStringMode::kOptionNone,
+                       const std::string& delimiter = ";") const {
+    return ToString(mode, "", delimiter);
+  }
+
+  std::string ToString(const std::string& delimiter) const {
+    return ToString(OptionStringMode::kOptionNone, "", delimiter);
+  }
+  std::string ToString(uint32_t mode, const std::string& prefix,
+                       const std::string& delimiter) const;
+#endif  // ROCKSDB_LITE
+  /**
+   * Returns the value of the option associated with the input name
+   */
+  Status GetOption(const std::string& name, std::string* value) const;
+  /**
+   * Checks to see if this Configurable is equivalent to other.
+   * Level controls how pedantic the comparison must be for equivalency to be
+   achieved
+
+   */
+  bool Matches(const Configurable* other, OptionsSanityCheckLevel level) const;
+  bool Matches(const Configurable* other, OptionsSanityCheckLevel level,
+               std::string* name) const;
+
+ protected:  // Virtual functions that should be overridden by derived classes
+  virtual Status Validate(const DBOptions&, const ColumnFamilyOptions&) const;
+
+  virtual Status Sanitize(DBOptions& db_opts, ColumnFamilyOptions& cf_opts);
+  /**
+   * Returns the raw pointer for the associated named option.
+   */
+  virtual const void* GetOptionsPtr(const std::string& /* name */) const;
+
+  /**
+   * Returns a pointer to a map of name-sanity levels for the named option.
+   * This method allows a class to better control how the sanity check level of
+   * fields within the options are handled.  If no map is returned, the behavior
+   * depends on thetype of the option.
+   *
+   * This method returns a map (with names equivalent to the option map) for the
+   * named option. If no map is specified or the option name is not found in the
+   * map, the default behavior of the option type is used.  Otherwise, the
+   * returned option type will be used when checking for equivalence.
+   */
+  virtual const std::unordered_map<std::string, OptionsSanityCheckLevel>*
+  GetOptionsSanityCheckLevel(const std::string& /* name */) const {
+    return nullptr;
+  }
+  virtual OptionsSanityCheckLevel GetSanityLevelForOption(
+      const std::unordered_map<std::string, OptionsSanityCheckLevel>* map,
+      const std::string& name) const;
+
+ protected:  // Virtual functions that must be specified by functions not
+             // registering option maps.
+  /**
+   * Matches the input "other" object at the corresponding sanity level.
+   */
+  virtual bool MatchesOption(const Configurable* other,
+                             OptionsSanityCheckLevel level,
+                             std::string* name) const;
+  virtual Status ParseStringOptions(const DBOptions& /*db_opts */,
+                                    const std::string& options,
+                                    bool /*ignore_unused_options */,
+                                    bool /*input_strings_escaped */) {
+    return (options.empty())
+               ? Status::OK()
+               : Status::InvalidArgument("Cannot parse option: ", options);
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   *  Sets the name and value of a configurable object
+   * Sets found_option=true if the name matches a valid option for this object
+   * (false otherwise) Returns OK if the option was successfully updated or not
+   * found Returns a non-OK status if the name was found but the value was not
+   * valid
+   *
+   * Objects that have options that cannot be parsed by the typical means (via
+   * Maps and SetOption) should override this method,
+   */
+  virtual Status SetOption(const DBOptions& db_opts, const std::string& name,
+                           const std::string& value, bool input_strins_escaped,
+                           bool* found_option);
+  virtual Status ParseOption(const OptionTypeInfo& opt_info,
+                             const DBOptions& db_opts, void* opt_ptr,
+                             const std::string& opt_name,
+                             const std::string& opt_value,
+                             bool input_strings_escaped);
+  // Tests to see if the single option name/info matches for this and that
+  virtual bool OptionIsEqual(const std::string& name,
+                             const OptionTypeInfo& opt_info,
+                             OptionsSanityCheckLevel level,
+                             const char* this_option, const char* that_option,
+                             std::string* bad_name) const;
+  // If this and that do not match, use some other means to see if they
+  // might match (like checking the verification type).
+  virtual bool VerifyOptionEqual(const std::string& opt_name,
+                                 const OptionTypeInfo& opt_info,
+                                 const char* this_offset,
+                                 const char* that_offset) const;
+#endif
+  /**
+   * Dumps the values associated with this object to the logger.
+   */
+  virtual void DumpOptions(Logger* log, const std::string& indent,
+                           uint32_t mode) const;
+#ifndef ROCKSDB_LITE
+  virtual std::string AsString(uint32_t mode, const std::string& prefix,
+                               const std::string& delimiter) const;
+  /**
+   * Converts the options associated with this object into the result string.
+   * The options are separated by the input delimiter.
+   * The mode is a bitset that controls how the various options are printed
+   *   - If kOptionPrefix is set, the prefix is prepended to each option string;
+   *   - if kOptionShallow is set, nested configuration values are not included;
+   *   - if kOptionDeatched is set, nested configuration options are printed
+   * individually, otherwise, they are grouped inside "{ options }" Returns OK
+   * if the options could be succcessfully serialized, non-OK on failure
+   */
+  virtual Status SerializeOptions(uint32_t mode, std::string* result,
+                                  const std::string& prefix,
+                                  const std::string& delimiter) const;
+  virtual Status ListOptions(uint32_t mode, const std::string& prefix,
+                             std::unordered_set<std::string>* result) const;
+#endif  // ROCKSDB_LITE
+ protected:
+  // Returns printable options for dump
+  // If this method returns non-empty string, the result is used for dumping
+  // the options. If an empty string is returned, the registered options are
+  // used.
+  virtual std::string GetPrintableOptions() const { return ""; }
+  // Returns true if this configurable represents a mutable object
+  // Mutable classes should override this method.
+  virtual bool IsMutable() const { return is_mutable_; }
+  /**
+   *  Given a prefixed name (e.g. rocksdb.my.type.opt), returns the short name
+   * ("opt")
+   */
+  virtual std::string GetOptionName(const std::string& long_name) const;
+#ifndef ROCKSDB_LITE
+
+  Status SerializeOption(const std::string& opt_name,
+                         const OptionTypeInfo& opt_info, const char* opt_addr,
+                         uint32_t mode, std::string* opt_value,
+                         const std::string& prefix,
+                         const std::string& delimiter) const;
+
+  // Returns the offset of ptrfor the given option
+  // If the configurable is mutable, returns the mutable offset (if any).
+  // Otherwise returns the standard one
+  const char* GetOptAddress(const OptionTypeInfo& opt_info,
+                            const void* ptr) const {
+    if (!IsMutable()) {
+      return reinterpret_cast<const char*>(ptr) + opt_info.offset;
+    } else if (opt_info.IsMutable()) {
+      return reinterpret_cast<const char*>(ptr) + opt_info.mutable_offset;
+    } else {
+      return nullptr;
+    }
+  }
+
+  // Returns the offset of ptrfor the given option
+  // If the configurable is mutable, returns the mutable offset (if any).
+  // Otherwise returns the standard one
+  char* GetOptAddress(const OptionTypeInfo& opt_info, void* ptr) const {
+    if (!IsMutable()) {
+      return reinterpret_cast<char*>(ptr) + opt_info.offset;
+    } else if (opt_info.IsMutable()) {
+      return reinterpret_cast<char*>(ptr) + opt_info.mutable_offset;
+    } else {
+      return nullptr;
+    }
+  }
+
+  /**
+   * Returns the option info for the named option from the input map, or nullptr
+   * if not found.
+   */
+  OptionTypeMap::const_iterator FindOption(
+      const std::string& option, const OptionTypeMap& options_map) const;
+
+  /**
+   * Compares the options specified by this_option and that_option for
+   * equivalence, returning true if they match. This method looks at the options
+   * in the input opt_map and sees if the values in this_option and that_option
+   * are equivalent
+   *
+   * @param opt_map       The set of options to check
+   * @param sanity_level  How diligent the comparison must be for equivalence
+   * @param opt_level     Optional map specifying a sanity check level for the
+   * named options in opt_map.
+   * @param this_option   One option to compare
+   * @param that_option   The option to compare to
+   * @parm opt_name       If the method returns false, opt_name returns the name
+   *                      of the first option that failed to match.
+   */
+  bool OptionsAreEqual(
+      const OptionTypeMap& opt_map,
+      const std::unordered_map<std::string, OptionsSanityCheckLevel>* opt_level,
+      OptionsSanityCheckLevel sanity_check_level, const char* this_option,
+      const char* that_option, std::string* opt_name) const;
+  Status SerializeSingleOption(uint32_t mode, const std::string& name,
+                               std::string* value, bool* found_it) const;
+#endif  // ROCKSDB_LITE
+  /**
+   * Registers the input name with the options and associated map.
+   * When classes register their options in this manner, most of the
+   * functionality (excluding unknown options and validate/sanitize) is
+   * implemented by the base class.
+   *
+   * @param name    The name of this option (@see GetOptionsPtr)
+   * @param opt_ptr Pointer to the options to associate with this name
+   * @param opt_map Options map that controls how this option is configured.
+   */
+  void RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                          const OptionTypeMap& opt_map);
+
+  /**
+   * Serializes a single option, typically into "name=value" format.
+   * The actual representation is controlled by the mode parameter.
+   */
+  void PrintSingleOption(const std::string& prefix, const std::string& name,
+                         const std::string& value, const std::string& delimiter,
+                         std::string* result) const;
+
+ protected:
+  // Methods for dealing with unknown options, either of type "kUnknown",
+  // or not found in the map for some other reason
+
+  /**
+   * Sets the name and value of the configurable object of unknown type.
+   * Sets found_option=true if the name matches a valid option for this object
+   * Returns OK if the option was successfully updated or not found
+   * Returns a non-OK status if the name was found but the value was not valid
+   * Objects that have options that cannot be parsed by the typical means (via
+   * Maps and ParseOption) should override this method,
+   */
+  virtual Status SetUnknown(const DBOptions& /* db_opts */,
+                            const std::string& name,
+                            const std::string& /* value */) {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  virtual Status SetEnum(const DBOptions& /* db_opts */,
+                         const std::string& name,
+                         const std::string& /* value */, char* /* addr */) {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  /**
+   * Converts the unknown named option into its string form and returns that
+   * value in result.
+   */
+  virtual Status UnknownToString(uint32_t /* mode */, const std::string& name,
+                                 std::string* /*result */) const {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  virtual Status EnumToString(uint32_t /* mode */, const std::string& name,
+                              std::string* /*result */) const {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Compares to unknown options for equivalence.
+   */
+  virtual bool IsUnknownEqual(const std::string& /* opt_name */,
+                              const OptionTypeInfo& /* type_info */,
+                              OptionsSanityCheckLevel /* sanity_check_level */,
+                              const char* this_addr,
+                              const char* that_addr) const {
+    return this_addr == that_addr;
+  }
+
+  virtual bool IsEnumEqual(const std::string& /* opt_name */,
+                           const OptionTypeInfo& /* type_info */,
+                           OptionsSanityCheckLevel /* sanity_check_level */,
+                           const char* this_addr, const char* that_addr) const {
+    return this_addr == that_addr;
+  }
+
+  virtual bool IsConfigEqual(const std::string& opt_name,
+                             const OptionTypeInfo& opt_info,
+                             OptionsSanityCheckLevel level,
+                             const Configurable* this_config,
+                             const Configurable* that_config,
+                             std::string* mismatch) const;
+#endif
+};
+}  // namespace rocksdb

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+struct DBOptions;
+enum OptionsSanityCheckLevel : unsigned char {
+  // Performs no sanity check at all.
+  kSanityLevelNone = 0x00,
+  // Performs minimum check to ensure the RocksDB instance can be
+  // opened without corrupting / mis-interpreting the data.
+  kSanityLevelLooselyCompatible = 0x01,
+  // Perform exact match sanity check.
+  kSanityLevelExactMatch = 0xFF,
+};
+
+enum class OptionType {
+  kBoolean,
+  kInt,
+  kInt32T,
+  kInt64T,
+  kVectorInt,
+  kUInt,
+  kUInt32T,
+  kUInt64T,
+  kSizeT,
+  kString,
+  kDouble,
+  kCompactionStyle,
+  kCompactionPri,
+  kSliceTransform,
+  kCompressionType,
+  kCompressionOpts,
+  kVectorCompressionType,
+  kTableFactory,
+  kComparator,
+  kCompactionFilter,
+  kCompactionFilterFactory,
+  kCompactionOptionsFIFO,
+  kCompactionOptionsUniversal,
+  kCompactionStopStyle,
+  kMergeOperator,
+  kMemTableRepFactory,
+  kBlockBasedTableIndexType,
+  kBlockBasedTableDataBlockIndexType,
+  kBlockBasedTableIndexShorteningMode,
+  kFilterPolicy,
+  kFlushBlockPolicyFactory,
+  kChecksumType,
+  kEncodingType,
+  kWALRecoveryMode,
+  kAccessHint,
+  kInfoLogLevel,
+  kLRUCacheOptions,
+  kEnv,
+  kEnum,
+  kUnknown,
+};
+
+enum class OptionVerificationType {
+  kNormal,
+  kByName,               // The option is pointer typed so we can only verify
+                         // based on it's name.
+  kByNameAllowNull,      // Same as kByName, but it also allows the case
+                         // where one of them is a nullptr.
+  kByNameAllowFromNull,  // Same as kByName, but it also allows the case
+                         // where the old option is nullptr.
+  kDeprecated,           // The option is no longer used in rocksdb. The RocksDB
+                         // OptionsParser will still accept this option if it
+                         // happen to exists in some Options file.  However,
+                         // the parser will not include it in serialization
+                         // and verification processes.
+  kAlias                 // This option represents is a name/shortcut for
+                         // another option and should not be written or verified
+                         // independently
+};
+
+enum OptionTypeFlags {
+  kNone = 0x00,     // No flags
+  kMutable = 0x01,  // Option is mutable
+  kPointer = 0x02,  // The option is stored as a pointer
+  kShared = 0x04,   // The option is stored as a shared_ptr
+  kUnique = 0x08,   // The option is stored as a unique_ptr
+  kEnum = 0x10,     // The option represents an enumerated type
+  kMutableEnum = (kEnum | kMutable),  // Mutable enumerated type
+};
+
+// A struct for storing constant option information such as option name,
+// option type, and offset.
+struct OptionTypeInfo {
+  int offset;
+  OptionType type;
+  OptionVerificationType verification;
+  OptionTypeFlags flags;  // This is a bitmask of OptionTypeFlag values
+  int mutable_offset;
+
+  bool IsMutable() const {
+    return (flags & OptionTypeFlags::kMutable) == OptionTypeFlags::kMutable;
+  }
+  bool IsSharedPtr() const {
+    return (flags & OptionTypeFlags::kShared) == OptionTypeFlags::kShared;
+  }
+  bool IsUniquePtr() const {
+    return (flags & OptionTypeFlags::kUnique) == OptionTypeFlags::kUnique;
+  }
+  bool IsRawPtr() const {
+    return (flags & OptionTypeFlags::kPointer) == OptionTypeFlags::kPointer;
+  }
+
+  bool IsEnum() const {
+    return type == OptionType::kEnum ||
+           ((flags & OptionTypeFlags::kEnum) == OptionTypeFlags::kEnum);
+  }
+
+  template <typename T>
+  const T *GetPointer(const char *addr) const {
+    if (addr == nullptr) {
+      return nullptr;
+    } else if (IsUniquePtr()) {
+      const std::unique_ptr<T> *ptr =
+          reinterpret_cast<const std::unique_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsSharedPtr()) {
+      const std::shared_ptr<T> *ptr =
+          reinterpret_cast<const std::shared_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsRawPtr()) {
+      const T *const *ptr = reinterpret_cast<const T *const *>(addr);
+      return *ptr;
+    } else {
+      return reinterpret_cast<const T *>(addr);
+    }
+  }
+  template <typename T>
+  T *GetPointer(char *addr) const {
+    if (addr == nullptr) {
+      return nullptr;
+    } else if (IsUniquePtr()) {
+      std::unique_ptr<T> *ptr = reinterpret_cast<std::unique_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsSharedPtr()) {
+      std::shared_ptr<T> *ptr = reinterpret_cast<std::shared_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsRawPtr()) {
+      T **ptr = reinterpret_cast<T **>(addr);
+      return *ptr;
+    } else {
+      return reinterpret_cast<T *>(addr);
+    }
+  }
+};
+
+}  // namespace rocksdb

--- a/options/configurable.cc
+++ b/options/configurable.cc
@@ -1,0 +1,971 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/configurable.h"
+#include "options/options_helper.h"
+#include "options/options_parser.h"
+#include "rocksdb/status.h"
+#include "rocksdb/utilities/options_type.h"
+#include "util/string_util.h"
+
+namespace rocksdb {
+
+const std::string Configurable::kDefaultPrefix = "rocksdb.";
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Configuring Options from Strings/Name-Value Pairs/Maps */
+/*                                                                               */
+/*********************************************************************************/
+
+#ifndef ROCKSDB_LITE
+/**
+ * Updates the object with the named-value property values, returning OK on
+ * succcess. Any names properties that could not be found are returned in
+ * used_opts. Returns OK if all of the properties were successfully updated.
+ */
+Status Configurable::DoConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, bool ignore_unused_options,
+    std::unordered_set<std::string>* unused_opts) {
+  Status s, result, invalid;
+  bool found_one = false;
+  std::unordered_set<std::string> invalid_opts;
+  std::string curr_opts;
+  if (!ignore_unused_options) {
+    // If we are not ignoring unused, get the defaults in case we need to reset
+    GetOptionString(&curr_opts, ";");
+  }
+  // Go through all of the values in the input map and attempt to configure the
+  // property.
+  for (const auto& o : opts_map) {
+    s = ConfigureOption(db_opts, o.first, o.second, input_strings_escaped);
+    if (s.ok()) {
+      found_one = true;
+    } else if (s.IsNotFound()) {
+      result = s;
+      unused_opts->insert(o.first);
+    } else if (s.IsNotSupported()) {
+      invalid_opts.insert(o.first);
+    } else {
+      invalid_opts.insert(o.first);
+      invalid = s;
+    }
+  }
+  // While there are unused properties and we processed at least one,
+  // go through the remaining unused properties and attempt to configure them.
+  while (found_one && !unused_opts->empty()) {
+    result = Status::OK();
+    found_one = false;
+    for (auto it = unused_opts->begin(); it != unused_opts->end();) {
+      s = ConfigureOption(db_opts, *it, opts_map.at(*it),
+                          input_strings_escaped);
+      if (s.ok()) {
+        found_one = true;
+        it = unused_opts->erase(it);
+      } else if (s.IsNotFound()) {
+        result = s;
+        ++it;
+      } else if (s.IsNotSupported()) {
+        invalid_opts.insert(*it);
+        it = unused_opts->erase(it);
+      } else {
+        invalid_opts.insert(*it);
+        it = unused_opts->erase(it);
+        invalid = s;
+      }
+    }
+  }
+  if (!invalid_opts.empty()) {
+    unused_opts->insert(invalid_opts.begin(), invalid_opts.end());
+  }
+  if (ignore_unused_options || (invalid.ok() && result.ok())) {
+    return Status::OK();
+  } else {
+    if (!curr_opts.empty()) {
+      // There are some options to reset from this current error
+      ConfigureFromString(db_opts, curr_opts, input_strings_escaped, true);
+    }
+    if (!invalid.ok()) {
+      return invalid;
+    } else {
+      return result;
+    }
+  }
+}
+
+Status Configurable::ConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, bool ignore_unused_options) {
+  std::unordered_set<std::string> unused_opts;
+  Status s = DoConfigureFromMap(db_opts, opts_map, input_strings_escaped,
+                                ignore_unused_options, &unused_opts);
+  return s;
+}
+
+Status Configurable::ConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, std::unordered_set<std::string>* unused) {
+  return DoConfigureFromMap(db_opts, opts_map, input_strings_escaped, true,
+                            unused);
+}
+
+Status Configurable::ConfigureFromString(
+    const DBOptions& db_opts, const std::string& opt_str,
+    bool input_strings_escaped, std::unordered_set<std::string>* unused_opts) {
+  std::unordered_map<std::string, std::string> opt_map;
+  Status s = StringToMap(opt_str, &opt_map);
+  if (s.ok()) {
+    s = DoConfigureFromMap(db_opts, opt_map, input_strings_escaped, true,
+                           unused_opts);
+  }
+  return s;
+}
+#endif  // ROCKSDB_LITE
+
+Status Configurable::ConfigureFromString(const DBOptions& db_opts,
+                                         const std::string& opts_str,
+                                         bool input_strings_escaped,
+                                         bool ignore_unused_options) {
+  Status s;
+  if (!opts_str.empty()) {
+    if (opts_str.find(';') == std::string::npos &&
+        opts_str.find('=') == std::string::npos) {
+      return ParseStringOptions(db_opts, opts_str, input_strings_escaped,
+                                ignore_unused_options);
+    } else {
+#ifndef ROCKSDB_LITE
+      std::unordered_map<std::string, std::string> opt_map;
+      std::unordered_set<std::string> unused_opts;
+
+      s = StringToMap(opts_str, &opt_map);
+      if (s.ok()) {
+        s = DoConfigureFromMap(db_opts, opt_map, input_strings_escaped,
+                               ignore_unused_options, &unused_opts);
+      }
+#else
+      s = ParseStringOptions(db_opts, opts_str, input_strings_escaped,
+                             ignore_unused_options);
+#endif  // ROCKSDB_LITE
+    }
+  }
+  return s;
+}
+
+/**
+ * Sets the value of the named property to the input value, returning OK on
+ * succcess.
+ */
+Status Configurable::ConfigureOption(const DBOptions& db_opts,
+                                     const std::string& name,
+                                     const std::string& value,
+                                     bool input_strings_escaped) {
+  const std::string& option_name = GetOptionName(name);
+  const std::string& option_value =
+      input_strings_escaped ? UnescapeOptionString(value) : value;
+  bool found_it = false;
+  Status status;
+#ifndef ROCKSDB_LITE
+  status = SetOption(db_opts, option_name, option_value, input_strings_escaped,
+                     &found_it);
+#endif
+  if (!found_it) {
+    status = SetUnknown(db_opts, option_name, option_value);
+  }
+  return status;
+}
+
+/**
+ * Looks for the named option amongst the options for this type and sets
+ * the value for it to be the input value.
+ * If the name was found, found_option will be set to true and the resulting
+ * status should be returned.
+ */
+#ifndef ROCKSDB_LITE
+Status Configurable::SetOption(const DBOptions& db_opts,
+                               const std::string& name,
+                               const std::string& value,
+                               bool input_strings_escaped, bool* found_option) {
+  // By the time this method is called, the name is the short name (no prefix)
+  // and the value is unescaped.
+  Status status;
+  *found_option = false;
+  // Look for the name in all of the registered option maps until it is found
+  for (auto iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    // Look up the value in the map
+    auto opt_iter = FindOption(name, opt_map);
+    if (opt_iter != opt_map.end()) {
+      const auto& opt_info = opt_iter->second;
+      *found_option = true;
+      if (name == opt_iter->first) {
+        status = ParseOption(opt_info, db_opts, opt_ptr, name, value,
+                             input_strings_escaped);
+      } else {
+        status = ParseOption(opt_info, db_opts, opt_ptr,
+                             name.substr(opt_iter->first.size() + 1), value,
+                             input_strings_escaped);
+      }
+      if (status.IsNotFound()) {
+        *found_option = false;
+      }
+      return status;
+    } else {
+      for (auto map_iter : opt_map) {
+        if (map_iter.second.IsConfigurable()) {
+          char* opt_addr = GetOptAddress(map_iter.second, opt_ptr);
+          Configurable* config =
+              map_iter.second.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->ConfigureOption(db_opts, name, value);
+            if (!status.IsNotFound()) {
+              *found_option = true;
+              return status;
+            }
+          }
+        }  // End if config option
+      }
+    }
+  }
+  return status;
+}
+
+Status Configurable::ParseOption(const OptionTypeInfo& opt_info,
+                                 const DBOptions& db_opts, void* opt_ptr,
+                                 const std::string& opt_name,
+                                 const std::string& opt_value,
+                                 bool input_strings_escaped) {
+  Status status;
+  if (opt_info.verification != OptionVerificationType::kDeprecated) {
+    try {
+      char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr == nullptr) {
+        if (IsMutable()) {
+          return Status::InvalidArgument("Option not changeable: " + opt_name);
+        } else {
+          status = Status::NotFound("Could not find property:", opt_name);
+        }
+      } else if (opt_info.pfunc != nullptr) {
+        status = opt_info.pfunc(db_opts, opt_name, opt_addr, opt_value);
+      } else if (ParseOptionHelper(opt_addr, opt_info, opt_value)) {
+        status = Status::OK();
+      } else if (opt_info.IsConfigurable()) {
+        Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+        if (!opt_value.empty()) {
+          if (config == nullptr) {
+            status =
+                Status::NotFound("Could not find configurable: ", opt_name);
+          } else if (opt_value.find("=") != std::string::npos) {
+            status = config->ConfigureFromString(db_opts, opt_value,
+                                                 input_strings_escaped);
+          } else {
+            status = config->ConfigureOption(db_opts, opt_name, opt_value,
+                                             input_strings_escaped);
+          }
+        }
+      } else if (opt_info.IsEnum()) {
+        status = SetEnum(db_opts, opt_name, opt_value, opt_addr);
+      } else if (opt_info.type == OptionType::kUnknown) {
+        status = SetUnknown(db_opts, opt_name, opt_value);
+      } else if (opt_info.verification == OptionVerificationType::kByName ||
+                 opt_info.verification ==
+                     OptionVerificationType::kByNameAllowNull ||
+                 opt_info.verification ==
+                     OptionVerificationType::kByNameAllowFromNull) {
+        status = Status::NotSupported("Deserializing the option " + opt_name +
+                                      " is not supported");
+      } else {
+        status = Status::InvalidArgument("Error parsing:", opt_name);
+      }
+    } catch (std::exception& e) {
+      status = Status::InvalidArgument("Error parsing " + opt_name + ":" +
+                                       std::string(e.what()));
+    }
+  }
+  return status;
+}
+
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Converting Options into strings */
+/*                                                                               */
+/*********************************************************************************/
+
+#ifndef ROCKSDB_LITE
+std::string Configurable::ToString(uint32_t mode, const std::string& prefix,
+                                   const std::string& delimiter) const {
+  std::string result = AsString(mode, prefix, delimiter);
+  if (result.empty() || result.find('=') == std::string::npos) {
+    return result;
+  } else if ((mode & OptionStringMode::kOptionDetached) != 0) {
+    return result;
+  } else {
+    return "{" + result + "}";
+  }
+}
+
+std::string Configurable::AsString(uint32_t mode, const std::string& header,
+                                   const std::string& delimiter) const {
+  std::string result;
+  Status s = SerializeOptions(mode, &result, header, delimiter);
+  assert(s.ok());
+  return result;
+}
+
+Status Configurable::GetOptionString(uint32_t mode, std::string* result,
+                                     const std::string& delimiter) const {
+  assert(result);
+  result->clear();
+  Status s = SerializeOptions(mode, result, "", delimiter);
+  return s;
+}
+
+Status Configurable::GetOptionNames(
+    uint32_t mode, std::unordered_set<std::string>* result) const {
+  assert(result);
+  return ListOptions(mode, "", result);
+}
+
+#endif  // ROCKSDB_LITE
+
+Status Configurable::GetOption(const std::string& name,
+                               std::string* value) const {
+  assert(value);
+  value->clear();
+  Status status;
+  bool found_it = false;
+  const std::string& option_name = GetOptionName(name);
+
+#ifndef ROCKSDB_LITE
+  status = SerializeSingleOption(OptionStringMode::kOptionDetached, option_name,
+                                 value, &found_it);
+#endif
+  if (!found_it) {
+    status =
+        UnknownToString(OptionStringMode::kOptionDetached, option_name, value);
+  }
+  return status;
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::SerializeOption(const std::string& opt_name,
+                                     const OptionTypeInfo& opt_info,
+                                     const char* opt_addr, uint32_t mode,
+                                     std::string* opt_value,
+                                     const std::string& prefix,
+                                     const std::string& delimiter) const {
+  // If the option is no longer used in rocksdb and marked as deprecated,
+  // we skip it in the serialization.
+  Status s;
+  if (opt_addr != nullptr &&
+      opt_info.verification != OptionVerificationType::kDeprecated) {
+    if (opt_info.sfunc != nullptr) {
+      s = opt_info.sfunc(mode, opt_name, opt_addr, opt_value);
+    } else if (SerializeSingleOptionHelper(opt_addr, opt_info, opt_value)) {
+      s = Status::OK();
+    } else if (opt_info.IsConfigurable()) {
+      const Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+      if (config != nullptr) {
+        if ((mode & OptionStringMode::kOptionDetached) != 0) {
+          *opt_value = config->ToString(mode, prefix, delimiter);
+        } else {
+          *opt_value = config->ToString(mode, "", "; ");
+        }
+      }
+    } else if (opt_info.type == OptionType::kUnknown) {
+      s = UnknownToString(mode, opt_name, opt_value);
+    } else {
+      s = Status::InvalidArgument("Cannot serialize option: ", opt_name);
+    }
+  }
+  return s;
+}
+
+Status Configurable::SerializeOptions(uint32_t mode, std::string* result,
+                                      const std::string& prefix,
+                                      const std::string& delimiter) const {
+  assert(result);
+  auto header = ((mode & OptionStringMode::kOptionPrefix) != 0)
+                    ? GetOptionsPrefix()
+                    : prefix;
+  for (auto const iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+         ++opt_iter) {
+      const auto& opt_name = opt_iter->first;
+      const auto& opt_info = opt_iter->second;
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        std::string value;
+        Status s = SerializeOption(
+            opt_name, opt_info, opt_addr, mode, &value,
+            ((mode & OptionStringMode::kOptionDetached) != 0) ? opt_name + "."
+                                                              : header,
+            delimiter);
+        if (!s.ok()) {
+          return s;
+        } else if (!opt_info.IsConfigurable()) {
+          PrintSingleOption(header, opt_name, value, delimiter, result);
+        } else if ((mode & OptionStringMode::kOptionDetached) != 0) {
+          result->append(value);
+        } else if (!value.empty()) {
+          PrintSingleOption(header, opt_name, value, delimiter, result);
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Status Configurable::ListOptions(
+    uint32_t mode, const std::string& prefix,
+    std::unordered_set<std::string>* result) const {
+  Status status;
+  std::string header = ((mode & OptionStringMode::kOptionPrefix) != 0)
+                           ? GetOptionsPrefix() + prefix
+                           : prefix;
+  for (auto const iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+         ++opt_iter) {
+      const auto& opt_name = opt_iter->first;
+      const auto& opt_info = opt_iter->second;
+      // If the option is no longer used in rocksdb and marked as deprecated,
+      // we skip it in the serialization.
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr &&
+          opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          const Configurable* config =
+              opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->ListOptions(mode | OptionStringMode::kOptionPrefix,
+                                         prefix, result);
+          }
+        } else {
+          result->emplace(header + opt_name);
+        }
+      }
+      if (!status.ok()) {
+        return status;
+      }
+    }
+  }
+  return status;
+}
+
+Status Configurable::SerializeSingleOption(uint32_t mode,
+                                           const std::string& name,
+                                           std::string* value,
+                                           bool* found_it) const {
+  assert(value);
+  *found_it = false;
+  // By the time this method is called, the name is the short name (no prefix)
+  // and the value is unescaped.
+  // Look for the name in all of the registered option maps until it is found
+  for (auto iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    // Look up the value in the map
+    auto opt_iter = FindOption(name, opt_map);
+    if (opt_iter != opt_map.end()) {
+      const auto& opt_info = opt_iter->second;
+      *found_it = true;
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr) {
+        if (name == opt_iter->first) {
+          return SerializeOption(name, opt_info, opt_addr, mode, value, "",
+                                 ";");
+        } else if (opt_info.IsConfigurable()) {
+          auto const* config = opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            return config->GetOption(name.substr(opt_iter->first.size() + 1),
+                                     value);
+          }
+        }
+      }
+      return Status::NotFound("Cannot find option: ", name);
+    } else {
+      for (auto const map_iter : opt_map) {
+        if (map_iter.second.IsConfigurable()) {
+          const char* opt_addr = GetOptAddress(map_iter.second, opt_ptr);
+          auto const* config =
+              map_iter.second.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            Status status = config->GetOption(name, value);
+            if (!status.IsNotFound()) {
+              *found_it = true;
+              return status;
+            }
+          }
+        }
+      }
+    }
+  }
+  return Status::NotFound("Could not find option: ", name);
+}
+#endif  // ROCKSDB_LITE
+
+#ifndef ROCKSDB_LITE
+void Configurable::RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                                      const OptionTypeMap& opt_map) {
+  options_[name] = std::pair<void*, OptionTypeMap>(opt_ptr, opt_map);
+}
+#else
+void Configurable::RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                                      const OptionTypeMap&) {
+  options_[name] = opt_ptr;
+}
+#endif  // ROCKSDB_LITE
+
+void Configurable::PrintSingleOption(const std::string& prefix,
+                                     const std::string& name,
+                                     const std::string& value,
+                                     const std::string& delimiter,
+                                     std::string* result) const {
+  result->append(prefix);
+  result->append(name);  // Add the name
+  result->append("=");
+  result->append(value);
+  result->append(delimiter);
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Validating and Sanitizing Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+Status Configurable::SanitizeOptions() {
+  Options opts;
+  return Sanitize(opts, opts);
+}
+
+Status Configurable::SanitizeOptions(DBOptions& db_opts) {
+  ColumnFamilyOptions cf_opts;
+  return Sanitize(db_opts, cf_opts);
+}
+
+Status Configurable::SanitizeOptions(DBOptions& db_opts,
+                                     ColumnFamilyOptions& cf_opts) {
+  Status status = Sanitize(db_opts, cf_opts);
+  if (status.ok()) {
+    status = Validate(db_opts, cf_opts);
+  }
+  return status;
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::Sanitize(DBOptions& db_opts,
+                              ColumnFamilyOptions& cf_opts) {
+  Status status;
+  for (auto opt_iter : options_) {
+    const auto opt_map = opt_iter.second.second;
+    for (auto map_iter = opt_map.begin(); map_iter != opt_map.end();
+         ++map_iter) {
+      auto& opt_info = map_iter->second;
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          char* opt_addr = GetOptAddress(opt_info, opt_iter.second.first);
+          Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->Sanitize(db_opts, cf_opts);
+          } else if (opt_info.verification !=
+                     OptionVerificationType::kByNameAllowFromNull) {
+            status = Status::NotFound("Missing configurable object",
+                                      map_iter->first);
+          }
+          if (!status.ok()) {
+            return status;
+          }
+        }
+      }
+    }
+  }
+  return status;
+}
+#else
+Status Configurable::Sanitize(DBOptions&, ColumnFamilyOptions&) {
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
+Status Configurable::ValidateOptions() const {
+  Options opts;
+  return ValidateOptions(opts, opts);
+}
+
+Status Configurable::ValidateOptions(const DBOptions& db_opts) const {
+  ColumnFamilyOptions cf_opts;
+  return Validate(db_opts, cf_opts);
+}
+
+Status Configurable::ValidateOptions(const DBOptions& db_opts,
+                                     const ColumnFamilyOptions& cf_opts) const {
+  return Validate(db_opts, cf_opts);
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::Validate(const DBOptions& db_opts,
+                              const ColumnFamilyOptions& cf_opts) const {
+  Status status;
+  for (auto opt_iter : options_) {
+    const auto opt_map = opt_iter.second.second;
+    for (auto map_iter = opt_map.begin(); map_iter != opt_map.end();
+         ++map_iter) {
+      auto& opt_info = map_iter->second;
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          const char* opt_addr = GetOptAddress(opt_info, opt_iter.second.first);
+          const Configurable* config =
+              opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->Validate(db_opts, cf_opts);
+          } else if (opt_info.verification !=
+                     OptionVerificationType::kByNameAllowFromNull) {
+            status = Status::NotFound("Missing configurable object",
+                                      map_iter->first);
+          }
+          if (!status.ok()) {
+            return status;
+          }
+        }
+      }
+    }
+  }
+  return status;
+}
+#else
+Status Configurable::Validate(const DBOptions&,
+                              const ColumnFamilyOptions&) const {
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Comparing Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+bool Configurable::Matches(const Configurable* other,
+                           OptionsSanityCheckLevel level) const {
+  std::string name;
+  return Matches(other, level, &name);
+}
+
+bool Configurable::Matches(const Configurable* other,
+                           OptionsSanityCheckLevel level,
+                           std::string* name) const {
+  assert(name);
+  name->clear();
+  if (this == other || level == OptionsSanityCheckLevel::kSanityLevelNone) {
+    return true;
+  } else if (other != nullptr) {
+    return MatchesOption(other, level, name);
+  } else {
+    return false;
+  }
+}
+
+bool Configurable::MatchesOption(const Configurable* that,
+                                 OptionsSanityCheckLevel level,
+                                 std::string* name) const {
+  assert(name != nullptr);
+  if (this == that || level == OptionsSanityCheckLevel::kSanityLevelNone) {
+    return true;
+  } else {
+#ifndef ROCKSDB_LITE
+    for (auto const iter : options_) {
+      const char* this_option =
+          reinterpret_cast<const char*>(iter.second.first);
+      const char* that_option = that->GetOptions<const char>(iter.first);
+      if (!OptionsAreEqual(iter.second.second,
+                           GetOptionsSanityCheckLevel(iter.first), level,
+                           this_option, that_option, name)) {
+        return false;
+      }
+    }
+    return true;
+#endif  // ROCKSDB_LITE
+    return false;
+  }
+}
+
+OptionsSanityCheckLevel Configurable::GetSanityLevelForOption(
+    const std::unordered_map<std::string, OptionsSanityCheckLevel>* map,
+    const std::string& name) const {
+  if (map != nullptr) {
+    auto iter = map->find(name);
+    if (iter != map->end()) {
+      return iter->second;
+    }
+  }
+  return OptionsSanityCheckLevel::kSanityLevelExactMatch;
+}
+
+#ifndef ROCKSDB_LITE
+bool Configurable::VerifyOptionEqual(const std::string& opt_name,
+                                     const OptionTypeInfo& opt_info,
+                                     const char* this_offset,
+                                     const char* that_offset) const {
+  std::string this_value, that_value;
+
+  OptionStringMode mode = OptionStringMode::kOptionNone;
+  if (opt_info.verification != OptionVerificationType::kByName &&
+      opt_info.verification != OptionVerificationType::kByNameAllowNull &&
+      opt_info.verification != OptionVerificationType::kByNameAllowFromNull) {
+    return false;
+  } else if (opt_info.sfunc != nullptr) {
+    if (!opt_info.sfunc(mode, opt_name, this_offset, &this_value).ok() ||
+        !opt_info.sfunc(mode, opt_name, that_offset, &that_value).ok()) {
+      return false;
+    }
+  } else if (!SerializeOption(opt_name, opt_info, this_offset, mode,
+                              &this_value, "", ";")
+                  .ok() ||
+             !SerializeOption(opt_name, opt_info, that_offset, mode,
+                              &that_value, "", ";")
+                  .ok()) {
+    return false;
+  }
+  if (opt_info.verification == OptionVerificationType::kByNameAllowFromNull &&
+      that_value == kNullptrString) {
+    return true;
+  } else if (opt_info.verification ==
+                 OptionVerificationType::kByNameAllowNull &&
+             this_value == kNullptrString) {
+    return true;
+  } else if (this_value != that_value) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+bool Configurable::IsConfigEqual(const std::string& /* opt_name */,
+                                 const OptionTypeInfo& /* opt_info */,
+                                 OptionsSanityCheckLevel level,
+                                 const Configurable* this_config,
+                                 const Configurable* that_config,
+                                 std::string* mismatch) const {
+  if (this_config == that_config) {
+    return true;
+  } else if (this_config != nullptr && that_config != nullptr) {
+    return this_config->Matches(that_config, level, mismatch);
+  } else {
+    return false;
+  }
+}
+
+bool Configurable::OptionIsEqual(const std::string& opt_name,
+                                 const OptionTypeInfo& opt_info,
+                                 OptionsSanityCheckLevel level,
+                                 const char* this_offset,
+                                 const char* that_offset,
+                                 std::string* bad_name) const {
+  if (this_offset == nullptr || that_offset == nullptr) {
+    if (this_offset != that_offset) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.efunc != nullptr) {
+    return opt_info.efunc(level, opt_name, this_offset, that_offset);
+  } else if (IsOptionEqual(level, opt_info, this_offset, that_offset)) {
+    return true;
+  } else if (opt_info.type == OptionType::kUnknown) {
+    if (!IsUnknownEqual(opt_name, opt_info, level, this_offset, that_offset)) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.IsEnum()) {
+    if (!IsEnumEqual(opt_name, opt_info, level, this_offset, that_offset)) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.IsConfigurable()) {
+    std::string mismatch;
+    const auto* this_config = opt_info.GetPointer<Configurable>(this_offset);
+    const auto* that_config = opt_info.GetPointer<Configurable>(that_offset);
+    if (!IsConfigEqual(opt_name, opt_info, level, this_config, that_config,
+                       &mismatch)) {
+      *bad_name = opt_name;
+      if (!mismatch.empty()) {
+        bad_name->append("." + mismatch);
+      }
+      return false;
+    }
+  } else {
+    *bad_name = opt_name;
+    return false;
+  }
+  return true;
+}
+
+bool Configurable::OptionsAreEqual(
+    const OptionTypeMap& opt_map,
+    const std::unordered_map<std::string, OptionsSanityCheckLevel>* opt_level,
+    OptionsSanityCheckLevel sanity_check_level, const char* this_option,
+    const char* that_option, std::string* bad_name) const {
+  *bad_name = "";
+  if (this_option == that_option) {
+    return true;
+  } else if (this_option == nullptr || that_option == nullptr) {
+    return false;
+  } else {
+    for (auto& pair : opt_map) {
+      const auto& opt_info = pair.second;
+      // We skip checking deprecated variables as they might
+      // contain random values since they might not be initialized
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        OptionsSanityCheckLevel level =
+            GetSanityLevelForOption(opt_level, pair.first);
+        if (level > OptionsSanityCheckLevel::kSanityLevelNone &&
+            level <= sanity_check_level) {
+          const char* this_offset = GetOptAddress(opt_info, this_option);
+          const char* that_offset = GetOptAddress(opt_info, that_option);
+          if (!OptionIsEqual(pair.first, opt_info, level, this_offset,
+                             that_offset, bad_name) &&
+              !VerifyOptionEqual(pair.first, opt_info, this_offset,
+                                 that_offset)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+}
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Retrieving Options from Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+const void* Configurable::GetOptionsPtr(const std::string& name) const {
+  const auto& iter = options_.find(name);
+  if (iter != options_.end()) {
+#ifndef ROCKSDB_LITE
+    return iter->second.first;
+#else
+    return iter->second;
+#endif  // ROCKSDB_LITE
+  }
+  return nullptr;
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Logging Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+void Configurable::DumpOptions(Logger* logger, const std::string& indent,
+#ifndef ROCKSDB_LITE
+                               uint32_t mode
+#else
+                               uint32_t
+#endif  // ROCKSDB_LITE
+                               ) const {
+  std::string value = GetPrintableOptions();
+  if (!value.empty()) {
+    ROCKS_LOG_HEADER(logger, "%s Options: %s\n", indent.c_str(), value.c_str());
+  } else {
+#ifndef ROCKSDB_LITE
+    for (auto const iter : options_) {
+      std::string header = iter.first;
+      if ((mode & OptionStringMode::kOptionPrefix) != 0) {
+        header.append("::" + GetOptionsPrefix());
+      } else {
+        header.append(".");
+      }
+      const auto& opt_map = iter.second.second;
+      const void* opt_ptr = iter.second.first;
+
+      for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+           ++opt_iter) {
+        auto& opt_name = opt_iter->first;
+        auto& opt_info = opt_iter->second;
+        // If the option is no longer used in rocksdb and marked as deprecated,
+        // we skip it in the serialization.
+        const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+        if (opt_addr != nullptr &&
+            opt_info.verification != OptionVerificationType::kAlias) {
+          if (opt_info.IsConfigurable() &&
+              (mode & OptionStringMode::kOptionDetached) != 0) {
+            // Nested options on individual lines
+            const Configurable* config =
+                opt_info.GetPointer<Configurable>(opt_addr);
+            if (config != nullptr) {
+              ROCKS_LOG_HEADER(logger, "%s%s%s Options:\n", indent.c_str(),
+                               header.c_str(), opt_name.c_str());
+              config->Dump(logger, indent + "  ", mode);
+            }
+          } else {
+            Status s = SerializeOption(opt_name, opt_info, opt_addr, mode,
+                                       &value, "", ";");
+            if (s.ok()) {
+              ROCKS_LOG_HEADER(logger, "%s%s%s: %s\n", indent.c_str(),
+                               header.c_str(), opt_name.c_str(), value.c_str());
+            }
+          }
+        }
+      }
+    }
+#endif  // ROCKSDB_LITE
+  }
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Configurable Support and Utility Methods */
+/*                                                                               */
+/*********************************************************************************/
+
+std::string Configurable::GetOptionName(const std::string& long_name) const {
+  auto& prefix = GetOptionsPrefix();
+  auto prefix_len = prefix.length();
+  if (long_name.compare(0, prefix_len, prefix) == 0) {
+    return long_name.substr(prefix_len);
+  } else {
+    return long_name;
+  }
+}
+
+#ifndef ROCKSDB_LITE
+
+OptionTypeMap::const_iterator Configurable::FindOption(
+    const std::string& option, const OptionTypeMap& options_map) const {
+  auto iter = options_map.find(option);  // Look up the value in the map
+  if (iter == options_map.end()) {       // Didn't find the option in the map
+    auto idx = option.find(".");         // Look for a separator
+    if (idx > 0 && idx != std::string::npos) {  // We found a separator
+      auto siter =
+          options_map.find(option.substr(0, idx));  // Look for the short name
+      if (siter != options_map.end() &&             // We found the short name
+          siter->second.IsConfigurable()) {  // and the object is a configurable
+        return siter;                        // Return the short name value
+      }
+    }
+  }
+  return iter;
+}
+#endif  // ROCKSDB_LITE
+
+}  // namespace rocksdb

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "rocksdb/configurable.h"
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+struct DBOptions;
+
+#ifndef ROCKSDB_LITE
+// Wrapper class for configuring structs.
+// This class can be used to configure classes that
+// do not inherit from Configurable (such as structs)
+// and that do not need special handling of options
+template <typename T>
+class ConfigurableStruct : public Configurable {
+ public:
+  ConfigurableStruct(const T& options, const OptionTypeMap& opt_map,
+                     bool is_mutable = false)
+      : ConfigurableStruct(opt_map, is_mutable) {
+    options_ = options;
+  }
+
+  ConfigurableStruct(const OptionTypeMap& opt_map, bool is_mutable = false)
+      : Configurable("Options", &options_, opt_map, is_mutable) {}
+
+  const T* GetStructOptions() const { return &options_; }
+
+ private:
+  T options_;
+};
+#endif  // ROCKSDB_LITE
+}  // namespace rocksdb

--- a/options/configurable_test.cc
+++ b/options/configurable_test.cc
@@ -1,0 +1,864 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <cctype>
+#include <cinttypes>
+#include <cstring>
+#include <unordered_map>
+
+#include "rocksdb/configurable.h"
+
+#include "options/configurable_helper.h"
+#include "options/options_helper.h"
+#include "options/options_parser.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+#ifndef GFLAGS
+bool FLAGS_enable_print = false;
+#else
+#include "util/gflags_compat.h"
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+DEFINE_bool(enable_print, false, "Print options generated to console.");
+#endif  // GFLAGS
+
+namespace rocksdb {
+class StringLogger : public Logger {
+ public:
+  using Logger::Logv;
+  void Logv(const char* format, va_list ap) override {
+    char buffer[1000];
+    vsnprintf(buffer, sizeof(buffer), format, ap);
+    string_.append(buffer);
+  }
+  const std::string& str() const { return string_; }
+  void clear() { string_.clear(); }
+
+ private:
+  std::string string_;
+};
+
+struct SimpleOptions {
+  int i = 0;
+  bool b = false;
+  bool d = true;
+  std::string s = "";
+  std::string u = "";
+};
+
+static std::unordered_map<std::string, OptionTypeInfo> simple_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offsetof(struct SimpleOptions, i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bool",
+     {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offsetof(struct SimpleOptions, s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"unknown",
+     {offsetof(struct SimpleOptions, u), OptionType::kUnknown,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0,
+      [](const DBOptions& /*opts*/, const std::string& /* name */, char* addr,
+         const std::string& value) {
+        *reinterpret_cast<std::string*>(addr) = value;
+        return Status::OK();
+      },
+      [](uint32_t, const std::string&, const char* addr, std::string* value) {
+        *value = *reinterpret_cast<const std::string*>(addr);
+        return Status::OK();
+      },
+      [](OptionsSanityCheckLevel, const std::string&, const char* this_addr,
+         const char* that_addr) {
+        return (*reinterpret_cast<const std::string*>(this_addr) ==
+                *reinterpret_cast<const std::string*>(that_addr));
+      }}},
+#endif  // ROCKSDB_LITE
+};
+
+class SimpleConfigurable : public Configurable {
+ private:
+  std::string name_;
+  std::string prefix_;
+  std::shared_ptr<SimpleOptions> options_;
+  std::unordered_map<std::string, OptionTypeInfo> map_;
+
+ public:
+  SimpleConfigurable(const std::string& name,
+                     const std::shared_ptr<SimpleOptions>& options,
+                     const OptionTypeMap& map)
+      : name_(name), options_(options), map_(map) {
+    prefix_ = "test." + name + ".";
+    RegisterOptionsMap(name, options_.get(), map);
+  }
+
+ protected:
+  const std::string& GetOptionsPrefix() const override { return prefix_; }
+
+  Status SetUnknown(const DBOptions& opts, const std::string& name,
+                    const std::string& value) override {
+    if (name == "unknown") {
+      options_->u = value;
+      return Status::OK();
+    } else {
+      return Configurable::SetUnknown(opts, name, value);
+    }
+  }
+
+  Status Validate(const DBOptions& db_opts,
+                  const ColumnFamilyOptions& cf_opts) const override {
+    if (!options_->b) {
+      return Status::InvalidArgument("Sanitized must be true");
+    } else {
+      return Configurable::Validate(db_opts, cf_opts);
+    }
+  }
+
+  Status Sanitize(DBOptions& db_opts, ColumnFamilyOptions& cf_opts) override {
+    options_->b = true;
+    return Configurable::Sanitize(db_opts, cf_opts);
+  }
+
+  Status UnknownToString(uint32_t mode, const std::string& name,
+                         std::string* result) const override {
+    if (name == "unknown") {
+      if (!options_->u.empty()) {
+        *result = options_->u;
+      }
+      return Status::OK();
+    } else {
+      return Configurable::UnknownToString(mode, name, result);
+    }
+  }
+
+#ifndef ROCKSDB_LITE
+  bool IsUnknownEqual(const std::string& name, const OptionTypeInfo& type_info,
+                      OptionsSanityCheckLevel sanity_check_level,
+                      const char* this_addr,
+                      const char* that_addr) const override {
+    if (name == "unknown") {
+      return (*(reinterpret_cast<const std::string*>(this_addr)) ==
+              *(reinterpret_cast<const std::string*>(that_addr)));
+    } else {
+      return Configurable::IsUnknownEqual(name, type_info, sanity_check_level,
+                                          this_addr, that_addr);
+    }
+  }
+#endif
+};  // End class SimpleConfigurable
+
+static Configurable* NewSimpleConfigurable(const std::string& name = "simple") {
+  std::shared_ptr<SimpleOptions> options = std::make_shared<SimpleOptions>();
+  return new SimpleConfigurable(name, options, simple_option_info);
+}
+
+// A NestedOptions/Configurable has another Configurable as part of its options
+// (has-a)
+struct NestedOptions : public SimpleOptions {
+  NestedOptions(const std::string& inner, int mode) {
+    if (mode > 0) {
+      unique.reset(NewSimpleConfigurable(inner));
+    } else if (mode < 0) {
+      shared.reset(NewSimpleConfigurable(inner));
+    } else {
+      config = NewSimpleConfigurable(inner);
+    }
+  }
+
+  std::unique_ptr<Configurable> unique;
+  std::shared_ptr<Configurable> shared;
+  Configurable* config = nullptr;
+};
+
+static NestedOptions dummy_nested_options("inner", 1);
+
+template <typename T1>
+int offset_of(T1 SimpleOptions::*member) {
+  return int(size_t(&(dummy_nested_options.*member)) -
+             size_t(&dummy_nested_options));
+}
+
+template <typename T1>
+int offset_of(T1 NestedOptions::*member) {
+  return int(size_t(&(dummy_nested_options.*member)) -
+             size_t(&dummy_nested_options));
+}
+
+// A MutableOptions/Configurable has another Configurable as part of its options
+struct MutableOptions : public SimpleOptions {
+  MutableOptions() { unique.reset(NewSimpleConfigurable("mutable")); }
+  std::unique_ptr<Configurable> unique;
+};
+
+static MutableOptions dummy_mutable_options;
+
+template <typename T1>
+int offset_of(T1 MutableOptions::*member) {
+  return int(size_t(&(dummy_mutable_options.*member)) -
+             size_t(&dummy_mutable_options));
+}
+
+static OptionTypeMap nested_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offset_of(&NestedOptions::i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offset_of(&MutableOptions::i)}},
+    {"bool",
+     {offset_of(&NestedOptions::b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offset_of(&NestedOptions::s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"unique",
+     {offset_of(&NestedOptions::unique), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMConfigurableU,
+      offset_of(&MutableOptions::unique)}},
+    {"shared",
+     {offset_of(&NestedOptions::shared), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurableS, 0}},
+    {"config",
+     {offset_of(&NestedOptions::config), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurableP, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewNestedConfigurable(const std::string& outer,
+                                           const std::string& inner, int mode) {
+  std::shared_ptr<Configurable> result;
+  std::shared_ptr<NestedOptions> options =
+      std::make_shared<NestedOptions>(inner, mode);
+  return new SimpleConfigurable(outer, options, nested_option_info);
+}
+
+class MutableConfigurable : public SimpleConfigurable {
+ public:
+  MutableConfigurable(const std::string& name)
+      : SimpleConfigurable(name, std::make_shared<MutableOptions>(),
+                           nested_option_info) {}
+
+ protected:
+  bool IsMutable() const override { return true; }
+};
+
+struct EmbeddedOptions : public SimpleOptions {
+  EmbeddedOptions(const std::string& name = "embedded")
+      : embedded(name, std::make_shared<SimpleOptions>(), simple_option_info) {}
+  SimpleConfigurable embedded;
+};
+
+static EmbeddedOptions dummy_embedded_options;
+
+template <typename T1>
+int offset_of(T1 EmbeddedOptions::*member) {
+  return int(size_t(&(dummy_embedded_options.*member)) -
+             size_t(&dummy_embedded_options));
+}
+
+static OptionTypeMap embedded_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offset_of(&EmbeddedOptions::i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bool",
+     {offset_of(&EmbeddedOptions::b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offset_of(&EmbeddedOptions::s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"embedded",
+     {offset_of(&EmbeddedOptions::embedded), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurable, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewEmbeddedConfigurable(
+    const std::string& outer = "outer", const std::string& inner = "embedded") {
+  std::shared_ptr<EmbeddedOptions> options =
+      std::make_shared<EmbeddedOptions>(inner);
+  return new SimpleConfigurable(outer, options, embedded_option_info);
+}
+
+static OptionTypeMap inherited_option_info = {
+#ifndef ROCKSDB_LITE
+    {"outer.int",
+     {offsetof(struct SimpleOptions, i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"outer.bool",
+     {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"outer.string",
+     {offsetof(struct SimpleOptions, s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+// This is a class that extents a SimpleConfigurable (is-a)
+class InheritedConfigurable : public SimpleConfigurable {
+ private:
+  SimpleOptions outer_;
+
+ public:
+  InheritedConfigurable(const std::string& name, OptionTypeMap& map,
+                        const std::shared_ptr<SimpleOptions>& inner)
+      : SimpleConfigurable(name, inner, map) {
+    RegisterOptionsMap("outer", &outer_, inherited_option_info);
+  }
+
+  Status SetUnknown(const DBOptions& opts, const std::string& name,
+                    const std::string& value) override {
+    if (name == "outer.unknown") {
+      outer_.u = value;
+      return Status::OK();
+    } else {
+      return SimpleConfigurable::SetUnknown(opts, name, value);
+    }
+  }
+
+  Status UnknownToString(uint32_t mode, const std::string& name,
+                         std::string* result) const override {
+    if (name == "other.unknown") {
+      *result = outer_.u;
+      return Status::OK();
+    } else {
+      return SimpleConfigurable::UnknownToString(mode, name, result);
+    }
+  }
+
+#ifndef ROCKSDB_LITE
+  bool IsUnknownEqual(const std::string& name, const OptionTypeInfo& type_info,
+                      OptionsSanityCheckLevel sanity_check_level,
+                      const char* this_addr,
+                      const char* that_addr) const override {
+    if (name == "outer.unknown") {
+      return (*(reinterpret_cast<const std::string*>(this_addr)) ==
+              *(reinterpret_cast<const std::string*>(that_addr)));
+    } else {
+      return SimpleConfigurable::IsUnknownEqual(
+          name, type_info, sanity_check_level, this_addr, that_addr);
+    }
+  }
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewInheritedSimpleConfigurable(const std::string& name) {
+  std::shared_ptr<SimpleOptions> options = std::make_shared<SimpleOptions>();
+  return new InheritedConfigurable(name, simple_option_info, options);
+}
+
+static Configurable* NewInheritedNestedConfigurable(const std::string& inner,
+                                                    const std::string& nested,
+                                                    int mode) {
+  std::shared_ptr<NestedOptions> options =
+      std::make_shared<NestedOptions>(nested, mode);
+  return new InheritedConfigurable(inner, nested_option_info, options);
+}
+
+using ConfigTestFactoryFunc = std::function<Configurable*()>;
+
+class ConfigurableTest : public testing::Test {
+ public:
+  DBOptions db_opts_;
+};
+
+class ConfigurableParamTest
+    : public ConfigurableTest,
+      virtual public ::testing::WithParamInterface<
+          std::pair<std::string, ConfigTestFactoryFunc> > {
+ public:
+  ConfigurableParamTest() {
+    configuration_ = GetParam().first;
+    factory_ = GetParam().second;
+    object_.reset(factory_());
+  }
+  ConfigTestFactoryFunc factory_;
+  std::string configuration_;
+  std::unique_ptr<Configurable> object_;
+};
+
+TEST_F(ConfigurableTest, GetOptionsPtrTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_NE(configurable->GetOptions<SimpleOptions>("simple"), nullptr);
+  ASSERT_EQ(configurable->GetOptions<SimpleOptions>("bad-opt"), nullptr);
+}
+
+#ifndef ROCKSDB_LITE  // GetOptionsFromMap is not supported in ROCKSDB_LITE
+TEST_F(ConfigurableTest, ConfigureFromMapTest) {
+  std::unordered_map<std::string, std::string> options_map = {
+      {"int", "1"}, {"bool", "true"}, {"string", "string"}};
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(configurable->ConfigureFromMap(db_opts_, options_map));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->i, 1);
+  ASSERT_EQ(simple->b, true);
+  ASSERT_EQ(simple->s, "string");
+}
+
+TEST_F(ConfigurableTest, ConfigureFromStringTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "int=1;bool=true;string=s"));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->i, 1);
+  ASSERT_EQ(simple->b, true);
+  ASSERT_EQ(simple->s, "s");
+}
+
+TEST_F(ConfigurableTest, ConfigureFromOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_map<std::string, std::string> options_map = {{"unused", "u"}};
+  ASSERT_NOK(configurable->ConfigureFromMap(db_opts_, options_map));
+  ASSERT_OK(configurable->ConfigureFromMap(db_opts_, options_map, false, true));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "unused=u"));
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "unused=u", false, true));
+}
+
+TEST_F(ConfigurableTest, ConfigureUnusedOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_set<std::string> unused;
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "unused=u", false, &unused));
+  ASSERT_EQ(unused.size(), 1);
+  unused.clear();
+  ASSERT_OK(configurable->ConfigureOption(db_opts_, "int", "42"));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "int=u", false, &unused));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_OK(configurable->ConfigureFromString(db_opts_, "int=33;unused=u",
+                                              false, &unused));
+  ASSERT_EQ(simple->i, 33);
+}
+
+TEST_F(ConfigurableTest, ConfigureFromPropsTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "int=24;string=outer;unique={int=42;string=nested}"));
+  ASSERT_OK(simple->GetOptionString(
+      OptionStringMode::kOptionPrefix | OptionStringMode::kOptionDetached,
+      &opt_str, "\n"));
+  std::istringstream iss(opt_str);
+  std::unordered_map<std::string, std::string> copy_map;
+  std::string line;
+  for (int line_num = 0; std::getline(iss, line); line_num++) {
+    std::string name;
+    std::string value;
+    ASSERT_OK(
+        RocksDBOptionsParser::ParseStatement(&name, &value, line, line_num));
+    copy_map[name] = value;
+  }
+  std::unique_ptr<Configurable> copy(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(copy->ConfigureFromMap(db_opts_, copy_map));
+  ASSERT_TRUE(simple->Matches(copy.get(),
+                              OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_F(ConfigurableTest, GetOptionsTest) {
+  std::string value;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->ConfigureOption(db_opts_, "int", "24"));
+  ASSERT_OK(simple->GetOption("int", &value));
+  ASSERT_EQ(value, "24");
+
+  ASSERT_OK(simple->ConfigureOption(db_opts_, "string", "outer"));
+  ASSERT_OK(simple->GetOption("string", &value));
+  ASSERT_EQ(value, "outer");
+
+  ASSERT_OK(
+      simple->ConfigureOption(db_opts_, "unique", "int=42;string=nested"));
+  ASSERT_OK(simple->GetOption("unique", &value));
+  std::unordered_map<std::string, std::string> map;
+  ASSERT_OK(StringToMap(value, &map));
+  auto iter = map.find("int");
+  ASSERT_NE(iter, map.end());
+  ASSERT_EQ(iter->second, "42");
+  iter = map.find("string");
+  ASSERT_NE(iter, map.end());
+  ASSERT_EQ(iter->second, "nested");
+  ASSERT_OK(simple->GetOption("unique.int", &value));
+  ASSERT_EQ(value, "42");
+  ASSERT_OK(simple->GetOption("shared", &value));
+  ASSERT_EQ(value, "");  // There is a shared option, just no config
+  ASSERT_NOK(simple->GetOption("shared.int", &value));
+  ASSERT_NOK(simple->GetOption("unique.bad", &value));
+  ASSERT_NOK(simple->GetOption("bad option", &value));
+  ASSERT_TRUE(value.empty());
+}
+
+TEST_F(ConfigurableTest, GetOptionNamesTest) {
+  std::string value;
+  std::unordered_set<std::string> names;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->GetOptionString(
+      OptionStringMode::kOptionDetached | OptionStringMode::kOptionPrefix,
+      &value, "; "));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, value));
+  ASSERT_OK(simple->GetOptionNames(&names));
+  for (auto& n : names) {
+    ASSERT_OK(simple->GetOption(n, &value));
+  }
+  names.clear();
+  ASSERT_OK(simple->GetOptionNames(OptionStringMode::kOptionPrefix, &names));
+  for (auto& n : names) {
+    ASSERT_OK(simple->GetOption(n, &value));
+  }
+}
+
+TEST_F(ConfigurableTest, ConfigureBadOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(configurable->ConfigureOption(db_opts_, "int", "42"));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "int", "fred"));
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "bool", "fred"));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "int=33;unused=u"));
+  ASSERT_EQ(simple->i, 42);
+}
+
+TEST_F(ConfigurableTest, ConfigureMissingOptionsTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_NOK(simple->ConfigureFromString(db_opts_,
+                                         "unique={missing=42;string=nested}"));
+  ASSERT_NOK(simple->ConfigureFromString(
+      db_opts_, "unique.missing=42;unique.string=nested"));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "unique={missing=42;string=nested}", false, true));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "unique.missing=42;unique.string=nested", false, true));
+}
+
+TEST_F(ConfigurableTest, SetUnknownTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(configurable->ConfigureFromString(db_opts_, "unknown=u"));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->u, "u");
+  ASSERT_OK(configurable->GetOptionString(&opt_str, ";"));
+  std::unique_ptr<Configurable> copy(NewSimpleConfigurable());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  simple = copy->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->u, "u");
+}
+
+TEST_F(ConfigurableTest, InvalidOptionTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_map<std::string, std::string> options_map = {
+      {"bad-option", "bad"}};
+  ASSERT_NOK(configurable->ConfigureFromMap(db_opts_, options_map));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "bad-option=bad"));
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "bad-option", "bad"));
+}
+
+TEST_F(ConfigurableTest, ValidateOptionTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  DBOptions db_opts;
+  ColumnFamilyOptions cf_opts;
+  ASSERT_OK(configurable->ConfigureOption(db_opts, "bool", "false"));
+  ASSERT_NOK(configurable->ValidateOptions(db_opts, cf_opts));
+  ASSERT_OK(configurable->SanitizeOptions(db_opts, cf_opts));
+  ASSERT_OK(configurable->ValidateOptions(db_opts, cf_opts));
+}
+
+TEST_F(ConfigurableTest, DeprecatedOptionsTest) {
+  static std::unordered_map<std::string, OptionTypeInfo>
+      deprecated_option_info = {
+          {"deprecated",
+           {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+            OptionVerificationType::kDeprecated, OptionTypeFlags::kNone, 0}}};
+  std::unique_ptr<Configurable> orig(new SimpleConfigurable(
+      "simple", std::make_shared<SimpleOptions>(), deprecated_option_info));
+  SimpleOptions* simple = orig->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  simple->d = true;
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "deprecated", "false"));
+  ASSERT_TRUE(simple->d);
+  ASSERT_OK(orig->ConfigureFromString(db_opts_, "deprecated=false"));
+  ASSERT_TRUE(simple->d);
+}
+
+TEST_F(ConfigurableTest, AliasOptionsTest) {
+  static std::unordered_map<std::string, OptionTypeInfo> alias_option_info = {
+      {"bool",
+       {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+        OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+      {"alias",
+       {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+        OptionVerificationType::kAlias, OptionTypeFlags::kNone, 0}}};
+  std::unique_ptr<Configurable> orig(new SimpleConfigurable(
+      "simple", std::make_shared<SimpleOptions>(), alias_option_info));
+  SimpleOptions* simple = orig->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "alias", "true"));
+  ASSERT_TRUE(simple->b);
+  std::string opts_str;
+  ASSERT_OK(orig->GetOptionString(&opts_str, ";"));
+  ASSERT_EQ(opts_str.find("alias"), std::string::npos);
+
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "bool", "false"));
+  ASSERT_FALSE(simple->b);
+  ASSERT_OK(orig->GetOption("alias", &opts_str));
+  ASSERT_EQ(opts_str, "false");
+}
+
+TEST_F(ConfigurableTest, NestedUniqueConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->unique, nullptr);
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "unique={int=42;string=nested}"));
+  SimpleOptions* inner = outer->unique->GetOptions<SimpleOptions>("inner");
+  ASSERT_NE(inner, nullptr);
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+}
+
+TEST_F(ConfigurableTest, NestedSharedConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", -1));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "shared={int=42;string=nested}"));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->shared, nullptr);
+  SimpleOptions* inner = outer->shared->GetOptions<SimpleOptions>("inner");
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+}
+
+TEST_F(ConfigurableTest, NestedRawConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 0));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "config={int=42;string=nested}"));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->config, nullptr);
+  SimpleOptions* inner = outer->config->GetOptions<SimpleOptions>("inner");
+  ASSERT_NE(inner, nullptr);
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+  delete outer->config;
+}
+
+TEST_F(ConfigurableTest, MatchesTest) {
+  std::shared_ptr<NestedOptions> n1 =
+      std::make_shared<NestedOptions>("unique", 1);
+  n1->shared.reset(NewSimpleConfigurable("shared"));
+  std::shared_ptr<NestedOptions> n2 =
+      std::make_shared<NestedOptions>("unique", 1);
+  n2->shared.reset(NewSimpleConfigurable("shared"));
+
+  std::unique_ptr<Configurable> c1(
+      new SimpleConfigurable("outer", n1, nested_option_info));
+  std::unique_ptr<Configurable> c2(
+      new SimpleConfigurable("outer", n2, nested_option_info));
+
+  ASSERT_OK(c1->ConfigureFromString(
+      db_opts_,
+      "int=11;string=outer;unique={int=22;string=u};shared={int=33;string=s}"));
+  ASSERT_OK(c2->ConfigureFromString(
+      db_opts_,
+      "int=11;string=outer;unique={int=22;string=u};shared={int=33;string=s}"));
+  ASSERT_TRUE(
+      c1->Matches(c2.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(c2->ConfigureOption(db_opts_, "shared", "int=44"));
+  std::string mismatch;
+  ASSERT_FALSE(c1->Matches(
+      c2.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch, &mismatch));
+  ASSERT_EQ(mismatch, "shared.int");
+  std::string c1value, c2value;
+  ASSERT_OK(c1->GetOption(mismatch, &c1value));
+  ASSERT_OK(c2->GetOption(mismatch, &c2value));
+  ASSERT_NE(c1value, c2value);
+}
+
+TEST_F(ConfigurableTest, MutableOptionsTest) {
+  std::unique_ptr<Configurable> base(new MutableConfigurable("outer"));
+  std::string opt_str;
+  ASSERT_OK(
+      base->ConfigureOption(db_opts_, "int", "24"));  // This one is mutable
+  ASSERT_NOK(
+      base->ConfigureOption(db_opts_, "string", "s"));  // This one is not
+  ASSERT_OK(base->ConfigureOption(db_opts_, "unique", "int=42;string=nested"));
+  ASSERT_OK(base->GetOption("int", &opt_str));  // Can get the mutable option
+  ASSERT_NOK(base->GetOption("string", &opt_str));  // Cannot get this one
+  ASSERT_OK(
+      base->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  ASSERT_EQ(opt_str.find("test.outer.string"), std::string::npos);
+  std::unique_ptr<Configurable> copy(new MutableConfigurable("outer"));
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(base->Matches(copy.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  std::unique_ptr<Configurable> nested(
+      NewNestedConfigurable("outer", "mutable", 1));
+  ASSERT_OK(nested->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_FALSE(nested->Matches(
+      base.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_TRUE(base->Matches(nested.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(
+      nested->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  copy.reset(new MutableConfigurable("outer"));
+  ASSERT_NOK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str, false, true));
+  ASSERT_TRUE(copy->Matches(nested.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_F(ConfigurableTest, ConfigureStructTest) {
+  ConfigurableStruct<SimpleOptions> config(simple_option_info);
+  std::string opts_str;
+  ASSERT_OK(config.ConfigureFromString(db_opts_, "int=1;bool=true;string=s"));
+  ASSERT_EQ(config.GetStructOptions()->i, 1);
+  ASSERT_EQ(config.GetStructOptions()->b, true);
+  ASSERT_EQ(config.GetStructOptions()->s, "s");
+  ASSERT_OK(config.GetOptionString(&opts_str, ";"));
+  ConfigurableStruct<SimpleOptions> copy(simple_option_info);
+  ASSERT_OK(copy.ConfigureFromString(db_opts_, opts_str));
+  ASSERT_TRUE(
+      config.Matches(&copy, OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, GetOptionsStringTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(object_->GetOptionString(&opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, ConfigureDetachedOptionsTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(object_->GetOptionString(OptionStringMode::kOptionDetached,
+                                     &opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, OptionsPrefixTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(
+      object_->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(object_->GetOptionString(
+      OptionStringMode::kOptionPrefix | OptionStringMode::kOptionDetached,
+      &opt_str, ";"));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, DumpOptionsTest) {
+  std::string opt_str;
+  StringLogger logger;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  object_->Dump(&logger);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionDetached);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionPrefix);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionDetached |
+                             OptionStringMode::kOptionPrefix);
+}
+
+#endif  // !ROCKSDB_LITE
+
+static Configurable* SimpleFactory() { return NewSimpleConfigurable("simple"); }
+
+static Configurable* NestedUniqueFactory() {
+  return NewNestedConfigurable("simple", "unique", 1);
+}
+
+static Configurable* NestedSharedFactory() {
+  return NewNestedConfigurable("simple", "shared", -1);
+}
+
+static Configurable* EmbeddedFactory() {
+  return NewEmbeddedConfigurable("outer", "embedded");
+}
+
+static Configurable* InheritedSimpleFactory() {
+  return NewInheritedSimpleConfigurable("inner");
+}
+
+static Configurable* InheritedNestedUniqueFactory() {
+  return NewInheritedNestedConfigurable("inner", "unique", 1);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ParamTest, ConfigurableParamTest,
+    testing::Values(std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=42;bool=true;string=s", SimpleFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "unique={int=42;string=inner}",
+                        NestedUniqueFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "shared={int=42;string=inner}",
+                        NestedSharedFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "embedded={int=42;string=inner}",
+                        EmbeddedFactory),
+
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=42;bool=true;string=inner;"
+                        "outer.int=24;outer.bool=true;outer.string=outer",
+                        InheritedSimpleFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "outer.int=24;outer.bool=true;outer.string=other;"
+                        "int=33;bool=true;string=inner;"
+                        "unique={int=42;string=nested}",
+                        InheritedNestedUniqueFactory)));
+
+}  // namespace rocksdb
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+#ifdef GFLAGS
+  ParseCommandLineFlags(&argc, &argv, true);
+#endif  // GFLAGS
+  return RUN_ALL_TESTS();
+}

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -863,6 +863,10 @@ Status StringToMap(const std::string& opts_str,
   //              "nested_opt={opt1=1;opt2=2};max_bytes_for_level_base=100"
   size_t pos = 0;
   std::string opts = trim(opts_str);
+  // If the input string starts and ends with "{...}", strip off the brackets
+  while (opts.size() > 2 && opts[0] == '{' && opts[opts.size() - 1] == '}') {
+    opts = trim(opts.substr(1, opts.size() - 2));
+  }
   while (pos < opts.size()) {
     size_t eq_pos = opts.find('=', pos);
     if (eq_pos == std::string::npos) {

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -96,6 +96,9 @@ class RocksDBOptionsParser {
 
   static Status ExtraParserCheck(const RocksDBOptionsParser& input_parser);
 
+  static Status ParseStatement(std::string* name, std::string* value,
+                               const std::string& line, const int line_num);
+
  protected:
   bool IsSection(const std::string& line);
   Status ParseSection(OptionSection* section, std::string* title,
@@ -105,9 +108,6 @@ class RocksDBOptionsParser {
   Status CheckSection(const OptionSection section,
                       const std::string& section_arg, const int line_num);
 
-  Status ParseStatement(std::string* name, std::string* value,
-                        const std::string& line, const int line_num);
-
   Status EndSection(const OptionSection section, const std::string& title,
                     const std::string& section_arg,
                     const std::unordered_map<std::string, std::string>& opt_map,
@@ -115,7 +115,7 @@ class RocksDBOptionsParser {
 
   Status ValidityCheck();
 
-  Status InvalidArgument(const int line_num, const std::string& message);
+  static Status InvalidArgument(const int line_num, const std::string& message);
 
   Status ParseVersionNumber(const std::string& ver_name,
                             const std::string& ver_string, const int max_count,

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -37,9 +37,13 @@ Status PersistRocksDBOptions(const DBOptions& db_opt,
                              const std::vector<ColumnFamilyOptions>& cf_opts,
                              const std::string& file_name, Env* env);
 
+extern bool IsOptionEqual(OptionsSanityCheckLevel level,
+                          const OptionTypeInfo& opt_info, const char* offset1,
+                          const char* offset2);
+
 extern bool AreEqualOptions(
-    const char* opt1, const char* opt2, const OptionTypeInfo& type_info,
-    const std::string& opt_name,
+    OptionsSanityCheckLevel level, const char* opt1, const char* opt2,
+    const OptionTypeInfo& type_info, const std::string& opt_name,
     const std::unordered_map<std::string, std::string>* opt_map);
 
 class RocksDBOptionsParser {

--- a/options/options_sanity_check.h
+++ b/options/options_sanity_check.h
@@ -9,17 +9,10 @@
 #include <unordered_map>
 
 #ifndef ROCKSDB_LITE
+#include "rocksdb/utilities/options_type.h"
+
 namespace rocksdb {
 // This enum defines the RocksDB options sanity level.
-enum OptionsSanityCheckLevel : unsigned char {
-  // Performs no sanity check at all.
-  kSanityLevelNone = 0x00,
-  // Performs minimum check to ensure the RocksDB instance can be
-  // opened without corrupting / mis-interpreting the data.
-  kSanityLevelLooselyCompatible = 0x01,
-  // Perform exact match sanity check.
-  kSanityLevelExactMatch = 0xFF,
-};
 
 // The sanity check level for DB options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>

--- a/src.mk
+++ b/src.mk
@@ -99,6 +99,7 @@ LIB_SOURCES =                                                   \
   monitoring/thread_status_util.cc                              \
   monitoring/thread_status_util_debug.cc                        \
   options/cf_options.cc                                         \
+  options/configurable.cc                                       \
   options/db_options.cc                                         \
   options/options.cc                                            \
   options/options_helper.cc                                     \
@@ -360,6 +361,7 @@ MAIN_SOURCES =                                                          \
   monitoring/iostats_context_test.cc                                    \
   monitoring/statistics_test.cc                                         \
   monitoring/stats_history_test.cc                                      \
+  options/configurable_test.cc                                          \
   options/options_test.cc                                               \
   table/block_based/block_based_filter_block_test.cc                    \
   table/block_based/block_test.cc                                       \

--- a/table/block_based/block_based_table_factory.h
+++ b/table/block_based/block_based_table_factory.h
@@ -14,10 +14,9 @@
 #include <string>
 
 #include "db/dbformat.h"
-#include "options/options_helper.h"
-#include "options/options_parser.h"
 #include "rocksdb/flush_block_policy.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 
 namespace rocksdb {
 
@@ -92,104 +91,5 @@ extern Status VerifyBlockBasedTableFactory(
     const BlockBasedTableFactory* base_tf,
     const BlockBasedTableFactory* file_tf,
     OptionsSanityCheckLevel sanity_check_level);
-
-static std::unordered_map<std::string, OptionTypeInfo>
-    block_based_table_type_info = {
-        /* currently not supported
-          std::shared_ptr<Cache> block_cache = nullptr;
-          std::shared_ptr<Cache> block_cache_compressed = nullptr;
-         */
-        {"flush_block_policy_factory",
-         {offsetof(struct BlockBasedTableOptions, flush_block_policy_factory),
-          OptionType::kFlushBlockPolicyFactory, OptionVerificationType::kByName,
-          false, 0}},
-        {"cache_index_and_filter_blocks",
-         {offsetof(struct BlockBasedTableOptions,
-                   cache_index_and_filter_blocks),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"cache_index_and_filter_blocks_with_high_priority",
-         {offsetof(struct BlockBasedTableOptions,
-                   cache_index_and_filter_blocks_with_high_priority),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"pin_l0_filter_and_index_blocks_in_cache",
-         {offsetof(struct BlockBasedTableOptions,
-                   pin_l0_filter_and_index_blocks_in_cache),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"index_type",
-         {offsetof(struct BlockBasedTableOptions, index_type),
-          OptionType::kBlockBasedTableIndexType,
-          OptionVerificationType::kNormal, false, 0}},
-        {"hash_index_allow_collision",
-         {offsetof(struct BlockBasedTableOptions, hash_index_allow_collision),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"data_block_index_type",
-         {offsetof(struct BlockBasedTableOptions, data_block_index_type),
-          OptionType::kBlockBasedTableDataBlockIndexType,
-          OptionVerificationType::kNormal, false, 0}},
-        {"index_shortening",
-         {offsetof(struct BlockBasedTableOptions, index_shortening),
-          OptionType::kBlockBasedTableIndexShorteningMode,
-          OptionVerificationType::kNormal, false, 0}},
-        {"data_block_hash_table_util_ratio",
-         {offsetof(struct BlockBasedTableOptions,
-                   data_block_hash_table_util_ratio),
-          OptionType::kDouble, OptionVerificationType::kNormal, false, 0}},
-        {"checksum",
-         {offsetof(struct BlockBasedTableOptions, checksum),
-          OptionType::kChecksumType, OptionVerificationType::kNormal, false,
-          0}},
-        {"no_block_cache",
-         {offsetof(struct BlockBasedTableOptions, no_block_cache),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"block_size",
-         {offsetof(struct BlockBasedTableOptions, block_size),
-          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-        {"block_size_deviation",
-         {offsetof(struct BlockBasedTableOptions, block_size_deviation),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"index_block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, index_block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"index_per_partition",
-         {0, OptionType::kUInt64T, OptionVerificationType::kDeprecated, false,
-          0}},
-        {"metadata_block_size",
-         {offsetof(struct BlockBasedTableOptions, metadata_block_size),
-          OptionType::kUInt64T, OptionVerificationType::kNormal, false, 0}},
-        {"partition_filters",
-         {offsetof(struct BlockBasedTableOptions, partition_filters),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"filter_policy",
-         {offsetof(struct BlockBasedTableOptions, filter_policy),
-          OptionType::kFilterPolicy, OptionVerificationType::kByName, false,
-          0}},
-        {"whole_key_filtering",
-         {offsetof(struct BlockBasedTableOptions, whole_key_filtering),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"skip_table_builder_flush",
-         {0, OptionType::kBoolean, OptionVerificationType::kDeprecated, false,
-          0}},
-        {"format_version",
-         {offsetof(struct BlockBasedTableOptions, format_version),
-          OptionType::kUInt32T, OptionVerificationType::kNormal, false, 0}},
-        {"verify_compression",
-         {offsetof(struct BlockBasedTableOptions, verify_compression),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"read_amp_bytes_per_bit",
-         {offsetof(struct BlockBasedTableOptions, read_amp_bytes_per_bit),
-          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-        {"enable_index_compression",
-         {offsetof(struct BlockBasedTableOptions, enable_index_compression),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"block_align",
-         {offsetof(struct BlockBasedTableOptions, block_align),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"pin_top_level_index_and_filter",
-         {offsetof(struct BlockBasedTableOptions,
-                   pin_top_level_index_and_filter),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 #endif  // !ROCKSDB_LITE
 }  // namespace rocksdb

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -17,6 +17,7 @@
 
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
+#include "options/options_helper.h"
 
 #include "rocksdb/cache.h"
 #include "rocksdb/comparator.h"

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -17,6 +17,34 @@
 #include "util/string_util.h"
 
 namespace rocksdb {
+static std::unordered_map<std::string, OptionTypeInfo> plain_table_type_info = {
+    {"user_key_len",
+     {offsetof(struct PlainTableOptions, user_key_len), OptionType::kUInt32T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bloom_bits_per_key",
+     {offsetof(struct PlainTableOptions, bloom_bits_per_key), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"hash_table_ratio",
+     {offsetof(struct PlainTableOptions, hash_table_ratio), OptionType::kDouble,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"index_sparseness",
+     {offsetof(struct PlainTableOptions, index_sparseness), OptionType::kSizeT,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"huge_page_tlb_size",
+     {offsetof(struct PlainTableOptions, huge_page_tlb_size),
+      OptionType::kSizeT, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"encoding_type",
+     {offsetof(struct PlainTableOptions, encoding_type),
+      OptionType::kEncodingType, OptionVerificationType::kByName,
+      OptionTypeFlags::kEnum, 0}},
+    {"full_scan_mode",
+     {offsetof(struct PlainTableOptions, full_scan_mode), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"store_index_in_file",
+     {offsetof(struct PlainTableOptions, store_index_in_file),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}}};
 
 Status PlainTableFactory::NewTableReader(
     const TableReaderOptions& table_reader_options,
@@ -180,7 +208,7 @@ std::string ParsePlainTableOptions(const std::string& name,
   const auto& opt_info = iter->second;
   if (opt_info.verification != OptionVerificationType::kDeprecated &&
       !ParseOptionHelper(reinterpret_cast<char*>(new_options) + opt_info.offset,
-                         opt_info.type, value)) {
+                         opt_info, value)) {
     return "Invalid value";
   }
   return "";

--- a/table/plain/plain_table_factory.h
+++ b/table/plain/plain_table_factory.h
@@ -10,9 +10,9 @@
 #include <string>
 #include <stdint.h>
 
-#include "options/options_helper.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 
 namespace rocksdb {
 
@@ -192,32 +192,6 @@ class PlainTableFactory : public TableFactory {
  private:
   PlainTableOptions table_options_;
 };
-
-static std::unordered_map<std::string, OptionTypeInfo> plain_table_type_info = {
-    {"user_key_len",
-     {offsetof(struct PlainTableOptions, user_key_len), OptionType::kUInt32T,
-      OptionVerificationType::kNormal, false, 0}},
-    {"bloom_bits_per_key",
-     {offsetof(struct PlainTableOptions, bloom_bits_per_key), OptionType::kInt,
-      OptionVerificationType::kNormal, false, 0}},
-    {"hash_table_ratio",
-     {offsetof(struct PlainTableOptions, hash_table_ratio), OptionType::kDouble,
-      OptionVerificationType::kNormal, false, 0}},
-    {"index_sparseness",
-     {offsetof(struct PlainTableOptions, index_sparseness), OptionType::kSizeT,
-      OptionVerificationType::kNormal, false, 0}},
-    {"huge_page_tlb_size",
-     {offsetof(struct PlainTableOptions, huge_page_tlb_size),
-      OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-    {"encoding_type",
-     {offsetof(struct PlainTableOptions, encoding_type),
-      OptionType::kEncodingType, OptionVerificationType::kByName, false, 0}},
-    {"full_scan_mode",
-     {offsetof(struct PlainTableOptions, full_scan_mode), OptionType::kBoolean,
-      OptionVerificationType::kNormal, false, 0}},
-    {"store_index_in_file",
-     {offsetof(struct PlainTableOptions, store_index_in_file),
-      OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 
 }  // namespace rocksdb
 #endif  // ROCKSDB_LITE

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -264,6 +264,20 @@ std::string trim(const std::string& str) {
   return std::string();
 }
 
+bool EndsWith(const std::string& string, const std::string& pattern) {
+  size_t plen = pattern.size();
+  size_t slen = string.size();
+  if (plen <= slen) {
+    return string.compare(slen - plen, plen, pattern) == 0;
+  } else {
+    return false;
+  }
+}
+
+bool StartsWith(const std::string& string, const std::string& pattern) {
+  return string.compare(0, pattern.size(), pattern) == 0;
+}
+
 #ifndef ROCKSDB_LITE
 
 bool ParseBoolean(const std::string& type, const std::string& value) {

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -109,6 +109,12 @@ std::string UnescapeOptionString(const std::string& escaped_string);
 
 std::string trim(const std::string& str);
 
+// Returns true if "string" ends with "pattern"
+bool EndsWith(const std::string& string, const std::string& pattern);
+
+// Returns true if "string" starts with "pattern"
+bool StartsWith(const std::string& string, const std::string& pattern);
+
 #ifndef ROCKSDB_LITE
 bool ParseBoolean(const std::string& type, const std::string& value);
 


### PR DESCRIPTION
This change adds a new Configurable class.  A Configurable object can:
- Be populated by ConfigureFromString or ConfigureFromMap
- Have individual fields updated, via ConfigureOption
- Convert itself into a string suitable for storing in initialization files (GetOptionsString)
- Dump its properties to a Logger
- See if it matches another Configurable (Matches)
- Check/Change its settings if they are not proper (SanitizeOptions)
- Verify that it settings are valid (VerifyOptions)
- Return a pointer to the underlying options object (GetOptions)

The Configurable class uses an OptionsTypeMap (map<string, OptionTypeInfo) in order to implement this functionality.  

The code for this class is based on the code for configuring a TableFactory instance.  A follow-on PR will show this code being used by the TableFactory class.

Any class can be a Configurable simply by inheritance.  By registering an OptionsTypeMap with the base implementation, the object will automatically gain the Configurable functionality.  If no map is registered, the class will behave as it does today (the methods will do nothing).