### PR TITLE
Fix regression affecting partitioned indexes/filters when cache_index_and_filter_blocks is false

### DIFF
--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -565,6 +565,7 @@ struct BlockBasedTable::Rep {
 
   SequenceNumber get_global_seqno(BlockType block_type) const {
     return (block_type == BlockType::kFilter ||
+            block_type == BlockType::kFilterPartition ||
             block_type == BlockType::kCompressionDictionary)
                ? kDisableGlobalSequenceNumber
                : global_seqno;

--- a/table/block_based/block_type.h
+++ b/table/block_based/block_type.h
@@ -13,9 +13,13 @@ namespace rocksdb {
 // See https://github.com/facebook/rocksdb/wiki/Rocksdb-BlockBasedTable-Format
 // for details.
 
+// Note: index/filter partitions act like the main index/filter block in some
+// contexts and as pure data blocks in others. Hence, it makes sense to treat
+// them as separate types that are distinct from the above.
 enum class BlockType : uint8_t {
   kData,
   kFilter,
+  kFilterPartition,
   kProperties,
   kCompressionDictionary,
   kRangeDeletion,
@@ -23,6 +27,7 @@ enum class BlockType : uint8_t {
   kHashIndexMetadata,
   kMetaIndex,
   kIndex,
+  kIndexPartition,
   // Note: keep kInvalid the last value when adding new enum values.
   kInvalid
 };

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -223,10 +223,10 @@ Status PartitionedFilterBlockReader::GetFilterPartitionBlock(
     read_options.read_tier = kBlockCacheTier;
   }
 
-  const Status s =
-      table()->RetrieveBlock(prefetch_buffer, read_options, fltr_blk_handle,
-                             UncompressionDict::GetEmptyDict(), filter_block,
-                             BlockType::kFilter, get_context, lookup_context);
+  const Status s = table()->RetrieveBlock(
+      prefetch_buffer, read_options, fltr_blk_handle,
+      UncompressionDict::GetEmptyDict(), filter_block,
+      BlockType::kFilterPartition, get_context, lookup_context);
 
   return s;
 }
@@ -336,7 +336,7 @@ void PartitionedFilterBlockReader::CacheDependencies(bool pin) {
     // filter blocks
     s = table()->MaybeReadBlockAndLoadToCache(
         prefetch_buffer.get(), read_options, handle,
-        UncompressionDict::GetEmptyDict(), &block, BlockType::kFilter,
+        UncompressionDict::GetEmptyDict(), &block, BlockType::kFilterPartition,
         nullptr /* get_context */, &lookup_context, nullptr /* contents */);
 
     assert(s.ok() || block.GetValue() == nullptr);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -224,6 +224,7 @@ Status BlockFetcher::ReadBlockContents() {
     // TODO: introduce dedicated perf counter for range tombstones
     switch (block_type_) {
       case BlockType::kFilter:
+      case BlockType::kFilterPartition:
         PERF_COUNTER_ADD(filter_block_read_count, 1);
         break;
 
@@ -232,6 +233,7 @@ Status BlockFetcher::ReadBlockContents() {
         break;
 
       case BlockType::kIndex:
+      case BlockType::kIndexPartition:
         PERF_COUNTER_ADD(index_block_read_count, 1);
         break;
 


### PR DESCRIPTION
Summary:
PR #5298 (and subsequent related patches) unintentionally changed the
semantics of cache_index_and_filter_blocks: historically, this option
only affected the main index/filter block; with the changes, it affects
index/filter partitions as well. This can cause performance issues when
cache_index_and_filter_blocks is false since in this case, partitions are
neither cached nor preloaded (i.e. they are loaded on demand upon each
access). The patch reverts to the earlier behavior, that is, partitions
are cached similarly to data blocks regardless of the value of the above
option.

Test Plan:
make check
./db_bench -benchmarks=fillrandom --statistics --stats_interval_seconds=1 --duration=30 --num=500000000 --bloom_bits=20 --partition_index_and_filters=true --cache_index_and_filter_blocks=false
./db_bench -benchmarks=readrandom --use_existing_db --statistics --stats_interval_seconds=1 --duration=10 --num=500000000 --bloom_bits=20 --partition_index_and_filters=true --cache_index_and_filter_blocks=false --cache_size=8000000000

Relevant statistics from the readrandom benchmark with the old code:

rocksdb.block.cache.index.miss COUNT : 0
rocksdb.block.cache.index.hit COUNT : 0
rocksdb.block.cache.index.add COUNT : 0
rocksdb.block.cache.index.bytes.insert COUNT : 0
rocksdb.block.cache.index.bytes.evict COUNT : 0
rocksdb.block.cache.filter.miss COUNT : 0
rocksdb.block.cache.filter.hit COUNT : 0
rocksdb.block.cache.filter.add COUNT : 0
rocksdb.block.cache.filter.bytes.insert COUNT : 0
rocksdb.block.cache.filter.bytes.evict COUNT : 0

With the new code:

rocksdb.block.cache.index.miss COUNT : 2619
rocksdb.block.cache.index.hit COUNT : 41155
rocksdb.block.cache.index.add COUNT : 2619
rocksdb.block.cache.index.bytes.insert COUNT : 4247072
rocksdb.block.cache.index.bytes.evict COUNT : 0
rocksdb.block.cache.filter.miss COUNT : 2619
rocksdb.block.cache.filter.hit COUNT : 4258369
rocksdb.block.cache.filter.add COUNT : 2619
rocksdb.block.cache.filter.bytes.insert COUNT : 10826040
rocksdb.block.cache.filter.bytes.evict COUNT : 0