### PR TITLE
Move out valid blobs from the oldest blob files during compaction

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -641,8 +641,10 @@ void CompactionIterator::NextFromInput() {
 void CompactionIterator::PrepareOutput() {
   if (valid_) {
     if (compaction_filter_ && ikey_.type == kTypeBlobIndex) {
-      if (compaction_filter_->PrepareBlobOutput(user_key(), value_,
-                                                &compaction_filter_value_)) {
+      const auto blob_decision = compaction_filter_->PrepareBlobOutput(
+          user_key(), value_, &compaction_filter_value_);
+
+      if (blob_decision == CompactionFilter::BlobDecision::kChangeValue) {
         value_ = compaction_filter_value_;
       }
     }

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -644,7 +644,10 @@ void CompactionIterator::PrepareOutput() {
       const auto blob_decision = compaction_filter_->PrepareBlobOutput(
           user_key(), value_, &compaction_filter_value_);
 
-      if (blob_decision == CompactionFilter::BlobDecision::kError) {
+      if (blob_decision == CompactionFilter::BlobDecision::kCorruption) {
+        status_ = Status::Corruption(
+            "Corrupted blob reference encountered during GC");
+      } else if (blob_decision == CompactionFilter::BlobDecision::kIOError) {
         status_ = Status::IOError("Could not relocate blob during GC");
       } else if (blob_decision ==
                  CompactionFilter::BlobDecision::kChangeValue) {

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -641,9 +641,8 @@ void CompactionIterator::NextFromInput() {
 void CompactionIterator::PrepareOutput() {
   if (valid_) {
     if (compaction_filter_ && ikey_.type == kTypeBlobIndex) {
-      if (compaction_filter_->PrepareOutput(
-              user_key(), CompactionFilter::ValueType::kBlobIndex, value_,
-              &compaction_filter_value_)) {
+      if (compaction_filter_->PrepareBlobOutput(user_key(), value_,
+                                                &compaction_filter_value_)) {
         value_ = compaction_filter_value_;
       }
     }

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -644,7 +644,10 @@ void CompactionIterator::PrepareOutput() {
       const auto blob_decision = compaction_filter_->PrepareBlobOutput(
           user_key(), value_, &compaction_filter_value_);
 
-      if (blob_decision == CompactionFilter::BlobDecision::kChangeValue) {
+      if (blob_decision == CompactionFilter::BlobDecision::kError) {
+        status_ = Status::IOError("Could not relocate blob during GC");
+      } else if (blob_decision ==
+                 CompactionFilter::BlobDecision::kChangeValue) {
         value_ = compaction_filter_value_;
       }
     }

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -639,28 +639,38 @@ void CompactionIterator::NextFromInput() {
 }
 
 void CompactionIterator::PrepareOutput() {
-  // Zeroing out the sequence number leads to better compression.
-  // If this is the bottommost level (no files in lower levels)
-  // and the earliest snapshot is larger than this seqno
-  // and the userkey differs from the last userkey in compaction
-  // then we can squash the seqno to zero.
-  //
-  // This is safe for TransactionDB write-conflict checking since transactions
-  // only care about sequence number larger than any active snapshots.
-  //
-  // Can we do the same for levels above bottom level as long as
-  // KeyNotExistsBeyondOutputLevel() return true?
-  if ((compaction_ != nullptr && !compaction_->allow_ingest_behind()) &&
-      ikeyNotNeededForIncrementalSnapshot() && bottommost_level_ && valid_ &&
-      IN_EARLIEST_SNAPSHOT(ikey_.sequence) && ikey_.type != kTypeMerge) {
-    assert(ikey_.type != kTypeDeletion && ikey_.type != kTypeSingleDeletion);
-    if (ikey_.type == kTypeDeletion || ikey_.type == kTypeSingleDeletion) {
-      ROCKS_LOG_FATAL(info_log_,
-                      "Unexpected key type %d for seq-zero optimization",
-                      ikey_.type);
+  if (valid_) {
+    if (compaction_filter_ && ikey_.type == kTypeBlobIndex) {
+      if (compaction_filter_->PrepareOutput(
+              user_key(), CompactionFilter::ValueType::kBlobIndex, value_,
+              &compaction_filter_value_)) {
+        value_ = compaction_filter_value_;
+      }
     }
-    ikey_.sequence = 0;
-    current_key_.UpdateInternalKey(0, ikey_.type);
+
+    // Zeroing out the sequence number leads to better compression.
+    // If this is the bottommost level (no files in lower levels)
+    // and the earliest snapshot is larger than this seqno
+    // and the userkey differs from the last userkey in compaction
+    // then we can squash the seqno to zero.
+    //
+    // This is safe for TransactionDB write-conflict checking since transactions
+    // only care about sequence number larger than any active snapshots.
+    //
+    // Can we do the same for levels above bottom level as long as
+    // KeyNotExistsBeyondOutputLevel() return true?
+    if ((compaction_ != nullptr && !compaction_->allow_ingest_behind()) &&
+        ikeyNotNeededForIncrementalSnapshot() && bottommost_level_ &&
+        IN_EARLIEST_SNAPSHOT(ikey_.sequence) && ikey_.type != kTypeMerge) {
+      assert(ikey_.type != kTypeDeletion && ikey_.type != kTypeSingleDeletion);
+      if (ikey_.type == kTypeDeletion || ikey_.type == kTypeSingleDeletion) {
+        ROCKS_LOG_FATAL(info_log_,
+                        "Unexpected key type %d for seq-zero optimization",
+                        ikey_.type);
+      }
+      ikey_.sequence = 0;
+      current_key_.UpdateInternalKey(0, ikey_.type);
+    }
   }
 }
 

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -45,7 +45,7 @@ class CompactionFilter {
     kRemoveAndSkipUntil,
   };
 
-  enum class BlobDecision { kKeep, kChangeValue, kError };
+  enum class BlobDecision { kKeep, kChangeValue, kCorruption, kIOError };
 
   // Context information of a compaction run
   struct Context {

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -173,6 +173,12 @@ class CompactionFilter {
     return Decision::kKeep;
   }
 
+  virtual bool PrepareOutput(const Slice& /* key */, ValueType /* value_type */,
+                             const Slice& /* existing_value */,
+                             std::string* /* new_value */) const {
+    return false;
+  }
+
   // This function is deprecated. Snapshots will always be ignored for
   // compaction filters, because we realized that not ignoring snapshots doesn't
   // provide the gurantee we initially thought it would provide. Repeatable

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -173,9 +173,10 @@ class CompactionFilter {
     return Decision::kKeep;
   }
 
-  virtual bool PrepareOutput(const Slice& /* key */, ValueType /* value_type */,
-                             const Slice& /* existing_value */,
-                             std::string* /* new_value */) const {
+  // Internal (BlobDB) use only. Do not override.
+  virtual bool PrepareBlobOutput(const Slice& /* key */,
+                                 const Slice& /* existing_value */,
+                                 std::string* /* new_value */) const {
     return false;
   }
 

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -173,7 +173,7 @@ class CompactionFilter {
     return Decision::kKeep;
   }
 
-  // Internal (BlobDB) use only. Do not override.
+  // Internal (BlobDB) use only. Do not override in application code.
   virtual bool PrepareBlobOutput(const Slice& /* key */,
                                  const Slice& /* existing_value */,
                                  std::string* /* new_value */) const {

--- a/include/rocksdb/compaction_filter.h
+++ b/include/rocksdb/compaction_filter.h
@@ -45,6 +45,8 @@ class CompactionFilter {
     kRemoveAndSkipUntil,
   };
 
+  enum class BlobDecision { kKeep, kChangeValue, kError };
+
   // Context information of a compaction run
   struct Context {
     // Does this compaction run include all data files
@@ -174,10 +176,10 @@ class CompactionFilter {
   }
 
   // Internal (BlobDB) use only. Do not override in application code.
-  virtual bool PrepareBlobOutput(const Slice& /* key */,
-                                 const Slice& /* existing_value */,
-                                 std::string* /* new_value */) const {
-    return false;
+  virtual BlobDecision PrepareBlobOutput(const Slice& /* key */,
+                                         const Slice& /* existing_value */,
+                                         std::string* /* new_value */) const {
+    return BlobDecision::kKeep;
   }
 
   // This function is deprecated. Snapshots will always be ignored for

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -250,11 +250,9 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
       return false;
     }
 
-    blob_file_->blob_count_++;
-
     const uint64_t new_size =
         BlobLogRecord::kHeaderSize + key.size() + blob.size();
-    blob_file_->file_size_ += new_size;
+    blob_file_->BlobRecordAdded(new_size);
 
     BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
     assert(blob_db_impl);

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -14,9 +14,9 @@ namespace blob_db {
 // CompactionFilter to delete expired blob index from base DB.
 class BlobIndexCompactionFilter : public CompactionFilter {
  public:
-  BlobIndexCompactionFilter(BlobCompactionContext context,
+  BlobIndexCompactionFilter(BlobCompactionContext&& context,
                             uint64_t current_time, Statistics* statistics)
-      : context_(context),
+      : context_(std::move(context)),
         current_time_(current_time),
         statistics_(statistics) {}
 
@@ -249,7 +249,7 @@ BlobIndexCompactionFilterFactory::CreateCompactionFilter(
   blob_db_impl_->GetCompactionContext(&context);
 
   return std::unique_ptr<CompactionFilter>(new BlobIndexCompactionFilter(
-      context, static_cast<uint64_t>(current_time), statistics_));
+      std::move(context), static_cast<uint64_t>(current_time), statistics_));
 }
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -119,8 +119,7 @@ class BlobIndexCompactionFilter : public CompactionFilter {
       }
 
       WriteLock wl(&context_.blob_db_impl->mutex_);
-      context_.blob_db_impl->blob_files_.insert(
-          std::make_pair(blob_file_->BlobFileNumber(), blob_file_));
+      context_.blob_db_impl->RegisterBlobFile(blob_file_);
     }
 
     assert(blob_file_);

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -83,16 +83,11 @@ class BlobIndexCompactionFilter : public CompactionFilter {
     return Decision::kKeep;
   }
 
-  bool PrepareOutput(const Slice& key, ValueType value_type,
-                     const Slice& existing_value,
-                     std::string* new_value) const override {
+  bool PrepareBlobOutput(const Slice& key, const Slice& existing_value,
+                         std::string* new_value) const override {
     assert(new_value);
 
     if (!context_.blob_db_impl->bdb_options_.enable_garbage_collection) {
-      return false;
-    }
-
-    if (value_type != kBlobIndex) {
       return false;
     }
 

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -84,6 +84,10 @@ bool BlobIndexCompactionFilterGC::PrepareBlobOutput(
     return false;
   }
 
+  // Note: each compaction generates its own blob files, which, depending on the
+  // workload, might result in many small blob files. The total number of files
+  // is bounded though (determined by the number of compactions and the blob
+  // file size option).
   if (!OpenNewBlobFileIfNeeded()) {
     return false;
   }

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -118,6 +118,8 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
     assert(new_value);
 
     const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+    (void)blob_db_impl;
+
     assert(blob_db_impl);
     assert(blob_db_impl->bdb_options_.enable_garbage_collection);
 

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -11,298 +11,233 @@
 namespace rocksdb {
 namespace blob_db {
 
-// CompactionFilter to delete expired blob index from base DB.
-class BlobIndexCompactionFilterBase : public CompactionFilter {
- public:
-  BlobIndexCompactionFilterBase(BlobCompactionContext&& context,
-                                uint64_t current_time, Statistics* statistics)
-      : context_(std::move(context)),
-        current_time_(current_time),
-        statistics_(statistics) {}
-
-  ~BlobIndexCompactionFilterBase() override {
-    RecordTick(statistics_, BLOB_DB_BLOB_INDEX_EXPIRED_COUNT, expired_count_);
-    RecordTick(statistics_, BLOB_DB_BLOB_INDEX_EXPIRED_SIZE, expired_size_);
-    RecordTick(statistics_, BLOB_DB_BLOB_INDEX_EVICTED_COUNT, evicted_count_);
-    RecordTick(statistics_, BLOB_DB_BLOB_INDEX_EVICTED_SIZE, evicted_size_);
+CompactionFilter::Decision BlobIndexCompactionFilterBase::FilterV2(
+    int /*level*/, const Slice& key, ValueType value_type, const Slice& value,
+    std::string* /*new_value*/, std::string* /*skip_until*/) const {
+  if (value_type != kBlobIndex) {
+    return Decision::kKeep;
   }
-
-  // Filter expired blob indexes regardless of snapshots.
-  bool IgnoreSnapshots() const override { return true; }
-
-  Decision FilterV2(int /*level*/, const Slice& key, ValueType value_type,
-                    const Slice& value, std::string* /*new_value*/,
-                    std::string* /*skip_until*/) const override {
-    if (value_type != kBlobIndex) {
-      return Decision::kKeep;
-    }
-    BlobIndex blob_index;
-    Status s = blob_index.DecodeFrom(value);
-    if (!s.ok()) {
-      // Unable to decode blob index. Keeping the value.
-      return Decision::kKeep;
-    }
-    if (blob_index.HasTTL() && blob_index.expiration() <= current_time_) {
-      // Expired
-      expired_count_++;
-      expired_size_ += key.size() + value.size();
-      return Decision::kRemove;
-    }
-    if (!blob_index.IsInlined() &&
-        blob_index.file_number() < context_.next_file_number &&
-        context_.current_blob_files.count(blob_index.file_number()) == 0) {
-      // Corresponding blob file gone. Could have been garbage collected or
-      // evicted by FIFO eviction.
+  BlobIndex blob_index;
+  Status s = blob_index.DecodeFrom(value);
+  if (!s.ok()) {
+    // Unable to decode blob index. Keeping the value.
+    return Decision::kKeep;
+  }
+  if (blob_index.HasTTL() && blob_index.expiration() <= current_time_) {
+    // Expired
+    expired_count_++;
+    expired_size_ += key.size() + value.size();
+    return Decision::kRemove;
+  }
+  if (!blob_index.IsInlined() &&
+      blob_index.file_number() < context_.next_file_number &&
+      context_.current_blob_files.count(blob_index.file_number()) == 0) {
+    // Corresponding blob file gone. Could have been garbage collected or
+    // evicted by FIFO eviction.
+    evicted_count_++;
+    evicted_size_ += key.size() + value.size();
+    return Decision::kRemove;
+  }
+  if (context_.fifo_eviction_seq > 0 && blob_index.HasTTL() &&
+      blob_index.expiration() < context_.evict_expiration_up_to) {
+    // Hack: Internal key is passed to BlobIndexCompactionFilter for it to
+    // get sequence number.
+    ParsedInternalKey ikey;
+    bool ok = ParseInternalKey(key, &ikey);
+    // Remove keys that could have been remove by last FIFO eviction.
+    // If get error while parsing key, ignore and continue.
+    if (ok && ikey.sequence < context_.fifo_eviction_seq) {
       evicted_count_++;
       evicted_size_ += key.size() + value.size();
       return Decision::kRemove;
     }
-    if (context_.fifo_eviction_seq > 0 && blob_index.HasTTL() &&
-        blob_index.expiration() < context_.evict_expiration_up_to) {
-      // Hack: Internal key is passed to BlobIndexCompactionFilter for it to
-      // get sequence number.
-      ParsedInternalKey ikey;
-      bool ok = ParseInternalKey(key, &ikey);
-      // Remove keys that could have been remove by last FIFO eviction.
-      // If get error while parsing key, ignore and continue.
-      if (ok && ikey.sequence < context_.fifo_eviction_seq) {
-        evicted_count_++;
-        evicted_size_ += key.size() + value.size();
-        return Decision::kRemove;
-      }
-    }
-    return Decision::kKeep;
+  }
+  return Decision::kKeep;
+}
+
+bool BlobIndexCompactionFilterGC::PrepareBlobOutput(
+    const Slice& key, const Slice& existing_value,
+    std::string* new_value) const {
+  assert(new_value);
+
+  const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  (void)blob_db_impl;
+
+  assert(blob_db_impl);
+  assert(blob_db_impl->bdb_options_.enable_garbage_collection);
+
+  BlobIndex blob_index;
+  const Status s = blob_index.DecodeFrom(existing_value);
+  if (!s.ok()) {
+    return false;
   }
 
- private:
-  BlobCompactionContext context_;
-  const uint64_t current_time_;
-  Statistics* statistics_;
-  // It is safe to not using std::atomic since the compaction filter, created
-  // from a compaction filter factroy, will not be called from multiple threads.
-  mutable uint64_t expired_count_ = 0;
-  mutable uint64_t expired_size_ = 0;
-  mutable uint64_t evicted_count_ = 0;
-  mutable uint64_t evicted_size_ = 0;
-};
-
-class BlobIndexCompactionFilter : public BlobIndexCompactionFilterBase {
- public:
-  BlobIndexCompactionFilter(BlobCompactionContext&& context,
-                            uint64_t current_time, Statistics* statistics)
-      : BlobIndexCompactionFilterBase(std::move(context), current_time,
-                                      statistics) {}
-
-  const char* Name() const override { return "BlobIndexCompactionFilter"; }
-};
-
-class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
- public:
-  BlobIndexCompactionFilterGC(BlobCompactionContext&& context,
-                              BlobCompactionContextGC&& context_gc,
-                              uint64_t current_time, Statistics* statistics)
-      : BlobIndexCompactionFilterBase(std::move(context), current_time,
-                                      statistics),
-        context_gc_(std::move(context_gc)) {}
-
-  ~BlobIndexCompactionFilterGC() override {
-    if (blob_file_) {
-      CloseAndRegisterNewBlobFile();
-    }
+  if (blob_index.IsInlined()) {
+    return false;
   }
 
-  const char* Name() const override { return "BlobIndexCompactionFilterGC"; }
-
-  bool PrepareBlobOutput(const Slice& key, const Slice& existing_value,
-                         std::string* new_value) const override {
-    assert(new_value);
-
-    const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-    (void)blob_db_impl;
-
-    assert(blob_db_impl);
-    assert(blob_db_impl->bdb_options_.enable_garbage_collection);
-
-    BlobIndex blob_index;
-    const Status s = blob_index.DecodeFrom(existing_value);
-    if (!s.ok()) {
-      return false;
-    }
-
-    if (blob_index.IsInlined()) {
-      return false;
-    }
-
-    if (blob_index.HasTTL()) {
-      return false;
-    }
-
-    if (blob_index.file_number() >= context_gc_.cutoff_file_number) {
-      return false;
-    }
-
-    if (!OpenNewBlobFileIfNeeded()) {
-      return false;
-    }
-
-    PinnableSlice blob;
-    CompressionType compression_type = kNoCompression;
-    if (!ReadBlobFromOldFile(key, blob_index, &blob, &compression_type)) {
-      return false;
-    }
-
-    uint64_t new_blob_file_number = 0;
-    uint64_t new_blob_offset = 0;
-    if (!WriteBlobToNewFile(key, blob, &new_blob_file_number,
-                            &new_blob_offset)) {
-      return false;
-    }
-
-    if (!CloseAndRegisterNewBlobFileIfNeeded()) {
-      return false;
-    }
-
-    BlobIndex::EncodeBlob(new_value, new_blob_file_number, new_blob_offset,
-                          blob.size(), compression_type);
-
-    return true;
+  if (blob_index.HasTTL()) {
+    return false;
   }
 
- private:
-  bool OpenNewBlobFileIfNeeded() const {
-    if (blob_file_) {
-      assert(writer_);
-      return true;
-    }
+  if (blob_index.file_number() >= context_gc_.cutoff_file_number) {
+    return false;
+  }
 
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-    assert(blob_db_impl);
+  if (!OpenNewBlobFileIfNeeded()) {
+    return false;
+  }
 
-    const Status s = blob_db_impl->CreateBlobFileAndWriter(
-        /* has_ttl */ false, ExpirationRange(), "GC", &blob_file_, &writer_);
-    if (!s.ok()) {
-      ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
-                      "Error opening new blob file during GC, status: %s",
-                      s.ToString().c_str());
+  PinnableSlice blob;
+  CompressionType compression_type = kNoCompression;
+  if (!ReadBlobFromOldFile(key, blob_index, &blob, &compression_type)) {
+    return false;
+  }
 
-      return false;
-    }
+  uint64_t new_blob_file_number = 0;
+  uint64_t new_blob_offset = 0;
+  if (!WriteBlobToNewFile(key, blob, &new_blob_file_number, &new_blob_offset)) {
+    return false;
+  }
 
-    assert(blob_file_);
+  if (!CloseAndRegisterNewBlobFileIfNeeded()) {
+    return false;
+  }
+
+  BlobIndex::EncodeBlob(new_value, new_blob_file_number, new_blob_offset,
+                        blob.size(), compression_type);
+
+  return true;
+}
+
+bool BlobIndexCompactionFilterGC::OpenNewBlobFileIfNeeded() const {
+  if (blob_file_) {
     assert(writer_);
-
     return true;
   }
 
-  bool ReadBlobFromOldFile(const Slice& key, const BlobIndex& blob_index,
-                           PinnableSlice* blob,
-                           CompressionType* compression_type) const {
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-    assert(blob_db_impl);
+  BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  assert(blob_db_impl);
 
-    const Status s = blob_db_impl->GetRawBlobFromFile(
-        key, blob_index.file_number(), blob_index.offset(), blob_index.size(),
-        blob, compression_type);
+  const Status s = blob_db_impl->CreateBlobFileAndWriter(
+      /* has_ttl */ false, ExpirationRange(), "GC", &blob_file_, &writer_);
+  if (!s.ok()) {
+    ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
+                    "Error opening new blob file during GC, status: %s",
+                    s.ToString().c_str());
 
-    if (!s.ok()) {
-      ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
-                      "Error reading blob during GC, key: %s (%s), status: %s",
-                      key.ToString(/* output_hex */ true).c_str(),
-                      blob_index.DebugString(/* output_hex */ true).c_str(),
-                      s.ToString().c_str());
-
-      return false;
-    }
-
-    return true;
+    return false;
   }
 
-  bool WriteBlobToNewFile(const Slice& key, const Slice& blob,
-                          uint64_t* new_blob_file_number,
-                          uint64_t* new_blob_offset) const {
-    assert(new_blob_file_number);
-    assert(new_blob_offset);
+  assert(blob_file_);
+  assert(writer_);
 
-    assert(blob_file_);
-    *new_blob_file_number = blob_file_->BlobFileNumber();
+  return true;
+}
 
-    assert(writer_);
-    uint64_t new_key_offset = 0;
-    const Status s = writer_->AddRecord(key, blob, kNoExpiration,
-                                        &new_key_offset, new_blob_offset);
+bool BlobIndexCompactionFilterGC::ReadBlobFromOldFile(
+    const Slice& key, const BlobIndex& blob_index, PinnableSlice* blob,
+    CompressionType* compression_type) const {
+  BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  assert(blob_db_impl);
 
-    if (!s.ok()) {
-      const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-      assert(blob_db_impl);
+  const Status s = blob_db_impl->GetRawBlobFromFile(
+      key, blob_index.file_number(), blob_index.offset(), blob_index.size(),
+      blob, compression_type);
 
-      ROCKS_LOG_ERROR(
-          blob_db_impl->db_options_.info_log,
-          "Error writing blob to new file %s during GC, key: %s, status: %s",
-          blob_file_->PathName().c_str(),
-          key.ToString(/* output_hex */ true).c_str(), s.ToString().c_str());
-      return false;
-    }
+  if (!s.ok()) {
+    ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
+                    "Error reading blob during GC, key: %s (%s), status: %s",
+                    key.ToString(/* output_hex */ true).c_str(),
+                    blob_index.DebugString(/* output_hex */ true).c_str(),
+                    s.ToString().c_str());
 
-    const uint64_t new_size =
-        BlobLogRecord::kHeaderSize + key.size() + blob.size();
-    blob_file_->BlobRecordAdded(new_size);
-
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-    assert(blob_db_impl);
-
-    blob_db_impl->total_blob_size_ += new_size;
-
-    return true;
+    return false;
   }
 
-  bool CloseAndRegisterNewBlobFileIfNeeded() const {
+  return true;
+}
+
+bool BlobIndexCompactionFilterGC::WriteBlobToNewFile(
+    const Slice& key, const Slice& blob, uint64_t* new_blob_file_number,
+    uint64_t* new_blob_offset) const {
+  assert(new_blob_file_number);
+  assert(new_blob_offset);
+
+  assert(blob_file_);
+  *new_blob_file_number = blob_file_->BlobFileNumber();
+
+  assert(writer_);
+  uint64_t new_key_offset = 0;
+  const Status s = writer_->AddRecord(key, blob, kNoExpiration, &new_key_offset,
+                                      new_blob_offset);
+
+  if (!s.ok()) {
     const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
     assert(blob_db_impl);
 
-    assert(blob_file_);
-    if (blob_file_->GetFileSize() < blob_db_impl->bdb_options_.blob_file_size) {
-      return true;
-    }
-
-    return CloseAndRegisterNewBlobFile();
+    ROCKS_LOG_ERROR(
+        blob_db_impl->db_options_.info_log,
+        "Error writing blob to new file %s during GC, key: %s, status: %s",
+        blob_file_->PathName().c_str(),
+        key.ToString(/* output_hex */ true).c_str(), s.ToString().c_str());
+    return false;
   }
 
-  bool CloseAndRegisterNewBlobFile() const {
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
-    assert(blob_db_impl);
-    assert(blob_file_);
+  const uint64_t new_size =
+      BlobLogRecord::kHeaderSize + key.size() + blob.size();
+  blob_file_->BlobRecordAdded(new_size);
 
-    Status s;
+  BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  assert(blob_db_impl);
 
-    {
-      WriteLock wl(&blob_db_impl->mutex_);
+  blob_db_impl->total_blob_size_ += new_size;
 
-      s = blob_db_impl->CloseBlobFile(blob_file_);
+  return true;
+}
 
-      // Note: we delay registering the new blob file until it's closed to
-      // prevent FIFO eviction from processing it during the GC run.
-      blob_db_impl->RegisterBlobFile(blob_file_);
-    }
+bool BlobIndexCompactionFilterGC::CloseAndRegisterNewBlobFileIfNeeded() const {
+  const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  assert(blob_db_impl);
 
-    assert(blob_file_->Immutable());
-    blob_file_.reset();
-
-    if (!s.ok()) {
-      ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
-                      "Error closing new blob file %s during GC, status: %s",
-                      blob_file_->PathName().c_str(), s.ToString().c_str());
-
-      return false;
-    }
-
+  assert(blob_file_);
+  if (blob_file_->GetFileSize() < blob_db_impl->bdb_options_.blob_file_size) {
     return true;
   }
 
- private:
-  BlobCompactionContextGC context_gc_;
-  mutable std::shared_ptr<BlobFile> blob_file_;
-  mutable std::shared_ptr<Writer> writer_;
-};
+  return CloseAndRegisterNewBlobFile();
+}
+
+bool BlobIndexCompactionFilterGC::CloseAndRegisterNewBlobFile() const {
+  BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+  assert(blob_db_impl);
+  assert(blob_file_);
+
+  Status s;
+
+  {
+    WriteLock wl(&blob_db_impl->mutex_);
+
+    s = blob_db_impl->CloseBlobFile(blob_file_);
+
+    // Note: we delay registering the new blob file until it's closed to
+    // prevent FIFO eviction from processing it during the GC run.
+    blob_db_impl->RegisterBlobFile(blob_file_);
+  }
+
+  assert(blob_file_->Immutable());
+  blob_file_.reset();
+
+  if (!s.ok()) {
+    ROCKS_LOG_ERROR(blob_db_impl->db_options_.info_log,
+                    "Error closing new blob file %s during GC, status: %s",
+                    blob_file_->PathName().c_str(), s.ToString().c_str());
+
+    return false;
+  }
+
+  return true;
+}
 
 template <typename Filter>
 class FilterTraits;

--- a/utilities/blob_db/blob_compaction_filter.cc
+++ b/utilities/blob_db/blob_compaction_filter.cc
@@ -117,7 +117,7 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
                          std::string* new_value) const override {
     assert(new_value);
 
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+    const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
     assert(blob_db_impl);
     assert(blob_db_impl->bdb_options_.enable_garbage_collection);
 
@@ -230,7 +230,7 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
                                         &new_key_offset, new_blob_offset);
 
     if (!s.ok()) {
-      BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+      const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
       assert(blob_db_impl);
 
       ROCKS_LOG_ERROR(
@@ -254,7 +254,7 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
   }
 
   bool CloseAndRegisterNewBlobFileIfNeeded() const {
-    BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
+    const BlobDBImpl* const blob_db_impl = context_gc_.blob_db_impl;
     assert(blob_db_impl);
 
     assert(blob_file_);

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -38,7 +38,7 @@ class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
                                        Statistics* statistics)
       : blob_db_impl_(blob_db_impl), env_(env), statistics_(statistics) {}
 
-  virtual std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
       const CompactionFilter::Context& /*context*/) override;
 
  private:
@@ -54,7 +54,7 @@ class BlobIndexCompactionFilterFactory
                                    Statistics* statistics)
       : BlobIndexCompactionFilterFactoryBase(blob_db_impl, env, statistics) {}
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "BlobIndexCompactionFilterFactory";
   }
 };
@@ -66,7 +66,7 @@ class BlobIndexCompactionFilterFactoryGC
                                      Statistics* statistics)
       : BlobIndexCompactionFilterFactoryBase(blob_db_impl, env, statistics) {}
 
-  virtual const char* Name() const override {
+  const char* Name() const override {
     return "BlobIndexCompactionFilterFactoryGC";
   }
 };

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -111,6 +111,9 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
   mutable std::shared_ptr<Writer> writer_;
 };
 
+// Compaction filter factory; similarly to the filters above, it comes
+// in two flavors, one that creates filters that support GC, and one
+// that creates non-GC filters.
 template <typename Filter>
 class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
  public:

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -17,7 +17,9 @@ namespace rocksdb {
 namespace blob_db {
 
 struct BlobCompactionContext {
+  BlobDBImpl* blob_db_impl;
   uint64_t next_file_number;
+  uint64_t cutoff_file_number;
   std::unordered_set<uint64_t> current_blob_files;
   SequenceNumber fifo_eviction_seq;
   uint64_t evict_expiration_up_to;

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -114,15 +114,16 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
 // Compaction filter factory; similarly to the filters above, it comes
 // in two flavors, one that creates filters that support GC, and one
 // that creates non-GC filters.
-template <typename Filter>
 class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
  public:
   BlobIndexCompactionFilterFactoryBase(BlobDBImpl* blob_db_impl, Env* env,
                                        Statistics* statistics)
       : blob_db_impl_(blob_db_impl), env_(env), statistics_(statistics) {}
 
-  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
-      const CompactionFilter::Context& /*context*/) override;
+ protected:
+  BlobDBImpl* blob_db_impl() const { return blob_db_impl_; }
+  Env* env() const { return env_; }
+  Statistics* statistics() const { return statistics_; }
 
  private:
   BlobDBImpl* blob_db_impl_;
@@ -131,7 +132,7 @@ class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
 };
 
 class BlobIndexCompactionFilterFactory
-    : public BlobIndexCompactionFilterFactoryBase<BlobIndexCompactionFilter> {
+    : public BlobIndexCompactionFilterFactoryBase {
  public:
   BlobIndexCompactionFilterFactory(BlobDBImpl* blob_db_impl, Env* env,
                                    Statistics* statistics)
@@ -140,10 +141,13 @@ class BlobIndexCompactionFilterFactory
   const char* Name() const override {
     return "BlobIndexCompactionFilterFactory";
   }
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override;
 };
 
 class BlobIndexCompactionFilterFactoryGC
-    : public BlobIndexCompactionFilterFactoryBase<BlobIndexCompactionFilterGC> {
+    : public BlobIndexCompactionFilterFactoryBase {
  public:
   BlobIndexCompactionFilterFactoryGC(BlobDBImpl* blob_db_impl, Env* env,
                                      Statistics* statistics)
@@ -152,6 +156,9 @@ class BlobIndexCompactionFilterFactoryGC
   const char* Name() const override {
     return "BlobIndexCompactionFilterFactoryGC";
   }
+
+  std::unique_ptr<CompactionFilter> CreateCompactionFilter(
+      const CompactionFilter::Context& /*context*/) override;
 };
 
 }  // namespace blob_db

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -91,8 +91,8 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
 
   const char* Name() const override { return "BlobIndexCompactionFilterGC"; }
 
-  bool PrepareBlobOutput(const Slice& key, const Slice& existing_value,
-                         std::string* new_value) const override;
+  BlobDecision PrepareBlobOutput(const Slice& key, const Slice& existing_value,
+                                 std::string* new_value) const override;
 
  private:
   bool OpenNewBlobFileIfNeeded() const;

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -68,10 +68,14 @@ struct BlobDBOptions {
   // what compression to use for Blob's
   CompressionType compression = kNoCompression;
 
-  // If enabled, blob DB periodically cleanup stale data by rewriting remaining
-  // live data in blob files to new files. If garbage collection is not enabled,
-  // blob files will be cleanup based on TTL.
+  // If enabled, BlobDB cleans up stale blobs in non-TTL files during compaction
+  // by rewriting the remaining live blobs to new files.
   bool enable_garbage_collection = false;
+
+  // The cutoff in terms of blob file age for garbage collection. Blobs in
+  // the oldest N non-TTL blob files will be rewritten when encountered during
+  // compaction, where N = garbage_collection_cutoff * number_of_non_TTL_files.
+  double garbage_collection_cutoff = 0.25;
 
   // Disable all background job. Used for test only.
   bool disable_background_tasks = false;

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1077,7 +1077,8 @@ Status BlobDBImpl::CompactFiles(
   return s;
 }
 
-void BlobDBImpl::GetCompactionContextCommon(BlobCompactionContext* context) {
+void BlobDBImpl::GetCompactionContextCommon(
+    BlobCompactionContext* context) const {
   assert(context);
 
   context->next_file_number = next_file_number_.load();

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -728,7 +728,6 @@ Status BlobDBImpl::CreateBlobFileAndWriter(
                     "Failed to write header to new blob file: %s"
                     " status: '%s'",
                     (*blob_file)->PathName().c_str(), s.ToString().c_str());
-    return s;
   }
 
   (*blob_file)->SetFileSize(BlobLogHeader::kSize);
@@ -1064,6 +1063,15 @@ Status BlobDBImpl::CompactFiles(
 
 void BlobDBImpl::GetCompactionContext(BlobCompactionContext* context) {
   ReadLock l(&mutex_);
+
+  context->blob_db_impl = this;
+
+  if (!live_imm_non_ttl_blob_files_.empty()) {
+    auto it = live_imm_non_ttl_blob_files_.begin();
+    std::advance(it, 0.25 * live_imm_non_ttl_blob_files_.size());
+    assert(it != live_imm_non_ttl_blob_files_.end());
+    context->cutoff_file_number = it->first;
+  }
 
   context->next_file_number = next_file_number_.load();
   context->current_blob_files.clear();

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1120,8 +1120,9 @@ void BlobDBImpl::GetCompactionContext(BlobCompactionContext* context,
     auto it = live_imm_non_ttl_blob_files_.begin();
     std::advance(it, bdb_options_.garbage_collection_cutoff *
                          live_imm_non_ttl_blob_files_.size());
-    assert(it != live_imm_non_ttl_blob_files_.end());
-    context_gc->cutoff_file_number = it->first;
+    context_gc->cutoff_file_number = it != live_imm_non_ttl_blob_files_.end()
+                                         ? it->first
+                                         : std::numeric_limits<uint64_t>::max();
   }
 }
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -739,6 +739,7 @@ Status BlobDBImpl::CreateBlobFileAndWriter(
                     "Failed to write header to new blob file: %s"
                     " status: '%s'",
                     (*blob_file)->PathName().c_str(), s.ToString().c_str());
+    return s;
   }
 
   (*blob_file)->SetFileSize(BlobLogHeader::kSize);

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1611,7 +1611,10 @@ Status BlobDBImpl::CloseBlobFile(std::shared_ptr<BlobFile> bfile) {
   assert(bfile);
   assert(!bfile->Immutable());
   assert(!bfile->Obsolete());
-  write_mutex_.AssertHeld();
+
+  if (bfile->HasTTL() || bfile == open_non_ttl_file_) {
+    write_mutex_.AssertHeld();
+  }
 
   ROCKS_LOG_INFO(db_options_.info_log,
                  "Closing blob file %" PRIu64 ". Path: %s",

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -607,7 +607,7 @@ std::shared_ptr<BlobFile> BlobDBImpl::NewBlobFile(
   return blob_file;
 }
 
-void BlobDBImpl::RegisterBlobFile(const std::shared_ptr<BlobFile>& blob_file) {
+void BlobDBImpl::RegisterBlobFile(std::shared_ptr<BlobFile> blob_file) {
   const uint64_t blob_file_number = blob_file->BlobFileNumber();
 
   auto it = blob_files_.lower_bound(blob_file_number);
@@ -615,7 +615,7 @@ void BlobDBImpl::RegisterBlobFile(const std::shared_ptr<BlobFile>& blob_file) {
 
   blob_files_.insert(it,
                      std::map<uint64_t, std::shared_ptr<BlobFile>>::value_type(
-                         blob_file_number, blob_file));
+                         blob_file_number, std::move(blob_file)));
 }
 
 Status BlobDBImpl::CreateWriterLocked(const std::shared_ptr<BlobFile>& bfile) {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1078,7 +1078,8 @@ void BlobDBImpl::GetCompactionContext(BlobCompactionContext* context) {
 
   if (!live_imm_non_ttl_blob_files_.empty()) {
     auto it = live_imm_non_ttl_blob_files_.begin();
-    std::advance(it, 0.25 * live_imm_non_ttl_blob_files_.size());
+    std::advance(it, bdb_options_.garbage_collection_cutoff *
+                         live_imm_non_ttl_blob_files_.size());
     assert(it != live_imm_non_ttl_blob_files_.end());
     context->cutoff_file_number = it->first;
   }

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1240,11 +1240,8 @@ Status BlobDBImpl::AppendBlob(const std::shared_ptr<BlobFile>& bfile,
     return s;
   }
 
-  // increment blob count
-  bfile->blob_count_++;
-
   uint64_t size_put = headerbuf.size() + key.size() + value.size();
-  bfile->file_size_ += size_put;
+  bfile->BlobRecordAdded(size_put);
   total_blob_size_ += size_put;
 
   if (expiration == kNoExpiration) {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -131,13 +131,22 @@ BlobDBOptions BlobDBImpl::GetBlobDBOptions() const { return bdb_options_; }
 Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   assert(handles != nullptr);
   assert(db_ == nullptr);
+
   if (blob_dir_.empty()) {
     return Status::NotSupported("No blob directory in options");
   }
+
   if (cf_options_.compaction_filter != nullptr ||
       cf_options_.compaction_filter_factory != nullptr) {
     return Status::NotSupported("Blob DB doesn't support compaction filter.");
   }
+
+  if (bdb_options_.garbage_collection_cutoff < 0.0 ||
+      bdb_options_.garbage_collection_cutoff > 1.0) {
+    return Status::InvalidArgument(
+        "Garbage collection cutoff must be in the interval [0.0, 1.0]");
+  }
+
   // BlobDB does not support Periodic Compactions. So disable periodic
   // compactions irrespective of the user set value.
   cf_options_.periodic_compaction_seconds = 0;

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -79,6 +79,7 @@ class BlobDBImpl : public BlobDB {
   friend class BlobDBIterator;
   friend class BlobDBListener;
   friend class BlobDBListenerGC;
+  friend class BlobIndexCompactionFilter;
 
  public:
   // deletions check period

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -255,7 +255,9 @@ class BlobDBImpl : public BlobDB {
 
   // Close a file by appending a footer, and removes file from open files list.
   // REQUIRES: lock held on write_mutex_, write lock held on both the db mutex_
-  // and the blob file's mutex_.
+  // and the blob file's mutex_. If called on a blob file which is visible only
+  // to a single thread (like in the case of new files written during GC), the
+  // locks on write_mutex_ and the blob file's mutex_ can be avoided.
   Status CloseBlobFile(std::shared_ptr<BlobFile> bfile);
 
   // Close a file if its size exceeds blob_file_size

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -183,7 +183,7 @@ class BlobDBImpl : public BlobDB {
 
   // Common part of the two GetCompactionContext methods below.
   // REQUIRES: read lock on mutex_
-  void GetCompactionContextCommon(BlobCompactionContext* context);
+  void GetCompactionContextCommon(BlobCompactionContext* context) const;
 
   void GetCompactionContext(BlobCompactionContext* context);
   void GetCompactionContext(BlobCompactionContext* context,

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -318,6 +318,10 @@ class BlobDBImpl : public BlobDB {
                                         const ExpirationRange& expiration_range,
                                         const std::string& reason);
 
+  // Register a new blob file.
+  // REQUIRES: write lock on mutex_.
+  void RegisterBlobFile(const std::shared_ptr<BlobFile>& blob_file);
+
   // collect all the blob log files from the blob directory
   Status GetAllBlobFiles(std::set<uint64_t>* file_numbers);
 

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -320,7 +320,7 @@ class BlobDBImpl : public BlobDB {
 
   // Register a new blob file.
   // REQUIRES: write lock on mutex_.
-  void RegisterBlobFile(const std::shared_ptr<BlobFile>& blob_file);
+  void RegisterBlobFile(std::shared_ptr<BlobFile> blob_file);
 
   // collect all the blob log files from the blob directory
   Status GetAllBlobFiles(std::set<uint64_t>* file_numbers);

--- a/utilities/blob_db/blob_db_impl.h
+++ b/utilities/blob_db/blob_db_impl.h
@@ -44,6 +44,7 @@ struct FlushJobInfo;
 namespace blob_db {
 
 struct BlobCompactionContext;
+struct BlobCompactionContextGC;
 class BlobDBImpl;
 class BlobFile;
 
@@ -79,7 +80,7 @@ class BlobDBImpl : public BlobDB {
   friend class BlobDBIterator;
   friend class BlobDBListener;
   friend class BlobDBListenerGC;
-  friend class BlobIndexCompactionFilter;
+  friend class BlobIndexCompactionFilterGC;
 
  public:
   // deletions check period
@@ -180,7 +181,13 @@ class BlobDBImpl : public BlobDB {
 
   Status SyncBlobFiles() override;
 
+  // Common part of the two GetCompactionContext methods below.
+  // REQUIRES: read lock on mutex_
+  void GetCompactionContextCommon(BlobCompactionContext* context);
+
   void GetCompactionContext(BlobCompactionContext* context);
+  void GetCompactionContext(BlobCompactionContext* context,
+                            BlobCompactionContextGC* context_gc);
 
 #ifndef NDEBUG
   Status TEST_GetBlobValue(const Slice& key, const Slice& index_entry,

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1602,8 +1602,8 @@ TEST_F(BlobDBTest, GarbageCollection) {
   constexpr uint64_t kSmallValueSize = 1 << 6;
   constexpr uint64_t kLargeValueSize = 1 << 8;
   constexpr uint64_t kMinBlobSize = 1 << 7;
-  static_assert(kSmallValueSize < kMinBlobSize);
-  static_assert(kLargeValueSize > kMinBlobSize);
+  static_assert(kSmallValueSize < kMinBlobSize, "");
+  static_assert(kLargeValueSize > kMinBlobSize, "");
 
   constexpr size_t kBlobsPerFile = 8;
   constexpr size_t kNumBlobFiles = kNumPuts / kBlobsPerFile;

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1712,6 +1712,8 @@ TEST_F(BlobDBTest, GarbageCollection) {
     ASSERT_EQ(live_imm_files.size(), kNumBlobFiles);
     for (size_t i = 0; i < kNumBlobFiles; ++i) {
       ASSERT_EQ(live_imm_files[i]->BlobFileNumber(), i + 1);
+      ASSERT_EQ(live_imm_files[i]->GetFileSize(),
+                kBlobFileSize + BlobLogFooter::kSize);
     }
   }
 
@@ -1764,6 +1766,8 @@ TEST_F(BlobDBTest, GarbageCollection) {
       }
 
       ASSERT_EQ(live_imm_files[i]->BlobFileNumber(), expected_file_number);
+      ASSERT_EQ(live_imm_files[i]->GetFileSize(),
+                kBlobFileSize + BlobLogFooter::kSize);
     }
   }
 }

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -8,8 +8,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
+#include <iomanip>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -35,10 +37,22 @@ class BlobDBTest : public testing::Test {
  public:
   const int kMaxBlobSize = 1 << 14;
 
-  struct BlobRecord {
-    std::string key;
-    std::string value;
-    uint64_t expiration = 0;
+  struct BlobIndexVersion {
+    BlobIndexVersion() = default;
+    BlobIndexVersion(std::string _user_key, uint64_t _file_number,
+                     uint64_t _expiration, SequenceNumber _sequence,
+                     ValueType _type)
+        : user_key(std::move(_user_key)),
+          file_number(_file_number),
+          expiration(_expiration),
+          sequence(_sequence),
+          type(_type) {}
+
+    std::string user_key;
+    uint64_t file_number = kInvalidBlobFileNumber;
+    uint64_t expiration = kNoExpiration;
+    SequenceNumber sequence = 0;
+    ValueType type = kTypeValue;
   };
 
   BlobDBTest()
@@ -227,6 +241,45 @@ class BlobDBTest : public testing::Test {
         ASSERT_EQ(expected_version.value, value.ToString());
       }
       i++;
+    }
+  }
+
+  void VerifyBaseDBBlobIndex(
+      const std::map<std::string, BlobIndexVersion> &expected_versions) {
+    const size_t kMaxKeys = 10000;
+    std::vector<KeyVersion> versions;
+    ASSERT_OK(
+        GetAllKeyVersions(blob_db_->GetRootDB(), "", "", kMaxKeys, &versions));
+    ASSERT_EQ(versions.size(), expected_versions.size());
+
+    size_t i = 0;
+    for (const auto &expected_pair : expected_versions) {
+      const BlobIndexVersion &expected_version = expected_pair.second;
+
+      ASSERT_EQ(versions[i].user_key, expected_version.user_key);
+      ASSERT_EQ(versions[i].sequence, expected_version.sequence);
+      ASSERT_EQ(versions[i].type, expected_version.type);
+      if (versions[i].type != kTypeBlobIndex) {
+        ASSERT_EQ(kInvalidBlobFileNumber, expected_version.file_number);
+        ASSERT_EQ(kNoExpiration, expected_version.expiration);
+
+        ++i;
+        continue;
+      }
+
+      BlobIndex blob_index;
+      ASSERT_OK(blob_index.DecodeFrom(versions[i].value));
+
+      const uint64_t file_number = !blob_index.IsInlined()
+                                       ? blob_index.file_number()
+                                       : kInvalidBlobFileNumber;
+      ASSERT_EQ(file_number, expected_version.file_number);
+
+      const uint64_t expiration =
+          blob_index.HasTTL() ? blob_index.expiration() : kNoExpiration;
+      ASSERT_EQ(expiration, expected_version.expiration);
+
+      ++i;
     }
   }
 
@@ -1536,6 +1589,159 @@ TEST_F(BlobDBTest, FilterForFIFOEviction) {
   data_after_compact["large_key2"] = large_value;
   data_after_compact["large_key3"] = large_value;
   VerifyDB(data_after_compact);
+}
+
+TEST_F(BlobDBTest, GarbageCollection) {
+  constexpr size_t kNumPuts = 1 << 10;
+
+  constexpr uint64_t kExpiration = 1000;
+  constexpr uint64_t kCompactTime = 500;
+
+  constexpr uint64_t kKeySize = 7;  // "key" + 4 digits
+
+  constexpr uint64_t kSmallValueSize = 1 << 6;
+  constexpr uint64_t kLargeValueSize = 1 << 8;
+  constexpr uint64_t kMinBlobSize = 1 << 7;
+  static_assert(kSmallValueSize < kMinBlobSize);
+  static_assert(kLargeValueSize > kMinBlobSize);
+
+  constexpr size_t kBlobsPerFile = 8;
+  constexpr size_t kNumBlobFiles = kNumPuts / kBlobsPerFile;
+  constexpr uint64_t kBlobFileSize =
+      BlobLogHeader::kSize +
+      (BlobLogRecord::kHeaderSize + kKeySize + kLargeValueSize) * kBlobsPerFile;
+
+  BlobDBOptions bdb_options;
+  bdb_options.min_blob_size = kMinBlobSize;
+  bdb_options.blob_file_size = kBlobFileSize;
+  bdb_options.enable_garbage_collection = true;
+  bdb_options.garbage_collection_cutoff = 0.25;
+  bdb_options.disable_background_tasks = true;
+
+  Options options;
+  options.env = mock_env_.get();
+
+  Open(bdb_options, options);
+
+  std::map<std::string, std::string> data;
+  std::map<std::string, KeyVersion> blob_value_versions;
+  std::map<std::string, BlobIndexVersion> blob_index_versions;
+
+  Random rnd(301);
+
+  // Add a bunch of large non-TTL values. These will be written to non-TTL
+  // blob files and will be subject to GC.
+  for (size_t i = 0; i < kNumPuts; ++i) {
+    std::ostringstream oss;
+    oss << "key" << std::setw(4) << std::setfill('0') << i;
+
+    const std::string key(oss.str());
+    const std::string value(
+        test::RandomHumanReadableString(&rnd, kLargeValueSize));
+    const SequenceNumber sequence = blob_db_->GetLatestSequenceNumber() + 1;
+
+    ASSERT_OK(Put(key, value));
+    ASSERT_EQ(blob_db_->GetLatestSequenceNumber(), sequence);
+
+    data[key] = value;
+    blob_value_versions[key] = KeyVersion(key, value, sequence, kTypeBlobIndex);
+    blob_index_versions[key] =
+        BlobIndexVersion(key, /* file_number */ (i >> 3) + 1, kNoExpiration,
+                         sequence, kTypeBlobIndex);
+  }
+
+  // Add some small and/or TTL values that will be ignored during GC.
+  // First, add a large TTL value will be written to its own TTL blob file.
+  {
+    const std::string key("key2000");
+    const std::string value(
+        test::RandomHumanReadableString(&rnd, kLargeValueSize));
+    const SequenceNumber sequence = blob_db_->GetLatestSequenceNumber() + 1;
+
+    ASSERT_OK(PutUntil(key, value, kExpiration));
+    ASSERT_EQ(blob_db_->GetLatestSequenceNumber(), sequence);
+
+    data[key] = value;
+    blob_value_versions[key] = KeyVersion(key, value, sequence, kTypeBlobIndex);
+    blob_index_versions[key] =
+        BlobIndexVersion(key, /* file_number */ kNumBlobFiles + 1, kExpiration,
+                         sequence, kTypeBlobIndex);
+  }
+
+  // Now add a small TTL value (which will be inlined).
+  {
+    const std::string key("key3000");
+    const std::string value(
+        test::RandomHumanReadableString(&rnd, kSmallValueSize));
+    const SequenceNumber sequence = blob_db_->GetLatestSequenceNumber() + 1;
+
+    ASSERT_OK(PutUntil(key, value, kExpiration));
+    ASSERT_EQ(blob_db_->GetLatestSequenceNumber(), sequence);
+
+    data[key] = value;
+    blob_value_versions[key] = KeyVersion(key, value, sequence, kTypeBlobIndex);
+    blob_index_versions[key] = BlobIndexVersion(
+        key, kInvalidBlobFileNumber, kExpiration, sequence, kTypeBlobIndex);
+  }
+
+  // Finally, add a small non-TTL value (which will be stored as a regular
+  // value).
+  {
+    const std::string key("key4000");
+    const std::string value(
+        test::RandomHumanReadableString(&rnd, kSmallValueSize));
+    const SequenceNumber sequence = blob_db_->GetLatestSequenceNumber() + 1;
+
+    ASSERT_OK(Put(key, value));
+    ASSERT_EQ(blob_db_->GetLatestSequenceNumber(), sequence);
+
+    data[key] = value;
+    blob_value_versions[key] = KeyVersion(key, value, sequence, kTypeValue);
+    blob_index_versions[key] = BlobIndexVersion(
+        key, kInvalidBlobFileNumber, kNoExpiration, sequence, kTypeValue);
+  }
+
+  VerifyDB(data);
+  VerifyBaseDB(blob_value_versions);
+  VerifyBaseDBBlobIndex(blob_index_versions);
+
+  mock_env_->set_current_time(kCompactTime);
+
+  ASSERT_OK(blob_db_->CompactRange(CompactRangeOptions(),
+                                   blob_db_->DefaultColumnFamily(), nullptr,
+                                   nullptr));
+
+  // We expect the data to remain the same and the blobs from the oldest N files
+  // to be moved to new files. Sequence numbers get zeroed out during the
+  // compaction.
+  VerifyDB(data);
+
+  for (auto &pair : blob_value_versions) {
+    KeyVersion &version = pair.second;
+    version.sequence = 0;
+  }
+
+  VerifyBaseDB(blob_value_versions);
+
+  const uint64_t cutoff =
+      bdb_options.garbage_collection_cutoff * kNumBlobFiles + 1;
+  for (auto &pair : blob_index_versions) {
+    BlobIndexVersion &version = pair.second;
+
+    version.sequence = 0;
+
+    if (version.file_number == kInvalidBlobFileNumber) {
+      continue;
+    }
+
+    if (version.file_number >= cutoff) {
+      continue;
+    }
+
+    version.file_number += kNumBlobFiles + 1;
+  }
+
+  VerifyBaseDBBlobIndex(blob_index_versions);
 }
 
 // File should be evicted after expiration.

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1735,7 +1735,8 @@ TEST_F(BlobDBTest, GarbageCollection) {
 
   VerifyBaseDB(blob_value_versions);
 
-  const uint64_t cutoff = bdb_options.garbage_collection_cutoff * kNumBlobFiles;
+  const uint64_t cutoff = static_cast<uint64_t>(
+      bdb_options.garbage_collection_cutoff * kNumBlobFiles);
   for (auto &pair : blob_index_versions) {
     BlobIndexVersion &version = pair.second;
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -2045,36 +2045,6 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     ASSERT_EQ(obsolete_files[0]->BlobFileNumber(), 1);
   }
 
-  // Simulate a failed compaction. No mappings should be updated.
-  {
-    CompactionJobInfo info{};
-    info.input_file_infos.emplace_back(CompactionFileInfo{1, 7, 2});
-    info.input_file_infos.emplace_back(CompactionFileInfo{2, 22, 5});
-    info.output_file_infos.emplace_back(CompactionFileInfo{2, 25, 3});
-    info.status = Status::Corruption();
-
-    blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
-
-    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
-        {}, {7}, {3, 8, 23}, {4, 9}, {5, 10, 22}};
-    const std::vector<bool> expected_obsolete{true, false, false, false, false};
-    for (size_t i = 0; i < 5; ++i) {
-      const auto &blob_file = blob_files[i];
-      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
-      ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
-    }
-
-    auto live_imm_files = blob_db_impl()->TEST_GetLiveImmNonTTLFiles();
-    ASSERT_EQ(live_imm_files.size(), 4);
-    for (size_t i = 0; i < 4; ++i) {
-      ASSERT_EQ(live_imm_files[i]->BlobFileNumber(), i + 2);
-    }
-
-    auto obsolete_files = blob_db_impl()->TEST_GetObsoleteFiles();
-    ASSERT_EQ(obsolete_files.size(), 1);
-    ASSERT_EQ(obsolete_files[0]->BlobFileNumber(), 1);
-  }
-
   // Simulate another compaction. Blob file 2 loses all its linked SSTs
   // but since it got marked immutable at sequence number 300 which hasn't
   // been flushed yet, it cannot be marked obsolete at this point.

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -2045,6 +2045,36 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     ASSERT_EQ(obsolete_files[0]->BlobFileNumber(), 1);
   }
 
+  // Simulate a failed compaction. No mappings should be updated.
+  {
+    CompactionJobInfo info{};
+    info.input_file_infos.emplace_back(CompactionFileInfo{1, 7, 2});
+    info.input_file_infos.emplace_back(CompactionFileInfo{2, 22, 5});
+    info.output_file_infos.emplace_back(CompactionFileInfo{2, 25, 3});
+    info.status = Status::Corruption();
+
+    blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
+
+    const std::vector<std::unordered_set<uint64_t>> expected_sst_files{
+        {}, {7}, {3, 8, 23}, {4, 9}, {5, 10, 22}};
+    const std::vector<bool> expected_obsolete{true, false, false, false, false};
+    for (size_t i = 0; i < 5; ++i) {
+      const auto &blob_file = blob_files[i];
+      ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
+    }
+
+    auto live_imm_files = blob_db_impl()->TEST_GetLiveImmNonTTLFiles();
+    ASSERT_EQ(live_imm_files.size(), 4);
+    for (size_t i = 0; i < 4; ++i) {
+      ASSERT_EQ(live_imm_files[i]->BlobFileNumber(), i + 2);
+    }
+
+    auto obsolete_files = blob_db_impl()->TEST_GetObsoleteFiles();
+    ASSERT_EQ(obsolete_files.size(), 1);
+    ASSERT_EQ(obsolete_files[0]->BlobFileNumber(), 1);
+  }
+
   // Simulate another compaction. Blob file 2 loses all its linked SSTs
   // but since it got marked immutable at sequence number 300 which hasn't
   // been flushed yet, it cannot be marked obsolete at this point.

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -241,6 +241,11 @@ class BlobFile {
   void SetFileSize(uint64_t fs) { file_size_ = fs; }
 
   void SetBlobCount(uint64_t bc) { blob_count_ = bc; }
+
+  void BlobRecordAdded(uint64_t record_size) {
+    ++blob_count_;
+    file_size_ += record_size;
+  }
 };
 }  // namespace blob_db
 }  // namespace rocksdb

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -27,7 +27,7 @@ class BlobFile {
   friend class BlobDBImpl;
   friend struct BlobFileComparator;
   friend struct BlobFileComparatorTTL;
-  friend class BlobIndexCompactionFilter;
+  friend class BlobIndexCompactionFilterGC;
 
  private:
   // access to parent

--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -27,6 +27,7 @@ class BlobFile {
   friend class BlobDBImpl;
   friend struct BlobFileComparator;
   friend struct BlobFileComparatorTTL;
+  friend class BlobIndexCompactionFilter;
 
  private:
   // access to parent


### PR DESCRIPTION
Summary:
The patch adds logic that relocates live blobs from the oldest N non-TTL
blob files as they are encountered during compaction (assuming the BlobDB
configuration option `enable_garbage_collection` is `true`), where N is defined
as the number of immutable non-TTL blob files multiplied by the value of
a new BlobDB configuration option called `garbage_collection_cutoff`.
(The default value of this parameter is 0.25, that is, by default the valid blobs
residing in the oldest 25% of immutable non-TTL blob files are relocated.)

Test Plan:
Added unit test and tested using the BlobDB mode of `db_bench`.