### PR TITLE
Implement PinnableSlice::remove_prefix

### DIFF
--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -255,7 +255,7 @@ class Cache {
   // Always delete the DB object before calling this method!
   virtual void DisownData(){
       // default implementation is noop
-  };
+  }
 
   // Apply callback to all entries in the cache
   // If thread_safe is true, it will also lock the accesses. Otherwise, it will

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -672,7 +672,7 @@ class RandomAccessFile {
   virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
     return 0;  // Default implementation to prevent issues with backwards
                // compatibility.
-  };
+  }
 
   enum AccessPattern { NORMAL, RANDOM, SEQUENTIAL, WILLNEED, DONTNEED };
 
@@ -1414,7 +1414,7 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   }
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
-  };
+  }
   void Hint(AccessPattern pattern) override { target_->Hint(pattern); }
   bool use_direct_io() const override { return target_->use_direct_io(); }
   size_t GetRequiredBufferAlignment() const override {

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -195,8 +195,15 @@ class PinnableSlice : public Slice, public Cleanable {
     }
   }
 
-  void remove_prefix(size_t /*n*/) {
-    assert(0);  // Not implemented
+  void remove_prefix(size_t n) {
+    assert(n <= size());
+    if (pinned_) {
+      data_ += n;
+      size_ -= n;
+    } else {
+      buf_->erase(0, n);
+      PinSelf();
+    }
   }
 
   void Reset() {

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -523,7 +523,7 @@ class Statistics {
   virtual bool getTickerMap(std::map<std::string, uint64_t>*) const {
     // Do nothing by default
     return false;
-  };
+  }
 
   // Override this function to disable particular histogram collection
   virtual bool HistEnabledForType(uint32_t type) const {


### PR DESCRIPTION
The function was left unimplemented. Although we currently don't have a use for that it was declared with an assert(0) to prevent mistakenly using the remove_prefix of the parent class. The function body  with only assert(0) however causes issues with some compiler's warning levels. The patch implements the function to avoid the warning.
It also piggybacks some minor code warning for unnecessary semicolons after the function definition.s