### PR TITLE
Turn on periodic compaction in universal by default if compaction filter is used.

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -349,12 +349,14 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   // Turn on periodic compactions and set them to occur once every 30 days if
   // compaction filters are used and periodic_compaction_seconds is set to the
   // default value.
-  if (result.compaction_style == kCompactionStyleLevel &&
-      (result.compaction_filter != nullptr ||
-       result.compaction_filter_factory != nullptr) &&
-      result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
-    result.periodic_compaction_seconds = kDefaultTtlSecs;
-  } else if (result.compaction_style == kCompactionStyleFIFO) {
+  if (result.compaction_style != kCompactionStyleFIFO) {
+    if ((result.compaction_filter != nullptr ||
+         result.compaction_filter_factory != nullptr) &&
+        result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
+      result.periodic_compaction_seconds = kDefaultTtlSecs;
+    }
+  } else {
+    // result.compaction_style == kCompactionStyleFIFO
     if (result.ttl == 0) {
       if (result.periodic_compaction_seconds == kDefaultPeriodicCompSecs) {
         result.periodic_compaction_seconds = kDefaultTtlSecs;

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -2149,6 +2149,29 @@ TEST_F(DBTestUniversalCompaction2, IngestBehind) {
   ASSERT_GT(NumTableFilesAtLevel(5), 0);
 }
 
+TEST_F(DBTestUniversalCompaction2, PeriodicCompactionDefault) {
+  Options options;
+  options.compaction_style = kCompactionStyleUniversal;
+
+  KeepFilterFactory* filter = new KeepFilterFactory(true);
+  options.compaction_filter_factory.reset(filter);
+  Reopen(options);
+  ASSERT_EQ(30 * 24 * 60 * 60,
+            dbfull()->GetOptions().periodic_compaction_seconds);
+
+  KeepFilter df;
+  options.compaction_filter_factory.reset();
+  options.compaction_filter = &df;
+  Reopen(options);
+  ASSERT_EQ(30 * 24 * 60 * 60,
+            dbfull()->GetOptions().periodic_compaction_seconds);
+
+  options.compaction_filter = nullptr;
+  Reopen(options);
+  ASSERT_EQ(options.periodic_compaction_seconds,
+            dbfull()->GetOptions().periodic_compaction_seconds);
+}
+
 TEST_F(DBTestUniversalCompaction2, PeriodicCompaction) {
   Options opts = CurrentOptions();
   opts.env = env_;


### PR DESCRIPTION
Summary: Recently, periodic compaction got turned on by default for leveled compaction is compaction filter is used. Since periodic compaction is now supported in universal compaction too, we do the same default for universal now.

Test Plan: Add a new unit test.