### PR TITLE
Skip certain files during ingest cleanup

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -291,6 +291,12 @@ void ExternalSstFileIngestionJob::Cleanup(const Status& status) {
     // We failed to add the files to the database
     // remove all the files we copied
     for (IngestedFileInfo& f : files_to_ingest_) {
+      // If internal_file_path is empty str, we have reached the first file
+      // that has not been linked/copied successfully, thus no need to iterate
+      // over the rest of files_to_ingest_.
+      if (f.internal_file_path.empty()) {
+        break;
+      }
       Status s = env_->DeleteFile(f.internal_file_path);
       if (!s.ok()) {
         ROCKS_LOG_WARN(db_options_.info_log,

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -160,7 +160,7 @@ Status ExternalSstFileIngestionJob::Prepare(
     // We failed, remove all files that we copied into the db
     for (IngestedFileInfo& f : files_to_ingest_) {
       if (f.internal_file_path.empty()) {
-        break;
+        continue;
       }
       Status s = env_->DeleteFile(f.internal_file_path);
       if (!s.ok()) {
@@ -295,7 +295,7 @@ void ExternalSstFileIngestionJob::Cleanup(const Status& status) {
       // that has not been linked/copied successfully, thus no need to iterate
       // over the rest of files_to_ingest_.
       if (f.internal_file_path.empty()) {
-        break;
+        continue;
       }
       Status s = env_->DeleteFile(f.internal_file_path);
       if (!s.ok()) {


### PR DESCRIPTION
During cleanup phase of external file ingestion, we do not need to perform
unlink operation on certain internal db path if the corresponding file has not
been linked or copied successfully during prepare phase.

Test plan (on devserver)
```
$make all && make check
```