### PR TITLE
db_stress: fix run time error when prefix_size = -1

### DIFF
--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -4285,9 +4285,12 @@ class CfConsistencyStressTest : public StressTest {
                                 const ReadOptions& readoptions,
                                 const std::vector<int>& rand_column_families,
                                 const std::vector<int64_t>& rand_keys) {
+    size_t prefix_to_use =
+        (FLAGS_prefix_size < 0) ? 7 : static_cast<size_t>(FLAGS_prefix_size);
+
     std::string key_str = Key(rand_keys[0]);
     Slice key = key_str;
-    Slice prefix = Slice(key.data(), FLAGS_prefix_size);
+    Slice prefix = Slice(key.data(), prefix_to_use);
 
     std::string upper_bound;
     Slice ub_slice;
@@ -4305,7 +4308,7 @@ class CfConsistencyStressTest : public StressTest {
          iter->Next()) {
       ++count;
     }
-    assert(count <= (static_cast<long>(1) << ((8 - FLAGS_prefix_size) * 8)));
+    assert(count <= (static_cast<long>(1) << ((8 - prefix_to_use) * 8)));
     Status s = iter->status();
     if (s.ok()) {
       thread->stats.AddPrefixes(1, count);


### PR DESCRIPTION
Summary: When prefix_size = -1, stress test crashes with run time error because of overflow. Fix it by not using -1 but 7 in prefix scan mode.

Test Plan: Run
python -u tools/db_crashtest.py --simple whitebox --random_kill_odd \
      888887 --compression_type=zstd
and see it doesn't crash.