### PR TITLE
Fix test failure in LITE mode

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1664,6 +1664,7 @@ class DBBasicTestWithParallelIO
     Random rnd(301);
     BlockBasedTableOptions table_options;
 
+#ifndef ROCKSDB_LITE
     if (compression_enabled_) {
       std::vector<CompressionType> compression_types;
       compression_types = GetSupportedCompressions();
@@ -1675,6 +1676,12 @@ class DBBasicTestWithParallelIO
         options.compression = compression_types[0];
       }
     }
+#else
+    // GetSupportedCompressions() is not available in LITE build
+    if (!Snappy_Supported()) {
+      compression_enabled_ = false;
+    }
+#endif //ROCKSDB_LITE
 
     table_options.block_cache = uncompressed_cache_;
     if (table_options.block_cache == nullptr) {


### PR DESCRIPTION
GetSupportedCompressions() is not available in LITE build, so check and use Snappy compression in db_basic_test.cc.

Test plan:
make LITE=1 check
make check