### PR TITLE
Update comment on max_valid_backups_to_open

### DIFF
--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -104,13 +104,13 @@ struct BackupableDBOptions {
   // Default: 4194304
   uint64_t callback_trigger_interval_size;
 
-  // When Open() is called, it will open at most this many of the latest
-  // non-corrupted backups.
+  // For BackupEngineReadOnly, Open() will open at most this many of the
+  // latest non-corrupted backups.
   //
-  // Note setting this to a non-default value prevents old files from being
-  // deleted in the shared directory, as we can't do proper ref-counting. If
-  // using this option, make sure to occasionally disable it (by resetting to
-  // INT_MAX) and run GarbageCollect to clean accumulated stale files.
+  // Note: this setting is ignored (behaves like INT_MAX) for any kind of
+  // writable BackupEngine because it would inhibit accounting for shared
+  // files for proper backup deletion, including purging any incompletely
+  // created backups on creation of a new backup.
   //
   // Default: INT_MAX
   int max_valid_backups_to_open;


### PR DESCRIPTION
Summary: To reflect changes in PR #6072

This comment also implies that a seemingly valid use-case for
max_valid_backups_to_open is flawed: even if you only want to add a new
backup without trying to delete, you might need to clean up after a
backup creation that never finished. To clean up properly requires
opening all backups to get proper ref counts on shared files.

Test Plan: code comment only