### PR TITLE
Enable trace_replay with multi-threads

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -798,7 +798,6 @@ DEFINE_string(trace_file, "", "Trace workload to a file. ");
 
 DEFINE_int32(trace_replay_fast_forward, 1,
              "Fast forward trace replay, must >= 1. ");
-
 DEFINE_int32(block_cache_trace_sampling_frequency, 1,
              "Block cache trace sampling frequency, termed s. It uses spatial "
              "downsampling and samples accesses to one out of s blocks.");
@@ -809,6 +808,7 @@ DEFINE_int64(
     "will not be logged if the trace file size exceeds this threshold. Default "
     "is 64 GB.");
 DEFINE_string(block_cache_trace_file, "", "Block cache trace file path.");
+DEFINE_uint32(trace_replay_threads, 1, "The number of threads to replay. ");
 
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
@@ -6529,8 +6529,7 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    //s = replayer.Replay();
-    s = replayer.MultiThreadReplay(15);
+    s = replayer.MultiThreadReplay(FLAGS_trace_replay_threads);
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -6529,7 +6529,8 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    s = replayer.Replay();
+    //s = replayer.Replay();
+    s = replayer.MultiThreadReplay(15);
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -808,7 +808,8 @@ DEFINE_int64(
     "will not be logged if the trace file size exceeds this threshold. Default "
     "is 64 GB.");
 DEFINE_string(block_cache_trace_file, "", "Block cache trace file path.");
