### PR TITLE
Fix another bug caused by recent hash index fix

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3304,6 +3304,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   assert(get_context != nullptr);
   Status s;
   const bool no_io = read_options.read_tier == kBlockCacheTier;
+
   FilterBlockReader* const filter =
       !skip_filters ? rep_->filter.get() : nullptr;
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3304,7 +3304,6 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
   assert(get_context != nullptr);
   Status s;
   const bool no_io = read_options.read_tier == kBlockCacheTier;
-
   FilterBlockReader* const filter =
       !skip_filters ? rep_->filter.get() : nullptr;
 
@@ -3467,7 +3466,7 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
       PERF_COUNTER_BY_LEVEL_ADD(bloom_filter_full_true_positive, 1,
                                 rep_->level);
     }
-    if (s.ok()) {
+    if (s.ok() && !iiter->status().IsNotFound()) {
       s = iiter->status();
     }
   }


### PR DESCRIPTION
Summary: Recent bug fix related to hash index introduced a new bug: hash index can return NotFound but it is not handled by BlockBasedTable::Get(). The end result is that Get() stops being executed too early. Fix it by ignoring NotFound code in Get().

Test Plan: 1. add a unit test case which would fail before the fix. 2. A problematic DB used to return NotFound incorrectly, and now able to return correct result.