### PR TITLE
Add example to show the effect of Get in snapshot isolation

### DIFF
--- a/examples/transaction_example.cc
+++ b/examples/transaction_example.cc
@@ -94,9 +94,19 @@ int main() {
   s = txn_db->Put(write_options, "abc", "xyz");
   assert(s.ok());
 
+  // Read the latest committed value.
+  s = txn->Get(read_options, "abc", &value);
+  assert(s.ok());
+  assert(value == "xyz");
+
+  // Read the snapshotted value.
+  read_options.snapshot = snapshot;
+  s = txn->Get(read_options, "abc", &value);
+  assert(s.ok());
+  assert(value == "def");
+
   // Attempt to read a key using the snapshot.  This will fail since
   // the previous write outside this txn conflicts with this read.
-  read_options.snapshot = snapshot;
   s = txn->GetForUpdate(read_options, "abc", &value);
   assert(s.IsBusy());
 

--- a/examples/transaction_example.cc
+++ b/examples/transaction_example.cc
@@ -136,10 +136,13 @@ int main() {
   // Do some reads and writes to key "x"
   read_options.snapshot = txn_db->GetSnapshot();
   s = txn->Get(read_options, "x", &value);
-  txn->Put("x", "x");
+  assert(s.IsNotFound());
+  s = txn->Put("x", "x");
+  assert(s.ok());
 
   // Do a write outside of the transaction to key "y"
-  s = txn_db->Put(write_options, "y", "y");
+  s = txn_db->Put(write_options, "y", "y1");
+  assert(s.ok());
 
   // Set a new snapshot in the transaction
   txn->SetSnapshot();
@@ -150,7 +153,10 @@ int main() {
   // Since the snapshot was advanced, the write done outside of the
   // transaction does not conflict.
   s = txn->GetForUpdate(read_options, "y", &value);
-  txn->Put("y", "y");
+  assert(s.ok());
+  assert(value == "y1");
+  s = txn->Put("y", "y2");
+  assert(s.ok());
 
   // Decide we want to revert the last write from this transaction.
   txn->RollbackToSavePoint();
@@ -161,6 +167,15 @@ int main() {
   delete txn;
   // Clear snapshot from read options since it is no longer valid
   read_options.snapshot = nullptr;
+
+  // db state is at the save point.
+  s = txn_db->Get(read_options, "x", &value);
+  assert(s.ok());
+  assert(value == "x");
+
+  s = txn_db->Get(read_options, "y", &value);
+  assert(s.ok());
+  assert(value == "y1");
 
   // Cleanup
   delete txn_db;

--- a/examples/transaction_example.cc
+++ b/examples/transaction_example.cc
@@ -112,6 +112,7 @@ int main() {
 
   txn->Rollback();
 
+  // Snapshot will be released upon deleting the transaction.
   delete txn;
   // Clear snapshot from read options since it is no longer valid
   read_options.snapshot = nullptr;


### PR DESCRIPTION
Summary:
Adds example to show the difference of reading from snapshot and from the latest state.

Test Plan:
cd examples && make transaction_example && ./transaction_example