### PR TITLE
Disable new Bloom filter assertion

### DIFF
--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -443,7 +443,8 @@ void BloomFilterPolicy::CreateFilter(const Slice* keys, int n,
                                      std::string* dst) const {
   // We should ideally only be using this deprecated interface for
   // appropriately constructed BloomFilterPolicy
-  assert(mode_ == kDeprecatedBlock);
+  // FIXME disabled because of bug in C interface; see issue #6129
+  //assert(mode_ == kDeprecatedBlock);
 
   // Compute bloom filter size (in both bits and bytes)
   uint32_t bits = static_cast<uint32_t>(n * whole_bits_per_key_);


### PR DESCRIPTION
Summary: A longstanding bug in our C interface can trigger this
assertion; see issue #6129. Disabling the assertion for now
(for 6.6.0) and will re-enable on fix of that bug.