### PR TITLE
Avoid create directory for every column families

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1331,8 +1331,6 @@ Status ColumnFamilyData::AddDirectories(
       std::unique_ptr<Directory> path_directory;
       s = DBImpl::CreateAndNewDirectory(
           ioptions_.env, p.path,
-          created_dirs->find(p.path) == created_dirs->end()
-          /* known_already_exist */,
           &path_directory);
       if (!s.ok()) {
         return s;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1320,17 +1320,29 @@ Env::WriteLifeTimeHint ColumnFamilyData::CalculateSSTWriteHint(int level) {
                             static_cast<int>(Env::WLTH_MEDIUM));
 }
 
-Status ColumnFamilyData::AddDirectories() {
+Status ColumnFamilyData::AddDirectories(
+    std::map<std::string, std::shared_ptr<Directory>>* created_dirs) {
   Status s;
   assert(data_dirs_.empty());
   for (auto& p : ioptions_.cf_paths) {
-    std::unique_ptr<Directory> path_directory;
-    s = DBImpl::CreateAndNewDirectory(ioptions_.env, p.path, &path_directory);
-    if (!s.ok()) {
-      return s;
+    auto existing_dir = created_dirs->find(p.path);
+
+    if (existing_dir == created_dirs->end()) {
+      std::unique_ptr<Directory> path_directory;
+      s = DBImpl::CreateAndNewDirectory(
+          ioptions_.env, p.path,
+          created_dirs->find(p.path) == created_dirs->end()
+          /* known_already_exist */,
+          &path_directory);
+      if (!s.ok()) {
+        return s;
+      }
+      assert(path_directory != nullptr);
+      data_dirs_.emplace_back(path_directory.release());
+      (*created_dirs)[p.path] = data_dirs_.back();
+    } else {
+      data_dirs_.emplace_back(existing_dir->second);
     }
-    assert(path_directory != nullptr);
-    data_dirs_.emplace_back(path_directory.release());
   }
   assert(data_dirs_.size() == ioptions_.cf_paths.size());
   return s;

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1323,15 +1323,14 @@ Env::WriteLifeTimeHint ColumnFamilyData::CalculateSSTWriteHint(int level) {
 Status ColumnFamilyData::AddDirectories(
     std::map<std::string, std::shared_ptr<Directory>>* created_dirs) {
   Status s;
+  assert(created_dirs != nullptr);
   assert(data_dirs_.empty());
   for (auto& p : ioptions_.cf_paths) {
     auto existing_dir = created_dirs->find(p.path);
 
     if (existing_dir == created_dirs->end()) {
       std::unique_ptr<Directory> path_directory;
-      s = DBImpl::CreateAndNewDirectory(
-          ioptions_.env, p.path,
-          &path_directory);
+      s = DBImpl::CreateAndNewDirectory(ioptions_.env, p.path, &path_directory);
       if (!s.ok()) {
         return s;
       }

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -497,7 +497,10 @@ class ColumnFamilyData {
 
   Env::WriteLifeTimeHint CalculateSSTWriteHint(int level);
 
-  Status AddDirectories();
+  // created_dirs remembers directory created, so that we don't need to call
+  // the same data creation operation again.
+  Status AddDirectories(
+      std::map<std::string, std::shared_ptr<Directory>>* created_dirs);
 
   Directory* GetDataDir(size_t path_id) const;
 
@@ -589,7 +592,7 @@ class ColumnFamilyData {
   std::atomic<uint64_t> last_memtable_id_;
 
   // Directories corresponding to cf_paths.
-  std::vector<std::unique_ptr<Directory>> data_dirs_;
+  std::vector<std::shared_ptr<Directory>> data_dirs_;
 };
 
 // ColumnFamilySet has interesting thread-safety requirements

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -2301,7 +2301,8 @@ Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
       auto* cfd =
           versions_->GetColumnFamilySet()->GetColumnFamily(column_family_name);
       assert(cfd != nullptr);
-      s = cfd->AddDirectories();
+      std::map<std::string, std::shared_ptr<Directory>> dummy_created_dirs;
+      s = cfd->AddDirectories(&dummy_created_dirs);
     }
     if (s.ok()) {
       single_column_family_mode_ = false;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -826,10 +826,7 @@ class DBImpl : public DB {
                      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
                      const bool seq_per_batch, const bool batch_per_txn);
 
-  // If `known_already_exist` = true, no need to create the directory.
-  // The directory might still exist if it is false.
   static Status CreateAndNewDirectory(Env* env, const std::string& dirname,
-                                      bool known_already_exist,
                                       std::unique_ptr<Directory>* directory);
 
   // find stats map from stats_history_ with smallest timestamp in

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -826,8 +826,10 @@ class DBImpl : public DB {
                      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
                      const bool seq_per_batch, const bool batch_per_txn);
 
-
+  // If `known_already_exist` = true, no need to create the directory.
+  // The directory might still exist if it is false.
   static Status CreateAndNewDirectory(Env* env, const std::string& dirname,
+                                      bool known_already_exist,
                                       std::unique_ptr<Directory>* directory);
 
   // find stats map from stats_history_ with smallest timestamp in

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -295,20 +295,17 @@ Status DBImpl::NewDB() {
 }
 
 Status DBImpl::CreateAndNewDirectory(Env* env, const std::string& dirname,
-                                     bool known_already_exist,
                                      std::unique_ptr<Directory>* directory) {
-  if (known_already_exist) {
-    // We call CreateDirIfMissing() as the directory may already exist (if we
-    // are reopening a DB), when this happens we don't want creating the
-    // directory to cause an error. However, we need to check if creating the
-    // directory fails or else we may get an obscure message about the lock
-    // file not existing. One real-world example of this occurring is if
-    // env->CreateDirIfMissing() doesn't create intermediate directories, e.g.
-    // when dbname_ is "dir/db" but when "dir" doesn't exist.
-    Status s = env->CreateDirIfMissing(dirname);
-    if (!s.ok()) {
-      return s;
-    }
+  // We call CreateDirIfMissing() as the directory may already exist (if we
+  // are reopening a DB), when this happens we don't want creating the
+  // directory to cause an error. However, we need to check if creating the
+  // directory fails or else we may get an obscure message about the lock
+  // file not existing. One real-world example of this occurring is if
+  // env->CreateDirIfMissing() doesn't create intermediate directories, e.g.
+  // when dbname_ is "dir/db" but when "dir" doesn't exist.
+  Status s = env->CreateDirIfMissing(dirname);
+  if (!s.ok()) {
+    return s;
   }
   return env->NewDirectory(dirname, directory);
 }
@@ -316,14 +313,12 @@ Status DBImpl::CreateAndNewDirectory(Env* env, const std::string& dirname,
 Status Directories::SetDirectories(Env* env, const std::string& dbname,
                                    const std::string& wal_dir,
                                    const std::vector<DbPath>& data_paths) {
-  Status s = DBImpl::CreateAndNewDirectory(
-      env, dbname, false /* known_already_exist */, &db_dir_);
+  Status s = DBImpl::CreateAndNewDirectory(env, dbname, &db_dir_);
   if (!s.ok()) {
     return s;
   }
   if (!wal_dir.empty() && dbname != wal_dir) {
-    s = DBImpl::CreateAndNewDirectory(
-        env, wal_dir, false /* known_already_exist */, &wal_dir_);
+    s = DBImpl::CreateAndNewDirectory(env, wal_dir, &wal_dir_);
     if (!s.ok()) {
       return s;
     }
@@ -336,8 +331,7 @@ Status Directories::SetDirectories(Env* env, const std::string& dbname,
       data_dirs_.emplace_back(nullptr);
     } else {
       std::unique_ptr<Directory> path_directory;
-      s = DBImpl::CreateAndNewDirectory(
-          env, db_path, false /* known_already_exist */, &path_directory);
+      s = DBImpl::CreateAndNewDirectory(env, db_path, , &path_directory);
       if (!s.ok()) {
         return s;
       }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -459,8 +459,8 @@ Status DBImpl::Recover(
   if (immutable_db_options_.paranoid_checks && s.ok()) {
     s = CheckConsistency();
   }
-  std::map<std::string, std::shared_ptr<Directory>> created_dirs;
   if (s.ok() && !read_only) {
+    std::map<std::string, std::shared_ptr<Directory>> created_dirs;
     for (auto cfd : *versions_->GetColumnFamilySet()) {
       s = cfd->AddDirectories(&created_dirs);
       if (!s.ok()) {

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -295,17 +295,20 @@ Status DBImpl::NewDB() {
 }
 
 Status DBImpl::CreateAndNewDirectory(Env* env, const std::string& dirname,
+                                     bool known_already_exist,
                                      std::unique_ptr<Directory>* directory) {
-  // We call CreateDirIfMissing() as the directory may already exist (if we
-  // are reopening a DB), when this happens we don't want creating the
-  // directory to cause an error. However, we need to check if creating the
-  // directory fails or else we may get an obscure message about the lock
-  // file not existing. One real-world example of this occurring is if
-  // env->CreateDirIfMissing() doesn't create intermediate directories, e.g.
-  // when dbname_ is "dir/db" but when "dir" doesn't exist.
-  Status s = env->CreateDirIfMissing(dirname);
-  if (!s.ok()) {
-    return s;
+  if (known_already_exist) {
+    // We call CreateDirIfMissing() as the directory may already exist (if we
+    // are reopening a DB), when this happens we don't want creating the
+    // directory to cause an error. However, we need to check if creating the
+    // directory fails or else we may get an obscure message about the lock
+    // file not existing. One real-world example of this occurring is if
+    // env->CreateDirIfMissing() doesn't create intermediate directories, e.g.
+    // when dbname_ is "dir/db" but when "dir" doesn't exist.
+    Status s = env->CreateDirIfMissing(dirname);
+    if (!s.ok()) {
+      return s;
+    }
   }
   return env->NewDirectory(dirname, directory);
 }
@@ -313,12 +316,14 @@ Status DBImpl::CreateAndNewDirectory(Env* env, const std::string& dirname,
 Status Directories::SetDirectories(Env* env, const std::string& dbname,
                                    const std::string& wal_dir,
                                    const std::vector<DbPath>& data_paths) {
-  Status s = DBImpl::CreateAndNewDirectory(env, dbname, &db_dir_);
+  Status s = DBImpl::CreateAndNewDirectory(
+      env, dbname, false /* known_already_exist */, &db_dir_);
   if (!s.ok()) {
     return s;
   }
   if (!wal_dir.empty() && dbname != wal_dir) {
-    s = DBImpl::CreateAndNewDirectory(env, wal_dir, &wal_dir_);
+    s = DBImpl::CreateAndNewDirectory(
+        env, wal_dir, false /* known_already_exist */, &wal_dir_);
     if (!s.ok()) {
       return s;
     }
@@ -331,7 +336,8 @@ Status Directories::SetDirectories(Env* env, const std::string& dbname,
       data_dirs_.emplace_back(nullptr);
     } else {
       std::unique_ptr<Directory> path_directory;
-      s = DBImpl::CreateAndNewDirectory(env, db_path, &path_directory);
+      s = DBImpl::CreateAndNewDirectory(
+          env, db_path, false /* known_already_exist */, &path_directory);
       if (!s.ok()) {
         return s;
       }
@@ -453,9 +459,10 @@ Status DBImpl::Recover(
   if (immutable_db_options_.paranoid_checks && s.ok()) {
     s = CheckConsistency();
   }
+  std::map<std::string, std::shared_ptr<Directory>> created_dirs;
   if (s.ok() && !read_only) {
     for (auto cfd : *versions_->GetColumnFamilySet()) {
-      s = cfd->AddDirectories();
+      s = cfd->AddDirectories(&created_dirs);
       if (!s.ok()) {
         return s;
       }

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -331,7 +331,7 @@ Status Directories::SetDirectories(Env* env, const std::string& dbname,
       data_dirs_.emplace_back(nullptr);
     } else {
       std::unique_ptr<Directory> path_directory;
-      s = DBImpl::CreateAndNewDirectory(env, db_path, , &path_directory);
+      s = DBImpl::CreateAndNewDirectory(env, db_path, &path_directory);
       if (!s.ok()) {
         return s;
       }


### PR DESCRIPTION
Summary:
A relatively recent regression causes for every CF, create and open directory is called for the DB directory, unless CF has a private directory. This doesn't scale well with large number of column families.

Test Plan: Run all existing tests and see it pass. strace with db_bench --num_column_families and observe it doesn't open directory for number of column families.