### PR TITLE
Allow concurrent CF iteration and drop

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -106,6 +106,10 @@ const Comparator* ColumnFamilyHandleImpl::GetComparator() const {
   return cfd()->user_comparator();
 }
 
+ColumnFamilyHandle* ColumnFamilyHandleImpl::CloneHandle() const {
+  return new ColumnFamilyHandleImpl(this->cfd_, this->db_, this->mutex_);
+}
+
 void GetIntTblPropCollectorFactory(
     const ImmutableCFOptions& ioptions,
     std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -169,6 +169,7 @@ class ColumnFamilyHandleImpl : public ColumnFamilyHandle {
   virtual const std::string& GetName() const override;
   virtual Status GetDescriptor(ColumnFamilyDescriptor* desc) override;
   virtual const Comparator* GetComparator() const override;
+  virtual ColumnFamilyHandle* CloneHandle() const override;
 
  private:
   ColumnFamilyData* cfd_;

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -612,6 +612,9 @@ class ColumnFamilyHandleImplDummy : public ColumnFamilyHandleImpl {
   const Comparator* GetComparator() const override {
     return BytewiseComparator();
   }
+  ColumnFamilyHandle* CloneHandle() const override {
+    return new ColumnFamilyHandleImplDummy(id_);
+  }
 
  private:
   uint32_t id_;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -88,6 +88,8 @@ class ColumnFamilyHandle {
   // Returns the comparator of the column family associated with the
   // current handle.
   virtual const Comparator* GetComparator() const = 0;
+  // Returns a copy of this handle used to pin column family
+  virtual ColumnFamilyHandle* CloneHandle() const = 0;
 };
 
 static const int kMajorVersion = __ROCKSDB_MAJOR__;

--- a/java/rocksjni/columnfamilyhandle.cc
+++ b/java/rocksjni/columnfamilyhandle.cc
@@ -60,6 +60,19 @@ jobject Java_org_rocksdb_ColumnFamilyHandle_getDescriptor(JNIEnv* env,
 
 /*
  * Class:     org_rocksdb_ColumnFamilyHandle
+ * Method:    cloneHandle
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_rocksdb_ColumnFamilyHandle_cloneHandle(JNIEnv* /*env*/,
+                                                                        jobject /*jobj*/,
+                                                                        jlong jhandle) {
+  auto* cfh = reinterpret_cast<rocksdb::ColumnFamilyHandle*>(jhandle);
+  auto* clone = cfh->CloneHandle();
+  return reinterpret_cast<jlong>(clone);
+}
+
+/*
+ * Class:     org_rocksdb_ColumnFamilyHandle
  * Method:    disposeInternal
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
+++ b/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
@@ -21,10 +21,18 @@ package org.rocksdb;
  */
 public abstract class AbstractRocksIterator<P extends RocksObject>
     extends RocksObject implements RocksIteratorInterface {
+  final RocksObject owner_;
   final P parent_;
 
   protected AbstractRocksIterator(final P parent, final long nativeHandle) {
+    this(null, parent, nativeHandle);
+  }
+
+  protected AbstractRocksIterator(final RocksObject owner, final P parent,
+      final long nativeHandle) {
     super(nativeHandle);
+    // owner for pinning underlying C++ owner object, or it can be null
+    owner_ = owner;
     // parent must point to a valid RocksDB instance.
     assert (parent != null);
     // RocksIterator must hold a reference to the related parent instance
@@ -93,6 +101,9 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
   protected void disposeInternal() {
     if (parent_.isOwningHandle()) {
       disposeInternal(nativeHandle_);
+    }
+    if (owner_ != null) {
+      owner_.close();
     }
   }
 

--- a/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
+++ b/java/src/main/java/org/rocksdb/AbstractRocksIterator.java
@@ -23,8 +23,7 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
     extends RocksObject implements RocksIteratorInterface {
   final P parent_;
 
-  protected AbstractRocksIterator(final P parent,
-      final long nativeHandle) {
+  protected AbstractRocksIterator(final P parent, final long nativeHandle) {
     super(nativeHandle);
     // parent must point to a valid RocksDB instance.
     assert (parent != null);
@@ -92,9 +91,9 @@ public abstract class AbstractRocksIterator<P extends RocksObject>
    */
   @Override
   protected void disposeInternal() {
-      if (parent_.isOwningHandle()) {
-        disposeInternal(nativeHandle_);
-      }
+    if (parent_.isOwningHandle()) {
+      disposeInternal(nativeHandle_);
+    }
   }
 
   abstract boolean isValid0(long handle);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
@@ -120,10 +120,15 @@ public class ColumnFamilyHandle extends RocksObject {
    */
   @Override
   protected void disposeInternal() {
+    if (iter_ != null) {
+      iter_.close();
+    }
     if(rocksDB_.isOwningHandle()) {
       disposeInternal(nativeHandle_);
     }
   }
+
+  protected AbstractRocksIterator iter_ = null;
 
   private native byte[] getName(final long handle) throws RocksDBException;
   private native int getID(final long handle);

--- a/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
@@ -63,6 +63,18 @@ public class ColumnFamilyHandle extends RocksObject {
     return getDescriptor(nativeHandle_);
   }
 
+  /**
+   * Gets a copy of the Column Family Handle, used to prevent Column Family
+   * from being released before some operations based on the Column Family,
+   * such as iterators for querying the Column Family.
+   *
+   * @return a copy ColumnFamilyHandle
+   */
+  public ColumnFamilyHandle cloneHandle() {
+    assert(isOwningHandle());
+    return new ColumnFamilyHandle(this.rocksDB_, cloneHandle(nativeHandle_));
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -109,6 +121,7 @@ public class ColumnFamilyHandle extends RocksObject {
   private native byte[] getName(final long handle) throws RocksDBException;
   private native int getID(final long handle);
   private native ColumnFamilyDescriptor getDescriptor(final long handle) throws RocksDBException;
+  private native long cloneHandle(final long handle);
   @Override protected final native void disposeInternal(final long handle);
 
   private final RocksDB rocksDB_;

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -18,9 +18,17 @@ package org.rocksdb;
  *
  * @see org.rocksdb.RocksObject
  */
-public class RocksIterator extends AbstractRocksIterator<RocksDB> {
-  protected RocksIterator(RocksDB rocksDB, long nativeHandle) {
-    super(rocksDB, nativeHandle);
+public class RocksIterator extends AbstractRocksIterator<ColumnFamilyHandle> {
+  final ColumnFamilyHandle cfHandle_;
+
+  protected RocksIterator(final RocksDB rocksDB, final long nativeHandle) {
+    super(rocksDB.getDefaultColumnFamily(), nativeHandle);
+    this.cfHandle_ = null;
+  }
+
+  protected RocksIterator(final ColumnFamilyHandle parent, final long nativeHandle) {
+    super(parent, nativeHandle);
+    this.cfHandle_ = parent;
   }
 
   /**
@@ -48,6 +56,14 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
   public byte[] value() {
     assert(isOwningHandle());
     return value0(nativeHandle_);
+  }
+
+  @Override
+  protected void disposeInternal() {
+    super.disposeInternal();
+    if (cfHandle_ != null) {
+      cfHandle_.close();
+    }
   }
 
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -26,10 +26,14 @@ public class RocksIterator extends AbstractRocksIterator<RocksDB> {
 
   protected RocksIterator(final ColumnFamilyHandle cfHandle, final long nativeHandle) {
     super(cfHandle, cfHandle.rocksDB_, nativeHandle);
+    cfHandle.iter_ = this;
   }
 
   protected RocksIterator(final RocksIterator base, final long nativeHandle) {
     super(base.owner_, base.parent_, nativeHandle);
+    if (base.owner_ != null) {
+      ((ColumnFamilyHandle) base.owner_).iter_ = this;
+    }
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/RocksIterator.java
+++ b/java/src/main/java/org/rocksdb/RocksIterator.java
@@ -18,17 +18,18 @@ package org.rocksdb;
  *
  * @see org.rocksdb.RocksObject
  */
-public class RocksIterator extends AbstractRocksIterator<ColumnFamilyHandle> {
-  final ColumnFamilyHandle cfHandle_;
+public class RocksIterator extends AbstractRocksIterator<RocksDB> {
 
   protected RocksIterator(final RocksDB rocksDB, final long nativeHandle) {
-    super(rocksDB.getDefaultColumnFamily(), nativeHandle);
-    this.cfHandle_ = null;
+    super(rocksDB, nativeHandle);
   }
 
-  protected RocksIterator(final ColumnFamilyHandle parent, final long nativeHandle) {
-    super(parent, nativeHandle);
-    this.cfHandle_ = parent;
+  protected RocksIterator(final ColumnFamilyHandle cfHandle, final long nativeHandle) {
+    super(cfHandle, cfHandle.rocksDB_, nativeHandle);
+  }
+
+  protected RocksIterator(final RocksIterator base, final long nativeHandle) {
+    super(base.owner_, base.parent_, nativeHandle);
   }
 
   /**
@@ -56,14 +57,6 @@ public class RocksIterator extends AbstractRocksIterator<ColumnFamilyHandle> {
   public byte[] value() {
     assert(isOwningHandle());
     return value0(nativeHandle_);
-  }
-
-  @Override
-  protected void disposeInternal() {
-    super.disposeInternal();
-    if (cfHandle_ != null) {
-      cfHandle_.close();
-    }
   }
 
   @Override protected final native void disposeInternal(final long handle);

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -149,7 +149,7 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
    * point-in-timefrom baseIterator and modifications made in this write batch.
    */
   public RocksIterator newIteratorWithBase(final RocksIterator baseIterator) {
-    return newIteratorWithBase(baseIterator.parent_.getDefaultColumnFamily(), baseIterator);
+    return newIteratorWithBase(baseIterator.parent_, baseIterator);
   }
 
   /**

--- a/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
+++ b/java/src/main/java/org/rocksdb/WriteBatchWithIndex.java
@@ -129,9 +129,8 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
   public RocksIterator newIteratorWithBase(
       final ColumnFamilyHandle columnFamilyHandle,
       final RocksIterator baseIterator) {
-    RocksIterator iterator = new RocksIterator(baseIterator.parent_,
-        iteratorWithBase(
-            nativeHandle_, columnFamilyHandle.nativeHandle_, baseIterator.nativeHandle_));
+    RocksIterator iterator = new RocksIterator(baseIterator, iteratorWithBase(
+        nativeHandle_, columnFamilyHandle.nativeHandle_, baseIterator.nativeHandle_));
     // when the iterator is deleted it will also delete the baseIterator
     baseIterator.disOwnNativeHandle();
     return iterator;
@@ -149,7 +148,7 @@ public class WriteBatchWithIndex extends AbstractWriteBatch {
    * point-in-timefrom baseIterator and modifications made in this write batch.
    */
   public RocksIterator newIteratorWithBase(final RocksIterator baseIterator) {
-    return newIteratorWithBase(baseIterator.parent_, baseIterator);
+    return newIteratorWithBase(baseIterator.parent_.getDefaultColumnFamily(), baseIterator);
   }
 
   /**

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -31,6 +31,9 @@ class ColumnFamilyHandleImplDummy : public ColumnFamilyHandleImpl {
         comparator_(comparator) {}
   uint32_t GetID() const override { return id_; }
   const Comparator* GetComparator() const override { return comparator_; }
+  ColumnFamilyHandle* CloneHandle() const override {
+    return new ColumnFamilyHandleImplDummy(id_, comparator_);
+  }
 
  private:
   uint32_t id_;


### PR DESCRIPTION
Closing ColumnFamilyHandle with unreleased iterators is easy to cause coredump,
because the iterator release is controlled by java GC when using JNI.

This patch fixed it, we let an iterator hold a ColumnFamilyData reference to
prevent the CF from being released too early.

fixed #5982