### PR TITLE
db_stress: sometimes call CancelAllBackgroundWork() and Close() before closing DB

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1651,19 +1651,25 @@ void StressTest::Open() {
 }
 
 void StressTest::Reopen(ThreadState* thread) {
+#ifndef ROCKSDB_LITE
   if (thread->rand.OneIn(2)) {
     CancelAllBackgroundWork(db_, static_cast<bool>(thread->rand.OneIn(2)));
   }
+#else
+  (void) thread;
+#endif
 
   for (auto cf : column_families_) {
     delete cf;
   }
   column_families_.clear();
 
+#ifndef ROCKSDB_LITE
   if (thread->rand.OneIn(2)) {
     Status s = db_->Close();
     assert(s.ok());
   }
+#endif
   delete db_;
   db_ = nullptr;
 #ifndef ROCKSDB_LITE

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -159,7 +159,7 @@ class StressTest {
 
   void Open();
 
-  void Reopen();
+  void Reopen(ThreadState* thread);
 
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;


### PR DESCRIPTION
Summary:
CancelAllBackgroundWork() and Close() are frequently used features but we don't cover it in stress test. Simply execute them before closing the DB with 1/2 chance.

Test Plan: Run "db_stress".