### PR TITLE
Fix db_bloom_filter_test clang LITE build

### DIFF
--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -16,12 +16,6 @@ namespace rocksdb {
 
 namespace {
 using BFP = BloomFilterPolicy;
-
-namespace BFP2 {
-// Extends BFP::Mode with option to use Plain table
-using PseudoMode = int;
-static constexpr PseudoMode kPlainTable = -1;
-}  // namespace BFP2
 }  // namespace
 
 // DB tests related to bloom filter.
@@ -1031,6 +1025,14 @@ TEST_F(DBBloomFilterTest, MemtablePrefixBloomOutOfDomain) {
 }
 
 #ifndef ROCKSDB_LITE
+namespace {
+namespace BFP2 {
+// Extends BFP::Mode with option to use Plain table
+using PseudoMode = int;
+static constexpr PseudoMode kPlainTable = -1;
+}  // namespace BFP2
+}  // namespace
+
 class BloomStatsTestWithParam
     : public DBBloomFilterTest,
       public testing::WithParamInterface<std::tuple<BFP2::PseudoMode, bool>> {


### PR DESCRIPTION
Summary:
db_bloom_filter_test break with clang LITE build with following message:

db/db_bloom_filter_test.cc:23:29: error: unused variable 'kPlainTable' [-Werror,-Wunused-const-variable]
static constexpr PseudoMode kPlainTable = -1;
                            ^

Fix it by moving the declaration out of LITE build

Test Plan: USE_CLANG=1 LITE=1 make db_bloom_filter_test
and without LITE=1