### PR TITLE
Create a BlockCacheLookupContext to enable fine-grained block cache tracing.

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -526,7 +526,7 @@ void CompactionJob::GenSubcompactionBoundaries() {
     // mutex to reduce contention
     db_mutex_->Unlock();
     uint64_t size = versions_->ApproximateSize(v, a, b, start_lvl, out_lvl + 1,
-                                               /*for compaction*/ true);
+                                               /*for_compaction*/ true);
     db_mutex_->Lock();
     ranges.emplace_back(a, b, size);
     sum += size;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -525,7 +525,8 @@ void CompactionJob::GenSubcompactionBoundaries() {
     // to the index block and may incur I/O cost in the process. Unlock db
     // mutex to reduce contention
     db_mutex_->Unlock();
-    uint64_t size = versions_->ApproximateSize(v, a, b, start_lvl, out_lvl + 1);
+    uint64_t size = versions_->ApproximateSize(v, a, b, start_lvl, out_lvl + 1,
+                                               /*for compaction*/ true);
     db_mutex_->Lock();
     ranges.emplace_back(a, b, size);
     sum += size;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4767,7 +4767,7 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
 // maintain state of where they first appear in the files.
 uint64_t VersionSet::ApproximateSize(Version* v, const Slice& start,
                                      const Slice& end, int start_level,
-                                     int end_level) {
+                                     int end_level, bool for_compaction) {
   // pre-condition
   assert(v->cfd_->internal_comparator().Compare(start, end) <= 0);
 
@@ -4805,7 +4805,7 @@ uint64_t VersionSet::ApproximateSize(Version* v, const Slice& start,
     // inferred from the sorted order
     for (uint64_t i = idx_start; i < files_brief.num_files; i++) {
       uint64_t val;
-      val = ApproximateSize(v, files_brief.files[i], end);
+      val = ApproximateSize(v, files_brief.files[i], end, for_compaction);
       if (!val) {
         // the files after this will not have the range
         break;
@@ -4816,7 +4816,7 @@ uint64_t VersionSet::ApproximateSize(Version* v, const Slice& start,
       if (i == idx_start) {
         // subtract the bytes needed to be scanned to get to the starting
         // key
-        val = ApproximateSize(v, files_brief.files[i], start);
+        val = ApproximateSize(v, files_brief.files[i], start, for_compaction);
         assert(size >= val);
         size -= val;
       }
@@ -4829,13 +4829,16 @@ uint64_t VersionSet::ApproximateSize(Version* v, const Slice& start,
 uint64_t VersionSet::ApproximateSizeLevel0(Version* v,
                                            const LevelFilesBrief& files_brief,
                                            const Slice& key_start,
-                                           const Slice& key_end) {
+                                           const Slice& key_end,
+                                           bool for_compaction) {
   // level 0 files are not in sorted order, we need to iterate through
   // the list to compute the total bytes that require scanning
   uint64_t size = 0;
   for (size_t i = 0; i < files_brief.num_files; i++) {
-    const uint64_t start = ApproximateSize(v, files_brief.files[i], key_start);
-    const uint64_t end = ApproximateSize(v, files_brief.files[i], key_end);
+    const uint64_t start =
+        ApproximateSize(v, files_brief.files[i], key_start, for_compaction);
+    const uint64_t end =
+        ApproximateSize(v, files_brief.files[i], key_end, for_compaction);
     assert(end >= start);
     size += end - start;
   }
@@ -4843,7 +4846,7 @@ uint64_t VersionSet::ApproximateSizeLevel0(Version* v,
 }
 
 uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
-                                     const Slice& key) {
+                                     const Slice& key, bool for_compaction) {
   // pre-condition
   assert(v);
 
@@ -4863,7 +4866,7 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
         *f.file_metadata, nullptr /* range_del_agg */,
         v->GetMutableCFOptions().prefix_extractor.get(), &table_reader_ptr);
     if (table_reader_ptr != nullptr) {
-      result = table_reader_ptr->ApproximateOffsetOf(key);
+      result = table_reader_ptr->ApproximateOffsetOf(key, for_compaction);
     }
     delete iter;
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -965,7 +965,8 @@ class VersionSet {
   // in levels [start_level, end_level). If end_level == 0 it will search
   // through all non-empty levels
   uint64_t ApproximateSize(Version* v, const Slice& start, const Slice& end,
-                           int start_level = 0, int end_level = -1);
+                           int start_level = 0, int end_level = -1,
+                           bool for_compaction = false);
 
   // Return the size of the current manifest file
   uint64_t manifest_file_size() const { return manifest_file_size_; }
@@ -1015,10 +1016,11 @@ class VersionSet {
 
   // ApproximateSize helper
   uint64_t ApproximateSizeLevel0(Version* v, const LevelFilesBrief& files_brief,
-                                 const Slice& start, const Slice& end);
+                                 const Slice& start, const Slice& end,
+                                 bool for_compaction = false);
 
   uint64_t ApproximateSize(Version* v, const FdWithKeyRange& f,
-                           const Slice& key);
+                           const Slice& key, bool for_compaction = false);
 
   // Save current contents to *log
   Status WriteSnapshot(log::Writer* log);

--- a/table/block_based/block_based_filter_block.cc
+++ b/table/block_based/block_based_filter_block.cc
@@ -187,7 +187,8 @@ BlockBasedFilterBlockReader::BlockBasedFilterBlockReader(
 bool BlockBasedFilterBlockReader::KeyMayMatch(
     const Slice& key, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
   assert(block_offset != kNotValid);
   if (!whole_key_filtering_) {
     return true;
@@ -198,7 +199,8 @@ bool BlockBasedFilterBlockReader::KeyMayMatch(
 bool BlockBasedFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
   assert(block_offset != kNotValid);
   return MayMatch(prefix, block_offset);
 }

--- a/table/block_based/block_based_filter_block.h
+++ b/table/block_based/block_based_filter_block.h
@@ -87,11 +87,13 @@ class BlockBasedFilterBlockReader : public FilterBlockReader {
   virtual bool KeyMayMatch(
       const Slice& key, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* lookup_context = nullptr) override;
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* lookup_context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
   // convert this object to a human readable form

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2060,7 +2060,7 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
     BlockCacheLookupContext* /*lookup_context*/,
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& ro,
     const BlockHandle& handle, const UncompressionDict& uncompression_dict,
-    CachableEntry<Block>* block_entry, BlockType type,
+    CachableEntry<Block>* block_entry, const BlockType& type,
     GetContext* get_context) const {
   // TODO(haoyu): Trace data/index/range deletion block access here.
   assert(block_entry != nullptr);
@@ -2139,7 +2139,7 @@ Status BlockBasedTable::RetrieveBlock(
     BlockCacheLookupContext* lookup_context,
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& ro,
     const BlockHandle& handle, const UncompressionDict& uncompression_dict,
-    CachableEntry<Block>* block_entry, BlockType type,
+    CachableEntry<Block>* block_entry, const BlockType& type,
     GetContext* get_context) const {
   assert(block_entry);
   assert(block_entry->IsEmpty());
@@ -2240,9 +2240,10 @@ BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
 //
 // REQUIRES: this method shouldn't be called while the DB lock is held.
 bool BlockBasedTable::PrefixMayMatch(
-    const Slice& internal_key, const ReadOptions& read_options,
+    BlockCacheLookupContext* context, const Slice& internal_key,
+    const ReadOptions& read_options,
     const SliceTransform* options_prefix_extractor,
-    const bool need_upper_bound_check, BlockCacheLookupContext *context) const {
+    const bool need_upper_bound_check) const {
   if (!rep_->filter_policy) {
     return true;
   }
@@ -3035,8 +3036,8 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
 }
 
 Status BlockBasedTable::VerifyChecksum() {
-  // TODO(haoyu): This function is called from external sst ingestion and user's
-  // VerifyChecksum.
+  // TODO(haoyu): This function is called by external sst ingestion and user.
+  // We don't log its block cache accesses for now.
   Status s;
   // Check Meta blocks
   std::unique_ptr<Block> meta;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1855,8 +1855,7 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
 CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
     FilePrefetchBuffer* prefetch_buffer, bool no_io, GetContext* get_context,
-    BlockCacheLookupContext* lookup_context) const {
-  assert(lookup_context);
+    BlockCacheLookupContext* /*lookup_context*/) const {
   // TODO(haoyu): Trace the access on the uncompression dictionary here.
   if (!rep_->table_options.cache_index_and_filter_blocks) {
     // block cache is either disabled or not used for meta-blocks. In either

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -122,9 +122,11 @@ class BlockBasedTable : public TableReader {
   InternalIterator* NewIterator(
       const ReadOptions&, const SliceTransform* prefix_extractor,
       Arena* arena = nullptr, bool skip_filters = false,
-      /*TODO(haoyu) External SST ingestion also sets this for_compaction as
-        false. We treat external SST ingestion as a user is calling the iterator
-        for now. We should differentiate the caller. */
+      /*TODO(haoyu) 1. External SST ingestion sets for_compaction as false. 2.
+        Compaction also sets it to false when paranoid_file_checks is true,
+        i.e., it will populate the block cache with blocks in the new SST files.
+        We treat those as a user is calling iterator for now. We should
+        differentiate the caller. */
       bool for_compaction = false) override;
 
   FragmentedRangeTombstoneIterator* NewRangeTombstoneIterator(

--- a/table/block_based/cachable_entry.h
+++ b/table/block_based/cachable_entry.h
@@ -37,7 +37,6 @@ struct BlockCacheLookupContext {
   BlockCacheLookupContext(const BlockCacheLookupCaller& _caller)
       : caller(_caller) {}
   const BlockCacheLookupCaller caller;
-  BlockType block_type;
 };
 
 // CachableEntry is a handle to an object that may or may not be in the block

--- a/table/block_based/cachable_entry.h
+++ b/table/block_based/cachable_entry.h
@@ -14,6 +14,30 @@
 #include "rocksdb/cleanable.h"
 
 namespace rocksdb {
+enum BlockCacheLookupCaller : char {
+  kUnknown = 0,
+  kUserGet = 1,
+  kUserMGet = 2,
+  kUserIterator = 3,
+  kPrefetch = 4,
+  kCompaction = 5
+};
+
+enum BlockType : char {
+  kBlockTraceIndexBlock = 1,
+  kBlockTraceFilterBlock = 2,
+  kBlockTraceDataBlock = 3,
+  kBlockTraceUncompressionDictBlock = 4,
+  kBlockTraceRangeDeletionBlock = 5,
+};
+
+// Lookup context for tracing block cache accesses.
+struct BlockCacheLookupContext {
+  BlockCacheLookupContext(const BlockCacheLookupCaller& _caller)
+      : caller(_caller) {}
+  const BlockCacheLookupCaller caller;
+  BlockType block_type;
+};
 
 // CachableEntry is a handle to an object that may or may not be in the block
 // cache. It is used in a variety of ways:

--- a/table/block_based/cachable_entry.h
+++ b/table/block_based/cachable_entry.h
@@ -19,16 +19,17 @@ enum BlockCacheLookupCaller : char {
   kUserGet = 1,
   kUserMGet = 2,
   kUserIterator = 3,
-  kPrefetch = 4,
-  kCompaction = 5
+  kUserApproximateSize = 4,
+  kPrefetch = 5,
+  kCompaction = 6,
 };
 
 enum BlockType : char {
-  kBlockTraceIndexBlock = 1,
-  kBlockTraceFilterBlock = 2,
-  kBlockTraceDataBlock = 3,
-  kBlockTraceUncompressionDictBlock = 4,
-  kBlockTraceRangeDeletionBlock = 5,
+  kIndexBlock = 1,
+  kFilterBlock = 2,
+  kDataBlock = 3,
+  kUncompressionDictBlock = 4,
+  kRangeDeletionBlock = 5,
 };
 
 // Lookup context for tracing block cache accesses.

--- a/table/block_based/cachable_entry.h
+++ b/table/block_based/cachable_entry.h
@@ -23,7 +23,6 @@ enum BlockCacheLookupCaller : char {
   kUserApproximateSize = 4,
   /*When a BlockBasedTable is opend, it may prefetch range deletion, index, and
      filter blocks into the block cache.*/
-
   kPrefetch = 5,
   /*Compaction looks up blocks in the block cache but does not insert blocks
      upon cache misses. */
@@ -45,9 +44,9 @@ enum BlockType : char {
 // 3. BlockBasedTable::MaybeReadAndLoadToCache. (To trace access on data, index,
 // and range deletion block.)
 // 4. BlockBasedTable::Get. (To trace the referenced key and whether the
-// referenced key exists in the data block.)
+// referenced key exists in a fetched data block.)
 // 5. BlockBasedTable::MultiGet. (To trace the referenced key and whether the
-// referenced key exists in the data block.)
+// referenced key exists in a fetched data block.)
 // The context is created at:
 // 1. BlockBasedTable::Get. (kUserGet)
 // 2. BlockBasedTable::MultiGet. (kUserMGet)

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -30,6 +30,7 @@
 #include "rocksdb/table.h"
 #include "table/format.h"
 #include "table/multiget_context.h"
+#include "table/block_based/cachable_entry.h"
 #include "util/hash.h"
 
 namespace rocksdb {

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -28,9 +28,9 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/table.h"
+#include "table/block_based/cachable_entry.h"
 #include "table/format.h"
 #include "table/multiget_context.h"
-#include "table/block_based/cachable_entry.h"
 #include "util/hash.h"
 
 namespace rocksdb {
@@ -102,16 +102,19 @@ class FilterBlockReader {
                            const SliceTransform* prefix_extractor,
                            uint64_t block_offset = kNotValid,
                            const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr) = 0;
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) = 0;
 
   virtual void KeysMayMatch(MultiGetRange* range,
                             const SliceTransform* prefix_extractor,
                             uint64_t block_offset = kNotValid,
-                            const bool no_io = false) {
+                            const bool no_io = false,
+                            BlockCacheLookupContext* context = nullptr) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
-      if (!KeyMayMatch(ukey, prefix_extractor, block_offset, no_io, &ikey)) {
+      if (!KeyMayMatch(ukey, prefix_extractor, block_offset, no_io, &ikey,
+                       context)) {
         range->SkipKey(iter);
       }
     }
@@ -124,17 +127,19 @@ class FilterBlockReader {
                               const SliceTransform* prefix_extractor,
                               uint64_t block_offset = kNotValid,
                               const bool no_io = false,
-                              const Slice* const const_ikey_ptr = nullptr) = 0;
+                              const Slice* const const_ikey_ptr = nullptr,
+                              BlockCacheLookupContext* context = nullptr) = 0;
 
   virtual void PrefixesMayMatch(MultiGetRange* range,
                                 const SliceTransform* prefix_extractor,
                                 uint64_t block_offset = kNotValid,
-                                const bool no_io = false) {
+                                const bool no_io = false,
+                                BlockCacheLookupContext* context = nullptr) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
       if (!KeyMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
-                       block_offset, no_io, &ikey)) {
+                       block_offset, no_io, &ikey, context)) {
         range->SkipKey(iter);
       }
     }
@@ -155,15 +160,18 @@ class FilterBlockReader {
   virtual void CacheDependencies(bool /*pin*/,
                                  const SliceTransform* /*prefix_extractor*/) {}
 
-  virtual bool RangeMayExist(
-      const Slice* /*iterate_upper_bound*/, const Slice& user_key,
-      const SliceTransform* prefix_extractor,
-      const Comparator* /*comparator*/, const Slice* const const_ikey_ptr,
-      bool* filter_checked, bool /*need_upper_bound_check*/) {
+  virtual bool RangeMayExist(const Slice* /*iterate_upper_bound*/,
+                             const Slice& user_key,
+                             const SliceTransform* prefix_extractor,
+                             const Comparator* /*comparator*/,
+                             const Slice* const const_ikey_ptr,
+                             bool* filter_checked,
+                             bool /*need_upper_bound_check*/,
+                             BlockCacheLookupContext* context = nullptr) {
     *filter_checked = true;
     Slice prefix = prefix_extractor->Transform(user_key);
     return PrefixMayMatch(prefix, prefix_extractor, kNotValid, false,
-                          const_ikey_ptr);
+                          const_ikey_ptr, context);
   }
 
  protected:

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -124,7 +124,8 @@ FullFilterBlockReader::FullFilterBlockReader(
 bool FullFilterBlockReader::KeyMayMatch(
     const Slice& key, const SliceTransform* /*prefix_extractor*/,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)block_offset;
 #endif
@@ -138,7 +139,8 @@ bool FullFilterBlockReader::KeyMayMatch(
 bool FullFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)block_offset;
 #endif
@@ -161,7 +163,8 @@ bool FullFilterBlockReader::MayMatch(const Slice& entry) {
 
 void FullFilterBlockReader::KeysMayMatch(
     MultiGetRange* range, const SliceTransform* /*prefix_extractor*/,
-    uint64_t block_offset, const bool /*no_io*/) {
+    uint64_t block_offset, const bool /*no_io*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)range;
   (void)block_offset;
@@ -177,7 +180,8 @@ void FullFilterBlockReader::KeysMayMatch(
 
 void FullFilterBlockReader::PrefixesMayMatch(
     MultiGetRange* range, const SliceTransform* /* prefix_extractor */,
-    uint64_t block_offset, const bool /*no_io*/) {
+    uint64_t block_offset, const bool /*no_io*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)range;
   (void)block_offset;
@@ -224,10 +228,11 @@ size_t FullFilterBlockReader::ApproximateMemoryUsage() const {
   return usage;
 }
 
-bool FullFilterBlockReader::RangeMayExist(const Slice* iterate_upper_bound,
-    const Slice& user_key, const SliceTransform* prefix_extractor,
-    const Comparator* comparator, const Slice* const const_ikey_ptr,
-    bool* filter_checked, bool need_upper_bound_check) {
+bool FullFilterBlockReader::RangeMayExist(
+    const Slice* iterate_upper_bound, const Slice& user_key,
+    const SliceTransform* prefix_extractor, const Comparator* comparator,
+    const Slice* const const_ikey_ptr, bool* filter_checked,
+    bool need_upper_bound_check, BlockCacheLookupContext* /*context*/) {
   if (!prefix_extractor || !prefix_extractor->InDomain(user_key)) {
     *filter_checked = false;
     return true;

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -99,31 +99,36 @@ class FullFilterBlockReader : public FilterBlockReader {
 
   virtual bool IsBlockBased() override { return false; }
 
-  virtual bool KeyMayMatch(
-      const Slice& key, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+  virtual bool KeyMayMatch(const Slice& key,
+                           const SliceTransform* prefix_extractor,
+                           uint64_t block_offset = kNotValid,
+                           const bool no_io = false,
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) override;
 
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* context = nullptr) override;
 
-  virtual void KeysMayMatch(MultiGetRange* range,
-                            const SliceTransform* prefix_extractor,
-                            uint64_t block_offset = kNotValid,
-                            const bool no_io = false) override;
+  virtual void KeysMayMatch(
+      MultiGetRange* range, const SliceTransform* prefix_extractor,
+      uint64_t block_offset = kNotValid, const bool no_io = false,
+      BlockCacheLookupContext* context = nullptr) override;
 
-  virtual void PrefixesMayMatch(MultiGetRange* range,
-                                const SliceTransform* prefix_extractor,
-                                uint64_t block_offset = kNotValid,
-                                const bool no_io = false) override;
+  virtual void PrefixesMayMatch(
+      MultiGetRange* range, const SliceTransform* prefix_extractor,
+      uint64_t block_offset = kNotValid, const bool no_io = false,
+      BlockCacheLookupContext* context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
-  virtual bool RangeMayExist(const Slice* iterate_upper_bound, const Slice& user_key,
-                             const SliceTransform* prefix_extractor,
-                             const Comparator* comparator,
-                             const Slice* const const_ikey_ptr, bool* filter_checked,
-                             bool need_upper_bound_check) override;
+  virtual bool RangeMayExist(
+      const Slice* iterate_upper_bound, const Slice& user_key,
+      const SliceTransform* prefix_extractor, const Comparator* comparator,
+      const Slice* const const_ikey_ptr, bool* filter_checked,
+      bool need_upper_bound_check,
+      BlockCacheLookupContext* context = nullptr) override;
+
  private:
   const SliceTransform* prefix_extractor_;
   Slice contents_;

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -252,7 +252,8 @@ PartitionedFilterBlockReader::GetFilterPartition(
           nullptr /* cache_handle */, false /* own_value */};
       }
     }
-    return table_->GetFilter(/*prefetch_buffer*/ nullptr, fltr_blk_handle,
+    // TODO(haoyu).
+    return table_->GetFilter(nullptr, /*prefetch_buffer*/ nullptr, fltr_blk_handle,
                              is_a_filter_partition, no_io,
                              /* get_context */ nullptr, prefix_extractor);
   } else {
@@ -307,7 +308,8 @@ void PartitionedFilterBlockReader::CacheDependencies(
     handle = biter.value();
     const bool no_io = true;
     const bool is_a_filter_partition = true;
-    auto filter = table_->GetFilter(
+    // TODO(haoyu).
+    auto filter = table_->GetFilter(nullptr,
         prefetch_buffer.get(), handle, is_a_filter_partition, !no_io,
         /* get_context */ nullptr, prefix_extractor);
     if (LIKELY(filter.IsCached())) {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -162,8 +162,8 @@ PartitionedFilterBlockReader::~PartitionedFilterBlockReader() {
 
 bool PartitionedFilterBlockReader::KeyMayMatch(
     const Slice& key, const SliceTransform* prefix_extractor,
-    uint64_t block_offset, const bool no_io,
-    const Slice* const const_ikey_ptr) {
+    uint64_t block_offset, const bool no_io, const Slice* const const_ikey_ptr,
+    BlockCacheLookupContext* context) {
   assert(const_ikey_ptr != nullptr);
   assert(block_offset == kNotValid);
   if (!whole_key_filtering_) {
@@ -177,8 +177,8 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
     return false;
   }
   auto filter_partition =
-      GetFilterPartition(nullptr /* prefetch_buffer */, filter_handle, no_io,
-                         prefix_extractor);
+      GetFilterPartition(context, nullptr /* prefetch_buffer */, filter_handle,
+                         no_io, prefix_extractor);
   if (UNLIKELY(!filter_partition.GetValue())) {
     return true;
   }
@@ -188,8 +188,8 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
 
 bool PartitionedFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* prefix_extractor,
-    uint64_t block_offset, const bool no_io,
-    const Slice* const const_ikey_ptr) {
+    uint64_t block_offset, const bool no_io, const Slice* const const_ikey_ptr,
+    BlockCacheLookupContext* context) {
 #ifdef NDEBUG
   (void)block_offset;
 #endif
@@ -206,8 +206,8 @@ bool PartitionedFilterBlockReader::PrefixMayMatch(
     return false;
   }
   auto filter_partition =
-      GetFilterPartition(nullptr /* prefetch_buffer */, filter_handle, no_io,
-                         prefix_extractor);
+      GetFilterPartition(context, nullptr /* prefetch_buffer */, filter_handle,
+                         no_io, prefix_extractor);
   if (UNLIKELY(!filter_partition.GetValue())) {
     return true;
   }
@@ -233,8 +233,9 @@ BlockHandle PartitionedFilterBlockReader::GetFilterPartitionHandle(
 
 CachableEntry<FilterBlockReader>
 PartitionedFilterBlockReader::GetFilterPartition(
-    FilePrefetchBuffer* prefetch_buffer, BlockHandle& fltr_blk_handle,
-    const bool no_io, const SliceTransform* prefix_extractor) {
+    BlockCacheLookupContext* context, FilePrefetchBuffer* prefetch_buffer,
+    BlockHandle& fltr_blk_handle, const bool no_io,
+    const SliceTransform* prefix_extractor) {
   const bool is_a_filter_partition = true;
   auto block_cache = table_->rep_->table_options.block_cache.get();
   if (LIKELY(block_cache != nullptr)) {
@@ -252,9 +253,8 @@ PartitionedFilterBlockReader::GetFilterPartition(
           nullptr /* cache_handle */, false /* own_value */};
       }
     }
-    // TODO(haoyu).
-    return table_->GetFilter(nullptr, /*prefetch_buffer*/ nullptr, fltr_blk_handle,
-                             is_a_filter_partition, no_io,
+    return table_->GetFilter(context, /*prefetch_buffer*/ nullptr,
+                             fltr_blk_handle, is_a_filter_partition, no_io,
                              /* get_context */ nullptr, prefix_extractor);
   } else {
     auto filter = table_->ReadFilter(prefetch_buffer, fltr_blk_handle,
@@ -279,6 +279,7 @@ size_t PartitionedFilterBlockReader::ApproximateMemoryUsage() const {
 void PartitionedFilterBlockReader::CacheDependencies(
     bool pin, const SliceTransform* prefix_extractor) {
   // Before read partitions, prefetch them to avoid lots of IOs
+  BlockCacheLookupContext context{BlockCacheLookupCaller::kPrefetch};
   IndexBlockIter biter;
   Statistics* kNullStats = nullptr;
   idx_on_fltr_blk_->NewIterator<IndexBlockIter>(
@@ -308,9 +309,8 @@ void PartitionedFilterBlockReader::CacheDependencies(
     handle = biter.value();
     const bool no_io = true;
     const bool is_a_filter_partition = true;
-    // TODO(haoyu).
-    auto filter = table_->GetFilter(nullptr,
-        prefetch_buffer.get(), handle, is_a_filter_partition, !no_io,
+    auto filter = table_->GetFilter(
+        &context, prefetch_buffer.get(), handle, is_a_filter_partition, !no_io,
         /* get_context */ nullptr, prefix_extractor);
     if (LIKELY(filter.IsCached())) {
       if (pin) {

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -80,21 +80,25 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   virtual ~PartitionedFilterBlockReader();
 
   virtual bool IsBlockBased() override { return false; }
-  virtual bool KeyMayMatch(
-      const Slice& key, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+  virtual bool KeyMayMatch(const Slice& key,
+                           const SliceTransform* prefix_extractor,
+                           uint64_t block_offset = kNotValid,
+                           const bool no_io = false,
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) override;
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
  private:
   BlockHandle GetFilterPartitionHandle(const Slice& entry);
   CachableEntry<FilterBlockReader> GetFilterPartition(
-      FilePrefetchBuffer* prefetch_buffer, BlockHandle& handle,
-      const bool no_io, const SliceTransform* prefix_extractor = nullptr);
+      BlockCacheLookupContext* context, FilePrefetchBuffer* prefetch_buffer,
+      BlockHandle& handle, const bool no_io,
+      const SliceTransform* prefix_extractor = nullptr);
   virtual void CacheDependencies(
       bool bin, const SliceTransform* prefix_extractor) override;
 

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -29,9 +29,9 @@ class MockedBlockBasedTable : public BlockBasedTable {
   }
 
   CachableEntry<FilterBlockReader> GetFilter(
-      BlockCacheLookupContext *,
-      FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
-      const bool /* unused */, bool /* unused */, GetContext* /* unused */,
+      BlockCacheLookupContext*, FilePrefetchBuffer*,
+      const BlockHandle& filter_blk_handle, const bool /* unused */,
+      bool /* unused */, GetContext* /* unused */,
       const SliceTransform* prefix_extractor) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -29,6 +29,7 @@ class MockedBlockBasedTable : public BlockBasedTable {
   }
 
   CachableEntry<FilterBlockReader> GetFilter(
+      BlockCacheLookupContext *,
       FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
       const bool /* unused */, bool /* unused */, GetContext* /* unused */,
       const SliceTransform* prefix_extractor) const override {

--- a/table/cuckoo/cuckoo_table_reader.h
+++ b/table/cuckoo/cuckoo_table_reader.h
@@ -56,7 +56,10 @@ class CuckooTableReader: public TableReader {
   size_t ApproximateMemoryUsage() const override;
 
   // Following methods are not implemented for Cuckoo Table Reader
-  uint64_t ApproximateOffsetOf(const Slice& /*key*/) override { return 0; }
+  uint64_t ApproximateOffsetOf(const Slice& /*key*/,
+                               bool /*for_compaction*/ = false) override {
+    return 0;
+  }
   void SetupForCompaction() override {}
   // End of methods not implemented.
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -50,7 +50,10 @@ class MockTableReader : public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
-  uint64_t ApproximateOffsetOf(const Slice& /*key*/) override { return 0; }
+  uint64_t ApproximateOffsetOf(const Slice& /*key*/,
+                               bool /*for_compaction*/ = false) override {
+    return 0;
+  }
 
   virtual size_t ApproximateMemoryUsage() const override { return 0; }
 

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -613,7 +613,8 @@ Status PlainTableReader::Get(const ReadOptions& /*ro*/, const Slice& target,
   return Status::OK();
 }
 
-uint64_t PlainTableReader::ApproximateOffsetOf(const Slice& /*key*/) {
+uint64_t PlainTableReader::ApproximateOffsetOf(const Slice& /*key*/,
+                                               bool /*for_compaction*/) {
   return 0;
 }
 

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -89,7 +89,8 @@ class PlainTableReader: public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
-  uint64_t ApproximateOffsetOf(const Slice& key) override;
+  uint64_t ApproximateOffsetOf(const Slice& key,
+                               bool for_compaction = false) override;
 
   uint32_t GetIndexSize() const { return index_.GetIndexSize(); }
   void SetupForCompaction() override;

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -61,7 +61,8 @@ class TableReader {
   // bytes, and so includes effects like compression of the underlying data.
   // E.g., the approximate offset of the last key in the table will
   // be close to the file length.
-  virtual uint64_t ApproximateOffsetOf(const Slice& key) = 0;
+  virtual uint64_t ApproximateOffsetOf(const Slice& key,
+                                       bool for_compaction = false) = 0;
 
   // Set up the table for Compaction. Might change some parameters with
   // posix_fadvise


### PR DESCRIPTION
Added three structures: BlockCacheLookupCaller,  BlockType, and BlockCacheLookupContext. 
1. A caller could be one of the following: kUserGet, kUserMGet, kUserIterator, kUserApproximateSize, kPrefetch, and kCompaction. 
2. A block type could be: kIndexBlock, kFilterBlock, kDataBlock, kUncompressionDictBlock, and kRangeDeletionBlock. 
3. BlockCacheLookupContext only contains the caller for now. 

We will trace block accesses at five places:
1. BlockBasedTable::GetFilter.
2. BlockBasedTable::GetUncompressedDict.
3. BlockBasedTable::MaybeReadAndLoadToCache. (To trace access on data, index, and range deletion block.)
4. BlockBasedTable::Get. (To trace the referenced key and whether the referenced key exists in a fetched data block.)
5. BlockBasedTable::MultiGet. (To trace the referenced key and whether the referenced key exists in a fetched data block.)

We create the context at: 
1. BlockBasedTable::Get. (kUserGet)
2. BlockBasedTable::MultiGet. (kUserMGet)
3. BlockBasedTable::NewIterator. (either kUserIterator, kCompaction, or external SST ingestion calls this function.)
4. BlockBasedTable::Open. (kPrefetch)
5. Index/Filter::CacheDependencies. (kPrefetch)
6. BlockBasedTable::ApproximateOffsetOf. (kCompaction or kUserApproximateSize).

TODOs. 
1. Create a caller for external SST file ingestion and differentiate the callers for iterator. 
2. Add tracer to trace block cache accesses.

cc: @ltamasi 
