### PR TITLE
Disable File Deletion after MANIFEST Write/Sync Fails

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -75,7 +75,8 @@ class CompactionJob {
       std::shared_ptr<Cache> table_cache, EventLogger* event_logger,
       bool paranoid_file_checks, bool measure_io_stats,
       const std::string& dbname, CompactionJobStats* compaction_job_stats,
-      Env::Priority thread_pri, SnapshotListFetchCallback* snap_list_callback);
+      Env::Priority thread_pri, SnapshotListFetchCallback* snap_list_callback,
+      ErrorContext* err_context);
 
   ~CompactionJob();
 
@@ -189,6 +190,7 @@ class CompactionJob {
   std::vector<uint64_t> sizes_;
   Env::WriteLifeTimeHint write_hint_;
   Env::Priority thread_pri_;
+  ErrorContext* error_context_;
 };
 
 }  // namespace rocksdb

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1285,7 +1285,7 @@ TEST_F(DBBasicTest, MultiGetBatchedMultiLevel) {
   }
 }
 
-TEST_F(DBBasicTest, TruncateManifestAfterSyncFailure) {
+TEST_F(DBBasicTest, DisableFileDeletionAfterManifestWriteOrSyncFailure) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
   options.disable_auto_compactions = true;

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -25,6 +25,11 @@ namespace rocksdb {
 
 Status DBImpl::DisableFileDeletions() {
   InstrumentedMutexLock l(&mutex_);
+  return DisableFileDeletionsWithLock();
+}
+
+Status DBImpl::DisableFileDeletionsWithLock() {
+  mutex_.AssertHeld();
   ++disable_delete_obsolete_files_;
   if (disable_delete_obsolete_files_ == 1) {
     ROCKS_LOG_INFO(immutable_db_options_.info_log, "File Deletions Disabled");

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -281,6 +281,7 @@ class DBImpl : public DB {
   using DB::ResetStats;
   virtual Status ResetStats() override;
   virtual Status DisableFileDeletions() override;
+  Status DisableFileDeletionsWithLock();
   virtual Status EnableFileDeletions(bool force) override;
   virtual int IsFileDeletionsEnabled() const;
   // All the returned filenames start with "/"

--- a/db/db_impl/db_impl_experimental.cc
+++ b/db/db_impl/db_impl_experimental.cc
@@ -132,7 +132,8 @@ Status DBImpl::PromoteL0(ColumnFamilyHandle* column_family, int target_level) {
     }
 
     status = versions_->LogAndApply(cfd, *cfd->GetLatestMutableCFOptions(),
-                                    &edit, &mutex_, directories_.GetDbDir());
+                                    &edit, &mutex_, nullptr /*err_context*/,
+                                    directories_.GetDbDir());
     if (status.ok()) {
       InstallSuperVersionAndScheduleWork(cfd,
                                          &job_context.superversion_contexts[0],

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -995,7 +995,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
       // log number
       versions_->MarkFileNumberUsed(max_log_number + 1);
       status = versions_->LogAndApply(cfd, *cfd->GetLatestMutableCFOptions(),
-                                      edit, &mutex_);
+                                      edit, &mutex_, nullptr /*err_context*/);
       if (!status.ok()) {
         // Recovery failed
         break;

--- a/db/error_context.h
+++ b/db/error_context.h
@@ -1,0 +1,20 @@
+//  Copyright (c) 2018-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#pragma once
+
+#include <string>
+
+#include "rocksdb/listener.h"
+
+namespace rocksdb {
+
+struct ErrorContext {
+  explicit ErrorContext() {}
+  ErrorContext(BackgroundErrorReason r) : reason(r) {}
+
+  BackgroundErrorReason reason;
+  std::string file_name;
+};
+}  // namespace rocksdb

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -159,7 +159,9 @@ void ErrorHandler::CancelErrorRecovery() {
 // This can also get called as part of a recovery operation. In that case, we
 // also track the error separately in recovery_error_ so we can tell in the
 // end whether recovery succeeded or not
-Status ErrorHandler::SetBGError(const Status& bg_err, BackgroundErrorReason reason) {
+Status ErrorHandler::SetBGError(const Status& bg_err,
+                                ErrorContext& err_context) {
+  BackgroundErrorReason reason = err_context.reason();
   db_mutex_->AssertHeld();
 
   if (bg_err.ok()) {

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -300,13 +300,15 @@ void ErrorHandler::RecoverFromNoSpace() {
 }
 
 void ErrorHandler::HandleManifestWriteOrSyncFailure() {
+#ifndef ROCKSDB_LITE
   db_mutex_->AssertHeld();
   Status s = db_->DisableFileDeletionsWithLock();
 #ifndef NDEBUG
   assert(s.ok());
 #else
   (void)s;
-#endif
+#endif  // NDEBUG
+#endif  // !ROCKSDB_LITE
 }
 
 Status ErrorHandler::ClearBGError() {

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -160,8 +160,8 @@ void ErrorHandler::CancelErrorRecovery() {
 // also track the error separately in recovery_error_ so we can tell in the
 // end whether recovery succeeded or not
 Status ErrorHandler::SetBGError(const Status& bg_err,
-                                ErrorContext& err_context) {
-  BackgroundErrorReason reason = err_context.reason();
+                                const ErrorContext& err_context) {
+  BackgroundErrorReason reason = err_context.reason;
   db_mutex_->AssertHeld();
 
   if (bg_err.ok()) {

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -71,6 +71,7 @@ class ErrorHandler {
 
     Status OverrideNoSpaceError(Status bg_error, bool* auto_recovery);
     void RecoverFromNoSpace();
+    void HandleManifestWriteOrSyncFailure();
 };
 
 }

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -13,6 +13,13 @@ namespace rocksdb {
 
 class DBImpl;
 
+struct ErrorContext {
+  ErrorContext(BackgroundErrorReason r) : reason_(r) {}
+
+  BackgroundErrorReason reason_;
+  std::string file_name_;
+};
+
 class ErrorHandler {
   public:
    ErrorHandler(DBImpl* db, const ImmutableDBOptions& db_options,
@@ -32,7 +39,7 @@ class ErrorHandler {
                                      Status::Code code,
                                      Status::SubCode subcode);
 
-   Status SetBGError(const Status& bg_err, BackgroundErrorReason reason);
+   Status SetBGError(const Status& bg_err, const ErrorContext& err_context);
 
    Status GetBGError() { return bg_error_; }
 

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -4,6 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
+#include "db/error_context.h"
 #include "monitoring/instrumented_mutex.h"
 #include "options/db_options.h"
 #include "rocksdb/listener.h"
@@ -12,13 +13,6 @@
 namespace rocksdb {
 
 class DBImpl;
-
-struct ErrorContext {
-  ErrorContext(BackgroundErrorReason r) : reason_(r) {}
-
-  BackgroundErrorReason reason_;
-  std::string file_name_;
-};
 
 class ErrorHandler {
   public:

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -69,7 +69,7 @@ class FlushJob {
            Directory* output_file_directory, CompressionType output_compression,
            Statistics* stats, EventLogger* event_logger, bool measure_io_stats,
            const bool sync_output_directory, const bool write_manifest,
-           Env::Priority thread_pri);
+           Env::Priority thread_pri, ErrorContext* err_context);
 
   ~FlushJob();
 
@@ -139,6 +139,7 @@ class FlushJob {
   Version* base_;
   bool pick_memtable_called;
   Env::Priority thread_pri_;
+  ErrorContext* error_context_;
 };
 
 }  // namespace rocksdb

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -119,14 +119,14 @@ TEST_F(FlushJobTest, Empty) {
   auto cfd = versions_->GetColumnFamilySet()->GetDefault();
   EventLogger event_logger(db_options_.info_log.get());
   SnapshotChecker* snapshot_checker = nullptr;  // not relavant
-  FlushJob flush_job(dbname_, versions_->GetColumnFamilySet()->GetDefault(),
-                     db_options_, *cfd->GetLatestMutableCFOptions(),
-                     nullptr /* memtable_id */, env_options_, versions_.get(),
-                     &mutex_, &shutting_down_, {}, kMaxSequenceNumber,
-                     snapshot_checker, &job_context, nullptr, nullptr, nullptr,
-                     kNoCompression, nullptr, &event_logger, false,
-                     true /* sync_output_directory */,
-                     true /* write_manifest */, Env::Priority::USER);
+  FlushJob flush_job(
+      dbname_, versions_->GetColumnFamilySet()->GetDefault(), db_options_,
+      *cfd->GetLatestMutableCFOptions(), nullptr /* memtable_id */,
+      env_options_, versions_.get(), &mutex_, &shutting_down_, {},
+      kMaxSequenceNumber, snapshot_checker, &job_context, nullptr, nullptr,
+      nullptr, kNoCompression, nullptr, &event_logger, false,
+      true /* sync_output_directory */, true /* write_manifest */,
+      Env::Priority::USER, &job_context.error_context);
   {
     InstrumentedMutexLock l(&mutex_);
     flush_job.PickMemTable();
@@ -167,14 +167,14 @@ TEST_F(FlushJobTest, NonEmpty) {
 
   EventLogger event_logger(db_options_.info_log.get());
   SnapshotChecker* snapshot_checker = nullptr;  // not relavant
-  FlushJob flush_job(dbname_, versions_->GetColumnFamilySet()->GetDefault(),
-                     db_options_, *cfd->GetLatestMutableCFOptions(),
-                     nullptr /* memtable_id */, env_options_, versions_.get(),
-                     &mutex_, &shutting_down_, {}, kMaxSequenceNumber,
-                     snapshot_checker, &job_context, nullptr, nullptr, nullptr,
-                     kNoCompression, db_options_.statistics.get(),
-                     &event_logger, true, true /* sync_output_directory */,
-                     true /* write_manifest */, Env::Priority::USER);
+  FlushJob flush_job(
+      dbname_, versions_->GetColumnFamilySet()->GetDefault(), db_options_,
+      *cfd->GetLatestMutableCFOptions(), nullptr /* memtable_id */,
+      env_options_, versions_.get(), &mutex_, &shutting_down_, {},
+      kMaxSequenceNumber, snapshot_checker, &job_context, nullptr, nullptr,
+      nullptr, kNoCompression, db_options_.statistics.get(), &event_logger,
+      true, true /* sync_output_directory */, true /* write_manifest */,
+      Env::Priority::USER, &job_context.error_context);
 
   HistogramData hist;
   FileMetaData file_meta;
@@ -231,14 +231,14 @@ TEST_F(FlushJobTest, FlushMemTablesSingleColumnFamily) {
   uint64_t smallest_memtable_id = memtable_ids.front();
   uint64_t flush_memtable_id = smallest_memtable_id + num_mems_to_flush - 1;
 
-  FlushJob flush_job(dbname_, versions_->GetColumnFamilySet()->GetDefault(),
-                     db_options_, *cfd->GetLatestMutableCFOptions(),
-                     &flush_memtable_id, env_options_, versions_.get(), &mutex_,
-                     &shutting_down_, {}, kMaxSequenceNumber, snapshot_checker,
-                     &job_context, nullptr, nullptr, nullptr, kNoCompression,
-                     db_options_.statistics.get(), &event_logger, true,
-                     true /* sync_output_directory */,
-                     true /* write_manifest */, Env::Priority::USER);
+  FlushJob flush_job(
+      dbname_, versions_->GetColumnFamilySet()->GetDefault(), db_options_,
+      *cfd->GetLatestMutableCFOptions(), &flush_memtable_id, env_options_,
+      versions_.get(), &mutex_, &shutting_down_, {}, kMaxSequenceNumber,
+      snapshot_checker, &job_context, nullptr, nullptr, nullptr, kNoCompression,
+      db_options_.statistics.get(), &event_logger, true,
+      true /* sync_output_directory */, true /* write_manifest */,
+      Env::Priority::USER, &job_context.error_context);
   HistogramData hist;
   FileMetaData file_meta;
   mutex_.Lock();
@@ -309,7 +309,7 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
         &job_context, nullptr, nullptr, nullptr, kNoCompression,
         db_options_.statistics.get(), &event_logger, true,
         false /* sync_output_directory */, false /* write_manifest */,
-        Env::Priority::USER);
+        Env::Priority::USER, nullptr /*err_context*/);
     k++;
   }
   HistogramData hist;
@@ -343,7 +343,8 @@ TEST_F(FlushJobTest, FlushMemtablesMultipleColumnFamilies) {
   Status s = InstallMemtableAtomicFlushResults(
       nullptr /* imm_lists */, all_cfds, mutable_cf_options_list, mems_list,
       versions_.get(), &mutex_, file_meta_ptrs, &job_context.memtables_to_free,
-      nullptr /* db_directory */, nullptr /* log_buffer */);
+      nullptr /* db_directory */, nullptr /* log_buffer */,
+      &job_context.error_context);
   ASSERT_OK(s);
 
   mutex_.Unlock();
@@ -418,14 +419,14 @@ TEST_F(FlushJobTest, Snapshots) {
 
   EventLogger event_logger(db_options_.info_log.get());
   SnapshotChecker* snapshot_checker = nullptr;  // not relavant
-  FlushJob flush_job(dbname_, versions_->GetColumnFamilySet()->GetDefault(),
-                     db_options_, *cfd->GetLatestMutableCFOptions(),
-                     nullptr /* memtable_id */, env_options_, versions_.get(),
-                     &mutex_, &shutting_down_, snapshots, kMaxSequenceNumber,
-                     snapshot_checker, &job_context, nullptr, nullptr, nullptr,
-                     kNoCompression, db_options_.statistics.get(),
-                     &event_logger, true, true /* sync_output_directory */,
-                     true /* write_manifest */, Env::Priority::USER);
+  FlushJob flush_job(
+      dbname_, versions_->GetColumnFamilySet()->GetDefault(), db_options_,
+      *cfd->GetLatestMutableCFOptions(), nullptr /* memtable_id */,
+      env_options_, versions_.get(), &mutex_, &shutting_down_, snapshots,
+      kMaxSequenceNumber, snapshot_checker, &job_context, nullptr, nullptr,
+      nullptr, kNoCompression, db_options_.statistics.get(), &event_logger,
+      true, true /* sync_output_directory */, true /* write_manifest */,
+      Env::Priority::USER, &job_context.error_context);
   mutex_.Lock();
   flush_job.PickMemTable();
   ASSERT_OK(flush_job.Run());

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -12,8 +12,9 @@
 #include <string>
 #include <vector>
 
-#include "db/log_writer.h"
 #include "db/column_family.h"
+#include "db/error_context.h"
+#include "db/log_writer.h"
 
 namespace rocksdb {
 

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -178,6 +178,8 @@ struct JobContext {
   // Snapshot taken before flush/compaction job.
   std::unique_ptr<ManagedSnapshot> job_snapshot;
 
+  ErrorContext error_context;
+
   explicit JobContext(int _job_id, bool create_superversion = false) {
     job_id = _job_id;
     manifest_file_number = 0;

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -28,7 +28,7 @@
 namespace rocksdb {
 
 class ColumnFamilyData;
-class ErrorContext;
+struct ErrorContext;
 class InternalKeyComparator;
 class InstrumentedMutex;
 class MergeIteratorBuilder;

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -28,6 +28,7 @@
 namespace rocksdb {
 
 class ColumnFamilyData;
+class ErrorContext;
 class InternalKeyComparator;
 class InstrumentedMutex;
 class MergeIteratorBuilder;
@@ -125,7 +126,7 @@ class MemTableListVersion {
       VersionSet* vset, InstrumentedMutex* mu,
       const autovector<FileMetaData*>& file_meta,
       autovector<MemTable*>* to_delete, Directory* db_directory,
-      LogBuffer* log_buffer);
+      LogBuffer* log_buffer, ErrorContext* err_context);
 
   // REQUIRE: m is an immutable memtable
   void Add(MemTable* m, autovector<MemTable*>* to_delete);
@@ -227,7 +228,7 @@ class MemTableList {
       const autovector<MemTable*>& m, LogsWithPrepTracker* prep_tracker,
       VersionSet* vset, InstrumentedMutex* mu, uint64_t file_number,
       autovector<MemTable*>* to_delete, Directory* db_directory,
-      LogBuffer* log_buffer);
+      LogBuffer* log_buffer, ErrorContext* err_context);
 
   // New memtables are inserted at the front of the list.
   // Takes ownership of the referenced held on *m by the caller of Add().
@@ -310,7 +311,7 @@ class MemTableList {
       VersionSet* vset, InstrumentedMutex* mu,
       const autovector<FileMetaData*>& file_meta,
       autovector<MemTable*>* to_delete, Directory* db_directory,
-      LogBuffer* log_buffer);
+      LogBuffer* log_buffer, ErrorContext* err_context);
 
   // DB mutex held
   void InstallNewVersion();
@@ -346,5 +347,5 @@ extern Status InstallMemtableAtomicFlushResults(
     const autovector<const autovector<MemTable*>*>& mems_list, VersionSet* vset,
     InstrumentedMutex* mu, const autovector<FileMetaData*>& file_meta,
     autovector<MemTable*>* to_delete, Directory* db_directory,
-    LogBuffer* log_buffer);
+    LogBuffer* log_buffer, ErrorContext* err_context);
 }  // namespace rocksdb

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include "db/error_context.h"
 #include "db/merge_context.h"
 #include "db/version_set.h"
 #include "db/write_controller.h"
@@ -114,12 +115,13 @@ class MemTableListTest : public testing::Test {
     auto cfd = column_family_set->GetDefault();
     EXPECT_TRUE(nullptr != cfd);
     uint64_t file_num = file_number.fetch_add(1);
+    ErrorContext err_context;
     // Create dummy mutex.
     InstrumentedMutex mutex;
     InstrumentedMutexLock l(&mutex);
     return list->TryInstallMemtableFlushResults(
         cfd, mutable_cf_options, m, &dummy_prep_tracker, &versions, &mutex,
-        file_num, to_delete, nullptr, &log_buffer);
+        file_num, to_delete, nullptr, &log_buffer, &err_context);
   }
 
   // Calls MemTableList::InstallMemtableFlushResults() and sets up all
@@ -173,11 +175,12 @@ class MemTableListTest : public testing::Test {
     for (auto& meta : file_metas) {
       file_meta_ptrs.push_back(&meta);
     }
+    ErrorContext err_context;
     InstrumentedMutex mutex;
     InstrumentedMutexLock l(&mutex);
     return InstallMemtableAtomicFlushResults(
         &lists, cfds, mutable_cf_options_list, mems_list, &versions, &mutex,
-        file_meta_ptrs, to_delete, nullptr, &log_buffer);
+        file_meta_ptrs, to_delete, nullptr, &log_buffer, &err_context);
   }
 };
 

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -154,9 +154,9 @@ class Repairer {
     edit.AddColumnFamily(cf_name);
 
     mutex_.Lock();
-    Status status = vset_.LogAndApply(cfd, mut_cf_opts, &edit, &mutex_,
-                                      nullptr /* db_directory */,
-                                      false /* new_descriptor_log */, cf_opts);
+    Status status = vset_.LogAndApply(
+        cfd, mut_cf_opts, &edit, &mutex_, nullptr /*err_context*/,
+        nullptr /* db_directory */, false /* new_descriptor_log */, cf_opts);
     mutex_.Unlock();
     return status;
   }
@@ -592,9 +592,10 @@ class Repairer {
       assert(next_file_number_ > 0);
       vset_.MarkFileNumberUsed(next_file_number_ - 1);
       mutex_.Lock();
-      Status status = vset_.LogAndApply(
-          cfd, *cfd->GetLatestMutableCFOptions(), &edit, &mutex_,
-          nullptr /* db_directory */, false /* new_descriptor_log */);
+      Status status = vset_.LogAndApply(cfd, *cfd->GetLatestMutableCFOptions(),
+                                        &edit, &mutex_, nullptr /*err_context*/,
+                                        nullptr /* db_directory */,
+                                        false /* new_descriptor_log */);
       mutex_.Unlock();
       if (!status.ok()) {
         return status;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3797,8 +3797,10 @@ Status VersionSet::ProcessManifestWrites(
     }
     ready->status = s;
     if (!s.ok() && !new_descriptor_log && nullptr != ready->error_context) {
-      ready->error_context->file_name =
-          DescriptorFileName(dbname_, manifest_file_number_);
+      char buf[100] = {0};
+      snprintf(buf, sizeof(buf), "MANIFEST-%06llu",
+               static_cast<unsigned long long>(manifest_file_number_));
+      ready->error_context->file_name.assign(buf);
     }
     ready->done = true;
     if (need_signal) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3664,6 +3664,8 @@ Status VersionSet::ProcessManifestWrites(
       }
       if (s.ok()) {
         s = SyncManifest(env_, db_options_, descriptor_log_->file());
+        TEST_SYNC_POINT_CALLBACK(
+            "VersionSet::ProcessManifestWrites:AfterSyncManifest", &s);
       }
       if (!s.ok()) {
         ROCKS_LOG_ERROR(db_options_->info_log, "MANIFEST write %s\n",

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -55,7 +55,7 @@ class Writer;
 }
 
 class Compaction;
-class ErrorContext;
+struct ErrorContext;
 class LogBuffer;
 class LookupKey;
 class MemTable;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -55,6 +55,7 @@ class Writer;
 }
 
 class Compaction;
+class ErrorContext;
 class LogBuffer;
 class LookupKey;
 class MemTable;
@@ -791,8 +792,8 @@ class VersionSet {
   Status LogAndApply(
       ColumnFamilyData* column_family_data,
       const MutableCFOptions& mutable_cf_options, VersionEdit* edit,
-      InstrumentedMutex* mu, Directory* db_directory = nullptr,
-      bool new_descriptor_log = false,
+      InstrumentedMutex* mu, ErrorContext* err_context,
+      Directory* db_directory = nullptr, bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
@@ -803,7 +804,8 @@ class VersionSet {
     edit_list.emplace_back(edit);
     edit_lists.emplace_back(edit_list);
     return LogAndApply(cfds, mutable_cf_options_list, edit_lists, mu,
-                       db_directory, new_descriptor_log, column_family_options);
+                       err_context, db_directory, new_descriptor_log,
+                       column_family_options);
   }
   // The batch version. If edit_list.size() > 1, caller must ensure that
   // no edit in the list column family add or drop
@@ -811,7 +813,8 @@ class VersionSet {
       ColumnFamilyData* column_family_data,
       const MutableCFOptions& mutable_cf_options,
       const autovector<VersionEdit*>& edit_list, InstrumentedMutex* mu,
-      Directory* db_directory = nullptr, bool new_descriptor_log = false,
+      ErrorContext* err_context, Directory* db_directory = nullptr,
+      bool new_descriptor_log = false,
       const ColumnFamilyOptions* column_family_options = nullptr) {
     autovector<ColumnFamilyData*> cfds;
     cfds.emplace_back(column_family_data);
@@ -820,7 +823,8 @@ class VersionSet {
     autovector<autovector<VersionEdit*>> edit_lists;
     edit_lists.emplace_back(edit_list);
     return LogAndApply(cfds, mutable_cf_options_list, edit_lists, mu,
-                       db_directory, new_descriptor_log, column_family_options);
+                       err_context, db_directory, new_descriptor_log,
+                       column_family_options);
   }
 
   // The across-multi-cf batch version. If edit_lists contain more than
@@ -830,8 +834,8 @@ class VersionSet {
       const autovector<ColumnFamilyData*>& cfds,
       const autovector<const MutableCFOptions*>& mutable_cf_options_list,
       const autovector<autovector<VersionEdit*>>& edit_lists,
-      InstrumentedMutex* mu, Directory* db_directory = nullptr,
-      bool new_descriptor_log = false,
+      InstrumentedMutex* mu, ErrorContext* err_context,
+      Directory* db_directory = nullptr, bool new_descriptor_log = false,
       const ColumnFamilyOptions* new_cf_options = nullptr);
 
   static Status GetCurrentManifestPath(const std::string& dbname, Env* env,
@@ -1206,8 +1210,8 @@ class ReactiveVersionSet : public VersionSet {
       const autovector<ColumnFamilyData*>& /*cfds*/,
       const autovector<const MutableCFOptions*>& /*mutable_cf_options_list*/,
       const autovector<autovector<VersionEdit*>>& /*edit_lists*/,
-      InstrumentedMutex* /*mu*/, Directory* /*db_directory*/,
-      bool /*new_descriptor_log*/,
+      InstrumentedMutex* /*mu*/, ErrorContext* /*err_context*/,
+      Directory* /*db_directory*/, bool /*new_descriptor_log*/,
       const ColumnFamilyOptions* /*new_cf_option*/) override {
     return Status::NotSupported("not supported in reactive mode");
   }

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -756,9 +756,10 @@ TEST_F(VersionSetTest, SameColumnFamilyGroupCommit) {
         ++count;
       });
   SyncPoint::GetInstance()->EnableProcessing();
+  ErrorContext err_context;
   mutex_.Lock();
-  Status s =
-      versions_->LogAndApply(cfds, all_mutable_cf_options, edit_lists, &mutex_);
+  Status s = versions_->LogAndApply(cfds, all_mutable_cf_options, edit_lists,
+                                    &mutex_, &err_context);
   mutex_.Unlock();
   EXPECT_OK(s);
   EXPECT_EQ(kGroupSize - 1, count);
@@ -1198,10 +1199,11 @@ TEST_P(VersionSetTestDropOneCF, HandleDroppedColumnFamilyInAtomicGroup) {
   // prevent it from being deleted.
   cfd_to_drop->Ref();
   drop_cf_edit.SetColumnFamily(cfd_to_drop->GetID());
+  ErrorContext err_context;
   mutex_.Lock();
   s = versions_->LogAndApply(cfd_to_drop,
                              *cfd_to_drop->GetLatestMutableCFOptions(),
-                             &drop_cf_edit, &mutex_);
+                             &drop_cf_edit, &mutex_, &err_context);
   mutex_.Unlock();
   ASSERT_OK(s);
 
@@ -1249,9 +1251,10 @@ TEST_P(VersionSetTestDropOneCF, HandleDroppedColumnFamilyInAtomicGroup) {
         ++called;
       });
   SyncPoint::GetInstance()->EnableProcessing();
+  ErrorContext err_context;
   mutex_.Lock();
-  s = versions_->LogAndApply(cfds, mutable_cf_options_list, edit_lists,
-                             &mutex_);
+  s = versions_->LogAndApply(cfds, mutable_cf_options_list, edit_lists, &mutex_,
+                             &err_context);
   mutex_.Unlock();
   ASSERT_OK(s);
   ASSERT_EQ(1, called);

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "db/version_set.h"
+#include "db/error_context.h"
 #include "db/log_writer.h"
 #include "logging/logging.h"
 #include "table/mock_table.h"
@@ -1251,7 +1252,6 @@ TEST_P(VersionSetTestDropOneCF, HandleDroppedColumnFamilyInAtomicGroup) {
         ++called;
       });
   SyncPoint::GetInstance()->EnableProcessing();
-  ErrorContext err_context;
   mutex_.Lock();
   s = versions_->LogAndApply(cfds, mutable_cf_options_list, edit_lists, &mutex_,
                              &err_context);


### PR DESCRIPTION
As #4990 describes, MANIFEST sync can fail but its newly appended entries may still exist when the process restarts and tries to recover. If the latest entry is flush or compaction, the db will try to access non-existing SST files because these files have been deleted after the previous MANIFEST sync failure. One possible fix is to truncate the MANIFEST to its last-synced size upon sync failure. However we are not going to take this approach because file truncation may not be supported on certain file systems. Instead, we disable deletion of obsolete files once RocksDB fails to write or sync MANIFEST.
This PR provides a unit test that simulates this scenario by manually overwriting the return status of a sync after the actual MANIFEST is persisted.
Test plan (on my dev machine)
```
$make clean && make -j32 db_basic_test
$./db_basic_test --gtest_filter=DBBasicTest.DisableFileDeletionAfterManifestWriteOrSyncFailure
```
All existing unit tests must pass too.
