### PR TITLE
ldb sometimes specify a string-append merge operator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,7 @@
 * Rate limited deletion of WALs is only enabled if DBOptions::wal_dir is not set, or explicitly set to db_name passed to DB::Open and DBOptions::db_paths is empty, or same as db_paths[0].path
 * Overload GetAllKeyVersions() to support non-default column family.
 * Added new APIs ExportColumnFamily() and CreateColumnFamilyWithImport() to support export and import of a Column Family. https://github.com/facebook/rocksdb/issues/3469
-* ldb sometimes specify a string-append merge operator if no merge operator is passed in. This is to allow users to print keys from a DB with a merge operator.
+* ldb sometimes uses a string-append merge operator if no merge operator is passed in. This is to allow users to print keys from a DB with a merge operator.
 
 ### New Features
 * Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 * Rate limited deletion of WALs is only enabled if DBOptions::wal_dir is not set, or explicitly set to db_name passed to DB::Open and DBOptions::db_paths is empty, or same as db_paths[0].path
 * Overload GetAllKeyVersions() to support non-default column family.
 * Added new APIs ExportColumnFamily() and CreateColumnFamilyWithImport() to support export and import of a Column Family. https://github.com/facebook/rocksdb/issues/3469
+* ldb sometimes specify a string-append merge operator if no merge operator is passed in. This is to allow users to print keys from a DB with a merge operator.
 
 ### New Features
 * Add an option `snap_refresh_nanos` (default to 0.1s) to periodically refresh the snapshot list in compaction jobs. Assign to 0 to disable the feature.


### PR DESCRIPTION
Summary:
Right now, ldb cannot scan a DB with merge operands with default ldb. There is no hard to give a general merge operator so that it can at least print out something

Test Plan: Run ldb against a DB with merge operands and see the outputs.