### PR TITLE
Fix spelling: commited -> committed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Rocksdb Change Log
 ## Unreleased
+### Public API Change
+* Fix spelling so that API now has correctly spelled transaction state name `COMMITTED`, while the old misspelled `COMMITED` is still available as an alias.
+
 ### Bug Fixes
 * Fix a bug where range tombstone blocks in ingested files were cached incorrectly during ingestion. If range tombstones were read from those incorrectly cached blocks, the keys they covered would be exposed.
 * Fix a data race that might cause crash when calling DB::GetCreationTimeOfOldestFile() by a small chance. The bug was introduced in 6.6 Release.

--- a/include/rocksdb/utilities/transaction.h
+++ b/include/rocksdb/utilities/transaction.h
@@ -491,7 +491,8 @@ class Transaction {
     AWAITING_PREPARE = 1,
     PREPARED = 2,
     AWAITING_COMMIT = 3,
-    COMMITED = 4,
+    COMMITTED = 4,
+    COMMITED = COMMITTED, // old misspelled name
     AWAITING_ROLLBACK = 5,
     ROLLEDBACK = 6,
     LOCKS_STOLEN = 7,

--- a/java/rocksjni/transaction.cc
+++ b/java/rocksjni/transaction.cc
@@ -1605,7 +1605,7 @@ jbyte Java_org_rocksdb_Transaction_getState(JNIEnv* /*env*/, jobject /*jobj*/,
     case ROCKSDB_NAMESPACE::Transaction::TransactionState::AWAITING_COMMIT:
       return 0x3;
 
-    case ROCKSDB_NAMESPACE::Transaction::TransactionState::COMMITED:
+    case ROCKSDB_NAMESPACE::Transaction::TransactionState::COMMITTED:
       return 0x4;
 
     case ROCKSDB_NAMESPACE::Transaction::TransactionState::AWAITING_ROLLBACK:

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -1797,7 +1797,7 @@ public class Transaction extends RocksObject {
      * Keep old misspelled variable as alias
      * Tip from https://stackoverflow.com/a/37092410/454544
      */
-    public static final Browser COMMITED=COMMITTED;
+    public static final TransactionState COMMITED = COMMITTED;
 
     private final byte value;
 

--- a/java/src/main/java/org/rocksdb/Transaction.java
+++ b/java/src/main/java/org/rocksdb/Transaction.java
@@ -1788,10 +1788,16 @@ public class Transaction extends RocksObject {
     AWAITING_PREPARE((byte)1),
     PREPARED((byte)2),
     AWAITING_COMMIT((byte)3),
-    COMMITED((byte)4),
+    COMMITTED((byte)4),
     AWAITING_ROLLBACK((byte)5),
     ROLLEDBACK((byte)6),
     LOCKS_STOLEN((byte)7);
+
+    /*
+     * Keep old misspelled variable as alias
+     * Tip from https://stackoverflow.com/a/37092410/454544
+     */
+    public static final Browser COMMITED=COMMITTED;
 
     private final byte value;
 

--- a/java/src/test/java/org/rocksdb/TransactionTest.java
+++ b/java/src/test/java/org/rocksdb/TransactionTest.java
@@ -209,7 +209,7 @@ public class TransactionTest extends AbstractTransactionTest {
             .isSameAs(Transaction.TransactionState.STARTED);
         txn.commit();
         assertThat(txn.getState())
-            .isSameAs(Transaction.TransactionState.COMMITED);
+            .isSameAs(Transaction.TransactionState.COMMITTED);
       }
 
       try(final Transaction txn = dbContainer.beginTransaction()) {


### PR DESCRIPTION
In most places in the code the variable names are spelled correctly as
COMMITTED but in a couple places not. This fixes them and ensures the
variable is always called COMMITTED everywhere.