### PR TITLE
cmake: s/SNAPPY_LIBRARIES/snappy_LIBRARIES/

### DIFF
--- a/cmake/modules/Findsnappy.cmake
+++ b/cmake/modules/Findsnappy.cmake
@@ -9,7 +9,7 @@ find_path(snappy_INCLUDE_DIRS
   NAMES snappy.h
   HINTS ${snappy_ROOT_DIR}/include)
 
-find_library(SNAPPY_LIBRARIES
+find_library(snappy_LIBRARIES
   NAMES snappy
   HINTS ${snappy_ROOT_DIR}/lib)
 


### PR DESCRIPTION
fix the regression introduced by cc9fa7fc

Signed-off-by: Kefu Chai <tchaikov@gmail.com>