### PR TITLE
Propagate SST and blob file numbers through the EventListener interface

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,7 @@
 * When using BlobDB, a mapping is maintained and persisted in the MANIFEST between each SST file and the oldest non-TTL blob file it references.
 * `db_bench` now supports and by default issues non-TTL Puts to BlobDB. TTL Puts can be enabled by specifying a non-zero value for the `blob_db_max_ttl_range` command line parameter explicitly.
 * `sst_dump` now supports printing BlobDB blob indexes in a human-readable format. This can be enabled by specifying the `decode_blob_index` flag on the command line.
+* A number of new information elements are now exposed through the EventListener interface. For flushes, the file numbers of the new SST file and the oldest blob file referenced by the SST are propagated. For compactions, the level, file number, and the oldest blob file referenced are passed to the client for each compaction input and output file.
 ### Public API Change
 * Added max_write_buffer_size_to_maintain option to better control memory usage of immutable memtables.
 * Added a lightweight API GetCurrentWalFile() to get last live WAL filename and size. Meant to be used as a helper for backup/restore tooling in a larger ecosystem such as MySQL with a MyRocks storage engine.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1120,9 +1120,10 @@ void DBImpl::NotifyOnCompactionBegin(ColumnFamilyData* cfd, Compaction* c,
     info.compression = c->output_compression();
     for (size_t i = 0; i < c->num_input_levels(); ++i) {
       for (const auto fmd : *c->inputs(i)) {
-        const uint64_t file_number = fmd->fd.GetNumber();
+        const FileDescriptor& desc = fmd->fd;
+        const uint64_t file_number = desc.GetNumber();
         auto fn = TableFileName(c->immutable_cf_options()->cf_paths,
-                                file_number, fmd->fd.GetPathId());
+                                file_number, desc.GetPathId());
         info.input_files.push_back(fn);
         info.input_levels_and_file_numbers.emplace_back(i, file_number);
         if (info.table_properties.count(fn) == 0) {
@@ -2962,9 +2963,10 @@ void DBImpl::BuildCompactionJobInfo(
   compaction_job_info->compression = c->output_compression();
   for (size_t i = 0; i < c->num_input_levels(); ++i) {
     for (const auto fmd : *c->inputs(i)) {
-      const uint64_t file_number = fmd->fd.GetNumber();
+      const FileDescriptor& desc = fmd->fd;
+      const uint64_t file_number = desc.GetNumber();
       auto fn = TableFileName(c->immutable_cf_options()->cf_paths, file_number,
-                              fmd->fd.GetPathId());
+                              desc.GetPathId());
       compaction_job_info->input_files.push_back(fn);
       compaction_job_info->input_levels_and_file_numbers.emplace_back(
           i, file_number);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -575,8 +575,10 @@ void DBImpl::NotifyOnFlushBegin(ColumnFamilyData* cfd, FileMetaData* file_meta,
     info.cf_name = cfd->GetName();
     // TODO(yhchiang): make db_paths dynamic in case flush does not
     //                 go to L0 in the future.
+    const uint64_t file_number = file_meta->fd.GetNumber();
     info.file_path = MakeTableFileName(cfd->ioptions()->cf_paths[0].path,
-                                       file_meta->fd.GetNumber());
+                                       file_number);
+    info.file_number = file_number;
     info.thread_id = env_->GetThreadID();
     info.job_id = job_id;
     info.triggered_writes_slowdown = triggered_writes_slowdown;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -436,8 +436,8 @@ std::unique_ptr<FlushJobInfo> FlushJob::GetFlushJobInfo() const {
   info->cf_name = cfd_->GetName();
 
   const uint64_t file_number = meta_.fd.GetNumber();
-  info->file_path = MakeTableFileName(cfd_->ioptions()->cf_paths[0].path,
-                                      file_number);
+  info->file_path =
+      MakeTableFileName(cfd_->ioptions()->cf_paths[0].path, file_number);
   info->file_number = file_number;
   info->oldest_blob_file_number = meta_.oldest_blob_file_number;
   info->thread_id = db_options_.env->GetThreadID();

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -434,8 +434,12 @@ std::unique_ptr<FlushJobInfo> FlushJob::GetFlushJobInfo() const {
   std::unique_ptr<FlushJobInfo> info(new FlushJobInfo);
   info->cf_id = cfd_->GetID();
   info->cf_name = cfd_->GetName();
+
+  const uint64_t file_number = meta_.fd.GetNumber();
   info->file_path = MakeTableFileName(cfd_->ioptions()->cf_paths[0].path,
-                                      meta_.fd.GetNumber());
+                                      file_number);
+  info->file_number = file_number;
+  info->oldest_blob_file_number = meta_.oldest_blob_file_number;
   info->thread_id = db_options_.env->GetThreadID();
   info->job_id = job_context_->job_id;
   info->smallest_seqno = meta_.fd.smallest_seqno;

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include "db/blob_index.h"
 #include "db/db_impl/db_impl.h"
 #include "db/db_test_util.h"
 #include "db/dbformat.h"
@@ -41,6 +42,14 @@ namespace rocksdb {
 class EventListenerTest : public DBTestBase {
  public:
   EventListenerTest() : DBTestBase("/listener_test") {}
+
+  static std::string BlobStr(uint64_t blob_file_number, uint64_t offset,
+                             uint64_t size) {
+    std::string blob_index;
+    BlobIndex::EncodeBlob(&blob_index, blob_file_number, offset, size,
+                          kNoCompression);
+    return blob_index;
+  }
 
   const size_t k110KB = 110 << 10;
 };

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -181,6 +181,12 @@ TEST_F(EventListenerTest, OnSingleDBCompactionTest) {
       "nikitich", "alyosha", "popovich"};
   CreateAndReopenWithCF(cf_names, options);
   ASSERT_OK(Put(1, "pikachu", std::string(90000, 'p')));
+
+  WriteBatch batch;
+  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 1, "ditto",
+                                             BlobStr(123, 0, 1 << 10)));
+  ASSERT_OK(dbfull()->Write(WriteOptions(), &batch));
+
   ASSERT_OK(Put(2, "ilya", std::string(90000, 'i')));
   ASSERT_OK(Put(3, "muromec", std::string(90000, 'm')));
   ASSERT_OK(Put(4, "dobrynia", std::string(90000, 'd')));
@@ -189,11 +195,9 @@ TEST_F(EventListenerTest, OnSingleDBCompactionTest) {
   ASSERT_OK(Put(7, "popovich", std::string(90000, 'p')));
   for (int i = 1; i < 8; ++i) {
     ASSERT_OK(Flush(i));
-    const Slice kRangeStart = "a";
-    const Slice kRangeEnd = "z";
-    ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), handles_[i],
-                                     &kRangeStart, &kRangeEnd));
     dbfull()->TEST_WaitForFlushMemTable();
+    ASSERT_OK(dbfull()->CompactRange(CompactRangeOptions(), handles_[i],
+                                     nullptr, nullptr));
     dbfull()->TEST_WaitForCompact();
   }
 
@@ -313,6 +317,12 @@ TEST_F(EventListenerTest, OnSingleDBFlushTest) {
   CreateAndReopenWithCF(cf_names, options);
 
   ASSERT_OK(Put(1, "pikachu", std::string(90000, 'p')));
+
+  WriteBatch batch;
+  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 1, "ditto",
+                                             BlobStr(456, 0, 1 << 10)));
+  ASSERT_OK(dbfull()->Write(WriteOptions(), &batch));
+
   ASSERT_OK(Put(2, "ilya", std::string(90000, 'i')));
   ASSERT_OK(Put(3, "muromec", std::string(90000, 'm')));
   ASSERT_OK(Put(4, "dobrynia", std::string(90000, 'd')));

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -199,10 +199,6 @@ struct FlushJobInfo {
 };
 
 struct CompactionJobInfo {
-  CompactionJobInfo() = default;
-  explicit CompactionJobInfo(const CompactionJobStats& _stats)
-      : stats(_stats) {}
-
   // the id of the column family where the compaction happened.
   uint32_t cf_id;
   // the name of the column family where the compaction happened.

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -170,6 +170,10 @@ struct FlushJobInfo {
   std::string cf_name;
   // the path to the newly created file
   std::string file_path;
+  // the file number of the newly created file
+  uint64_t file_number;
+  // the oldest blob file referenced by the newly created file
+  uint64_t oldest_blob_file_number;
   // the id of the thread that completed this flush job.
   uint64_t thread_id;
   // the job id, which is unique in the same thread.
@@ -213,11 +217,29 @@ struct CompactionJobInfo {
   int base_input_level;
   // the output level of the compaction.
   int output_level;
-  // the names of the compaction input files.
+
+  // The following variables contain information about compaction inputs
+  // and outputs. A file may appear in both the input and output lists
+  // if it was simply moved to a different level. The order of elements
+  // is the same across input_files and input_levels_and_file_numbers;
+  // similarly, it is the same across output_files,
+  // output_levels_and_file_numbers, and output_oldest_blob_file_numbers.
+
+  // The names of the compaction input files.
   std::vector<std::string> input_files;
 
-  // the names of the compaction output files.
+  // The levels and file numbers of the compaction input files.
+  std::vector<std::pair<int, uint64_t>> input_levels_and_file_numbers;
+
+  // The names of the compaction output files.
   std::vector<std::string> output_files;
+
+  // The levels and file numbers of the compaction output files.
+  std::vector<std::pair<int, uint64_t>> output_levels_and_file_numbers;
+
+  // The oldest blob file referenced by each compaction output file.
+  std::vector<uint64_t> output_oldest_blob_file_numbers;
+
   // Table properties for input and output tables.
   // The map is keyed by values from input_files and output_files.
   TablePropertiesCollection table_properties;

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -198,6 +198,17 @@ struct FlushJobInfo {
   FlushReason flush_reason;
 };
 
+struct CompactionFileInfo {
+  // The level of the file.
+  int level;
+
+  // The file number of the file.
+  uint64_t file_number;
+
+  // The file number of the oldest blob file this SST file references.
+  uint64_t oldest_blob_file_number;
+};
+
 struct CompactionJobInfo {
   // the id of the column family where the compaction happened.
   uint32_t cf_id;
@@ -217,24 +228,20 @@ struct CompactionJobInfo {
   // The following variables contain information about compaction inputs
   // and outputs. A file may appear in both the input and output lists
   // if it was simply moved to a different level. The order of elements
-  // is the same across input_files and input_levels_and_file_numbers;
-  // similarly, it is the same across output_files,
-  // output_levels_and_file_numbers, and output_oldest_blob_file_numbers.
+  // is the same across input_files and input_file_infos; similarly, it is
+  // the same across output_files and output_file_infos.
 
   // The names of the compaction input files.
   std::vector<std::string> input_files;
 
-  // The levels and file numbers of the compaction input files.
-  std::vector<std::pair<int, uint64_t>> input_levels_and_file_numbers;
+  // Additional information about the compaction input files.
+  std::vector<CompactionFileInfo> input_file_infos;
 
   // The names of the compaction output files.
   std::vector<std::string> output_files;
 
-  // The levels and file numbers of the compaction output files.
-  std::vector<std::pair<int, uint64_t>> output_levels_and_file_numbers;
-
-  // The oldest blob file referenced by each compaction output file.
-  std::vector<uint64_t> output_oldest_blob_file_numbers;
+  // Additional information about the compaction output files.
+  std::vector<CompactionFileInfo> output_file_infos;
 
   // Table properties for input and output tables.
   // The map is keyed by values from input_files and output_files.


### PR DESCRIPTION
Summary:
This patch adds a number of new information elements to the FlushJobInfo and
CompactionJobInfo structures that are passed to EventListeners via the
OnFlush{Begin, Completed} and OnCompaction{Begin, Completed} callbacks.
Namely, for flushes, the file numbers of the new SST and the oldest blob file it
references are propagated. For compactions, the new pieces of information are
the file number, level, and the oldest blob file referenced by each compaction
input and output file.

Test Plan:
Extended the EventListener unit tests with logic that checks that these information
elements are correctly propagated from the corresponding FileMetaData.