### PR TITLE
Revert "Enable partitioned index/filter in stress tests (#5895)"

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -41,8 +41,8 @@ default_params = {
     "enable_pipelined_write": 0,
     "expected_values_path": expected_values_file.name,
     "flush_one_in": 1000000,
-    # Temporarily disable hash index
-    "index_type": lambda: random.choice([0,2]),
+    # Temporarily disable hash and partitioned index
+    "index_type": 0,
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
@@ -51,7 +51,7 @@ default_params = {
     "nooverwritepercent": 1,
     "open_files": lambda : random.choice([-1, 500000]),
     # Temporarily disable partitioned filter
-    "partition_filters": lambda: random.randint(0, 1),
+    "partition_filters": 0,
     "prefixpercent": 5,
     "progress_reports": 0,
     "readpercent": 45,
@@ -179,10 +179,8 @@ def finalize_and_sanitize(src_params):
         # now assertion failures are triggered.
         dest_params["compaction_ttl"] = 0
     if dest_params["partition_filters"] == 1:
-        if dest_params["index_type"] != 2:
-            dest_params["partition_filters"] = 0
-        else:
-            dest_params["use_block_based_filter"] = 0
+        dest_params["index_type"] = 2
+        dest_params["use_block_based_filter"] = 0
     return dest_params
 
 

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -354,7 +354,8 @@ DEFINE_bool(use_block_based_filter, false, "use block based filter"
               "instead of full filter for block based table");
 
 DEFINE_bool(partition_filters, false,
-            "use partitioned filters for block-based table");
+            "use partitioned filters "
+            "for block-based table");
 
 DEFINE_int32(
     index_type,


### PR DESCRIPTION
This reverts commit 2f4e288143f1c0c9f5a9e829d1b20ce62aca4224.
We revert it since a failure in our stress tests is suspected to be started after this commit.