### PR TITLE
Support BlobDB in db_stress

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -65,6 +65,7 @@
 #include "util/mutexlock.h"
 #include "util/random.h"
 #include "util/string_util.h"
+#include "utilities/blob_db/blob_db.h"
 // SyncPoint is not supported in Released Windows Mode.
 #if !(defined NDEBUG) || !defined(OS_WIN)
 #include "test_util/sync_point.h"
@@ -208,6 +209,19 @@ DECLARE_bool(write_dbid_to_manifest);
 DECLARE_uint64(max_write_batch_group_size_bytes);
 DECLARE_bool(level_compaction_dynamic_level_bytes);
 DECLARE_int32(verify_checksum_one_in);
+
+#ifndef ROCKSDB_LITE
+DECLARE_bool(use_blob_db);
+DECLARE_bool(blob_db_is_fifo);
+DECLARE_uint64(blob_db_max_db_size);
+DECLARE_uint64(blob_db_max_ttl_range);
+DECLARE_uint64(blob_db_ttl_range_secs);
+DECLARE_uint64(blob_db_min_blob_size);
+DECLARE_uint64(blob_db_bytes_per_sync);
+DECLARE_uint64(blob_db_file_size);
+DECLARE_bool(blob_db_enable_gc);
+DECLARE_double(blob_db_gc_cutoff);
+#endif  // !ROCKSDB_LITE
 
 const long KB = 1024;
 const int kRandomValueMaxFactor = 3;

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -212,10 +212,6 @@ DECLARE_int32(verify_checksum_one_in);
 
 #ifndef ROCKSDB_LITE
 DECLARE_bool(use_blob_db);
