### PR TITLE
Fix the potential memory leak in trace_replay

### DIFF
--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -344,7 +344,7 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
                            nullptr, nullptr);
       ops++;
     } else if (ra->trace_entry.type == kTraceEnd) {
-      // Do nothing for now, free the ReplayerWorkerArg.
+      // Do nothing for now.
       // TODO: Add some validations later.
       break;
     } else {

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -341,7 +341,8 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
       thread_pool.Schedule(&Replayer::BGWorkIterSeekForPrev, ra, nullptr,
                            nullptr);
       ops++;
-    } else if (ra->trace_entry.type == kTraceEnd) {
+    } else {
+      // It is the case that ra->trace_entry.type == kTraceEnd
       // Do nothing for now.
       // TODO: Add some validations later.
       delete ra;

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -343,7 +343,9 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
       ops++;
     } else {
       // It is the case that ra->trace_entry.type == kTraceEnd
-      // Do nothing for now.
+      assert(ra->trace_entry.type == kTraceEnd);
+
+      // Do nothing for now, free the ReplayerWorkerArg.
       // TODO: Add some validations later.
       delete ra;
       break;

--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -348,8 +348,9 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
       // TODO: Add some validations later.
       break;
     } else {
-      // Other trace entry types that are not replayed.
-      assert(false);
+      // Other trace entry types that are not implemented for replay.
+      // To finish the replay, we continue the process.
+      continue;
     }
   }
 


### PR DESCRIPTION
In the previous PR #5934 , in the while loop, if/else if is used without ending with else to free the object referenced by ra, it might cause potential memory leak (warning during compiling). Fix it by adding "else" at the end to handle other trace entry types and replacing raw pointer with unique_ptr to avoid potential memory leak

Test plan: pass make asan check, pass the USE_CLANG=1 TEST_TMPDIR=/dev/shm/rocksdb OPT=-g make -j64 analyze.