### PR TITLE
C file should not include <cinttypes>, it is a C++ header.

### DIFF
--- a/util/crc32c_ppc.c
+++ b/util/crc32c_ppc.c
@@ -6,7 +6,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #define CRC_TABLE
-#include <cinttypes>
+#include <stdint.h>
 #include <stdlib.h>
 #include <strings.h>
 #include "util/crc32c_ppc_constants.h"


### PR DESCRIPTION
Include <inttypes.h> instead.