### PR TITLE
Fix double deletion in transaction_test

### DIFF
--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -170,8 +170,6 @@ class TransactionTestBase : public ::testing::Test {
     }
     if (!s.ok()) {
       delete stackable_db;
-      // just in case it was not deleted (and not set to nullptr).
-      delete root_db;
     }
     return s;
   }
@@ -207,8 +205,6 @@ class TransactionTestBase : public ::testing::Test {
     delete handles[0];
     if (!s.ok()) {
       delete stackable_db;
-      // just in case it was not deleted (and not set to nullptr).
-      delete root_db;
     }
     return s;
   }


### PR DESCRIPTION
Fix the following clang analyze failures:
```
In file included from utilities/transactions/transaction_test.cc:8:
./utilities/transactions/transaction_test.h:174:14: warning: Attempt to delete released memory
      delete root_db;
             ^
```
The destructor of StackableDB already deletes the root db and there is no need to delete the db separately.
test plan:  USE_CLANG=1 TEST_TMPDIR=/dev/shm/rocksdb OPT=-g make -j24 analyze