### PR TITLE
crash_test: disable periodic compaction in FIFO compaction.

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -175,6 +175,7 @@ def finalize_and_sanitize(src_params):
         # Disable compaction TTL in FIFO compaction, because right
         # now assertion failures are triggered.
         dest_params["compaction_ttl"] = 0
+        dest_params["periodic_compaction_seconds"] = 0
     if dest_params["partition_filters"] == 1:
         if dest_params["index_type"] != 2:
             dest_params["partition_filters"] = 0


### PR DESCRIPTION
Summary: A recent commit make periodic compaction option valid in FIFO, which means TTL. But we fail to disable it in crash test, causing assert failure. Fix it by having it disabled.

Test Plan: Hack db_crashtest.py so it starts with check_mode=2, restart "make crash_test" many times and make sure --periodic_compaction_seconds=0 is always the case and see "--compaction_style=2" is used.