### PR TITLE
Let new threads get to work first

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -319,8 +319,8 @@ void ThreadPoolImpl::Impl::SetBackgroundThreadsInternal(int num,
   if (num > total_threads_limit_ ||
       (num < total_threads_limit_ && allow_reduce)) {
     total_threads_limit_ = std::max(0, num);
-    WakeUpAllThreads();
     StartBGThreads();
+    WakeUpAllThreads();
   }
 }
 


### PR DESCRIPTION
Summary:
AppVeyor fails consistently with error 
```
[ RUN      ] DefaultEnvWithoutDirectIO/EnvPosixTestWithParam.DecreaseNumBgThreads/0
c:\projects\rocksdb\env\env_test.cc(590): error: Expected equality of these values:
  1U
    Which is: 1
  env_->GetThreadPoolQueueLen(Env::Priority::HIGH)
    Which is: 2
```
This might be because after increasing the number of threads, the queued task is not scheduled onto the new thread during the time of delay set in the test. This PR tries to let the new threads get task from queue ASAP.

Test Plan:
Wait for results from AppVeyor.