### PR TITLE
Add Transaction::MultiGet to db_stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -457,8 +457,9 @@ Status StressTest::CommitTxn(Transaction* txn) {
 
 Status StressTest::RollbackTxn(Transaction* txn) {
   if (!FLAGS_use_txn) {
-    return Status::InvalidArgument("RollbackTxn when FLAGS_use_txn is not"
-                                   " set");
+    return Status::InvalidArgument(
+        "RollbackTxn when FLAGS_use_txn is not"
+        " set");
   }
   Status s = txn->Rollback();
   delete txn;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -454,6 +454,16 @@ Status StressTest::CommitTxn(Transaction* txn) {
   delete txn;
   return s;
 }
+
+Status StressTest::RollbackTxn(Transaction* txn) {
+  if (!FLAGS_use_txn) {
+    return Status::InvalidArgument("RollbackTxn when FLAGS_use_txn is not"
+                                   " set");
+  }
+  Status s = txn->Rollback();
+  delete txn;
+  return s;
+}
 #endif
 
 void StressTest::OperateDb(ThreadState* thread) {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -51,6 +51,8 @@ class StressTest {
   Status NewTxn(WriteOptions& write_opts, Transaction** txn);
 
   Status CommitTxn(Transaction* txn);
+
+  Status RollbackTxn(Transaction* txn);
 #endif
 
   virtual void MaybeClearOneColumnFamily(ThreadState* /* thread */) {}


### PR DESCRIPTION
Call Transaction::MultiGet from TestMultiGet() in db_stress. We add some Puts/Merges/Deletes into the transaction in order to exercise MultiGetFromBatchAndDB. There is no data verification on read, just check status. There is currently no read data verification in db_stress as it requires synchronization with writes. It needs to be tackled separately.

Test plan:
make crash_test_with_txn