### PR TITLE
rocksdb_transaction_get_for_update now exports

### DIFF
--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1561,7 +1561,7 @@ extern ROCKSDB_LIBRARY_API char* rocksdb_transaction_get_for_update(
     const char* key, size_t klen, size_t* vlen, unsigned char exclusive,
     char** errptr);
 
-char* rocksdb_transaction_get_for_update_cf(
+extern ROCKSDB_LIBRARY_API char* rocksdb_transaction_get_for_update_cf(
     rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options,
     rocksdb_column_family_handle_t* column_family, const char* key, size_t klen,
     size_t* vlen, unsigned char exclusive, char** errptr);


### PR DESCRIPTION
Added missing ROCKSDB_LIBRARY_API decorator to rocksdb_transaction_get_for_update.