### PR TITLE
Fix MultiGet crash when no_block_cache is set

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@ file_creation_time of the oldest SST file in the DB.
 ### Performance Improvements
 * For 64-bit hashing, RocksDB is standardizing on a slightly modified preview version of XXH3. This function is now used for many non-persisted hashes, along with fastrange64() in place of the modulus operator, and some benchmarks show a slight improvement.
 
+### Bug Fixes
+* Fix a assertion failure in MultiGe4t() when BlockBasedTableOptions::no_block_cache is true and there is no compressed block cache
+
 ## 6.5.1 (10/16/2019)
 ### Bug Fixes
 * Revert the feature "Merging iterator to avoid child iterator reseek for some cases (#5286)" since it might cause strange results when reseek happens with a different iterator upper bound.

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1834,7 +1834,7 @@ INSTANTIATE_TEST_CASE_P(
     // Param 2 - Data compression enabled
     // Param 3 - ReadOptions::fill_cache
     ::testing::Combine(::testing::Bool(), ::testing::Bool(),
-                       ::testing::Bool(), testing::Bool()));
+                       ::testing::Bool(), ::testing::Bool()));
 
 class DBBasicTestWithTimestampWithParam
     : public DBTestBase,

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1619,8 +1619,8 @@ class DBBasicTestWithParallelIO
 
   bool fill_cache() { return fill_cache_; }
   bool compression_enabled() { return compression_enabled_; }
-  bool compressed_cache() { return compressed_cache_ != nullptr; }
-  bool uncompressed_cache() { return uncompressed_cache_ != nullptr; }
+  bool has_compressed_cache() { return compressed_cache_ != nullptr; }
+  bool has_uncompressed_cache() { return uncompressed_cache_ != nullptr; }
 
   static void SetUpTestCase() {}
   static void TearDownTestCase() {}
@@ -1797,9 +1797,9 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
 
   bool read_from_cache = false;
   if (fill_cache()) {
-    if (uncompressed_cache()) {
+    if (has_uncompressed_cache()) {
       read_from_cache = true;
-    } else if (compressed_cache() && compression_enabled()) {
+    } else if (has_compressed_cache() && compression_enabled()) {
       read_from_cache = true;
     }
   }

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1833,19 +1833,8 @@ INSTANTIATE_TEST_CASE_P(
     // Param 1 - Uncompressed cache enabled
     // Param 2 - Data compression enabled
     // Param 3 - ReadOptions::fill_cache
-    ::testing::Values(std::make_tuple(false, true, true, true),
-                      std::make_tuple(true, true, true, true),
-                      std::make_tuple(false, true, false, true),
-                      std::make_tuple(false, true, true, false),
-                      std::make_tuple(true, true, true, false),
-                      std::make_tuple(false, true, false, false),
-                      std::make_tuple(false, false, true, true),
-                      std::make_tuple(true, false, true, true),
-                      std::make_tuple(false, false, false, true),
-                      std::make_tuple(false, false, true, false),
-                      std::make_tuple(true, false, true, false),
-                      std::make_tuple(false, false, false, false),
-                      std::make_tuple(true, false, false, true)));
+    ::testing::Combine(::testing::Bool(), ::testing::Bool(),
+                       ::testing::Bool(), testing::Bool()));
 
 class DBBasicTestWithTimestampWithParam
     : public DBTestBase,

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2384,7 +2384,13 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       }
     }
     if (s.ok()) {
-      if (options.fill_cache) {
+      Cache* block_cache = rep_->table_options.block_cache.get();
+      // No point to cache compressed blocks if it never goes away
+      Cache* block_cache_compressed =
+          rep_->immortal_table
+              ? nullptr
+              : rep_->table_options.block_cache_compressed.get();
+      if (options.fill_cache && (block_cache || block_cache_compressed)) {
         BlockCacheLookupContext lookup_data_block_context(
             TableReaderCaller::kUserMultiGet);
         CachableEntry<Block>* block_entry = &(*results)[idx_in_batch];

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2384,13 +2384,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       }
     }
     if (s.ok()) {
-      Cache* block_cache = rep_->table_options.block_cache.get();
-      // No point to cache compressed blocks if it never goes away
-      Cache* block_cache_compressed =
-          rep_->immortal_table
-              ? nullptr
-              : rep_->table_options.block_cache_compressed.get();
-      if (options.fill_cache && (block_cache || block_cache_compressed)) {
+      if (options.fill_cache) {
         BlockCacheLookupContext lookup_data_block_context(
             TableReaderCaller::kUserMultiGet);
         CachableEntry<Block>* block_entry = &(*results)[idx_in_batch];
@@ -2401,33 +2395,41 @@ void BlockBasedTable::RetrieveMultipleBlocks(
             nullptr, options, handle, uncompression_dict, block_entry,
             BlockType::kData, mget_iter->get_context,
             &lookup_data_block_context, &raw_block_contents);
+
+        // block_entry value could be null if no block cache is present, i.e
+        // BlockBasedTableOptions::no_block_cache is true and no compressed
+        // block cache is configured. In that case, fall
+        // through and set up the block explicitly
+        if (block_entry->GetValue() != nullptr) {
+          continue;
+        }
+      }
+
+      CompressionType compression_type =
+          raw_block_contents.get_compression_type();
+      BlockContents contents;
+      if (compression_type != kNoCompression) {
+        UncompressionContext context(compression_type);
+        UncompressionInfo info(context, uncompression_dict, compression_type);
+        s = UncompressBlockContents(info, req.result.data(), handle.size(),
+                                    &contents, footer.version(),
+                                    rep_->ioptions, memory_allocator);
       } else {
-        CompressionType compression_type =
-            raw_block_contents.get_compression_type();
-        BlockContents contents;
-        if (compression_type != kNoCompression) {
-          UncompressionContext context(compression_type);
-          UncompressionInfo info(context, uncompression_dict, compression_type);
-          s = UncompressBlockContents(info, req.result.data(), handle.size(),
-                                      &contents, footer.version(),
-                                      rep_->ioptions, memory_allocator);
+        if (scratch != nullptr) {
+          // If we used the scratch buffer, then the contents need to be
+          // copied to heap
+          Slice raw = Slice(req.result.data(), handle.size());
+          contents = BlockContents(
+              CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
+              handle.size());
         } else {
-          if (scratch != nullptr) {
-            // If we used the scratch buffer, then the contents need to be
-            // copied to heap
-            Slice raw = Slice(req.result.data(), handle.size());
-            contents = BlockContents(
-                CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
-                handle.size());
-          } else {
-            contents = std::move(raw_block_contents);
-          }
+          contents = std::move(raw_block_contents);
         }
-        if (s.ok()) {
-          (*results)[idx_in_batch].SetOwnedValue(
-              new Block(std::move(contents), global_seqno,
-                        read_amp_bytes_per_bit, ioptions.statistics));
-        }
+      }
+      if (s.ok()) {
+        (*results)[idx_in_batch].SetOwnedValue(
+            new Block(std::move(contents), global_seqno,
+                      read_amp_bytes_per_bit, ioptions.statistics));
       }
     }
     (*statuses)[idx_in_batch] = s;


### PR DESCRIPTION
This PR fixes #5975. In ```BlockBasedTable::RetrieveMultipleBlocks()```, we were calling ```MaybeReadBlocksAndLoadToCache()```, which is a no-op if neither uncompressed nor compressed block cache are configured.

Test plan:
1. Add unit tests that fail with the old code and pass with the new
2. make check and asan_check

Cc @spetrunia 