### PR TITLE
Fix the constness issues around autovector::iterator_impl's dereference operators

### DIFF
--- a/util/autovector.h
+++ b/util/autovector.h
@@ -120,34 +120,19 @@ class autovector {
     }
 
     // -- Reference
-    reference operator*() {
+    reference operator*() const {
       assert(vect_->size() >= index_);
       return (*vect_)[index_];
     }
 
-    const_reference operator*() const {
-      assert(vect_->size() >= index_);
-      return (*vect_)[index_];
-    }
-
-    pointer operator->() {
+    pointer operator->() const {
       assert(vect_->size() >= index_);
       return &(*vect_)[index_];
     }
 
-    const_pointer operator->() const {
-      assert(vect_->size() >= index_);
-      return &(*vect_)[index_];
-    }
-
-    reference operator[](difference_type len) {
+    reference operator[](difference_type len) const {
       return *(*this + len);
     }
-
-    const_reference operator[](difference_type len) const {
-      return *(*this + len);
-    }
-
 
     // -- Logical Operators
     bool operator==(const self_type& other) const {


### PR DESCRIPTION
Summary:
As described in detail in issue #6048, iterators' dereference operators
(`*`, `->`, and `[]`) should return `pointer`s/`reference`s (as opposed to
`const_pointer`s/`const_reference`s) even if the iterator itself is `const`
to be in sync with the standard's iterator concept.

Test Plan:
make check