### PR TITLE
Fix bug which causes crash_test to always run on sync mode

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -92,7 +92,7 @@ default_params = {
         [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1, 30)]),
     # Sync mode might make test runs slower so running it in a smaller chance
     "sync" : lambda : random.choice(
-        [0 if t == 0 else 1 for t in range(1, 20)]),
+        [1 if t == 0 else 0 for t in range(0, 19)]),
     # Disable compation_readahead_size because the test is not passing.
     #"compaction_readahead_size" : lambda : random.choice(
     #    [0, 0, 1024 * 1024]),

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -92,7 +92,7 @@ default_params = {
         [t * 16384 if t < 3 else 1024 * 1024 * 1024 for t in range(1, 30)]),
     # Sync mode might make test runs slower so running it in a smaller chance
     "sync" : lambda : random.choice(
-        [1 if t == 0 else 0 for t in range(0, 19)]),
+        [1 if t == 0 else 0 for t in range(0, 20)]),
     # Disable compation_readahead_size because the test is not passing.
     #"compaction_readahead_size" : lambda : random.choice(
     #    [0, 0, 1024 * 1024]),


### PR DESCRIPTION
Summary:
A previous change meant to make db_stress to run on sync=1 mode for 1/20 of the time in crash_test, but a bug caused to to always run on sync=1 mode. Fix it.

Test Plan: Start and kill "python -u tools/db_crashtest.py --simple whitebox" multiple times and observe that most times sync=0 is used while some times sync=1 is used.