### PR TITLE
Add secondary instance to stress test

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -1666,13 +1666,26 @@ class StressTest {
            iter1->Valid() && iter2->Valid(); iter1->Next(), iter2->Next()) {
         if (iter1->key().compare(iter2->key()) != 0 ||
             iter1->value().compare(iter2->value())) {
-          fprintf(stderr, "Secondary contains different data\n");
+          fprintf(stderr,
+                  "Secondary %d contains different data from "
+                  "primary.\nPrimary: %s : %s\nSecondary: %s : %s\n",
+                  static_cast<int>(k),
+                  iter1->key().ToString(/*hex=*/true).c_str(),
+                  iter1->value().ToString(/*hex=*/true).c_str(),
+                  iter2->key().ToString(/*hex=*/true).c_str(),
+                  iter2->value().ToString(/*hex=*/true).c_str());
           return false;
         }
       }
-      if ((iter1->Valid() && !iter2->Valid()) ||
-          (!iter1->Valid() && iter2->Valid())) {
-        fprintf(stderr, "Secondary record count is different from primary\n");
+      if (iter1->Valid() && !iter2->Valid()) {
+        fprintf(stderr,
+                "Secondary %d record count is smaller than that of primary\n",
+                static_cast<int>(k));
+        return false;
+      } else if (!iter1->Valid() && iter2->Valid()) {
+        fprintf(stderr,
+                "Secondary %d record count is larger than that of primary\n",
+                static_cast<int>(k));
         return false;
       }
     }

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2290,6 +2290,7 @@ class StressTest {
         Status s = secondaries_[tid]->TryCatchUpWithPrimary();
         if (!s.ok()) {
           VerificationAbort(shared, "Secondary instance failed to catch up", s);
+          break;
         }
       }
 #endif

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2297,7 +2297,8 @@ class StressTest {
       thread->stats.FinishedSingleOp();
 #ifndef ROCKSDB_LITE
       uint32_t tid = thread->tid;
-      assert(static_cast<size_t>(tid) < secondaries_.size());
+      assert(secondaries_.empty() ||
+             static_cast<size_t>(tid) < secondaries_.size());
       if (FLAGS_secondary_catch_up_one_in > 0 &&
           thread->rand.Uniform(FLAGS_secondary_catch_up_one_in) == 0) {
         Status s = secondaries_[tid]->TryCatchUpWithPrimary();


### PR DESCRIPTION
This PR allows users to run stress tests on secondary instance.

Test plan (on devserver)
```
./db_stress -ops_per_thread=100000 -enable_secondary=true -threads=32 -secondary_catch_up_one_in=10000 -clear_column_family_one_in=1000 -reopen=100
```