### PR TITLE
Enable trace_replay with multi-threads

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -778,7 +778,8 @@ DEFINE_string(trace_file, "", "Trace workload to a file. ");
 DEFINE_int32(trace_replay_fast_forward, 1,
              "Fast forward trace replay, must >= 1. ");
 
-DEFINE_uint32(trace_replay_threads, 1, "The number of threads to replay. ");
+DEFINE_int32(trace_replay_threads, 1,
+             "The number of threads to replay, must >=1.");
 
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
@@ -6239,7 +6240,8 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    s = replayer.MultiThreadReplay(FLAGS_trace_replay_threads);
+    s = replayer.MultiThreadReplay(
+        static_cast<uint32_t>(FLAGS_trace_replay_threads));
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6237,7 +6237,8 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    s = replayer.Replay();
+    //s = replayer.Replay();
+    s = replayer.MultiThreadReplay(15);
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -778,6 +778,8 @@ DEFINE_string(trace_file, "", "Trace workload to a file. ");
 DEFINE_int32(trace_replay_fast_forward, 1,
              "Fast forward trace replay, must >= 1. ");
 
+DEFINE_uint32(trace_replay_threads, 1, "The number of threads to replay. ");
+
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
 
@@ -6237,8 +6239,7 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    //s = replayer.Replay();
-    s = replayer.MultiThreadReplay(15);
+    s = replayer.MultiThreadReplay(FLAGS_trace_replay_threads);
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/util/trace_replay.cc
+++ b/util/trace_replay.cc
@@ -13,6 +13,7 @@
 #include "rocksdb/write_batch.h"
 #include "util/coding.h"
 #include "util/string_util.h"
