### PR TITLE
Fix row cache with range deletion and merge operator bug

### DIFF
--- a/table/get_context.h
+++ b/table/get_context.h
@@ -120,7 +120,7 @@ class GetContext {
   // If a non-null string is passed, all the SaveValue calls will be
   // logged into the string. The operations can then be replayed on
   // another GetContext with replayGetContextLog.
-  void SetReplayLog(std::string* replay_log) { replay_log_ = replay_log; }
+  void SetReplayLog(std::string* replay_log);
 
   // Do we need to fetch the SequenceNumber for this key?
   bool NeedToReadSequence() const { return (seq_ != nullptr); }


### PR DESCRIPTION
TEST_F(DBTest, RowCache2) {
  Options options = CurrentOptions();
  options.row_cache = NewLRUCache(8192);
  options.merge_operator.reset(new rocksdb::StringAppendTESTOperator(','));
  DestroyAndReopen(options);

  ASSERT_OK(Put("foo", "foo"));
  ASSERT_OK(Flush());

  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
            "foo", "foo_"));
  ASSERT_OK(Merge("foo", "bar"));
  ASSERT_OK(Flush());

  ASSERT_EQ(Get("foo"), "bar");
  ASSERT_EQ(Get("foo"), "bar");
}