### PR TITLE
Fix LITE test build broken by recent commit

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4294,7 +4294,9 @@ TEST_F(DBTest2, SameSmallestInSameLevel) {
   ASSERT_OK(db_->Merge(WriteOptions(), "key", "8"));
   Flush();
   dbfull()->TEST_WaitForCompact(true);
+#ifndef ROCKSDB_LITE
   ASSERT_EQ("0,4,1", FilesPerLevel());
+#endif  // ROCKSDB_LITE
 
   ASSERT_EQ("2,3,4,5,6,7,8", Get("key"));
 }


### PR DESCRIPTION
Summary:
A recent commit adds a unit test that uses a function not available in LITE build. Fix it by avoiding the call

Test Plan: Run the test in LITE build and see it passes.