### PR TITLE
Avoid to get manifest file size when recovering from it.

### DIFF
--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -93,7 +93,7 @@ class Reader {
 
   uint64_t GetLogNumber() const { return log_number_; }
 
-  size_t end_of_buffer_offset() const {
+  size_t GetReadOffset() const {
     return static_cast<size_t>(end_of_buffer_offset_);
   }
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -93,6 +93,10 @@ class Reader {
 
   uint64_t GetLogNumber() const { return log_number_; }
 
+  size_t end_of_buffer_offset() const {
+    return static_cast<size_t>(end_of_buffer_offset_);
+  }
+
  protected:
   std::shared_ptr<Logger> info_log_;
   const std::unique_ptr<SequentialFileReader> file_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4403,12 +4403,6 @@ Status VersionSet::Recover(
         new SequentialFileReader(std::move(manifest_file), manifest_path,
                                  db_options_->log_readahead_size));
   }
-  uint64_t current_manifest_file_size;
-  s = fs_->GetFileSize(manifest_path, IOOptions(), &current_manifest_file_size,
-                       nullptr);
-  if (!s.ok()) {
-    return s;
-  }
 
   std::unordered_map<uint32_t, std::unique_ptr<BaseReferencedVersionBuilder>>
       builders;
@@ -4429,6 +4423,7 @@ Status VersionSet::Recover(
   builders.insert(
       std::make_pair(0, std::unique_ptr<BaseReferencedVersionBuilder>(
                             new BaseReferencedVersionBuilder(default_cfd))));
+  uint64_t current_manifest_file_size;
   VersionEditParams version_edit_params;
   {
     VersionSet::LogReporter reporter;
@@ -4441,6 +4436,7 @@ Status VersionSet::Recover(
     s = ReadAndRecover(&reader, &read_buffer, cf_name_to_options,
                        column_families_not_found, builders,
                        &version_edit_params, db_id);
+    current_manifest_file_size = reader.end_of_buffer_offset();
   }
 
   if (s.ok()) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4423,7 +4423,7 @@ Status VersionSet::Recover(
   builders.insert(
       std::make_pair(0, std::unique_ptr<BaseReferencedVersionBuilder>(
                             new BaseReferencedVersionBuilder(default_cfd))));
-  uint64_t current_manifest_file_size;
+  uint64_t current_manifest_file_size = 0;
   VersionEditParams version_edit_params;
   {
     VersionSet::LogReporter reporter;
@@ -4436,7 +4436,8 @@ Status VersionSet::Recover(
     s = ReadAndRecover(&reader, &read_buffer, cf_name_to_options,
                        column_families_not_found, builders,
                        &version_edit_params, db_id);
-    current_manifest_file_size = reader.end_of_buffer_offset();
+    current_manifest_file_size = reader.GetReadOffset();
+    assert(current_manifest_file_size != 0);
   }
 
   if (s.ok()) {


### PR DESCRIPTION
Summary:
Right now RocksDB gets manifest file size before recovering from it. The information is available in LogReader. Use it instead to prevent one file system call.

Test Plan: Run all existing tests