### PR TITLE
Fix an asan warning caused by the recent io_uring change

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -519,7 +519,6 @@ Status PosixRandomAccessFile::MultiRead(ReadRequest* reqs, size_t num_reqs) {
       sqe = io_uring_get_sqe(iu);
       req_wraps[index].iov.iov_base = reqs[index].scratch;
       req_wraps[index].iov.iov_len = reqs[index].len;
-      reqs[index].result = reqs[index].scratch;
       io_uring_prep_readv(sqe, fd_, &req_wraps[index].iov, 1,
                           reqs[index].offset);
       io_uring_sqe_set_data(sqe, &req_wraps[index]);


### PR DESCRIPTION
Summary:
ASAN reports:

internal_repo_rocksdb/repo:db_test - MultiThreaded/MultiThreadedDBTest.MultiThreaded/43: fatal
==2692739==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6130000500ca at pc 0x0000006be780 bp 0x7efef85ccd20 sp 0x7efef85cc4d0
[CONTEXT] === How to use this, how to get the raw stack trace, and more: fburl.com/ASAN ===
[CONTEXT] READ of size 331 at 0x6130000500ca thread T195
[CONTEXT]      #0 db_test_bin+0x6be77f                     __interceptor_strlen.part.35
[CONTEXT]      #1 internal_repo_rocksdb/repo/include/rocksdb/slice.h:55 rocksdb::Slice::Slice(char const*)
[CONTEXT]      #2 internal_repo_rocksdb/repo/env/io_posix.cc:522 rocksdb::PosixRandomAccessFile::MultiRead(rocksdb::ReadRequest*, unsigned long)

I looked at env/io_posix.cc:522 but don't see a reason why the line needs to be there at all, because it is not used before overwritten. So it must be a line that is put there as a bug. Remove it.

Test Plan: Rerun the same test which passes after the fix. Run all the tests and make sure they all pass.