### PR TITLE
Remove key length assertion LRUHandle::CalcTotalCharge

### DIFF
--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -133,7 +133,6 @@ struct LRUHandle {
   // Caclculate the memory usage by metadata
   inline size_t CalcTotalCharge(
       CacheMetadataChargePolicy metadata_charge_policy) {
-    assert(key_length);
     size_t meta_charge = 0;
     if (metadata_charge_policy == kFullChargeCacheMetadata) {
 #ifdef ROCKSDB_MALLOC_USABLE_SIZE


### PR DESCRIPTION
Inserting an entry in the block cache with 0 length key is a valid use case. Remove the assertion in ```LRUHandle::CalcTotalCharge```.