### PR TITLE
Add more verification to db_stress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,7 +745,7 @@ endif  # PLATFORM_SHARED_EXT
 	dbg rocksdbjavastatic rocksdbjava install install-static install-shared uninstall \
 	analyze tools tools_lib \
 	blackbox_crash_test_with_atomic_flush whitebox_crash_test_with_atomic_flush  \
-	blackbox_crash_test_with_txn whitebox_crash_test_with_txn 
+	blackbox_crash_test_with_txn whitebox_crash_test_with_txn
 
 
 all: $(LIBRARY) $(BENCHMARKS) tools tools_lib test_libs $(TESTS)

--- a/db_stress_tool/cf_consistency_stress.cc
+++ b/db_stress_tool/cf_consistency_stress.cc
@@ -494,6 +494,7 @@ class CfConsistencyStressTest : public StressTest {
     } while (true);
   }
 
+#ifndef ROCKSDB_LITE
   void ContinuouslyVerifyDb(ThreadState* thread) const override {
     assert(cmp_db_ != nullptr);
     Status s = cmp_db_->TryCatchUpWithPrimary();
@@ -525,7 +526,6 @@ class CfConsistencyStressTest : public StressTest {
           continue;
         }
         std::unique_ptr<Iterator> it(cmp_db_->NewIterator(ropts, cfh));
-        tmp_crc = 0;
         status = checksum_column_family(it.get(), &tmp_crc);
         if (!status.ok() || tmp_crc != crc) {
           break;
@@ -536,6 +536,7 @@ class CfConsistencyStressTest : public StressTest {
       shared->SetShouldStopTest();
     }
   }
+#endif  // !ROCKSDB_LITE
 
   std::vector<int> GenerateColumnFamilies(
       const int /* num_column_families */,

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -85,7 +85,7 @@ void PoolSizeChangeThread(void* v) {
   while (true) {
     {
       MutexLock l(shared->GetMutex());
-      if (shared->ShoudStopBgThread()) {
+      if (shared->ShouldStopBgThread()) {
         shared->SetBgThreadFinish();
         shared->GetCondVar()->SignalAll();
         return;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -141,7 +141,7 @@ DECLARE_bool(partition_filters);
 DECLARE_int32(index_type);
 DECLARE_string(db);
 DECLARE_string(secondaries_base);
-DECLARE_bool(enable_secondary);
+DECLARE_bool(test_secondary);
 DECLARE_string(expected_values_path);
 DECLARE_bool(verify_checksum);
 DECLARE_bool(mmap_read);
@@ -208,6 +208,7 @@ DECLARE_bool(write_dbid_to_manifest);
 DECLARE_uint64(max_write_batch_group_size_bytes);
 DECLARE_bool(level_compaction_dynamic_level_bytes);
 DECLARE_int32(verify_checksum_one_in);
+DECLARE_int32(verify_db_one_in);
 
 const long KB = 1024;
 const int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -209,6 +209,7 @@ DECLARE_uint64(max_write_batch_group_size_bytes);
 DECLARE_bool(level_compaction_dynamic_level_bytes);
 DECLARE_int32(verify_checksum_one_in);
 DECLARE_int32(verify_db_one_in);
+DECLARE_int32(continuous_verification_interval);
 
 const long KB = 1024;
 const int kRandomValueMaxFactor = 3;
@@ -367,6 +368,8 @@ extern inline void SanitizeDoubleParam(double* param) {
 }
 
 extern void PoolSizeChangeThread(void* v);
+
+extern void DbVerificationThread(void* v);
 
 extern void PrintKeyValue(int cf, uint64_t key, const char* value, size_t sz);
 

--- a/db_stress_tool/db_stress_driver.cc
+++ b/db_stress_tool/db_stress_driver.cc
@@ -87,9 +87,9 @@ bool RunStressTest(StressTest* stress) {
     }
     if (shared.ShouldVerifyAtBeginning()) {
       if (shared.HasVerificationFailedYet()) {
-        printf("Crash-recovery verification failed :(\n");
+        fprintf(stderr, "Crash-recovery verification failed :(\n");
       } else {
-        printf("Crash-recovery verification passed :)\n");
+        fprintf(stdout, "Crash-recovery verification passed :)\n");
       }
     }
 
@@ -148,7 +148,7 @@ bool RunStressTest(StressTest* stress) {
   }
 
   if (shared.HasVerificationFailedYet()) {
-    printf("Verification failed :(\n");
+    fprintf(stderr, "Verification failed :(\n");
     return false;
   }
   return true;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -586,4 +586,8 @@ DEFINE_int32(verify_db_one_in, 0,
              "If non-zero, call VerifyDb() once for every N ops. 0 indicates "
              "that VerifyDb() will not be called in OperateDb(). Note that "
              "enabling this can slow down tests.");
+
+DEFINE_int32(continuous_verification_interval, 0,
+             "While test is running, verify db every N milliseconds. 0 "
+             "disables continuous verification.");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -587,7 +587,7 @@ DEFINE_int32(verify_db_one_in, 0,
              "that VerifyDb() will not be called in OperateDb(). Note that "
              "enabling this can slow down tests.");
 
-DEFINE_int32(continuous_verification_interval, 0,
+DEFINE_int32(continuous_verification_interval, 1000,
              "While test is running, verify db every N milliseconds. 0 "
              "disables continuous verification.");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -307,7 +307,7 @@ DEFINE_string(db, "", "Use the db with the following name.");
 DEFINE_string(secondaries_base, "",
               "Use this path as the base path for secondary instances.");
 
-DEFINE_bool(enable_secondary, false, "Enable secondary instance.");
+DEFINE_bool(test_secondary, false, "Test secondary instance.");
 
 DEFINE_string(
     expected_values_path, "",
@@ -582,4 +582,8 @@ DEFINE_int32(verify_checksum_one_in, 0,
              " checksum verification of all the files in the database once for"
              " every N ops on average. 0 indicates that calls to"
              " VerifyChecksum() are disabled.");
+DEFINE_int32(verify_db_one_in, 0,
+             "If non-zero, call VerifyDb() once for every N ops. 0 indicates "
+             "that VerifyDb() will not be called in OperateDb(). Note that "
+             "enabling this can slow down tests.");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -13,7 +13,6 @@
 
 namespace rocksdb {
 const uint32_t SharedState::UNKNOWN_SENTINEL = 0xfffffffe;
-// indicates a key should definitely be deleted
 const uint32_t SharedState::DELETION_SENTINEL = 0xffffffff;
 }  // namespace rocksdb
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -57,7 +57,7 @@ class SharedState {
     // Pick random keys in each column family that will not experience
     // overwrite
 
-    printf("Choosing random keys with no overwrite\n");
+    fprintf(stdout, "Choosing random keys with no overwrite\n");
     Random64 rnd(seed_);
     // Start with the identity permutation. Subsequent iterations of
     // for loop below will start with perm of previous for loop
@@ -290,7 +290,7 @@ class SharedState {
 
   void SetShouldStopBgThread() { should_stop_bg_thread_ = true; }
 
-  bool ShoudStopBgThread() { return should_stop_bg_thread_; }
+  bool ShouldStopBgThread() { return should_stop_bg_thread_; }
 
   void SetBgThreadFinish() { bg_thread_finished_ = true; }
 

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -54,6 +54,7 @@ class SharedState {
         bg_thread_finished_(0),
         stress_test_(stress_test),
         verification_failure_(false),
+        should_stop_test_(false),
         no_overwrite_ids_(FLAGS_column_families),
         values_(nullptr),
         printing_verification_results_(false) {
@@ -210,7 +211,11 @@ class SharedState {
 
   void SetVerificationFailure() { verification_failure_.store(true); }
 
-  bool HasVerificationFailedYet() { return verification_failure_.load(); }
+  bool HasVerificationFailedYet() const { return verification_failure_.load(); }
+
+  void SetShouldStopTest() { should_stop_test_.store(true); }
+
+  bool ShouldStopTest() const { return should_stop_test_.load(); }
 
   port::Mutex* GetMutexForKey(int cf, int64_t key) {
     return key_locks_[cf][key >> log2_keys_per_lock_].get();
@@ -341,6 +346,7 @@ class SharedState {
   int bg_thread_finished_;
   StressTest* stress_test_;
   std::atomic<bool> verification_failure_;
+  std::atomic<bool> should_stop_test_;
 
   // Keys that should not be overwritten
   std::unordered_set<size_t> no_overwrite_ids_;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -522,7 +522,10 @@ void StressTest::OperateDb(ThreadState* thread) {
 
       if (thread->tid == 0 && FLAGS_verify_db_one_in > 0 &&
           thread->rand.OneIn(FLAGS_verify_db_one_in)) {
-        VerifyDb(thread);
+        ContinuouslyVerifyDb(thread);
+        if (thread->shared->ShouldStopTest()) {
+          break;
+        }
       }
 
       MaybeClearOneColumnFamily(thread);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -483,7 +483,8 @@ void StressTest::OperateDb(ThreadState* thread) {
 
   thread->stats.Start();
   for (int open_cnt = 0; open_cnt <= FLAGS_reopen; ++open_cnt) {
-    if (thread->shared->HasVerificationFailedYet()) {
+    if (thread->shared->HasVerificationFailedYet() ||
+        thread->shared->ShouldStopTest()) {
       break;
     }
     if (open_cnt != 0) {
@@ -1764,7 +1765,8 @@ void StressTest::Open() {
       secondary_cfh_lists_.clear();
       secondary_cfh_lists_.resize(FLAGS_threads);
       Options tmp_opts;
-      tmp_opts.max_open_files = FLAGS_open_files;
+      // TODO(yanqin) support max_open_files != -1 for secondary instance.
+      tmp_opts.max_open_files = -1;
       tmp_opts.statistics = dbstats_secondaries;
       tmp_opts.env = FLAGS_env;
       for (size_t i = 0; i != static_cast<size_t>(FLAGS_threads); ++i) {
@@ -1785,7 +1787,8 @@ void StressTest::Open() {
     }
     if (FLAGS_continuous_verification_interval > 0 && !cmp_db_) {
       Options tmp_opts;
-      tmp_opts.max_open_files = FLAGS_open_files;
+      // TODO(yanqin) support max_open_files != -1 for secondary instance.
+      tmp_opts.max_open_files = -1;
       tmp_opts.env = FLAGS_env;
       std::string secondary_path = FLAGS_secondaries_base + "/cmp_database";
       s = DB::OpenAsSecondary(tmp_opts, FLAGS_db, secondary_path,
@@ -1803,7 +1806,8 @@ void StressTest::Open() {
       std::fill(secondaries_.begin(), secondaries_.end(), nullptr);
       Options tmp_opts;
       tmp_opts.env = options_.env;
-      tmp_opts.max_open_files = FLAGS_open_files;
+      // TODO(yanqin) support max_open_files != -1 for secondary instance.
+      tmp_opts.max_open_files = -1;
       for (size_t i = 0; i != static_cast<size_t>(FLAGS_threads); ++i) {
         const std::string secondary_path =
             FLAGS_secondaries_base + "/" + std::to_string(i);

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -34,6 +34,7 @@ class StressTest {
 
   void OperateDb(ThreadState* thread);
   virtual void VerifyDb(ThreadState* thread) const = 0;
+  virtual void ContinuouslyVerifyDb(ThreadState* /*thread*/) const {}
 
   void PrintStatistics();
 
@@ -192,6 +193,10 @@ class StressTest {
   // Fields used for stress-testing secondary instance in the same process
   std::vector<DB*> secondaries_;
   std::vector<std::vector<ColumnFamilyHandle*>> secondary_cfh_lists_;
+
+  // Fields used for continuous verification from another thread
+  DB* cmp_db_;
+  std::vector<ColumnFamilyHandle*> cmp_cfhs_;
 };
 
 }  // namespace rocksdb

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -171,7 +171,8 @@ int db_stress_tool(int argc, char** argv) {
     FLAGS_db = default_db_path;
   }
 
-  if (FLAGS_test_secondary && FLAGS_secondaries_base.empty()) {
+  if ((FLAGS_test_secondary || FLAGS_continuous_verification_interval > 0) &&
+      FLAGS_secondaries_base.empty()) {
     std::string default_secondaries_path;
     FLAGS_env->GetTestDirectory(&default_secondaries_path);
     default_secondaries_path += "/dbstress_secondaries";

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -41,7 +41,7 @@ int db_stress_tool(int argc, char** argv) {
 
   if (FLAGS_statistics) {
     dbstats = rocksdb::CreateDBStatistics();
-    if (FLAGS_enable_secondary) {
+    if (FLAGS_test_secondary) {
       dbstats_secondaries = rocksdb::CreateDBStatistics();
     }
   }
@@ -171,7 +171,7 @@ int db_stress_tool(int argc, char** argv) {
     FLAGS_db = default_db_path;
   }
 
-  if (FLAGS_enable_secondary && FLAGS_secondaries_base.empty()) {
+  if (FLAGS_test_secondary && FLAGS_secondaries_base.empty()) {
     std::string default_secondaries_path;
     FLAGS_env->GetTestDirectory(&default_secondaries_path);
     default_secondaries_path += "/dbstress_secondaries";
@@ -184,8 +184,17 @@ int db_stress_tool(int argc, char** argv) {
     FLAGS_secondaries_base = default_secondaries_path;
   }
 
-  if (!FLAGS_enable_secondary && FLAGS_secondary_catch_up_one_in > 0) {
-    fprintf(stderr, "Secondary instance is disabled.\n");
+  if (!FLAGS_test_secondary && FLAGS_secondary_catch_up_one_in > 0) {
+    fprintf(
+        stderr,
+        "Must set -test_secondary=true if secondary_catch_up_one_in > 0.\n");
+    exit(1);
+  }
+
+  if (!FLAGS_test_cf_consistency && FLAGS_verify_db_one_in > 0) {
+    fprintf(stderr,
+            "For non cf_consistency tests, VerifyDb() is called only before "
+            "and after test.\n");
     exit(1);
   }
 

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -42,10 +42,9 @@ class NonBatchedOpsStressTest : public StressTest {
           if (thread->shared->HasVerificationFailedYet()) {
             break;
           }
-          // TODO(ljin): update "long" to uint64_t
           // Reseek when the prefix changes
           if (prefix_to_use > 0 &&
-              i % (static_cast<int64_t>(1) << 8 * (8 - prefix_to_use)) == 0) {
+              i % (static_cast<uint64_t>(1) << 8 * (8 - prefix_to_use)) == 0) {
             iter->Seek(Key(i));
           }
           std::string from_db;
@@ -65,7 +64,7 @@ class NonBatchedOpsStressTest : public StressTest {
           } else {
             // The iterator found no value for the key in question, so do not
             // move to the next item in the iterator
-            s = Status::NotFound(Slice());
+            s = Status::NotFound();
           }
           VerifyValue(static_cast<int>(cf), i, options, shared, from_db, s,
                       true);
@@ -506,7 +505,7 @@ class NonBatchedOpsStressTest : public StressTest {
 
   bool VerifyValue(int cf, int64_t key, const ReadOptions& /*opts*/,
                    SharedState* shared, const std::string& value_from_db,
-                   Status s, bool strict = false) const {
+                   const Status& s, bool strict = false) const {
     if (shared->HasVerificationFailedYet()) {
       return false;
     }

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -100,6 +100,7 @@ default_params = {
     # BlockBasedTable::ApproximateSize
     # "level_compaction_dynamic_level_bytes" : True,
     "verify_checksum_one_in": 1000000,
+    "verify_db_one_in": 100000,
     "continuous_verification_interval" : 0
 }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -99,7 +99,8 @@ default_params = {
     # Temporarily disabled because of assertion violations in
     # BlockBasedTable::ApproximateSize
     # "level_compaction_dynamic_level_bytes" : True,
-    "verify_checksum_one_in": 1000000
+    "verify_checksum_one_in": 1000000,
+    "continuous_verification_interval" : 0
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'


### PR DESCRIPTION
Currently, db_stress performs verification by calling `VerifyDb()` at the end of test and optionally before tests start. In case of corruption or incorrect result, it will be too late. This PR adds more verification in two ways.
1. For cf consistency test, each test thread takes a snapshot and verifies every N ops. N is configurable via `-verify_db_one_in`. This option is not supported in other stress tests.
2. For cf consistency test, we use another background thread in which a secondary instance periodically tails the primary (interval is configurable). We verify the secondary. Once an error is detected, we terminate the test and report. This does not affect other stress tests.

Test plan (devserver)
```
$./db_stress -test_cf_consistency -verify_db_one_in=0 -ops_per_thread=100000 -continuous_verification_interval=100
$./db_stress -test_cf_consistency -verify_db_one_in=1000 -ops_per_thread=10000 -continuous_verification_interval=0
$make crash_test
```