### PR TITLE
Add Struct Type to OptionsTypeInfo

### DIFF
--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -98,24 +98,15 @@ struct OptionsHelper {
       compression_type_string_map;
 #ifndef ROCKSDB_LITE
   static std::unordered_map<std::string, OptionTypeInfo> cf_options_type_info;
-  static std::unordered_map<std::string, OptionTypeInfo>
-      fifo_compaction_options_type_info;
-  static std::unordered_map<std::string, OptionTypeInfo>
-      universal_compaction_options_type_info;
   static std::unordered_map<std::string, CompactionStopStyle>
       compaction_stop_style_string_map;
   static std::unordered_map<std::string, OptionTypeInfo> db_options_type_info;
-  static std::unordered_map<std::string, OptionTypeInfo>
-      lru_cache_options_type_info;
   static std::unordered_map<std::string, EncodingType> encoding_type_string_map;
   static std::unordered_map<std::string, CompactionStyle>
       compaction_style_string_map;
   static std::unordered_map<std::string, CompactionPri>
       compaction_pri_string_map;
   static ColumnFamilyOptions dummy_cf_options;
-  static CompactionOptionsFIFO dummy_comp_options;
-  static LRUCacheOptions dummy_lru_cache_options;
-  static CompactionOptionsUniversal dummy_comp_options_universal;
 #endif  // !ROCKSDB_LITE
 };
 
@@ -128,15 +119,9 @@ static auto& compaction_stop_style_to_string =
 static auto& checksum_type_string_map = OptionsHelper::checksum_type_string_map;
 #ifndef ROCKSDB_LITE
 static auto& cf_options_type_info = OptionsHelper::cf_options_type_info;
-static auto& fifo_compaction_options_type_info =
-    OptionsHelper::fifo_compaction_options_type_info;
-static auto& universal_compaction_options_type_info =
-    OptionsHelper::universal_compaction_options_type_info;
 static auto& compaction_stop_style_string_map =
     OptionsHelper::compaction_stop_style_string_map;
 static auto& db_options_type_info = OptionsHelper::db_options_type_info;
-static auto& lru_cache_options_type_info =
-    OptionsHelper::lru_cache_options_type_info;
 static auto& compression_type_string_map =
     OptionsHelper::compression_type_string_map;
 static auto& encoding_type_string_map = OptionsHelper::encoding_type_string_map;

