### PR TITLE
WriteUnPrepared: Relax restriction on iterators and writes with no snapshot

### DIFF
--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -553,7 +553,7 @@ TEST_P(WriteUnpreparedTransactionTest, NoSnapshotWrite) {
   // snapshot, if iterator snapshot is fresh enough.
   ReadOptions roptions;
   auto iter = txn->GetIterator(roptions);
-  uint keys = 0;
+  int keys = 0;
   for (iter->SeekToLast(); iter->Valid(); iter->Prev(), keys++) {
     ASSERT_OK(iter->status());
     ASSERT_EQ(iter->key().ToString(), iter->value().ToString());

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -241,9 +241,9 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
 
   // Track the largest sequence number at which we performed snapshot
   // validation. If snapshot validation was skipped because no snapshot was set,
-  // then this is set to kMaxSequenceNumber. This value is useful because it
-  // means that for keys that have unprepared seqnos, we can guarantee that no
-  // committed keys by other transactions can exist between
+  // then this is set to GetLastPublishedSequence. This value is useful because
+  // it means that for keys that have unprepared seqnos, we can guarantee that
+  // no committed keys by other transactions can exist between
   // largest_validated_seq_ and max_unprep_seq. See
   // WriteUnpreparedTxnDB::NewIterator for an explanation for why this is
   // necessary for iterator Prev().


### PR DESCRIPTION
Currently, if a write is done without a snapshot, then `largest_validated_seq_` is set to `kMaxSequenceNumber`. This is too aggressive, because an iterator with a snapshot created after this write should be valid.

Set `largest_validated_seq_` to `GetLastPublishedSequence` instead. The variable means that no keys in the current tracked key set has changed by other transactions since `largest_validated_seq_`.

Also, do some extra cleanup in Clear() for safety.