### PR TITLE
Use ReadFileToString() to get content from IDENTITY file

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3353,31 +3353,12 @@ Status DBImpl::GetDbIdentity(std::string& identity) const {
 Status DBImpl::GetDbIdentityFromIdentityFile(std::string* identity) const {
   std::string idfilename = IdentityFileName(dbname_);
   const FileOptions soptions;
-  std::unique_ptr<SequentialFileReader> id_file_reader;
-  Status s;
-  {
-    std::unique_ptr<FSSequentialFile> idfile;
-    s = fs_->NewSequentialFile(idfilename, soptions, &idfile, nullptr);
-    if (!s.ok()) {
-      return s;
-    }
-    id_file_reader.reset(
-        new SequentialFileReader(std::move(idfile), idfilename));
+
+  Status s = ReadFileToString(fs_.get(), idfilename, identity);
+  if (!s.ok()) {
+    return s;
   }
 
-  uint64_t file_size;
-  s = fs_->GetFileSize(idfilename, IOOptions(), &file_size, nullptr);
-  if (!s.ok()) {
-    return s;
-  }
-  char* buffer =
-      reinterpret_cast<char*>(alloca(static_cast<size_t>(file_size)));
-  Slice id;
-  s = id_file_reader->Read(static_cast<size_t>(file_size), &id, buffer);
-  if (!s.ok()) {
-    return s;
-  }
-  identity->assign(id.ToString());
   // If last character is '\n' remove it from identity
   if (identity->size() > 0 && identity->back() == '\n') {
     identity->pop_back();


### PR DESCRIPTION
Summary: Right now when reading IDENTITY file, we use a very similar logic as ReadFileToString() while it does an extra file size check, which may be expensive in some file systems. There is no reason to duplicate the logic. Use ReadFileToString() instead.

Test Plan: RUn all existing tests.