### PR TITLE
Fix bad SuperVersion bug

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4032,6 +4032,7 @@ Status VersionSet::LogAndApply(
   }
   assert(!writers.empty());
   ManifestWriter& first_writer = writers.front();
+  TEST_SYNC_POINT_CALLBACK("VersionSet::LogAndApply::WriterIsWaiting", mu);
   while (!first_writer.done && &first_writer != manifest_writers_.front()) {
     first_writer.cv.Wait();
   }


### PR DESCRIPTION
We found out merge operator would cause data corruption two years ago.
Recently, we finally got time to analysis this bug.
The reason causing this bug is that one SuperVersion contains an immutable memtable and its flushed SSTable.  At the same time, this particular memtable has some merge operations, these merge operations will be applied multiple times.

We wrote some code illustrating this SuperVersion bug.
By the way, we do have a trivial fix of the bug.
Since it's not elegant, we are expecting your recommendations about this bug.