### PR TITLE
Disable blob iterator test with max_sequential_skip_in_iterations==0 in LITE mode

### DIFF
--- a/db/db_blob_index_test.cc
+++ b/db/db_blob_index_test.cc
@@ -419,7 +419,7 @@ TEST_F(DBBlobIndexTest, Iterate) {
            create_blob_iterator, check_is_blob(false));
     verify(15, Status::kOk, get_value(16, 0), get_value(14, 0),
            create_blob_iterator, check_is_blob(false));
-#endif
+#endif  // !ROCKSDB_LITE
 
     for (auto* snapshot : snapshots) {
       dbfull()->ReleaseSnapshot(snapshot);

--- a/db/db_blob_index_test.cc
+++ b/db/db_blob_index_test.cc
@@ -398,8 +398,10 @@ TEST_F(DBBlobIndexTest, Iterate) {
     verify(15, Status::kOk, get_value(16, 0), get_value(14, 0),
            create_blob_iterator, check_is_blob(false));
 
+#ifndef ROCKSDB_LITE
     // Iterator with blob support and using seek.
-    ASSERT_OK(dbfull()->SetOptions(cfh(), {{"max_sequential_skip_in_iterations", "0"}}));
+    ASSERT_OK(dbfull()->SetOptions(
+        cfh(), {{"max_sequential_skip_in_iterations", "0"}}));
     verify(1, Status::kOk, get_value(1, 0), get_value(1, 0),
            create_blob_iterator, check_is_blob(true));
     verify(3, Status::kOk, get_value(3, 0), get_value(3, 0),
@@ -417,6 +419,7 @@ TEST_F(DBBlobIndexTest, Iterate) {
            create_blob_iterator, check_is_blob(false));
     verify(15, Status::kOk, get_value(16, 0), get_value(14, 0),
            create_blob_iterator, check_is_blob(false));
+#endif
 
     for (auto* snapshot : snapshots) {
       dbfull()->ReleaseSnapshot(snapshot);


### PR DESCRIPTION
Summary:
The SetOptions API used by the test is not supported in LITE mode,
so we should skip the new chunk in this case.

Test Plan:
Ran the unit tests both in regular and LITE mode.