### PR TITLE
Fix a clang analyzer report, and 'analyze' make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1097,6 +1097,9 @@ parallel_check: $(TESTS)
 		TMPD=$(TMPD) J=$(J) db_test=0 parloop;
 
 analyze: clean
+	USE_CLANG=1 $(MAKE) analyze_incremental
+
+analyze_incremental:
 	$(CLANG_SCAN_BUILD) --use-analyzer=$(CLANG_ANALYZER) \
 		--use-c++=$(CXX) --use-cc=$(CC) --status-bugs \
 		-o $(CURDIR)/scan_build_report \

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -165,12 +165,15 @@ class NonBatchedOpsStressTest : public StressTest {
     std::vector<Status> statuses(num_keys);
     ColumnFamilyHandle* cfh = column_families_[rand_column_families[0]];
 
+    // To appease clang analyzer
+    const bool use_txn = FLAGS_use_txn;
+
     // Create a transaction in order to write some data. The purpose is to
     // exercise WriteBatchWithIndex::MultiGetFromBatchAndDB. The transaction
     // will be rolled back once MultiGet returns.
 #ifndef ROCKSDB_LITE
     Transaction* txn = nullptr;
-    if (FLAGS_use_txn) {
+    if (use_txn) {
       WriteOptions wo;
       NewTxn(wo, &txn);
     }
@@ -179,7 +182,7 @@ class NonBatchedOpsStressTest : public StressTest {
       key_str.emplace_back(Key(rand_keys[i]));
       keys.emplace_back(key_str.back());
 #ifndef ROCKSDB_LITE
-      if (FLAGS_use_txn) {
+      if (use_txn) {
         // With a 1 in 10 probability, insert the just added key in the batch
         // into the transaction. This will create an overlap with the MultiGet
         // keys and exercise some corner cases in the code
@@ -216,7 +219,7 @@ class NonBatchedOpsStressTest : public StressTest {
 #endif
     }
 
-    if (!FLAGS_use_txn) {
+    if (!use_txn) {
       db_->MultiGet(read_opts, cfh, num_keys, keys.data(), values.data(),
                     statuses.data());
     } else {

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -175,7 +175,11 @@ class NonBatchedOpsStressTest : public StressTest {
     Transaction* txn = nullptr;
     if (use_txn) {
       WriteOptions wo;
-      NewTxn(wo, &txn);
+      Status s = NewTxn(wo, &txn);
+      if (!s.ok()) {
+        fprintf(stderr, "NewTxn: %s\n", s.ToString().c_str());
+        std::terminate();
+      }
     }
 #endif
     for (size_t i = 0; i < num_keys; ++i) {


### PR DESCRIPTION
Summary: Clang analyzer was falsely reporting on use of txn=nullptr.
Added a new const variable so that it can properly prune impossible
control flows.

Also, 'make analyze' previously required setting USE_CLANG=1 as an
environment variable, not a make variable, or else compilation errors
like

g++: error: unrecognized command line option ‘-Wshorten-64-to-32’

Now USE_CLANG is not required for 'make analyze' (it's implied) and you
can do an incremental analysis (recompile what has changed) with
'USE_CLANG=1 make analyze_incremental'

Test Plan: 'make -j24 analyze', 'make crash_test'