### PR TITLE
db_stress: generate the key based on Zipfian distribution (hot key)

### DIFF
--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -61,7 +61,7 @@ void InitializeHotKeyGenerator(double alpha) {
 int64_t GetOneHotKeyID(double rand_seed, int64_t max_key) {
   int64_t low = 1, mid, high = zipf_sum_size, zipf = 0;
   while (low <= high) {
-    mid = std::loor((low + high) / 2);
+    mid = std::floor((low + high) / 2);
     if (sum_probs[mid] >= rand_seed && sum_probs[mid - 1] < rand_seed) {
       zipf = mid;
       break;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -79,6 +79,7 @@ using GFLAGS_NAMESPACE::SetUsageMessage;
 DECLARE_uint64(seed);
 DECLARE_bool(read_only);
 DECLARE_int64(max_key);
+DECLARE_double(hot_key_alpha);
 DECLARE_int32(column_families);
 DECLARE_string(options_file);
 DECLARE_int64(active_width);
@@ -372,5 +373,7 @@ extern size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
 extern StressTest* CreateCfConsistencyStressTest();
 extern StressTest* CreateBatchedOpsStressTest();
 extern StressTest* CreateNonBatchedOpsStressTest();
+extern void InitilizeHotKeyGenerator(double alpha);
+extern int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
 }  // namespace rocksdb
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -373,7 +373,7 @@ extern size_t GenerateValue(uint32_t rand, char* v, size_t max_sz);
 extern StressTest* CreateCfConsistencyStressTest();
 extern StressTest* CreateBatchedOpsStressTest();
 extern StressTest* CreateNonBatchedOpsStressTest();
-extern void InitilizeHotKeyGenerator(double alpha);
+extern void InitializeHotKeyGenerator(double alpha);
 extern int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
 }  // namespace rocksdb
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -30,6 +30,14 @@ DEFINE_int64(max_key, 1 * KB * KB,
 
 DEFINE_int32(column_families, 10, "Number of column families");
 
+DEFINE_double(hot_key_alpha, 0, "Use Zipfian distribution to generate the key "
+    "distribution. If it is not specified, write path will use random "
+    "distribution to generate the keys. The parameter is [0, double_max]). "
+    "However, the larger alpha is, the more shewed will be. If alpha is "
+    "larger than 2, it is likely that only 1 key will be accessed. The "
+    "Recommended value is [0.8-1.5]. The distribution is also related to "
+    "max_key and total iterations of generating the hot key. ");
+
 DEFINE_string(
     options_file, "",
     "The path to a RocksDB options file.  If specified, then db_stress will "

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -30,7 +30,9 @@ DEFINE_int64(max_key, 1 * KB * KB,
 
 DEFINE_int32(column_families, 10, "Number of column families");
 
-DEFINE_double(hot_key_alpha, 0, "Use Zipfian distribution to generate the key "
+DEFINE_double(
+    hot_key_alpha, 0,
+    "Use Zipfian distribution to generate the key "
     "distribution. If it is not specified, write path will use random "
     "distribution to generate the keys. The parameter is [0, double_max]). "
     "However, the larger alpha is, the more shewed will be. If alpha is "

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -21,8 +21,6 @@
 // different behavior. See comment of the flag for details.
 
 #ifdef GFLAGS
-#include <cmath>
-#include <cstdlib>
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_driver.h"
 

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -21,6 +21,8 @@
 // different behavior. See comment of the flag for details.
 
 #ifdef GFLAGS
+#include <cmath>
+#include <cstdlib>
 #include "db_stress_tool/db_stress_common.h"
 #include "db_stress_tool/db_stress_driver.h"
 
@@ -189,6 +191,20 @@ int db_stress_tool(int argc, char** argv) {
     stress.reset(CreateBatchedOpsStressTest());
   } else {
     stress.reset(CreateNonBatchedOpsStressTest());
+  }
+  InitilizeHotKeyGenerator(FLAGS_hot_key_alpha);
+  int64_t max_key = 100000;
+  std::map<int64_t, int64_t> counter;
+  srand(1);
+  for (int64_t i=0; i<100000; i++) {
+    double rand_seed = (static_cast<double>(rand()%max_key))/max_key;
+    int64_t cur_hot = GetOneHotKeyID(rand_seed, max_key);
+    counter[cur_hot]++;
+  }
+  for (auto i:counter) {
+    if (i.second>10) {
+      std::cout<<"key: "<<i.first<<" count: "<<i.second<<"\n";
+    }
   }
   if (RunStressTest(stress.get())) {
     return 0;

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -192,20 +192,8 @@ int db_stress_tool(int argc, char** argv) {
   } else {
     stress.reset(CreateNonBatchedOpsStressTest());
   }
-  InitilizeHotKeyGenerator(FLAGS_hot_key_alpha);
-  int64_t max_key = 100000;
-  std::map<int64_t, int64_t> counter;
-  srand(1);
-  for (int64_t i=0; i<100000; i++) {
-    double rand_seed = (static_cast<double>(rand()%max_key))/max_key;
-    int64_t cur_hot = GetOneHotKeyID(rand_seed, max_key);
-    counter[cur_hot]++;
-  }
-  for (auto i:counter) {
-    if (i.second>10) {
-      std::cout<<"key: "<<i.first<<" count: "<<i.second<<"\n";
-    }
-  }
+  // Initialize the Zipfian pre-calculated array
+  InitializeHotKeyGenerator(FLAGS_hot_key_alpha);
   if (RunStressTest(stress.get())) {
     return 0;
   } else {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -228,24 +228,12 @@ class NonBatchedOpsStressTest : public StressTest {
                  std::unique_ptr<MutexLock>& lock) override {
     auto shared = thread->shared;
     int64_t max_key = shared->GetMaxKey();
-    int64_t rand_seed = rand_keys[0];
-    int64_t rand_key;
-    if (FLAGS_hot_key_alpha != 0) {
-      double float_rand = (static_cast<double>(rand_seed%max_key))/max_key;
-      rand_key = GetOneHotKeyID(float_rand, max_key);
-    } else {
-      rand_key = rand_seed;
-    }
+    int64_t rand_key = rand_keys[0];
     int rand_column_family = rand_column_families[0];
     while (!shared->AllowsOverwrite(rand_key) &&
            (FLAGS_use_merge || shared->Exists(rand_column_family, rand_key))) {
       lock.reset();
-      if (FLAGS_hot_key_alpha != 0) {
-        double float_rand = (static_cast<double>(thread->rand.Next()%max_key))/max_key;
-        rand_key = GetOneHotKeyID(float_rand, max_key);
-      } else {
-        rand_key = thread->rand.Next() % max_key;
-      }
+      rand_key = thread->rand.Next() % max_key;
       rand_column_family = thread->rand.Next() % FLAGS_column_families;
       lock.reset(
           new MutexLock(shared->GetMutexForKey(rand_column_family, rand_key)));


### PR DESCRIPTION
In the current db_stress, all the keys are generated randomly and follows the uniform distribution. In order to test some corner cases that some key are always updated or read, we need to generate the key based on other distributions. In this PR, the key is generated based on Zipfian distribution and the skewness can be controlled by setting hot_key_alpha (0.8 to 1.5 is suggested). The larger hot_key_alpha is, the more skewed will be. Not that, usually, if hot_key_alpha is larger than 2, there might be only 1 or 2 keys that are generated. If hot_key_alpha is 0, it generate the key follows uniform distribution (random key)

Testing plan: pass the db_stress and printed the keys to make sure it follows the distribution.
