### PR TITLE
Use Env::GetChildren() instead of readdir

### DIFF
--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1108,7 +1108,7 @@ void ManifestDumpCommand::DoCommand() {
               "Multiple MANIFEST files found; use --path to select one");
           return;
         } else {
-          matched_file = std::move(file_path);
+          matched_file.swap(fname);
         }
       }
     }

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1081,18 +1081,10 @@ void ManifestDumpCommand::DoCommand() {
     const std::string kManifestNamePrefix = "MANIFEST-";
     const std::string* matched_file = nullptr;
     for (const auto& fname : files) {
-      if (fname.compare(0, kManifestNamePrefix.size(), kManifestNamePrefix) ==
-          0) {
-        try {
-          unsigned long long file_num =
-              std::stoull(fname.substr(kManifestNamePrefix.size()));
-          (void)file_num;
-        } catch (const std::invalid_argument& /*ex*/) {
-          std::string err_msg("Ill-formed MANIFEST file name: ");
-          err_msg.append(fname);
-          exec_state_ = LDBCommandExecuteResult::Failed(err_msg);
-          return;
-        }
+      uint64_t file_num = 0;
+      FileType file_type = kLogFile;  // Just for initialization
+      if (ParseFileName(fname, &file_num, &file_type) &&
+          file_type == kDescriptorFile) {
         if (matched_file) {
           exec_state_ = LDBCommandExecuteResult::Failed(
               "Multiple MANIFEST files found; use --path to select one");


### PR DESCRIPTION
Summary:
For more portability, switch from readdir to Env::GetChildren() in ldb's
manifest_dump subcommand.

Test Plan:
```
$make check
```
Manually check ldb command.