### PR TITLE
Block cache tracer: StartTrace returns busy if tracing is already started.

### DIFF
--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -233,7 +233,7 @@ Status BlockCacheTracer::StartTrace(
     std::unique_ptr<TraceWriter>&& trace_writer) {
   InstrumentedMutexLock lock_guard(&trace_writer_mutex_);
   if (writer_.load()) {
-    return Status::OK();
+    return Status::Busy();
   }
   trace_options_ = trace_options;
   writer_.store(

--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -195,6 +195,20 @@ TEST_F(BlockCacheTracerTest, AtomicWrite) {
   }
 }
 
+TEST_F(BlockCacheTracerTest, ConsecutiveStartTrace) {
+  BlockCacheTraceRecord record = GenerateAccessRecord();
+  {
+    TraceOptions trace_opt;
+    std::unique_ptr<TraceWriter> trace_writer;
+    ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
+                                 &trace_writer));
+    BlockCacheTracer writer;
+    ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+    ASSERT_NOK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+    ASSERT_OK(env_->FileExists(trace_file_path_));
+  }
+}
+
 TEST_F(BlockCacheTracerTest, AtomicNoWriteAfterEndTrace) {
   BlockCacheTraceRecord record = GenerateAccessRecord();
   {

--- a/trace_replay/block_cache_tracer_test.cc
+++ b/trace_replay/block_cache_tracer_test.cc
@@ -196,17 +196,14 @@ TEST_F(BlockCacheTracerTest, AtomicWrite) {
 }
 
 TEST_F(BlockCacheTracerTest, ConsecutiveStartTrace) {
-  BlockCacheTraceRecord record = GenerateAccessRecord();
-  {
-    TraceOptions trace_opt;
-    std::unique_ptr<TraceWriter> trace_writer;
-    ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
-                                 &trace_writer));
-    BlockCacheTracer writer;
-    ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
-    ASSERT_NOK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
-    ASSERT_OK(env_->FileExists(trace_file_path_));
-  }
+  TraceOptions trace_opt;
+  std::unique_ptr<TraceWriter> trace_writer;
+  ASSERT_OK(
+      NewFileTraceWriter(env_, env_options_, trace_file_path_, &trace_writer));
+  BlockCacheTracer writer;
+  ASSERT_OK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+  ASSERT_NOK(writer.StartTrace(env_, trace_opt, std::move(trace_writer)));
+  ASSERT_OK(env_->FileExists(trace_file_path_));
 }
 
 TEST_F(BlockCacheTracerTest, AtomicNoWriteAfterEndTrace) {


### PR DESCRIPTION
This PR is needed for integration into MyRocks. A second call on StartTrace returns Busy so that MyRocks may return an error to the user. 

Test plan: make clean && USE_CLANG=1 make check -j32