--- a/options/options_parser.cc
+++ b/options/options_parser.cc
@@ -610,14 +610,14 @@ Status RocksDBOptionsParser::VerifyDBOptions(
     const auto& opt_info = pair.second;
     if (config_options.IsCheckEnabled(opt_info.GetSanityLevel())) {
       const char* base_addr =
-          reinterpret_cast<const char*>(&base_opt) + opt_info.offset;
+          reinterpret_cast<const char*>(&base_opt) + opt_info.offset_;
       const char* file_addr =
-          reinterpret_cast<const char*>(&file_opt) + opt_info.offset;
+          reinterpret_cast<const char*>(&file_opt) + opt_info.offset_;
       std::string mismatch;
-      if (!opt_info.MatchesOption(config_options, pair.first, base_addr,
-                                  file_addr, &mismatch) &&
-          !opt_info.MatchesByName(config_options, pair.first, base_addr,
-                                  file_addr)) {
+      if (!opt_info.AreEqual(config_options, pair.first, base_addr, file_addr,
+                             &mismatch) &&
+          !opt_info.AreEqualByName(config_options, pair.first, base_addr,
+                                   file_addr)) {
         const size_t kBufferSize = 2048;
         char buffer[kBufferSize];
         std::string base_value;
@@ -627,11 +627,11 @@ Status RocksDBOptionsParser::VerifyDBOptions(
                      "[RocksDBOptionsParser]: "
                      "failed the verification on ColumnFamilyOptions::%s",
                      pair.first.c_str());
-        Status s = opt_info.SerializeOption(config_options, pair.first,
-                                            base_addr, &base_value);
+        Status s = opt_info.Serialize(config_options, pair.first, base_addr,
+                                      &base_value);
         if (s.ok()) {
-          s = opt_info.SerializeOption(config_options, pair.first, file_addr,
-                                       &file_value);
+          s = opt_info.Serialize(config_options, pair.first, file_addr,
+                                 &file_value);
         }
         snprintf(buffer, sizeof(buffer),
                  "[RocksDBOptionsParser]: "
@@ -668,11 +668,11 @@ Status RocksDBOptionsParser::VerifyCFOptions(
     if (config_options.IsCheckEnabled(opt_info.GetSanityLevel())) {
       std::string mismatch;
       const char* base_addr =
-          reinterpret_cast<const char*>(&base_opt) + opt_info.offset;
+          reinterpret_cast<const char*>(&base_opt) + opt_info.offset_;
       const char* file_addr =
-          reinterpret_cast<const char*>(&file_opt) + opt_info.offset;
-      bool matches = opt_info.MatchesOption(config_options, pair.first,
-                                            base_addr, file_addr, &mismatch);
+          reinterpret_cast<const char*>(&file_opt) + opt_info.offset_;
+      bool matches = opt_info.AreEqual(config_options, pair.first, base_addr,
+                                       file_addr, &mismatch);
       if (!matches && opt_info.IsByName()) {
         if (opt_map == nullptr) {
           matches = true;
@@ -681,8 +681,8 @@ Status RocksDBOptionsParser::VerifyCFOptions(
           if (iter == opt_map->end()) {
             matches = true;
           } else {
-            matches = opt_info.MatchesByName(config_options, pair.first,
-                                             base_addr, iter->second);
+            matches = opt_info.AreEqualByName(config_options, pair.first,
+                                              base_addr, iter->second);
           }
         }
       }
@@ -692,11 +692,11 @@ Status RocksDBOptionsParser::VerifyCFOptions(
         char buffer[kBufferSize];
         std::string base_value;
         std::string file_value;
-        Status s = opt_info.SerializeOption(config_options, pair.first,
-                                            base_addr, &base_value);
+        Status s = opt_info.Serialize(config_options, pair.first, base_addr,
+                                      &base_value);
         if (s.ok()) {
-          s = opt_info.SerializeOption(config_options, pair.first, file_addr,
-                                       &file_value);
+          s = opt_info.Serialize(config_options, pair.first, file_addr,
+                                 &file_value);
         }
         int offset =
             snprintf(buffer, sizeof(buffer),

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -661,9 +661,9 @@ std::string ParseBlockBasedTableOption(const ConfigOptions& config_options,
     }
   }
   const auto& opt_info = iter->second;
-  Status s = opt_info.ParseOption(
-      config_options, iter->first, value,
-      reinterpret_cast<char*>(new_options) + opt_info.offset);
+  Status s =
+      opt_info.Parse(config_options, iter->first, value,
+                     reinterpret_cast<char*>(new_options) + opt_info.offset_);
   if (s.ok()) {
     return "";
   } else {
@@ -757,14 +757,14 @@ Status VerifyBlockBasedTableFactory(const ConfigOptions& config_options,
     // contain random values since they might not be initialized
     if (config_options.IsCheckEnabled(pair.second.GetSanityLevel())) {
       const char* base_addr =
-          reinterpret_cast<const char*>(&base_opt) + pair.second.offset;
+          reinterpret_cast<const char*>(&base_opt) + pair.second.offset_;
       const char* file_addr =
-          reinterpret_cast<const char*>(&file_opt) + pair.second.offset;
+          reinterpret_cast<const char*>(&file_opt) + pair.second.offset_;
 
-      if (!pair.second.MatchesOption(config_options, pair.first, base_addr,
-                                     file_addr, &mismatch) &&
-          !pair.second.MatchesByName(config_options, pair.first, base_addr,
-                                     file_addr)) {
+      if (!pair.second.AreEqual(config_options, pair.first, base_addr,
+                                file_addr, &mismatch) &&
+          !pair.second.AreEqualByName(config_options, pair.first, base_addr,
+                                      file_addr)) {
         return Status::Corruption(
             "[RocksDBOptionsParser]: "
             "failed the verification on BlockBasedTableOptions::",

--- a/table/plain/plain_table_factory.cc
+++ b/table/plain/plain_table_factory.cc
@@ -220,9 +220,9 @@ std::string ParsePlainTableOptions(const ConfigOptions& config_options,
     }
   }
   const auto& opt_info = iter->second;
-  Status s = opt_info.ParseOption(
-      config_options, name, value,
-      reinterpret_cast<char*>(new_options) + opt_info.offset);
+  Status s =
+      opt_info.Parse(config_options, name, value,
+                     reinterpret_cast<char*>(new_options) + opt_info.offset_);
   if (s.ok()) {
     return "";
   } else {

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -263,6 +263,20 @@ std::string trim(const std::string& str) {
   return std::string();
 }
 
+bool EndsWith(const std::string& string, const std::string& pattern) {
+  size_t plen = pattern.size();
+  size_t slen = string.size();
+  if (plen <= slen) {
+    return string.compare(slen - plen, plen, pattern) == 0;
+  } else {
+    return false;
+  }
+}
+
+bool StartsWith(const std::string& string, const std::string& pattern) {
+  return string.compare(0, pattern.size(), pattern) == 0;
+}
+
 #ifndef ROCKSDB_LITE
 
 bool ParseBoolean(const std::string& type, const std::string& value) {

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -111,6 +111,12 @@ std::string UnescapeOptionString(const std::string& escaped_string);
 
 std::string trim(const std::string& str);
 
+// Returns true if "string" ends with "pattern"
+bool EndsWith(const std::string& string, const std::string& pattern);
+
+// Returns true if "string" starts with "pattern"
+bool StartsWith(const std::string& string, const std::string& pattern);
+
 #ifndef ROCKSDB_LITE
 bool ParseBoolean(const std::string& type, const std::string& value);
 


### PR DESCRIPTION
Added code for generically handing structs to OptionTypeInfo.  A struct is a collection of variables handled by their own map of OptionTypeInfos.  Examples of structs include Compaction and Cache options.