### PR TITLE
Fix a timer bug in MergingIterator::Seek() caused by #5871

### DIFF
--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -112,15 +112,18 @@ class MergingIterator : public InternalIterator {
     ClearHeaps();
     status_ = Status::OK();
     for (auto& child : children_) {
-      PERF_TIMER_GUARD(seek_child_seek_time);
-
-      child.Seek(target);
+      {
+        PERF_TIMER_GUARD(seek_child_seek_time);
+        child.Seek(target);
+      }
 
       PERF_COUNTER_ADD(seek_child_seek_count, 1);
-      // Strictly, we timed slightly more than min heap operation,
-      // but these operations are very cheap.
-      PERF_TIMER_GUARD(seek_min_heap_time);
-      AddToMinHeapOrCheckStatus(&child);
+      {
+        // Strictly, we timed slightly more than min heap operation,
+        // but these operations are very cheap.
+        PERF_TIMER_GUARD(seek_min_heap_time);
+        AddToMinHeapOrCheckStatus(&child);
+      }
     }
     direction_ = kForward;
     {


### PR DESCRIPTION
Summary:
Conflict resolving in 846e05005d78dfd4276cce6753967cb16930aabb ("Revert "Merging iterator to avoid child iterator reseek for some cases") caused some timer misplaced. Fix it.

Test Plan: See it build.

Reviewers: