### PR TITLE
Fix MultiGet() bug when whole_key_filtering is disabled

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 * Fixed a number of data races in BlobDB.
 * Fix a bug where the compaction snapshot refresh feature is not disabled as advertised when `snap_refresh_nanos` is set to 0..
+* Fix bloom filter lookups by the MultiGet batching API when BlockBasedTableOptions::whole_key_filtering is false, by checking that a key is in the perfix_extractor domain and extracting the prefix before looking up.
 ### New Features
 * VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size. For checksum verifying before external SST file ingestion, a new option IngestExternalFileOptions.verify_checksums_readahead_size, is added for this readahead setting.
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1287,10 +1287,21 @@ TEST_F(DBBasicTest, MultiGetBatchedMultiLevel) {
   }
 }
 
-TEST_F(DBBasicTest, MultiGetPrefixExtractor) {
+// Test class for batched MultiGet with prefix extractor
+// Param bool - If true, use partitioned filters
+//              If false, use full filter block
+class MultiGetPrefixExtractorTest
+    : public DBBasicTest,
+      public ::testing::WithParamInterface<bool> {};
+
+TEST_P(MultiGetPrefixExtractorTest, Batched) {
   Options options = CurrentOptions();
   options.prefix_extractor.reset(NewFixedPrefixTransform(2));
   BlockBasedTableOptions bbto;
+  if (GetParam()) {
+    bbto.index_type = BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+    bbto.partition_filters = true;
+  }
   bbto.filter_policy.reset(NewBloomFilterPolicy(10, false));
   bbto.whole_key_filtering = false;
   bbto.cache_index_and_filter_blocks = false;
@@ -1305,29 +1316,23 @@ TEST_F(DBBasicTest, MultiGetPrefixExtractor) {
   ASSERT_OK(Put("kk4", "v4"));
   ASSERT_OK(Flush());
 
-  std::vector<Slice> keys({"k", "kk1", "kk2", "kk3", "kk4"});
-  std::vector<PinnableSlice> values(keys.size());
-  std::vector<Status> s(keys.size());
-
+  std::vector<std::string> keys({"k", "kk1", "kk2", "kk3", "kk4"});
+  std::vector<std::string> values;
+  SetPerfLevel(kEnableCount);
   get_perf_context()->Reset();
-  db_->MultiGet(ReadOptions(), dbfull()->DefaultColumnFamily(), keys.size(),
-                keys.data(), values.data(), s.data(), true);
-
-  ASSERT_EQ(values.size(), keys.size());
-  ASSERT_EQ(std::string(values[0].data(), values[0].size()), "v0");
-  ASSERT_EQ(std::string(values[1].data(), values[1].size()), "v1");
-  ASSERT_EQ(std::string(values[2].data(), values[2].size()), "v2");
-  ASSERT_EQ(std::string(values[3].data(), values[3].size()), "v3");
-  ASSERT_EQ(std::string(values[4].data(), values[4].size()), "v4");
+  values = MultiGet(keys, nullptr);
+  ASSERT_EQ(values[0], "v0");
+  ASSERT_EQ(values[1], "v1");
+  ASSERT_EQ(values[2], "v2");
+  ASSERT_EQ(values[3], "v3");
+  ASSERT_EQ(values[4], "v4");
   // Filter hits for 4 in-domain keys
   ASSERT_EQ(get_perf_context()->bloom_sst_hit_count, 4);
-
-  ASSERT_OK(s[0]);
-  ASSERT_OK(s[1]);
-  ASSERT_OK(s[2]);
-  ASSERT_OK(s[3]);
-  ASSERT_OK(s[4]);
 }
+
+INSTANTIATE_TEST_CASE_P(
+    MultiGetPrefix, MultiGetPrefixExtractorTest,
+    ::testing::Bool());
 
 #ifndef ROCKSDB_LITE
 TEST_F(DBBasicTest, GetAllKeyVersions) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1309,6 +1309,7 @@ TEST_F(DBBasicTest, MultiGetPrefixExtractor) {
   std::vector<PinnableSlice> values(keys.size());
   std::vector<Status> s(keys.size());
 
+  get_perf_context()->Reset();
   db_->MultiGet(ReadOptions(), dbfull()->DefaultColumnFamily(), keys.size(),
                 keys.data(), values.data(), s.data(), true);
 
@@ -1318,6 +1319,8 @@ TEST_F(DBBasicTest, MultiGetPrefixExtractor) {
   ASSERT_EQ(std::string(values[2].data(), values[2].size()), "v2");
   ASSERT_EQ(std::string(values[3].data(), values[3].size()), "v3");
   ASSERT_EQ(std::string(values[4].data(), values[4].size()), "v4");
+  // Filter hits for 4 in-domain keys
+  ASSERT_EQ(get_perf_context()->bloom_sst_hit_count, 4);
 
   ASSERT_OK(s[0]);
   ASSERT_OK(s[1]);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3155,13 +3155,6 @@ void BlockBasedTable::FullFilterKeysMayMatch(
   } else if (!read_options.total_order_seek && prefix_extractor &&
              rep_->table_properties->prefix_extractor_name.compare(
                  prefix_extractor->Name()) == 0) {
-    for (auto iter = range->begin(); iter != range->end(); ++iter) {
-      Slice user_key = iter->lkey->user_key();
-
-      if (!prefix_extractor->InDomain(user_key)) {
-        range->SkipKey(iter);
-      }
-    }
     filter->PrefixesMayMatch(range, prefix_extractor, kNotValid, false,
                              lookup_context);
   }

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -138,7 +138,7 @@ class FilterBlockReader {
       const Slice ikey = iter->ikey;
       GetContext* const get_context = iter->get_context;
       if (prefix_extractor->InDomain(ukey) &&
-          !KeyMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
+          !PrefixMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
                        block_offset, no_io, &ikey, get_context,
                        lookup_context)) {
         range->SkipKey(iter);

--- a/table/block_based/filter_block.h
+++ b/table/block_based/filter_block.h
@@ -137,7 +137,8 @@ class FilterBlockReader {
       const Slice ukey = iter->ukey;
       const Slice ikey = iter->ikey;
       GetContext* const get_context = iter->get_context;
-      if (!KeyMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
+      if (prefix_extractor->InDomain(ukey) &&
+          !KeyMayMatch(prefix_extractor->Transform(ukey), prefix_extractor,
                        block_offset, no_io, &ikey, get_context,
                        lookup_context)) {
         range->SkipKey(iter);

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -280,7 +280,9 @@ void FullFilterBlockReader::MayMatch(
       range->SkipKey(iter);
       PERF_COUNTER_ADD(bloom_sst_miss_count, 1);
     } else {
-      PERF_COUNTER_ADD(bloom_sst_hit_count, 1);
+      //PERF_COUNTER_ADD(bloom_sst_hit_count, 1);
+      PerfContext* perf_ctx = get_perf_context();
+      perf_ctx->bloom_sst_hit_count++;
     }
     ++i;
   }

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -254,7 +254,7 @@ void FullFilterBlockReader::MayMatch(
   // declare both keys and may_match as arrays, which is also slightly less
   // expensive compared to autovector
   Slice* keys[MultiGetContext::MAX_BATCH_SIZE];
-  bool may_match[MultiGetContext::MAX_BATCH_SIZE] = {false};
+  bool may_match[MultiGetContext::MAX_BATCH_SIZE] = {true};
   autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> prefixes;
   int num_keys = 0;
   MultiGetRange filter_range(*range, range->begin(), range->end());

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -253,8 +253,8 @@ void FullFilterBlockReader::MayMatch(
   // &may_match[0] doesn't work for autovector<bool> (compiler error). So
   // declare both keys and may_match as arrays, which is also slightly less
   // expensive compared to autovector
-  Slice* keys[MultiGetContext::MAX_BATCH_SIZE];
-  bool may_match[MultiGetContext::MAX_BATCH_SIZE] = {true};
+  std::array<Slice*, MultiGetContext::MAX_BATCH_SIZE> keys;
+  std::array<bool, MultiGetContext::MAX_BATCH_SIZE> may_match = {true};
   autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> prefixes;
   int num_keys = 0;
   MultiGetRange filter_range(*range, range->begin(), range->end());

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -255,7 +255,7 @@ void FullFilterBlockReader::MayMatch(
   // declare both keys and may_match as arrays, which is also slightly less
   // expensive compared to autovector
   std::array<Slice*, MultiGetContext::MAX_BATCH_SIZE> keys;
-  std::array<bool, MultiGetContext::MAX_BATCH_SIZE> may_match = {true};
+  std::array<bool, MultiGetContext::MAX_BATCH_SIZE> may_match = {{true}};
   autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> prefixes;
   int num_keys = 0;
   MultiGetRange filter_range(*range, range->begin(), range->end());

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -278,6 +278,9 @@ void FullFilterBlockReader::MayMatch(
       // Update original MultiGet range to skip this key. The filter_range
       // was temporarily used just to skip keys not in prefix_extractor domain
       range->SkipKey(iter);
+      PERF_COUNTER_ADD(bloom_sst_miss_count, 1);
+    } else {
+      PERF_COUNTER_ADD(bloom_sst_hit_count, 1);
     }
     ++i;
   }

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include <array>
 #include "table/block_based/full_filter_block.h"
 
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE

--- a/table/block_based/full_filter_block.h
+++ b/table/block_based/full_filter_block.h
@@ -124,6 +124,7 @@ class FullFilterBlockReader : public FilterBlockReaderCommon<BlockContents> {
   bool MayMatch(const Slice& entry, bool no_io, GetContext* get_context,
                 BlockCacheLookupContext* lookup_context) const;
   void MayMatch(MultiGetRange* range, bool no_io,
+                const SliceTransform* prefix_extractor,
                 BlockCacheLookupContext* lookup_context) const;
   bool IsFilterCompatible(const Slice* iterate_upper_bound, const Slice& prefix,
                           const Comparator* comparator) const;


### PR DESCRIPTION
The batched MultiGet() implementation was not correctly handling bloom filter lookups when whole_key_filtering is disabled. It was incorrectly skipping keys not in the prefix_extractor domain, and not calling transform for keys in domain. This PR fixes both problems by moving the domain check and transformation to the FilterBlockReader.

Tests:
Unit test (confirmed failed before the fix)
make check