### PR TITLE
Add format_version=5 to db_crashtest

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -66,7 +66,7 @@ default_params = {
     "verify_checksum": 1,
     "write_buffer_size": 4 * 1024 * 1024,
     "writepercent": 35,
-    "format_version": lambda: random.randint(2, 4),
+    "format_version": lambda: random.choice([2, 3, 4, 5, 5]),
     "index_block_restart_interval": lambda: random.choice(range(1, 16)),
     "use_multiget" : lambda: random.randint(0, 1),
     "periodic_compaction_seconds" :


### PR DESCRIPTION
Summary: format_version=5 enables new Bloom filter. Using 2/5
probability for "latest and greatest" rather than naive 1/4.

Test Plan: start 'make blackbox_crash_test'