### PR TITLE
Fix: remove the potential dead store variable in block_based_table_reader.cc

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2374,7 +2374,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       req.scratch = new char[req.len];
     } else {
       req.scratch = scratch + buf_offset;
-      buf_offset += req.len;
     }
     req.status = IOStatus::OK();
     read_reqs.emplace_back(req);


### PR DESCRIPTION
buf_offset does not need to get the value from req.len for othe final block. It can cause test fail for clan_analyze. Remove it.

Test plan: pass make asan_check, no error reported in block_based_table_reader.cc by make analyze