### PR TITLE
Auto roll logger to enforce options.keep_log_file_num immediately after a new file is created

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * Now DB::Close() will return Aborted() error when there is unreleased snapshot. Users can retry after all snapshots are released.
 * Partitions of partitioned indexes no longer affect the read amplification statistics.
 * Due to a refactoring, block cache eviction statistics for indexes are temporarily broken. We plan to reintroduce them in a later phase.
+* options.keep_log_file_num will be enforced strictly all the time. File names of all log files will be tracked, which may take significantly amount of memory if options.keep_log_file_num is large and either of options.max_log_file_size or options.log_file_time_to_roll is set.
 
 ### New Features
 * Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -408,26 +408,29 @@ Status SyncManifest(Env* env, const ImmutableDBOptions* db_options,
 }
 
 Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
-                       const std::string& dbname,
-                       std::vector<std::string>* file_names) {
+                       const std::string& dbname, std::string* parent_dir,
+                       std::vector<std::string>* info_log_list) {
+  assert(parent_dir != nullptr);
+  assert(info_log_list != nullptr);
   uint64_t number = 0;
   FileType type;
-  std::string path;
 
   if (!db_log_dir.empty()) {
-    path = db_log_dir;
+    *parent_dir = db_log_dir;
   } else {
-    path = dbname;
+    *parent_dir = dbname;
   }
 
   InfoLogPrefix info_log_prefix(!db_log_dir.empty(), dbname);
-  Status s = env->GetChildren(path, file_names);
+
+  std::vector<std::string> file_names;
+  Status s = env->GetChildren(*parent_dir, &file_names);
 
   if (!s.ok()) {
     return s;
   }
 
-  for (auto f : file_names) {
+  for (auto& f : file_names) {
     if (ParseFileName(f, &number, info_log_prefix.prefix, &type) &&
         (type == kInfoLogFile)) {
       info_log_list->push_back(f);

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -407,4 +407,33 @@ Status SyncManifest(Env* env, const ImmutableDBOptions* db_options,
   return file->Sync(db_options->use_fsync);
 }
 
+Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
+                       const std::string& dbname,
+                       std::vector<std::string>* file_names) {
+  uint64_t number = 0;
+  FileType type;
+  std::string path;
+
+  if (!db_log_dir.empty()) {
+    path = db_log_dir;
+  } else {
+    path = dbname;
+  }
+
+  InfoLogPrefix info_log_prefix(!db_log_dir.empty(), dbname);
+  Status s = env->GetChildren(path, file_names);
+
+  if (!s.ok()) {
+    return s;
+  }
+
+  for (auto f : file_names) {
+    if (ParseFileName(f, &number, info_log_prefix.prefix, &type) &&
+        (type == kInfoLogFile)) {
+      info_log_list->push_back(f);
+    }
+  }
+  return Status::OK();
+}
+
 }  // namespace rocksdb

--- a/file/filename.h
+++ b/file/filename.h
@@ -169,4 +169,9 @@ extern Status SetIdentityFile(Env* env, const std::string& dbname);
 extern Status SyncManifest(Env* env, const ImmutableDBOptions* db_options,
                            WritableFileWriter* file);
 
+// Return list of file names of info logs in `file_names`.
+// `db_log_dir` should be the one as in options.db_log_dir
+extern Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
+                              const std::string& dbname,
+                              std::vector<std::string>* file_names);
 }  // namespace rocksdb

--- a/file/filename.h
+++ b/file/filename.h
@@ -170,8 +170,11 @@ extern Status SyncManifest(Env* env, const ImmutableDBOptions* db_options,
                            WritableFileWriter* file);
 
 // Return list of file names of info logs in `file_names`.
+// The list only contains file name. The parent directory name is stored
+// in `parent_dir`.
 // `db_log_dir` should be the one as in options.db_log_dir
 extern Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
                               const std::string& dbname,
+                              std::string* parent_dir,
                               std::vector<std::string>* file_names);
 }  // namespace rocksdb

