### PR TITLE
Fix syntax error (!) in db_crashtest.py

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -97,7 +97,6 @@ default_params = {
     "max_write_batch_group_size_bytes" : lambda: random.choice(
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]),
     "level_compaction_dynamic_level_bytes" : True,
-        [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1,30)]),
     "verify_checksum_one_in": 1000000
 }
 


### PR DESCRIPTION
Fixes syntax error from #6203

Test Plan: make blackbox_crash_test -> no more syntax error