### PR TITLE
Block cache tracer: Do not populate block cache trace record when tracing is disabled.

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1967,8 +1967,8 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     }
   }
 
-  if (block_cache_tracer_ && lookup_context &&
-      block_cache_tracer_->is_tracing_enabled()) {
+  if (block_cache_tracer_ && block_cache_tracer_->is_tracing_enabled() &&
+      lookup_context) {
     // Avoid making copy of block_key and cf_name when constructing the access
     // record.
     BlockCacheTraceRecord access_record(
@@ -2049,8 +2049,8 @@ CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
       }
     }
   }
-  if (block_cache_tracer_ && lookup_context &&
-      block_cache_tracer_->is_tracing_enabled()) {
+  if (block_cache_tracer_ && block_cache_tracer_->is_tracing_enabled() &&
+      lookup_context) {
     // Avoid making copy of block_key and cf_name when constructing the access
     // record.
     BlockCacheTraceRecord access_record(
@@ -2275,8 +2275,8 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
   }
 
   // Fill lookup_context.
-  if (block_cache_tracer_ && lookup_context &&
-      block_cache_tracer_->is_tracing_enabled()) {
+  if (block_cache_tracer_ && block_cache_tracer_->is_tracing_enabled() &&
+      lookup_context) {
     size_t usage = 0;
     uint64_t nkeys = 0;
     if (block_entry->GetValue()) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1967,7 +1967,8 @@ CachableEntry<FilterBlockReader> BlockBasedTable::GetFilter(
     }
   }
 
-  if (block_cache_tracer_ && lookup_context) {
+  if (block_cache_tracer_ && lookup_context &&
+      block_cache_tracer_->is_tracing_enabled()) {
     // Avoid making copy of block_key and cf_name when constructing the access
     // record.
     BlockCacheTraceRecord access_record(
@@ -2048,7 +2049,8 @@ CachableEntry<UncompressionDict> BlockBasedTable::GetUncompressionDict(
       }
     }
   }
-  if (block_cache_tracer_ && lookup_context) {
+  if (block_cache_tracer_ && lookup_context &&
+      block_cache_tracer_->is_tracing_enabled()) {
     // Avoid making copy of block_key and cf_name when constructing the access
     // record.
     BlockCacheTraceRecord access_record(
@@ -2273,7 +2275,8 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
   }
 
   // Fill lookup_context.
-  if (block_cache_tracer_ && lookup_context) {
+  if (block_cache_tracer_ && lookup_context &&
+      block_cache_tracer_->is_tracing_enabled()) {
     size_t usage = 0;
     uint64_t nkeys = 0;
     if (block_entry->GetValue()) {
@@ -3167,7 +3170,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
         s = biter.status();
       }
       // Write the block cache access record.
-      if (block_cache_tracer_) {
+      if (block_cache_tracer_ && block_cache_tracer_->is_tracing_enabled()) {
         // Avoid making copy of block_key, cf_name, and referenced_key when
         // constructing the access record.
         BlockCacheTraceRecord access_record(
@@ -3334,7 +3337,7 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
           s = biter.status();
         }
         // Write the block cache access.
-        if (block_cache_tracer_) {
+        if (block_cache_tracer_ && block_cache_tracer_->is_tracing_enabled()) {
           // Avoid making copy of block_key, cf_name, and referenced_key when
           // constructing the access record.
           BlockCacheTraceRecord access_record(

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -197,6 +197,8 @@ class BlockCacheTracer {
   // Stop writing block cache accesses to the trace_writer.
   void EndTrace();
 
+  bool is_tracing_enabled() const { return writer_.load(); }
+
   Status WriteBlockAccess(const BlockCacheTraceRecord& record,
                           const Slice& block_key, const Slice& cf_name,
                           const Slice& referenced_key);

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -197,7 +197,9 @@ class BlockCacheTracer {
   // Stop writing block cache accesses to the trace_writer.
   void EndTrace();
 
-  bool is_tracing_enabled() const { return writer_.load(); }
+  bool is_tracing_enabled() const {
+    return writer_.load(std::memory_order_relaxed);
+  }
 
   Status WriteBlockAccess(const BlockCacheTraceRecord& record,
                           const Slice& block_key, const Slice& cf_name,


### PR DESCRIPTION
This PR makes sure that trace record is not populated when tracing is disabled. 

Before this PR: 
DB path: [/data/mysql/rocks_regression_tests/OPTIONS-myrocks-40-33-10000000/2019-06-26-13-04-41/db]
readwhilewriting :       9.803 micros/op 1550408 ops/sec;  107.9 MB/s (5000000 of 5000000 found)
Microseconds per read:
Count: 80000000 Average: 9.8045  StdDev: 12.64
Min: 1  Median: 7.5246  Max: 25343
Percentiles: P50: 7.52 P75: 12.10 P99: 37.44 P99.9: 75.07 P99.99: 133.60

After this PR: 
DB path: [/data/mysql/rocks_regression_tests/OPTIONS-myrocks-40-33-10000000/2019-06-26-14-08-21/db]
readwhilewriting :       8.723 micros/op 1662882 ops/sec;  115.8 MB/s (5000000 of 5000000 found)
Microseconds per read:
Count: 80000000 Average: 8.7236  StdDev: 12.19
Min: 1  Median: 6.7262  Max: 25229
Percentiles: P50: 6.73 P75: 10.50 P99: 31.54 P99.9: 74.81 P99.99: 132.82