### PR TITLE
Fixes for g++ 4.9.x compatibility

### DIFF
--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -184,7 +184,7 @@ class TestSnapshotChecker : public SnapshotChecker {
  public:
   explicit TestSnapshotChecker(
       SequenceNumber last_committed_sequence,
-      const std::unordered_map<SequenceNumber, SequenceNumber>& snapshots = {})
+      const std::unordered_map<SequenceNumber, SequenceNumber>& snapshots = {{}})
       : last_committed_sequence_(last_committed_sequence),
         snapshots_(snapshots) {}
 

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -606,7 +606,7 @@ double FilterBench::RandomQueryTest(uint32_t inside_threshold, bool dry_run,
   }
 
   if (!dry_run) {
-    fp_rate_report_ = std::ostringstream();
+    fp_rate_report_.str("");
     uint64_t q = 0;
     uint64_t fp = 0;
     double worst_fp_rate = 0.0;


### PR DESCRIPTION
Summary: Taken from @merryChris in #6043

Reproduced the errors using minimal code snippets on https://godbolt.org/ with -std=c++11. Did not fail in g++ 5+.

Stackoverflow ref on {{}} vs. {}:
https://stackoverflow.com/questions/26947704/implicit-conversion-failure-from-initializer-list

Note to reader: .clear() does not empty out an ostringstream, but .str("")
suffices because we don't have to worry about clearing error flags.

Test Plan: make check, manual run of filter_bench