### PR TITLE
Validate DBOptions before CF options

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -159,14 +159,16 @@ Status SanitizeOptionsByTable(
 Status DBImpl::ValidateOptions(
     const DBOptions& db_options,
     const std::vector<ColumnFamilyDescriptor>& column_families) {
-  Status s;
+  Status s = ValidateOptions(db_options);
+  if (!s.ok()) {
+    return s;
+  }
   for (auto& cfd : column_families) {
     s = ColumnFamilyData::ValidateOptions(db_options, cfd.options);
     if (!s.ok()) {
       return s;
     }
   }
-  s = ValidateOptions(db_options);
   return s;
 }
 


### PR DESCRIPTION
DBOptions should be validated before CFOptions. This is the logical way in which the code should be laid out, as CFOptions are validated by comparing to DBOptions but not the other way around. Doing this change would also make the code similar to the structure in `SanitizeOptions`. 

It also helps slightly improving the validation speed when there are incompatible DBOptions and many column families (though I have not personally validated it). Reversing the checks for validating CFOptions and DBOptions makes it possible to fail fast when some DBOptions are not compatible, before even looking at every CF's Options.

Test Plan:
`make check`