### PR TITLE
Lower the risk for users to run options.force_consistency_checks = true

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Fix bloom filter lookups by the MultiGet batching API when BlockBasedTableOptions::whole_key_filtering is false, by checking that a key is in the perfix_extractor domain and extracting the prefix before looking up.
 ### New Features
 * VerifyChecksum() by default will issue readahead. Allow ReadOptions to be passed in to those functions to override the readhead size. For checksum verifying before external SST file ingestion, a new option IngestExternalFileOptions.verify_checksums_readahead_size, is added for this readahead setting.
+* When user uses options.force_consistency_check in RocksDb, instead of crashing the process, we now pass the error back to the users without killing the process.
 ### Public API Change
 * Added max_write_buffer_size_to_maintain option to better control memory usage of immutable memtables.
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -4662,35 +4662,26 @@ TEST_F(DBCompactionTest, ConsistencyFailTest) {
   Options options = CurrentOptions();
   DestroyAndReopen(options);
 
-  const int kKeySize = 16;
-  const int kKvSize = 1000;
   rocksdb::SyncPoint::GetInstance()->SetCallBack(
       "VersionBuilder::CheckConsistency", [&](void* arg) {
-        auto* p =
-        reinterpret_cast<std::pair<FileMetaData**, FileMetaData**>*>(arg);
+      auto p =
+            reinterpret_cast<std::pair<FileMetaData**, FileMetaData**>*>(arg);
         // just swap the two FileMetaData so that we hit error
         // in CheckConsistency funcion
-        auto temp = *(p->first);
+        FileMetaData* temp = *(p->first);
         *(p->first) = *(p->second);
         *(p->second) = temp;
       });
 
-
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
 
-  Random rnd(301);
-  std::vector<std::string> keys;
-  std::vector<std::string> values;
   for (int k = 0; k < 2; ++k) {
-    keys.emplace_back(RandomString(&rnd, kKeySize));
-    values.emplace_back(RandomString(&rnd, kKvSize - kKeySize));
-    ASSERT_OK(Put(Slice(keys[k]), Slice(values[k])));
+    ASSERT_OK(Put("foo", "bar"));
     Flush();
   }
 
-  ASSERT_NOK(Put(Slice(keys[0]), Slice(keys[0])));
+  ASSERT_NOK(Put("foo", "bar"));
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
-
 }
 #endif // !defined(ROCKSDB_LITE)
 }  // namespace rocksdb

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -255,7 +255,7 @@ class VersionBuilder::Rep {
     }
     if (!found) {
       fprintf(stderr, "not found %" PRIu64 "\n", number);
-      return Status::Corruption("not found "+ number);
+      return Status::Corruption("not found "+ NumberToString(number));
     }
     return Status::OK();
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -153,6 +153,9 @@ class VersionBuilder::Rep {
       for (size_t i = 1; i < level_files.size(); i++) {
         auto f1 = level_files[i - 1];
         auto f2 = level_files[i];
+        auto pair = std::make_pair(&f1,&f2);
+        TEST_SYNC_POINT_CALLBACK(
+            "VersionBuilder::CheckConsistency", &pair);
         if (level == 0) {
           if (!level_zero_cmp_(f1, f2)) {
             fprintf(stderr, "L0 files are not sorted properly");

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -27,6 +27,7 @@
 #include "db/version_set.h"
 #include "port/port.h"
 #include "table/table_reader.h"
+#include "util/string_util.h"
 
 namespace rocksdb {
 
@@ -138,12 +139,12 @@ class VersionBuilder::Rep {
     }
   }
 
-  void CheckConsistency(VersionStorageInfo* vstorage) {
+  Status CheckConsistency(VersionStorageInfo* vstorage) {
 #ifdef NDEBUG
     if (!vstorage->force_consistency_checks()) {
       // Dont run consistency checks in release mode except if
       // explicitly asked to
-      return;
+      return Status::OK();
     }
 #endif
     // make sure the files are sorted correctly
@@ -155,7 +156,7 @@ class VersionBuilder::Rep {
         if (level == 0) {
           if (!level_zero_cmp_(f1, f2)) {
             fprintf(stderr, "L0 files are not sorted properly");
-            abort();
+            return Status::Corruption("L0 files are not sorted properly");
           }
 
           if (f2->fd.smallest_seqno == f2->fd.largest_seqno) {
@@ -168,7 +169,11 @@ class VersionBuilder::Rep {
                       " vs. file with global_seqno %" PRIu64 "\n",
                       f1->fd.smallest_seqno, f1->fd.largest_seqno,
                       external_file_seqno);
-              abort();
+              return Status::Corruption(
+                  "L0 file with seqno " + NumberToString(f1->fd.smallest_seqno) +
+                  " " + NumberToString(f1->fd.largest_seqno) +
+                  " vs. file with global_seqno"
+                  + NumberToString(external_file_seqno));
             }
           } else if (f1->fd.smallest_seqno <= f2->fd.smallest_seqno) {
             fprintf(stderr,
@@ -176,12 +181,17 @@ class VersionBuilder::Rep {
                     " %" PRIu64 "\n",
                     f1->fd.smallest_seqno, f1->fd.largest_seqno,
                     f2->fd.smallest_seqno, f2->fd.largest_seqno);
-            abort();
+            return Status::Corruption(
+                "L0 files seqno " + NumberToString(f1->fd.smallest_seqno) + " "
+                + NumberToString(f1->fd.largest_seqno) + " vs. "
+                + NumberToString(f2->fd.smallest_seqno)
+                + " " + NumberToString(f2->fd.largest_seqno));
           }
         } else {
           if (!level_nonzero_cmp_(f1, f2)) {
             fprintf(stderr, "L%d files are not sorted properly", level);
-            abort();
+            return Status::Corruption("L" + NumberToString(level) +
+                " files are not sorted properly");
           }
 
           // Make sure there is no overlap in levels > 0
@@ -190,20 +200,24 @@ class VersionBuilder::Rep {
             fprintf(stderr, "L%d have overlapping ranges %s vs. %s\n", level,
                     (f1->largest).DebugString(true).c_str(),
                     (f2->smallest).DebugString(true).c_str());
-            abort();
+            return Status::Corruption("L" + NumberToString(level)
+                + " have overlapping ranges "
+                + (f1->largest).DebugString(true) + " vs. "
+                + (f2->smallest).DebugString(true));
           }
         }
       }
     }
+    return Status::OK();
   }
 
-  void CheckConsistencyForDeletes(VersionEdit* /*edit*/, uint64_t number,
+  Status CheckConsistencyForDeletes(VersionEdit* /*edit*/, uint64_t number,
                                   int level) {
 #ifdef NDEBUG
     if (!base_vstorage_->force_consistency_checks()) {
       // Dont run consistency checks in release mode except if
       // explicitly asked to
-      return;
+      return Status::OK();
     }
 #endif
     // a file to be deleted better exist in the previous version
@@ -241,8 +255,9 @@ class VersionBuilder::Rep {
     }
     if (!found) {
       fprintf(stderr, "not found %" PRIu64 "\n", number);
-      abort();
+      return Status::Corruption("not found "+ number);
     }
+    return Status::OK();
   }
 
   bool CheckConsistencyForNumLevels() {
@@ -259,8 +274,11 @@ class VersionBuilder::Rep {
   }
 
   // Apply all of the edits in *edit to the current state.
-  void Apply(VersionEdit* edit) {
-    CheckConsistency(base_vstorage_);
+  Status Apply(VersionEdit* edit) {
+    Status s = CheckConsistency(base_vstorage_);
+    if (!s.ok()) {
+      return s;
+    }
 
     // Delete files
     const VersionEdit::DeletedFileSet& del = edit->GetDeletedFiles();
@@ -308,12 +326,20 @@ class VersionBuilder::Rep {
         }
       }
     }
+    return s;
   }
 
   // Save the current state in *v.
-  void SaveTo(VersionStorageInfo* vstorage) {
-    CheckConsistency(base_vstorage_);
-    CheckConsistency(vstorage);
+  Status SaveTo(VersionStorageInfo* vstorage) {
+    Status s = CheckConsistency(base_vstorage_);
+    if (!s.ok()) {
+      return s;
+    }
+
+    s = CheckConsistency(vstorage);
+    if (!s.ok()) {
+      return s;
+    }
 
     for (int level = 0; level < num_levels_; level++) {
       const auto& cmp = (level == 0) ? level_zero_cmp_ : level_nonzero_cmp_;
@@ -357,7 +383,8 @@ class VersionBuilder::Rep {
       }
     }
 
-    CheckConsistency(vstorage);
+    s = CheckConsistency(vstorage);
+    return s;
   }
 
   Status LoadTableHandlers(InternalStats* internal_stats, int max_threads,
@@ -475,23 +502,23 @@ VersionBuilder::VersionBuilder(const EnvOptions& env_options,
 
 VersionBuilder::~VersionBuilder() { delete rep_; }
 
-void VersionBuilder::CheckConsistency(VersionStorageInfo* vstorage) {
-  rep_->CheckConsistency(vstorage);
+Status VersionBuilder::CheckConsistency(VersionStorageInfo* vstorage) {
+  return rep_->CheckConsistency(vstorage);
 }
 
-void VersionBuilder::CheckConsistencyForDeletes(VersionEdit* edit,
+Status VersionBuilder::CheckConsistencyForDeletes(VersionEdit* edit,
                                                 uint64_t number, int level) {
-  rep_->CheckConsistencyForDeletes(edit, number, level);
+  return rep_->CheckConsistencyForDeletes(edit, number, level);
 }
 
 bool VersionBuilder::CheckConsistencyForNumLevels() {
   return rep_->CheckConsistencyForNumLevels();
 }
 
-void VersionBuilder::Apply(VersionEdit* edit) { rep_->Apply(edit); }
+Status VersionBuilder::Apply(VersionEdit* edit) { return rep_->Apply(edit); }
 
-void VersionBuilder::SaveTo(VersionStorageInfo* vstorage) {
-  rep_->SaveTo(vstorage);
+Status VersionBuilder::SaveTo(VersionStorageInfo* vstorage) {
+  return rep_->SaveTo(vstorage);
 }
 
 Status VersionBuilder::LoadTableHandlers(

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -153,8 +153,10 @@ class VersionBuilder::Rep {
       for (size_t i = 1; i < level_files.size(); i++) {
         auto f1 = level_files[i - 1];
         auto f2 = level_files[i];
+#ifndef NDEBUG
         auto pair = std::make_pair(&f1, &f2);
         TEST_SYNC_POINT_CALLBACK("VersionBuilder::CheckConsistency", &pair);
+#endif
         if (level == 0) {
           if (!level_zero_cmp_(f1, f2)) {
             fprintf(stderr, "L0 files are not sorted properly");

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -27,12 +27,12 @@ class VersionBuilder {
   VersionBuilder(const EnvOptions& env_options, TableCache* table_cache,
                  VersionStorageInfo* base_vstorage, Logger* info_log = nullptr);
   ~VersionBuilder();
-  void CheckConsistency(VersionStorageInfo* vstorage);
-  void CheckConsistencyForDeletes(VersionEdit* edit, uint64_t number,
+  Status CheckConsistency(VersionStorageInfo* vstorage);
+  Status CheckConsistencyForDeletes(VersionEdit* edit, uint64_t number,
                                   int level);
   bool CheckConsistencyForNumLevels();
-  void Apply(VersionEdit* edit);
-  void SaveTo(VersionStorageInfo* vstorage);
+  Status Apply(VersionEdit* edit);
+  Status SaveTo(VersionStorageInfo* vstorage);
   Status LoadTableHandlers(InternalStats* internal_stats, int max_threads,
                            bool prefetch_index_and_filter_in_cache,
                            bool is_initial_load,

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -29,7 +29,7 @@ class VersionBuilder {
   ~VersionBuilder();
   Status CheckConsistency(VersionStorageInfo* vstorage);
   Status CheckConsistencyForDeletes(VersionEdit* edit, uint64_t number,
-                                  int level);
+                                    int level);
   bool CheckConsistencyForNumLevels();
   Status Apply(VersionEdit* edit);
   Status SaveTo(VersionStorageInfo* vstorage);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3633,7 +3633,10 @@ Status VersionSet::ProcessManifestWrites(
       assert(!builder_guards.empty() &&
              builder_guards.size() == versions.size());
       auto* builder = builder_guards[i]->version_builder();
-      builder->SaveTo(versions[i]->storage_info());
+      Status s = builder->SaveTo(versions[i]->storage_info());
+      if (!s.ok()) {
+        return s;
+      }
     }
   }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4017,8 +4017,8 @@ void VersionSet::LogAndApplyCFHelper(VersionEdit* edit) {
 }
 
 Status VersionSet::LogAndApplyHelper(ColumnFamilyData* cfd,
-                                   VersionBuilder* builder, VersionEdit* edit,
-                                   InstrumentedMutex* mu) {
+                                     VersionBuilder* builder, VersionEdit* edit,
+                                     InstrumentedMutex* mu) {
 #ifdef NDEBUG
   (void)cfd;
 #endif
@@ -4138,7 +4138,7 @@ Status VersionSet::ApplyOneVersionEditToBuilder(
     auto builder = builders.find(edit.column_family_);
     assert(builder != builders.end());
     Status s = builder->second->version_builder()->Apply(&edit);
-    if(!s.ok()) {
+    if (!s.ok()) {
       return s;
     }
   }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3624,6 +3624,10 @@ Status VersionSet::ProcessManifestWrites(
         }
         Status s = LogAndApplyHelper(last_writer->cfd, builder, e, mu);
         if (!s.ok()) {
+          // free up the allocated memory
+          for (auto v : versions) {
+            delete v;
+          }
           return s;
         }
         batch_edits.push_back(e);
@@ -3635,6 +3639,10 @@ Status VersionSet::ProcessManifestWrites(
       auto* builder = builder_guards[i]->version_builder();
       Status s = builder->SaveTo(versions[i]->storage_info());
       if (!s.ok()) {
+        // free up the allocated memory
+        for (auto v : versions) {
+          delete v;
+        }
         return s;
       }
     }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1154,7 +1154,7 @@ class VersionSet {
                                const ColumnFamilyOptions* new_cf_options);
 
   void LogAndApplyCFHelper(VersionEdit* edit);
-  void LogAndApplyHelper(ColumnFamilyData* cfd, VersionBuilder* b,
+  Status LogAndApplyHelper(ColumnFamilyData* cfd, VersionBuilder* b,
                          VersionEdit* edit, InstrumentedMutex* mu);
 };
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1155,7 +1155,7 @@ class VersionSet {
 
   void LogAndApplyCFHelper(VersionEdit* edit);
   Status LogAndApplyHelper(ColumnFamilyData* cfd, VersionBuilder* b,
-                         VersionEdit* edit, InstrumentedMutex* mu);
+                           VersionEdit* edit, InstrumentedMutex* mu);
 };
 
 // ReactiveVersionSet represents a collection of versions of the column


### PR DESCRIPTION
Open-source users recently reported two occurrences of LSM-tree corruption (https://github.com/facebook/rocksdb/issues/5558 is one), which would be caught by options.force_consistency_checks = true. options.force_consistency_checks has a usability limitation because it crashes the service once inconsistency is detected. This makes the feature hard to use. Most users serve from multiple RocksDB shards per server and the impacts of crashing the service is higher than it should be.

Instead, we just pass the error back to users without killing the service, and ask them to deal with the problem accordingly. 
