### PR TITLE
Declare snapshot refresh incompatible with delete range

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -275,6 +275,8 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // this option helps reducing the cpu usage of long-running compactions. The
   // feature is disabled when max_subcompactions is greater than one.
   //
+  // NOTE: This feautre is currently incompatible with RangeDeletes.
+  //
   // Default: 0
   //
   // Dynamically changeable through SetOptions() API


### PR DESCRIPTION
The ::snap_refresh_nanos option is incompatible with DeleteRange feature. Currently the code relies on range_del_agg.IsEmpty() to disable it if there are range delete tombstones. However ::IsEmpty does not guarantee that there is no RangeDelete tombstones in the SST files. The patch declares the two features incompatible in inline comments until we later figure how to properly detect the presence of RangeDelete tombstones in compaction inputs.