### PR TITLE
db_stress to cover SeekForPrev()

### DIFF
--- a/tools/db_stress_tool.cc
+++ b/tools/db_stress_tool.cc
@@ -2481,7 +2481,6 @@ class StressTest {
 
       LastIterateOp last_op;
       if (thread->rand.OneIn(8)) {
-        // 1/8 chance, does SeekForPrev(). Otherwise, Seek().
         iter->SeekForPrev(key);
         cmp_iter->SeekForPrev(key);
         last_op = kLastOpSeekForPrev;

--- a/tools/db_stress_tool.cc
+++ b/tools/db_stress_tool.cc
@@ -2510,6 +2510,7 @@ class StressTest {
             cmp_iter->Prev();
           }
         }
+        last_op = kLastOpNextOrPrev;
         VerifyIterator(thread, cmp_cfh, readoptionscopy, iter.get(),
                        cmp_iter.get(), last_op, key, &diverged);
       }


### PR DESCRIPTION
Summary:
Right now, db_stress doesn't cover SeekForPrev(). Add the coverage, which mirrors what we do for Seek().

Test Plan: Run "make crash_test". Do some manual source code hack to simular iterator wrong results and see it caught.