### PR TITLE
Ignore compile_commands.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ fbcode/
 fbcode
 buckifier/*.pyc
 buckifier/__pycache__
+
+compile_commands.json


### PR DESCRIPTION
Summary:
Both clangd and cquery-language-server requires a compile_commands.json file to
index the project. This file can be ignored by git.