### PR TITLE
Block cache tracing: Associate a unique id with Get and MultiGet

### DIFF
--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -38,15 +38,13 @@ void appendToReplayLog(std::string* replay_log, ValueType type, Slice value) {
 
 }  // namespace
 
-GetContext::GetContext(const Comparator* ucmp,
-                       const MergeOperator* merge_operator, Logger* logger,
-                       Statistics* statistics, GetState init_state,
-                       const Slice& user_key, PinnableSlice* pinnable_val,
-                       bool* value_found, MergeContext* merge_context,
-                       SequenceNumber* _max_covering_tombstone_seq, Env* env,
-                       SequenceNumber* seq,
-                       PinnedIteratorsManager* _pinned_iters_mgr,
-                       ReadCallback* callback, bool* is_blob_index)
+GetContext::GetContext(
+    const Comparator* ucmp, const MergeOperator* merge_operator, Logger* logger,
+    Statistics* statistics, GetState init_state, const Slice& user_key,
+    PinnableSlice* pinnable_val, bool* value_found, MergeContext* merge_context,
+    SequenceNumber* _max_covering_tombstone_seq, Env* env, SequenceNumber* seq,
+    PinnedIteratorsManager* _pinned_iters_mgr, ReadCallback* callback,
+    bool* is_blob_index, uint64_t tracing_get_id)
     : ucmp_(ucmp),
       merge_operator_(merge_operator),
       logger_(logger),