-DEFINE_uint32(trace_replay_threads, 1, "The number of threads to replay. ");
+DEFINE_int32(trace_replay_threads, 1,
+             "The number of threads to replay, must >=1.");
 
 static enum rocksdb::CompressionType StringToCompressionType(const char* ctype) {
   assert(ctype);
@@ -6529,7 +6530,8 @@ class Benchmark {
                       std::move(trace_reader));
     replayer.SetFastForward(
         static_cast<uint32_t>(FLAGS_trace_replay_fast_forward));
-    s = replayer.MultiThreadReplay(FLAGS_trace_replay_threads);
+    s = replayer.MultiThreadReplay(
+        static_cast<uint32_t>(FLAGS_trace_replay_threads));
     if (s.ok()) {
       fprintf(stdout, "Replay started from trace_file: %s\n",
               FLAGS_trace_file.c_str());

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -14,6 +14,7 @@
 #include "util/coding.h"
 #include "util/string_util.h"
 
+
 namespace rocksdb {
 
 const std::string kTraceMagic = "feedcafedeadbeef";
@@ -173,6 +174,7 @@ Replayer::Replayer(DB* db, const std::vector<ColumnFamilyHandle*>& handles,
     : trace_reader_(std::move(reader)) {
   assert(db != nullptr);
   db_ = static_cast<DBImpl*>(db->GetRootDB());
+  env_ = Env::Default();
   for (ColumnFamilyHandle* cfh : handles) {
     cf_map_[cfh->GetID()] = cfh;
   }
@@ -285,6 +287,69 @@ Status Replayer::Replay() {
   return s;
 }
 
+Status Replayer::MultiThreadReplay(uint32_t threads_num) {
+  Status s;
+  Trace header;
+  s = ReadHeader(&header);
+  if (!s.ok()) {
+    return s;
+  }
+  int threads = env_->GetBackgroundThreads(Env::Priority::LOW);
+  printf("threads: %d\n", threads);
+  if (threads_num > 1) {
+    env_->SetBackgroundThreads(static_cast<int>(threads_num));
+  }
+  threads = env_->GetBackgroundThreads(Env::Priority::LOW);
+  printf("threads: %d\n", threads);
+
+  std::chrono::system_clock::time_point replay_epoch =
+      std::chrono::system_clock::now();
+  WriteOptions woptions;
+  ReadOptions roptions;
+  ReplayerWorkerArg* ra;
+  uint64_t ops = 0;
+  while (s.ok()) {
+    ra = new ReplayerWorkerArg;
+    ra->db = db_;
+    s = ReadTrace(&(ra->trace_entry));
+    if (!s.ok()) {
+      break;
+    }
+    ra->woptions = woptions;
+    ra->roptions = roptions;
+
+    std::this_thread::sleep_until(
+        replay_epoch +
+        std::chrono::microseconds((ra->trace_entry.ts - header.ts) / fast_forward_));
+    if (ra->trace_entry.type == kTraceWrite) {
+      env_->Schedule(&Replayer::BGWorkWriteBatch, ra);
+      ops++;
+    } else if (ra->trace_entry.type == kTraceGet) {
+      env_->Schedule(&Replayer::BGWorkGet, ra);
+      ops++;
+    } else if (ra->trace_entry.type == kTraceIteratorSeek) {
+      env_->Schedule(&Replayer::BGWorkIterSeek, ra);
+      ops++;
+    } else if (ra->trace_entry.type == kTraceIteratorSeekForPrev) {
+      env_->Schedule(&Replayer::BGWorkIterSeekForPrev, ra);
+      ops++;
+    } else if (ra->trace_entry.type == kTraceEnd) {
+      // Do nothing for now.
+      // TODO: Add some validations later.
+      delete ra;
+      break;
+    }
+  }
+
+  if (s.IsIncomplete()) {
+    // Reaching eof returns Incomplete status at the moment.
+    // Could happen when killing a process without calling EndTrace() API.
+    // TODO: Add better error handling.
+    return Status::OK();
+  }
+  return s;
+}
+
 Status Replayer::ReadHeader(Trace* header) {
   assert(header != nullptr);
   Status s = ReadTrace(header);
@@ -323,6 +388,81 @@ Status Replayer::ReadTrace(Trace* trace) {
     return s;
   }
   return TracerHelper::DecodeTrace(encoded_trace, trace);
+}
+
+void Replayer::BGWorkGet(void* arg) {
+  ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
+  delete reinterpret_cast<ReplayerWorkerArg*>(arg);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  uint32_t cf_id = 0;
+  Slice key;
+  DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
+  if (cf_id > 0 && cf_map->find(cf_id) == cf_map->end()) {
+    return;
+  }
+
+  std::string value;
+  if (cf_id == 0) {
+      reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, key, &value);
+  } else {
+      reinterpret_cast<DB*>(ra.db)->Get(ra.roptions, (*cf_map)[cf_id], key, &value);
+  }
+
+  return;
+}
+
+void Replayer::BGWorkWriteBatch(void* arg) {
+  ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
+  delete reinterpret_cast<ReplayerWorkerArg*>(arg);
+  WriteBatch batch(ra.trace_entry.payload);
+  reinterpret_cast<DB*>(ra.db)->Write(ra.woptions, &batch);
+  return;
+}
+
+void Replayer::BGWorkIterSeek(void* arg) {
+  ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
+  delete reinterpret_cast<ReplayerWorkerArg*>(arg);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  uint32_t cf_id = 0;
+  Slice key;
+  DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
+  if (cf_id > 0 && cf_map->find(cf_id) == cf_map->end()) {
+      return;
+  }
+
+  std::string value;
+  Iterator* single_iter = nullptr;
+  if (cf_id == 0) {
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions);
+  } else {
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions, (*cf_map)[cf_id]);
+  }
+  single_iter->Seek(key);
+  delete single_iter;
+  return;
+}
+
+void Replayer::BGWorkIterSeekForPrev(void* arg) {
+  ReplayerWorkerArg ra = *(reinterpret_cast<ReplayerWorkerArg*>(arg));
+  delete reinterpret_cast<ReplayerWorkerArg*>(arg);
+  auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(ra.cf_map);
+  uint32_t cf_id = 0;
+  Slice key;
+  DecodeCFAndKey(ra.trace_entry.payload, &cf_id, &key);
+  if (cf_id > 0 && cf_map->find(cf_id) == cf_map->end()) {
+      return;
+  }
+
+  std::string value;
+  Iterator* single_iter = nullptr;
+  if (cf_id == 0) {
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions);
+  } else {
+    single_iter = reinterpret_cast<DB*>(ra.db)->NewIterator(ra.roptions, (*cf_map)[cf_id]);
+  }
+  single_iter->SeekForPrev(key);
+  delete single_iter;
+  return;
 }
 
 }  // namespace rocksdb

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -153,9 +153,21 @@ class Replayer {
   Status ReadHeader(Trace* header);
   Status ReadFooter(Trace* footer);
   Status ReadTrace(Trace* trace);
+
+  // The background function for MultiThreadReplay to execute Get query
+  // based on the trace records.
   static void BGWorkGet(void* arg);
+
+  // The background function for MultiThreadReplay to execute WriteBatch
+  // (Put, Delete, SingleDelete, DeleteRange) based on the trace records.
   static void BGWorkWriteBatch(void* arg);
+
+  // The background function for MultiThreadReplay to execute Iterator (Seek)
+  // based on the trace records.
   static void BGWorkIterSeek(void* arg);
+
+  // The background function for MultiThreadReplay to execute Iterator
+  // (SeekForPrev) based on the trace records.
   static void BGWorkIterSeekForPrev(void* arg);
 
   DBImpl* db_;
@@ -165,6 +177,7 @@ class Replayer {
   uint32_t fast_forward_;
 };
 
+// The passin arg of MultiThreadRepkay for each trace record.
 struct ReplayerWorkerArg {
   DB* db;
   Trace trace_entry;

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -137,9 +137,9 @@ class Replayer {
   // between the traces into consideration.
   Status Replay();
 
-  // Replay the provide trace stream as Replay() with multi-threads. Queries
-  // are scheduled in the thread pool job queue. User can set the number of
-  // threads in the thread pool.
+  // Replay the provide trace stream, which is the same as Replay(), with
+  // multi-threads. Queries are scheduled in the thread pool job queue.
+  // User can set the number of threads in the thread pool.
   Status MultiThreadReplay(uint32_t threads_num);
 
   // Enables fast forwarding a replay by reducing the delay between the ingested

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -137,6 +137,11 @@ class Replayer {
   // between the traces into consideration.
   Status Replay();
 
+  // Replay the provide trace stream as Replay() with multi-threads. Queries
+  // are scheduled in the thread pool job queue. User can set the number of
+  // threads in the thread pool.
+  Status MultiThreadReplay(uint32_t threads_num);
+
   // Enables fast forwarding a replay by reducing the delay between the ingested
   // traces.
   // fast_forward : Rate of replay speedup.
@@ -148,11 +153,24 @@ class Replayer {
   Status ReadHeader(Trace* header);
   Status ReadFooter(Trace* footer);
   Status ReadTrace(Trace* trace);
+  static void BGWorkGet(void* arg);
+  static void BGWorkWriteBatch(void* arg);
+  static void BGWorkIterSeek(void* arg);
+  static void BGWorkIterSeekForPrev(void* arg);
 
   DBImpl* db_;
+  Env* env_;
   std::unique_ptr<TraceReader> trace_reader_;
   std::unordered_map<uint32_t, ColumnFamilyHandle*> cf_map_;
   uint32_t fast_forward_;
+};
+
+struct ReplayerWorkerArg {
+  DB* db;
+  Trace trace_entry;
+  std::unordered_map<uint32_t, ColumnFamilyHandle*>* cf_map;
+  WriteOptions woptions;
+  ReadOptions roptions;
 };
 
 }  // namespace rocksdb


### PR DESCRIPTION
In the current trace replay, all the queries are serialized and called by single threads. It may not simulate the original application query situations closely. The multi-threads replay is implemented in this PR. Users can set the number of threads to replay the trace. The queries generated according to the trace records are scheduled in the thread pool job queue.

Test: test with make check and real trace replay.