### PR TITLE
Stress test to relax the iterator verification case for lower bound

### DIFF
--- a/tools/db_stress_tool.cc
+++ b/tools/db_stress_tool.cc
@@ -2513,9 +2513,13 @@ class StressTest {
       return;
     }
 
-    if (ro.iterate_lower_bound != nullptr) {
-      // Lower bound would create a lot of discrepency for now so disabling
-      // the verification for now.
+    if (ro.iterate_lower_bound != nullptr &&
+        (options_.comparator->Compare(*ro.iterate_lower_bound, seek_key) >= 0 ||
+         (ro.iterate_upper_bound != nullptr &&
+          options_.comparator->Compare(*ro.iterate_lower_bound,
+                                       *ro.iterate_upper_bound) >= 0))) {
+      // Lower bound behavior is not well defined if it is larger than
+      // seek key or upper bound. Disable the check for now.
       *diverged = true;
       return;
     }


### PR DESCRIPTION
Summary:
In stress test, all iterator verification is turned off is lower bound is enabled. This might be stricter than needed. This PR relaxes the condition and include the case where lower bound is lower than both of seek key and upper bound. It seems to work mostly fine when I run crash test locally.

Test Plan: Run crash_test