### PR TITLE
Fix kHashSearch bug with SeekForPrev

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -415,6 +415,49 @@ void IndexBlockIter::Seek(const Slice& target) {
   }
 }
 
+// This is a copy of IndexBlockIter::Seek except that for non-existing prefixes,
+// it returns the first key instead of invalid status.
+void IndexBlockIter::SeekForPrev(const Slice& target) {
+  TEST_SYNC_POINT("IndexBlockIter::Seek:0");
+  Slice seek_key = target;
+  if (!key_includes_seq_) {
+    seek_key = ExtractUserKey(target);
+  }
+  PERF_TIMER_GUARD(block_seek_nanos);
+  if (data_ == nullptr) {  // Not init yet
+    return;
+  }
+  uint32_t index = 0;
+  bool ok = false;
+  if (prefix_index_) {
+    ok = PrefixSeek(target, &index);
+    if (!ok && !Valid()) {
+      // If the prefix does not exist, we can return any key as long as it is
+      // smaller than the target. For simplicity we return the first.
+      SeekToFirst();
+      ok = true;
+    }
+  } else if (value_delta_encoded_) {
+    ok = BinarySeek<DecodeKeyV4>(seek_key, 0, num_restarts_ - 1, &index,
+                                 comparator_);
+  } else {
+    ok = BinarySeek<DecodeKey>(seek_key, 0, num_restarts_ - 1, &index,
+                               comparator_);
+  }
+
+  if (!ok) {
+    return;
+  }
+  SeekToRestartPoint(index);
+  // Linear search (within restart block) for first key >= target
+
+  while (true) {
+    if (!ParseNextIndexKey() || Compare(key_, seek_key) >= 0) {
+      return;
+    }
+  }
+}
+
 void DataBlockIter::SeekForPrev(const Slice& target) {
   PERF_TIMER_GUARD(block_seek_nanos);
   Slice seek_key = target;

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -539,18 +539,14 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
     }
   }
 
+  // It could return invalid if prefix is enabled and yet the prefix of target
+  // does not exist.
   virtual void Seek(const Slice& target) override;
 
-  virtual void SeekForPrev(const Slice&) override {
-    assert(false);
-    current_ = restarts_;
-    restart_index_ = num_restarts_;
-    status_ = Status::InvalidArgument(
-        "RocksDB internal error: should never call SeekForPrev() on index "
-        "blocks");
-    key_.Clear();
-    value_.clear();
-  }
+  // Same as ::Seek execept that it returns the first key if prefix is enabled
+  // and yet the prefix of the target does not exist. This is useful in
+  // implementation of BlockBasedTableIterator::SeekForPrev.
+  virtual void SeekForPrev(const Slice&) override;
 
   virtual void Prev() override;
 

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -539,14 +539,18 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
     }
   }
 
-  // It could return invalid if prefix is enabled and yet the prefix of target
-  // does not exist.
   virtual void Seek(const Slice& target) override;
 
-  // Same as ::Seek execept that it returns the first key if prefix is enabled
-  // and yet the prefix of the target does not exist. This is useful in
-  // implementation of BlockBasedTableIterator::SeekForPrev.
-  virtual void SeekForPrev(const Slice&) override;
+  virtual void SeekForPrev(const Slice&) override {
+    assert(false);
+    current_ = restarts_;
+    restart_index_ = num_restarts_;
+    status_ = Status::InvalidArgument(
+        "RocksDB internal error: should never call SeekForPrev() on index "
+        "blocks");
+    key_.Clear();
+    value_.clear();
+  }
 
   virtual void Prev() override;
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2885,7 +2885,7 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
 
   SavePrevIndexValue();
 
-  // Call Seek() rather than SeekForPrev() in the index block, because the
+  // Without prefix, SeekForPrev does the same as Seek in the index block since
   // target data block will likely to contain the position for `target`, the
   // same as Seek(), rather than than before.
   // For example, if we have three data blocks, each containing two keys:
