### PR TITLE
Increase Trash/DB size ratio in DBSSTTest.RateLimitedWALDelete

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -430,6 +430,7 @@ TEST_F(DBSSTTest, RateLimitedWALDelete) {
   env_->time_elapse_only_sleep_ = true;
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
+  options.compression = kNoCompression;
   options.env = env_;
 
   int64_t rate_bytes_per_sec = 1024 * 10;  // 10 Kbs / Sec

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -439,7 +439,7 @@ TEST_F(DBSSTTest, RateLimitedWALDelete) {
   ASSERT_OK(s);
   options.sst_file_manager->SetDeleteRateBytesPerSecond(rate_bytes_per_sec);
   auto sfm = static_cast<SstFileManagerImpl*>(options.sst_file_manager.get());
-  sfm->delete_scheduler()->SetMaxTrashDBRatio(2.1);
+  sfm->delete_scheduler()->SetMaxTrashDBRatio(3.1);
 
   ASSERT_OK(TryReopen(options));
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();


### PR DESCRIPTION
By increasing the ratio, we ensure that all files go through background deletion and eliminate flakiness due to timing of deletions.

Test plan:
make check
~/src/gtest-parallel/gtest-parallel ./db_sst_test --gtest_filter=DBSSTTest.RateLimitedWALDelete --repeat=10000