### PR TITLE
Make output of sst_dump parseable

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -3080,7 +3080,9 @@ void DumpSstFile(Options options, std::string filename, bool output_hex,
   // no verification
   // TODO: add support for decoding blob indexes in ldb as well
   ROCKSDB_NAMESPACE::SstFileDumper dumper(
-      options, filename, /* verify_checksum */ false, output_hex,
+      options, filename, /* verify_checksum */ false,
+      output_hex,
+      /* output_escape */ false,
       /* decode_blob_index */ false);
   Status st = dumper.ReadSequential(true, std::numeric_limits<uint64_t>::max(),
                                     false,            // has_from

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -18,7 +18,8 @@ namespace ROCKSDB_NAMESPACE {
 class SstFileDumper {
  public:
   explicit SstFileDumper(const Options& options, const std::string& file_name,
-                         bool verify_checksum, bool output_hex,
+                         bool verify_checksum,
+                         bool output_hex, bool output_escape,
                          bool decode_blob_index);
 
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
@@ -66,6 +67,7 @@ class SstFileDumper {
   bool verify_checksum_;
   bool output_hex_;
   bool decode_blob_index_;
+  bool output_escape_;
   EnvOptions soptions_;
 
   // options_ and internal_comparator_ will also be used in


### PR DESCRIPTION
The following patches will make output of the `sst_dump` parseable:
- the first patch will print the whole string, by using `size()`, before the part after `\0` will be ignored
- the second patch adds `--output_escape` to avoid breaking lines (by escaping symbols that can break lines, i.e. `\n` -> `\\n`)