### PR TITLE
Don't error on shadow warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if(FAIL_ON_WARNINGS)
   if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
   else() # assume GCC
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=shadow")
   endif()
 endif()
 


### PR DESCRIPTION
Clang 11.x (llvm 8.x) has new shadow warnings about enums which are
being tickled by RocksDB. As a temporary workaround, don't error out on
these warnings.

See facebook/rocksdb#4946