### PR TITLE
Add Env::SanitizeEnvOptions

### DIFF
--- a/env/env.cc
+++ b/env/env.cc
@@ -390,6 +390,7 @@ void AssignEnvOptions(EnvOptions* env_options, const DBOptions& options) {
       options.writable_file_max_buffer_size;
   env_options->allow_fallocate = options.allow_fallocate;
   env_options->strict_bytes_per_sync = options.strict_bytes_per_sync;
+  options.env->SanitizeEnvOptions(env_options);
 }
 
 }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -524,6 +524,8 @@ class Env {
     return Status::NotSupported();
   }
 
+  virtual void SanitizeEnvOptions(EnvOptions* /*env_opts*/) const {}
+
   // If you're adding methods here, remember to add them to EnvWrapper too.
 
  protected:
@@ -1358,6 +1360,9 @@ class EnvWrapper : public Env {
   }
   Status GetFreeSpace(const std::string& path, uint64_t* diskfree) override {
     return target_->GetFreeSpace(path, diskfree);
+  }
+  void SanitizeEnvOptions(EnvOptions* env_opts) const override {
+    target_->SanitizeEnvOptions(env_opts);
   }
 
  private:


### PR DESCRIPTION
Summary: Add Env::SanitizeEnvOptions to allow underlying environments properly
configure env options.

Test Plan:
```
make check
```