### PR TITLE
Vary key size and alignment in filter_bench

### DIFF
--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -75,6 +75,7 @@ void _always_assert_fail(int line, const char *file, const char *expr) {
 
 using rocksdb::BlockContents;
 using rocksdb::CachableEntry;
+using rocksdb::EncodeFixed32;
 using rocksdb::fastrange32;
 using rocksdb::FilterBitsBuilder;
 using rocksdb::FilterBitsReader;
@@ -87,28 +88,38 @@ struct KeyMaker {
   KeyMaker(size_t avg_size)
       : smallest_size_(avg_size -
                        (FLAGS_vary_key_size_log2_interval >= 30 ? 2 : 0)),
-        n_vals_((avg_size + 11) / 4),  // pad to vary key size and alignment
-        vals_(new uint32_t[n_vals_]),
-        data_(reinterpret_cast<char *>(vals_.get())) {
-    memset(data_, 0, n_vals_ * 4);
+        buf_size_(avg_size + 11),  // pad to vary key size and alignment
+        buf_(new char[buf_size_]) {
+    memset(buf_.get(), 0, buf_size_);
     assert(smallest_size_ > 8);
   }
   size_t smallest_size_;
-  size_t n_vals_;
-  std::unique_ptr<uint32_t[]> vals_;
-  char *data_;
+  size_t buf_size_;
+  std::unique_ptr<char[]> buf_;
 
+  // Returns a unique(-ish) key based on the given parameter values. Each
+  // call returns a Slice from the same buffer so previously returned
+  // Slices should be considered invalidated.
   Slice Get(uint32_t filter_num, uint32_t val_num) {
     size_t start = FLAGS_vary_key_alignment ? val_num % 4 : 0;
     size_t len = smallest_size_;
     if (FLAGS_vary_key_size_log2_interval < 30) {
+      // To get range [avg_size - 2, avg_size + 2]
+      // use range [smallest_size, smallest_size + 4]
       len += fastrange32(
           (val_num >> FLAGS_vary_key_size_log2_interval) * 1234567891, 5);
     }
-    vals_[0] = val_num;
-    vals_[1] = filter_num + val_num;
-    vals_[2] = val_num;
-    return Slice(data_ + start, len);
+    char * data = buf_.get() + start;
+    // Populate key data such that all data makes it into a key of at
+    // least 8 bytes. We also don't want all the within-filter key
+    // variance confined to a contiguous 32 bits, because then a 32 bit
+    // hash function can "cheat" the false positive rate by
+    // approximating a perfect hash.
+    EncodeFixed32(data, val_num);
+    EncodeFixed32(data + 4, filter_num + val_num);
+    // ensure clearing leftovers from different alignment
+    EncodeFixed32(data + 8, 0);
+    return Slice(data, len);
   }
 };
 


### PR DESCRIPTION
Summary: The first version of filter_bench has selectable key size
but that size does not vary throughout a test run. This artificially
favors "branchy" hash functions like the existing BloomHash,
MurmurHash1, probably because of optimal return for branch prediction.

This change primarily varies those key sizes from -2 to +2 bytes vs.
the average selected size. We also set the default key size at 24 to
better reflect our best guess of typical key size.

But steadily random key sizes may not be realistic either. So this
change introduces a new filter_bench option:
-vary_key_size_log2_interval=n where the same key size is used 2^n
times and then changes to another size. I've set the default at 5
(32 times same size) as a compromise between deployments with
rather consistent vs. rather variable key sizes. On my Skylake
system, the performance boost to MurmurHash1 largely lies between
n=10 and n=15.

Also added -vary_key_alignment (bool, now default=true), though this
doesn't currently seem to matter in hash functions under
consideration.

This change also does a "dry run" for each testing scenario, to improve
the accuracy of those numbers, as there was more difference between
scenarios than expected. Subtracting gross test run times from dry run
times is now also embedded in the output, because these "net" times are
generally the most useful.

Note for the future: if we really want/need to optimize hashing (unlikely
for block-based table, maybe for plain table), we could combine it with
prefix extraction (make it part of same virtual call) and instantiate a
template for common fixed sizes.