### PR TITLE
By default turn IO Uring off.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -44,6 +44,7 @@
 * BlobDB now garbage collects non-TTL blobs when `enable_garbage_collection` is set to `true` in `BlobDBOptions`. Garbage collection is performed during compaction: any valid blobs located in the oldest N files (where N is the number of non-TTL blob files multiplied by the value of `BlobDBOptions::garbage_collection_cutoff`) encountered during compaction get relocated to new blob files, and old blob files are dropped once they are no longer needed. Note: we recommend enabling periodic compactions for the base DB when using this feature to deal with the case when some old blob files are kept alive by SSTs that otherwise do not get picked for compaction.
 * `db_bench` now supports the `garbage_collection_cutoff` option for BlobDB.
 * Introduce ReadOptions.auto_prefix_mode. When set to true, iterator will return the same result as total order seek, but may choose to use prefix seek internally based on seek key and iterator upper bound.
+* MultiGet() can use IO Uring to parallelize read from the same SST file. This featuer is by default disabled. It can be enabled with environment variable ROCKSDB_USE_IO_URING.
 
 ## 6.6.2 (01/13/2020)
 ### Bug Fixes

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -150,18 +150,20 @@ case "$TARGET_OS" in
             PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -latomic"
         fi
         PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lpthread -lrt"
-        # check for liburing
-        $CXX $CFLAGS -x c++ - -luring -o /dev/null 2>/dev/null  <<EOF
-          #include <liburing.h>
-          int main() {
-            struct io_uring ring;
-            io_uring_queue_init(1, &ring, 0);
-            return 0;
-          }
+        if test $ROCKSDB_USE_IO_URING; then
+            # check for liburing
+            $CXX $CFLAGS -x c++ - -luring -o /dev/null 2>/dev/null  <<EOF
+              #include <liburing.h>
+              int main() {
+                struct io_uring ring;
+                io_uring_queue_init(1, &ring, 0);
+                return 0;
+              }
 EOF
-        if [ "$?" = 0 ]; then
-          PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -luring"
-          COMMON_FLAGS="$COMMON_FLAGS -DROCKSDB_IOURING_PRESENT"
+            if [ "$?" = 0 ]; then
+                PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -luring"
+                COMMON_FLAGS="$COMMON_FLAGS -DROCKSDB_IOURING_PRESENT"
+            fi
         fi
         if test -z "$USE_FOLLY_DISTRIBUTED_MUTEX"; then
           USE_FOLLY_DISTRIBUTED_MUTEX=1


### PR DESCRIPTION
Summary: We realized bugs related to IO Uring. Turn it off by default.

Test Plan: Manually run build_tools/build_detect_platform and observe outputs.

Reviewers:

Subscribers:

Tasks:

Tags: