### PR TITLE
Make FIFO compaction take default 30 days TTL by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ## Unreleased
 ### Public API Change
 * Changed the default value of periodic_compaction_seconds to `UINT64_MAX` which allows RocksDB to auto-tune periodic compaction scheduling. When using the default value, periodic compactions are now auto-enabled if a compaction filter is used. A value of `0` will turn off the feature completely.
-* With FIFO compaction style, options.periodic_compaction_seconds will have the same meeting as options.ttl. Whichever stricter will be used. With the default options.periodic_compaction_seconds value with options.ttl's default of 0, RocksDB will give a default of 30 days.
+* With FIFO compaction style, options.periodic_compaction_seconds will have the same meaning as options.ttl. Whichever stricter will be used. With the default options.periodic_compaction_seconds value with options.ttl's default of 0, RocksDB will give a default of 30 days.
 * Added an API GetCreationTimeOfOldestFile(uint64_t* creation_time) to get the
 file_creation_time of the oldest SST file in the DB. 
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Public API Change
 * Changed the default value of periodic_compaction_seconds to `UINT64_MAX` which allows RocksDB to auto-tune periodic compaction scheduling. When using the default value, periodic compactions are now auto-enabled if a compaction filter is used. A value of `0` will turn off the feature completely.
+* With FIFO compaction style, options.periodic_compaction_seconds will have the same meeting as options.ttl. Whichever stricter will be used. With the default options.periodic_compaction_seconds value with options.ttl's default of 0, RocksDB will give a default of 30 days.
 * Added an API GetCreationTimeOfOldestFile(uint64_t* creation_time) to get the
 file_creation_time of the oldest SST file in the DB. 
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -345,7 +345,7 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
 
   const uint64_t kDefaultPeriodicCompSecs = 0xffffffffffffffff;
   const uint64_t kDefaultTtlSecs = 30 * 24 * 60 * 60;
-  
+
   // Turn on periodic compactions and set them to occur once every 30 days if
   // compaction filters are used and periodic_compaction_seconds is set to the
   // default value.
@@ -354,7 +354,7 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
        result.compaction_filter_factory != nullptr) &&
       result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
     result.periodic_compaction_seconds = kDefaultTtlSecs;
-  } else if (result.compaction_style == kCompactionStyleFIFO) {    
+  } else if (result.compaction_style == kCompactionStyleFIFO) {
     if (result.ttl == 0) {
       if (result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
         result.periodic_compaction_seconds = kDefaultTtlSecs;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -344,7 +344,8 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   }
 
   const uint64_t kDefaultPeriodicCompSecs = 0xffffffffffffffff;
-
+  const uint64_t kDefaultTtlSecs = 30 * 24 * 60 * 60;
+  
   // Turn on periodic compactions and set them to occur once every 30 days if
   // compaction filters are used and periodic_compaction_seconds is set to the
   // default value.
@@ -352,11 +353,11 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
       (result.compaction_filter != nullptr ||
        result.compaction_filter_factory != nullptr) &&
       result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
-    result.periodic_compaction_seconds = 30 * 24 * 60 * 60;
+    result.periodic_compaction_seconds = kDefaultTtlSecs;
   } else if (result.compaction_style == kCompactionStyleFIFO) {    
     if (result.ttl == 0) {
       if (result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
-        result.periodic_compaction_seconds = 30 * 24 * 60 * 60;
+        result.periodic_compaction_seconds = kDefaultTtlSecs;
       }
       result.ttl = result.periodic_compaction_seconds;
     } else if (result.periodic_compaction_seconds != 0) {

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -631,7 +631,7 @@ TEST_F(DBOptionsTest, SanitizeFIFOPeriodicCompaction) {
   Reopen(options);
   ASSERT_EQ(300, dbfull()->GetOptions().ttl);
 }
-  
+
 TEST_F(DBOptionsTest, SetFIFOCompactionOptions) {
   Options options;
   options.compaction_style = kCompactionStyleFIFO;

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -606,6 +606,32 @@ TEST_F(DBOptionsTest, SanitizeDelayedWriteRate) {
   ASSERT_EQ(31 * 1024 * 1024, dbfull()->GetDBOptions().delayed_write_rate);
 }
 
+TEST_F(DBOptionsTest, SanitizeFIFOPeriodicCompaction) {
+  Options options;
+  options.compaction_style = kCompactionStyleFIFO;
+  options.ttl = 0;
+  Reopen(options);
+  ASSERT_EQ(30 * 24 * 60 * 60, dbfull()->GetOptions().ttl);
+
+  options.ttl = 100;
+  Reopen(options);
+  ASSERT_EQ(100, dbfull()->GetOptions().ttl);
+
+  options.ttl = 100 * 24 * 60 * 60;
+  Reopen(options);
+  ASSERT_EQ(100 * 24 * 60 * 60, dbfull()->GetOptions().ttl);
+
+  options.ttl = 200;
+  options.periodic_compaction_seconds = 300;
+  Reopen(options);
+  ASSERT_EQ(200, dbfull()->GetOptions().ttl);
+
+  options.ttl = 500;
+  options.periodic_compaction_seconds = 300;
+  Reopen(options);
+  ASSERT_EQ(300, dbfull()->GetOptions().ttl);
+}
+  
 TEST_F(DBOptionsTest, SetFIFOCompactionOptions) {
   Options options;
   options.compaction_style = kCompactionStyleFIFO;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -669,7 +669,7 @@ struct AdvancedColumnFamilyOptions {
   // age is based on the file's last modified time (given by the underlying
   // Env).
   //
-  // Only supported in Level compaction.
+  // Supported in Level and FIFO compaction.
   // In FIFO compaction, this option has the same meaning as TTL and whichever
   // stricter will be used.
   // Pre-req: max_open_file == -1.

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -653,6 +653,8 @@ struct AdvancedColumnFamilyOptions {
   //           compation process.
   // In FIFO: Files older than TTL will be deleted.
   // unit: seconds. Ex: 1 day = 1 * 24 * 60 * 60
+  // In FIFO, this option will have the same meaning as
+  // periodic_compaction_seconds. Whichever stricter will be used.
   //
   // Default: 0 (disabled)
   //
@@ -668,6 +670,8 @@ struct AdvancedColumnFamilyOptions {
   // Env).
   //
   // Only supported in Level compaction.
+  // In FIFO compaction, this option has the same meaning as TTL and whichever
+  // stricter will be used.
   // Pre-req: max_open_file == -1.
   // unit: seconds. Ex: 7 days = 7 * 24 * 60 * 60
   //
@@ -677,6 +681,9 @@ struct AdvancedColumnFamilyOptions {
   //     as needed. For now, RocksDB will change this value to 30 days
   //     (i.e 30 * 24 * 60 * 60) so that every file goes through the compaction
   //     process at least once every 30 days if not compacted sooner.
+  //     In FIFO compaction, since the option has the same meaning as ttl,
+  //     when this value is left default, and ttl is left to 0, 30 days will be
+  //     used. Otherwise, min(ttl, periodic_compaction_seconds) will be used.
   //
   // Default: UINT64_MAX (allow RocksDB to auto-tune)
   //


### PR DESCRIPTION
Summary: Right now, by default FIFO compaction has no TTL. We believe that a default TTL of 30 days will be better. With this patch, the default will be changed to 30 days. Default of Options.periodic_compaction_seconds will mean the same as options.ttl. If Options.ttl and Options.periodic_compaction_seconds left default, a default 30 days TTL will be used. If both options are set, the stricter value of the two will be used.

Test Plan: Add an option sanitize test to cover the case.