### PR TITLE
Skip swaths of keys covered by range tombstones

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1307,8 +1307,8 @@ void DBIter::Seek(const Slice& target) {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.Seek(saved_key_.GetInternalKey());
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.Seek(saved_key_.GetInternalKey());
   }
   RecordTick(statistics_, NUMBER_DB_SEEK);
   if (iter_.Valid()) {
@@ -1360,8 +1360,8 @@ void DBIter::SeekForPrev(const Slice& target) {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.SeekForPrev(saved_key_.GetInternalKey());
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekForPrev(saved_key_.GetInternalKey());
   }
 
 #ifndef ROCKSDB_LITE
@@ -1417,8 +1417,8 @@ void DBIter::SeekToFirst() {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.SeekToFirst();
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekToFirst();
   }
 
   RecordTick(statistics_, NUMBER_DB_SEEK);
@@ -1470,8 +1470,8 @@ void DBIter::SeekToLast() {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.SeekToLast();
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekToLast();
   }
   PrevInternal();
   if (statistics_ != nullptr) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -408,7 +408,8 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
   // updating the block cache.
   ro.fill_cache = false;
   std::unique_ptr<InternalIterator> iter(table_reader->NewIterator(
-      ro, sv->mutable_cf_options.prefix_extractor.get(), /*arena=*/nullptr,
+      ro, sv->mutable_cf_options.prefix_extractor.get(),
+      /*range_del_agg=*/nullptr, /*file_meta=*/nullptr, /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kExternalSSTIngestion));
   std::unique_ptr<InternalIterator> range_del_iter(
       table_reader->NewRangeTombstoneIterator(ro));

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -6,11 +6,12 @@
 
 #ifndef ROCKSDB_LITE
 
+#include <queue>
 #include <string>
 #include <vector>
-#include <queue>
 
 #include "db/dbformat.h"
+#include "db/range_del_aggregator.h"
 #include "memory/arena.h"
 #include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
@@ -121,6 +122,7 @@ class ForwardIterator : public InternalIterator {
   const SliceTransform* const prefix_extractor_;
   const Comparator* user_comparator_;
   MinIterHeap immutable_min_heap_;
+  ReadRangeDelAggregator range_del_agg_;
 
   SuperVersion* sv_;
   InternalIterator* mutable_iter_;

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -34,6 +34,19 @@ std::unique_ptr<InternalIterator> MakeRangeDelIter(
       new test::VectorIterator(keys, values));
 }
 
+void VerifyPartialTombstonesEq(const PartialRangeTombstoneEndpoint& a,
+                               const PartialRangeTombstoneEndpoint& b) {
+  ASSERT_EQ(a.seq(), b.seq());
+  ASSERT_EQ(a.dir(), b.dir());
+  if (a.endpoint() != nullptr) {
+    ASSERT_EQ(a.endpoint()->user_key, b.endpoint()->user_key);
+    ASSERT_EQ(a.endpoint()->sequence, b.endpoint()->sequence);
+    ASSERT_EQ(a.endpoint()->type, b.endpoint()->type);
+  } else {
+    ASSERT_EQ(b.endpoint(), nullptr);
+  }
+}
+
 std::vector<std::unique_ptr<FragmentedRangeTombstoneList>>
 MakeFragmentedTombstoneLists(
     const std::vector<std::vector<RangeTombstone>>& range_dels_list) {
@@ -63,6 +76,15 @@ struct TruncatedIterSeekTestCase {
 struct ShouldDeleteTestCase {
   ParsedInternalKey lookup_key;
   bool result;
+};
+
+struct GetEndpointTestCase {
+  ParsedInternalKey key;
+  SequenceNumber seqno;
+  struct {
+    ParsedInternalKey* endpoint;
+    SequenceNumber seqno;
+  } result, reverse_result;
 };
 
 struct IsRangeOverlappedTestCase {
@@ -154,6 +176,34 @@ void VerifyShouldDelete(RangeDelAggregator* range_del_agg,
         test_case.result,
         range_del_agg->ShouldDelete(
             test_case.lookup_key, RangeDelPositioningMode::kBackwardTraversal));
+  }
+}
+
+void VerifyGetEndpoint(ReadRangeDelAggregator* range_del_agg,
+                       const std::vector<GetEndpointTestCase>& test_cases) {
+  for (const auto& test_case : test_cases) {
+    std::string key;
+    AppendInternalKey(&key, test_case.key);
+    PartialRangeTombstoneEndpoint expected(
+        test_case.result.endpoint, RangeDelPositioningMode::kForwardTraversal,
+        test_case.result.seqno);
+    VerifyPartialTombstonesEq(
+        expected,
+        range_del_agg->GetEndpoint(key, test_case.seqno,
+                                   RangeDelPositioningMode::kForwardTraversal));
+  }
+  for (auto it = test_cases.rbegin(); it != test_cases.rend(); ++it) {
+    const auto& test_case = *it;
+    std::string key;
+    AppendInternalKey(&key, test_case.key);
+    PartialRangeTombstoneEndpoint expected(
+        test_case.reverse_result.endpoint,
+        RangeDelPositioningMode::kBackwardTraversal,
+        test_case.reverse_result.seqno);
+    VerifyPartialTombstonesEq(
+        expected,
+        range_del_agg->GetEndpoint(
+            key, test_case.seqno, RangeDelPositioningMode::kBackwardTraversal));
   }
 }
 
@@ -360,6 +410,22 @@ TEST_F(RangeDelAggregatorTest, SingleIterInAggregator) {
                                       {InternalValue("e", 7), true},
                                       {InternalValue("g", 7), false}});
 
+  ParsedInternalKey a = {"a", kMaxSequenceNumber, kTypeRangeDeletion},
+                    c = {"c", kMaxSequenceNumber, kTypeRangeDeletion},
+                    e = {"e", kMaxSequenceNumber, kTypeRangeDeletion},
+                    g = {"g", kMaxSequenceNumber, kTypeRangeDeletion};
+  VerifyGetEndpoint(
+      &range_del_agg,
+      {
+          {InternalValue("_", kMaxSequenceNumber), 9, {&a, 0}, {nullptr, 0}},
+          {InternalValue("a", kMaxSequenceNumber), 10, {&c, 0}, {&a, 0}},
+          {InternalValue("a", kMaxSequenceNumber), 9, {&c, 10}, {&a, 10}},
+          {InternalValue("a", 0), 9, {&c, 10}, {&a, 10}},
+          {InternalValue("c", kMaxSequenceNumber), 9, {&e, 10}, {&c, 10}},
+          {InternalValue("e", kMaxSequenceNumber), 7, {&g, 8}, {&e, 8}},
+          {InternalValue("g", kMaxSequenceNumber), 7, {nullptr, 0}, {&g, 0}},
+      });
+
   VerifyIsRangeOverlapped(&range_del_agg, {{"", "_", false},
                                            {"_", "a", true},
                                            {"a", "c", true},
@@ -390,6 +456,23 @@ TEST_F(RangeDelAggregatorTest, MultipleItersInAggregator) {
                                       {InternalValue("i", 24), false},
                                       {InternalValue("ii", 14), true},
                                       {InternalValue("j", 14), false}});
+
+  ParsedInternalKey a = {"a", kMaxSequenceNumber, kTypeRangeDeletion},
+                    b = {"b", kMaxSequenceNumber, kTypeRangeDeletion},
+                    c = {"c", kMaxSequenceNumber, kTypeRangeDeletion},
+                    e = {"e", kMaxSequenceNumber, kTypeRangeDeletion},
+                    g = {"g", kMaxSequenceNumber, kTypeRangeDeletion},
+                    h = {"h", kMaxSequenceNumber, kTypeRangeDeletion};
+  VerifyGetEndpoint(
+      &range_del_agg,
+      {
+          {InternalValue("a", kMaxSequenceNumber), 20, {&b, 0}, {&a, 0}},
+          {InternalValue("a", kMaxSequenceNumber), 19, {&b, 20}, {&a, 20}},
+          {InternalValue("b", kMaxSequenceNumber), 9, {&c, 10}, {&a, 10}},
+          {InternalValue("c", kMaxSequenceNumber), 9, {&e, 10}, {&c, 10}},
+          {InternalValue("e", kMaxSequenceNumber), 7, {&g, 8}, {&e, 8}},
+          {InternalValue("g", kMaxSequenceNumber), 7, {&h, 0}, {&g, 0}},
+      });
 
   VerifyIsRangeOverlapped(&range_del_agg, {{"", "_", false},
                                            {"_", "a", true},
@@ -422,6 +505,21 @@ TEST_F(RangeDelAggregatorTest, MultipleItersInAggregatorWithUpperBound) {
                                       {InternalValue("i", 24), false},
                                       {InternalValue("ii", 14), true},
                                       {InternalValue("j", 14), false}});
+
+  ParsedInternalKey a = {"a", kMaxSequenceNumber, kTypeRangeDeletion},
+                    c = {"c", kMaxSequenceNumber, kTypeRangeDeletion},
+                    e = {"e", kMaxSequenceNumber, kTypeRangeDeletion},
+                    g = {"g", kMaxSequenceNumber, kTypeRangeDeletion},
+                    ii = {"ii", kMaxSequenceNumber, kTypeRangeDeletion};
+  VerifyGetEndpoint(
+      &range_del_agg,
+      {
+          {InternalValue("a", kMaxSequenceNumber), 19, {&c, 0}, {&a, 0}},
+          {InternalValue("b", kMaxSequenceNumber), 9, {&c, 10}, {&a, 10}},
+          {InternalValue("c", kMaxSequenceNumber), 9, {&e, 10}, {&c, 10}},
+          {InternalValue("e", kMaxSequenceNumber), 7, {&g, 8}, {&e, 8}},
+          {InternalValue("g", kMaxSequenceNumber), 7, {&ii, 0}, {&g, 0}},
+      });
 
   VerifyIsRangeOverlapped(&range_del_agg, {{"", "_", false},
                                            {"_", "a", true},
@@ -461,6 +559,22 @@ TEST_F(RangeDelAggregatorTest, MultipleTruncatedItersInAggregator) {
                                       {InternalValue("x", 9), false},
                                       {InternalValue("x", 5), true},
                                       {InternalValue("z", 9), false}});
+
+  ParsedInternalKey a4 = {"a", 4, kTypeValue},
+                    m = {"m", kMaxSequenceNumber, kTypeRangeDeletion},
+                    m20 = {"m", 20, kTypeValue},
+                    x = {"x", kMaxSequenceNumber, kTypeRangeDeletion},
+                    x5 = {"x", 5, kTypeValue},
+                    z = {"z", kMaxSequenceNumber, kTypeRangeDeletion};
+  VerifyGetEndpoint(
+      &range_del_agg,
+      {
+          {InternalValue("a", kMaxSequenceNumber), 9, {&a4, 0}, {nullptr, 0}},
+          {InternalValue("a", 4), 9, {&m, 10}, {&a4, 10}},
+          {InternalValue("m", kMaxSequenceNumber), 9, {&m20, 0}, {&m, 0}},
+          {InternalValue("m", 20), 9, {&x, 10}, {&m20, 10}},
+          {InternalValue("x", 5), 9, {&z, 10}, {&x5, 10}},
+      });
 
   VerifyIsRangeOverlapped(&range_del_agg, {{"", "_", false},
                                            {"_", "a", true},
@@ -699,6 +813,13 @@ TEST_F(RangeDelAggregatorTest,
                                                                {"d", "f", 30},
                                                                {"d", "f", 8},
                                                                {"f", "g", 8}});
+}
+
+TEST_F(RangeDelAggregatorTest, IsEmpty) {
+  auto& icmp = bytewise_icmp;
+  const std::vector<SequenceNumber> snapshots;
+  ReadRangeDelAggregator range_del_agg(&icmp, kMaxSequenceNumber);
+  ASSERT_TRUE(range_del_agg.IsEmpty());
 }
 
 }  // namespace rocksdb

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -205,9 +205,9 @@ InternalIterator* TableCache::NewIterator(
         !options.table_filter(*table_reader->GetTableProperties())) {
       result = NewEmptyInternalIterator<Slice>(arena);
     } else {
-      result = table_reader->NewIterator(options, prefix_extractor, arena,
-                                         skip_filters, caller,
-                                         env_options.compaction_readahead_size);
+      result = table_reader->NewIterator(
+          options, prefix_extractor, range_del_agg, &file_meta, arena,
+          skip_filters, caller, env_options.compaction_readahead_size);
     }
     if (handle != nullptr) {
       result->RegisterCleanup(&UnrefEntry, cache_, handle);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1022,8 +1022,8 @@ void LevelIterator::SeekForPrev(const Slice& target) {
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
     file_iter_.SeekForPrev(target);
-    SkipEmptyFileBackward();
   }
+  SkipEmptyFileBackward();
 }
 
 void LevelIterator::SeekToFirst() {

--- a/table/cuckoo/cuckoo_table_reader.cc
+++ b/table/cuckoo/cuckoo_table_reader.cc
@@ -376,9 +376,10 @@ Slice CuckooTableIterator::value() const {
 
 InternalIterator* CuckooTableReader::NewIterator(
     const ReadOptions& /*read_options*/,
-    const SliceTransform* /* prefix_extractor */, Arena* arena,
-    bool /*skip_filters*/, TableReaderCaller /*caller*/,
-    size_t /*compaction_readahead_size*/) {
+    const SliceTransform* /* prefix_extractor */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */, Arena* arena, bool /*skip_filters*/,
+    TableReaderCaller /*caller*/, size_t /*compaction_readahead_size*/) {
   if (!status().ok()) {
     return NewErrorInternalIterator<Slice>(
         Status::Corruption("CuckooTableReader status is not okay."), arena);

--- a/table/cuckoo/cuckoo_table_reader.h
+++ b/table/cuckoo/cuckoo_table_reader.h
@@ -50,8 +50,10 @@ class CuckooTableReader: public TableReader {
   // true
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
-                                Arena* arena, bool skip_filters,
-                                TableReaderCaller caller, size_t compaction_readahead_size = 0) override;
+                                RangeDelAggregator* range_del_agg,
+                                const FileMetaData* file_meta, Arena* arena,
+                                bool skip_filters, TableReaderCaller caller,
+                                size_t compaction_readahead_size = 0) override;
   void Prepare(const Slice& target) override;
 
   // Report an approximation of how much memory has been used.

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -147,7 +147,8 @@ class CuckooReaderTest : public testing::Test {
                              GetSliceHash);
     ASSERT_OK(reader.status());
     InternalIterator* it = reader.NewIterator(
-        ReadOptions(), /*prefix_extractor=*/nullptr, /*arena=*/nullptr,
+        ReadOptions(), /*range_del_agg=*/nullptr, /*file_meta=*/nullptr,
+        /*prefix_extractor=*/nullptr, /*arena=*/nullptr,
         /*skip_filters=*/false, TableReaderCaller::kUncategorized);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
@@ -187,15 +188,16 @@ class CuckooReaderTest : public testing::Test {
     delete it;
 
     Arena arena;
-    it = reader.NewIterator(ReadOptions(), /*prefix_extractor=*/nullptr, &arena,
-                            /*skip_filters=*/false,
-                            TableReaderCaller::kUncategorized);
+    it = reader.NewIterator(
+        ReadOptions(), /*range_del_agg=*/nullptr, /*file_meta=*/nullptr,
+        /*prefix_extractor=*/nullptr, &arena, /*skip_filters=*/false,
+        TableReaderCaller::kUncategorized);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
-    it->Seek(keys[num_items/2]);
+    it->Seek(keys[num_items / 2]);
     ASSERT_TRUE(it->Valid());
     ASSERT_OK(it->status());
-    ASSERT_TRUE(keys[num_items/2] == it->key());
+    ASSERT_TRUE(keys[num_items / 2] == it->key());
     ASSERT_TRUE(values[num_items/2] == it->value());
     ASSERT_OK(it->status());
     it->~InternalIterator();

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -34,7 +34,10 @@ stl_wrappers::KVMap MakeMockFile(
 
 InternalIterator* MockTableReader::NewIterator(
     const ReadOptions&, const SliceTransform* /* prefix_extractor */,
-    Arena* /*arena*/, bool /*skip_filters*/, TableReaderCaller /*caller*/, size_t /*compaction_readahead_size*/) {
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */, Arena* /*arena*/,
+    bool /*skip_filters*/, TableReaderCaller /*caller*/,
+    size_t /*compaction_readahead_size*/) {
   return new MockTableIterator(table_);
 }
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -42,9 +42,10 @@ class MockTableReader : public TableReader {
 
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
-                                Arena* arena, bool skip_filters,
-                                TableReaderCaller caller,
-                              size_t compaction_readahead_size = 0) override;
+                                RangeDelAggregator* range_del_agg,
+                                const FileMetaData* file_meta, Arena* arena,
+                                bool skip_filters, TableReaderCaller caller,
+                                size_t compaction_readahead_size = 0) override;
 
   Status Get(const ReadOptions& readOptions, const Slice& key,
              GetContext* get_context, const SliceTransform* prefix_extractor,

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -196,8 +196,9 @@ void PlainTableReader::SetupForCompaction() {
 
 InternalIterator* PlainTableReader::NewIterator(
     const ReadOptions& options, const SliceTransform* /* prefix_extractor */,
-    Arena* arena, bool /*skip_filters*/, TableReaderCaller /*caller*/,
-    size_t /*compaction_readahead_size*/) {
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */, Arena* arena, bool /*skip_filters*/,
+    TableReaderCaller /*caller*/, size_t /*compaction_readahead_size*/) {
   bool use_prefix_seek = !IsTotalOrderMode() && !options.total_order_seek;
   if (arena == nullptr) {
     return new PlainTableIterator(this, use_prefix_seek);

--- a/table/plain/plain_table_reader.h
+++ b/table/plain/plain_table_reader.h
@@ -82,8 +82,10 @@ class PlainTableReader: public TableReader {
   // true
   InternalIterator* NewIterator(const ReadOptions&,
                                 const SliceTransform* prefix_extractor,
-                                Arena* arena, bool skip_filters,
-                                TableReaderCaller caller, size_t compaction_readahead_size = 0) override;
+                                RangeDelAggregator* range_del_agg,
+                                const FileMetaData* file_meta, Arena* arena,
+                                bool skip_filters, TableReaderCaller caller,
+                                size_t compaction_readahead_size = 0) override;
 
   void Prepare(const Slice& target) override;
 

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -66,7 +66,8 @@ Iterator* SstFileReader::NewIterator(const ReadOptions& options) {
                       ? options.snapshot->GetSequenceNumber()
                       : kMaxSequenceNumber;
   auto internal_iter = r->table_reader->NewIterator(
-      options, r->moptions.prefix_extractor.get(), /*arena=*/nullptr,
+      options, r->moptions.prefix_extractor.get(), /*range_del_agg=*/nullptr,
+      /*file_meta=*/nullptr, /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kSSTFileReader);
   return NewDBIterator(r->options.env, options, r->ioptions, r->moptions,
                        r->ioptions.user_comparator, internal_iter, sequence,

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -26,6 +26,8 @@ struct ReadOptions;
 struct TableProperties;
 class GetContext;
 class MultiGetContext;
+struct FileMetaData;
+class RangeDelAggregator;
 
 // A Table (also referred to as SST) is a sorted map from strings to strings.
 // Tables are immutable and persistent.  A Table may be safely accessed from
@@ -45,11 +47,13 @@ class TableReader {
   //        all the states but those allocated in arena.
   // skip_filters: disables checking the bloom filters even if they exist. This
   //               option is effective only for block-based table format.
-  // compaction_readahead_size: its value will only be used if caller = kCompaction
-  virtual InternalIterator* NewIterator(const ReadOptions&,
-                                        const SliceTransform* prefix_extractor,
-                                        Arena* arena, bool skip_filters,
-                                        TableReaderCaller caller, size_t compaction_readahead_size = 0) = 0;
+  // compaction_readahead_size: its value will only be used if caller =
+  // kCompaction
+  virtual InternalIterator* NewIterator(
+      const ReadOptions&, const SliceTransform* prefix_extractor,
+      RangeDelAggregator* range_del_agg, const FileMetaData* file_meta,
+      Arena* arena, bool skip_filters, TableReaderCaller caller,
+      size_t compaction_readahead_size = 0) = 0;
 
   virtual FragmentedRangeTombstoneIterator* NewRangeTombstoneIterator(
       const ReadOptions& /*read_options*/) {

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -199,7 +199,9 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
           InternalIterator* iiter = nullptr;
           if (!through_db) {
             iiter = table_reader->NewIterator(
-                read_options, /*prefix_extractor=*/nullptr, /*arena=*/nullptr,
+                read_options, /*prefix_extractor=*/nullptr,
+                /*range_del_agg=*/nullptr, /*file_meta=*/nullptr,
+                /*arena=*/nullptr,
                 /*skip_filters=*/false, TableReaderCaller::kUncategorized);
           } else {
             iter = db->NewIterator(read_options);

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -173,7 +173,8 @@ uint64_t SstFileDumper::CalculateCompressedTableSize(
       TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
       dest_writer.get()));
   std::unique_ptr<InternalIterator> iter(table_reader_->NewIterator(
-      ReadOptions(), moptions_.prefix_extractor.get(), /*arena=*/nullptr,
+      ReadOptions(), moptions_.prefix_extractor.get(),
+      /*range_del_agg=*/nullptr, /*file_meta=*/nullptr, /*arena=*/nullptr,
       /*skip_filters=*/false, TableReaderCaller::kSSTDumpTool));
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     if (!iter->status().ok()) {
@@ -301,6 +302,7 @@ Status SstFileDumper::ReadSequential(bool print_kv, uint64_t read_num,
 
   InternalIterator* iter = table_reader_->NewIterator(
       ReadOptions(verify_checksum_, false), moptions_.prefix_extractor.get(),
+      /*range_del_agg=*/nullptr, /*file_meta=*/nullptr,
       /*arena=*/nullptr, /*skip_filters=*/false,
       TableReaderCaller::kSSTDumpTool);
   uint64_t i = 0;


### PR DESCRIPTION
When the `RangeDelAggregator` contains a range tombstone that is
newer than all keys in a file being scanned by a
`BlockBasedTableIterator`, we can seek the table iterator to the
range tombstone endpoint. During forward iteration, this means seeking
the iterator to a key at or after the range tombstone end key (recall
range tombstones are end-key exclusive). During reverse iteration, this
means seeking the iterator to a key before the range tombstone start
key. This seeking optimization can be more efficient than iterating
over point keys and checking whether each one is covered, especially for
wider range tombstones.

The implementation consists of a few significant parts.

(1) A new data structure, `PartialRangeTombstoneEndpoint`. A
`BlockBasedTableIterator` caches one of these endpoints. It holds state
about the next range tombstone endpoint the iterator needs to know
about. For example, consider the iterator shown below, which is
positioned between two range tombstones, and moving in the forward
direction.

```
a---e
       h---l
     ^
     iterator at "f"
```

Its `PartialRangeTombstoneEndpoint` will satisfy the below conditions.

- `endpoint() != nullptr && *endpoint() == "h"`
- `is_valid() == true`
- `dir() == RangeDelPositioningMode::kForwardTraversal`
- `seq() == 0`: this indicates the keys between the current key and "h" are not covered

(2) `RangeDelAggregator::GetEndpoint()` function. This function returns
a `PartialRangeTombstoneEndpoint` like shown above. Note that this
function and `ShouldDelete()` share a common internal state for tracking
forward/backward movement. That means interleaved calls to
`ShouldDelete()` and `GetEndpoint()` with the same argument for
`RangeDelPositioningMode` need to be very careful to pass keys in a
consistent order (non-decreasing for
`RangeDelPositioningMode::kForwardTraversal`, or non-increasing for
`RangeDelPositioningMode::kBackwardTraversal`).

(3) `BlockBasedTableIterator` uses `GetEndpoint()` to obtain a range
tombstone endpoint. To satisfy the ordering requirement mentioned in
(2), when `Seek*()` is called, it simply provides the target key. In
`Next()` or `Prev()` calls, it provides the key the iterator is
positioned at before moving, as we know that key is at the top of the
merging iterator's heap, so there is no way for a future call to provide
an out-of-order key, unless the iterator's direction changes (that case
is handled by refreshing the range tombstone endpoint).

Most importantly, `BlockBasedTableIterator` uses its endpoint when
possible to skip over ranges of keys that are entirely covered by a
range tombstone. In `Seek*()`, that is done by adjusting the target key
when we know in advance it is covered by a range tombstone newer than
the file. In `Next()` and `Prev()`, that is done by performing a seek
when `GetTombstone()` tells us the current key is overlapped by a range
tombstone. In case of `Next()` the seek will be to the range tombstone's
end key, whereas in case of `Prev()` it would be to the range
tombstone's start key.

Test Plan:

- added unit tests
- ran modified `db_stress` (ajkr@49a0581) that verifies each operation in `TestIterate()`:

```
$ python ./tools/db_crashtest.py blackbox --simple \
	--write_buffer_size=524288 --target_file_size_base=524288 \
	--max_bytes_for_level_base=2097152 --compression_type=none \
	--max_background_compactions=8 --value_size_mult=33 --max_key=5000000 \
	--interval=10 --duration=7200 --delrangepercent=1 --delpercent=9 \
	--iterpercent=10 --writepercent=80 --readpercent=0 --prefixpercent=0 \
	--num_iterations=1000 --range_deletion_width=100
```