### PR TITLE
Create a BlockCacheLookupContext to enable fine-grained block cache tracing.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 ### Bug Fixes
 * Fix a bug in WAL replay of secondary instance by skipping write batches with older sequence numbers than the current last sequence number.
 * Fix flush's/compaction's merge processing logic which allowed `Put`s covered by range tombstones to reappear. Note `Put`s may exist even if the user only ever called `Merge()` due to an internal conversion during compaction to the bottommost level.
+* Fix/improve memtable earliest sequence assignment and WAL replay so that WAL entries of unflushed column families will not be skipped after replaying the MANIFEST and increasing db sequence due to another flushed/compacted column family.
 
 ## 6.2.0 (4/30/2019)
 ### New Features

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -109,13 +109,6 @@ else
   TASK_CREATION_TOOL="false"
 fi
 
-ARTIFACTS=" 'artifacts': [
-    {
-        'name':'database',
-        'paths':[ '/dev/shm/rocksdb' ],
-    }
-]"
-
 #
 # A mechanism to disable tests temporarily
 #
@@ -395,7 +388,6 @@ STRESS_CRASH_TEST_COMMANDS="[
                 $PARSER
             }
         ],
-        $ARTIFACTS,
         $REPORT
     }
 ]"
@@ -424,7 +416,6 @@ STRESS_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
                 $PARSER
             }
         ],
-        $ARTIFACTS,
         $REPORT
     }
 ]"

--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -369,7 +369,7 @@ REPORT_LITE_BINARY_SIZE_COMMANDS="[
 #
 STRESS_CRASH_TEST_COMMANDS="[
     {
-        'name':'Rocksdb Stress/Crash Test',
+        'name':'Rocksdb Stress and Crash Test',
         'oncall':'$ONCALL',
         'timeout': 86400,
         'steps': [
@@ -397,7 +397,7 @@ STRESS_CRASH_TEST_COMMANDS="[
 #
 STRESS_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
-        'name':'Rocksdb Stress/Crash Test (atomic flush)',
+        'name':'Rocksdb Stress and Crash Test with atomic flush',
         'oncall':'$ONCALL',
         'timeout': 86400,
         'steps': [
@@ -489,7 +489,7 @@ ASAN_CRASH_TEST_COMMANDS="[
 #
 ASAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
-        'name':'Rocksdb crash test (atomic flush) under ASAN',
+        'name':'Rocksdb crash test with atomic flush under ASAN',
         'oncall':'$ONCALL',
         'timeout': 86400,
         'steps': [
@@ -553,7 +553,7 @@ UBSAN_CRASH_TEST_COMMANDS="[
 #
 UBSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
-        'name':'Rocksdb crash test (atomic flush) under UBSAN',
+        'name':'Rocksdb crash test with atomic flush under UBSAN',
         'oncall':'$ONCALL',
         'timeout': 86400,
         'steps': [

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -520,7 +520,8 @@ void CompactionJob::GenSubcompactionBoundaries() {
     // to the index block and may incur I/O cost in the process. Unlock db
     // mutex to reduce contention
     db_mutex_->Unlock();
-    uint64_t size = versions_->ApproximateSize(v, a, b, start_lvl, out_lvl + 1);
+    uint64_t size = versions_->ApproximateSize(v, a, b, start_lvl, out_lvl + 1,
+                                               /*for_compaction*/ true);
     db_mutex_->Lock();
     ranges.emplace_back(a, b, size);
     sum += size;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2717,7 +2717,9 @@ void DBImpl::GetApproximateSizes(ColumnFamilyHandle* column_family,
     InternalKey k2(range[i].limit, kMaxSequenceNumber, kValueTypeForSeek);
     sizes[i] = 0;
     if (include_flags & DB::SizeApproximationFlags::INCLUDE_FILES) {
-      sizes[i] += versions_->ApproximateSize(v, k1.Encode(), k2.Encode());
+      sizes[i] += versions_->ApproximateSize(
+          v, k1.Encode(), k2.Encode(), /*start_level=*/0, /*end_level=*/-1,
+          /*for_compaction=*/false);
     }
     if (include_flags & DB::SizeApproximationFlags::INCLUDE_MEMTABLES) {
       sizes[i] += sv->mem->ApproximateStats(k1.Encode(), k2.Encode()).size;

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -107,6 +107,13 @@ Status DBImpl::SyncClosedLogs(JobContext* job_context) {
       if (!s.ok()) {
         break;
       }
+
+      if (immutable_db_options_.recycle_log_file_num > 0) {
+        s = log->Close();
+        if (!s.ok()) {
+          break;
+        }
+      }
     }
     if (s.ok()) {
       s = directories_.GetWalDir()->Fsync();

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -555,12 +555,13 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
   bool stop_replay_for_corruption = false;
   bool flushed = false;
   uint64_t corrupted_log_number = kMaxSequenceNumber;
+  uint64_t min_log_number = MinLogNumberToKeep();
   for (auto log_number : log_numbers) {
-    if (log_number < versions_->min_log_number_to_keep_2pc()) {
+    if (log_number < min_log_number) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Skipping log #%" PRIu64
                      " since it is older than min log to keep #%" PRIu64,
-                     log_number, versions_->min_log_number_to_keep_2pc());
+                     log_number, min_log_number);
       continue;
     }
     // The previous incarnation may not have written any MANIFEST

--- a/db/db_impl/db_secondary_test.cc
+++ b/db/db_impl/db_secondary_test.cc
@@ -576,6 +576,11 @@ TEST_F(DBSecondaryTest, SwitchWAL) {
 
 TEST_F(DBSecondaryTest, SwitchWALMultiColumnFamilies) {
   const int kNumKeysPerMemtable = 1;
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({
+      {"DBImpl::BackgroundCallFlush:ContextCleanedUp",
+       "DBSecondaryTest::SwitchWALMultipleColumnFamilies:BeforeCatchUp"}});
+  SyncPoint::GetInstance()->EnableProcessing();
   const std::string kCFName1 = "pikachu";
   Options options;
   options.env = env_;
@@ -629,8 +634,10 @@ TEST_F(DBSecondaryTest, SwitchWALMultiColumnFamilies) {
         Put(0 /*cf*/, "key" + std::to_string(k), "value" + std::to_string(k)));
     ASSERT_OK(
         Put(1 /*cf*/, "key" + std::to_string(k), "value" + std::to_string(k)));
+    TEST_SYNC_POINT("DBSecondaryTest::SwitchWALMultipleColumnFamilies:BeforeCatchUp");
     ASSERT_OK(db_secondary_->TryCatchUpWithPrimary());
     verify_db(dbfull(), handles_, db_secondary_, handles_secondary_);
+    SyncPoint::GetInstance()->ClearTrace();
   }
 }
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -467,6 +467,8 @@ inline bool DBIter::FindNextUserEntryInternal(bool skipping, bool prefix_check) 
 
     is_key_seqnum_zero_ = (ikey_.sequence == 0);
 
+    assert(iterate_upper_bound_ == nullptr || iter_.MayBeOutOfUpperBound() ||
+           user_comparator_.Compare(ikey_.user_key, *iterate_upper_bound_) < 0);
     if (iterate_upper_bound_ != nullptr && iter_.MayBeOutOfUpperBound() &&
         user_comparator_.Compare(ikey_.user_key, *iterate_upper_bound_) >= 0) {
       break;
@@ -859,6 +861,9 @@ void DBIter::PrevInternal() {
       return;
     }
 
+    assert(iterate_lower_bound_ == nullptr || iter_.MayBeOutOfLowerBound() ||
+           user_comparator_.Compare(saved_key_.GetUserKey(),
+                                    *iterate_lower_bound_) >= 0);
     if (iterate_lower_bound_ != nullptr && iter_.MayBeOutOfLowerBound() &&
         user_comparator_.Compare(saved_key_.GetUserKey(),
                                  *iterate_lower_bound_) < 0) {

--- a/db/pre_release_callback.h
+++ b/db/pre_release_callback.h
@@ -27,8 +27,12 @@ class PreReleaseCallback {
   // is_mem_disabled is currently used for debugging purposes to assert that
   // the callback is done from the right write queue.
   // If non-zero, log_number indicates the WAL log to which we wrote.
+  // index >= 0 specifies the order of callback in the same write thread.
+  // total > index specifies the total number of callbacks in the same write
+  // thread. Together with index, could be used to reduce the redundant
+  // operations among the callbacks.
   virtual Status Callback(SequenceNumber seq, bool is_mem_disabled,
-                          uint64_t log_number) = 0;
+                          uint64_t log_number, size_t index, size_t total) = 0;
 };
 
 }  //  namespace rocksdb

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -982,8 +982,7 @@ class VersionSet {
   // in levels [start_level, end_level). If end_level == 0 it will search
   // through all non-empty levels
   uint64_t ApproximateSize(Version* v, const Slice& start, const Slice& end,
-                           int start_level = 0, int end_level = -1,
-                           bool for_compaction = false);
+                           int start_level, int end_level, bool for_compaction);
 
   // Return the size of the current manifest file
   uint64_t manifest_file_size() const { return manifest_file_size_; }
@@ -1034,10 +1033,10 @@ class VersionSet {
   // ApproximateSize helper
   uint64_t ApproximateSizeLevel0(Version* v, const LevelFilesBrief& files_brief,
                                  const Slice& start, const Slice& end,
-                                 bool for_compaction = false);
+                                 bool for_compaction);
 
   uint64_t ApproximateSize(Version* v, const FdWithKeyRange& f,
-                           const Slice& key, bool for_compaction = false);
+                           const Slice& key, bool for_compaction);
 
   // Save current contents to *log
   Status WriteSnapshot(log::Writer* log);

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -982,7 +982,8 @@ class VersionSet {
   // in levels [start_level, end_level). If end_level == 0 it will search
   // through all non-empty levels
   uint64_t ApproximateSize(Version* v, const Slice& start, const Slice& end,
-                           int start_level = 0, int end_level = -1);
+                           int start_level = 0, int end_level = -1,
+                           bool for_compaction = false);
 
   // Return the size of the current manifest file
   uint64_t manifest_file_size() const { return manifest_file_size_; }
@@ -1032,10 +1033,11 @@ class VersionSet {
 
   // ApproximateSize helper
   uint64_t ApproximateSizeLevel0(Version* v, const LevelFilesBrief& files_brief,
-                                 const Slice& start, const Slice& end);
+                                 const Slice& start, const Slice& end,
+                                 bool for_compaction = false);
 
   uint64_t ApproximateSize(Version* v, const FdWithKeyRange& f,
-                           const Slice& key);
+                           const Slice& key, bool for_compaction = false);
 
   // Save current contents to *log
   Status WriteSnapshot(log::Writer* log);

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -304,7 +304,8 @@ TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
                     PublishSeqCallback(DBImpl* db_impl_in)
                         : db_impl_(db_impl_in) {}
                     Status Callback(SequenceNumber last_seq, bool /*not used*/,
-                                    uint64_t) override {
+                                    uint64_t, size_t /*index*/,
+                                    size_t /*total*/) override {
                       db_impl_->SetLastPublishedSequence(last_seq);
                       return Status::OK();
                     }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1123,7 +1123,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
 #endif
     ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
     for (size_t i = 0; i < kNumSectors; ++i) {
-      auto data = NewAligned(kSectorSize * 8, static_cast<const char>(i + 1));
+      auto data = NewAligned(kSectorSize * 8, static_cast<char>(i + 1));
       Slice slice(data.get(), kSectorSize);
       ASSERT_OK(wfile->Append(slice));
     }
@@ -1151,7 +1151,7 @@ TEST_P(EnvPosixTestWithParam, MultiRead) {
     ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
     ASSERT_OK(file->MultiRead(reqs.data(), reqs.size()));
     for (size_t i = 0; i < reqs.size(); ++i) {
-      auto buf = NewAligned(kSectorSize * 8, static_cast<const char>(i*2 + 1));
+      auto buf = NewAligned(kSectorSize * 8, static_cast<char>(i*2 + 1));
       ASSERT_OK(reqs[i].status);
       ASSERT_EQ(memcmp(reqs[i].scratch, buf.get(), kSectorSize), 0);
     }

--- a/table/block_based/block_based_filter_block.cc
+++ b/table/block_based/block_based_filter_block.cc
@@ -187,7 +187,8 @@ BlockBasedFilterBlockReader::BlockBasedFilterBlockReader(
 bool BlockBasedFilterBlockReader::KeyMayMatch(
     const Slice& key, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
   assert(block_offset != kNotValid);
   if (!whole_key_filtering_) {
     return true;
@@ -198,7 +199,8 @@ bool BlockBasedFilterBlockReader::KeyMayMatch(
 bool BlockBasedFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
   assert(block_offset != kNotValid);
   return MayMatch(prefix, block_offset);
 }

--- a/table/block_based/block_based_filter_block.h
+++ b/table/block_based/block_based_filter_block.h
@@ -86,15 +86,14 @@ class BlockBasedFilterBlockReader : public FilterBlockReader {
 
   virtual bool KeyMayMatch(const Slice& key,
                            const SliceTransform* prefix_extractor,
-                           uint64_t block_offset = kNotValid,
-                           const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr,
-                           BlockCacheLookupContext* context = nullptr) override;
-  virtual bool PrefixMayMatch(
-      const Slice& prefix, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr,
-      BlockCacheLookupContext* context = nullptr) override;
+                           uint64_t block_offset, const bool no_io,
+                           const Slice* const const_ikey_ptr,
+                           BlockCacheLookupContext* context) override;
+  virtual bool PrefixMayMatch(const Slice& prefix,
+                              const SliceTransform* prefix_extractor,
+                              uint64_t block_offset, const bool no_io,
+                              const Slice* const const_ikey_ptr,
+                              BlockCacheLookupContext* context) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
   // convert this object to a human readable form

--- a/table/block_based/block_based_filter_block.h
+++ b/table/block_based/block_based_filter_block.h
@@ -82,19 +82,18 @@ class BlockBasedFilterBlockReader : public FilterBlockReader {
                               const BlockBasedTableOptions& table_opt,
                               bool whole_key_filtering,
                               BlockContents&& contents, Statistics* statistics);
-  virtual bool IsBlockBased() override { return true; }
+  bool IsBlockBased() override { return true; }
 
-  virtual bool KeyMayMatch(const Slice& key,
-                           const SliceTransform* prefix_extractor,
-                           uint64_t block_offset, const bool no_io,
-                           const Slice* const const_ikey_ptr,
-                           BlockCacheLookupContext* context) override;
-  virtual bool PrefixMayMatch(const Slice& prefix,
-                              const SliceTransform* prefix_extractor,
-                              uint64_t block_offset, const bool no_io,
-                              const Slice* const const_ikey_ptr,
-                              BlockCacheLookupContext* context) override;
-  virtual size_t ApproximateMemoryUsage() const override;
+  bool KeyMayMatch(const Slice& key, const SliceTransform* prefix_extractor,
+                   uint64_t block_offset, const bool no_io,
+                   const Slice* const const_ikey_ptr,
+                   BlockCacheLookupContext* context) override;
+  bool PrefixMayMatch(const Slice& prefix,
+                      const SliceTransform* prefix_extractor,
+                      uint64_t block_offset, const bool no_io,
+                      const Slice* const const_ikey_ptr,
+                      BlockCacheLookupContext* context) override;
+  size_t ApproximateMemoryUsage() const override;
 
   // convert this object to a human readable form
   std::string ToString() const override;

--- a/table/block_based/block_based_filter_block.h
+++ b/table/block_based/block_based_filter_block.h
@@ -84,14 +84,17 @@ class BlockBasedFilterBlockReader : public FilterBlockReader {
                               BlockContents&& contents, Statistics* statistics);
   virtual bool IsBlockBased() override { return true; }
 
-  virtual bool KeyMayMatch(
-      const Slice& key, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+  virtual bool KeyMayMatch(const Slice& key,
+                           const SliceTransform* prefix_extractor,
+                           uint64_t block_offset = kNotValid,
+                           const bool no_io = false,
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) override;
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
   // convert this object to a human readable form

--- a/table/block_based/block_based_filter_block_test.cc
+++ b/table/block_based/block_based_filter_block_test.cc
@@ -57,8 +57,12 @@ TEST_F(FilterBlockTest, EmptyBuilder) {
   ASSERT_EQ("\\x00\\x00\\x00\\x00\\x0b", EscapeString(block.data));
   BlockBasedFilterBlockReader reader(nullptr, table_options_, true,
                                      std::move(block), nullptr);
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, uint64_t{0}));
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, 100000));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/100000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 TEST_F(FilterBlockTest, SingleChunk) {
@@ -76,13 +80,27 @@ TEST_F(FilterBlockTest, SingleChunk) {
   BlockContents block(builder.Finish());
   BlockBasedFilterBlockReader reader(nullptr, table_options_, true,
                                      std::move(block), nullptr);
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, 100));
-  ASSERT_TRUE(reader.KeyMayMatch("bar", nullptr, 100));
-  ASSERT_TRUE(reader.KeyMayMatch("box", nullptr, 100));
-  ASSERT_TRUE(reader.KeyMayMatch("hello", nullptr, 100));
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, 100));
-  ASSERT_TRUE(!reader.KeyMayMatch("missing", nullptr, 100));
-  ASSERT_TRUE(!reader.KeyMayMatch("other", nullptr, 100));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "missing", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "other", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 TEST_F(FilterBlockTest, MultiChunk) {
@@ -110,28 +128,60 @@ TEST_F(FilterBlockTest, MultiChunk) {
                                      std::move(block), nullptr);
 
   // Check first filter
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr, uint64_t{0}));
-  ASSERT_TRUE(reader.KeyMayMatch("bar", nullptr, 2000));
-  ASSERT_TRUE(!reader.KeyMayMatch("box", nullptr, uint64_t{0}));
-  ASSERT_TRUE(!reader.KeyMayMatch("hello", nullptr, uint64_t{0}));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/2000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check second filter
-  ASSERT_TRUE(reader.KeyMayMatch("box", nullptr, 3100));
-  ASSERT_TRUE(!reader.KeyMayMatch("foo", nullptr, 3100));
-  ASSERT_TRUE(!reader.KeyMayMatch("bar", nullptr, 3100));
-  ASSERT_TRUE(!reader.KeyMayMatch("hello", nullptr, 3100));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check third filter (empty)
-  ASSERT_TRUE(!reader.KeyMayMatch("foo", nullptr, 4100));
-  ASSERT_TRUE(!reader.KeyMayMatch("bar", nullptr, 4100));
-  ASSERT_TRUE(!reader.KeyMayMatch("box", nullptr, 4100));
-  ASSERT_TRUE(!reader.KeyMayMatch("hello", nullptr, 4100));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check last filter
-  ASSERT_TRUE(reader.KeyMayMatch("box", nullptr, 9000));
-  ASSERT_TRUE(reader.KeyMayMatch("hello", nullptr, 9000));
-  ASSERT_TRUE(!reader.KeyMayMatch("foo", nullptr, 9000));
-  ASSERT_TRUE(!reader.KeyMayMatch("bar", nullptr, 9000));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 // Test for block based filter block
@@ -154,8 +204,12 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedEmptyBuilder) {
   ASSERT_EQ("\\x00\\x00\\x00\\x00\\x0b", EscapeString(block.data));
   FilterBlockReader* reader = new BlockBasedFilterBlockReader(
       nullptr, table_options_, true, std::move(block), nullptr);
-  ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, uint64_t{0}));
-  ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, 100000));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/10000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   delete builder;
   delete reader;
@@ -175,13 +229,27 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedSingleChunk) {
   BlockContents block(builder->Finish());
   FilterBlockReader* reader = new BlockBasedFilterBlockReader(
       nullptr, table_options_, true, std::move(block), nullptr);
-  ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, 100));
-  ASSERT_TRUE(reader->KeyMayMatch("bar", nullptr, 100));
-  ASSERT_TRUE(reader->KeyMayMatch("box", nullptr, 100));
-  ASSERT_TRUE(reader->KeyMayMatch("hello", nullptr, 100));
-  ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, 100));
-  ASSERT_TRUE(!reader->KeyMayMatch("missing", nullptr, 100));
-  ASSERT_TRUE(!reader->KeyMayMatch("other", nullptr, 100));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "missing", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "other", /*prefix_extractor=*/nullptr, /*block_offset=*/100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   delete builder;
   delete reader;
