### PR TITLE
Make the TableFactory into a Configurable object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,6 +580,7 @@ set(SOURCES
         monitoring/thread_status_util.cc
         monitoring/thread_status_util_debug.cc
         options/cf_options.cc
+        options/configurable.cc
         options/db_options.cc
         options/options.cc
         options/options_helper.cc
@@ -963,6 +964,7 @@ if(WITH_TESTS)
         monitoring/iostats_context_test.cc
         monitoring/statistics_test.cc
         monitoring/stats_history_test.cc
+        options/configurable_test.cc
         options/options_settable_test.cc
         options/options_test.cc
         table/block_based/block_based_filter_block_test.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,7 @@ set(SOURCES
         table/plain/plain_table_reader.cc
         table/sst_file_reader.cc
         table/sst_file_writer.cc
+        table/table_factory.cc
         table/table_properties.cc
         table/two_level_iterator.cc
         test_util/sync_point.cc

--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,7 @@ TESTS = \
 	fault_injection_test \
 	filelock_test \
 	filename_test \
+	file_reader_writer_test \
 	block_based_filter_block_test \
 	full_filter_block_test \
 	partitioned_filter_block_test \
@@ -524,6 +525,7 @@ TESTS = \
 	obsolete_files_test \
 	table_test \
 	delete_scheduler_test \
+	configurable_test \
 	options_test \
 	options_settable_test \
 	options_util_test \
@@ -579,7 +581,6 @@ PARALLEL_TEST = \
 	external_sst_file_test \
 	import_column_family_test \
 	fault_injection_test \
-	file_reader_writer_test \
 	inlineskiplist_test \
 	manual_compaction_test \
 	persistent_cache_test \
@@ -1501,6 +1502,9 @@ compact_files_test: db/compact_files_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 options_test: options/options_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+configurable_test: options/configurable_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 options_settable_test: options/options_settable_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1166,7 +1166,8 @@ Status ColumnFamilyData::ValidateOptions(
           "TTL is only supported when files are always "
           "kept open (set max_open_files = -1). ");
     }
-    if (cf_options.table_factory->Name() != BlockBasedTableFactory().Name()) {
+    if (cf_options.table_factory->Name() !=
+        TableFactory::kBlockBasedTableName) {
       return Status::NotSupported(
           "TTL is only supported in Block-Based Table format. ");
     }
@@ -1178,7 +1179,8 @@ Status ColumnFamilyData::ValidateOptions(
           "Periodic Compaction is only supported when files are always "
           "kept open (set max_open_files = -1). ");
     }
-    if (cf_options.table_factory->Name() != BlockBasedTableFactory().Name()) {
+    if (cf_options.table_factory->Name() !=
+        TableFactory::kBlockBasedTableName) {
       return Status::NotSupported(
           "Periodic Compaction is only supported in "
           "Block-Based Table format. ");

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -167,7 +167,7 @@ Status SanitizeOptionsByTable(
     const std::vector<ColumnFamilyDescriptor>& column_families) {
   Status s;
   for (auto cf : column_families) {
-    s = cf.options.table_factory->SanitizeOptions(db_opts, cf.options);
+    s = cf.options.table_factory->ValidateOptions(db_opts, cf.options);
     if (!s.ok()) {
       return s;
     }

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -38,7 +38,7 @@ class DBOptionsTest : public DBTestBase {
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
     for (const auto opt : db_options_type_info) {
-      if (opt.second.is_mutable &&
+      if (opt.second.IsMutable() &&
           opt.second.verification != OptionVerificationType::kDeprecated) {
         mutable_map[opt.first] = options_map[opt.first];
       }
@@ -54,7 +54,7 @@ class DBOptionsTest : public DBTestBase {
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
     for (const auto opt : cf_options_type_info) {
-      if (opt.second.is_mutable &&
+      if (opt.second.IsMutable() &&
           opt.second.verification != OptionVerificationType::kDeprecated) {
         mutable_map[opt.first] = options_map[opt.first];
       }

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -52,12 +52,12 @@ class DBOptionsTest : public DBTestBase {
     GetStringFromColumnFamilyOptions(&options_str, options);
     std::unordered_map<std::string, std::string> options_map;
     StringToMap(options_str, &options_map);
+
     std::unordered_map<std::string, std::string> mutable_map;
-    for (const auto opt : cf_options_type_info) {
-      if (opt.second.IsMutable() &&
-          opt.second.verification != OptionVerificationType::kDeprecated) {
-        mutable_map[opt.first] = options_map[opt.first];
-      }
+    std::unordered_set<std::string> mutable_names;
+    GetColumnFamilyOptionNames(&mutable_names, true);
+    for (const auto opt : mutable_names) {
+      mutable_map[opt] = options_map[opt];
     }
     return mutable_map;
   }

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2420,11 +2420,11 @@ TEST_F(DBTest2, OptimizeForSmallDB) {
   options.OptimizeForSmallDb();
 
   // Find the cache object
-  ASSERT_EQ(std::string(BlockBasedTableFactory::kName),
+  ASSERT_EQ(std::string(TableFactory::kBlockBasedTableName),
             std::string(options.table_factory->Name()));
-  BlockBasedTableOptions* table_options =
-      reinterpret_cast<BlockBasedTableOptions*>(
-          options.table_factory->GetOptions());
+  auto* table_options =
+      options.table_factory->GetOptions<BlockBasedTableOptions>(
+          TableFactory::kBlockBasedTableOpts);
   ASSERT_TRUE(table_options != nullptr);
   std::shared_ptr<Cache> cache = table_options->block_cache;
 

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -896,19 +896,8 @@ bool InternalStats::HandleBlockCacheStat(Cache** block_cache) {
   assert(block_cache != nullptr);
   auto* table_factory = cfd_->ioptions()->table_factory;
   assert(table_factory != nullptr);
-  if (BlockBasedTableFactory::kName != table_factory->Name()) {
-    return false;
-  }
-  auto* table_options =
-      reinterpret_cast<BlockBasedTableOptions*>(table_factory->GetOptions());
-  if (table_options == nullptr) {
-    return false;
-  }
-  *block_cache = table_options->block_cache.get();
-  if (table_options->no_block_cache || *block_cache == nullptr) {
-    return false;
-  }
-  return true;
+  *block_cache = table_factory->GetOptions<Cache>("BlockCache");
+  return *block_cache != nullptr;
 }
 
 bool InternalStats::HandleBlockCacheCapacity(uint64_t* value, DBImpl* /*db*/,

--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -1,0 +1,495 @@
+
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "rocksdb/status.h"
+#include "rocksdb/utilities/options_type.h"
+
+namespace rocksdb {
+struct DBOptions;
+struct ColumnFamilyOptions;
+class Logger;
+struct OptionTypeInfo;
+typedef std::unordered_map<std::string, OptionTypeInfo> OptionTypeMap;
+
+/**
+ * Configurable is an is an base class used by the rocksdb that describes a
+ * standard way of configuring objects.  A Configurable object can:
+ *   -> Populate itself given:
+ *        - One or more "name/value" pair strings
+ *        - A string repesenting the set of name=value properties
+ *        - A map of name/value properties.
+ *   -> Convert itself into its string representation
+ *   -> Dump itself to a Logger
+ *   -> Compare itself to another Configurable object to see if the two objects
+ * are equivalent
+ *
+ * If a derived class calls RegisterOptionsMap to register (by name) how its
+ * options objects are to be processed, this functionality can typically be
+ * handled by this class without additional overrides. Otherwise, the derived
+ * class will need to implement the methods for handling the corresponding
+ * functionality.
+ *
+ * The Configurable class also provides hooks to validate the option values
+ * associated with it
+ *   - The SanitizeOptions method can be used to check and change any options
+ * required for validity
+ *   - The ValidateOptions method can be used to check (but not change the
+ * values) of the options. These two methods must be overridden by derived
+ * classes to implement class-specific validation.
+ */
+class Configurable {
+ protected:
+  static const std::string kDefaultPrefix /*  = "rocksdb." */;
+
+ private:
+#ifndef ROCKSDB_LITE
+  std::unordered_map<std::string, std::pair<void*, OptionTypeMap>> options_;
+#else
+  std::unordered_map<std::string, void*> options_;
+#endif  // ROCKSDB_LITE
+  bool is_mutable_;
+
+ protected:
+#ifndef ROCKSDB_LITE
+  Status DoConfigureFromMap(const DBOptions&,
+                            const std::unordered_map<std::string, std::string>&,
+                            bool input_strings_escaped,
+                            bool ignore_used_options,
+                            std::unordered_set<std::string>* unused);
+#endif  // ROCKSDB_LITE
+  /**
+   * To disambiguate options from different Configurable objects,configurations
+   * may specify a prefix. It is strongly recommended that derived classes
+   * override this method to some unique representative value.
+   */
+  virtual const std::string& GetOptionsPrefix() const { return kDefaultPrefix; }
+
+ public:
+  Configurable(bool is_mutable = false) : is_mutable_(is_mutable) {}
+  Configurable(const std::string& name, void* options,
+               const OptionTypeMap& opt_map, bool is_mutable = false)
+      : is_mutable_(is_mutable) {
+    RegisterOptionsMap(name, options, opt_map);
+  }
+  virtual ~Configurable() {}
+
+ public:  // Public API methods exposed by Configurable
+  /**
+   *  Attempts to make the local options valid for the specified DB Options
+   * and ColumnFamilyOptions. If necessary, this method can change values of
+   * itself or the DBOptions or the ColumnFamilyOptions (unlike
+   * ValidateOptions). After calling this method, the
+   * DBOptions/ColumnFamilyOptions should be valid. a non-ok Status will be
+   * returned.
+   */
+  Status SanitizeOptions();
+  Status SanitizeOptions(DBOptions& db_opts);
+  Status SanitizeOptions(DBOptions& db_opts, ColumnFamilyOptions& cf_opts);
+
+  /**
+   *  Validates the local options are valid for the specified DB Options
+   * and ColumnFamilyOptions. If the options are not valid,
+   * a non-ok Status will be returned.  This method cannot change its input
+   * arguments or the object itself.
+   */
+  Status ValidateOptions() const;
+  Status ValidateOptions(const DBOptions&) const;
+  Status ValidateOptions(const DBOptions& db_opts,
+                         const ColumnFamilyOptions& cf_opts) const;
+
+  /**
+   *  Prints the configuration object settings to the input Logger
+   */
+  void Dump(Logger* log, const std::string& indent,
+            uint32_t mode = OptionStringMode::kOptionNone) const {
+    DumpOptions(log, indent, mode);
+  }
+  void Dump(Logger* log, uint32_t mode = OptionStringMode::kOptionNone) const {
+    Dump(log, "              ", mode);
+  }
+
+  /**
+   *  Returns the raw pointer of the named options that is used by this
+   * object, or nullptr if this function is not supported.
+   * Since the return value is a raw pointer, the object owns the
+   * pointer and the caller should not delete the pointer.
+   *
+   * Note that changing the underlying options while the object
+   * is currently used by any open DB is undefined behavior.
+   * Developers should use DB::SetOption() instead to dynamically change
+   * options while the DB is open.
+   */
+  template <typename T>
+  const T* GetOptions(const std::string& name) const {
+    return reinterpret_cast<const T*>(GetOptionsPtr(name));
+  }
+  template <typename T>
+  T* GetOptions(const std::string& name) {
+    return reinterpret_cast<T*>(const_cast<void*>(GetOptionsPtr(name)));
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Configures the options for this extension based on the input parameters.
+   * Returns an OK status if configuration was successful.
+   * Parameters:
+   *   opt_map                 The name/value pair map of the options to set
+   *   opt_str                 String of name/value pairs of the options to set
+   *   input_strings_escaped   True if the strings are escaped (old-style?)
+   *   ignore_unusued_options  If true and there are any unused options,
+   *                           they will be ignored and OK will be returned
+   *   unused_opts             The set of any unused option names from the map
+   */
+  Status ConfigureFromMap(const DBOptions&,
+                          const std::unordered_map<std::string, std::string>&,
+                          bool input_strings_escaped = false,
+                          bool ignore_unused_options = false);
+  Status ConfigureFromMap(const DBOptions&,
+                          const std::unordered_map<std::string, std::string>&,
+                          bool input_strings_escaped,
+                          std::unordered_set<std::string>* unused);
+
+  Status ConfigureFromString(const DBOptions&, const std::string& opts,
+                             bool input_strings_escaped,
+                             std::unordered_set<std::string>* unused);
+#endif  // ROCKSDB_LITE
+
+  Status ConfigureFromString(const DBOptions&, const std::string& opts,
+                             bool input_strings_escaped = false,
+                             bool ignore_unused_options = false);
+
+  /**
+   *  Updates the named option to the input value, returning OK if successful.
+   * Parameters:
+   *     name                  The name of the option to update
+   *     value                 The value to set for the named option
+   * Returns:  OK              on success
+   *           NotFound        if the name is not a valid option
+   *           InvalidArgument if the value is valid for the named option
+   *           NotSupported    If the name/value is not supported
+   */
+  Status ConfigureOption(const DBOptions& db_opts, const std::string& name,
+                         const std::string& value,
+                         bool input_strings_escaped = false);
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Fills in result with the string representation of the configuration options
+   * Parameters:
+   *   result:                The returned string representation of the options
+   *   delimiter:             Separator between options in the string
+   *   mode:                  OR-ed together string mode options controlling how
+   * the options are returned
+   */
+  Status GetOptionString(std::string* result,
+                         const std::string& delimiter) const {
+    return GetOptionString(OptionStringMode::kOptionNone, result, delimiter);
+  }
+  Status GetOptionString(uint32_t mode, std::string* result,
+                         const std::string& delimiter) const;
+
+  // Returns the list of option names associated with this configurable
+  Status GetOptionNames(std::unordered_set<std::string>* result) const {
+    return GetOptionNames(OptionStringMode::kOptionShallow, result);
+  }
+
+  Status GetOptionNames(uint32_t mode,
+                        std::unordered_set<std::string>* result) const;
+  // Converts this object to a delimited-string
+  std::string ToString(uint32_t mode = OptionStringMode::kOptionNone,
+                       const std::string& delimiter = ";") const {
+    return ToString(mode, "", delimiter);
+  }
+
+  std::string ToString(const std::string& delimiter) const {
+    return ToString(OptionStringMode::kOptionNone, "", delimiter);
+  }
+  std::string ToString(uint32_t mode, const std::string& prefix,
+                       const std::string& delimiter) const;
+#endif  // ROCKSDB_LITE
+  /**
+   * Returns the value of the option associated with the input name
+   */
+  Status GetOption(const std::string& name, std::string* value) const;
+  /**
+   * Checks to see if this Configurable is equivalent to other.
+   * Level controls how pedantic the comparison must be for equivalency to be
+   achieved
+
+   */
+  bool Matches(const Configurable* other, OptionsSanityCheckLevel level) const;
+  bool Matches(const Configurable* other, OptionsSanityCheckLevel level,
+               std::string* name) const;
+
+ protected:  // Virtual functions that should be overridden by derived classes
+  virtual Status Validate(const DBOptions&, const ColumnFamilyOptions&) const;
+
+  virtual Status Sanitize(DBOptions& db_opts, ColumnFamilyOptions& cf_opts);
+  /**
+   * Returns the raw pointer for the associated named option.
+   */
+  virtual const void* GetOptionsPtr(const std::string& /* name */) const;
+
+  /**
+   * Returns a pointer to a map of name-sanity levels for the named option.
+   * This method allows a class to better control how the sanity check level of
+   * fields within the options are handled.  If no map is returned, the behavior
+   * depends on thetype of the option.
+   *
+   * This method returns a map (with names equivalent to the option map) for the
+   * named option. If no map is specified or the option name is not found in the
+   * map, the default behavior of the option type is used.  Otherwise, the
+   * returned option type will be used when checking for equivalence.
+   */
+  virtual const std::unordered_map<std::string, OptionsSanityCheckLevel>*
+  GetOptionsSanityCheckLevel(const std::string& /* name */) const {
+    return nullptr;
+  }
+  virtual OptionsSanityCheckLevel GetSanityLevelForOption(
+      const std::unordered_map<std::string, OptionsSanityCheckLevel>* map,
+      const std::string& name) const;
+
+ protected:  // Virtual functions that must be specified by functions not
+             // registering option maps.
+  /**
+   * Matches the input "other" object at the corresponding sanity level.
+   */
+  virtual bool MatchesOption(const Configurable* other,
+                             OptionsSanityCheckLevel level,
+                             std::string* name) const;
+  virtual Status ParseStringOptions(const DBOptions& /*db_opts */,
+                                    const std::string& options,
+                                    bool /*ignore_unused_options */,
+                                    bool /*input_strings_escaped */) {
+    return (options.empty())
+               ? Status::OK()
+               : Status::InvalidArgument("Cannot parse option: ", options);
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   *  Sets the name and value of a configurable object
+   * Sets found_option=true if the name matches a valid option for this object
+   * (false otherwise) Returns OK if the option was successfully updated or not
+   * found Returns a non-OK status if the name was found but the value was not
+   * valid
+   *
+   * Objects that have options that cannot be parsed by the typical means (via
+   * Maps and SetOption) should override this method,
+   */
+  virtual Status SetOption(const DBOptions& db_opts, const std::string& name,
+                           const std::string& value, bool input_strins_escaped,
+                           bool* found_option);
+  virtual Status ParseOption(const OptionTypeInfo& opt_info,
+                             const DBOptions& db_opts, void* opt_ptr,
+                             const std::string& opt_name,
+                             const std::string& opt_value,
+                             bool input_strings_escaped);
+  // Tests to see if the single option name/info matches for this and that
+  virtual bool OptionIsEqual(const std::string& name,
+                             const OptionTypeInfo& opt_info,
+                             OptionsSanityCheckLevel level,
+                             const char* this_option, const char* that_option,
+                             std::string* bad_name) const;
+  // If this and that do not match, use some other means to see if they
+  // might match (like checking the verification type).
+  virtual bool VerifyOptionEqual(const std::string& opt_name,
+                                 const OptionTypeInfo& opt_info,
+                                 const char* this_offset,
+                                 const char* that_offset) const;
+#endif
+  /**
+   * Dumps the values associated with this object to the logger.
+   */
+  virtual void DumpOptions(Logger* log, const std::string& indent,
+                           uint32_t mode) const;
+#ifndef ROCKSDB_LITE
+  virtual std::string AsString(uint32_t mode, const std::string& prefix,
+                               const std::string& delimiter) const;
+  /**
+   * Converts the options associated with this object into the result string.
+   * The options are separated by the input delimiter.
+   * The mode is a bitset that controls how the various options are printed
+   *   - If kOptionPrefix is set, the prefix is prepended to each option string;
+   *   - if kOptionShallow is set, nested configuration values are not included;
+   *   - if kOptionDeatched is set, nested configuration options are printed
+   * individually, otherwise, they are grouped inside "{ options }" Returns OK
+   * if the options could be succcessfully serialized, non-OK on failure
+   */
+  virtual Status SerializeOptions(uint32_t mode, std::string* result,
+                                  const std::string& prefix,
+                                  const std::string& delimiter) const;
+  virtual Status ListOptions(uint32_t mode, const std::string& prefix,
+                             std::unordered_set<std::string>* result) const;
+#endif  // ROCKSDB_LITE
+ protected:
+  // Returns printable options for dump
+  // If this method returns non-empty string, the result is used for dumping
+  // the options. If an empty string is returned, the registered options are
+  // used.
+  virtual std::string GetPrintableOptions() const { return ""; }
+  // Returns true if this configurable represents a mutable object
+  // Mutable classes should override this method.
+  virtual bool IsMutable() const { return is_mutable_; }
+  /**
+   *  Given a prefixed name (e.g. rocksdb.my.type.opt), returns the short name
+   * ("opt")
+   */
+  virtual std::string GetOptionName(const std::string& long_name) const;
+#ifndef ROCKSDB_LITE
+
+  Status SerializeOption(const std::string& opt_name,
+                         const OptionTypeInfo& opt_info, const char* opt_addr,
+                         uint32_t mode, std::string* opt_value,
+                         const std::string& prefix,
+                         const std::string& delimiter) const;
+
+  // Returns the offset of ptrfor the given option
+  // If the configurable is mutable, returns the mutable offset (if any).
+  // Otherwise returns the standard one
+  const char* GetOptAddress(const OptionTypeInfo& opt_info,
+                            const void* ptr) const {
+    if (!IsMutable()) {
+      return reinterpret_cast<const char*>(ptr) + opt_info.offset;
+    } else if (opt_info.IsMutable()) {
+      return reinterpret_cast<const char*>(ptr) + opt_info.mutable_offset;
+    } else {
+      return nullptr;
+    }
+  }
+
+  // Returns the offset of ptrfor the given option
+  // If the configurable is mutable, returns the mutable offset (if any).
+  // Otherwise returns the standard one
+  char* GetOptAddress(const OptionTypeInfo& opt_info, void* ptr) const {
+    if (!IsMutable()) {
+      return reinterpret_cast<char*>(ptr) + opt_info.offset;
+    } else if (opt_info.IsMutable()) {
+      return reinterpret_cast<char*>(ptr) + opt_info.mutable_offset;
+    } else {
+      return nullptr;
+    }
+  }
+
+  /**
+   * Returns the option info for the named option from the input map, or nullptr
+   * if not found.
+   */
+  OptionTypeMap::const_iterator FindOption(
+      const std::string& option, const OptionTypeMap& options_map) const;
+
+  /**
+   * Compares the options specified by this_option and that_option for
+   * equivalence, returning true if they match. This method looks at the options
+   * in the input opt_map and sees if the values in this_option and that_option
+   * are equivalent
+   *
+   * @param opt_map       The set of options to check
+   * @param sanity_level  How diligent the comparison must be for equivalence
+   * @param opt_level     Optional map specifying a sanity check level for the
+   * named options in opt_map.
+   * @param this_option   One option to compare
+   * @param that_option   The option to compare to
+   * @parm opt_name       If the method returns false, opt_name returns the name
+   *                      of the first option that failed to match.
+   */
+  bool OptionsAreEqual(
+      const OptionTypeMap& opt_map,
+      const std::unordered_map<std::string, OptionsSanityCheckLevel>* opt_level,
+      OptionsSanityCheckLevel sanity_check_level, const char* this_option,
+      const char* that_option, std::string* opt_name) const;
+  Status SerializeSingleOption(uint32_t mode, const std::string& name,
+                               std::string* value, bool* found_it) const;
+#endif  // ROCKSDB_LITE
+  /**
+   * Registers the input name with the options and associated map.
+   * When classes register their options in this manner, most of the
+   * functionality (excluding unknown options and validate/sanitize) is
+   * implemented by the base class.
+   *
+   * @param name    The name of this option (@see GetOptionsPtr)
+   * @param opt_ptr Pointer to the options to associate with this name
+   * @param opt_map Options map that controls how this option is configured.
+   */
+  void RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                          const OptionTypeMap& opt_map);
+
+  /**
+   * Serializes a single option, typically into "name=value" format.
+   * The actual representation is controlled by the mode parameter.
+   */
+  void PrintSingleOption(const std::string& prefix, const std::string& name,
+                         const std::string& value, const std::string& delimiter,
+                         std::string* result) const;
+
+ protected:
+  // Methods for dealing with unknown options, either of type "kUnknown",
+  // or not found in the map for some other reason
+
+  /**
+   * Sets the name and value of the configurable object of unknown type.
+   * Sets found_option=true if the name matches a valid option for this object
+   * Returns OK if the option was successfully updated or not found
+   * Returns a non-OK status if the name was found but the value was not valid
+   * Objects that have options that cannot be parsed by the typical means (via
+   * Maps and ParseOption) should override this method,
+   */
+  virtual Status SetUnknown(const DBOptions& /* db_opts */,
+                            const std::string& name,
+                            const std::string& /* value */) {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  virtual Status SetEnum(const DBOptions& /* db_opts */,
+                         const std::string& name,
+                         const std::string& /* value */, char* /* addr */) {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  /**
+   * Converts the unknown named option into its string form and returns that
+   * value in result.
+   */
+  virtual Status UnknownToString(uint32_t /* mode */, const std::string& name,
+                                 std::string* /*result */) const {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+  virtual Status EnumToString(uint32_t /* mode */, const std::string& name,
+                              std::string* /*result */) const {
+    return Status::NotFound("Could not find option: ", name);
+  }
+
+#ifndef ROCKSDB_LITE
+  /**
+   * Compares to unknown options for equivalence.
+   */
+  virtual bool IsUnknownEqual(const std::string& /* opt_name */,
+                              const OptionTypeInfo& /* type_info */,
+                              OptionsSanityCheckLevel /* sanity_check_level */,
+                              const char* this_addr,
+                              const char* that_addr) const {
+    return this_addr == that_addr;
+  }
+
+  virtual bool IsEnumEqual(const std::string& /* opt_name */,
+                           const OptionTypeInfo& /* type_info */,
+                           OptionsSanityCheckLevel /* sanity_check_level */,
+                           const char* this_addr, const char* that_addr) const {
+    return this_addr == that_addr;
+  }
+
+  virtual bool IsConfigEqual(const std::string& opt_name,
+                             const OptionTypeInfo& opt_info,
+                             OptionsSanityCheckLevel level,
+                             const Configurable* this_config,
+                             const Configurable* that_config,
+                             std::string* mismatch) const;
+#endif
+};
+}  // namespace rocksdb

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -206,73 +206,6 @@ Status GetDBOptionsFromMap(
     DBOptions* new_options, bool input_strings_escaped = false,
     bool ignore_unknown_options = false);
 
-// Take a default BlockBasedTableOptions "table_options" in addition to a
-// map "opts_map" of option name to option value to construct the new
-// BlockBasedTableOptions "new_table_options".
-//
-// Below are the instructions of how to config some non-primitive-typed
-// options in BlockBasedTableOptions:
-//
-// * filter_policy:
-//   We currently only support the following FilterPolicy in the convenience
-//   functions:
-//   - BloomFilter: use "bloomfilter:[bits_per_key]:[use_block_based_builder]"
-//     to specify BloomFilter.  The above string is equivalent to calling
-//     NewBloomFilterPolicy(bits_per_key, use_block_based_builder).
-//     [Example]:
-//     - Pass {"filter_policy", "bloomfilter:4:true"} in
-//       GetBlockBasedTableOptionsFromMap to use a BloomFilter with 4-bits
-//       per key and use_block_based_builder enabled.
-//
-// * block_cache / block_cache_compressed:
-//   We currently only support LRU cache in the GetOptions API.  The LRU
-//   cache can be set by directly specifying its size.
-//   [Example]:
-//   - Passing {"block_cache", "1M"} in GetBlockBasedTableOptionsFromMap is
-//     equivalent to setting block_cache using NewLRUCache(1024 * 1024).
-//
-// @param table_options the default options of the output "new_table_options".
-// @param opts_map an option name to value map for specifying how
-//     "new_table_options" should be set.
-// @param new_table_options the resulting options based on "table_options"
-//     with the change specified in "opts_map".
-// @param input_strings_escaped when set to true, each escaped characters
-//     prefixed by '\' in the values of the opts_map will be further converted
-//     back to the raw string before assigning to the associated options.
-// @param ignore_unknown_options when set to true, unknown options are ignored
-//     instead of resulting in an unknown-option error.
-// @return Status::OK() on success.  Otherwise, a non-ok status indicating
-//     error will be returned, and "new_table_options" will be set to
-//     "table_options".
-Status GetBlockBasedTableOptionsFromMap(
-    const BlockBasedTableOptions& table_options,
-    const std::unordered_map<std::string, std::string>& opts_map,
-    BlockBasedTableOptions* new_table_options,
-    bool input_strings_escaped = false, bool ignore_unknown_options = false);
-
-// Take a default PlainTableOptions "table_options" in addition to a
-// map "opts_map" of option name to option value to construct the new
-// PlainTableOptions "new_table_options".
-//
-// @param table_options the default options of the output "new_table_options".
-// @param opts_map an option name to value map for specifying how
-//     "new_table_options" should be set.
-// @param new_table_options the resulting options based on "table_options"
-//     with the change specified in "opts_map".
-// @param input_strings_escaped when set to true, each escaped characters
-//     prefixed by '\' in the values of the opts_map will be further converted
-//     back to the raw string before assigning to the associated options.
-// @param ignore_unknown_options when set to true, unknown options are ignored
-//     instead of resulting in an unknown-option error.
-// @return Status::OK() on success.  Otherwise, a non-ok status indicating
-//     error will be returned, and "new_table_options" will be set to
-//     "table_options".
-Status GetPlainTableOptionsFromMap(
-    const PlainTableOptions& table_options,
-    const std::unordered_map<std::string, std::string>& opts_map,
-    PlainTableOptions* new_table_options, bool input_strings_escaped = false,
-    bool ignore_unknown_options = false);
-
 // Take a string representation of option names and  values, apply them into the
 // base_options, and return the new options as a result. The string has the
 // following format:
@@ -302,14 +235,6 @@ Status GetStringFromCompressionType(std::string* compression_str,
                                     CompressionType compression_type);
 
 std::vector<CompressionType> GetSupportedCompressions();
-
-Status GetBlockBasedTableOptionsFromString(
-    const BlockBasedTableOptions& table_options, const std::string& opts_str,
-    BlockBasedTableOptions* new_table_options);
-
-Status GetPlainTableOptionsFromString(const PlainTableOptions& table_options,
-                                      const std::string& opts_str,
-                                      PlainTableOptions* new_table_options);
 
 Status GetMemTableRepFactoryFromString(
     const std::string& opts_str,

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "rocksdb/db.h"
@@ -166,10 +167,13 @@ namespace rocksdb {
 // @return Status::OK() on success.  Otherwise, a non-ok status indicating
 //     error will be returned, and "new_options" will be set to "base_options".
 Status GetColumnFamilyOptionsFromMap(
-    const ColumnFamilyOptions& base_options,
+    const DBOptions& db_options, const ColumnFamilyOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
     ColumnFamilyOptions* new_options, bool input_strings_escaped = false,
     bool ignore_unknown_options = false);
+
+Status GetCFOptionNames(std::unordered_set<std::string>* opt_names,
+                        bool use_mutable = false);
 
 // Take a default DBOptions "base_options" in addition to a
 // map "opts_map" of option name to option value to construct the new
@@ -277,7 +281,8 @@ Status GetPlainTableOptionsFromMap(
 // BlockBasedTableOptions as part of the string for block-based table factory:
 //   "write_buffer_size=1024;block_based_table_factory={block_size=4k};"
 //   "max_write_buffer_num=2"
-Status GetColumnFamilyOptionsFromString(const ColumnFamilyOptions& base_options,
+Status GetColumnFamilyOptionsFromString(const DBOptions& db_options,
+                                        const ColumnFamilyOptions& base_options,
                                         const std::string& opts_str,
                                         ColumnFamilyOptions* new_options);
 

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+struct DBOptions;
+enum OptionsSanityCheckLevel : unsigned char {
+  // Performs no sanity check at all.
+  kSanityLevelNone = 0x00,
+  // Performs minimum check to ensure the RocksDB instance can be
+  // opened without corrupting / mis-interpreting the data.
+  kSanityLevelLooselyCompatible = 0x01,
+  // Perform exact match sanity check.
+  kSanityLevelExactMatch = 0xFF,
+};
+
+enum class OptionType {
+  kBoolean,
+  kInt,
+  kInt32T,
+  kInt64T,
+  kVectorInt,
+  kUInt,
+  kUInt32T,
+  kUInt64T,
+  kSizeT,
+  kString,
+  kDouble,
+  kCompactionStyle,
+  kCompactionPri,
+  kSliceTransform,
+  kCompressionType,
+  kCompressionOpts,
+  kVectorCompressionType,
+  kTableFactory,
+  kComparator,
+  kCompactionFilter,
+  kCompactionFilterFactory,
+  kCompactionOptionsFIFO,
+  kCompactionOptionsUniversal,
+  kCompactionStopStyle,
+  kMergeOperator,
+  kMemTableRepFactory,
+  kBlockBasedTableIndexType,
+  kBlockBasedTableDataBlockIndexType,
+  kBlockBasedTableIndexShorteningMode,
+  kFilterPolicy,
+  kFlushBlockPolicyFactory,
+  kChecksumType,
+  kEncodingType,
+  kWALRecoveryMode,
+  kAccessHint,
+  kInfoLogLevel,
+  kLRUCacheOptions,
+  kEnv,
+  kEnum,
+  kUnknown,
+};
+
+enum class OptionVerificationType {
+  kNormal,
+  kByName,               // The option is pointer typed so we can only verify
+                         // based on it's name.
+  kByNameAllowNull,      // Same as kByName, but it also allows the case
+                         // where one of them is a nullptr.
+  kByNameAllowFromNull,  // Same as kByName, but it also allows the case
+                         // where the old option is nullptr.
+  kDeprecated,           // The option is no longer used in rocksdb. The RocksDB
+                         // OptionsParser will still accept this option if it
+                         // happen to exists in some Options file.  However,
+                         // the parser will not include it in serialization
+                         // and verification processes.
+  kAlias                 // This option represents is a name/shortcut for
+                         // another option and should not be written or verified
+                         // independently
+};
+
+enum OptionTypeFlags {
+  kNone = 0x00,     // No flags
+  kMutable = 0x01,  // Option is mutable
+  kPointer = 0x02,  // The option is stored as a pointer
+  kShared = 0x04,   // The option is stored as a shared_ptr
+  kUnique = 0x08,   // The option is stored as a unique_ptr
+  kEnum = 0x10,     // The option represents an enumerated type
+  kMutableEnum = (kEnum | kMutable),  // Mutable enumerated type
+};
+
+// A struct for storing constant option information such as option name,
+// option type, and offset.
+struct OptionTypeInfo {
+  int offset;
+  OptionType type;
+  OptionVerificationType verification;
+  OptionTypeFlags flags;  // This is a bitmask of OptionTypeFlag values
+  int mutable_offset;
+
+  bool IsMutable() const {
+    return (flags & OptionTypeFlags::kMutable) == OptionTypeFlags::kMutable;
+  }
+  bool IsSharedPtr() const {
+    return (flags & OptionTypeFlags::kShared) == OptionTypeFlags::kShared;
+  }
+  bool IsUniquePtr() const {
+    return (flags & OptionTypeFlags::kUnique) == OptionTypeFlags::kUnique;
+  }
+  bool IsRawPtr() const {
+    return (flags & OptionTypeFlags::kPointer) == OptionTypeFlags::kPointer;
+  }
+
+  bool IsEnum() const {
+    return type == OptionType::kEnum ||
+           ((flags & OptionTypeFlags::kEnum) == OptionTypeFlags::kEnum);
+  }
+
+  template <typename T>
+  const T *GetPointer(const char *addr) const {
+    if (addr == nullptr) {
+      return nullptr;
+    } else if (IsUniquePtr()) {
+      const std::unique_ptr<T> *ptr =
+          reinterpret_cast<const std::unique_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsSharedPtr()) {
+      const std::shared_ptr<T> *ptr =
+          reinterpret_cast<const std::shared_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsRawPtr()) {
+      const T *const *ptr = reinterpret_cast<const T *const *>(addr);
+      return *ptr;
+    } else {
+      return reinterpret_cast<const T *>(addr);
+    }
+  }
+  template <typename T>
+  T *GetPointer(char *addr) const {
+    if (addr == nullptr) {
+      return nullptr;
+    } else if (IsUniquePtr()) {
+      std::unique_ptr<T> *ptr = reinterpret_cast<std::unique_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsSharedPtr()) {
+      std::shared_ptr<T> *ptr = reinterpret_cast<std::shared_ptr<T> *>(addr);
+      return ptr->get();
+    } else if (IsRawPtr()) {
+      T **ptr = reinterpret_cast<T **>(addr);
+      return *ptr;
+    } else {
+      return reinterpret_cast<T *>(addr);
+    }
+  }
+};
+
+}  // namespace rocksdb

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -5,17 +5,30 @@
 
 #include "options/cf_options.h"
 
-#include <cinttypes>
 #include <cassert>
+#include <cinttypes>
 #include <limits>
 #include <string>
 #include "options/db_options.h"
+#include "options/options_helper.h"
+#include "options/options_parser.h"
+#include "util/cast_util.h"
+
 #include "port/port.h"
-#include "rocksdb/env.h"
-#include "rocksdb/options.h"
+#include "rocksdb/comparator.h"
 #include "rocksdb/concurrent_task_limiter.h"
+#include "rocksdb/configurable.h"
+#include "rocksdb/convenience.h"
+#include "rocksdb/env.h"
+#include "rocksdb/merge_operator.h"
+#include "rocksdb/options.h"
+#include "rocksdb/table.h"
+#include "rocksdb/utilities/object_registry.h"
+#include "table/plain/plain_table_factory.h"
 
 namespace rocksdb {
+const std::string kNameComparator = "comparator";
+const std::string kNameMergeOperator = "merge_operator";
 
 ImmutableCFOptions::ImmutableCFOptions(const Options& options)
     : ImmutableCFOptions(ImmutableDBOptions(options), options) {}
@@ -103,6 +116,9 @@ uint64_t MaxFileSizeForLevel(const MutableCFOptions& cf_options,
     return cf_options.max_file_size[level - base_level];
   }
 }
+
+MutableCFOptions::MutableCFOptions(const Options& options)
+    : MutableCFOptions(ColumnFamilyOptions(options)) {}
 
 void MutableCFOptions::RefreshDerivedOptions(int num_levels,
                                              CompactionStyle compaction_style) {
@@ -222,7 +238,756 @@ void MutableCFOptions::Dump(Logger* log) const {
                  compaction_options_fifo.allow_compaction);
 }
 
-MutableCFOptions::MutableCFOptions(const Options& options)
-    : MutableCFOptions(ColumnFamilyOptions(options)) {}
+#ifndef ROCKSDB_LITE
 
+static Status ParseCompressionOptions(const std::string& value,
+                                      const std::string& name,
+                                      CompressionOptions& compression_opts) {
+  size_t start = 0;
+  size_t end = value.find(':');
+  if (end == std::string::npos) {
+    return Status::InvalidArgument("unable to parse the specified CF option " +
+                                   name);
+  }
+  compression_opts.window_bits = ParseInt(value.substr(start, end - start));
+  start = end + 1;
+  end = value.find(':', start);
+  if (end == std::string::npos) {
+    return Status::InvalidArgument("unable to parse the specified CF option " +
+                                   name);
+  }
+  compression_opts.level = ParseInt(value.substr(start, end - start));
+  start = end + 1;
+  if (start >= value.size()) {
+    return Status::InvalidArgument("unable to parse the specified CF option " +
+                                   name);
+  }
+  end = value.find(':', start);
+  compression_opts.strategy =
+      ParseInt(value.substr(start, value.size() - start));
+  // max_dict_bytes is optional for backwards compatibility
+  if (end != std::string::npos) {
+    start = end + 1;
+    if (start >= value.size()) {
+      return Status::InvalidArgument(
+          "unable to parse the specified CF option " + name);
+    }
+    compression_opts.max_dict_bytes =
+        ParseInt(value.substr(start, value.size() - start));
+    end = value.find(':', start);
+  }
+  // zstd_max_train_bytes is optional for backwards compatibility
+  if (end != std::string::npos) {
+    start = end + 1;
+    if (start >= value.size()) {
+      return Status::InvalidArgument(
+          "unable to parse the specified CF option " + name);
+    }
+    compression_opts.zstd_max_train_bytes =
+        ParseInt(value.substr(start, value.size() - start));
+    end = value.find(':', start);
+  }
+  // enabled is optional for backwards compatibility
+  if (end != std::string::npos) {
+    start = end + 1;
+    if (start >= value.size()) {
+      return Status::InvalidArgument(
+          "unable to parse the specified CF option " + name);
+    }
+    compression_opts.enabled =
+        ParseBoolean("", value.substr(start, value.size() - start));
+  }
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
+// offset_of is used to get the offset of a class data member
+// ex: offset_of(&ColumnFamilyOptions::num_levels)
+// This call will return the offset of num_levels in ColumnFamilyOptions class
+//
+// This is the same as offsetof() but allow us to work with non standard-layout
+// classes and structures
+// refs:
+// http://en.cppreference.com/w/cpp/concept/StandardLayoutType
+// https://gist.github.com/graphitemaster/494f21190bb2c63c5516
+#ifndef ROCKSDB_LITE
+static ColumnFamilyOptions dummy_cf_options;
+
+template <typename T1>
+int offset_of(T1 ColumnFamilyOptions::*member) {
+  return int(size_t(&(dummy_cf_options.*member)) - size_t(&dummy_cf_options));
+}
+template <typename T1>
+int offset_of(T1 AdvancedColumnFamilyOptions::*member) {
+  return int(size_t(&(dummy_cf_options.*member)) - size_t(&dummy_cf_options));
+}
+
+static std::unordered_map<std::string, OptionTypeInfo> cf_options_type_info = {
+    /* not yet supported
+     CompressionOptions compression_opts;
+     TablePropertiesCollectorFactories table_properties_collector_factories;
+     typedef std::vector<std::shared_ptr<TablePropertiesCollectorFactory>>
+         TablePropertiesCollectorFactories;
+     UpdateStatus (*inplace_callback)(char* existing_value,
+                                      uint34_t* existing_value_size,
+                                      Slice delta_value,
+                                      std::string* merged_value);
+     std::vector<DbPath> cf_paths;
+      */
+    {"report_bg_io_stats",
+     {offset_of(&ColumnFamilyOptions::report_bg_io_stats), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, report_bg_io_stats)}},
+    {"compaction_measure_io_stats",
+     {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kNone, 0}},
+    {"disable_auto_compactions",
+     {offset_of(&ColumnFamilyOptions::disable_auto_compactions),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, disable_auto_compactions)}},
+    {"filter_deletes",
+     {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"inplace_update_support",
+     {offset_of(&ColumnFamilyOptions::inplace_update_support),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"level_compaction_dynamic_level_bytes",
+     {offset_of(&ColumnFamilyOptions::level_compaction_dynamic_level_bytes),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"optimize_filters_for_hits",
+     {offset_of(&ColumnFamilyOptions::optimize_filters_for_hits),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"paranoid_file_checks",
+     {offset_of(&ColumnFamilyOptions::paranoid_file_checks),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, paranoid_file_checks)}},
+    {"force_consistency_checks",
+     {offset_of(&ColumnFamilyOptions::force_consistency_checks),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"purge_redundant_kvs_while_flush",
+     {offset_of(&ColumnFamilyOptions::purge_redundant_kvs_while_flush),
+      OptionType::kBoolean, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kNone, 0}},
+    {"verify_checksums_in_compaction",
+     {0, OptionType::kBoolean, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"soft_pending_compaction_bytes_limit",
+     {offset_of(&ColumnFamilyOptions::soft_pending_compaction_bytes_limit),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, soft_pending_compaction_bytes_limit)}},
+    {"hard_pending_compaction_bytes_limit",
+     {offset_of(&ColumnFamilyOptions::hard_pending_compaction_bytes_limit),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, hard_pending_compaction_bytes_limit)}},
+    {"hard_rate_limit",
+     {0, OptionType::kDouble, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"soft_rate_limit",
+     {0, OptionType::kDouble, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"max_compaction_bytes",
+     {offset_of(&ColumnFamilyOptions::max_compaction_bytes),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_compaction_bytes)}},
+    {"expanded_compaction_factor",
+     {0, OptionType::kInt, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"level0_file_num_compaction_trigger",
+     {offset_of(&ColumnFamilyOptions::level0_file_num_compaction_trigger),
+      OptionType::kInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, level0_file_num_compaction_trigger)}},
+    {"level0_slowdown_writes_trigger",
+     {offset_of(&ColumnFamilyOptions::level0_slowdown_writes_trigger),
+      OptionType::kInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, level0_slowdown_writes_trigger)}},
+    {"level0_stop_writes_trigger",
+     {offset_of(&ColumnFamilyOptions::level0_stop_writes_trigger),
+      OptionType::kInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, level0_stop_writes_trigger)}},
+    {"max_grandparent_overlap_factor",
+     {0, OptionType::kInt, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"max_mem_compaction_level",
+     {0, OptionType::kInt, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kNone, 0}},
+    {"max_write_buffer_number",
+     {offset_of(&ColumnFamilyOptions::max_write_buffer_number),
+      OptionType::kInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_write_buffer_number)}},
+    {"max_write_buffer_number_to_maintain",
+     {offset_of(&ColumnFamilyOptions::max_write_buffer_number_to_maintain),
+      OptionType::kInt, OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+      0}},
+    {"min_write_buffer_number_to_merge",
+     {offset_of(&ColumnFamilyOptions::min_write_buffer_number_to_merge),
+      OptionType::kInt, OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+      0}},
+    {"num_levels",
+     {offset_of(&ColumnFamilyOptions::num_levels), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"source_compaction_factor",
+     {0, OptionType::kInt, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"target_file_size_multiplier",
+     {offset_of(&ColumnFamilyOptions::target_file_size_multiplier),
+      OptionType::kInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, target_file_size_multiplier)}},
+    {"arena_block_size",
+     {offset_of(&ColumnFamilyOptions::arena_block_size), OptionType::kSizeT,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, arena_block_size)}},
+    {"inplace_update_num_locks",
+     {offset_of(&ColumnFamilyOptions::inplace_update_num_locks),
+      OptionType::kSizeT, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, inplace_update_num_locks)}},
+    {"max_successive_merges",
+     {offset_of(&ColumnFamilyOptions::max_successive_merges),
+      OptionType::kSizeT, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_successive_merges)}},
+    {"memtable_huge_page_size",
+     {offset_of(&ColumnFamilyOptions::memtable_huge_page_size),
+      OptionType::kSizeT, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, memtable_huge_page_size)}},
+    {"memtable_prefix_bloom_huge_page_tlb_size",
+     {0, OptionType::kSizeT, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"write_buffer_size",
+     {offset_of(&ColumnFamilyOptions::write_buffer_size), OptionType::kSizeT,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, write_buffer_size)}},
+    {"bloom_locality",
+     {offset_of(&ColumnFamilyOptions::bloom_locality), OptionType::kUInt32T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"memtable_prefix_bloom_bits",
+     {0, OptionType::kUInt32T, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"memtable_prefix_bloom_size_ratio",
+     {offset_of(&ColumnFamilyOptions::memtable_prefix_bloom_size_ratio),
+      OptionType::kDouble, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, memtable_prefix_bloom_size_ratio)}},
+    {"memtable_prefix_bloom_probes",
+     {0, OptionType::kUInt32T, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"memtable_whole_key_filtering",
+     {offset_of(&ColumnFamilyOptions::memtable_whole_key_filtering),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, memtable_whole_key_filtering)}},
+    {"min_partial_merge_operands",
+     {0, OptionType::kUInt32T, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kMutable, 0}},
+    {"max_bytes_for_level_base",
+     {offset_of(&ColumnFamilyOptions::max_bytes_for_level_base),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_bytes_for_level_base)}},
+    {"snap_refresh_nanos",
+     {offset_of(&ColumnFamilyOptions::snap_refresh_nanos), OptionType::kUInt64T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, snap_refresh_nanos)}},
+    {"max_bytes_for_level_multiplier",
+     {offset_of(&ColumnFamilyOptions::max_bytes_for_level_multiplier),
+      OptionType::kDouble, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_bytes_for_level_multiplier)}},
+    {"max_bytes_for_level_multiplier_additional",
+     {offset_of(
+          &ColumnFamilyOptions::max_bytes_for_level_multiplier_additional),
+      OptionType::kVectorInt, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions,
+               max_bytes_for_level_multiplier_additional)}},
+    {"max_sequential_skip_in_iterations",
+     {offset_of(&ColumnFamilyOptions::max_sequential_skip_in_iterations),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, max_sequential_skip_in_iterations)}},
+    {"target_file_size_base",
+     {offset_of(&ColumnFamilyOptions::target_file_size_base),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, target_file_size_base)}},
+    {"rate_limit_delay_max_milliseconds",
+     {0, OptionType::kUInt, OptionVerificationType::kDeprecated,
+      OptionTypeFlags::kNone, 0}},
+    {"compression",
+     {offset_of(&ColumnFamilyOptions::compression),
+      OptionType::kCompressionType, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutableEnum,
+      offsetof(struct MutableCFOptions, compression)}},
+    {"compression_opts",
+     {offset_of(&ColumnFamilyOptions::compression_opts), OptionType::kUnknown,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        Status s;
+        if (!value.empty()) {
+          auto* opts = reinterpret_cast<CompressionOptions*>(addr);
+          s = ParseCompressionOptions(value, name, *(opts));
+        }
+        return s;
+      }}},
+    {"compression_per_level",
+     {offset_of(&ColumnFamilyOptions::compression_per_level),
+      OptionType::kVectorCompressionType, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"bottommost_compression",
+     {offset_of(&ColumnFamilyOptions::bottommost_compression),
+      OptionType::kCompressionType, OptionVerificationType::kNormal,
+      OptionTypeFlags::kEnum, 0}},
+    {"bottommost_compression_opts",
+     {offset_of(&ColumnFamilyOptions::bottommost_compression_opts),
+      OptionType::kUnknown, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        Status s;
+        if (!value.empty()) {
+          s = ParseCompressionOptions(
+              value, name, *(reinterpret_cast<CompressionOptions*>(addr)));
+        }
+        return s;
+      }}},
+    {kNameComparator,
+     {offset_of(&ColumnFamilyOptions::comparator), OptionType::kComparator,
+      OptionVerificationType::kByName, OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string&, char* addr,
+         const std::string& value) {
+        // Try to get comparator from object registry first.
+        const auto comp = reinterpret_cast<const Comparator**>(addr);
+        Status status =
+            ObjectRegistry::NewInstance()->NewStaticObject<const Comparator>(
+                value, comp);
+
+        return Status::OK();
+      }}},
+    {"prefix_extractor",
+     {offset_of(&ColumnFamilyOptions::prefix_extractor),
+      OptionType::kSliceTransform, OptionVerificationType::kByNameAllowNull,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, prefix_extractor)}},
+    {"memtable_insert_with_hint_prefix_extractor",
+     {offset_of(
+          &ColumnFamilyOptions::memtable_insert_with_hint_prefix_extractor),
+      OptionType::kSliceTransform, OptionVerificationType::kByNameAllowNull,
+      OptionTypeFlags::kNone, 0}},
+    {"memtable_factory",
+     {offset_of(&ColumnFamilyOptions::memtable_factory),
+      OptionType::kMemTableRepFactory, OptionVerificationType::kByName,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        std::unique_ptr<MemTableRepFactory> factory;
+        Status mem_factory_s = GetMemTableRepFactoryFromString(value, &factory);
+        if (!mem_factory_s.ok()) {
+          return Status::InvalidArgument(
+              "unable to parse the specified CF option " + name);
+        }
+        (reinterpret_cast<std::shared_ptr<MemTableRepFactory>*>(addr))
+            ->reset(factory.release());
+        return Status::OK();
+      }}},
+    {"memtable",
+     {offset_of(&ColumnFamilyOptions::memtable_factory),
+      OptionType::kMemTableRepFactory, OptionVerificationType::kAlias,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        std::unique_ptr<MemTableRepFactory> factory;
+        Status mem_factory_s = GetMemTableRepFactoryFromString(value, &factory);
+        if (!mem_factory_s.ok()) {
+          return Status::InvalidArgument(
+              "unable to parse the specified CF option " + name);
+        }
+        (reinterpret_cast<std::shared_ptr<MemTableRepFactory>*>(addr))
+            ->reset(factory.release());
+        return Status::OK();
+      }}},
+    {"table_factory",
+     {offset_of(&ColumnFamilyOptions::table_factory), OptionType::kTableFactory,
+      OptionVerificationType::kByName, OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string&, char* addr,
+         const std::string& value) {
+        std::unordered_map<std::string, std::string> dummy;
+        auto tf = reinterpret_cast<std::shared_ptr<TableFactory>*>(addr);
+        Status s = GetTableFactoryFromMap(value, dummy, tf, true);
+        return s;
+      }}},
+    {"block_based_table_factory",
+     {offset_of(&ColumnFamilyOptions::table_factory), OptionType::kUnknown,
+      OptionVerificationType::kAlias, OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        // Nested options
+        BlockBasedTableOptions table_opt, base_table_options;
+        auto tf = reinterpret_cast<std::shared_ptr<TableFactory>*>(addr);
+        BlockBasedTableFactory* block_based_table_factory =
+            static_cast_with_check<BlockBasedTableFactory, TableFactory>(
+                tf->get());
+        if (block_based_table_factory != nullptr) {
+          base_table_options = block_based_table_factory->table_options();
+        }
+        Status table_opt_s = GetBlockBasedTableOptionsFromString(
+            base_table_options, value, &table_opt);
+        if (!table_opt_s.ok()) {
+          return Status::InvalidArgument(
+              "unable to parse the specified CF option " + name);
+        }
+        tf->reset(NewBlockBasedTableFactory(table_opt));
+        return Status::OK();
+      }}},
+    {"plain_table_factory",
+     {offset_of(&ColumnFamilyOptions::table_factory), OptionType::kUnknown,
+      OptionVerificationType::kAlias, OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string& name, char* addr,
+         const std::string& value) {
+        // Nested options
+        auto tf = reinterpret_cast<std::shared_ptr<TableFactory>*>(addr);
+        PlainTableOptions table_opt, base_table_options;
+        PlainTableFactory* plain_table_factory =
+            static_cast_with_check<PlainTableFactory, TableFactory>(tf->get());
+        if (plain_table_factory != nullptr) {
+          base_table_options = plain_table_factory->table_options();
+        }
+        Status table_opt_s = GetPlainTableOptionsFromString(base_table_options,
+                                                            value, &table_opt);
+        if (!table_opt_s.ok()) {
+          return Status::InvalidArgument(
+              "unable to parse the specified CF option " + name);
+        }
+        tf->reset(NewPlainTableFactory(table_opt));
+        return Status::OK();
+      }}},
+    {"compaction_filter",
+     {offset_of(&ColumnFamilyOptions::compaction_filter),
+      OptionType::kCompactionFilter, OptionVerificationType::kByName,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string&, char*,
+         const std::string& /* value */) {
+        return Status::OK();  // Ignored at the moment during parse
+      }}},
+    {"compaction_filter_factory",
+     {offset_of(&ColumnFamilyOptions::compaction_filter_factory),
+      OptionType::kCompactionFilterFactory, OptionVerificationType::kByName,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string&, char*,
+         const std::string& /* value */) {
+        return Status::OK();  // Ignored at the moment during parse
+      }}},
+    {kNameMergeOperator,
+     {offset_of(&ColumnFamilyOptions::merge_operator),
+      OptionType::kMergeOperator, OptionVerificationType::kByNameAllowFromNull,
+      OptionTypeFlags::kNone, 0,
+      [](const DBOptions&, const std::string&, char* addr,
+         const std::string& value) {
+        // Try to get merge operator from object registry first.
+        auto* mo = reinterpret_cast<std::shared_ptr<MergeOperator>*>(addr);
+        Status status =
+            ObjectRegistry::NewInstance()->NewSharedObject<MergeOperator>(value,
+                                                                          mo);
+        return Status::OK();
+      }}},
+    {"compaction_style",
+     {offset_of(&ColumnFamilyOptions::compaction_style),
+      OptionType::kCompactionStyle, OptionVerificationType::kNormal,
+      OptionTypeFlags::kEnum, 0}},
+    {"compaction_pri",
+     {offset_of(&ColumnFamilyOptions::compaction_pri),
+      OptionType::kCompactionPri, OptionVerificationType::kNormal,
+      OptionTypeFlags::kEnum, 0}},
+    {"compaction_options_fifo",
+     {offset_of(&ColumnFamilyOptions::compaction_options_fifo),
+      OptionType::kCompactionOptionsFIFO, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, compaction_options_fifo)}},
+    {"compaction_options_universal",
+     {offset_of(&ColumnFamilyOptions::compaction_options_universal),
+      OptionType::kCompactionOptionsUniversal, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, compaction_options_universal)}},
+    {"ttl",
+     {offset_of(&ColumnFamilyOptions::ttl), OptionType::kUInt64T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, ttl)}},
+    {"periodic_compaction_seconds",
+     {offset_of(&ColumnFamilyOptions::periodic_compaction_seconds),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, periodic_compaction_seconds)}},
+    {"sample_for_compression",
+     {offset_of(&ColumnFamilyOptions::sample_for_compression),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kMutable,
+      offsetof(struct MutableCFOptions, sample_for_compression)}}};
+
+class ConfigurableMutableCFOptions : public Configurable {
+ private:
+  MutableCFOptions options_;
+
+ public:
+  ConfigurableMutableCFOptions(const MutableCFOptions& options)
+      : options_(options) {
+    RegisterOptionsMap("ColumnFamilyOptions", &options_, cf_options_type_info);
+  }
+
+ protected:
+  bool IsMutable() const override { return true; }
+};
+
+class ConfigurableCFOptions : public Configurable {
+ private:
+  ColumnFamilyOptions options_;
+  const std::unordered_map<std::string, std::string>* opt_map;
+
+ public:
+  ConfigurableCFOptions(
+      const ColumnFamilyOptions& options,
+      const std::unordered_map<std::string, std::string>* opt_map = nullptr);
+
+ protected:
+  Status UnknownToString(uint32_t /* mode */, const std::string& name,
+                                 std::string* result) const override;
+  const std::unordered_map<std::string, OptionsSanityCheckLevel>*
+  GetOptionsSanityCheckLevel(const std::string& name) const override;
+  bool VerifyOptionEqual(const std::string& opt_name,
+                         const OptionTypeInfo& opt_info,
+                         const char* this_offset,
+                         const char* that_offset) const override;
+  bool IsConfigEqual(const std::string& opt_name,
+                     const OptionTypeInfo& opt_info,
+                     OptionsSanityCheckLevel level,
+                     const Configurable* this_config,
+                     const Configurable* that_config,
+                     std::string* mismatch) const override;
+};
+
+ConfigurableCFOptions::ConfigurableCFOptions(
+    const ColumnFamilyOptions& options,
+    const std::unordered_map<std::string, std::string>* map)
+    : options_(options), opt_map(map) {
+  RegisterOptionsMap("ColumnFamilyOptions", &options_, cf_options_type_info);
+}
+
+bool ConfigurableCFOptions::VerifyOptionEqual(const std::string& opt_name,
+                                              const OptionTypeInfo& opt_info,
+                                              const char* this_offset,
+                                              const char* that_offset) const {
+  std::string this_value, that_value;
+  OptionStringMode mode = OptionStringMode::kOptionNone;
+  if (opt_info.verification != OptionVerificationType::kByName &&
+      opt_info.verification != OptionVerificationType::kByNameAllowFromNull &&
+      opt_info.verification != OptionVerificationType::kByNameAllowNull) {
+    return false;
+  } else if (opt_info.sfunc != nullptr) {
+    if (!opt_info.sfunc(mode, opt_name, this_offset, &this_value).ok() ||
+        !opt_info.sfunc(mode, opt_name, that_offset, &that_value).ok()) {
+      return false;
+    }
+  } else if (!SerializeOption(opt_name, opt_info, this_offset, mode,
+                              &this_value, "", ";").ok() ||
+             !SerializeOption(opt_name, opt_info, that_offset, mode,
+                              &that_value, "", ";").ok()) {
+    return false;
+  }
+  if (opt_map == nullptr) {
+    return true;
+  } else {
+    auto iter = opt_map->find(opt_name);
+    if (iter == opt_map->end()) {
+      return true;
+    } else if (opt_info.verification ==
+                   OptionVerificationType::kByNameAllowNull &&
+               (iter->second == kNullptrString ||
+                this_value == kNullptrString)) {
+      return true;
+    } else if (opt_info.verification ==
+                   OptionVerificationType::kByNameAllowFromNull &&
+               iter->second == kNullptrString) {
+      return true;
+    } else {
+      return (this_value == iter->second);
+    }
+  }
+}
+
+const std::unordered_map<std::string, OptionsSanityCheckLevel>*
+ConfigurableCFOptions::GetOptionsSanityCheckLevel(
+    const std::string& name) const {
+  static const std::unordered_map<std::string, OptionsSanityCheckLevel>
+      cf_sanity_level_options = {
+          {"comparator", kSanityLevelLooselyCompatible},
+          {"table_factory", kSanityLevelLooselyCompatible},
+          {"merge_operator", kSanityLevelLooselyCompatible},
+          {"compression_opts", kSanityLevelNone},
+          {"bottommost_compression_opts", kSanityLevelNone},
+      };
+  if (name == "ColumnFamilyOptions") {
+    return &cf_sanity_level_options;
+  } else {
+    return Configurable::GetOptionsSanityCheckLevel(name);
+  }
+}
+
+Status ConfigurableCFOptions::UnknownToString(uint32_t /* mode */,
+                                              const std::string& name,
+                                              std::string* result) const {
+  if (name == "bottommost_compression_opts") {
+    *result = "";
+  } else if (name == "compression_opts") {
+    *result = "";
+  }
+  return Status::OK();
+}
+
+bool ConfigurableCFOptions::IsConfigEqual(const std::string& opt_name,
+                                          const OptionTypeInfo& opt_info,
+                                          OptionsSanityCheckLevel level,
+                                          const Configurable* this_config,
+                                          const Configurable* that_config,
+                                          std::string* mismatch) const {
+  bool is_equal = Configurable::IsConfigEqual(opt_name, opt_info, level, this_config, that_config, mismatch);
+  // If the options are equal and there is no config but there is a map
+  if (is_equal && this_config == nullptr && opt_map != nullptr) {
+    // Check if the option name exists in the map
+    const auto iter = opt_map->find(opt_name);
+    // If the name exists in the map and is not empty,
+    // then the this_config should be set.
+    if (iter != opt_map->end() && !iter->second.empty()) {
+      is_equal = false;
+    }
+  }
+  return is_equal;
+}
+  
+Status GetColumnFamilyOptionsFromMap(
+    const DBOptions& db_options, const ColumnFamilyOptions& base_options,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    ColumnFamilyOptions* new_options, bool input_strings_escaped,
+    bool ignore_unknown_options) {
+  ConfigurableCFOptions config(base_options);
+  const ColumnFamilyOptions* updated =
+      config.GetOptions<ColumnFamilyOptions>("ColumnFamilyOptions");
+  Status status = config.ConfigureFromMap(
+      db_options, opts_map, input_strings_escaped, ignore_unknown_options);
+  if (status.ok()) {
+    *new_options = *updated;
+  } else {
+    *new_options = base_options;
+  }
+  return status;
+}
+
+Status GetColumnFamilyOptionsFromMapInternal(
+    const DBOptions& db_options, const ColumnFamilyOptions& base_options,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    ColumnFamilyOptions* new_options, bool input_strings_escaped,
+    std::unordered_set<std::string>* unused, bool ignore_unknown_options) {
+  ConfigurableCFOptions config(base_options);
+  const ColumnFamilyOptions* updated =
+      config.GetOptions<ColumnFamilyOptions>("ColumnFamilyOptions");
+  Status status = config.ConfigureFromMap(db_options, opts_map,
+                                          input_strings_escaped, unused);
+  if (ignore_unknown_options || status.ok()) {
+    *new_options = *updated;
+  } else {
+    *new_options = base_options;
+  }
+  return status;
+}
+
+Status GetColumnFamilyOptionsFromString(const DBOptions& db_options,
+                                        const ColumnFamilyOptions& base_options,
+                                        const std::string& opts_str,
+                                        ColumnFamilyOptions* new_options) {
+  std::unordered_map<std::string, std::string> opts_map;
+  Status s = StringToMap(opts_str, &opts_map);
+  if (!s.ok()) {
+    *new_options = base_options;
+    return s;
+  }
+  return GetColumnFamilyOptionsFromMap(db_options, base_options, opts_map,
+                                       new_options);
+}
+
+Status GetColumnFamilyOptionNames(std::unordered_set<std::string>* option_names,
+                                  bool use_mutable) {
+  if (use_mutable) {
+    MutableCFOptions opts;
+    ConfigurableMutableCFOptions config(opts);
+    return config.GetOptionNames(option_names);
+  } else {
+    ColumnFamilyOptions opts;
+    ConfigurableCFOptions config(opts);
+    return config.GetOptionNames(option_names);
+  }
+}
+Status GetStringFromColumnFamilyOptions(std::string* opt_string,
+                                        const ColumnFamilyOptions& cf_options,
+                                        const std::string& delimiter) {
+  ConfigurableCFOptions config(cf_options);
+  return config.GetOptionString(opt_string, delimiter);
+}
+
+Status GetMutableOptionsFromStrings(
+    const MutableCFOptions& base_options,
+    const std::unordered_map<std::string, std::string>& options_map,
+    Logger* /* info_log */, MutableCFOptions* new_options) {
+  assert(new_options);
+  DBOptions db_options;
+  ConfigurableMutableCFOptions config(base_options);
+  Status status = config.ConfigureFromMap(db_options, options_map);
+  if (status.ok()) {
+    *new_options =
+        *(config.GetOptions<MutableCFOptions>("ColumnFamilyOptions"));
+  } else {
+    *new_options = base_options;
+  }
+  return status;
+}
+
+Status RocksDBOptionsParser::VerifyCFOptions(
+    const ColumnFamilyOptions& base_opt,
+    const ColumnFamilyOptions& persisted_opt,
+    const std::unordered_map<std::string, std::string>* persisted_opt_map,
+    OptionsSanityCheckLevel sanity_check_level) {
+  ConfigurableCFOptions base_config(base_opt, persisted_opt_map);
+  ConfigurableCFOptions persisted_config(persisted_opt, persisted_opt_map);
+  std::string mismatch;
+  if (!base_config.Matches(&persisted_config, sanity_check_level, &mismatch)) {
+    std::string base_value;
+    std::string persisted_value;
+    const size_t kBufferSize = 2048;
+    char buffer[kBufferSize];
+
+    base_config.GetOption(mismatch, &base_value);
+    persisted_config.GetOption(mismatch, &persisted_value);
+    snprintf(buffer, sizeof(buffer),
+             "[RocksDBOptionsParser]: "
+             "failed the verification on ColumnFamilyOptions::%s --- "
+             "The specified one is %s while the persisted one is %s.\n",
+             mismatch.c_str(), base_value.c_str(), persisted_value.c_str());
+    return Status::InvalidArgument(Slice(buffer, sizeof(buffer)));
+  }
+  return Status::OK();
+}
+
+#endif  // ROCKSDB_LITE
 }  // namespace rocksdb

