### PR TITLE
Make db_bloom_filter_test parallel

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -539,7 +539,7 @@ ROCKS_TESTS = [
     [
         "db_bloom_filter_test",
         "db/db_bloom_filter_test.cc",
-        "serial",
+        "parallel",
     ],
     [
         "db_compaction_filter_test",


### PR DESCRIPTION
When run under TSAN it sometimes goes over 10m and times out. The slowest ones are `DBBloomFilterTestWithParam.BloomFilter` which we have 6 of them. Making the tests run in parallel should take care of the timeout issue.