### PR TITLE
crash_test to skip compaction TTL for FIFO compaction.

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -170,6 +170,10 @@ def finalize_and_sanitize(src_params):
         # with open_files = -1
         dest_params["compaction_ttl"] = 0
         dest_params["periodic_compaction_seconds"] = 0
+    if dest_params.get("compaction_style", 0) == 2:
+        # Disable compaction TTL in FIFO compaction, because right
+        # now assertion failures are triggered.
+        dest_params["compaction_ttl"] = 0
     return dest_params
 
 


### PR DESCRIPTION
Summary: https://github.com/facebook/rocksdb/pull/5741 added compaction TTL to crash test, but it causes assertion fails for FIFO compaction. Disable this combination for now while we debug the assertion failure.

Test Plan: Run crash test and observe that when compaction_style=2, compaction_ttl is always 0.