### PR TITLE
Return early on failure when constructing CuckooTableReader

### DIFF
--- a/table/cuckoo/cuckoo_table_reader.cc
+++ b/table/cuckoo/cuckoo_table_reader.cc
@@ -54,6 +54,7 @@ CuckooTableReader::CuckooTableReader(
       get_slice_hash_(get_slice_hash) {
   if (!ioptions.allow_mmap_reads) {
     status_ = Status::InvalidArgument("File is not mmaped");
+    return;
   }
   TableProperties* props = nullptr;
   status_ = ReadTableProperties(file_.get(), file_size, kCuckooTableMagicNumber,

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -215,6 +215,14 @@ class CuckooReaderTest : public testing::Test {
   EnvOptions env_options;
 };
 
+TEST_F(CuckooReaderTest, FileNotMmaped) {
+  options.allow_mmap_reads = false;
+  ImmutableCFOptions ioptions(options);
+  CuckooTableReader reader(ioptions, nullptr, 0, nullptr, nullptr);
+  ASSERT_TRUE(reader.status().IsInvalidArgument());
+  ASSERT_STREQ("File is not mmaped", reader.status().getState());
+}
+
 TEST_F(CuckooReaderTest, WhenKeyExists) {
   SetUp(kNumHashFunc);
   fname = test::PerThreadDBPath("CuckooReader_WhenKeyExists");


### PR DESCRIPTION
Summary:
If file is not mmaped, CuckooTableReader should not try to read table properties from the file.

Test Plan:
Added a new unit test