### PR TITLE
Expose atomic flush option in C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2736,6 +2736,12 @@ void rocksdb_options_set_ratelimiter(rocksdb_options_t *opt, rocksdb_ratelimiter
   }
 }
 
+void rocksdb_options_set_atomic_flush(
+  rocksdb_options_t *opt,
+  unsigned char atomic_flush) {
+    opt->rep.atomic_flush = atomic_flush;
+}
+
 rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(
     int64_t rate_bytes_per_sec,
     int64_t refill_period_us,

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -737,6 +737,8 @@ rocksdb_block_based_options_set_pin_top_level_index_and_filter(
     rocksdb_block_based_table_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_block_based_table_factory(
     rocksdb_options_t* opt, rocksdb_block_based_table_options_t* table_options);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_atomic_flush(
+    rocksdb_options_t* opt, unsigned char);
 
 /* Cuckoo table options */
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -737,8 +737,6 @@ rocksdb_block_based_options_set_pin_top_level_index_and_filter(
     rocksdb_block_based_table_options_t*, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_block_based_table_factory(
     rocksdb_options_t* opt, rocksdb_block_based_table_options_t* table_options);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_atomic_flush(
-    rocksdb_options_t* opt, unsigned char);
 
 /* Cuckoo table options */
 
@@ -1039,6 +1037,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_fifo_compaction_options(
     rocksdb_options_t* opt, rocksdb_fifo_compaction_options_t* fifo);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_ratelimiter(
     rocksdb_options_t* opt, rocksdb_ratelimiter_t* limiter);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_atomic_flush(
+    rocksdb_options_t* opt, unsigned char);
 
 /* RateLimiter */
 extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(


### PR DESCRIPTION
This PR adds a `rocksdb_options_set_atomic_flush` function to the C API.