### PR TITLE
Disable kPipelinedWrite in MultiThreaded

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2285,6 +2285,7 @@ class MultiThreadedDBTest
 };
 
 TEST_P(MultiThreadedDBTest, MultiThreaded) {
+  if (option_config_ == kPipelinedWrite) return;
   anon::OptionsOverride options_override;
   options_override.skip_policy = kSkipNoSnapshot;
   Options options = CurrentOptions(options_override);


### PR DESCRIPTION
TSAN tests report a race condition. We temporarily exclude kPipelinedWrite from MultiThreaded until the race condition is fixed.

Test plan: COMPILE_WITH_TSAN=1 make -j32 check