### PR TITLE
Fix Buck build on macOS

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -32,7 +32,7 @@ ROCKSDB_EXTERNAL_DEPS = [
 ROCKSDB_OS_DEPS = [
     (
         "linux",
-        ["third-party//numa:numa", "third-party//liburing:uring],
+        ["third-party//numa:numa", "third-party//liburing:uring"],
     ),
 ]
 

--- a/TARGETS
+++ b/TARGETS
@@ -26,14 +26,13 @@ ROCKSDB_EXTERNAL_DEPS = [
     ("lz4", None, "lz4"),
     ("zstd", None),
     ("tbb", None),
-    ("liburing", None, "uring"),
     ("googletest", None, "gtest"),
 ]
 
 ROCKSDB_OS_DEPS = [
     (
         "linux",
-        ["third-party//numa:numa"],
+        ["third-party//numa:numa", "third-party//liburing:uring],
     ),
 ]
 
@@ -50,6 +49,7 @@ ROCKSDB_OS_PREPROCESSOR_FLAGS = [
             "-DROCKSDB_IOURING_PRESENT",
             "-DHAVE_SSE42",
             "-DNUMA",
+            "-DLIBURING",
         ],
     ),
     (
@@ -72,7 +72,6 @@ ROCKSDB_PREPROCESSOR_FLAGS = [
     "-DZSTD_STATIC_LINKING_ONLY",
     "-DGFLAGS=gflags",
     "-DTBB",
-    "-DLIBURING",
 
     # Added missing flags from output of build_detect_platform
     "-DROCKSDB_BACKTRACE",

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -38,7 +38,7 @@ ROCKSDB_EXTERNAL_DEPS = [
 ROCKSDB_OS_DEPS = [
     (
         "linux",
-        ["third-party//numa:numa", "third-party//liburing:uring],
+        ["third-party//numa:numa", "third-party//liburing:uring"],
     ),
 ]
 

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -32,14 +32,13 @@ ROCKSDB_EXTERNAL_DEPS = [
     ("lz4", None, "lz4"),
     ("zstd", None),
     ("tbb", None),
-    ("liburing", None, "uring"),
     ("googletest", None, "gtest"),
 ]
 
 ROCKSDB_OS_DEPS = [
     (
         "linux",
-        ["third-party//numa:numa"],
+        ["third-party//numa:numa", "third-party//liburing:uring],
     ),
 ]
 
@@ -56,6 +55,7 @@ ROCKSDB_OS_PREPROCESSOR_FLAGS = [
             "-DROCKSDB_IOURING_PRESENT",
             "-DHAVE_SSE42",
             "-DNUMA",
+            "-DLIBURING",
         ],
     ),
     (
@@ -78,7 +78,6 @@ ROCKSDB_PREPROCESSOR_FLAGS = [
     "-DZSTD_STATIC_LINKING_ONLY",
     "-DGFLAGS=gflags",
     "-DTBB",
-    "-DLIBURING",
 
     # Added missing flags from output of build_detect_platform
     "-DROCKSDB_BACKTRACE",


### PR DESCRIPTION
liburing is a Linux-specific dependency, so make sure it's configured in the Linux-only Buck rules.