### PR TITLE
Introduce IngestExternalFileOptions.verify_checksums_readahead_size

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 * Fixed a number of data races in BlobDB.
 ### New Features
-* VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size. For checksum verifying before external SST file ingestion, a new option IngestExternalFileOptions.verify_checksums_readahead_size for this readahead setting.
+* VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size. For checksum verifying before external SST file ingestion, a new option IngestExternalFileOptions.verify_checksums_readahead_size, is added for this readahead setting.
 
 ## 6.4.0 (7/30/2019)
 ### Default Option Change

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 * Fixed a number of data races in BlobDB.
 ### New Features
-* VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size.
+* VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size. For checksum verifying before external SST file ingestion, a new option IngestExternalFileOptions.verify_checksums_readahead_size for this readahead setting.
 
 ## 6.4.0 (7/30/2019)
 ### Default Option Change

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -350,8 +350,10 @@ Status ExternalSstFileIngestionJob::GetIngestedFileInfo(
     // If customized readahead size is needed, we can pass a user option
     // all the way to here. Right now we just rely on the default readahead
     // to keep things simple.
+    ReadOptions ro;
+    ro.readahead_size = ingestion_options_.verify_checksums_readahead_size;
     status = table_reader->VerifyChecksum(
-        ReadOptions(), TableReaderCaller::kExternalSSTIngestion);
+        ro, TableReaderCaller::kExternalSSTIngestion);
   }
   if (!status.ok()) {
     return status;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1477,6 +1477,13 @@ struct IngestExternalFileOptions {
   // Warning: setting this to true causes slowdown in file ingestion because
   // the external SST file has to be read.
   bool verify_checksums_before_ingest = false;
+  // When verify_checksums_before_ingest = true, RocksDB uses default
+  // readahead setting to scan the file while verifying checksums before
+  // ingestion.
+  // Users can override the default value using this option.
+  // Using a large readahead size (> 2MB) can typically improve the performance
+  // of forward iteration on spinning disks.
+  size_t verify_checksums_readahead_size = 0;
 };
 
 enum TraceFilterType : uint64_t {


### PR DESCRIPTION
Summary:
Recently readahead is introduced for checksum verifying. However, users cannot override the setting for the checksum verifying before external SST file ingestion. Introduce a new option for the purpose.

Test Plan: Add a new unit test for it.