### PR TITLE
Remove include math.h

### DIFF
--- a/monitoring/histogram.cc
+++ b/monitoring/histogram.cc
@@ -9,10 +9,10 @@
 
 #include "monitoring/histogram.h"
 
-#include <math.h>
 #include <stdio.h>
 #include <cassert>
 #include <cinttypes>
+#include <cmath>
 
 #include "port/port.h"
 #include "util/cast_util.h"
@@ -177,7 +177,7 @@ double HistogramStat::StandardDeviation() const {
   double variance =
       static_cast<double>(cur_sum_squares * cur_num - cur_sum * cur_sum) /
       static_cast<double>(cur_num * cur_num);
-  return sqrt(variance);
+  return std::sqrt(variance);
 }
 std::string HistogramStat::ToString() const {
   uint64_t cur_num = num();

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -16,7 +16,6 @@
 #include <unistd.h>
 #endif
 #include <fcntl.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
Summary:
We see some odd errors complaining math. However, it doesn't seem that it is needed to be included. Remove the include of math.h. Just removing it from db_bench doesn't seem to break anything. Replacing sqrt from std::sqrt seems to work for histogram.cc

Test Plan: Watch Travis and appveyor to run.