### PR TITLE
Disable refresh snapshot feature by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,7 +20,7 @@
 * Added new APIs ExportColumnFamily() and CreateColumnFamilyWithImport() to support export and import of a Column Family. https://github.com/facebook/rocksdb/issues/3469
 
 ### New Features
-* Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.
+* Add an option `snap_refresh_nanos` (default to 0) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.
 * Add an option `unordered_write` which trades snapshot guarantees with higher write throughput. When used with WRITE_PREPARED transactions with two_write_queues=true, it offers higher throughput with however no compromise on guarantees.
 * Allow DBImplSecondary to remove memtables with obsolete data after replaying MANIFEST and WAL.
 * Add an option `failed_move_fall_back_to_copy` (default is true) for external SST ingestion. When `move_files` is true and hard link fails, ingestion falls back to copy if `failed_move_fall_back_to_copy` is true. Otherwise, ingestion reports an error.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -275,7 +275,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // this option helps reducing the cpu usage of long-running compactions. The
   // feature is disabled when max_subcompactions is greater than one.
   //
-  // Default: 0.1s
+  // Default: 0
   //
   // Dynamically changeable through SetOptions() API
   uint64_t snap_refresh_nanos = 0;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -278,7 +278,7 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: 0.1s
   //
   // Dynamically changeable through SetOptions() API
-  uint64_t snap_refresh_nanos = 100 * 1000 * 1000;  // 0.1s
+  uint64_t snap_refresh_nanos = 0;
 
   // Disable automatic compactions. Manual compactions can still
   // be issued on this column family


### PR DESCRIPTION
There are concerns about the correctness of this patch. Disabling by default until the concerns are resolved.