### PR TITLE
Fix LITE build with DBTest2.AutoPrefixMode1

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -4404,6 +4404,7 @@ TEST_F(DBTest2, BlockBasedTablePrefixGetIndexNotFound) {
   ASSERT_EQ("ok", Get("b1"));
 }
 
+#ifndef ROCKSDB_LITE
 TEST_F(DBTest2, AutoPrefixMode1) {
   // create a DB with block prefix index
   BlockBasedTableOptions table_options;
@@ -4510,6 +4511,7 @@ TEST_F(DBTest2, AutoPrefixMode1) {
     ASSERT_EQ("a1", iterator->key().ToString());
   }
 }
+#endif  // ROCKSDB_LITE
 }  // namespace rocksdb
 
 #ifdef ROCKSDB_UNITTESTS_WITH_CUSTOM_OBJECTS_FROM_STATIC_LIBS

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1254,7 +1254,8 @@ struct ReadOptions {
   // When true, by default use total_order_seek = true, and RocksDB can
   // selectively enable prefix seek mode if won't generate a different result
   // from total_order_seek, based on seek key, and iterator upper bound.
-  // Not supported in ROCKSDB_LITE mode!
+  // Not suppported in ROCKSDB_LITE mode, in the way that even with value true
+  // prefix mode is not used.
   bool auto_prefix_mode;
 
   // Enforce that the iterator only iterates over the same prefix as the seek.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1254,6 +1254,7 @@ struct ReadOptions {
   // When true, by default use total_order_seek = true, and RocksDB can
   // selectively enable prefix seek mode if won't generate a different result
   // from total_order_seek, based on seek key, and iterator upper bound.
+  // Not supported in ROCKSDB_LITE mode!
   bool auto_prefix_mode;
 
   // Enforce that the iterator only iterates over the same prefix as the seek.


### PR DESCRIPTION
Summary:
DBTest2.AutoPrefixMode1 doesn't pass because auto prefix mode is not supported there.
Fix it by disabling the test.

Test Plan: Run DBTest2.AutoPrefixMode1 in lite mode