### PR TITLE
exclude TEST_ENV_URI from rocksdb lite

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -63,8 +63,9 @@ class EnvCounter : public EnvWrapper {
 class ColumnFamilyTestBase : public testing::Test {
  public:
   explicit ColumnFamilyTestBase(uint32_t format) : rnd_(139), format_(format) {
-    const char* test_env_uri = getenv("TEST_ENV_URI");
     Env* base_env = Env::Default();
+#ifndef ROCKSDB_LITE
+    const char* test_env_uri = getenv("TEST_ENV_URI");
     if (test_env_uri) {
       Status s = ObjectRegistry::NewInstance()->NewSharedObject(test_env_uri,
                                                                 &env_guard_);
@@ -72,6 +73,7 @@ class ColumnFamilyTestBase : public testing::Test {
       EXPECT_OK(s);
       EXPECT_NE(Env::Default(), base_env);
     }
+#endif  // !ROCKSDB_LITE
     EXPECT_NE(nullptr, base_env);
     env_ = new EnvCounter(base_env);
     dbname_ = test::PerThreadDBPath("column_family_test");

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -51,8 +51,9 @@ DBTestBase::DBTestBase(const std::string path)
     : mem_env_(nullptr),
       encrypted_env_(nullptr),
       option_config_(kDefault) {
-  const char* test_env_uri = getenv("TEST_ENV_URI");
   Env* base_env = Env::Default();
+#ifndef ROCKSDB_LITE
+  const char* test_env_uri = getenv("TEST_ENV_URI");
   if (test_env_uri) {
     Status s = ObjectRegistry::NewInstance()->NewSharedObject(test_env_uri,
                                                               &env_guard_);
@@ -60,6 +61,7 @@ DBTestBase::DBTestBase(const std::string path)
     EXPECT_OK(s);
     EXPECT_NE(Env::Default(), base_env);
   }
+#endif  // !ROCKSDB_LITE
   EXPECT_NE(nullptr, base_env);
   if (getenv("MEM_ENV")) {
     mem_env_ = new MockEnv(base_env);


### PR DESCRIPTION
PR https://github.com/facebook/rocksdb/pull/5676 added some test coverage for `TEST_ENV_URI`, which unfortunately isn't supported in lite mode, causing some test failures for rocksdb lite. For example, 
```
db/db_test_util.cc: In constructor ‘rocksdb::DBTestBase::DBTestBase(std::__cxx11::string)’:
db/db_test_util.cc:57:16: error: ‘ObjectRegistry’ has not been declared
     Status s = ObjectRegistry::NewInstance()->NewSharedObject(test_env_uri,
                ^
```
This PR fixes these errors by excluding the new code from test functions for lite mode. 