### PR TITLE
[FB Internal] Remove IO URING compiler flags

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -46,10 +46,8 @@ ROCKSDB_OS_PREPROCESSOR_FLAGS = [
             "-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX",
             "-DROCKSDB_RANGESYNC_PRESENT",
             "-DROCKSDB_SCHED_GETCPU_PRESENT",
-            "-DROCKSDB_IOURING_PRESENT",
             "-DHAVE_SSE42",
             "-DNUMA",
-            "-DLIBURING",
         ],
     ),
     (

--- a/buckifier/targets_cfg.py
+++ b/buckifier/targets_cfg.py
@@ -52,10 +52,8 @@ ROCKSDB_OS_PREPROCESSOR_FLAGS = [
             "-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX",
             "-DROCKSDB_RANGESYNC_PRESENT",
             "-DROCKSDB_SCHED_GETCPU_PRESENT",
-            "-DROCKSDB_IOURING_PRESENT",
             "-DHAVE_SSE42",
             "-DNUMA",
-            "-DLIBURING",
         ],
     ),
     (


### PR DESCRIPTION
Summary: Since IO Uring feature is not stable. Remove it from buck configuration.

Test Plan: See internal build pass