### PR TITLE
Consider all compaction input files to compute the oldest ancestor time

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * A new `OptimisticTransactionDBOptions` Option that allows users to configure occ validation policy. The default policy changes from kValidateSerial to kValidateParallel to reduce mutex contention.
 
 ### Bug Fixes
+* Fixed a bug where non-L0 compaction input files were not considered to compute the `creation_time` of new compaction outputs.
 * Fix a bug that can cause unnecessary bg thread to be scheduled(#6104).
 * Fix a bug in which a snapshot read could be affected by a DeleteRange after the snapshot (#6062).
 * Fix crash caused by concurrent CF iterations and drops(#6147).

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -545,11 +545,13 @@ bool Compaction::ShouldFormSubcompactions() const {
 
 uint64_t Compaction::MinInputFileOldestAncesterTime() const {
   uint64_t min_oldest_ancester_time = port::kMaxUint64;
-  for (const auto& file : inputs_[0].files) {
-    uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();
-    if (oldest_ancester_time != 0) {
-      min_oldest_ancester_time =
-          std::min(min_oldest_ancester_time, oldest_ancester_time);
+  for (const auto& level_files : inputs_) {
+    for (const auto& file : level_files.files) {
+      uint64_t oldest_ancester_time = file->TryGetOldestAncesterTime();
+      if (oldest_ancester_time != 0) {
+        min_oldest_ancester_time =
+            std::min(min_oldest_ancester_time, oldest_ancester_time);
+      }
     }
   }
   return min_oldest_ancester_time;


### PR DESCRIPTION
Look at all compaction input files to compute the oldest ancestor time. 

In #5992 we changed how creation_time (aka oldest-ancestor-time) table property of compaction output files is computed from max(creation-time-of-all-compaction-inputs) to min(creation-time-of-all-inputs). This exposed a bug where, during compaction, the creation_time:s of only the L0 compaction inputs were being looked at, and all other input levels were being ignored. This PR fixes the issue. 
Some TTL compactions when using Level-Style compactions might not have run due to this bug. 

Test plan:
Enhanced the unit tests to validate that the correct time is propagated to the compaction outputs.