### PR TITLE
Parallelize file_reader_writer_test in order to reduce timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,6 @@ TESTS = \
 	fault_injection_test \
 	filelock_test \
 	filename_test \
-	file_reader_writer_test \
 	block_based_filter_block_test \
 	full_filter_block_test \
 	partitioned_filter_block_test \
@@ -580,6 +579,7 @@ PARALLEL_TEST = \
 	external_sst_file_test \
 	import_column_family_test \
 	fault_injection_test \
+	file_reader_writer_test \
 	inlineskiplist_test \
 	manual_compaction_test \
 	persistent_cache_test \

--- a/TARGETS
+++ b/TARGETS
@@ -753,7 +753,7 @@ ROCKS_TESTS = [
     [
         "file_reader_writer_test",
         "util/file_reader_writer_test.cc",
-        "serial",
+        "parallel",
     ],
     [
         "filelock_test",


### PR DESCRIPTION
Test Plan:
make check
buck test @mode/dev-tsan internal_repo_rocksdb/repo:file_reader_writer_test -- --run-disabled
