### PR TITLE
db_stress should not keep manifest files under checkpoint directory

### DIFF
--- a/db_stress_tool/db_stress_env_wrapper.h
+++ b/db_stress_tool/db_stress_env_wrapper.h
@@ -20,8 +20,10 @@ class DbStressEnvWrapper : public EnvWrapper {
     // We determine whether it is a manifest file by searching a strong,
     // so that there will be false positive if the directory path contains the
     // keyword but it is unlikely.
+    // Checkpoint directory needs to be exempted.
     if (!if_preserve_all_manifests ||
-        f.find("MANIFEST-") == std::string::npos) {
+        f.find("MANIFEST-") == std::string::npos ||
+        f.find("checkpoint") != std::string::npos) {
       return target()->DeleteFile(f);
     }
     return Status::OK();


### PR DESCRIPTION
Summary:
Recently db_stress starts to use a special Env that keeps all manifest files. This should not apply to checkpoint directory and causes test failure like this:

Verification failed: Checkpoint gave inconsistent state. Status is IO error: While mkdir: /dev/shm/rocksdb/rocksdb_crashtest_whitebox/.checkpoint27.tmp: File exists

Test Plan: Run crash_test with high chance of checkpoint and make sure it doesn't reproduce.