### PR TITLE
fix compilation error on MSVC

### DIFF
--- a/port/jemalloc_helper.h
+++ b/port/jemalloc_helper.h
@@ -16,6 +16,14 @@
 #define JEMALLOC_CXX_THROW
 #endif
 
+#if defined(OS_WIN) && defined(_MSC_VER)
+
+// MSVC does not have weak symbol support. As long as ROCKSDB_JEMALLOC is defined,
+// Jemalloc memory allocator is used.
+static inline bool HasJemalloc() { return true; }
+
+#else
+
 // Declare non-standard jemalloc APIs as weak symbols. We can null-check these
 // symbols to detect whether jemalloc is linked with the binary.
 extern "C" void* mallocx(size_t, int) __attribute__((__weak__));
@@ -49,5 +57,7 @@ static inline bool HasJemalloc() {
          mallctlnametomib != nullptr && mallctlbymib != nullptr &&
          malloc_stats_print != nullptr && malloc_usable_size != nullptr;
 }
+
+#endif
 
 #endif  // ROCKSDB_JEMALLOC


### PR DESCRIPTION
"__attribute__((__weak__))" was introduced in port\jemalloc_helper.h. It's not supported by Microsoft VS 2015, resulting in compile error. This fix adds a #if branch to work around the compile issue.