### PR TITLE
Improve instructions to install formatter

### DIFF
--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -13,11 +13,12 @@ then
   echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
   echo "You can download clang-format-diff.py by running: "
   echo "    curl --location http://goo.gl/iUW1u2 -o ${CLANG_FORMAT_DIFF}"
-  echo "You can download clang-format. One way is to run"
+  echo "You can download clang-format by running:"
   echo "    brew install clang-format"
-  echo "  Another way might be"
+  echo "  Or"
+  echo "    apt install clang-format"
+  echo "  This might work too:"
   echo "    yum install git-clang-format"
-  
   echo "Then, move both files (i.e. ${CLANG_FORMAT_DIFF} and clang-format) to some directory within PATH=${PATH}"
   echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
   exit 128

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -13,9 +13,13 @@ then
   echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
   echo "You can download clang-format-diff.py by running: "
   echo "    curl --location http://goo.gl/iUW1u2 -o ${CLANG_FORMAT_DIFF}"
-  echo "You can download clang-format by running: "
+  echo "You can download clang-format. One way is to run"
   echo "    brew install clang-format"
+  echo "  Another way might be"
+  echo "    yum install git-clang-format"
+  
   echo "Then, move both files (i.e. ${CLANG_FORMAT_DIFF} and clang-format) to some directory within PATH=${PATH}"
+  echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
   exit 128
 fi
 


### PR DESCRIPTION
Summary:
While the instruction of installing "make format" dependencies works on some platforms, it is hard to use for some others. Improve it a little bit.

Test Plan: Run "make format" on an envrionment missing the dependencies and see the instructions printed out