### PR TITLE
Add SyncWAL to db_stress

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -197,6 +197,7 @@ DECLARE_string(memtablerep);
 DECLARE_int32(prefix_size);
 DECLARE_bool(use_merge);
 DECLARE_bool(use_full_merge_v1);
+DECLARE_int32(sync_wal_one_in);
 
 const long KB = 1024;
 const int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -533,4 +533,8 @@ DEFINE_bool(use_merge, false,
 DEFINE_bool(use_full_merge_v1, false,
             "On true, use a merge operator that implement the deprecated "
             "version of FullMerge");
+
+DEFINE_int32(sync_wal_one_in, 0,
+             "If non-zero, then SyncWAL() will be called once for every N ops "
+             "on average. 0 indicates that calls to SyncWAL() are disabled.");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -516,8 +516,8 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (FLAGS_sync_wal_one_in > 0 &&
           thread->rand.Uniform(FLAGS_sync_wal_one_in) == 0) {
         Status s = db_->SyncWAL();
-        if (!s.ok()) {
-          fprintf(stdout, "Unable to SyncWAL(): %s\n", s.ToString().c_str());
+        if (!s.ok() && !s.IsNotSupported()) {
+          fprintf(stdout, "SyncWAL() failed: %s\n", s.ToString().c_str());
         }
       }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -513,6 +513,14 @@ void StressTest::OperateDb(ThreadState* thread) {
 
       MaybeClearOneColumnFamily(thread);
 
+      if (FLAGS_sync_wal_one_in > 0 &&
+          thread->rand.Uniform(FLAGS_sync_wal_one_in) == 0) {
+        Status s = db_->SyncWAL();
+        if (!s.ok()) {
+          fprintf(stdout, "Unable to SyncWAL(): %s\n", s.ToString().c_str());
+        }
+      }
+
 #ifndef ROCKSDB_LITE
       if (FLAGS_compact_files_one_in > 0 &&
           thread->rand.Uniform(FLAGS_compact_files_one_in) == 0) {


### PR DESCRIPTION
Summary:
Add SyncWAL to db_stress. Specify with `-sync_wal_one_in=N` so that it will be
called once every N operations on average.

Test Plan:
```
$make db_stress
$./db_stress -sync_wal_one_in=100 -ops_per_thread=100000
```