### PR TITLE
Fix data races in BlobDB

### DIFF
--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -12,7 +12,6 @@
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "util/file_reader_writer.h"
-#include "util/mutexlock.h"
 #include "utilities/blob_db/blob_log_format.h"
 #include "utilities/blob_db/blob_log_reader.h"
 #include "utilities/blob_db/blob_log_writer.h"
@@ -158,13 +157,9 @@ class BlobFile {
 
   // All Get functions which are not atomic, will need ReadLock on the mutex
 
-  ExpirationRange GetExpirationRange() const {
-    ReadLock rl(&mutex_);
-    return expiration_range_;
-  }
+  ExpirationRange GetExpirationRange() const { return expiration_range_; }
 
   void ExtendExpirationRange(uint64_t expiration) {
-    WriteLock wl(&mutex_);
     expiration_range_.first = std::min(expiration_range_.first, expiration);
     expiration_range_.second = std::max(expiration_range_.second, expiration);
   }

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -12,6 +12,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "util/file_reader_writer.h"
+#include "util/mutexlock.h"
 #include "utilities/blob_db/blob_log_format.h"
 #include "utilities/blob_db/blob_log_reader.h"
 #include "utilities/blob_db/blob_log_writer.h"
@@ -157,9 +158,13 @@ class BlobFile {
 
   // All Get functions which are not atomic, will need ReadLock on the mutex
 
-  ExpirationRange GetExpirationRange() const { return expiration_range_; }
+  ExpirationRange GetExpirationRange() const {
+    ReadLock rl(&mutex_);
+    return expiration_range_;
+  }
 
   void ExtendExpirationRange(uint64_t expiration) {
+    WriteLock wl(&mutex_);
     expiration_range_.first = std::min(expiration_range_.first, expiration);
     expiration_range_.second = std::max(expiration_range_.second, expiration);
   }


### PR DESCRIPTION
Summary:
Some accesses to blob_files_ and open_ttl_files_ in BlobDBImpl, as well
as to expiration_range_ in BlobFile were not properly synchronized.
The patch fixes this and also makes sure the invariant that obsolete_files_
is a subset of blob_files_ holds even when an attempt to delete an obsolete
blob file fails.

Test Plan:
COMPILE_WITH_TSAN=1 make blob_db_test
gtest-parallel --repeat=1000 ./blob_db_test

The test fails with TSAN errors ~20 times out of 1000 in the test case ShutdownWait
without the patch but completes successfully 1000 out of 1000 times with the fix.