### PR TITLE
Auto enable Periodic Compactions if a Compaction Filter is used

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
 ### Public API Change
+* Changed the default value of periodic_compaction_seconds to `UINT64_MAX` which allows RocksDB to auto-tune periodic compaction scheduling. When using the default value, periodic compactions are now auto-enabled if a compaction filter is used. A value of `0` will turn off the feature completely.
 * Added an API GetCreationTimeOfOldestFile(uint64_t* creation_time) to get the
 file_creation_time of the oldest SST file in the DB. 
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3780,7 +3780,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithCompactionFilters) {
   for (COMPACTION_FILTER_TYPE comp_filter_type :
        {USE_COMPACTION_FILTER, USE_COMPCTION_FILTER_FACTORY}) {
     // Assert that periodic compactions are not enabled.
-    ASSERT_EQ(0, options.periodic_compaction_seconds);
+    ASSERT_EQ(port::kMaxUint64, options.periodic_compaction_seconds);
 
     if (comp_filter_type == USE_COMPACTION_FILTER) {
       options.compaction_filter = &test_compaction_filter;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3772,20 +3772,20 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithCompactionFilters) {
   options.env = env_;
   env_->addon_time_.store(0);
 
-  enum COMPACTION_FILTER_TYPE {
-    USE_COMPACTION_FILTER,
-    USE_COMPCTION_FILTER_FACTORY
+  enum CompactionFilterType {
+    kUseCompactionFilter,
+    kUseCompactionFilterFactory
   };
 
-  for (COMPACTION_FILTER_TYPE comp_filter_type :
-       {USE_COMPACTION_FILTER, USE_COMPCTION_FILTER_FACTORY}) {
+  for (CompactionFilterType comp_filter_type :
+       {kUseCompactionFilter, kUseCompactionFilterFactory}) {
     // Assert that periodic compactions are not enabled.
     ASSERT_EQ(port::kMaxUint64, options.periodic_compaction_seconds);
 
-    if (comp_filter_type == USE_COMPACTION_FILTER) {
+    if (comp_filter_type == kUseCompactionFilter) {
       options.compaction_filter = &test_compaction_filter;
       options.compaction_filter_factory.reset();
-    } else if (comp_filter_type == USE_COMPCTION_FILTER_FACTORY) {
+    } else if (comp_filter_type == kUseCompactionFilterFactory) {
       options.compaction_filter = nullptr;
       options.compaction_filter_factory.reset(
           new TestCompactionFilterFactory());

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3792,7 +3792,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithCompactionFilters) {
     }
     DestroyAndReopen(options);
 
-    // periodic_compaction_seconds should be set to the sanitized value since
+    // periodic_compaction_seconds should be set to the sanitized value when
     // a compaction filter or a compaction filter factory is used.
     ASSERT_EQ(30 * 24 * 60 * 60,
               dbfull()->GetOptions().periodic_compaction_seconds);
@@ -3820,7 +3820,7 @@ TEST_F(DBCompactionTest, LevelPeriodicCompactionWithCompactionFilters) {
     ASSERT_EQ("2", FilesPerLevel());
     ASSERT_EQ(0, periodic_compactions);
 
-    // Add 50 hours and do a write
+    // Add 31 days and do a write
     env_->addon_time_.fetch_add(31 * 24 * 60 * 60);
     ASSERT_OK(Put("a", "1"));
     Flush();

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -670,10 +670,18 @@ struct AdvancedColumnFamilyOptions {
   // Only supported in Level compaction.
   // Pre-req: max_open_file == -1.
   // unit: seconds. Ex: 7 days = 7 * 24 * 60 * 60
-  // Default: 0 (disabled)
+  //
+  // Values:
+  // 0: Turn off Periodic compactions.
+  // UINT64_MAX (i.e 0xffffffffffffffff): Let RocksDB control this feature
+  //     as needed. For now, RocksDB will change this value to 30 days
+  //     (i.e 30 * 24 * 60 * 60) so that every file goes through the compaction
+  //     process at least once every 30 days if not compacted sooner.
+  //
+  // Default: UINT64_MAX (allow RocksDB to auto-tune)
   //
   // Dynamically changeable through SetOptions() API
-  uint64_t periodic_compaction_seconds = 0;
+  uint64_t periodic_compaction_seconds = 0xffffffffffffffff;
 
   // If this option is set then 1 in N blocks are compressed
   // using a fast (lz4) and slow (zstd) compression algorithm.

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -137,6 +137,9 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
       cf_options_.compaction_filter_factory != nullptr) {
     return Status::NotSupported("Blob DB doesn't support compaction filter.");
   }
+  // BlobDB does not support Periodic Compactions. So disable periodic
+  // compactions irrespective of the user set value.
+  cf_options_.periodic_compaction_seconds = 0;
 
   Status s;
 


### PR DESCRIPTION
- Periodic compactions are auto-enabled if a compaction filter or a compaction filter factory is set, in Level Compaction. 
- The default value of `periodic_compaction_seconds` is changed to UINT64_MAX, which lets RocksDB auto-tune periodic compactions as needed. An explicit value of 0 will still work as before ie. to disable periodic compactions completely. For now, on seeing a compaction filter along with a UINT64_MAX value for `periodic_compaction_seconds`, RocksDB will make SST files older than 30 days to go through periodic copmactions.

Some RocksDB users make use of compaction filters to control when their data can be deleted, usually with a custom TTL logic. But it is occasionally possible that the compactions get delayed by considerable time due to factors like low writes to a key range, data reaching bottom level, etc before the TTL expiry. Periodic Compactions feature was originally built to help such cases. Now periodic compactions are auto enabled by default when compaction filters or compaction filter factories are used, as it is generally helpful to all cases to collect garbage. 

`periodic_compaction_seconds` is set to a large value, 30 days, in `SanitizeOptions` when RocksDB sees that a `compaction_filter` or `compaction_filter_factory` is used. 

This is done only for Level Compaction style.

Test Plan:
- Added a new test `DBCompactionTest.LevelPeriodicCompactionWithCompactionFilters` to make sure that `periodic_compaction_seconds` is set if either `compaction_filter` or `compaction_filter_factory` options are set.
- `COMPILE_WITH_ASAN=1 make check`