### PR TITLE
Exclude StatsHistoryTest.ForceManualFlushStatsCF test from lite mode

### DIFF
--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -567,7 +567,6 @@ TEST_F(StatsHistoryTest, PersistentStatsReadOnly) {
   // Now check keys in read only mode.
   ASSERT_OK(ReadOnlyReopen(options));
 }
-#endif  // !ROCKSDB_LITE
 
 TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
   Options options;
@@ -644,6 +643,7 @@ TEST_F(StatsHistoryTest, ForceManualFlushStatsCF) {
   Close();
 }
 
+#endif  // !ROCKSDB_LITE
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Recent commit 3886dddc3b44bf5061c0f93eab578c51e8bad7bd introduced a new test which is not compatible with lite mode and breaks contrun test:
```
[ RUN      ] StatsHistoryTest.ForceManualFlushStatsCF
monitoring/stats_history_test.cc:642: Failure
Expected: (cfd_stats->GetLogNumber()) < (cfd_test->GetLogNumber()), actual: 15 vs 15
```
This PR excludes the test from lite mode to appease the failing test