### PR TITLE
Fix bug when prefix_same_as_start = true and keys not in domain

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -238,7 +238,8 @@ bool DBIter::FindNextUserEntryInternal(bool skipping_saved_key,
 
     assert(prefix == nullptr || prefix_extractor_ != nullptr);
     if (prefix != nullptr &&
-        prefix_extractor_->Transform(ikey_.user_key).compare(*prefix) != 0) {
+        (!prefix_extractor_->InDomain(ikey_.user_key) ||
+         prefix_extractor_->Transform(ikey_.user_key).compare(*prefix) != 0)) {
       assert(prefix_same_as_start_);
       break;
     }
@@ -637,8 +638,9 @@ void DBIter::PrevInternal(const Slice* prefix) {
 
     assert(prefix == nullptr || prefix_extractor_ != nullptr);
     if (prefix != nullptr &&
-        prefix_extractor_->Transform(saved_key_.GetUserKey())
-                .compare(*prefix) != 0) {
+        (!prefix_extractor_->InDomain(saved_key_.GetUserKey()) ||
+         prefix_extractor_->Transform(saved_key_.GetUserKey())
+                 .compare(*prefix) != 0)) {
       assert(prefix_same_as_start_);
       // Current key does not have the same prefix as start
       valid_ = false;
@@ -1129,10 +1131,10 @@ void DBIter::Seek(const Slice& target) {
   // we need to find out the next key that is visible to the user.
   //
   ClearSavedValue();
-  if (prefix_same_as_start_) {
+  assert(!prefix_same_as_start_ || prefix_extractor_ != nullptr);
+  if (prefix_same_as_start_ && prefix_extractor_->InDomain(target)) {
     // The case where the iterator needs to be invalidated if it has exausted
     // keys within the same prefix of the seek key.
-    assert(prefix_extractor_ != nullptr);
     Slice target_prefix;
     target_prefix = prefix_extractor_->Transform(target);
     FindNextUserEntry(false /* not skipping saved_key */,
@@ -1190,10 +1192,10 @@ void DBIter::SeekForPrev(const Slice& target) {
   // we need to find out the first key that is visible to the user in the
   // backward direction.
   ClearSavedValue();
-  if (prefix_same_as_start_) {
+  assert(!prefix_same_as_start_ || prefix_extractor_ != nullptr);
+  if (prefix_same_as_start_ && prefix_extractor_->InDomain(target)) {
     // The case where the iterator needs to be invalidated if it has exausted
     // keys within the same prefix of the seek key.
-    assert(prefix_extractor_ != nullptr);
     Slice target_prefix;
     target_prefix = prefix_extractor_->Transform(target);
     PrevInternal(&target_prefix);
@@ -1255,8 +1257,9 @@ void DBIter::SeekToFirst() {
   } else {
     valid_ = false;
   }
-  if (valid_ && prefix_same_as_start_) {
-    assert(prefix_extractor_ != nullptr);
+  assert(!prefix_same_as_start_ || prefix_extractor_ != nullptr);
+  if (valid_ && prefix_same_as_start_ &&
+      prefix_extractor_->InDomain(saved_key_.GetUserKey())) {
     prefix_.SetUserKey(prefix_extractor_->Transform(saved_key_.GetUserKey()));
   }
 }
@@ -1299,8 +1302,9 @@ void DBIter::SeekToLast() {
       PERF_COUNTER_ADD(iter_read_bytes, key().size() + value().size());
     }
   }
-  if (valid_ && prefix_same_as_start_) {
-    assert(prefix_extractor_ != nullptr);
+  assert(!prefix_same_as_start_ || prefix_extractor_ != nullptr);
+  if (valid_ && prefix_same_as_start_ &&
+      prefix_extractor_->InDomain(saved_key_.GetUserKey())) {
     prefix_.SetUserKey(prefix_extractor_->Transform(saved_key_.GetUserKey()));
   }
 }


### PR DESCRIPTION
Summary: Prefix extractor needs to be invoked for a key only when it is in domain. However, when prefix_same_as_start = true, this assumption is broken. The fix is to add InDomain() check before any Transform() call when prefix_same_as_start = true.

Test Plan: Add a unit test to cover prefix_same_as_start = true with seek keys and keys on DB not in domain.