--- a/options/configurable.cc
+++ b/options/configurable.cc
@@ -1,0 +1,971 @@
+// Copyright (c) 2011-present, Facebook, Inc. All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "rocksdb/configurable.h"
+#include "options/options_helper.h"
+#include "options/options_parser.h"
+#include "rocksdb/status.h"
+#include "rocksdb/utilities/options_type.h"
+#include "util/string_util.h"
+
+namespace rocksdb {
+
+const std::string Configurable::kDefaultPrefix = "rocksdb.";
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Configuring Options from Strings/Name-Value Pairs/Maps */
+/*                                                                               */
+/*********************************************************************************/
+
+#ifndef ROCKSDB_LITE
+/**
+ * Updates the object with the named-value property values, returning OK on
+ * succcess. Any names properties that could not be found are returned in
+ * used_opts. Returns OK if all of the properties were successfully updated.
+ */
+Status Configurable::DoConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, bool ignore_unused_options,
+    std::unordered_set<std::string>* unused_opts) {
+  Status s, result, invalid;
+  bool found_one = false;
+  std::unordered_set<std::string> invalid_opts;
+  std::string curr_opts;
+  if (!ignore_unused_options) {
+    // If we are not ignoring unused, get the defaults in case we need to reset
+    GetOptionString(&curr_opts, ";");
+  }
+  // Go through all of the values in the input map and attempt to configure the
+  // property.
+  for (const auto& o : opts_map) {
+    s = ConfigureOption(db_opts, o.first, o.second, input_strings_escaped);
+    if (s.ok()) {
+      found_one = true;
+    } else if (s.IsNotFound()) {
+      result = s;
+      unused_opts->insert(o.first);
+    } else if (s.IsNotSupported()) {
+      invalid_opts.insert(o.first);
+    } else {
+      invalid_opts.insert(o.first);
+      invalid = s;
+    }
+  }
+  // While there are unused properties and we processed at least one,
+  // go through the remaining unused properties and attempt to configure them.
+  while (found_one && !unused_opts->empty()) {
+    result = Status::OK();
+    found_one = false;
+    for (auto it = unused_opts->begin(); it != unused_opts->end();) {
+      s = ConfigureOption(db_opts, *it, opts_map.at(*it),
+                          input_strings_escaped);
+      if (s.ok()) {
+        found_one = true;
+        it = unused_opts->erase(it);
+      } else if (s.IsNotFound()) {
+        result = s;
+        ++it;
+      } else if (s.IsNotSupported()) {
+        invalid_opts.insert(*it);
+        it = unused_opts->erase(it);
+      } else {
+        invalid_opts.insert(*it);
+        it = unused_opts->erase(it);
+        invalid = s;
+      }
+    }
+  }
+  if (!invalid_opts.empty()) {
+    unused_opts->insert(invalid_opts.begin(), invalid_opts.end());
+  }
+  if (ignore_unused_options || (invalid.ok() && result.ok())) {
+    return Status::OK();
+  } else {
+    if (!curr_opts.empty()) {
+      // There are some options to reset from this current error
+      ConfigureFromString(db_opts, curr_opts, input_strings_escaped, true);
+    }
+    if (!invalid.ok()) {
+      return invalid;
+    } else {
+      return result;
+    }
+  }
+}
+
+Status Configurable::ConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, bool ignore_unused_options) {
+  std::unordered_set<std::string> unused_opts;
+  Status s = DoConfigureFromMap(db_opts, opts_map, input_strings_escaped,
+                                ignore_unused_options, &unused_opts);
+  return s;
+}
+
+Status Configurable::ConfigureFromMap(
+    const DBOptions& db_opts,
+    const std::unordered_map<std::string, std::string>& opts_map,
+    bool input_strings_escaped, std::unordered_set<std::string>* unused) {
+  return DoConfigureFromMap(db_opts, opts_map, input_strings_escaped, true,
+                            unused);
+}
+
+Status Configurable::ConfigureFromString(
+    const DBOptions& db_opts, const std::string& opt_str,
+    bool input_strings_escaped, std::unordered_set<std::string>* unused_opts) {
+  std::unordered_map<std::string, std::string> opt_map;
+  Status s = StringToMap(opt_str, &opt_map);
+  if (s.ok()) {
+    s = DoConfigureFromMap(db_opts, opt_map, input_strings_escaped, true,
+                           unused_opts);
+  }
+  return s;
+}
+#endif  // ROCKSDB_LITE
+
+Status Configurable::ConfigureFromString(const DBOptions& db_opts,
+                                         const std::string& opts_str,
+                                         bool input_strings_escaped,
+                                         bool ignore_unused_options) {
+  Status s;
+  if (!opts_str.empty()) {
+    if (opts_str.find(';') == std::string::npos &&
+        opts_str.find('=') == std::string::npos) {
+      return ParseStringOptions(db_opts, opts_str, input_strings_escaped,
+                                ignore_unused_options);
+    } else {
+#ifndef ROCKSDB_LITE
+      std::unordered_map<std::string, std::string> opt_map;
+      std::unordered_set<std::string> unused_opts;
+
+      s = StringToMap(opts_str, &opt_map);
+      if (s.ok()) {
+        s = DoConfigureFromMap(db_opts, opt_map, input_strings_escaped,
+                               ignore_unused_options, &unused_opts);
+      }
+#else
+      s = ParseStringOptions(db_opts, opts_str, input_strings_escaped,
+                             ignore_unused_options);
+#endif  // ROCKSDB_LITE
+    }
+  }
+  return s;
+}
+
+/**
+ * Sets the value of the named property to the input value, returning OK on
+ * succcess.
+ */
+Status Configurable::ConfigureOption(const DBOptions& db_opts,
+                                     const std::string& name,
+                                     const std::string& value,
+                                     bool input_strings_escaped) {
+  const std::string& option_name = GetOptionName(name);
+  const std::string& option_value =
+      input_strings_escaped ? UnescapeOptionString(value) : value;
+  bool found_it = false;
+  Status status;
+#ifndef ROCKSDB_LITE
+  status = SetOption(db_opts, option_name, option_value, input_strings_escaped,
+                     &found_it);
+#endif
+  if (!found_it) {
+    status = SetUnknown(db_opts, option_name, option_value);
+  }
+  return status;
+}
+
+/**
+ * Looks for the named option amongst the options for this type and sets
+ * the value for it to be the input value.
+ * If the name was found, found_option will be set to true and the resulting
+ * status should be returned.
+ */
+#ifndef ROCKSDB_LITE
+Status Configurable::SetOption(const DBOptions& db_opts,
+                               const std::string& name,
+                               const std::string& value,
+                               bool input_strings_escaped, bool* found_option) {
+  // By the time this method is called, the name is the short name (no prefix)
+  // and the value is unescaped.
+  Status status;
+  *found_option = false;
+  // Look for the name in all of the registered option maps until it is found
+  for (auto iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    // Look up the value in the map
+    auto opt_iter = FindOption(name, opt_map);
+    if (opt_iter != opt_map.end()) {
+      const auto& opt_info = opt_iter->second;
+      *found_option = true;
+      if (name == opt_iter->first) {
+        status = ParseOption(opt_info, db_opts, opt_ptr, name, value,
+                             input_strings_escaped);
+      } else {
+        status = ParseOption(opt_info, db_opts, opt_ptr,
+                             name.substr(opt_iter->first.size() + 1), value,
+                             input_strings_escaped);
+      }
+      if (status.IsNotFound()) {
+        *found_option = false;
+      }
+      return status;
+    } else {
+      for (auto map_iter : opt_map) {
+        if (map_iter.second.IsConfigurable()) {
+          char* opt_addr = GetOptAddress(map_iter.second, opt_ptr);
+          Configurable* config =
+              map_iter.second.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->ConfigureOption(db_opts, name, value);
+            if (!status.IsNotFound()) {
+              *found_option = true;
+              return status;
+            }
+          }
+        }  // End if config option
+      }
+    }
+  }
+  return status;
+}
+
+Status Configurable::ParseOption(const OptionTypeInfo& opt_info,
+                                 const DBOptions& db_opts, void* opt_ptr,
+                                 const std::string& opt_name,
+                                 const std::string& opt_value,
+                                 bool input_strings_escaped) {
+  Status status;
+  if (opt_info.verification != OptionVerificationType::kDeprecated) {
+    try {
+      char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr == nullptr) {
+        if (IsMutable()) {
+          return Status::InvalidArgument("Option not changeable: " + opt_name);
+        } else {
+          status = Status::NotFound("Could not find property:", opt_name);
+        }
+      } else if (opt_info.pfunc != nullptr) {
+        status = opt_info.pfunc(db_opts, opt_name, opt_addr, opt_value);
+      } else if (ParseOptionHelper(opt_addr, opt_info, opt_value)) {
+        status = Status::OK();
+      } else if (opt_info.IsConfigurable()) {
+        Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+        if (!opt_value.empty()) {
+          if (config == nullptr) {
+            status =
+                Status::NotFound("Could not find configurable: ", opt_name);
+          } else if (opt_value.find("=") != std::string::npos) {
+            status = config->ConfigureFromString(db_opts, opt_value,
+                                                 input_strings_escaped);
+          } else {
+            status = config->ConfigureOption(db_opts, opt_name, opt_value,
+                                             input_strings_escaped);
+          }
+        }
+      } else if (opt_info.IsEnum()) {
+        status = SetEnum(db_opts, opt_name, opt_value, opt_addr);
+      } else if (opt_info.type == OptionType::kUnknown) {
+        status = SetUnknown(db_opts, opt_name, opt_value);
+      } else if (opt_info.verification == OptionVerificationType::kByName ||
+                 opt_info.verification ==
+                     OptionVerificationType::kByNameAllowNull ||
+                 opt_info.verification ==
+                     OptionVerificationType::kByNameAllowFromNull) {
+        status = Status::NotSupported("Deserializing the option " + opt_name +
+                                      " is not supported");
+      } else {
+        status = Status::InvalidArgument("Error parsing:", opt_name);
+      }
+    } catch (std::exception& e) {
+      status = Status::InvalidArgument("Error parsing " + opt_name + ":" +
+                                       std::string(e.what()));
+    }
+  }
+  return status;
+}
+
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Converting Options into strings */
+/*                                                                               */
+/*********************************************************************************/
+
+#ifndef ROCKSDB_LITE
+std::string Configurable::ToString(uint32_t mode, const std::string& prefix,
+                                   const std::string& delimiter) const {
+  std::string result = AsString(mode, prefix, delimiter);
+  if (result.empty() || result.find('=') == std::string::npos) {
+    return result;
+  } else if ((mode & OptionStringMode::kOptionDetached) != 0) {
+    return result;
+  } else {
+    return "{" + result + "}";
+  }
+}
+
+std::string Configurable::AsString(uint32_t mode, const std::string& header,
+                                   const std::string& delimiter) const {
+  std::string result;
+  Status s = SerializeOptions(mode, &result, header, delimiter);
+  assert(s.ok());
+  return result;
+}
+
+Status Configurable::GetOptionString(uint32_t mode, std::string* result,
+                                     const std::string& delimiter) const {
+  assert(result);
+  result->clear();
+  Status s = SerializeOptions(mode, result, "", delimiter);
+  return s;
+}
+
+Status Configurable::GetOptionNames(
+    uint32_t mode, std::unordered_set<std::string>* result) const {
+  assert(result);
+  return ListOptions(mode, "", result);
+}
+
+#endif  // ROCKSDB_LITE
+
+Status Configurable::GetOption(const std::string& name,
+                               std::string* value) const {
+  assert(value);
+  value->clear();
+  Status status;
+  bool found_it = false;
+  const std::string& option_name = GetOptionName(name);
+
+#ifndef ROCKSDB_LITE
+  status = SerializeSingleOption(OptionStringMode::kOptionDetached, option_name,
+                                 value, &found_it);
+#endif
+  if (!found_it) {
+    status =
+        UnknownToString(OptionStringMode::kOptionDetached, option_name, value);
+  }
+  return status;
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::SerializeOption(const std::string& opt_name,
+                                     const OptionTypeInfo& opt_info,
+                                     const char* opt_addr, uint32_t mode,
+                                     std::string* opt_value,
+                                     const std::string& prefix,
+                                     const std::string& delimiter) const {
+  // If the option is no longer used in rocksdb and marked as deprecated,
+  // we skip it in the serialization.
+  Status s;
+  if (opt_addr != nullptr &&
+      opt_info.verification != OptionVerificationType::kDeprecated) {
+    if (opt_info.sfunc != nullptr) {
+      s = opt_info.sfunc(mode, opt_name, opt_addr, opt_value);
+    } else if (SerializeSingleOptionHelper(opt_addr, opt_info, opt_value)) {
+      s = Status::OK();
+    } else if (opt_info.IsConfigurable()) {
+      const Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+      if (config != nullptr) {
+        if ((mode & OptionStringMode::kOptionDetached) != 0) {
+          *opt_value = config->ToString(mode, prefix, delimiter);
+        } else {
+          *opt_value = config->ToString(mode, "", "; ");
+        }
+      }
+    } else if (opt_info.type == OptionType::kUnknown) {
+      s = UnknownToString(mode, opt_name, opt_value);
+    } else {
+      s = Status::InvalidArgument("Cannot serialize option: ", opt_name);
+    }
+  }
+  return s;
+}
+
+Status Configurable::SerializeOptions(uint32_t mode, std::string* result,
+                                      const std::string& prefix,
+                                      const std::string& delimiter) const {
+  assert(result);
+  auto header = ((mode & OptionStringMode::kOptionPrefix) != 0)
+                    ? GetOptionsPrefix()
+                    : prefix;
+  for (auto const iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+         ++opt_iter) {
+      const auto& opt_name = opt_iter->first;
+      const auto& opt_info = opt_iter->second;
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        std::string value;
+        Status s = SerializeOption(
+            opt_name, opt_info, opt_addr, mode, &value,
+            ((mode & OptionStringMode::kOptionDetached) != 0) ? opt_name + "."
+                                                              : header,
+            delimiter);
+        if (!s.ok()) {
+          return s;
+        } else if (!opt_info.IsConfigurable()) {
+          PrintSingleOption(header, opt_name, value, delimiter, result);
+        } else if ((mode & OptionStringMode::kOptionDetached) != 0) {
+          result->append(value);
+        } else if (!value.empty()) {
+          PrintSingleOption(header, opt_name, value, delimiter, result);
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Status Configurable::ListOptions(
+    uint32_t mode, const std::string& prefix,
+    std::unordered_set<std::string>* result) const {
+  Status status;
+  std::string header = ((mode & OptionStringMode::kOptionPrefix) != 0)
+                           ? GetOptionsPrefix() + prefix
+                           : prefix;
+  for (auto const iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+         ++opt_iter) {
+      const auto& opt_name = opt_iter->first;
+      const auto& opt_info = opt_iter->second;
+      // If the option is no longer used in rocksdb and marked as deprecated,
+      // we skip it in the serialization.
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr &&
+          opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          const Configurable* config =
+              opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->ListOptions(mode | OptionStringMode::kOptionPrefix,
+                                         prefix, result);
+          }
+        } else {
+          result->emplace(header + opt_name);
+        }
+      }
+      if (!status.ok()) {
+        return status;
+      }
+    }
+  }
+  return status;
+}
+
+Status Configurable::SerializeSingleOption(uint32_t mode,
+                                           const std::string& name,
+                                           std::string* value,
+                                           bool* found_it) const {
+  assert(value);
+  *found_it = false;
+  // By the time this method is called, the name is the short name (no prefix)
+  // and the value is unescaped.
+  // Look for the name in all of the registered option maps until it is found
+  for (auto iter : options_) {
+    const auto& opt_map = iter.second.second;
+    void* opt_ptr = iter.second.first;
+    // Look up the value in the map
+    auto opt_iter = FindOption(name, opt_map);
+    if (opt_iter != opt_map.end()) {
+      const auto& opt_info = opt_iter->second;
+      *found_it = true;
+      const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+      if (opt_addr != nullptr) {
+        if (name == opt_iter->first) {
+          return SerializeOption(name, opt_info, opt_addr, mode, value, "",
+                                 ";");
+        } else if (opt_info.IsConfigurable()) {
+          auto const* config = opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            return config->GetOption(name.substr(opt_iter->first.size() + 1),
+                                     value);
+          }
+        }
+      }
+      return Status::NotFound("Cannot find option: ", name);
+    } else {
+      for (auto const map_iter : opt_map) {
+        if (map_iter.second.IsConfigurable()) {
+          const char* opt_addr = GetOptAddress(map_iter.second, opt_ptr);
+          auto const* config =
+              map_iter.second.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            Status status = config->GetOption(name, value);
+            if (!status.IsNotFound()) {
+              *found_it = true;
+              return status;
+            }
+          }
+        }
+      }
+    }
+  }
+  return Status::NotFound("Could not find option: ", name);
+}
+#endif  // ROCKSDB_LITE
+
+#ifndef ROCKSDB_LITE
+void Configurable::RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                                      const OptionTypeMap& opt_map) {
+  options_[name] = std::pair<void*, OptionTypeMap>(opt_ptr, opt_map);
+}
+#else
+void Configurable::RegisterOptionsMap(const std::string& name, void* opt_ptr,
+                                      const OptionTypeMap&) {
+  options_[name] = opt_ptr;
+}
+#endif  // ROCKSDB_LITE
+
+void Configurable::PrintSingleOption(const std::string& prefix,
+                                     const std::string& name,
+                                     const std::string& value,
+                                     const std::string& delimiter,
+                                     std::string* result) const {
+  result->append(prefix);
+  result->append(name);  // Add the name
+  result->append("=");
+  result->append(value);
+  result->append(delimiter);
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Validating and Sanitizing Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+Status Configurable::SanitizeOptions() {
+  Options opts;
+  return Sanitize(opts, opts);
+}
+
+Status Configurable::SanitizeOptions(DBOptions& db_opts) {
+  ColumnFamilyOptions cf_opts;
+  return Sanitize(db_opts, cf_opts);
+}
+
+Status Configurable::SanitizeOptions(DBOptions& db_opts,
+                                     ColumnFamilyOptions& cf_opts) {
+  Status status = Sanitize(db_opts, cf_opts);
+  if (status.ok()) {
+    status = Validate(db_opts, cf_opts);
+  }
+  return status;
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::Sanitize(DBOptions& db_opts,
+                              ColumnFamilyOptions& cf_opts) {
+  Status status;
+  for (auto opt_iter : options_) {
+    const auto opt_map = opt_iter.second.second;
+    for (auto map_iter = opt_map.begin(); map_iter != opt_map.end();
+         ++map_iter) {
+      auto& opt_info = map_iter->second;
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          char* opt_addr = GetOptAddress(opt_info, opt_iter.second.first);
+          Configurable* config = opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->Sanitize(db_opts, cf_opts);
+          } else if (opt_info.verification !=
+                     OptionVerificationType::kByNameAllowFromNull) {
+            status = Status::NotFound("Missing configurable object",
+                                      map_iter->first);
+          }
+          if (!status.ok()) {
+            return status;
+          }
+        }
+      }
+    }
+  }
+  return status;
+}
+#else
+Status Configurable::Sanitize(DBOptions&, ColumnFamilyOptions&) {
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
+Status Configurable::ValidateOptions() const {
+  Options opts;
+  return ValidateOptions(opts, opts);
+}
+
+Status Configurable::ValidateOptions(const DBOptions& db_opts) const {
+  ColumnFamilyOptions cf_opts;
+  return Validate(db_opts, cf_opts);
+}
+
+Status Configurable::ValidateOptions(const DBOptions& db_opts,
+                                     const ColumnFamilyOptions& cf_opts) const {
+  return Validate(db_opts, cf_opts);
+}
+
+#ifndef ROCKSDB_LITE
+Status Configurable::Validate(const DBOptions& db_opts,
+                              const ColumnFamilyOptions& cf_opts) const {
+  Status status;
+  for (auto opt_iter : options_) {
+    const auto opt_map = opt_iter.second.second;
+    for (auto map_iter = opt_map.begin(); map_iter != opt_map.end();
+         ++map_iter) {
+      auto& opt_info = map_iter->second;
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        if (opt_info.IsConfigurable()) {
+          const char* opt_addr = GetOptAddress(opt_info, opt_iter.second.first);
+          const Configurable* config =
+              opt_info.GetPointer<Configurable>(opt_addr);
+          if (config != nullptr) {
+            status = config->Validate(db_opts, cf_opts);
+          } else if (opt_info.verification !=
+                     OptionVerificationType::kByNameAllowFromNull) {
+            status = Status::NotFound("Missing configurable object",
+                                      map_iter->first);
+          }
+          if (!status.ok()) {
+            return status;
+          }
+        }
+      }
+    }
+  }
+  return status;
+}
+#else
+Status Configurable::Validate(const DBOptions&,
+                              const ColumnFamilyOptions&) const {
+  return Status::OK();
+}
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Comparing Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+bool Configurable::Matches(const Configurable* other,
+                           OptionsSanityCheckLevel level) const {
+  std::string name;
+  return Matches(other, level, &name);
+}
+
+bool Configurable::Matches(const Configurable* other,
+                           OptionsSanityCheckLevel level,
+                           std::string* name) const {
+  assert(name);
+  name->clear();
+  if (this == other || level == OptionsSanityCheckLevel::kSanityLevelNone) {
+    return true;
+  } else if (other != nullptr) {
+    return MatchesOption(other, level, name);
+  } else {
+    return false;
+  }
+}
+
+bool Configurable::MatchesOption(const Configurable* that,
+                                 OptionsSanityCheckLevel level,
+                                 std::string* name) const {
+  assert(name != nullptr);
+  if (this == that || level == OptionsSanityCheckLevel::kSanityLevelNone) {
+    return true;
+  } else {
+#ifndef ROCKSDB_LITE
+    for (auto const iter : options_) {
+      const char* this_option =
+          reinterpret_cast<const char*>(iter.second.first);
+      const char* that_option = that->GetOptions<const char>(iter.first);
+      if (!OptionsAreEqual(iter.second.second,
+                           GetOptionsSanityCheckLevel(iter.first), level,
+                           this_option, that_option, name)) {
+        return false;
+      }
+    }
+    return true;
+#endif  // ROCKSDB_LITE
+    return false;
+  }
+}
+
+OptionsSanityCheckLevel Configurable::GetSanityLevelForOption(
+    const std::unordered_map<std::string, OptionsSanityCheckLevel>* map,
+    const std::string& name) const {
+  if (map != nullptr) {
+    auto iter = map->find(name);
+    if (iter != map->end()) {
+      return iter->second;
+    }
+  }
+  return OptionsSanityCheckLevel::kSanityLevelExactMatch;
+}
+
+#ifndef ROCKSDB_LITE
+bool Configurable::VerifyOptionEqual(const std::string& opt_name,
+                                     const OptionTypeInfo& opt_info,
+                                     const char* this_offset,
+                                     const char* that_offset) const {
+  std::string this_value, that_value;
+
+  OptionStringMode mode = OptionStringMode::kOptionNone;
+  if (opt_info.verification != OptionVerificationType::kByName &&
+      opt_info.verification != OptionVerificationType::kByNameAllowNull &&
+      opt_info.verification != OptionVerificationType::kByNameAllowFromNull) {
+    return false;
+  } else if (opt_info.sfunc != nullptr) {
+    if (!opt_info.sfunc(mode, opt_name, this_offset, &this_value).ok() ||
+        !opt_info.sfunc(mode, opt_name, that_offset, &that_value).ok()) {
+      return false;
+    }
+  } else if (!SerializeOption(opt_name, opt_info, this_offset, mode,
+                              &this_value, "", ";")
+                  .ok() ||
+             !SerializeOption(opt_name, opt_info, that_offset, mode,
+                              &that_value, "", ";")
+                  .ok()) {
+    return false;
+  }
+  if (opt_info.verification == OptionVerificationType::kByNameAllowFromNull &&
+      that_value == kNullptrString) {
+    return true;
+  } else if (opt_info.verification ==
+                 OptionVerificationType::kByNameAllowNull &&
+             this_value == kNullptrString) {
+    return true;
+  } else if (this_value != that_value) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+bool Configurable::IsConfigEqual(const std::string& /* opt_name */,
+                                 const OptionTypeInfo& /* opt_info */,
+                                 OptionsSanityCheckLevel level,
+                                 const Configurable* this_config,
+                                 const Configurable* that_config,
+                                 std::string* mismatch) const {
+  if (this_config == that_config) {
+    return true;
+  } else if (this_config != nullptr && that_config != nullptr) {
+    return this_config->Matches(that_config, level, mismatch);
+  } else {
+    return false;
+  }
+}
+
+bool Configurable::OptionIsEqual(const std::string& opt_name,
+                                 const OptionTypeInfo& opt_info,
+                                 OptionsSanityCheckLevel level,
+                                 const char* this_offset,
+                                 const char* that_offset,
+                                 std::string* bad_name) const {
+  if (this_offset == nullptr || that_offset == nullptr) {
+    if (this_offset != that_offset) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.efunc != nullptr) {
+    return opt_info.efunc(level, opt_name, this_offset, that_offset);
+  } else if (IsOptionEqual(level, opt_info, this_offset, that_offset)) {
+    return true;
+  } else if (opt_info.type == OptionType::kUnknown) {
+    if (!IsUnknownEqual(opt_name, opt_info, level, this_offset, that_offset)) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.IsEnum()) {
+    if (!IsEnumEqual(opt_name, opt_info, level, this_offset, that_offset)) {
+      *bad_name = opt_name;
+      return false;
+    }
+  } else if (opt_info.IsConfigurable()) {
+    std::string mismatch;
+    const auto* this_config = opt_info.GetPointer<Configurable>(this_offset);
+    const auto* that_config = opt_info.GetPointer<Configurable>(that_offset);
+    if (!IsConfigEqual(opt_name, opt_info, level, this_config, that_config,
+                       &mismatch)) {
+      *bad_name = opt_name;
+      if (!mismatch.empty()) {
+        bad_name->append("." + mismatch);
+      }
+      return false;
+    }
+  } else {
+    *bad_name = opt_name;
+    return false;
+  }
+  return true;
+}
+
+bool Configurable::OptionsAreEqual(
+    const OptionTypeMap& opt_map,
+    const std::unordered_map<std::string, OptionsSanityCheckLevel>* opt_level,
+    OptionsSanityCheckLevel sanity_check_level, const char* this_option,
+    const char* that_option, std::string* bad_name) const {
+  *bad_name = "";
+  if (this_option == that_option) {
+    return true;
+  } else if (this_option == nullptr || that_option == nullptr) {
+    return false;
+  } else {
+    for (auto& pair : opt_map) {
+      const auto& opt_info = pair.second;
+      // We skip checking deprecated variables as they might
+      // contain random values since they might not be initialized
+      if (opt_info.verification != OptionVerificationType::kDeprecated &&
+          opt_info.verification != OptionVerificationType::kAlias) {
+        OptionsSanityCheckLevel level =
+            GetSanityLevelForOption(opt_level, pair.first);
+        if (level > OptionsSanityCheckLevel::kSanityLevelNone &&
+            level <= sanity_check_level) {
+          const char* this_offset = GetOptAddress(opt_info, this_option);
+          const char* that_offset = GetOptAddress(opt_info, that_option);
+          if (!OptionIsEqual(pair.first, opt_info, level, this_offset,
+                             that_offset, bad_name) &&
+              !VerifyOptionEqual(pair.first, opt_info, this_offset,
+                                 that_offset)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+}
+#endif  // ROCKSDB_LITE
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Retrieving Options from Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+const void* Configurable::GetOptionsPtr(const std::string& name) const {
+  const auto& iter = options_.find(name);
+  if (iter != options_.end()) {
+#ifndef ROCKSDB_LITE
+    return iter->second.first;
+#else
+    return iter->second;
+#endif  // ROCKSDB_LITE
+  }
+  return nullptr;
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Methods for Logging Configurables */
+/*                                                                               */
+/*********************************************************************************/
+
+void Configurable::DumpOptions(Logger* logger, const std::string& indent,
+#ifndef ROCKSDB_LITE
+                               uint32_t mode
+#else
+                               uint32_t
+#endif  // ROCKSDB_LITE
+                               ) const {
+  std::string value = GetPrintableOptions();
+  if (!value.empty()) {
+    ROCKS_LOG_HEADER(logger, "%s Options: %s\n", indent.c_str(), value.c_str());
+  } else {
+#ifndef ROCKSDB_LITE
+    for (auto const iter : options_) {
+      std::string header = iter.first;
+      if ((mode & OptionStringMode::kOptionPrefix) != 0) {
+        header.append("::" + GetOptionsPrefix());
+      } else {
+        header.append(".");
+      }
+      const auto& opt_map = iter.second.second;
+      const void* opt_ptr = iter.second.first;
+
+      for (auto opt_iter = opt_map.begin(); opt_iter != opt_map.end();
+           ++opt_iter) {
+        auto& opt_name = opt_iter->first;
+        auto& opt_info = opt_iter->second;
+        // If the option is no longer used in rocksdb and marked as deprecated,
+        // we skip it in the serialization.
+        const char* opt_addr = GetOptAddress(opt_info, opt_ptr);
+        if (opt_addr != nullptr &&
+            opt_info.verification != OptionVerificationType::kAlias) {
+          if (opt_info.IsConfigurable() &&
+              (mode & OptionStringMode::kOptionDetached) != 0) {
+            // Nested options on individual lines
+            const Configurable* config =
+                opt_info.GetPointer<Configurable>(opt_addr);
+            if (config != nullptr) {
+              ROCKS_LOG_HEADER(logger, "%s%s%s Options:\n", indent.c_str(),
+                               header.c_str(), opt_name.c_str());
+              config->Dump(logger, indent + "  ", mode);
+            }
+          } else {
+            Status s = SerializeOption(opt_name, opt_info, opt_addr, mode,
+                                       &value, "", ";");
+            if (s.ok()) {
+              ROCKS_LOG_HEADER(logger, "%s%s%s: %s\n", indent.c_str(),
+                               header.c_str(), opt_name.c_str(), value.c_str());
+            }
+          }
+        }
+      }
+    }
+#endif  // ROCKSDB_LITE
+  }
+}
+
+/*********************************************************************************/
+/*                                                                               */
+/*       Configurable Support and Utility Methods */
+/*                                                                               */
+/*********************************************************************************/
+
+std::string Configurable::GetOptionName(const std::string& long_name) const {
+  auto& prefix = GetOptionsPrefix();
+  auto prefix_len = prefix.length();
+  if (long_name.compare(0, prefix_len, prefix) == 0) {
+    return long_name.substr(prefix_len);
+  } else {
+    return long_name;
+  }
+}
+
+#ifndef ROCKSDB_LITE
+
+OptionTypeMap::const_iterator Configurable::FindOption(
+    const std::string& option, const OptionTypeMap& options_map) const {
+  auto iter = options_map.find(option);  // Look up the value in the map
+  if (iter == options_map.end()) {       // Didn't find the option in the map
+    auto idx = option.find(".");         // Look for a separator
+    if (idx > 0 && idx != std::string::npos) {  // We found a separator
+      auto siter =
+          options_map.find(option.substr(0, idx));  // Look for the short name
+      if (siter != options_map.end() &&             // We found the short name
+          siter->second.IsConfigurable()) {  // and the object is a configurable
+        return siter;                        // Return the short name value
+      }
+    }
+  }
+  return iter;
+}
+#endif  // ROCKSDB_LITE
+
+}  // namespace rocksdb

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "rocksdb/configurable.h"
+#include "rocksdb/status.h"
+
+namespace rocksdb {
+struct DBOptions;
+
+#ifndef ROCKSDB_LITE
+// Wrapper class for configuring structs.
+// This class can be used to configure classes that
+// do not inherit from Configurable (such as structs)
+// and that do not need special handling of options
+template <typename T>
+class ConfigurableStruct : public Configurable {
+ public:
+  ConfigurableStruct(const T& options, const OptionTypeMap& opt_map,
+                     bool is_mutable = false)
+      : ConfigurableStruct(opt_map, is_mutable) {
+    options_ = options;
+  }
+
+  ConfigurableStruct(const OptionTypeMap& opt_map, bool is_mutable = false)
+      : Configurable("Options", &options_, opt_map, is_mutable) {}
+
+  const T* GetStructOptions() const { return &options_; }
+
+ private:
+  T options_;
+};
+#endif  // ROCKSDB_LITE
+}  // namespace rocksdb

--- a/options/configurable_test.cc
+++ b/options/configurable_test.cc
@@ -1,0 +1,864 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <cctype>
+#include <cinttypes>
+#include <cstring>
+#include <unordered_map>
+
+#include "rocksdb/configurable.h"
+
+#include "options/configurable_helper.h"
+#include "options/options_helper.h"
+#include "options/options_parser.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+#ifndef GFLAGS
+bool FLAGS_enable_print = false;
+#else
+#include "util/gflags_compat.h"
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+DEFINE_bool(enable_print, false, "Print options generated to console.");
+#endif  // GFLAGS
+
+namespace rocksdb {
+class StringLogger : public Logger {
+ public:
+  using Logger::Logv;
+  void Logv(const char* format, va_list ap) override {
+    char buffer[1000];
+    vsnprintf(buffer, sizeof(buffer), format, ap);
+    string_.append(buffer);
+  }
+  const std::string& str() const { return string_; }
+  void clear() { string_.clear(); }
+
+ private:
+  std::string string_;
+};
+
+struct SimpleOptions {
+  int i = 0;
+  bool b = false;
+  bool d = true;
+  std::string s = "";
+  std::string u = "";
+};
+
+static std::unordered_map<std::string, OptionTypeInfo> simple_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offsetof(struct SimpleOptions, i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bool",
+     {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offsetof(struct SimpleOptions, s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"unknown",
+     {offsetof(struct SimpleOptions, u), OptionType::kUnknown,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0,
+      [](const DBOptions& /*opts*/, const std::string& /* name */, char* addr,
+         const std::string& value) {
+        *reinterpret_cast<std::string*>(addr) = value;
+        return Status::OK();
+      },
+      [](uint32_t, const std::string&, const char* addr, std::string* value) {
+        *value = *reinterpret_cast<const std::string*>(addr);
+        return Status::OK();
+      },
+      [](OptionsSanityCheckLevel, const std::string&, const char* this_addr,
+         const char* that_addr) {
+        return (*reinterpret_cast<const std::string*>(this_addr) ==
+                *reinterpret_cast<const std::string*>(that_addr));
+      }}},
+#endif  // ROCKSDB_LITE
+};
+
+class SimpleConfigurable : public Configurable {
+ private:
+  std::string name_;
+  std::string prefix_;
+  std::shared_ptr<SimpleOptions> options_;
+  std::unordered_map<std::string, OptionTypeInfo> map_;
+
+ public:
+  SimpleConfigurable(const std::string& name,
+                     const std::shared_ptr<SimpleOptions>& options,
+                     const OptionTypeMap& map)
+      : name_(name), options_(options), map_(map) {
+    prefix_ = "test." + name + ".";
+    RegisterOptionsMap(name, options_.get(), map);
+  }
+
+ protected:
+  const std::string& GetOptionsPrefix() const override { return prefix_; }
+
+  Status SetUnknown(const DBOptions& opts, const std::string& name,
+                    const std::string& value) override {
+    if (name == "unknown") {
+      options_->u = value;
+      return Status::OK();
+    } else {
+      return Configurable::SetUnknown(opts, name, value);
+    }
+  }
+
+  Status Validate(const DBOptions& db_opts,
+                  const ColumnFamilyOptions& cf_opts) const override {
+    if (!options_->b) {
+      return Status::InvalidArgument("Sanitized must be true");
+    } else {
+      return Configurable::Validate(db_opts, cf_opts);
+    }
+  }
+
+  Status Sanitize(DBOptions& db_opts, ColumnFamilyOptions& cf_opts) override {
+    options_->b = true;
+    return Configurable::Sanitize(db_opts, cf_opts);
+  }
+
+  Status UnknownToString(uint32_t mode, const std::string& name,
+                         std::string* result) const override {
+    if (name == "unknown") {
+      if (!options_->u.empty()) {
+        *result = options_->u;
+      }
+      return Status::OK();
+    } else {
+      return Configurable::UnknownToString(mode, name, result);
+    }
+  }
+
+#ifndef ROCKSDB_LITE
+  bool IsUnknownEqual(const std::string& name, const OptionTypeInfo& type_info,
+                      OptionsSanityCheckLevel sanity_check_level,
+                      const char* this_addr,
+                      const char* that_addr) const override {
+    if (name == "unknown") {
+      return (*(reinterpret_cast<const std::string*>(this_addr)) ==
+              *(reinterpret_cast<const std::string*>(that_addr)));
+    } else {
+      return Configurable::IsUnknownEqual(name, type_info, sanity_check_level,
+                                          this_addr, that_addr);
+    }
+  }
+#endif
+};  // End class SimpleConfigurable
+
+static Configurable* NewSimpleConfigurable(const std::string& name = "simple") {
+  std::shared_ptr<SimpleOptions> options = std::make_shared<SimpleOptions>();
+  return new SimpleConfigurable(name, options, simple_option_info);
+}
+
+// A NestedOptions/Configurable has another Configurable as part of its options
+// (has-a)
+struct NestedOptions : public SimpleOptions {
+  NestedOptions(const std::string& inner, int mode) {
+    if (mode > 0) {
+      unique.reset(NewSimpleConfigurable(inner));
+    } else if (mode < 0) {
+      shared.reset(NewSimpleConfigurable(inner));
+    } else {
+      config = NewSimpleConfigurable(inner);
+    }
+  }
+
+  std::unique_ptr<Configurable> unique;
+  std::shared_ptr<Configurable> shared;
+  Configurable* config = nullptr;
+};
+
+static NestedOptions dummy_nested_options("inner", 1);
+
+template <typename T1>
+int offset_of(T1 SimpleOptions::*member) {
+  return int(size_t(&(dummy_nested_options.*member)) -
+             size_t(&dummy_nested_options));
+}
+
+template <typename T1>
+int offset_of(T1 NestedOptions::*member) {
+  return int(size_t(&(dummy_nested_options.*member)) -
+             size_t(&dummy_nested_options));
+}
+
+// A MutableOptions/Configurable has another Configurable as part of its options
+struct MutableOptions : public SimpleOptions {
+  MutableOptions() { unique.reset(NewSimpleConfigurable("mutable")); }
+  std::unique_ptr<Configurable> unique;
+};
+
+static MutableOptions dummy_mutable_options;
+
+template <typename T1>
+int offset_of(T1 MutableOptions::*member) {
+  return int(size_t(&(dummy_mutable_options.*member)) -
+             size_t(&dummy_mutable_options));
+}
+
+static OptionTypeMap nested_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offset_of(&NestedOptions::i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+      offset_of(&MutableOptions::i)}},
+    {"bool",
+     {offset_of(&NestedOptions::b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offset_of(&NestedOptions::s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"unique",
+     {offset_of(&NestedOptions::unique), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kMConfigurableU,
+      offset_of(&MutableOptions::unique)}},
+    {"shared",
+     {offset_of(&NestedOptions::shared), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurableS, 0}},
+    {"config",
+     {offset_of(&NestedOptions::config), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurableP, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewNestedConfigurable(const std::string& outer,
+                                           const std::string& inner, int mode) {
+  std::shared_ptr<Configurable> result;
+  std::shared_ptr<NestedOptions> options =
+      std::make_shared<NestedOptions>(inner, mode);
+  return new SimpleConfigurable(outer, options, nested_option_info);
+}
+
+class MutableConfigurable : public SimpleConfigurable {
+ public:
+  MutableConfigurable(const std::string& name)
+      : SimpleConfigurable(name, std::make_shared<MutableOptions>(),
+                           nested_option_info) {}
+
+ protected:
+  bool IsMutable() const override { return true; }
+};
+
+struct EmbeddedOptions : public SimpleOptions {
+  EmbeddedOptions(const std::string& name = "embedded")
+      : embedded(name, std::make_shared<SimpleOptions>(), simple_option_info) {}
+  SimpleConfigurable embedded;
+};
+
+static EmbeddedOptions dummy_embedded_options;
+
+template <typename T1>
+int offset_of(T1 EmbeddedOptions::*member) {
+  return int(size_t(&(dummy_embedded_options.*member)) -
+             size_t(&dummy_embedded_options));
+}
+
+static OptionTypeMap embedded_option_info = {
+#ifndef ROCKSDB_LITE
+    {"int",
+     {offset_of(&EmbeddedOptions::i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bool",
+     {offset_of(&EmbeddedOptions::b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"string",
+     {offset_of(&EmbeddedOptions::s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"embedded",
+     {offset_of(&EmbeddedOptions::embedded), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kConfigurable, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewEmbeddedConfigurable(
+    const std::string& outer = "outer", const std::string& inner = "embedded") {
+  std::shared_ptr<EmbeddedOptions> options =
+      std::make_shared<EmbeddedOptions>(inner);
+  return new SimpleConfigurable(outer, options, embedded_option_info);
+}
+
+static OptionTypeMap inherited_option_info = {
+#ifndef ROCKSDB_LITE
+    {"outer.int",
+     {offsetof(struct SimpleOptions, i), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"outer.bool",
+     {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"outer.string",
+     {offsetof(struct SimpleOptions, s), OptionType::kString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+#endif  // ROCKSDB_LITE
+};
+
+// This is a class that extents a SimpleConfigurable (is-a)
+class InheritedConfigurable : public SimpleConfigurable {
+ private:
+  SimpleOptions outer_;
+
+ public:
+  InheritedConfigurable(const std::string& name, OptionTypeMap& map,
+                        const std::shared_ptr<SimpleOptions>& inner)
+      : SimpleConfigurable(name, inner, map) {
+    RegisterOptionsMap("outer", &outer_, inherited_option_info);
+  }
+
+  Status SetUnknown(const DBOptions& opts, const std::string& name,
+                    const std::string& value) override {
+    if (name == "outer.unknown") {
+      outer_.u = value;
+      return Status::OK();
+    } else {
+      return SimpleConfigurable::SetUnknown(opts, name, value);
+    }
+  }
+
+  Status UnknownToString(uint32_t mode, const std::string& name,
+                         std::string* result) const override {
+    if (name == "other.unknown") {
+      *result = outer_.u;
+      return Status::OK();
+    } else {
+      return SimpleConfigurable::UnknownToString(mode, name, result);
+    }
+  }
+
+#ifndef ROCKSDB_LITE
+  bool IsUnknownEqual(const std::string& name, const OptionTypeInfo& type_info,
+                      OptionsSanityCheckLevel sanity_check_level,
+                      const char* this_addr,
+                      const char* that_addr) const override {
+    if (name == "outer.unknown") {
+      return (*(reinterpret_cast<const std::string*>(this_addr)) ==
+              *(reinterpret_cast<const std::string*>(that_addr)));
+    } else {
+      return SimpleConfigurable::IsUnknownEqual(
+          name, type_info, sanity_check_level, this_addr, that_addr);
+    }
+  }
+#endif  // ROCKSDB_LITE
+};
+
+static Configurable* NewInheritedSimpleConfigurable(const std::string& name) {
+  std::shared_ptr<SimpleOptions> options = std::make_shared<SimpleOptions>();
+  return new InheritedConfigurable(name, simple_option_info, options);
+}
+
+static Configurable* NewInheritedNestedConfigurable(const std::string& inner,
+                                                    const std::string& nested,
+                                                    int mode) {
+  std::shared_ptr<NestedOptions> options =
+      std::make_shared<NestedOptions>(nested, mode);
+  return new InheritedConfigurable(inner, nested_option_info, options);
+}
+
+using ConfigTestFactoryFunc = std::function<Configurable*()>;
+
+class ConfigurableTest : public testing::Test {
+ public:
+  DBOptions db_opts_;
+};
+
+class ConfigurableParamTest
+    : public ConfigurableTest,
+      virtual public ::testing::WithParamInterface<
+          std::pair<std::string, ConfigTestFactoryFunc> > {
+ public:
+  ConfigurableParamTest() {
+    configuration_ = GetParam().first;
+    factory_ = GetParam().second;
+    object_.reset(factory_());
+  }
+  ConfigTestFactoryFunc factory_;
+  std::string configuration_;
+  std::unique_ptr<Configurable> object_;
+};
+
+TEST_F(ConfigurableTest, GetOptionsPtrTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_NE(configurable->GetOptions<SimpleOptions>("simple"), nullptr);
+  ASSERT_EQ(configurable->GetOptions<SimpleOptions>("bad-opt"), nullptr);
+}
+
+#ifndef ROCKSDB_LITE  // GetOptionsFromMap is not supported in ROCKSDB_LITE
+TEST_F(ConfigurableTest, ConfigureFromMapTest) {
+  std::unordered_map<std::string, std::string> options_map = {
+      {"int", "1"}, {"bool", "true"}, {"string", "string"}};
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(configurable->ConfigureFromMap(db_opts_, options_map));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->i, 1);
+  ASSERT_EQ(simple->b, true);
+  ASSERT_EQ(simple->s, "string");
+}
+
+TEST_F(ConfigurableTest, ConfigureFromStringTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "int=1;bool=true;string=s"));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->i, 1);
+  ASSERT_EQ(simple->b, true);
+  ASSERT_EQ(simple->s, "s");
+}
+
+TEST_F(ConfigurableTest, ConfigureFromOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_map<std::string, std::string> options_map = {{"unused", "u"}};
+  ASSERT_NOK(configurable->ConfigureFromMap(db_opts_, options_map));
+  ASSERT_OK(configurable->ConfigureFromMap(db_opts_, options_map, false, true));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "unused=u"));
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "unused=u", false, true));
+}
+
+TEST_F(ConfigurableTest, ConfigureUnusedOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_set<std::string> unused;
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "unused=u", false, &unused));
+  ASSERT_EQ(unused.size(), 1);
+  unused.clear();
+  ASSERT_OK(configurable->ConfigureOption(db_opts_, "int", "42"));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_OK(
+      configurable->ConfigureFromString(db_opts_, "int=u", false, &unused));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_OK(configurable->ConfigureFromString(db_opts_, "int=33;unused=u",
+                                              false, &unused));
+  ASSERT_EQ(simple->i, 33);
+}
+
+TEST_F(ConfigurableTest, ConfigureFromPropsTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "int=24;string=outer;unique={int=42;string=nested}"));
+  ASSERT_OK(simple->GetOptionString(
+      OptionStringMode::kOptionPrefix | OptionStringMode::kOptionDetached,
+      &opt_str, "\n"));
+  std::istringstream iss(opt_str);
+  std::unordered_map<std::string, std::string> copy_map;
+  std::string line;
+  for (int line_num = 0; std::getline(iss, line); line_num++) {
+    std::string name;
+    std::string value;
+    ASSERT_OK(
+        RocksDBOptionsParser::ParseStatement(&name, &value, line, line_num));
+    copy_map[name] = value;
+  }
+  std::unique_ptr<Configurable> copy(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(copy->ConfigureFromMap(db_opts_, copy_map));
+  ASSERT_TRUE(simple->Matches(copy.get(),
+                              OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_F(ConfigurableTest, GetOptionsTest) {
+  std::string value;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->ConfigureOption(db_opts_, "int", "24"));
+  ASSERT_OK(simple->GetOption("int", &value));
+  ASSERT_EQ(value, "24");
+
+  ASSERT_OK(simple->ConfigureOption(db_opts_, "string", "outer"));
+  ASSERT_OK(simple->GetOption("string", &value));
+  ASSERT_EQ(value, "outer");
+
+  ASSERT_OK(
+      simple->ConfigureOption(db_opts_, "unique", "int=42;string=nested"));
+  ASSERT_OK(simple->GetOption("unique", &value));
+  std::unordered_map<std::string, std::string> map;
+  ASSERT_OK(StringToMap(value, &map));
+  auto iter = map.find("int");
+  ASSERT_NE(iter, map.end());
+  ASSERT_EQ(iter->second, "42");
+  iter = map.find("string");
+  ASSERT_NE(iter, map.end());
+  ASSERT_EQ(iter->second, "nested");
+  ASSERT_OK(simple->GetOption("unique.int", &value));
+  ASSERT_EQ(value, "42");
+  ASSERT_OK(simple->GetOption("shared", &value));
+  ASSERT_EQ(value, "");  // There is a shared option, just no config
+  ASSERT_NOK(simple->GetOption("shared.int", &value));
+  ASSERT_NOK(simple->GetOption("unique.bad", &value));
+  ASSERT_NOK(simple->GetOption("bad option", &value));
+  ASSERT_TRUE(value.empty());
+}
+
+TEST_F(ConfigurableTest, GetOptionNamesTest) {
+  std::string value;
+  std::unordered_set<std::string> names;
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_OK(simple->GetOptionString(
+      OptionStringMode::kOptionDetached | OptionStringMode::kOptionPrefix,
+      &value, "; "));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, value));
+  ASSERT_OK(simple->GetOptionNames(&names));
+  for (auto& n : names) {
+    ASSERT_OK(simple->GetOption(n, &value));
+  }
+  names.clear();
+  ASSERT_OK(simple->GetOptionNames(OptionStringMode::kOptionPrefix, &names));
+  for (auto& n : names) {
+    ASSERT_OK(simple->GetOption(n, &value));
+  }
+}
+
+TEST_F(ConfigurableTest, ConfigureBadOptionsTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(configurable->ConfigureOption(db_opts_, "int", "42"));
+  ASSERT_EQ(simple->i, 42);
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "int", "fred"));
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "bool", "fred"));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "int=33;unused=u"));
+  ASSERT_EQ(simple->i, 42);
+}
+
+TEST_F(ConfigurableTest, ConfigureMissingOptionsTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  ASSERT_NOK(simple->ConfigureFromString(db_opts_,
+                                         "unique={missing=42;string=nested}"));
+  ASSERT_NOK(simple->ConfigureFromString(
+      db_opts_, "unique.missing=42;unique.string=nested"));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "unique={missing=42;string=nested}", false, true));
+  ASSERT_OK(simple->ConfigureFromString(
+      db_opts_, "unique.missing=42;unique.string=nested", false, true));
+}
+
+TEST_F(ConfigurableTest, SetUnknownTest) {
+  std::string opt_str;
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  ASSERT_OK(configurable->ConfigureFromString(db_opts_, "unknown=u"));
+  SimpleOptions* simple = configurable->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->u, "u");
+  ASSERT_OK(configurable->GetOptionString(&opt_str, ";"));
+  std::unique_ptr<Configurable> copy(NewSimpleConfigurable());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  simple = copy->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_EQ(simple->u, "u");
+}
+
+TEST_F(ConfigurableTest, InvalidOptionTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  std::unordered_map<std::string, std::string> options_map = {
+      {"bad-option", "bad"}};
+  ASSERT_NOK(configurable->ConfigureFromMap(db_opts_, options_map));
+  ASSERT_NOK(configurable->ConfigureFromString(db_opts_, "bad-option=bad"));
+  ASSERT_NOK(configurable->ConfigureOption(db_opts_, "bad-option", "bad"));
+}
+
+TEST_F(ConfigurableTest, ValidateOptionTest) {
+  std::unique_ptr<Configurable> configurable(NewSimpleConfigurable());
+  DBOptions db_opts;
+  ColumnFamilyOptions cf_opts;
+  ASSERT_OK(configurable->ConfigureOption(db_opts, "bool", "false"));
+  ASSERT_NOK(configurable->ValidateOptions(db_opts, cf_opts));
+  ASSERT_OK(configurable->SanitizeOptions(db_opts, cf_opts));
+  ASSERT_OK(configurable->ValidateOptions(db_opts, cf_opts));
+}
+
+TEST_F(ConfigurableTest, DeprecatedOptionsTest) {
+  static std::unordered_map<std::string, OptionTypeInfo>
+      deprecated_option_info = {
+          {"deprecated",
+           {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+            OptionVerificationType::kDeprecated, OptionTypeFlags::kNone, 0}}};
+  std::unique_ptr<Configurable> orig(new SimpleConfigurable(
+      "simple", std::make_shared<SimpleOptions>(), deprecated_option_info));
+  SimpleOptions* simple = orig->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  simple->d = true;
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "deprecated", "false"));
+  ASSERT_TRUE(simple->d);
+  ASSERT_OK(orig->ConfigureFromString(db_opts_, "deprecated=false"));
+  ASSERT_TRUE(simple->d);
+}
+
+TEST_F(ConfigurableTest, AliasOptionsTest) {
+  static std::unordered_map<std::string, OptionTypeInfo> alias_option_info = {
+      {"bool",
+       {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+        OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+      {"alias",
+       {offsetof(struct SimpleOptions, b), OptionType::kBoolean,
+        OptionVerificationType::kAlias, OptionTypeFlags::kNone, 0}}};
+  std::unique_ptr<Configurable> orig(new SimpleConfigurable(
+      "simple", std::make_shared<SimpleOptions>(), alias_option_info));
+  SimpleOptions* simple = orig->GetOptions<SimpleOptions>("simple");
+  ASSERT_NE(simple, nullptr);
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "alias", "true"));
+  ASSERT_TRUE(simple->b);
+  std::string opts_str;
+  ASSERT_OK(orig->GetOptionString(&opts_str, ";"));
+  ASSERT_EQ(opts_str.find("alias"), std::string::npos);
+
+  ASSERT_OK(orig->ConfigureOption(db_opts_, "bool", "false"));
+  ASSERT_FALSE(simple->b);
+  ASSERT_OK(orig->GetOption("alias", &opts_str));
+  ASSERT_EQ(opts_str, "false");
+}
+
+TEST_F(ConfigurableTest, NestedUniqueConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 1));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->unique, nullptr);
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "unique={int=42;string=nested}"));
+  SimpleOptions* inner = outer->unique->GetOptions<SimpleOptions>("inner");
+  ASSERT_NE(inner, nullptr);
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+}
+
+TEST_F(ConfigurableTest, NestedSharedConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", -1));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "shared={int=42;string=nested}"));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->shared, nullptr);
+  SimpleOptions* inner = outer->shared->GetOptions<SimpleOptions>("inner");
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+}
+
+TEST_F(ConfigurableTest, NestedRawConfigTest) {
+  std::unique_ptr<Configurable> simple(
+      NewNestedConfigurable("outer", "inner", 0));
+  ASSERT_OK(simple->ConfigureFromString(db_opts_, "int=24;string=outer"));
+  ASSERT_OK(
+      simple->ConfigureFromString(db_opts_, "config={int=42;string=nested}"));
+  NestedOptions* outer = simple->GetOptions<NestedOptions>("outer");
+  ASSERT_NE(outer, nullptr);
+  ASSERT_NE(outer->config, nullptr);
+  SimpleOptions* inner = outer->config->GetOptions<SimpleOptions>("inner");
+  ASSERT_NE(inner, nullptr);
+  ASSERT_EQ(outer->i, 24);
+  ASSERT_EQ(outer->s, "outer");
+  ASSERT_EQ(inner->i, 42);
+  ASSERT_EQ(inner->s, "nested");
+  delete outer->config;
+}
+
+TEST_F(ConfigurableTest, MatchesTest) {
+  std::shared_ptr<NestedOptions> n1 =
+      std::make_shared<NestedOptions>("unique", 1);
+  n1->shared.reset(NewSimpleConfigurable("shared"));
+  std::shared_ptr<NestedOptions> n2 =
+      std::make_shared<NestedOptions>("unique", 1);
+  n2->shared.reset(NewSimpleConfigurable("shared"));
+
+  std::unique_ptr<Configurable> c1(
+      new SimpleConfigurable("outer", n1, nested_option_info));
+  std::unique_ptr<Configurable> c2(
+      new SimpleConfigurable("outer", n2, nested_option_info));
+
+  ASSERT_OK(c1->ConfigureFromString(
+      db_opts_,
+      "int=11;string=outer;unique={int=22;string=u};shared={int=33;string=s}"));
+  ASSERT_OK(c2->ConfigureFromString(
+      db_opts_,
+      "int=11;string=outer;unique={int=22;string=u};shared={int=33;string=s}"));
+  ASSERT_TRUE(
+      c1->Matches(c2.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(c2->ConfigureOption(db_opts_, "shared", "int=44"));
+  std::string mismatch;
+  ASSERT_FALSE(c1->Matches(
+      c2.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch, &mismatch));
+  ASSERT_EQ(mismatch, "shared.int");
+  std::string c1value, c2value;
+  ASSERT_OK(c1->GetOption(mismatch, &c1value));
+  ASSERT_OK(c2->GetOption(mismatch, &c2value));
+  ASSERT_NE(c1value, c2value);
+}
+
+TEST_F(ConfigurableTest, MutableOptionsTest) {
+  std::unique_ptr<Configurable> base(new MutableConfigurable("outer"));
+  std::string opt_str;
+  ASSERT_OK(
+      base->ConfigureOption(db_opts_, "int", "24"));  // This one is mutable
+  ASSERT_NOK(
+      base->ConfigureOption(db_opts_, "string", "s"));  // This one is not
+  ASSERT_OK(base->ConfigureOption(db_opts_, "unique", "int=42;string=nested"));
+  ASSERT_OK(base->GetOption("int", &opt_str));  // Can get the mutable option
+  ASSERT_NOK(base->GetOption("string", &opt_str));  // Cannot get this one
+  ASSERT_OK(
+      base->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  ASSERT_EQ(opt_str.find("test.outer.string"), std::string::npos);
+  std::unique_ptr<Configurable> copy(new MutableConfigurable("outer"));
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(base->Matches(copy.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  std::unique_ptr<Configurable> nested(
+      NewNestedConfigurable("outer", "mutable", 1));
+  ASSERT_OK(nested->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_FALSE(nested->Matches(
+      base.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_TRUE(base->Matches(nested.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(
+      nested->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  copy.reset(new MutableConfigurable("outer"));
+  ASSERT_NOK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str, false, true));
+  ASSERT_TRUE(copy->Matches(nested.get(),
+                            OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_F(ConfigurableTest, ConfigureStructTest) {
+  ConfigurableStruct<SimpleOptions> config(simple_option_info);
+  std::string opts_str;
+  ASSERT_OK(config.ConfigureFromString(db_opts_, "int=1;bool=true;string=s"));
+  ASSERT_EQ(config.GetStructOptions()->i, 1);
+  ASSERT_EQ(config.GetStructOptions()->b, true);
+  ASSERT_EQ(config.GetStructOptions()->s, "s");
+  ASSERT_OK(config.GetOptionString(&opts_str, ";"));
+  ConfigurableStruct<SimpleOptions> copy(simple_option_info);
+  ASSERT_OK(copy.ConfigureFromString(db_opts_, opts_str));
+  ASSERT_TRUE(
+      config.Matches(&copy, OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, GetOptionsStringTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(object_->GetOptionString(&opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, ConfigureDetachedOptionsTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(object_->GetOptionString(OptionStringMode::kOptionDetached,
+                                     &opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, OptionsPrefixTest) {
+  std::string opt_str;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  ASSERT_OK(
+      object_->GetOptionString(OptionStringMode::kOptionPrefix, &opt_str, ";"));
+  std::unique_ptr<Configurable> copy(factory_());
+  ASSERT_OK(copy->ConfigureFromString(db_opts_, opt_str));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+  ASSERT_OK(object_->GetOptionString(
+      OptionStringMode::kOptionPrefix | OptionStringMode::kOptionDetached,
+      &opt_str, ";"));
+  ASSERT_TRUE(object_->Matches(
+      copy.get(), OptionsSanityCheckLevel::kSanityLevelExactMatch));
+}
+
+TEST_P(ConfigurableParamTest, DumpOptionsTest) {
+  std::string opt_str;
+  StringLogger logger;
+  ASSERT_OK(object_->ConfigureFromString(db_opts_, configuration_));
+  object_->Dump(&logger);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionDetached);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionPrefix);
+  logger.clear();
+  object_->Dump(&logger, OptionStringMode::kOptionDetached |
+                             OptionStringMode::kOptionPrefix);
+}
+
+#endif  // !ROCKSDB_LITE
+
+static Configurable* SimpleFactory() { return NewSimpleConfigurable("simple"); }
+
+static Configurable* NestedUniqueFactory() {
+  return NewNestedConfigurable("simple", "unique", 1);
+}
+
+static Configurable* NestedSharedFactory() {
+  return NewNestedConfigurable("simple", "shared", -1);
+}
+
+static Configurable* EmbeddedFactory() {
+  return NewEmbeddedConfigurable("outer", "embedded");
+}
+
+static Configurable* InheritedSimpleFactory() {
+  return NewInheritedSimpleConfigurable("inner");
+}
+
+static Configurable* InheritedNestedUniqueFactory() {
+  return NewInheritedNestedConfigurable("inner", "unique", 1);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ParamTest, ConfigurableParamTest,
+    testing::Values(std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=42;bool=true;string=s", SimpleFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "unique={int=42;string=inner}",
+                        NestedUniqueFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "shared={int=42;string=inner}",
+                        NestedSharedFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=33;bool=true;string=outer;"
+                        "embedded={int=42;string=inner}",
+                        EmbeddedFactory),
+
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "int=42;bool=true;string=inner;"
+                        "outer.int=24;outer.bool=true;outer.string=outer",
+                        InheritedSimpleFactory),
+                    std::pair<std::string, ConfigTestFactoryFunc>(
+                        "outer.int=24;outer.bool=true;outer.string=other;"
+                        "int=33;bool=true;string=inner;"
+                        "unique={int=42;string=nested}",
+                        InheritedNestedUniqueFactory)));
+
+}  // namespace rocksdb
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+#ifdef GFLAGS
+  ParseCommandLineFlags(&argc, &argv, true);
+#endif  // GFLAGS
+  return RUN_ALL_TESTS();
+}

--- a/options/options.cc
+++ b/options/options.cc
@@ -124,8 +124,7 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    memtable_factory->Name());
   ROCKS_LOG_HEADER(log, "           Options.table_factory: %s",
                    table_factory->Name());
-  ROCKS_LOG_HEADER(log, "           table_factory options: %s",
-                   table_factory->GetPrintableTableOptions().c_str());
+  table_factory->Dump(log);
   ROCKS_LOG_HEADER(log, "       Options.write_buffer_size: %" ROCKSDB_PRIszt,
                    write_buffer_size);
   ROCKS_LOG_HEADER(log, " Options.max_write_buffer_number: %d",

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -863,6 +863,10 @@ Status StringToMap(const std::string& opts_str,
   //              "nested_opt={opt1=1;opt2=2};max_bytes_for_level_base=100"
   size_t pos = 0;
   std::string opts = trim(opts_str);
+  // If the input string starts and ends with "{...}", strip off the brackets
+  while (opts.size() > 2 && opts[0] == '{' && opts[opts.size() - 1] == '}') {
+    opts = trim(opts.substr(1, opts.size() - 2));
+  }
   while (pos < opts.size()) {
     size_t eq_pos = opts.find('=', pos);
     if (eq_pos == std::string::npos) {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1169,39 +1169,6 @@ Status GetOptionsFromString(const Options& base_options,
   return Status::OK();
 }
 
-Status GetTableFactoryFromMap(
-    const std::string& factory_name,
-    const std::unordered_map<std::string, std::string>& opt_map,
-    std::shared_ptr<TableFactory>* table_factory, bool ignore_unknown_options) {
-  Status s;
-  if (factory_name == BlockBasedTableFactory().Name()) {
-    BlockBasedTableOptions bbt_opt;
-    s = GetBlockBasedTableOptionsFromMap(BlockBasedTableOptions(), opt_map,
-                                         &bbt_opt,
-                                         true, /* input_strings_escaped */
-                                         ignore_unknown_options);
-    if (!s.ok()) {
-      return s;
-    }
-    table_factory->reset(new BlockBasedTableFactory(bbt_opt));
-    return Status::OK();
-  } else if (factory_name == PlainTableFactory().Name()) {
-    PlainTableOptions pt_opt;
-    s = GetPlainTableOptionsFromMap(PlainTableOptions(), opt_map, &pt_opt,
-                                    true, /* input_strings_escaped */
-                                    ignore_unknown_options);
-    if (!s.ok()) {
-      return s;
-    }
-    table_factory->reset(new PlainTableFactory(pt_opt));
-    return Status::OK();
-  }
-  // Return OK for not supported table factories as TableFactory
-  // Deserialization is optional.
-  table_factory->reset();
-  return Status::OK();
-}
-
 std::unordered_map<std::string, OptionTypeInfo>
     OptionsHelper::db_options_type_info = {
         /*

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -8,6 +8,8 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "rocksdb/options.h"
@@ -31,7 +33,6 @@ ColumnFamilyOptions BuildColumnFamilyOptions(
     const MutableCFOptions& mutable_cf_options);
 
 #ifndef ROCKSDB_LITE
-
 Status GetMutableOptionsFromStrings(
     const MutableCFOptions& base_options,
     const std::unordered_map<std::string, std::string>& options_map,
@@ -68,11 +69,14 @@ Status GetDBOptionsFromMapInternal(
 // this further takes an optional output vector "unsupported_options_names",
 // which stores the name of all the unsupported options specified in "opts_map".
 Status GetColumnFamilyOptionsFromMapInternal(
-    const ColumnFamilyOptions& base_options,
+    const DBOptions& db_options, const ColumnFamilyOptions& base_options,
     const std::unordered_map<std::string, std::string>& opts_map,
     ColumnFamilyOptions* new_options, bool input_strings_escaped,
-    std::vector<std::string>* unsupported_options_names = nullptr,
+    std::unordered_set<std::string>* unsupported_options_names = nullptr,
     bool ignore_unknown_options = false);
+
+Status GetColumnFamilyOptionNames(std::unordered_set<std::string>* option_names,
+                                  bool use_mutable = false);
 
 bool ParseSliceTransform(
     const std::string& value,
@@ -119,7 +123,6 @@ struct OptionsHelper {
   static std::unordered_map<std::string, CompressionType>
       compression_type_string_map;
 #ifndef ROCKSDB_LITE
-  static std::unordered_map<std::string, OptionTypeInfo> cf_options_type_info;
   static std::unordered_map<std::string, OptionTypeInfo>
       fifo_compaction_options_type_info;
   static std::unordered_map<std::string, OptionTypeInfo>
@@ -148,7 +151,6 @@ struct OptionsHelper {
       access_hint_string_map;
   static std::unordered_map<std::string, InfoLogLevel>
       info_log_level_string_map;
-  static ColumnFamilyOptions dummy_cf_options;
   static CompactionOptionsFIFO dummy_comp_options;
   static LRUCacheOptions dummy_lru_cache_options;
   static CompactionOptionsUniversal dummy_comp_options_universal;
@@ -163,7 +165,6 @@ static auto& compaction_stop_style_to_string =
     OptionsHelper::compaction_stop_style_to_string;
 static auto& checksum_type_string_map = OptionsHelper::checksum_type_string_map;
 #ifndef ROCKSDB_LITE
-static auto& cf_options_type_info = OptionsHelper::cf_options_type_info;
 static auto& fifo_compaction_options_type_info =
     OptionsHelper::fifo_compaction_options_type_info;
 static auto& universal_compaction_options_type_info =

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -43,12 +43,6 @@ Status GetMutableDBOptionsFromStrings(
     const std::unordered_map<std::string, std::string>& options_map,
     MutableDBOptions* new_options);
 
-Status GetTableFactoryFromMap(
-    const std::string& factory_name,
-    const std::unordered_map<std::string, std::string>& opt_map,
-    std::shared_ptr<TableFactory>* table_factory,
-    bool ignore_unknown_options = false);
-
 // A helper function that converts "opt_address" to a std::string
 // based on the specified OptionType.
 bool SerializeSingleOptionHelper(const char* opt_address,

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -96,6 +96,9 @@ class RocksDBOptionsParser {
 
   static Status ExtraParserCheck(const RocksDBOptionsParser& input_parser);
 
+  static Status ParseStatement(std::string* name, std::string* value,
+                               const std::string& line, const int line_num);
+
  protected:
   bool IsSection(const std::string& line);
   Status ParseSection(OptionSection* section, std::string* title,
@@ -105,9 +108,6 @@ class RocksDBOptionsParser {
   Status CheckSection(const OptionSection section,
                       const std::string& section_arg, const int line_num);
 
-  Status ParseStatement(std::string* name, std::string* value,
-                        const std::string& line, const int line_num);
-
   Status EndSection(const OptionSection section, const std::string& title,
                     const std::string& section_arg,
                     const std::unordered_map<std::string, std::string>& opt_map,
@@ -115,7 +115,7 @@ class RocksDBOptionsParser {
 
   Status ValidityCheck();
 
-  Status InvalidArgument(const int line_num, const std::string& message);
+  static Status InvalidArgument(const int line_num, const std::string& message);
 
   Status ParseVersionNumber(const std::string& ver_name,
                             const std::string& ver_string, const int max_count,

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -37,9 +37,13 @@ Status PersistRocksDBOptions(const DBOptions& db_opt,
                              const std::vector<ColumnFamilyOptions>& cf_opts,
                              const std::string& file_name, Env* env);
 
+extern bool IsOptionEqual(OptionsSanityCheckLevel level,
+                          const OptionTypeInfo& opt_info, const char* offset1,
+                          const char* offset2);
+
 extern bool AreEqualOptions(
-    const char* opt1, const char* opt2, const OptionTypeInfo& type_info,
-    const std::string& opt_name,
+    OptionsSanityCheckLevel level, const char* opt1, const char* opt2,
+    const OptionTypeInfo& type_info, const std::string& opt_name,
     const std::unordered_map<std::string, std::string>* opt_map);
 
 class RocksDBOptionsParser {

--- a/options/options_sanity_check.cc
+++ b/options/options_sanity_check.cc
@@ -23,11 +23,6 @@ OptionsSanityCheckLevel DBOptionSanityCheckLevel(
   return SanityCheckLevelHelper(sanity_level_db_options, option_name);
 }
 
-OptionsSanityCheckLevel CFOptionSanityCheckLevel(
-    const std::string& option_name) {
-  return SanityCheckLevelHelper(sanity_level_cf_options, option_name);
-}
-
 OptionsSanityCheckLevel BBTOptionSanityCheckLevel(
     const std::string& option_name) {
   return SanityCheckLevelHelper(sanity_level_bbt_options, option_name);

--- a/options/options_sanity_check.cc
+++ b/options/options_sanity_check.cc
@@ -23,11 +23,6 @@ OptionsSanityCheckLevel DBOptionSanityCheckLevel(
   return SanityCheckLevelHelper(sanity_level_db_options, option_name);
 }
 
-OptionsSanityCheckLevel BBTOptionSanityCheckLevel(
-    const std::string& option_name) {
-  return SanityCheckLevelHelper(sanity_level_bbt_options, option_name);
-}
-
 }  // namespace rocksdb
 
 #endif  // !ROCKSDB_LITE

--- a/options/options_sanity_check.h
+++ b/options/options_sanity_check.h
@@ -9,17 +9,10 @@
 #include <unordered_map>
 
 #ifndef ROCKSDB_LITE
+#include "rocksdb/utilities/options_type.h"
+
 namespace rocksdb {
 // This enum defines the RocksDB options sanity level.
-enum OptionsSanityCheckLevel : unsigned char {
-  // Performs no sanity check at all.
-  kSanityLevelNone = 0x00,
-  // Performs minimum check to ensure the RocksDB instance can be
-  // opened without corrupting / mis-interpreting the data.
-  kSanityLevelLooselyCompatible = 0x01,
-  // Perform exact match sanity check.
-  kSanityLevelExactMatch = 0xFF,
-};
 
 // The sanity check level for DB options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>

--- a/options/options_sanity_check.h
+++ b/options/options_sanity_check.h
@@ -18,20 +18,11 @@ namespace rocksdb {
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
     sanity_level_db_options {};
 
-// The sanity check level for column-family options
-static const std::unordered_map<std::string, OptionsSanityCheckLevel>
-    sanity_level_cf_options = {
-        {"comparator", kSanityLevelLooselyCompatible},
-        {"table_factory", kSanityLevelLooselyCompatible},
-        {"merge_operator", kSanityLevelLooselyCompatible}};
-
 // The sanity check level for block-based table options
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
     sanity_level_bbt_options {};
 
 OptionsSanityCheckLevel DBOptionSanityCheckLevel(
-    const std::string& options_name);
-OptionsSanityCheckLevel CFOptionSanityCheckLevel(
     const std::string& options_name);
 OptionsSanityCheckLevel BBTOptionSanityCheckLevel(
     const std::string& options_name);

--- a/options/options_sanity_check.h
+++ b/options/options_sanity_check.h
@@ -18,13 +18,7 @@ namespace rocksdb {
 static const std::unordered_map<std::string, OptionsSanityCheckLevel>
     sanity_level_db_options {};
 
-// The sanity check level for block-based table options
-static const std::unordered_map<std::string, OptionsSanityCheckLevel>
-    sanity_level_bbt_options {};
-
 OptionsSanityCheckLevel DBOptionSanityCheckLevel(
-    const std::string& options_name);
-OptionsSanityCheckLevel BBTOptionSanityCheckLevel(
     const std::string& options_name);
 
 }  // namespace rocksdb

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -402,10 +402,10 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       new (new_options_ptr) ColumnFamilyOptions();
   FillWithSpecialChar(new_options_ptr, sizeof(ColumnFamilyOptions),
                       kColumnFamilyOptionsBlacklist);
-
+  DBOptions db_opts;
   // Need to update the option string if a new option is added.
   ASSERT_OK(GetColumnFamilyOptionsFromString(
-      *options,
+      db_opts, *options,
       "compaction_filter_factory=mpudlojcujCompactionFilterFactory;"
       "table_factory=PlainTable;"
       "prefix_extractor=rocksdb.CappedPrefix.13;"

--- a/src.mk
+++ b/src.mk
@@ -141,6 +141,7 @@ LIB_SOURCES =                                                   \
   table/plain/plain_table_reader.cc                             \
   table/sst_file_reader.cc                                      \
   table/sst_file_writer.cc                                      \
+  table/table_factory.cc                                        \
   table/table_properties.cc                                     \
   table/two_level_iterator.cc                                   \
   test_util/sync_point.cc                                       \

--- a/src.mk
+++ b/src.mk
@@ -99,6 +99,7 @@ LIB_SOURCES =                                                   \
   monitoring/thread_status_util.cc                              \
   monitoring/thread_status_util_debug.cc                        \
   options/cf_options.cc                                         \
+  options/configurable.cc                                       \
   options/db_options.cc                                         \
   options/options.cc                                            \
   options/options_helper.cc                                     \
@@ -360,6 +361,7 @@ MAIN_SOURCES =                                                          \
   monitoring/iostats_context_test.cc                                    \
   monitoring/statistics_test.cc                                         \
   monitoring/stats_history_test.cc                                      \
+  options/configurable_test.cc                                          \
   options/options_test.cc                                               \
   table/block_based/block_based_filter_block_test.cc                    \
   table/block_based/block_test.cc                                       \

--- a/table/adaptive/adaptive_table_factory.cc
+++ b/table/adaptive/adaptive_table_factory.cc
@@ -75,40 +75,29 @@ TableBuilder* AdaptiveTableFactory::NewTableBuilder(
                                                   column_family_id, file);
 }
 
-std::string AdaptiveTableFactory::GetPrintableTableOptions() const {
-  std::string ret;
-  ret.reserve(20000);
-  const int kBufferSize = 200;
-  char buffer[kBufferSize];
-
+void AdaptiveTableFactory::DumpOptions(Logger* logger,
+                                       const std::string& indent,
+                                       uint32_t mode) const {
   if (table_factory_to_write_) {
-    snprintf(buffer, kBufferSize, "  write factory (%s) options:\n%s\n",
-             (table_factory_to_write_->Name() ? table_factory_to_write_->Name()
-                                              : ""),
-             table_factory_to_write_->GetPrintableTableOptions().c_str());
-    ret.append(buffer);
+    ROCKS_LOG_HEADER(logger, "%swrite factory(%s) options:", indent.c_str(),
+                     table_factory_to_write_->Name());
+    table_factory_to_write_->Dump(logger, indent + "  ", mode);
   }
   if (plain_table_factory_) {
-    snprintf(buffer, kBufferSize, "  %s options:\n%s\n",
-             plain_table_factory_->Name() ? plain_table_factory_->Name() : "",
-             plain_table_factory_->GetPrintableTableOptions().c_str());
-    ret.append(buffer);
+    ROCKS_LOG_HEADER(logger, "%s%s options:", indent.c_str(),
+                     plain_table_factory_->Name());
+    plain_table_factory_->Dump(logger, indent + " ", mode);
   }
   if (block_based_table_factory_) {
-    snprintf(
-        buffer, kBufferSize, "  %s options:\n%s\n",
-        (block_based_table_factory_->Name() ? block_based_table_factory_->Name()
-                                            : ""),
-        block_based_table_factory_->GetPrintableTableOptions().c_str());
-    ret.append(buffer);
+    ROCKS_LOG_HEADER(logger, "%s%s options:", indent.c_str(),
+                     block_based_table_factory_->Name());
+    block_based_table_factory_->Dump(logger, indent + " ", mode);
   }
   if (cuckoo_table_factory_) {
-    snprintf(buffer, kBufferSize, "  %s options:\n%s\n",
-             cuckoo_table_factory_->Name() ? cuckoo_table_factory_->Name() : "",
-             cuckoo_table_factory_->GetPrintableTableOptions().c_str());
-    ret.append(buffer);
+    ROCKS_LOG_HEADER(logger, "%s%s options:", indent.c_str(),
+                     cuckoo_table_factory_->Name());
+    cuckoo_table_factory_->Dump(logger, indent + " ", mode);
   }
-  return ret;
 }
 
 extern TableFactory* NewAdaptiveTableFactory(

--- a/table/adaptive/adaptive_table_factory.h
+++ b/table/adaptive/adaptive_table_factory.h
@@ -43,14 +43,9 @@ class AdaptiveTableFactory : public TableFactory {
       const TableBuilderOptions& table_builder_options,
       uint32_t column_family_id, WritableFileWriter* file) const override;
 
-  // Sanitizes the specified DB Options.
-  Status SanitizeOptions(
-      const DBOptions& /*db_opts*/,
-      const ColumnFamilyOptions& /*cf_opts*/) const override {
-    return Status::OK();
-  }
-
-  std::string GetPrintableTableOptions() const override;
+ protected:
+  void DumpOptions(Logger* log, const std::string& indent,
+                   uint32_t mode) const override;
 
  private:
   std::shared_ptr<TableFactory> table_factory_to_write_;

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -28,7 +28,8 @@
 #include "util/string_util.h"
 
 namespace rocksdb {
-
+const std::string BlockBasedTableFactory::kBlockTablePrefix =
+    "rocksdb.table.block_based.";
 void TailPrefetchStats::RecordEffectiveSize(size_t len) {
   MutexLock l(&mutex_);
   if (num_records_ < kNumTracked) {
@@ -159,268 +160,40 @@ size_t TailPrefetchStats::GetSuggestedPrefetchSize() {
   return std::min(kMaxPrefetchSize, max_qualified_size);
 }
 
-BlockBasedTableFactory::BlockBasedTableFactory(
-    const BlockBasedTableOptions& _table_options)
-    : table_options_(_table_options) {
-  if (table_options_.flush_block_policy_factory == nullptr) {
-    table_options_.flush_block_policy_factory.reset(
-        new FlushBlockBySizePolicyFactory());
-  }
-  if (table_options_.no_block_cache) {
-    table_options_.block_cache.reset();
-  } else if (table_options_.block_cache == nullptr) {
-    LRUCacheOptions co;
-    co.capacity = 8 << 20;
-    // It makes little sense to pay overhead for mid-point insertion while the
-    // block size is only 8MB.
-    co.high_pri_pool_ratio = 0.0;
-    table_options_.block_cache = NewLRUCache(co);
-  }
-  if (table_options_.block_size_deviation < 0 ||
-      table_options_.block_size_deviation > 100) {
-    table_options_.block_size_deviation = 0;
-  }
-  if (table_options_.block_restart_interval < 1) {
-    table_options_.block_restart_interval = 1;
-  }
-  if (table_options_.index_block_restart_interval < 1) {
-    table_options_.index_block_restart_interval = 1;
-  }
-  if (table_options_.partition_filters &&
-      table_options_.index_type !=
-          BlockBasedTableOptions::kTwoLevelIndexSearch) {
-    // We do not support partitioned filters without partitioning indexes
-    table_options_.partition_filters = false;
-  }
-}
-
-Status BlockBasedTableFactory::NewTableReader(
-    const TableReaderOptions& table_reader_options,
-    std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
-    std::unique_ptr<TableReader>* table_reader,
-    bool prefetch_index_and_filter_in_cache) const {
-  return BlockBasedTable::Open(
-      table_reader_options.ioptions, table_reader_options.env_options,
-      table_options_, table_reader_options.internal_comparator, std::move(file),
-      file_size, table_reader, table_reader_options.prefix_extractor,
-      prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
-      table_reader_options.level, table_reader_options.immortal,
-      table_reader_options.largest_seqno, &tail_prefetch_stats_,
-      table_reader_options.block_cache_tracer);
-}
-
-TableBuilder* BlockBasedTableFactory::NewTableBuilder(
-    const TableBuilderOptions& table_builder_options, uint32_t column_family_id,
-    WritableFileWriter* file) const {
-  auto table_builder = new BlockBasedTableBuilder(
-      table_builder_options.ioptions, table_builder_options.moptions,
-      table_options_, table_builder_options.internal_comparator,
-      table_builder_options.int_tbl_prop_collector_factories, column_family_id,
-      file, table_builder_options.compression_type,
-      table_builder_options.sample_for_compression,
-      table_builder_options.compression_opts,
-      table_builder_options.skip_filters,
-      table_builder_options.column_family_name,
-      table_builder_options.creation_time,
-      table_builder_options.oldest_key_time,
-      table_builder_options.target_file_size,
-      table_builder_options.file_creation_time);
-
-  return table_builder;
-}
-
-Status BlockBasedTableFactory::SanitizeOptions(
-    const DBOptions& db_opts, const ColumnFamilyOptions& cf_opts) const {
-  if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
-      cf_opts.prefix_extractor == nullptr) {
-    return Status::InvalidArgument(
-        "Hash index is specified for block-based "
-        "table, but prefix_extractor is not given");
-  }
-  if (table_options_.cache_index_and_filter_blocks &&
-      table_options_.no_block_cache) {
-    return Status::InvalidArgument(
-        "Enable cache_index_and_filter_blocks, "
-        ", but block cache is disabled");
-  }
-  if (table_options_.pin_l0_filter_and_index_blocks_in_cache &&
-      table_options_.no_block_cache) {
-    return Status::InvalidArgument(
-        "Enable pin_l0_filter_and_index_blocks_in_cache, "
-        ", but block cache is disabled");
-  }
-  if (!BlockBasedTableSupportedVersion(table_options_.format_version)) {
-    return Status::InvalidArgument(
-        "Unsupported BlockBasedTable format_version. Please check "
-        "include/rocksdb/table.h for more info");
-  }
-  if (table_options_.block_align && (cf_opts.compression != kNoCompression)) {
-    return Status::InvalidArgument(
-        "Enable block_align, but compression "
-        "enabled");
-  }
-  if (table_options_.block_align &&
-      (table_options_.block_size & (table_options_.block_size - 1))) {
-    return Status::InvalidArgument(
-        "Block alignment requested but block size is not a power of 2");
-  }
-  if (table_options_.block_size > port::kMaxUint32) {
-    return Status::InvalidArgument(
-        "block size exceeds maximum number (4GiB) allowed");
-  }
-  if (table_options_.data_block_index_type ==
-          BlockBasedTableOptions::kDataBlockBinaryAndHash &&
-      table_options_.data_block_hash_table_util_ratio <= 0) {
-    return Status::InvalidArgument(
-        "data_block_hash_table_util_ratio should be greater than 0 when "
-        "data_block_index_type is set to kDataBlockBinaryAndHash");
-  }
-  if (db_opts.unordered_write && cf_opts.max_successive_merges > 0) {
-    // TODO(myabandeh): support it
-    return Status::InvalidArgument(
-        "max_successive_merges larger than 0 is currently inconsistent with "
-        "unordered_write");
-  }
-  return Status::OK();
-}
-
-std::string BlockBasedTableFactory::GetPrintableTableOptions() const {
-  std::string ret;
-  ret.reserve(20000);
-  const int kBufferSize = 200;
-  char buffer[kBufferSize];
-
-  snprintf(buffer, kBufferSize, "  flush_block_policy_factory: %s (%p)\n",
-           table_options_.flush_block_policy_factory->Name(),
-           static_cast<void*>(table_options_.flush_block_policy_factory.get()));
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  cache_index_and_filter_blocks: %d\n",
-           table_options_.cache_index_and_filter_blocks);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize,
-           "  cache_index_and_filter_blocks_with_high_priority: %d\n",
-           table_options_.cache_index_and_filter_blocks_with_high_priority);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize,
-           "  pin_l0_filter_and_index_blocks_in_cache: %d\n",
-           table_options_.pin_l0_filter_and_index_blocks_in_cache);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  pin_top_level_index_and_filter: %d\n",
-           table_options_.pin_top_level_index_and_filter);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  index_type: %d\n",
-           table_options_.index_type);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  data_block_index_type: %d\n",
-           table_options_.data_block_index_type);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  index_shortening: %d\n",
-           static_cast<int>(table_options_.index_shortening));
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  data_block_hash_table_util_ratio: %lf\n",
-           table_options_.data_block_hash_table_util_ratio);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  hash_index_allow_collision: %d\n",
-           table_options_.hash_index_allow_collision);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  checksum: %d\n", table_options_.checksum);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  no_block_cache: %d\n",
-           table_options_.no_block_cache);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  block_cache: %p\n",
-           static_cast<void*>(table_options_.block_cache.get()));
-  ret.append(buffer);
-  if (table_options_.block_cache) {
-    const char* block_cache_name = table_options_.block_cache->Name();
-    if (block_cache_name != nullptr) {
-      snprintf(buffer, kBufferSize, "  block_cache_name: %s\n",
-               block_cache_name);
-      ret.append(buffer);
-    }
-    ret.append("  block_cache_options:\n");
-    ret.append(table_options_.block_cache->GetPrintableOptions());
-  }
-  snprintf(buffer, kBufferSize, "  block_cache_compressed: %p\n",
-           static_cast<void*>(table_options_.block_cache_compressed.get()));
-  ret.append(buffer);
-  if (table_options_.block_cache_compressed) {
-    const char* block_cache_compressed_name =
-        table_options_.block_cache_compressed->Name();
-    if (block_cache_compressed_name != nullptr) {
-      snprintf(buffer, kBufferSize, "  block_cache_name: %s\n",
-               block_cache_compressed_name);
-      ret.append(buffer);
-    }
-    ret.append("  block_cache_compressed_options:\n");
-    ret.append(table_options_.block_cache_compressed->GetPrintableOptions());
-  }
-  snprintf(buffer, kBufferSize, "  persistent_cache: %p\n",
-           static_cast<void*>(table_options_.persistent_cache.get()));
-  ret.append(buffer);
-  if (table_options_.persistent_cache) {
-    snprintf(buffer, kBufferSize, "  persistent_cache_options:\n");
-    ret.append(buffer);
-    ret.append(table_options_.persistent_cache->GetPrintableOptions());
-  }
-  snprintf(buffer, kBufferSize, "  block_size: %" ROCKSDB_PRIszt "\n",
-           table_options_.block_size);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  block_size_deviation: %d\n",
-           table_options_.block_size_deviation);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  block_restart_interval: %d\n",
-           table_options_.block_restart_interval);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  index_block_restart_interval: %d\n",
-           table_options_.index_block_restart_interval);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  metadata_block_size: %" PRIu64 "\n",
-           table_options_.metadata_block_size);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  partition_filters: %d\n",
-           table_options_.partition_filters);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  use_delta_encoding: %d\n",
-           table_options_.use_delta_encoding);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  filter_policy: %s\n",
-           table_options_.filter_policy == nullptr
-               ? "nullptr"
-               : table_options_.filter_policy->Name());
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  whole_key_filtering: %d\n",
-           table_options_.whole_key_filtering);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  verify_compression: %d\n",
-           table_options_.verify_compression);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  read_amp_bytes_per_bit: %d\n",
-           table_options_.read_amp_bytes_per_bit);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  format_version: %d\n",
-           table_options_.format_version);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  enable_index_compression: %d\n",
-           table_options_.enable_index_compression);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  block_align: %d\n",
-           table_options_.block_align);
-  ret.append(buffer);
-  return ret;
-}
-
-#ifndef ROCKSDB_LITE
 static std::unordered_map<std::string, OptionTypeInfo>
     block_based_table_type_info = {
+#ifndef ROCKSDB_LITE
         /* currently not supported
           std::shared_ptr<Cache> block_cache = nullptr;
           std::shared_ptr<Cache> block_cache_compressed = nullptr;
          */
         {"flush_block_policy_factory",
          {offsetof(struct BlockBasedTableOptions, flush_block_policy_factory),
-          OptionType::kFlushBlockPolicyFactory, OptionVerificationType::kByName,
-          OptionTypeFlags::kNone, 0}},
+          OptionType::kUnknown, OptionVerificationType::kByName,
+          OptionTypeFlags::kNone, 0,
+          [](const DBOptions&, const std::string&, char*, const std::string&) {
+            // Currently, we do not do anything to create a flush block policy
+            // factory
+            return Status::OK();
+          },
+          [](uint32_t, const std::string&, const char* addr,
+             std::string* value) {
+            const auto factory =
+                *(reinterpret_cast<
+                    const std::shared_ptr<FlushBlockPolicyFactory>*>(addr));
+            if (factory) {
+              *value = factory->Name();
+            } else {
+              *value = kNullptrString;
+            }
+            return Status::OK();
+          },
+          [](OptionsSanityCheckLevel, const std::string&, const char*,
+             const char*) {
+            return true;  //**TODO: In the original code, we never bother to
+                          // check that
+            // the factories are equal
+          }}},
         {"cache_index_and_filter_blocks",
          {offsetof(struct BlockBasedTableOptions,
                    cache_index_and_filter_blocks),
@@ -494,7 +267,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone, 0}},
         {"filter_policy",
          {offsetof(struct BlockBasedTableOptions, filter_policy),
-          OptionType::kFilterPolicy, OptionVerificationType::kByName,
+          OptionType::kUnknown, OptionVerificationType::kByName,
           OptionTypeFlags::kNone, 0}},
         {"whole_key_filtering",
          {offsetof(struct BlockBasedTableOptions, whole_key_filtering),
@@ -527,230 +300,328 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct BlockBasedTableOptions,
                    pin_top_level_index_and_filter),
           OptionType::kBoolean, OptionVerificationType::kNormal,
-          OptionTypeFlags::kNone, 0}}};
-
-namespace {
-bool SerializeSingleBlockBasedTableOption(
-    std::string* opt_string, const BlockBasedTableOptions& bbt_options,
-    const std::string& name, const std::string& delimiter) {
-  auto iter = block_based_table_type_info.find(name);
-  if (iter == block_based_table_type_info.end()) {
-    return false;
-  }
-  auto& opt_info = iter->second;
-  const char* opt_address =
-      reinterpret_cast<const char*>(&bbt_options) + opt_info.offset;
-  std::string value;
-  bool result = SerializeSingleOptionHelper(opt_address, opt_info, &value);
-  if (result) {
-    *opt_string = name + "=" + value + delimiter;
-  }
-  return result;
-}
-}  // namespace
-
-Status BlockBasedTableFactory::GetOptionString(
-    std::string* opt_string, const std::string& delimiter) const {
-  assert(opt_string);
-  opt_string->clear();
-  for (auto iter = block_based_table_type_info.begin();
-       iter != block_based_table_type_info.end(); ++iter) {
-    if (iter->second.verification == OptionVerificationType::kDeprecated) {
-      // If the option is no longer used in rocksdb and marked as deprecated,
-      // we skip it in the serialization.
-      continue;
-    }
-    std::string single_output;
-    bool result = SerializeSingleBlockBasedTableOption(
-        &single_output, table_options_, iter->first, delimiter);
-    assert(result);
-    if (result) {
-      opt_string->append(single_output);
-    }
-  }
-  return Status::OK();
-}
-#else
-Status BlockBasedTableFactory::GetOptionString(
-    std::string* /*opt_string*/, const std::string& /*delimiter*/) const {
-  return Status::OK();
-}
+          OptionTypeFlags::kNone, 0}},
 #endif  // !ROCKSDB_LITE
