### PR TITLE
Fix clang_check and lite failures

### DIFF
--- a/third-party/folly/folly/detail/Futex.cpp
+++ b/third-party/folly/folly/detail/Futex.cpp
@@ -49,7 +49,7 @@ namespace {
 #endif
 
 int nativeFutexWake(const void* addr, int count, uint32_t wakeMask) {
-  int rv = syscall(
+  long rv = syscall(
       __NR_futex,
       addr, /* addr1 */
       FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG, /* op */
@@ -65,7 +65,7 @@ int nativeFutexWake(const void* addr, int count, uint32_t wakeMask) {
   if (rv < 0) {
     return 0;
   }
-  return rv;
+  return static_cast<int>(rv);
 }
 
 template <class Clock>
@@ -111,7 +111,7 @@ FutexResult nativeFutexWaitImpl(
 
   // Unlike FUTEX_WAIT, FUTEX_WAIT_BITSET requires an absolute timeout
   // value - http://locklessinc.com/articles/futex_cheat_sheet/
-  int rv = syscall(
+  long rv = syscall(
       __NR_futex,
       addr, /* addr1 */
       op, /* op */

--- a/third-party/folly/folly/synchronization/DistributedMutex-inl.h
+++ b/third-party/folly/folly/synchronization/DistributedMutex-inl.h
@@ -1311,6 +1311,7 @@ inline std::uintptr_t tryCombine(
     std::uint64_t iteration,
     std::chrono::nanoseconds now,
     CombineFunction task) {
+#ifndef ROCKSDB_LITE
   // if the waiter has asked for a combine operation, we should combine its
   // critical section and move on to the next waiter
   //
@@ -1339,7 +1340,7 @@ inline std::uintptr_t tryCombine(
     }
     return next;
   }
-
+#endif  // ROCKSDB_LITE
   return 0;
 }
 

--- a/third-party/folly/folly/synchronization/test/DistributedMutexTest.cpp
+++ b/third-party/folly/folly/synchronization/test/DistributedMutexTest.cpp
@@ -13,6 +13,8 @@
 #include <gtest/gtest.h>
 #endif
 
+#ifndef ROCKSDB_LITE
+
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -960,7 +962,6 @@ class ExceptionWithConstructionTrack : public std::exception {
 TEST(DistributedMutex, TestExceptionPropagationUncontended) {
   TestConstruction::reset();
   auto&& mutex = folly::DistributedMutex{};
-
   auto&& thread = std::thread{[&]() {
     try {
       mutex.lock_combine([&]() { throw ExceptionWithConstructionTrack{46}; });
@@ -969,11 +970,9 @@ TEST(DistributedMutex, TestExceptionPropagationUncontended) {
       EXPECT_EQ(integer, 46);
       EXPECT_GT(TestConstruction::defaultConstructs(), 0);
     }
-
     EXPECT_EQ(
         TestConstruction::defaultConstructs(), TestConstruction::destructs());
   }};
-
   thread.join();
 }
 
@@ -1123,6 +1122,7 @@ TEST(DistributedMutex, StressBigValueReturnSixtyFourThreads) {
 }
 
 } // namespace folly
+#endif  // ROCKSDB_LITE
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This PR fixes two test failures:
1. clang check:
```
third-party/folly/folly/detail/Futex.cpp:52:12: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
  int rv = syscall(
      ~~   ^~~~~~~~
third-party/folly/folly/detail/Futex.cpp:114:12: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
  int rv = syscall(
      ~~   ^~~~~~~~
```
2. lite
```
./third-party/folly/folly/synchronization/DistributedMutex-inl.h:1337:7: error: exception handling disabled, use -fexceptions to enable
     } catch (...) {
       ^
```