### PR TITLE
Fix msvc build errors in block_cache_trace_analyzer.cc (#5746)

### DIFF
--- a/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
@@ -1211,8 +1211,8 @@ void BlockCacheTraceAnalyzer::WriteBlockReuseTimeline(
   TraverseBlocks(block_callback);
 
   // A cell is the number of blocks accessed in a reuse window.
-  const auto reuse_table =
-      std::make_unique<uint64_t[]>(reuse_vector_size * reuse_vector_size);
+  const std::unique_ptr<uint64_t[]> reuse_table(
+      new uint64_t[reuse_vector_size * reuse_vector_size]);
 
   for (uint64_t start_time = 0; start_time < reuse_vector_size; start_time++) {
     // Initialize the reuse_table.

--- a/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
+++ b/tools/block_cache_analyzer/block_cache_trace_analyzer.cc
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <random>
 #include <sstream>
 


### PR DESCRIPTION
Use a dynamically allocated array for reuse_table, since msvc does not
support stack-allocated arrays whose size is unknown at compile time.
Add a couple of explicit casts to avoid numeric conversion warnings.

N.B. I have not been able to test this change properly since I can't get the tests to run successfully using "make check" on Linux. Please let me know if there is a better way to do this.