### PR TITLE
Avoid heading tags in javadocs; fix EnvironmentTest

### DIFF
--- a/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
@@ -254,7 +254,8 @@ public interface AdvancedColumnFamilyOptionsInterface<
    * levels extra size. After the data accumulates more so that we need to
    * move the base level to the third last one, and so on.</p>
    *
-   * <h2>Example</h2>
+   * <p><b>Example</b></p>
+   *
    * <p>For example, assume {@code max_bytes_for_level_multiplier=10},
    * {@code num_levels=6}, and {@code max_bytes_for_level_base=10MB}.</p>
    *

--- a/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
+++ b/java/src/test/java/org/rocksdb/util/EnvironmentTest.java
@@ -229,9 +229,11 @@ public class EnvironmentTest {
     try {
       field = Environment.class.getDeclaredField(fieldName);
       field.setAccessible(true);
+      /* Fails in JDK 13; and not needed unless fields are final
       final Field modifiersField = Field.class.getDeclaredField("modifiers");
       modifiersField.setAccessible(true);
       modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+      */
       return (T)field.get(null);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException(e);
@@ -243,9 +245,11 @@ public class EnvironmentTest {
     try {
       field = Environment.class.getDeclaredField(fieldName);
       field.setAccessible(true);
+      /* Fails in JDK 13; and not needed unless fields are final
       final Field modifiersField = Field.class.getDeclaredField("modifiers");
       modifiersField.setAccessible(true);
       modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+      */
       field.set(null, value);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Summary: Should fix Travis build error that randomly showed up upon
using Java 13 version of javadoc.

    AdvancedColumnFamilyOptionsInterface.java:257: error:
      unexpected heading used: <H2>, compared to implicit preceding heading: <H3>

According to this reference https://bugs.openjdk.java.net/browse/JDK-8220379
it should work to start at h4, but that didn't work, so avoiding
headings should be fine.

Also fix Java EnvironmentTest for JDK13.

Test Plan: Travis run on PR (don't have Java 13 handy)