### PR TITLE
Improve EnvPosixTestWithParam::DecreaseNumBgThreads waiting

### DIFF
--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -123,6 +123,7 @@ class EnvPosixTestWithParam
       }
       Env::Default()->SleepForMicroseconds(kCheckInterval);
     }
+    ASSERT_EQ(len, env_->GetThreadPoolQueueLen(pri));
   }
 
   ~EnvPosixTestWithParam() override { WaitThreadPoolsEmpty(); }


### PR DESCRIPTION
Summary: Test EnvPosixTestWithParam::DecreaseNumBgThreads sometimes fail. One theory is that the sleep is not long enough. In this commit, we make the sleep limit longer but check periodically to exit earlier.

Test Plan: Run the test and see it fail. Watch CI