### PR TITLE
Fix static_cast SstFileManagerImpl

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -320,7 +320,7 @@ ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
   // were not deleted yet, when we open the DB we will find these .trash files
   // and schedule them to be deleted (or delete immediately if SstFileManager
   // was not used)
-  auto sfm = static_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
+  auto sfm = dynamic_cast<SstFileManagerImpl*>(db_options.sst_file_manager.get());
   for (size_t i = 0; i < result.cf_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(db_options.env, sfm, result.cf_paths[i].path);
   }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1368,7 +1368,7 @@ Status CompactionJob::FinishCompactionOutputFile(
 #ifndef ROCKSDB_LITE
   // Report new file to SstFileManagerImpl
   auto sfm =
-      static_cast<SstFileManagerImpl*>(db_options_.sst_file_manager.get());
+      dynamic_cast<SstFileManagerImpl*>(db_options_.sst_file_manager.get());
   if (sfm && meta != nullptr && meta->fd.GetPathId() == 0) {
     sfm->OnAddFile(fname);
     if (sfm->IsMaxAllowedSpaceReached()) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -578,9 +578,10 @@ Status DBImpl::CloseHelper() {
   // Close() on it before closing the info_log. Otherwise, background thread
   // in SstFileManagerImpl might try to log something
   if (immutable_db_options_.sst_file_manager && own_sfm_) {
-    auto sfm = static_cast<SstFileManagerImpl*>(
-        immutable_db_options_.sst_file_manager.get());
-    sfm->Close();
+    if (auto sfm = dynamic_cast<SstFileManagerImpl*>(
+            immutable_db_options_.sst_file_manager.get())) {
+      sfm->Close();
+    }
   }
 #endif  // ROCKSDB_LITE
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -30,7 +30,7 @@ bool DBImpl::EnoughRoomForCompaction(
   // Check if we have enough room to do the compaction
   bool enough_room = true;
 #ifndef ROCKSDB_LITE
-  auto sfm = static_cast<SstFileManagerImpl*>(
+  auto sfm = dynamic_cast<SstFileManagerImpl*>(
       immutable_db_options_.sst_file_manager.get());
   if (sfm) {
     // Pass the current bg_error_ to SFM so it can decide what checks to
@@ -214,7 +214,7 @@ Status DBImpl::FlushMemTableToOutputFile(
     // may temporarily unlock and lock the mutex.
     NotifyOnFlushCompleted(cfd, mutable_cf_options,
                            flush_job.GetCommittedFlushJobsInfo());
-    auto sfm = static_cast<SstFileManagerImpl*>(
+    auto sfm = dynamic_cast<SstFileManagerImpl*>(
         immutable_db_options_.sst_file_manager.get());
     if (sfm) {
       // Notify sst_file_manager that a new file was added
@@ -518,7 +518,7 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
       *made_progress = true;
     }
 #ifndef ROCKSDB_LITE
-    auto sfm = static_cast<SstFileManagerImpl*>(
+    auto sfm = dynamic_cast<SstFileManagerImpl*>(
         immutable_db_options_.sst_file_manager.get());
     assert(all_mutable_cf_options.size() == static_cast<size_t>(num_cfs));
     for (int i = 0; i != num_cfs; ++i) {
@@ -1004,7 +1004,7 @@ Status DBImpl::CompactFilesImpl(
   c->ReleaseCompactionFiles(s);
 #ifndef ROCKSDB_LITE
   // Need to make sure SstFileManager does its bookkeeping
-  auto sfm = static_cast<SstFileManagerImpl*>(
+  auto sfm = dynamic_cast<SstFileManagerImpl*>(
       immutable_db_options_.sst_file_manager.get());
   if (sfm && sfm_reserved_compact_space) {
     sfm->OnCompactionCompletion(c.get());
@@ -2787,7 +2787,7 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
 
 #ifndef ROCKSDB_LITE
     // Need to make sure SstFileManager does its bookkeeping
-    auto sfm = static_cast<SstFileManagerImpl*>(
+    auto sfm = dynamic_cast<SstFileManagerImpl*>(
         immutable_db_options_.sst_file_manager.get());
     if (sfm && sfm_reserved_compact_space) {
       sfm->OnCompactionCompletion(c.get());

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -159,7 +159,7 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src) {
   // were not deleted yet, when we open the DB we will find these .trash files
   // and schedule them to be deleted (or delete immediately if SstFileManager
   // was not used)
-  auto sfm = static_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
+  auto sfm = dynamic_cast<SstFileManagerImpl*>(result.sst_file_manager.get());
   for (size_t i = 0; i < result.db_paths.size(); i++) {
     DeleteScheduler::CleanupDirectory(result.env, sfm, result.db_paths[i].path);
   }
@@ -1553,7 +1553,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
   impl->mutex_.Unlock();
 
 #ifndef ROCKSDB_LITE
-  auto sfm = static_cast<SstFileManagerImpl*>(
+  auto sfm = dynamic_cast<SstFileManagerImpl*>(
       impl->immutable_db_options_.sst_file_manager.get());
   if (s.ok() && sfm) {
     // Notify SstFileManager about all sst files that already exist in

--- a/db/error_handler.cc
+++ b/db/error_handler.cc
@@ -127,8 +127,8 @@ void ErrorHandler::CancelErrorRecovery() {
   // We'll release the lock before calling sfm, so make sure no new
   // recovery gets scheduled at that point
   auto_recovery_ = false;
-  SstFileManagerImpl* sfm = reinterpret_cast<SstFileManagerImpl*>(
-      db_options_.sst_file_manager.get());
+  SstFileManagerImpl* sfm =
+      dynamic_cast<SstFileManagerImpl*>(db_options_.sst_file_manager.get());
   if (sfm) {
     // This may or may not cancel a pending recovery
     db_mutex_->Unlock();
@@ -278,7 +278,7 @@ Status ErrorHandler::OverrideNoSpaceError(Status bg_error,
 void ErrorHandler::RecoverFromNoSpace() {
 #ifndef ROCKSDB_LITE
   SstFileManagerImpl* sfm =
-      reinterpret_cast<SstFileManagerImpl*>(db_options_.sst_file_manager.get());
+      dynamic_cast<SstFileManagerImpl*>(db_options_.sst_file_manager.get());
 
   // Inform SFM of the error, so it can kick-off the recovery
   if (sfm) {

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -94,7 +94,7 @@ Status DeleteDBFile(const ImmutableDBOptions* db_options,
                     const bool force_bg, const bool force_fg) {
 #ifndef ROCKSDB_LITE
   SstFileManagerImpl* sfm =
-      static_cast<SstFileManagerImpl*>(db_options->sst_file_manager.get());
+      dynamic_cast<SstFileManagerImpl*>(db_options->sst_file_manager.get());
   if (sfm && !force_fg) {
     return sfm->ScheduleFileDeletion(fname, dir_to_sync, force_bg);
   } else {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -234,7 +234,7 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   }
 
   // Add trash files in blob dir to file delete scheduler.
-  SstFileManagerImpl* sfm = static_cast<SstFileManagerImpl*>(
+  SstFileManagerImpl* sfm = dynamic_cast<SstFileManagerImpl*>(
       db_impl_->immutable_db_options().sst_file_manager.get());
   DeleteScheduler::CleanupDirectory(env_, sfm, blob_dir_);
 


### PR DESCRIPTION
RocksDB exposes `sst_file_manager` as a public option: https://github.com/facebook/rocksdb/blob/29e24434fec91cbeae1deb6cd96319af1b308716/include/rocksdb/options.h#L424.
However, internal implementation uses `static_cast` to cast to `SstFileManagerImpl`, which means if user passes in Custom SST File Manager, it will crash since this is `static_cast`.

Use `dynamic_cast` in this case to have a runtime check to prevent such scenario.