+};
 
-const BlockBasedTableOptions& BlockBasedTableFactory::table_options() const {
-  return table_options_;
+BlockBasedTableFactory::BlockBasedTableFactory(
+    const BlockBasedTableOptions& _table_options)
+    : table_options_(_table_options) {
+  if (table_options_.flush_block_policy_factory == nullptr) {
+    table_options_.flush_block_policy_factory.reset(
+        new FlushBlockBySizePolicyFactory());
+  }
+  if (table_options_.no_block_cache) {
+    table_options_.block_cache.reset();
+  } else if (table_options_.block_cache == nullptr) {
+    LRUCacheOptions co;
+    co.capacity = 8 << 20;
+    // It makes little sense to pay overhead for mid-point insertion while the
+    // block size is only 8MB.
+    co.high_pri_pool_ratio = 0.0;
+    table_options_.block_cache = NewLRUCache(co);
+  }
+  if (table_options_.block_size_deviation < 0 ||
+      table_options_.block_size_deviation > 100) {
+    table_options_.block_size_deviation = 0;
+  }
+  if (table_options_.block_restart_interval < 1) {
+    table_options_.block_restart_interval = 1;
+  }
+  if (table_options_.index_block_restart_interval < 1) {
+    table_options_.index_block_restart_interval = 1;
+  }
+  if (table_options_.partition_filters &&
+      table_options_.index_type !=
+          BlockBasedTableOptions::kTwoLevelIndexSearch) {
+    // We do not support partitioned filters without partitioning indexes
+    table_options_.partition_filters = false;
+  }
+  RegisterOptionsMap(kBlockBasedTableOpts, &table_options_,
+                     block_based_table_type_info);
+}
+#ifndef ROCKSDB_LITE
+const std::unordered_map<std::string, OptionsSanityCheckLevel>*
+BlockBasedTableFactory::GetOptionsSanityCheckLevel(
+    const std::string& name) const {
+  static std::unordered_map<std::string, OptionsSanityCheckLevel> skipped = {
+      {"filter_policy", OptionsSanityCheckLevel::kSanityLevelNone},
+  };
+  if (name == kBlockBasedTableOpts) {
+    return &skipped;
+  } else {
+    return TableFactory::GetOptionsSanityCheckLevel(name);
+  }
+}
+#endif  // ROCKSDB_LITE
+
+Status BlockBasedTableFactory::NewTableReader(
+    const TableReaderOptions& table_reader_options,
+    std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
+    std::unique_ptr<TableReader>* table_reader,
+    bool prefetch_index_and_filter_in_cache) const {
+  return BlockBasedTable::Open(
+      table_reader_options.ioptions, table_reader_options.env_options,
+      table_options_, table_reader_options.internal_comparator, std::move(file),
+      file_size, table_reader, table_reader_options.prefix_extractor,
+      prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
+      table_reader_options.level, table_reader_options.immortal,
+      table_reader_options.largest_seqno, &tail_prefetch_stats_,
+      table_reader_options.block_cache_tracer);
+}
+
+TableBuilder* BlockBasedTableFactory::NewTableBuilder(
+    const TableBuilderOptions& table_builder_options, uint32_t column_family_id,
+    WritableFileWriter* file) const {
+  auto table_builder = new BlockBasedTableBuilder(
+      table_builder_options.ioptions, table_builder_options.moptions,
+      table_options_, table_builder_options.internal_comparator,
+      table_builder_options.int_tbl_prop_collector_factories, column_family_id,
+      file, table_builder_options.compression_type,
+      table_builder_options.sample_for_compression,
+      table_builder_options.compression_opts,
+      table_builder_options.skip_filters,
+      table_builder_options.column_family_name,
+      table_builder_options.creation_time,
+      table_builder_options.oldest_key_time,
+      table_builder_options.target_file_size,
+      table_builder_options.file_creation_time);
+
+  return table_builder;
+}
+
+Status BlockBasedTableFactory::Validate(
+    const DBOptions& db_opts, const ColumnFamilyOptions& cf_opts) const {
+  if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
+      cf_opts.prefix_extractor == nullptr) {
+    return Status::InvalidArgument(
+        "Hash index is specified for block-based "
+        "table, but prefix_extractor is not given");
+  }
+  if (table_options_.cache_index_and_filter_blocks &&
+      table_options_.no_block_cache) {
+    return Status::InvalidArgument(
+        "Enable cache_index_and_filter_blocks, "
+        ", but block cache is disabled");
+  }
+  if (table_options_.pin_l0_filter_and_index_blocks_in_cache &&
+      table_options_.no_block_cache) {
+    return Status::InvalidArgument(
+        "Enable pin_l0_filter_and_index_blocks_in_cache, "
+        ", but block cache is disabled");
+  }
+  if (!BlockBasedTableSupportedVersion(table_options_.format_version)) {
+    return Status::InvalidArgument(
+        "Unsupported BlockBasedTable format_version. Please check "
+        "include/rocksdb/table.h for more info");
+  }
+  if (table_options_.block_align && (cf_opts.compression != kNoCompression)) {
+    return Status::InvalidArgument(
+        "Enable block_align, but compression "
+        "enabled");
+  }
+  if (table_options_.block_align &&
+      (table_options_.block_size & (table_options_.block_size - 1))) {
+    return Status::InvalidArgument(
+        "Block alignment requested but block size is not a power of 2");
+  }
+  if (table_options_.block_size > port::kMaxUint32) {
+    return Status::InvalidArgument(
+        "block size exceeds maximum number (4GiB) allowed");
+  }
+  if (table_options_.data_block_index_type ==
+          BlockBasedTableOptions::kDataBlockBinaryAndHash &&
+      table_options_.data_block_hash_table_util_ratio <= 0) {
+    return Status::InvalidArgument(
+        "data_block_hash_table_util_ratio should be greater than 0 when "
+        "data_block_index_type is set to kDataBlockBinaryAndHash");
+  }
+  if (db_opts.unordered_write && cf_opts.max_successive_merges > 0) {
+    // TODO(myabandeh): support it
+    return Status::InvalidArgument(
+        "max_successive_merges larger than 0 is currently inconsistent with "
+        "unordered_write");
+  }
+  return TableFactory::Validate(db_opts, cf_opts);
+}
+
+const void* BlockBasedTableFactory::GetOptionsPtr(
+    const std::string& name) const {
+  if (name == "BlockCache") {
+    if (table_options_.no_block_cache) {
+      return nullptr;
+    } else {
+      return table_options_.block_cache.get();
+    }
+  } else {
+    return TableFactory::GetOptionsPtr(name);
+  }
 }
 
 #ifndef ROCKSDB_LITE
