### PR TITLE
Merge adjacent file block reads in RocksDB MultiGet()

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,7 +6,6 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-// #include <iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1710,10 +1710,11 @@ class DBBasicTestWithParallelIO
     for (int i = 0; i < 100; ++i) {
       // block cannot gain space by compression
       uncompressable_values_.emplace_back(RandomString(&rnd, 256) + '\0');
-      assert(Put("a"+Key(i+100), uncompressable_values_[i]) == Status::OK());
+      std::string tmp_key = "a" + Key(i);
+      assert(Put(tmp_key, uncompressable_values_[i]) == Status::OK());
     }
     Flush();
- }
+  }
 
   bool CheckValue(int i, const std::string& value) {
     if (values_[i].compare(value) == 0) {
@@ -1723,7 +1724,7 @@ class DBBasicTestWithParallelIO
   }
 
   bool CheckUncompressableValue(int i, const std::string& value) {
-    if (uncompressable_values_[i-100].compare(value) == 0) {
+    if (uncompressable_values_[i].compare(value) == 0) {
       return true;
     }
     return false;
@@ -1952,9 +1953,9 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
 
   keys.resize(10);
   statuses.resize(10);
-  std::vector<int> key_uncmp{11, 12, 115, 116, 155, 181, 182, 183, 184, 185};
+  std::vector<int> key_uncmp{1, 2, 15, 16, 55, 81, 82, 83, 84, 85};
   for (size_t i = 0; i < key_uncmp.size(); ++i) {
-    key_data[i] = "a"+Key(key_uncmp[i]);
+    key_data[i] = "a" + Key(key_uncmp[i]);
     keys[i] = Slice(key_data[i]);
     statuses[i] = Status::OK();
     values[i].Reset();
@@ -1966,12 +1967,33 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
     ASSERT_TRUE(CheckUncompressableValue(key_uncmp[i], values[i].ToString()));
   }
   if (compression_enabled() && !has_compressed_cache()) {
-    expected_reads += (read_from_cache ? 2 : 3);
+    expected_reads += (read_from_cache ? 3 : 3);
   } else {
-    expected_reads += (read_from_cache ? 2 : 4);
+    expected_reads += (read_from_cache ? 4 : 4);
   }
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
+  keys.resize(5);
+  statuses.resize(5);
+  std::vector<int> key_tr{1, 2, 15, 16, 55};
+  for (size_t i = 0; i < key_tr.size(); ++i) {
+    key_data[i] = "a" + Key(key_tr[i]);
+    keys[i] = Slice(key_data[i]);
+    statuses[i] = Status::OK();
+    values[i].Reset();
+  }
+  dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
+                     keys.data(), values.data(), statuses.data(), true);
+  for (size_t i = 0; i < key_tr.size(); ++i) {
+    ASSERT_OK(statuses[i]);
+    ASSERT_TRUE(CheckUncompressableValue(key_tr[i], values[i].ToString()));
+  }
+  if (compression_enabled() && !has_compressed_cache()) {
+    expected_reads += (read_from_cache ? 0 : 2);
+  } else {
+    expected_reads += (read_from_cache ? 0 : 3);
+  }
+  ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2463,6 +2463,9 @@ void BlockBasedTable::RetrieveMultipleBlocks(
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+#ifndef NDEBUG
+        raw_block_contents.is_raw_block = true;
+#endif
       }
     }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2483,7 +2483,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
           // copied to heap
           // If the read buffer is shared but the block is not compressed, copy
           // to the heap
-          Slice raw = Slice(req.result.data(), handle.size());
+          Slice raw = Slice(req.result.data() + req_offset, handle.size());
           contents = BlockContents(
               CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
               handle.size());

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,7 +9,6 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
@@ -2519,9 +2518,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       }
     }
     (*statuses)[idx_in_batch] = s;
-    if (!s.ok()) {
-      std::cout << s.ToString() << "\n";
-    }
   }
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,7 +9,6 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,6 +9,7 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
@@ -2456,13 +2457,14 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // to the heap such that it can be added to the block cache.
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
-      if (rep_->blocks_maybe_compressed && compression_type == kNoCompression) {
-      }
-      if (blocks_share_scratch && compression_type == kNoCompression) {
+      if (rep_->blocks_maybe_compressed &&
+          rep_->table_options.block_cache_compressed == nullptr &&
+          compression_type == kNoCompression && blocks_share_scratch) {
         Slice raw = Slice(req.scratch + req_offset, handle.size());
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+
 #ifndef NDEBUG
         raw_block_contents.is_raw_block = true;
 #endif


### PR DESCRIPTION
In the current MultiGet, if the KV-pairs do not belong to the data blocks in the block cache, multiple blocks are read from a SST. It will trigger one block read for each block request and read them in parallel. In some cases, if some data blocks are adjacent in the SST, the reads for these blocks can be combined to a single large read, which can reduce the system calls and reduce the read latency if possible.

Considering to fill the block cache, if multiple data blocks are in the same memory buffer, we need to copy them to the heap separately. Therefore, only in the case that 1) data block compression is enabled, and 2) compressed block cache is null, we can do combined read. Otherwise, extra memory copy is needed, which may cause extra overhead. In the current case, data blocks will be uncompressed to a new memory space.

Test plan: Added test case to ParallelIO.MultiGet. Pass make asan_check