### PR TITLE
Merge adjacent file block reads in RocksDB MultiGet() and Add uncompressed block to cache

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,7 +6,6 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-#include<iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1993,7 +1992,6 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 0 : 3);
   }
-  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,7 +6,6 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-// #include <iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,6 +6,7 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
+#include<iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1992,6 +1993,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 0 : 3);
   }
+  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,6 +6,7 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
+#include <iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1926,6 +1927,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   }
 
   int expected_reads = random_reads + (read_from_cache ? 0 : 2);
+  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(10);
@@ -1948,6 +1950,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 2 : 4);
   }
+  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(10);
@@ -1970,6 +1973,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 4 : 4);
   }
+  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(5);
@@ -1992,6 +1996,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 0 : 3);
   }
+  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1710,10 +1710,11 @@ class DBBasicTestWithParallelIO
     for (int i = 0; i < 100; ++i) {
       // block cannot gain space by compression
       uncompressable_values_.emplace_back(RandomString(&rnd, 256) + '\0');
-      assert(Put("a"+Key(i+100), uncompressable_values_[i]) == Status::OK());
+      std::string tmp_key = "a" + Key(i);
+      assert(Put(tmp_key, uncompressable_values_[i]) == Status::OK());
     }
     Flush();
- }
+  }
 
   bool CheckValue(int i, const std::string& value) {
     if (values_[i].compare(value) == 0) {
@@ -1723,7 +1724,7 @@ class DBBasicTestWithParallelIO
   }
 
   bool CheckUncompressableValue(int i, const std::string& value) {
-    if (uncompressable_values_[i-100].compare(value) == 0) {
+    if (uncompressable_values_[i].compare(value) == 0) {
       return true;
     }
     return false;
@@ -1952,9 +1953,9 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
 
   keys.resize(10);
   statuses.resize(10);
-  std::vector<int> key_uncmp{11, 12, 115, 116, 155, 181, 182, 183, 184, 185};
+  std::vector<int> key_uncmp{1, 2, 15, 16, 55, 81, 82, 83, 84, 85};
   for (size_t i = 0; i < key_uncmp.size(); ++i) {
-    key_data[i] = "a"+Key(key_uncmp[i]);
+    key_data[i] = "a" + Key(key_uncmp[i]);
     keys[i] = Slice(key_data[i]);
     statuses[i] = Status::OK();
     values[i].Reset();
@@ -1966,12 +1967,33 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
     ASSERT_TRUE(CheckUncompressableValue(key_uncmp[i], values[i].ToString()));
   }
   if (compression_enabled() && !has_compressed_cache()) {
-    expected_reads += (read_from_cache ? 2 : 3);
+    expected_reads += (read_from_cache ? 3 : 3);
   } else {
-    expected_reads += (read_from_cache ? 2 : 4);
+    expected_reads += (read_from_cache ? 4 : 4);
   }
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
+  keys.resize(5);
+  statuses.resize(5);
+  std::vector<int> key_tr{1, 2, 15, 16, 55};
+  for (size_t i = 0; i < key_tr.size(); ++i) {
+    key_data[i] = "a" + Key(key_tr[i]);
+    keys[i] = Slice(key_data[i]);
+    statuses[i] = Status::OK();
+    values[i].Reset();
+  }
+  dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
+                     keys.data(), values.data(), statuses.data(), true);
+  for (size_t i = 0; i < key_tr.size(); ++i) {
+    ASSERT_OK(statuses[i]);
+    ASSERT_TRUE(CheckUncompressableValue(key_tr[i], values[i].ToString()));
+  }
+  if (compression_enabled() && !has_compressed_cache()) {
+    expected_reads += (read_from_cache ? 0 : 2);
+  } else {
+    expected_reads += (read_from_cache ? 0 : 3);
+  }
+  ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1993,11 +1993,15 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   }
   if (compression_enabled() && !has_compressed_cache()) {
     expected_reads += (read_from_cache ? 0 : 2);
+    ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
   } else {
-    expected_reads += (read_from_cache ? 0 : 3);
+    if (has_uncompressed_cache()) {
+      expected_reads += (read_from_cache ? 0 : 3);
+      ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
+    } else {
+      ASSERT_TRUE(env_->random_read_counter_.Read() >= expected_reads);
+    }
   }
-  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
-  ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,7 +6,6 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-#include <iostream>
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1927,7 +1926,6 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   }
 
   int expected_reads = random_reads + (read_from_cache ? 0 : 2);
