### PR TITLE
BlobDB: Maintain mapping between blob files and SSTs

### DIFF
--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -204,12 +204,12 @@ class BlobDB : public StackableDB {
     return NewIterator(options);
   }
 
-  virtual Status CompactFiles(
+  Status CompactFiles(
       const CompactionOptions& compact_options,
       const std::vector<std::string>& input_file_names, const int output_level,
       const int output_path_id = -1,
       std::vector<std::string>* const output_file_names = nullptr,
-      CompactionJobInfo* compaction_job_info = nullptr) = 0;
+      CompactionJobInfo* compaction_job_info = nullptr) override = 0;
   Status CompactFiles(
       const CompactionOptions& compact_options,
       ColumnFamilyHandle* column_family,

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -204,6 +204,28 @@ class BlobDB : public StackableDB {
     return NewIterator(options);
   }
 
+  virtual Status CompactFiles(
+      const CompactionOptions& compact_options,
+      const std::vector<std::string>& input_file_names, const int output_level,
+      const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = nullptr,
+      CompactionJobInfo* compaction_job_info = nullptr) = 0;
+  Status CompactFiles(
+      const CompactionOptions& compact_options,
+      ColumnFamilyHandle* column_family,
+      const std::vector<std::string>& input_file_names, const int output_level,
+      const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = nullptr,
+      CompactionJobInfo* compaction_job_info = nullptr) override {
+    if (column_family != DefaultColumnFamily()) {
+      return Status::NotSupported(
+          "Blob DB doesn't support non-default column family.");
+    }
+
+    return CompactFiles(compact_options, input_file_names, output_level,
+                        output_path_id, output_file_names, compaction_job_info);
+  }
+
   using rocksdb::StackableDB::Close;
   virtual Status Close() override = 0;
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -141,6 +141,11 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   // compactions irrespective of the user set value.
   cf_options_.periodic_compaction_seconds = 0;
 
+  // Temporarily disable compactions in the base DB during open; save the user
+  // defined value beforehand so we can restore it once BlobDB is initialized.
+  const bool disable_auto_compactions = cf_options_.disable_auto_compactions;
+  cf_options_.disable_auto_compactions = true;
+
   Status s;
 
   // Create info log.
@@ -187,29 +192,20 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   }
   db_impl_ = static_cast_with_check<DBImpl, DB>(db_->GetRootDB());
 
-  // Initialize SST file <-> oldest blob file mapping. Pausing background work
-  // so we can get a consistent picture more easily.
-  s = db_->PauseBackgroundWork();
-  if (!s.ok()) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
-                    "Failed to pause background flushes/compactions during "
-                    "open, status: %s",
-                    s.ToString().c_str());
-    return s;
-  }
-
+  // Initialize SST file <-> oldest blob file mapping.
   std::vector<LiveFileMetaData> live_files;
   db_->GetLiveFilesMetaData(&live_files);
 
   InitializeParentSstMapping(live_files);
 
