### PR TITLE
Remove some code duplication in bloom filter code

### DIFF
--- a/table/full_filter_bits_builder.h
+++ b/table/full_filter_bits_builder.h
@@ -56,9 +56,6 @@ class FullFilterBitsBuilder : public FilterBitsBuilder {
   size_t num_probes_;
   std::vector<uint32_t> hash_entries_;
 
-  // Get totalbits that optimized for cpu cache line
-  uint32_t GetTotalBitsForLocality(uint32_t total_bits);
-
   // Reserve space for new filter
   char* ReserveSpace(const int num_entry, uint32_t* total_bits,
                      uint32_t* num_lines);
@@ -70,5 +67,18 @@ class FullFilterBitsBuilder : public FilterBitsBuilder {
   FullFilterBitsBuilder(const FullFilterBitsBuilder&);
   void operator=(const FullFilterBitsBuilder&);
 };
+
+inline uint32_t GetTotalBitsForLocality(uint32_t total_bits) {
+  uint32_t num_blocks =
+      (total_bits + CACHE_LINE_SIZE * 8 - 1) / (CACHE_LINE_SIZE * 8);
+
+  // Make num_blocks an odd number to make sure more bits are involved
+  // when determining which block
+  if (num_blocks % 2 == 0) {
+    num_blocks++;
+  }
+
+  return num_blocks * (CACHE_LINE_SIZE * 8);
+}
 
 }  // namespace rocksdb

--- a/table/plain/plain_table_bloom.cc
+++ b/table/plain/plain_table_bloom.cc
@@ -7,28 +7,13 @@
 
 #include <string>
 #include <algorithm>
+#include "table/full_filter_bits_builder.h"
 #include "util/dynamic_bloom.h"
 
 #include "memory/allocator.h"
 
 
 namespace rocksdb {
-
-namespace {
-
-uint32_t GetTotalBitsForLocality(uint32_t total_bits) {
-  uint32_t num_blocks =
-      (total_bits + CACHE_LINE_SIZE * 8 - 1) / (CACHE_LINE_SIZE * 8);
-
-  // Make num_blocks an odd number to make sure more bits are involved
-  // when determining which block.
-  if (num_blocks % 2 == 0) {
-    num_blocks++;
-  }
-
-  return num_blocks * (CACHE_LINE_SIZE * 8);
-}
-}
 
 PlainTableBloomV1::PlainTableBloomV1(uint32_t num_probes)
     : kTotalBits(0), kNumBlocks(0), kNumProbes(num_probes), data_(nullptr) {}

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -57,18 +57,6 @@ FullFilterBitsBuilder::FullFilterBitsBuilder(const size_t bits_per_key,
     return Slice(data, total_bits / 8 + 5);
   }
 
-uint32_t FullFilterBitsBuilder::GetTotalBitsForLocality(uint32_t total_bits) {
-  uint32_t num_lines =
-      (total_bits + CACHE_LINE_SIZE * 8 - 1) / (CACHE_LINE_SIZE * 8);
-
-  // Make num_lines an odd number to make sure more bits are involved
-  // when determining which block.
-  if (num_lines % 2 == 0) {
-    num_lines++;
-  }
-  return num_lines * (CACHE_LINE_SIZE * 8);
-}
-
 uint32_t FullFilterBitsBuilder::CalculateSpace(const int num_entry,
                                                uint32_t* total_bits,
                                                uint32_t* num_lines) {

--- a/util/dynamic_bloom.cc
+++ b/util/dynamic_bloom.cc
@@ -10,6 +10,7 @@
 #include "memory/allocator.h"
 #include "port/port.h"
 #include "rocksdb/slice.h"
+#include "table/full_filter_bits_builder.h"
 #include "util/hash.h"
 
 namespace rocksdb {


### PR DESCRIPTION
Consolidate multiple definitions of ```GetTotalBitsForLocality()``` into one inline function. The duplication was also causing a failure in the Sandcastle unity test.

Test plan:
make check
make asan_check
make unity_test