### PR TITLE
Shorten certain test names to avoid infra failure

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -668,13 +668,10 @@ void rocksdb_options_set_uint64add_merge_operator(rocksdb_options_t* opt) {
 }
 
 rocksdb_t* rocksdb_open_column_families(
-    const rocksdb_options_t* db_options,
-    const char* name,
-    int num_column_families,
-    const char* const* column_family_names,
+    const rocksdb_options_t* db_options, const char* name,
+    int num_column_families, const char* const* column_family_names,
     const rocksdb_options_t* const* column_family_options,
-    rocksdb_column_family_handle_t** column_family_handles,
-    char** errptr) {
+    rocksdb_column_family_handle_t** column_family_handles, char** errptr) {
   std::vector<ColumnFamilyDescriptor> column_families;
   for (int i = 0; i < num_column_families; i++) {
     column_families.push_back(ColumnFamilyDescriptor(
@@ -700,14 +697,11 @@ rocksdb_t* rocksdb_open_column_families(
 }
 
 rocksdb_t* rocksdb_open_for_read_only_column_families(
-    const rocksdb_options_t* db_options,
-    const char* name,
-    int num_column_families,
-    const char* const* column_family_names,
+    const rocksdb_options_t* db_options, const char* name,
+    int num_column_families, const char* const* column_family_names,
     const rocksdb_options_t* const* column_family_options,
     rocksdb_column_family_handle_t** column_family_handles,
-    unsigned char error_if_log_file_exist,
-    char** errptr) {
+    unsigned char error_if_log_file_exist, char** errptr) {
   std::vector<ColumnFamilyDescriptor> column_families;
   for (int i = 0; i < num_column_families; i++) {
     column_families.push_back(ColumnFamilyDescriptor(
@@ -2736,10 +2730,9 @@ void rocksdb_options_set_ratelimiter(rocksdb_options_t *opt, rocksdb_ratelimiter
   }
 }
 
-void rocksdb_options_set_atomic_flush(
-  rocksdb_options_t *opt,
-  unsigned char atomic_flush) {
-    opt->rep.atomic_flush = atomic_flush;
+void rocksdb_options_set_atomic_flush(rocksdb_options_t* opt,
+                                      unsigned char atomic_flush) {
+  opt->rep.atomic_flush = atomic_flush;
 }
 
 rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(

--- a/db/db_compaction_filter_test.cc
+++ b/db/db_compaction_filter_test.cc
@@ -47,8 +47,7 @@ class DBTestCompactionFilterWithCompactParam
 
 #ifndef ROCKSDB_VALGRIND_RUN
 INSTANTIATE_TEST_CASE_P(
-    DBTestCompactionFilterWithCompactOption,
-    DBTestCompactionFilterWithCompactParam,
+    CompactionFilterWithOption, DBTestCompactionFilterWithCompactParam,
     ::testing::Values(DBTestBase::OptionConfig::kDefault,
                       DBTestBase::OptionConfig::kUniversalCompaction,
                       DBTestBase::OptionConfig::kUniversalCompactionMultiLevel,
@@ -56,7 +55,7 @@ INSTANTIATE_TEST_CASE_P(
                       DBTestBase::OptionConfig::kUniversalSubcompactions));
 #else
 // Run fewer cases in valgrind
-INSTANTIATE_TEST_CASE_P(DBTestCompactionFilterWithCompactOption,
+INSTANTIATE_TEST_CASE_P(CompactionFilterWithOption,
                         DBTestCompactionFilterWithCompactParam,
                         ::testing::Values(DBTestBase::OptionConfig::kDefault));
 #endif  // ROCKSDB_VALGRIND_RUN

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -748,8 +748,7 @@ TEST_P(DBTestUniversalCompactionMultiLevels, UniversalCompactionTrivialMove) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-INSTANTIATE_TEST_CASE_P(DBTestUniversalCompactionMultiLevels,
-                        DBTestUniversalCompactionMultiLevels,
+INSTANTIATE_TEST_CASE_P(MultiLevels, DBTestUniversalCompactionMultiLevels,
                         ::testing::Combine(::testing::Values(3, 20),
                                            ::testing::Bool()));
 
@@ -938,8 +937,7 @@ TEST_P(DBTestUniversalCompactionParallel, PickByFileNumberBug) {
   EXPECT_GE(total_picked_compactions, 2);
 }
 
-INSTANTIATE_TEST_CASE_P(DBTestUniversalCompactionParallel,
-                        DBTestUniversalCompactionParallel,
+INSTANTIATE_TEST_CASE_P(Parallel, DBTestUniversalCompactionParallel,
                         ::testing::Combine(::testing::Values(1, 10),
                                            ::testing::Values(false)));
 #endif  // ROCKSDB_VALGRIND_RUN
@@ -1840,7 +1838,7 @@ TEST_P(DBTestUniversalCompaction, FinalSortedRunCompactFilesConflict) {
   compact_files_thread.join();
 }
 
-INSTANTIATE_TEST_CASE_P(UniversalCompactionNumLevels, DBTestUniversalCompaction,
+INSTANTIATE_TEST_CASE_P(NumLevels, DBTestUniversalCompaction,
                         ::testing::Combine(::testing::Values(1, 3, 5),
                                            ::testing::Bool()));
 
@@ -1910,7 +1908,7 @@ TEST_P(DBTestUniversalManualCompactionOutputPathId,
                   .IsInvalidArgument());
 }
 
-INSTANTIATE_TEST_CASE_P(DBTestUniversalManualCompactionOutputPathId,
+INSTANTIATE_TEST_CASE_P(OutputPathId,
                         DBTestUniversalManualCompactionOutputPathId,
                         ::testing::Combine(::testing::Values(1, 8),
                                            ::testing::Bool()));

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -266,13 +266,13 @@ class ReadaheadRandomAccessFileTest
   std::unique_ptr<char[]> scratch_;
 };
 
-TEST_P(ReadaheadRandomAccessFileTest, EmptySourceStrTest) {
+TEST_P(ReadaheadRandomAccessFileTest, EmptySourceStr) {
   ASSERT_EQ("", Read(0, 1));
   ASSERT_EQ("", Read(0, 0));
   ASSERT_EQ("", Read(13, 13));
 }
 
-TEST_P(ReadaheadRandomAccessFileTest, SourceStrLenLessThanReadaheadSizeTest) {
+TEST_P(ReadaheadRandomAccessFileTest, SourceStrLenLessThanReadaheadSize) {
   std::string str = "abcdefghijklmnopqrs";
   ResetSourceStr(str);
   ASSERT_EQ(str.substr(3, 4), Read(3, 4));
@@ -283,8 +283,7 @@ TEST_P(ReadaheadRandomAccessFileTest, SourceStrLenLessThanReadaheadSizeTest) {
   ASSERT_EQ("", Read(100, 100));
 }
 
-TEST_P(ReadaheadRandomAccessFileTest,
-       SourceStrLenGreaterThanReadaheadSizeTest) {
+TEST_P(ReadaheadRandomAccessFileTest, SourceStrLenGreaterThanReadaheadSize) {
   Random rng(42);
   for (int k = 0; k < 100; ++k) {
     size_t strLen = k * GetReadaheadSize() +
@@ -301,7 +300,7 @@ TEST_P(ReadaheadRandomAccessFileTest,
   }
 }
 
-TEST_P(ReadaheadRandomAccessFileTest, ReadExceedsReadaheadSizeTest) {
+TEST_P(ReadaheadRandomAccessFileTest, ReadExceedsReadaheadSize) {
   Random rng(7);
   size_t strLen = 4 * GetReadaheadSize() +
                   rng.Uniform(static_cast<int>(GetReadaheadSize()));
@@ -318,16 +317,16 @@ TEST_P(ReadaheadRandomAccessFileTest, ReadExceedsReadaheadSizeTest) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    EmptySourceStrTest, ReadaheadRandomAccessFileTest,
+    EmptySourceStr, ReadaheadRandomAccessFileTest,
     ::testing::ValuesIn(ReadaheadRandomAccessFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    SourceStrLenLessThanReadaheadSizeTest, ReadaheadRandomAccessFileTest,
+    SourceStrLenLessThanReadaheadSize, ReadaheadRandomAccessFileTest,
     ::testing::ValuesIn(ReadaheadRandomAccessFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    SourceStrLenGreaterThanReadaheadSizeTest, ReadaheadRandomAccessFileTest,
+    SourceStrLenGreaterThanReadaheadSize, ReadaheadRandomAccessFileTest,
     ::testing::ValuesIn(ReadaheadRandomAccessFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    ReadExceedsReadaheadSizeTest, ReadaheadRandomAccessFileTest,
+    ReadExceedsReadaheadSize, ReadaheadRandomAccessFileTest,
     ::testing::ValuesIn(ReadaheadRandomAccessFileTest::GetReadaheadSizeList()));
 
 class ReadaheadSequentialFileTest : public testing::Test,
@@ -362,13 +361,13 @@ class ReadaheadSequentialFileTest : public testing::Test,
   std::unique_ptr<char[]> scratch_;
 };
 
-TEST_P(ReadaheadSequentialFileTest, EmptySourceStrTest) {
+TEST_P(ReadaheadSequentialFileTest, EmptySourceStr) {
   ASSERT_EQ("", Read(0));
   ASSERT_EQ("", Read(1));
   ASSERT_EQ("", Read(13));
 }
 
-TEST_P(ReadaheadSequentialFileTest, SourceStrLenLessThanReadaheadSizeTest) {
+TEST_P(ReadaheadSequentialFileTest, SourceStrLenLessThanReadaheadSize) {
   std::string str = "abcdefghijklmnopqrs";
   ResetSourceStr(str);
   ASSERT_EQ(str.substr(0, 3), Read(3));
@@ -377,7 +376,7 @@ TEST_P(ReadaheadSequentialFileTest, SourceStrLenLessThanReadaheadSizeTest) {
   ASSERT_EQ("", Read(100));
 }
 
-TEST_P(ReadaheadSequentialFileTest, SourceStrLenGreaterThanReadaheadSizeTest) {
+TEST_P(ReadaheadSequentialFileTest, SourceStrLenGreaterThanReadaheadSize) {
   Random rng(42);
   for (int s = 0; s < 1; ++s) {
     for (int k = 0; k < 100; ++k) {
@@ -400,7 +399,7 @@ TEST_P(ReadaheadSequentialFileTest, SourceStrLenGreaterThanReadaheadSizeTest) {
   }
 }
 
-TEST_P(ReadaheadSequentialFileTest, ReadExceedsReadaheadSizeTest) {
+TEST_P(ReadaheadSequentialFileTest, ReadExceedsReadaheadSize) {
   Random rng(42);
   for (int s = 0; s < 1; ++s) {
     for (int k = 0; k < 100; ++k) {
@@ -425,16 +424,16 @@ TEST_P(ReadaheadSequentialFileTest, ReadExceedsReadaheadSizeTest) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    EmptySourceStrTest, ReadaheadSequentialFileTest,
+    EmptySourceStr, ReadaheadSequentialFileTest,
     ::testing::ValuesIn(ReadaheadSequentialFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    SourceStrLenLessThanReadaheadSizeTest, ReadaheadSequentialFileTest,
+    SourceStrLenLessThanReadaheadSize, ReadaheadSequentialFileTest,
     ::testing::ValuesIn(ReadaheadSequentialFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    SourceStrLenGreaterThanReadaheadSizeTest, ReadaheadSequentialFileTest,
+    SourceStrLenGreaterThanReadaheadSize, ReadaheadSequentialFileTest,
     ::testing::ValuesIn(ReadaheadSequentialFileTest::GetReadaheadSizeList()));
 INSTANTIATE_TEST_CASE_P(
-    ReadExceedsReadaheadSizeTest, ReadaheadSequentialFileTest,
+    ReadExceedsReadaheadSize, ReadaheadSequentialFileTest,
     ::testing::ValuesIn(ReadaheadSequentialFileTest::GetReadaheadSizeList()));
 }  // namespace rocksdb
 

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -582,7 +582,7 @@ class SeqAdvanceConcurrentTest
 };
 
 INSTANTIATE_TEST_CASE_P(
-    WritePreparedTransactionTest, WritePreparedTransactionTest,
+    WritePreparedTransaction, WritePreparedTransactionTest,
     ::testing::Values(
         std::make_tuple(false, false, WRITE_PREPARED, kOrderedWrite),
         std::make_tuple(false, true, WRITE_PREPARED, kOrderedWrite),
@@ -697,7 +697,7 @@ INSTANTIATE_TEST_CASE_P(
         std::make_tuple(false, false, WRITE_PREPARED, kOrderedWrite, 9, 10)));
 #endif  // ROCKSDB_VALGRIND_RUN
 
-TEST_P(WritePreparedTransactionTest, CommitMapTest) {
+TEST_P(WritePreparedTransactionTest, CommitMap) {
   WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
   assert(wp_db);
   assert(wp_db->db_impl_);
@@ -1081,7 +1081,7 @@ TEST_P(WritePreparedTransactionTest, OldCommitMapGC) {
   }
 }
 
-TEST_P(WritePreparedTransactionTest, CheckAgainstSnapshotsTest) {
+TEST_P(WritePreparedTransactionTest, CheckAgainstSnapshots) {
   std::vector<SequenceNumber> snapshots = {100l, 200l, 300l, 400l, 500l,
                                            600l, 700l, 800l, 900l};
   const size_t snapshot_cache_bits = 2;
@@ -1172,7 +1172,7 @@ TEST_P(WritePreparedTransactionTest, CheckAgainstSnapshotsTest) {
 #ifndef ROCKSDB_VALGRIND_RUN
 // Test that CheckAgainstSnapshots will not miss a live snapshot if it is run in
 // parallel with UpdateSnapshots.
-TEST_P(SnapshotConcurrentAccessTest, SnapshotConcurrentAccessTest) {
+TEST_P(SnapshotConcurrentAccessTest, SnapshotConcurrentAccess) {
   // We have a sync point in the method under test after checking each snapshot.
   // If you increase the max number of snapshots in this test, more sync points
   // in the methods must also be added.
@@ -1253,7 +1253,7 @@ TEST_P(SnapshotConcurrentAccessTest, SnapshotConcurrentAccessTest) {
 #endif  // TRAVIS
 
 // This test clarifies the contract of AdvanceMaxEvictedSeq method
-TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasicTest) {
+TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqBasic) {
   DBImpl* mock_db = new DBImpl(options, dbname);
   std::unique_ptr<WritePreparedTxnDBMock> wp_db(
       new WritePreparedTxnDBMock(mock_db, txn_db_options));
@@ -1541,7 +1541,7 @@ TEST_P(WritePreparedTransactionTest, TxnInitialize) {
 // is advancing their prepared sequence numbers. This will not be the case if
 // for example the txn does not add the prepared seq for the second sub-batch to
 // the PreparedHeap structure.
-TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqWithDuplicatesTest) {
+TEST_P(WritePreparedTransactionTest, AdvanceMaxEvictedSeqWithDuplicates) {
   const size_t snapshot_cache_bits = 7;  // same as default
   const size_t commit_cache_bits = 1;    // disable commit cache
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
@@ -1642,7 +1642,7 @@ TEST_P(WritePreparedTransactionTest, SmallestUnCommittedSeq) {
 }
 #endif  // ROCKSDB_VALGRIND_RUN
 
-TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrentTest) {
+TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrent) {
   // Given the sequential run of txns, with this timeout we should never see a
   // deadlock nor a timeout unless we have a key conflict, which should be
   // almost infeasible.
@@ -1787,7 +1787,7 @@ TEST_P(SeqAdvanceConcurrentTest, SeqAdvanceConcurrentTest) {
 // Run a couple of different txns among them some uncommitted. Restart the db at
 // a couple points to check whether the list of uncommitted txns are recovered
 // properly.
-TEST_P(WritePreparedTransactionTest, BasicRecoveryTest) {
+TEST_P(WritePreparedTransactionTest, BasicRecovery) {
   options.disable_auto_compactions = true;
   ReOpen();
   WritePreparedTxnDB* wp_db = dynamic_cast<WritePreparedTxnDB*>(db);
@@ -1927,7 +1927,7 @@ TEST_P(WritePreparedTransactionTest, BasicRecoveryTest) {
 // After recovery the commit map is empty while the max is set. The code would
 // go through a different path which requires a separate test. Test that the
 // committed data before the restart is visible to all snapshots.
-TEST_P(WritePreparedTransactionTest, IsInSnapshotEmptyMapTest) {
+TEST_P(WritePreparedTransactionTest, IsInSnapshotEmptyMap) {
   for (bool end_with_prepare : {false, true}) {
     ReOpen();
     WriteOptions woptions;
@@ -2061,7 +2061,7 @@ TEST_P(WritePreparedTransactionTest, IsInSnapshotReleased) {
 
 // Test WritePreparedTxnDB's IsInSnapshot against different ordering of
 // snapshot, max_committed_seq_, prepared, and commit entries.
-TEST_P(WritePreparedTransactionTest, IsInSnapshotTest) {
+TEST_P(WritePreparedTransactionTest, IsInSnapshot) {
   WriteOptions wo;
   // Use small commit cache to trigger lots of eviction and fast advance of
   // max_evicted_seq_
@@ -2212,7 +2212,7 @@ void ASSERT_SAME(TransactionDB* db, Status exp_s, PinnableSlice& exp_v,
   ASSERT_SAME(ReadOptions(), db, exp_s, exp_v, key);
 }
 
-TEST_P(WritePreparedTransactionTest, RollbackTest) {
+TEST_P(WritePreparedTransactionTest, Rollback) {
   ReadOptions roptions;
   WriteOptions woptions;
   TransactionOptions txn_options;
@@ -2322,7 +2322,7 @@ TEST_P(WritePreparedTransactionTest, RollbackTest) {
   }
 }
 
-TEST_P(WritePreparedTransactionTest, DisableGCDuringRecoveryTest) {
+TEST_P(WritePreparedTransactionTest, DisableGCDuringRecovery) {
   // Use large buffer to avoid memtable flush after 1024 insertions
   options.write_buffer_size = 1024 * 1024;
   ReOpen();
@@ -2349,7 +2349,7 @@ TEST_P(WritePreparedTransactionTest, DisableGCDuringRecoveryTest) {
   VerifyInternalKeys(versions);
 }
 
-TEST_P(WritePreparedTransactionTest, SequenceNumberZeroTest) {
+TEST_P(WritePreparedTransactionTest, SequenceNumberZero) {
   ASSERT_OK(db->Put(WriteOptions(), "foo", "bar"));
   VerifyKeys({{"foo", "bar"}});
   const Snapshot* snapshot = db->GetSnapshot();
@@ -2780,7 +2780,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
 // A more complex test to verify compaction/flush should keep keys visible
 // to snapshots.
 TEST_P(WritePreparedTransactionTest,
-       CompactionShouldKeepSnapshotVisibleKeysRandomized) {
+       CompactionKeepSnapshotVisibleKeysRandomized) {
   constexpr size_t kNumTransactions = 10;
   constexpr size_t kNumIterations = 1000;
 

--- a/utilities/transactions/write_prepared_txn_db.h
+++ b/utilities/transactions/write_prepared_txn_db.h
@@ -470,26 +470,25 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
   friend class PreparedHeap_BasicsTest_Test;
   friend class PreparedHeap_Concurrent_Test;
   friend class PreparedHeap_EmptyAtTheEnd_Test;
-  friend class SnapshotConcurrentAccessTest_SnapshotConcurrentAccessTest_Test;
+  friend class SnapshotConcurrentAccessTest_SnapshotConcurrentAccess_Test;
   friend class WritePreparedCommitEntryPreReleaseCallback;
   friend class WritePreparedTransactionTestBase;
   friend class WritePreparedTxn;
   friend class WritePreparedTxnDBMock;
   friend class WritePreparedTransactionTest_AddPreparedBeforeMax_Test;
-  friend class WritePreparedTransactionTest_AdvanceMaxEvictedSeqBasicTest_Test;
+  friend class WritePreparedTransactionTest_AdvanceMaxEvictedSeqBasic_Test;
   friend class
-      WritePreparedTransactionTest_AdvanceMaxEvictedSeqWithDuplicatesTest_Test;
+      WritePreparedTransactionTest_AdvanceMaxEvictedSeqWithDuplicates_Test;
   friend class WritePreparedTransactionTest_AdvanceSeqByOne_Test;
-  friend class WritePreparedTransactionTest_BasicRecoveryTest_Test;
-  friend class WritePreparedTransactionTest_CheckAgainstSnapshotsTest_Test;
+  friend class WritePreparedTransactionTest_BasicRecovery_Test;
+  friend class WritePreparedTransactionTest_CheckAgainstSnapshots_Test;
   friend class WritePreparedTransactionTest_CleanupSnapshotEqualToMax_Test;
-  friend class
-      WritePreparedTransactionTest_ConflictDetectionAfterRecoveryTest_Test;
-  friend class WritePreparedTransactionTest_CommitMapTest_Test;
+  friend class WritePreparedTransactionTest_ConflictDetectionAfterRecovery_Test;
+  friend class WritePreparedTransactionTest_CommitMap_Test;
   friend class WritePreparedTransactionTest_DoubleSnapshot_Test;
-  friend class WritePreparedTransactionTest_IsInSnapshotEmptyMapTest_Test;
+  friend class WritePreparedTransactionTest_IsInSnapshotEmptyMap_Test;
   friend class WritePreparedTransactionTest_IsInSnapshotReleased_Test;
-  friend class WritePreparedTransactionTest_IsInSnapshotTest_Test;
+  friend class WritePreparedTransactionTest_IsInSnapshot_Test;
   friend class WritePreparedTransactionTest_NewSnapshotLargerThanMax_Test;
   friend class WritePreparedTransactionTest_MaxCatchupWithNewSnapshot_Test;
   friend class WritePreparedTransactionTest_MaxCatchupWithUnbackedSnapshot_Test;
@@ -499,7 +498,7 @@ class WritePreparedTxnDB : public PessimisticTransactionDB {
       WritePreparedTransactionTest_NonAtomicUpdateOfDelayedPrepared_Test;
   friend class WritePreparedTransactionTest_NonAtomicUpdateOfMaxEvictedSeq_Test;
   friend class WritePreparedTransactionTest_OldCommitMapGC_Test;
-  friend class WritePreparedTransactionTest_RollbackTest_Test;
+  friend class WritePreparedTransactionTest_Rollback_Test;
   friend class WritePreparedTransactionTest_SmallestUnCommittedSeq_Test;
   friend class WriteUnpreparedTxn;
   friend class WriteUnpreparedTxnDB;


### PR DESCRIPTION
Unit test names, together with other components,  are used to create log files
during some internal testing. Overly long names cause infra failure due to file
names being too long.

Look for internal tests.