### PR TITLE
Wait for CancelAllBackgroundWork before Close in db stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1773,8 +1773,9 @@ void StressTest::Reopen(ThreadState* thread) {
 #ifndef ROCKSDB_LITE
   bool bg_canceled = false;
   if (thread->rand.OneIn(2)) {
-    CancelAllBackgroundWork(db_, static_cast<bool>(thread->rand.OneIn(2)));
-    bg_canceled = true;
+    const bool wait = static_cast<bool>(thread->rand.OneIn(2);
+    CancelAllBackgroundWork(db_, wait));
+    bg_canceled = wait;
   }
 #else
   (void) thread;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1773,7 +1773,7 @@ void StressTest::Reopen(ThreadState* thread) {
 #ifndef ROCKSDB_LITE
   bool bg_canceled = false;
   if (thread->rand.OneIn(2)) {
-    const bool wait = static_cast<bool>(thread->rand.OneIn(2);
+    const bool wait = static_cast<bool>(thread->rand.OneIn(2));
     CancelAllBackgroundWork(db_, wait);
     bg_canceled = wait;
   }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1774,7 +1774,7 @@ void StressTest::Reopen(ThreadState* thread) {
   bool bg_canceled = false;
   if (thread->rand.OneIn(2)) {
     const bool wait = static_cast<bool>(thread->rand.OneIn(2);
-    CancelAllBackgroundWork(db_, wait));
+    CancelAllBackgroundWork(db_, wait);
     bg_canceled = wait;
   }
 #else


### PR DESCRIPTION
In #6174 we fixed the stress test to respect the CancelAllBackgroundWork + Close order for WritePrepared transactions. The fix missed to take into account that some invocation of CancelAllBackgroundWork are with wait=false parameter which essentially breaks the order.