### PR TITLE
Add missing check before calling PurgeObsoleteFiles in EnableFileDeletions

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -57,7 +57,9 @@ Status DBImpl::EnableFileDeletions(bool force) {
   }
   if (file_deletion_enabled) {
     ROCKS_LOG_INFO(immutable_db_options_.info_log, "File Deletions Enabled");
-    PurgeObsoleteFiles(job_context);
+    if (job_context.HaveSomethingToDelete()) {
+      PurgeObsoleteFiles(job_context);
+    }
   } else {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "File Deletions Enable, but not really enabled. Counter: %d",


### PR DESCRIPTION
Summary:
Calling PurgeObsoleteFiles with a JobContext for which HaveSomethingToDelete
is false is a precondition violation. This would trigger an assertion in debug builds;
however, in release builds with assertions disabled, this can result in the
pending_purge_obsolete_files_ counter in DBImpl underflowing, which in turn can lead
to the process hanging during database close.

Test Plan:
Tested that the sequence DisableFileDeletions -> move database directory ->
EnableFileDeletions works correctly with the patch (this results in assertion failure or
hang during close without the patch).