### PR TITLE
Fix build failure for db_stress tool when building with CMake

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(TOOLS
   sst_dump.cc
   db_sanity_test.cc
-  db_stress.cc
   write_stress.cc
   ldb.cc
   db_repl_stress.cc
@@ -14,6 +13,11 @@ foreach(src ${TOOLS})
   target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
   list(APPEND tool_deps ${exename})
 endforeach()
+
+add_executable(db_stress${ARTIFACT_SUFFIX} db_stress.cc db_stress_tool.cc)
+target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${LIBS})
+list(APPEND tool_deps db_stress)
+
 add_custom_target(tools
   DEPENDS ${tool_deps})
 add_custom_target(ldb_tests


### PR DESCRIPTION
Summary:
PR #5937 changed the db_stress tool to also require db_stress_tool.cc,
and updated the Makefile but not the CMakeLists.txt file.  This updates
the CMakeLists.txt file so that the CMake build succeeds again.

PR #5950 updated the Makefile build to package db_stress_tool.cc into
its own librocksdb_stress.a library.  I haven't done that here since
there didn't really seem to be much benefit: the Makefile-based build
does not install this library.

Test Plan:
Confirmed the CMake build succeeds on an Ubuntu 18.04 system.