### PR TITLE
Fix thread_local_test failure caused by recent io_uring change

### DIFF
--- a/util/thread_local_test.cc
+++ b/util/thread_local_test.cc
@@ -65,45 +65,45 @@ TEST_F(ThreadLocalTest, UniqueIdTest) {
   port::Mutex mu;
   port::CondVar cv(&mu);
 
-  ASSERT_EQ(IDChecker::PeekId(), 0u);
+  uint32_t base_id = IDChecker::PeekId();
   // New ThreadLocal instance bumps id by 1
   {
     // Id used 0
     Params p1(&mu, &cv, nullptr, 1u);
-    ASSERT_EQ(IDChecker::PeekId(), 1u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 1u);
     // Id used 1
     Params p2(&mu, &cv, nullptr, 1u);
-    ASSERT_EQ(IDChecker::PeekId(), 2u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 2u);
     // Id used 2
     Params p3(&mu, &cv, nullptr, 1u);
-    ASSERT_EQ(IDChecker::PeekId(), 3u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 3u);
     // Id used 3
     Params p4(&mu, &cv, nullptr, 1u);
-    ASSERT_EQ(IDChecker::PeekId(), 4u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 4u);
   }
   // id 3, 2, 1, 0 are in the free queue in order
-  ASSERT_EQ(IDChecker::PeekId(), 0u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 0u);
 
   // pick up 0
   Params p1(&mu, &cv, nullptr, 1u);
-  ASSERT_EQ(IDChecker::PeekId(), 1u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 1u);
   // pick up 1
   Params* p2 = new Params(&mu, &cv, nullptr, 1u);
-  ASSERT_EQ(IDChecker::PeekId(), 2u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 2u);
   // pick up 2
   Params p3(&mu, &cv, nullptr, 1u);
-  ASSERT_EQ(IDChecker::PeekId(), 3u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 3u);
   // return up 1
   delete p2;
-  ASSERT_EQ(IDChecker::PeekId(), 1u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 1u);
   // Now we have 3, 1 in queue
   // pick up 1
   Params p4(&mu, &cv, nullptr, 1u);
-  ASSERT_EQ(IDChecker::PeekId(), 3u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 3u);
   // pick up 3
   Params p5(&mu, &cv, nullptr, 1u);
   // next new id
-  ASSERT_EQ(IDChecker::PeekId(), 4u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 4u);
   // After exit, id sequence in queue:
   // 3, 1, 2, 0
 }
@@ -111,7 +111,7 @@ TEST_F(ThreadLocalTest, UniqueIdTest) {
 
 TEST_F(ThreadLocalTest, SequentialReadWriteTest) {
   // global id list carries over 3, 1, 2, 0
-  ASSERT_EQ(IDChecker::PeekId(), 0u);
+  uint32_t base_id = IDChecker::PeekId();
 
   port::Mutex mu;
   port::CondVar cv(&mu);
@@ -141,7 +141,7 @@ TEST_F(ThreadLocalTest, SequentialReadWriteTest) {
   };
 
   for (int iter = 0; iter < 1024; ++iter) {
-    ASSERT_EQ(IDChecker::PeekId(), 1u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 1u);
     // Another new thread, read/write should not see value from previous thread
     env_->StartThread(func, static_cast<void*>(&p));
     mu.Lock();
@@ -149,13 +149,13 @@ TEST_F(ThreadLocalTest, SequentialReadWriteTest) {
       cv.Wait();
     }
     mu.Unlock();
-    ASSERT_EQ(IDChecker::PeekId(), 1u);
+    ASSERT_EQ(IDChecker::PeekId(), base_id + 1u);
   }
 }
 
 TEST_F(ThreadLocalTest, ConcurrentReadWriteTest) {
   // global id list carries over 3, 1, 2, 0
-  ASSERT_EQ(IDChecker::PeekId(), 0u);
+  uint32_t base_id = IDChecker::PeekId();
 
   ThreadLocalPtr tls2;
   port::Mutex mu1;
@@ -236,12 +236,10 @@ TEST_F(ThreadLocalTest, ConcurrentReadWriteTest) {
   }
   mu2.Unlock();
 
-  ASSERT_EQ(IDChecker::PeekId(), 3u);
+  ASSERT_EQ(IDChecker::PeekId(), base_id + 3u);
 }
 
 TEST_F(ThreadLocalTest, Unref) {
-  ASSERT_EQ(IDChecker::PeekId(), 0u);
-
   auto unref = [](void* ptr) {
     auto& p = *static_cast<Params*>(ptr);
     p.mu->Lock();


### PR DESCRIPTION
Summary:
thread_local_test now fails because it asserts no thread local instance is created when the test started. However, right now a thread local instance might be created when creating PosixEnv as a static variable. Fix the test by relaxing the assumption of starting from 0.

Test Plan: Find an environment where the test fails, and see it passes with the fix applied.