### PR TITLE
Set CompactionIterator::valid_ to false when PrepareBlobOutput indicates error

### DIFF
--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -668,7 +668,8 @@ void CompactionIterator::PrepareOutput() {
     //
     // Can we do the same for levels above bottom level as long as
     // KeyNotExistsBeyondOutputLevel() return true?
-    if ((compaction_ != nullptr && !compaction_->allow_ingest_behind()) &&
+    if (valid_ && compaction_ != nullptr &&
+        !compaction_->allow_ingest_behind() &&
         ikeyNotNeededForIncrementalSnapshot() && bottommost_level_ &&
         IN_EARLIEST_SNAPSHOT(ikey_.sequence) && ikey_.type != kTypeMerge) {
       assert(ikey_.type != kTypeDeletion && ikey_.type != kTypeSingleDeletion);

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -647,8 +647,10 @@ void CompactionIterator::PrepareOutput() {
       if (blob_decision == CompactionFilter::BlobDecision::kCorruption) {
         status_ = Status::Corruption(
             "Corrupted blob reference encountered during GC");
+        valid_ = false;
       } else if (blob_decision == CompactionFilter::BlobDecision::kIOError) {
         status_ = Status::IOError("Could not relocate blob during GC");
+        valid_ = false;
       } else if (blob_decision ==
                  CompactionFilter::BlobDecision::kChangeValue) {
         value_ = compaction_filter_value_;


### PR DESCRIPTION
Summary:
With https://github.com/facebook/rocksdb/pull/6121, errors returned by `PrepareBlobValue`
result in `CompactionIterator::status_` being set to `Corruption` or `IOError`
as appropriate, however, `valid_` is not set to `false`. The error is eventually propagated in
`CompactionJob::ProcessKeyValueCompaction` but only after the main loop completes.
Setting `valid_` to `false` upon errors enables us to terminate the loop early and fail the
compaction sooner.

Test Plan:
Ran `make check` and used `db_bench` in BlobDB mode.