### PR TITLE
WriteUnPrepared: increase test coverage in transaction_test

### DIFF
--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -467,7 +467,6 @@ class Transaction {
   virtual void SetLogNumber(uint64_t log) { log_number_ = log; }
 
   virtual uint64_t GetLogNumber() const { return log_number_; }
-  virtual uint64_t GetLastLogNumber() const { return log_number_; }
 
   virtual Status SetName(const TransactionName& name) = 0;
 
@@ -523,9 +522,13 @@ class Transaction {
     id_ = id;
   }
 
+  virtual uint64_t GetLastLogNumber() const { return log_number_; }
+
  private:
   friend class PessimisticTransactionDB;
   friend class WriteUnpreparedTxnDB;
+  friend class TransactionTest_TwoPhaseLogRollingTest_Test;
+  friend class TransactionTest_TwoPhaseLogRollingTest2_Test;
   // No copying allowed
   Transaction(const Transaction&);
   void operator=(const Transaction&);

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -467,6 +467,7 @@ class Transaction {
   virtual void SetLogNumber(uint64_t log) { log_number_ = log; }
 
   virtual uint64_t GetLogNumber() const { return log_number_; }
+  virtual uint64_t GetLastLogNumber() const { return log_number_; }
 
   virtual Status SetName(const TransactionName& name) = 0;
 

--- a/include/rocksdb/utilities/transaction_db.h
+++ b/include/rocksdb/utilities/transaction_db.h
@@ -112,8 +112,14 @@ struct TransactionDBOptions {
   // 8m entry, 64MB size
   size_t wp_commit_cache_bits = static_cast<size_t>(23);
 
+  // For testing, whether transaction name should be auto-generated or not. This
+  // is useful for write unprepared which requires named transactions.
+  bool autogenerate_name = false;
+
   friend class WritePreparedTxnDB;
+  friend class WriteUnpreparedTxn;
   friend class WritePreparedTransactionTestBase;
+  friend class TransactionTestBase;
   friend class MySQLStyleTransactionTest;
 };
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -3128,17 +3128,12 @@ TEST_P(TransactionTest, LostUpdate) {
 }
 
 TEST_P(TransactionTest, UntrackedWrites) {
-  // In WriteUnprepared, untracked writes will break snapshot validation logic.
-  // Snapshot validation will only check the largest sequence number of a key to
-  // see if it was committed or not. However, an untracked unprepared write will
-  // hide smaller committed sequence numbers.
-  //
-  // TODO(lth): To fix this, snapshot validation will have to validate all
-  // values larger than snap_seq. If the performance cost is too high, then for
-  // WriteUnprepard, return Status::NotSupported for the untracked calls.
   if (txn_db_options.write_policy == WRITE_UNPREPARED) {
+    // TODO(lth): For WriteUnprepared, validate that untracked writes are
+    // not supported.
     return;
   }
+
   WriteOptions write_options;
   ReadOptions read_options;
   std::string value;

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -1612,7 +1612,7 @@ TEST_P(WritePreparedTransactionTest, SmallestUnCommittedSeq) {
         txn = txns[index];
         txns.erase(txns.begin() + index);
       }
-      // Since commit cahce is practically disabled, commit results in immediate
+      // Since commit cache is practically disabled, commit results in immediate
       // advance in max_evicted_seq_ and subsequently moving some prepared txns
       // to delayed_prepared_.
       txn->Commit();

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -335,6 +335,10 @@ TEST_P(WriteUnpreparedTransactionTest, RecoveryTest) {
           for (int i = 0; i < num_batches; i++) {
             ASSERT_OK(txn->Put("k" + ToString(i), "value" + ToString(i)));
             if (txn_options.write_batch_flush_threshold == 1) {
+              // WriteUnprepared will check write_batch_flush_threshold and
+              // possibly flush before appending to the write batch. No flush
+              // will happen at the first write because the batch is still
+              // empty, so after k puts, there should be k-1 flushed batches.
               ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i);
             } else {
               ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), 0);
@@ -411,6 +415,10 @@ TEST_P(WriteUnpreparedTransactionTest, UnpreparedBatch) {
         for (int i = 0; i < kNumKeys; i++) {
           txn->Put("k" + ToString(i), "v" + ToString(i));
           if (txn_options.write_batch_flush_threshold == 1) {
+            // WriteUnprepared will check write_batch_flush_threshold and
+            // possibly flush before appending to the write batch. No flush will
+            // happen at the first write because the batch is still empty, so
+            // after k puts, there should be k-1 flushed batches.
             ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i);
           } else {
             ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), 0);

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -335,7 +335,7 @@ TEST_P(WriteUnpreparedTransactionTest, RecoveryTest) {
           for (int i = 0; i < num_batches; i++) {
             ASSERT_OK(txn->Put("k" + ToString(i), "value" + ToString(i)));
             if (txn_options.write_batch_flush_threshold == 1) {
-              ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i + 1);
+              ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i);
             } else {
               ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), 0);
             }
@@ -411,7 +411,7 @@ TEST_P(WriteUnpreparedTransactionTest, UnpreparedBatch) {
         for (int i = 0; i < kNumKeys; i++) {
           txn->Put("k" + ToString(i), "v" + ToString(i));
           if (txn_options.write_batch_flush_threshold == 1) {
-            ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i + 1);
+            ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), i);
           } else {
             ASSERT_EQ(wup_txn->GetUnpreparedSequenceNumbers().size(), 0);
           }

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -273,7 +273,7 @@ Status WriteUnpreparedTxn::FlushWriteBatchToDBInternal(bool prepared) {
     } else
 #endif
     {
-      Status::InvalidArgument("Cannot write to DB without SetName.");
+      return Status::InvalidArgument("Cannot write to DB without SetName.");
     }
   }
 

