### PR TITLE
Separate enable-WAL and disable-WAL writer to avoid unwanted data in log files

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -945,9 +945,6 @@ WriteBatch* DBImpl::MergeBatch(const WriteThread::WriteGroup& write_group,
     // interface
     merged_batch = tmp_batch;
     for (auto writer : write_group) {
-      if(writer->disable_wal) {
-          continue;
-      }
       if (!writer->CallbackFailed()) {
         WriteBatchInternal::Append(merged_batch, writer->batch,
                                    /*WAL_only*/ true);
@@ -1012,9 +1009,6 @@ Status DBImpl::WriteToWAL(const WriteThread::WriteGroup& write_group,
     write_group.leader->log_used = logfile_number_;
   } else if (write_with_wal > 1) {
     for (auto writer : write_group) {
-      if(writer->disable_wal) {
-          continue;
-      }
       writer->log_used = logfile_number_;
     }
   }
@@ -1089,9 +1083,6 @@ Status DBImpl::ConcurrentWriteToWAL(const WriteThread::WriteGroup& write_group,
     write_group.leader->log_used = logfile_number_;
   } else if (write_with_wal > 1) {
     for (auto writer : write_group) {
-      if(writer->disable_wal) {
-          continue;
-      }
       writer->log_used = logfile_number_;
     }
   }

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -945,6 +945,9 @@ WriteBatch* DBImpl::MergeBatch(const WriteThread::WriteGroup& write_group,
     // interface
     merged_batch = tmp_batch;
     for (auto writer : write_group) {
+      if(writer->disable_wal) {
+          continue;
+      }
       if (!writer->CallbackFailed()) {
         WriteBatchInternal::Append(merged_batch, writer->batch,
                                    /*WAL_only*/ true);
@@ -1009,6 +1012,9 @@ Status DBImpl::WriteToWAL(const WriteThread::WriteGroup& write_group,
     write_group.leader->log_used = logfile_number_;
   } else if (write_with_wal > 1) {
     for (auto writer : write_group) {
+      if(writer->disable_wal) {
+          continue;
+      }
       writer->log_used = logfile_number_;
     }
   }
@@ -1083,6 +1089,9 @@ Status DBImpl::ConcurrentWriteToWAL(const WriteThread::WriteGroup& write_group,
     write_group.leader->log_used = logfile_number_;
   } else if (write_with_wal > 1) {
     for (auto writer : write_group) {
+      if(writer->disable_wal) {
+          continue;
+      }
       writer->log_used = logfile_number_;
     }
   }

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -216,7 +216,7 @@ TEST_P(DBWriteTest, ConcurrentlyDisabledWAL) {
     for (auto& t: threads) {
         t.join();
     }
-    uint32_t bytes_num = options.statistics->getTickerCount(rocksdb::Tickers::WAL_FILE_BYTES);
+    uint64_t bytes_num = options.statistics->getTickerCount(rocksdb::Tickers::WAL_FILE_BYTES);
     // written WAL size should less than 100KB (even included HEADER & FOOTER overhead)
     ASSERT_LE(bytes_num, 1024 * 100);
 }

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -444,8 +444,8 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
       break;
     }
 
-    if (!w->disable_wal && leader->disable_wal) {
-      // Do not include a write that needs WAL into a batch that has
+    if (w->disable_wal != leader->disable_wal) {
+      // Do not mix writes that enable WAL with the ones whose
       // WAL disabled.
       break;
     }


### PR DESCRIPTION
When we do concurrently writes, and different write operations will have WAL enable or disable.
But the data from write operation with WAL disabled will still be logged into log files, which will lead to extra disk write/sync since we do not want any guarantee for these part of data.

Detail can be found in https://github.com/facebook/rocksdb/issues/6280. This PR avoid mixing the two types in a write group. The advantage is simpler reasoning about the write group content
