### PR TITLE
WritePrepared: reduce prepared_mutex_ overhead

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -365,6 +365,10 @@ class DBImpl : public DB {
     }
   }
 
+  void SetLastSequence(SequenceNumber seq) const {
+    versions_->SetLastSequence(seq);
+  }
+
   // REQUIRES: joined the main write queue if two_write_queues is disabled, and
   // the second write queue otherwise.
   virtual void SetLastPublishedSequence(SequenceNumber seq);

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -365,10 +365,6 @@ class DBImpl : public DB {
     }
   }
 
-  void SetLastSequence(SequenceNumber seq) const {
-    versions_->SetLastSequence(seq);
-  }
-
   // REQUIRES: joined the main write queue if two_write_queues is disabled, and
   // the second write queue otherwise.
   virtual void SetLastPublishedSequence(SequenceNumber seq);

--- a/db/pre_release_callback.h
+++ b/db/pre_release_callback.h
@@ -27,8 +27,12 @@ class PreReleaseCallback {
   // is_mem_disabled is currently used for debugging purposes to assert that
   // the callback is done from the right write queue.
   // If non-zero, log_number indicates the WAL log to which we wrote.
+  // index >= 0 specifies the order of callback in the same write thread.
+  // total > index specifies the total number of callbacks in the same write
+  // thread. Together with index, could be used to reduce the redundant
+  // operations among the callbacks.
   virtual Status Callback(SequenceNumber seq, bool is_mem_disabled,
-                          uint64_t log_number) = 0;
+                          uint64_t log_number, size_t index, size_t total) = 0;
 };
 
 }  //  namespace rocksdb

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -304,7 +304,8 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                     PublishSeqCallback(DBImpl* db_impl_in)
                         : db_impl_(db_impl_in) {}
                     Status Callback(SequenceNumber last_seq, bool /*not used*/,
-                                    uint64_t) override {
+                                    uint64_t, size_t /*index*/,
+                                    size_t /*total*/) override {
                       db_impl_->SetLastPublishedSequence(last_seq);
                       return Status::OK();
                     }

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -231,7 +231,8 @@ Status WriteCommittedTxn::PrepareInternal() {
       (void)two_write_queues_;  // to silence unused private field warning
     }
     virtual Status Callback(SequenceNumber, bool is_mem_disabled,
-                            uint64_t log_number) override {
+                            uint64_t log_number, size_t /*index*/,
+                            size_t /*total*/) override {
 #ifdef NDEBUG
       (void)is_mem_disabled;
 #endif

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -55,25 +55,17 @@ TEST(PreparedHeap, BasicsTest) {
   heap.push(34l);
   // Test that old min is still on top
   ASSERT_EQ(14l, heap.top());
-  heap.push(13l);
-  // Test that the new min will be on top
-  ASSERT_EQ(13l, heap.top());
-  // Test that it is persistent
-  ASSERT_EQ(13l, heap.top());
   heap.push(44l);
   heap.push(54l);
   heap.push(64l);
   heap.push(74l);
   heap.push(84l);
   // Test that old min is still on top
-  ASSERT_EQ(13l, heap.top());
+  ASSERT_EQ(14l, heap.top());
   heap.erase(24l);
   // Test that old min is still on top
-  ASSERT_EQ(13l, heap.top());
+  ASSERT_EQ(14l, heap.top());
   heap.erase(14l);
-  // Test that old min is still on top
-  ASSERT_EQ(13l, heap.top());
-  heap.erase(13l);
   // Test that the new comes to the top after multiple erase
   ASSERT_EQ(34l, heap.top());
   heap.erase(34l);
@@ -1110,8 +1102,7 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasicTest) {
   }
   // This updates the max value and also set old prepared
   SequenceNumber init_max = 100;
-  const bool kPreparedMutexLocked = true;
-  wp_db->AdvanceMaxEvictedSeq(zero_max, init_max, !kPreparedMutexLocked);
+  wp_db->AdvanceMaxEvictedSeq(zero_max, init_max);
   const std::vector<SequenceNumber> initial_snapshots = {20, 40};
   wp_db->SetDBSnapshots(initial_snapshots);
   // This will update the internal cache of snapshots from the DB
@@ -1121,7 +1112,7 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasicTest) {
   const std::vector<SequenceNumber> latest_snapshots = {20, 110, 220, 300};
   wp_db->SetDBSnapshots(latest_snapshots);
   SequenceNumber new_max = 200;
-  wp_db->AdvanceMaxEvictedSeq(init_max, new_max, !kPreparedMutexLocked);
+  wp_db->AdvanceMaxEvictedSeq(init_max, new_max);
 
   // 3. Verify that the state matches with AdvanceMaxEvictedSeq contract
   // a. max should be updated to new_max
@@ -1753,9 +1744,8 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   ASSERT_TRUE(released);
 
   // This make the snapshot release to reflect in txn db structures
-  const bool kPreparedMutexLocked = true;
   wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_,
-                              wp_db->max_evicted_seq_ + 1, !kPreparedMutexLocked);
+                              wp_db->max_evicted_seq_ + 1);
 
   released = false;
   // Released snapshot lower than max
