### PR TITLE
Temporarily disable snapshot list refresh for atomic flush stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -141,6 +141,7 @@ atomic_flush_params = {
     "write_buffer_size": 1024 * 1024,
     # disable pipelined write when test_atomic_flush is true
     "enable_pipelined_write": 0,
+    "snap_refresh_nanos": 0,
 }
 
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -512,6 +512,10 @@ DEFINE_uint64(num_iterations, 10, "Number of iterations per MultiIterate run");
 static const bool FLAGS_num_iterations_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_num_iterations, &ValidateUint32Range);
 
+DEFINE_uint64(
+    snap_refresh_nanos, 100 * 1000 * 1000,
+    "If non-zero, compactions will periodically refresh snapshot list.");
+
 namespace {
 enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
@@ -2724,6 +2728,8 @@ class StressTest {
         fprintf(stdout, "  %s\n", p.c_str());
       }
     }
+    fprintf(stdout, "Snapshot refresh nanos    : %" PRIu64 "\n",
+            FLAGS_snap_refresh_nanos);
 
     fprintf(stdout, "------------------------------------------------\n");
   }
@@ -2873,6 +2879,7 @@ class StressTest {
     } else {
       options_.merge_operator = MergeOperators::CreatePutOperator();
     }
+    options_.snap_refresh_nanos = FLAGS_snap_refresh_nanos;
 
     fprintf(stdout, "DB path: [%s]\n", FLAGS_db.c_str());
 


### PR DESCRIPTION
Atomic flush test started to fail after #5099. Then #5278 provided a fix after
which the same error occurred much less frequently. However it still occur
occasionally. Not sure what the root cause is. This PR disables the feature of
snapshot list refresh, and we should keep an eye on the failure in the future.