### PR TITLE
Cache simulator: Add a ghost cache for admission control and a hybrid row-block cache.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,6 +1005,7 @@ if(WITH_TESTS)
         utilities/options/options_util_test.cc
         utilities/persistent_cache/hash_table_test.cc
         utilities/persistent_cache/persistent_cache_test.cc
+        utilities/simulator_cache/cache_simulator_test.cc
         utilities/simulator_cache/sim_cache_test.cc
         utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
         utilities/transactions/optimistic_transaction_test.cc

--- a/Makefile
+++ b/Makefile
@@ -509,6 +509,7 @@ TESTS = \
 	cassandra_serialize_test \
 	ttl_test \
 	backupable_db_test \
+	cache_simulator_test \
 	sim_cache_test \
 	version_edit_test \
 	version_set_test \
@@ -1318,6 +1319,9 @@ backupable_db_test: utilities/backupable/backupable_db_test.o $(LIBOBJECTS) $(TE
 	$(AM_LINK)
 
 checkpoint_test: utilities/checkpoint/checkpoint_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+cache_simulator_test: utilities/simulator_cache/cache_simulator_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 sim_cache_test: utilities/simulator_cache/sim_cache_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/Makefile
+++ b/Makefile
@@ -1321,7 +1321,7 @@ backupable_db_test: utilities/backupable/backupable_db_test.o $(LIBOBJECTS) $(TE
 checkpoint_test: utilities/checkpoint/checkpoint_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
-cache_simulator_test: utilities/simulator_cache/cache_simulator_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
+cache_simulator_test: utilities/simulator_cache/cache_simulator_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 sim_cache_test: utilities/simulator_cache/sim_cache_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/TARGETS
+++ b/TARGETS
@@ -419,6 +419,11 @@ ROCKS_TESTS = [
         "serial",
     ],
     [
+        "cache_simulator_test",
+        "utilities/simulator_cache/cache_simulator_test.cc",
+        "serial",
+    ],
+    [
         "cassandra_format_test",
         "utilities/cassandra/cassandra_format_test.cc",
         "serial",

--- a/src.mk
+++ b/src.mk
@@ -404,6 +404,7 @@ MAIN_SOURCES =                                                          \
   utilities/object_registry_test.cc                                     \
   utilities/option_change_migration/option_change_migration_test.cc     \
   utilities/options/options_util_test.cc                                \
+  utilities/simulator_cache/cache_simulator_test.cc                     \
   utilities/simulator_cache/sim_cache_test.cc                           \
   utilities/table_properties_collectors/compact_on_deletion_collector_test.cc  \
   utilities/transactions/optimistic_transaction_test.cc                 \

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -198,7 +198,8 @@ void BlockCacheTraceAnalyzer::WriteMissRatioCurves() const {
   }
   // Write header.
   const std::string header =
-      "cache_name,num_shard_bits,capacity,miss_ratio,total_accesses";
+      "cache_name,num_shard_bits,ghost_capacity,capacity,miss_ratio,total_"
+      "accesses";
   out << header << std::endl;
   for (auto const& config_caches : cache_simulator_->sim_caches()) {
     const CacheConfiguration& config = config_caches.first;
@@ -208,6 +209,8 @@ void BlockCacheTraceAnalyzer::WriteMissRatioCurves() const {
       out << config.cache_name;
       out << ",";
       out << config.num_shard_bits;
+      out << ",";
+      out << config.ghost_cache_capacity;
       out << ",";
       out << config.cache_capacities[i];
       out << ",";

--- a/tools/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_trace_analyzer.cc
@@ -24,10 +24,11 @@ DEFINE_string(
     "The config file path. One cache configuration per line. The format of a "
     "cache configuration is "
     "cache_name,num_shard_bits,ghost_capacity,cache_capacity_1,...,cache_"
-    "capacity_N. "
-    "Supported cache names are lru, lru_priority, ghost_lru and "
-    "ghost_lru_priority. ghost_capacity and cache_capacity can be xK, xM or xG "
-    "where x is a positive number.");
+    "capacity_N. Supported cache names are lru, lru_priority, lru_hybrid, and "
+    "lru_hybrid_no_insert_on_row_miss. User may also add a prefix 'ghost_' to "
+    "a cache_name to add a ghost cache in front of the real cache. "
+    "ghost_capacity and cache_capacity can be xK, xM or xG where x is a "
+    "positive number.");
 DEFINE_int32(block_cache_trace_downsample_ratio, 1,
              "The trace collected accesses on one in every "
              "block_cache_trace_downsample_ratio blocks. We scale "
@@ -107,7 +108,9 @@ const std::set<std::string> kGroupbyLabels{
     kGroupbyBlock,     kGroupbyColumnFamily, kGroupbySSTFile, kGroupbyLevel,
     kGroupbyBlockType, kGroupbyCaller,       kGroupbyAll};
 const std::string kSupportedCacheNames =
-    " lru lru_priority ghost_lru ghost_lru_priority ";
+    " lru ghost_lru lru_priority ghost_lru_priority lru_hybrid "
+    "ghost_lru_hybrid lru_hybrid_no_insert_on_row_miss "
+    "ghost_lru_hybrid_no_insert_on_row_miss ";
 
 std::string block_type_to_string(TraceType type) {
   switch (type) {

--- a/tools/block_cache_trace_analyzer_test.cc
+++ b/tools/block_cache_trace_analyzer_test.cc
@@ -205,7 +205,7 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
   }
   {
     // Generate a cache sim config.
-    std::string config = "lru,1,1K,1M,1G";
+    std::string config = "lru,1,0,1K,1M,1G";
     std::ofstream out(block_cache_sim_config_path_);
     ASSERT_TRUE(out.is_open());
     out << config << std::endl;
@@ -230,14 +230,15 @@ TEST_F(BlockCacheTracerTest, BlockCacheAnalyzer) {
         getline(ss, substr, ',');
         result_strs.push_back(substr);
       }
-      ASSERT_EQ(5, result_strs.size());
+      ASSERT_EQ(6, result_strs.size());
       ASSERT_LT(config_index, expected_capacities.size());
       ASSERT_EQ("lru", result_strs[0]);  // cache_name
       ASSERT_EQ("1", result_strs[1]);    // num_shard_bits
+      ASSERT_EQ("0", result_strs[2]);    // ghost_cache_capacity
       ASSERT_EQ(std::to_string(expected_capacities[config_index]),
-                result_strs[2]);         // cache_capacity
-      ASSERT_EQ("100.0000", result_strs[3]);  // miss_ratio
-      ASSERT_EQ("50", result_strs[4]);   // number of accesses.
+                result_strs[3]);              // cache_capacity
+      ASSERT_EQ("100.0000", result_strs[4]);  // miss_ratio
+      ASSERT_EQ("50", result_strs[5]);        // number of accesses.
       config_index++;
     }
     ASSERT_EQ(expected_capacities.size(), config_index);

--- a/trace_replay/block_cache_tracer.cc
+++ b/trace_replay/block_cache_tracer.cc
@@ -45,6 +45,14 @@ bool BlockCacheTraceHelper::ShouldTraceGetId(TableReaderCaller caller) {
          caller == TableReaderCaller::kUserMultiGet;
 }
 
+bool BlockCacheTraceHelper::IsUserAccess(TableReaderCaller caller) {
+  return caller == TableReaderCaller::kUserGet ||
+         caller == TableReaderCaller::kUserMultiGet ||
+         caller == TableReaderCaller::kUserIterator ||
+         caller == TableReaderCaller::kUserApproximateSize ||
+         caller == TableReaderCaller::kUserVerifyChecksum;
+}
+
 BlockCacheTraceWriter::BlockCacheTraceWriter(
     Env* env, const TraceOptions& trace_options,
     std::unique_ptr<TraceWriter>&& trace_writer)

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -23,6 +23,7 @@ class BlockCacheTraceHelper {
   static bool ShouldTraceReferencedKey(TraceType block_type,
                                        TableReaderCaller caller);
   static bool ShouldTraceGetId(TableReaderCaller caller);
+  static bool IsUserAccess(TableReaderCaller caller);
 
   static const std::string kUnknownColumnFamilyName;
   static const uint64_t kReservedGetId;

--- a/utilities/simulator_cache/cache_simulator.h
+++ b/utilities/simulator_cache/cache_simulator.h
@@ -17,7 +17,7 @@ struct CacheConfiguration {
   std::vector<uint64_t>
       cache_capacities;  // simulate cache capacities in bytes.
 
-  bool operator=(const CacheConfiguration& o) const {
+  bool operator==(const CacheConfiguration& o) const {
     return cache_name == o.cache_name && num_shard_bits == o.num_shard_bits &&
            ghost_cache_capacity == o.ghost_cache_capacity;
   }
@@ -32,7 +32,7 @@ struct CacheConfiguration {
 // A ghost cache admits an entry on its second access.
 class GhostCache {
  public:
-  GhostCache(std::shared_ptr<Cache> sim_cache);
+  explicit GhostCache(std::shared_ptr<Cache> sim_cache);
   ~GhostCache() = default;
   // No copy and move.
   GhostCache(const GhostCache&) = delete;
@@ -67,21 +67,21 @@ class CacheSimulator {
     user_accesses_ = 0;
     user_misses_ = 0;
   }
-  double miss_ratio() {
+  double miss_ratio() const {
     if (num_accesses_ == 0) {
       return -1;
     }
     return static_cast<double>(num_misses_ * 100.0 / num_accesses_);
   }
-  uint64_t total_accesses() { return num_accesses_; }
+  uint64_t total_accesses() const { return num_accesses_; }
 
-  double user_miss_ratio() {
+  double user_miss_ratio() const {
     if (user_accesses_ == 0) {
       return -1;
     }
     return static_cast<double>(user_misses_ * 100.0 / user_accesses_);
   }
-  uint64_t user_accesses() { return user_accesses_; }
+  uint64_t user_accesses() const { return user_accesses_; }
 
  protected:
   void UpdateMetrics(bool is_user_access, bool is_cache_miss);
@@ -111,7 +111,8 @@ class PrioritizedCacheSimulator : public CacheSimulator {
                     bool is_user_access, bool* is_cache_miss, bool* admitted,
                     bool update_metrics);
 
-  Cache::Priority ComputeBlockPriority(const BlockCacheTraceRecord& access);
+  Cache::Priority ComputeBlockPriority(
+      const BlockCacheTraceRecord& access) const;
 };
 
 // A hybrid row and block cache simulator. It looks up/inserts key-value pairs

--- a/utilities/simulator_cache/cache_simulator.h
+++ b/utilities/simulator_cache/cache_simulator.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <set>
 #include "trace_replay/block_cache_tracer.h"
 
 namespace rocksdb {
@@ -109,7 +108,8 @@ class PrioritizedCacheSimulator : public CacheSimulator {
   // Access the key-value pair and returns true upon a cache miss.
   void AccessKVPair(const Slice& key, uint64_t value_size,
                     Cache::Priority priority, bool no_insert,
-                    bool is_user_access, bool* is_cache_miss, bool* admitted);
+                    bool is_user_access, bool* is_cache_miss, bool* admitted,
+                    bool update_metrics);
 
   Cache::Priority ComputeBlockPriority(const BlockCacheTraceRecord& access);
 };
@@ -136,9 +136,9 @@ class HybridRowBlockCacheSimulator : public PrioritizedCacheSimulator {
  private:
   // Row key is a concatenation of the access's fd_number and the referenced
   // user key.
+  // TODO(haoyu): the row key should contain sequence number.
   std::string ComputeRowKey(const BlockCacheTraceRecord& access);
 
-  //
   enum InsertResult : char {
     INSERTED,
     ADMITTED,

--- a/utilities/simulator_cache/cache_simulator.h
+++ b/utilities/simulator_cache/cache_simulator.h
@@ -147,7 +147,7 @@ class HybridRowBlockCacheSimulator : public PrioritizedCacheSimulator {
   };
 
   // A map stores get_id to a map of row keys. For each row key, it stores a
-  // pair of booleans. The first bool is true when we observe a miss upon the
+  // boolean and an enum. The first bool is true when we observe a miss upon the
   // first time we encounter the row key. The second arg is INSERTED when the
   // kv-pair has been inserted into the cache, ADMITTED if it should be inserted
   // but haven't been, NO_INSERT if it should not be inserted.

--- a/utilities/simulator_cache/cache_simulator_test.cc
+++ b/utilities/simulator_cache/cache_simulator_test.cc
@@ -1,0 +1,173 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "utilities/simulator_cache/cache_simulator.h"
+
+#include <cstdlib>
+#include "db/db_test_util.h"
+
+namespace rocksdb {
+namespace {
+const std::string kBlockKeyPrefix = "test-block-";
+const std::string kRefKeyPrefix = "test-get-";
+const uint64_t kGetId = 1;
+const uint64_t kGetBlockId = 100;
+const uint64_t kCompactionBlockId = 1000;
+const uint64_t kCacheSize = 1024 * 1024;
+const uint64_t kGhostCacheSize = 1024;
+}  // namespace
+
+class CacheSimulatorTest : public DBTestBase {
+ public:
+  const size_t kNumBlocks = 5;
+  const size_t kValueSize = 1000;
+
+  CacheSimulatorTest() : DBTestBase("/cache_simulator_test") {}
+
+  BlockCacheTraceRecord GenerateGetRecord(uint64_t getid) {
+    BlockCacheTraceRecord record;
+    record.block_type = TraceType::kBlockTraceDataBlock;
+    record.block_size = 4096;
+    record.block_key = kBlockKeyPrefix + std::to_string(kGetBlockId);
+    record.access_timestamp = env_->NowMicros();
+    record.cf_id = 0;
+    record.cf_name = "test";
+    record.caller = TableReaderCaller::kUserGet;
+    record.level = 6;
+    record.sst_fd_number = kGetBlockId;
+    record.get_id = getid;
+    record.is_cache_hit = Boolean::kFalse;
+    record.no_insert = Boolean::kFalse;
+    record.referenced_key = kRefKeyPrefix + std::to_string(kGetBlockId);
+    record.referenced_key_exist_in_block = Boolean::kTrue;
+    record.num_keys_in_block = 300;
+    return record;
+  }
+
+  BlockCacheTraceRecord GenerateCompactionRecord() {
+    BlockCacheTraceRecord record;
+    record.block_type = TraceType::kBlockTraceDataBlock;
+    record.block_size = 4096;
+    record.block_key = kBlockKeyPrefix + std::to_string(kCompactionBlockId);
+    record.access_timestamp = env_->NowMicros();
+    record.cf_id = 0;
+    record.cf_name = "test";
+    record.caller = TableReaderCaller::kCompaction;
+    record.level = 6;
+    record.sst_fd_number = kCompactionBlockId;
+    record.is_cache_hit = Boolean::kFalse;
+    record.no_insert = Boolean::kTrue;
+    return record;
+  }
+};
+
+TEST_F(CacheSimulatorTest, GhostCache) {
+  const std::string key1 = "test1";
+  const std::string key2 = "test2";
+  std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
+      NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0)));
+  EXPECT_FALSE(ghost_cache->Admit(key1));
+  EXPECT_TRUE(ghost_cache->Admit(key1));
+  EXPECT_TRUE(ghost_cache->Admit(key1));
+  EXPECT_FALSE(ghost_cache->Admit(key2));
+  EXPECT_TRUE(ghost_cache->Admit(key2));
+}
+
+TEST_F(CacheSimulatorTest, CacheSimulator) {
+  const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+  const BlockCacheTraceRecord& compaction_access = GenerateCompactionRecord();
+  std::shared_ptr<Cache> sim_cache =
+      NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0);
+  std::unique_ptr<CacheSimulator> cache_simulator(
+      new CacheSimulator(nullptr, sim_cache));
+  cache_simulator->Access(access);
+  cache_simulator->Access(access);
+  ASSERT_EQ(2, cache_simulator->total_accesses());
+  ASSERT_EQ(50, cache_simulator->miss_ratio());
+  ASSERT_EQ(2, cache_simulator->user_accesses());
+  ASSERT_EQ(50, cache_simulator->user_miss_ratio());
+
+  cache_simulator->Access(compaction_access);
+  cache_simulator->Access(compaction_access);
+  ASSERT_EQ(4, cache_simulator->total_accesses());
+  ASSERT_EQ(75, cache_simulator->miss_ratio());
+  ASSERT_EQ(2, cache_simulator->user_accesses());
+  ASSERT_EQ(50, cache_simulator->user_miss_ratio());
+
+  cache_simulator->reset_counter();
+  ASSERT_EQ(0, cache_simulator->total_accesses());
+  ASSERT_EQ(-1, cache_simulator->miss_ratio());
+  auto handle = sim_cache->Lookup(access.block_key);
+  ASSERT_NE(nullptr, handle);
+  sim_cache->Release(handle);
+  handle = sim_cache->Lookup(compaction_access.block_key);
+  ASSERT_EQ(nullptr, handle);
+}
+
+TEST_F(CacheSimulatorTest, GhostCacheSimulator) {
+  const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+  std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
+      NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0)));
+  std::unique_ptr<CacheSimulator> cache_simulator(new CacheSimulator(
+      std::move(ghost_cache),
+      NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0)));
+  cache_simulator->Access(access);
+  cache_simulator->Access(access);
+  ASSERT_EQ(2, cache_simulator->total_accesses());
+  // Both of them will be miss since we have a ghost cache.
+  ASSERT_EQ(100, cache_simulator->miss_ratio());
+}
+
+TEST_F(CacheSimulatorTest, PrioritizedCacheSimulator) {
+  const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+  std::shared_ptr<Cache> sim_cache =
+      NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0);
+  std::unique_ptr<PrioritizedCacheSimulator> cache_simulator(
+      new PrioritizedCacheSimulator(nullptr, sim_cache));
+  cache_simulator->Access(access);
+  cache_simulator->Access(access);
+  ASSERT_EQ(2, cache_simulator->total_accesses());
+  ASSERT_EQ(50, cache_simulator->miss_ratio());
+
+  auto handle = sim_cache->Lookup(access.block_key);
+  ASSERT_NE(nullptr, handle);
+  sim_cache->Release(handle);
+}
+
+TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
+  const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+  std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
+      NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0)));
+  std::unique_ptr<PrioritizedCacheSimulator> cache_simulator(
+      new PrioritizedCacheSimulator(
+          std::move(ghost_cache),
+          NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                      /*strict_capacity_limit=*/false,
+                      /*high_pri_pool_ratio=*/0)));
+  cache_simulator->Access(access);
+  cache_simulator->Access(access);
+  ASSERT_EQ(2, cache_simulator->total_accesses());
+  // Both of them will be miss since we have a ghost cache.
+  ASSERT_EQ(100, cache_simulator->miss_ratio());
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/simulator_cache/cache_simulator_test.cc
+++ b/utilities/simulator_cache/cache_simulator_test.cc
@@ -6,7 +6,9 @@
 #include "utilities/simulator_cache/cache_simulator.h"
 
 #include <cstdlib>
-#include "db/db_test_util.h"
+#include "rocksdb/env.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
 
 namespace rocksdb {
 namespace {
@@ -19,12 +21,12 @@ const uint64_t kCacheSize = 1024 * 1024 * 1024;
 const uint64_t kGhostCacheSize = 1024 * 1024;
 }  // namespace
 
-class CacheSimulatorTest : public DBTestBase {
+class CacheSimulatorTest : public testing::Test {
  public:
   const size_t kNumBlocks = 5;
   const size_t kValueSize = 1000;
 
-  CacheSimulatorTest() : DBTestBase("/cache_simulator_test") {}
+  CacheSimulatorTest() { env_ = rocksdb::Env::Default(); }
 
   BlockCacheTraceRecord GenerateGetRecord(uint64_t getid) {
     BlockCacheTraceRecord record;
@@ -63,6 +65,8 @@ class CacheSimulatorTest : public DBTestBase {
     record.no_insert = Boolean::kTrue;
     return record;
   }
+
+  Env* env_;
 };
 
 TEST_F(CacheSimulatorTest, GhostCache) {

--- a/utilities/simulator_cache/cache_simulator_test.cc
+++ b/utilities/simulator_cache/cache_simulator_test.cc
@@ -26,7 +26,11 @@ class CacheSimulatorTest : public DBTestBase {
 
   CacheSimulatorTest() : DBTestBase("/cache_simulator_test") {}
 
+<<<<<<< HEAD
   BlockCacheTraceRecord GenerateGetRecord(uint64_t getid) {
+=======
+  BlockCacheTraceRecord GenerateAccessRecord(uint32_t key_id, bool no_insert) {
+>>>>>>> Add more tests
     BlockCacheTraceRecord record;
     record.block_type = TraceType::kBlockTraceDataBlock;
     record.block_size = 4096;
@@ -39,8 +43,13 @@ class CacheSimulatorTest : public DBTestBase {
     record.sst_fd_number = kGetBlockId;
     record.get_id = getid;
     record.is_cache_hit = Boolean::kFalse;
+<<<<<<< HEAD
     record.no_insert = Boolean::kFalse;
     record.referenced_key = kRefKeyPrefix + std::to_string(kGetBlockId);
+=======
+    record.no_insert = no_insert ? Boolean::kTrue : Boolean::kFalse;
+    record.referenced_key = kRefKeyPrefix + std::to_string(key_id);
+>>>>>>> Add more tests
     record.referenced_key_exist_in_block = Boolean::kTrue;
     record.num_keys_in_block = 300;
     return record;
@@ -78,6 +87,7 @@ TEST_F(CacheSimulatorTest, GhostCache) {
 }
 
 TEST_F(CacheSimulatorTest, CacheSimulator) {
+<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
   const BlockCacheTraceRecord& compaction_access = GenerateCompactionRecord();
   std::shared_ptr<Cache> sim_cache =
@@ -86,10 +96,21 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
                   /*high_pri_pool_ratio=*/0);
   std::unique_ptr<CacheSimulator> cache_simulator(
       new CacheSimulator(nullptr, sim_cache));
+=======
+  const BlockCacheTraceRecord& access =
+      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
+  const BlockCacheTraceRecord& access_no_insert =
+      GenerateAccessRecord(/*key_id=*/1, /*no_insert=*/true);
+  std::unique_ptr<CacheSimulator> cache_simulator(new CacheSimulator(
+      nullptr, NewLRUCache(/*capacity=*/cache_size, /*num_shard_bits=*/1,
+                           /*strict_capacity_limit=*/false,
+                           /*high_pri_pool_ratio=*/0)));
+>>>>>>> Add more tests
   cache_simulator->Access(access);
   cache_simulator->Access(access);
   ASSERT_EQ(2, cache_simulator->total_accesses());
   ASSERT_EQ(50, cache_simulator->miss_ratio());
+<<<<<<< HEAD
   ASSERT_EQ(2, cache_simulator->user_accesses());
   ASSERT_EQ(50, cache_simulator->user_miss_ratio());
 
@@ -99,6 +120,12 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
   ASSERT_EQ(75, cache_simulator->miss_ratio());
   ASSERT_EQ(2, cache_simulator->user_accesses());
   ASSERT_EQ(50, cache_simulator->user_miss_ratio());
+=======
+  cache_simulator->Access(access_no_insert);
+  cache_simulator->Access(access_no_insert);
+  ASSERT_EQ(4, cache_simulator->total_accesses());
+  ASSERT_EQ(75, cache_simulator->miss_ratio());
+>>>>>>> Add more tests
 
   cache_simulator->reset_counter();
   ASSERT_EQ(0, cache_simulator->total_accesses());
@@ -111,7 +138,12 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
 }
 
 TEST_F(CacheSimulatorTest, GhostCacheSimulator) {
+<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+=======
+  const BlockCacheTraceRecord& access =
+      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
+>>>>>>> Add more tests
   std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
       NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,
@@ -129,17 +161,25 @@ TEST_F(CacheSimulatorTest, GhostCacheSimulator) {
 }
 
 TEST_F(CacheSimulatorTest, PrioritizedCacheSimulator) {
+<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
   std::shared_ptr<Cache> sim_cache =
       NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,
                   /*high_pri_pool_ratio=*/0);
+=======
+  const BlockCacheTraceRecord& access =
+      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
+  const BlockCacheTraceRecord& access_no_insert =
+      GenerateAccessRecord(/*key_id=*/1, /*no_insert=*/true);
+>>>>>>> Add more tests
   std::unique_ptr<PrioritizedCacheSimulator> cache_simulator(
       new PrioritizedCacheSimulator(nullptr, sim_cache));
   cache_simulator->Access(access);
   cache_simulator->Access(access);
   ASSERT_EQ(2, cache_simulator->total_accesses());
   ASSERT_EQ(50, cache_simulator->miss_ratio());
+<<<<<<< HEAD
 
   auto handle = sim_cache->Lookup(access.block_key);
   ASSERT_NE(nullptr, handle);
@@ -148,6 +188,17 @@ TEST_F(CacheSimulatorTest, PrioritizedCacheSimulator) {
 
 TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
+=======
+  cache_simulator->Access(access_no_insert);
+  cache_simulator->Access(access_no_insert);
+  ASSERT_EQ(4, cache_simulator->total_accesses());
+  ASSERT_EQ(75, cache_simulator->miss_ratio());
+}
+
+TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
+  const BlockCacheTraceRecord& access =
+      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
+>>>>>>> Add more tests
   std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
       NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,

--- a/utilities/simulator_cache/cache_simulator_test.cc
+++ b/utilities/simulator_cache/cache_simulator_test.cc
@@ -15,8 +15,8 @@ const std::string kRefKeyPrefix = "test-get-";
 const uint64_t kGetId = 1;
 const uint64_t kGetBlockId = 100;
 const uint64_t kCompactionBlockId = 1000;
-const uint64_t kCacheSize = 1024 * 1024;
-const uint64_t kGhostCacheSize = 1024;
+const uint64_t kCacheSize = 1024 * 1024 * 1024;
+const uint64_t kGhostCacheSize = 1024 * 1024;
 }  // namespace
 
 class CacheSimulatorTest : public DBTestBase {
@@ -26,11 +26,7 @@ class CacheSimulatorTest : public DBTestBase {
 
   CacheSimulatorTest() : DBTestBase("/cache_simulator_test") {}
 
-<<<<<<< HEAD
   BlockCacheTraceRecord GenerateGetRecord(uint64_t getid) {
-=======
-  BlockCacheTraceRecord GenerateAccessRecord(uint32_t key_id, bool no_insert) {
->>>>>>> Add more tests
     BlockCacheTraceRecord record;
     record.block_type = TraceType::kBlockTraceDataBlock;
     record.block_size = 4096;
@@ -43,14 +39,11 @@ class CacheSimulatorTest : public DBTestBase {
     record.sst_fd_number = kGetBlockId;
     record.get_id = getid;
     record.is_cache_hit = Boolean::kFalse;
-<<<<<<< HEAD
     record.no_insert = Boolean::kFalse;
-    record.referenced_key = kRefKeyPrefix + std::to_string(kGetBlockId);
-=======
-    record.no_insert = no_insert ? Boolean::kTrue : Boolean::kFalse;
-    record.referenced_key = kRefKeyPrefix + std::to_string(key_id);
->>>>>>> Add more tests
+    record.referenced_key =
+        kRefKeyPrefix + std::to_string(kGetId) + std::string(8, 'c');
     record.referenced_key_exist_in_block = Boolean::kTrue;
+    record.referenced_data_size = 100;
     record.num_keys_in_block = 300;
     return record;
   }
@@ -87,7 +80,6 @@ TEST_F(CacheSimulatorTest, GhostCache) {
 }
 
 TEST_F(CacheSimulatorTest, CacheSimulator) {
-<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
   const BlockCacheTraceRecord& compaction_access = GenerateCompactionRecord();
   std::shared_ptr<Cache> sim_cache =
@@ -96,21 +88,10 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
                   /*high_pri_pool_ratio=*/0);
   std::unique_ptr<CacheSimulator> cache_simulator(
       new CacheSimulator(nullptr, sim_cache));
-=======
-  const BlockCacheTraceRecord& access =
-      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
-  const BlockCacheTraceRecord& access_no_insert =
-      GenerateAccessRecord(/*key_id=*/1, /*no_insert=*/true);
-  std::unique_ptr<CacheSimulator> cache_simulator(new CacheSimulator(
-      nullptr, NewLRUCache(/*capacity=*/cache_size, /*num_shard_bits=*/1,
-                           /*strict_capacity_limit=*/false,
-                           /*high_pri_pool_ratio=*/0)));
->>>>>>> Add more tests
   cache_simulator->Access(access);
   cache_simulator->Access(access);
   ASSERT_EQ(2, cache_simulator->total_accesses());
   ASSERT_EQ(50, cache_simulator->miss_ratio());
-<<<<<<< HEAD
   ASSERT_EQ(2, cache_simulator->user_accesses());
   ASSERT_EQ(50, cache_simulator->user_miss_ratio());
 
@@ -120,12 +101,6 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
   ASSERT_EQ(75, cache_simulator->miss_ratio());
   ASSERT_EQ(2, cache_simulator->user_accesses());
   ASSERT_EQ(50, cache_simulator->user_miss_ratio());
-=======
-  cache_simulator->Access(access_no_insert);
-  cache_simulator->Access(access_no_insert);
-  ASSERT_EQ(4, cache_simulator->total_accesses());
-  ASSERT_EQ(75, cache_simulator->miss_ratio());
->>>>>>> Add more tests
 
   cache_simulator->reset_counter();
   ASSERT_EQ(0, cache_simulator->total_accesses());
@@ -138,12 +113,7 @@ TEST_F(CacheSimulatorTest, CacheSimulator) {
 }
 
 TEST_F(CacheSimulatorTest, GhostCacheSimulator) {
-<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
-=======
-  const BlockCacheTraceRecord& access =
-      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
->>>>>>> Add more tests
   std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
       NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,
@@ -161,25 +131,17 @@ TEST_F(CacheSimulatorTest, GhostCacheSimulator) {
 }
 
 TEST_F(CacheSimulatorTest, PrioritizedCacheSimulator) {
-<<<<<<< HEAD
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
   std::shared_ptr<Cache> sim_cache =
       NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,
                   /*high_pri_pool_ratio=*/0);
-=======
-  const BlockCacheTraceRecord& access =
-      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
-  const BlockCacheTraceRecord& access_no_insert =
-      GenerateAccessRecord(/*key_id=*/1, /*no_insert=*/true);
->>>>>>> Add more tests
   std::unique_ptr<PrioritizedCacheSimulator> cache_simulator(
       new PrioritizedCacheSimulator(nullptr, sim_cache));
   cache_simulator->Access(access);
   cache_simulator->Access(access);
   ASSERT_EQ(2, cache_simulator->total_accesses());
   ASSERT_EQ(50, cache_simulator->miss_ratio());
-<<<<<<< HEAD
 
   auto handle = sim_cache->Lookup(access.block_key);
   ASSERT_NE(nullptr, handle);
@@ -188,17 +150,6 @@ TEST_F(CacheSimulatorTest, PrioritizedCacheSimulator) {
 
 TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
   const BlockCacheTraceRecord& access = GenerateGetRecord(kGetId);
-=======
-  cache_simulator->Access(access_no_insert);
-  cache_simulator->Access(access_no_insert);
-  ASSERT_EQ(4, cache_simulator->total_accesses());
-  ASSERT_EQ(75, cache_simulator->miss_ratio());
-}
-
-TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
-  const BlockCacheTraceRecord& access =
-      GenerateAccessRecord(/*key_id=*/0, /*no_insert=*/false);
->>>>>>> Add more tests
   std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
       NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
                   /*strict_capacity_limit=*/false,
@@ -214,6 +165,160 @@ TEST_F(CacheSimulatorTest, GhostPrioritizedCacheSimulator) {
   ASSERT_EQ(2, cache_simulator->total_accesses());
   // Both of them will be miss since we have a ghost cache.
   ASSERT_EQ(100, cache_simulator->miss_ratio());
+}
+
+TEST_F(CacheSimulatorTest, HybridRowBlockCacheSimulator) {
+  uint64_t block_id = 100;
+  BlockCacheTraceRecord first_get = GenerateGetRecord(kGetId);
+  BlockCacheTraceRecord second_get = GenerateGetRecord(kGetId + 1);
+  second_get.referenced_data_size = 0;
+  second_get.referenced_key_exist_in_block = Boolean::kFalse;
+  second_get.referenced_key = kRefKeyPrefix + std::to_string(kGetId);
+  BlockCacheTraceRecord third_get = GenerateGetRecord(kGetId + 2);
+  third_get.referenced_data_size = 0;
+  third_get.referenced_key_exist_in_block = Boolean::kFalse;
+  third_get.referenced_key = kRefKeyPrefix + "third_get";
+  // We didn't find the referenced key in the third get.
+  third_get.referenced_key_exist_in_block = Boolean::kFalse;
+  third_get.referenced_data_size = 0;
+  std::shared_ptr<Cache> sim_cache =
+      NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0);
+  std::unique_ptr<HybridRowBlockCacheSimulator> cache_simulator(
+      new HybridRowBlockCacheSimulator(
+          nullptr, sim_cache, /*insert_blocks_row_kvpair_misses=*/true));
+  // The first get request accesses 9 blocks. We should only report 10 accesses
+  // and 100% miss.
+  for (uint32_t i = 0; i < 9; i++) {
+    first_get.block_key = kBlockKeyPrefix + std::to_string(block_id);
+    cache_simulator->Access(first_get);
+    block_id++;
+  }
+  ASSERT_EQ(10, cache_simulator->total_accesses());
+  ASSERT_EQ(100, cache_simulator->miss_ratio());
+  ASSERT_EQ(10, cache_simulator->user_accesses());
+  ASSERT_EQ(100, cache_simulator->user_miss_ratio());
+  auto handle =
+      sim_cache->Lookup(ExtractUserKey(std::to_string(first_get.sst_fd_number) +
+                                       "_" + first_get.referenced_key));
+  ASSERT_NE(nullptr, handle);
+  sim_cache->Release(handle);
+  for (uint32_t i = 100; i < block_id; i++) {
+    handle = sim_cache->Lookup(kBlockKeyPrefix + std::to_string(i));
+    ASSERT_NE(nullptr, handle);
+    sim_cache->Release(handle);
+  }
+
+  // The second get request accesses the same key. We should report one
+  // access and 90% miss, 10 miss with 11 accesses.
+  for (uint32_t i = 0; i < 4; i++) {
+    second_get.block_key = kBlockKeyPrefix + std::to_string(block_id);
+    cache_simulator->Access(second_get);
+    block_id++;
+  }
+  ASSERT_EQ(11, cache_simulator->total_accesses());
+  ASSERT_EQ(90, static_cast<uint64_t>(cache_simulator->miss_ratio()));
+  ASSERT_EQ(11, cache_simulator->user_accesses());
+  ASSERT_EQ(90, static_cast<uint64_t>(cache_simulator->user_miss_ratio()));
+  handle = sim_cache->Lookup(std::to_string(second_get.sst_fd_number) + "_" +
+                             second_get.referenced_key);
+  ASSERT_NE(nullptr, handle);
+  sim_cache->Release(handle);
+  for (uint32_t i = 100; i < block_id; i++) {
+    handle = sim_cache->Lookup(kBlockKeyPrefix + std::to_string(i));
+    if (i < 109) {
+      ASSERT_NE(nullptr, handle) << i;
+      sim_cache->Release(handle);
+    } else {
+      ASSERT_EQ(nullptr, handle) << i;
+    }
+  }
+
+  // The third get on a different key and does not have a size.
+  for (uint32_t i = 0; i < 4; i++) {
+    third_get.block_key = kBlockKeyPrefix + std::to_string(block_id);
+    cache_simulator->Access(third_get);
+    block_id++;
+  }
+  ASSERT_EQ(16, cache_simulator->total_accesses());
+  ASSERT_EQ(93, static_cast<uint64_t>(cache_simulator->miss_ratio()));
+  ASSERT_EQ(16, cache_simulator->user_accesses());
+  ASSERT_EQ(93, static_cast<uint64_t>(cache_simulator->user_miss_ratio()));
+  handle = sim_cache->Lookup(std::to_string(third_get.sst_fd_number) + "_" +
+                             third_get.referenced_key);
+  ASSERT_EQ(nullptr, handle);
+  for (uint32_t i = 100; i < block_id; i++) {
+    if (i < 109 || i >= 113) {
+      handle = sim_cache->Lookup(kBlockKeyPrefix + std::to_string(i));
+      ASSERT_NE(nullptr, handle) << i;
+      sim_cache->Release(handle);
+    } else {
+      handle = sim_cache->Lookup(kBlockKeyPrefix + std::to_string(i));
+      ASSERT_EQ(nullptr, handle) << i;
+    }
+  }
+}
+
+TEST_F(CacheSimulatorTest, HybridRowBlockNoInsertCacheSimulator) {
+  uint64_t block_id = 100;
+  BlockCacheTraceRecord first_get = GenerateGetRecord(kGetId);
+  std::shared_ptr<Cache> sim_cache =
+      NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0);
+  std::unique_ptr<HybridRowBlockCacheSimulator> cache_simulator(
+      new HybridRowBlockCacheSimulator(
+          nullptr, sim_cache, /*insert_blocks_row_kvpair_misses=*/false));
+  for (uint32_t i = 0; i < 9; i++) {
+    first_get.block_key = kBlockKeyPrefix + std::to_string(block_id);
+    cache_simulator->Access(first_get);
+    block_id++;
+  }
+  auto handle =
+      sim_cache->Lookup(ExtractUserKey(std::to_string(first_get.sst_fd_number) +
+                                       "_" + first_get.referenced_key));
+  ASSERT_NE(nullptr, handle);
+  sim_cache->Release(handle);
+  // All blocks are missing from the cache since insert_blocks_row_kvpair_misses
+  // is set to false.
+  for (uint32_t i = 100; i < block_id; i++) {
+    handle = sim_cache->Lookup(kBlockKeyPrefix + std::to_string(i));
+    ASSERT_EQ(nullptr, handle);
+  }
+}
+
+TEST_F(CacheSimulatorTest, GhostHybridRowBlockCacheSimulator) {
+  std::unique_ptr<GhostCache> ghost_cache(new GhostCache(
+      NewLRUCache(/*capacity=*/kGhostCacheSize, /*num_shard_bits=*/1,
+                  /*strict_capacity_limit=*/false,
+                  /*high_pri_pool_ratio=*/0)));
+  const BlockCacheTraceRecord& first_get = GenerateGetRecord(kGetId);
+  const BlockCacheTraceRecord& second_get = GenerateGetRecord(kGetId + 1);
+  const BlockCacheTraceRecord& third_get = GenerateGetRecord(kGetId + 2);
+  std::unique_ptr<HybridRowBlockCacheSimulator> cache_simulator(
+      new HybridRowBlockCacheSimulator(
+          std::move(ghost_cache),
+          NewLRUCache(/*capacity=*/kCacheSize, /*num_shard_bits=*/1,
+                      /*strict_capacity_limit=*/false,
+                      /*high_pri_pool_ratio=*/0),
+          /*insert_blocks_row_kvpair_misses=*/false));
+  // Two get requests access the same key.
+  cache_simulator->Access(first_get);
+  cache_simulator->Access(second_get);
+  ASSERT_EQ(4, cache_simulator->total_accesses());
+  ASSERT_EQ(100, cache_simulator->miss_ratio());
+  ASSERT_EQ(4, cache_simulator->user_accesses());
+  ASSERT_EQ(100, cache_simulator->user_miss_ratio());
+  // We insert the key-value pair upon the second get request. A third get
+  // request should observe a hit.
+  for (uint32_t i = 0; i < 10; i++) {
+    cache_simulator->Access(third_get);
+  }
+  ASSERT_EQ(5, cache_simulator->total_accesses());
+  ASSERT_EQ(80, static_cast<uint64_t>(cache_simulator->miss_ratio()));
+  ASSERT_EQ(5, cache_simulator->user_accesses());
+  ASSERT_EQ(80, static_cast<uint64_t>(cache_simulator->user_miss_ratio()));
 }
 
 }  // namespace rocksdb


### PR DESCRIPTION
This PR adds a ghost cache for admission control. Specifically, it admits an entry on its second access. 
It also adds a hybrid row-block cache that caches the referenced key-value pairs of a Get/MultiGet request instead of its blocks. 

Test plan: make clean && COMPILE_WITH_ASAN=1 make check -j32