### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ blob_dump
 block_cache_trace_analyzer
 tools/block_cache_analyzer/*.pyc
 column_aware_encoding_exp
-util/build_version.cc
+**/util/build_version.cc
 build_tools/VALGRIND_LOGS/
 coverage/COVERAGE_REPORT
 .gdbhistory


### PR DESCRIPTION
ensures "util/build_version.cc" when generated.