### PR TITLE
Fix BloomFilterPolicy changes for unsigned char (ARM)

### DIFF
--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -338,7 +338,8 @@ FilterBitsReader* BloomFilterPolicy::GetFilterBitsReader(
     return new AlwaysFalseFilter();
   }
 
-  char raw_num_probes = contents.data()[len_with_meta - 5];
+  int8_t raw_num_probes =
+      static_cast<int8_t>(contents.data()[len_with_meta - 5]);
   // NB: *num_probes > 30 and < 128 probably have not been used, because of
   // BloomFilterPolicy::initialize, unless directly calling
   // FullFilterBitsBuilder as an API, but we are leaving those cases in


### PR DESCRIPTION
Summary: Bug in PR #5941 when char is unsigned that should only affect
assertion on unused/invalid filter metadata.

Test Plan: on ARM: ./bloom_test && ./db_bloom_filter_test && ./block_based_filter_block_test && ./full_filter_block_test && ./partitioned_filter_block_test