### PR TITLE
Enable partitioned index/filter in stress tests

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -41,8 +41,8 @@ default_params = {
     "enable_pipelined_write": 0,
     "expected_values_path": expected_values_file.name,
     "flush_one_in": 1000000,
-    # Temporarily disable hash and partitioned index
-    "index_type": 0,
+    # Temporarily disable hash index
+    "index_type": lambda: random.choice([0,2]),
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
@@ -50,8 +50,7 @@ default_params = {
     "mmap_read": lambda: random.randint(0, 1),
     "nooverwritepercent": 1,
     "open_files": lambda : random.choice([-1, 500000]),
-    # Temporarily disable partitioned filter
-    "partition_filters": 0,
+    "partition_filters": lambda: random.randint(0, 1),
     "prefixpercent": 5,
     "progress_reports": 0,
     "readpercent": 45,
@@ -179,8 +178,10 @@ def finalize_and_sanitize(src_params):
         # now assertion failures are triggered.
         dest_params["compaction_ttl"] = 0
     if dest_params["partition_filters"] == 1:
-        dest_params["index_type"] = 2
-        dest_params["use_block_based_filter"] = 0
+        if dest_params["index_type"] != 2:
+            dest_params["partition_filters"] = 0
+        else:
+            dest_params["use_block_based_filter"] = 0
     return dest_params
 
 


### PR DESCRIPTION
This is the 3rd attempt after the revert of #4020 and #5895
The last bug is fixed https://github.com/facebook/rocksdb/pull/5907
Test: 
```
make -j32 crash_test
```