@@ -213,28 +281,60 @@ TEST_F(BlockBasedFilterBlockTest, BlockBasedMultiChunk) {
       nullptr, table_options_, true, std::move(block), nullptr);
 
   // Check first filter
-  ASSERT_TRUE(reader->KeyMayMatch("foo", nullptr, uint64_t{0}));
-  ASSERT_TRUE(reader->KeyMayMatch("bar", nullptr, 2000));
-  ASSERT_TRUE(!reader->KeyMayMatch("box", nullptr, uint64_t{0}));
-  ASSERT_TRUE(!reader->KeyMayMatch("hello", nullptr, uint64_t{0}));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/2000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/uint64_t{0},
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check second filter
-  ASSERT_TRUE(reader->KeyMayMatch("box", nullptr, 3100));
-  ASSERT_TRUE(!reader->KeyMayMatch("foo", nullptr, 3100));
-  ASSERT_TRUE(!reader->KeyMayMatch("bar", nullptr, 3100));
-  ASSERT_TRUE(!reader->KeyMayMatch("hello", nullptr, 3100));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/3100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check third filter (empty)
-  ASSERT_TRUE(!reader->KeyMayMatch("foo", nullptr, 4100));
-  ASSERT_TRUE(!reader->KeyMayMatch("bar", nullptr, 4100));
-  ASSERT_TRUE(!reader->KeyMayMatch("box", nullptr, 4100));
-  ASSERT_TRUE(!reader->KeyMayMatch("hello", nullptr, 4100));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/4100,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   // Check last filter
-  ASSERT_TRUE(reader->KeyMayMatch("box", nullptr, 9000));
-  ASSERT_TRUE(reader->KeyMayMatch("hello", nullptr, 9000));
-  ASSERT_TRUE(!reader->KeyMayMatch("foo", nullptr, 9000));
-  ASSERT_TRUE(!reader->KeyMayMatch("bar", nullptr, 9000));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader->KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader->KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/9000,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 
   delete builder;
   delete reader;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2597,9 +2597,15 @@ void BlockBasedTableIterator<TBlockIter, TValue>::FindBlockForward() {
       return;
     }
     // Whether next data block is out of upper bound, if there is one.
-    bool next_block_is_out_of_bound =
+    // TODO: we should be able to use !data_block_within_upper_bound_ here
+    // instead of performing the comparison; however, the flag can apparently
+    // be out of sync with the comparison in some cases. This should be
+    // investigated.
+    const bool next_block_is_out_of_bound =
         read_options_.iterate_upper_bound != nullptr &&
-        block_iter_points_to_real_block_ && !data_block_within_upper_bound_;
+        block_iter_points_to_real_block_ &&
+        (user_comparator_.Compare(*read_options_.iterate_upper_bound,
+                                  index_iter_->user_key()) <= 0);
     ResetDataIter();
     index_iter_->Next();
     if (next_block_is_out_of_bound) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1869,7 +1869,6 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
 }
 
 CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
-
     const SliceTransform* prefix_extractor, FilePrefetchBuffer* prefetch_buffer,
     bool no_io, GetContext* get_context,
     BlockCacheLookupContext* lookup_context) const {
@@ -1880,7 +1879,6 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 }
 
 CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
-
     FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
     const bool is_a_filter_partition, bool no_io, GetContext* get_context,
     BlockCacheLookupContext* /*lookup_context*/,
