### PR TITLE
Fix destroydb

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3591,6 +3591,11 @@ Status DestroyDB(const std::string& dbname, const Options& options,
 
     env->UnlockFile(lock);  // Ignore error since state is already gone
     env->DeleteFile(lockname);
+
+    // sst_file_manager holds a ref to the logger. Make sure the logger is
+    // gone before trying to remove the directory.
+    soptions.sst_file_manager.reset();
+
     env->DeleteDir(dbname);  // Ignore error in case dir contains other files
   }
   return result;


### PR DESCRIPTION
It's observed on Windows DestroyDB failed to remove the log file because the logger is still alive in sst file manager and holding a handle to the log file. This fix makes sure the logger is released before attempt to clear the database directory.