### PR TITLE
delete memtable in background thread

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -210,7 +210,6 @@ struct SuperVersion {
 
   // should be called outside the mutex
   SuperVersion() = default;
-  ~SuperVersion();
   SuperVersion* Ref();
   // If Unref() returns true, Cleanup() should be called with mutex held
   // before deleting this SuperVersion.
@@ -235,10 +234,6 @@ struct SuperVersion {
 
  private:
   std::atomic<uint32_t> refs;
-  // We need to_delete because during Cleanup(), imm->Unref() returns
-  // all memtables that we need to free through this vector. We then
-  // delete all those memtables outside of mutex, during destruction
-  autovector<MemTable*> to_delete;
 };
 
 extern Status CheckCompressionSupported(const ColumnFamilyOptions& cf_options);


### PR DESCRIPTION
I found that CleanupSuperVersion() may block Get() for 30ms+ （per MemTable is 256MB）.

Then I found delete td; in.
~SuperVersion() takes the time.

The backtrace looks like this

DBImpl::GetImpl() -> DBImpl::ReturnAndCleanupSuperVersion() ->
DBImpl::CleanupSuperVersion() : delete sv;  -> ~SuperVersion()

I think it's better to delete in a background thread, but I'm not sure if my code has
no risk， please review it。