### PR TITLE
Fix or skip tests that failed when EncryptedEnv is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ env:
   - JOB_NAME=cmake # 3-5 minutes
   - JOB_NAME=cmake-gcc8 # 3-5 minutes
   - JOB_NAME=cmake-mingw # 3 minutes
+  - JOB_NAME=encrypted_env # 16-18 minutes
 
 matrix:
   exclude:
@@ -128,6 +129,9 @@ script:
       ;;
     cmake*)
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release && make -j4 rocksdb rocksdbjni
+      ;;
+    encrypted_env)
+      OPT=-DTRAVIS V=1 ROCKSDBTESTS_END=db_block_cache_test ENCRYPTED_ENV=1 make -j4 all_but_some_tests check_some
       ;;
     esac
 notifications:

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -598,7 +598,7 @@ TEST_F(DBOptionsTest, MaxOpenFilesChange) {
 }
 
 TEST_F(DBOptionsTest, SanitizeDelayedWriteRate) {
-  Options options;
+  Options options = CurrentOptions();
   options.delayed_write_rate = 0;
   Reopen(options);
   ASSERT_EQ(16 * 1024 * 1024, dbfull()->GetDBOptions().delayed_write_rate);
@@ -814,10 +814,11 @@ TEST_F(DBOptionsTest, CompactionReadaheadSizeChange) {
 }
 
 TEST_F(DBOptionsTest, FIFOTtlBackwardCompatible) {
-  Options options;
+  Options options = CurrentOptions();
   options.compaction_style = kCompactionStyleFIFO;
   options.write_buffer_size = 10 << 10;  // 10KB
   options.create_if_missing = true;
+  options.max_open_files = -1;
 
   ASSERT_OK(TryReopen(options));
 

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -609,7 +609,7 @@ TEST_F(DBOptionsTest, SanitizeDelayedWriteRate) {
 }
 
 TEST_F(DBOptionsTest, SanitizeUniversalTTLCompaction) {
-  Options options;
+  Options options = CurrentOptions();
   options.compaction_style = kCompactionStyleUniversal;
 
   options.ttl = 0;
@@ -638,7 +638,7 @@ TEST_F(DBOptionsTest, SanitizeUniversalTTLCompaction) {
 }
 
 TEST_F(DBOptionsTest, SanitizeTtlDefault) {
-  Options options;
+  Options options = CurrentOptions();
   Reopen(options);
   ASSERT_EQ(30 * 24 * 60 * 60, dbfull()->GetOptions().ttl);
 
@@ -653,7 +653,7 @@ TEST_F(DBOptionsTest, SanitizeTtlDefault) {
 }
 
 TEST_F(DBOptionsTest, SanitizeFIFOPeriodicCompaction) {
-  Options options;
+  Options options = CurrentOptions();
   options.compaction_style = kCompactionStyleFIFO;
   options.ttl = 0;
   Reopen(options);

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -1404,7 +1404,7 @@ TEST_F(DBPropertiesTest, NeedCompactHintPersistentTest) {
 }
 
 TEST_F(DBPropertiesTest, EstimateNumKeysUnderflow) {
-  Options options;
+  Options options = CurrentOptions();
   Reopen(options);
   Put("foo", "bar");
   Delete("foo");
@@ -1415,7 +1415,7 @@ TEST_F(DBPropertiesTest, EstimateNumKeysUnderflow) {
 }
 
 TEST_F(DBPropertiesTest, EstimateOldestKeyTime) {
-  std::unique_ptr<MockTimeEnv> mock_env(new MockTimeEnv(Env::Default()));
+  std::unique_ptr<MockTimeEnv> mock_env(new MockTimeEnv(env_));
   uint64_t oldest_key_time = 0;
   Options options;
   options.env = mock_env.get();
@@ -1515,7 +1515,7 @@ TEST_F(DBPropertiesTest, SstFilesSize) {
   };
   std::shared_ptr<TestListener> listener = std::make_shared<TestListener>();
 
-  Options options;
+  Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.listeners.push_back(listener);
   Reopen(options);
@@ -1597,7 +1597,7 @@ TEST_F(DBPropertiesTest, MinObsoleteSstNumberToKeep) {
 }
 
 TEST_F(DBPropertiesTest, BlockCacheProperties) {
-  Options options;
+  Options options = CurrentOptions();
   uint64_t value;
 
   // Block cache properties are not available for tables other than

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -139,7 +139,7 @@ TEST_F(DBSSTTest, SkipCheckingSSTFileSizesOnDBOpen) {
   ASSERT_OK(Flush());
 
   // Just open the DB with the option set to true and check that we don't crash.
-  Options options;
+  Options options = CurrentOptions();
   options.skip_checking_sst_file_sizes_on_db_open = true;
   Reopen(options);
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2921,7 +2921,7 @@ TEST_F(DBTest2, RateLimitedCompactionReads) {
 // Make sure DB can be reopen with reduced number of levels, given no file
 // is on levels higher than the new num_levels.
 TEST_F(DBTest2, ReduceLevel) {
-  Options options;
+  Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.num_levels = 7;
   Reopen(options);
@@ -2947,7 +2947,7 @@ TEST_F(DBTest2, ReduceLevel) {
 
 // Test that ReadCallback is actually used in both memtbale and sst tables
 TEST_F(DBTest2, ReadCallbackTest) {
-  Options options;
+  Options options = CurrentOptions();
   options.disable_auto_compactions = true;
   options.num_levels = 7;
   Reopen(options);
@@ -3209,7 +3209,8 @@ TEST_F(DBTest2, TraceAndReplay) {
   column_families.push_back(
       ColumnFamilyDescriptor("pikachu", ColumnFamilyOptions()));
   std::vector<ColumnFamilyHandle*> handles;
-  ASSERT_OK(DB::Open(DBOptions(), dbname2, column_families, &handles, &db2));
+  ASSERT_OK(
+      DB::Open(CurrentOptions(), dbname2, column_families, &handles, &db2));
 
   env_->SleepForMicroseconds(100);
   // Verify that the keys don't already exist
@@ -3284,7 +3285,8 @@ TEST_F(DBTest2, TraceWithLimit) {
   column_families.push_back(
       ColumnFamilyDescriptor("pikachu", ColumnFamilyOptions()));
   std::vector<ColumnFamilyHandle*> handles;
-  ASSERT_OK(DB::Open(DBOptions(), dbname2, column_families, &handles, &db2));
+  ASSERT_OK(
+      DB::Open(CurrentOptions(), dbname2, column_families, &handles, &db2));
 
   env_->SleepForMicroseconds(100);
   // Verify that the keys don't already exist
@@ -3352,7 +3354,8 @@ TEST_F(DBTest2, TraceWithSampling) {
   column_families.push_back(
       ColumnFamilyDescriptor("pikachu", ColumnFamilyOptions()));
   std::vector<ColumnFamilyHandle*> handles;
-  ASSERT_OK(DB::Open(DBOptions(), dbname2, column_families, &handles, &db2));
+  ASSERT_OK(
+      DB::Open(CurrentOptions(), dbname2, column_families, &handles, &db2));
 
   env_->SleepForMicroseconds(100);
   ASSERT_TRUE(db2->Get(ro, handles[0], "a", &value).IsNotFound());
@@ -3452,7 +3455,8 @@ TEST_F(DBTest2, TraceWithFilter) {
   column_families.push_back(
       ColumnFamilyDescriptor("pikachu", ColumnFamilyOptions()));
   std::vector<ColumnFamilyHandle*> handles;
-  ASSERT_OK(DB::Open(DBOptions(), dbname2, column_families, &handles, &db2));
+  ASSERT_OK(
+      DB::Open(CurrentOptions(), dbname2, column_families, &handles, &db2));
 
   env_->SleepForMicroseconds(100);
   // Verify that the keys don't already exist
@@ -3498,7 +3502,8 @@ TEST_F(DBTest2, TraceWithFilter) {
   handles.clear();
 
   DB* db3 =  nullptr;
-  ASSERT_OK(DB::Open(DBOptions(), dbname3, column_families, &handles, &db3));
+  ASSERT_OK(
+      DB::Open(CurrentOptions(), dbname3, column_families, &handles, &db3));
 
   env_->SleepForMicroseconds(100);
   // Verify that the keys don't already exist
@@ -3553,6 +3558,9 @@ TEST_F(DBTest2, TraceWithFilter) {
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBTest2, PinnableSliceAndMmapReads) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   Options options = CurrentOptions();
   options.allow_mmap_reads = true;
   options.max_open_files = 100;
@@ -3831,7 +3839,7 @@ TEST_F(DBTest2, TestCompactFiles) {
   });
   SyncPoint::GetInstance()->EnableProcessing();
 
-  Options options;
+  Options options = CurrentOptions();
   options.num_levels = 2;
   options.disable_auto_compactions = true;
   Reopen(options);

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2149,6 +2149,9 @@ TEST_F(DBTest2, ReadAmpBitmap) {
 
 #ifndef OS_SOLARIS // GetUniqueIdFromFile is not implemented
 TEST_F(DBTest2, ReadAmpBitmapLiveInCacheAfterDBClose) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   {
     const int kIdBufLen = 100;
     char id_buf[kIdBufLen];

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1040,6 +1040,9 @@ class RecoveryTestHelper {
 // at the end of any of the logs
 // - We do not expect to open the data store for corruption
 TEST_F(DBWALTest, kTolerateCorruptedTailRecords) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   const int jstart = RecoveryTestHelper::kWALFileOffset;
   const int jend = jstart + RecoveryTestHelper::kWALFilesCount;
 
@@ -1111,6 +1114,9 @@ TEST_F(DBWALTest, kAbsoluteConsistency) {
 // We don't expect the data store to be opened if there is any inconsistency
 // between WAL and SST files
 TEST_F(DBWALTest, kPointInTimeRecoveryCFConsistency) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   Options options = CurrentOptions();
   options.avoid_flush_during_recovery = true;
 
@@ -1144,6 +1150,9 @@ TEST_F(DBWALTest, kPointInTimeRecoveryCFConsistency) {
 // - We expect to open data store under all circumstances
 // - We expect only data upto the point where the first error was encountered
 TEST_F(DBWALTest, kPointInTimeRecovery) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   const int jstart = RecoveryTestHelper::kWALFileOffset;
   const int jend = jstart + RecoveryTestHelper::kWALFilesCount;
   const int maxkeys =
@@ -1195,6 +1204,9 @@ TEST_F(DBWALTest, kPointInTimeRecovery) {
 // - We expect to open the data store under all scenarios
 // - We expect to have recovered records past the corruption zone
 TEST_F(DBWALTest, kSkipAnyCorruptedRecords) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   const int jstart = RecoveryTestHelper::kWALFileOffset;
   const int jend = jstart + RecoveryTestHelper::kWALFilesCount;
 
@@ -1402,6 +1414,9 @@ TEST_F(DBWALTest, RecoverWithoutFlushMultipleCF) {
 //   3. Append more data without flushing, which creates new WAL log.
 //   4. Open again. See if it can correctly handle previous corruption.
 TEST_F(DBWALTest, RecoverFromCorruptedWALWithoutFlush) {
+  if (getenv("ENCRYPTED_ENV")) {
+    return;
+  }
   const int jstart = RecoveryTestHelper::kWALFileOffset;
   const int jend = jstart + RecoveryTestHelper::kWALFilesCount;
   const int kAppendKeys = 100;

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -134,7 +134,7 @@ TEST_P(DBWriteTest, WriteThreadHangOnWriteStall) {
 TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
   constexpr int kNumThreads = 5;
   std::unique_ptr<FaultInjectionTestEnv> mock_env(
-      new FaultInjectionTestEnv(Env::Default()));
+      new FaultInjectionTestEnv(env_));
   Options options = GetOptions();
   options.env = mock_env.get();
   Reopen(options);
@@ -203,7 +203,7 @@ TEST_P(DBWriteTest, ManualWalFlushInEffect) {
 
 TEST_P(DBWriteTest, IOErrorOnWALWriteTriggersReadOnlyMode) {
   std::unique_ptr<FaultInjectionTestEnv> mock_env(
-      new FaultInjectionTestEnv(Env::Default()));
+      new FaultInjectionTestEnv(env_));
   Options options = GetOptions();
   options.env = mock_env.get();
   Reopen(options);
@@ -235,7 +235,7 @@ TEST_P(DBWriteTest, IOErrorOnWALWriteTriggersReadOnlyMode) {
 TEST_P(DBWriteTest, IOErrorOnSwitchMemtable) {
   Random rnd(301);
   std::unique_ptr<FaultInjectionTestEnv> mock_env(
-      new FaultInjectionTestEnv(Env::Default()));
+      new FaultInjectionTestEnv(env_));
   Options options = GetOptions();
   options.env = mock_env.get();
   options.writable_file_max_buffer_size = 4 * 1024 * 1024;

--- a/db/error_handler_test.cc
+++ b/db/error_handler_test.cc
@@ -546,7 +546,7 @@ TEST_F(DBErrorHandlingTest, WALWriteError) {
 
 TEST_F(DBErrorHandlingTest, MultiCFWALWriteError) {
   std::unique_ptr<FaultInjectionTestEnv> fault_env(
-      new FaultInjectionTestEnv(Env::Default()));
+      new FaultInjectionTestEnv(env_));
   std::shared_ptr<ErrorHandlerListener> listener(new ErrorHandlerListener());
   Options options = GetDefaultOptions();
   options.create_if_missing = true;


### PR DESCRIPTION
Summary:
Some tests are failing when EncryptedEnv is enabled in test. Fixing some by make them use `env_` instead of `Env::Default()`. Disable others that don't have apparent fix. Also add CI to run some of the tests with `ENCRYPTED_ENV=1` env variable set.

Test Plan:
run `ENCRYPTED_ENV=1 make check`