### PR TITLE
Block cache tracing: Fix minor bugs with downsampling and some benchmark results. 

### DIFF
--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -442,7 +442,7 @@ void BlockCacheTraceAnalyzer::PrintStatsSummary() const {
             caller_bt_num_access_map[caller][type] += num_accesses;
             caller_level_num_access_map[caller][level] += num_accesses;
             // Column Family stats.
-            cf_num_accesses++;
+            cf_num_accesses += num_accesses;
             cf_caller_num_accesses_map[caller] += num_accesses;
             cf_caller_level_num_accesses_map[caller][level] += num_accesses;
             cf_caller_file_num_accesses_map[caller][fd] += num_accesses;

--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -16,15 +16,14 @@ namespace rocksdb {
 namespace {
 const unsigned int kCharSize = 1;
 
-bool ShouldTrace(const BlockCacheTraceRecord& record,
-                 const TraceOptions& trace_options) {
+bool ShouldTrace(const Slice& block_key, const TraceOptions& trace_options) {
   if (trace_options.sampling_frequency == 0 ||
       trace_options.sampling_frequency == 1) {
     return true;
   }
   // We use spatial downsampling so that we have a complete access history for a
   // block.
-  const uint64_t hash = GetSliceNPHash64(Slice(record.block_key));
+  const uint64_t hash = GetSliceNPHash64(block_key);
   return hash % trace_options.sampling_frequency == 0;
 }
 }  // namespace
@@ -255,7 +254,7 @@ Status BlockCacheTracer::WriteBlockAccess(const BlockCacheTraceRecord& record,
                                           const Slice& block_key,
                                           const Slice& cf_name,
                                           const Slice& referenced_key) {
-  if (!writer_.load() || !ShouldTrace(record, trace_options_)) {
+  if (!writer_.load() || !ShouldTrace(block_key, trace_options_)) {
     return Status::OK();
   }
   InstrumentedMutexLock lock_guard(&trace_writer_mutex_);


### PR DESCRIPTION
As the code changes for block cache tracing are almost complete, I did a benchmark to compare the performance when block cache tracing is enabled/disabled. 

Summary: With 1% downsampling ratio, the performance overhead of block cache tracing is negligible. When we trace all block accesses, the throughput drops by 6 folds with 16 threads issuing random reads and all reads are served in block cache. 

Setup: 
RocksDB:    version 6.2
Date:       Mon Jun 17 17:11:13 2019
CPU:        24 * Intel Core Processor (Skylake)
CPUCache:   16384 KB
Keys:       20 bytes each
Values:     100 bytes each (100 bytes after compression)
Entries:    10000000
Prefix:    20 bytes
Keys per prefix:    0
RawSize:    1144.4 MB (estimated)
FileSize:   1144.4 MB (estimated)
Write rate: 0 bytes/second
Read rate: 0 ops/second
Compression: NoCompression
Compression sampling rate: 0
Memtablerep: skip_list
Perf Level: 1

I ran the readrandom workload for 1 minute. Detailed throughput results:  (ops/second)
Sample rate 0: no block cache tracing. 
Sample rate 1: trace all block accesses. 
Sample rate 100: trace accesses 1% blocks. 
1 thread |   |   |  -- | -- | -- | --
Sample rate | 0 | 1 | 100
1 MB block cache size | 13,094 | 13,166 | 13,341
10 GB block cache size | 202,243 | 188,677 | 229,182

16 threads |   |   |  -- | -- | -- | --
Sample rate | 0 | 1 | 100
1 MB block cache size | 208,761 | 178,700 | 201,872
10 GB block cache size | 2,645,996 | 426,295 | 2,587,605
