### PR TITLE
WriteUnPrepared: Pass snap_released to the callback

### DIFF
--- a/utilities/transactions/write_unprepared_txn.cc
+++ b/utilities/transactions/write_unprepared_txn.cc
@@ -26,7 +26,8 @@ bool WriteUnpreparedTxnReadCallback::IsVisibleFullCheck(SequenceNumber seq) {
   }
 
   bool snap_released = false;
-  auto ret = db_->IsInSnapshot(seq, wup_snapshot_, min_uncommitted_);
+  auto ret =
+      db_->IsInSnapshot(seq, wup_snapshot_, min_uncommitted_, &snap_released);
   assert(!snap_released || backed_by_snapshot_ == kUnbackedByDBSnapshot);
   snap_released_ |= snap_released;
   return ret;


### PR DESCRIPTION
With changes made in https://github.com/facebook/rocksdb/pull/5664 we meant to pass snap_released parameter of ::IsInSnapshot from the read callbacks. Although the variable was defined, passing it to the callback in WritePreparedTxnReadCallback was missing, which is fixed in this PR.