### PR TITLE
Set executeLocal on child lego jobs

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -133,6 +133,7 @@ UNIT_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -153,6 +154,7 @@ UNIT_TEST_NON_SHM_COMMANDS="[
     {
         'name':'Rocksdb Unit Test',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -175,6 +177,7 @@ RELEASE_BUILD_COMMANDS="[
     {
         'name':'Rocksdb Release Build',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -195,6 +198,7 @@ UNIT_TEST_COMMANDS_481="[
     {
         'name':'Rocksdb Unit Test on GCC 4.8.1',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -215,6 +219,7 @@ RELEASE_BUILD_COMMANDS_481="[
     {
         'name':'Rocksdb Release on GCC 4.8.1',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -235,6 +240,7 @@ CLANG_UNIT_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -255,6 +261,7 @@ CLANG_RELEASE_BUILD_COMMANDS="[
     {
         'name':'Rocksdb CLANG Release Build',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -275,6 +282,7 @@ CLANG_ANALYZE_COMMANDS="[
     {
         'name':'Rocksdb analyze',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -295,6 +303,7 @@ CODE_COV_COMMANDS="[
     {
         'name':'Rocksdb Unit Test Code Coverage',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -315,6 +324,7 @@ UNITY_COMMANDS="[
     {
         'name':'Rocksdb Unity',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -335,6 +345,7 @@ LITE_BUILD_COMMANDS="[
     {
         'name':'Rocksdb Lite build',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -354,6 +365,7 @@ REPORT_LITE_BINARY_SIZE_COMMANDS="[
     {
         'name':'Rocksdb Lite Binary Size',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -371,6 +383,7 @@ STRESS_CRASH_TEST_COMMANDS="[
     {
         'name':'Rocksdb Stress and Crash Test',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -399,6 +412,7 @@ STRESS_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
         'name':'Rocksdb Stress and Crash Test with atomic flush',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -427,6 +441,7 @@ WRITE_STRESS_COMMANDS="[
     {
         'name':'Rocksdb Write Stress Test',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -449,6 +464,7 @@ ASAN_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test under ASAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -469,6 +485,7 @@ ASAN_CRASH_TEST_COMMANDS="[
     {
         'name':'Rocksdb crash test under ASAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -491,6 +508,7 @@ ASAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
         'name':'Rocksdb crash test with atomic flush under ASAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -513,6 +531,7 @@ UBSAN_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test under UBSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -533,6 +552,7 @@ UBSAN_CRASH_TEST_COMMANDS="[
     {
         'name':'Rocksdb crash test under UBSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -555,6 +575,7 @@ UBSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
         'name':'Rocksdb crash test with atomic flush under UBSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -577,6 +598,7 @@ VALGRIND_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test under valgrind',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -599,6 +621,7 @@ TSAN_UNIT_TEST_COMMANDS="[
     {
         'name':'Rocksdb Unit Test under TSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -621,6 +644,7 @@ TSAN_CRASH_TEST_COMMANDS="[
     {
         'name':'Rocksdb Crash Test under TSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -643,6 +667,7 @@ TSAN_CRASH_TEST_WITH_ATOMIC_FLUSH_COMMANDS="[
     {
         'name':'Rocksdb Crash Test with atomic flush under TSAN',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'timeout': 86400,
         'steps': [
             $CLEANUP_ENV,
@@ -675,6 +700,7 @@ FORMAT_COMPATIBLE_COMMANDS="[
     {
         'name':'Rocksdb Format Compatible tests',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -708,6 +734,7 @@ NO_COMPRESSION_COMMANDS="[
     {
         'name':'Rocksdb No Compression tests',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {
@@ -785,6 +812,7 @@ JAVA_BUILD_TEST_COMMANDS="[
     {
         'name':'Rocksdb Java Build',
         'oncall':'$ONCALL',
+        'executeLocal': 'true',
         'steps': [
             $CLEANUP_ENV,
             {


### PR DESCRIPTION
This property is needed to run the child jobs on the same host and thus propagate the child job status back to the parent's.