### PR TITLE
Auto Roll Logger to add some extra checking to avoid segfault.

### DIFF
--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -156,6 +156,11 @@ std::string AutoRollLogger::ValistToString(const char* format,
 
 void AutoRollLogger::LogInternal(const char* format, ...) {
   mutex_.AssertHeld();
+
+  if (!logger_) {
+    return;
+  }
+
   va_list args;
   va_start(args, format);
   logger_->Logv(format, args);
@@ -164,7 +169,10 @@ void AutoRollLogger::LogInternal(const char* format, ...) {
 
 void AutoRollLogger::Logv(const char* format, va_list ap) {
   assert(GetStatus().ok());
-
+  if (!logger_) {
+    return;
+  }
+  
   std::shared_ptr<Logger> logger;
   {
     MutexLock l(&mutex_);
@@ -208,6 +216,10 @@ void AutoRollLogger::WriteHeaderInfo() {
 }
 
 void AutoRollLogger::LogHeader(const char* format, va_list args) {
+  if (!logger_) {
+    return;
+  }
+
   // header message are to be retained in memory. Since we cannot make any
   // assumptions about the data contained in va_list, we will retain them as
   // strings

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -41,6 +41,10 @@ class AutoRollLogger : public Logger {
   }
 
   size_t GetLogFileSize() const override {
+    if (!logger_) {
+      return 0;
+    }
+
     std::shared_ptr<Logger> logger;
     {
       MutexLock l(&mutex_);


### PR DESCRIPTION
Summary: AutoRollLogger sets GetStatus() to be non-OK if the log file fails to be created and logger_ is set to null. It is left to the caller to check the status before calling function to this class. There is no harm to create another null checking to logger_ before we using it, so that in case users mis-use the logger, they don't get a segfault.

Test Plan: Run all existing tests.