-DECLARE_bool(blob_db_is_fifo);
-DECLARE_uint64(blob_db_max_db_size);
-DECLARE_uint64(blob_db_max_ttl_range);
-DECLARE_uint64(blob_db_ttl_range_secs);
 DECLARE_uint64(blob_db_min_blob_size);
 DECLARE_uint64(blob_db_bytes_per_sync);
 DECLARE_uint64(blob_db_file_size);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -274,21 +274,6 @@ DEFINE_bool(enable_write_thread_adaptive_yield, true,
 // BlobDB Options
 DEFINE_bool(use_blob_db, false, "Use BlobDB.");
 
-DEFINE_bool(blob_db_is_fifo, rocksdb::blob_db::BlobDBOptions().is_fifo,
-            "Enable FIFO eviction in BlobDB.");
-
-DEFINE_uint64(blob_db_max_db_size,
-              rocksdb::blob_db::BlobDBOptions().max_db_size,
-              "Maximum size of the database when using BlobDB.");
-
-DEFINE_uint64(
-    blob_db_max_ttl_range, 0,
-    "TTL range in seconds when generating BlobDB data. 0 means no TTL.");
-
-DEFINE_uint64(blob_db_ttl_range_secs,
-              rocksdb::blob_db::BlobDBOptions().ttl_range_secs,
-              "TTL bucket size to use when creating blob files.");
-
 DEFINE_uint64(blob_db_min_blob_size,
               rocksdb::blob_db::BlobDBOptions().min_blob_size,
               "Smallest blob to store in a file. Blobs smaller than this "

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -270,6 +270,47 @@ DEFINE_bool(allow_concurrent_memtable_write, false,
 DEFINE_bool(enable_write_thread_adaptive_yield, true,
             "Use a yielding spin loop for brief writer thread waits.");
 
+#ifndef ROCKSDB_LITE
+// BlobDB Options
+DEFINE_bool(use_blob_db, false, "Use BlobDB.");
+
+DEFINE_bool(blob_db_is_fifo, rocksdb::blob_db::BlobDBOptions().is_fifo,
+            "Enable FIFO eviction in BlobDB.");
+
+DEFINE_uint64(blob_db_max_db_size,
+              rocksdb::blob_db::BlobDBOptions().max_db_size,
+              "Maximum size of the database when using BlobDB.");
+
+DEFINE_uint64(
+    blob_db_max_ttl_range, 0,
+    "TTL range in seconds when generating BlobDB data. 0 means no TTL.");
+
+DEFINE_uint64(blob_db_ttl_range_secs,
+              rocksdb::blob_db::BlobDBOptions().ttl_range_secs,
+              "TTL bucket size to use when creating blob files.");
+
+DEFINE_uint64(blob_db_min_blob_size,
+              rocksdb::blob_db::BlobDBOptions().min_blob_size,
+              "Smallest blob to store in a file. Blobs smaller than this "
+              "will be inlined with the key in the LSM tree.");
+
+DEFINE_uint64(blob_db_bytes_per_sync,
+              rocksdb::blob_db::BlobDBOptions().bytes_per_sync,
+              "Sync blob files once per every N bytes written.");
+
+DEFINE_uint64(blob_db_file_size,
+              rocksdb::blob_db::BlobDBOptions().blob_file_size,
+              "Target size of each blob file.");
+
+DEFINE_bool(blob_db_enable_gc,
+            rocksdb::blob_db::BlobDBOptions().enable_garbage_collection,
+            "Enable BlobDB garbage collection.");
+
+DEFINE_double(blob_db_gc_cutoff,
+              rocksdb::blob_db::BlobDBOptions().garbage_collection_cutoff,
+              "Cutoff ratio for BlobDB garbage collection.");
+#endif  // !ROCKSDB_LITE
+
 static const bool FLAGS_subcompactions_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_subcompactions, &ValidateUint32Range);
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1425,6 +1425,10 @@ void StressTest::PrintEnv() const {
   fprintf(stdout, "Format version            : %d\n", FLAGS_format_version);
   fprintf(stdout, "TransactionDB             : %s\n",
           FLAGS_use_txn ? "true" : "false");
+#ifndef ROCKSDB_LITE
+  fprintf(stdout, "BlobDB                    : %s\n",
+          FLAGS_use_blob_db ? "true" : "false");
+#endif  // !ROCKSDB_LITE
   fprintf(stdout, "Read only mode            : %s\n",
           FLAGS_read_only ? "true" : "false");
   fprintf(stdout, "Atomic flush              : %s\n",
@@ -1731,12 +1735,34 @@ void StressTest::Open() {
         new DbStressListener(FLAGS_db, options_.db_paths, cf_descriptors));
     options_.create_missing_column_families = true;
     if (!FLAGS_use_txn) {
-      if (db_preload_finished_.load() && FLAGS_read_only) {
-        s = DB::OpenForReadOnly(DBOptions(options_), FLAGS_db, cf_descriptors,
-                                &column_families_, &db_);
-      } else {
-        s = DB::Open(DBOptions(options_), FLAGS_db, cf_descriptors,
-                     &column_families_, &db_);
+#ifndef ROCKSDB_LITE
+      if (FLAGS_use_blob_db) {
+        blob_db::BlobDBOptions blob_db_options;
+        blob_db_options.is_fifo = FLAGS_blob_db_is_fifo;
+        blob_db_options.max_db_size = FLAGS_blob_db_max_db_size;
+        blob_db_options.ttl_range_secs = FLAGS_blob_db_ttl_range_secs;
+        blob_db_options.min_blob_size = FLAGS_blob_db_min_blob_size;
+        blob_db_options.bytes_per_sync = FLAGS_blob_db_bytes_per_sync;
+        blob_db_options.blob_file_size = FLAGS_blob_db_file_size;
+        blob_db_options.enable_garbage_collection = FLAGS_blob_db_enable_gc;
+        blob_db_options.garbage_collection_cutoff = FLAGS_blob_db_gc_cutoff;
+
+        blob_db::BlobDB* blob_db = nullptr;
+        s = blob_db::BlobDB::Open(options_, blob_db_options, FLAGS_db,
+                                  &blob_db);
+        if (s.ok()) {
+          db_ = blob_db;
+        }
+      } else
+#endif  // !ROCKSDB_LITE
+      {
+        if (db_preload_finished_.load() && FLAGS_read_only) {
+          s = DB::OpenForReadOnly(DBOptions(options_), FLAGS_db, cf_descriptors,
+                                  &column_families_, &db_);
+        } else {
+          s = DB::Open(DBOptions(options_), FLAGS_db, cf_descriptors,
+                       &column_families_, &db_);
+        }
       }
     } else {
 #ifndef ROCKSDB_LITE

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1755,7 +1755,7 @@ void StressTest::Open() {
 
         blob_db::BlobDB* blob_db = nullptr;
         s = blob_db::BlobDB::Open(options_, blob_db_options, FLAGS_db,
-                                  &blob_db);
+                                  cf_descriptors, &column_families_, &blob_db);
         if (s.ok()) {
           db_ = blob_db;
         }

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1748,9 +1748,6 @@ void StressTest::Open() {
 #ifndef ROCKSDB_LITE
       if (FLAGS_use_blob_db) {
         blob_db::BlobDBOptions blob_db_options;
-        blob_db_options.is_fifo = FLAGS_blob_db_is_fifo;
-        blob_db_options.max_db_size = FLAGS_blob_db_max_db_size;
-        blob_db_options.ttl_range_secs = FLAGS_blob_db_ttl_range_secs;
         blob_db_options.min_blob_size = FLAGS_blob_db_min_blob_size;
         blob_db_options.bytes_per_sync = FLAGS_blob_db_bytes_per_sync;
         blob_db_options.blob_file_size = FLAGS_blob_db_file_size;

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -42,10 +42,14 @@ StressTest::StressTest()
     // Remove files without preserving manfiest files
     options.env = FLAGS_env->target();
 
+#ifndef ROCKSDB_LITE
     const Status s = !FLAGS_use_blob_db
                          ? DestroyDB(FLAGS_db, options)
                          : blob_db::DestroyBlobDB(FLAGS_db, options,
                                                   blob_db::BlobDBOptions());
+#else
+    const Status s = DestroyDB(FLAGS_db, options);
+#endif  // !ROCKSDB_LITE
 
     if (!s.ok()) {
       fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -37,10 +37,16 @@ StressTest::StressTest()
         FLAGS_env->DeleteFile(FLAGS_db + "/" + files[i]);
       }
     }
+
     Options options;
     // Remove files without preserving manfiest files
     options.env = FLAGS_env->target();
-    Status s = DestroyDB(FLAGS_db, options);
+
+    const Status s = !FLAGS_use_blob_db
+                         ? DestroyDB(FLAGS_db, options)
+                         : blob_db::DestroyBlobDB(FLAGS_db, options,
+                                                  blob_db::BlobDBOptions());
+
     if (!s.ok()) {
       fprintf(stderr, "Cannot destroy original db: %s\n", s.ToString().c_str());
       exit(1);


### PR DESCRIPTION
Summary:
The patch adds support for BlobDB to `db_stress`. Note that BlobDB currently does
not support (amongst other features) Column Families or the `SingleDelete` API,
so for now, those should be disabled on the command line when running `db_stress` in
BlobDB mode (using `-column_families=1` and `-nooverwritepercent=0`,
respectively). Also, some BlobDB features that do not go well with the verification logic
in `db_stress` like TTL and FIFO eviction are not supported currently.

Test Plan:
```
./db_stress -max_key=100000 -use_blob_db -column_families=1 -nooverwritepercent=0 -reopen=1 -blob_db_file_size=1000000 -target_file_size_base=1000000 -blob_db_enable_gc -blob_db_gc_cutoff=0.1 -blob_db_min_blob_size=10 -blob_db_bytes_per_sync=16384
```