### PR TITLE
WriteUnPrepared: Use int64_t instead of ssize_t

### DIFF
--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -104,7 +104,7 @@ struct TransactionDBOptions {
   // This option is only valid for write unprepared. If a write batch exceeds
   // this threshold, then the transaction will implicitly flush the currently
   // pending writes into the database. A value of 0 or less means no limit.
-  ssize_t default_write_batch_flush_threshold = 0;
+  int64_t default_write_batch_flush_threshold = 0;
 
  private:
   // 128 entries
@@ -171,7 +171,7 @@ struct TransactionOptions {
   // See TransactionDBOptions::default_write_batch_flush_threshold for
   // description. If a negative value is specified, then the default value from
   // TransactionDBOptions is used.
-  ssize_t write_batch_flush_threshold = -1;
+  int64_t write_batch_flush_threshold = -1;
 };
 
 // The per-write optimizations that do not involve transactions. TransactionDB

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -167,7 +167,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // write_batch_flush_threshold_ has been exceeded, and then call
   // FlushWriteBatchToDB if so. This logic is encapsulated in
   // MaybeFlushWriteBatchToDB.
-  ssize_t write_batch_flush_threshold_;
+  int64_t write_batch_flush_threshold_;
   WriteUnpreparedTxnDB* wupt_db_;
 
   // Ordered list of unprep_seq sequence numbers that we have already written


### PR DESCRIPTION
The ssize_t type was introduced in https://github.com/facebook/rocksdb/pull/5633, but it seems like it's a POSIX specific type.

I just need a signed type to represent number of bytes, so use int64_t instead. It seems like we have a typedef from SSIZE_T for Windows, but it doesn't seem like we ever include "port/port.h" in our public header files.