### PR TITLE
MultiGet batching in memtable

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1362,6 +1362,7 @@ class MultiGetPrefixExtractorTest : public DBBasicTest,
 TEST_P(MultiGetPrefixExtractorTest, Batched) {
   Options options = CurrentOptions();
   options.prefix_extractor.reset(NewFixedPrefixTransform(2));
+  options.memtable_prefix_bloom_size_ratio = 10;
   BlockBasedTableOptions bbto;
   if (GetParam()) {
     bbto.index_type = BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
@@ -1379,9 +1380,17 @@ TEST_P(MultiGetPrefixExtractorTest, Batched) {
   ASSERT_OK(Put("kk2", "v2"));
   ASSERT_OK(Put("kk3", "v3"));
   ASSERT_OK(Put("kk4", "v4"));
+  std::vector<std::string> keys({"k", "kk1", "kk2", "kk3", "kk4"});
+  std::vector<std::string> inmem_values;
+  inmem_values = MultiGet(keys, nullptr);
+  ASSERT_EQ(inmem_values[0], "v0");
+  ASSERT_EQ(inmem_values[1], "v1");
+  ASSERT_EQ(inmem_values[2], "v2");
+  ASSERT_EQ(inmem_values[3], "v3");
+  ASSERT_EQ(inmem_values[4], "v4");
+
   ASSERT_OK(Flush());
 
-  std::vector<std::string> keys({"k", "kk1", "kk2", "kk3", "kk4"});
   std::vector<std::string> values;
   SetPerfLevel(kEnableCount);
   get_perf_context()->Reset();

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1374,25 +1374,30 @@ TEST_P(MultiGetPrefixExtractorTest, Batched) {
   options.table_factory.reset(NewBlockBasedTableFactory(bbto));
   Reopen(options);
 
+  SetPerfLevel(kEnableCount);
+  get_perf_context()->Reset();
+
   // First key is not in the prefix_extractor domain
   ASSERT_OK(Put("k", "v0"));
   ASSERT_OK(Put("kk1", "v1"));
   ASSERT_OK(Put("kk2", "v2"));
   ASSERT_OK(Put("kk3", "v3"));
   ASSERT_OK(Put("kk4", "v4"));
-  std::vector<std::string> keys({"k", "kk1", "kk2", "kk3", "kk4"});
+  std::vector<std::string> mem_keys(
+      {"k", "kk1", "kk2", "kk3", "kk4", "rofl", "lmho"});
   std::vector<std::string> inmem_values;
-  inmem_values = MultiGet(keys, nullptr);
+  inmem_values = MultiGet(mem_keys, nullptr);
   ASSERT_EQ(inmem_values[0], "v0");
   ASSERT_EQ(inmem_values[1], "v1");
   ASSERT_EQ(inmem_values[2], "v2");
   ASSERT_EQ(inmem_values[3], "v3");
   ASSERT_EQ(inmem_values[4], "v4");
-
+  ASSERT_EQ(get_perf_context()->bloom_memtable_miss_count, 2);
+  ASSERT_EQ(get_perf_context()->bloom_memtable_hit_count, 5);
   ASSERT_OK(Flush());
 
+  std::vector<std::string> keys({"k", "kk1", "kk2", "kk3", "kk4"});
   std::vector<std::string> values;
-  SetPerfLevel(kEnableCount);
   get_perf_context()->Reset();
   values = MultiGet(keys, nullptr);
   ASSERT_EQ(values[0], "v0");

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1280,6 +1280,8 @@ TEST_F(DBBasicTest, MultiGetBatchedSimpleSorted) {
 TEST_F(DBBasicTest, MultiGetBatchedMultiLevel) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
+  options.memtable_whole_key_filtering = true;
+  options.memtable_prefix_bloom_size_ratio = 10;
   Reopen(options);
   int num_keys = 0;
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1280,8 +1280,6 @@ TEST_F(DBBasicTest, MultiGetBatchedSimpleSorted) {
 TEST_F(DBBasicTest, MultiGetBatchedMultiLevel) {
   Options options = CurrentOptions();
   options.disable_auto_compactions = true;
-  options.memtable_whole_key_filtering = true;
-  options.memtable_prefix_bloom_size_ratio = 10;
   Reopen(options);
   int num_keys = 0;
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -19,6 +19,7 @@
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <iostream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -1959,6 +1960,7 @@ void DBImpl::MultiGetImpl(
     bool lookup_current = false;
 
     keys_left -= batch_size;
+//    uint64_t start = env_->NowMicros();
 //    for (auto mget_iter = range.begin(); mget_iter != range.end();
 //         ++mget_iter) {
 //      MergeContext& merge_context = mget_iter->merge_context;
@@ -1995,7 +1997,10 @@ void DBImpl::MultiGetImpl(
 //        lookup_current = true;
 //      }
 //    }
+//    uint64_t end = env_->NowMicros();
+//    std::cout << "Total time: " << (end-start);
 
+    uint64_t start = env_->NowMicros();
     for (auto mget_iter = range.begin(); mget_iter != range.end();
          ++mget_iter) {
       mget_iter->merge_context.Clear();
@@ -2012,7 +2017,8 @@ void DBImpl::MultiGetImpl(
             }
         }
     }
-
+    uint64_t end = env_->NowMicros();
+    std::cout << "Total time: " << (end-start);
     if (lookup_current) {
       PERF_TIMER_GUARD(get_from_output_files_time);
       super_version->current->MultiGet(read_options, &range, callback,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1977,8 +1977,8 @@ void DBImpl::MultiGetImpl(
       }
       if (!range.empty()) {
         lookup_current = true;
-//        uint64_t left = range.KeysLeft();
-//        RecordTick(stats_, MEMTABLE_MISS, left);
+        uint64_t left = range.KeysLeft();
+        RecordTick(stats_, MEMTABLE_MISS, left);
       }
     }
     if (lookup_current) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstdio>
-#include <iostream>
 #include <map>
 #include <set>
 #include <stdexcept>

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1977,6 +1977,8 @@ void DBImpl::MultiGetImpl(
       }
       if (!range.empty()) {
         lookup_current = true;
+//        uint64_t left = range.KeysLeft();
+//        RecordTick(stats_, MEMTABLE_MISS, left);
       }
     }
     if (lookup_current) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2000,7 +2000,7 @@ void DBImpl::MultiGetImpl(
 //    uint64_t end = env_->NowMicros();
 //    std::cout << "Total time: " << (end-start);
 
-    uint64_t start = env_->NowMicros();
+//    uint64_t start = env_->NowMicros();
     for (auto mget_iter = range.begin(); mget_iter != range.end();
          ++mget_iter) {
       mget_iter->merge_context.Clear();
@@ -2009,16 +2009,16 @@ void DBImpl::MultiGetImpl(
 
     bool skip_memtable = (read_options.read_tier == kPersistedTier && has_unpersisted_data_.load(std::memory_order_relaxed));
     if (!skip_memtable) {
-        bool found_all_keys = super_version->mem->MultiGet(read_options, &range, callback, is_blob_index);
-        if (!found_all_keys) {
-            found_all_keys = super_version->imm->MultiGet(read_options, &range, callback, is_blob_index);
-            if (!found_all_keys) {
-                lookup_current = true;
-            }
+        super_version->mem->MultiGet(read_options, &range, callback, is_blob_index);
+        if (!range.empty()) {
+            super_version->imm->MultiGet(read_options, &range, callback, is_blob_index);
+        }
+        if (!range.empty()) {
+            lookup_current = true;
         }
     }
-    uint64_t end = env_->NowMicros();
-    std::cout << "Total time: " << (end-start);
+//    uint64_t end = env_->NowMicros();
+//    std::cout << "Total time: " << (end-start);
     if (lookup_current) {
       PERF_TIMER_GUARD(get_from_output_files_time);
       super_version->current->MultiGet(read_options, &range, callback,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -16,10 +16,10 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstdio>
+#include <iostream>
 #include <map>
 #include <set>
 #include <stdexcept>
-#include <iostream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -1960,65 +1960,26 @@ void DBImpl::MultiGetImpl(
     bool lookup_current = false;
 
     keys_left -= batch_size;
-//    uint64_t start = env_->NowMicros();
-//    for (auto mget_iter = range.begin(); mget_iter != range.end();
-//         ++mget_iter) {
-//      MergeContext& merge_context = mget_iter->merge_context;
-//      merge_context.Clear();
-//      Status& s = *mget_iter->s;
-//      PinnableSlice* value = mget_iter->value;
-//      s = Status::OK();
-//
-//      bool skip_memtable =
-//          (read_options.read_tier == kPersistedTier &&
-//           has_unpersisted_data_.load(std::memory_order_relaxed));
-//      bool done = false;
-//      if (!skip_memtable) {
-//        if (super_version->mem->Get(*(mget_iter->lkey), value->GetSelf(), &s,
-//                                    &merge_context,
-//                                    &mget_iter->max_covering_tombstone_seq,
-//                                    read_options, callback, is_blob_index)) {
-//          done = true;
-//          value->PinSelf();
-//          RecordTick(stats_, MEMTABLE_HIT);
-//        } else if (super_version->imm->Get(
-//                       *(mget_iter->lkey), value->GetSelf(), &s, &merge_context,
-//                       &mget_iter->max_covering_tombstone_seq, read_options,
-//                       callback, is_blob_index)) {
-//          done = true;
-//          value->PinSelf();
-//          RecordTick(stats_, MEMTABLE_HIT);
-//        }
-//      }
-//      if (done) {
-//        range.MarkKeyDone(mget_iter);
-//      } else {
-//        RecordTick(stats_, MEMTABLE_MISS);
-//        lookup_current = true;
-//      }
-//    }
-//    uint64_t end = env_->NowMicros();
-//    std::cout << "Total time: " << (end-start);
-
-//    uint64_t start = env_->NowMicros();
     for (auto mget_iter = range.begin(); mget_iter != range.end();
          ++mget_iter) {
       mget_iter->merge_context.Clear();
       *mget_iter->s = Status::OK();
     }
 
-    bool skip_memtable = (read_options.read_tier == kPersistedTier && has_unpersisted_data_.load(std::memory_order_relaxed));
+    bool skip_memtable =
+        (read_options.read_tier == kPersistedTier &&
+         has_unpersisted_data_.load(std::memory_order_relaxed));
     if (!skip_memtable) {
-        super_version->mem->MultiGet(read_options, &range, callback, is_blob_index);
-        if (!range.empty()) {
-            super_version->imm->MultiGet(read_options, &range, callback, is_blob_index);
-        }
-        if (!range.empty()) {
-            lookup_current = true;
-        }
+      super_version->mem->MultiGet(read_options, &range, callback,
+                                   is_blob_index);
+      if (!range.empty()) {
+        super_version->imm->MultiGet(read_options, &range, callback,
+                                     is_blob_index);
+      }
+      if (!range.empty()) {
+        lookup_current = true;
+      }
     }
-//    uint64_t end = env_->NowMicros();
-//    std::cout << "Total time: " << (end-start);
     if (lookup_current) {
       PERF_TIMER_GUARD(get_from_output_files_time);
       super_version->current->MultiGet(read_options, &range, callback,

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -881,6 +881,7 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
     int idx = 0;
     for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
       if (prefix_extractor_ && !prefix_extractor_->InDomain(iter->ukey)) {
+        PERF_COUNTER_ADD(bloom_memtable_hit_count, 1);
         continue;
       }
       if (!may_match[idx]) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -770,8 +770,7 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
                    MergeContext* merge_context,
                    SequenceNumber* max_covering_tombstone_seq,
                    SequenceNumber* seq, const ReadOptions& read_opts,
-                   ReadCallback* callback, bool* is_blob_index, bool do_merge,
-                   bool skip_filter_check) {
+                   ReadCallback* callback, bool* is_blob_index, bool do_merge) {
   // The sequence number is updated synchronously in version_set.h
   if (IsEmpty()) {
     // Avoiding recording stats for speed.
@@ -779,33 +778,22 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
   }
   PERF_TIMER_GUARD(get_from_memtable_time);
 
-  std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
-      NewRangeTombstoneIterator(read_opts,
-                                GetInternalKeySeqno(key.internal_key())));
-  if (range_del_iter != nullptr) {
-    *max_covering_tombstone_seq =
-        std::max(*max_covering_tombstone_seq,
-                 range_del_iter->MaxCoveringTombstoneSeqnum(key.user_key()));
-  }
-
   Slice user_key = key.user_key();
   bool found_final_value = false;
   bool merge_in_progress = s->IsMergeInProgress();
   bool may_contain = true;
   size_t ts_sz = GetInternalKeyComparator().user_comparator()->timestamp_size();
-  if (!skip_filter_check) {
-    if (bloom_filter_) {
-      // when both memtable_whole_key_filtering and prefix_extractor_ are set,
-      // only do whole key filtering for Get() to save CPU
-      if (moptions_.memtable_whole_key_filtering) {
-        may_contain = bloom_filter_->MayContain(
-            StripTimestampFromUserKey(user_key, ts_sz));
-      } else {
-        assert(prefix_extractor_);
-        may_contain =
-            !prefix_extractor_->InDomain(user_key) ||
-            bloom_filter_->MayContain(prefix_extractor_->Transform(user_key));
-      }
+  if (bloom_filter_) {
+    // when both memtable_whole_key_filtering and prefix_extractor_ are set,
+    // only do whole key filtering for Get() to save CPU
+    if (moptions_.memtable_whole_key_filtering) {
+      may_contain = bloom_filter_->MayContain(
+          StripTimestampFromUserKey(user_key, ts_sz));
+    } else {
+      assert(prefix_extractor_);
+      may_contain =
+          !prefix_extractor_->InDomain(user_key) ||
+          bloom_filter_->MayContain(prefix_extractor_->Transform(user_key));
     }
   }
 
@@ -817,10 +805,39 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
       if (bloom_filter_) {
           PERF_COUNTER_ADD(bloom_memtable_hit_count, 1);
       }
+      GetFromTable(key, value, s, merge_context, max_covering_tombstone_seq,
+              seq, read_opts, callback, is_blob_index, do_merge,
+              &found_final_value, &merge_in_progress);
+  }
+
+  // No change to value, since we have not yet found a Put/Delete
+  if (!found_final_value && merge_in_progress) {
+    *s = Status::MergeInProgress();
+  }
+  PERF_COUNTER_ADD(get_from_memtable_count, 1);
+  return found_final_value;
+}
+
+void MemTable::GetFromTable(const LookupKey& key, std::string* value, Status* s,
+        MergeContext* merge_context,
+        SequenceNumber* max_covering_tombstone_seq,
+        SequenceNumber* seq, const ReadOptions& read_opts,
+        ReadCallback* callback, bool* is_blob_index, bool do_merge,
+        bool* found_final_value, bool* merge_in_progress) {
+
+    std::unique_ptr<FragmentedRangeTombstoneIterator> range_del_iter(
+        NewRangeTombstoneIterator(read_opts,
+                                  GetInternalKeySeqno(key.internal_key())));
+    if (range_del_iter != nullptr) {
+      *max_covering_tombstone_seq =
+          std::max(*max_covering_tombstone_seq,
+                   range_del_iter->MaxCoveringTombstoneSeqnum(key.user_key()));
+    }
+
     Saver saver;
     saver.status = s;
-    saver.found_final_value = &found_final_value;
-    saver.merge_in_progress = &merge_in_progress;
+    saver.found_final_value = found_final_value;
+    saver.merge_in_progress = merge_in_progress;
     saver.key = &key;
     saver.value = value;
     saver.seq = kMaxSequenceNumber;
@@ -837,75 +854,60 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s,
     saver.do_merge = do_merge;
     table_->Get(key, &saver, SaveValue);
     *seq = saver.seq;
-  }
 
-  // No change to value, since we have not yet found a Put/Delete
-  if (!found_final_value && merge_in_progress) {
-    *s = Status::MergeInProgress();
-  }
-  PERF_COUNTER_ADD(get_from_memtable_count, 1);
-  return found_final_value;
 }
 
-bool MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                         ReadCallback* callback, bool* is_blob) {
   // The sequence number is updated synchronously in version_set.h
   if (IsEmpty()) {
     // Avoiding recording stats for speed.
-    return false;
+      return;
   }
-  std::bitset<MultiGetContext::MAX_BATCH_SIZE> keys;
-  int idx = 0;
-  for (auto iter = range->begin(); iter != range->end(); ++iter) {
-    Slice user_key = iter->lkey->user_key();
-    size_t ts_sz =
-        GetInternalKeyComparator().user_comparator()->timestamp_size();
-    bool may_contain = true;
-    if (bloom_filter_) {
-      // when both memtable_whole_key_filtering and prefix_extractor_ are set,
-      // only do whole key filtering for Get() to save CPU
-      if (moptions_.memtable_whole_key_filtering) {
-        may_contain = bloom_filter_->MayContain(
-            StripTimestampFromUserKey(user_key, ts_sz));
-      } else {
-        assert(prefix_extractor_);
-        may_contain =
-            !prefix_extractor_->InDomain(user_key) ||
-            bloom_filter_->MayContain(prefix_extractor_->Transform(user_key));
-      }
+  PERF_TIMER_GUARD(get_from_memtable_time);
 
-      if (may_contain) {
-        keys.set(idx);
+  MultiGetRange temp_range(*range, range->begin(), range->end());
+  if (bloom_filter_) {
+      std::array<Slice*, MultiGetContext::MAX_BATCH_SIZE> keys;
+      std::array<bool, MultiGetContext::MAX_BATCH_SIZE> may_match = {{true}};
+      autovector<Slice, MultiGetContext::MAX_BATCH_SIZE> prefixes;
+      int num_keys = 0;
+      for (auto iter = temp_range.begin(); iter != temp_range.end();
+              ++iter) {
+        if (!prefix_extractor_) {
+          keys[num_keys++] = &iter->ukey;
+        } else if (prefix_extractor_->InDomain(iter->ukey)) {
+          prefixes.emplace_back(prefix_extractor_->Transform(iter->ukey));
+          keys[num_keys++] = &prefixes.back();
+        } else {
+            temp_range.SkipKey(iter);
+        }
       }
-      idx++;
-    }
+      bloom_filter_->MayContain(num_keys, &keys[0], &may_match[0]);
+      int idx = 0;
+      for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+          if (!may_match[idx]) {
+              temp_range.SkipKey(iter);
+              PERF_COUNTER_ADD(bloom_memtable_miss_count, 1);
+          } else {
+              PERF_COUNTER_ADD(bloom_memtable_hit_count, 1);
+          }
+          idx++;
+      }
   }
-
-  idx = 0;
-  bool found_all_keys = true;
-  for (auto iter = range->begin(); iter != range->end(); ++iter) {
-    SequenceNumber seq;
-    if (!keys.test(idx)) {
-      // iter is null if prefix bloom says the key does not exist
-      PERF_COUNTER_ADD(bloom_memtable_miss_count, 1);
-      seq = kMaxSequenceNumber;
-      found_all_keys = false;
-    } else {
-      PERF_COUNTER_ADD(bloom_memtable_hit_count, 1);
-      bool found_final_value = Get(*(iter->lkey), iter->value->GetSelf(), iter->s, &(iter->merge_context),
+  for (auto iter = temp_range.begin(); iter != temp_range.end(); ++iter) {
+      SequenceNumber seq = kMaxSequenceNumber;
+      bool found_final_value{false};
+      bool merge_in_progress = iter->s->IsMergeInProgress();
+     GetFromTable(*(iter->lkey), iter->value->GetSelf(), iter->s, &(iter->merge_context),
               &iter->max_covering_tombstone_seq, &seq, read_options, callback,
-              is_blob, true, true);
+              is_blob, true, &found_final_value, &merge_in_progress);
       if (found_final_value) {
           iter->value->PinSelf();
           range->MarkKeyDone(iter);
-      } else {
-          found_all_keys = false;
       }
-    }
-    idx++;
   }
-
-  return found_all_keys;
+  PERF_COUNTER_ADD(get_from_memtable_count, 1);
 }
 
 void MemTable::Update(SequenceNumber seq,

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -641,12 +641,6 @@ static bool SaveValue(void* arg, const char* entry) {
   uint32_t key_length;
   const char* key_ptr = GetVarint32Ptr(entry, entry + 5, &key_length);
   Slice user_key_slice = Slice(key_ptr, key_length - 8);
-  //  std::cout << user_key_slice.ToString(false) <<"=="<<
-  //  s->key->user_key().ToString(false) << "\n"; std::cout <<
-  //  s->mem->GetInternalKeyComparator()
-  //                  .user_comparator()
-  //                  ->CompareWithoutTimestamp(user_key_slice,
-  //                  s->key->user_key()) << "\n";
   if (s->mem->GetInternalKeyComparator()
           .user_comparator()
           ->CompareWithoutTimestamp(user_key_slice, s->key->user_key()) == 0) {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -10,6 +10,7 @@
 #include "db/memtable.h"
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <limits>
 #include <memory>

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -211,8 +211,7 @@ class MemTable {
            MergeContext* merge_context,
            SequenceNumber* max_covering_tombstone_seq, SequenceNumber* seq,
            const ReadOptions& read_opts, ReadCallback* callback = nullptr,
-           bool* is_blob_index = nullptr, bool do_merge = true,
-           bool skip_filter_check = false);
+           bool* is_blob_index = nullptr, bool do_merge = true);
 
   bool Get(const LookupKey& key, std::string* value, Status* s,
            MergeContext* merge_context,
@@ -225,7 +224,7 @@ class MemTable {
                read_opts, callback, is_blob_index, do_merge, skip_filter_check);
   }
 
-  bool MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+  void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                 ReadCallback* callback, bool* is_blob);
 
   // Attempts to update the new_value inplace, else does normal Add
@@ -514,6 +513,13 @@ class MemTable {
   void UpdateFlushState();
 
   void UpdateOldestKeyTime();
+
+  void GetFromTable(const LookupKey& key, std::string* value, Status* s,
+          MergeContext* merge_context,
+          SequenceNumber* max_covering_tombstone_seq,
+          SequenceNumber* seq, const ReadOptions& read_opts,
+          ReadCallback* callback, bool* is_blob_index, bool do_merge,
+          bool* found_final_value, bool* merge_in_progress);
 };
 
 extern const char* EncodeKey(std::string* scratch, const Slice& target);

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -513,11 +513,11 @@ class MemTable {
 
   void UpdateOldestKeyTime();
 
-  void GetFromTable(const LookupKey& key, std::string* value, Status* s,
-                    MergeContext* merge_context,
-                    SequenceNumber* max_covering_tombstone_seq,
-                    SequenceNumber* seq, ReadCallback* callback,
-                    bool* is_blob_index, bool do_merge, bool* found_final_value,
+  void GetFromTable(const LookupKey& key,
+                    SequenceNumber max_covering_tombstone_seq, bool do_merge,
+                    ReadCallback* callback, bool* is_blob_index,
+                    std::string* value, Status* s, MergeContext* merge_context,
+                    SequenceNumber* seq, bool* found_final_value,
                     bool* merge_in_progress);
 };
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -217,11 +217,10 @@ class MemTable {
            MergeContext* merge_context,
            SequenceNumber* max_covering_tombstone_seq,
            const ReadOptions& read_opts, ReadCallback* callback = nullptr,
-           bool* is_blob_index = nullptr, bool do_merge = true,
-           bool skip_filter_check = false) {
+           bool* is_blob_index = nullptr, bool do_merge = true) {
     SequenceNumber seq;
     return Get(key, value, s, merge_context, max_covering_tombstone_seq, &seq,
-               read_opts, callback, is_blob_index, do_merge, skip_filter_check);
+               read_opts, callback, is_blob_index, do_merge);
   }
 
   void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
@@ -515,11 +514,11 @@ class MemTable {
   void UpdateOldestKeyTime();
 
   void GetFromTable(const LookupKey& key, std::string* value, Status* s,
-          MergeContext* merge_context,
-          SequenceNumber* max_covering_tombstone_seq,
-          SequenceNumber* seq, const ReadOptions& read_opts,
-          ReadCallback* callback, bool* is_blob_index, bool do_merge,
-          bool* found_final_value, bool* merge_in_progress);
+                    MergeContext* merge_context,
+                    SequenceNumber* max_covering_tombstone_seq,
+                    SequenceNumber* seq, ReadCallback* callback,
+                    bool* is_blob_index, bool do_merge, bool* found_final_value,
+                    bool* merge_in_progress);
 };
 
 extern const char* EncodeKey(std::string* scratch, const Slice& target);

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -113,15 +113,15 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                      is_blob_index);
 }
 
-void MemTableListVersion::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
-              ReadCallback* callback, bool* is_blob) {
-
-    for (auto memtable : memlist_) {
-        memtable->MultiGet(read_options, range, callback, is_blob);
-        if (range->empty()) {
-            return;
-        }
+void MemTableListVersion::MultiGet(const ReadOptions& read_options,
+                                   MultiGetRange* range, ReadCallback* callback,
+                                   bool* is_blob) {
+  for (auto memtable : memlist_) {
+    memtable->MultiGet(read_options, range, callback, is_blob);
+    if (range->empty()) {
+      return;
     }
+  }
 }
 
 bool MemTableListVersion::GetMergeOperands(

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -113,6 +113,19 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                      is_blob_index);
 }
 
+bool MemTableListVersion::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+              ReadCallback* callback, bool* is_blob) {
+
+    for (auto memtable : memlist_) {
+      bool found_all_keys = memtable->MultiGet(read_options, range, callback, is_blob);
+
+      if (found_all_keys) {
+          return true;
+      }
+    }
+    return false;
+}
+
 bool MemTableListVersion::GetMergeOperands(
     const LookupKey& key, Status* s, MergeContext* merge_context,
     SequenceNumber* max_covering_tombstone_seq, const ReadOptions& read_opts) {

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -113,17 +113,15 @@ bool MemTableListVersion::Get(const LookupKey& key, std::string* value,
                      is_blob_index);
 }
 
-bool MemTableListVersion::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+void MemTableListVersion::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
               ReadCallback* callback, bool* is_blob) {
 
     for (auto memtable : memlist_) {
-      bool found_all_keys = memtable->MultiGet(read_options, range, callback, is_blob);
-
-      if (found_all_keys) {
-          return true;
-      }
+        memtable->MultiGet(read_options, range, callback, is_blob);
+        if (range->empty()) {
+            return;
+        }
     }
-    return false;
 }
 
 bool MemTableListVersion::GetMergeOperands(

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -72,6 +72,9 @@ class MemTableListVersion {
                read_opts, callback, is_blob_index);
   }
 
+  bool MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+                ReadCallback* callback, bool* is_blob);
+
   // Returns all the merge operands corresponding to the key by searching all
   // memtables starting from the most recent one.
   bool GetMergeOperands(const LookupKey& key, Status* s,

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -72,7 +72,7 @@ class MemTableListVersion {
                read_opts, callback, is_blob_index);
   }
 
-  bool MultiGet(const ReadOptions& read_options, MultiGetRange* range,
+  void MultiGet(const ReadOptions& read_options, MultiGetRange* range,
                 ReadCallback* callback, bool* is_blob);
 
   // Returns all the merge operands corresponding to the key by searching all

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -229,6 +229,16 @@ class MultiGetContext {
       return ctx_->value_mask_ & (1ull << iter.index_);
     }
 
+    uint64_t KeysLeft() {
+      uint64_t new_val = skip_mask_ | ctx_->value_mask_;
+      uint64_t count = 0;
+      while (new_val) {
+        new_val = new_val & (new_val - 1);
+        count++;
+      }
+      return end_ - count;
+    }
+
    private:
     friend MultiGetContext;
     MultiGetContext* ctx_;

--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -123,7 +123,7 @@ inline bool DynamicBloom::MayContain(const Slice& key) const {
 inline void DynamicBloom::MayContain(int num_keys, Slice** keys,
                                      bool* may_match) const {
   std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> hashes;
-  std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
+  std::array<size_t, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
   for (int i = 0; i < num_keys; ++i) {
     hashes[i] = BloomHash(*keys[i]);
     size_t a = fastrange32(kLen, hashes[i]);

--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -122,8 +122,8 @@ inline bool DynamicBloom::MayContain(const Slice& key) const {
 
 inline void DynamicBloom::MayContain(int num_keys, Slice** keys,
                                      bool* may_match) const {
-  std::array<int, MultiGetContext::MAX_BATCH_SIZE> hashes;
-  std::array<int, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
+  std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> hashes;
+  std::array<uint32_t, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
   for (int i = 0; i < num_keys; ++i) {
     hashes[i] = BloomHash(*keys[i]);
     size_t a = fastrange32(kLen, hashes[i]);

--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <string>
-
+#include <array>
 #include "port/port.h"
 #include "rocksdb/slice.h"
 #include "table/multiget_context.h"
@@ -122,8 +122,8 @@ inline bool DynamicBloom::MayContain(const Slice& key) const {
 
 inline void DynamicBloom::MayContain(int num_keys, Slice** keys,
                                      bool* may_match) const {
-  uint32_t hashes[MultiGetContext::MAX_BATCH_SIZE];
-  size_t byte_offsets[MultiGetContext::MAX_BATCH_SIZE];
+  std::array<int, MultiGetContext::MAX_BATCH_SIZE> hashes;
+  std::array<int, MultiGetContext::MAX_BATCH_SIZE> byte_offsets;
   for (int i = 0; i < num_keys; ++i) {
     hashes[i] = BloomHash(*keys[i]);
     size_t a = fastrange32(kLen, hashes[i]);

--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "rocksdb/slice.h"
-
+#include "table/multiget_context.h"
 #include "port/port.h"
 #include "util/hash.h"
 
@@ -65,6 +65,8 @@ class DynamicBloom {
   // Multithreaded access to this function is OK
   bool MayContain(const Slice& key) const;
 
+  void MayContain(int num_keys, Slice** keys, bool* may_match) const;
+
   // Multithreaded access to this function is OK
   bool MayContainHash(uint32_t hash) const;
 
@@ -84,6 +86,8 @@ class DynamicBloom {
   // concurrency safety, working with bytes.
   template <typename OrFunc>
   void AddHash(uint32_t hash, const OrFunc& or_func);
+
+  bool DoubleProbe(uint32_t h32, size_t a) const;
 };
 
 inline void DynamicBloom::Add(const Slice& key) { AddHash(BloomHash(key)); }
@@ -114,6 +118,21 @@ inline void DynamicBloom::AddHashConcurrently(uint32_t hash) {
 
 inline bool DynamicBloom::MayContain(const Slice& key) const {
   return (MayContainHash(BloomHash(key)));
+}
+
+inline void DynamicBloom::MayContain(int num_keys, Slice** keys, bool* may_match) const {
+    uint32_t hashes[MultiGetContext::MAX_BATCH_SIZE];
+    size_t byte_offsets[MultiGetContext::MAX_BATCH_SIZE];
+    for (int i = 0; i < num_keys; ++i) {
+      hashes[i] = BloomHash(*keys[i]);
+      size_t a = fastrange32(kLen, hashes[i]);
+      PREFETCH(data_ + a, 0, 3);
+      byte_offsets[i] = a;
+    }
+
+    for (int i = 0; i < num_keys; i++){
+        may_match[i] = DoubleProbe(hashes[i], byte_offsets[i]);
+    }
 }
 
 #if defined(_MSC_VER)
@@ -154,6 +173,7 @@ inline bool DynamicBloom::MayContainHash(uint32_t h32) const {
   size_t a = fastrange32(kLen, h32);
   PREFETCH(data_ + a, 0, 3);
   // Expand/remix with 64-bit golden ratio
+<<<<<<< HEAD
   uint64_t h = 0x9e3779b97f4a7c13ULL * h32;
   for (unsigned i = 0;; ++i) {
     // Two bit probes per uint64_t probe
@@ -164,9 +184,26 @@ inline bool DynamicBloom::MayContainHash(uint32_t h32) const {
       return (val & mask) == mask;
     } else if ((val & mask) != mask) {
       return false;
+=======
+  return DoubleProbe(h32, a);
+}
+
+inline bool DynamicBloom::DoubleProbe(uint32_t h32, size_t byte_offset) const {
+    // Expand/remix with 64-bit golden ratio
+    uint64_t h = 0x9e3779b97f4a7c13ULL * h32;
+    for (unsigned i = 0;; ++i) {
+      // Two bit probes per uint64_t probe
+      uint64_t mask = ((uint64_t)1 << (h & 63))
+                    | ((uint64_t)1 << ((h >> 6) & 63));
+      uint64_t val = data_[byte_offset ^ i].load(std::memory_order_relaxed);
+      if (i + 1 >= kNumDoubleProbes) {
+        return (val & mask) == mask;
+      } else if ((val & mask) != mask) {
+        return false;
+      }
+      h = (h >> 12) | (h << 52);
+>>>>>>> prefetch in loop and pushdown all keys for bloom-filter lookup
     }
-    h = (h >> 12) | (h << 52);
-  }
 }
 
 template <typename OrFunc>

--- a/util/dynamic_bloom.h
+++ b/util/dynamic_bloom.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <string>
 #include <array>
+#include <string>
 #include "port/port.h"
 #include "rocksdb/slice.h"
 #include "table/multiget_context.h"


### PR DESCRIPTION
RocksDB has a MultiGet() API that implements batched key lookup for higher performance (https://github.com/facebook/rocksdb/blob/master/include/rocksdb/db.h#L468). Currently, batching is implemented in BlockBasedTableReader::MultiGet() for SST file lookups. One of the ways it improves performance is by pipelining bloom filter lookups (by prefetching required cachelines for all the keys in the batch, and then doing the probe) and thus hiding the cache miss latency. The same concept can be extended to the memtable as well. This PR involves implementing a pipelined bloom filter lookup in DynamicBloom, and implementing MemTable::MultiGet() that can leverage it.

Test plan:
Existing tests

Performance Test:
Ran the below command which fills up the memtable and makes sure there are no flushes and then call multiget. Ran it on master and on the new change and see an average of 3.5% improvement across 10 runs. 

<img width="423" alt="Screen Shot 2019-10-03 at 2 00 28 PM" src="https://user-images.githubusercontent.com/1004951/66163937-56064100-e5e6-11e9-8804-107af5205581.png">

TEST_TMPDIR=. numactl -C 10 ./db_bench -benchmarks="fillseq,readrandom,multireadrandom" -num=6000000 -compression_type="none" -level_compaction_dynamic_level_bytes -write_buffer_size=2000000000 -target_file_size_base=2000000000 -max_bytes_for_level_base=16777216 -reads=90000 -threads=1 -compression_type=none -cache_size=4194304000 -batch_size=32 -disable_auto_compactions=true -bloom_bits=10 -cache_index_and_filter_blocks=true -pin_l0_filter_and_index_blocks_in_cache=true -multiread_batched=true -multiread_stride=16 -statistics -memtable_whole_key_filtering=true -memtable_bloom_size_ratio=10