-  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(10);
@@ -1950,7 +1948,6 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 2 : 4);
   }
-  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(10);
@@ -1973,7 +1970,6 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   } else {
     expected_reads += (read_from_cache ? 4 : 4);
   }
-  std::cout<<env_->random_read_counter_.Read()<<" "<<expected_reads<<"\n";
   ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
 
   keys.resize(5);
@@ -1999,6 +1995,10 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
       expected_reads += (read_from_cache ? 0 : 3);
       ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
     } else {
+      // A rare case, the we enable the block compression but the data
+      // block might not be compressed. At the same time, we only have
+      // compressed cache, so 0 to 3 data blocks might no tbe cached, and
+      // block reads will be triggered.
       ASSERT_TRUE(env_->random_read_counter_.Read() >= expected_reads);
     }
   }

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1995,10 +1995,11 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
       expected_reads += (read_from_cache ? 0 : 3);
       ASSERT_EQ(env_->random_read_counter_.Read(), expected_reads);
     } else {
-      // A rare case, the we enable the block compression but the data
-      // block might not be compressed. At the same time, we only have
-      // compressed cache, so 0 to 3 data blocks might no tbe cached, and
-      // block reads will be triggered.
+      // A rare case, even we enable the block compression but some of data
+      // blocks are not compressed due to content. If user only enable the
+      // compressed cache, the uncompressed blocks will not tbe cached, and
+      // block reads will be triggered. The number of reads is related to
+      // the compression algorithm.
       ASSERT_TRUE(env_->random_read_counter_.Read() >= expected_reads);
     }
   }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -10,7 +10,6 @@
 #include "table/block_based/block_based_table_builder.h"
 
 #include <assert.h>
-#include <iostream>
 #include <stdio.h>
 #include <list>
 #include <map>
@@ -100,7 +99,6 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
 
 bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
   // Check to see if compressed less than 12.5%
-  std::cout<<raw_size<<" "<<compressed_size<<" "<<raw_size - (raw_size / 8u)<<"\n";
   return compressed_size < raw_size - (raw_size / 8u);
 }
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -10,6 +10,7 @@
 #include "table/block_based/block_based_table_builder.h"
 
 #include <assert.h>
+#include <iostream>
 #include <stdio.h>
 #include <list>
 #include <map>
@@ -99,6 +100,7 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
 
 bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
   // Check to see if compressed less than 12.5%
+  std::cout<<raw_size<<" "<<compressed_size<<" "<<raw_size - (raw_size / 8u)<<"\n";
   return compressed_size < raw_size - (raw_size / 8u);
 }
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -11,7 +11,6 @@
 
 #include <assert.h>
 #include <stdio.h>
-#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
@@ -100,7 +99,6 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
 
 bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
   // Check to see if compressed less than 12.5%
-  std::cout<<raw_size<<" "<<raw_size - (raw_size / 8u)<<" "<<compressed_size<<"\n";
   return compressed_size < raw_size - (raw_size / 8u);
 }
 

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -11,7 +11,7 @@
 
 #include <assert.h>
 #include <stdio.h>
