### PR TITLE
promote both db and cf stats and turn enums into enum class

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -741,7 +741,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
     if (write_stall_condition == WriteStallCondition::kStopped &&
         write_stall_cause == WriteStallCause::kMemtableLimit) {
       write_controller_token_ = write_controller->GetStopToken();
-      internal_stats_->AddCFStats(InternalStats::MEMTABLE_LIMIT_STOPS, 1);
+      internal_stats_->AddCFStats(InternalCFStatsType::MEMTABLE_LIMIT_STOPS, 1);
       ROCKS_LOG_WARN(
           ioptions_.info_log,
           "[%s] Stopping writes because we have %d immutable memtables "
@@ -751,10 +751,10 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
     } else if (write_stall_condition == WriteStallCondition::kStopped &&
                write_stall_cause == WriteStallCause::kL0FileCountLimit) {
       write_controller_token_ = write_controller->GetStopToken();
-      internal_stats_->AddCFStats(InternalStats::L0_FILE_COUNT_LIMIT_STOPS, 1);
+      internal_stats_->AddCFStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_STOPS, 1);
       if (compaction_picker_->IsLevel0CompactionInProgress()) {
         internal_stats_->AddCFStats(
-            InternalStats::LOCKED_L0_FILE_COUNT_LIMIT_STOPS, 1);
+            InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_STOPS, 1);
       }
       ROCKS_LOG_WARN(ioptions_.info_log,
                      "[%s] Stopping writes because we have %d level-0 files",
@@ -763,7 +763,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
                write_stall_cause == WriteStallCause::kPendingCompactionBytes) {
       write_controller_token_ = write_controller->GetStopToken();
       internal_stats_->AddCFStats(
-          InternalStats::PENDING_COMPACTION_BYTES_LIMIT_STOPS, 1);
+          InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_STOPS, 1);
       ROCKS_LOG_WARN(
           ioptions_.info_log,
           "[%s] Stopping writes because of estimated pending compaction "
@@ -775,7 +775,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
           SetupDelay(write_controller, compaction_needed_bytes,
                      prev_compaction_needed_bytes_, was_stopped,
                      mutable_cf_options.disable_auto_compactions);
-      internal_stats_->AddCFStats(InternalStats::MEMTABLE_LIMIT_SLOWDOWNS, 1);
+      internal_stats_->AddCFStats(InternalCFStatsType::MEMTABLE_LIMIT_SLOWDOWNS, 1);
       ROCKS_LOG_WARN(
           ioptions_.info_log,
           "[%s] Stalling writes because we have %d immutable memtables "
@@ -793,11 +793,11 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
           SetupDelay(write_controller, compaction_needed_bytes,
                      prev_compaction_needed_bytes_, was_stopped || near_stop,
                      mutable_cf_options.disable_auto_compactions);
-      internal_stats_->AddCFStats(InternalStats::L0_FILE_COUNT_LIMIT_SLOWDOWNS,
+      internal_stats_->AddCFStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_SLOWDOWNS,
                                   1);
       if (compaction_picker_->IsLevel0CompactionInProgress()) {
         internal_stats_->AddCFStats(
-            InternalStats::LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS, 1);
+            InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS, 1);
       }
       ROCKS_LOG_WARN(ioptions_.info_log,
                      "[%s] Stalling writes because we have %d level-0 files "
@@ -822,7 +822,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
                      prev_compaction_needed_bytes_, was_stopped || near_stop,
                      mutable_cf_options.disable_auto_compactions);
       internal_stats_->AddCFStats(
-          InternalStats::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS, 1);
+          InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS, 1);
       ROCKS_LOG_WARN(
           ioptions_.info_log,
           "[%s] Stalling writes because of estimated pending compaction "

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1074,7 +1074,7 @@ Status DBImpl::WriteLevel0TableForRecovery(int job_id, ColumnFamilyData* cfd,
   stats.bytes_written = meta.fd.GetFileSize();
   stats.num_output_files = 1;
   cfd->internal_stats()->AddCompactionStats(level, Env::Priority::USER, stats);
-  cfd->internal_stats()->AddCFStats(InternalStats::BYTES_FLUSHED,
+  cfd->internal_stats()->AddCFStats(InternalCFStatsType::BYTES_FLUSHED,
                                     meta.fd.GetFileSize());
   RecordTick(stats_, COMPACT_WRITE_BYTES, meta.fd.GetFileSize());
   return s;

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -254,17 +254,17 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
     // We're optimistic, updating the stats before we successfully
     // commit.  That lets us release our leader status early.
     auto stats = default_cf_internal_stats_;
-    stats->AddDBStats(InternalStats::NUMBER_KEYS_WRITTEN, total_count,
+    stats->AddDBStats(InternalDBStatsType::NUMBER_KEYS_WRITTEN, total_count,
                       concurrent_update);
     RecordTick(stats_, NUMBER_KEYS_WRITTEN, total_count);
-    stats->AddDBStats(InternalStats::BYTES_WRITTEN, total_byte_size,
+    stats->AddDBStats(InternalDBStatsType::BYTES_WRITTEN, total_byte_size,
                       concurrent_update);
     RecordTick(stats_, BYTES_WRITTEN, total_byte_size);
-    stats->AddDBStats(InternalStats::WRITE_DONE_BY_SELF, 1, concurrent_update);
+    stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_SELF, 1, concurrent_update);
     RecordTick(stats_, WRITE_DONE_BY_SELF);
     auto write_done_by_other = write_group.size - 1;
     if (write_done_by_other > 0) {
-      stats->AddDBStats(InternalStats::WRITE_DONE_BY_OTHER, write_done_by_other,
+      stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_OTHER, write_done_by_other,
                         concurrent_update);
       RecordTick(stats_, WRITE_DONE_BY_OTHER, write_done_by_other);
     }
@@ -459,9 +459,9 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
     }
 
     auto stats = default_cf_internal_stats_;
-    stats->AddDBStats(InternalStats::NUMBER_KEYS_WRITTEN, total_count);
+    stats->AddDBStats(InternalDBStatsType::NUMBER_KEYS_WRITTEN, total_count);
     RecordTick(stats_, NUMBER_KEYS_WRITTEN, total_count);
-    stats->AddDBStats(InternalStats::BYTES_WRITTEN, total_byte_size);
+    stats->AddDBStats(InternalDBStatsType::BYTES_WRITTEN, total_byte_size);
     RecordTick(stats_, BYTES_WRITTEN, total_byte_size);
     RecordInHistogram(stats_, BYTES_PER_WRITE, total_byte_size);
 
@@ -469,10 +469,10 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
 
     if (w.status.ok() && !write_options.disableWAL) {
       PERF_TIMER_GUARD(write_wal_time);
-      stats->AddDBStats(InternalStats::WRITE_DONE_BY_SELF, 1);
+      stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_SELF, 1);
       RecordTick(stats_, WRITE_DONE_BY_SELF, 1);
       if (wal_write_group.size > 1) {
-        stats->AddDBStats(InternalStats::WRITE_DONE_BY_OTHER,
+        stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_OTHER,
                           wal_write_group.size - 1);
         RecordTick(stats_, WRITE_DONE_BY_OTHER, wal_write_group.size - 1);
       }
@@ -583,14 +583,14 @@ Status DBImpl::WriteImplWALOnly(const WriteOptions& write_options,
   // We're optimistic, updating the stats before we successfully
   // commit.  That lets us release our leader status early.
   auto stats = default_cf_internal_stats_;
-  stats->AddDBStats(InternalStats::BYTES_WRITTEN, total_byte_size,
+  stats->AddDBStats(InternalDBStatsType::BYTES_WRITTEN, total_byte_size,
                     concurrent_update);
   RecordTick(stats_, BYTES_WRITTEN, total_byte_size);
-  stats->AddDBStats(InternalStats::WRITE_DONE_BY_SELF, 1, concurrent_update);
+  stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_SELF, 1, concurrent_update);
   RecordTick(stats_, WRITE_DONE_BY_SELF);
   auto write_done_by_other = write_group.size - 1;
   if (write_done_by_other > 0) {
-    stats->AddDBStats(InternalStats::WRITE_DONE_BY_OTHER, write_done_by_other,
+    stats->AddDBStats(InternalDBStatsType::WRITE_DONE_BY_OTHER, write_done_by_other,
                       concurrent_update);
     RecordTick(stats_, WRITE_DONE_BY_OTHER, write_done_by_other);
   }
@@ -900,12 +900,12 @@ Status DBImpl::WriteToWAL(const WriteThread::WriteGroup& write_group,
   if (status.ok()) {
     auto stats = default_cf_internal_stats_;
     if (need_log_sync) {
-      stats->AddDBStats(InternalStats::WAL_FILE_SYNCED, 1);
+      stats->AddDBStats(InternalDBStatsType::WAL_FILE_SYNCED, 1);
       RecordTick(stats_, WAL_FILE_SYNCED);
     }
-    stats->AddDBStats(InternalStats::WAL_FILE_BYTES, log_size);
+    stats->AddDBStats(InternalDBStatsType::WAL_FILE_BYTES, log_size);
     RecordTick(stats_, WAL_FILE_BYTES, log_size);
-    stats->AddDBStats(InternalStats::WRITE_WITH_WAL, write_with_wal);
+    stats->AddDBStats(InternalDBStatsType::WRITE_WITH_WAL, write_with_wal);
     RecordTick(stats_, WRITE_WITH_WAL, write_with_wal);
   }
   return status;
@@ -951,9 +951,9 @@ Status DBImpl::ConcurrentWriteToWAL(const WriteThread::WriteGroup& write_group,
   if (status.ok()) {
     const bool concurrent = true;
     auto stats = default_cf_internal_stats_;
-    stats->AddDBStats(InternalStats::WAL_FILE_BYTES, log_size, concurrent);
+    stats->AddDBStats(InternalDBStatsType::WAL_FILE_BYTES, log_size, concurrent);
     RecordTick(stats_, WAL_FILE_BYTES, log_size);
-    stats->AddDBStats(InternalStats::WRITE_WITH_WAL, write_with_wal,
+    stats->AddDBStats(InternalDBStatsType::WRITE_WITH_WAL, write_with_wal,
                       concurrent);
     RecordTick(stats_, WRITE_WITH_WAL, write_with_wal);
   }
@@ -1249,7 +1249,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
   }
   assert(!delayed || !write_options.no_slowdown);
   if (delayed) {
-    default_cf_internal_stats_->AddDBStats(InternalStats::WRITE_STALL_MICROS,
+    default_cf_internal_stats_->AddDBStats(InternalDBStatsType::WRITE_STALL_MICROS,
                                            time_delayed);
     RecordTick(stats_, STALL_MICROS, time_delayed);
   }

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -229,7 +229,7 @@ void ExternalSstFileIngestionJob::UpdateStats() {
     stats.num_output_files = 1;
     cfd_->internal_stats()->AddCompactionStats(f.picked_level,
                                                Env::Priority::USER, stats);
-    cfd_->internal_stats()->AddCFStats(InternalStats::BYTES_INGESTED_ADD_FILE,
+    cfd_->internal_stats()->AddCFStats(InternalCFStatsType::BYTES_INGESTED_ADD_FILE,
                                        f.fd.GetFileSize());
     total_keys += f.num_entries;
     if (f.picked_level == 0) {
@@ -242,12 +242,12 @@ void ExternalSstFileIngestionJob::UpdateStats() {
         f.external_file_path.c_str(), f.picked_level,
         f.internal_file_path.c_str(), f.assigned_seqno);
   }
-  cfd_->internal_stats()->AddCFStats(InternalStats::INGESTED_NUM_KEYS_TOTAL,
+  cfd_->internal_stats()->AddCFStats(InternalCFStatsType::INGESTED_NUM_KEYS_TOTAL,
                                      total_keys);
-  cfd_->internal_stats()->AddCFStats(InternalStats::INGESTED_NUM_FILES_TOTAL,
+  cfd_->internal_stats()->AddCFStats(InternalCFStatsType::INGESTED_NUM_FILES_TOTAL,
                                      files_to_ingest_.size());
   cfd_->internal_stats()->AddCFStats(
-      InternalStats::INGESTED_LEVEL0_NUM_FILES_TOTAL, total_l0_files);
+      InternalCFStatsType::INGESTED_LEVEL0_NUM_FILES_TOTAL, total_l0_files);
 }
 
 void ExternalSstFileIngestionJob::Cleanup(const Status& status) {

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -420,7 +420,7 @@ Status FlushJob::WriteLevel0Table() {
   stats.bytes_written = meta_.fd.GetFileSize();
   RecordTimeToHistogram(stats_, FLUSH_TIME, stats.micros);
   cfd_->internal_stats()->AddCompactionStats(0 /* level */, thread_pri_, stats);
-  cfd_->internal_stats()->AddCFStats(InternalStats::BYTES_FLUSHED,
+  cfd_->internal_stats()->AddCFStats(InternalCFStatsType::BYTES_FLUSHED,
                                      meta_.fd.GetFileSize());
   RecordFlushIOStats();
   return s;

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -958,14 +958,14 @@ void InternalStats::DumpDBStats(std::string* value) {
            seconds_up, interval_seconds_up);
   value->append(buf);
   // Cumulative
-  uint64_t user_bytes_written = GetDBStats(InternalStats::BYTES_WRITTEN);
-  uint64_t num_keys_written = GetDBStats(InternalStats::NUMBER_KEYS_WRITTEN);
-  uint64_t write_other = GetDBStats(InternalStats::WRITE_DONE_BY_OTHER);
-  uint64_t write_self = GetDBStats(InternalStats::WRITE_DONE_BY_SELF);
-  uint64_t wal_bytes = GetDBStats(InternalStats::WAL_FILE_BYTES);
-  uint64_t wal_synced = GetDBStats(InternalStats::WAL_FILE_SYNCED);
-  uint64_t write_with_wal = GetDBStats(InternalStats::WRITE_WITH_WAL);
-  uint64_t write_stall_micros = GetDBStats(InternalStats::WRITE_STALL_MICROS);
+  uint64_t user_bytes_written = GetDBStats(InternalDBStatsType::BYTES_WRITTEN);
+  uint64_t num_keys_written = GetDBStats(InternalDBStatsType::NUMBER_KEYS_WRITTEN);
+  uint64_t write_other = GetDBStats(InternalDBStatsType::WRITE_DONE_BY_OTHER);
+  uint64_t write_self = GetDBStats(InternalDBStatsType::WRITE_DONE_BY_SELF);
+  uint64_t wal_bytes = GetDBStats(InternalDBStatsType::WAL_FILE_BYTES);
+  uint64_t wal_synced = GetDBStats(InternalDBStatsType::WAL_FILE_SYNCED);
+  uint64_t write_with_wal = GetDBStats(InternalDBStatsType::WRITE_WITH_WAL);
+  uint64_t write_stall_micros = GetDBStats(InternalDBStatsType::WRITE_STALL_MICROS);
 
   const int kHumanMicrosLen = 32;
   char human_micros[kHumanMicrosLen];
@@ -1118,8 +1118,8 @@ void InternalStats::DumpCFMapStats(
   int total_files = 0;
   int total_files_being_compacted = 0;
   double total_file_size = 0;
-  uint64_t flush_ingest = cf_stats_value_[BYTES_FLUSHED];
-  uint64_t add_file_ingest = cf_stats_value_[BYTES_INGESTED_ADD_FILE];
+  uint64_t flush_ingest = GetCFValueStats(InternalCFStatsType::BYTES_FLUSHED);
+  uint64_t add_file_ingest = GetCFValueStats(InternalCFStatsType::BYTES_INGESTED_ADD_FILE);
   uint64_t curr_ingest = flush_ingest + add_file_ingest;
   for (int level = 0; level < number_levels_; level++) {
     int files = vstorage->NumLevelFiles(level);
@@ -1173,30 +1173,30 @@ void InternalStats::DumpCFMapStatsByPriority(
 void InternalStats::DumpCFMapStatsIOStalls(
     std::map<std::string, std::string>* cf_stats) {
   (*cf_stats)["io_stalls.level0_slowdown"] =
-      std::to_string(cf_stats_count_[L0_FILE_COUNT_LIMIT_SLOWDOWNS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_SLOWDOWNS));
   (*cf_stats)["io_stalls.level0_slowdown_with_compaction"] =
-      std::to_string(cf_stats_count_[LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS));
   (*cf_stats)["io_stalls.level0_numfiles"] =
-      std::to_string(cf_stats_count_[L0_FILE_COUNT_LIMIT_STOPS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_STOPS));
   (*cf_stats)["io_stalls.level0_numfiles_with_compaction"] =
-      std::to_string(cf_stats_count_[LOCKED_L0_FILE_COUNT_LIMIT_STOPS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_STOPS));
   (*cf_stats)["io_stalls.stop_for_pending_compaction_bytes"] =
-      std::to_string(cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_STOPS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_STOPS));
   (*cf_stats)["io_stalls.slowdown_for_pending_compaction_bytes"] =
-      std::to_string(cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS));
   (*cf_stats)["io_stalls.memtable_compaction"] =
-      std::to_string(cf_stats_count_[MEMTABLE_LIMIT_STOPS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_STOPS));
   (*cf_stats)["io_stalls.memtable_slowdown"] =
-      std::to_string(cf_stats_count_[MEMTABLE_LIMIT_SLOWDOWNS]);
+      std::to_string(GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_SLOWDOWNS));
 
-  uint64_t total_stop = cf_stats_count_[L0_FILE_COUNT_LIMIT_STOPS] +
-                        cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_STOPS] +
-                        cf_stats_count_[MEMTABLE_LIMIT_STOPS];
+  uint64_t total_stop = GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_STOPS) +
+                        GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_STOPS) +
+                        GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_STOPS);
 
   uint64_t total_slowdown =
-      cf_stats_count_[L0_FILE_COUNT_LIMIT_SLOWDOWNS] +
-      cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS] +
-      cf_stats_count_[MEMTABLE_LIMIT_SLOWDOWNS];
+      GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_SLOWDOWNS) +
+      GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS) +
+      GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_SLOWDOWNS);
 
   (*cf_stats)["io_stalls.total_stop"] = std::to_string(total_stop);
   (*cf_stats)["io_stalls.total_slowdown"] = std::to_string(total_slowdown);
@@ -1228,20 +1228,20 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
   PrintLevelStats(buf, sizeof(buf), "Sum", levels_stats[-1]);
   value->append(buf);
 
-  uint64_t flush_ingest = cf_stats_value_[BYTES_FLUSHED];
-  uint64_t add_file_ingest = cf_stats_value_[BYTES_INGESTED_ADD_FILE];
-  uint64_t ingest_files_addfile = cf_stats_value_[INGESTED_NUM_FILES_TOTAL];
+  uint64_t flush_ingest = GetCFValueStats(InternalCFStatsType::BYTES_FLUSHED);
+  uint64_t add_file_ingest = GetCFValueStats(InternalCFStatsType::BYTES_INGESTED_ADD_FILE);
+  uint64_t ingest_files_addfile = GetCFValueStats(InternalCFStatsType::INGESTED_NUM_FILES_TOTAL);
   uint64_t ingest_l0_files_addfile =
-      cf_stats_value_[INGESTED_LEVEL0_NUM_FILES_TOTAL];
-  uint64_t ingest_keys_addfile = cf_stats_value_[INGESTED_NUM_KEYS_TOTAL];
+      GetCFValueStats(InternalCFStatsType::INGESTED_LEVEL0_NUM_FILES_TOTAL);
+  uint64_t ingest_keys_addfile = GetCFValueStats(InternalCFStatsType::INGESTED_NUM_KEYS_TOTAL);
   // Cumulative summary
   uint64_t total_stall_count =
-      cf_stats_count_[L0_FILE_COUNT_LIMIT_SLOWDOWNS] +
-      cf_stats_count_[L0_FILE_COUNT_LIMIT_STOPS] +
-      cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS] +
-      cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_STOPS] +
-      cf_stats_count_[MEMTABLE_LIMIT_STOPS] +
-      cf_stats_count_[MEMTABLE_LIMIT_SLOWDOWNS];
+      GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_SLOWDOWNS) +
+      GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_STOPS) +
+      GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS) +
+      GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_STOPS) +
+      GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_STOPS) +
+      GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_SLOWDOWNS);
   // Interval summary
   uint64_t interval_flush_ingest =
       flush_ingest - cf_stats_snapshot_.ingest_bytes_flush;