@@ -3003,13 +2993,13 @@ TEST_P(WritePreparedTransactionTest, AddPreparedBeforeMax) {
   ASSERT_OK(txn->Put(Slice("key0"), uncommitted_value));
   port::Mutex txn_mutex_;
 
-  // t1) Insert prepared entry, t2) commit other entires to advance max
-  // evicted sec and finish checking the existing prepared entires, t1)
+  // t1) Insert prepared entry, t2) commit other entries to advance max
+  // evicted sec and finish checking the existing prepared entries, t1)
   // AddPrepared, t2) update max_evicted_seq_
   rocksdb::SyncPoint::GetInstance()->LoadDependency({
-      {"AddPrepared::begin:pause", "AddPreparedBeforeMax::read_thread:start"},
-      {"AdvanceMaxEvictedSeq::update_max:pause", "AddPrepared::begin:resume"},
-      {"AddPrepared::end", "AdvanceMaxEvictedSeq::update_max:resume"},
+      {"AddPreparedCallback::AddPrepared::begin:pause", "AddPreparedBeforeMax::read_thread:start"},
+      {"AdvanceMaxEvictedSeq::update_max:pause", "AddPreparedCallback::AddPrepared::begin:resume"},
+      {"AddPreparedCallback::AddPrepared::end", "AdvanceMaxEvictedSeq::update_max:resume"},
   });
   SyncPoint::GetInstance()->EnableProcessing();
 
@@ -3063,20 +3053,31 @@ TEST_P(WritePreparedTransactionTest, CommitOfDelayedPrepared) {
       ReOpen();
       std::atomic<const Snapshot*> snap = {nullptr};
       std::atomic<SequenceNumber> exp_prepare = {0};
+      std::atomic<bool> finished = {false};
       // Value is synchronized via snap
       PinnableSlice value;
       // Take a snapshot after publish and before RemovePrepared:Start
+      auto snap_callback = [&]() {
+            ASSERT_EQ(nullptr, snap.load());
+            snap.store(db->GetSnapshot());
+            ReadOptions roptions;
+            roptions.snapshot = snap.load();
+            auto s =
+                db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
+            ASSERT_OK(s);
+            finished.store(true);
+      };
       auto callback = [&](void* param) {
         SequenceNumber prep_seq = *((SequenceNumber*)param);
         if (prep_seq == exp_prepare.load()) {  // only for write_thread
-          ASSERT_EQ(nullptr, snap.load());
-          snap.store(db->GetSnapshot());
-          ReadOptions roptions;
-          roptions.snapshot = snap.load();
-          auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
-          ASSERT_OK(s);
+          auto t = rocksdb::port::Thread(snap_callback);
+          t.detach();
+          TEST_SYNC_POINT("callback:end");
         }
       };
+      rocksdb::SyncPoint::GetInstance()->LoadDependency({
+          {"WritePreparedTxnDB::GetSnapshotInternal:first", "callback:end"},
+      });
       SyncPoint::GetInstance()->SetCallBack("RemovePrepared:Start", callback);
       SyncPoint::GetInstance()->EnableProcessing();
       // Thread to cause frequent evictions
@@ -3100,9 +3101,14 @@ TEST_P(WritePreparedTransactionTest, CommitOfDelayedPrepared) {
           // Let an eviction to kick in
           std::this_thread::yield();
 
+          finished.store(false);
           exp_prepare.store(txn->GetId());
           ASSERT_OK(txn->Commit());
           delete txn;
+          TEST_SYNC_POINT("writh_thread:commit:after");
+          while (!finished) {
+            std::this_thread::yield();
+          }
 
           // Read with the snapshot taken before delayed_prepared_ cleanup
           ReadOptions roptions;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1110,7 +1110,8 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasicTest) {
   }
   // This updates the max value and also set old prepared
   SequenceNumber init_max = 100;
-  wp_db->AdvanceMaxEvictedSeq(zero_max, init_max);
+  const bool kPreparedMutexLocked = true;
+  wp_db->AdvanceMaxEvictedSeq(zero_max, init_max, !kPreparedMutexLocked);
   const std::vector<SequenceNumber> initial_snapshots = {20, 40};
   wp_db->SetDBSnapshots(initial_snapshots);
   // This will update the internal cache of snapshots from the DB
@@ -1120,7 +1121,7 @@ TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasicTest) {
   const std::vector<SequenceNumber> latest_snapshots = {20, 110, 220, 300};
   wp_db->SetDBSnapshots(latest_snapshots);
   SequenceNumber new_max = 200;
-  wp_db->AdvanceMaxEvictedSeq(init_max, new_max);
+  wp_db->AdvanceMaxEvictedSeq(init_max, new_max, !kPreparedMutexLocked);
 
   // 3. Verify that the state matches with AdvanceMaxEvictedSeq contract
   // a. max should be updated to new_max
@@ -1752,8 +1753,9 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
   ASSERT_TRUE(released);
 
   // This make the snapshot release to reflect in txn db structures
+  const bool kPreparedMutexLocked = true;
   wp_db->AdvanceMaxEvictedSeq(wp_db->max_evicted_seq_,
-                              wp_db->max_evicted_seq_ + 1);
+                              wp_db->max_evicted_seq_ + 1, !kPreparedMutexLocked);
 
   released = false;
   // Released snapshot lower than max

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -7,9 +7,9 @@
 
 #include "utilities/transactions/transaction_test.h"
 
-#include <cinttypes>
 #include <algorithm>
 #include <atomic>
+#include <cinttypes>
 #include <functional>
 #include <string>
 #include <thread>
@@ -2997,9 +2997,12 @@ TEST_P(WritePreparedTransactionTest, AddPreparedBeforeMax) {
   // evicted sec and finish checking the existing prepared entries, t1)
   // AddPrepared, t2) update max_evicted_seq_
   rocksdb::SyncPoint::GetInstance()->LoadDependency({
-      {"AddPreparedCallback::AddPrepared::begin:pause", "AddPreparedBeforeMax::read_thread:start"},
-      {"AdvanceMaxEvictedSeq::update_max:pause", "AddPreparedCallback::AddPrepared::begin:resume"},
-      {"AddPreparedCallback::AddPrepared::end", "AdvanceMaxEvictedSeq::update_max:resume"},
+      {"AddPreparedCallback::AddPrepared::begin:pause",
+       "AddPreparedBeforeMax::read_thread:start"},
+      {"AdvanceMaxEvictedSeq::update_max:pause",
+       "AddPreparedCallback::AddPrepared::begin:resume"},
+      {"AddPreparedCallback::AddPrepared::end",
+       "AdvanceMaxEvictedSeq::update_max:resume"},
   });
   SyncPoint::GetInstance()->EnableProcessing();
 
@@ -3058,14 +3061,13 @@ TEST_P(WritePreparedTransactionTest, CommitOfDelayedPrepared) {
       PinnableSlice value;
       // Take a snapshot after publish and before RemovePrepared:Start
       auto snap_callback = [&]() {
-            ASSERT_EQ(nullptr, snap.load());
-            snap.store(db->GetSnapshot());
-            ReadOptions roptions;
-            roptions.snapshot = snap.load();
-            auto s =
-                db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
-            ASSERT_OK(s);
-            snapshot_taken.store(true);
+        ASSERT_EQ(nullptr, snap.load());
+        snap.store(db->GetSnapshot());
+        ReadOptions roptions;
+        roptions.snapshot = snap.load();
+        auto s = db->Get(roptions, db->DefaultColumnFamily(), "key", &value);
+        ASSERT_OK(s);
+        snapshot_taken.store(true);
       };
       auto callback = [&](void* param) {
         SequenceNumber prep_seq = *((SequenceNumber*)param);

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -170,13 +170,13 @@ Status WritePreparedTxn::CommitInternal() {
   const SequenceNumber commit_batch_seq = seq_used;
   if (LIKELY(do_one_write || !s.ok())) {
     if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues && s.ok())) {
-      // Note RemovePrepared should be called after WriteImpl that publishsed
+      // Note: RemovePrepared should be called after WriteImpl that publishsed
       // the seq. Otherwise SmallestUnCommittedSeq optimization breaks.
       wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
-    }
+    } // else RemovePrepared is called from within PreReleaseCallback
     if (UNLIKELY(!do_one_write)) {
       assert(!s.ok());
-      // TODO(myabandeh): AddPrepared for this seems to be missing
+      // Cleanup the prepared entry we added with add_prepared_callback
       wpt_db_->RemovePrepared(commit_batch_seq, commit_batch_cnt);
     }
     return s;
@@ -201,13 +201,14 @@ Status WritePreparedTxn::CommitInternal() {
                           NO_REF_LOG, DISABLE_MEMTABLE, &seq_used, ONE_BATCH,
                           &update_commit_map_with_aux_batch);
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
-  if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues && s.ok())) {
-    // Note RemovePrepared should be called after WriteImpl that publishsed the
-    // seq. Otherwise SmallestUnCommittedSeq optimization breaks.
-    wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
-    // TODO(myabandeh): AddPrepared for this seems to be missing
+  if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues)) {
+    if (s.ok()) {
+      // Note: RemovePrepared should be called after WriteImpl that publishsed
+      // the seq. Otherwise SmallestUnCommittedSeq optimization breaks.
+      wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
+    }
     wpt_db_->RemovePrepared(commit_batch_seq, commit_batch_cnt);
-  }
+  }  // else RemovePrepared is called from within PreReleaseCallback
   return s;
 }
 
