### PR TITLE
Print out non-ok DB::Open status in db_stress

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1947,6 +1947,11 @@ void StressTest::Open() {
       }
       s = TransactionDB::Open(options_, txn_db_options, FLAGS_db,
                               cf_descriptors, &column_families_, &txn_db_);
+      if (!s.ok()) {
+        fprintf(stdout, "Error in opening the TransactionDB [%s]\n",
+                s.ToString().c_str());
+        fflush(stderr);
+      }
       assert(s.ok());
       db_ = txn_db_;
       // after a crash, rollback to commit recovered transactions

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -1948,7 +1948,7 @@ void StressTest::Open() {
       s = TransactionDB::Open(options_, txn_db_options, FLAGS_db,
                               cf_descriptors, &column_families_, &txn_db_);
       if (!s.ok()) {
-        fprintf(stdout, "Error in opening the TransactionDB [%s]\n",
+        fprintf(stderr, "Error in opening the TransactionDB [%s]\n",
                 s.ToString().c_str());
         fflush(stderr);
       }


### PR DESCRIPTION
The crash test is failing with non-ok status after TransactionDB::Open. This patch adds more debugging information.