### PR TITLE
Support decoding blob indexes in sst_dump

### DIFF
--- a/db/blob_index.h
+++ b/db/blob_index.h
@@ -5,6 +5,9 @@
 #pragma once
 #ifndef ROCKSDB_LITE
 
+#include <sstream>
+#include <string>
+
 #include "rocksdb/options.h"
 #include "util/coding.h"
 #include "util/string_util.h"
@@ -106,6 +109,23 @@ class BlobIndex {
       }
     }
     return Status::OK();
+  }
+
+  std::string DebugString(bool output_hex) {
+    std::ostringstream oss;
+
+    if (IsInlined()) {
+      oss << "[inlined blob] " << value_.ToString(output_hex);
+    } else {
+      oss << "[blob ref] file:" << file_number_ << " offset:" << offset_
+          << " size:" << size_;
+    }
+
+    if (HasTTL()) {
+      oss << " exp:" << expiration_;
+    }
+
+    return oss.str();
   }
 
   static void EncodeInlinedTTL(std::string* dst, uint64_t expiration,

--- a/db/blob_index.h
+++ b/db/blob_index.h
@@ -115,7 +115,7 @@ class BlobIndex {
     std::ostringstream oss;
 
     if (IsInlined()) {
-      oss << "[inlined blob] " << value_.ToString(output_hex);
+      oss << "[inlined blob] value:" << value_.ToString(output_hex);
     } else {
       oss << "[blob ref] file:" << file_number_ << " offset:" << offset_
           << " size:" << size_;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2945,7 +2945,7 @@ void DumpSstFile(Options options, std::string filename, bool output_hex,
     return;
   }
   // no verification
-  rocksdb::SstFileDumper dumper(options, filename, false, output_hex);
+  rocksdb::SstFileDumper dumper(options, filename, false, output_hex, false);
   Status st = dumper.ReadSequential(true, std::numeric_limits<uint64_t>::max(),
                                     false,            // has_from
                                     from_key, false,  // has_to

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2945,7 +2945,9 @@ void DumpSstFile(Options options, std::string filename, bool output_hex,
     return;
   }
   // no verification
-  rocksdb::SstFileDumper dumper(options, filename, false, output_hex, false);
+  // TODO: add support for decoding blob indexes in ldb as well
+  rocksdb::SstFileDumper dumper(options, filename, /* verify_checksum */ false,
+                                output_hex, /* decode_blob_index */ false);
   Status st = dumper.ReadSequential(true, std::numeric_limits<uint64_t>::max(),
                                     false,            // has_from
                                     from_key, false,  // has_to

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -18,7 +18,8 @@ namespace rocksdb {
 class SstFileDumper {
  public:
   explicit SstFileDumper(const Options& options, const std::string& file_name,
-                         bool verify_checksum, bool output_hex);
+                         bool verify_checksum, bool output_hex,
+                         bool decode_blob_index);
 
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
                         const std::string& from_key, bool has_to,
@@ -64,6 +65,7 @@ class SstFileDumper {
   uint64_t read_num_;
   bool verify_checksum_;
   bool output_hex_;
+  bool decode_blob_index_;
   EnvOptions soptions_;
 
   // options_ and internal_comparator_ will also be used in


### PR DESCRIPTION
Summary:
The patch adds a new command line parameter --decode_blob_index to sst_dump.
If this switch is specified, sst_dump prints blob indexes in a human readable format,
printing the blob file number, offset, size, and expiration (if applicable) for blob
references, and the blob value (and expiration) for inlined blobs.

Test Plan:
Used db_bench's BlobDB mode to generate SST files containing blob references with
and without expiration, as well as inlined blobs with and without expiration (note: the
latter are stored as plain values), and confirmed sst_dump correctly prints all four types
of records.