### PR TITLE
Remove unused variable

### DIFF
--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -141,7 +141,6 @@ class BlockCacheTracerTest : public testing::Test {
 TEST_F(BlockCacheTracerTest, AtomicWriteBeforeStartTrace) {
   BlockCacheTraceRecord record = GenerateAccessRecord();
   {
-    TraceOptions trace_opt;
     std::unique_ptr<TraceWriter> trace_writer;
     ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
                                  &trace_writer));


### PR DESCRIPTION
This PR removes the unused variable that causes CLANG build to fail. 

Test plan: make clean && USE_CLANG=1 make -j32