@@ -376,10 +377,12 @@ Status WritePreparedTxn::RollbackInternal() {
   ROCKS_LOG_DETAILS(db_impl_->immutable_db_options().info_log,
                     "RollbackInternal (status=%s) commit: %" PRIu64,
                     s.ToString().c_str(), GetId());
+  // TODO(lth): For WriteUnPrepared that rollback is called frequently,
+  // RemovePrepared could be moved to the callback to reduce lock contention.
   if (s.ok()) {
     wpt_db_->RemovePrepared(GetId(), prepare_batch_cnt_);
   }
-  // TODO(myabandeh): AddPrepared for this seems to be missing
+  // Note: RemovePrepared for prepared batch is called from within PreReleaseCallback
   wpt_db_->RemovePrepared(rollback_seq, ONE_BATCH);
 
   return s;

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -169,11 +169,12 @@ Status WritePreparedTxn::CommitInternal() {
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
   const SequenceNumber commit_batch_seq = seq_used;
   if (LIKELY(do_one_write || !s.ok())) {
-    if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues && s.ok())) {
+    if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues &&
+                 s.ok())) {
       // Note: RemovePrepared should be called after WriteImpl that publishsed
       // the seq. Otherwise SmallestUnCommittedSeq optimization breaks.
       wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
-    } // else RemovePrepared is called from within PreReleaseCallback
+    }  // else RemovePrepared is called from within PreReleaseCallback
     if (UNLIKELY(!do_one_write)) {
       assert(!s.ok());
       // Cleanup the prepared entry we added with add_prepared_callback
@@ -382,7 +383,8 @@ Status WritePreparedTxn::RollbackInternal() {
   if (s.ok()) {
     wpt_db_->RemovePrepared(GetId(), prepare_batch_cnt_);
   }
-  // Note: RemovePrepared for prepared batch is called from within PreReleaseCallback
+  // Note: RemovePrepared for prepared batch is called from within
+  // PreReleaseCallback
   wpt_db_->RemovePrepared(rollback_seq, ONE_BATCH);
 
   return s;

--- a/utilities/transactions/write_prepared_txn.cc
+++ b/utilities/transactions/write_prepared_txn.cc
@@ -169,12 +169,14 @@ Status WritePreparedTxn::CommitInternal() {
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
   const SequenceNumber commit_batch_seq = seq_used;
   if (LIKELY(do_one_write || !s.ok())) {
-    if (LIKELY(s.ok())) {
+    if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues && s.ok())) {
       // Note RemovePrepared should be called after WriteImpl that publishsed
       // the seq. Otherwise SmallestUnCommittedSeq optimization breaks.
       wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
     }
     if (UNLIKELY(!do_one_write)) {
+      assert(!s.ok());
+      // TODO(myabandeh): AddPrepared for this seems to be missing
       wpt_db_->RemovePrepared(commit_batch_seq, commit_batch_cnt);
     }
     return s;
@@ -199,10 +201,13 @@ Status WritePreparedTxn::CommitInternal() {
                           NO_REF_LOG, DISABLE_MEMTABLE, &seq_used, ONE_BATCH,
                           &update_commit_map_with_aux_batch);
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
-  // Note RemovePrepared should be called after WriteImpl that publishsed the
-  // seq. Otherwise SmallestUnCommittedSeq optimization breaks.
-  wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
-  wpt_db_->RemovePrepared(commit_batch_seq, commit_batch_cnt);
+  if (UNLIKELY(!db_impl_->immutable_db_options().two_write_queues && s.ok())) {
+    // Note RemovePrepared should be called after WriteImpl that publishsed the
+    // seq. Otherwise SmallestUnCommittedSeq optimization breaks.
+    wpt_db_->RemovePrepared(prepare_seq, prepare_batch_cnt_);
+    // TODO(myabandeh): AddPrepared for this seems to be missing
+    wpt_db_->RemovePrepared(commit_batch_seq, commit_batch_cnt);
+  }
   return s;
 }
 
@@ -348,6 +353,7 @@ Status WritePreparedTxn::RollbackInternal() {
     return s;
   }
   if (do_one_write) {
+    assert(!db_impl_->immutable_db_options().two_write_queues);
     wpt_db_->RemovePrepared(GetId(), prepare_batch_cnt_);
     return s;
   }  // else do the 2nd write for commit
@@ -373,6 +379,7 @@ Status WritePreparedTxn::RollbackInternal() {
   if (s.ok()) {
     wpt_db_->RemovePrepared(GetId(), prepare_batch_cnt_);
   }
+  // TODO(myabandeh): AddPrepared for this seems to be missing
   wpt_db_->RemovePrepared(rollback_seq, ONE_BATCH);
 
   return s;

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -61,8 +61,8 @@ Status WritePreparedTxnDB::Initialize(
     explicit CommitSubBatchPreReleaseCallback(WritePreparedTxnDB* db)
         : db_(db) {}
     Status Callback(SequenceNumber commit_seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(!is_mem_disabled);
       db_->AddCommitted(commit_seq, commit_seq);
       return Status::OK();

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -408,7 +408,7 @@ void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max,
       prepared_txns_.push_pop_mutex()->Unlock();
     }
     WriteLock wl(&prepared_mutex_);
-    // Need to fetch feresh values of ::top after mutex is acquired
+    // Need to fetch fresh values of ::top after mutex is acquired
     while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
       auto to_be_popped = prepared_txns_.top();
       delayed_prepared_.insert(to_be_popped);

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -7,8 +7,8 @@
 
 #include "utilities/transactions/write_prepared_txn_db.h"
 
-#include <cinttypes>
 #include <algorithm>
+#include <cinttypes>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -387,7 +387,8 @@ void WritePreparedTxnDB::Init(const TransactionDBOptions& /* unused */) {
       new std::atomic<CommitEntry64b>[COMMIT_CACHE_SIZE] {});
 }
 
-void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max, bool locked) {
+void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max,
+                                                 bool locked) {
   // When max_evicted_seq_ advances, move older entries from prepared_txns_
   // to delayed_prepared_. This guarantees that if a seq is lower than max,
   // then it is not in prepared_txns_ and save an expensive, synchronized

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -778,7 +778,8 @@ class AddPreparedCallback : public PreReleaseCallback {
   }
   virtual Status Callback(SequenceNumber prepare_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t log_number) override {
+                          uint64_t log_number, size_t /*index*/,
+                          size_t /*total*/) override {
     // Always Prepare from the main queue
     assert(!two_write_queues_ || !is_mem_disabled);  // implies the 1st queue
     for (size_t i = 0; i < sub_batch_cnt_; i++) {
@@ -826,7 +827,8 @@ class WritePreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t) override {
+                          uint64_t, size_t /*index*/,
+                          size_t /*total*/) override {
     // Always commit from the 2nd queue
     assert(!db_impl_->immutable_db_options().two_write_queues ||
            is_mem_disabled);
@@ -907,8 +909,8 @@ class WritePreparedRollbackPreReleaseCallback : public PreReleaseCallback {
     assert(prep_batch_cnt_ > 0);
   }
 
-  Status Callback(SequenceNumber commit_seq, bool is_mem_disabled,
-                  uint64_t) override {
+  Status Callback(SequenceNumber commit_seq, bool is_mem_disabled, uint64_t,
+                  size_t /*index*/, size_t /*total*/) override {
     // Always commit from the 2nd queue
     assert(is_mem_disabled);  // implies the 2nd queue
     assert(db_impl_->immutable_db_options().two_write_queues);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -815,7 +815,7 @@ class AddPreparedCallback : public PreReleaseCallback {
                           uint64_t log_number, size_t index,
                           size_t total) override {
     assert(index < total);
-    // To reduce lock intention with the conccurrent prepare requests, lock on
+    // To reduce lock intention with the concurrent prepare requests, lock on
     // the first callback and unlock on the last.
     const bool do_lock = !two_write_queues_ || index == 0;
     const bool do_unlock = !two_write_queues_ || index + 1 == total;

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -815,8 +815,8 @@ class AddPreparedCallback : public PreReleaseCallback {
                           uint64_t log_number, size_t index,
                           size_t total) override {
     assert(index < total);
-    // To reduce lock intention with the concurrent prepare requests, lock on
-    // the first callback and unlock on the last.
+    // To reduce the cost of lock acquisition competing with the concurrent
+    // prepare requests, lock on the first callback and unlock on the last.
     const bool do_lock = !two_write_queues_ || index == 0;
     const bool do_unlock = !two_write_queues_ || index + 1 == total;
     // Always Prepare from the main queue

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -530,13 +530,11 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     }
     port::Mutex* push_pop_mutex() { return &push_pop_mutex_; }
 
-    inline bool empty(){return top() == kMaxSequenceNumber;}
+    inline bool empty() { return top() == kMaxSequenceNumber; }
     // Returns kMaxSequenceNumber if empty() and the smallest otherwise.
-    inline uint64_t top() {
-      return heap_top_.load(std::memory_order_acquire);
-    }
-    inline void push(uint64_t v) { 
-      heap_.push(v); 
+    inline uint64_t top() { return heap_top_.load(std::memory_order_acquire); }
+    inline void push(uint64_t v) {
+      heap_.push(v);
       heap_top_.store(heap_.top(), std::memory_order_release);
     }
     void pop(bool locked = false) {
@@ -561,7 +559,8 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       while (heap_.empty() && !erased_heap_.empty()) {
         erased_heap_.pop();
       }
-      heap_top_.store(!heap_.empty() ? heap_.top() : kMaxSequenceNumber, std::memory_order_release);
+      heap_top_.store(!heap_.empty() ? heap_.top() : kMaxSequenceNumber,
+                      std::memory_order_release);
       if (!locked) {
         push_pop_mutex()->Unlock();
       }
@@ -637,8 +636,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       // that latest value in the memtable.
       return db_impl_->GetLatestSequenceNumber() + 1;
     } else {
-      return std::min(min_prep,
-                      db_impl_->GetLatestSequenceNumber() + 1);
+      return std::min(min_prep, db_impl_->GetLatestSequenceNumber() + 1);
     }
   }
   // Enhance the snapshot object by recording in it the smallest uncommitted seq

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -319,8 +319,8 @@ Status WriteUnpreparedTxn::CommitInternal() {
     explicit PublishSeqPreReleaseCallback(DBImpl* db_impl)
         : db_impl_(db_impl) {}
     Status Callback(SequenceNumber seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(is_mem_disabled);
       assert(db_impl_->immutable_db_options().two_write_queues);
       db_impl_->SetLastPublishedSequence(seq);

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -185,8 +185,8 @@ Status WriteUnpreparedTxnDB::Initialize(
     explicit CommitSubBatchPreReleaseCallback(WritePreparedTxnDB* db)
         : db_(db) {}
     Status Callback(SequenceNumber commit_seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(!is_mem_disabled);
       db_->AddCommitted(commit_seq, commit_seq);
       return Status::OK();

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -291,7 +291,8 @@ Status WriteUnpreparedTxnDB::Initialize(
 
   SequenceNumber prev_max = max_evicted_seq_;
   SequenceNumber last_seq = db_impl_->GetLatestSequenceNumber();
-  AdvanceMaxEvictedSeq(prev_max, last_seq);
+  const bool kPreparedMutexLocked = true;
+  AdvanceMaxEvictedSeq(prev_max, last_seq, !kPreparedMutexLocked);
   // Create a gap between max and the next snapshot. This simplifies the logic
   // in IsInSnapshot by not having to consider the special case of max ==
   // snapshot after recovery. This is tested in IsInSnapshotEmptyMapTest.

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -291,8 +291,7 @@ Status WriteUnpreparedTxnDB::Initialize(
 
   SequenceNumber prev_max = max_evicted_seq_;
   SequenceNumber last_seq = db_impl_->GetLatestSequenceNumber();
-  const bool kPreparedMutexLocked = true;
-  AdvanceMaxEvictedSeq(prev_max, last_seq, !kPreparedMutexLocked);
+  AdvanceMaxEvictedSeq(prev_max, last_seq);
   // Create a gap between max and the next snapshot. This simplifies the logic
   // in IsInSnapshot by not having to consider the special case of max ==
   // snapshot after recovery. This is tested in IsInSnapshotEmptyMapTest.

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -57,7 +57,8 @@ class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t) override {
+                          uint64_t, size_t /*index*/,
+                          size_t /*total*/) override {
     const uint64_t last_commit_seq = LIKELY(data_batch_cnt_ <= 1)
                                          ? commit_seq
                                          : commit_seq + data_batch_cnt_ - 1;
@@ -121,7 +122,8 @@ class WriteUnpreparedRollbackPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t) override {
+                          uint64_t, size_t /*index*/,
+                          size_t /*total*/) override {
     assert(is_mem_disabled);  // implies the 2nd queue
     const uint64_t last_commit_seq = commit_seq;
     db_->AddCommitted(rollback_seq_, last_commit_seq);


### PR DESCRIPTION
The patch reduces the contention over prepared_mutex_ using these techniques:
1) Move ::RemovePrepared() to be called from the commit callback when we have two write queues.
2) Use two separate mutex for PreparedHeap, one prepared_mutex_ needed for ::RemovePrepared, and one ::push_pop_mutex() needed for ::AddPrepared(). Given that we call ::AddPrepared only from the first write queue and ::RemovePrepared mostly from the 2nd, this will result into each the two write queues not competing with each other over a single mutex. ::RemovePrepared might occasionally need to acquire ::push_pop_mutex() if ::erase() ends up with calling ::pop()
3) Acquire ::push_pop_mutex() on the first callback of the write queue and release it on the last.