-  s = db_->ContinueBackgroundWork();
-  if (!s.ok()) {
-    ROCKS_LOG_ERROR(db_options_.info_log,
-                    "Failed to resume background flushes/compactions during "
-                    "open, status: %s",
-                    s.ToString().c_str());
-    return s;
+  if (!disable_auto_compactions) {
+    s = db_->EnableAutoCompaction(*handles);
+    if (!s.ok()) {
+      ROCKS_LOG_ERROR(db_options_.info_log,
+          "Failed to enable automatic compactions during open, status: %s",
+          s.ToString().c_str());
+      return s;
+    }
   }
 
   // Add trash files in blob dir to file delete scheduler.

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -335,6 +335,7 @@ Status BlobDBImpl::OpenAllBlobFiles() {
 
 void BlobDBImpl::LinkParentSstToBlobFile(uint64_t sst_file_number,
                                          uint64_t blob_file_number) {
+  assert(bdb_options_.enable_garbage_collection);
   assert(blob_file_number != kInvalidBlobFileNumber);
 
   auto it = blob_files_.find(blob_file_number);
@@ -362,6 +363,7 @@ void BlobDBImpl::LinkParentSstToBlobFile(uint64_t sst_file_number,
 
 void BlobDBImpl::UnlinkParentSstFromBlobFile(uint64_t sst_file_number,
                                              uint64_t blob_file_number) {
+  assert(bdb_options_.enable_garbage_collection);
   assert(blob_file_number != kInvalidBlobFileNumber);
 
   auto it = blob_files_.find(blob_file_number);
@@ -389,6 +391,8 @@ void BlobDBImpl::UnlinkParentSstFromBlobFile(uint64_t sst_file_number,
 
 void BlobDBImpl::InitializeParentSstMapping(
     const std::vector<LiveFileMetaData>& live_files) {
+  assert(bdb_options_.enable_garbage_collection);
+
   for (const auto& live_file : live_files) {
     const uint64_t sst_file_number = live_file.file_number;
     const uint64_t blob_file_number = live_file.oldest_blob_file_number;
@@ -402,6 +406,8 @@ void BlobDBImpl::InitializeParentSstMapping(
 }
 
 void BlobDBImpl::UpdateParentSstMapping(const FlushJobInfo& info) {
+  assert(bdb_options_.enable_garbage_collection);
+
   if (info.oldest_blob_file_number == kInvalidBlobFileNumber) {
     return;
   }
@@ -413,6 +419,8 @@ void BlobDBImpl::UpdateParentSstMapping(const FlushJobInfo& info) {
 }
 
 void BlobDBImpl::UpdateParentSstMapping(const CompactionJobInfo& info) {
+  assert(bdb_options_.enable_garbage_collection);
+
   // Note: the same SST file may appear in both the input and the output
   // file list in case of a trivial move. We process the inputs first
   // to ensure the blob file still has a link after processing all updates.

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -2076,6 +2076,11 @@ Status BlobDBImpl::TEST_GetBlobValue(const Slice& key, const Slice& index_entry,
   return GetBlobValue(key, index_entry, value);
 }
 
+void BlobDBImpl::TEST_AddDummyBlobFile(uint64_t blob_file_number) {
+  blob_files_[blob_file_number] = std::make_shared<BlobFile>(
+      this, blob_dir_, blob_file_number, db_options_.info_log.get());
+}
+
 std::vector<std::shared_ptr<BlobFile>> BlobDBImpl::TEST_GetBlobFiles() const {
   ReadLock l(&mutex_);
   std::vector<std::shared_ptr<BlobFile>> blob_files;
@@ -2122,6 +2127,20 @@ void BlobDBImpl::TEST_EvictExpiredFiles() {
 }
 
 uint64_t BlobDBImpl::TEST_live_sst_size() { return live_sst_size_.load(); }
+
+void BlobDBImpl::TEST_InitializeParentSstMapping(
+    const std::vector<LiveFileMetaData>& live_files) {
+  InitializeParentSstMapping(live_files);
+}
+
+void BlobDBImpl::TEST_UpdateParentSstMapping(const FlushJobInfo& info) {
+  UpdateParentSstMapping(info);
+}
+
+void BlobDBImpl::TEST_UpdateParentSstMapping(const CompactionJobInfo& info) {
+  UpdateParentSstMapping(info);
+}
+
 #endif  //  !NDEBUG
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -405,7 +405,7 @@ void BlobDBImpl::InitializeParentSstMapping(
   }
 }
 
-void BlobDBImpl::UpdateParentSstMapping(const FlushJobInfo& info) {
+void BlobDBImpl::ProcessFlushJobInfo(const FlushJobInfo& info) {
   assert(bdb_options_.enable_garbage_collection);
 
   if (info.oldest_blob_file_number == kInvalidBlobFileNumber) {
@@ -418,7 +418,7 @@ void BlobDBImpl::UpdateParentSstMapping(const FlushJobInfo& info) {
   }
 }
 
-void BlobDBImpl::UpdateParentSstMapping(const CompactionJobInfo& info) {
+void BlobDBImpl::ProcessCompactionJobInfo(const CompactionJobInfo& info) {
   assert(bdb_options_.enable_garbage_collection);
 
   // Note: the same SST file may appear in both the input and the output
@@ -945,7 +945,7 @@ Status BlobDBImpl::CompactFiles(
 
   if (bdb_options_.enable_garbage_collection) {
     assert(compaction_job_info);
-    UpdateParentSstMapping(*compaction_job_info);
+    ProcessCompactionJobInfo(*compaction_job_info);
   }
 
   return s;
@@ -2133,12 +2133,12 @@ void BlobDBImpl::TEST_InitializeParentSstMapping(
   InitializeParentSstMapping(live_files);
 }
 
-void BlobDBImpl::TEST_UpdateParentSstMapping(const FlushJobInfo& info) {
-  UpdateParentSstMapping(info);
+void BlobDBImpl::TEST_ProcessFlushJobInfo(const FlushJobInfo& info) {
+  ProcessFlushJobInfo(info);
 }
 
-void BlobDBImpl::TEST_UpdateParentSstMapping(const CompactionJobInfo& info) {
-  UpdateParentSstMapping(info);
+void BlobDBImpl::TEST_ProcessCompactionJobInfo(const CompactionJobInfo& info) {
+  ProcessCompactionJobInfo(info);
 }
 
 #endif  //  !NDEBUG

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -302,8 +302,16 @@ class BlobDBImpl : public BlobDB {
   // Open all blob files found in blob_dir.
   Status OpenAllBlobFiles();
 
-  // Link an SST to a blob file.
+  // Link an SST to a blob file. Comes in locking and non-locking varieties
+  // (the latter is used during Open).
+  template <typename Linker>
+  void LinkSstToBlobFileImpl(uint64_t sst_file_number,
+                             uint64_t blob_file_number, Linker linker);
+
   void LinkSstToBlobFile(uint64_t sst_file_number, uint64_t blob_file_number);
+
+  void LinkSstToBlobFileNoLock(uint64_t sst_file_number,
+                               uint64_t blob_file_number);
 
   // Unlink an SST from a blob file.
   void UnlinkSstFromBlobFile(uint64_t sst_file_number,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -213,9 +213,9 @@ class BlobDBImpl : public BlobDB {
   void TEST_InitializeParentSstMapping(
       const std::vector<LiveFileMetaData>& live_files);
 
-  void TEST_UpdateParentSstMapping(const FlushJobInfo& info);
+  void TEST_ProcessFlushJobInfo(const FlushJobInfo& info);
 
-  void TEST_UpdateParentSstMapping(const CompactionJobInfo& info);
+  void TEST_ProcessCompactionJobInfo(const CompactionJobInfo& info);
 
 #endif  //  !NDEBUG
 
@@ -315,12 +315,11 @@ class BlobDBImpl : public BlobDB {
   void InitializeParentSstMapping(
       const std::vector<LiveFileMetaData>& live_files);
 
-  // Update the mapping between blob files and their parent SSTs after a flush.
-  void UpdateParentSstMapping(const FlushJobInfo& info);
+  // Update the mapping between blob files and SSTs after a flush.
+  void ProcessFlushJobInfo(const FlushJobInfo& info);
 
-  // Update the mapping between blob files and their parent SSTs after a
-  // compaction.
-  void UpdateParentSstMapping(const CompactionJobInfo& info);
+  // Update the mapping between blob files and SSTs after a compaction.
+  void ProcessCompactionJobInfo(const CompactionJobInfo& info);
 
   void UpdateLiveSSTSize();
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -185,6 +185,8 @@ class BlobDBImpl : public BlobDB {
   Status TEST_GetBlobValue(const Slice& key, const Slice& index_entry,
                            PinnableSlice* value);
 
+  void TEST_AddDummyBlobFile(uint64_t blob_file_number);
+
   std::vector<std::shared_ptr<BlobFile>> TEST_GetBlobFiles() const;
 
   std::vector<std::shared_ptr<BlobFile>> TEST_GetObsoleteFiles() const;
@@ -207,6 +209,14 @@ class BlobDBImpl : public BlobDB {
   uint64_t TEST_live_sst_size();
 
   const std::string& TEST_blob_dir() const { return blob_dir_; }
+
+  void TEST_InitializeParentSstMapping(
+      const std::vector<LiveFileMetaData>& live_files);
+
+  void TEST_UpdateParentSstMapping(const FlushJobInfo& info);
+
+  void TEST_UpdateParentSstMapping(const CompactionJobInfo& info);
+
 #endif  //  !NDEBUG
 
  private:

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -78,6 +78,7 @@ class BlobDBImpl : public BlobDB {
   friend class BlobFile;
   friend class BlobDBIterator;
   friend class BlobDBListener;
+  friend class BlobDBListenerGC;
 
  public:
   // deletions check period

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -210,7 +210,7 @@ class BlobDBImpl : public BlobDB {
 
   const std::string& TEST_blob_dir() const { return blob_dir_; }
 
-  void TEST_InitializeParentSstMapping(
+  void TEST_InitializeBlobFileToSstMapping(
       const std::vector<LiveFileMetaData>& live_files);
 
   void TEST_ProcessFlushJobInfo(const FlushJobInfo& info);
@@ -302,17 +302,15 @@ class BlobDBImpl : public BlobDB {
   // Open all blob files found in blob_dir.
   Status OpenAllBlobFiles();
 
-  // Link a parent SST to a blob file.
-  void LinkParentSstToBlobFile(uint64_t sst_file_number,
-                               uint64_t blob_file_number);
+  // Link an SST to a blob file.
+  void LinkSstToBlobFile(uint64_t sst_file_number, uint64_t blob_file_number);
 
-  // Unlink a parent SST from a blob file.
-  void UnlinkParentSstFromBlobFile(uint64_t sst_file_number,
-                                   uint64_t blob_file_number);
+  // Unlink an SST from a blob file.
+  void UnlinkSstFromBlobFile(uint64_t sst_file_number,
+                             uint64_t blob_file_number);
 
-  // Initialize the mapping between blob files and their parent SSTs
-  // during Open.
-  void InitializeParentSstMapping(
+  // Initialize the mapping between blob files and SSTs during Open.
+  void InitializeBlobFileToSstMapping(
       const std::vector<LiveFileMetaData>& live_files);
 
   // Update the mapping between blob files and SSTs after a flush.

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -150,6 +150,14 @@ class BlobDBImpl : public BlobDB {
   Status PutUntil(const WriteOptions& options, const Slice& key,
                   const Slice& value, uint64_t expiration) override;
 
+  using BlobDB::CompactFiles;
+  Status CompactFiles(
+      const CompactionOptions& compact_options,
+      const std::vector<std::string>& input_file_names, const int output_level,
+      const int output_path_id = -1,
+      std::vector<std::string>* const output_file_names = nullptr,
+      CompactionJobInfo* compaction_job_info = nullptr) override;
+
   BlobDBOptions GetBlobDBOptions() const override;
 
   BlobDBImpl(const std::string& dbname, const BlobDBOptions& bdb_options,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -284,6 +284,11 @@ class BlobDBImpl : public BlobDB {
   // Open all blob files found in blob_dir.
   Status OpenAllBlobFiles();
 
+  // Initialize the mapping between blob files and their parent SSTs
+  // dduring Open.
+  void InitializeParentSstMapping(
+      const std::vector<LiveFileMetaData>& live_files);
+
   Status GetBlobFileReader(const std::shared_ptr<BlobFile>& blob_file,
                            std::shared_ptr<RandomAccessFileReader>* reader);
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -77,6 +77,7 @@ struct GCStats {
 class BlobDBImpl : public BlobDB {
   friend class BlobFile;
   friend class BlobDBIterator;
+  friend class BlobDBListener;
 
  public:
   // deletions check period
@@ -168,8 +169,6 @@ class BlobDBImpl : public BlobDB {
   Status Open(std::vector<ColumnFamilyHandle*>* handles);
 
   Status SyncBlobFiles() override;
-
-  void UpdateLiveSSTSize();
 
   void GetCompactionContext(BlobCompactionContext* context);
 
@@ -284,10 +283,27 @@ class BlobDBImpl : public BlobDB {
   // Open all blob files found in blob_dir.
   Status OpenAllBlobFiles();
 
+  // Link a parent SST to a blob file.
+  void LinkParentSstToBlobFile(uint64_t sst_file_number,
+                               uint64_t blob_file_number);
+
+  // Unlink a parent SST from a blob file.
+  void UnlinkParentSstFromBlobFile(uint64_t sst_file_number,
+                                   uint64_t blob_file_number);
+
   // Initialize the mapping between blob files and their parent SSTs
-  // dduring Open.
+  // during Open.
   void InitializeParentSstMapping(
       const std::vector<LiveFileMetaData>& live_files);
+
+  // Update the mapping between blob files and their parent SSTs after a flush.
+  void UpdateParentSstMapping(const FlushJobInfo& info);
+
+  // Update the mapping between blob files and their parent SSTs after a
+  // compaction.
+  void UpdateParentSstMapping(const CompactionJobInfo& info);
+
+  void UpdateLiveSSTSize();
 
   Status GetBlobFileReader(const std::shared_ptr<BlobFile>& blob_file,
                            std::shared_ptr<RandomAccessFileReader>* reader);

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -26,14 +26,16 @@ class BlobDBListener : public EventListener {
     blob_db_impl_->SyncBlobFiles();
   }
 
-  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& /*info*/) override {
+  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
     assert(blob_db_impl_ != nullptr);
+    blob_db_impl_->UpdateParentSstMapping(info);
     blob_db_impl_->UpdateLiveSSTSize();
   }
 
   void OnCompactionCompleted(DB* /*db*/,
-                             const CompactionJobInfo& /*info*/) override {
+                             const CompactionJobInfo& info) override {
     assert(blob_db_impl_ != nullptr);
+    blob_db_impl_->UpdateParentSstMapping(info);
     blob_db_impl_->UpdateLiveSSTSize();
   }
 

--- a/utilities/blob_db/blob_db_listener.h
+++ b/utilities/blob_db/blob_db_listener.h
@@ -50,14 +50,14 @@ class BlobDBListenerGC : public BlobDBListener {
     BlobDBListener::OnFlushCompleted(db, info);
 
     assert(blob_db_impl_);
-    blob_db_impl_->UpdateParentSstMapping(info);
+    blob_db_impl_->ProcessFlushJobInfo(info);
   }
 
   void OnCompactionCompleted(DB* db, const CompactionJobInfo& info) override {
     BlobDBListener::OnCompactionCompleted(db, info);
 
     assert(blob_db_impl_);
-    blob_db_impl_->UpdateParentSstMapping(info);
+    blob_db_impl_->ProcessCompactionJobInfo(info);
   }
 };
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1654,7 +1654,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
   ASSERT_EQ(blob_files.size(), 5);
 
   {
-    const std::vector<BlobFile::SstFileSet> expected_sst_files{
+    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
@@ -1669,7 +1669,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
 
     blob_db_impl()->TEST_ProcessFlushJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_sst_files{
+    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
@@ -1685,7 +1685,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
 
     blob_db_impl()->TEST_ProcessFlushJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_sst_files{
+    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
@@ -1710,7 +1710,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
 
     blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_sst_files{
+    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
         {6}, {7}, {3, 8, 23}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1614,7 +1614,7 @@ TEST_F(BlobDBTest, DisableFileDeletions) {
   }
 }
 
-TEST_F(BlobDBTest, MaintainParentSstMapping) {
+TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
   BlobDBOptions bdb_options;
   bdb_options.enable_garbage_collection = true;
   bdb_options.disable_background_tasks = true;
@@ -1646,7 +1646,7 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
     live_files.emplace_back(live_file);
   }
 
-  blob_db_impl()->TEST_InitializeParentSstMapping(live_files);
+  blob_db_impl()->TEST_InitializeBlobFileToSstMapping(live_files);
 
   // Check that the blob <-> SST mappings have been correctly initialized.
   auto blob_files = blob_db_impl()->TEST_GetBlobFiles();
@@ -1654,11 +1654,11 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
   ASSERT_EQ(blob_files.size(), 5);
 
   {
-    const std::vector<BlobFile::SstFileSet> expected_parent_files{
+    const std::vector<BlobFile::SstFileSet> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
-      ASSERT_EQ(blob_file->GetParentSstFiles(), expected_parent_files[i]);
+      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
     }
   }
 
@@ -1669,11 +1669,11 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
 
     blob_db_impl()->TEST_ProcessFlushJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_parent_files{
+    const std::vector<BlobFile::SstFileSet> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
-      ASSERT_EQ(blob_file->GetParentSstFiles(), expected_parent_files[i]);
+      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
     }
   }
 
@@ -1685,11 +1685,11 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
 
     blob_db_impl()->TEST_ProcessFlushJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_parent_files{
+    const std::vector<BlobFile::SstFileSet> expected_sst_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
-      ASSERT_EQ(blob_file->GetParentSstFiles(), expected_parent_files[i]);
+      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
     }
   }
 
@@ -1710,11 +1710,11 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
 
     blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
 
-    const std::vector<BlobFile::SstFileSet> expected_parent_files{
+    const std::vector<BlobFile::SstFileSet> expected_sst_files{
         {6}, {7}, {3, 8, 23}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
-      ASSERT_EQ(blob_file->GetParentSstFiles(), expected_parent_files[i]);
+      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
     }
   }
 }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1663,12 +1663,12 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
   }
 
   // Simulate a flush where the SST does not reference any blob files.
-  FlushJobInfo info1{};
-  info1.file_number = 21;
-
-  blob_db_impl()->TEST_UpdateParentSstMapping(info1);
-
   {
+    FlushJobInfo info{};
+    info.file_number = 21;
+
+    blob_db_impl()->TEST_ProcessFlushJobInfo(info);
+
     const std::vector<BlobFile::SstFileSet> expected_parent_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
     for (size_t i = 0; i < 5; ++i) {
@@ -1678,13 +1678,13 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
   }
 
   // Simulate a flush where the SST references a blob file.
-  FlushJobInfo info2{};
-  info2.file_number = 22;
-  info2.oldest_blob_file_number = 5;
-
-  blob_db_impl()->TEST_UpdateParentSstMapping(info2);
-
   {
+    FlushJobInfo info{};
+    info.file_number = 22;
+    info.oldest_blob_file_number = 5;
+
+    blob_db_impl()->TEST_ProcessFlushJobInfo(info);
+
     const std::vector<BlobFile::SstFileSet> expected_parent_files{
         {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {
@@ -1696,20 +1696,20 @@ TEST_F(BlobDBTest, MaintainParentSstMapping) {
   // Simulate a compaction. Some inputs and outputs have blob file references,
   // some don't. There is also a trivial move (which means the SST appears on
   // both the input and the output list).
-  CompactionJobInfo info3{};
-  info3.input_file_infos.emplace_back(CompactionFileInfo{1, 1, 1});
-  info3.input_file_infos.emplace_back(CompactionFileInfo{1, 2, 2});
-  info3.input_file_infos.emplace_back(
-      CompactionFileInfo{1, 11, kInvalidBlobFileNumber});
-  info3.input_file_infos.emplace_back(CompactionFileInfo{1, 5, 22});
-  info3.output_file_infos.emplace_back(CompactionFileInfo{2, 23, 3});
-  info3.output_file_infos.emplace_back(
-      CompactionFileInfo{2, 24, kInvalidBlobFileNumber});
-  info3.output_file_infos.emplace_back(CompactionFileInfo{2, 5, 22});
-
-  blob_db_impl()->TEST_UpdateParentSstMapping(info3);
-
   {
+    CompactionJobInfo info{};
+    info.input_file_infos.emplace_back(CompactionFileInfo{1, 1, 1});
+    info.input_file_infos.emplace_back(CompactionFileInfo{1, 2, 2});
+    info.input_file_infos.emplace_back(
+        CompactionFileInfo{1, 11, kInvalidBlobFileNumber});
+    info.input_file_infos.emplace_back(CompactionFileInfo{1, 5, 22});
+    info.output_file_infos.emplace_back(CompactionFileInfo{2, 23, 3});
+    info.output_file_infos.emplace_back(
+        CompactionFileInfo{2, 24, kInvalidBlobFileNumber});
+    info.output_file_infos.emplace_back(CompactionFileInfo{2, 5, 22});
+
+    blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
+
     const std::vector<BlobFile::SstFileSet> expected_parent_files{
         {6}, {7}, {3, 8, 23}, {4, 9}, {5, 10, 22}};
     for (size_t i = 0; i < 5; ++i) {

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -131,7 +131,7 @@ class BlobFile {
   void LinkSstFile(uint64_t sst_file_number) {
     auto it = linked_sst_files_.find(sst_file_number);
     assert(it == linked_sst_files_.end());
-    linked_sst_files_.insert(it, sst_file_number);
+    linked_sst_files_.insert(sst_file_number);
   }
 
   // Unlink an SST file whose oldest blob file reference points to this file.

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -27,9 +27,6 @@ class BlobFile {
   friend struct BlobFileComparator;
   friend struct BlobFileComparatorTTL;
 
- public:
-  using SstFileSet = std::unordered_set<uint64_t>;
-
  private:
   // access to parent
   const BlobDBImpl* parent_;
@@ -44,7 +41,7 @@ class BlobFile {
 
   // The file numbers of the SST files whose oldest blob file reference
   // points to this blob file.
-  SstFileSet linked_sst_files_;
+  std::unordered_set<uint64_t> linked_sst_files_;
 
   // Info log.
   Logger* info_log_;
@@ -126,7 +123,9 @@ class BlobFile {
 
   // Get the set of SST files whose oldest blob file reference points to
   // this file.
-  const SstFileSet& GetLinkedSstFiles() const { return linked_sst_files_; }
+  const std::unordered_set<uint64_t>& GetLinkedSstFiles() const {
+    return linked_sst_files_;
+  }
 
   // Link an SST file whose oldest blob file reference points to this file.
   void LinkSstFile(uint64_t sst_file_number) {

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -129,8 +129,7 @@ class BlobFile {
 
   // Link an SST file whose oldest blob file reference points to this file.
   void LinkSstFile(uint64_t sst_file_number) {
-    auto it = linked_sst_files_.find(sst_file_number);
-    assert(it == linked_sst_files_.end());
+    assert(linked_sst_files_.find(sst_file_number) == linked_sst_files_.end());
     linked_sst_files_.insert(sst_file_number);
   }
 

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -44,7 +44,7 @@ class BlobFile {
 
   // The file numbers of the SST files whose oldest blob file reference
   // points to this blob file.
-  SstFileSet parent_sst_files_;
+  SstFileSet linked_sst_files_;
 
   // Info log.
   Logger* info_log_;
@@ -126,20 +126,20 @@ class BlobFile {
 
   // Get the set of SST files whose oldest blob file reference points to
   // this file.
-  const SstFileSet& GetParentSstFiles() const { return parent_sst_files_; }
+  const SstFileSet& GetLinkedSstFiles() const { return linked_sst_files_; }
 
-  // Add an SST file whose oldest blob file reference points to this file.
-  void AddParentSstFile(uint64_t sst_file_number) {
-    auto it = parent_sst_files_.find(sst_file_number);
-    assert(it == parent_sst_files_.end());
-    parent_sst_files_.insert(it, sst_file_number);
+  // Link an SST file whose oldest blob file reference points to this file.
+  void LinkSstFile(uint64_t sst_file_number) {
+    auto it = linked_sst_files_.find(sst_file_number);
+    assert(it == linked_sst_files_.end());
+    linked_sst_files_.insert(it, sst_file_number);
   }
 
-  // Remove an SST file whose oldest blob file reference points to this file.
-  void RemoveParentSstFile(uint64_t sst_file_number) {
-    auto it = parent_sst_files_.find(sst_file_number);
-    assert(it != parent_sst_files_.end());
-    parent_sst_files_.erase(it);
+  // Unlink an SST file whose oldest blob file reference points to this file.
+  void UnlinkSstFile(uint64_t sst_file_number) {
+    auto it = linked_sst_files_.find(sst_file_number);
+    assert(it != linked_sst_files_.end());
+    linked_sst_files_.erase(it);
   }
 
   // the following functions are atomic, and don't need


### PR DESCRIPTION
Summary:
The patch adds logic to BlobDB to maintain the mapping between blob files
and SSTs for which the blob file in question is the oldest blob file referenced
by the SST file. The mapping is initialized during database open based on the
information retrieved using `GetLiveFilesMetaData`, and updated after
flushes/compactions based on the information received through the `EventListener`
interface (or, in the case of manual compactions issued through the `CompactFiles`
API, the `CompactionJobInfo` object).

Test Plan:
Added a unit test; also tested using the BlobDB mode of `db_bench`.