### PR TITLE
Revert to checking the upper bound on a per-key basis in BlockBasedTableIterator

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -467,6 +467,8 @@ inline bool DBIter::FindNextUserEntryInternal(bool skipping, bool prefix_check) 
 
     is_key_seqnum_zero_ = (ikey_.sequence == 0);
 
+    assert(iterate_upper_bound_ == nullptr || iter_.MayBeOutOfUpperBound() ||
+           user_comparator_.Compare(ikey_.user_key, *iterate_upper_bound_) < 0);
     if (iterate_upper_bound_ != nullptr && iter_.MayBeOutOfUpperBound() &&
         user_comparator_.Compare(ikey_.user_key, *iterate_upper_bound_) >= 0) {
       break;
@@ -859,6 +861,9 @@ void DBIter::PrevInternal() {
       return;
     }
 
+    assert(iterate_lower_bound_ == nullptr || iter_.MayBeOutOfLowerBound() ||
+           user_comparator_.Compare(saved_key_.GetUserKey(),
+                                    *iterate_lower_bound_) >= 0);
     if (iterate_lower_bound_ != nullptr && iter_.MayBeOutOfLowerBound() &&
         user_comparator_.Compare(saved_key_.GetUserKey(),
                                  *iterate_lower_bound_) < 0) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2597,9 +2597,15 @@ void BlockBasedTableIterator<TBlockIter, TValue>::FindBlockForward() {
       return;
     }
     // Whether next data block is out of upper bound, if there is one.
-    bool next_block_is_out_of_bound =
+    // TODO: we should be able to use !data_block_within_upper_bound_ here
+    // instead of performing the comparison; however, the flag can apparently
+    // be out of sync with the comparison in some cases. This should be
+    // investigated.
+    const bool next_block_is_out_of_bound =
         read_options_.iterate_upper_bound != nullptr &&
-        block_iter_points_to_real_block_ && !data_block_within_upper_bound_;
+        block_iter_points_to_real_block_ &&
+        (user_comparator_.Compare(*read_options_.iterate_upper_bound,
+                                  index_iter_->user_key()) <= 0);
     ResetDataIter();
     index_iter_->Next();
     if (next_block_is_out_of_bound) {


### PR DESCRIPTION
Summary:
PR #5111 reduced the number of key comparisons when iterating with
upper/lower bounds; however, this caused a regression for MyRocks.
Reverting to the previous behavior in BlockBasedTableIterator as a hotfix.

Test Plan:
make check + affected MyRocks test