### PR TITLE
[WIP] Trigger compactions based on number of reads to SST files

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -94,6 +94,8 @@ const char* GetCompactionReasonString(CompactionReason compaction_reason) {
       return "ExternalSstIngestion";
     case CompactionReason::kPeriodicCompaction:
       return "PeriodicCompaction";
+    case CompactionReason::kReadTriggered:
+      return "ReadTriggered";
     case CompactionReason::kNumOfReasons:
       // fall through
     default:

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1543,6 +1543,10 @@ class DBImpl : public DB {
       const DBOptions& db_options,
       const std::vector<ColumnFamilyDescriptor>& column_families);
 
+  // Triggers compaction based on number of reads, if it hasn't been done yet.
+  void TriggerReadCompactionIfRequired(ColumnFamilyData* cfd,
+                                       VersionStorageInfo* storage_info);
+
   // table_cache_ provides its own synchronization
   std::shared_ptr<Cache> table_cache_;
 

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -93,6 +93,8 @@ enum class CompactionReason : int {
   kExternalSstIngestion,
   // Compaction due to SST file being too old
   kPeriodicCompaction,
+  // Compaction due to number of reads to SST files.
+  kReadTriggered,
   // total number of compaction reasons, new reasons must be added above this.
   kNumOfReasons,
 };


### PR DESCRIPTION
Summary:

Trigger a compaction if the number of reads to any SST file exceeds a
threshold. Currently the threshold is hardcoded, there's a TODO to
potentially calculate the threshold based on file size (TBD).

Test Plan:

- existing unit tests pass
- with triggering compaction on every read, some tests fails, have to
  look into those
- should add a new test