### PR TITLE
Parallelize db_bloom_filter_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,6 @@ TESTS = \
 	db_block_cache_test \
 	db_test \
 	db_blob_index_test \
-	db_bloom_filter_test \
 	db_iter_test \
 	db_iter_stress_test \
 	db_log_iter_test \
@@ -569,6 +568,7 @@ TESTS = \
 
 PARALLEL_TEST = \
 	backupable_db_test \
+	db_bloom_filter_test \
 	db_compaction_filter_test \
 	db_compaction_test \
 	db_merge_operator_test \

--- a/TARGETS
+++ b/TARGETS
@@ -586,7 +586,7 @@ ROCKS_TESTS = [
     [
         "db_bloom_filter_test",
         "db/db_bloom_filter_test.cc",
-        "serial",
+        "parallel",
     ],
     [
         "db_compaction_filter_test",


### PR DESCRIPTION
Summary:
This test frequently times out under TSAN; parallelizing it should fix
this issue.

Test Plan:
make check
buck test @mode/dev-tsan internal_repo_rocksdb/repo:db_bloom_filter_test