### PR TITLE
Exclude MergeInProgress from errors in stress tests

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -242,6 +242,9 @@ class NonBatchedOpsStressTest : public StressTest {
       } else if (s.IsNotFound()) {
         // not found case
         thread->stats.AddGets(1, 0);
+      } else if (s.IsMergeInProgress() && use_txn) {
+        // With txn this is sometimes expected.
+        thread->stats.AddGets(1, 1);
       } else {
         // errors case
         fprintf(stderr, "MultiGet error: %s\n", s.ToString().c_str());


### PR DESCRIPTION
When called on transactions, MultiGet could return a legit MergeInProgress status. The patch excludes this case from errors.