### PR TITLE
WriteUnPrepared: improve read your own write functionality

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1499,7 +1499,12 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
                    ? versions_->LastSequence()
                    : versions_->LastPublishedSequence();
     if (callback) {
+      // The unprep_seqs are not published for write unprepared, so it could be
+      // that max_visible_seq is larger. Seek to the std::max of the two.
+      // However, we still want our callback to contain the actual snapshot so
+      // that it can do the correct visibility filtering.
       callback->Refresh(snapshot);
+      snapshot = std::max(snapshot, callback->max_visible_seq());
     }
   }
   TEST_SYNC_POINT("DBImpl::GetImpl:3");

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1504,6 +1504,9 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       // However, we still want our callback to contain the actual snapshot so
       // that it can do the correct visibility filtering.
       callback->Refresh(snapshot);
+
+      // Internally, WriteUnpreparedTxnReadCallback::Refresh would set
+      // max_visible_seq = max(max_visible_seq, snapshot)
       snapshot = callback->max_visible_seq();
     }
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1504,7 +1504,7 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       // However, we still want our callback to contain the actual snapshot so
       // that it can do the correct visibility filtering.
       callback->Refresh(snapshot);
-      snapshot = std::max(snapshot, callback->max_visible_seq());
+      snapshot = callback->max_visible_seq();
     }
   }
   TEST_SYNC_POINT("DBImpl::GetImpl:3");

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1507,6 +1507,13 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
 
       // Internally, WriteUnpreparedTxnReadCallback::Refresh would set
       // max_visible_seq = max(max_visible_seq, snapshot)
+      //
+      // Currently, the commented out assert is broken by
+      // InvalidSnapshotReadCallback, but if write unprepared recovery followed
+      // the regular transaction flow, then this special read callback would not
+      // be needed.
+      //
+      // assert(callback->max_visible_seq() >= snapshot);
       snapshot = callback->max_visible_seq();
     }
   }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -172,7 +172,8 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       w.status = WriteBatchInternal::InsertInto(
           &w, w.sequence, &column_family_memtables, &flush_scheduler_,
           write_options.ignore_missing_column_families, 0 /*log_number*/, this,
-          true /*concurrent_memtable_writes*/, seq_per_batch_, w.batch_cnt);
+          true /*concurrent_memtable_writes*/, seq_per_batch_, w.batch_cnt,
+          batch_per_txn_);
 
       PERF_TIMER_START(write_pre_and_post_process_time);
     }