--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -37,6 +37,7 @@ WriteUnpreparedTxn::WriteUnpreparedTxn(WriteUnpreparedTxnDB* txn_db,
                                        const TransactionOptions& txn_options)
     : WritePreparedTxn(txn_db, write_options, txn_options),
       wupt_db_(txn_db),
+      last_log_number_(0),
       recovered_txn_(false),
       largest_validated_seq_(0) {
   if (txn_options.write_batch_flush_threshold < 0) {
@@ -56,10 +57,15 @@ WriteUnpreparedTxn::~WriteUnpreparedTxn() {
     // We should rollback regardless of GetState, but some unit tests that
     // test crash recovery run the destructor assuming that rollback does not
     // happen, so that rollback during recovery can be exercised.
-    if (GetState() == STARTED) {
-      auto s __attribute__((__unused__)) = RollbackInternal();
-      // TODO(lth): Better error handling.
+    if (GetState() == STARTED || GetState() == LOCKS_STOLEN) {
+      auto s = RollbackInternal();
       assert(s.ok());
+      if (!s.ok()) {
+        ROCKS_LOG_ERROR(
+            wupt_db_->info_log_,
+            "Rollback of WriteUnprepared transaction failed in destructor: %s",
+            s.ToString().c_str());
+      }
       dbimpl_->logs_with_prep_tracker()->MarkLogAsHavingPrepSectionFlushed(
           log_number_);
     }
@@ -233,6 +239,7 @@ Status WriteUnpreparedTxn::MaybeFlushWriteBatchToDB() {
   const bool kPrepared = true;
   Status s;
   if (write_batch_flush_threshold_ > 0 &&
+      WriteBatchInternal::Count(write_batch_.GetWriteBatch()) > 0 &&
       write_batch_.GetDataSize() >
           static_cast<size_t>(write_batch_flush_threshold_)) {
     assert(GetState() != PREPARED);
@@ -257,7 +264,16 @@ Status WriteUnpreparedTxn::FlushWriteBatchToDB(bool prepared) {
 
 Status WriteUnpreparedTxn::FlushWriteBatchToDBInternal(bool prepared) {
   if (name_.empty()) {
-    return Status::InvalidArgument("Cannot write to DB without SetName.");
+    assert(!prepared);
+#ifndef NDEBUG
+    // To avoid changing all tests to call SetName, just autogenerate one.
+    if (wupt_db_->autogenerate_name_) {
+      SetName(std::string("xid") + ToString(db_->GetEnv()->NowMicros()));
+    }
+#endif
+    if (name_.empty()) {
+      Status::InvalidArgument("Cannot write to DB without SetName.");
+    }
   }
 
   // TODO(lth): Reduce duplicate code with WritePrepared prepare logic.
@@ -285,11 +301,14 @@ Status WriteUnpreparedTxn::FlushWriteBatchToDBInternal(bool prepared) {
   // from the current transaction. This means that if log_number_ is set,
   // WriteImpl should not overwrite that value, so set log_used to nullptr if
   // log_number_ is already set.
-  uint64_t* log_used = log_number_ ? nullptr : &log_number_;
-  auto s = db_impl_->WriteImpl(write_options, GetWriteBatch()->GetWriteBatch(),
-                               /*callback*/ nullptr, log_used, /*log ref*/
-                               0, !DISABLE_MEMTABLE, &seq_used,
-                               prepare_batch_cnt_, &add_prepared_callback);
+  auto s =
+      db_impl_->WriteImpl(write_options, GetWriteBatch()->GetWriteBatch(),
+                          /*callback*/ nullptr, &last_log_number_, /*log ref*/
+                          0, !DISABLE_MEMTABLE, &seq_used, prepare_batch_cnt_,
+                          &add_prepared_callback);
+  if (log_number_ == 0) {
+    log_number_ = last_log_number_;
+  }
   assert(!s.ok() || seq_used != kMaxSequenceNumber);
   auto prepare_seq = seq_used;
 

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -147,6 +147,10 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
   virtual Status RebuildFromWriteBatch(WriteBatch*) override;
 
+  virtual uint64_t GetLastLogNumber() const override {
+    return last_log_number_;
+  }
+
  protected:
   void Initialize(const TransactionOptions& txn_options) override;
 
@@ -218,6 +222,8 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // are treated similarily in prepare heap/commit map, so it simplifies the
   // commit callbacks.
   std::map<SequenceNumber, size_t> unprep_seqs_;
+
+  uint64_t last_log_number_;
 
   // Recovered transactions have tracked_keys_ populated, but are not actually
   // locked for efficiency reasons. For recovered transactions, skip unlocking

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -145,6 +145,15 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
                               const SliceParts& key,
                               const bool assume_tracked = false) override;
 
+  // In WriteUnprepared, untracked writes will break snapshot validation logic.
+  // Snapshot validation will only check the largest sequence number of a key to
+  // see if it was committed or not. However, an untracked unprepared write will
+  // hide smaller committed sequence numbers.
+  //
+  // TODO(lth): Investigate whether it is worth having snapshot validation
+  // validate all values larger than snap_seq. Otherwise, we should return
+  // Status::NotSupported for untracked writes.
+
   virtual Status RebuildFromWriteBatch(WriteBatch*) override;
 
   virtual uint64_t GetLastLogNumber() const override {

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -34,11 +34,6 @@ class WriteUnpreparedTxnDB : public WritePreparedTxnDB {
 
  private:
   Status RollbackRecoveredTransaction(const DBImpl::RecoveredTransaction* rtxn);
-
-#ifndef NDEBUG
- public:
-  bool autogenerate_name_ = false;
-#endif
 };
 
 class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -34,6 +34,11 @@ class WriteUnpreparedTxnDB : public WritePreparedTxnDB {
 
  private:
   Status RollbackRecoveredTransaction(const DBImpl::RecoveredTransaction* rtxn);
+
+#ifndef NDEBUG
+ public:
+  bool autogenerate_name_ = false;
+#endif
 };
 
 class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {


### PR DESCRIPTION
The changes transaction_test to set `txn_db_options.default_write_batch_flush_threshold = 1` in order to give better test coverage for WriteUnprepared.

As part of the change, some tests had to be updated.