### PR TITLE
build_tools/precommit_checker.py: don't hard-code a platform-afflicted python path

### DIFF
--- a/build_tools/precommit_checker.py
+++ b/build_tools/precommit_checker.py
@@ -1,4 +1,4 @@
-#!/usr/local/fbcode/gcc-4.9-glibc-2.20-fb/bin/python2.7
+#!/usr/bin/env python2.7
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 from __future__ import absolute_import


### PR DESCRIPTION
Summary:
Use `#!/usr/bin/env python2.7` instead.

Test Plan:
`J=8 make commit_prereq`