### PR TITLE
Temporarily disable level_compaction_dynamic_level_bytes in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -96,7 +96,9 @@ default_params = {
     "write_dbid_to_manifest" : random.randint(0, 1),
     "max_write_batch_group_size_bytes" : lambda: random.choice(
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]),
-    "level_compaction_dynamic_level_bytes" : True,
+    # Temporarily disabled because of assertion violations in
+    # BlockBasedTable::ApproximateSize
+    # "level_compaction_dynamic_level_bytes" : True,
     "verify_checksum_one_in": 1000000
 }
 


### PR DESCRIPTION
Summary: We're seeing assertion violations like this in crash test:

db_stress: table/block_based/block_based_table_reader.cc:4129: virtual uint64_t rocksdb::BlockBasedTable::ApproximateSize(const rocksdb::Slice&, const rocksdb::Slice&, rocksdb::TableReaderCaller): Assertion `end_offset >= start_offset' failed.***

And ApproximateSize appears only to be called with the level_compaction_dynamic_level_bytes option.

Test Plan: temporarily put an assert(false) in ApproximateSize and
briefly run 'make crash_test'