### PR TITLE
Add operator[] to autovector::iterator_impl.

### DIFF
--- a/util/autovector.h
+++ b/util/autovector.h
@@ -140,6 +140,14 @@ class autovector {
       return &(*vect_)[index_];
     }
 
+    reference operator[](difference_type len) {
+      return *(*this + len);
+    }
+
+    const_reference operator[](difference_type len) const {
+      return *(*this + len);
+    }
+
 
     // -- Logical Operators
     bool operator==(const self_type& other) const {


### PR DESCRIPTION
This is a required operator for random-access iterators, and an upcoming update for Visual Studio 2019 will change the C++ Standard Library's heap algorithms to use this operator.