@@ -62,7 +60,8 @@ GetContext::GetContext(const Comparator* ucmp,
       replay_log_(nullptr),
       pinned_iters_mgr_(_pinned_iters_mgr),
       callback_(callback),
-      is_blob_index_(is_blob_index) {
+      is_blob_index_(is_blob_index),
+      tracing_get_id_(tracing_get_id) {
   if (seq_) {
     *seq_ = kMaxSequenceNumber;
   }

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -85,7 +85,8 @@ class GetContext {
              SequenceNumber* max_covering_tombstone_seq, Env* env,
              SequenceNumber* seq = nullptr,
              PinnedIteratorsManager* _pinned_iters_mgr = nullptr,
-             ReadCallback* callback = nullptr, bool* is_blob_index = nullptr);
+             ReadCallback* callback = nullptr, bool* is_blob_index = nullptr,
+             uint64_t tracing_get_id = 0);
 
   GetContext() = default;
 
@@ -135,6 +136,8 @@ class GetContext {
 
   void ReportCounters();
 
+  uint64_t tracing_get_id() const { return tracing_get_id_; }
+
  private:
   const Comparator* ucmp_;
   const MergeOperator* merge_operator_;
@@ -158,6 +161,9 @@ class GetContext {
   ReadCallback* callback_;
   bool sample_;
   bool* is_blob_index_;
+  // Used for block cache tracing only. A tracing get id uniquely identifies a
+  // Get and a MultiGet.
+  const uint64_t tracing_get_id_;
 };
 
 // Call this to replay a log and bring the get_context up to date. The replay

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -162,7 +162,7 @@ class GetContext {
   bool sample_;
   bool* is_blob_index_;
   // Used for block cache tracing only. A tracing get id uniquely identifies a
-  // Get and a MultiGet.
+  // Get or a MultiGet.
   const uint64_t tracing_get_id_;
 };
 

--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -283,7 +283,7 @@ Status BlockCacheTracer::WriteBlockAccess(const BlockCacheTraceRecord& record,
 
 uint64_t BlockCacheTracer::NextGetId() {
   if (!writer_.load(std::memory_order_relaxed)) {
-    return 0;
+    return BlockCacheTraceHelper::kReservedGetId;
   }
   uint64_t prev_value = get_id_counter_.fetch_add(1);
   if (prev_value == BlockCacheTraceHelper::kReservedGetId) {

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -18,6 +18,16 @@ namespace rocksdb {
 
 extern const uint64_t kMicrosInSecond;
 
+class BlockCacheTraceHelper {
+ public:
+  static bool ShouldTraceReferencedKey(TraceType block_type,
+                                       TableReaderCaller caller);
+  static bool ShouldTraceGetId(TableReaderCaller caller);
+
+  static const std::string kUnknownColumnFamilyName;
+  static const uint64_t kReservedGetId;
+};
+
 // Lookup context for tracing block cache accesses.
 // We trace block accesses at five places:
 // 1. BlockBasedTable::GetFilter
@@ -38,8 +48,10 @@ extern const uint64_t kMicrosInSecond;
 // 6. BlockBasedTable::ApproximateOffsetOf. (kCompaction or
 // kUserApproximateSize).
 struct BlockCacheLookupContext {
-BlockCacheLookupContext(const TableReaderCaller& _caller) : caller(_caller) {}
-const TableReaderCaller caller;
+  BlockCacheLookupContext(const TableReaderCaller& _caller) : caller(_caller) {}
+  BlockCacheLookupContext(const TableReaderCaller& _caller, uint64_t _get_id)
+      : caller(_caller), get_id(_get_id) {}
+  const TableReaderCaller caller;
   // These are populated when we perform lookup/insert on block cache. The block
   // cache tracer uses these inforation when logging the block access at
   // BlockBasedTable::GET and BlockBasedTable::MultiGet.
@@ -49,6 +61,10 @@ const TableReaderCaller caller;
   uint64_t block_size = 0;
   std::string block_key;
   uint64_t num_keys_in_block = 0;
+  // The unique id associated with Get and MultiGet. This enables us to track
+  // how many blocks a Get/MultiGet request accesses. We can also measure the
+  // impact of row cache vs block cache.
+  uint64_t get_id = 0;
 
   void FillLookupContext(bool _is_cache_hit, bool _no_insert,
                          TraceType _block_type, uint64_t _block_size,
@@ -78,7 +94,8 @@ struct BlockCacheTraceRecord {
   TableReaderCaller caller = TableReaderCaller::kMaxBlockCacheLookupCaller;
   Boolean is_cache_hit = Boolean::kFalse;
   Boolean no_insert = Boolean::kFalse;
-
+  // Required field for Get and MultiGet
+  uint64_t get_id = BlockCacheTraceHelper::kReservedGetId;
   // Required fields for data block and user Get/Multi-Get only.
   std::string referenced_key;
   uint64_t referenced_data_size = 0;
@@ -91,7 +108,7 @@ struct BlockCacheTraceRecord {
                         TraceType _block_type, uint64_t _block_size,
                         uint64_t _cf_id, std::string _cf_name, uint32_t _level,
                         uint64_t _sst_fd_number, TableReaderCaller _caller,
-                        bool _is_cache_hit, bool _no_insert,
+                        bool _is_cache_hit, bool _no_insert, uint64_t _get_id,
                         std::string _referenced_key = "",
                         uint64_t _referenced_data_size = 0,
                         uint64_t _num_keys_in_block = 0,
@@ -107,6 +124,7 @@ struct BlockCacheTraceRecord {
         caller(_caller),
         is_cache_hit(_is_cache_hit ? Boolean::kTrue : Boolean::kFalse),
         no_insert(_no_insert ? Boolean::kTrue : Boolean::kFalse),
+        get_id(_get_id),
         referenced_key(_referenced_key),
         referenced_data_size(_referenced_data_size),
         num_keys_in_block(_num_keys_in_block),
@@ -119,14 +137,6 @@ struct BlockCacheTraceHeader {
   uint64_t start_time;
   uint32_t rocksdb_major_version;
   uint32_t rocksdb_minor_version;
-};
-
-class BlockCacheTraceHelper {
- public:
-  static bool ShouldTraceReferencedKey(TraceType block_type,
-                                       TableReaderCaller caller);
-
-  static const std::string kUnknownColumnFamilyName;
 };
 
 // BlockCacheTraceWriter captures all RocksDB block cache accesses using a
@@ -207,11 +217,17 @@ class BlockCacheTracer {
                           const Slice& block_key, const Slice& cf_name,
                           const Slice& referenced_key);
 
+  // GetId cycles from 1 to port::kMaxUint64.
+  uint64_t NextGetId();
+
  private:
   TraceOptions trace_options_;
   // A mutex protects the writer_.
   InstrumentedMutex trace_writer_mutex_;
   std::atomic<BlockCacheTraceWriter*> writer_;
+  // A mutex protects get_id_counter_.
+  InstrumentedMutex get_id_counter_mutex_;
+  uint64_t get_id_counter_ = 1;
 };
 
 }  // namespace rocksdb

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -225,9 +225,7 @@ class BlockCacheTracer {
   // A mutex protects the writer_.
   InstrumentedMutex trace_writer_mutex_;
   std::atomic<BlockCacheTraceWriter*> writer_;
-  // A mutex protects get_id_counter_.
-  InstrumentedMutex get_id_counter_mutex_;
-  uint64_t get_id_counter_ = 1;
+  std::atomic<uint64_t> get_id_counter_;
 };
 
 }  // namespace rocksdb

--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -248,6 +248,20 @@ TEST_F(BlockCacheTracerTest, AtomicNoWriteAfterEndTrace) {
   }
 }
 
+TEST_F(BlockCacheTracerTest, NextGetId) {
+  TraceOptions trace_opt;
+  std::unique_ptr<TraceWriter> trace_writer;
+  ASSERT_OK(
+      NewFileTraceWriter(env_, env_options_, trace_file_path_, &trace_writer));
+  BlockCacheTracer writer;
+  // next get id should always return 0 before we call StartTrace.
+  ASSERT_EQ(0, writer.NextGetId());
+  ASSERT_EQ(0, writer.NextGetId());
+  ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+  ASSERT_EQ(1, writer.NextGetId());
+  ASSERT_EQ(2, writer.NextGetId());
+}
+
 TEST_F(BlockCacheTracerTest, MixedBlocks) {
   {
     // Generate a trace file containing a mix of blocks.

--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -249,17 +249,32 @@ TEST_F(BlockCacheTracerTest, AtomicNoWriteAfterEndTrace) {
 }
 
 TEST_F(BlockCacheTracerTest, NextGetId) {
-  TraceOptions trace_opt;
-  std::unique_ptr<TraceWriter> trace_writer;
-  ASSERT_OK(
-      NewFileTraceWriter(env_, env_options_, trace_file_path_, &trace_writer));
   BlockCacheTracer writer;
-  // next get id should always return 0 before we call StartTrace.
-  ASSERT_EQ(0, writer.NextGetId());
-  ASSERT_EQ(0, writer.NextGetId());
-  ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
-  ASSERT_EQ(1, writer.NextGetId());
-  ASSERT_EQ(2, writer.NextGetId());
+  {
+    TraceOptions trace_opt;
+    std::unique_ptr<TraceWriter> trace_writer;
+    ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
+                                 &trace_writer));
+    // next get id should always return 0 before we call StartTrace.
+    ASSERT_EQ(0, writer.NextGetId());
+    ASSERT_EQ(0, writer.NextGetId());
+    ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+    ASSERT_EQ(1, writer.NextGetId());
+    ASSERT_EQ(2, writer.NextGetId());
+    writer.EndTrace();
+    // next get id should return 0.
+    ASSERT_EQ(0, writer.NextGetId());
+  }
+
+  // Start trace again and next get id should return 1.
+  {
+    TraceOptions trace_opt;
+    std::unique_ptr<TraceWriter> trace_writer;
+    ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
+                                 &trace_writer));
+    ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+    ASSERT_EQ(1, writer.NextGetId());
+  }
 }
 
 TEST_F(BlockCacheTracerTest, MixedBlocks) {

--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -71,6 +71,9 @@ class BlockCacheTracerTest : public testing::Test {
       record.sst_fd_number = kSSTFDNumber + key_id;
       record.is_cache_hit = Boolean::kFalse;
       record.no_insert = Boolean::kFalse;
+      // Provide get_id for all callers. The writer should only write get_id
+      // when the caller is either GET or MGET.
+      record.get_id = key_id + 1;
       // Provide these fields for all block types.
       // The writer should only write these fields for data blocks and the
       // caller is either GET or MGET.
@@ -120,6 +123,12 @@ class BlockCacheTracerTest : public testing::Test {
       ASSERT_EQ(kSSTFDNumber + key_id, record.sst_fd_number);
       ASSERT_EQ(Boolean::kFalse, record.is_cache_hit);
       ASSERT_EQ(Boolean::kFalse, record.no_insert);
+      if (record.caller == TableReaderCaller::kUserGet ||
+          record.caller == TableReaderCaller::kUserMultiGet) {
+        ASSERT_EQ(key_id + 1, record.get_id);
+      } else {
+        ASSERT_EQ(BlockCacheTraceHelper::kReservedGetId, record.get_id);
+      }
       if (block_type == TraceType::kBlockTraceDataBlock &&
           (record.caller == TableReaderCaller::kUserGet ||
            record.caller == TableReaderCaller::kUserMultiGet)) {


### PR DESCRIPTION
This PR associates a unique id with Get and MultiGet. This enables us to track how many blocks a Get/MultiGet request accesses. We can also measure the impact of row cache vs block cache. 

Test plan: make clean && COMPILE_WITH_ASAN=1 make check -j32