-namespace {
-std::string ParseBlockBasedTableOption(const std::string& name,
-                                       const std::string& org_value,
-                                       BlockBasedTableOptions* new_options,
-                                       bool input_strings_escaped = false,
-                                       bool ignore_unknown_options = false) {
-  const std::string& value =
-      input_strings_escaped ? UnescapeOptionString(org_value) : org_value;
-  if (!input_strings_escaped) {
-    // if the input string is not escaped, it means this function is
-    // invoked from SetOptions, which takes the old format.
-    if (name == "block_cache" || name == "block_cache_compressed") {
-      // cache options can be specified in the following format
-      //   "block_cache={capacity=1M;num_shard_bits=4;
-      //    strict_capacity_limit=true;high_pri_pool_ratio=0.5;}"
-      // To support backward compatibility, the following format
-      // is also supported.
-      //   "block_cache=1M"
-      std::shared_ptr<Cache> cache;
-      // block_cache is specified in format block_cache=<cache_size>.
-      if (value.find('=') == std::string::npos) {
-        cache = NewLRUCache(ParseSizeT(value));
-      } else {
-        LRUCacheOptions cache_opts;
-        OptionTypeInfo cache_info{0, OptionType::kLRUCacheOptions,
-                                  OptionVerificationType::kNormal,
-                                  OptionTypeFlags::kNone, 0};
-        if (!ParseOptionHelper(reinterpret_cast<char*>(&cache_opts), cache_info,
-                               value)) {
-          return "Invalid cache options";
-        }
-        cache = NewLRUCache(cache_opts);
-      }
-
-      if (name == "block_cache") {
-        new_options->block_cache = cache;
-      } else {
-        new_options->block_cache_compressed = cache;
-      }
-      return "";
-    } else if (name == "filter_policy") {
-      // Expect the following format
-      // bloomfilter:int:bool
-      const std::string kName = "bloomfilter:";
-      if (value.compare(0, kName.size(), kName) != 0) {
-        return "Invalid filter policy name";
-      }
-      size_t pos = value.find(':', kName.size());
-      if (pos == std::string::npos) {
-        return "Invalid filter policy config, missing bits_per_key";
-      }
-      int bits_per_key =
-          ParseInt(trim(value.substr(kName.size(), pos - kName.size())));
-      bool use_block_based_builder =
-          ParseBoolean("use_block_based_builder", trim(value.substr(pos + 1)));
-      new_options->filter_policy.reset(
-          NewBloomFilterPolicy(bits_per_key, use_block_based_builder));
-      return "";
-    }
-  }
-  const auto iter = block_based_table_type_info.find(name);
-  if (iter == block_based_table_type_info.end()) {
-    if (ignore_unknown_options) {
-      return "";
+Status BlockBasedTableFactory::UnknownToString(uint32_t mode,
+                                               const std::string& name,
+                                               std::string* value) const {
+  Status status;
+  if (name == "filter_policy") {
+    if (table_options_.filter_policy) {
+      *value = table_options_.filter_policy->Name();
     } else {
-      return "Unrecognized option";
+      *value = kNullptrString;
     }
+  } else {
+    status = TableFactory::UnknownToString(mode, name, value);
   }
-  const auto& opt_info = iter->second;
-  if (opt_info.verification != OptionVerificationType::kDeprecated &&
-      !ParseOptionHelper(reinterpret_cast<char*>(new_options) + opt_info.offset,
-                         opt_info, value)) {
-    return "Invalid value";
-  }
-  return "";
-}
-}  // namespace
-
-Status GetBlockBasedTableOptionsFromString(
-    const BlockBasedTableOptions& table_options, const std::string& opts_str,
-    BlockBasedTableOptions* new_table_options) {
-  std::unordered_map<std::string, std::string> opts_map;
-  Status s = StringToMap(opts_str, &opts_map);
-  if (!s.ok()) {
-    return s;
-  }
-
-  return GetBlockBasedTableOptionsFromMap(table_options, opts_map,
-                                          new_table_options);
+  return status;
 }
 
-Status GetBlockBasedTableOptionsFromMap(
-    const BlockBasedTableOptions& table_options,
-    const std::unordered_map<std::string, std::string>& opts_map,
-    BlockBasedTableOptions* new_table_options, bool input_strings_escaped,
-    bool ignore_unknown_options) {
-  assert(new_table_options);
-  *new_table_options = table_options;
-  for (const auto& o : opts_map) {
-    auto error_message = ParseBlockBasedTableOption(
-        o.first, o.second, new_table_options, input_strings_escaped,
-        ignore_unknown_options);
-    if (error_message != "") {
-      const auto iter = block_based_table_type_info.find(o.first);
-      if (iter == block_based_table_type_info.end() ||
-          !input_strings_escaped ||  // !input_strings_escaped indicates
-                                     // the old API, where everything is
-                                     // parsable.
-          (iter->second.verification != OptionVerificationType::kByName &&
-           iter->second.verification !=
-               OptionVerificationType::kByNameAllowNull &&
-           iter->second.verification !=
-               OptionVerificationType::kByNameAllowFromNull &&
-           iter->second.verification != OptionVerificationType::kDeprecated)) {
-        // Restore "new_options" to the default "base_options".
-        *new_table_options = table_options;
-        return Status::InvalidArgument("Can't parse BlockBasedTableOptions:",
-                                       o.first + " " + error_message);
+bool BlockBasedTableFactory::IsUnknownEqual(
+    const std::string& name, const OptionTypeInfo& /* type_info */,
+    OptionsSanityCheckLevel /* sanity_check_level */, const char* thisOffset,
+    const char* thatOffset) const {
+  if (name == "filter_policy") {
+    const auto* thisOne =
+        reinterpret_cast<const std::shared_ptr<FilterPolicy>*>(thisOffset)
+            ->get();
+    const auto* thatOne =
+        reinterpret_cast<const std::shared_ptr<FilterPolicy>*>(thatOffset)
+            ->get();
+    if (thisOne == thatOne) {
+      return true;
+    } else if (thisOne != nullptr) {
+      return thatOne == nullptr ||
+             strcmp(thisOne->Name(), thatOne->Name()) == 0;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+
+// Take a default BlockBasedTableOptions "table_options" in addition to a
+// map "opts_map" of option name to option value to construct the new
+// BlockBasedTableOptions "new_table_options".
+//
+// Below are the instructions of how to config some non-primitive-typed
+// options in BlockBasedTableOptions:
+//
+// * filter_policy:
+//   We currently only support the following FilterPolicy in the convenience
+//   functions:
+//   - BloomFilter: use "bloomfilter:[bits_per_key]:[use_block_based_builder]"
+//     to specify BloomFilter.  The above string is equivalent to calling
+//     NewBloomFilterPolicy(bits_per_key, use_block_based_builder).
+//     [Example]:
+//     - Pass {"filter_policy", "bloomfilter:4:true"} in
+//       GetBlockBasedTableOptionsFromMap to use a BloomFilter with 4-bits
+//       per key and use_block_based_builder enabled.
+//
+// * block_cache / block_cache_compressed:
+//   We currently only support LRU cache in the GetOptions API.  The LRU
+//   cache can be set by directly specifying its size.
+//   [Example]:
+//   - Passing {"block_cache", "1M"} in GetBlockBasedTableOptionsFromMap is
+//     equivalent to setting block_cache using NewLRUCache(1024 * 1024).
+//
+// @param table_options the default options of the output "new_table_options".
+// @param opts_map an option name to value map for specifying how
+//     "new_table_options" should be set.
+// @param new_table_options the resulting options based on "table_options"
+//     with the change specified in "opts_map".
+// @param input_strings_escaped when set to true, each escaped characters
+//     prefixed by '\' in the values of the opts_map will be further converted
+//     back to the raw string before assigning to the associated options.
+// @param ignore_unknown_options when set to true, unknown options are ignored
+//     instead of resulting in an unknown-option error.
+// @return Status::OK() on success.  Otherwise, a non-ok status indicating
+//     error will be returned, and "new_table_options" will be set to
+//     "table_options".
+Status BlockBasedTableFactory::SetUnknown(const DBOptions& db_opts,
+                                          const std::string& name,
+                                          const std::string& value) {
+  Status status = Status::OK();
+  if (name == "block_cache" || name == "block_cache_compressed") {
+    // cache options can be specified in the following format
+    //   "block_cache={capacity=1M;num_shard_bits=4;
+    //    strict_capacity_limit=true;high_pri_pool_ratio=0.5;}"
+    // To support backward compatibility, the following format
+    // is also supported.
+    //   "block_cache=1M"
+    std::shared_ptr<Cache> cache;
+    // block_cache is specified in format block_cache=<cache_size>.
+    if (value.find('=') == std::string::npos) {
+      cache = NewLRUCache(ParseSizeT(value));
+    } else {
+      LRUCacheOptions cache_opts;
+      OptionTypeInfo cache_info{0, OptionType::kLRUCacheOptions,
+                                OptionVerificationType::kNormal,
+                                OptionTypeFlags::kNone, 0};
+      if (!ParseOptionHelper(reinterpret_cast<char*>(&cache_opts), cache_info,
+                             value)) {
+        return Status::InvalidArgument("Invalid cache options");
       }
+      cache = NewLRUCache(cache_opts);
     }
-  }
-  return Status::OK();
-}
-
-Status VerifyBlockBasedTableFactory(
-    const BlockBasedTableFactory* base_tf,
-    const BlockBasedTableFactory* file_tf,
-    OptionsSanityCheckLevel sanity_check_level) {
-  if ((base_tf != nullptr) != (file_tf != nullptr) &&
-      sanity_check_level > kSanityLevelNone) {
-    return Status::Corruption(
-        "[RocksDBOptionsParser]: Inconsistent TableFactory class type");
-  }
-  if (base_tf == nullptr) {
-    return Status::OK();
-  }
-  assert(file_tf != nullptr);
-
-  const auto& base_opt = base_tf->table_options();
-  const auto& file_opt = file_tf->table_options();
-
-  for (auto& pair : block_based_table_type_info) {
-    if (pair.second.verification == OptionVerificationType::kDeprecated) {
-      // We skip checking deprecated variables as they might
-      // contain random values since they might not be initialized
-      continue;
+    if (name == "block_cache") {
+      table_options_.block_cache = cache;
+    } else {
+      table_options_.block_cache_compressed = cache;
     }
-    auto level = BBTOptionSanityCheckLevel(pair.first);
-    if (level <= sanity_check_level) {
-      if (!AreEqualOptions(level, reinterpret_cast<const char*>(&base_opt),
-                           reinterpret_cast<const char*>(&file_opt),
-                           pair.second, pair.first, nullptr)) {
-        return Status::Corruption(
-            "[RocksDBOptionsParser]: "
-            "failed the verification on BlockBasedTableOptions::",
-            pair.first);
+  } else if (name == "filter_policy") {
+    // Expect the following format
+    // bloomfilter:int:bool
+    const std::string kBloomName = "bloomfilter:";
+    if (value == kNullptrString || value == "rocksdb.BuiltinBloomFilter") {
+      table_options_.filter_policy.reset();
+    } else if (value.compare(0, kBloomName.size(), kBloomName) == 0) {
+      size_t pos = value.find(':', kBloomName.size());
+      if (pos == std::string::npos) {
+        status = Status::InvalidArgument(
+            "Invalid filter policy config, missing bits_per_key");
+      } else {
+        int bits_per_key = ParseInt(
+            trim(value.substr(kBloomName.size(), pos - kBloomName.size())));
+        bool use_block_based_builder = ParseBoolean(
+            "use_block_based_builder", trim(value.substr(pos + 1)));
+        table_options_.filter_policy.reset(
+            NewBloomFilterPolicy(bits_per_key, use_block_based_builder));
       }
+    } else {
+      status = Status::InvalidArgument("Invalid filter policy name ", value);
+    }
+  } else {
+    status = TableFactory::SetUnknown(db_opts, name, value);
+  }
+  return status;
+}
+
+Status BlockBasedTableFactory::ParseOption(const OptionTypeInfo& opt_info,
+                                           const DBOptions& db_opts,
+                                           void* opt_ptr,
+                                           const std::string& opt_name,
+                                           const std::string& opt_value,
+                                           bool input_strings_escaped) {
+  Status status = TableFactory::ParseOption(
+      opt_info, db_opts, opt_ptr, opt_name, opt_value, input_strings_escaped);
+  if (input_strings_escaped && !status.ok()) {  // Got an error
+    // !input_strings_escaped indicates the old API, where everything is
+    // parsable.
+    if (opt_info.verification == OptionVerificationType::kByName ||
+        opt_info.verification == OptionVerificationType::kByNameAllowNull ||
+        opt_info.verification == OptionVerificationType::kByNameAllowFromNull) {
+      status = Status::OK();
     }
   }
-  return Status::OK();
+  return status;
 }
-#endif  // !ROCKSDB_LITE
+#endif  // ROCKSDB_LITE
 
 TableFactory* NewBlockBasedTableFactory(
     const BlockBasedTableOptions& _table_options) {
   return new BlockBasedTableFactory(_table_options);
 }
 
-const std::string BlockBasedTableFactory::kName = "BlockBasedTable";
 const std::string BlockBasedTablePropertyNames::kIndexType =
     "rocksdb.block.based.table.index.type";
 const std::string BlockBasedTablePropertyNames::kWholeKeyFiltering =

--- a/table/block_based/block_based_table_factory.h
+++ b/table/block_based/block_based_table_factory.h
@@ -14,10 +14,9 @@
 #include <string>
 
 #include "db/dbformat.h"
-#include "options/options_helper.h"
-#include "options/options_parser.h"
 #include "rocksdb/flush_block_policy.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 
 namespace rocksdb {
 
@@ -92,104 +91,5 @@ extern Status VerifyBlockBasedTableFactory(
     const BlockBasedTableFactory* base_tf,
     const BlockBasedTableFactory* file_tf,
     OptionsSanityCheckLevel sanity_check_level);
-
-static std::unordered_map<std::string, OptionTypeInfo>
-    block_based_table_type_info = {
-        /* currently not supported
-          std::shared_ptr<Cache> block_cache = nullptr;
-          std::shared_ptr<Cache> block_cache_compressed = nullptr;
-         */
-        {"flush_block_policy_factory",
-         {offsetof(struct BlockBasedTableOptions, flush_block_policy_factory),
-          OptionType::kFlushBlockPolicyFactory, OptionVerificationType::kByName,
-          false, 0}},
-        {"cache_index_and_filter_blocks",
-         {offsetof(struct BlockBasedTableOptions,
-                   cache_index_and_filter_blocks),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"cache_index_and_filter_blocks_with_high_priority",
-         {offsetof(struct BlockBasedTableOptions,
-                   cache_index_and_filter_blocks_with_high_priority),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"pin_l0_filter_and_index_blocks_in_cache",
-         {offsetof(struct BlockBasedTableOptions,
-                   pin_l0_filter_and_index_blocks_in_cache),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"index_type",
-         {offsetof(struct BlockBasedTableOptions, index_type),
-          OptionType::kBlockBasedTableIndexType,
-          OptionVerificationType::kNormal, false, 0}},
-        {"hash_index_allow_collision",
-         {offsetof(struct BlockBasedTableOptions, hash_index_allow_collision),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"data_block_index_type",
-         {offsetof(struct BlockBasedTableOptions, data_block_index_type),
-          OptionType::kBlockBasedTableDataBlockIndexType,
-          OptionVerificationType::kNormal, false, 0}},
-        {"index_shortening",
-         {offsetof(struct BlockBasedTableOptions, index_shortening),
-          OptionType::kBlockBasedTableIndexShorteningMode,
-          OptionVerificationType::kNormal, false, 0}},
-        {"data_block_hash_table_util_ratio",
-         {offsetof(struct BlockBasedTableOptions,
-                   data_block_hash_table_util_ratio),
-          OptionType::kDouble, OptionVerificationType::kNormal, false, 0}},
-        {"checksum",
-         {offsetof(struct BlockBasedTableOptions, checksum),
-          OptionType::kChecksumType, OptionVerificationType::kNormal, false,
-          0}},
-        {"no_block_cache",
-         {offsetof(struct BlockBasedTableOptions, no_block_cache),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"block_size",
-         {offsetof(struct BlockBasedTableOptions, block_size),
-          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-        {"block_size_deviation",
-         {offsetof(struct BlockBasedTableOptions, block_size_deviation),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"index_block_restart_interval",
-         {offsetof(struct BlockBasedTableOptions, index_block_restart_interval),
-          OptionType::kInt, OptionVerificationType::kNormal, false, 0}},
-        {"index_per_partition",
-         {0, OptionType::kUInt64T, OptionVerificationType::kDeprecated, false,
-          0}},
-        {"metadata_block_size",
-         {offsetof(struct BlockBasedTableOptions, metadata_block_size),
-          OptionType::kUInt64T, OptionVerificationType::kNormal, false, 0}},
-        {"partition_filters",
-         {offsetof(struct BlockBasedTableOptions, partition_filters),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"filter_policy",
-         {offsetof(struct BlockBasedTableOptions, filter_policy),
-          OptionType::kFilterPolicy, OptionVerificationType::kByName, false,
-          0}},
-        {"whole_key_filtering",
-         {offsetof(struct BlockBasedTableOptions, whole_key_filtering),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"skip_table_builder_flush",
-         {0, OptionType::kBoolean, OptionVerificationType::kDeprecated, false,
-          0}},
-        {"format_version",
-         {offsetof(struct BlockBasedTableOptions, format_version),
-          OptionType::kUInt32T, OptionVerificationType::kNormal, false, 0}},
-        {"verify_compression",
-         {offsetof(struct BlockBasedTableOptions, verify_compression),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"read_amp_bytes_per_bit",
-         {offsetof(struct BlockBasedTableOptions, read_amp_bytes_per_bit),
-          OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-        {"enable_index_compression",
-         {offsetof(struct BlockBasedTableOptions, enable_index_compression),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"block_align",
-         {offsetof(struct BlockBasedTableOptions, block_align),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}},
-        {"pin_top_level_index_and_filter",
-         {offsetof(struct BlockBasedTableOptions,
-                   pin_top_level_index_and_filter),
-          OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 #endif  // !ROCKSDB_LITE
 }  // namespace rocksdb

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -17,6 +17,7 @@
 
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
+#include "options/options_helper.h"
 
 #include "rocksdb/cache.h"
 #include "rocksdb/comparator.h"

--- a/table/cuckoo/cuckoo_table_factory.cc
+++ b/table/cuckoo/cuckoo_table_factory.cc
@@ -11,6 +11,8 @@
 #include "table/cuckoo/cuckoo_table_reader.h"
 
 namespace rocksdb {
+const std::string CuckooTableFactory::kCuckooTablePrefix =
+    "rocksdb.table.cuckoo.";
 
 Status CuckooTableFactory::NewTableReader(
     const TableReaderOptions& table_reader_options,
@@ -43,25 +45,35 @@ TableBuilder* CuckooTableFactory::NewTableBuilder(
       column_family_id, table_builder_options.column_family_name);
 }
 
-std::string CuckooTableFactory::GetPrintableTableOptions() const {
-  std::string ret;
-  ret.reserve(2000);
-  const int kBufferSize = 200;
-  char buffer[kBufferSize];
+static std::unordered_map<std::string, OptionTypeInfo> cuckoo_table_type_info =
+    {
+#ifndef ROCKSDB_LITE
+        {"hash_table_ratio",
+         {offsetof(struct CuckooTableOptions, hash_table_ratio),
+          OptionType::kDouble, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone, 0}},
+        {"max_search_depth",
+         {offsetof(struct CuckooTableOptions, max_search_depth),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone, 0}},
+        {"cuckoo_block_size",
+         {offsetof(struct CuckooTableOptions, cuckoo_block_size),
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone, 0}},
+        {"identity_as_first_hash",
+         {offsetof(struct CuckooTableOptions, identity_as_first_hash),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone, 0}},
+        {"use_module_hash",
+         {offsetof(struct CuckooTableOptions, use_module_hash),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone, 0}},
+#endif  // ROCKSDB_LITE
+};
 
-  snprintf(buffer, kBufferSize, "  hash_table_ratio: %lf\n",
-           table_options_.hash_table_ratio);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  max_search_depth: %u\n",
-           table_options_.max_search_depth);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  cuckoo_block_size: %u\n",
-           table_options_.cuckoo_block_size);
-  ret.append(buffer);
-  snprintf(buffer, kBufferSize, "  identity_as_first_hash: %d\n",
-           table_options_.identity_as_first_hash);
-  ret.append(buffer);
-  return ret;
+CuckooTableFactory::CuckooTableFactory(const CuckooTableOptions& table_options)
+    : table_options_(table_options) {
+  RegisterOptionsMap(kCuckooTableOpts, &table_options_, cuckoo_table_type_info);
 }
 
 TableFactory* NewCuckooTableFactory(const CuckooTableOptions& table_options) {

--- a/table/cuckoo/cuckoo_table_factory.h
+++ b/table/cuckoo/cuckoo_table_factory.h
@@ -51,13 +51,18 @@ static inline uint64_t CuckooHash(
 // - Does not support Merge operations.
 // - Does not support prefix bloom filters.
 class CuckooTableFactory : public TableFactory {
+ private:
+  static const std::string kCuckooTablePrefix;
+
  public:
-  explicit CuckooTableFactory(const CuckooTableOptions& table_options)
-    : table_options_(table_options) {}
+  explicit CuckooTableFactory(
+      const CuckooTableOptions& table_options = CuckooTableOptions());
   ~CuckooTableFactory() {}
 
   const char* Name() const override { return "CuckooTable"; }
-
+  const std::string& GetOptionsPrefix() const override {
+    return kCuckooTablePrefix;
+  }
   Status NewTableReader(
       const TableReaderOptions& table_reader_options,
       std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
@@ -67,23 +72,6 @@ class CuckooTableFactory : public TableFactory {
   TableBuilder* NewTableBuilder(
       const TableBuilderOptions& table_builder_options,
       uint32_t column_family_id, WritableFileWriter* file) const override;
-
-  // Sanitizes the specified DB Options.
-  Status SanitizeOptions(
-      const DBOptions& /*db_opts*/,
-      const ColumnFamilyOptions& /*cf_opts*/) const override {
-    return Status::OK();
-  }
-
-  std::string GetPrintableTableOptions() const override;
-
-  void* GetOptions() override { return &table_options_; }
-
-  Status GetOptionString(std::string* /*opt_string*/,
-                         const std::string& /*delimiter*/) const override {
-    return Status::OK();
-  }
-
  private:
   CuckooTableOptions table_options_;
 };

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -175,16 +175,6 @@ class MockTableFactory : public TableFactory {
   Status CreateMockTable(Env* env, const std::string& fname,
                          stl_wrappers::KVMap file_contents);
 
-  virtual Status SanitizeOptions(
-      const DBOptions& /*db_opts*/,
-      const ColumnFamilyOptions& /*cf_opts*/) const override {
-    return Status::OK();
-  }
-
-  virtual std::string GetPrintableTableOptions() const override {
-    return std::string();
-  }
-
   // This function will assert that only a single file exists and that the
   // contents are equal to file_contents
   void AssertSingleFile(const stl_wrappers::KVMap& file_contents);

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -139,7 +139,7 @@ Status GetMemTableRepFactoryFromString(
 
   MemTableRepFactory* mem_factory = nullptr;
 
-  if (opts_list[0] == "skip_list") {
+  if (opts_list[0] == "skip_list" || opts_list[0] == "SkipListFactory") {
     // Expecting format
     // skip_list:<lookahead>
     if (2 == len) {
@@ -148,7 +148,8 @@ Status GetMemTableRepFactoryFromString(
     } else if (1 == len) {
       mem_factory = new SkipListFactory();
     }
-  } else if (opts_list[0] == "prefix_hash") {
+  } else if (opts_list[0] == "prefix_hash" ||
+             opts_list[0] == "HashSkipListRepFactory") {
     // Expecting format
     // prfix_hash:<hash_bucket_count>
     if (2 == len) {
@@ -157,7 +158,8 @@ Status GetMemTableRepFactoryFromString(
     } else if (1 == len) {
       mem_factory = NewHashSkipListRepFactory();
     }
-  } else if (opts_list[0] == "hash_linkedlist") {
+  } else if (opts_list[0] == "hash_linkedlist" ||
+             opts_list[0] == "HashLinkListRepFactory") {
     // Expecting format
     // hash_linkedlist:<hash_bucket_count>
     if (2 == len) {
@@ -166,7 +168,7 @@ Status GetMemTableRepFactoryFromString(
     } else if (1 == len) {
       mem_factory = NewHashLinkListRepFactory();
     }
-  } else if (opts_list[0] == "vector") {
+  } else if (opts_list[0] == "vector" || opts_list[0] == "VectorRepFactory") {
     // Expecting format
     // vector:<count>
     if (2 == len) {

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -17,6 +17,34 @@
 #include "util/string_util.h"
 
 namespace rocksdb {
+static std::unordered_map<std::string, OptionTypeInfo> plain_table_type_info = {
+    {"user_key_len",
+     {offsetof(struct PlainTableOptions, user_key_len), OptionType::kUInt32T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"bloom_bits_per_key",
+     {offsetof(struct PlainTableOptions, bloom_bits_per_key), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"hash_table_ratio",
+     {offsetof(struct PlainTableOptions, hash_table_ratio), OptionType::kDouble,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"index_sparseness",
+     {offsetof(struct PlainTableOptions, index_sparseness), OptionType::kSizeT,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"huge_page_tlb_size",
+     {offsetof(struct PlainTableOptions, huge_page_tlb_size),
+      OptionType::kSizeT, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}},
+    {"encoding_type",
+     {offsetof(struct PlainTableOptions, encoding_type),
+      OptionType::kEncodingType, OptionVerificationType::kByName,
+      OptionTypeFlags::kEnum, 0}},
+    {"full_scan_mode",
+     {offsetof(struct PlainTableOptions, full_scan_mode), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone, 0}},
+    {"store_index_in_file",
+     {offsetof(struct PlainTableOptions, store_index_in_file),
+      OptionType::kBoolean, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone, 0}}};
 
 Status PlainTableFactory::NewTableReader(
     const TableReaderOptions& table_reader_options,
@@ -180,7 +208,7 @@ std::string ParsePlainTableOptions(const std::string& name,
   const auto& opt_info = iter->second;
   if (opt_info.verification != OptionVerificationType::kDeprecated &&
       !ParseOptionHelper(reinterpret_cast<char*>(new_options) + opt_info.offset,
-                         opt_info.type, value)) {
+                         opt_info, value)) {
     return "Invalid value";
   }
   return "";

--- a/table/plain/plain_table_factory.h
+++ b/table/plain/plain_table_factory.h
@@ -10,9 +10,9 @@
 #include <string>
 #include <stdint.h>
 
-#include "options/options_helper.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 
 namespace rocksdb {
 
@@ -192,32 +192,6 @@ class PlainTableFactory : public TableFactory {
  private:
   PlainTableOptions table_options_;
 };
-
-static std::unordered_map<std::string, OptionTypeInfo> plain_table_type_info = {
-    {"user_key_len",
-     {offsetof(struct PlainTableOptions, user_key_len), OptionType::kUInt32T,
-      OptionVerificationType::kNormal, false, 0}},
-    {"bloom_bits_per_key",
-     {offsetof(struct PlainTableOptions, bloom_bits_per_key), OptionType::kInt,
-      OptionVerificationType::kNormal, false, 0}},
-    {"hash_table_ratio",
-     {offsetof(struct PlainTableOptions, hash_table_ratio), OptionType::kDouble,
-      OptionVerificationType::kNormal, false, 0}},
-    {"index_sparseness",
-     {offsetof(struct PlainTableOptions, index_sparseness), OptionType::kSizeT,
-      OptionVerificationType::kNormal, false, 0}},
-    {"huge_page_tlb_size",
-     {offsetof(struct PlainTableOptions, huge_page_tlb_size),
-      OptionType::kSizeT, OptionVerificationType::kNormal, false, 0}},
-    {"encoding_type",
-     {offsetof(struct PlainTableOptions, encoding_type),
-      OptionType::kEncodingType, OptionVerificationType::kByName, false, 0}},
-    {"full_scan_mode",
-     {offsetof(struct PlainTableOptions, full_scan_mode), OptionType::kBoolean,
-      OptionVerificationType::kNormal, false, 0}},
-    {"store_index_in_file",
-     {offsetof(struct PlainTableOptions, store_index_in_file),
-      OptionType::kBoolean, OptionVerificationType::kNormal, false, 0}}};
 
 }  // namespace rocksdb
 #endif  // ROCKSDB_LITE

--- a/table/plain/plain_table_factory.h
+++ b/table/plain/plain_table_factory.h
@@ -138,6 +138,9 @@ class TableBuilder;
 //
 //
 class PlainTableFactory : public TableFactory {
+ private:
+  static const std::string kPlainTablePrefix /* = rocksdb.table.plain */;
+
  public:
   ~PlainTableFactory() {}
   // user_key_len is the length of the user key. If it is set to be
@@ -156,10 +159,9 @@ class PlainTableFactory : public TableFactory {
   // page TLB and the page size if allocating from there. See comments of
   // Arena::AllocateAligned() for details.
   explicit PlainTableFactory(
-      const PlainTableOptions& _table_options = PlainTableOptions())
-      : table_options_(_table_options) {}
+      const PlainTableOptions& _table_options = PlainTableOptions());
 
-  const char* Name() const override { return "PlainTable"; }
+  const char* Name() const override { return kPlainTableName.c_str(); }
   Status NewTableReader(const TableReaderOptions& table_reader_options,
                         std::unique_ptr<RandomAccessFileReader>&& file,
                         uint64_t file_size, std::unique_ptr<TableReader>* table,
@@ -169,24 +171,11 @@ class PlainTableFactory : public TableFactory {
       const TableBuilderOptions& table_builder_options,
       uint32_t column_family_id, WritableFileWriter* file) const override;
 
-  std::string GetPrintableTableOptions() const override;
-
-  const PlainTableOptions& table_options() const;
-
   static const char kValueTypeSeqId0 = char(~0);
 
-  // Sanitizes the specified DB Options.
-  Status SanitizeOptions(
-      const DBOptions& /*db_opts*/,
-      const ColumnFamilyOptions& /*cf_opts*/) const override {
-    return Status::OK();
-  }
-
-  void* GetOptions() override { return &table_options_; }
-
-  Status GetOptionString(std::string* /*opt_string*/,
-                         const std::string& /*delimiter*/) const override {
-    return Status::OK();
+ protected:
+  virtual const std::string& GetOptionsPrefix() const override {
+    return kPlainTablePrefix;
   }
 
  private:

--- a/table/table_factory.cc
+++ b/table/table_factory.cc
@@ -1,0 +1,39 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "rocksdb/table.h"
+#include "table/block_based/block_based_table_factory.h"
+#include "table/cuckoo/cuckoo_table_factory.h"
+#include "table/plain/plain_table_factory.h"
+
+namespace rocksdb {
+const std::string TableFactory::kBlockBasedTableName = "BlockBasedTable";
+const std::string TableFactory::kBlockBasedTableOpts = "BlockTableOptions";
+const std::string TableFactory::kPlainTableName = "PlainTable";
+const std::string TableFactory::kPlainTableOpts = "PlainTableOptions";
+const std::string TableFactory::kCuckooTableName = "CuckooTable";
+const std::string TableFactory::kCuckooTableOpts = "CuckooTableOptions";
+
+Status TableFactory::LoadTableFactory(const std::string &id,
+                                      std::shared_ptr<TableFactory> *factory) {
+  Status status;
+  std::string name = id;
+  if (factory->get() == nullptr || name != factory->get()->Name()) {
+    if (name == kBlockBasedTableName) {
+      factory->reset(new BlockBasedTableFactory());
+#ifndef ROCKSDB_LITE
+    } else if (name == kPlainTableName) {
+      factory->reset(new PlainTableFactory());
+    } else if (name == kCuckooTableName) {
+      factory->reset(new CuckooTableFactory());
+#endif  // ROCKSDB_LITE
+    } else {
+      status = Status::NotFound("Could not load table factory: ", name);
+    }
+  }
+  return status;
+}
+
+}  // namespace rocksdb

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2765,7 +2765,8 @@ void ValidateBlockSizeDeviation(int value, int expected) {
   BlockBasedTableFactory* factory = new BlockBasedTableFactory(table_options);
 
   const BlockBasedTableOptions* normalized_table_options =
-      (const BlockBasedTableOptions*)factory->GetOptions();
+      factory->GetOptions<BlockBasedTableOptions>(
+          TableFactory::kBlockBasedTableOpts);
   ASSERT_EQ(normalized_table_options->block_size_deviation, expected);
 
   delete factory;
@@ -2777,7 +2778,8 @@ void ValidateBlockRestartInterval(int value, int expected) {
   BlockBasedTableFactory* factory = new BlockBasedTableFactory(table_options);
 
   const BlockBasedTableOptions* normalized_table_options =
-      (const BlockBasedTableOptions*)factory->GetOptions();
+      factory->GetOptions<BlockBasedTableOptions>(
+          TableFactory::kBlockBasedTableOpts);
   ASSERT_EQ(normalized_table_options->block_restart_interval, expected);
 
   delete factory;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -36,6 +36,7 @@
 #include "monitoring/histogram.h"
 #include "monitoring/statistics.h"
 #include "options/cf_options.h"
+#include "options/options_helper.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "rocksdb/cache.h"
@@ -3743,11 +3744,10 @@ class Benchmark {
     options.compression_opts.zstd_max_train_bytes =
         FLAGS_compression_zstd_max_train_bytes;
     // If this is a block based table, set some related options
-    if (options.table_factory->Name() == BlockBasedTableFactory::kName &&
-        options.table_factory->GetOptions() != nullptr) {
-      BlockBasedTableOptions* table_options =
-          reinterpret_cast<BlockBasedTableOptions*>(
-              options.table_factory->GetOptions());
+    auto* table_options =
+        options.table_factory->GetOptions<BlockBasedTableOptions>(
+            TableFactory::kBlockBasedTableOpts);
+    if (table_options != nullptr) {
       if (FLAGS_cache_size) {
         table_options->block_cache = cache_;
       }
@@ -6353,6 +6353,7 @@ class Benchmark {
 int db_bench_tool(int argc, char** argv) {
   rocksdb::port::InstallStackTraceHandler();
   static bool initialized = false;
+  DBOptions db_options;  //**TODO: This should be initialized from the file...
   if (!initialized) {
     SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
                     " [OPTIONS]...");

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -128,7 +128,7 @@ Status SstFileDumper::NewTableReader(
     std::unique_ptr<TableReader>* /*table_reader*/) {
   // We need to turn off pre-fetching of index and filter nodes for
   // BlockBasedTable
-  if (BlockBasedTableFactory::kName == options_.table_factory->Name()) {
+  if (TableFactory::kBlockBasedTableName == options_.table_factory->Name()) {
     return options_.table_factory->NewTableReader(
         TableReaderOptions(ioptions_, moptions_.prefix_extractor.get(),
                            soptions_, internal_comparator_),

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -264,6 +264,20 @@ std::string trim(const std::string& str) {
   return std::string();
 }
 
+bool EndsWith(const std::string& string, const std::string& pattern) {
+  size_t plen = pattern.size();
+  size_t slen = string.size();
+  if (plen <= slen) {
+    return string.compare(slen - plen, plen, pattern) == 0;
+  } else {
+    return false;
+  }
+}
+
+bool StartsWith(const std::string& string, const std::string& pattern) {
+  return string.compare(0, pattern.size(), pattern) == 0;
+}
+
 #ifndef ROCKSDB_LITE
 
 bool ParseBoolean(const std::string& type, const std::string& value) {

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -109,6 +109,12 @@ std::string UnescapeOptionString(const std::string& escaped_string);
 
 std::string trim(const std::string& str);
 
+// Returns true if "string" ends with "pattern"
+bool EndsWith(const std::string& string, const std::string& pattern);
+
+// Returns true if "string" starts with "pattern"
+bool StartsWith(const std::string& string, const std::string& pattern);
+
 #ifndef ROCKSDB_LITE
 bool ParseBoolean(const std::string& type, const std::string& value);
 

--- a/utilities/memory/memory_test.cc
+++ b/utilities/memory/memory_test.cc
@@ -43,12 +43,11 @@ class MemoryTest : public testing::Test {
   void GetCachePointersFromTableFactory(
       const TableFactory* factory,
       std::unordered_set<const Cache*>* cache_set) {
-    const BlockBasedTableFactory* bbtf =
-        dynamic_cast<const BlockBasedTableFactory*>(factory);
-    if (bbtf != nullptr) {
-      const auto bbt_opts = bbtf->table_options();
-      cache_set->insert(bbt_opts.block_cache.get());
-      cache_set->insert(bbt_opts.block_cache_compressed.get());
+    const auto* bbto = factory->GetOptions<BlockBasedTableOptions>(
+        TableFactory::kBlockBasedTableOpts);
+    if (bbto != nullptr) {
+      cache_set->insert(bbto->block_cache.get());
+      cache_set->insert(bbto->block_cache_compressed.get());
     }
   }
 

--- a/utilities/options/options_util.cc
+++ b/utilities/options/options_util.cc
@@ -10,6 +10,7 @@
 #include "file/filename.h"
 #include "options/options_parser.h"
 #include "rocksdb/options.h"
+#include "rocksdb/table.h"
 
 namespace rocksdb {
 Status LoadOptionsFromFile(const std::string& file_name, Env* env,
@@ -30,11 +31,12 @@ Status LoadOptionsFromFile(const std::string& file_name, Env* env,
     cf_descs->push_back({cf_names[i], cf_opts[i]});
     if (cache != nullptr) {
       TableFactory* tf = cf_opts[i].table_factory.get();
-      if (tf != nullptr && tf->GetOptions() != nullptr &&
-          tf->Name() == BlockBasedTableFactory().Name()) {
-        auto* loaded_bbt_opt =
-            reinterpret_cast<BlockBasedTableOptions*>(tf->GetOptions());
-        loaded_bbt_opt->block_cache = *cache;
+      if (tf != nullptr) {
+        auto* opts = tf->GetOptions<BlockBasedTableOptions>(
+            TableFactory::kBlockBasedTableOpts);
+        if (opts != nullptr) {
+          opts->block_cache = *cache;
+        }
       }
     }
   }


### PR DESCRIPTION
This change demonstrates how to use the Configurable class by changing the TableFactory to be an instance of this class.  This change allows many of the methods that were written to configure a TableFactory to be removed, as the Configurable class itself implements this functionality.

Additionally, the CuckooTableFactory can now be configured via properties (it still cannot be created from an INI file -- stay tuned for that change!)
