### PR TITLE
Fix a clang analyze warning

### DIFF
--- a/file/filename.cc
+++ b/file/filename.cc
@@ -413,7 +413,7 @@ Status GetInfoLogFiles(Env* env, const std::string& db_log_dir,
   assert(parent_dir != nullptr);
   assert(info_log_list != nullptr);
   uint64_t number = 0;
-  FileType type;
+  FileType type = kLogFile;
 
   if (!db_log_dir.empty()) {
     *parent_dir = db_log_dir;


### PR DESCRIPTION
Clang analyzer is reporting a false positive warning thinking `type` is uninitialized. The variable is initialized by `ParseFileName` by reference so assigning a default value to keep clang happy. 
Current failure:
```
file/filename.cc:435:15: warning: The left operand of '==' is a garbage value
        (type == kInfoLogFile)) {
         ~~~~ ^
1 warning generated.
```