### PR TITLE
Add function to set row cache on rocksdb_options_t

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2765,6 +2765,12 @@ void rocksdb_ratelimiter_destroy(rocksdb_ratelimiter_t *limiter) {
   delete limiter;
 }
 
+void rocksdb_options_set_row_cache(rocksdb_options_t* opt, rocksdb_cache_t* cache) {
+  if(cache) {
+    opt->rep.row_cache = cache->rep;
+  }
+}
+
 void rocksdb_set_perf_level(int v) {
   PerfLevel level = static_cast<PerfLevel>(v);
   SetPerfLevel(level);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1047,6 +1047,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_ratelimiter(
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_atomic_flush(
     rocksdb_options_t* opt, unsigned char);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
+    rocksdb_options_t* opt, rocksdb_cache_t* cache
+);
+
 /* RateLimiter */
 extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(
     int64_t rate_bytes_per_sec, int64_t refill_period_us, int32_t fairness);


### PR DESCRIPTION
Adding a C API function to set `row_cache` on `rocksdb_options_t` as this functionality is missing.