### PR TITLE
Fix a bug caused by recent fix of Prefix Hash

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4355,6 +4355,10 @@ TEST_F(DBTest2, BlockBasedTablePrefixIndexSeekForPrev) {
     if (iterator->Valid()) {
       ASSERT_EQ("a1", iterator->key().ToString());
     }
+
+    iterator->SeekForPrev("y3");
+    ASSERT_TRUE(iterator->Valid());
+    ASSERT_EQ("y1", iterator->key().ToString());
   }
 }
 

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -390,6 +390,7 @@ void IndexBlockIter::Seek(const Slice& target) {
   if (data_ == nullptr) {  // Not init yet
     return;
   }
+  status_ = Status::OK();
   uint32_t index = 0;
   bool ok = false;
   if (prefix_index_) {
@@ -470,6 +471,7 @@ void IndexBlockIter::SeekToFirst() {
   if (data_ == nullptr) {  // Not init yet
     return;
   }
+  status_ = Status::OK();
   SeekToRestartPoint(0);
   ParseNextIndexKey();
 }
@@ -488,6 +490,7 @@ void IndexBlockIter::SeekToLast() {
   if (data_ == nullptr) {  // Not init yet
     return;
   }
+  status_ = Status::OK();
   SeekToRestartPoint(num_restarts_ - 1);
   while (ParseNextIndexKey() && NextEntryOffset() < restarts_) {
     // Keep skipping


### PR DESCRIPTION
Summary: Recent fix to Prefix Hash https://github.com/facebook/rocksdb/pull/6292 caused a bug that the newly created NotFound status in hash index is never reset. This causes reseek or implict reseek to return wrong results sometimes.

Test Plan: Add a unit test that would fail. Not fix.
crash test with hash test would fail in several seconds. With the fix, it will run about several minutes before failing with another failure.