+#include "util/threadpool_imp.h"
 
 
 namespace rocksdb {
@@ -273,13 +274,15 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
   if (!s.ok()) {
     return s;
   }
-  int threads = env_->GetBackgroundThreads(Env::Priority::LOW);
-  printf("threads: %d\n", threads);
+
+  ThreadPoolImpl thread_pool;
+  thread_pool.SetHostEnv(env_);
+
   if (threads_num > 1) {
-    env_->SetBackgroundThreads(static_cast<int>(threads_num));
+    thread_pool.SetBackgroundThreads(static_cast<int>(threads_num));
+  } else {
+    thread_pool.SetBackgroundThreads(1);
   }
-  threads = env_->GetBackgroundThreads(Env::Priority::LOW);
-  printf("threads: %d\n", threads);
 
   std::chrono::system_clock::time_point replay_epoch =
       std::chrono::system_clock::now();
@@ -301,16 +304,16 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
         replay_epoch +
         std::chrono::microseconds((ra->trace_entry.ts - header.ts) / fast_forward_));
     if (ra->trace_entry.type == kTraceWrite) {
-      env_->Schedule(&Replayer::BGWorkWriteBatch, ra);
+      thread_pool.Schedule(&Replayer::BGWorkWriteBatch, ra, nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceGet) {
-      env_->Schedule(&Replayer::BGWorkGet, ra);
+      thread_pool.Schedule(&Replayer::BGWorkGet, ra, nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceIteratorSeek) {
-      env_->Schedule(&Replayer::BGWorkIterSeek, ra);
+      thread_pool.Schedule(&Replayer::BGWorkIterSeek, ra, nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceIteratorSeekForPrev) {
-      env_->Schedule(&Replayer::BGWorkIterSeekForPrev, ra);
+      thread_pool.Schedule(&Replayer::BGWorkIterSeekForPrev, ra, nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceEnd) {
       // Do nothing for now.
@@ -324,8 +327,10 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
     // Reaching eof returns Incomplete status at the moment.
     // Could happen when killing a process without calling EndTrace() API.
     // TODO: Add better error handling.
+    thread_pool.JoinAllThreads();
     return Status::OK();
   }
+  thread_pool.JoinAllThreads();
   return s;
 }
 

--- a/util/trace_replay.cc
+++ b/util/trace_replay.cc
@@ -15,7 +15,6 @@
 #include "util/string_util.h"
 #include "util/threadpool_imp.h"
 
-
 namespace rocksdb {
 
 const std::string kTraceMagic = "feedcafedeadbeef";
@@ -301,8 +300,8 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
     ra->roptions = roptions;
 
     std::this_thread::sleep_until(
-        replay_epoch +
-        std::chrono::microseconds((ra->trace_entry.ts - header.ts) / fast_forward_));
+        replay_epoch + std::chrono::microseconds(
+                           (ra->trace_entry.ts - header.ts) / fast_forward_));
     if (ra->trace_entry.type == kTraceWrite) {
       thread_pool.Schedule(&Replayer::BGWorkWriteBatch, ra, nullptr, nullptr);
       ops++;
@@ -313,7 +312,8 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
       thread_pool.Schedule(&Replayer::BGWorkIterSeek, ra, nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceIteratorSeekForPrev) {
-      thread_pool.Schedule(&Replayer::BGWorkIterSeekForPrev, ra, nullptr, nullptr);
+      thread_pool.Schedule(&Replayer::BGWorkIterSeekForPrev, ra, nullptr,
+                           nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceEnd) {
       // Do nothing for now.
@@ -383,7 +383,8 @@ Status Replayer::ReadTrace(Trace* trace) {
 void Replayer::BGWorkGet(void* arg) {
   ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
   delete reinterpret_cast<ReplayerWorkerArg*>(arg);
-  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
+      ra.cf_map);
   uint32_t cf_id = 0;
   Slice key;
   DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
@@ -393,9 +394,10 @@ void Replayer::BGWorkGet(void* arg) {
 
   std::string value;
   if (cf_id == 0) {
-      reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, key, &value);
+    reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, key, &value);
   } else {
-      reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, (*cf_map)[cf_id], key, &value);
+    reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, (*cf_map)[cf_id], key,
+                                      &value);
   }
 
   return;
@@ -412,12 +414,13 @@ void Replayer::BGWorkWriteBatch(void* arg) {
 void Replayer::BGWorkIterSeek(void* arg) {
   ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
   delete reinterpret_cast<ReplayerWorkerArg*>(arg);
-  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
+      ra.cf_map);
   uint32_t cf_id = 0;
   Slice key;
   DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
   if (cf_id > 0 && cf_map->find(cf_id) == cf_map->end()) {
-      return;
+    return;
   }
 
   std::string value;
@@ -425,7 +428,8 @@ void Replayer::BGWorkIterSeek(void* arg) {
   if (cf_id == 0) {
     single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions);
   } else {
-    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions, (*cf_map)[cf_id]);
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions,
+                                                            (*cf_map)[cf_id]);
   }
   single_iter->Seek(key);
   delete single_iter;
@@ -435,12 +439,13 @@ void Replayer::BGWorkIterSeek(void* arg) {
 void Replayer::BGWorkIterSeekForPrev(void* arg) {
   ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
   delete reinterpret_cast<ReplayerWorkerArg*>(arg);
-  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
+      ra.cf_map);
   uint32_t cf_id = 0;
   Slice key;
   DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
   if (cf_id > 0 && cf_map->find(cf_id) == cf_map->end()) {
-      return;
+    return;
   }
 
   std::string value;
@@ -448,7 +453,8 @@ void Replayer::BGWorkIterSeekForPrev(void* arg) {
   if (cf_id == 0) {
     single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions);
   } else {
-    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions, (*cf_map)[cf_id]);
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions,
+                                                            (*cf_map)[cf_id]);
   }
   single_iter->SeekForPrev(key);
   delete single_iter;

--- a/util/trace_replay.h
+++ b/util/trace_replay.h
@@ -122,9 +122,9 @@ class Replayer {
   // between the traces into consideration.
   Status Replay();
 
-  // Replay the provide trace stream as Replay() with multi-threads. Queries
-  // are scheduled in the thread pool job queue. User can set the number of
-  // threads in the thread pool.
+  // Replay the provide trace stream, which is the same as Replay(), with
+  // multi-threads. Queries are scheduled in the thread pool job queue.
+  // User can set the number of threads in the thread pool.
   Status MultiThreadReplay(uint32_t threads_num);
 
   // Enables fast forwarding a replay by reducing the delay between the ingested


### PR DESCRIPTION
In the current trace replay, all the queries are serialized and called by single threads. It may not simulate the original application query situations closely. The multi-threads replay is implemented in this PR. Users can set the number of threads to replay the trace. The queries generated according to the trace records are scheduled in the thread pool job queue.

Test: test with make check and real trace replay.