### PR TITLE
bugfix: MemTableList::RemoveOldMemTables invalid iterator after remov…

### DIFF
--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -742,7 +742,7 @@ void MemTableList::RemoveOldMemTables(uint64_t log_number,
     if (mem->GetNextLogNumber() > log_number) {
       break;
     }
-    old_memtables.push_back(mem);    
+    old_memtables.push_back(mem);
   }
 
   for (auto it = old_memtables.begin(); it!= old_memtables.end(); ++it) {

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -736,17 +736,24 @@ void MemTableList::RemoveOldMemTables(uint64_t log_number,
   assert(to_delete != nullptr);
   InstallNewVersion();
   auto& memlist = current_->memlist_;
+  autovector<MemTable*> old_memtables;
   for (auto it = memlist.rbegin(); it != memlist.rend(); ++it) {
     MemTable* mem = *it;
     if (mem->GetNextLogNumber() > log_number) {
       break;
     }
+    old_memtables.push_back(mem);    
+  }
+
+  for (auto it = old_memtables.begin(); it!= old_memtables.end(); ++it) {
+    MemTable* mem = *it;
     current_->Remove(mem, to_delete);
     --num_flush_not_started_;
     if (0 == num_flush_not_started_) {
       imm_flush_needed.store(false, std::memory_order_release);
     }
   }
+
   UpdateMemoryUsageExcludingLast();
   ResetTrimHistoryNeeded();
 }

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -745,7 +745,7 @@ void MemTableList::RemoveOldMemTables(uint64_t log_number,
     old_memtables.push_back(mem);
   }
 
-  for (auto it = old_memtables.begin(); it!= old_memtables.end(); ++it) {
+  for (auto it = old_memtables.begin(); it != old_memtables.end(); ++it) {
     MemTable* mem = *it;
     current_->Remove(mem, to_delete);
     --num_flush_not_started_;


### PR DESCRIPTION
Fix issue #6012.

I found that it may be caused by the following codes in function _RemoveOldMemTables()_ in **db/memtable_list.cc**  :
```
  for (auto it = memlist.rbegin(); it != memlist.rend(); ++it) {
    MemTable* mem = *it;
    if (mem->GetNextLogNumber() > log_number) {
      break;
    }
    current_->Remove(mem, to_delete);
```

The iterator **it** turns invalid after `current_->Remove(mem, to_delete);` 

Test plan:
```
make check
```


