### PR TITLE
Use Env::LoadEnv to create custom Env objects

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -67,9 +67,9 @@ class ColumnFamilyTestBase : public testing::Test {
 #ifndef ROCKSDB_LITE
     const char* test_env_uri = getenv("TEST_ENV_URI");
     if (test_env_uri) {
-      Status s = ObjectRegistry::NewInstance()->NewSharedObject(test_env_uri,
-                                                                &env_guard_);
-      base_env = env_guard_.get();
+      Env* test_env = nullptr;
+      Status s = Env::LoadEnv(test_env_uri, &test_env, &env_guard_);
+      base_env = test_env;
       EXPECT_OK(s);
       EXPECT_NE(Env::Default(), base_env);
     }

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -53,9 +53,9 @@ DBTestBase::DBTestBase(const std::string path)
 #ifndef ROCKSDB_LITE
   const char* test_env_uri = getenv("TEST_ENV_URI");
   if (test_env_uri) {
-    Status s = ObjectRegistry::NewInstance()->NewSharedObject(test_env_uri,
-                                                              &env_guard_);
-    base_env = env_guard_.get();
+    Env* test_env = nullptr;
+    Status s = Env::LoadEnv(test_env_uri, &test_env, &env_guard_);
+    base_env = test_env;
     EXPECT_OK(s);
     EXPECT_NE(Env::Default(), base_env);
   }


### PR DESCRIPTION
Summary:
As title. Previous assumption was that the underlying lib can always return
a shared_ptr<Env>. This is too strong. Therefore, we use Env::LoadEnv to relax
it.

Test Plan:
make check