### PR TITLE
Pass info_log_level to the inner logger of AutoRollLogger

### DIFF
--- a/logging/auto_roll_logger.cc
+++ b/logging/auto_roll_logger.cc
@@ -59,6 +59,8 @@ Status AutoRollLogger::ResetLogger() {
   if (!status_.ok()) {
     return status_;
   }
+  assert(logger_);
+  logger_->SetInfoLogLevel(Logger::GetInfoLogLevel());
 
   if (logger_->GetLogFileSize() == Logger::kDoNotSupportGetLogFileSize) {
     status_ = Status::NotSupported(

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -73,6 +73,24 @@ class AutoRollLogger : public Logger {
     }
   }
 
+  using Logger::GetInfoLogLevel;
+  InfoLogLevel GetInfoLogLevel() const override {
+    MutexLock l(&mutex_);
+    if (!logger_) {
+      return Logger::GetInfoLogLevel();
+    }
+    return logger_->GetInfoLogLevel();
+  }
+
+  using Logger::SetInfoLogLevel;
+  void SetInfoLogLevel(const InfoLogLevel log_level) override {
+    MutexLock lock(&mutex_);
+    Logger::SetInfoLogLevel(log_level);
+    if (logger_) {
+      logger_->SetInfoLogLevel(log_level);
+    }
+  }
+
   void SetCallNowMicrosEveryNRecords(uint64_t call_NowMicros_every_N_records) {
     call_NowMicros_every_N_records_ = call_NowMicros_every_N_records;
   }
@@ -83,6 +101,8 @@ class AutoRollLogger : public Logger {
   }
 
   uint64_t TEST_ctime() const { return ctime_; }
+
+  Logger* TEST_inner_logger() const { return logger_.get(); }
 
  protected:
   // Implementation of Close()

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -132,6 +132,9 @@ void AutoRollLoggerTest::RollLogFileBySizeTest(AutoRollLogger* logger,
                                                size_t log_max_size,
                                                const std::string& log_message) {
   logger->SetInfoLogLevel(InfoLogLevel::INFO_LEVEL);
+  ASSERT_EQ(InfoLogLevel::INFO_LEVEL, logger->GetInfoLogLevel());
+  ASSERT_EQ(InfoLogLevel::INFO_LEVEL,
+            logger->TEST_inner_logger()->GetInfoLogLevel());
   // measure the size of each message, which is supposed
   // to be equal or greater than log_message.size()
   LogMessage(logger, log_message.c_str());
@@ -219,6 +222,25 @@ TEST_F(AutoRollLoggerTest, RollLogFileByTime) {
 
   RollLogFileByTimeTest(&nse, &logger, time,
                         kSampleMessage + ":RollLogFileByTime");
+}
+
+TEST_F(AutoRollLoggerTest, SetInfoLogLevel) {
+  InitTestDb();
+  Options options;
+  options.info_log_level = InfoLogLevel::FATAL_LEVEL;
+  options.max_log_file_size = 1024;
+  std::shared_ptr<Logger> logger;
+  ASSERT_OK(CreateLoggerFromOptions(kTestDir, options, &logger));
+  auto* auto_roll_logger = dynamic_cast<AutoRollLogger*>(logger.get());
+  ASSERT_NE(nullptr, auto_roll_logger);
+  ASSERT_EQ(InfoLogLevel::FATAL_LEVEL, auto_roll_logger->GetInfoLogLevel());
+  ASSERT_EQ(InfoLogLevel::FATAL_LEVEL,
+            auto_roll_logger->TEST_inner_logger()->GetInfoLogLevel());
+  auto_roll_logger->SetInfoLogLevel(InfoLogLevel::DEBUG_LEVEL);
+  ASSERT_EQ(InfoLogLevel::DEBUG_LEVEL, auto_roll_logger->GetInfoLogLevel());
+  ASSERT_EQ(InfoLogLevel::DEBUG_LEVEL, logger->GetInfoLogLevel());
+  ASSERT_EQ(InfoLogLevel::DEBUG_LEVEL,
+            auto_roll_logger->TEST_inner_logger()->GetInfoLogLevel());
 }
 
 TEST_F(AutoRollLoggerTest, OpenLogFilesMultipleTimesWithOptionLog_max_size) {


### PR DESCRIPTION
Before this fix, the info_log_level passed from CreateLoggerFromOptions() will
be ignored by AutoRollLogger::logger_. This PR fixes it by setting the info log
level of logger_ during ResetLogger().

Test plan (dev server):
```
COMPILE_WITH_TSAN=1 make all && make check
make all && make check
```