### PR TITLE
Fix VerifyChecksum readahead with mmap mode

### DIFF
--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -369,6 +369,12 @@ TEST_F(CorruptionTest, VerifyChecksumReadahead) {
   ASSERT_GE(senv.random_read_counter_.Read(), 213);
   ASSERT_LE(senv.random_read_counter_.Read(), 447);
 
+  // Test readahead shouldn't break mmap mode (where it should be
+  // disabled).
+  options.allow_mmap_reads = true;
+  Reopen(&options);
+  ASSERT_OK(dbi->VerifyChecksum(ro));
+
   CloseDb();
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3750,8 +3750,11 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
   size_t readahead_size = (read_options.readahead_size != 0)
                               ? read_options.readahead_size
                               : kMaxAutoReadaheadSize;
+  // FilePrefetchBuffer doesn't work in mmap mode and readahead is not
+  // needed there.
   FilePrefetchBuffer prefetch_buffer(rep_->file.get(), readahead_size,
-                                     readahead_size);
+                                     readahead_size,
+                                     !rep_->ioptions.allow_mmap_reads);
 
   for (index_iter->SeekToFirst(); index_iter->Valid(); index_iter->Next()) {
     s = index_iter->status();


### PR DESCRIPTION
Summary: A recent change introduced readahead inside VerifyChecksum(). However it is not compatible with mmap mode and generated wrong checksum verification failure. Fix it by not enabling readahead in mmap mode.

Test Plan: Add a new unit test which failed without the failure.