### PR TITLE
Disable folly_synchronization_distributed_mutex_test on ARM for now

### DIFF
--- a/third-party/folly/folly/synchronization/test/DistributedMutexTest.cpp
+++ b/third-party/folly/folly/synchronization/test/DistributedMutexTest.cpp
@@ -13,7 +13,7 @@
 #include <gtest/gtest.h>
 #endif
 
-#ifndef ROCKSDB_LITE
+#if !defined(ROCKSDB_LITE) && !defined(__ARM_ARCH)
 
 #include <chrono>
 #include <cmath>
@@ -1128,9 +1128,15 @@ TEST(DistributedMutex, StressBigValueReturnSixtyFourThreads) {
 }
 
 } // namespace folly
-#endif  // ROCKSDB_LITE
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+#else
+int main(int /*argc*/, char** /*argv*/) {
+  printf("DistributedMutex is not supported in ROCKSDB_LITE or on ARM\n");
+  return 0;
+}
+#endif  // !ROCKSDB_LITE && !__ARM_ARCH


### PR DESCRIPTION
Summary: This test is crashing on ARM but is not yet production code.
Let's not let it block ARM CI. See PR #5932

Test Plan: ./folly_synchronization_distributed_mutex_test, on Linux/ARM,
on Linux/x86_64, and with LITE=1 on Linux/x86_64 (also disabled)