### PR TITLE
Revert "crash_test to enable block-based table hash index (#6310)"

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -52,7 +52,8 @@ default_params = {
     "expected_values_path": expected_values_file.name,
     "flush_one_in": 1000000,
     "get_live_files_and_wal_files_one_in": 1000000,
-    "index_type": lambda: random.choice([0, 0, 1, 2, 2]),
+    # Temporarily disable hash index
+    "index_type": lambda: random.choice([0,2]),
     "max_background_compactions": 20,
     "max_bytes_for_level_base": 10485760,
     "max_key": 100000000,
@@ -235,12 +236,6 @@ def finalize_and_sanitize(src_params):
             dest_params["partition_filters"] = 0
         else:
             dest_params["use_block_based_filter"] = 0
-    if dest_params["index_type"] == 1 and \
-        dest_params.get("prefix_size", 7) == -1:
-        dest_params["index_type"] = 0       
-    # kHashSearch is incompatible with index_block_restart_interval > 1
-    if dest_params["index_type"] == 1:
-        dest_params["index_block_restart_interval"] = 1;
     if dest_params.get("atomic_flush", 0) == 1:
         # disable pipelined write when atomic flush is used.
         dest_params["enable_pipelined_write"] = 0


### PR DESCRIPTION
This reverts commit 8e309b35bbc00aebf29038ac5936f704d22ea303.
The stress tests are failing . Revert it until we figure the root cause.