--- a/util/auto_roll_logger.cc
+++ b/util/auto_roll_logger.cc
@@ -95,8 +95,10 @@ void AutoRollLogger::GetExistingFiles() {
     std::swap(old_log_files_, empty);
   }
 
+  std::string parent_dir;
   std::vector<std::string> info_log_files;
-  Status s = GetInfoLogFiles(env_, db_log_dir_, dbname_, &info_log_files);
+  Status s =
+      GetInfoLogFiles(env_, db_log_dir_, dbname_, &parent_dir, &info_log_files);
   if (status_.ok()) {
     status_ = s;
   }

--- a/util/auto_roll_logger.cc
+++ b/util/auto_roll_logger.cc
@@ -3,13 +3,53 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
+#include <algorithm>
 #include "util/auto_roll_logger.h"
+#include "util/logging.h"
 #include "util/mutexlock.h"
 
 namespace rocksdb {
 
 #ifndef ROCKSDB_LITE
 // -- AutoRollLogger
+
+AutoRollLogger::AutoRollLogger(Env* env, const std::string& dbname,
+                               const std::string& db_log_dir,
+                               size_t log_max_size,
+                               size_t log_file_time_to_roll,
+                               size_t keep_log_file_num,
+                               const InfoLogLevel log_level)
+    : Logger(log_level),
+      dbname_(dbname),
+      db_log_dir_(db_log_dir),
+      env_(env),
+      status_(Status::OK()),
+      kMaxLogFileSize(log_max_size),
+      kLogFileTimeToRoll(log_file_time_to_roll),
+      kKeepLogFileNum(keep_log_file_num),
+      cached_now(static_cast<uint64_t>(env_->NowMicros() * 1e-6)),
+      ctime_(cached_now),
+      cached_now_access_count(0),
+      call_NowMicros_every_N_records_(100),
+      mutex_() {
+  Status s = env->GetAbsolutePath(dbname, &db_absolute_path_);
+  if (s.IsNotSupported()) {
+    db_absolute_path_ = dbname;
+  } else {
+    status_ = s;
+  }
+  log_fname_ = InfoLogFileName(dbname_, db_absolute_path_, db_log_dir_);
+  if (env_->FileExists(log_fname_).ok()) {
+    RollLogFile();
+  }
+  GetExistingFiles();
+  ResetLogger();
+  s = TrimOldLogFiles();
+  if (!status_.ok()) {
+    status_ = s;
+  }
+}
+
 Status AutoRollLogger::ResetLogger() {
   TEST_SYNC_POINT("AutoRollLogger::ResetLogger:BeforeNewLogger");
   status_ = env_->NewLogger(log_fname_, &logger_);
@@ -44,6 +84,70 @@ void AutoRollLogger::RollLogFile() {
     now++;
   } while (env_->FileExists(old_fname).ok());
   env_->RenameFile(log_fname_, old_fname);
+  old_log_files_.push(old_fname);
+}
+
+void AutoRollLogger::GetExistingFiles() {
+  {
+    // Empty the queue to avoid duplicated entries in the queue.
+    std::queue<std::string> empty;
+    std::swap(old_log_files_, empty);
+  }
+
+  std::vector<std::string> all_files;
+  std::string parent_dir = db_log_dir_.empty() ? dbname_ : db_log_dir_;
+  Status s = env_->GetChildren(parent_dir, &all_files);
+  if (status_.ok()) {
+    status_ = s;
+  }
+  InfoLogPrefix info_log_prefix(!db_log_dir_.empty(), dbname_);
+  std::vector<std::string> info_log_files;
+  for (const std::string& f : all_files) {
+    // Files we cannot recognize cannot be log file.
+    uint64_t number;
+    FileType type;
+    if (!ParseFileName(f, &number, info_log_prefix.prefix, &type)) {
+      continue;
+    }
+    if (type == kInfoLogFile) {
+      info_log_files.push_back(f);
+    }
+  }
+  // We need to sort the file before enqueing it so that when we
+  // delete file from the front, it is the oldest file.
+  std::sort(info_log_files.begin(), info_log_files.end());
+
+  for (const std::string& f : info_log_files) {
+    old_log_files_.push(parent_dir + "/" + f);
+  }
+}
+
+Status AutoRollLogger::TrimOldLogFiles() {
+  // Here we directly list info files and delete them through Env.
+  // The deletion isn't going through DB, so there are shortcomes:
+  // 1. the deletion is not rate limited by SstFileManager
+  // 2. there is a chance that an I/O will be issued here
+  // Since it's going to be complicated to pass DB object down to
+  // here, we take a simple approach to keep the code easier to
+  // maintain.
+
+  // old_log_files_.empty() is helpful for the corner case that
+  // kKeepLogFileNum == 0. We can instead check kKeepLogFileNum != 0 but
+  // it's essentially the same thing, and checking empty before accessing
+  // the queue feels safer.
+  while (!old_log_files_.empty() && old_log_files_.size() >= kKeepLogFileNum) {
+    Status s = env_->DeleteFile(old_log_files_.front());
+    // Remove the file from the tracking anyway. It's possible that
+    // DB cleaned up the old log file, or people cleaned it up manually.
+    old_log_files_.pop();
+    // To make the file really go away, we should sync parent directory.
+    // Since there isn't any consistency issue involved here, skipping
+    // this part to avoid one I/O here.
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  return Status::OK();
 }
 
 std::string AutoRollLogger::ValistToString(const char* format,
@@ -78,12 +182,19 @@ void AutoRollLogger::Logv(const char* format, va_list ap) {
         (kMaxLogFileSize > 0 && logger_->GetLogFileSize() >= kMaxLogFileSize)) {
       RollLogFile();
       Status s = ResetLogger();
+      Status s2 = TrimOldLogFiles();
+
       if (!s.ok()) {
         // can't really log the error if creating a new LOG file failed
         return;
       }
 
       WriteHeaderInfo();
+
+      if (!s2.ok()) {
+        ROCKS_LOG_WARN(logger.get(), "Fail to trim old info log file: %s",
+                       s2.ToString().c_str());
+      }
     }
 
     // pin down the current logger_ instance before releasing the mutex.
@@ -153,7 +264,8 @@ Status CreateLoggerFromOptions(const std::string& dbname,
   if (options.log_file_time_to_roll > 0 || options.max_log_file_size > 0) {
     AutoRollLogger* result = new AutoRollLogger(
         env, dbname, options.db_log_dir, options.max_log_file_size,
-        options.log_file_time_to_roll, options.info_log_level);
+        options.log_file_time_to_roll, options.keep_log_file_num,
+        options.info_log_level);
     Status s = result->GetStatus();
     if (!s.ok()) {
       delete result;

--- a/util/auto_roll_logger.h
+++ b/util/auto_roll_logger.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <list>
+#include <queue>
 #include <string>
 
 #include "file/filename.h"
@@ -24,25 +25,8 @@ class AutoRollLogger : public Logger {
  public:
   AutoRollLogger(Env* env, const std::string& dbname,
                  const std::string& db_log_dir, size_t log_max_size,
-                 size_t log_file_time_to_roll,
-                 const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
-      : Logger(log_level),
-        dbname_(dbname),
-        db_log_dir_(db_log_dir),
-        env_(env),
-        status_(Status::OK()),
-        kMaxLogFileSize(log_max_size),
-        kLogFileTimeToRoll(log_file_time_to_roll),
-        cached_now(static_cast<uint64_t>(env_->NowMicros() * 1e-6)),
-        ctime_(cached_now),
-        cached_now_access_count(0),
-        call_NowMicros_every_N_records_(100),
-        mutex_() {
-    env->GetAbsolutePath(dbname, &db_absolute_path_);
-    log_fname_ = InfoLogFileName(dbname_, db_absolute_path_, db_log_dir_);
-    RollLogFile();
-    ResetLogger();
-  }
+                 size_t log_file_time_to_roll, size_t keep_log_file_num,
+                 const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL);
 
   using Logger::Logv;
   void Logv(const char* format, va_list ap) override;
@@ -110,6 +94,11 @@ class AutoRollLogger : public Logger {
   bool LogExpired();
   Status ResetLogger();
   void RollLogFile();
+  // Read all names of old log files into old_log_files_
+  // If there is any error, put the error code in status_
+  void GetExistingFiles();
+  // Delete old log files if it excceeds the limit.
+  Status TrimOldLogFiles();
   // Log message to logger without rolling
   void LogInternal(const char* format, ...);
   // Serialize the va_list to a string
@@ -126,8 +115,14 @@ class AutoRollLogger : public Logger {
   Status status_;
   const size_t kMaxLogFileSize;
   const size_t kLogFileTimeToRoll;
+  const size_t kKeepLogFileNum;
   // header information
   std::list<std::string> headers_;
+  // List of all existing info log files. Used for enforcing number of
+  // info log files.
+  // Full path is stored here. It consumes signifianctly more memory
+  // than only storing file name. Can optimize if it causes a problem.
+  std::queue<std::string> old_log_files_;
   // to avoid frequent env->NowMicros() calls, we cached the current time
   uint64_t cached_now;
   uint64_t ctime_;

--- a/utilities/convenience/info_log_finder.cc
+++ b/utilities/convenience/info_log_finder.cc
@@ -14,35 +14,11 @@
 namespace rocksdb {
 
 Status GetInfoLogList(DB* db, std::vector<std::string>* info_log_list) {
-  uint64_t number = 0;
-  FileType type;
-  std::string path;
-
   if (!db) {
     return Status::InvalidArgument("DB pointer is not valid");
   }
-
-  const Options& options = db->GetOptions();
-  if (!options.db_log_dir.empty()) {
-    path = options.db_log_dir;
-  } else {
-    path = db->GetName();
-  }
-  InfoLogPrefix info_log_prefix(!options.db_log_dir.empty(), db->GetName());
-  auto* env = options.env;
-  std::vector<std::string> file_names;
-  Status s = env->GetChildren(path, &file_names);
-
-  if (!s.ok()) {
-    return s;
-  }
-
-  for (auto f : file_names) {
-    if (ParseFileName(f, &number, info_log_prefix.prefix, &type) &&
-        (type == kInfoLogFile)) {
-      info_log_list->push_back(f);
-    }
-  }
-  return Status::OK();
+  const Options& options = ;
+  return GetInfoLogFiles(options.env, db->GetOptions().db_log_dir,
+                         db->GetName(), info_log_list);
 }
 }  // namespace rocksdb

--- a/utilities/convenience/info_log_finder.cc
+++ b/utilities/convenience/info_log_finder.cc
@@ -17,8 +17,9 @@ Status GetInfoLogList(DB* db, std::vector<std::string>* info_log_list) {
   if (!db) {
     return Status::InvalidArgument("DB pointer is not valid");
   }
-  const Options& options = ;
-  return GetInfoLogFiles(options.env, db->GetOptions().db_log_dir,
-                         db->GetName(), info_log_list);
+  std::string parent_path;
+  const Options& options = db->GetOptions();
+  return GetInfoLogFiles(options.env, options.db_log_dir, db->GetName(),
+                         &parent_path, info_log_list);
 }
 }  // namespace rocksdb


### PR DESCRIPTION
Summary:
Right now, with auto roll logger, options.keep_log_file_num enforcement is triggered by events like DB reopen or full obsolete scan happens. In the mean time, the size and number of log files can grow without a limit. We put a stronger enforcement to the option, so that the number of log files can always under control.

Test Plan: Add new unit tests for it.