### PR TITLE
Use unique_ptr in writebatch hint

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -469,7 +469,8 @@ MemTable::MemTableStats MemTable::ApproximateStats(const Slice& start_ikey,
 bool MemTable::Add(SequenceNumber s, ValueType type,
                    const Slice& key, /* user key */
                    const Slice& value, bool allow_concurrent,
-                   MemTablePostProcessInfo* post_process_info, void** hint) {
+                   MemTablePostProcessInfo* post_process_info,
+                   std::unique_ptr<char[]>* hint) {
   // Format of an entry is concatenation of:
   //  key_size     : varint32 of internal_key.size()
   //  key bytes    : char[internal_key.size()]

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -183,7 +183,7 @@ class MemTable {
   bool Add(SequenceNumber seq, ValueType type, const Slice& key,
            const Slice& value, bool allow_concurrent = false,
            MemTablePostProcessInfo* post_process_info = nullptr,
-           void** hint = nullptr);
+           std::unique_ptr<char[]>* hint = nullptr);
 
   // Used to Get value associated with key or Get Merge Operands associated
   // with key.

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1229,7 +1229,7 @@ class MemTableInserter : public WriteBatch::Handler {
   bool hint_per_batch_;
   bool hint_created_;
   // Hints for this batch
-  using HintMap = std::unordered_map<MemTable*, void*>;
+  using HintMap = std::unordered_map<MemTable*, std::unique_ptr<char[]>>;
   using HintMapType = std::aligned_storage<sizeof(HintMap)>::type;
   HintMapType hint_;
 
@@ -1315,9 +1315,6 @@ class MemTableInserter : public WriteBatch::Handler {
         (&mem_post_info_map_)->~MemPostInfoMap();
     }
     if (hint_created_) {
-      for (auto iter : GetHintMap()) {
-        delete[] reinterpret_cast<char*>(iter.second);
-      }
       reinterpret_cast<HintMap*>(&hint_)->~HintMap();
     }
     delete rebuilding_trx_;

--- a/include/rocksdb/memtablerep.h
+++ b/include/rocksdb/memtablerep.h
@@ -129,7 +129,8 @@ class MemTableRep {
   //
   // Currently only skip-list based memtable implement the interface. Other
   // implementations will fallback to InsertConcurrently() by default.
-  virtual void InsertWithHintConcurrently(KeyHandle handle, void** /*hint*/) {
+  virtual void InsertWithHintConcurrently(KeyHandle handle,
+                                          std::unique_ptr<char[]>* /*hint*/) {
     // Ignore the hint by default.
     InsertConcurrently(handle);
   }
@@ -137,7 +138,8 @@ class MemTableRep {
   // Same as ::InsertWithHintConcurrently
   // Returns false if MemTableRepFactory::CanHandleDuplicatedKey() is true and
   // the <key, seq> already exists.
-  virtual bool InsertKeyWithHintConcurrently(KeyHandle handle, void** hint) {
+  virtual bool InsertKeyWithHintConcurrently(KeyHandle handle,
+                                             std::unique_ptr<char[]>* hint) {
     InsertWithHintConcurrently(handle, hint);
     return true;
   }

--- a/memtable/inlineskiplist_test.cc
+++ b/memtable/inlineskiplist_test.cc
@@ -418,9 +418,8 @@ class ConcurrentTest {
     char* buf = list_.AllocateKey(sizeof(Key));
     memcpy(buf, &new_key, sizeof(Key));
     if (use_hint) {
-      void* hint = nullptr;
+      std::unique_ptr<char[]> hint = nullptr;
       list_.InsertWithHintConcurrently(buf, &hint);
-      delete[] reinterpret_cast<char*>(hint);
     } else {
       list_.InsertConcurrently(buf);
     }

--- a/memtable/skiplistrep.cc
+++ b/memtable/skiplistrep.cc
@@ -50,11 +50,13 @@ public:
    return skip_list_.InsertWithHint(static_cast<char*>(handle), hint);
  }
 
- void InsertWithHintConcurrently(KeyHandle handle, void** hint) override {
+ void InsertWithHintConcurrently(KeyHandle handle,
+                                 std::unique_ptr<char[]>* hint) override {
    skip_list_.InsertWithHintConcurrently(static_cast<char*>(handle), hint);
  }
 
- bool InsertKeyWithHintConcurrently(KeyHandle handle, void** hint) override {
+ bool InsertKeyWithHintConcurrently(KeyHandle handle,
+                                    std::unique_ptr<char[]>* hint) override {
    return skip_list_.InsertWithHintConcurrently(static_cast<char*>(handle),
                                                 hint);
  }


### PR DESCRIPTION
Improve #5728, use unique_ptr in writebatch hint to make ownership more clear.