### PR TITLE
Arm64 CRC32 compiling warning suppression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,8 @@ HAVE_POWER8=1
 endif
 
 ifeq (,$(shell $(CXX) -fsyntax-only -march=armv8-a+crc -xc /dev/null 2>&1))
-CXXFLAGS += -march=armv8-a+crc
-CFLAGS += -march=armv8-a+crc
+CXXFLAGS += -march=armv8-a+crc -Wno-unused-function
+CFLAGS += -march=armv8-a+crc -Wno-unused-function
 ARMCRC_SOURCE=1
 endif
 


### PR DESCRIPTION
When 'HAS_ARMV8_CRC' is enabled, 'rocksdb::crc32c::isPCLMULQDQ() / isSSE42()'
will not be used but have been actually defined.
So it's needed to suppress the warning here.
