### PR TITLE
Gracefully degrade GetAggregatedIntProperty() (#4878)

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2581,6 +2581,7 @@ bool DBImpl::GetAggregatedIntProperty(const Slice& property,
     return false;
   }
 
+  bool ret = false;
   uint64_t sum = 0;
   {
     // Needs mutex to protect the list of column families.
@@ -2592,13 +2593,12 @@ bool DBImpl::GetAggregatedIntProperty(const Slice& property,
       }
       if (GetIntPropertyInternal(cfd, *property_info, true, &value)) {
         sum += value;
-      } else {
-        return false;
+        ret |= true;
       }
     }
   }
   *aggregated_value = sum;
-  return true;
+  return ret;
 }
 
 SuperVersion* DBImpl::GetAndRefSuperVersion(ColumnFamilyData* cfd) {


### PR DESCRIPTION
fixes #4878

Summary:
DB::GetAggregatedIntProperty() fails (returns false) when one CF's
GetIntProperty() fails. In cases where some columns lack a property
this interface cannot be used at all to aggregate the remainder.

This change considers a failure condition only if all CF's do not
succeed. If values are added to the sum the function returns true.