### PR TITLE
Block cache analyzer: Add more stats 

### DIFF
--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -422,12 +422,15 @@ void BlockCacheTraceAnalyzer::WriteGetSpatialLocality(
     const std::string label =
         BuildLabel(labels, cf_name, fd, level, TraceType::kBlockTraceDataBlock,
                    TableReaderCaller::kUserGet, /*block_id=*/0);
-    const uint64_t percent_referenced_for_existing_keys = static_cast<uint64_t>(
-        percent(block.key_num_access_map.size(), block.num_keys));
-    const uint64_t percent_accesses_for_existing_keys = static_cast<uint64_t>(
-        percent(block.num_referenced_key_exist_in_block, naccesses));
+
+    const uint64_t percent_referenced_for_existing_keys =
+        static_cast<uint64_t>(std::max(
+            percent(block.key_num_access_map.size(), block.num_keys), 0.0));
+    const uint64_t percent_accesses_for_existing_keys =
+        static_cast<uint64_t>(std::max(
+            percent(block.num_referenced_key_exist_in_block, naccesses), 0.0));
     const uint64_t percent_referenced_data_size = static_cast<uint64_t>(
-        percent(block.referenced_data_size, block.block_size));
+        std::max(percent(block.referenced_data_size, block.block_size), 0.0));
     if (label_pnrefkeys_nblocks.find(label) == label_pnrefkeys_nblocks.end()) {
       for (auto const& percent_bucket : percent_buckets) {
         label_pnrefkeys_nblocks[label][percent_bucket] = 0;

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -986,15 +986,12 @@ void BlockCacheTraceAnalyzer::WriteAccessCountSummaryStats(
              block_type_aggregates.second.block_access_info_map) {
           total_nblocks += 1;
           uint64_t naccesses = 0;
-          if (user_access_only) {
-            for (auto const& caller_access :
-                 block_access_info.second.caller_num_access_map) {
-              if (is_user_access(caller_access.first)) {
-                naccesses += caller_access.second;
-              }
+          for (auto const& caller_access :
+               block_access_info.second.caller_num_access_map) {
+            if (!user_access_only ||
+                (user_access_only && is_user_access(caller_access.first))) {
+              naccesses += caller_access.second;
             }
-          } else {
-            naccesses = block_access_info.second.num_accesses;
           }
           bt_access_nblocks[block_type].upper_bound(naccesses)->second += 1;
           cf_access_nblocks[cf_name].upper_bound(naccesses)->second += 1;

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -988,7 +988,6 @@ void BlockCacheTraceAnalyzer::WriteAccessCountSummaryStats(
 
         for (auto const& block_access_info :
              block_type_aggregates.second.block_access_info_map) {
-          total_nblocks += 1;
           uint64_t naccesses = 0;
           for (auto const& caller_access :
                block_access_info.second.caller_num_access_map) {
@@ -997,6 +996,10 @@ void BlockCacheTraceAnalyzer::WriteAccessCountSummaryStats(
               naccesses += caller_access.second;
             }
           }
+          if (naccesses == 0) {
+            continue;
+          }
+          total_nblocks += 1;
           bt_access_nblocks[block_type].upper_bound(naccesses)->second += 1;
           cf_access_nblocks[cf_name].upper_bound(naccesses)->second += 1;
         }

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -142,6 +142,24 @@ const std::string kSupportedCacheNames =
     "ghost_lru_hybrid lru_hybrid_no_insert_on_row_miss "
     "ghost_lru_hybrid_no_insert_on_row_miss ";
 
+// The suffix for the generated csv files.
+const std::string kFileNameSuffixAccessTimeline = "access_timeline";
+const std::string kFileNameSuffixAvgReuseIntervalNaccesses =
+    "avg_reuse_interval_naccesses";
+const std::string kFileNameSuffixAvgReuseInterval = "avg_reuse_interval";
+const std::string kFileNameSuffixReuseInterval = "access_reuse_interval";
+const std::string kFileNameSuffixReuseLifetime = "reuse_lifetime";
+const std::string kFileNameSuffixAccessReuseBlocksTimeline =
+    "reuse_blocks_timeline";
+const std::string kFileNameSuffixPercentOfAccessSummary =
+    "percentage_of_accesses_summary";
+const std::string kFileNameSuffixPercentRefKeys = "percent_ref_keys";
+const std::string kFileNameSuffixPercentDataSizeOnRefKeys =
+    "percent_data_size_on_ref_keys";
+const std::string kFileNameSuffixPercentAccessesOnRefKeys =
+    "percent_accesses_on_ref_keys";
+const std::string kFileNameSuffixAccessCountSummary = "access_count_summary";
+
 std::string block_type_to_string(TraceType type) {
   switch (type) {
     case kBlockTraceFilterBlock:
@@ -429,11 +447,13 @@ void BlockCacheTraceAnalyzer::WriteGetSpatialLocality(
     nblocks += 1;
   };
   TraverseBlocks(block_callback);
-  WriteStatsToFile(label_str, percent_buckets, "_percent_ref_keys",
+  WriteStatsToFile(label_str, percent_buckets, kFileNameSuffixPercentRefKeys,
                    label_pnrefkeys_nblocks, nblocks);
-  WriteStatsToFile(label_str, percent_buckets, "_percent_accesses_on_ref_keys",
+  WriteStatsToFile(label_str, percent_buckets,
+                   kFileNameSuffixPercentAccessesOnRefKeys,
                    label_pnrefs_nblocks, nblocks);
-  WriteStatsToFile(label_str, percent_buckets, "_percent_data_size_on_ref_keys",
+  WriteStatsToFile(label_str, percent_buckets,
+                   kFileNameSuffixPercentDataSizeOnRefKeys,
                    label_pndatasize_nblocks, nblocks);
 }
 
@@ -478,7 +498,7 @@ void BlockCacheTraceAnalyzer::WriteAccessTimeline(const std::string& label_str,
       user_access_only ? "user_access_only_" : "all_access_";
   const std::string output_path = output_dir_ + "/" + user_access_prefix +
                                   label_str + "_" + std::to_string(time_unit) +
-                                  "_access_timeline";
+                                  "_" + kFileNameSuffixAccessTimeline;
   std::ofstream out(output_path);
   if (!out.is_open()) {
     return;
@@ -629,7 +649,7 @@ void BlockCacheTraceAnalyzer::WriteStatsToFile(
     const std::map<std::string, std::map<uint64_t, uint64_t>>& label_data,
     uint64_t ntotal) const {
   const std::string output_path =
-      output_dir_ + "/" + label_str + filename_suffix;
+      output_dir_ + "/" + label_str + "_" + filename_suffix;
   std::ofstream out(output_path);
   if (!out.is_open()) {
     return;
@@ -713,11 +733,12 @@ void BlockCacheTraceAnalyzer::WriteReuseInterval(
   TraverseBlocks(block_callback);
 
   // Write the stats into files.
-  WriteStatsToFile(label_str, time_buckets, "_reuse_interval",
+  WriteStatsToFile(label_str, time_buckets, kFileNameSuffixReuseInterval,
                    label_time_num_reuses, total_num_reuses);
-  WriteStatsToFile(label_str, time_buckets, "_avg_reuse_interval",
+  WriteStatsToFile(label_str, time_buckets, kFileNameSuffixAvgReuseInterval,
                    label_avg_reuse_nblocks, total_nblocks);
-  WriteStatsToFile(label_str, time_buckets, "_avg_reuse_interval_naccesses",
+  WriteStatsToFile(label_str, time_buckets,
+                   kFileNameSuffixAvgReuseIntervalNaccesses,
                    label_avg_reuse_naccesses, total_accesses);
 }
 
@@ -752,7 +773,7 @@ void BlockCacheTraceAnalyzer::WriteReuseLifetime(
     total_nblocks += 1;
   };
   TraverseBlocks(block_callback);
-  WriteStatsToFile(label_str, time_buckets, "_reuse_lifetime",
+  WriteStatsToFile(label_str, time_buckets, kFileNameSuffixReuseLifetime,
                    label_lifetime_nblocks, total_nblocks);
 }
 
@@ -818,8 +839,8 @@ void BlockCacheTraceAnalyzer::WriteBlockReuseTimeline(
       user_access_only ? "_user_access_only_" : "_all_access_";
   const std::string output_path =
       output_dir_ + "/" + block_type_to_string(block_type) +
-      user_access_prefix + std::to_string(reuse_window) +
-      "_reuse_blocks_timeline";
+      user_access_prefix + std::to_string(reuse_window) + "_" +
+      kFileNameSuffixAccessReuseBlocksTimeline;
   std::ofstream out(output_path);
   if (!out.is_open()) {
     return;
@@ -881,7 +902,7 @@ void BlockCacheTraceAnalyzer::WritePercentAccessSummaryStats() const {
   TraverseBlocks(block_callback);
 
   const std::string output_path =
-      output_dir_ + "/percentage_of_accesses_summary";
+      output_dir_ + "/" + kFileNameSuffixPercentOfAccessSummary;
   std::ofstream out(output_path);
   if (!out.is_open()) {
     return;
@@ -923,9 +944,9 @@ void BlockCacheTraceAnalyzer::WriteDetailedPercentAccessSummaryStats(
       };
   TraverseBlocks(block_callback);
   {
-    const std::string output_path = output_dir_ + "/" +
-                                    caller_to_string(analyzing_caller) +
-                                    "_level_percentage_of_accesses_summary";
+    const std::string output_path =
+        output_dir_ + "/" + caller_to_string(analyzing_caller) + "_level_" +
+        kFileNameSuffixPercentOfAccessSummary;
     std::ofstream out(output_path);
     if (!out.is_open()) {
       return;
@@ -946,9 +967,9 @@ void BlockCacheTraceAnalyzer::WriteDetailedPercentAccessSummaryStats(
     out.close();
   }
   {
-    const std::string output_path = output_dir_ + "/" +
-                                    caller_to_string(analyzing_caller) +
-                                    "_bt_percentage_of_accesses_summary";
+    const std::string output_path =
+        output_dir_ + "/" + caller_to_string(analyzing_caller) + "_bt_" +
+        kFileNameSuffixPercentOfAccessSummary;
     std::ofstream out(output_path);
     if (!out.is_open()) {
       return;
@@ -1011,12 +1032,12 @@ void BlockCacheTraceAnalyzer::WriteAccessCountSummaryStats(
       };
   TraverseBlocks(block_callback);
   const std::string user_access_prefix =
-      user_access_only ? "_user_access_only_" : "_all_access_";
+      user_access_only ? "user_access_only_" : "all_access_";
   WriteStatsToFile("cf", access_count_buckets,
-                   user_access_prefix + "access_count_summary",
+                   user_access_prefix + kFileNameSuffixAccessCountSummary,
                    cf_access_nblocks, total_nblocks);
   WriteStatsToFile("bt", access_count_buckets,
-                   user_access_prefix + "access_count_summary",
+                   user_access_prefix + kFileNameSuffixAccessCountSummary,
                    bt_access_nblocks, total_nblocks);
 }
 

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -461,18 +461,6 @@ void BlockCacheTraceAnalyzer::WriteReuseDistance(
     header += label_it.first;
   }
   out << header << std::endl;
-  // Absolute values.
-  for (auto const& bucket : distance_buckets) {
-    std::string row(std::to_string(bucket));
-    for (auto const& label_it : label_distance_num_reuses) {
-      auto const& it = label_it.second.find(bucket);
-      assert(it != label_it.second.end());
-      row += ",";
-      row += std::to_string(it->second);
-    }
-    out << row << std::endl;
-  }
-  // Percentage values.
   for (auto const& bucket : distance_buckets) {
     std::string row(std::to_string(bucket));
     for (auto const& label_it : label_distance_num_reuses) {
@@ -587,18 +575,6 @@ void BlockCacheTraceAnalyzer::WriteReuseInterval(
     header += label_it.first;
   }
   out << header << std::endl;
-  // Absolute values.
-  for (auto const& bucket : time_buckets) {
-    std::string row(std::to_string(bucket));
-    for (auto const& label_it : label_time_num_reuses) {
-      auto const& it = label_it.second.find(bucket);
-      assert(it != label_it.second.end());
-      row += ",";
-      row += std::to_string(it->second);
-    }
-    out << row << std::endl;
-  }
-  // Percentage values.
   for (auto const& bucket : time_buckets) {
     std::string row(std::to_string(bucket));
     for (auto const& label_it : label_time_num_reuses) {

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -477,8 +477,8 @@ void BlockCacheTraceAnalyzer::WriteAccessTimeline(const std::string& label_str,
   const std::string user_access_prefix =
       user_access_only ? "user_access_only_" : "all_access_";
   const std::string output_path = output_dir_ + "/" + user_access_prefix +
-                                  label_str + "_access_timeline_" +
-                                  std::to_string(time_unit);
+                                  label_str + "_" + std::to_string(time_unit) +
+                                  "_access_timeline";
   std::ofstream out(output_path);
   if (!out.is_open()) {
     return;

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -721,6 +721,8 @@ void BlockCacheTraceAnalyzer::WriteReuseLifetime(
 
 void BlockCacheTraceAnalyzer::WriteBlockReuseTimeline(
     uint64_t reuse_window, bool user_access_only) const {
+  // A map from block key to an array of bools that states whether a block is
+  // accessed in a time window.
   std::map<std::string, std::vector<bool>> block_accessed;
   const uint64_t trace_duration =
       trace_end_timestamp_in_seconds_ - trace_start_timestamp_in_seconds_;
@@ -801,7 +803,7 @@ void BlockCacheTraceAnalyzer::WriteBlockReuseTimeline(
     for (uint64_t j = 0; j < reuse_vector_size; j++) {
       row += ",";
       if (j < start_time) {
-        row += "0.0";
+        row += "100.0";
       } else {
         row += std::to_string(percent(reuse_table[start_time][j],
                                       reuse_table[start_time][start_time]));

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -752,7 +752,9 @@ void BlockCacheTraceAnalyzer::WriteBlockReuseTimeline(
                   timestamp - trace_start_timestamp_in_seconds_;
               if (!user_access_only ||
                   (user_access_only && is_user_access(caller))) {
-                block_accessed[block_key][elapsed_time / reuse_window] = true;
+                uint64_t index = std::min(elapsed_time / reuse_window,
+                                          reuse_vector_size - 1);
+                block_accessed[block_key][index] = true;
               }
             }
           }

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -133,10 +133,16 @@ class BlockCacheTraceAnalyzer {
   // accesses on keys exist in a data block and its break down by column family.
   void PrintDataBlockAccessStats() const;
 
+  // Write the percentage of accesses break down by column family into a csv
+  // file saved in 'output_dir'.
   void WritePercentAccessSummaryStats() const;
 
+  // Write the percentage of accesses for the given caller break down by column
+  // family, level, and block type into a csv file saved in 'output_dir'.
   void WriteDetailedPercentAccessSummaryStats(TableReaderCaller caller) const;
 
+  // Write the access count summary into a csv file saved in 'output_dir'.
+  // It groups blocks by their access count.
   void WriteAccessCountSummaryStats(
       const std::vector<uint64_t>& access_count_buckets,
       bool user_access_only) const;
@@ -184,6 +190,10 @@ class BlockCacheTraceAnalyzer {
       std::map<std::string, std::map<uint64_t, uint64_t>>*
           label_time_num_reuses,
       uint64_t* total_num_reuses) const;
+
+  std::string OutputPercentAccessStats(
+      uint64_t total_accesses,
+      const std::map<std::string, uint64_t>& cf_access_count) const;
 
   rocksdb::Env* env_;
   const std::string trace_file_path_;

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -166,6 +166,12 @@ class BlockCacheTraceAnalyzer {
   void WriteReuseInterval(const std::string& label_str,
                           const std::vector<uint64_t>& time_buckets) const;
 
+  // Write the reuse lifetime into a csv file saved in 'output_dir'. Reuse
+  // lifetime is defined as the time interval between the first access of a
+  // block and its last access.
+  void WriteReuseLifetime(const std::string& label_str,
+                          const std::vector<uint64_t>& time_buckets) const;
+
   const std::map<std::string, ColumnFamilyAccessInfoAggregate>&
   TEST_cf_aggregates_map() const {
     return cf_aggregates_map_;

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -210,11 +210,11 @@ class BlockCacheTraceAnalyzer {
 
   // Write the reuse timeline into a csv file saved in 'output_dir'.
   //
-  // The file is named "user_access_only_reuse_window_reuse_timeline".
-  // The file format is start_time,0,1,...,N where N equals trace_duration /
-  // reuse_window.
-  void WriteBlockReuseTimeline(uint64_t reuse_window,
-                               bool user_access_only) const;
+  // The file is named
+  // "block_type_user_access_only_reuse_window_reuse_timeline". The file format
+  // is start_time,0,1,...,N where N equals trace_duration / reuse_window.
+  void WriteBlockReuseTimeline(uint64_t reuse_window, bool user_access_only,
+                               TraceType block_type) const;
 
   const std::map<std::string, ColumnFamilyAccessInfoAggregate>&
   TEST_cf_aggregates_map() const {

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -23,11 +23,12 @@ struct BlockAccessInfo {
   uint64_t first_access_time = 0;
   uint64_t last_access_time = 0;
   uint64_t num_keys = 0;
-  std::map<std::string, uint64_t>
+  std::map<std::string, std::map<TableReaderCaller, uint64_t>>
       key_num_access_map;  // for keys exist in this block.
-  std::map<std::string, uint64_t>
+  std::map<std::string, std::map<TableReaderCaller, uint64_t>>
       non_exist_key_num_access_map;  // for keys do not exist in this block.
   uint64_t num_referenced_key_exist_in_block = 0;
+  uint64_t referenced_data_size = 0;
   std::map<TableReaderCaller, uint64_t> caller_num_access_map;
   // caller:timestamp:number_of_accesses. The granularity of the timestamp is
   // seconds.
@@ -54,10 +55,14 @@ struct BlockAccessInfo {
                                                         access.caller)) {
       num_keys = access.num_keys_in_block;
       if (access.referenced_key_exist_in_block == Boolean::kTrue) {
-        key_num_access_map[access.referenced_key]++;
+        if (key_num_access_map.find(access.referenced_key) ==
+            key_num_access_map.end()) {
+          referenced_data_size += access.referenced_data_size;
+        }
+        key_num_access_map[access.referenced_key][access.caller]++;
         num_referenced_key_exist_in_block++;
       } else {
-        non_exist_key_num_access_map[access.referenced_key]++;
+        non_exist_key_num_access_map[access.referenced_key][access.caller]++;
       }
     }
   }

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -135,42 +135,81 @@ class BlockCacheTraceAnalyzer {
 
   // Write the percentage of accesses break down by column family into a csv
   // file saved in 'output_dir'.
+  //
+  // The file is named "percentage_of_accesses_summary". The file format is
+  // caller,cf_0,cf_1,...,cf_n where the cf_i is the column family name found in
+  // the trace.
   void WritePercentAccessSummaryStats() const;
 
   // Write the percentage of accesses for the given caller break down by column
   // family, level, and block type into a csv file saved in 'output_dir'.
+  //
+  // It generates two files: 1) caller_level_percentage_of_accesses_summary and
+  // 2) caller_bt_percentage_of_accesses_summary which break down by the level
+  // and block type, respectively. The file format is
+  // level/bt,cf_0,cf_1,...,cf_n where cf_i is the column family name found in
+  // the trace.
   void WriteDetailedPercentAccessSummaryStats(TableReaderCaller caller) const;
 
   // Write the access count summary into a csv file saved in 'output_dir'.
   // It groups blocks by their access count.
+  //
+  // It generates two files: 1) cf_access_count_summary and 2)
+  // bt_access_count_summary which break down the access count by column family
+  // and block type, respectively. The file format is
+  // cf/bt,bucket_0,bucket_1,...,bucket_N.
   void WriteAccessCountSummaryStats(
       const std::vector<uint64_t>& access_count_buckets,
       bool user_access_only) const;
 
   // Write miss ratio curves of simulated cache configurations into a csv file
-  // saved in 'output_dir'.
+  // named "mrc" saved in 'output_dir'.
+  //
+  // The file format is
+  // "cache_name,num_shard_bits,capacity,miss_ratio,total_accesses".
   void WriteMissRatioCurves() const;
 
   // Write the access timeline into a csv file saved in 'output_dir'.
+  //
+  // The file is named "label_access_timeline".The file format is
+  // "time,label_1_access_per_second,label_2_access_per_second,...,label_N_access_per_second"
+  // where N is the number of unique labels found in the trace.
   void WriteAccessTimeline(const std::string& label) const;
 
   // Write the reuse distance into a csv file saved in 'output_dir'. Reuse
   // distance is defined as the cumulated size of unique blocks read between two
   // consective accesses on the same block.
+  //
+  // The file is named "label_reuse_distance". The file format is
+  // bucket,label_1,label_2,...,label_N.
   void WriteReuseDistance(const std::string& label_str,
                           const std::vector<uint64_t>& distance_buckets) const;
 
   // Write the reuse interval into a csv file saved in 'output_dir'. Reuse
   // interval is defined as the time between two consecutive accesses on the
-  // same block..
+  // same block.
+  //
+  // The file is named "label_reuse_interval". The file format is
+  // bucket,label_1,label_2,...,label_N.
   void WriteReuseInterval(const std::string& label_str,
                           const std::vector<uint64_t>& time_buckets) const;
 
   // Write the reuse lifetime into a csv file saved in 'output_dir'. Reuse
   // lifetime is defined as the time interval between the first access of a
   // block and its last access.
+  //
+  // The file is named "label_reuse_lifetime". The file format is
+  // bucket,label_1,label_2,...,label_N.
   void WriteReuseLifetime(const std::string& label_str,
                           const std::vector<uint64_t>& time_buckets) const;
+
+  // Write the reuse timeline into a csv file saved in 'output_dir'.
+  //
+  // The file is named "user_access_only_reuse_window_reuse_timeline".
+  // The file format is start_time,0,1,...,N where N equals trace_duration /
+  // reuse_window.
+  void WriteBlockReuseTimeline(uint64_t reuse_window,
+                               bool user_access_only) const;
 
   const std::map<std::string, ColumnFamilyAccessInfoAggregate>&
   TEST_cf_aggregates_map() const {
@@ -210,6 +249,8 @@ class BlockCacheTraceAnalyzer {
   std::unique_ptr<BlockCacheTraceSimulator> cache_simulator_;
   std::map<std::string, ColumnFamilyAccessInfoAggregate> cf_aggregates_map_;
   std::map<std::string, BlockAccessInfo*> block_info_map_;
+  uint64_t trace_start_timestamp_in_seconds_ = 0;
+  uint64_t trace_end_timestamp_in_seconds_ = 0;
 };
 
 int block_cache_trace_analyzer_tool(int argc, char** argv);

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -16,10 +16,6 @@
 #include "utilities/simulator_cache/cache_simulator.h"
 
 namespace rocksdb {
-
-const uint64_t kSecondInMinute = 60;
-const uint64_t kSecondInHour = 3600;
-
 // Statistics of a block.
 struct BlockAccessInfo {
   uint64_t num_accesses = 0;

--- a/tools/block_cache_trace_analyzer.h
+++ b/tools/block_cache_trace_analyzer.h
@@ -74,12 +74,6 @@ struct BlockAccessInfo {
         if (referenced_data_size > block_size && block_size != 0) {
           ParsedInternalKey internal_key;
           ParseInternalKey(access.referenced_key, &internal_key);
-          printf(
-              "######cf=%s fd=%lu ads=%lu abs=%lu ds=%lu bs=%lu t=%d uk=%s\n",
-              access.cf_name.c_str(), access.sst_fd_number,
-              access.referenced_data_size, access.block_size,
-              referenced_data_size, block_size, internal_key.type,
-              internal_key.user_key.ToString().c_str());
         }
       } else {
         non_exist_key_num_access_map[access.referenced_key][access.caller]++;
@@ -281,8 +275,11 @@ class BlockCacheTraceAnalyzer {
       uint64_t ntotal) const;
 
   void TraverseBlocks(
-      std::function<void(const std::string&, uint64_t, uint32_t, TraceType,
-                         const std::string&, uint64_t, const BlockAccessInfo&)>
+      std::function<void(const std::string& /*cf_name*/, uint64_t /*fd*/,
+                         uint32_t /*level*/, TraceType /*block_type*/,
+                         const std::string& /*block_key*/,
+                         uint64_t /*block_key_id*/,
+                         const BlockAccessInfo& /*block_access_info*/)>
           block_callback) const;
 
   rocksdb::Env* env_;

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -296,9 +296,7 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
     for (auto const& test : test_reuse_csv_files) {
       const std::string& file_suffix = test.first;
       const std::string& labels = test.second;
-      const uint32_t expected_num_rows = 10;
-      const uint32_t expected_num_rows_absolute_values = 5;
-      const uint32_t expected_reused_blocks = 0;
+      const uint32_t expected_num_rows = 5;
       std::stringstream ss(labels);
       while (ss.good()) {
         std::string l;
@@ -307,7 +305,6 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
         std::ifstream infile(reuse_csv_file);
         std::string line;
         ASSERT_TRUE(getline(infile, line));
-        uint32_t nblocks = 0;
         double npercentage = 0;
         uint32_t nrows = 0;
         while (getline(infile, line)) {
@@ -321,15 +318,10 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
               label_read = true;
               continue;
             }
-            if (nrows < expected_num_rows_absolute_values) {
-              nblocks += ParseUint32(substr);
-            } else {
-              npercentage += ParseDouble(substr);
-            }
+            npercentage += ParseDouble(substr);
           }
         }
         ASSERT_EQ(expected_num_rows, nrows);
-        ASSERT_EQ(expected_reused_blocks, nblocks);
         ASSERT_LT(npercentage, 0);
         ASSERT_OK(env_->DeleteFile(reuse_csv_file));
       }

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -318,7 +318,7 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
   {
     // Validate the reuse_interval and reuse_distance csv files.
     std::map<std::string, std::string> test_reuse_csv_files;
-    test_reuse_csv_files["_reuse_interval"] = reuse_interval_labels_;
+    test_reuse_csv_files["_access_reuse_interval"] = reuse_interval_labels_;
     test_reuse_csv_files["_reuse_distance"] = reuse_distance_labels_;
     test_reuse_csv_files["_reuse_lifetime"] = reuse_lifetime_labels_;
     test_reuse_csv_files["_avg_reuse_interval"] = reuse_interval_labels_;

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -160,12 +160,14 @@ class BlockCacheTracerTest : public testing::Test {
         "-print_access_count_stats",
         "-print_data_block_access_count_stats",
         "-cache_sim_warmup_seconds=0",
+        "-analyze_bottom_k_access_count_blocks=5",
+        "-analyze_top_k_access_count_blocks=5",
         "-timeline_labels=" + timeline_labels_,
         "-reuse_distance_labels=" + reuse_distance_labels_,
         "-reuse_distance_buckets=" + reuse_distance_buckets_,
         "-reuse_interval_labels=" + reuse_interval_labels_,
         "-reuse_interval_buckets=" + reuse_interval_buckets_,
-        "-analyzing_callers=" + analyzing_callers_,
+        "-analyze_callers=" + analyzing_callers_,
         "-access_count_buckets=" + access_count_buckets_};
     char arg_buffer[kArgBufferSize];
     char* argv[kMaxArgCount];

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -420,15 +420,15 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
       }
     }
   }
-  const std::vector<std::string> access_types{"user_access_only",
-                                              "all_access"};
+  const std::vector<std::string> access_types{"user_access_only", "all_access"};
   const std::vector<std::string> prefix{"bt", "cf"};
   for (auto const& pre : prefix) {
     for (auto const& access_type : access_types) {
       {
         // Validate the access count summary.
-        const std::string bt_access_count_summary =
-            test_path_ + "/" + pre + "_" + access_type + "_access_count_summary";
+        const std::string bt_access_count_summary = test_path_ + "/" + pre +
+                                                    "_" + access_type +
+                                                    "_access_count_summary";
         std::ifstream infile(bt_access_count_summary);
         std::string line;
         ASSERT_TRUE(getline(infile, line));

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -284,8 +284,8 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
             }
           }
           const std::string timeline_file = test_path_ + "/" +
-                                            user_access_only + l +
-                                            "_access_timeline" + unit;
+                                            user_access_only + l + unit +
+                                            "_access_timeline";
           std::ifstream infile(timeline_file);
           std::string line;
           const uint64_t expected_naccesses = 50;

--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -29,6 +29,8 @@ bool ShouldTrace(const Slice& block_key, const TraceOptions& trace_options) {
 }  // namespace
 
 const uint64_t kMicrosInSecond = 1000 * 1000;
+const uint64_t kSecondInMinute = 60;
+const uint64_t kSecondInHour = 3600;
 const std::string BlockCacheTraceHelper::kUnknownColumnFamilyName =
     "UnknownColumnFamily";
 const uint64_t BlockCacheTraceHelper::kReservedGetId = 0;

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -17,6 +17,9 @@
 namespace rocksdb {
 
 extern const uint64_t kMicrosInSecond;
+extern const uint64_t kSecondInMinute;
+extern const uint64_t kSecondInHour;
+
 
 class BlockCacheTraceHelper {
  public:


### PR DESCRIPTION
This PR provides more command line options for block cache analyzer to better understand block cache access pattern. 
-analyze_bottom_k_access_count_blocks
-analyze_top_k_access_count_blocks
-reuse_lifetime_labels
-reuse_lifetime_buckets
-analyze_callers
-access_count_buckets
-analyze_blocks_reuse_k_reuse_window

Test plan: make clean && COMPILE_WITH_ASAN=1 make check -j32