### PR TITLE
Dedup IsFileSectorAligned() to fix unity build.

### DIFF
--- a/file/read_write_util.cc
+++ b/file/read_write_util.cc
@@ -58,4 +58,9 @@ bool ReadOneLine(std::istringstream* iss, SequentialFile* seq_file,
   return *has_data || has_complete_line;
 }
 
+#ifndef NDEBUG
+bool IsFileSectorAligned(const size_t off, size_t sector_size) {
+  return off % sector_size == 0;
+}
+#endif  // NDEBUG
 }  // namespace rocksdb

--- a/file/read_write_util.h
+++ b/file/read_write_util.h
@@ -26,4 +26,9 @@ extern Status NewWritableFile(Env* env, const std::string& fname,
 bool ReadOneLine(std::istringstream* iss, SequentialFile* seq_file,
                  std::string* output, bool* has_data, Status* result);
 
+#ifndef NDEBUG
+bool IsFileSectorAligned(const size_t off, size_t sector_size) {
+  return off % sector_size == 0;
+}
+#endif  // NDEBUG
 }  // namespace rocksdb

--- a/file/read_write_util.h
+++ b/file/read_write_util.h
@@ -27,8 +27,6 @@ bool ReadOneLine(std::istringstream* iss, SequentialFile* seq_file,
                  std::string* output, bool* has_data, Status* result);
 
 #ifndef NDEBUG
-bool IsFileSectorAligned(const size_t off, size_t sector_size) {
-  return off % sector_size == 0;
-}
+bool IsFileSectorAligned(const size_t off, size_t sector_size);
 #endif  // NDEBUG
 }  // namespace rocksdb

--- a/file/readahead_raf.cc
+++ b/file/readahead_raf.cc
@@ -15,15 +15,6 @@
 #include "util/rate_limiter.h"
 
 namespace rocksdb {
-
-#ifndef NDEBUG
-namespace {
-bool IsFileSectorAligned(const size_t off, size_t sector_size) {
-  return off % sector_size == 0;
-}
-}  // namespace
-#endif
-
 namespace {
 class ReadaheadRandomAccessFile : public RandomAccessFile {
  public:

--- a/file/readahead_raf.cc
+++ b/file/readahead_raf.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include "file/read_write_util.h"
 #include "util/aligned_buffer.h"
 #include "util/rate_limiter.h"
 

--- a/file/sequence_file_reader.cc
+++ b/file/sequence_file_reader.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <mutex>
 
+#include "file/read_write_util.h"
 #include "monitoring/histogram.h"
 #include "monitoring/iostats_context_imp.h"
 #include "port/port.h"
@@ -21,15 +22,6 @@
 #include "util/rate_limiter.h"
 
 namespace rocksdb {
-
-#ifndef NDEBUG
-namespace {
-bool IsFileSectorAligned(const size_t off, size_t sector_size) {
-  return off % sector_size == 0;
-}
-}  // namespace
-#endif
-
 Status SequentialFileReader::Read(size_t n, Slice* result, char* scratch) {
   Status s;
   if (use_direct_io()) {


### PR DESCRIPTION
Summary:
Unity build fails because of name conflict of IsFileSectorAligned() after recent refactoring. Consolidate the function.

Test Plan: make unity. At least the failure goes away. Also "make all", "make release" and see no regression in normal cases.