### PR TITLE
Fix the potential memory leak of ReplayMultiThread

### DIFF
--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -313,13 +313,13 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
       std::chrono::system_clock::now();
   WriteOptions woptions;
   ReadOptions roptions;
-  ReplayerWorkerArg* ra;
   uint64_t ops = 0;
   while (s.ok()) {
-    ra = new ReplayerWorkerArg;
+    ReplayerWorkerArg* ra = new ReplayerWorkerArg;
     ra->db = db_;
     s = ReadTrace(&(ra->trace_entry));
     if (!s.ok()) {
+      delete ra;
       break;
     }
     ra->woptions = woptions;


### PR DESCRIPTION
The pointer ra needs to be freed the status s returns not OK. In the previous  PR #5934  , the ra is not freed which might cause potential memory leak. Fix this issue by moving the clarification of ra inside the while loop and freeing it as desired.

Test plan: pass make asan check.