### PR TITLE
Make clang analyze happy with options_test

### DIFF
--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -1541,9 +1541,10 @@ TEST_F(OptionsParserTest, Readahead) {
   ASSERT_OK(PersistRocksDBOptions(base_db_opt, cf_names, base_cf_opts,
                                   kOptionsFileName, fs_.get()));
 
-  uint64_t file_size;
+  uint64_t file_size = 0;
   ASSERT_OK(env_->GetFileSize(kOptionsFileName, &file_size));
-
+  assert(file_size > 0);
+  
   RocksDBOptionsParser parser;
 
   env_->num_seq_file_read_ = 0;


### PR DESCRIPTION
Summary: clang analysis shows following warning:

options/options_test.cc:1554:24: warning: The left operand of '-' is a garbage value
            (file_size - 1) / readahead_size + 1);
             ~~~~~~~~~ ^

Explicitly initialize file_size and add an assertion to make clang analysis happy.

Test Plan: Run "make analysis" and see the warning goes away.