### PR TITLE
db_stress: listners to implement all functions

### DIFF
--- a/db_stress_tool/db_stress_listener.h
+++ b/db_stress_tool/db_stress_listener.h
@@ -21,8 +21,8 @@ class DbStressListener : public EventListener {
         db_paths_(db_paths),
         column_families_(column_families),
         num_pending_file_creations_(0) {}
-  ~DbStressListener() override { assert(num_pending_file_creations_ == 0); }
 #ifndef ROCKSDB_LITE
+  ~DbStressListener() override { assert(num_pending_file_creations_ == 0); }
   void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
     assert(IsValidColumnFamilyName(info.cf_name));
     VerifyFilePath(info.file_path);


### PR DESCRIPTION
Summary: Listners are one source of bugs because we frequently release some mutex to invoke them, which introduce race conditions. Implement all callback functions in db_stress's listener class, and randomly sleep.

Test Plan: Run crash_test for a while and see no obvious problem.