### PR TITLE
BlobDB: handle the case when OnCompactionCompleted precedes OnFlushCompleted

### DIFF
--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -519,7 +519,8 @@ bool BlobDBImpl::MarkBlobFileObsoleteIfNeeded(
   // blob file obsolete if there are still unflushed memtables from before
   // the time the blob file was closed.
   if (blob_file->GetImmutableSequence() > flush_sequence_ ||
-      !blob_file->GetLinkedSstFiles().empty()) {
+      !blob_file->GetLinkedSstFiles().empty() ||
+      !blob_file->GetUnlinkedSstFiles().empty()) {
     return false;
   }
 

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1655,6 +1655,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1683,6 +1684,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1712,6 +1714,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1750,6 +1753,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1780,6 +1784,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1811,6 +1816,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1841,6 +1847,7 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMapping) {
     for (size_t i = 0; i < 5; ++i) {
       const auto &blob_file = blob_files[i];
       ASSERT_EQ(blob_file->GetLinkedSstFiles(), expected_sst_files[i]);
+      ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
       ASSERT_EQ(blob_file->Obsolete(), expected_obsolete[i]);
     }
 
@@ -1877,11 +1884,12 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMappingRace) {
   {
     CompactionJobInfo info{};
     info.input_file_infos.emplace_back(CompactionFileInfo{1, 10, 1});
-    info.output_file_infos.emplace_back(CompactionFileInfo{2, 10, 1});
 
     blob_db_impl()->TEST_ProcessCompactionJobInfo(info);
 
-    ASSERT_EQ(blob_file->GetLinkedSstFiles(), std::unordered_set<uint64_t>{});
+    ASSERT_TRUE(blob_file->GetLinkedSstFiles().empty());
+    ASSERT_EQ(blob_file->GetUnlinkedSstFiles(),
+              std::unordered_set<uint64_t>{10});
     ASSERT_FALSE(blob_file->Obsolete());
   }
 
@@ -1894,7 +1902,8 @@ TEST_F(BlobDBTest, MaintainBlobFileToSstMappingRace) {
 
     blob_db_impl()->TEST_ProcessFlushJobInfo(info);
 
-    ASSERT_EQ(blob_file->GetLinkedSstFiles(), std::unordered_set<uint64_t>{});
+    ASSERT_TRUE(blob_file->GetLinkedSstFiles().empty());
+    ASSERT_TRUE(blob_file->GetUnlinkedSstFiles().empty());
     ASSERT_TRUE(blob_file->Obsolete());
   }
 }


### PR DESCRIPTION
Summary:
BlobDB keeps track of the mapping between SSTs and blob files using
the `OnFlushCompleted` and `OnCompactionCompleted` callbacks of
the `Listener` interface: upon receiving a flush notification, a link is added
between the newly flushed SST and the corresponding blob file; for
compactions, links are removed for the inputs and added for the outputs.
In certain cases, it is possible for the compaction notification that results
in a link being removed to precede the flush notification that establishes
the link (see #6338).
The earlier code did not handle this case, resulting in assertion failures.
With the patch, BlobDB stores unmatched link removals in a separate set,
and reconciles them with link additions as they arrive.

Test Plan:
Added a unit test that simulates this case.