### PR TITLE
Re-enable level_compaction_dynamic_level_bytes in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -102,9 +102,7 @@ default_params = {
     "write_dbid_to_manifest" : random.randint(0, 1),
     "max_write_batch_group_size_bytes" : lambda: random.choice(
         [16, 64, 1024 * 1024, 16 * 1024 * 1024]),
-    # Temporarily disabled because of assertion violations in
-    # BlockBasedTable::ApproximateSize
-    # "level_compaction_dynamic_level_bytes" : True,
+    "level_compaction_dynamic_level_bytes" : True,
     "verify_checksum_one_in": 1000000,
     "verify_db_one_in": 100000,
     "continuous_verification_interval" : 0


### PR DESCRIPTION
Summary: Was probably a false signal suggesting a problem in #6217 

Test Plan: 'make crash_test'