### PR TITLE
Make it possible to enable periodic compactions for BlobDB

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -147,10 +147,6 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
         "Garbage collection cutoff must be in the interval [0.0, 1.0]");
   }
 
-  // BlobDB does not support Periodic Compactions. So disable periodic
-  // compactions irrespective of the user set value.
-  cf_options_.periodic_compaction_seconds = 0;
-
   // Temporarily disable compactions in the base DB during open; save the user
   // defined value beforehand so we can restore it once BlobDB is initialized.
   // Note: this is only needed if garbage collection is enabled.


### PR DESCRIPTION
Summary:
Periodic compactions ensure that even SSTs that do not get picked up
otherwise eventually go through compaction; used in conjunction with
BlobDB's garbage collection, they enable BlobDB to reclaim space when
old blob files are used by such straggling SSTs.

Test Plan:
Ran `make check` and used the BlobDB mode of `db_bench`.