--- a/db/read_callback.h
+++ b/db/read_callback.h
@@ -42,9 +42,6 @@ class ReadCallback {
   // Refresh to a more recent visible seq
   virtual void Refresh(SequenceNumber seq) { max_visible_seq_ = seq; }
 
-  // Refer to DBIter::CanReseekToSkip
-  virtual bool CanReseekToSkip() { return true; }
-
  protected:
   // The max visible seq, it is usually the snapshot but could be larger if
   // transaction has its own writes written to db.

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3471,6 +3471,12 @@ TEST_P(TransactionTest, LockLimitTest) {
 }
 
 TEST_P(TransactionTest, IteratorTest) {
+  // This test does writes without snapshot validation, and then tries to create
+  // iterator later, which is unsupported in write unprepared.
+  if (txn_db_options.write_policy == WRITE_UNPREPARED) {
+    return;
+  }
+
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   std::string value;

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3599,8 +3599,8 @@ TEST_P(TransactionTest, DisableIndexingTest) {
   // read your own writes, so depending on whether batches are flushed or not,
   // only some writes will be visible.
   //
-  // Also, write unprepared does not support txn->Put() without snapshot
-  // validation, and then creating an iterator later.
+  // Also, write unprepared does not support creating iterators if there has
+  // been txn->Put() without snapshot validation.
   if (txn_db_options.write_policy == WRITE_UNPREPARED) {
     return;
   }

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3589,6 +3589,16 @@ TEST_P(TransactionTest, IteratorTest) {
 }
 
 TEST_P(TransactionTest, DisableIndexingTest) {
+  // Skip this test for write unprepared. It does not solely rely on WBWI for
+  // read your own writes, so depending on whether batches are flushed or not,
+  // only some writes will be visible.
+  //
+  // Also, write unprepared does not support txn->Put() without snapshot
+  // validation, and then creating an iterator later.
+  if (txn_db_options.write_policy == WRITE_UNPREPARED) {
+    return;
+  }
+
   WriteOptions write_options;
   ReadOptions read_options;
   std::string value;

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -203,14 +203,14 @@ TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWriteStress) {
                               const std::string& value) {
           if (owned_keys.count(key) > 0) {
             ASSERT_EQ(value.size(), 16);
-            ASSERT_EQ(((uint64_t*)value.c_str())[0], id);
-            ASSERT_GE(((uint64_t*)value.c_str())[1], snapshot_num);
+            ASSERT_EQ(((int64_t*)value.c_str())[0], id);
+            ASSERT_GE(((int64_t*)value.c_str())[1], snapshot_num);
           } else if (use_snapshot) {
             // If we're reading using a snapshot, then the key value should
             // always be less than snapshot_num. We can't say much about id
             // though.
             ASSERT_EQ(value.size(), 16);
-            ASSERT_LE(((uint64_t*)value.c_str())[1], snapshot_num);
+            ASSERT_LE(((int64_t*)value.c_str())[1], snapshot_num);
           }
         };
 

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -37,6 +37,9 @@ INSTANTIATE_TEST_CASE_P(
                       std::make_tuple(false, true, WRITE_UNPREPARED)));
 
 TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWrite) {
+  // The following tests checks whether reading your own write for
+  // a transaction works for write unprepared, when there are uncommitted
+  // values written into DB.
   auto verify_state = [](Iterator* iter, const std::string& key,
                          const std::string& value) {
     ASSERT_TRUE(iter->Valid());
@@ -45,155 +48,229 @@ TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWrite) {
     ASSERT_EQ(value, iter->value().ToString());
   };
 
-  options.disable_auto_compactions = true;
-  ReOpen();
+  // Test always reseeking vs never reseeking.
+  for (uint64_t max_skip : {0, std::numeric_limits<int>::max()}) {
+    // for (uint64_t max_skip : {0, std::numeric_limits<uint64_t>::max()}) {
+    options.max_sequential_skip_in_iterations = max_skip;
+    options.disable_auto_compactions = true;
+    ReOpen();
 
-  // The following tests checks whether reading your own write for
-  // a transaction works for write unprepared, when there are uncommitted
-  // values written into DB.
-  //
-  // Although the values written by DB::Put are technically committed, we add
-  // their seq num to unprep_seqs_ to pretend that they were written into DB
-  // as part of an unprepared batch, and then check if they are visible to the
-  // transaction.
-  auto snapshot0 = db->GetSnapshot();
-  ASSERT_OK(db->Put(WriteOptions(), "a", "v1"));
-  ASSERT_OK(db->Put(WriteOptions(), "b", "v2"));
-  auto snapshot2 = db->GetSnapshot();
-  ASSERT_OK(db->Put(WriteOptions(), "a", "v3"));
-  ASSERT_OK(db->Put(WriteOptions(), "b", "v4"));
-  auto snapshot4 = db->GetSnapshot();
-  ASSERT_OK(db->Put(WriteOptions(), "a", "v5"));
-  ASSERT_OK(db->Put(WriteOptions(), "b", "v6"));
-  auto snapshot6 = db->GetSnapshot();
-  ASSERT_OK(db->Put(WriteOptions(), "a", "v7"));
-  ASSERT_OK(db->Put(WriteOptions(), "b", "v8"));
-  auto snapshot8 = db->GetSnapshot();
+    TransactionOptions txn_options;
+    WriteOptions woptions;
+    ReadOptions roptions;
 
-  TransactionOptions txn_options;
-  WriteOptions write_options;
-  Transaction* txn = db->BeginTransaction(write_options, txn_options);
-  WriteUnpreparedTxn* wup_txn = dynamic_cast<WriteUnpreparedTxn*>(txn);
+    ASSERT_OK(db->Put(woptions, "a", ""));
+    ASSERT_OK(db->Put(woptions, "b", ""));
 
-  ReadOptions roptions;
-  roptions.snapshot = snapshot0;
+    Transaction* txn = db->BeginTransaction(woptions, txn_options);
+    WriteUnpreparedTxn* wup_txn = dynamic_cast<WriteUnpreparedTxn*>(txn);
+    txn->SetSnapshot();
 
-  wup_txn->unprep_seqs_[snapshot2->GetSequenceNumber() + 1] =
-      snapshot4->GetSequenceNumber() - snapshot2->GetSequenceNumber();
-  auto iter = txn->GetIterator(roptions);
+    for (int i = 0; i < 5; i++) {
+      std::string stored_value = "v" + ToString(i);
+      ASSERT_OK(txn->Put("a", stored_value));
+      ASSERT_OK(txn->Put("b", stored_value));
+      wup_txn->FlushWriteBatchToDB(false);
 
-  // Test Get().
-  std::string value;
+      // Test Get()
+      std::string value;
+      ASSERT_OK(txn->Get(roptions, "a", &value));
+      ASSERT_EQ(value, stored_value);
+      ASSERT_OK(txn->Get(roptions, "b", &value));
+      ASSERT_EQ(value, stored_value);
 
-  ASSERT_OK(txn->Get(roptions, Slice("a"), &value));
-  ASSERT_EQ(value, "v3");
+      // Test Next()
+      auto iter = txn->GetIterator(roptions);
+      iter->Seek("a");
+      verify_state(iter, "a", stored_value);
 
-  ASSERT_OK(txn->Get(roptions, Slice("b"), &value));
-  ASSERT_EQ(value, "v4");
+      iter->Next();
+      verify_state(iter, "b", stored_value);
 
-  wup_txn->unprep_seqs_[snapshot6->GetSequenceNumber() + 1] =
-      snapshot8->GetSequenceNumber() - snapshot6->GetSequenceNumber();
-  delete iter;
-  iter = txn->GetIterator(roptions);
+      iter->SeekToFirst();
+      verify_state(iter, "a", stored_value);
 
-  ASSERT_OK(txn->Get(roptions, Slice("a"), &value));
-  ASSERT_EQ(value, "v7");
+      iter->Next();
+      verify_state(iter, "b", stored_value);
 
-  ASSERT_OK(txn->Get(roptions, Slice("b"), &value));
-  ASSERT_EQ(value, "v8");
+      delete iter;
 
-  wup_txn->unprep_seqs_.clear();
+      // Test Prev()
+      iter = txn->GetIterator(roptions);
+      iter->SeekForPrev("b");
+      verify_state(iter, "b", stored_value);
 
-  // Test Next().
-  wup_txn->unprep_seqs_[snapshot2->GetSequenceNumber() + 1] =
-      snapshot4->GetSequenceNumber() - snapshot2->GetSequenceNumber();
-  delete iter;
-  iter = txn->GetIterator(roptions);
+      iter->Prev();
+      verify_state(iter, "a", stored_value);
 
-  iter->Seek("a");
-  verify_state(iter, "a", "v3");
+      iter->SeekToLast();
+      verify_state(iter, "b", stored_value);
 
-  iter->Next();
-  verify_state(iter, "b", "v4");
+      iter->Prev();
+      verify_state(iter, "a", stored_value);
 
-  iter->SeekToFirst();
-  verify_state(iter, "a", "v3");
+      delete iter;
+    }
 
-  iter->Next();
-  verify_state(iter, "b", "v4");
+    delete txn;
+  }
+}
 
-  wup_txn->unprep_seqs_[snapshot6->GetSequenceNumber() + 1] =
-      snapshot8->GetSequenceNumber() - snapshot6->GetSequenceNumber();
-  delete iter;
-  iter = txn->GetIterator(roptions);
+TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWriteStress) {
+  // This is a stress test where different threads are writing random keys, and
+  // then before committing or aborting the transaction, it validates to see
+  // that it can read the keys it wrote, and the keys it did not write respect
+  // the snapshot. To avoid row lock contention (and simply stressing the
+  // locking system), each thread is mostly only writing to its own set of keys.
+  const uint32_t NUM_ITERS = 1000;
+  const uint32_t NUM_THREADS = 10;
+  const uint32_t NUM_KEYS = 5;
 
-  iter->Seek("a");
-  verify_state(iter, "a", "v7");
+  std::default_random_engine g(
+      std::hash<std::thread::id>()(std::this_thread::get_id()));
 
-  iter->Next();
-  verify_state(iter, "b", "v8");
+  // Test reading with and without read_options.snapshot set.
+  for (bool use_snapshot : {true, false}) {
+    WriteOptions write_options;
+    txn_db_options.transaction_lock_timeout = -1;
+    options.disable_auto_compactions = true;
+    ReOpen();
 
-  iter->SeekToFirst();
-  verify_state(iter, "a", "v7");
+    std::vector<std::string> keys;
+    for (uint32_t k = 0; k < NUM_KEYS * NUM_THREADS; k++) {
+      keys.push_back("k" + ToString(k));
+    }
+    std::shuffle(keys.begin(), keys.end(), g);
 
-  iter->Next();
-  verify_state(iter, "b", "v8");
+    // This counter will act as a "sequence number" to help us validate
+    // visibility logic with snapshots.
+    std::atomic<int64_t> counter(0);
 
-  wup_txn->unprep_seqs_.clear();
+    std::function<void(uint32_t)> stress_thread = [&](int id) {
+      size_t tid = std::hash<std::thread::id>()(std::this_thread::get_id());
+      Random64 rnd(static_cast<uint32_t>(tid));
 
-  // Test Prev(). For Prev(), we need to adjust the snapshot to match what is
-  // possible in WriteUnpreparedTxn.
-  //
-  // Because of row locks and ValidateSnapshot, there cannot be any committed
-  // entries after snapshot, but before the first prepared key.
-  roptions.snapshot = snapshot2;
-  wup_txn->unprep_seqs_[snapshot2->GetSequenceNumber() + 1] =
-      snapshot4->GetSequenceNumber() - snapshot2->GetSequenceNumber();
-  delete iter;
-  iter = txn->GetIterator(roptions);
+      Transaction* txn;
+      TransactionOptions txn_options;
+      // batch_size of 1 causes writes to DB for every marker.
+      txn_options.max_write_batch_size = 1;
+      ReadOptions read_options;
 
-  iter->SeekForPrev("b");
-  verify_state(iter, "b", "v4");
+      for (uint32_t i = 0; i < NUM_ITERS; i++) {
+        std::set<std::string> owned_keys(&keys[id * NUM_KEYS],
+                                         &keys[(id + 1) * NUM_KEYS]);
+        // Add unowned keys to make the workload more interesting, but this
+        // increases row lock contention, so just do it sometimes.
+        if (rnd.OneIn(2)) {
+          owned_keys.insert(keys[rnd.Uniform(NUM_KEYS * NUM_THREADS)]);
+        }
 
-  iter->Prev();
-  verify_state(iter, "a", "v3");
+        txn = db->BeginTransaction(write_options, txn_options);
+        txn->SetName(ToString(id));
+        txn->SetSnapshot();
+        if (use_snapshot) {
+          read_options.snapshot = txn->GetSnapshot();
+          ASSERT_TRUE(read_options.snapshot != nullptr);
+        }
 
-  iter->SeekToLast();
-  verify_state(iter, "b", "v4");
+        uint64_t buf[2];
+        buf[0] = id;
 
-  iter->Prev();
-  verify_state(iter, "a", "v3");
+        // When scanning through the database, make sure that all unprepared
+        // keys have value >= snapshot and all other keys have value < snapshot.
+        int64_t snapshot_num = counter.fetch_add(1);
 
-  roptions.snapshot = snapshot6;
-  wup_txn->unprep_seqs_[snapshot6->GetSequenceNumber() + 1] =
-      snapshot8->GetSequenceNumber() - snapshot6->GetSequenceNumber();
-  delete iter;
-  iter = txn->GetIterator(roptions);
+        Status s;
+        for (const auto& key : owned_keys) {
+          buf[1] = counter.fetch_add(1);
+          s = txn->Put(key, Slice((const char*)buf, sizeof(buf)));
+          if (!s.ok()) {
+            break;
+          }
+        }
 
-  iter->SeekForPrev("b");
-  verify_state(iter, "b", "v8");
+        // Failure is possible due to snapshot validation. In this case,
+        // rollback and move onto next iteration.
+        if (!s.ok()) {
+          ASSERT_TRUE(s.IsBusy());
+          ASSERT_OK(txn->Rollback());
+          delete txn;
+          continue;
+        }
 
-  iter->Prev();
-  verify_state(iter, "a", "v7");
+        auto verify_key = [&owned_keys, &use_snapshot, &id, &snapshot_num](
+                              const std::string& key,
+                              const std::string& value) {
+          if (owned_keys.count(key) > 0) {
+            ASSERT_EQ(value.size(), 16);
+            ASSERT_EQ(((uint64_t*)value.c_str())[0], id);
+            ASSERT_GE(((uint64_t*)value.c_str())[1], snapshot_num);
+          } else if (use_snapshot) {
+            // If we're reading using a snapshot, then the key value should
+            // always be less than snapshot_num. We can't say much about id
+            // though.
+            ASSERT_EQ(value.size(), 16);
+            ASSERT_LE(((uint64_t*)value.c_str())[1], snapshot_num);
+          }
+        };
 
-  iter->SeekToLast();
-  verify_state(iter, "b", "v8");
+        // Validate Get()/Next()/Prev(). Do only one of them to save time, and
+        // reduce lock contention.
+        switch (rnd.Uniform(3)) {
+          case 0:  // Validate Get()
+          {
+            for (const auto& key : keys) {
+              std::string value;
+              s = txn->Get(read_options, Slice(key), &value);
+              if (!s.ok()) {
+                ASSERT_TRUE(s.IsNotFound());
+                ASSERT_EQ(owned_keys.count(key), 0);
+              } else {
+                verify_key(key, value);
+              }
+            }
+            break;
+          }
+          case 1:  // Validate Next()
+          {
+            Iterator* iter = txn->GetIterator(read_options);
+            for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+              verify_key(iter->key().ToString(), iter->value().ToString());
+            }
+            delete iter;
+            break;
+          }
+          case 2:  // Validate Prev()
+          {
+            Iterator* iter = txn->GetIterator(read_options);
+            for (iter->SeekToLast(); iter->Valid(); iter->Prev()) {
+              verify_key(iter->key().ToString(), iter->value().ToString());
+            }
+            delete iter;
+            break;
+          }
+          default:
+            ASSERT_TRUE(false);
+        }
 
-  iter->Prev();
-  verify_state(iter, "a", "v7");
+        if (rnd.OneIn(2)) {
+          ASSERT_OK(txn->Commit());
+        } else {
+          ASSERT_OK(txn->Rollback());
+        }
+        delete txn;
+      }
+    };
 
-  // Since the unprep_seqs_ data were faked for testing, we do not want the
-  // destructor for the transaction to be rolling back data that did not
-  // exist.
-  wup_txn->unprep_seqs_.clear();
+    std::vector<port::Thread> threads;
+    for (uint32_t i = 0; i < NUM_THREADS; i++) {
+      threads.emplace_back(stress_thread, i);
+    }
 
-  db->ReleaseSnapshot(snapshot0);
-  db->ReleaseSnapshot(snapshot2);
-  db->ReleaseSnapshot(snapshot4);
-  db->ReleaseSnapshot(snapshot6);
-  db->ReleaseSnapshot(snapshot8);
-  delete iter;
-  delete txn;
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
 }
 
 // This tests how write unprepared behaves during recovery when the DB crashes

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -126,8 +126,8 @@ TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWriteStress) {
   const uint32_t NUM_THREADS = 10;
   const uint32_t NUM_KEYS = 5;
 
-  std::default_random_engine g(
-      std::hash<std::thread::id>()(std::this_thread::get_id()));
+  std::default_random_engine g(static_cast<uint32_t>(
+      std::hash<std::thread::id>()(std::this_thread::get_id())));
 
   // Test reading with and without read_options.snapshot set.
   for (bool use_snapshot : {true, false}) {

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -193,7 +193,7 @@ TEST_P(WriteUnpreparedTransactionTest, ReadYourOwnWriteStress) {
           }
           if (a == REFRESH_SNAPSHOT) {
             txn->SetSnapshot();
-            read_options.snapshot = db->GetSnapshot();
+            read_options.snapshot = txn->GetSnapshot();
             snapshot_num = counter.fetch_add(1);
           }
         }

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -44,7 +44,8 @@ WriteUnpreparedTxn::WriteUnpreparedTxn(WriteUnpreparedTxnDB* txn_db,
                                        const TransactionOptions& txn_options)
     : WritePreparedTxn(txn_db, write_options, txn_options),
       wupt_db_(txn_db),
-      recovered_txn_(false) {
+      recovered_txn_(false),
+      largest_validated_seq_(0) {
   max_write_batch_size_ = txn_options.max_write_batch_size;
   // We set max bytes to zero so that we don't get a memory limit error.
   // Instead of trying to keep write batch strictly under the size limit, we
@@ -85,75 +86,82 @@ void WriteUnpreparedTxn::Initialize(const TransactionOptions& txn_options) {
   write_batch_.SetMaxBytes(0);
   unprep_seqs_.clear();
   recovered_txn_ = false;
+  largest_validated_seq_ = 0;
+}
+
+Status WriteUnpreparedTxn::HandleWrite(std::function<Status()> do_write) {
+  Status s = MaybeFlushWriteBatchToDB();
+  if (!s.ok()) {
+    return s;
+  }
+  s = do_write();
+  if (s.ok()) {
+    if (snapshot_) {
+      largest_validated_seq_ =
+          std::max(largest_validated_seq_, snapshot_->GetSequenceNumber());
+    } else {
+      largest_validated_seq_ = kMaxSequenceNumber;
+    }
+  }
+  return s;
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const Slice& key, const Slice& value,
                                const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::Put(ColumnFamilyHandle* column_family,
                                const SliceParts& key, const SliceParts& value,
                                const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::Put(column_family, key, value, assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::Merge(ColumnFamilyHandle* column_family,
                                  const Slice& key, const Slice& value,
                                  const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::Merge(column_family, key, value, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::Merge(column_family, key, value,
+                                      assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
                                   const Slice& key, const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::Delete(ColumnFamilyHandle* column_family,
                                   const SliceParts& key,
                                   const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::Delete(column_family, key, assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const Slice& key,
                                         const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::SingleDelete(column_family, key, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::SingleDelete(column_family, key,
+                                             assume_tracked);
+  });
 }
 
 Status WriteUnpreparedTxn::SingleDelete(ColumnFamilyHandle* column_family,
                                         const SliceParts& key,
                                         const bool assume_tracked) {
-  Status s = MaybeFlushWriteBatchToDB();
-  if (!s.ok()) {
-    return s;
-  }
-  return TransactionBaseImpl::SingleDelete(column_family, key, assume_tracked);
+  return HandleWrite([&]() {
+    return TransactionBaseImpl::SingleDelete(column_family, key,
+                                             assume_tracked);
+  });
 }
 
 // WriteUnpreparedTxn::RebuildFromWriteBatch is only called on recovery. For

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -32,7 +32,7 @@ bool WriteUnpreparedTxnReadCallback::IsVisibleFullCheck(SequenceNumber seq) {
 
 SequenceNumber WriteUnpreparedTxnReadCallback::CalcMaxUnpreparedSequenceNumber(
     WriteUnpreparedTxn* txn) {
-  auto unprep_seqs = txn->GetUnpreparedSequenceNumbers();
+  const auto& unprep_seqs = txn->GetUnpreparedSequenceNumbers();
   if (unprep_seqs.size()) {
     return unprep_seqs.rbegin()->first + unprep_seqs.rbegin()->second - 1;
   }

--- a/utilities/transactions/write_unprepared_txn_db.cc
+++ b/utilities/transactions/write_unprepared_txn_db.cc
@@ -372,9 +372,9 @@ Iterator* WriteUnpreparedTxnDB::NewIterator(const ReadOptions& options,
   SequenceNumber min_uncommitted = 0;
 
   // Currently, the Prev() iterator logic does not work well without snapshot
-  // validation. The logic simply iterates through versions of a key in
-  // ascending seqno order, stopping at the first non-visible key and returning
-  // the last visible key.
+  // validation. The logic simply iterates through values of a key in
+  // ascending seqno order, stopping at the first non-visible value and
+  // returning the last visible value.
   //
   // For example, if snapshot sequence is 3, and we have the following keys:
   // foo: v1 1
@@ -430,7 +430,9 @@ Iterator* WriteUnpreparedTxnDB::NewIterator(const ReadOptions& options,
   // logic.
   if (txn->largest_validated_seq_ > snapshot->GetSequenceNumber() &&
       !txn->unprep_seqs_.empty()) {
-    ROCKS_LOG_ERROR(info_log_, "WriteUnprepared iterator creation failed");
+    ROCKS_LOG_ERROR(info_log_,
+                    "WriteUnprepared iterator creation failed since the "
+                    "transaction has performed unvalidated writes");
     return nullptr;
   }
   min_uncommitted =


### PR DESCRIPTION
There are a number of fixes in this PR (with most bugs found via the added stress tests):
1. Re-enable reseek optimization. This was initially disabled to avoid infinite loops in https://github.com/facebook/rocksdb/pull/3955 but this can be resolved by remembering not to reseek after a reseek has already been done. This problem only affects forward iteration in `DBIter::FindNextUserEntryInternal`, as we already disable reseeking in `DBIter::FindValueForCurrentKeyUsingSeek`.
2. Verify that ReadOption.snapshot can be safely used for iterator creation. Some snapshots would not give correct results because snaphsot validation would not be enforced, breaking some assumptions in Prev() iteration.
3. In the non-snapshot Get() case, reads done at `LastPublishedSequence` may not be enough, because unprepared sequence numbers are not published. Use `std::max(published_seq, max_visible_seq)` to do lookups instead.
4. Add stress test to test reading own writes.
5. Minor bug in the allow_concurrent_memtable_write case where we forgot to pass in batch_per_txn_.
6. Minor performance optimization in `CalcMaxUnpreparedSequenceNumber` by assigning by reference instead of value.
7. Add some more comments everywhere.