### PR TITLE
Fix lower bound check error when iterate across file boundary

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -984,7 +984,8 @@ class LevelIterator final : public InternalIterator {
   // Note MyRocks may update iterate bounds between seek. To workaround it,
   // we need to check and update may_be_out_of_lower_bound_ accordingly.
   void CheckMayBeOutOfLowerBound() {
-    if (Valid() && read_options_.iterate_lower_bound != nullptr) {
+    if (read_options_.iterate_lower_bound != nullptr &&
+        file_index_ < flevel_->num_files) {
       may_be_out_of_lower_bound_ =
           user_comparator_.Compare(
               ExtractUserKey(file_smallest_key(file_index_)),


### PR DESCRIPTION
Summary:
Since #5468 `LevelIterator` compare lower bound and file smallest key on `NewFileIterator` and cache the result to reduce per key lower bound check. However when iterate across file boundary, it doesn't update the cached result since `Valid()=false` because `Valid()` still reflect the status of the previous file iterator. Fixing it by remove the `Valid()` check from `CheckMayBeOutOfLowerBound()`.

Test Plan:
See the new test.

Signed-off-by: Yi Wu <yiwu@pingcap.com>