@@ -1364,14 +1364,14 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
            "%" PRIu64
            " memtable_slowdown, "
            "interval %" PRIu64 " total count\n",
-           cf_stats_count_[L0_FILE_COUNT_LIMIT_SLOWDOWNS],
-           cf_stats_count_[LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS],
-           cf_stats_count_[L0_FILE_COUNT_LIMIT_STOPS],
-           cf_stats_count_[LOCKED_L0_FILE_COUNT_LIMIT_STOPS],
-           cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_STOPS],
-           cf_stats_count_[PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS],
-           cf_stats_count_[MEMTABLE_LIMIT_STOPS],
-           cf_stats_count_[MEMTABLE_LIMIT_SLOWDOWNS],
+           GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_SLOWDOWNS),
+           GetCFCountStats(InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS),
+           GetCFCountStats(InternalCFStatsType::L0_FILE_COUNT_LIMIT_STOPS),
+           GetCFCountStats(InternalCFStatsType::LOCKED_L0_FILE_COUNT_LIMIT_STOPS),
+           GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_STOPS),
+           GetCFCountStats(InternalCFStatsType::PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS),
+           GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_STOPS),
+           GetCFCountStats(InternalCFStatsType::MEMTABLE_LIMIT_SLOWDOWNS),
            total_stall_count - cf_stats_snapshot_.stall_count);
   value->append(buf);
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -86,39 +86,39 @@ struct LevelStat {
   std::string header_name;
 };
 
