### PR TITLE
Add range delete function to C-API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -852,6 +852,17 @@ void rocksdb_delete_cf(
         Slice(key, keylen)));
 }
 
+void rocksdb_delete_range_cf(
+    rocksdb_t* db,
+    const rocksdb_writeoptions_t* options,
+    rocksdb_column_family_handle_t* column_family,
+    const char* start_key, size_t start_key_len,
+    const char* end_key, size_t end_key_len,
+    char** errptr) {
+  SaveError(errptr, db->rep->DeleteRange(options->rep, column_family->rep,
+        Slice(start_key, start_key_len), Slice(end_key, end_key_len)));
+}
+
 void rocksdb_merge(
     rocksdb_t* db,
     const rocksdb_writeoptions_t* options,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1244,6 +1244,15 @@ int main(int argc, char** argv) {
     rocksdb_put_cf(db, woptions, handles[1], "foo", 3, "hello", 5, &err);
     CheckNoError(err);
 
+    rocksdb_put_cf(db, woptions, handles[1], "foobar1", 7, "hello1", 6, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, handles[1], "foobar2", 7, "hello2", 6, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, handles[1], "foobar3", 7, "hello3", 6, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, woptions, handles[1], "foobar4", 7, "hello4", 6, &err);
+    CheckNoError(err);
+
     rocksdb_flushoptions_t *flush_options = rocksdb_flushoptions_create();
     rocksdb_flushoptions_set_wait(flush_options, 1);
     rocksdb_flush_cf(db, flush_options, handles[1], &err);
@@ -1254,6 +1263,9 @@ int main(int argc, char** argv) {
     CheckPinGetCF(db, roptions, handles[1], "foo", "hello");
 
     rocksdb_delete_cf(db, woptions, handles[1], "foo", 3, &err);
+    CheckNoError(err);
+
+    rocksdb_delete_range_cf(db, woptions, handles[1], "foobar2", 7, "foobar4", 7, &err);
     CheckNoError(err);
 
     CheckGetCF(db, roptions, handles[1], "foo", NULL);
@@ -1308,7 +1320,7 @@ int main(int argc, char** argv) {
     for (i = 0; rocksdb_iter_valid(iter) != 0; rocksdb_iter_next(iter)) {
       i++;
     }
-    CheckCondition(i == 1);
+    CheckCondition(i == 3);
     rocksdb_iter_get_error(iter, &err);
     CheckNoError(err);
     rocksdb_iter_destroy(iter);
@@ -1332,7 +1344,7 @@ int main(int argc, char** argv) {
     for (i = 0; rocksdb_iter_valid(iter) != 0; rocksdb_iter_next(iter)) {
       i++;
     }
-    CheckCondition(i == 1);
+    CheckCondition(i == 3);
     rocksdb_iter_get_error(iter, &err);
     CheckNoError(err);
     rocksdb_iter_destroy(iter);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -267,6 +267,13 @@ extern ROCKSDB_LIBRARY_API void rocksdb_delete_cf(
     rocksdb_column_family_handle_t* column_family, const char* key,
     size_t keylen, char** errptr);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_delete_range_cf(
+    rocksdb_t* db, const rocksdb_writeoptions_t* options,
+    rocksdb_column_family_handle_t* column_family,
+    const char* start_key, size_t start_key_len,
+    const char* end_key, size_t end_key_len,
+    char** errptr);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_merge(
     rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key,
     size_t keylen, const char* val, size_t vallen, char** errptr);


### PR DESCRIPTION
It seems that the C-API doesn't expose the range delete functionality at the moment, so add the API.