### PR TITLE
Remove unnecessary cfd ref and unref

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1668,9 +1668,7 @@ Status DBImpl::AtomicFlushMemTables(
       if (cfd->mem()->IsEmpty() && cached_recoverable_state_empty_.load()) {
         continue;
       }
-      cfd->Ref();
       s = SwitchMemtable(cfd, &context);
-      cfd->Unref();
       if (!s.ok()) {
         break;
       }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1247,9 +1247,7 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
     MaybeFlushStatsCF(&cfds);
   }
   for (const auto cfd : cfds) {
-    cfd->Ref();
     status = SwitchMemtable(cfd, write_context);
-    cfd->Unref();
     if (!status.ok()) {
       break;
     }
@@ -1318,9 +1316,7 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
     if (cfd->mem()->IsEmpty()) {
       continue;
     }
-    cfd->Ref();
     status = SwitchMemtable(cfd, write_context);
-    cfd->Unref();
     if (!status.ok()) {
       break;
     }


### PR DESCRIPTION
Summary:
When we call SwitchMemtable in the write thread, we do not need to call
cfd->Ref() before SwitchMemtable because DropColumnFamily() will be blocked
outside the write thread even if db mutex is released.

Test Plan:
```
COMPILE_WITH_ASAN=1 make all && make check
```