@@ -2898,7 +2898,9 @@ void BlockBasedTableIterator<TBlockIter, TValue>::SeekForPrev(
   // first block, rather than the second. However, we don't have the information
   // to distinguish the two unless we read the second block. In this case, we'll
   // end up with reading two blocks.
-  index_iter_->Seek(target);
+  // With prefix, SeekForPrev() returns the first block instead of invalid
+  // status when the prefix does not exist.
+  index_iter_->SeekForPrev(target);
 
   if (!index_iter_->Valid()) {
     if (!index_iter_->status().ok()) {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -686,7 +686,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<TValue> {
     return block_iter_.value();
   }
   Status status() const override {
-    if (!index_iter_->status().ok()) {
+    // Prefix index set status to NotFound when the prefix does not exist
+    if (!index_iter_->status().ok() && !index_iter_->status().IsNotFound()) {
       return index_iter_->status();
     } else if (block_iter_points_to_real_block_) {
       return block_iter_.status();

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1822,6 +1822,9 @@ void TableTest::IndexTest(BlockBasedTableOptions table_options) {
   std::vector<std::string> prefixes = {"001", "003", "005", "007", "009"};
   std::vector<std::string> lower_bound = {keys[0], keys[1], keys[2],
                                           keys[7], keys[9], };
+  std::vector<std::string> prev_lower_bound = {keys[0], keys[1], keys[6],
+                                          keys[8], keys[9], };
+
 
   // find the lower bound of the prefix
   for (size_t i = 0; i < prefixes.size(); ++i) {
@@ -1855,8 +1858,8 @@ void TableTest::IndexTest(BlockBasedTableOptions table_options) {
   for (size_t i = 0; i < prefixes.size(); ++i) {
     // the key is greater than any existing keys.
     auto key = prefixes[i] + "9";
-    index_iter->Seek(InternalKey(key, 0, kTypeValue).Encode());
 
+    index_iter->Seek(InternalKey(key, 0, kTypeValue).Encode());
     ASSERT_TRUE(index_iter->status().ok() || index_iter->status().IsNotFound());
     ASSERT_TRUE(!index_iter->status().IsNotFound() || !index_iter->Valid());
     if (i == prefixes.size() - 1) {
@@ -1866,6 +1869,16 @@ void TableTest::IndexTest(BlockBasedTableOptions table_options) {
       ASSERT_TRUE(index_iter->Valid());
       // seek the first element in the block
       ASSERT_EQ(upper_bound[i], index_iter->key().ToString());
+      ASSERT_EQ("v", index_iter->value().ToString());
+    }
+
+    index_iter->SeekForPrev(InternalKey(key, 0, kTypeValue).Encode());
+    ASSERT_TRUE(index_iter->status().ok() || index_iter->status().IsNotFound());
+    ASSERT_TRUE(!index_iter->status().IsNotFound() || !index_iter->Valid());
+    {
+      ASSERT_TRUE(index_iter->Valid());
+      // seek the first element in the block
+      ASSERT_EQ( prev_lower_bound[i], index_iter->key().ToString());
       ASSERT_EQ("v", index_iter->value().ToString());
     }
   }


### PR DESCRIPTION
When prefix is enabled the expected behavior when the prefix of the target does not exist is for Seek is to seek to any key larger than target and SeekToPrev to any key less than the target.
Currently. the prefix index (kHashSearch) returns OK status but sets Invalid() to indicate two cases: a prefix of the searched key does not exist, ii) the key is beyond the range of the keys in SST file. The SeekForPrev implementation in BlockBasedTable thus does not have enough information to know when it should set the index key to first (to return a key smaller than target). The patch fixes that by returning NotFound status for cases that the prefix does not exist. SeekForPrev in BlockBasedTable accordingly SeekToFirst instead of SeekToLast on the index iterator.
Test: SeekForPrev of non-exsiting prefix is added to block_test.cc