### PR TITLE
Pass BlockCacheLookupContext to BlockBasedTable::GetUncompressionDict.

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1855,8 +1855,7 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
 CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
     FilePrefetchBuffer* prefetch_buffer, bool no_io, GetContext* get_context,
-    BlockCacheLookupContext* lookup_context) const {
-  assert(lookup_context);
+    BlockCacheLookupContext* /*lookup_context*/) const {
   // TODO(haoyu): Trace the access on the uncompression dictionary here.
   if (!rep_->table_options.cache_index_and_filter_blocks) {
     // block cache is either disabled or not used for meta-blocks. In either


### PR DESCRIPTION
Pass BlockCacheLookupContext to BlockBasedTable::GetUncompressionDict so that we can trace accesses on  uncompression dictionary block.
This is the first PR that uses a block cache lookup context to enable fine-grained tracing on block accesses. 
I will send subsequent PRs for other block types: data/index/range deletion/filter.