@@ -2197,7 +2195,6 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
 }
 
 Status BlockBasedTable::RetrieveBlock(
-
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& ro,
     const BlockHandle& handle, const UncompressionDict& uncompression_dict,
     CachableEntry<Block>* block_entry, BlockType block_type,
@@ -3296,7 +3293,6 @@ BlockBasedTableOptions::IndexType BlockBasedTable::UpdateIndexType() {
 //  4. internal_comparator
 //  5. index_type
 Status BlockBasedTable::CreateIndexReader(
-
     FilePrefetchBuffer* prefetch_buffer,
     InternalIterator* preloaded_meta_index_iter, bool use_cache, bool prefetch,
     bool pin, IndexReader** index_reader,

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -260,7 +260,7 @@ Status BlockBasedTable::IndexReaderCommon::GetOrReadIndexBlock(
     return Status::OK();
   }
 
-  return ReadIndexBlock(table_, nullptr /* prefetch_buffer */, read_options,
+  return ReadIndexBlock(table_, /*prefetch_buffer=*/nullptr, read_options,
                         get_context, lookup_context, index_block);
 }
 
@@ -282,9 +282,9 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
 
     CachableEntry<Block> index_block;
     if (prefetch || !use_cache) {
-      const Status s = ReadIndexBlock(table, prefetch_buffer, ReadOptions(),
-                                      nullptr /* get_context */, lookup_context,
-                                      &index_block);
+      const Status s =
+          ReadIndexBlock(table, prefetch_buffer, ReadOptions(),
+                         /*get_context=*/nullptr, lookup_context, &index_block);
       if (!s.ok()) {
         return s;
       }
@@ -416,8 +416,7 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
       // filter blocks
       s = table()->MaybeReadBlockAndLoadToCache(
           prefetch_buffer.get(), ro, handle, UncompressionDict::GetEmptyDict(),
-          &block, BlockType::kIndex, nullptr /* get_context */,
-          &lookup_context);
+          &block, BlockType::kIndex, /*get_context=*/nullptr, &lookup_context);
 
       assert(s.ok() || block.GetValue() == nullptr);
       if (s.ok() && block.GetValue() != nullptr) {
@@ -2396,7 +2395,7 @@ bool BlockBasedTable::PrefixMayMatch(
         BlockHandle handle = iiter->value();
         may_match = filter->PrefixMayMatch(
             prefix, prefix_extractor, handle.offset(), /*no_io=*/false,
-            /*const_key_ptr*/ nullptr, lookup_context);
+            /*const_key_ptr=*/nullptr, lookup_context);
       }
     }
   }
@@ -2880,7 +2879,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
           filter != nullptr && filter->IsBlockBased() == true &&
           !filter->KeyMayMatch(ExtractUserKeyAndStripTimestamp(key, ts_sz),
                                prefix_extractor, handle.offset(), no_io,
-                               nullptr, &lookup_context);
+                               /*const_ikey_ptr=*/nullptr, &lookup_context);
 
       if (not_exist_in_filter) {
         // Not found

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -174,7 +174,8 @@ class BlockBasedTable::IndexReaderCommon : public BlockBasedTable::IndexReader {
   }
 
  protected:
-  static Status ReadIndexBlock(const BlockBasedTable* table,
+  static Status ReadIndexBlock(BlockCacheLookupContext* lookup_context,
+                               const BlockBasedTable* table,
                                FilePrefetchBuffer* prefetch_buffer,
                                const ReadOptions& read_options,
                                GetContext* get_context,
@@ -209,7 +210,8 @@ class BlockBasedTable::IndexReaderCommon : public BlockBasedTable::IndexReader {
     return properties == nullptr || !properties->index_value_is_delta_encoded;
   }
 
-  Status GetOrReadIndexBlock(const ReadOptions& read_options,
+  Status GetOrReadIndexBlock(BlockCacheLookupContext* lookup_context,
+                             const ReadOptions& read_options,
                              GetContext* get_context,
                              CachableEntry<Block>* index_block) const;
 
@@ -226,9 +228,9 @@ class BlockBasedTable::IndexReaderCommon : public BlockBasedTable::IndexReader {
 };
 
 Status BlockBasedTable::IndexReaderCommon::ReadIndexBlock(
-    const BlockBasedTable* table, FilePrefetchBuffer* prefetch_buffer,
-    const ReadOptions& read_options, GetContext* get_context,
-    CachableEntry<Block>* index_block) {
+    BlockCacheLookupContext* lookup_context, const BlockBasedTable* table,
+    FilePrefetchBuffer* prefetch_buffer, const ReadOptions& read_options,
+    GetContext* get_context, CachableEntry<Block>* index_block) {
   PERF_TIMER_GUARD(read_index_block_nanos);
 
   assert(table != nullptr);
@@ -239,7 +241,7 @@ Status BlockBasedTable::IndexReaderCommon::ReadIndexBlock(
   assert(rep != nullptr);
 
   const Status s = table->RetrieveBlock(
-      prefetch_buffer, read_options, rep->footer.index_handle(),
+      lookup_context, prefetch_buffer, read_options, rep->footer.index_handle(),
       UncompressionDict::GetEmptyDict(), index_block, BlockType::kIndex,
       get_context);
 
@@ -247,8 +249,8 @@ Status BlockBasedTable::IndexReaderCommon::ReadIndexBlock(
 }
 
 Status BlockBasedTable::IndexReaderCommon::GetOrReadIndexBlock(
-    const ReadOptions& read_options, GetContext* get_context,
-    CachableEntry<Block>* index_block) const {
+    BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+    GetContext* get_context, CachableEntry<Block>* index_block) const {
   assert(index_block != nullptr);
 
   if (!index_block_.IsEmpty()) {
@@ -256,8 +258,8 @@ Status BlockBasedTable::IndexReaderCommon::GetOrReadIndexBlock(
     return Status::OK();
   }
 
-  return ReadIndexBlock(table_, nullptr /* prefetch_buffer */, read_options,
-                        get_context, index_block);
+  return ReadIndexBlock(lookup_context, table_, nullptr /* prefetch_buffer */,
+                        read_options, get_context, index_block);
 }
 
 // Index that allows binary search lookup in a two-level index structure.
@@ -267,7 +269,8 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
   // `PartitionIndexReader`.
   // On success, index_reader will be populated; otherwise it will remain
   // unmodified.
-  static Status Create(const BlockBasedTable* table,
+  static Status Create(BlockCacheLookupContext* lookup_context,
+                       const BlockBasedTable* table,
                        FilePrefetchBuffer* prefetch_buffer, bool use_cache,
                        bool prefetch, bool pin, IndexReader** index_reader) {
     assert(table != nullptr);
@@ -277,8 +280,9 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
 
     CachableEntry<Block> index_block;
     if (prefetch || !use_cache) {
-      const Status s = ReadIndexBlock(table, prefetch_buffer, ReadOptions(),
-                                      nullptr /* get_context */, &index_block);
+      const Status s =
+          ReadIndexBlock(lookup_context, table, prefetch_buffer, ReadOptions(),
+                         nullptr /* get_context */, &index_block);
       if (!s.ok()) {
         return s;
       }
@@ -295,11 +299,12 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
 
   // return a two-level iterator: first level is on the partition index
   InternalIteratorBase<BlockHandle>* NewIterator(
-      const ReadOptions& read_options, bool /* disable_prefix_seek */,
-      IndexBlockIter* iter, GetContext* get_context) override {
+      BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+      bool /* disable_prefix_seek */, IndexBlockIter* iter,
+      GetContext* get_context) override {
     CachableEntry<Block> index_block;
-    const Status s =
-        GetOrReadIndexBlock(read_options, get_context, &index_block);
+    const Status s = GetOrReadIndexBlock(lookup_context, read_options,
+                                         get_context, &index_block);
     if (!s.ok()) {
       if (iter != nullptr) {
         iter->Invalidate(s);
@@ -352,14 +357,15 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
 
   void CacheDependencies(bool pin) override {
     // Before read partitions, prefetch them to avoid lots of IOs
+    BlockCacheLookupContext lookup_context{BlockCacheLookupCaller::kPrefetch};
     auto rep = table()->rep_;
     IndexBlockIter biter;
     BlockHandle handle;
     Statistics* kNullStats = nullptr;
 
     CachableEntry<Block> index_block;
-    Status s = GetOrReadIndexBlock(ReadOptions(), nullptr /* get_context */,
-                                   &index_block);
+    Status s = GetOrReadIndexBlock(&lookup_context, ReadOptions(),
+                                   nullptr /* get_context */, &index_block);
     if (!s.ok()) {
       ROCKS_LOG_WARN(rep->ioptions.info_log,
                      "Error retrieving top-level index block while trying to "
@@ -407,8 +413,9 @@ class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
       // TODO: Support counter batch update for partitioned index and
       // filter blocks
       s = table()->MaybeReadBlockAndLoadToCache(
-          prefetch_buffer.get(), ro, handle, UncompressionDict::GetEmptyDict(),
-          &block, BlockType::kIndex, nullptr /* get_context */);
+          &lookup_context, prefetch_buffer.get(), ro, handle,
+          UncompressionDict::GetEmptyDict(), &block, BlockType::kIndex,
+          nullptr /* get_context */);
 
       assert(s.ok() || block.GetValue() == nullptr);
       if (s.ok() && block.GetValue() != nullptr) {
@@ -449,7 +456,8 @@ class BinarySearchIndexReader : public BlockBasedTable::IndexReaderCommon {
   // `BinarySearchIndexReader`.
   // On success, index_reader will be populated; otherwise it will remain
   // unmodified.
-  static Status Create(const BlockBasedTable* table,
+  static Status Create(BlockCacheLookupContext* lookup_context,
+                       const BlockBasedTable* table,
                        FilePrefetchBuffer* prefetch_buffer, bool use_cache,
                        bool prefetch, bool pin, IndexReader** index_reader) {
     assert(table != nullptr);
@@ -459,8 +467,9 @@ class BinarySearchIndexReader : public BlockBasedTable::IndexReaderCommon {
 
     CachableEntry<Block> index_block;
     if (prefetch || !use_cache) {
-      const Status s = ReadIndexBlock(table, prefetch_buffer, ReadOptions(),
-                                      nullptr /* get_context */, &index_block);
+      const Status s =
+          ReadIndexBlock(lookup_context, table, prefetch_buffer, ReadOptions(),
+                         nullptr /* get_context */, &index_block);
       if (!s.ok()) {
         return s;
       }
@@ -476,11 +485,12 @@ class BinarySearchIndexReader : public BlockBasedTable::IndexReaderCommon {
   }
 
   InternalIteratorBase<BlockHandle>* NewIterator(
-      const ReadOptions& read_options, bool /* disable_prefix_seek */,
-      IndexBlockIter* iter, GetContext* get_context) override {
+      BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+      bool /* disable_prefix_seek */, IndexBlockIter* iter,
+      GetContext* get_context) override {
     CachableEntry<Block> index_block;
-    const Status s =
-        GetOrReadIndexBlock(read_options, get_context, &index_block);
+    const Status s = GetOrReadIndexBlock(lookup_context, read_options,
+                                         get_context, &index_block);
     if (!s.ok()) {
       if (iter != nullptr) {
         iter->Invalidate(s);
@@ -523,7 +533,8 @@ class BinarySearchIndexReader : public BlockBasedTable::IndexReaderCommon {
 // key.
 class HashIndexReader : public BlockBasedTable::IndexReaderCommon {
  public:
-  static Status Create(const BlockBasedTable* table,
+  static Status Create(BlockCacheLookupContext* lookup_context,
+                       const BlockBasedTable* table,
                        FilePrefetchBuffer* prefetch_buffer,
                        InternalIterator* meta_index_iter, bool use_cache,
                        bool prefetch, bool pin, IndexReader** index_reader) {
@@ -536,8 +547,9 @@ class HashIndexReader : public BlockBasedTable::IndexReaderCommon {
 
     CachableEntry<Block> index_block;
     if (prefetch || !use_cache) {
-      const Status s = ReadIndexBlock(table, prefetch_buffer, ReadOptions(),
-                                      nullptr /* get_context */, &index_block);
+      const Status s =
+          ReadIndexBlock(lookup_context, table, prefetch_buffer, ReadOptions(),
+                         nullptr /* get_context */, &index_block);
       if (!s.ok()) {
         return s;
       }
@@ -615,11 +627,12 @@ class HashIndexReader : public BlockBasedTable::IndexReaderCommon {
   }
 
   InternalIteratorBase<BlockHandle>* NewIterator(
-      const ReadOptions& read_options, bool disable_prefix_seek,
-      IndexBlockIter* iter, GetContext* get_context) override {
+      BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+      bool disable_prefix_seek, IndexBlockIter* iter,
+      GetContext* get_context) override {
     CachableEntry<Block> index_block;
-    const Status s =
-        GetOrReadIndexBlock(read_options, get_context, &index_block);
+    const Status s = GetOrReadIndexBlock(lookup_context, read_options,
+                                         get_context, &index_block);
     if (!s.ok()) {
       if (iter != nullptr) {
         iter->Invalidate(s);
@@ -1055,6 +1068,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   // Better not mutate rep_ after the creation. eg. internal_prefix_transform
   // raw pointer will be used to create HashIndexReader, whose reset may
   // access a dangling pointer.
+  BlockCacheLookupContext lookup_context{BlockCacheLookupCaller::kPrefetch};
   Rep* rep = new BlockBasedTable::Rep(ioptions, env_options, table_options,
                                       internal_comparator, skip_filters, level,
                                       immortal_table);
@@ -1094,14 +1108,14 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
   if (!s.ok()) {
     return s;
   }
-  s = new_table->ReadRangeDelBlock(prefetch_buffer.get(), meta_iter.get(),
-                                   internal_comparator);
+  s = new_table->ReadRangeDelBlock(&lookup_context, prefetch_buffer.get(),
+                                   meta_iter.get(), internal_comparator);
   if (!s.ok()) {
     return s;
   }
   s = new_table->PrefetchIndexAndFilterBlocks(
-      prefetch_buffer.get(), meta_iter.get(), new_table.get(), prefetch_all,
-      table_options, level);
+      &lookup_context, prefetch_buffer.get(), meta_iter.get(), new_table.get(),
+      prefetch_all, table_options, level);
 
   if (s.ok()) {
     // Update tail prefetch stats
@@ -1303,6 +1317,7 @@ Status BlockBasedTable::ReadPropertiesBlock(
 }
 
 Status BlockBasedTable::ReadRangeDelBlock(
+    BlockCacheLookupContext* lookup_context,
     FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
     const InternalKeyComparator& internal_comparator) {
   Status s;
@@ -1317,10 +1332,10 @@ Status BlockBasedTable::ReadRangeDelBlock(
   } else if (found_range_del_block && !range_del_handle.IsNull()) {
     ReadOptions read_options;
     std::unique_ptr<InternalIterator> iter(NewDataBlockIterator<DataBlockIter>(
-        read_options, range_del_handle, nullptr /* input_iter */,
-        BlockType::kRangeDeletion, true /* key_includes_seq */,
-        true /* index_key_is_full */, nullptr /* get_context */, Status(),
-        prefetch_buffer));
+        lookup_context, read_options, range_del_handle,
+        nullptr /* input_iter */, BlockType::kRangeDeletion,
+        true /* key_includes_seq */, true /* index_key_is_full */,
+        nullptr /* get_context */, Status(), prefetch_buffer));
     assert(iter != nullptr);
     s = iter->status();
     if (!s.ok()) {
@@ -1368,6 +1383,7 @@ Status BlockBasedTable::ReadCompressionDictBlock(
 }
 
 Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
+    BlockCacheLookupContext* lookup_context,
     FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
     BlockBasedTable* new_table, bool prefetch_all,
     const BlockBasedTableOptions& table_options, const int level) {
@@ -1439,8 +1455,9 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
 
   IndexReader* index_reader = nullptr;
   if (s.ok()) {
-    s = new_table->CreateIndexReader(prefetch_buffer, meta_iter, use_cache,
-                                     prefetch_index, pin_index, &index_reader);
+    s = new_table->CreateIndexReader(lookup_context, prefetch_buffer, meta_iter,
+                                     use_cache, prefetch_index, pin_index,
+                                     &index_reader);
     if (s.ok()) {
       assert(index_reader != nullptr);
       rep_->index_reader.reset(index_reader);
@@ -1466,8 +1483,8 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
     assert(table_options.block_cache != nullptr);
     if (s.ok() && prefetch_filter) {
       // Hack: Call GetFilter() to implicitly add filter to the block_cache
-      auto filter_entry =
-          new_table->GetFilter(rep_->table_prefix_extractor.get());
+      auto filter_entry = new_table->GetFilter(
+          lookup_context, rep_->table_prefix_extractor.get());
       if (filter_entry.GetValue() != nullptr && prefetch_all) {
         filter_entry.GetValue()->CacheDependencies(
             pin_all, rep_->table_prefix_extractor.get());
@@ -1848,18 +1865,22 @@ FilterBlockReader* BlockBasedTable::ReadFilter(
 }
 
 CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
+    BlockCacheLookupContext* lookup_context,
     const SliceTransform* prefix_extractor, FilePrefetchBuffer* prefetch_buffer,
     bool no_io, GetContext* get_context) const {
   const BlockHandle& filter_blk_handle = rep_->filter_handle;
   const bool is_a_filter_partition = true;
-  return GetFilter(prefetch_buffer, filter_blk_handle, !is_a_filter_partition,
-                   no_io, get_context, prefix_extractor);
+  return GetFilter(lookup_context, prefetch_buffer, filter_blk_handle,
+                   !is_a_filter_partition, no_io, get_context,
+                   prefix_extractor);
 }
 
 CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
+    BlockCacheLookupContext* /*lookup_context*/,
     FilePrefetchBuffer* prefetch_buffer, const BlockHandle& filter_blk_handle,
     const bool is_a_filter_partition, bool no_io, GetContext* get_context,
     const SliceTransform* prefix_extractor) const {
+  // TODO(haoyu): Trace filter block access here.
   // If cache_index_and_filter_blocks is false, filter should be pre-populated.
   // We will return rep_->filter anyway. rep_->filter can be nullptr if filter
   // read fails at Open() time. We don't want to reload again since it will
@@ -1924,8 +1945,10 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 }
 
 CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
+    BlockCacheLookupContext* /*lookup_context*/,
     FilePrefetchBuffer* prefetch_buffer, bool no_io,
     GetContext* get_context) const {
+  // TODO(haoyu): Trace the access on the uncompression dictionary here.
   if (!rep_->table_options.cache_index_and_filter_blocks) {
     // block cache is either disabled or not used for meta-blocks. In either
     // case, BlockBasedTableReader is the owner of the uncompression dictionary.
@@ -1986,15 +2009,17 @@ CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
 // disable_prefix_seek should be set to true when prefix_extractor found in SST
 // differs from the one in mutable_cf_options and index type is HashBasedIndex
 InternalIteratorBase<BlockHandle>* BlockBasedTable::NewIndexIterator(
-    const ReadOptions& read_options, bool disable_prefix_seek,
-    IndexBlockIter* input_iter, GetContext* get_context) const {
+    BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+    bool disable_prefix_seek, IndexBlockIter* input_iter,
+    GetContext* get_context) const {
   assert(rep_ != nullptr);
   assert(rep_->index_reader != nullptr);
 
   // We don't return pinned data from index blocks, so no need
   // to set `block_contents_pinned`.
-  return rep_->index_reader->NewIterator(read_options, disable_prefix_seek,
-                                         input_iter, get_context);
+  return rep_->index_reader->NewIterator(lookup_context, read_options,
+                                         disable_prefix_seek, input_iter,
+                                         get_context);
 }
 
 // Convert an index iterator value (i.e., an encoded BlockHandle)
@@ -2003,10 +2028,10 @@ InternalIteratorBase<BlockHandle>* BlockBasedTable::NewIndexIterator(
 // If input_iter is not null, update this iter and return it
 template <typename TBlockIter>
 TBlockIter* BlockBasedTable::NewDataBlockIterator(
-    const ReadOptions& ro, const BlockHandle& handle, TBlockIter* input_iter,
-    BlockType block_type, bool key_includes_seq, bool index_key_is_full,
-    GetContext* get_context, Status s,
-    FilePrefetchBuffer* prefetch_buffer) const {
+    BlockCacheLookupContext* lookup_context, const ReadOptions& ro,
+    const BlockHandle& handle, TBlockIter* input_iter, BlockType block_type,
+    bool key_includes_seq, bool index_key_is_full, GetContext* get_context,
+    Status s, FilePrefetchBuffer* prefetch_buffer) const {
   PERF_TIMER_GUARD(new_table_block_iter_nanos);
 
   TBlockIter* iter = input_iter != nullptr ? input_iter : new TBlockIter;
@@ -2017,15 +2042,15 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
 
   const bool no_io = (ro.read_tier == kBlockCacheTier);
   auto uncompression_dict_storage =
-      GetUncompressionDict(prefetch_buffer, no_io, get_context);
+      GetUncompressionDict(lookup_context, prefetch_buffer, no_io, get_context);
   const UncompressionDict& uncompression_dict =
       uncompression_dict_storage.GetValue() == nullptr
           ? UncompressionDict::GetEmptyDict()
           : *uncompression_dict_storage.GetValue();
 
   CachableEntry<Block> block;
-  s = RetrieveBlock(prefetch_buffer, ro, handle, uncompression_dict, &block,
-                    block_type, get_context);
+  s = RetrieveBlock(lookup_context, prefetch_buffer, ro, handle,
+                    uncompression_dict, &block, block_type, get_context);
 
   if (!s.ok()) {
     assert(block.IsEmpty());
@@ -2090,10 +2115,12 @@ TBlockIter* BlockBasedTable::NewDataBlockIterator(
 }
 
 Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
+    BlockCacheLookupContext* /*lookup_context*/,
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& ro,
     const BlockHandle& handle, const UncompressionDict& uncompression_dict,
     CachableEntry<Block>* block_entry, BlockType block_type,
     GetContext* get_context) const {
+  // TODO(haoyu): Trace data/index/range deletion block access here.
   assert(block_entry != nullptr);
   const bool no_io = (ro.read_tier == kBlockCacheTier);
   Cache* block_cache = rep_->table_options.block_cache.get();
@@ -2166,6 +2193,7 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
 }
 
 Status BlockBasedTable::RetrieveBlock(
+    BlockCacheLookupContext* lookup_context,
     FilePrefetchBuffer* prefetch_buffer, const ReadOptions& ro,
     const BlockHandle& handle, const UncompressionDict& uncompression_dict,
     CachableEntry<Block>* block_entry, BlockType block_type,
@@ -2178,8 +2206,8 @@ Status BlockBasedTable::RetrieveBlock(
       (block_type != BlockType::kFilter &&
        block_type != BlockType::kCompressionDictionary &&
        block_type != BlockType::kIndex)) {
-    s = MaybeReadBlockAndLoadToCache(prefetch_buffer, ro, handle,
-                                     uncompression_dict, block_entry,
+    s = MaybeReadBlockAndLoadToCache(lookup_context, prefetch_buffer, ro,
+                                     handle, uncompression_dict, block_entry,
                                      block_type, get_context);
 
     if (!s.ok()) {
@@ -2269,7 +2297,8 @@ BlockBasedTable::PartitionedIndexIteratorState::NewSecondaryIterator(
 //
 // REQUIRES: this method shouldn't be called while the DB lock is held.
 bool BlockBasedTable::PrefixMayMatch(
-    const Slice& internal_key, const ReadOptions& read_options,
+    BlockCacheLookupContext* lookup_context, const Slice& internal_key,
+    const ReadOptions& read_options,
     const SliceTransform* options_prefix_extractor,
     const bool need_upper_bound_check) const {
   if (!rep_->filter_policy) {
@@ -2295,7 +2324,7 @@ bool BlockBasedTable::PrefixMayMatch(
   Status s;
 
   // First, try check with full filter
-  auto filter_entry = GetFilter(prefix_extractor);
+  auto filter_entry = GetFilter(lookup_context, prefix_extractor);
   FilterBlockReader* filter = filter_entry.GetValue();
   bool filter_checked = true;
   if (filter != nullptr) {
@@ -2304,7 +2333,7 @@ bool BlockBasedTable::PrefixMayMatch(
       may_match = filter->RangeMayExist(
           read_options.iterate_upper_bound, user_key, prefix_extractor,
           rep_->internal_comparator.user_comparator(), const_ikey_ptr,
-          &filter_checked, need_upper_bound_check);
+          &filter_checked, need_upper_bound_check, lookup_context);
     } else {
       // if prefix_extractor changed for block based filter, skip filter
       if (need_upper_bound_check) {
@@ -2324,7 +2353,7 @@ bool BlockBasedTable::PrefixMayMatch(
       // we already know prefix_extractor and prefix_extractor_name must match
       // because `CheckPrefixMayMatch` first checks `check_filter_ == true`
       std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter(
-          NewIndexIterator(no_io_read_options,
+          NewIndexIterator(lookup_context, no_io_read_options,
                            /* need_upper_bound_check */ false));
       iiter->Seek(internal_prefix);
 
@@ -2357,8 +2386,8 @@ bool BlockBasedTable::PrefixMayMatch(
         // possibly contain the key.  Thus, the corresponding data block
         // is the only on could potentially contain the prefix.
         BlockHandle handle = iiter->value();
-        may_match =
-            filter->PrefixMayMatch(prefix, prefix_extractor, handle.offset());
+        may_match = filter->PrefixMayMatch(prefix, prefix_extractor,
+                                           handle.offset(), lookup_context);
       }
     }
   }
@@ -2586,8 +2615,8 @@ void BlockBasedTableIterator<TBlockIter, TValue>::InitDataBlock() {
 
     Status s;
     table_->NewDataBlockIterator<TBlockIter>(
-        read_options_, data_block_handle, &block_iter_, block_type_,
-        key_includes_seq_, index_key_is_full_,
+        &lookup_context_, read_options_, data_block_handle, &block_iter_,
+        block_type_, key_includes_seq_, index_key_is_full_,
         /* get_context */ nullptr, s, prefetch_buffer_.get());
     block_iter_points_to_real_block_ = true;
     if (read_options_.iterate_upper_bound != nullptr) {
@@ -2682,13 +2711,16 @@ void BlockBasedTableIterator<TBlockIter, TValue>::CheckOutOfBound() {
 InternalIterator* BlockBasedTable::NewIterator(
     const ReadOptions& read_options, const SliceTransform* prefix_extractor,
     Arena* arena, bool skip_filters, bool for_compaction) {
+  BlockCacheLookupContext lookup_context{
+      for_compaction ? BlockCacheLookupCaller::kCompaction
+                     : BlockCacheLookupCaller::kUserIterator};
   bool need_upper_bound_check =
       PrefixExtractorChanged(rep_->table_properties.get(), prefix_extractor);
   if (arena == nullptr) {
     return new BlockBasedTableIterator<DataBlockIter>(
         this, read_options, rep_->internal_comparator,
         NewIndexIterator(
-            read_options,
+            &lookup_context, read_options,
             need_upper_bound_check &&
                 rep_->index_type == BlockBasedTableOptions::kHashSearch),
         !skip_filters && !read_options.total_order_seek &&
@@ -2700,7 +2732,7 @@ InternalIterator* BlockBasedTable::NewIterator(
         arena->AllocateAligned(sizeof(BlockBasedTableIterator<DataBlockIter>));
     return new (mem) BlockBasedTableIterator<DataBlockIter>(
         this, read_options, rep_->internal_comparator,
-        NewIndexIterator(read_options, need_upper_bound_check),
+        NewIndexIterator(&lookup_context, read_options, need_upper_bound_check),
         !skip_filters && !read_options.total_order_seek &&
             prefix_extractor != nullptr,
         need_upper_bound_check, prefix_extractor, BlockType::kData,
@@ -2722,8 +2754,8 @@ FragmentedRangeTombstoneIterator* BlockBasedTable::NewRangeTombstoneIterator(
 }
 
 bool BlockBasedTable::FullFilterKeyMayMatch(
-    const ReadOptions& read_options, FilterBlockReader* filter,
-    const Slice& internal_key, const bool no_io,
+    BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+    FilterBlockReader* filter, const Slice& internal_key, const bool no_io,
     const SliceTransform* prefix_extractor) const {
   if (filter == nullptr || filter->IsBlockBased()) {
     return true;
@@ -2735,15 +2767,16 @@ bool BlockBasedTable::FullFilterKeyMayMatch(
     size_t ts_sz =
         rep_->internal_comparator.user_comparator()->timestamp_size();
     Slice user_key_without_ts = StripTimestampFromUserKey(user_key, ts_sz);
-    may_match = filter->KeyMayMatch(user_key_without_ts, prefix_extractor,
-                                    kNotValid, no_io, const_ikey_ptr);
+    may_match =
+        filter->KeyMayMatch(user_key_without_ts, prefix_extractor, kNotValid,
+                            no_io, const_ikey_ptr, lookup_context);
   } else if (!read_options.total_order_seek && prefix_extractor &&
              rep_->table_properties->prefix_extractor_name.compare(
                  prefix_extractor->Name()) == 0 &&
              prefix_extractor->InDomain(user_key) &&
              !filter->PrefixMayMatch(prefix_extractor->Transform(user_key),
                                      prefix_extractor, kNotValid, false,
-                                     const_ikey_ptr)) {
+                                     const_ikey_ptr, lookup_context)) {
     may_match = false;
   }
   if (may_match) {
@@ -2754,14 +2787,15 @@ bool BlockBasedTable::FullFilterKeyMayMatch(
 }
 
 void BlockBasedTable::FullFilterKeysMayMatch(
-    const ReadOptions& read_options, FilterBlockReader* filter,
-    MultiGetRange* range, const bool no_io,
+    BlockCacheLookupContext* lookup_context, const ReadOptions& read_options,
+    FilterBlockReader* filter, MultiGetRange* range, const bool no_io,
     const SliceTransform* prefix_extractor) const {
   if (filter == nullptr || filter->IsBlockBased()) {
     return;
   }
   if (filter->whole_key_filtering()) {
-    filter->KeysMayMatch(range, prefix_extractor, kNotValid, no_io);
+    filter->KeysMayMatch(range, prefix_extractor, kNotValid, no_io,
+                         lookup_context);
   } else if (!read_options.total_order_seek && prefix_extractor &&
              rep_->table_properties->prefix_extractor_name.compare(
                  prefix_extractor->Name()) == 0) {
@@ -2772,7 +2806,8 @@ void BlockBasedTable::FullFilterKeysMayMatch(
         range->SkipKey(iter);
       }
     }
-    filter->PrefixesMayMatch(range, prefix_extractor, kNotValid, false);
+    filter->PrefixesMayMatch(range, prefix_extractor, kNotValid, false,
+                             lookup_context);
   }
 }
 
@@ -2786,18 +2821,19 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   CachableEntry<FilterBlockReader> filter_entry;
   bool may_match;
   FilterBlockReader* filter = nullptr;
+  BlockCacheLookupContext lookup_context{BlockCacheLookupCaller::kUserGet};
   {
     if (!skip_filters) {
-      filter_entry =
-          GetFilter(prefix_extractor, /*prefetch_buffer*/ nullptr,
-                    read_options.read_tier == kBlockCacheTier, get_context);
+      filter_entry = GetFilter(
+          &lookup_context, prefix_extractor, /*prefetch_buffer*/ nullptr,
+          read_options.read_tier == kBlockCacheTier, get_context);
     }
     filter = filter_entry.GetValue();
 
     // First check the full filter
     // If full filter not useful, Then go into each block
-    may_match = FullFilterKeyMayMatch(read_options, filter, key, no_io,
-                                      prefix_extractor);
+    may_match = FullFilterKeyMayMatch(&lookup_context, read_options, filter,
+                                      key, no_io, prefix_extractor);
   }
   if (!may_match) {
     RecordTick(rep_->ioptions.statistics, BLOOM_FILTER_USEFUL);
@@ -2811,8 +2847,9 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
       need_upper_bound_check = PrefixExtractorChanged(
           rep_->table_properties.get(), prefix_extractor);
     }
-    auto iiter = NewIndexIterator(read_options, need_upper_bound_check,
-                                  &iiter_on_stack, get_context);
+    auto iiter =
+        NewIndexIterator(&lookup_context, read_options, need_upper_bound_check,
+                         &iiter_on_stack, get_context);
     std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter_unique_ptr;
     if (iiter != &iiter_on_stack) {
       iiter_unique_ptr.reset(iiter);
@@ -2828,7 +2865,8 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
       bool not_exist_in_filter =
           filter != nullptr && filter->IsBlockBased() == true &&
           !filter->KeyMayMatch(ExtractUserKeyAndStripTimestamp(key, ts_sz),
-                               prefix_extractor, handle.offset(), no_io);
+                               prefix_extractor, handle.offset(), no_io,
+                               nullptr, &lookup_context);
 
       if (not_exist_in_filter) {
         // Not found
@@ -2840,9 +2878,9 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
       } else {
         DataBlockIter biter;
         NewDataBlockIterator<DataBlockIter>(
-            read_options, iiter->value(), &biter, BlockType::kData,
-            true /* key_includes_seq */, true /* index_key_is_full */,
-            get_context);
+            &lookup_context, read_options, iiter->value(), &biter,
+            BlockType::kData, true /* key_includes_seq */,
+            true /* index_key_is_full */, get_context);
 
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {
@@ -2907,6 +2945,7 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
                                const MultiGetRange* mget_range,
                                const SliceTransform* prefix_extractor,
                                bool skip_filters) {
+  BlockCacheLookupContext lookup_context{BlockCacheLookupCaller::kUserMGet};
   const bool no_io = read_options.read_tier == kBlockCacheTier;
   CachableEntry<FilterBlockReader> filter_entry;
   FilterBlockReader* filter = nullptr;
@@ -2915,16 +2954,16 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
   {
     if (!skip_filters) {
       // TODO: Figure out where the stats should go
-      filter_entry = GetFilter(prefix_extractor, /*prefetch_buffer*/ nullptr,
-                               read_options.read_tier == kBlockCacheTier,
-                               nullptr /*get_context*/);
+      filter_entry = GetFilter(
+          &lookup_context, prefix_extractor, /*prefetch_buffer*/ nullptr,
+          read_options.read_tier == kBlockCacheTier, nullptr /*get_context*/);
     }
     filter = filter_entry.GetValue();
 
     // First check the full filter
     // If full filter not useful, Then go into each block
-    FullFilterKeysMayMatch(read_options, filter, &sst_file_range, no_io,
-                           prefix_extractor);
+    FullFilterKeysMayMatch(&lookup_context, read_options, filter,
+                           &sst_file_range, no_io, prefix_extractor);
   }
   if (skip_filters || !sst_file_range.empty()) {
     IndexBlockIter iiter_on_stack;
@@ -2936,8 +2975,8 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
           rep_->table_properties.get(), prefix_extractor);
     }
     auto iiter =
-        NewIndexIterator(read_options, need_upper_bound_check, &iiter_on_stack,
-                         sst_file_range.begin()->get_context);
+        NewIndexIterator(&lookup_context, read_options, need_upper_bound_check,
+                         &iiter_on_stack, sst_file_range.begin()->get_context);
     std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter_unique_ptr;
     if (iiter != &iiter_on_stack) {
       iiter_unique_ptr.reset(iiter);
@@ -2957,12 +2996,11 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
         if (iiter->value().offset() != offset) {
           offset = iiter->value().offset();
           biter.Invalidate(Status::OK());
-          NewDataBlockIterator<DataBlockIter>(
+          NewDataBlockIterator<DataBlockIter>(&lookup_context,
               read_options, iiter->value(), &biter, BlockType::kData, false,
               true /* key_includes_seq */, get_context);
           reusing_block = false;
         }
-
         if (read_options.read_tier == kBlockCacheTier &&
             biter.status().IsIncomplete()) {
           // couldn't get block from block_cache
@@ -3040,9 +3078,10 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
   if (begin && end && comparator.Compare(*begin, *end) > 0) {
     return Status::InvalidArgument(*begin, *end);
   }
-
+  BlockCacheLookupContext lookup_context{BlockCacheLookupCaller::kPrefetch};
   IndexBlockIter iiter_on_stack;
-  auto iiter = NewIndexIterator(ReadOptions(), false, &iiter_on_stack);
+  auto iiter =
+      NewIndexIterator(&lookup_context, ReadOptions(), false, &iiter_on_stack);
   std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter_unique_ptr;
   if (iiter != &iiter_on_stack) {
     iiter_unique_ptr =
@@ -3077,7 +3116,8 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
 
     // Load the block specified by the block_handle into the block cache
     DataBlockIter biter;
-    NewDataBlockIterator<DataBlockIter>(ReadOptions(), block_handle, &biter);
+    NewDataBlockIterator<DataBlockIter>(&lookup_context, ReadOptions(),
+                                        block_handle, &biter);
 
     if (!biter.status().ok()) {
       // there was an unexpected error while pre-fetching
@@ -3089,6 +3129,8 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
 }
 
 Status BlockBasedTable::VerifyChecksum() {
+  // TODO(haoyu): This function is called by external sst ingestion and user.
+  // We don't log its block cache accesses for now.
   Status s;
   // Check Meta blocks
   std::unique_ptr<Block> meta;
@@ -3105,7 +3147,7 @@ Status BlockBasedTable::VerifyChecksum() {
   // Check Data blocks
   IndexBlockIter iiter_on_stack;
   InternalIteratorBase<BlockHandle>* iiter =
-      NewIndexIterator(ReadOptions(), false, &iiter_on_stack);
+      NewIndexIterator(nullptr, ReadOptions(), false, &iiter_on_stack);
   std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter_unique_ptr;
   if (iiter != &iiter_on_stack) {
     iiter_unique_ptr =
@@ -3200,7 +3242,7 @@ bool BlockBasedTable::TEST_BlockInCache(const BlockHandle& handle) const {
 bool BlockBasedTable::TEST_KeyInCache(const ReadOptions& options,
                                       const Slice& key) {
   std::unique_ptr<InternalIteratorBase<BlockHandle>> iiter(
-      NewIndexIterator(options));
+      NewIndexIterator(nullptr, options));
   iiter->Seek(key);
   assert(iiter->Valid());
 
@@ -3232,6 +3274,7 @@ BlockBasedTableOptions::IndexType BlockBasedTable::UpdateIndexType() {
 //  4. internal_comparator
 //  5. index_type
 Status BlockBasedTable::CreateIndexReader(
+    BlockCacheLookupContext* lookup_context,
     FilePrefetchBuffer* prefetch_buffer,
     InternalIterator* preloaded_meta_index_iter, bool use_cache, bool prefetch,
     bool pin, IndexReader** index_reader) {
@@ -3245,11 +3288,13 @@ Status BlockBasedTable::CreateIndexReader(
 
   switch (index_type_on_file) {
     case BlockBasedTableOptions::kTwoLevelIndexSearch: {
-      return PartitionIndexReader::Create(this, prefetch_buffer, use_cache,
-                                          prefetch, pin, index_reader);
+      return PartitionIndexReader::Create(lookup_context, this, prefetch_buffer,
+                                          use_cache, prefetch, pin,
+                                          index_reader);
     }
     case BlockBasedTableOptions::kBinarySearch: {
-      return BinarySearchIndexReader::Create(this, prefetch_buffer, use_cache,
+      return BinarySearchIndexReader::Create(lookup_context, this,
+                                             prefetch_buffer, use_cache,
                                              prefetch, pin, index_reader);
     }
     case BlockBasedTableOptions::kHashSearch: {
@@ -3264,14 +3309,16 @@ Status BlockBasedTable::CreateIndexReader(
           ROCKS_LOG_WARN(rep_->ioptions.info_log,
                          "Unable to read the metaindex block."
                          " Fall back to binary search index.");
-          return BinarySearchIndexReader::Create(
-              this, prefetch_buffer, use_cache, prefetch, pin, index_reader);
+          return BinarySearchIndexReader::Create(lookup_context, this,
+                                                 prefetch_buffer, use_cache,
+                                                 prefetch, pin, index_reader);
         }
         meta_index_iter = meta_iter_guard.get();
       }
 
-      return HashIndexReader::Create(this, prefetch_buffer, meta_index_iter,
-                                     use_cache, prefetch, pin, index_reader);
+      return HashIndexReader::Create(lookup_context, this, prefetch_buffer,
+                                     meta_index_iter, use_cache, prefetch, pin,
+                                     index_reader);
     }
     default: {
       std::string error_message =
@@ -3281,9 +3328,13 @@ Status BlockBasedTable::CreateIndexReader(
   }
 }
 
-uint64_t BlockBasedTable::ApproximateOffsetOf(const Slice& key) {
+uint64_t BlockBasedTable::ApproximateOffsetOf(const Slice& key,
+                                              bool for_compaction) {
+  BlockCacheLookupContext context(
+      for_compaction ? BlockCacheLookupCaller::kCompaction
+                     : BlockCacheLookupCaller::kUserApproximateSize);
   std::unique_ptr<InternalIteratorBase<BlockHandle>> index_iter(
-      NewIndexIterator(ReadOptions()));
+      NewIndexIterator(&context, ReadOptions()));
 
   index_iter->Seek(key);
   uint64_t result;
@@ -3319,7 +3370,7 @@ bool BlockBasedTable::TEST_IndexBlockInCache() const {
 Status BlockBasedTable::GetKVPairsFromDataBlocks(
     std::vector<KVPairBlock>* kv_pair_blocks) {
   std::unique_ptr<InternalIteratorBase<BlockHandle>> blockhandles_iter(
-      NewIndexIterator(ReadOptions()));
+      NewIndexIterator(nullptr, ReadOptions()));
 
   Status s = blockhandles_iter->status();
   if (!s.ok()) {
@@ -3337,7 +3388,7 @@ Status BlockBasedTable::GetKVPairsFromDataBlocks(
 
     std::unique_ptr<InternalIterator> datablock_iter;
     datablock_iter.reset(NewDataBlockIterator<DataBlockIter>(
-        ReadOptions(), blockhandles_iter->value()));
+        nullptr, ReadOptions(), blockhandles_iter->value()));
     s = datablock_iter->status();
 
     if (!s.ok()) {
@@ -3545,7 +3596,7 @@ Status BlockBasedTable::DumpIndexBlock(WritableFile* out_file) {
       "Index Details:\n"
       "--------------------------------------\n");
   std::unique_ptr<InternalIteratorBase<BlockHandle>> blockhandles_iter(
-      NewIndexIterator(ReadOptions()));
+      NewIndexIterator(nullptr, ReadOptions()));
   Status s = blockhandles_iter->status();
   if (!s.ok()) {
     out_file->Append("Can not read Index Block \n\n");
@@ -3594,7 +3645,7 @@ Status BlockBasedTable::DumpIndexBlock(WritableFile* out_file) {
 
 Status BlockBasedTable::DumpDataBlocks(WritableFile* out_file) {
   std::unique_ptr<InternalIteratorBase<BlockHandle>> blockhandles_iter(
-      NewIndexIterator(ReadOptions()));
+      NewIndexIterator(nullptr, ReadOptions()));
   Status s = blockhandles_iter->status();
   if (!s.ok()) {
     out_file->Append("Can not read Index Block \n\n");
@@ -3628,7 +3679,7 @@ Status BlockBasedTable::DumpDataBlocks(WritableFile* out_file) {
 
     std::unique_ptr<InternalIterator> datablock_iter;
     datablock_iter.reset(NewDataBlockIterator<DataBlockIter>(
-        ReadOptions(), blockhandles_iter->value()));
+        nullptr, ReadOptions(), blockhandles_iter->value()));
     s = datablock_iter->status();
 
     if (!s.ok()) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1384,7 +1384,6 @@ Status BlockBasedTable::ReadCompressionDictBlock(
 }
 
 Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
-
     FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
     BlockBasedTable* new_table, bool prefetch_all,
     const BlockBasedTableOptions& table_options, const int level,
@@ -1674,8 +1673,7 @@ Status BlockBasedTable::GetDataBlockFromCache(
       size_t charge = block_holder->ApproximateMemoryUsage();
       Cache::Handle* cache_handle = nullptr;
       s = block_cache->Insert(block_cache_key, block_holder.get(), charge,
-                              &DeleteCachedEntry<Block>,
-                              &cache_handle);
+                              &DeleteCachedEntry<Block>, &cache_handle);
 #ifndef NDEBUG
       block_cache->TEST_mark_as_data_block(block_cache_key, charge);
 #endif  // NDEBUG
@@ -1779,8 +1777,7 @@ Status BlockBasedTable::PutDataBlockToCache(
     size_t charge = block_holder->ApproximateMemoryUsage();
     Cache::Handle* cache_handle = nullptr;
     s = block_cache->Insert(block_cache_key, block_holder.get(), charge,
-                            &DeleteCachedEntry<Block>,
-                            &cache_handle, priority);
+                            &DeleteCachedEntry<Block>, &cache_handle, priority);
 #ifndef NDEBUG
     block_cache->TEST_mark_as_data_block(block_cache_key, charge);
 #endif  // NDEBUG
@@ -1890,8 +1887,8 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   // most probably fail again.
   if (!is_a_filter_partition &&
       !rep_->table_options.cache_index_and_filter_blocks) {
-    return {rep_->filter.get(), nullptr /* cache */,
-      nullptr /* cache_handle */, false /* own_value */};
+    return {rep_->filter.get(), /*cache=*/nullptr, /*cache_handle=*/nullptr,
+            /*own_value=*/false};
   }
 
   Cache* block_cache = rep_->table_options.block_cache.get();
@@ -1901,8 +1898,8 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   }
 
   if (!is_a_filter_partition && rep_->filter_entry.IsCached()) {
-    return {rep_->filter_entry.GetValue(), nullptr /* cache */,
-      nullptr /* cache_handle */, false /* own_value */};
+    return {rep_->filter_entry.GetValue(), /*cache=*/nullptr,
+    /*cache_handle=*/nullptr, /*own_value=*/false};
   }
 
   PERF_TIMER_GUARD(read_filter_block_nanos);
@@ -1944,7 +1941,7 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   }
 
   return {filter, cache_handle ? block_cache : nullptr, cache_handle,
-    false /* own_value */};
+          /*own_value=*/false};
 }
 
 CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
@@ -3146,8 +3143,8 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
 }
 
 Status BlockBasedTable::VerifyChecksum() {
-  // TODO(haoyu): This function is called by external sst ingestion and user.
-  // We don't log its block cache accesses for now.
+  // TODO(haoyu): This function is called by external sst ingestion and the verify checksum
+  // public API. We don't log its block cache accesses for now.
   Status s;
   // Check Meta blocks
   std::unique_ptr<Block> meta;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1887,8 +1887,8 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
   // most probably fail again.
   if (!is_a_filter_partition &&
       !rep_->table_options.cache_index_and_filter_blocks) {
-    return {rep_->filter.get(), /*cache=*/nullptr, /*cache_handle=*/nullptr,
-            /*own_value=*/false};
+    return {rep_->filter.get(), /*cache=*/nullptr,
+            /*cache_handle=*/nullptr, /*own_value=*/false};
   }
 
   Cache* block_cache = rep_->table_options.block_cache.get();
@@ -1899,7 +1899,7 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
 
   if (!is_a_filter_partition && rep_->filter_entry.IsCached()) {
     return {rep_->filter_entry.GetValue(), /*cache=*/nullptr,
-    /*cache_handle=*/nullptr, /*own_value=*/false};
+            /*cache_handle=*/nullptr, /*own_value=*/false};
   }
 
   PERF_TIMER_GUARD(read_filter_block_nanos);
@@ -2873,7 +2873,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
           filter != nullptr && filter->IsBlockBased() == true &&
           !filter->KeyMayMatch(ExtractUserKeyAndStripTimestamp(key, ts_sz),
                                prefix_extractor, handle.offset(), no_io,
-                               /*const_ikey_ptr=*/nullptr, &lookup_context);
+                               nullptr, &lookup_context);
 
       if (not_exist_in_filter) {
         // Not found
@@ -3005,9 +3005,10 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
           offset = iiter->value().offset();
           biter.Invalidate(Status::OK());
           NewDataBlockIterator<DataBlockIter>(
-              read_options, iiter->value(), &biter, BlockType::kData, false,
-              /*key_includes_seq=*/true, get_context, &lookup_context, Status(),
-              nullptr);
+              read_options, iiter->value(), &biter, BlockType::kData,
+              /*key_includes_seq=*/false,
+              /*index_key_is_full=*/true, get_context, &lookup_context,
+              Status(), nullptr);
           reusing_block = false;
         }
         if (read_options.read_tier == kBlockCacheTier &&
@@ -3143,8 +3144,8 @@ Status BlockBasedTable::Prefetch(const Slice* const begin,
 }
 
 Status BlockBasedTable::VerifyChecksum() {
-  // TODO(haoyu): This function is called by external sst ingestion and the verify checksum
-  // public API. We don't log its block cache accesses for now.
+  // TODO(haoyu): This function is called by external sst ingestion and the
+  // verify checksum public API. We don't log its block cache accesses for now.
   Status s;
   // Check Meta blocks
   std::unique_ptr<Block> meta;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -154,8 +154,7 @@ class BlockBasedTable : public TableReader {
   // bytes, and so includes effects like compression of the underlying data.
   // E.g., the approximate offset of the last key in the table will
   // be close to the file length.
-  uint64_t ApproximateOffsetOf(const Slice& key,
-                               bool for_compaction = false) override;
+  uint64_t ApproximateOffsetOf(const Slice& key, bool for_compaction) override;
 
   bool TEST_BlockInCache(const BlockHandle& handle) const;
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -397,7 +397,6 @@ class BlockBasedTable : public TableReader {
       FilePrefetchBuffer* prefetch_buffer,
       std::unique_ptr<const BlockContents>* compression_dict_block) const;
   Status PrefetchIndexAndFilterBlocks(
-
       FilePrefetchBuffer* prefetch_buffer, InternalIterator* meta_iter,
       BlockBasedTable* new_table, bool prefetch_all,
       const BlockBasedTableOptions& table_options, const int level,

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -100,16 +100,14 @@ class FilterBlockReader {
    */
   virtual bool KeyMayMatch(const Slice& key,
                            const SliceTransform* prefix_extractor,
-                           uint64_t block_offset = kNotValid,
-                           const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr,
-                           BlockCacheLookupContext* context = nullptr) = 0;
+                           uint64_t block_offset, const bool no_io,
+                           const Slice* const const_ikey_ptr,
+                           BlockCacheLookupContext* context) = 0;
 
   virtual void KeysMayMatch(MultiGetRange* range,
                             const SliceTransform* prefix_extractor,
-                            uint64_t block_offset = kNotValid,
-                            const bool no_io = false,
-                            BlockCacheLookupContext* context = nullptr) {
+                            uint64_t block_offset, const bool no_io,
+                            BlockCacheLookupContext* context) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
@@ -125,16 +123,14 @@ class FilterBlockReader {
    */
   virtual bool PrefixMayMatch(const Slice& prefix,
                               const SliceTransform* prefix_extractor,
-                              uint64_t block_offset = kNotValid,
-                              const bool no_io = false,
-                              const Slice* const const_ikey_ptr = nullptr,
-                              BlockCacheLookupContext* context = nullptr) = 0;
+                              uint64_t block_offset, const bool no_io,
+                              const Slice* const const_ikey_ptr,
+                              BlockCacheLookupContext* context) = 0;
 
   virtual void PrefixesMayMatch(MultiGetRange* range,
                                 const SliceTransform* prefix_extractor,
-                                uint64_t block_offset = kNotValid,
-                                const bool no_io = false,
-                                BlockCacheLookupContext* context = nullptr) {
+                                uint64_t block_offset, const bool no_io,
+                                BlockCacheLookupContext* context) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
@@ -160,14 +156,11 @@ class FilterBlockReader {
   virtual void CacheDependencies(bool /*pin*/,
                                  const SliceTransform* /*prefix_extractor*/) {}
 
-  virtual bool RangeMayExist(const Slice* /*iterate_upper_bound*/,
-                             const Slice& user_key,
-                             const SliceTransform* prefix_extractor,
-                             const Comparator* /*comparator*/,
-                             const Slice* const const_ikey_ptr,
-                             bool* filter_checked,
-                             bool /*need_upper_bound_check*/,
-                             BlockCacheLookupContext* context = nullptr) {
+  virtual bool RangeMayExist(
+      const Slice* /*iterate_upper_bound*/, const Slice& user_key,
+      const SliceTransform* prefix_extractor, const Comparator* /*comparator*/,
+      const Slice* const const_ikey_ptr, bool* filter_checked,
+      bool /*need_upper_bound_check*/, BlockCacheLookupContext* context) {
     *filter_checked = true;
     Slice prefix = prefix_extractor->Transform(user_key);
     return PrefixMayMatch(prefix, prefix_extractor, kNotValid, false,

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -30,6 +30,7 @@
 #include "rocksdb/table.h"
 #include "table/format.h"
 #include "table/multiget_context.h"
+#include "trace_replay/block_cache_tracer.h"
 #include "util/hash.h"
 
 namespace rocksdb {
@@ -101,16 +102,19 @@ class FilterBlockReader {
                            const SliceTransform* prefix_extractor,
                            uint64_t block_offset = kNotValid,
                            const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr) = 0;
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) = 0;
 
   virtual void KeysMayMatch(MultiGetRange* range,
                             const SliceTransform* prefix_extractor,
                             uint64_t block_offset = kNotValid,
-                            const bool no_io = false) {
+                            const bool no_io = false,
+                            BlockCacheLookupContext* context = nullptr) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
-      if (!KeyMayMatch(ukey, prefix_extractor, block_offset, no_io, &ikey)) {
+      if (!KeyMayMatch(ukey, prefix_extractor, block_offset, no_io, &ikey,
+                       context)) {
         range->SkipKey(iter);
       }
     }
@@ -123,17 +127,19 @@ class FilterBlockReader {
                               const SliceTransform* prefix_extractor,
                               uint64_t block_offset = kNotValid,
                               const bool no_io = false,
-                              const Slice* const const_ikey_ptr = nullptr) = 0;
+                              const Slice* const const_ikey_ptr = nullptr,
+                              BlockCacheLookupContext* context = nullptr) = 0;
 
   virtual void PrefixesMayMatch(MultiGetRange* range,
                                 const SliceTransform* prefix_extractor,
                                 uint64_t block_offset = kNotValid,
-                                const bool no_io = false) {
+                                const bool no_io = false,
+                                BlockCacheLookupContext* context = nullptr) {
     for (auto iter = range->begin(); iter != range->end(); ++iter) {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
       if (!KeyMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
-                       block_offset, no_io, &ikey)) {
+                       block_offset, no_io, &ikey, context)) {
         range->SkipKey(iter);
       }
     }
@@ -154,15 +160,18 @@ class FilterBlockReader {
   virtual void CacheDependencies(bool /*pin*/,
                                  const SliceTransform* /*prefix_extractor*/) {}
 
-  virtual bool RangeMayExist(
-      const Slice* /*iterate_upper_bound*/, const Slice& user_key,
-      const SliceTransform* prefix_extractor,
-      const Comparator* /*comparator*/, const Slice* const const_ikey_ptr,
-      bool* filter_checked, bool /*need_upper_bound_check*/) {
+  virtual bool RangeMayExist(const Slice* /*iterate_upper_bound*/,
+                             const Slice& user_key,
+                             const SliceTransform* prefix_extractor,
+                             const Comparator* /*comparator*/,
+                             const Slice* const const_ikey_ptr,
+                             bool* filter_checked,
+                             bool /*need_upper_bound_check*/,
+                             BlockCacheLookupContext* context = nullptr) {
     *filter_checked = true;
     Slice prefix = prefix_extractor->Transform(user_key);
     return PrefixMayMatch(prefix, prefix_extractor, kNotValid, false,
-                          const_ikey_ptr);
+                          const_ikey_ptr, context);
   }
 
  protected:

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -124,7 +124,8 @@ FullFilterBlockReader::FullFilterBlockReader(
 bool FullFilterBlockReader::KeyMayMatch(
     const Slice& key, const SliceTransform* /*prefix_extractor*/,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)block_offset;
 #endif
@@ -138,7 +139,8 @@ bool FullFilterBlockReader::KeyMayMatch(
 bool FullFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* /* prefix_extractor */,
     uint64_t block_offset, const bool /*no_io*/,
-    const Slice* const /*const_ikey_ptr*/) {
+    const Slice* const /*const_ikey_ptr*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)block_offset;
 #endif
@@ -161,7 +163,8 @@ bool FullFilterBlockReader::MayMatch(const Slice& entry) {
 
 void FullFilterBlockReader::KeysMayMatch(
     MultiGetRange* range, const SliceTransform* /*prefix_extractor*/,
-    uint64_t block_offset, const bool /*no_io*/) {
+    uint64_t block_offset, const bool /*no_io*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)range;
   (void)block_offset;
@@ -177,7 +180,8 @@ void FullFilterBlockReader::KeysMayMatch(
 
 void FullFilterBlockReader::PrefixesMayMatch(
     MultiGetRange* range, const SliceTransform* /* prefix_extractor */,
-    uint64_t block_offset, const bool /*no_io*/) {
+    uint64_t block_offset, const bool /*no_io*/,
+    BlockCacheLookupContext* /*context*/) {
 #ifdef NDEBUG
   (void)range;
   (void)block_offset;
@@ -224,10 +228,11 @@ size_t FullFilterBlockReader::ApproximateMemoryUsage() const {
   return usage;
 }
 
-bool FullFilterBlockReader::RangeMayExist(const Slice* iterate_upper_bound,
-    const Slice& user_key, const SliceTransform* prefix_extractor,
-    const Comparator* comparator, const Slice* const const_ikey_ptr,
-    bool* filter_checked, bool need_upper_bound_check) {
+bool FullFilterBlockReader::RangeMayExist(
+    const Slice* iterate_upper_bound, const Slice& user_key,
+    const SliceTransform* prefix_extractor, const Comparator* comparator,
+    const Slice* const const_ikey_ptr, bool* filter_checked,
+    bool need_upper_bound_check, BlockCacheLookupContext* context) {
   if (!prefix_extractor || !prefix_extractor->InDomain(user_key)) {
     *filter_checked = false;
     return true;
@@ -240,7 +245,7 @@ bool FullFilterBlockReader::RangeMayExist(const Slice* iterate_upper_bound,
   } else {
     *filter_checked = true;
     return PrefixMayMatch(prefix, prefix_extractor, kNotValid, false,
-                          const_ikey_ptr);
+                          const_ikey_ptr, context);
   }
 }
 

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -99,31 +99,36 @@ class FullFilterBlockReader : public FilterBlockReader {
 
   virtual bool IsBlockBased() override { return false; }
 
-  virtual bool KeyMayMatch(
-      const Slice& key, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+  virtual bool KeyMayMatch(const Slice& key,
+                           const SliceTransform* prefix_extractor,
+                           uint64_t block_offset = kNotValid,
+                           const bool no_io = false,
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) override;
 
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* context = nullptr) override;
 
-  virtual void KeysMayMatch(MultiGetRange* range,
-                            const SliceTransform* prefix_extractor,
-                            uint64_t block_offset = kNotValid,
-                            const bool no_io = false) override;
+  virtual void KeysMayMatch(
+      MultiGetRange* range, const SliceTransform* prefix_extractor,
+      uint64_t block_offset = kNotValid, const bool no_io = false,
+      BlockCacheLookupContext* context = nullptr) override;
 
-  virtual void PrefixesMayMatch(MultiGetRange* range,
-                                const SliceTransform* prefix_extractor,
-                                uint64_t block_offset = kNotValid,
-                                const bool no_io = false) override;
+  virtual void PrefixesMayMatch(
+      MultiGetRange* range, const SliceTransform* prefix_extractor,
+      uint64_t block_offset = kNotValid, const bool no_io = false,
+      BlockCacheLookupContext* context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
-  virtual bool RangeMayExist(const Slice* iterate_upper_bound, const Slice& user_key,
-                             const SliceTransform* prefix_extractor,
-                             const Comparator* comparator,
-                             const Slice* const const_ikey_ptr, bool* filter_checked,
-                             bool need_upper_bound_check) override;
+  virtual bool RangeMayExist(
+      const Slice* iterate_upper_bound, const Slice& user_key,
+      const SliceTransform* prefix_extractor, const Comparator* comparator,
+      const Slice* const const_ikey_ptr, bool* filter_checked,
+      bool need_upper_bound_check,
+      BlockCacheLookupContext* context = nullptr) override;
+
  private:
   const SliceTransform* prefix_extractor_;
   Slice contents_;

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -95,39 +95,37 @@ class FullFilterBlockReader : public FilterBlockReader {
 
   // bits_reader is created in filter_policy, it should be passed in here
   // directly. and be deleted here
-  ~FullFilterBlockReader() {}
+  ~FullFilterBlockReader() override {}
 
-  virtual bool IsBlockBased() override { return false; }
+  bool IsBlockBased() override { return false; }
 
-  virtual bool KeyMayMatch(const Slice& key,
-                           const SliceTransform* prefix_extractor,
-                           uint64_t block_offset, const bool no_io,
-                           const Slice* const const_ikey_ptr,
-                           BlockCacheLookupContext* context) override;
+  bool KeyMayMatch(const Slice& key, const SliceTransform* prefix_extractor,
+                   uint64_t block_offset, const bool no_io,
+                   const Slice* const const_ikey_ptr,
+                   BlockCacheLookupContext* context) override;
 
-  virtual bool PrefixMayMatch(const Slice& prefix,
-                              const SliceTransform* prefix_extractor,
-                              uint64_t block_offset, const bool no_io,
-                              const Slice* const const_ikey_ptr,
-                              BlockCacheLookupContext* context) override;
+  bool PrefixMayMatch(const Slice& prefix,
+                      const SliceTransform* prefix_extractor,
+                      uint64_t block_offset, const bool no_io,
+                      const Slice* const const_ikey_ptr,
+                      BlockCacheLookupContext* context) override;
 
-  virtual void KeysMayMatch(MultiGetRange* range,
-                            const SliceTransform* prefix_extractor,
-                            uint64_t block_offset, const bool no_io,
-                            BlockCacheLookupContext* context) override;
+  void KeysMayMatch(MultiGetRange* range,
+                    const SliceTransform* prefix_extractor,
+                    uint64_t block_offset, const bool no_io,
+                    BlockCacheLookupContext* context) override;
 
-  virtual void PrefixesMayMatch(MultiGetRange* range,
-                                const SliceTransform* prefix_extractor,
-                                uint64_t block_offset, const bool no_io,
-                                BlockCacheLookupContext* context) override;
-  virtual size_t ApproximateMemoryUsage() const override;
-  virtual bool RangeMayExist(const Slice* iterate_upper_bound,
-                             const Slice& user_key,
-                             const SliceTransform* prefix_extractor,
-                             const Comparator* comparator,
-                             const Slice* const const_ikey_ptr,
-                             bool* filter_checked, bool need_upper_bound_check,
-                             BlockCacheLookupContext* context) override;
+  void PrefixesMayMatch(MultiGetRange* range,
+                        const SliceTransform* prefix_extractor,
+                        uint64_t block_offset, const bool no_io,
+                        BlockCacheLookupContext* context) override;
+  size_t ApproximateMemoryUsage() const override;
+  bool RangeMayExist(const Slice* iterate_upper_bound, const Slice& user_key,
+                     const SliceTransform* prefix_extractor,
+                     const Comparator* comparator,
+                     const Slice* const const_ikey_ptr, bool* filter_checked,
+                     bool need_upper_bound_check,
+                     BlockCacheLookupContext* context) override;
 
  private:
   const SliceTransform* prefix_extractor_;

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -101,33 +101,33 @@ class FullFilterBlockReader : public FilterBlockReader {
 
   virtual bool KeyMayMatch(const Slice& key,
                            const SliceTransform* prefix_extractor,
-                           uint64_t block_offset = kNotValid,
-                           const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr,
-                           BlockCacheLookupContext* context = nullptr) override;
+                           uint64_t block_offset, const bool no_io,
+                           const Slice* const const_ikey_ptr,
+                           BlockCacheLookupContext* context) override;
 
-  virtual bool PrefixMayMatch(
-      const Slice& prefix, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr,
-      BlockCacheLookupContext* context = nullptr) override;
+  virtual bool PrefixMayMatch(const Slice& prefix,
+                              const SliceTransform* prefix_extractor,
+                              uint64_t block_offset, const bool no_io,
+                              const Slice* const const_ikey_ptr,
+                              BlockCacheLookupContext* context) override;
 
-  virtual void KeysMayMatch(
-      MultiGetRange* range, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      BlockCacheLookupContext* context = nullptr) override;
+  virtual void KeysMayMatch(MultiGetRange* range,
+                            const SliceTransform* prefix_extractor,
+                            uint64_t block_offset, const bool no_io,
+                            BlockCacheLookupContext* context) override;
 
-  virtual void PrefixesMayMatch(
-      MultiGetRange* range, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      BlockCacheLookupContext* context = nullptr) override;
+  virtual void PrefixesMayMatch(MultiGetRange* range,
+                                const SliceTransform* prefix_extractor,
+                                uint64_t block_offset, const bool no_io,
+                                BlockCacheLookupContext* context) override;
   virtual size_t ApproximateMemoryUsage() const override;
-  virtual bool RangeMayExist(
-      const Slice* iterate_upper_bound, const Slice& user_key,
-      const SliceTransform* prefix_extractor, const Comparator* comparator,
-      const Slice* const const_ikey_ptr, bool* filter_checked,
-      bool need_upper_bound_check,
-      BlockCacheLookupContext* context = nullptr) override;
+  virtual bool RangeMayExist(const Slice* iterate_upper_bound,
+                             const Slice& user_key,
+                             const SliceTransform* prefix_extractor,
+                             const Comparator* comparator,
+                             const Slice* const const_ikey_ptr,
+                             bool* filter_checked, bool need_upper_bound_check,
+                             BlockCacheLookupContext* context) override;
 
  private:
   const SliceTransform* prefix_extractor_;

--- a/table/block_based/full_filter_block_test.cc
+++ b/table/block_based/full_filter_block_test.cc
@@ -112,7 +112,9 @@ TEST_F(PluginFullFilterBlockTest, PluginEmptyBuilder) {
       nullptr, true, block,
       table_options_.filter_policy->GetFilterBitsReader(block), nullptr);
   // Remain same symantic with blockbased filter
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 TEST_F(PluginFullFilterBlockTest, PluginSingleChunk) {
@@ -127,13 +129,27 @@ TEST_F(PluginFullFilterBlockTest, PluginSingleChunk) {
   FullFilterBlockReader reader(
       nullptr, true, block,
       table_options_.filter_policy->GetFilterBitsReader(block), nullptr);
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("bar", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("box", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("hello", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
-  ASSERT_TRUE(!reader.KeyMayMatch("missing", nullptr));
-  ASSERT_TRUE(!reader.KeyMayMatch("other", nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "missing", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "other", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 class FullFilterBlockTest : public testing::Test {
@@ -157,7 +173,9 @@ TEST_F(FullFilterBlockTest, EmptyBuilder) {
       nullptr, true, block,
       table_options_.filter_policy->GetFilterBitsReader(block), nullptr);
   // Remain same symantic with blockbased filter
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 TEST_F(FullFilterBlockTest, DuplicateEntries) {
@@ -207,13 +225,27 @@ TEST_F(FullFilterBlockTest, SingleChunk) {
   FullFilterBlockReader reader(
       nullptr, true, block,
       table_options_.filter_policy->GetFilterBitsReader(block), nullptr);
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("bar", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("box", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("hello", nullptr));
-  ASSERT_TRUE(reader.KeyMayMatch("foo", nullptr));
-  ASSERT_TRUE(!reader.KeyMayMatch("missing", nullptr));
-  ASSERT_TRUE(!reader.KeyMayMatch("other", nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "bar", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "box", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "hello", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(reader.KeyMayMatch(
+      "foo", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "missing", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
+  ASSERT_TRUE(!reader.KeyMayMatch(
+      "other", /*prefix_extractor=*/nullptr, /*block_offset=*/kNotValid,
+      /*no_io=*/false, /*const_ikey_ptr=*/nullptr, /*context=*/nullptr));
 }
 
 }  // namespace rocksdb

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -207,7 +207,7 @@ bool PartitionedFilterBlockReader::PrefixMayMatch(
     return false;
   }
   auto filter_partition =
-      GetFilterPartition(nullptr /* prefetch_buffer */, filter_handle, no_io,
+      GetFilterPartition(/*prefetch_buffer=*/nullptr, filter_handle, no_io,
                          prefix_extractor, context);
   if (UNLIKELY(!filter_partition.GetValue())) {
     return true;
@@ -250,9 +250,9 @@ PartitionedFilterBlockReader::GetFilterPartition(
           nullptr /* cache_handle */, false /* own_value */};
       }
     }
-    return table_->GetFilter(/*prefetch_buffer*/ nullptr, fltr_blk_handle,
+    return table_->GetFilter(/*prefetch_buffer=*/nullptr, fltr_blk_handle,
                              is_a_filter_partition, no_io,
-                             /* get_context */ nullptr, context,
+                             /*get_context=*/nullptr, context,
                              prefix_extractor);
   } else {
     auto filter = table_->ReadFilter(prefetch_buffer, fltr_blk_handle,

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -77,20 +77,19 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
       Statistics* stats, const InternalKeyComparator comparator,
       const BlockBasedTable* table, const bool index_key_includes_seq,
       const bool index_value_is_full);
-  virtual ~PartitionedFilterBlockReader();
+  ~PartitionedFilterBlockReader() override;
 
-  virtual bool IsBlockBased() override { return false; }
-  virtual bool KeyMayMatch(const Slice& key,
-                           const SliceTransform* prefix_extractor,
-                           uint64_t block_offset, const bool no_io,
-                           const Slice* const const_ikey_ptr,
-                           BlockCacheLookupContext* context) override;
-  virtual bool PrefixMayMatch(const Slice& prefix,
-                              const SliceTransform* prefix_extractor,
-                              uint64_t block_offset, const bool no_io,
-                              const Slice* const const_ikey_ptr,
-                              BlockCacheLookupContext* context) override;
-  virtual size_t ApproximateMemoryUsage() const override;
+  bool IsBlockBased() override { return false; }
+  bool KeyMayMatch(const Slice& key, const SliceTransform* prefix_extractor,
+                   uint64_t block_offset, const bool no_io,
+                   const Slice* const const_ikey_ptr,
+                   BlockCacheLookupContext* context) override;
+  bool PrefixMayMatch(const Slice& prefix,
+                      const SliceTransform* prefix_extractor,
+                      uint64_t block_offset, const bool no_io,
+                      const Slice* const const_ikey_ptr,
+                      BlockCacheLookupContext* context) override;
+  size_t ApproximateMemoryUsage() const override;
 
  private:
   BlockHandle GetFilterPartitionHandle(const Slice& entry);
@@ -98,8 +97,8 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
       FilePrefetchBuffer* prefetch_buffer, BlockHandle& handle,
       const bool no_io, const SliceTransform* prefix_extractor,
       BlockCacheLookupContext* context);
-  virtual void CacheDependencies(
-      bool bin, const SliceTransform* prefix_extractor) override;
+  void CacheDependencies(bool bin,
+                         const SliceTransform* prefix_extractor) override;
 
   const SliceTransform* prefix_extractor_;
   std::unique_ptr<Block> idx_on_fltr_blk_;

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -82,23 +82,22 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   virtual bool IsBlockBased() override { return false; }
   virtual bool KeyMayMatch(const Slice& key,
                            const SliceTransform* prefix_extractor,
-                           uint64_t block_offset = kNotValid,
-                           const bool no_io = false,
-                           const Slice* const const_ikey_ptr = nullptr,
-                           BlockCacheLookupContext* context = nullptr) override;
-  virtual bool PrefixMayMatch(
-      const Slice& prefix, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr,
-      BlockCacheLookupContext* context = nullptr) override;
+                           uint64_t block_offset, const bool no_io,
+                           const Slice* const const_ikey_ptr,
+                           BlockCacheLookupContext* context) override;
+  virtual bool PrefixMayMatch(const Slice& prefix,
+                              const SliceTransform* prefix_extractor,
+                              uint64_t block_offset, const bool no_io,
+                              const Slice* const const_ikey_ptr,
+                              BlockCacheLookupContext* context) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
  private:
   BlockHandle GetFilterPartitionHandle(const Slice& entry);
   CachableEntry<FilterBlockReader> GetFilterPartition(
-      BlockCacheLookupContext* context, FilePrefetchBuffer* prefetch_buffer,
-      BlockHandle& handle, const bool no_io,
-      const SliceTransform* prefix_extractor = nullptr);
+      FilePrefetchBuffer* prefetch_buffer, BlockHandle& handle,
+      const bool no_io, const SliceTransform* prefix_extractor,
+      BlockCacheLookupContext* context);
   virtual void CacheDependencies(
       bool bin, const SliceTransform* prefix_extractor) override;
 

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -80,21 +80,25 @@ class PartitionedFilterBlockReader : public FilterBlockReader {
   virtual ~PartitionedFilterBlockReader();
 
   virtual bool IsBlockBased() override { return false; }
-  virtual bool KeyMayMatch(
-      const Slice& key, const SliceTransform* prefix_extractor,
-      uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+  virtual bool KeyMayMatch(const Slice& key,
+                           const SliceTransform* prefix_extractor,
+                           uint64_t block_offset = kNotValid,
+                           const bool no_io = false,
+                           const Slice* const const_ikey_ptr = nullptr,
+                           BlockCacheLookupContext* context = nullptr) override;
   virtual bool PrefixMayMatch(
       const Slice& prefix, const SliceTransform* prefix_extractor,
       uint64_t block_offset = kNotValid, const bool no_io = false,
-      const Slice* const const_ikey_ptr = nullptr) override;
+      const Slice* const const_ikey_ptr = nullptr,
+      BlockCacheLookupContext* context = nullptr) override;
   virtual size_t ApproximateMemoryUsage() const override;
 
  private:
   BlockHandle GetFilterPartitionHandle(const Slice& entry);
   CachableEntry<FilterBlockReader> GetFilterPartition(
-      FilePrefetchBuffer* prefetch_buffer, BlockHandle& handle,
-      const bool no_io, const SliceTransform* prefix_extractor = nullptr);
+      BlockCacheLookupContext* context, FilePrefetchBuffer* prefetch_buffer,
+      BlockHandle& handle, const bool no_io,
+      const SliceTransform* prefix_extractor = nullptr);
   virtual void CacheDependencies(
       bool bin, const SliceTransform* prefix_extractor) override;
 

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -29,8 +29,9 @@ class MockedBlockBasedTable : public BlockBasedTable {
   }
 
   CachableEntry<FilterBlockReader> GetFilter(
-      FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
-      const bool /* unused */, bool /* unused */, GetContext* /* unused */,
+      BlockCacheLookupContext* /*context*/, FilePrefetchBuffer*,
+      const BlockHandle& filter_blk_handle, const bool /* unused */,
+      bool /* unused */, GetContext* /* unused */,
       const SliceTransform* prefix_extractor) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -29,9 +29,9 @@ class MockedBlockBasedTable : public BlockBasedTable {
   }
 
   CachableEntry<FilterBlockReader> GetFilter(
-      BlockCacheLookupContext* /*context*/, FilePrefetchBuffer*,
-      const BlockHandle& filter_blk_handle, const bool /* unused */,
-      bool /* unused */, GetContext* /* unused */,
+      FilePrefetchBuffer*, const BlockHandle& filter_blk_handle,
+      const bool /* unused */, bool /* unused */, GetContext* /* unused */,
+      BlockCacheLookupContext* /*context*/,
       const SliceTransform* prefix_extractor) const override {
     Slice slice = slices[filter_blk_handle.offset()];
     auto obj = new FullFilterBlockReader(
@@ -169,14 +169,14 @@ class PartitionedFilterBlockTest
       auto ikey = InternalKey(key, 0, ValueType::kTypeValue);
       const Slice ikey_slice = Slice(*ikey.rep());
       ASSERT_TRUE(reader->KeyMayMatch(key, prefix_extractor, kNotValid, !no_io,
-                                      &ikey_slice));
+                                      &ikey_slice, nullptr));
     }
     {
       // querying a key twice
       auto ikey = InternalKey(keys[0], 0, ValueType::kTypeValue);
       const Slice ikey_slice = Slice(*ikey.rep());
       ASSERT_TRUE(reader->KeyMayMatch(keys[0], prefix_extractor, kNotValid,
-                                      !no_io, &ikey_slice));
+                                      !no_io, &ikey_slice, nullptr));
     }
     // querying missing keys
     for (auto key : missing_keys) {
@@ -184,11 +184,11 @@ class PartitionedFilterBlockTest
       const Slice ikey_slice = Slice(*ikey.rep());
       if (empty) {
         ASSERT_TRUE(reader->KeyMayMatch(key, prefix_extractor, kNotValid,
-                                        !no_io, &ikey_slice));
+                                        !no_io, &ikey_slice, nullptr));
       } else {
         // assuming a good hash function
         ASSERT_FALSE(reader->KeyMayMatch(key, prefix_extractor, kNotValid,
-                                         !no_io, &ikey_slice));
+                                         !no_io, &ikey_slice, nullptr));
       }
     }
   }
@@ -338,7 +338,7 @@ TEST_P(PartitionedFilterBlockTest, SamePrefixInMultipleBlocks) {
     const Slice ikey_slice = Slice(*ikey.rep());
     ASSERT_TRUE(reader->PrefixMayMatch(prefix_extractor->Transform(key),
                                        prefix_extractor.get(), kNotValid,
-                                       false /*no_io*/, &ikey_slice));
+                                       false /*no_io*/, &ikey_slice, nullptr));
   }
 }
 

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -169,14 +169,15 @@ class PartitionedFilterBlockTest
       auto ikey = InternalKey(key, 0, ValueType::kTypeValue);
       const Slice ikey_slice = Slice(*ikey.rep());
       ASSERT_TRUE(reader->KeyMayMatch(key, prefix_extractor, kNotValid, !no_io,
-                                      &ikey_slice, nullptr));
+                                      &ikey_slice, /*context=*/nullptr));
     }
     {
       // querying a key twice
       auto ikey = InternalKey(keys[0], 0, ValueType::kTypeValue);
       const Slice ikey_slice = Slice(*ikey.rep());
       ASSERT_TRUE(reader->KeyMayMatch(keys[0], prefix_extractor, kNotValid,
-                                      !no_io, &ikey_slice, nullptr));
+                                      !no_io, &ikey_slice,
+                                      /*context=*/nullptr));
     }
     // querying missing keys
     for (auto key : missing_keys) {
@@ -184,11 +185,13 @@ class PartitionedFilterBlockTest
       const Slice ikey_slice = Slice(*ikey.rep());
       if (empty) {
         ASSERT_TRUE(reader->KeyMayMatch(key, prefix_extractor, kNotValid,
-                                        !no_io, &ikey_slice, nullptr));
+                                        !no_io, &ikey_slice,
+                                        /*context=*/nullptr));
       } else {
         // assuming a good hash function
         ASSERT_FALSE(reader->KeyMayMatch(key, prefix_extractor, kNotValid,
-                                         !no_io, &ikey_slice, nullptr));
+                                         !no_io, &ikey_slice,
+                                         /*context=*/nullptr));
       }
     }
   }
@@ -336,9 +339,9 @@ TEST_P(PartitionedFilterBlockTest, SamePrefixInMultipleBlocks) {
   for (auto key : pkeys) {
     auto ikey = InternalKey(key, 0, ValueType::kTypeValue);
     const Slice ikey_slice = Slice(*ikey.rep());
-    ASSERT_TRUE(reader->PrefixMayMatch(prefix_extractor->Transform(key),
-                                       prefix_extractor.get(), kNotValid,
-                                       false /*no_io*/, &ikey_slice, nullptr));
+    ASSERT_TRUE(reader->PrefixMayMatch(
+        prefix_extractor->Transform(key), prefix_extractor.get(), kNotValid,
+        /*no_io=*/false, &ikey_slice, /*context=*/nullptr));
   }
 }
 

--- a/table/cuckoo/cuckoo_table_reader.h
+++ b/table/cuckoo/cuckoo_table_reader.h
@@ -56,7 +56,10 @@ class CuckooTableReader: public TableReader {
   size_t ApproximateMemoryUsage() const override;
 
   // Following methods are not implemented for Cuckoo Table Reader
-  uint64_t ApproximateOffsetOf(const Slice& /*key*/) override { return 0; }
+  uint64_t ApproximateOffsetOf(const Slice& /*key*/,
+                               bool /*for_compaction*/ = false) override {
+    return 0;
+  }
   void SetupForCompaction() override {}
   // End of methods not implemented.
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -50,7 +50,10 @@ class MockTableReader : public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
-  uint64_t ApproximateOffsetOf(const Slice& /*key*/) override { return 0; }
+  uint64_t ApproximateOffsetOf(const Slice& /*key*/,
+                               bool /*for_compaction*/ = false) override {
+    return 0;
+  }
 
   virtual size_t ApproximateMemoryUsage() const override { return 0; }
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -55,7 +55,7 @@ class MockTableReader : public TableReader {
     return 0;
   }
 
-  virtual size_t ApproximateMemoryUsage() const override { return 0; }
+  size_t ApproximateMemoryUsage() const override { return 0; }
 
   void SetupForCompaction() override {}
 

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -613,7 +613,8 @@ Status PlainTableReader::Get(const ReadOptions& /*ro*/, const Slice& target,
   return Status::OK();
 }
 
-uint64_t PlainTableReader::ApproximateOffsetOf(const Slice& /*key*/) {
+uint64_t PlainTableReader::ApproximateOffsetOf(const Slice& /*key*/,
+                                               bool /*for_compaction*/) {
   return 0;
 }
 

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -89,7 +89,8 @@ class PlainTableReader: public TableReader {
              GetContext* get_context, const SliceTransform* prefix_extractor,
              bool skip_filters = false) override;
 
-  uint64_t ApproximateOffsetOf(const Slice& key) override;
+  uint64_t ApproximateOffsetOf(const Slice& key,
+                               bool for_compaction = false) override;
 
   uint32_t GetIndexSize() const { return index_.GetIndexSize(); }
   void SetupForCompaction() override;

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -61,7 +61,8 @@ class TableReader {
   // bytes, and so includes effects like compression of the underlying data.
   // E.g., the approximate offset of the last key in the table will
   // be close to the file length.
-  virtual uint64_t ApproximateOffsetOf(const Slice& key) = 0;
+  virtual uint64_t ApproximateOffsetOf(const Slice& key,
+                                       bool for_compaction = false) = 0;
 
   // Set up the table for Compaction. Might change some parameters with
   // posix_fadvise

--- a/utilities/transactions/pessimistic_transaction.cc
+++ b/utilities/transactions/pessimistic_transaction.cc
@@ -231,7 +231,8 @@ Status WriteCommittedTxn::PrepareInternal() {
       (void)two_write_queues_;  // to silence unused private field warning
     }
     virtual Status Callback(SequenceNumber, bool is_mem_disabled,
-                            uint64_t log_number) override {
+                            uint64_t log_number, size_t /*index*/,
+                            size_t /*total*/) override {
 #ifdef NDEBUG
       (void)is_mem_disabled;
 #endif

--- a/utilities/transactions/write_prepared_txn_db.cc
+++ b/utilities/transactions/write_prepared_txn_db.cc
@@ -7,8 +7,8 @@
 
 #include "utilities/transactions/write_prepared_txn_db.h"
 
-#include <cinttypes>
 #include <algorithm>
+#include <cinttypes>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -61,8 +61,8 @@ Status WritePreparedTxnDB::Initialize(
     explicit CommitSubBatchPreReleaseCallback(WritePreparedTxnDB* db)
         : db_(db) {}
     Status Callback(SequenceNumber commit_seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(!is_mem_disabled);
       db_->AddCommitted(commit_seq, commit_seq);
       return Status::OK();
@@ -211,9 +211,7 @@ Status WritePreparedTxnDB::WriteInternal(const WriteOptions& write_options_orig,
                           no_log_ref, DISABLE_MEMTABLE, &seq_used, ONE_BATCH,
                           &update_commit_map_with_prepare);
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
-  // Note RemovePrepared should be called after WriteImpl that publishsed the
-  // seq. Otherwise SmallestUnCommittedSeq optimization breaks.
-  RemovePrepared(prepare_seq, batch_cnt);
+  // Note: RemovePrepared is called from within PreReleaseCallback
   return s;
 }
 
@@ -389,8 +387,8 @@ void WritePreparedTxnDB::Init(const TransactionDBOptions& /* unused */) {
       new std::atomic<CommitEntry64b>[COMMIT_CACHE_SIZE] {});
 }
 
-void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max) {
-  prepared_mutex_.AssertHeld();
+void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max,
+                                                 bool locked) {
   // When max_evicted_seq_ advances, move older entries from prepared_txns_
   // to delayed_prepared_. This guarantees that if a seq is lower than max,
   // then it is not in prepared_txns_ and save an expensive, synchronized
@@ -401,25 +399,42 @@ void WritePreparedTxnDB::CheckPreparedAgainstMax(SequenceNumber new_max) {
       "CheckPreparedAgainstMax prepared_txns_.empty() %d top: %" PRIu64,
       prepared_txns_.empty(),
       prepared_txns_.empty() ? 0 : prepared_txns_.top());
-  while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
-    auto to_be_popped = prepared_txns_.top();
-    delayed_prepared_.insert(to_be_popped);
-    ROCKS_LOG_WARN(info_log_,
-                   "prepared_mutex_ overhead %" PRIu64 " (prep=%" PRIu64
-                   " new_max=%" PRIu64,
-                   static_cast<uint64_t>(delayed_prepared_.size()),
-                   to_be_popped, new_max);
-    prepared_txns_.pop();
-    delayed_prepared_empty_.store(false, std::memory_order_release);
+  const SequenceNumber prepared_top = prepared_txns_.top();
+  const bool empty = prepared_top == kMaxSequenceNumber;
+  // Preliminary check to avoid the synchronization cost
+  if (!empty && prepared_top <= new_max) {
+    if (locked) {
+      // Needed to avoid double locking in pop().
+      prepared_txns_.push_pop_mutex()->Unlock();
+    }
+    WriteLock wl(&prepared_mutex_);
+    // Need to fetch fresh values of ::top after mutex is acquired
+    while (!prepared_txns_.empty() && prepared_txns_.top() <= new_max) {
+      auto to_be_popped = prepared_txns_.top();
+      delayed_prepared_.insert(to_be_popped);
+      ROCKS_LOG_WARN(info_log_,
+                     "prepared_mutex_ overhead %" PRIu64 " (prep=%" PRIu64
+                     " new_max=%" PRIu64,
+                     static_cast<uint64_t>(delayed_prepared_.size()),
+                     to_be_popped, new_max);
+      prepared_txns_.pop();
+      delayed_prepared_empty_.store(false, std::memory_order_release);
+    }
+    if (locked) {
+      prepared_txns_.push_pop_mutex()->Lock();
+    }
   }
 }
 
-void WritePreparedTxnDB::AddPrepared(uint64_t seq) {
+void WritePreparedTxnDB::AddPrepared(uint64_t seq, bool locked) {
   ROCKS_LOG_DETAILS(info_log_, "Txn %" PRIu64 " Preparing with max %" PRIu64,
                     seq, max_evicted_seq_.load());
   TEST_SYNC_POINT("AddPrepared::begin:pause");
   TEST_SYNC_POINT("AddPrepared::begin:resume");
-  WriteLock wl(&prepared_mutex_);
+  if (!locked) {
+    prepared_txns_.push_pop_mutex()->Lock();
+  }
+  prepared_txns_.push_pop_mutex()->AssertHeld();
   prepared_txns_.push(seq);
   auto new_max = future_max_evicted_seq_.load();
   if (UNLIKELY(seq <= new_max)) {
@@ -429,7 +444,10 @@ void WritePreparedTxnDB::AddPrepared(uint64_t seq) {
         "Added prepare_seq is not larger than max_evicted_seq_: %" PRIu64
         " <= %" PRIu64,
         seq, new_max);
-    CheckPreparedAgainstMax(new_max);
+    CheckPreparedAgainstMax(new_max, true /*locked*/);
+  }
+  if (!locked) {
+    prepared_txns_.push_pop_mutex()->Unlock();
   }
   TEST_SYNC_POINT("AddPrepared::end");
 }
@@ -582,10 +600,7 @@ void WritePreparedTxnDB::AdvanceMaxEvictedSeq(const SequenceNumber& prev_max,
              std::memory_order_relaxed)) {
   };
 
-  {
-    WriteLock wl(&prepared_mutex_);
-    CheckPreparedAgainstMax(new_max);
-  }
+  CheckPreparedAgainstMax(new_max, false /*locked*/);
 
   // With each change to max_evicted_seq_ fetch the live snapshots behind it.
   // We use max as the version of snapshots to identify how fresh are the
@@ -641,6 +656,7 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
   // than the smallest uncommitted seq when the snapshot was taken.
   auto min_uncommitted = WritePreparedTxnDB::SmallestUnCommittedSeq();
   SnapshotImpl* snap_impl = db_impl_->GetSnapshotImpl(for_ww_conflict_check);
+  TEST_SYNC_POINT("WritePreparedTxnDB::GetSnapshotInternal:first");
   assert(snap_impl);
   SequenceNumber snap_seq = snap_impl->GetSequenceNumber();
   // Note: Check against future_max_evicted_seq_ (in contrast with
@@ -679,6 +695,7 @@ SnapshotImpl* WritePreparedTxnDB::GetSnapshotInternal(
       db_impl_->immutable_db_options().info_log,
       "GetSnapshot %" PRIu64 " ww:%" PRIi32 " min_uncommitted: %" PRIu64,
       snap_impl->GetSequenceNumber(), for_ww_conflict_check, min_uncommitted);
+  TEST_SYNC_POINT("WritePreparedTxnDB::GetSnapshotInternal:end");
   return snap_impl;
 }
 

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -319,8 +319,8 @@ Status WriteUnpreparedTxn::CommitInternal() {
     explicit PublishSeqPreReleaseCallback(DBImpl* db_impl)
         : db_impl_(db_impl) {}
     Status Callback(SequenceNumber seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(is_mem_disabled);
       assert(db_impl_->immutable_db_options().two_write_queues);
       db_impl_->SetLastPublishedSequence(seq);

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -185,8 +185,8 @@ Status WriteUnpreparedTxnDB::Initialize(
     explicit CommitSubBatchPreReleaseCallback(WritePreparedTxnDB* db)
         : db_(db) {}
     Status Callback(SequenceNumber commit_seq,
-                    bool is_mem_disabled __attribute__((__unused__)),
-                    uint64_t) override {
+                    bool is_mem_disabled __attribute__((__unused__)), uint64_t,
+                    size_t /*index*/, size_t /*total*/) override {
       assert(!is_mem_disabled);
       db_->AddCommitted(commit_seq, commit_seq);
       return Status::OK();

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -57,7 +57,8 @@ class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t) override {
+                          uint64_t, size_t /*index*/,
+                          size_t /*total*/) override {
     const uint64_t last_commit_seq = LIKELY(data_batch_cnt_ <= 1)
                                          ? commit_seq
                                          : commit_seq + data_batch_cnt_ - 1;
@@ -121,7 +122,8 @@ class WriteUnpreparedRollbackPreReleaseCallback : public PreReleaseCallback {
 
   virtual Status Callback(SequenceNumber commit_seq,
                           bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t) override {
+                          uint64_t, size_t /*index*/,
+                          size_t /*total*/) override {
     assert(is_mem_disabled);  // implies the 2nd queue
     const uint64_t last_commit_seq = commit_seq;
     db_->AddCommitted(rollback_seq_, last_commit_seq);


### PR DESCRIPTION
BlockCacheLookupContext only contains the caller for now.
We will trace block accesses at five places:
1. BlockBasedTable::GetFilter.
2. BlockBasedTable::GetUncompressedDict.
3. BlockBasedTable::MaybeReadAndLoadToCache. (To trace access on data, index, and range deletion block.)
4. BlockBasedTable::Get. (To trace the referenced key and whether the referenced key exists in a fetched data block.)
5. BlockBasedTable::MultiGet. (To trace the referenced key and whether the referenced key exists in a fetched data block.)

We create the context at:
1. BlockBasedTable::Get. (kUserGet)
2. BlockBasedTable::MultiGet. (kUserMGet)
3. BlockBasedTable::NewIterator. (either kUserIterator, kCompaction, or external SST ingestion calls this function.)
4. BlockBasedTable::Open. (kPrefetch)
5. Index/Filter::CacheDependencies. (kPrefetch)
6. BlockBasedTable::ApproximateOffsetOf. (kCompaction or kUserApproximateSize).

I loaded 1 million key-value pairs into the database and ran the readrandom benchmark with a single thread. I gave the block cache 10 GB to make sure all reads hit the block cache after warmup. The throughput is comparable.
Throughput of this PR: 231334 ops/s.
Throughput of the master branch: 238428 ops/s.

Experiment setup: 
RocksDB:    version 6.2
Date:       Mon Jun 10 10:42:51 2019
CPU:        24 * Intel Core Processor (Skylake)
CPUCache:   16384 KB
Keys:       20 bytes each
Values:     100 bytes each (100 bytes after compression)
Entries:    1000000
Prefix:    20 bytes
Keys per prefix:    0
RawSize:    114.4 MB (estimated)
FileSize:   114.4 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Compression sampling rate: 0
Memtablerep: skip_list
Perf Level: 1

Load command: ./db_bench --benchmarks="fillseq" --key_size=20 --prefix_size=20 --keys_per_prefix=0 --value_size=100 --statistics --cache_index_and_filter_blocks --cache_size=10737418240 --disable_auto_compactions=1 --disable_wal=1 --compression_type=none --min_level_to_compress=-1 --compression_ratio=1 --num=1000000

Run command: ./db_bench --benchmarks="readrandom,stats" --use_existing_db --threads=1 --duration=120 --key_size=20 --prefix_size=20 --keys_per_prefix=0 --value_size=100 --statistics --cache_index_and_filter_blocks --cache_size=10737418240 --disable_auto_compactions=1 --disable_wal=1 --compression_type=none --min_level_to_compress=-1 --compression_ratio=1 --num=1000000 --duration=120

TODOs:
1. Create a caller for external SST file ingestion and differentiate the callers for iterator.
2. Integrate tracer to trace block cache accesses. 