### PR TITLE
Reduce the number of random iterations in compact_on_deletion_collector_test

### DIFF
--- a/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
+++ b/utilities/table_properties_collectors/compact_on_deletion_collector_test.cc
@@ -40,7 +40,7 @@ int main(int /*argc*/, char** /*argv*/) {
   // randomize tests
   rocksdb::Random rnd(301);
   const int kMaxTestSize = 100000l;
-  for (int random_test = 0; random_test < 30; random_test++) {
+  for (int random_test = 0; random_test < 10; random_test++) {
     int window_size = rnd.Uniform(kMaxTestSize) + 1;
     int deletion_trigger = rnd.Uniform(window_size);
     window_sizes.emplace_back(window_size);


### PR DESCRIPTION
Summary:
This test frequently times out under TSAN; reducing the number of random
iterations to make it complete faster.

Test Plan:
buck test @mode/dev-tsan internal_repo_rocksdb/repo:compact_on_deletion_collector_test