### PR TITLE
WriteUnPrepared: support iterating while writing to transaction

### DIFF
--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -592,14 +592,14 @@ TEST_P(WriteUnpreparedTransactionTest, IterateAndWrite) {
       }
 
       if (a == DELETE) {
-        txn->Delete(iter->key());
+        ASSERT_OK(txn->Delete(iter->key()));
       } else {
-        txn->Put(iter->key(), "b");
+        ASSERT_OK(txn->Put(iter->key(), "b"));
       }
     }
 
     delete iter;
-    txn->Commit();
+    ASSERT_OK(txn->Commit());
 
     iter = db->NewIterator(roptions);
     if (a == DELETE) {

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -570,9 +570,9 @@ TEST_P(WriteUnpreparedTransactionTest, IterateAndWrite) {
   TransactionOptions txn_options;
   txn_options.write_batch_flush_threshold = 1;
 
-  enum Action { DELETE, UPDATE };
+  enum Action { DO_DELETE, DO_UPDATE };
 
-  for (Action a : {DELETE, UPDATE}) {
+  for (Action a : {DO_DELETE, DO_UPDATE}) {
     for (int i = 0; i < 100; i++) {
       ASSERT_OK(db->Put(woptions, ToString(i), ToString(i)));
     }
@@ -591,7 +591,7 @@ TEST_P(WriteUnpreparedTransactionTest, IterateAndWrite) {
         ASSERT_EQ(iter->key().ToString(), iter->value().ToString());
       }
 
-      if (a == DELETE) {
+      if (a == DO_DELETE) {
         ASSERT_OK(txn->Delete(iter->key()));
       } else {
         ASSERT_OK(txn->Put(iter->key(), "b"));
@@ -602,7 +602,7 @@ TEST_P(WriteUnpreparedTransactionTest, IterateAndWrite) {
     ASSERT_OK(txn->Commit());
 
     iter = db->NewIterator(roptions);
-    if (a == DELETE) {
+    if (a == DO_DELETE) {
       // Check that db is empty.
       iter->SeekToFirst();
       ASSERT_FALSE(iter->Valid());

--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -564,6 +564,63 @@ TEST_P(WriteUnpreparedTransactionTest, NoSnapshotWrite) {
   delete txn;
 }
 
+// Test whether write to a transaction while iterating is supported.
+TEST_P(WriteUnpreparedTransactionTest, IterateAndWrite) {
+  WriteOptions woptions;
+  TransactionOptions txn_options;
+  txn_options.write_batch_flush_threshold = 1;
+
+  enum Action { DELETE, UPDATE };
+
+  for (Action a : {DELETE, UPDATE}) {
+    for (int i = 0; i < 100; i++) {
+      ASSERT_OK(db->Put(woptions, ToString(i), ToString(i)));
+    }
+
+    Transaction* txn = db->BeginTransaction(woptions, txn_options);
+    // write_batch_ now contains 1 key.
+    ASSERT_OK(txn->Put("9", "a"));
+
+    ReadOptions roptions;
+    auto iter = txn->GetIterator(roptions);
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      ASSERT_OK(iter->status());
+      if (iter->key() == "9") {
+        ASSERT_EQ(iter->value().ToString(), "a");
+      } else {
+        ASSERT_EQ(iter->key().ToString(), iter->value().ToString());
+      }
+
+      if (a == DELETE) {
+        txn->Delete(iter->key());
+      } else {
+        txn->Put(iter->key(), "b");
+      }
+    }
+
+    delete iter;
+    txn->Commit();
+
+    iter = db->NewIterator(roptions);
+    if (a == DELETE) {
+      // Check that db is empty.
+      iter->SeekToFirst();
+      ASSERT_FALSE(iter->Valid());
+    } else {
+      int keys = 0;
+      // Check that all values are updated to b.
+      for (iter->SeekToFirst(); iter->Valid(); iter->Next(), keys++) {
+        ASSERT_OK(iter->status());
+        ASSERT_EQ(iter->value().ToString(), "b");
+      }
+      ASSERT_EQ(keys, 100);
+    }
+
+    delete iter;
+    delete txn;
+  }
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -160,6 +160,12 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
     return last_log_number_;
   }
 
+  void RemoveActiveIterator(Iterator* iter) {
+    active_iterators_.erase(
+        std::remove(active_iterators_.begin(), active_iterators_.end(), iter),
+        active_iterators_.end());
+  }
+
  protected:
   void Initialize(const TransactionOptions& txn_options) override;
 
@@ -302,6 +308,13 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   std::unique_ptr<autovector<WriteUnpreparedTxn::SavePoint>>
       flushed_save_points_;
   std::unique_ptr<autovector<size_t>> unflushed_save_points_;
+
+  // It is currently unsafe to flush a write batch if there are active iterators
+  // created from this transaction. This is because we use WriteBatchWithIndex
+  // to do merging reads from the DB and the write batch. If we flush the write
+  // batch, it is possible that the delta iterator on the iterator will point to
+  // invalid memory.
+  std::vector<Iterator*> active_iterators_;
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
In MyRocks, there are cases where we write while iterating through keys. This currently breaks WBWIIterator, because if a write batch flushes during iteration, the delta iterator would point to invalid memory.

For now, fix by disallowing flush if there are active iterators. In the future, we will loop through all the iterators on a transaction, and refresh the iterators when a write batch is flushed.