### PR TITLE
Propagate cf id, name, and fd number into block based table reader. 

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -448,7 +448,8 @@ ColumnFamilyData::ColumnFamilyData(
   if (_dummy_versions != nullptr) {
     internal_stats_.reset(
         new InternalStats(ioptions_.num_levels, db_options.env, this));
-    table_cache_.reset(new TableCache(ioptions_, env_options, _table_cache));
+    table_cache_.reset(
+        new TableCache(ioptions_, env_options, _table_cache, id_, name_));
     if (ioptions_.compaction_style == kCompactionStyleLevel) {
       compaction_picker_.reset(
           new LevelCompactionPicker(ioptions_, &internal_comparator_));

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -68,11 +68,14 @@ void AppendVarint64(IterKey* key, uint64_t v) {
 }  // namespace
 
 TableCache::TableCache(const ImmutableCFOptions& ioptions,
-                       const EnvOptions& env_options, Cache* const cache)
+                       const EnvOptions& env_options, Cache* const cache,
+                       uint32_t cf_id, const std::string& cf_name)
     : ioptions_(ioptions),
       env_options_(env_options),
       cache_(cache),
-      immortal_tables_(false) {
+      immortal_tables_(false),
+      cf_id_(cf_id),
+      cf_name_(cf_name) {
   if (ioptions_.row_cache) {
     // If the same cache is shared by multiple instances, we need to
     // disambiguate its entries.
@@ -125,7 +128,8 @@ Status TableCache::GetTableReader(
     s = ioptions_.table_factory->NewTableReader(
         TableReaderOptions(ioptions_, prefix_extractor, env_options,
                            internal_comparator, skip_filters, immortal_tables_,
-                           level, fd.largest_seqno),
+                           level, fd.largest_seqno, cf_id_, cf_name_,
+                           fd.GetNumber()),
         std::move(file_reader), fd.GetFileSize(), table_reader,
         prefetch_index_and_filter_in_cache);
     TEST_SYNC_POINT("TableCache::GetTableReader:0");

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -48,7 +48,8 @@ class HistogramImpl;
 class TableCache {
  public:
   TableCache(const ImmutableCFOptions& ioptions,
-             const EnvOptions& storage_options, Cache* cache);
+             const EnvOptions& storage_options, Cache* cache,
+             uint32_t cf_id = 0, const std::string& cf_name = "");
   ~TableCache();
 
   // Return an iterator for the specified file number (the corresponding
@@ -188,6 +189,8 @@ class TableCache {
   Cache* const cache_;
   std::string row_cache_id_;
   bool immortal_tables_;
+  uint32_t cf_id_;
+  std::string cf_name_;
 };
 
 }  // namespace rocksdb

--- a/table/block_based_table_factory.cc
+++ b/table/block_based_table_factory.cc
@@ -203,7 +203,9 @@ Status BlockBasedTableFactory::NewTableReader(
       file_size, table_reader, table_reader_options.prefix_extractor,
       prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
       table_reader_options.level, table_reader_options.immortal,
-      table_reader_options.largest_seqno, &tail_prefetch_stats_);
+      table_reader_options.largest_seqno, &tail_prefetch_stats_,
+      table_reader_options.cf_id, table_reader_options.cf_name,
+      table_reader_options.fd_number);
 }
 
 TableBuilder* BlockBasedTableFactory::NewTableBuilder(

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -95,19 +95,18 @@ class BlockBasedTable : public TableReader {
   // @param skip_filters Disables loading/accessing the filter block. Overrides
   //    prefetch_index_and_filter_in_cache, so filter will be skipped if both
   //    are set.
-  static Status Open(const ImmutableCFOptions& ioptions,
-                     const EnvOptions& env_options,
-                     const BlockBasedTableOptions& table_options,
-                     const InternalKeyComparator& internal_key_comparator,
-                     std::unique_ptr<RandomAccessFileReader>&& file,
-                     uint64_t file_size,
-                     std::unique_ptr<TableReader>* table_reader,
-                     const SliceTransform* prefix_extractor = nullptr,
-                     bool prefetch_index_and_filter_in_cache = true,
-                     bool skip_filters = false, int level = -1,
-                     const bool immortal_table = false,
-                     const SequenceNumber largest_seqno = 0,
-                     TailPrefetchStats* tail_prefetch_stats = nullptr);
+  static Status Open(
+      const ImmutableCFOptions& ioptions, const EnvOptions& env_options,
+      const BlockBasedTableOptions& table_options,
+      const InternalKeyComparator& internal_key_comparator,
+      std::unique_ptr<RandomAccessFileReader>&& file, uint64_t file_size,
+      std::unique_ptr<TableReader>* table_reader,
+      const SliceTransform* prefix_extractor = nullptr,
+      bool prefetch_index_and_filter_in_cache = true, bool skip_filters = false,
+      int level = -1, const bool immortal_table = false,
+      const SequenceNumber largest_seqno = 0,
+      TailPrefetchStats* tail_prefetch_stats = nullptr, uint32_t cf_id = 0,
+      const std::string& cf_name = "", uint64_t fd_number = 0);
 
   bool PrefixMayMatch(const Slice& internal_key,
                       const ReadOptions& read_options,
@@ -263,12 +262,12 @@ class BlockBasedTable : public TableReader {
   // Similar to the above, with one crucial difference: it will retrieve the
   // block from the file even if there are no caches configured (assuming the
   // read options allow I/O).
-  static Status RetrieveBlock(
-      FilePrefetchBuffer* prefetch_buffer, const Rep* rep,
-      const ReadOptions& ro, const BlockHandle& handle,
-      const UncompressionDict& uncompression_dict,
-      CachableEntry<Block>* block_entry, bool is_index,
-      GetContext* get_context);
+  static Status RetrieveBlock(FilePrefetchBuffer* prefetch_buffer,
+                              const Rep* rep, const ReadOptions& ro,
+                              const BlockHandle& handle,
+                              const UncompressionDict& uncompression_dict,
+                              CachableEntry<Block>* block_entry, bool is_index,
+                              GetContext* get_context);
 
   // For the following two functions:
   // if `no_io == true`, we will not try to read filter/index from sst file
@@ -310,8 +309,8 @@ class BlockBasedTable : public TableReader {
   static Status GetDataBlockFromCache(
       const Slice& block_cache_key, const Slice& compressed_block_cache_key,
       Cache* block_cache, Cache* block_cache_compressed, const Rep* rep,
-      const ReadOptions& read_options,
-      CachableEntry<Block>* block, const UncompressionDict& uncompression_dict,
+      const ReadOptions& read_options, CachableEntry<Block>* block,
+      const UncompressionDict& uncompression_dict,
       size_t read_amp_bytes_per_bit, bool is_index = false,
       GetContext* get_context = nullptr);
 
@@ -351,10 +350,10 @@ class BlockBasedTable : public TableReader {
   // Optionally, user can pass a preloaded meta_index_iter for the index that
   // need to access extra meta blocks for index construction. This parameter
   // helps avoid re-reading meta index block if caller already created one.
-  Status CreateIndexReader(
-      FilePrefetchBuffer* prefetch_buffer,
-      InternalIterator* preloaded_meta_index_iter, bool use_cache,
-      bool prefetch, bool pin, IndexReader** index_reader);
+  Status CreateIndexReader(FilePrefetchBuffer* prefetch_buffer,
+                           InternalIterator* preloaded_meta_index_iter,
+                           bool use_cache, bool prefetch, bool pin,
+                           IndexReader** index_reader);
 
   bool FullFilterKeyMayMatch(
       const ReadOptions& read_options, FilterBlockReader* filter,
@@ -450,7 +449,8 @@ struct BlockBasedTable::Rep {
   Rep(const ImmutableCFOptions& _ioptions, const EnvOptions& _env_options,
       const BlockBasedTableOptions& _table_opt,
       const InternalKeyComparator& _internal_comparator, bool skip_filters,
-      int _level, const bool _immortal_table)
+      int _level, const bool _immortal_table, uint32_t _cf_id,
+      const std::string& _cf_name, uint64_t _fd_number)
       : ioptions(_ioptions),
         env_options(_env_options),
         table_options(_table_opt),
@@ -463,7 +463,10 @@ struct BlockBasedTable::Rep {
         prefix_filtering(true),
         global_seqno(kDisableGlobalSequenceNumber),
         level(_level),
-        immortal_table(_immortal_table) {}
+        immortal_table(_immortal_table),
+        cf_id(_cf_id),
+        cf_name(_cf_name),
+        fd_number(_fd_number) {}
 
   const ImmutableCFOptions& ioptions;
   const EnvOptions& env_options;
@@ -551,6 +554,12 @@ struct BlockBasedTable::Rep {
 
   bool closed = false;
   const bool immortal_table;
+
+  // Which column family does this table/file belongs to.
+  uint32_t cf_id;
+  std::string cf_name;
+  // The file number.
+  uint64_t fd_number;
 
   SequenceNumber get_global_seqno(bool is_index) const {
     return is_index ? kDisableGlobalSequenceNumber : global_seqno;

--- a/table/partitioned_filter_block_test.cc
+++ b/table/partitioned_filter_block_test.cc
@@ -148,7 +148,7 @@ class PartitionedFilterBlockTest
     const bool kImmortal = true;
     table.reset(new MockedBlockBasedTable(
         new BlockBasedTable::Rep(ioptions, env_options, table_options_, icomp,
-                                 !kSkipFilters, 0, !kImmortal)));
+                                 !kSkipFilters, 0, !kImmortal, 0, "test", 0)));
     auto reader = new PartitionedFilterBlockReader(
         prefix_extractor, true, BlockContents(slice), nullptr, nullptr, icomp,
         table.get(), pib->seperator_is_key_plus_seq(),

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -32,10 +32,12 @@ struct TableReaderOptions {
                      const EnvOptions& _env_options,
                      const InternalKeyComparator& _internal_comparator,
                      bool _skip_filters = false, bool _immortal = false,
-                     int _level = -1)
+                     int _level = -1, uint32_t _cf_id = 0,
+                     const std::string& _cf_name = "", uint64_t _fd_number = 0)
       : TableReaderOptions(_ioptions, _prefix_extractor, _env_options,
                            _internal_comparator, _skip_filters, _immortal,
-                           _level, 0 /* _largest_seqno */) {}
+                           _level, 0 /* _largest_seqno */, _cf_id, _cf_name,
+                           _fd_number) {}
 
   // @param skip_filters Disables loading/accessing the filter block
   TableReaderOptions(const ImmutableCFOptions& _ioptions,
@@ -43,7 +45,8 @@ struct TableReaderOptions {
                      const EnvOptions& _env_options,
                      const InternalKeyComparator& _internal_comparator,
                      bool _skip_filters, bool _immortal, int _level,
-                     SequenceNumber _largest_seqno)
+                     SequenceNumber _largest_seqno, uint32_t _cf_id,
+                     const std::string& _cf_name, uint64_t _fd_number)
       : ioptions(_ioptions),
         prefix_extractor(_prefix_extractor),
         env_options(_env_options),
@@ -51,7 +54,10 @@ struct TableReaderOptions {
         skip_filters(_skip_filters),
         immortal(_immortal),
         level(_level),
-        largest_seqno(_largest_seqno) {}
+        largest_seqno(_largest_seqno),
+        cf_id(_cf_id),
+        cf_name(_cf_name),
+        fd_number(_fd_number) {}
 
   const ImmutableCFOptions& ioptions;
   const SliceTransform* prefix_extractor;
@@ -65,6 +71,12 @@ struct TableReaderOptions {
   int level;
   // largest seqno in the table
   SequenceNumber largest_seqno;
+
+  // Which column family does this table/file belongs to.
+  uint32_t cf_id;
+  std::string cf_name;
+  // The file number.
+  uint64_t fd_number;
 };
 
 struct TableBuilderOptions {


### PR DESCRIPTION
This commit propagates cf id, name and fd number into the block based table reader Rep class. 
These information is propagated in this sequence: 
ColumnFamilyData -> TableCache -> TableReaderOption -> BlockBasedTableFactory -> BlockBasedTable. 

In this way, we can log the column family and SST file information upon a block cache access. 