### PR TITLE
Add VerifyChecksum() to db_stress

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -207,6 +207,7 @@ DECLARE_bool(avoid_unnecessary_blocking_io);
 DECLARE_bool(write_dbid_to_manifest);
 DECLARE_uint64(max_write_batch_group_size_bytes);
 DECLARE_bool(level_compaction_dynamic_level_bytes);
+DECLARE_int32(verify_checksum_one_in);
 
 const long KB = 1024;
 const int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -577,4 +577,9 @@ DEFINE_bool(level_compaction_dynamic_level_bytes,
             rocksdb::Options().level_compaction_dynamic_level_bytes,
             "Use dynamic level");
 
+DEFINE_int32(verify_checksum_one_in, 0,
+             "If non-zero, then DB::VerifyChecksum() will be called to do"
+             " checksum verification of all the files in the database once for"
+             " every N ops on average. 0 indicates that calls to"
+             " VerifyChecksum() are disabled.");
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -625,6 +625,13 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       }
 
+      if (thread->rand.OneInOpt(FLAGS_verify_checksum_one_in)) {
+        Status status = db_->VerifyChecksum();
+        if (!status.ok()) {
+          VerificationAbort(shared, "VerifyChecksum status not OK", status);
+        }
+      }
+
       std::vector<int64_t> rand_keys = GenerateKeys(rand_key);
 
       if (thread->rand.OneInOpt(FLAGS_ingest_external_file_one_in)) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -625,12 +625,14 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       }
 
+#ifndef ROCKSDB_LITE
       if (thread->rand.OneInOpt(FLAGS_verify_checksum_one_in)) {
         Status status = db_->VerifyChecksum();
         if (!status.ok()) {
           VerificationAbort(shared, "VerifyChecksum status not OK", status);
         }
       }
+#endif
 
       std::vector<int64_t> rand_keys = GenerateKeys(rand_key);
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -96,6 +96,8 @@ default_params = {
     "max_write_batch_group_size_bytes" : lambda: random.choice(
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]),
     "level_compaction_dynamic_level_bytes" : True,
+        [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1,30)]),
+    "verify_checksum_one_in": 1000000
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'


### PR DESCRIPTION
Add an option to db_stress, verify_checksum_one_in, to call DB::VerifyChecksum() once every N ops.