### PR TITLE
Improve detection and recovery from incomplete backup deletion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,7 @@
 * Added AVX2 instructions to USE_SSE builds to accelerate the new Bloom filter and XXH3-based hash function on compatible x86_64 platforms (Haswell and later, ~2014).
 * Support options.ttl with options.max_open_files = -1. File's oldest ancester time will be written to manifest. If it is availalbe, this information will be used instead of creation_time in table properties.
 * Setting options.ttl for universal compaction now has the same meaning as setting periodic_compaction_seconds.
+* Deletion and GC of backups is supported by a new canary file. Whenever a backup is created, it is associated with a new canary file. In the process of a deletion of a backup, its canary file is the first one to be deleted (even before any metedata). The advantage is that backups with no canary file are safe to be deleted by a garbage collection. Hence garbage collection is faster because it can exclude private folders of backups that are associated with a canary file.
 
 ### Performance Improvements
 * For 64-bit hashing, RocksDB is standardizing on a slightly modified preview version of XXH3. This function is now used for many non-persisted hashes, along with fastrange64() in place of the modulus operator, and some benchmarks show a slight improvement.

--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -115,6 +115,12 @@ struct BackupableDBOptions {
   // Default: INT_MAX
   int max_valid_backups_to_open;
 
+  // If equal to true, a canary file is added to a backup on creation.
+  // The file can be used to detect backups that have been corrupted on
+  // deletion.
+  // Default: false
+  bool with_canary_delete_files;
+
   void Dump(Logger* logger) const;
 
   explicit BackupableDBOptions(
@@ -124,7 +130,8 @@ struct BackupableDBOptions {
       bool _backup_log_files = true, uint64_t _backup_rate_limit = 0,
       uint64_t _restore_rate_limit = 0, int _max_background_operations = 1,
       uint64_t _callback_trigger_interval_size = 4 * 1024 * 1024,
-      int _max_valid_backups_to_open = INT_MAX)
+      int _max_valid_backups_to_open = INT_MAX,
+      bool _with_canary_delete_files = false)
       : backup_dir(_backup_dir),
         backup_env(_backup_env),
         share_table_files(_share_table_files),
@@ -137,7 +144,8 @@ struct BackupableDBOptions {
         share_files_with_checksum(false),
         max_background_operations(_max_background_operations),
         callback_trigger_interval_size(_callback_trigger_interval_size),
-        max_valid_backups_to_open(_max_valid_backups_to_open) {
+        max_valid_backups_to_open(_max_valid_backups_to_open),
+        with_canary_delete_files(_with_canary_delete_files) {
     assert(share_table_files || !share_files_with_checksum);
   }
 };


### PR DESCRIPTION
Prioritize deletion of canary file on DeleteBackup and PurgeOldBackups to detect partial deletions.

Deletion and GC of backups is supported by a new canary file. Whenever a backup is created, it is associated with a new canary file. In the process of a deletion of a backup, its canary file is the first one to be deleted (even before any metadata). The advantage is that backups with no canary file are safe to be deleted by a garbage collection. Hence garbage collection is faster because it can exclude private folders of backups that are associated with a canary file.

Note: Test case DeleteTmpFiles of BackupableDBTest needs to be deleted because it is not valid with the new logic of deletion and GC.