### PR TITLE
Remove passing const variable to thread

### DIFF
--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -164,7 +164,7 @@ TEST(PreparedHeap, Concurrent) {
 
   for (size_t n = 0; n < 100; n++) {
     last = 0;
-    t[0] = rocksdb::port::Thread([&heap, t_cnt, &last]() {
+    t[0] = rocksdb::port::Thread([&heap, &last]() {
       Random rnd(1103);
       for (size_t seq = 1; seq <= t_cnt; seq++) {
         // This is not recommended usage but we should be resilient against it.


### PR DESCRIPTION
CLANG complains that passing const to thread is not necessary. The patch removes it form PreparedHeap::Concurrent test.