### PR TITLE
FilePrefetchBuffer to include return bytes in readahead size

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -111,12 +111,8 @@ bool FilePrefetchBuffer::TryReadFromCache(uint64_t offset, size_t n,
       assert(file_reader_ != nullptr);
       assert(max_readahead_size_ >= readahead_size_);
       Status s;
-      if (for_compaction) {
-        s = Prefetch(file_reader_, offset, std::max(n, readahead_size_),
-                     for_compaction);
-      } else {
-        s = Prefetch(file_reader_, offset, n + readahead_size_, for_compaction);
-      }
+      s = Prefetch(file_reader_, offset, std::max(n, readahead_size_),
+                   for_compaction);
       if (!s.ok()) {
         return false;
       }


### PR DESCRIPTION
Summary:
Right now, in compaction readahead, readahead size includes size to return, so that readahead_size = 2MB will generate exact 2MB I/O, while in non-compaction workloads, it is bytes_to_read + 2MB. We consolidate to the former case to make the code easier to maintain.

Test Plan: make all check