### PR TITLE
db_stress: Added the verification for GetLiveFiles, GetSortedWalFiles and GetCurrentWalFile

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -124,6 +124,7 @@ DECLARE_int32(universal_min_merge_width);
 DECLARE_int32(universal_max_merge_width);
 DECLARE_int32(universal_max_size_amplification_percent);
 DECLARE_int32(clear_column_family_one_in);
+DECLARE_int32(get_live_files_and_wal_files_one_in);
 DECLARE_int32(set_options_one_in);
 DECLARE_int32(set_in_place_one_in);
 DECLARE_int64(cache_size);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -239,6 +239,11 @@ DEFINE_int32(clear_column_family_one_in, 1000000,
              "it again. If N == 0, never drop/create column families. "
              "When test_batches_snapshots is true, this flag has no effect");
 
+DEFINE_int32(get_live_files_and_wal_files_one_in, 1000000,
+             "With a chance of 1/N, call GetLiveFiles, GetSortedWalFiles "
+             "and GetCurrentWalFile to verify if it returns correctly. If "
+             "N == 0, never call the three interfaces.");
+
 DEFINE_int32(set_options_one_in, 0,
              "With a chance of 1/N, change some random options");
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -559,8 +559,8 @@ void StressTest::OperateDb(ThreadState* thread) {
       if (thread->rand.OneInOpt(FLAGS_get_live_files_and_wal_files_one_in)) {
         Status status = VerifyGetLiveAndWalFiles(thread);
         if (!status.ok()) {
-            VerificationAbort(shared, "VerifyGetLiveAndWalFiles status not OK",
-                                    status);
+          VerificationAbort(shared, "VerifyGetLiveAndWalFiles status not OK",
+                            status);
         }
       }
 
@@ -877,7 +877,7 @@ Status StressTest::TestIterate(ThreadState* thread,
 // GetCurrentWalFile. Each time, randomly select one of them to run
 // and return the status.
 Status StressTest::VerifyGetLiveAndWalFiles(ThreadState* thread) {
-  int case_num = thread->rand.Next() % 3;
+  int case_num = thread->rand.Uniform(3);
   if (case_num == 0) {
     std::vector<std::string> live_file;
     uint64_t manifest_size;
@@ -893,7 +893,8 @@ Status StressTest::VerifyGetLiveAndWalFiles(ThreadState* thread) {
     std::unique_ptr<LogFile> cur_wal_file;
     return db_->GetCurrentWalFile(&cur_wal_file);
   }
-  return Status::OK();
+  assert(false);
+  return Status::Corruption("Undefined case happens!");
 }
 
 // Compare the two iterator, iter and cmp_iter are in the same position,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -553,6 +553,32 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       }
 
+      // Every 1 in N do the following to get live files and wal files test
+      // to check if the status are ok.
+      if (thread->rand.OneInOpt(FLAGS_get_live_files_and_wal_files_one_in)) {
+        Status s;
+        std::vector<std::string> live_file;
+        uint64_t manifest_size;
+        s = db_->GetLiveFiles(live_file, &manifest_size);
+        if (!s.ok()) {
+          fprintf(stdout, "Get live files failed: %s\n", s.ToString().c_str());
+        }
+
+        VectorLogPtr log_ptr;
+        s = db_->GetSortedWalFiles(log_ptr);
+        if (!s.ok()) {
+          fprintf(stdout, "Get sorted Wal files failed: %s\n",
+                  s.ToString().c_str());
+        }
+
+        std::unique_ptr<LogFile> cur_wal_file;
+        s = db_->GetCurrentWalFile(&cur_wal_file);
+        if (!s.ok()) {
+          fprintf(stdout, "Get current Wal file failed: %s\n",
+                  s.ToString().c_str());
+        }
+      }
+
       if (thread->rand.OneInOpt(FLAGS_pause_background_one_in)) {
         Status status = TestPauseBackground(thread);
         if (!status.ok()) {

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -553,6 +553,7 @@ void StressTest::OperateDb(ThreadState* thread) {
         }
       }
 
+#ifndef ROCKSDB_LITE
       // Every 1 in N verify the one of the following: 1) GetLiveFiles
       // 2) GetSortedWalFiles 3) GetCurrentWalFile. Each time, randomly select
       // one of them to run the test.
@@ -563,6 +564,7 @@ void StressTest::OperateDb(ThreadState* thread) {
                             status);
         }
       }
+#endif  // !ROCKSDB_LITE
 
       if (thread->rand.OneInOpt(FLAGS_pause_background_one_in)) {
         Status status = TestPauseBackground(thread);
@@ -873,6 +875,7 @@ Status StressTest::TestIterate(ThreadState* thread,
   return s;
 }
 
+#ifndef ROCKSDB_LITE
 // Test the return status of GetLiveFiles, GetSortedWalFiles, and
 // GetCurrentWalFile. Each time, randomly select one of them to run
 // and return the status.
@@ -896,6 +899,7 @@ Status StressTest::VerifyGetLiveAndWalFiles(ThreadState* thread) {
   assert(false);
   return Status::Corruption("Undefined case happens!");
 }
+#endif  // !ROCKSDB_LITE
 
 // Compare the two iterator, iter and cmp_iter are in the same position,
 // unless iter might be made invalidate or undefined because of

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -173,6 +173,8 @@ class StressTest {
 
   Status MaybeReleaseSnapshots(ThreadState* thread, uint64_t i);
 
+  Status VerifyGetLiveAndWalFiles(ThreadState* thread);
+
   void VerificationAbort(SharedState* shared, std::string msg, Status s) const;
 
   void VerificationAbort(SharedState* shared, std::string msg, int cf,

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -172,9 +172,9 @@ class StressTest {
                            const std::string& keystr, uint64_t i);
 
   Status MaybeReleaseSnapshots(ThreadState* thread, uint64_t i);
-
+#ifndef ROCKSDB_LITE
   Status VerifyGetLiveAndWalFiles(ThreadState* thread);
-
+#endif    // !ROCKSDB_LITE
   void VerificationAbort(SharedState* shared, std::string msg, Status s) const;
 
   void VerificationAbort(SharedState* shared, std::string msg, int cf,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -46,6 +46,7 @@ default_params = {
     "enable_pipelined_write": lambda: random.randint(0, 1),
     "expected_values_path": expected_values_file.name,
     "flush_one_in": 1000000,
+    "get_live_files_and_wal_files_one_in": 1000000,
     # Temporarily disable hash index
     "index_type": lambda: random.choice([0,2]),
     "max_background_compactions": 20,


### PR DESCRIPTION
Add the verification in operateDB to verify GetLiveFiles, GetSortedWalFiles and GetCurrentWalFile. The test will be called every 1 out of N, N is decided by get_live_files_and_wal_files_one_i, whose default is 1000000.

Test: pass db_stress default run.