### PR TITLE
Revert "Add kHashSearch to stress tests (#6210)"

### DIFF
--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -157,8 +157,6 @@ size_t TailPrefetchStats::GetSuggestedPrefetchSize() {
   return std::min(kMaxPrefetchSize, max_qualified_size);
 }
 
-// TODO(myabandeh): We should return an error instead of silently changing the
-// options
 BlockBasedTableFactory::BlockBasedTableFactory(
     const BlockBasedTableOptions& _table_options)
     : table_options_(_table_options) {
@@ -184,11 +182,6 @@ BlockBasedTableFactory::BlockBasedTableFactory(
     table_options_.block_restart_interval = 1;
   }
   if (table_options_.index_block_restart_interval < 1) {
-    table_options_.index_block_restart_interval = 1;
-  }
-  if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
-      table_options_.index_block_restart_interval != 1) {
-    // Currently kHashSearch is incompatible with index_block_restart_interval > 1
     table_options_.index_block_restart_interval = 1;
   }
   if (table_options_.partition_filters &&

--- a/table/block_based/index_builder.cc
+++ b/table/block_based/index_builder.cc
@@ -39,9 +39,6 @@ IndexBuilder* IndexBuilder::CreateIndexBuilder(
           table_opt.index_shortening, /* include_first_key */ false);
     } break;
     case BlockBasedTableOptions::kHashSearch: {
-      // Currently kHashSearch is incompatible with index_block_restart_interval
-      // > 1
-      assert(table_opt.index_block_restart_interval == 1);
       result = new HashIndexBuilder(
           comparator, int_key_slice_transform,
           table_opt.index_block_restart_interval, table_opt.format_version,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -47,7 +47,7 @@ default_params = {
     "expected_values_path": expected_values_file.name,
     "flush_one_in": 1000000,
     # Temporarily disable hash index
-    "index_type": lambda: random.randint(0,2),
+    "index_type": lambda: random.choice([0,2]),
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
@@ -226,12 +226,6 @@ def finalize_and_sanitize(src_params):
             dest_params["partition_filters"] = 0
         else:
             dest_params["use_block_based_filter"] = 0
-    # kHashSearch is incompatible with index_block_restart_interval > 1
-    if dest_params["index_type"] == 1:
-        dest_params["index_block_restart_interval"] = 1;
-        # KHashSearch need prefix_extractor to be set
-        if dest_params.get("prefix_size", 0) < 1:
-             dest_params["prefix_size"] = 3;
     if dest_params.get("atomic_flush", 0) == 1:
         # disable pipelined write when atomic flush is used.
         dest_params["enable_pipelined_write"] = 0


### PR DESCRIPTION
This reverts commit 54f9092b0c12d99971f340e180d42fffc9f73bc1.
It making our daily stress tests fail. Revert it until the issues are fixed.