### PR TITLE
WIP: Flush MemTable based on number of reads.

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -81,6 +81,8 @@ const char* GetFlushReasonString (FlushReason flush_reason) {
       return "Manual Flush";
     case FlushReason::kErrorRecovery:
       return "Error Recovery";
+    case FlushReason::kReadTriggered:
+      return "Read Triggered";
     default:
       return "Invalid";
   }

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -110,6 +110,7 @@ enum class FlushReason : int {
   kAutoCompaction = 0x09,
   kManualFlush = 0x0a,
   kErrorRecovery = 0xb,
+  kReadTriggered = 0xc,
 };
 
 enum class BackgroundErrorReason {


### PR DESCRIPTION
Summary:

Sample number of reads to MemTable and trigger a flush when number of
reads reaches a threshold. This is intended to improve read performance
for read-heavy workloads.

Test Plan:

- Ran db_test and db_test2 with kSampleRate=1 and kNumReadsUntilFlush=1.
  Worked apart from a few exceptions where assumptions about flushes are
  made.
- 'make check' fails a bunch of tests with above settings due to
  assumptions about flushes. Flushing based on reads will be off by
  default in the final version when there are proper options (there's a TODO).
- Should add a new unit test.