### PR TITLE
Make buckifier python3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tp2/
 fbcode/
 fbcode
 buckifier/*.pyc
+buckifier/__pycache__

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -108,9 +108,9 @@ def get_tests(repo_path):
 # Parse extra dependencies passed by user from command line
 def get_dependencies():
     deps_map = {
-        ''.encode('ascii'): {
-            'extra_deps'.encode('ascii'): [],
-            'extra_compiler_flags'.encode('ascii'): []
+        ''.encode('utf-8'): {
+            'extra_deps'.encode('utf-8').decode('utf-8'): [],
+            'extra_compiler_flags'.encode('utf-8').decode('utf-8'): []
         }
     }
     if len(sys.argv) < 2:
@@ -119,12 +119,12 @@ def get_dependencies():
     def encode_dict(data):
         rv = {}
         for k, v in data.items():
-            if isinstance(k, unicode):
-                k = k.encode('ascii')
-            if isinstance(v, unicode):
-                v = v.encode('ascii')
+            if isinstance(k, str):
+                k = k.encode('utf-8').decode('utf-8')
+            if isinstance(v, str):
+                v = v.encode('utf-8').decode('utf-8')
             elif isinstance(v, list):
-                v = [x.encode('ascii') for x in v]
+                v = [x.encode('utf-8').decode('utf-8') for x in v]
             elif isinstance(v, dict):
                 v = encode_dict(v)
             rv[k] = v

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -112,9 +112,9 @@ def get_tests(repo_path):
 # Parse extra dependencies passed by user from command line
 def get_dependencies():
     deps_map = {
-        ''.encode('utf-8'): {
-            'extra_deps'.encode('utf-8').decode('utf-8'): [],
-            'extra_compiler_flags'.encode('utf-8').decode('utf-8'): []
+        '': {
+            'extra_deps': [],
+            'extra_compiler_flags': []
         }
     }
     if len(sys.argv) < 2:
@@ -124,11 +124,11 @@ def get_dependencies():
         rv = {}
         for k, v in data.items():
             if isinstance(k, str):
-                k = k.encode('utf-8').decode('utf-8')
+                k = k
             if isinstance(v, str):
-                v = v.encode('utf-8').decode('utf-8')
+                v = v
             elif isinstance(v, list):
-                v = [x.encode('utf-8').decode('utf-8') for x in v]
+                v = [x for x in v]
             elif isinstance(v, dict):
                 v = encode_dict(v)
             rv[k] = v

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -123,13 +123,7 @@ def get_dependencies():
     def encode_dict(data):
         rv = {}
         for k, v in data.items():
-            if isinstance(k, str):
-                k = k
-            if isinstance(v, str):
-                v = v
-            elif isinstance(v, list):
-                v = [x for x in v]
-            elif isinstance(v, dict):
+            if isinstance(v, dict):
                 v = encode_dict(v)
             rv[k] = v
         return rv

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+try:
+    from builtins import str
+except ImportError:
+    from __builtin__ import str
 from targets_builder import TARGETSBuilder
 import json
 import os

--- a/buckifier/targets_builder.py
+++ b/buckifier/targets_builder.py
@@ -3,6 +3,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+try:
+    from builtins import object
+    from builtins import str
+except ImportError:
+    from __builtin__ import object
+    from __builtin__ import str
 import targets_cfg
 
 def pretty_list(lst, indent=8):
@@ -18,7 +24,7 @@ def pretty_list(lst, indent=8):
     return res
 
 
-class TARGETSBuilder:
+class TARGETSBuilder(object):
     def __init__(self, path):
         self.path = path
         self.targets_file = open(path, 'w')

--- a/buckifier/util.py
+++ b/buckifier/util.py
@@ -21,7 +21,8 @@ class ColorString:
 
     @staticmethod
     def _make_color_str(text, color):
-        return "".join([color, text.encode('utf-8'), ColorString.ENDC])
+        return "".join(
+            [color, text.encode('utf-8').decode('utf-8'), ColorString.ENDC])
 
     @staticmethod
     def ok(text):

--- a/buckifier/util.py
+++ b/buckifier/util.py
@@ -6,11 +6,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+try:
+    from builtins import object
+except ImportError:
+    from __builtin__ import object
 import subprocess
 import os
 import time
 
-class ColorString:
+class ColorString(object):
     """ Generate colorful strings on terminal """
     HEADER = '\033[95m'
     BLUE = '\033[94m'

--- a/buckifier/util.py
+++ b/buckifier/util.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     from __builtin__ import object
 import subprocess
+import sys
 import os
 import time
 
@@ -25,6 +26,11 @@ class ColorString(object):
 
     @staticmethod
     def _make_color_str(text, color):
+        # In Python2, default encoding for unicode string is ASCII
+        if sys.version_info.major <= 2:
+            return "".join(
+                [color, text.encode('utf-8'), ColorString.ENDC])
+        # From Python3, default encoding for unicode string is UTF-8
         return "".join(
             [color, text, ColorString.ENDC])
 

--- a/buckifier/util.py
+++ b/buckifier/util.py
@@ -26,7 +26,7 @@ class ColorString(object):
     @staticmethod
     def _make_color_str(text, color):
         return "".join(
-            [color, text.encode('utf-8').decode('utf-8'), ColorString.ENDC])
+            [color, text, ColorString.ENDC])
 
     @staticmethod
     def ok(text):


### PR DESCRIPTION
Summary:
Make buckifier/buckify_rocksdb.py run on both Python 3 and 2

Test Plan:
```
$python3 buckifier/buckify_rocksdb.py
$python3 buckifier/buckify_rocksdb.py '{"fake": {"extra_deps": [":test_dep", "//fakes/module:mock1"], "extra_compiler_flags": ["-DROCKSDB_LITE", "-Os"]}}'
$python2 buckifier/buckify_rocksdb.py
$python2 buckifier/buckify_rocksdb.py '{"fake": {"extra_deps": [":test_dep", "//fakes/module:mock1"], "extra_compiler_flags": ["-DROCKSDB_LITE", "-Os"]}}'
```