### PR TITLE
Remove RandomAccessFileReader.for_compaction_

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -93,7 +93,7 @@ Status TableCache::GetTableReader(
     bool sequential_mode, bool record_read_stats, HistogramImpl* file_read_hist,
     std::unique_ptr<TableReader>* table_reader,
     const SliceTransform* prefix_extractor, bool skip_filters, int level,
-    bool prefetch_index_and_filter_in_cache, bool for_compaction) {
+    bool prefetch_index_and_filter_in_cache) {
   std::string fname =
       TableFileName(ioptions_.cf_paths, fd.GetNumber(), fd.GetPathId());
   std::unique_ptr<RandomAccessFile> file;
@@ -109,8 +109,7 @@ Status TableCache::GetTableReader(
         new RandomAccessFileReader(
             std::move(file), fname, ioptions_.env,
             record_read_stats ? ioptions_.statistics : nullptr, SST_READ_MICROS,
-            file_read_hist, ioptions_.rate_limiter, for_compaction,
-            ioptions_.listeners));
+            file_read_hist, ioptions_.rate_limiter, ioptions_.listeners));
     s = ioptions_.table_factory->NewTableReader(
         TableReaderOptions(ioptions_, prefix_extractor, env_options,
                            internal_comparator, skip_filters, immortal_tables_,

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -179,8 +179,7 @@ class TableCache {
                         std::unique_ptr<TableReader>* table_reader,
                         const SliceTransform* prefix_extractor = nullptr,
                         bool skip_filters = false, int level = -1,
-                        bool prefetch_index_and_filter_in_cache = true,
-                        bool for_compaction = false);
+                        bool prefetch_index_and_filter_in_cache = true);
 
   const ImmutableCFOptions& ioptions_;
   const EnvOptions& env_options_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1231,8 +1231,7 @@ Status Version::GetTableProperties(std::shared_ptr<const TableProperties>* tp,
       new RandomAccessFileReader(
           std::move(file), file_name, nullptr /* env */, nullptr /* stats */,
           0 /* hist_type */, nullptr /* file_read_hist */,
-          nullptr /* rate_limiter */, false /* for_compaction*/,
-          ioptions->listeners));
+          nullptr /* rate_limiter */, ioptions->listeners));
   s = ReadTableProperties(
       file_reader.get(), file_meta->fd.GetFileSize(),
       Footer::kInvalidTableMagicNumber /* table's magic number */, *ioptions,

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -197,7 +197,6 @@ Status RandomAccessFileReader::MultiRead(ReadRequest* read_reqs,
   Status s;
   uint64_t elapsed = 0;
   assert(!use_direct_io());
-  assert(!for_compaction_);
   {
     StopWatch sw(env_, stats_, hist_type_,
                  (stats_ != nullptr) ? &elapsed : nullptr, true /*overwrite*/,

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -108,7 +108,6 @@ class RandomAccessFileReader {
   uint32_t        hist_type_;
   HistogramImpl*  file_read_hist_;
   RateLimiter* rate_limiter_;
-  bool for_compaction_;
   std::vector<std::shared_ptr<EventListener>> listeners_;
 
  public:
@@ -116,7 +115,7 @@ class RandomAccessFileReader {
       std::unique_ptr<RandomAccessFile>&& raf, std::string _file_name,
       Env* env = nullptr, Statistics* stats = nullptr, uint32_t hist_type = 0,
       HistogramImpl* file_read_hist = nullptr,
-      RateLimiter* rate_limiter = nullptr, bool for_compaction = false,
+      RateLimiter* rate_limiter = nullptr,
       const std::vector<std::shared_ptr<EventListener>>& listeners = {})
       : file_(std::move(raf)),
         file_name_(std::move(_file_name)),
@@ -125,7 +124,6 @@ class RandomAccessFileReader {
         hist_type_(hist_type),
         file_read_hist_(file_read_hist),
         rate_limiter_(rate_limiter),
-        for_compaction_(for_compaction),
         listeners_() {
 #ifndef ROCKSDB_LITE
     std::for_each(listeners.begin(), listeners.end(),
@@ -151,7 +149,6 @@ class RandomAccessFileReader {
     hist_type_ = std::move(o.hist_type_);
     file_read_hist_ = std::move(o.file_read_hist_);
     rate_limiter_ = std::move(o.rate_limiter_);
-    for_compaction_ = std::move(o.for_compaction_);
     return *this;
   }
 


### PR DESCRIPTION
Summary:
RandomAccessFileReader.for_compaction_ doesn't seem to be used anymore. Remove it.

Test Plan: USE_CLANG=1 make all check -j