### PR TITLE
More fixes to auto-GarbageCollect in BackupEngine

### DIFF
--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -276,10 +276,14 @@ class BackupEngine {
                                        progress_callback);
   }
 
-  // deletes old backups, keeping latest num_backups_to_keep alive
+  // Deletes old backups, keeping latest num_backups_to_keep alive.
+  // See also DeleteBackup.
   virtual Status PurgeOldBackups(uint32_t num_backups_to_keep) = 0;
 
-  // deletes a specific backup
+  // Deletes a specific backup. If this operation (or PurgeOldBackups)
+  // is not completed due to crash, power failure, etc. the state
+  // will be cleaned up the next time you call DeleteBackup,
+  // PurgeOldBackups, or GarbageCollect.
   virtual Status DeleteBackup(BackupID backup_id) = 0;
 
   // Call this from another thread if you want to stop the backup
@@ -287,8 +291,8 @@ class BackupEngine {
   // not wait for the backup to stop.
   // The backup will stop ASAP and the call to CreateNewBackup will
   // return Status::Incomplete(). It will not clean up after itself, but
-  // the state will remain consistent. The state will be cleaned up
-  // next time you create BackupableDB or RestoreBackupableDB.
+  // the state will remain consistent. The state will be cleaned up the
+  // next time you call CreateNewBackup or GarbageCollect.
   virtual void StopBackup() = 0;
 
   // Returns info about backups in backup_info
@@ -323,12 +327,13 @@ class BackupEngine {
   // Returns Status::OK() if all checks are good
   virtual Status VerifyBackup(BackupID backup_id) = 0;
 
-  // Will delete all the files we don't need anymore
-  // It will do the full scan of the files/ directory and delete all the
-  // files that are not referenced. PurgeOldBackups() and DeleteBackup()
-  // will do a similar operation as needed to clean up from any incomplete
-  // deletions, so this function is not really needed if calling one of
-  // those.
+  // Will delete any files left over from incomplete creation or deletion of
+  // a backup. This is not normally needed as those operations also clean up
+  // after prior incomplete calls to the same kind of operation (create or
+  // delete).
+  // NOTE: This is not designed to delete arbitrary files added to the backup
+  // directory outside of BackupEngine, and clean-up is always subject to
+  // permissions on and availability of the underlying filesystem.
   virtual Status GarbageCollect() = 0;
 };
 

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -10,6 +10,7 @@
 #if !defined(ROCKSDB_LITE) && !defined(OS_WIN)
 
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -1290,7 +1291,7 @@ TEST_F(BackupableDBTest, DeleteTmpFiles) {
                             shared_option);
       ASSERT_OK(backup_engine_->CreateNewBackup(db_.get()));
       BackupID next_id = 1;
-      BackupID oldest_id = INT_MAX;
+      BackupID oldest_id = std::numeric_limits<BackupID>::max();
       {
         std::vector<BackupInfo> backup_info;
         backup_engine_->GetBackupInfo(&backup_info);
@@ -1308,7 +1309,7 @@ TEST_F(BackupableDBTest, DeleteTmpFiles) {
       // NOTE: both shared and shared_checksum should be cleaned up
       // regardless of how the backup engine is opened.
       std::vector<std::string> tmp_files_and_dirs;
-      for (auto&& dir_and_file : {
+      for (const auto& dir_and_file : {
                std::make_pair(std::string("shared"),
                               std::string(".00006.sst.tmp")),
                std::make_pair(std::string("shared_checksum"),

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -516,13 +516,13 @@ static void AssertEmpty(DB* db, int from, int to) {
 
 class BackupableDBTest : public testing::Test {
  public:
-  enum SharedOption {
+  enum ShareOption {
     kNoShare,
     kShareNoChecksum,
     kShareWithChecksum,
   };
 
-  const std::vector<SharedOption> kAllSharedOptions = {
+  const std::vector<ShareOption> kAllShareOptions = {
       kNoShare, kShareNoChecksum, kShareWithChecksum};
 
   BackupableDBTest() {
@@ -571,7 +571,7 @@ class BackupableDBTest : public testing::Test {
   }
 
   void OpenDBAndBackupEngine(bool destroy_old_data = false, bool dummy = false,
-                             SharedOption shared_option = kShareNoChecksum) {
+                             ShareOption shared_option = kShareNoChecksum) {
     // reset all the defaults
     test_backup_env_->SetLimitWrittenFiles(1000000);
     test_db_env_->SetLimitWrittenFiles(1000000);
@@ -1285,7 +1285,7 @@ TEST_F(BackupableDBTest, ShareTableFilesWithChecksumsTransition) {
 // of a new backup.
 TEST_F(BackupableDBTest, DeleteTmpFiles) {
   for (int cleanup_fn : {1, 2, 3, 4}) {
-    for (SharedOption shared_option : kAllSharedOptions) {
+    for (ShareOption shared_option : kAllShareOptions) {
       OpenDBAndBackupEngine(false /* destroy_old_data */, false /* dummy */,
                             shared_option);
       ASSERT_OK(backup_engine_->CreateNewBackup(db_.get()));


### PR DESCRIPTION
Summary:
Production:
* Fixes GarbageCollect (and auto-GC triggered by PurgeOldBackups, DeleteBackup, or CreateNewBackup) to clean up backup directory independent of current settings (except max_valid_backups_to_open; see issue #4997) and prior settings used with same backup directory.
* Fixes GarbageCollect (and auto-GC) not to attempt to remove "." and ".." entries from directories.
* Clarifies contract with users in modifying BackupEngine operations. In short, leftovers from any incomplete operation are cleaned up by any subsequent call to that same kind of operation (PurgeOldBackups and DeleteBackup considered the same kind of operation). GarbageCollect is available to clean up after all kinds. (NB: right now PurgeOldBackups and DeleteBackup will clean up after incomplete CreateNewBackup, but we aren't promising to continue that behavior.)

Test:
* Refactors open parameters to use an option enum, for readability, etc. (Also fixes an unused parameter bug in the redundant OpenDBAndBackupEngineShareWithChecksum.)
* Fixes an apparent bug in ShareTableFilesWithChecksumsTransition in which old backup data was destroyed in the transition to be tested. That test is now augmented to ensure GarbageCollect (or auto-GC) does not remove shared files when BackupEngine is opened with share_table_files=false.
* Augments DeleteTmpFiles test to ensure that CreateNewBackup does auto-GC when an incompletely created backup is detected, and to verify that auto-GC works across various settings.

Not in this commit / TODO: make DeleteBackup, PurgeOldBackups, and GarbageCollect fail if there's any failure to get a directory listing or to delete a file (but still delete as much as it can). I consider this slightly too risky for backport, so I'm keeping it separate.