### PR TITLE
fix rocksdb lite and clang contrun test failures

### DIFF
--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -25,8 +25,6 @@
 
 namespace rocksdb {
 
-const int kMicrosInSec = 1000000;
-
 class DBOptionsTest : public DBTestBase {
  public:
   DBOptionsTest() : DBTestBase("/db_options_test") {}

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -30,6 +30,7 @@ class StatsHistoryTest : public DBTestBase {
  public:
   StatsHistoryTest() : DBTestBase("/stats_history_test") {}
 };
+#ifndef ROCKSDB_LITE
 
 TEST_F(StatsHistoryTest, RunStatsDumpPeriodSec) {
   Options options;
@@ -566,6 +567,7 @@ TEST_F(StatsHistoryTest, PersistentStatsReadOnly) {
   // Now check keys in read only mode.
   ASSERT_OK(ReadOnlyReopen(options));
 }
+#endif  // !ROCKSDB_LITE
 
 }  // namespace rocksdb
 


### PR DESCRIPTION
recent commit 671d15cbdd3839acb54cb21a2aa82efca4917155 introduced some test failures:
```
===== Running stats_history_test
[==========] Running 9 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 9 tests from StatsHistoryTest
[ RUN      ] StatsHistoryTest.RunStatsDumpPeriodSec
monitoring/stats_history_test.cc:63: Failure
dbfull()->SetDBOptions({{"stats_dump_period_sec", "0"}})
Not implemented: Not supported in ROCKSDB LITE


db/db_options_test.cc:28:11: error: unused variable 'kMicrosInSec' [-Werror,-Wunused-const-variable]
const int kMicrosInSec = 1000000;
```
This PR fixes these failures