### PR TITLE
Syntax check python files on testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -939,6 +939,7 @@ check: all
 	fi
 	rm -rf $(TMPD)
 ifneq ($(PLATFORM), OS_AIX)
+	python tools/check_all_python.py
 ifeq ($(filter -DROCKSDB_LITE,$(OPT)),)
 	python tools/ldb_test.py
 	sh tools/rocksdb_dump_test.sh
@@ -2051,6 +2052,7 @@ jtest_run:
 
 jtest: rocksdbjava
 	cd java;$(MAKE) sample;$(MAKE) test;
+	python tools/check_all_python.py # TODO peterd: find a better place for this check in CI targets
 
 jdb_bench:
 	cd java;$(MAKE) db_bench;

--- a/tools/check_all_python.py
+++ b/tools/check_all_python.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python2
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+import glob
+
+# Checks that all python files in the repository are at least free of syntax
+# errors. This provides a minimal pre-/post-commit check for python file
+# modifications.
+
+count = 0
+# Clean this up when we finally upgrade to Python 3
+for filename in glob.glob("*.py") + glob.glob("*/*.py") + glob.glob("*/*/*.py") + glob.glob("*/*/*/*.py"):
+    source = open(filename, 'r').read() + '\n'
+    # Parses and syntax checks the file, throwing on error. (No pyc written.)
+    _ = compile(source, filename, 'exec')
+    count = count + 1
+
+print("No syntax errors in {0} .py files".format(count))


### PR DESCRIPTION
Summary: Adds a python script to syntax check all python files in the
repository and report any errors.

Test Plan: 'make check' with and without seeded syntax errors. Also look
for "No syntax errors in 34 .py files" on success, and in java_test CI output