### PR TITLE
Fix regression bug of Auto rolling logger when handling failures

### DIFF
--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -47,7 +47,7 @@ AutoRollLogger::AutoRollLogger(Env* env, const std::string& dbname,
   GetExistingFiles();
   ResetLogger();
   s = TrimOldLogFiles();
-  if (!status_.ok()) {
+  if (!s.ok() && status_.ok()) {
     status_ = s;
   }
 }

--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -46,9 +46,8 @@ AutoRollLogger::AutoRollLogger(Env* env, const std::string& dbname,
   }
   GetExistingFiles();
   ResetLogger();
-  s = TrimOldLogFiles();
-  if (!s.ok() && status_.ok()) {
-    status_ = s;
+  if (status_.ok()) {
+    status_ = TrimOldLogFiles();
   }
 }
 

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -635,6 +635,15 @@ TEST_F(AutoRollLoggerTest, LogFileExistence) {
   delete db;
 }
 
+TEST_F(AutoRollLoggerTest, FileCreateFailure) {
+  Options options;
+  options.max_log_file_size = 100 * 1024 * 1024;
+  options.db_log_dir = "/a/dir/does/not/exist/at/all";
+
+  std::shared_ptr<Logger> logger;
+  ASSERT_NOK(CreateLoggerFromOptions("", options, &logger));
+  ASSERT_TRUE(!logger);
+}
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary: Auto roll logger fails to handle file creation error in the correct way, which may expose to seg fault condition to users. Fix it.

Test Plan: Add a unit test on creating file under a non-existing directory. The test fails without the fix.