### PR TITLE
Fix a clang analyze error

### DIFF
--- a/util/sst_file_manager_impl.cc
+++ b/util/sst_file_manager_impl.cc
@@ -264,7 +264,7 @@ void SstFileManagerImpl::ClearError() {
       return;
     }
 
-    uint64_t free_space;
+    uint64_t free_space = 0;
     Status s = env_->GetFreeSpace(path_, &free_space);
     free_space = max_allowed_space_ > 0
                      ? std::min(max_allowed_space_, free_space)


### PR DESCRIPTION
Summary:
The analyzer thinks max_allowed_ space can be 0. In that case, free_space will
be assigned as free_space. It fails to realize that the function call
GetFreeSpace actually sets the free_space variable properly, which is possibly
due to lack of inter-function call analysis.

Test Plan:
```
$USE_CLANG=1 TEST_TMPDIR=/dev/shm/rocksdb OPT=-g make -j16 analyze
```