### PR TITLE
Access Maven Central over HTTPS

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -318,7 +318,7 @@ if (DEFINED CUSTOM_REPO_URL)
   set(CENTRAL_REPO_URL ${CUSTOM_REPO_URL}/)
 else ()
   set(SEARCH_REPO_URL "http://search.maven.org/remotecontent?filepath=")
-  set(CENTRAL_REPO_URL "http://central.maven.org/maven2/")
+  set(CENTRAL_REPO_URL "https://repo1.maven.org/maven2/")
 endif()
 
 if(NOT EXISTS ${JAVA_JUNIT_JAR})

--- a/java/Makefile
+++ b/java/Makefile
@@ -214,7 +214,7 @@ ifneq ($(DEBUG_LEVEL),0)
 endif
 
 SEARCH_REPO_URL?=http://search.maven.org/remotecontent?filepath=
-CENTRAL_REPO_URL?=http://central.maven.org/maven2/
+CENTRAL_REPO_URL?=https://repo1.maven.org/maven2/
 
 clean:
 	$(AM_V_at)rm -rf include/*


### PR DESCRIPTION
Summary:
As of 1/15/2020, Maven Central does not support plain HTTP. Because of
this, our Travis and AppVeyor builds have started failing during the
assertj download step. This patch will hopefully fix these issues.

See https://blog.sonatype.com/central-repository-moving-to-https
for more info.

Test Plan:
Will monitor the builds. ("I don't always test my changes but when I do,
I do it in production.")