### PR TITLE
add __STDC_FORMAT_MACROS macro before all inclusion of inttypes.h

### DIFF
--- a/db/c_test.c
+++ b/db/c_test.c
@@ -16,6 +16,11 @@
 #ifndef OS_WIN
 #include <unistd.h>
 #endif
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 // Can not use port/port.h macros as this is a c file

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -11,6 +11,10 @@
 
 #include "rocksdb/db.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -3,11 +3,11 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include "db/db_info_dumper.h"
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
-
-#include "db/db_info_dumper.h"
 
 #include <inttypes.h>
 #include <stdio.h>

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -9,6 +9,10 @@
 #include <functional>
 #include <set>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/examples/multi_processes_example.cc
+++ b/examples/multi_processes_example.cc
@@ -14,6 +14,11 @@
 // run for a while, tailing the logs of the primary. After process with primary
 // instance exits, this process will keep running until you hit 'CTRL+C'.
 
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <chrono>
 #include <cstdio>

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -9,9 +9,12 @@
 
 #include "table/block_based/index_builder.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <assert.h>
 #include <inttypes.h>
-
 #include <list>
 #include <string>
 

--- a/table/block_based/index_builder.h
+++ b/table/block_based/index_builder.h
@@ -9,6 +9,10 @@
 
 #pragma once
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <assert.h>
 #include <inttypes.h>
 

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -9,6 +9,10 @@
 
 #include "table/block_fetcher.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <string>
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -9,6 +9,10 @@
 
 #include "table/format.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <string>
 

--- a/table/sst_file_reader_test.cc
+++ b/table/sst_file_reader_test.cc
@@ -5,6 +5,10 @@
 
 #ifndef ROCKSDB_LITE
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #include "rocksdb/db.h"

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -30,7 +30,7 @@ int main() {
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
-#endif  // __STDC_FORMAT_MACROS
+#endif
 
 #include <fcntl.h>
 #include <inttypes.h>

--- a/util/crc32c_arm64.h
+++ b/util/crc32c_arm64.h
@@ -6,6 +6,10 @@
 #ifndef UTIL_CRC32C_ARM64_H
 #define UTIL_CRC32C_ARM64_H
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #if defined(__aarch64__) || defined(__AARCH64__)

--- a/util/crc32c_ppc.c
+++ b/util/crc32c_ppc.c
@@ -6,6 +6,11 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #define CRC_TABLE
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <stdlib.h>
 #include <strings.h>


### PR DESCRIPTION
User have witnessed [compilation errors](https://github.com/facebook/rocksdb/issues/5159) due to inclusion of <inttypes.h> without defining `__STDC_FORMAT_MACROS`
This PR adds such macros to every files that include <inttypes.h> 