### PR TITLE
Improve error msg for SstFileWriter Merge

### DIFF
--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -70,7 +70,8 @@ struct SstFileWriter::Rep {
       if (internal_comparator.user_comparator()->Compare(
               user_key, file_info.largest_key) <= 0) {
         // Make sure that keys are added in order
-        return Status::InvalidArgument("Keys must be added in order");
+        return Status::InvalidArgument(
+            "Keys must be added in strict ascending order.");
       }
     }
 


### PR DESCRIPTION
Reword the error message when keys are not added in strict ascending order.
Specifically, original error message is not clear when application tries to
call SstFileWriter::Merge() with duplicate keys.

Test plan (dev server)
```
make check
```