### PR TITLE
WritePrepared: switch PreparedHeap from priority_queue to deque

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -81,11 +81,14 @@ TEST(PreparedHeap, BasicsTest) {
   ASSERT_EQ(64l, heap.top());
   heap.erase(84l);
   ASSERT_EQ(64l, heap.top());
-  heap.push(85l);
-  heap.push(86l);
-  heap.push(87l);
-  heap.push(88l);
-  heap.push(89l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(85l);
+    heap.push(86l);
+    heap.push(87l);
+    heap.push(88l);
+    heap.push(89l);
+  }
   heap.erase(87l);
   heap.erase(85l);
   heap.erase(89l);
@@ -106,13 +109,19 @@ TEST(PreparedHeap, BasicsTest) {
 // not resurface again.
 TEST(PreparedHeap, EmptyAtTheEnd) {
   WritePreparedTxnDB::PreparedHeap heap;
-  heap.push(40l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(40l);
+  }
   ASSERT_EQ(40l, heap.top());
   // Although not a recommended scenario, we must be resilient against erase
   // without a prior push.
   heap.erase(50l);
   ASSERT_EQ(40l, heap.top());
-  heap.push(60l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(60l);
+  }
   ASSERT_EQ(40l, heap.top());
 
   heap.erase(60l);
@@ -120,11 +129,17 @@ TEST(PreparedHeap, EmptyAtTheEnd) {
   heap.erase(40l);
   ASSERT_TRUE(heap.empty());
 
-  heap.push(40l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(40l);
+  }
   ASSERT_EQ(40l, heap.top());
   heap.erase(50l);
   ASSERT_EQ(40l, heap.top());
-  heap.push(60l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(60l);
+  }
   ASSERT_EQ(40l, heap.top());
 
   heap.erase(40l);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -146,7 +146,7 @@ TEST(PreparedHeap, Concurrent) {
 
   for (size_t n = 0; n < 100; n++) {
     last = 0;
-    t[0] = rocksdb::port::Thread([&heap, &prepared_mutex, &last]() {
+    t[0] = rocksdb::port::Thread([&heap, t_cnt, &last]() {
       Random rnd(1103);
       for (size_t seq = 1; seq <= t_cnt; seq++) {
         // This is not recommended usage but we should be resilient against it.

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -48,18 +48,21 @@ using CommitEntry64bFormat = WritePreparedTxnDB::CommitEntry64bFormat;
 
 TEST(PreparedHeap, BasicsTest) {
   WritePreparedTxnDB::PreparedHeap heap;
-  heap.push(14l);
-  // Test with one element
-  ASSERT_EQ(14l, heap.top());
-  heap.push(24l);
-  heap.push(34l);
-  // Test that old min is still on top
-  ASSERT_EQ(14l, heap.top());
-  heap.push(44l);
-  heap.push(54l);
-  heap.push(64l);
-  heap.push(74l);
-  heap.push(84l);
+  {
+    MutexLock ml(heap.push_pop_mutex());
+    heap.push(14l);
+    // Test with one element
+    ASSERT_EQ(14l, heap.top());
+    heap.push(24l);
+    heap.push(34l);
+    // Test that old min is still on top
+    ASSERT_EQ(14l, heap.top());
+    heap.push(44l);
+    heap.push(54l);
+    heap.push(64l);
+    heap.push(74l);
+    heap.push(84l);
+  }
   // Test that old min is still on top
   ASSERT_EQ(14l, heap.top());
   heap.erase(24l);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -572,13 +572,16 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // Concurrrent calls needs external synchronization. It is safe to be called
     // concurrent to push and pop though.
     void erase(uint64_t seq) {
-      if (!heap_.empty()) {
+      if (!empty()) {
         auto top_seq = top();
         if (seq < top_seq) {
           // Already popped, ignore it.
         } else if (top_seq == seq) {
           pop();
+#ifndef NDEBUG
+          MutexLock ml(push_pop_mutex());
           assert(heap_.empty() || heap_.front() != seq);
+#endif
         } else {  // top() > seq
           // Down the heap, remember to pop it later
           erased_heap_.push(seq);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -511,9 +511,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // The mutex is required for push and pop from PreparedHeap. ::erase will
     // use external synchronization via prepared_mutex_.
     port::Mutex push_pop_mutex_;
-    // TODO(myabandeh): replace it with deque
-    std::priority_queue<uint64_t, std::vector<uint64_t>, std::greater<uint64_t>>
-        heap_;
+    std::deque<uint64_t> heap_;
     std::priority_queue<uint64_t, std::vector<uint64_t>, std::greater<uint64_t>>
         erased_heap_;
     std::atomic<uint64_t> heap_top_ = {kMaxSequenceNumber};
@@ -534,21 +532,25 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // Returns kMaxSequenceNumber if empty() and the smallest otherwise.
     inline uint64_t top() { return heap_top_.load(std::memory_order_acquire); }
     inline void push(uint64_t v) {
-      heap_.push(v);
-      heap_top_.store(heap_.top(), std::memory_order_release);
+      if (heap_.empty()) {
+        heap_top_.store(v, std::memory_order_release);
+      } else {
+        assert(heap_top_.load() < v);
+      }
+      heap_.push_back(v); 
     }
     void pop(bool locked = false) {
       if (!locked) {
         push_pop_mutex()->Lock();
       }
-      heap_.pop();
+      heap_.pop_front();
       while (!heap_.empty() && !erased_heap_.empty() &&
              // heap_.top() > erased_heap_.top() could happen if we have erased
              // a non-existent entry. Ideally the user should not do that but we
              // should be resilient against it.
-             heap_.top() >= erased_heap_.top()) {
-        if (heap_.top() == erased_heap_.top()) {
-          heap_.pop();
+             heap_.front() >= erased_heap_.top()) {
+        if (heap_.front() == erased_heap_.top()) {
+          heap_.pop_front();
         }
         uint64_t erased __attribute__((__unused__));
         erased = erased_heap_.top();
@@ -559,7 +561,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       while (heap_.empty() && !erased_heap_.empty()) {
         erased_heap_.pop();
       }
-      heap_top_.store(!heap_.empty() ? heap_.top() : kMaxSequenceNumber,
+      heap_top_.store(!heap_.empty() ? heap_.front() : kMaxSequenceNumber,
                       std::memory_order_release);
       if (!locked) {
         push_pop_mutex()->Unlock();
@@ -574,7 +576,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
           // Already popped, ignore it.
         } else if (top_seq == seq) {
           pop();
-          assert(heap_.empty() || heap_.top() != seq);
+          assert(heap_.empty() || heap_.front() != seq);
         } else {  // top() > seq
           // Down the heap, remember to pop it later
           erased_heap_.push(seq);

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -532,6 +532,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
     // Returns kMaxSequenceNumber if empty() and the smallest otherwise.
     inline uint64_t top() { return heap_top_.load(std::memory_order_acquire); }
     inline void push(uint64_t v) {
+      push_pop_mutex_.AssertHeld();
       if (heap_.empty()) {
         heap_top_.store(v, std::memory_order_release);
       } else {
@@ -543,6 +544,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       if (!locked) {
         push_pop_mutex()->Lock();
       }
+      push_pop_mutex_.AssertHeld();
       heap_.pop_front();
       while (!heap_.empty() && !erased_heap_.empty() &&
              // heap_.top() > erased_heap_.top() could happen if we have erased


### PR DESCRIPTION
Internally PreparedHeap is currently using a priority_queue. The rationale was the in the initial design PreparedHeap::AddPrepared could be called in arbitrary order. With the recent optimizations, we call ::AddPrepared only from the main write queue, which results into in-order insertion into PreparedHeap. The patch thus replaces the underlying priority_queue with a more efficient deque implementation.