### PR TITLE
utilities/env_librados: copy use bufferlist::iterator

### DIFF
--- a/utilities/env_librados.cc
+++ b/utilities/env_librados.cc
@@ -127,7 +127,7 @@ public:
     Status s;
     int r = _io_ctx->read(_fid, buffer, n, _offset);
     if (r >= 0) {
-      buffer.copy(0, r, scratch);
+      buffer.begin().copy(r, scratch);
       *result = Slice(scratch, r);
       _offset += r;
       s = Status::OK();
@@ -205,7 +205,7 @@ public:
     Status s;
     int r = _io_ctx->read(_fid, buffer, n, offset);
     if (r >= 0) {
-      buffer.copy(0, r, scratch);
+      buffer.begin().copy(r, scratch);
       *result = Slice(scratch, r);
       s = Status::OK();
     } else {


### PR DESCRIPTION
to adapt the change in ceph upstream where the bufferlist::copy() method
was removed in
https://github.com/ceph/ceph/commit/c724369010a753bd44e11a534d1f42156c4fc12d

Signed-off-by: Kefu Chai <tchaikov@gmail.com>