### PR TITLE
Remove inappropriate comments

### DIFF
--- a/include/rocksdb/cleanable.h
+++ b/include/rocksdb/cleanable.h
@@ -5,16 +5,6 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
-//
-// An iterator yields a sequence of key/value pairs from a source.
-// The following class defines the interface.  Multiple implementations
-// are provided by this library.  In particular, iterators are provided
-// to access the contents of a Table or a DB.
-//
-// Multiple threads can invoke const methods on an Iterator without
-// external synchronization, but if any of the threads may call a
-// non-const method, all threads accessing the same Iterator must use
-// external synchronization.
 
 #pragma once
 


### PR DESCRIPTION
Summary:
The comments are for iterators, not Cleanable.