### PR TITLE
Java: Enable keyMayExist to use a null StringBuilder

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -1618,7 +1618,7 @@ jboolean key_may_exist_helper(JNIEnv* env, rocksdb::DB* db,
   delete[] key;
 
   // extract the value
-  if (value_found && !value.empty()) {
+  if (value_found && !value.empty() && jstring_builder != nullptr) {
     jobject jresult_string_builder =
         rocksdb::StringBuilderJni::append(env, jstring_builder, value.c_str());
     if (jresult_string_builder == nullptr) {


### PR DESCRIPTION
Currently StringBuilder is mandatory in the keyMayExist method. This way a StringBuilder needs to be created even when not needed and causes a crash on Android platform is the value is a non UTF8 valid String. 

This PR enables to pass a null StringBuilder to keyMayExist.

The API is not changed but it introduces another check before appending to the StringBuilder.

This MR introduces a way to circumvent a crash on Android: #6183 