### PR TITLE
Cleanup .trash WAL files

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -129,7 +129,10 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   for (size_t i = 0; i < result.db_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(result.env, sfm, result.db_paths[i].path);
   }
-  DeleteScheduler::CleanupDirectory(result.env, sfm, std::string(result.wal_dir));
+  if (!result.wal_dir.empty()) {
+    DeleteScheduler::CleanupDirectory(result.env, sfm,
+                                      std::string(result.wal_dir));
+  }
 
   // Create a default SstFileManager for purposes of tracking compaction size
   // and facilitating recovery from out of space errors.

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -92,7 +92,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
   }
 
-  const bool separate_wal_dir = true;
+  bool separate_wal_dir = true;
   if (result.wal_dir.empty()) {
     // Use dbname as default
     result.wal_dir = dbname;

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -143,6 +143,8 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
         NewSstFileManager(result.env, result.info_log));
     result.sst_file_manager = sst_file_manager;
   }
+#else
+  (void) separate_wal_dir;
 #endif
   return result;
 }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -92,9 +92,11 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
   }
 
+  const separate_wal_dir = true;
   if (result.wal_dir.empty()) {
     // Use dbname as default
     result.wal_dir = dbname;
+    separate_wal_dir = false;
   }
   if (result.wal_dir.back() == '/') {
     result.wal_dir = result.wal_dir.substr(0, result.wal_dir.size() - 1);
@@ -129,7 +131,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   for (size_t i = 0; i < result.db_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(result.env, sfm, result.db_paths[i].path);
   }
-  if (!result.wal_dir.empty()) {
+  if (separate_wal_dir) {
     DeleteScheduler::CleanupDirectory(result.env, sfm,
                                       std::string(result.wal_dir));
   }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -129,6 +129,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   for (size_t i = 0; i < result.db_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(result.env, sfm, result.db_paths[i].path);
   }
+  DeleteScheduler::CleanupDirectory(result.env, sfm, std::string(result.wal_dir));
 
   // Create a default SstFileManager for purposes of tracking compaction size
   // and facilitating recovery from out of space errors.

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -92,7 +92,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
     result.wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
   }
 
-  const separate_wal_dir = true;
+  const bool separate_wal_dir = true;
   if (result.wal_dir.empty()) {
     // Use dbname as default
     result.wal_dir = dbname;


### PR DESCRIPTION
By rate limiting WAL deletion introduced in https://github.com/facebook/rocksdb/pull/5116 we could end up with WAL files with appendix ".trash". We should cleanup such files on db open similarly to other trash files.
Leave adding unit test as a TODO.