### PR TITLE
WriteUnPrepared: Pass in correct subbatch count during rollback

### DIFF
--- a/utilities/transactions/write_unprepared_txn.h
+++ b/utilities/transactions/write_unprepared_txn.h
@@ -262,7 +262,6 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // value when calling RollbackToSavepoint.
   SequenceNumber largest_validated_seq_;
 
-  using KeySet = std::unordered_map<uint32_t, std::vector<std::string>>;
   struct SavePoint {
     // Record of unprep_seqs_ at this savepoint. The set of unprep_seq is
     // used during RollbackToSavepoint to determine visibility when restoring
@@ -333,6 +332,7 @@ class WriteUnpreparedTxn : public WritePreparedTxn {
   // last savepoint. Also, it may make sense to merge this into tracked_keys_
   // and differentiate between tracked but not locked keys to avoid having two
   // very similar data structures.
+  using KeySet = std::unordered_map<uint32_t, std::vector<std::string>>;
   KeySet untracked_keys_;
 };
 

--- a/utilities/transactions/write_unprepared_txn_db.h
+++ b/utilities/transactions/write_unprepared_txn_db.h
@@ -104,45 +104,5 @@ class WriteUnpreparedCommitEntryPreReleaseCallback : public PreReleaseCallback {
   bool publish_seq_;
 };
 
-class WriteUnpreparedRollbackPreReleaseCallback : public PreReleaseCallback {
-  // TODO(lth): Reduce code duplication with
-  // WritePreparedCommitEntryPreReleaseCallback
- public:
-  WriteUnpreparedRollbackPreReleaseCallback(
-      WritePreparedTxnDB* db, DBImpl* db_impl,
-      const std::map<SequenceNumber, size_t>& unprep_seqs,
-      SequenceNumber rollback_seq)
-      : db_(db),
-        db_impl_(db_impl),
-        unprep_seqs_(unprep_seqs),
-        rollback_seq_(rollback_seq) {
-    assert(unprep_seqs.size() > 0);
-    assert(db_impl_->immutable_db_options().two_write_queues);
-  }
-
-  virtual Status Callback(SequenceNumber commit_seq,
-                          bool is_mem_disabled __attribute__((__unused__)),
-                          uint64_t, size_t /*index*/,
-                          size_t /*total*/) override {
-    assert(is_mem_disabled);  // implies the 2nd queue
-    const uint64_t last_commit_seq = commit_seq;
-    db_->AddCommitted(rollback_seq_, last_commit_seq);
-    // Recall that unprep_seqs maps (un)prepared_seq => prepare_batch_cnt.
-    for (const auto& s : unprep_seqs_) {
-      for (size_t i = 0; i < s.second; i++) {
-        db_->AddCommitted(s.first + i, last_commit_seq);
-      }
-    }
-    db_impl_->SetLastPublishedSequence(last_commit_seq);
-    return Status::OK();
-  }
-
- private:
-  WritePreparedTxnDB* db_;
-  DBImpl* db_impl_;
-  const std::map<SequenceNumber, size_t>& unprep_seqs_;
-  SequenceNumber rollback_seq_;
-};
-
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // ROCKSDB_LITE


### PR DESCRIPTION
Today `WriteUnpreparedTxn::RollbackInternal` will write the rollback batch assuming that there is only a single subbatch. However, because untracked_keys_ are currently not deduplicated, it's possible for duplicate keys to exist, and thus split the batch. Also, tracked_keys_ also does not support compators outside of the bytewise comparators, so it's possible for duplicates to occur there as well.

To solve this, just pass in the correct subbatch count.

Also, removed `WriteUnpreparedRollbackPreReleaseCallback` to unify the Commit/Rollback codepaths some more.

Also, fixed a bug in `CommitInternal` where if 1. two_write_queue is true and 2. include_data is true, then `WriteUnpreparedCommitEntryPreReleaseCallback` ends up calling `AddCommitted` on the commit time write batch a second time on the second write. To fix, `WriteUnpreparedCommitEntryPreReleaseCallback` is re-initialized.