### PR TITLE
Remove unused/undefined ImmutableCFOptions()

### DIFF
--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -20,7 +20,6 @@ namespace rocksdb {
 // of DB. Raw pointers defined in this struct do not have ownership to the data
 // they point to. Options contains std::shared_ptr to these data.
 struct ImmutableCFOptions {
-  ImmutableCFOptions();
   explicit ImmutableCFOptions(const Options& options);
 
   ImmutableCFOptions(const ImmutableDBOptions& db_options,


### PR DESCRIPTION
Summary: default constructor not used or even defined