### PR TITLE
Fix bugs in DBWALTest.kTolerateCorruptedTailRecords triggered by #5520

### DIFF
--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -824,7 +824,9 @@ class RecoveryTestHelper {
   // Create WAL files with values filled in
   static void FillData(DBWALTest* test, const Options& options,
                        const size_t wal_count, size_t* count) {
-    const ImmutableDBOptions db_options(options);
+    // Calling internal functions requires sanitized options.
+    Options sanitized_options = SanitizeOptions(test->dbname_, options);
+    const ImmutableDBOptions db_options(sanitized_options);
 
     *count = 0;
 

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -110,6 +110,7 @@ Status DeleteDBFile(const ImmutableDBOptions* db_options,
 
 bool IsWalDirSameAsDBPath(const ImmutableDBOptions* db_options) {
   bool same = false;
+  assert(!db_options->db_paths.empty());
   Status s = db_options->env->AreFilesSame(db_options->wal_dir,
                                            db_options->db_paths[0].path, &same);
   if (s.IsNotSupported()) {


### PR DESCRIPTION
Summary: https://github.com/facebook/rocksdb/pull/5520 caused a buffer overflow bug in DBWALTest.kTolerateCorruptedTailRecords. Fix it.

Test Plan: Run the test in UBSAN. It used to fail. Not it succeeds.