### PR TITLE
[Java] fix assert error while db.getDefaultColumnFamily().getDescriptor()

### DIFF
--- a/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
@@ -32,6 +32,7 @@ public class ColumnFamilyHandle extends RocksObject {
    * @throws RocksDBException if an error occurs whilst retrieving the name.
    */
   public byte[] getName() throws RocksDBException {
+    assert(isOwningHandle() || isDefaultColumnFamily());
     return getName(nativeHandle_);
   }
 
@@ -41,6 +42,7 @@ public class ColumnFamilyHandle extends RocksObject {
    * @return the ID of the Column Family.
    */
   public int getID() {
+    assert(isOwningHandle() || isDefaultColumnFamily());
     return getID(nativeHandle_);
   }
 
@@ -59,7 +61,7 @@ public class ColumnFamilyHandle extends RocksObject {
    *     descriptor.
    */
   public ColumnFamilyDescriptor getDescriptor() throws RocksDBException {
-    assert(isOwningHandle());
+    assert(isOwningHandle() || isDefaultColumnFamily());
     return getDescriptor(nativeHandle_);
   }
 
@@ -89,6 +91,10 @@ public class ColumnFamilyHandle extends RocksObject {
     } catch (RocksDBException e) {
       throw new RuntimeException("Cannot calculate hash code of column family handle", e);
     }
+  }
+
+  protected boolean isDefaultColumnFamily() {
+    return nativeHandle_ == rocksDB_.getDefaultColumnFamily().nativeHandle_;
   }
 
   /**

--- a/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ColumnFamilyTest.java
@@ -75,6 +75,7 @@ public class ColumnFamilyTest {
 
         assertThat(cfh.getName()).isEqualTo("default".getBytes(UTF_8));
         assertThat(cfh.getID()).isEqualTo(0);
+        assertThat(cfh.getDescriptor().getName()).isEqualTo("default".getBytes(UTF_8));
 
         final byte[] key = "key".getBytes();
         final byte[] value = "value".getBytes();


### PR DESCRIPTION
Threw assert error at assert(isOwningHandle()) in ColumnFamilyHandle.getDescriptor(),
because default CF don't own a handle, due to [RocksDB.getDefaultColumnFamily()](https://github.com/facebook/rocksdb/blob/3a408eeae95614150ac930fc7f244524ed8c6f1c/java/src/main/java/org/rocksdb/RocksDB.java#L3702) called cfHandle.disOwnNativeHandle().