### PR TITLE
Add blob file state to VersionEdit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,7 @@ set(SOURCES
         cache/lru_cache.cc
         cache/sharded_cache.cc
         db/arena_wrapped_db_iter.cc
+        db/blob_file_state.cc
         db/builder.cc
         db/c.cc
         db/column_family.cc
@@ -919,6 +920,7 @@ if(WITH_TESTS)
   set(TESTS
         cache/cache_test.cc
         cache/lru_cache_test.cc
+        db/blob_file_state_test.cc
         db/column_family_test.cc
         db/compact_files_test.cc
         db/compaction/compaction_job_stats_test.cc

--- a/Makefile
+++ b/Makefile
@@ -597,6 +597,7 @@ TESTS = \
 	block_cache_tracer_test \
 	block_cache_trace_analyzer_test \
 	defer_test \
+	blob_file_state_test \
 
 ifeq ($(USE_FOLLY_DISTRIBUTED_MUTEX),1)
 	TESTS += folly_synchronization_distributed_mutex_test
@@ -1716,6 +1717,9 @@ block_cache_trace_analyzer_test: tools/block_cache_analyzer/block_cache_trace_an
 	$(AM_LINK)
 
 defer_test: util/defer_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+blob_file_state_test: db/blob_file_state_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/TARGETS
+++ b/TARGETS
@@ -114,6 +114,7 @@ cpp_library(
         "cache/lru_cache.cc",
         "cache/sharded_cache.cc",
         "db/arena_wrapped_db_iter.cc",
+        "db/blob_file_state.cc",
         "db/builder.cc",
         "db/c.cc",
         "db/column_family.cc",
@@ -471,6 +472,13 @@ ROCKS_TESTS = [
     [
         "blob_db_test",
         "utilities/blob_db/blob_db_test.cc",
+        "serial",
+        [],
+        [],
+    ],
+    [
+        "blob_file_state_test",
+        "db/blob_file_state_test.cc",
         "serial",
         [],
         [],

--- a/db/blob_file_state.cc
+++ b/db/blob_file_state.cc
@@ -1,0 +1,126 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob_file_state.h"
+
+#include "logging/event_logger.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "test_util/sync_point.h"
+#include "util/coding.h"
+
+#include <sstream>
+
+namespace rocksdb {
+
+namespace {
+
+// Tags for custom fields. Note that these get persisted in the manifest,
+// so existing tags should not be modified.
+enum CustomFieldTags : uint32_t {
+  kEndMarker,
+
+  // Add forward compatible fields here
+
+  /////////////////////////////////////////////////////////////////////
+
+  kForwardIncompatibleMask = 1 << 6,
+
+  // Add forward incompatible fields here
+};
+
+}  // anonymous namespace
+
+void BlobFileState::EncodeTo(std::string* output) const {
+  PutVarint64(output, blob_file_number_);
+  PutVarint64(output, total_blob_count_);
+  PutVarint64(output, total_blob_bytes_);
+  PutVarint64(output, garbage_blob_count_);
+  PutVarint64(output, garbage_blob_bytes_);
+
+  // Encode any custom fields here. The format to use is a Varint32 tag (see
+  // CustomFieldTags above) followed by a length prefixed slice. Unknown custom
+  // fields will be ignored during decoding unless they're in the forward
+  // incompatible range.
+
+  TEST_SYNC_POINT_CALLBACK("BlobFileState::EncodeTo::CustomFields", output);
+
+  PutVarint32(output, kEndMarker);
+}
+
+Status BlobFileState::DecodeFrom(Slice* input) {
+  constexpr char class_name[] = "BlobFileState";
+
+  if (!GetVarint64(input, &blob_file_number_)) {
+    return Status::Corruption(class_name, "Error decoding blob file number");
+  }
+
+  if (!GetVarint64(input, &total_blob_count_)) {
+    return Status::Corruption(class_name, "Error decoding total blob count");
+  }
+
+  if (!GetVarint64(input, &total_blob_bytes_)) {
+    return Status::Corruption(class_name, "Error decoding total blob bytes");
+  }
+
+  if (!GetVarint64(input, &garbage_blob_count_)) {
+    return Status::Corruption(class_name, "Error decoding garbage blob count");
+  }
+
+  if (!GetVarint64(input, &garbage_blob_bytes_)) {
+    return Status::Corruption(class_name, "Error decoding garbage blob bytes");
+  }
+
+  while (true) {
+    uint32_t custom_field_tag = 0;
+    if (!GetVarint32(input, &custom_field_tag)) {
+      return Status::Corruption(class_name, "Error decoding custom field tag");
+    }
+
+    if (custom_field_tag == kEndMarker) {
+      break;
+    }
+
+    if (custom_field_tag & kForwardIncompatibleMask) {
+      return Status::Corruption(
+          class_name, "Forward incompatible custom field encountered");
+    }
+
+    Slice custom_field_value;
+    if (!GetLengthPrefixedSlice(input, &custom_field_value)) {
+      return Status::Corruption(class_name,
+                                "Error decoding custom field value");
+    }
+  }
+
+  return Status::OK();
+}
+
+std::string BlobFileState::DebugString() const {
+  std::ostringstream oss;
+
+  oss << "blob_file_number: " << blob_file_number_
+      << " total_blob_count: " << total_blob_count_
+      << " total_blob_bytes: " << total_blob_bytes_
+      << " garbage_blob_count: " << garbage_blob_count_
+      << " garbage_blob_bytes: " << garbage_blob_bytes_;
+
+  return oss.str();
+}
+
+std::string BlobFileState::DebugJSON() const {
+  JSONWriter jw;
+
+  jw << "BlobFileNumber" << blob_file_number_ << "TotalBlobCount"
+     << total_blob_count_ << "TotalBlobBytes" << total_blob_bytes_
+     << "GarbageBlobCount" << garbage_blob_count_ << "GarbageBlobBytes"
+     << garbage_blob_bytes_;
+
+  jw.EndObject();
+
+  return jw.Get();
+}
+
+}  // namespace rocksdb

--- a/db/blob_file_state.cc
+++ b/db/blob_file_state.cc
@@ -117,6 +117,18 @@ std::string BlobFileState::DebugJSON() const {
   return jw.Get();
 }
 
+bool operator==(const BlobFileState& lhs, const BlobFileState& rhs) {
+  return lhs.GetBlobFileNumber() == rhs.GetBlobFileNumber() &&
+         lhs.GetTotalBlobCount() == rhs.GetTotalBlobCount() &&
+         lhs.GetTotalBlobBytes() == rhs.GetTotalBlobBytes() &&
+         lhs.GetGarbageBlobCount() == rhs.GetGarbageBlobCount() &&
+         lhs.GetGarbageBlobBytes() == rhs.GetGarbageBlobBytes();
+}
+
+bool operator!=(const BlobFileState& lhs, const BlobFileState& rhs) {
+  return !(lhs == rhs);
+}
+
 std::ostream& operator<<(std::ostream& os,
                          const BlobFileState& blob_file_state) {
   os << "blob_file_number: " << blob_file_state.GetBlobFileNumber()

--- a/db/blob_file_state.cc
+++ b/db/blob_file_state.cc
@@ -11,6 +11,7 @@
 #include "test_util/sync_point.h"
 #include "util/coding.h"
 
+#include <ostream>
 #include <sstream>
 
 namespace rocksdb {
@@ -101,11 +102,7 @@ Status BlobFileState::DecodeFrom(Slice* input) {
 std::string BlobFileState::DebugString() const {
   std::ostringstream oss;
 
-  oss << "blob_file_number: " << blob_file_number_
-      << " total_blob_count: " << total_blob_count_
-      << " total_blob_bytes: " << total_blob_bytes_
-      << " garbage_blob_count: " << garbage_blob_count_
-      << " garbage_blob_bytes: " << garbage_blob_bytes_;
+  oss << *this;
 
   return oss.str();
 }
@@ -113,14 +110,32 @@ std::string BlobFileState::DebugString() const {
 std::string BlobFileState::DebugJSON() const {
   JSONWriter jw;
 
-  jw << "BlobFileNumber" << blob_file_number_ << "TotalBlobCount"
-     << total_blob_count_ << "TotalBlobBytes" << total_blob_bytes_
-     << "GarbageBlobCount" << garbage_blob_count_ << "GarbageBlobBytes"
-     << garbage_blob_bytes_;
+  jw << *this;
 
   jw.EndObject();
 
   return jw.Get();
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const BlobFileState& blob_file_state) {
+  os << "blob_file_number: " << blob_file_state.GetBlobFileNumber()
+     << " total_blob_count: " << blob_file_state.GetTotalBlobCount()
+     << " total_blob_bytes: " << blob_file_state.GetTotalBlobBytes()
+     << " garbage_blob_count: " << blob_file_state.GetGarbageBlobCount()
+     << " garbage_blob_bytes: " << blob_file_state.GetGarbageBlobBytes();
+
+  return os;
+}
+
+JSONWriter& operator<<(JSONWriter& jw, const BlobFileState& blob_file_state) {
+  jw << "BlobFileNumber" << blob_file_state.GetBlobFileNumber()
+     << "TotalBlobCount" << blob_file_state.GetTotalBlobCount()
+     << "TotalBlobBytes" << blob_file_state.GetTotalBlobBytes()
+     << "GarbageBlobCount" << blob_file_state.GetGarbageBlobCount()
+     << "GarbageBlobBytes" << blob_file_state.GetGarbageBlobBytes();
+
+  return jw;
 }
 
 }  // namespace rocksdb

--- a/db/blob_file_state.cc
+++ b/db/blob_file_state.cc
@@ -14,7 +14,7 @@
 #include <ostream>
 #include <sstream>
 
-namespace rocksdb {
+namespace ROCKSDB_NAMESPACE {
 
 namespace {
 
@@ -170,4 +170,4 @@ JSONWriter& operator<<(JSONWriter& jw, const BlobFileState& blob_file_state) {
   return jw;
 }
 
-}  // namespace rocksdb
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -10,7 +10,7 @@
 #include <iosfwd>
 #include <string>
 
-namespace rocksdb {
+namespace ROCKSDB_NAMESPACE {
 
 constexpr uint64_t kInvalidBlobFileNumber = 0;
 
@@ -97,4 +97,4 @@ std::ostream& operator<<(std::ostream& os,
                          const BlobFileState& blob_file_state);
 JSONWriter& operator<<(JSONWriter& jw, const BlobFileState& blob_file_state);
 
-}  // namespace rocksdb
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -68,16 +68,6 @@ class BlobFileState {
   std::string DebugString() const;
   std::string DebugJSON() const;
 
-  bool operator==(const BlobFileState& rhs) const {
-    return blob_file_number_ == rhs.blob_file_number_ &&
-           total_blob_count_ == rhs.total_blob_count_ &&
-           total_blob_bytes_ == rhs.total_blob_bytes_ &&
-           garbage_blob_count_ == rhs.garbage_blob_count_ &&
-           garbage_blob_bytes_ == rhs.garbage_blob_bytes_;
-  }
-
-  bool operator!=(const BlobFileState& rhs) const { return !(*this == rhs); }
-
  private:
   uint64_t blob_file_number_ = kInvalidBlobFileNumber;
   uint64_t total_blob_count_ = 0;
@@ -85,6 +75,9 @@ class BlobFileState {
   uint64_t garbage_blob_count_ = 0;
   uint64_t garbage_blob_bytes_ = 0;
 };
+
+bool operator==(const BlobFileState& lhs, const BlobFileState& rhs);
+bool operator!=(const BlobFileState& lhs, const BlobFileState& rhs);
 
 std::ostream& operator<<(std::ostream& os,
                          const BlobFileState& blob_file_state);

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -7,12 +7,14 @@
 
 #include <cassert>
 #include <cstdint>
+#include <iosfwd>
 #include <string>
 
 namespace rocksdb {
 
 constexpr uint64_t kInvalidBlobFileNumber = 0;
 
+class JSONWriter;
 class Slice;
 class Status;
 
@@ -83,5 +85,9 @@ class BlobFileState {
   uint64_t garbage_blob_count_ = 0;
   uint64_t garbage_blob_bytes_ = 0;
 };
+
+std::ostream& operator<<(std::ostream& os,
+                         const BlobFileState& blob_file_state);
+JSONWriter& operator<<(JSONWriter& jw, const BlobFileState& blob_file_state);
 
 }  // namespace rocksdb

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -23,19 +23,28 @@ class BlobFileState {
   BlobFileState() = default;
 
   BlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
-                uint64_t total_blob_bytes)
+                uint64_t total_blob_bytes, std::string checksum_method,
+                std::string checksum_value)
       : blob_file_number_(blob_file_number),
         total_blob_count_(total_blob_count),
-        total_blob_bytes_(total_blob_bytes) {}
+        total_blob_bytes_(total_blob_bytes),
+        checksum_method_(std::move(checksum_method)),
+        checksum_value_(std::move(checksum_value)) {
+    assert(checksum_method_.empty() == checksum_value_.empty());
+  }
 
   BlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
                 uint64_t total_blob_bytes, uint64_t garbage_blob_count,
-                uint64_t garbage_blob_bytes)
+                uint64_t garbage_blob_bytes, std::string checksum_method,
+                std::string checksum_value)
       : blob_file_number_(blob_file_number),
         total_blob_count_(total_blob_count),
         total_blob_bytes_(total_blob_bytes),
         garbage_blob_count_(garbage_blob_count),
-        garbage_blob_bytes_(garbage_blob_bytes) {
+        garbage_blob_bytes_(garbage_blob_bytes),
+        checksum_method_(std::move(checksum_method)),
+        checksum_value_(std::move(checksum_value)) {
+    assert(checksum_method_.empty() == checksum_value_.empty());
     assert(garbage_blob_count_ <= total_blob_count_);
     assert(garbage_blob_bytes_ <= total_blob_bytes_);
   }
@@ -62,6 +71,9 @@ class BlobFileState {
     return !(garbage_blob_count_ < total_blob_count_);
   }
 
+  const std::string& GetChecksumMethod() const { return checksum_method_; }
+  const std::string& GetChecksumValue() const { return checksum_value_; }
+
   void EncodeTo(std::string* output) const;
   Status DecodeFrom(Slice* input);
 
@@ -74,6 +86,8 @@ class BlobFileState {
   uint64_t total_blob_bytes_ = 0;
   uint64_t garbage_blob_count_ = 0;
   uint64_t garbage_blob_bytes_ = 0;
+  std::string checksum_method_;
+  std::string checksum_value_;
 };
 
 bool operator==(const BlobFileState& lhs, const BlobFileState& rhs);

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "rocksdb/rocksdb_namespace.h"
+
 #include <cassert>
 #include <cstdint>
 #include <iosfwd>

--- a/db/blob_file_state.h
+++ b/db/blob_file_state.h
@@ -1,0 +1,87 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+
+namespace rocksdb {
+
+constexpr uint64_t kInvalidBlobFileNumber = 0;
+
+class Slice;
+class Status;
+
+class BlobFileState {
+ public:
+  BlobFileState() = default;
+
+  BlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
+                uint64_t total_blob_bytes)
+      : blob_file_number_(blob_file_number),
+        total_blob_count_(total_blob_count),
+        total_blob_bytes_(total_blob_bytes) {}
+
+  BlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
+                uint64_t total_blob_bytes, uint64_t garbage_blob_count,
+                uint64_t garbage_blob_bytes)
+      : blob_file_number_(blob_file_number),
+        total_blob_count_(total_blob_count),
+        total_blob_bytes_(total_blob_bytes),
+        garbage_blob_count_(garbage_blob_count),
+        garbage_blob_bytes_(garbage_blob_bytes) {
+    assert(garbage_blob_count_ <= total_blob_count_);
+    assert(garbage_blob_bytes_ <= total_blob_bytes_);
+  }
+
+  uint64_t GetBlobFileNumber() const { return blob_file_number_; }
+
+  uint64_t GetTotalBlobCount() const { return total_blob_count_; }
+  uint64_t GetTotalBlobBytes() const { return total_blob_bytes_; }
+
+  void AddGarbageBlob(uint64_t size) {
+    assert(garbage_blob_count_ < total_blob_count_);
+    assert(garbage_blob_bytes_ + size <= total_blob_bytes_);
+
+    ++garbage_blob_count_;
+    garbage_blob_bytes_ += size;
+  }
+
+  uint64_t GetGarbageBlobCount() const { return garbage_blob_count_; }
+  uint64_t GetGarbageBlobBytes() const { return garbage_blob_bytes_; }
+
+  bool IsObsolete() const {
+    assert(garbage_blob_count_ <= total_blob_count_);
+
+    return !(garbage_blob_count_ < total_blob_count_);
+  }
+
+  void EncodeTo(std::string* output) const;
+  Status DecodeFrom(Slice* input);
+
+  std::string DebugString() const;
+  std::string DebugJSON() const;
+
+  bool operator==(const BlobFileState& rhs) const {
+    return blob_file_number_ == rhs.blob_file_number_ &&
+           total_blob_count_ == rhs.total_blob_count_ &&
+           total_blob_bytes_ == rhs.total_blob_bytes_ &&
+           garbage_blob_count_ == rhs.garbage_blob_count_ &&
+           garbage_blob_bytes_ == rhs.garbage_blob_bytes_;
+  }
+
+  bool operator!=(const BlobFileState& rhs) const { return !(*this == rhs); }
+
+ private:
+  uint64_t blob_file_number_ = kInvalidBlobFileNumber;
+  uint64_t total_blob_count_ = 0;
+  uint64_t total_blob_bytes_ = 0;
+  uint64_t garbage_blob_count_ = 0;
+  uint64_t garbage_blob_bytes_ = 0;
+};
+
+}  // namespace rocksdb

--- a/db/blob_file_state_test.cc
+++ b/db/blob_file_state_test.cc
@@ -12,7 +12,7 @@
 #include <cstring>
 #include <string>
 
-namespace rocksdb {
+namespace ROCKSDB_NAMESPACE {
 
 class BlobFileStateTest : public testing::Test {
  public:
@@ -276,7 +276,7 @@ TEST_F(BlobFileStateTest, ForwardIncompatibleCustomField) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
-}  // namespace rocksdb
+}  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/db/blob_file_state_test.cc
+++ b/db/blob_file_state_test.cc
@@ -180,7 +180,9 @@ TEST_F(BlobFileStateTest, ForwardCompatibleCustomField) {
       "BlobFileState::EncodeTo::CustomFields", [&](void* arg) {
         std::string* output = static_cast<std::string*>(arg);
 
-        PutVarint32(output, 2);
+        constexpr uint32_t forward_compatible_tag = 2;
+        PutVarint32(output, forward_compatible_tag);
+
         PutLengthPrefixedSlice(output, "deadbeef");
       });
   SyncPoint::GetInstance()->EnableProcessing();
@@ -206,7 +208,9 @@ TEST_F(BlobFileStateTest, ForwardIncompatibleCustomField) {
       "BlobFileState::EncodeTo::CustomFields", [&](void* arg) {
         std::string* output = static_cast<std::string*>(arg);
 
-        PutVarint32(output, (1 << 6) + 1);
+        constexpr uint32_t forward_incompatible_tag = (1 << 6) + 1;
+        PutVarint32(output, forward_incompatible_tag);
+
         PutLengthPrefixedSlice(output, "foobar");
       });
   SyncPoint::GetInstance()->EnableProcessing();

--- a/db/blob_file_state_test.cc
+++ b/db/blob_file_state_test.cc
@@ -1,0 +1,240 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob_file_state.h"
+#include "test_util/sync_point.h"
+#include "test_util/testharness.h"
+#include "util/coding.h"
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace rocksdb {
+
+class BlobFileStateTest : public testing::Test {
+ public:
+  static void TestEncodeDecode(const BlobFileState& blob_file_state) {
+    std::string encoded;
+    blob_file_state.EncodeTo(&encoded);
+
+    BlobFileState decoded;
+    Slice input(encoded);
+    ASSERT_OK(decoded.DecodeFrom(&input));
+
+    ASSERT_EQ(blob_file_state, decoded);
+  }
+};
+
+TEST_F(BlobFileStateTest, Empty) {
+  BlobFileState blob_file_state;
+
+  ASSERT_EQ(blob_file_state.GetBlobFileNumber(), kInvalidBlobFileNumber);
+  ASSERT_EQ(blob_file_state.GetTotalBlobCount(), 0);
+  ASSERT_EQ(blob_file_state.GetTotalBlobBytes(), 0);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobCount(), 0);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobBytes(), 0);
+  ASSERT_TRUE(blob_file_state.IsObsolete());
+
+  TestEncodeDecode(blob_file_state);
+}
+
+TEST_F(BlobFileStateTest, NonEmpty) {
+  constexpr uint64_t blob_file_number = 123;
+  constexpr uint64_t total_blob_count = 2;
+  constexpr uint64_t total_blob_bytes = 123456;
+  constexpr uint64_t garbage_blob_count = 1;
+  constexpr uint64_t garbage_blob_bytes = 9876;
+
+  BlobFileState blob_file_state(blob_file_number, total_blob_count,
+                                total_blob_bytes, garbage_blob_count,
+                                garbage_blob_bytes);
+
+  ASSERT_EQ(blob_file_state.GetBlobFileNumber(), blob_file_number);
+  ASSERT_EQ(blob_file_state.GetTotalBlobCount(), total_blob_count);
+  ASSERT_EQ(blob_file_state.GetTotalBlobBytes(), total_blob_bytes);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobCount(), garbage_blob_count);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobBytes(), garbage_blob_bytes);
+  ASSERT_FALSE(blob_file_state.IsObsolete());
+
+  TestEncodeDecode(blob_file_state);
+}
+
+TEST_F(BlobFileStateTest, AddGarbageBlob) {
+  constexpr uint64_t blob_file_number = 123;
+  constexpr uint64_t total_blob_count = 2;
+  constexpr uint64_t total_blob_bytes = 123456;
+
+  BlobFileState blob_file_state(blob_file_number, total_blob_count,
+                                total_blob_bytes);
+
+  ASSERT_EQ(blob_file_state.GetBlobFileNumber(), blob_file_number);
+  ASSERT_EQ(blob_file_state.GetTotalBlobCount(), total_blob_count);
+  ASSERT_EQ(blob_file_state.GetTotalBlobBytes(), total_blob_bytes);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobCount(), 0);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobBytes(), 0);
+  ASSERT_FALSE(blob_file_state.IsObsolete());
+
+  TestEncodeDecode(blob_file_state);
+
+  blob_file_state.AddGarbageBlob(123000);
+
+  ASSERT_EQ(blob_file_state.GetBlobFileNumber(), blob_file_number);
+  ASSERT_EQ(blob_file_state.GetTotalBlobCount(), total_blob_count);
+  ASSERT_EQ(blob_file_state.GetTotalBlobBytes(), total_blob_bytes);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobCount(), 1);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobBytes(), 123000);
+  ASSERT_FALSE(blob_file_state.IsObsolete());
+
+  TestEncodeDecode(blob_file_state);
+
+  blob_file_state.AddGarbageBlob(456);
+
+  ASSERT_EQ(blob_file_state.GetBlobFileNumber(), blob_file_number);
+  ASSERT_EQ(blob_file_state.GetTotalBlobCount(), total_blob_count);
+  ASSERT_EQ(blob_file_state.GetTotalBlobBytes(), total_blob_bytes);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobCount(), total_blob_count);
+  ASSERT_EQ(blob_file_state.GetGarbageBlobBytes(), total_blob_bytes);
+  ASSERT_TRUE(blob_file_state.IsObsolete());
+
+  TestEncodeDecode(blob_file_state);
+}
+
+TEST_F(BlobFileStateTest, DecodeErrors) {
+  std::string str;
+  Slice slice(str);
+
+  BlobFileState blob_file_state;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "blob file number"));
+  }
+
+  constexpr uint64_t blob_file_number = 123;
+  PutVarint64(&str, blob_file_number);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "total blob count"));
+  }
+
+  constexpr uint64_t total_blob_count = 4567;
+  PutVarint64(&str, total_blob_count);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "total blob bytes"));
+  }
+
+  constexpr uint64_t total_blob_bytes = 12345678;
+  PutVarint64(&str, total_blob_bytes);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "garbage blob count"));
+  }
+
+  constexpr uint64_t garbage_blob_count = 1234;
+  PutVarint64(&str, garbage_blob_count);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "garbage blob bytes"));
+  }
+
+  constexpr uint64_t garbage_blob_bytes = 5678;
+  PutVarint64(&str, garbage_blob_bytes);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "custom field tag"));
+  }
+
+  constexpr uint32_t custom_tag = 2;
+  PutVarint32(&str, custom_tag);
+  slice = str;
+
+  {
+    const Status s = blob_file_state.DecodeFrom(&slice);
+    ASSERT_TRUE(s.IsCorruption());
+    ASSERT_TRUE(std::strstr(s.getState(), "custom field value"));
+  }
+}
+
+TEST_F(BlobFileStateTest, ForwardCompatibleCustomField) {
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobFileState::EncodeTo::CustomFields", [&](void* arg) {
+        std::string* output = static_cast<std::string*>(arg);
+
+        PutVarint32(output, 2);
+        PutLengthPrefixedSlice(output, "deadbeef");
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  constexpr uint64_t blob_file_number = 678;
+  constexpr uint64_t total_blob_count = 9999;
+  constexpr uint64_t total_blob_bytes = 100000000;
+  constexpr uint64_t garbage_blob_count = 3333;
+  constexpr uint64_t garbage_blob_bytes = 2500000;
+
+  BlobFileState blob_file_state(blob_file_number, total_blob_count,
+                                total_blob_bytes, garbage_blob_count,
+                                garbage_blob_bytes);
+
+  TestEncodeDecode(blob_file_state);
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(BlobFileStateTest, ForwardIncompatibleCustomField) {
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobFileState::EncodeTo::CustomFields", [&](void* arg) {
+        std::string* output = static_cast<std::string*>(arg);
+
+        PutVarint32(output, (1 << 6) + 1);
+        PutLengthPrefixedSlice(output, "foobar");
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  constexpr uint64_t blob_file_number = 456;
+  constexpr uint64_t total_blob_count = 100;
+  constexpr uint64_t total_blob_bytes = 2000000;
+
+  BlobFileState blob_file_state(blob_file_number, total_blob_count,
+                                total_blob_bytes);
+
+  std::string encoded;
+  blob_file_state.EncodeTo(&encoded);
+
+  BlobFileState decoded_blob_file_state;
+  Slice input(encoded);
+  const Status s = decoded_blob_file_state.DecodeFrom(&input);
+
+  ASSERT_TRUE(s.IsCorruption());
+  ASSERT_TRUE(std::strstr(s.getState(), "Forward incompatible"));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -818,7 +818,7 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
 
     for (const auto& blob_file_state : blob_file_states_) {
       jw.StartArrayedObject();
-      jw << blob_file_state.DebugJSON();
+      jw << blob_file_state;
       jw.EndArrayedObject();
     }
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -349,10 +349,13 @@ class VersionEdit {
   // Add blob file state for the specified file.
   void AddBlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
                         uint64_t total_blob_bytes, uint64_t garbage_blob_count,
-                        uint64_t garbage_blob_bytes) {
-    blob_file_states_.emplace_back(blob_file_number, total_blob_count,
-                                   total_blob_bytes, garbage_blob_count,
-                                   garbage_blob_bytes);
+                        uint64_t garbage_blob_bytes,
+                        std::string checksum_method,
+                        std::string checksum_value) {
+    blob_file_states_.emplace_back(
+        blob_file_number, total_blob_count, total_blob_bytes,
+        garbage_blob_count, garbage_blob_bytes, std::move(checksum_method),
+        std::move(checksum_value));
   }
 
   // Retrieve all the blob file states added.

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "db/blob_file_state.h"
 #include "db/dbformat.h"
 #include "memory/arena.h"
 #include "rocksdb/cache.h"
@@ -24,7 +25,6 @@ namespace ROCKSDB_NAMESPACE {
 class VersionSet;
 
 constexpr uint64_t kFileNumberMask = 0x3FFFFFFFFFFFFFFF;
-constexpr uint64_t kInvalidBlobFileNumber = 0;
 constexpr uint64_t kUnknownOldestAncesterTime = 0;
 constexpr uint64_t kUnknownFileCreationTime = 0;
 
@@ -307,16 +307,16 @@ class VersionEdit {
   bool HasLastSequence() const { return has_last_sequence_; }
   SequenceNumber GetLastSequence() const { return last_sequence_; }
 
-  // Delete the specified "file" from the specified "level".
+  // Delete the specified SST file from the specified level.
   void DeleteFile(int level, uint64_t file) {
     deleted_files_.emplace(level, file);
   }
 
-  // Retrieve the files deleted as well as their associated levels.
+  // Retrieve the SST files deleted as well as their associated levels.
   using DeletedFiles = std::set<std::pair<int, uint64_t>>;
   const DeletedFiles& GetDeletedFiles() const { return deleted_files_; }
 
-  // Add the specified file at the specified level.
+  // Add the specified SST file at the specified level.
   // REQUIRES: This version has not been saved (see VersionSet::SaveTo)
   // REQUIRES: "smallest" and "largest" are smallest and largest keys in file
   // REQUIRES: "oldest_blob_file_number" is the number of the oldest blob file
@@ -342,12 +342,27 @@ class VersionEdit {
     new_files_.emplace_back(level, f);
   }
 
-  // Retrieve the files added as well as their associated levels.
+  // Retrieve the SST files added as well as their associated levels.
   using NewFiles = std::vector<std::pair<int, FileMetaData>>;
   const NewFiles& GetNewFiles() const { return new_files_; }
 
+  // Add blob file state for the specified file.
+  void AddBlobFileState(uint64_t blob_file_number, uint64_t total_blob_count,
+                        uint64_t total_blob_bytes, uint64_t garbage_blob_count,
+                        uint64_t garbage_blob_bytes) {
+    blob_file_states_.emplace_back(blob_file_number, total_blob_count,
+                                   total_blob_bytes, garbage_blob_count,
+                                   garbage_blob_bytes);
+  }
+
+  // Retrieve all the blob file states added.
+  using BlobFileStates = std::vector<BlobFileState>;
+  const BlobFileStates& GetBlobFileStates() const { return blob_file_states_; }
+
   // Number of edits
-  size_t NumEntries() const { return new_files_.size() + deleted_files_.size(); }
+  size_t NumEntries() const {
+    return new_files_.size() + deleted_files_.size() + blob_file_states_.size();
+  }
 
   void SetColumnFamily(uint32_t column_family_id) {
     column_family_ = column_family_id;
@@ -420,6 +435,8 @@ class VersionEdit {
 
   DeletedFiles deleted_files_;
   NewFiles new_files_;
+
+  BlobFileStates blob_file_states_;
 
   // Each version edit record should have column_family_ set
   // If it's not set, it is default (0)

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -307,16 +307,16 @@ class VersionEdit {
   bool HasLastSequence() const { return has_last_sequence_; }
   SequenceNumber GetLastSequence() const { return last_sequence_; }
 
-  // Delete the specified SST file from the specified level.
+  // Delete the specified table file from the specified level.
   void DeleteFile(int level, uint64_t file) {
     deleted_files_.emplace(level, file);
   }
 
-  // Retrieve the SST files deleted as well as their associated levels.
+  // Retrieve the table files deleted as well as their associated levels.
   using DeletedFiles = std::set<std::pair<int, uint64_t>>;
   const DeletedFiles& GetDeletedFiles() const { return deleted_files_; }
 
-  // Add the specified SST file at the specified level.
+  // Add the specified table file at the specified level.
   // REQUIRES: This version has not been saved (see VersionSet::SaveTo)
   // REQUIRES: "smallest" and "largest" are smallest and largest keys in file
   // REQUIRES: "oldest_blob_file_number" is the number of the oldest blob file
@@ -342,7 +342,7 @@ class VersionEdit {
     new_files_.emplace_back(level, f);
   }
 
-  // Retrieve the SST files added as well as their associated levels.
+  // Retrieve the table files added as well as their associated levels.
   using NewFiles = std::vector<std::pair<int, FileMetaData>>;
   const NewFiles& GetNewFiles() const { return new_files_; }
 

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -11,6 +11,7 @@
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "util/coding.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -281,6 +282,9 @@ TEST_F(VersionEditTest, DbId) {
 TEST_F(VersionEditTest, BlobFileState) {
   VersionEdit edit;
 
+  const std::string checksum_method_prefix = "Hash";
+  const std::string checksum_value_prefix = "Value";
+
   for (uint64_t blob_file_number = 1; blob_file_number <= 10;
        ++blob_file_number) {
     const uint64_t total_blob_count = blob_file_number << 10;
@@ -288,8 +292,15 @@ TEST_F(VersionEditTest, BlobFileState) {
     const uint64_t garbage_blob_count = total_blob_count >> 2;
     const uint64_t garbage_blob_bytes = total_blob_bytes >> 1;
 
+    std::string checksum_method(checksum_method_prefix);
+    AppendNumberTo(&checksum_method, blob_file_number);
+
+    std::string checksum_value(checksum_value_prefix);
+    AppendNumberTo(&checksum_value, blob_file_number);
+
     edit.AddBlobFileState(blob_file_number, total_blob_count, total_blob_bytes,
-                          garbage_blob_count, garbage_blob_bytes);
+                          garbage_blob_count, garbage_blob_bytes,
+                          checksum_method, checksum_value);
   }
 
   TestEncodeDecode(edit);

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -278,6 +278,23 @@ TEST_F(VersionEditTest, DbId) {
   TestEncodeDecode(edit);
 }
 
+TEST_F(VersionEditTest, BlobFileState) {
+  VersionEdit edit;
+
+  for (uint64_t blob_file_number = 1; blob_file_number <= 10;
+       ++blob_file_number) {
+    const uint64_t total_blob_count = blob_file_number << 10;
+    const uint64_t total_blob_bytes = blob_file_number << 20;
+    const uint64_t garbage_blob_count = total_blob_count >> 2;
+    const uint64_t garbage_blob_bytes = total_blob_bytes >> 1;
+
+    edit.AddBlobFileState(blob_file_number, total_blob_count, total_blob_bytes,
+                          garbage_blob_count, garbage_blob_bytes);
+  }
+
+  TestEncodeDecode(edit);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/src.mk
+++ b/src.mk
@@ -4,6 +4,7 @@ LIB_SOURCES =                                                   \
   cache/lru_cache.cc                                            \
   cache/sharded_cache.cc                                        \
   db/arena_wrapped_db_iter.cc                                   \
+  db/blob_file_state.cc                                         \
   db/builder.cc                                                 \
   db/c.cc                                                       \
   db/column_family.cc                                           \
@@ -295,6 +296,7 @@ MAIN_SOURCES =                                                          \
   cache/cache_bench.cc                                                  \
   cache/cache_test.cc                                                   \
   db_stress_tool/db_stress.cc                                           \
+  db/blob_file_state_test.cc                                            \
   db/column_family_test.cc                                              \
   db/compact_files_test.cc                                              \
   db/compaction/compaction_iterator_test.cc                             \


### PR DESCRIPTION
Summary:
BlobDB currently does not keep track of blob files: no records are written to
the manifest when a blob file is added or removed, and upon opening a database,
the list of blob files is populated simply based on the contents of the blob directory.
This means that lost blob files cannot be detected at the moment. We plan to solve
this issue by making blob files a part of `Version`; as a first step, this patch makes
it possible to store information about blob files in `VersionEdit`. Currently, this information
includes blob file number, total number and size of all blobs, and total number and size
of garbage blobs. However, the format is extensible: new fields can be added in
both a forward compatible and a forward incompatible manner if needed (similarly
to `kNewFile4`).

Test Plan:
`make check`