### PR TITLE
fix a race in wal_manager.cc

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2217,13 +2217,12 @@ Status DBImpl::CreateColumnFamilies(
 Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
                                       const std::string& column_family_name,
                                       ColumnFamilyHandle** handle) {
-  Status s;
   Status persist_options_status;
   *handle = nullptr;
 
   DBOptions db_options =
       BuildDBOptions(immutable_db_options_, mutable_db_options_);
-  s = ColumnFamilyData::ValidateOptions(db_options, cf_options);
+  Status s = ColumnFamilyData::ValidateOptions(db_options, cf_options);
   if (s.ok()) {
     for (auto& cf_path : cf_options.cf_paths) {
       s = env_->CreateDirIfMissing(cf_path.path);

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -378,7 +378,7 @@ Status TableCache::Get(const ReadOptions& options,
   Status s;
   TableReader* t = fd.table_reader;
   Cache::Handle* handle = nullptr;
-  if (!done && s.ok()) {
+  if (!done) {
     if (t == nullptr) {
       s = FindTable(
           env_options_, internal_comparator, fd, &handle, prefix_extractor,
@@ -438,7 +438,6 @@ Status TableCache::MultiGet(const ReadOptions& options,
                             HistogramImpl* file_read_hist, bool skip_filters,
                             int level) {
   auto& fd = file_meta.fd;
-  Status s;
   TableReader* t = fd.table_reader;
   Cache::Handle* handle = nullptr;
   MultiGetRange table_range(*mget_range, mget_range->begin(),
@@ -462,7 +461,6 @@ Status TableCache::MultiGet(const ReadOptions& options,
     for (auto miter = table_range.begin(); miter != table_range.end();
          ++miter) {
       const Slice& user_key = miter->ukey;
-      ;
       GetContext* get_context = miter->get_context;
 
       if (GetFromRowCache(user_key, row_cache_key, row_cache_key_prefix_size,
@@ -476,9 +474,10 @@ Status TableCache::MultiGet(const ReadOptions& options,
   }
 #endif  // ROCKSDB_LITE
 
+  Status s;
   // Check that table_range is not empty. Its possible all keys may have been
   // found in the row cache and thus the range may now be empty
-  if (s.ok() && !table_range.empty()) {
+  if (!table_range.empty()) {
     if (t == nullptr) {
       s = FindTable(
           env_options_, internal_comparator, fd, &handle, prefix_extractor,
@@ -525,7 +524,6 @@ Status TableCache::MultiGet(const ReadOptions& options,
          ++miter) {
       std::string& row_cache_entry = row_cache_entries[row_idx++];
       const Slice& user_key = miter->ukey;
-      ;
       GetContext* get_context = miter->get_context;
 
       get_context->SetReplayLog(nullptr);
@@ -581,7 +579,6 @@ size_t TableCache::GetMemoryUsageByTableReader(
     const EnvOptions& env_options,
     const InternalKeyComparator& internal_comparator, const FileDescriptor& fd,
     const SliceTransform* prefix_extractor) {
-  Status s;
   auto table_reader = fd.table_reader;
   // table already been pre-loaded?
   if (table_reader) {
@@ -589,8 +586,8 @@ size_t TableCache::GetMemoryUsageByTableReader(
   }
 
   Cache::Handle* table_handle = nullptr;
-  s = FindTable(env_options, internal_comparator, fd, &table_handle,
-                prefix_extractor, true);
+  Status s = FindTable(env_options, internal_comparator, fd, &table_handle,
+                       prefix_extractor, true);
   if (!s.ok()) {
     return 0;
   }

--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -112,10 +112,9 @@ bool DeleteScheduler::IsTrashFile(const std::string& file_path) {
 
 Status DeleteScheduler::CleanupDirectory(Env* env, SstFileManagerImpl* sfm,
                                          const std::string& path) {
-  Status s;
   // Check if there are any files marked as trash in this path
   std::vector<std::string> files_in_path;
-  s = env->GetChildren(path, &files_in_path);
+  Status s = env->GetChildren(path, &files_in_path);
   if (!s.ok()) {
     return s;
   }

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -72,11 +72,10 @@ Status CopyFile(Env* env, const std::string& source,
 Status CreateFile(Env* env, const std::string& destination,
                   const std::string& contents, bool use_fsync) {
   const EnvOptions soptions;
-  Status s;
   std::unique_ptr<WritableFileWriter> dest_writer;
 
   std::unique_ptr<WritableFile> destfile;
-  s = env->NewWritableFile(destination, &destfile, soptions);
+  Status s = env->NewWritableFile(destination, &destfile, soptions);
   if (!s.ok()) {
     return s;
   }


### PR DESCRIPTION
a race can occur when an archived logfile is first found by
env->GetChildren, but then later removed by a concurrent thread
while iterating over the list of found files. in this case,
iteration was aborted with an IOError, but it seems it is expected
to happen in case of bad luck. this change makes the iteration
just ignore this particular type of error and go on without
bothering about that particular archived logfile.