### PR TITLE
Fix a test failure in error_handler_test

### DIFF
--- a/db/error_handler_test.cc
+++ b/db/error_handler_test.cc
@@ -298,7 +298,7 @@ TEST_F(DBErrorHandlingTest, CompactionManifestWriteError) {
         "DBImpl::BackgroundCallCompaction:FoundObsoleteFiles"},
       // Wait for DB instance to clear bg_error before calling
       // TEST_WaitForCompact
-       {"SstFileManagerImpl::ClearError",
+       {"SstFileManagerImpl::ErrorCleared",
         "CompactionManifestWriteError:2"}});
   // trigger manifest write failure in compaction thread
   rocksdb::SyncPoint::GetInstance()->SetCallBack(

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -308,8 +308,8 @@ void SstFileManagerImpl::ClearError() {
       // since the ErrorHandler::recovery_in_prog_ flag would be true
       cur_instance_ = error_handler;
       mu_.Unlock();
-      TEST_SYNC_POINT("SstFileManagerImpl::ClearError");
       s = error_handler->RecoverFromBGError();
+      TEST_SYNC_POINT("SstFileManagerImpl::ErrorCleared");
       mu_.Lock();
       // The DB instance might have been deleted while we were
       // waiting for the mutex, so check cur_instance_ to make sure its


### PR DESCRIPTION
Summary:
Fix an intermittent failure in
DBErrorHandlingTest.CompactionManifestWriteError due to a race between
background error recovery and the main test thread calling
TEST_WaitForCompact().

Test Plan:
Run the test using gtest_parallel