### PR TITLE
ThreadPoolImpl::Impl::BGThreadWrapper() returns void

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -99,7 +99,7 @@ struct ThreadPoolImpl::Impl {
 
 private:
 
-  static void* BGThreadWrapper(void* arg);
+  static void BGThreadWrapper(void* arg);
 
   bool low_io_priority_;
   bool low_cpu_priority_;
@@ -275,7 +275,7 @@ struct BGThreadMetadata {
       : thread_pool_(thread_pool), thread_id_(thread_id) {}
 };
 
-void* ThreadPoolImpl::Impl::BGThreadWrapper(void* arg) {
+void ThreadPoolImpl::Impl::BGThreadWrapper(void* arg) {
   BGThreadMetadata* meta = reinterpret_cast<BGThreadMetadata*>(arg);
   size_t thread_id = meta->thread_id_;
   ThreadPoolImpl::Impl* tp = meta->thread_pool_;
@@ -298,7 +298,7 @@ void* ThreadPoolImpl::Impl::BGThreadWrapper(void* arg) {
       break;
     case Env::Priority::TOTAL:
       assert(false);
-      return nullptr;
+      return;
   }
   assert(thread_type != ThreadStatus::NUM_THREAD_TYPES);
   ThreadStatusUtil::RegisterThread(tp->GetHostEnv(), thread_type);
@@ -308,7 +308,7 @@ void* ThreadPoolImpl::Impl::BGThreadWrapper(void* arg) {
 #ifdef ROCKSDB_USING_THREAD_STATUS
   ThreadStatusUtil::UnregisterThread();
 #endif
-  return nullptr;
+  return;
 }
 
 void ThreadPoolImpl::Impl::SetBackgroundThreadsInternal(int num,


### PR DESCRIPTION
there is no need to return void*, as
std::thread::thread(Func&& f, Args&&... args ) only requires `Func` to
be callable.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>