### PR TITLE
Fix some shadow warning

### DIFF
--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -627,8 +627,9 @@ class CompositeEnvWrapper : public Env {
 
 class LegacySequentialFileWrapper : public FSSequentialFile {
  public:
-  explicit LegacySequentialFileWrapper(std::unique_ptr<SequentialFile>&& target)
-      : target_(std::move(target)) {}
+  explicit LegacySequentialFileWrapper(
+      std::unique_ptr<SequentialFile>&& _target)
+      : target_(std::move(_target)) {}
 
   IOStatus Read(size_t n, const IOOptions& /*options*/, Slice* result,
                 char* scratch, IODebugContext* /*dbg*/) override {
@@ -716,8 +717,8 @@ class LegacyRandomAccessFileWrapper : public FSRandomAccessFile {
 
 class LegacyWritableFileWrapper : public FSWritableFile {
  public:
-  explicit LegacyWritableFileWrapper(std::unique_ptr<WritableFile>&& target)
-      : target_(std::move(target)) {}
+  explicit LegacyWritableFileWrapper(std::unique_ptr<WritableFile>&& _target)
+      : target_(std::move(_target)) {}
 
   IOStatus Append(const Slice& data, const IOOptions& /*options*/,
                   IODebugContext* /*dbg*/) override {

--- a/utilities/blob_db/blob_compaction_filter.h
+++ b/utilities/blob_db/blob_compaction_filter.h
@@ -116,9 +116,9 @@ class BlobIndexCompactionFilterGC : public BlobIndexCompactionFilterBase {
 // that creates non-GC filters.
 class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
  public:
-  BlobIndexCompactionFilterFactoryBase(BlobDBImpl* blob_db_impl, Env* env,
-                                       Statistics* statistics)
-      : blob_db_impl_(blob_db_impl), env_(env), statistics_(statistics) {}
+  BlobIndexCompactionFilterFactoryBase(BlobDBImpl* _blob_db_impl, Env* _env,
+                                       Statistics* _statistics)
+      : blob_db_impl_(_blob_db_impl), env_(_env), statistics_(_statistics) {}
 
  protected:
   BlobDBImpl* blob_db_impl() const { return blob_db_impl_; }
@@ -134,9 +134,10 @@ class BlobIndexCompactionFilterFactoryBase : public CompactionFilterFactory {
 class BlobIndexCompactionFilterFactory
     : public BlobIndexCompactionFilterFactoryBase {
  public:
-  BlobIndexCompactionFilterFactory(BlobDBImpl* blob_db_impl, Env* env,
-                                   Statistics* statistics)
-      : BlobIndexCompactionFilterFactoryBase(blob_db_impl, env, statistics) {}
+  BlobIndexCompactionFilterFactory(BlobDBImpl* _blob_db_impl, Env* _env,
+                                   Statistics* _statistics)
+      : BlobIndexCompactionFilterFactoryBase(_blob_db_impl, _env, _statistics) {
+  }
 
   const char* Name() const override {
     return "BlobIndexCompactionFilterFactory";
@@ -149,9 +150,10 @@ class BlobIndexCompactionFilterFactory
 class BlobIndexCompactionFilterFactoryGC
     : public BlobIndexCompactionFilterFactoryBase {
  public:
-  BlobIndexCompactionFilterFactoryGC(BlobDBImpl* blob_db_impl, Env* env,
-                                     Statistics* statistics)
-      : BlobIndexCompactionFilterFactoryBase(blob_db_impl, env, statistics) {}
+  BlobIndexCompactionFilterFactoryGC(BlobDBImpl* _blob_db_impl, Env* _env,
+                                     Statistics* _statistics)
+      : BlobIndexCompactionFilterFactoryBase(_blob_db_impl, _env, _statistics) {
+  }
 
   const char* Name() const override {
     return "BlobIndexCompactionFilterFactoryGC";


### PR DESCRIPTION
Summary: Some shadow warning shows up when using gcc 4.8. An example:

./utilities/blob_db/blob_compaction_filter.h: In constructor ‘rocksdb::blob_db::BlobIndexCompactionFilterFactoryBase::BlobIndexCompactionFilterFactoryBase(rocksdb::blob_db::lobDBImpl*, rocksdb::Env*, rocksdb::Statistics*)’:
./utilities/blob_db/blob_compaction_filter.h:121:7: error: declaration of ‘blob_db_impl’ shadows a member of 'this' [-Werror=shadow]
       : blob_db_impl_(blob_db_impl), env_(_env), statistics_(_statistics) {}
       ^

Fix them.

Test Plan: Build and see the warnings go away.