### PR TITLE
Be able to read compatible leveldb sst files

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -102,6 +102,14 @@ TEST_F(DBSSTTest, SSTsWithLdbSuffixHandling) {
   int const num_files = GetSstFileCount(dbname_);
   ASSERT_GT(num_files, 0);
 
+  Reopen(options);
+  std::vector<std::string> values;
+  values.reserve(key_id);
+  for (int k = 0; k < key_id; ++k) {
+    values.push_back(Get(Key(k)));
+  }
+  Close();
+
   std::vector<std::string> filenames;
   GetSstFiles(env_, dbname_, &filenames);
   int num_ldb_files = 0;
@@ -119,7 +127,7 @@ TEST_F(DBSSTTest, SSTsWithLdbSuffixHandling) {
 
   Reopen(options);
   for (int k = 0; k < key_id; ++k) {
-    ASSERT_NE("NOT_FOUND", Get(Key(k)));
+    ASSERT_EQ(values[k], Get(Key(k)));
   }
   Destroy(options);
 }

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -100,6 +100,10 @@ Status TableCache::GetTableReader(
   std::unique_ptr<FSRandomAccessFile> file;
   Status s = ioptions_.fs->NewRandomAccessFile(fname, file_options, &file,
                                                nullptr);
+  if (s.IsPathNotFound()) {
+    fname = Rocks2LevelTableFileName(fname);
+    s = ioptions_.fs->NewRandomAccessFile(fname, file_options, &file, nullptr);
+  }
 
   RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   if (s.ok()) {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -100,12 +100,13 @@ Status TableCache::GetTableReader(
   std::unique_ptr<FSRandomAccessFile> file;
   Status s = ioptions_.fs->NewRandomAccessFile(fname, file_options, &file,
                                                nullptr);
+  RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   if (s.IsPathNotFound()) {
     fname = Rocks2LevelTableFileName(fname);
     s = ioptions_.fs->NewRandomAccessFile(fname, file_options, &file, nullptr);
+    RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   }
 
-  RecordTick(ioptions_.statistics, NO_FILE_OPENS);
   if (s.ok()) {
     if (!sequential_mode && ioptions_.advise_random_on_open) {
       file->Hint(FSRandomAccessFile::kRandom);


### PR DESCRIPTION
Summary:
In `DBSSTTest.SSTsWithLdbSuffixHandling`, some sst files are renamed to ldb files, the original intention of the test is to test that the ldb files can be loaded along with the sst files.

The original test checks this by `ASSERT_NE("NOT_FOUND", Get(Key(k)))`, but the problem is `Get(Key(k))` returns IO error due to path not found instead of NOT_FOUND, so the success of ASSERT_NE does not mean the key can be retrieved.

This PR updates the test to make sure Get(Key(k)) returns the original value.

Test Plan:
make db_sst_test && ./db_sst_test