+enum class InternalCFStatsType {
+  L0_FILE_COUNT_LIMIT_SLOWDOWNS,
+  LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS,
+  MEMTABLE_LIMIT_STOPS,
+  MEMTABLE_LIMIT_SLOWDOWNS,
+  L0_FILE_COUNT_LIMIT_STOPS,
+  LOCKED_L0_FILE_COUNT_LIMIT_STOPS,
+  PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS,
+  PENDING_COMPACTION_BYTES_LIMIT_STOPS,
+  WRITE_STALLS_ENUM_MAX,
+  BYTES_FLUSHED,
+  BYTES_INGESTED_ADD_FILE,
+  INGESTED_NUM_FILES_TOTAL,
+  INGESTED_LEVEL0_NUM_FILES_TOTAL,
+  INGESTED_NUM_KEYS_TOTAL,
+  ENUM_MAX,
+};
+
+enum class InternalDBStatsType {
+  WAL_FILE_BYTES,
+  WAL_FILE_SYNCED,
+  BYTES_WRITTEN,
+  NUMBER_KEYS_WRITTEN,
+  WRITE_DONE_BY_OTHER,
+  WRITE_DONE_BY_SELF,
+  WRITE_WITH_WAL,
+  WRITE_STALL_MICROS,
+  ENUM_MAX,
+};
+
 class InternalStats {
  public:
   static const std::map<LevelStatType, LevelStat> compaction_level_stats;
-
-  enum InternalCFStatsType {
-    L0_FILE_COUNT_LIMIT_SLOWDOWNS,
-    LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS,
-    MEMTABLE_LIMIT_STOPS,
-    MEMTABLE_LIMIT_SLOWDOWNS,
-    L0_FILE_COUNT_LIMIT_STOPS,
-    LOCKED_L0_FILE_COUNT_LIMIT_STOPS,
-    PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS,
-    PENDING_COMPACTION_BYTES_LIMIT_STOPS,
-    WRITE_STALLS_ENUM_MAX,
-    BYTES_FLUSHED,
-    BYTES_INGESTED_ADD_FILE,
-    INGESTED_NUM_FILES_TOTAL,
-    INGESTED_LEVEL0_NUM_FILES_TOTAL,
-    INGESTED_NUM_KEYS_TOTAL,
-    INTERNAL_CF_STATS_ENUM_MAX,
-  };
-
-  enum InternalDBStatsType {
-    WAL_FILE_BYTES,
-    WAL_FILE_SYNCED,
-    BYTES_WRITTEN,
-    NUMBER_KEYS_WRITTEN,
-    WRITE_DONE_BY_OTHER,
-    WRITE_DONE_BY_SELF,
-    WRITE_WITH_WAL,
-    WRITE_STALL_MICROS,
-    INTERNAL_DB_STATS_ENUM_MAX,
-  };
 
   InternalStats(int num_levels, Env* env, ColumnFamilyData* cfd)
       : db_stats_{},
@@ -300,10 +300,10 @@ class InternalStats {
   };
 
   void Clear() {
-    for (int i = 0; i < INTERNAL_DB_STATS_ENUM_MAX; i++) {
+    for (int i = 0; i < static_cast<int>(InternalDBStatsType::ENUM_MAX); i++) {
       db_stats_[i].store(0);
     }
-    for (int i = 0; i < INTERNAL_CF_STATS_ENUM_MAX; i++) {
+    for (int i = 0; i < static_cast<int>(InternalCFStatsType::ENUM_MAX); i++) {
       cf_stats_count_[i] = 0;
       cf_stats_value_[i] = 0;
     }
@@ -330,13 +330,21 @@ class InternalStats {
   }
 
   void AddCFStats(InternalCFStatsType type, uint64_t value) {
-    cf_stats_value_[type] += value;
-    ++cf_stats_count_[type];
+    cf_stats_value_[static_cast<size_t>(type)] += value;
+    ++cf_stats_count_[static_cast<size_t>(type)];
+  }
+
+  uint64_t GetCFCountStats(InternalCFStatsType type) {
+    return cf_stats_count_[static_cast<size_t>(type)];
+  }
+
+  uint64_t GetCFValueStats(InternalCFStatsType type) {
+    return cf_stats_value_[static_cast<size_t>(type)];
   }
 
   void AddDBStats(InternalDBStatsType type, uint64_t value,
                   bool concurrent = false) {
-    auto& v = db_stats_[type];
+    auto& v = db_stats_[static_cast<size_t>(type)];
     if (concurrent) {
       v.fetch_add(value, std::memory_order_relaxed);
     } else {
@@ -346,7 +354,7 @@ class InternalStats {
   }
 
   uint64_t GetDBStats(InternalDBStatsType type) {
-    return db_stats_[type].load(std::memory_order_relaxed);
+    return db_stats_[static_cast<size_t>(type)].load(std::memory_order_relaxed);
   }
 
   HistogramImpl* GetFileReadHist(int level) {
@@ -394,10 +402,10 @@ class InternalStats {
   bool HandleBlockCacheStat(Cache** block_cache);
 
   // Per-DB stats
-  std::atomic<uint64_t> db_stats_[INTERNAL_DB_STATS_ENUM_MAX];
+  std::atomic<uint64_t> db_stats_[static_cast<size_t>(InternalDBStatsType::ENUM_MAX)];
   // Per-ColumnFamily stats
-  uint64_t cf_stats_value_[INTERNAL_CF_STATS_ENUM_MAX];
-  uint64_t cf_stats_count_[INTERNAL_CF_STATS_ENUM_MAX];
+  uint64_t cf_stats_value_[static_cast<size_t>(InternalCFStatsType::ENUM_MAX)];
+  uint64_t cf_stats_count_[static_cast<size_t>(InternalCFStatsType::ENUM_MAX)];
   // Per-ColumnFamily/level compaction stats
   std::vector<CompactionStats> comp_stats_;
   std::vector<CompactionStats> comp_stats_by_pri_;
@@ -574,36 +582,6 @@ class InternalStats {
 
 class InternalStats {
  public:
-  enum InternalCFStatsType {
-    L0_FILE_COUNT_LIMIT_SLOWDOWNS,
-    LOCKED_L0_FILE_COUNT_LIMIT_SLOWDOWNS,
-    MEMTABLE_LIMIT_STOPS,
-    MEMTABLE_LIMIT_SLOWDOWNS,
-    L0_FILE_COUNT_LIMIT_STOPS,
-    LOCKED_L0_FILE_COUNT_LIMIT_STOPS,
-    PENDING_COMPACTION_BYTES_LIMIT_SLOWDOWNS,
-    PENDING_COMPACTION_BYTES_LIMIT_STOPS,
-    WRITE_STALLS_ENUM_MAX,
-    BYTES_FLUSHED,
-    BYTES_INGESTED_ADD_FILE,
-    INGESTED_NUM_FILES_TOTAL,
-    INGESTED_LEVEL0_NUM_FILES_TOTAL,
-    INGESTED_NUM_KEYS_TOTAL,
-    INTERNAL_CF_STATS_ENUM_MAX,
-  };
-
-  enum InternalDBStatsType {
-    WAL_FILE_BYTES,
-    WAL_FILE_SYNCED,
-    BYTES_WRITTEN,
-    NUMBER_KEYS_WRITTEN,
-    WRITE_DONE_BY_OTHER,
-    WRITE_DONE_BY_SELF,
-    WRITE_WITH_WAL,
-    WRITE_STALL_MICROS,
-    INTERNAL_DB_STATS_ENUM_MAX,
-  };
-
   InternalStats(int /*num_levels*/, Env* /*env*/, ColumnFamilyData* /*cfd*/) {}
 
   struct CompactionStats {


### PR DESCRIPTION
This is proposed fix for #4946 as stated in comment

> this fix probably has invalid formatting and might have few issues, but it seems to be compiling,
> (I haven't checked ROCKSDB_LITE ifdef branch though).
> The fix consists of fairly simple changes:
> 1. promotes InternalCFStatsType and InternalDBStatsType to top rocksdb namespace
> 2. turns both enums into enum classes
> 3. fixes usage
> (this is on top of 6.2.fb branch, but it should be fairly trivial to rebase if needed)