-
+#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
@@ -100,6 +100,7 @@ FilterBlockBuilder* CreateFilterBlockBuilder(
 
 bool GoodCompressionRatio(size_t compressed_size, size_t raw_size) {
   // Check to see if compressed less than 12.5%
+  std::cout<<raw_size<<" "<<raw_size - (raw_size / 8u)<<" "<<compressed_size<<"\n";
   return compressed_size < raw_size - (raw_size / 8u);
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,6 +9,7 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
@@ -2457,13 +2458,14 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // to the heap such that it can be added to the block cache.
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
-      if (rep_->blocks_maybe_compressed && compression_type == kNoCompression) {
-      }
-      if (blocks_share_scratch && compression_type == kNoCompression) {
+      if (rep_->blocks_maybe_compressed &&
+          rep_->table_options.block_cache_compressed == nullptr &&
+          compression_type == kNoCompression && blocks_share_scratch) {
         Slice raw = Slice(req.scratch + req_offset, handle.size());
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+
 #ifndef NDEBUG
         raw_block_contents.is_raw_block = true;
 #endif

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2458,13 +2458,12 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // to the heap such that it can be added to the block cache.
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
-      if (rep_->blocks_maybe_compressed &&
-          rep_->table_options.block_cache_compressed == nullptr &&
-          compression_type == kNoCompression && blocks_share_scratch) {
+      if (scratch != nullptr && compression_type == kNoCompression) {
         Slice raw = Slice(req.scratch + req_offset, handle.size());
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+        std::cout<<req.result.size()<<" "<<handle.size()<<" rare case, compress enabled but not block not compressed\n";
 
 #ifndef NDEBUG
         raw_block_contents.is_raw_block = true;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2504,12 +2504,12 @@ void BlockBasedTable::RetrieveMultipleBlocks(
                                     handle.size(), &contents, footer.version(),
                                     rep_->ioptions, memory_allocator);
       } else {
-        if (scratch != nullptr || block_size(handle) != req.result.size()) {
+        if (scratch != nullptr || blocks_share_scratch) {
           // If we used the scratch buffer, then the contents need to be
           // copied to heap
           // If the read buffer is shared but the block is not compressed, copy
           // to the head
-          Slice raw = Slice(req.result.data(), handle.size());
+          Slice raw = Slice(req.result.data() + req_offset, handle.size());
           contents = BlockContents(
               CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
               handle.size());

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2464,6 +2464,9 @@ void BlockBasedTable::RetrieveMultipleBlocks(
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+#ifndef NDEBUG
+        raw_block_contents.is_raw_block = true;
+#endif
       }
     }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2338,9 +2338,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     // If current block is adjacent to the previous one, at the same time,
     // compression is enabled and there is no compressed cache, we combine
     // the two block read as one.
-    if (rep_->blocks_maybe_compressed &&
-        rep_->table_options.block_cache_compressed == nullptr &&
-        prev_end == handle.offset()) {
+    if (scratch != nullptr && prev_end == handle.offset()) {
       req_offset_for_block.emplace_back(prev_len);
       prev_len += block_size(handle);
     } else {
@@ -2460,7 +2458,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // At the same time, some blocks are actually not compressed,
       // since its compression space saving is smaller than the threshold. In
       // this case, if the block shares the scratch memory, we need to copy it
-      // to the heap such that it can be added to the regular elock cache.
+      // to the heap such that it can be added to the regular block cache.
       CompressionType compression_type =
           raw_block_contents.get_compression_type();
       if (scratch != nullptr && compression_type == kNoCompression) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2345,7 +2345,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // No compression or current block and previous one is not adjacent:
       // Step 1, create a new request for previous blocks
       if (prev_len != 0) {
-        ReadRequest req;
+        FSReadRequest req;
         req.offset = prev_offset;
         req.len = prev_len;
         if (scratch == nullptr) {
@@ -2354,7 +2354,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
           req.scratch = scratch + buf_offset;
           buf_offset += req.len;
         }
-        req.status = Status::OK();
+        req.status = IOStatus::OK();
         read_reqs.emplace_back(req);
       }
 
@@ -2367,7 +2367,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
   }
   // Handle the last block and process the pending last request
   if (prev_len != 0) {
-    ReadRequest req;
+    FSReadRequest req;
     req.offset = prev_offset;
     req.len = prev_len;
     if (scratch == nullptr) {
@@ -2376,7 +2376,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       req.scratch = scratch + buf_offset;
       buf_offset += req.len;
     }
-    req.status = Status::OK();
+    req.status = IOStatus::OK();
     read_reqs.emplace_back(req);
   }
 
@@ -2398,7 +2398,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     size_t& req_idx = req_idx_for_block[valid_batch_idx];
     size_t& req_offset = req_offset_for_block[valid_batch_idx];
     valid_batch_idx++;
-    ReadRequest& req = read_reqs[req_idx];
+    FSReadRequest& req = read_reqs[req_idx];
     Status s = req.status;
     if (s.ok()) {
       if (req.result.size() != req.len) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2422,6 +2422,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     }
 
     bool blocks_share_scratch = (req.result.size() != block_size(handle));
+    std::cout<<"req: "<<req_idx<<" "<<req_offset<<" "<<req.result.size()<<" handle "<<handle.offset()<<" "<<block_size(handle)<<"\n";
 
     if (s.ok()) {
       if (scratch == nullptr && !blocks_share_scratch) {
@@ -2464,6 +2465,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
+        std::cout<<"rare case: scratch!=null or combined read\n";
 
 #ifndef NDEBUG
         raw_block_contents.is_raw_block = true;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -7,9 +7,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #include "table/block_based/block_based_table_reader.h"
-
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
@@ -2320,6 +2320,66 @@ void BlockBasedTable::RetrieveMultipleBlocks(
   autovector<FSReadRequest, MultiGetContext::MAX_BATCH_SIZE> read_reqs;
   size_t buf_offset = 0;
   size_t idx_in_batch = 0;
+
+  uint64_t prev_offset = 0;
+  size_t prev_len = 0;
+  autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_idx_for_block;
+  autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_offset_for_block;
+  for (auto mget_iter = batch->begin(); mget_iter != batch->end();
+       ++mget_iter, ++idx_in_batch) {
+    const BlockHandle& handle = (*handles)[idx_in_batch];
+    if (handle.IsNull()) {
+      continue;
+    }
+
+    size_t prev_end = static_cast<size_t>(prev_offset) + prev_len;
+
+    // Current block is next to the previous one and also enable compression
+    if (rep_->blocks_maybe_compressed != kNoCompression &&
+        rep_->table_options.block_cache_compressed == nullptr &&
+        prev_end == handle.offset()) {
+      req_offset_for_block.emplace_back(prev_len);
+      prev_len += block_size(handle);
+    } else {
+      // No compression or current block and previous on is not adjacent
+      // Step 1, create a new request for previous blocks
+      if (prev_len != 0) {
+        ReadRequest req;
+        req.offset = prev_offset;
+        req.len = prev_len;
+        if (scratch == nullptr) {
+          req.scratch = new char[req.len];
+        } else {
+          req.scratch = scratch + buf_offset;
+          buf_offset += req.len;
+        }
+        req.status = Status::OK();
+        read_reqs.emplace_back(req);
+      }
+
+      // Step 2, remeber the previous block info
+      prev_offset = handle.offset();
+      prev_len = block_size(handle);
+      req_offset_for_block.emplace_back(0);
+    }
+    req_idx_for_block.emplace_back(read_reqs.size());
+  }
+  // Hanle the last block if no more blocks needs to be handled
+  if (prev_len != 0) {
+    ReadRequest req;
+    req.offset = prev_offset;
+    req.len = prev_len;
+    if (scratch == nullptr) {
+      req.scratch = new char[req.len];
+    } else {
+      req.scratch = scratch + buf_offset;
+      buf_offset += req.len;
+    }
+    req.status = Status::OK();
+    read_reqs.emplace_back(req);
+  }
+
+  /*
   for (auto mget_iter = batch->begin(); mget_iter != batch->end();
        ++mget_iter, ++idx_in_batch) {
     const BlockHandle& handle = (*handles)[idx_in_batch];
@@ -2339,9 +2399,146 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     req.status = IOStatus::OK();
     read_reqs.emplace_back(req);
   }
+  */
 
   file->MultiRead(&read_reqs[0], read_reqs.size());
 
+  idx_in_batch = 0;
+  size_t valid_batch_idx = 0;
+  for (auto mget_iter = batch->begin(); mget_iter != batch->end();
+       ++mget_iter, ++idx_in_batch) {
+    const BlockHandle& handle = (*handles)[idx_in_batch];
+
+    if (handle.IsNull()) {
+      continue;
+    }
+
+    assert(valid_batch_idx < req_idx_for_block.size());
+    assert(valid_batch_idx < req_offset_for_block.size());
+    assert(req_idx_for_block[valid_batch_idx] < read_reqs.size());
+    size_t& req_idx = req_idx_for_block[valid_batch_idx];
+    size_t& req_offset = req_offset_for_block[valid_batch_idx];
+    valid_batch_idx++;
+    ReadRequest& req = read_reqs[req_idx];
+    Status s = req.status;
+    if (s.ok()) {
+      if (req.result.size() != req.len) {
+        s = Status::Corruption(
+            "truncated block read from " + rep_->file->file_name() +
+            " offset " + ToString(handle.offset()) + ", expected " +
+            ToString(req.len) + " bytes, got " + ToString(req.result.size()));
+      }
+    }
+
+    BlockContents raw_block_contents;
+    size_t cur_read_end = req_offset + block_size(handle);
+    if (cur_read_end > req.result.size()) {
+      s = Status::Corruption(
+          "truncated block read from " + rep_->file->file_name() + " offset " +
+          ToString(handle.offset()) + ", expected " + ToString(req.len) +
+          " bytes, got " + ToString(req.result.size()));
+    }
+
+    bool blocks_share_scratch = (req.result.size() != block_size(handle));
+
+    if (s.ok()) {
+      if (scratch == nullptr && !blocks_share_scratch) {
+        // We allocated a buffer for this block. Give ownership of it to
+        // BlockContents so it can free the memory
+        assert(req.result.data() == req.scratch);
+        std::unique_ptr<char[]> raw_block(req.scratch + req_offset);
+        raw_block_contents = BlockContents(std::move(raw_block), handle.size());
+      } else {
+        // We used the scratch buffer, so no need to free anything
+        raw_block_contents =
+            BlockContents(Slice(req.scratch + req_offset, handle.size()));
+      }
+
+#ifndef NDEBUG
+      raw_block_contents.is_raw_block = true;
+#endif
+      if (options.verify_checksums) {
+        PERF_TIMER_GUARD(block_checksum_time);
+        const char* data = req.result.data();
+        uint32_t expected =
+            DecodeFixed32(data + req_offset + handle.size() + 1);
+        s = rocksdb::VerifyChecksum(footer.checksum(),
+                                    req.result.data() + req_offset,
+                                    handle.size() + 1, expected);
+      }
+    }
+
+    if (s.ok()) {
+      // It handles a rare case: compression is set and these is no compressed
+      // cache (enable combined read), some block is actually not compressed
+      // since its compression space saving is smaller than the threshold. In
+      // this case, if the block shares the scratch memory, we need to copy it
+      // to the heap such that it can be added to the block cache.
+      CompressionType compression_type =
+            raw_block_contents.get_compression_type();
+      if (blocks_share_scratch && compression_type == kNoCompression){
+        Slice raw = Slice(req.scratch + req_offset, handle.size());
+        raw_block_contents = BlockContents(
+              CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
+              handle.size());
+      }
+    }
+
+    if (s.ok()) {
+      if (options.fill_cache) {
+        BlockCacheLookupContext lookup_data_block_context(
+            TableReaderCaller::kUserMultiGet);
+        CachableEntry<Block>* block_entry = &(*results)[idx_in_batch];
+        // MaybeReadBlockAndLoadToCache will insert into the block caches if
+        // necessary. Since we're passing the raw block contents, it will
+        // avoid looking up the block cache
+        s = MaybeReadBlockAndLoadToCache(
+            nullptr, options, handle, uncompression_dict, block_entry,
+            BlockType::kData, mget_iter->get_context,
+            &lookup_data_block_context, &raw_block_contents);
+
+        // block_entry value could be null if no block cache is present, i.e
+        // BlockBasedTableOptions::no_block_cache is true and no compressed
+        // block cache is configured. In that case, fall
+        // through and set up the block explicitly
+        if (block_entry->GetValue() != nullptr) {
+          continue;
+        }
+      }
+
+      CompressionType compression_type =
+          raw_block_contents.get_compression_type();
+      BlockContents contents;
+      if (compression_type != kNoCompression) {
+        UncompressionContext context(compression_type);
+        UncompressionInfo info(context, uncompression_dict, compression_type);
+        s = UncompressBlockContents(info, req.result.data() + req_offset,
+                                    handle.size(), &contents, footer.version(),
+                                    rep_->ioptions, memory_allocator);
+      } else {
+        if (scratch != nullptr || block_size(handle) != req.result.size()) {
+          // If we used the scratch buffer, then the contents need to be
+          // copied to heap
+          // If the read buffer is shared but the block is not compressed, copy
+          // to the head
+          Slice raw = Slice(req.result.data(), handle.size());
+          contents = BlockContents(
+              CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
+              handle.size());
+        } else {
+          contents = std::move(raw_block_contents);
+        }
+      }
+      if (s.ok()) {
+        (*results)[idx_in_batch].SetOwnedValue(
+            new Block(std::move(contents), global_seqno, read_amp_bytes_per_bit,
+                      ioptions.statistics));
+      }
+    }
+    (*statuses)[idx_in_batch] = s;
+  }
+
+  /*
   size_t read_req_idx = 0;
   idx_in_batch = 0;
   for (auto mget_iter = batch->begin(); mget_iter != batch->end();
@@ -2438,6 +2635,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     }
     (*statuses)[idx_in_batch] = s;
   }
+  */
 }
 
 template <typename TBlocklike>

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,7 +9,6 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>
@@ -2422,8 +2421,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     }
 
     bool blocks_share_scratch = (req.result.size() != block_size(handle));
-    std::cout<<"req: "<<req_idx<<" "<<req_offset<<" "<<req.result.size()<<" handle "<<handle.offset()<<" "<<block_size(handle)<<"\n";
-
     if (s.ok()) {
       if (scratch == nullptr && !blocks_share_scratch) {
         // We allocated a buffer for this block. Give ownership of it to
@@ -2465,8 +2462,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
         raw_block_contents = BlockContents(
             CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
             handle.size());
-        std::cout<<"rare case: scratch!=null or combined read\n";
-
 #ifndef NDEBUG
         raw_block_contents.is_raw_block = true;
 #endif

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2280,6 +2280,8 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
 // false and scratch is non-null and the blocks are uncompressed, it copies
 // the buffers to heap. In any case, the CachableEntry<Block> returned will
 // own the data bytes.
+// If compression is enabled and also there is no compressed block cache,
+// the adjacent blocks are read out in one IO (combined read)
 // batch - A MultiGetRange with only those keys with unique data blocks not
 //         found in cache
 // handles - A vector of block handles. Some of them me be NULL handles
@@ -2334,14 +2336,16 @@ void BlockBasedTable::RetrieveMultipleBlocks(
 
     size_t prev_end = static_cast<size_t>(prev_offset) + prev_len;
 
-    // Current block is next to the previous one and also enable compression
-    if (rep_->blocks_maybe_compressed != kNoCompression &&
+    // If current block is adjacent to the previous one, at the same time,
+    // compression is enabled and there is no compressed cache, we combine
+    // the two block read as one.
+    if (rep_->blocks_maybe_compressed &&
         rep_->table_options.block_cache_compressed == nullptr &&
         prev_end == handle.offset()) {
       req_offset_for_block.emplace_back(prev_len);
       prev_len += block_size(handle);
     } else {
-      // No compression or current block and previous on is not adjacent
+      // No compression or current block and previous one is not adjacent:
       // Step 1, create a new request for previous blocks
       if (prev_len != 0) {
         ReadRequest req;
@@ -2364,7 +2368,7 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     }
     req_idx_for_block.emplace_back(read_reqs.size());
   }
-  // Hanle the last block if no more blocks needs to be handled
+  // Hanle the last block and process the pending last request
   if (prev_len != 0) {
     ReadRequest req;
     req.offset = prev_offset;
@@ -2378,28 +2382,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     req.status = Status::OK();
     read_reqs.emplace_back(req);
   }
-
-  /*
-  for (auto mget_iter = batch->begin(); mget_iter != batch->end();
-       ++mget_iter, ++idx_in_batch) {
-    const BlockHandle& handle = (*handles)[idx_in_batch];
-    if (handle.IsNull()) {
-      continue;
-    }
-
-    FSReadRequest req;
-    req.len = block_size(handle);
-    if (scratch == nullptr) {
-      req.scratch = new char[req.len];
-    } else {
-      req.scratch = scratch + buf_offset;
-      buf_offset += req.len;
-    }
-    req.offset = handle.offset();
-    req.status = IOStatus::OK();
-    read_reqs.emplace_back(req);
-  }
-  */
 
   file->MultiRead(&read_reqs[0], read_reqs.size());
 
@@ -2475,12 +2457,14 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // this case, if the block shares the scratch memory, we need to copy it
       // to the heap such that it can be added to the block cache.
       CompressionType compression_type =
-            raw_block_contents.get_compression_type();
-      if (blocks_share_scratch && compression_type == kNoCompression){
+          raw_block_contents.get_compression_type();
+      if (rep_->blocks_maybe_compressed && compression_type == kNoCompression) {
+      }
+      if (blocks_share_scratch && compression_type == kNoCompression) {
         Slice raw = Slice(req.scratch + req_offset, handle.size());
         raw_block_contents = BlockContents(
-              CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
-              handle.size());
+            CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
+            handle.size());
       }
     }
 
@@ -2537,105 +2521,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
     }
     (*statuses)[idx_in_batch] = s;
   }
-
-  /*
-  size_t read_req_idx = 0;
-  idx_in_batch = 0;
-  for (auto mget_iter = batch->begin(); mget_iter != batch->end();
-       ++mget_iter, ++idx_in_batch) {
-    const BlockHandle& handle = (*handles)[idx_in_batch];
-
-    if (handle.IsNull()) {
-      continue;
-    }
-
-    FSReadRequest& req = read_reqs[read_req_idx++];
-    Status s = req.status;
-    if (s.ok()) {
-      if (req.result.size() != req.len) {
-        s = Status::Corruption("truncated block read from " +
-                               rep_->file->file_name() + " offset " +
-                               ToString(handle.offset()) + ", expected " +
-                               ToString(req.len) +
-                               " bytes, got " + ToString(req.result.size()));
-      }
-    }
-
-    BlockContents raw_block_contents;
-    if (s.ok()) {
-      if (scratch == nullptr) {
-        // We allocated a buffer for this block. Give ownership of it to
-        // BlockContents so it can free the memory
-        assert(req.result.data() == req.scratch);
-        std::unique_ptr<char[]> raw_block(req.scratch);
-        raw_block_contents = BlockContents(std::move(raw_block), handle.size());
-      } else {
-        // We used the scratch buffer, so no need to free anything
-        raw_block_contents = BlockContents(Slice(req.scratch, handle.size()));
-      }
-#ifndef NDEBUG
-      raw_block_contents.is_raw_block = true;
-#endif
-      if (options.verify_checksums) {
-        PERF_TIMER_GUARD(block_checksum_time);
-        const char* data = req.result.data();
-        uint32_t expected = DecodeFixed32(data + handle.size() + 1);
-        s = rocksdb::VerifyChecksum(footer.checksum(), req.result.data(),
-                                    handle.size() + 1, expected);
-      }
-    }
-    if (s.ok()) {
-      if (options.fill_cache) {
-        BlockCacheLookupContext lookup_data_block_context(
-            TableReaderCaller::kUserMultiGet);
-        CachableEntry<Block>* block_entry = &(*results)[idx_in_batch];
-        // MaybeReadBlockAndLoadToCache will insert into the block caches if
-        // necessary. Since we're passing the raw block contents, it will
-        // avoid looking up the block cache
-        s = MaybeReadBlockAndLoadToCache(
-            nullptr, options, handle, uncompression_dict, block_entry,
-            BlockType::kData, mget_iter->get_context,
-            &lookup_data_block_context, &raw_block_contents);
-
-        // block_entry value could be null if no block cache is present, i.e
-        // BlockBasedTableOptions::no_block_cache is true and no compressed
-        // block cache is configured. In that case, fall
-        // through and set up the block explicitly
-        if (block_entry->GetValue() != nullptr) {
-          continue;
-        }
-      }
-
-      CompressionType compression_type =
-          raw_block_contents.get_compression_type();
-      BlockContents contents;
-      if (compression_type != kNoCompression) {
-        UncompressionContext context(compression_type);
-        UncompressionInfo info(context, uncompression_dict, compression_type);
-        s = UncompressBlockContents(info, req.result.data(), handle.size(),
-                                    &contents, footer.version(),
-                                    rep_->ioptions, memory_allocator);
-      } else {
-        if (scratch != nullptr) {
-          // If we used the scratch buffer, then the contents need to be
-          // copied to heap
-          Slice raw = Slice(req.result.data(), handle.size());
-          contents = BlockContents(
-              CopyBufferToHeap(GetMemoryAllocator(rep_->table_options), raw),
-              handle.size());
-        } else {
-          contents = std::move(raw_block_contents);
-        }
-      }
-      if (s.ok()) {
-        (*results)[idx_in_batch].SetOwnedValue(
-            new Block(std::move(contents), global_seqno,
-                      read_amp_bytes_per_bit, ioptions.statistics));
-      }
-    }
-    (*statuses)[idx_in_batch] = s;
-  }
-  */
 }
 
 template <typename TBlocklike>

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -9,7 +9,6 @@
 #include "table/block_based/block_based_table_reader.h"
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <utility>


### PR DESCRIPTION
In the current MultiGet, if the KV-pairs do not belong to the data blocks in the block cache, multiple blocks are read from a SST. It will trigger one block read for each block request and read them in parallel. In some cases, if some data blocks are adjacent in the SST, the reads for these blocks can be combined to a single large read, which can reduce the system calls and reduce the read latency if possible.

Considering to fill the block cache, if multiple data blocks are in the same memory buffer, we need to copy them to the heap separately. Therefore, only in the case that 1) data block compression is enabled, and 2) compressed block cache is null, we can do combined read. Otherwise, extra memory copy is needed, which may cause extra overhead. In the current case, data blocks will be uncompressed to a new memory space.

Also, in the case that 1) data block compression is enabled, and 2) compressed block cache is null, it is possible the data block is actually not compressed. In the current logic, these data blocks will not be added to the uncompressed_cache. So if memory buffer is shared and the data block is not compressed, the data block are copied to the head and fill the cache.

Test plan: Added test case to ParallelIO.MultiGet. Pass make asan_check