### PR TITLE
Skip high levels with no key falling in the range in CompactRange

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,9 +5,7 @@
 * Fix a data race that might cause crash when calling DB::GetCreationTimeOfOldestFile() by a small chance. The bug was introduced in 6.6 Release.
 
 ### Performance Improvements
-* In CompactRange, for levels starting from 0, if the level does not have any file with any key
-falling in the specified range, the level is skipped. So instead of always compacting from level 0,
-the compaction starts from the first level with keys in the specified range until the last such level.
+* In CompactRange, for levels starting from 0, if the level does not have any file with any key falling in the specified range, the level is skipped. So instead of always compacting from level 0, the compaction starts from the first level with keys in the specified range until the last such level.
 
 ## 6.8.0 (02/24/2020)
 ### Java API Changes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@
 * Fix a bug where range tombstone blocks in ingested files were cached incorrectly during ingestion. If range tombstones were read from those incorrectly cached blocks, the keys they covered would be exposed.
 * Fix a data race that might cause crash when calling DB::GetCreationTimeOfOldestFile() by a small chance. The bug was introduced in 6.6 Release.
 
+### Performance Improvements
+* In CompactRange, for levels starting from 0, if the level does not have any file with any key
+falling in the specified range, the level is skipped. So instead of always compacting from level 0,
+the compaction starts from the first level with keys in the specified range until the last such level.
+
 ## 6.8.0 (02/24/2020)
 ### Java API Changes
 * Major breaking changes to Java comparators, toward standardizing on ByteBuffer for performant, locale-neutral operations on keys (#6252).

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -2459,7 +2459,7 @@ TEST_P(DBCompactionTestWithParam, ManualCompaction) {
     ASSERT_EQ("1,1,1", FilesPerLevel(1));
 
     // Compaction range overlaps files
-    Compact(1, "p1", "p9");
+    Compact(1, "p", "q");
     ASSERT_EQ("0,0,1", FilesPerLevel(1));
 
     // Populate a different range
@@ -2526,7 +2526,7 @@ TEST_P(DBCompactionTestWithParam, ManualLevelCompactionOutputPathId) {
     ASSERT_EQ("3", FilesPerLevel(1));
 
     // Compaction range overlaps files
-    Compact(1, "p1", "p9", 1);
+    Compact(1, "p", "q", 1);
     ASSERT_OK(dbfull()->TEST_WaitForCompact());
     ASSERT_EQ("0,1", FilesPerLevel(1));
     ASSERT_EQ(1, GetSstFileCount(options.db_paths[1].path));
@@ -4655,7 +4655,7 @@ TEST_P(DBCompactionDirectIOTest, DirectIO) {
   CreateAndReopenWithCF({"pikachu"}, options);
   MakeTables(3, "p", "q", 1);
   ASSERT_EQ("1,1,1", FilesPerLevel(1));
-  Compact(1, "p1", "p9");
+  Compact(1, "p", "q");
   ASSERT_EQ(readahead, options.use_direct_reads);
   ASSERT_EQ("0,0,1", FilesPerLevel(1));
   Destroy(options);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -718,8 +718,7 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
     next_file_number = versions_->current_next_file_number();
   }
 
-  int final_output_level = 0;
-
+  int final_output_level = max_level_with_files;
   if (cfd->ioptions()->compaction_style == kCompactionStyleUniversal &&
       cfd->NumberLevels() > 1) {
     // Always compact all files together.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -712,10 +712,11 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
            level++) {
         overlap = true;
         if (begin != nullptr && end != nullptr) {
-          s = current_version->OverlapWithLevelIterator(
+          Status status = current_version->OverlapWithLevelIterator(
               ro, file_options_, *begin, *end, level, &overlap);
-          if (!s.ok()) {
-            break;
+          if (!status.ok()) {
+            overlap = current_version->storage_info()->OverlapInLevel(
+                level, begin, end);
           }
         } else {
           overlap = current_version->storage_info()->OverlapInLevel(level,

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -4297,7 +4297,7 @@ TEST_P(DBTestWithParam, PreShutdownManualCompaction) {
     ASSERT_EQ("1,1,1", FilesPerLevel(1));
 
     // Compaction range overlaps files
-    Compact(1, "p1", "p9");
+    Compact(1, "p", "q");
     ASSERT_EQ("0,0,1", FilesPerLevel(1));
 
     // Populate a different range

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1678,12 +1678,12 @@ TEST_P(PinL0IndexAndFilterBlocksTest, DisablePrefetchingNonL0IndexAndFilter) {
     ASSERT_EQ(fm + 3, TestGetTickerCount(options, BLOCK_CACHE_FILTER_MISS));
     ASSERT_EQ(fh, TestGetTickerCount(options, BLOCK_CACHE_FILTER_HIT));
     ASSERT_EQ(im + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_MISS));
-    ASSERT_EQ(ih + 2, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
+    ASSERT_EQ(ih + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
   } else {
     ASSERT_EQ(fm + 3, TestGetTickerCount(options, BLOCK_CACHE_FILTER_MISS));
     ASSERT_EQ(fh + 1, TestGetTickerCount(options, BLOCK_CACHE_FILTER_HIT));
     ASSERT_EQ(im + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_MISS));
-    ASSERT_EQ(ih + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
+    ASSERT_EQ(ih + 4, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
   }
 
   // Bloom and index hit will happen when a Get() happens.
@@ -1692,12 +1692,12 @@ TEST_P(PinL0IndexAndFilterBlocksTest, DisablePrefetchingNonL0IndexAndFilter) {
     ASSERT_EQ(fm + 3, TestGetTickerCount(options, BLOCK_CACHE_FILTER_MISS));
     ASSERT_EQ(fh + 1, TestGetTickerCount(options, BLOCK_CACHE_FILTER_HIT));
     ASSERT_EQ(im + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_MISS));
-    ASSERT_EQ(ih + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
+    ASSERT_EQ(ih + 4, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
   } else {
     ASSERT_EQ(fm + 3, TestGetTickerCount(options, BLOCK_CACHE_FILTER_MISS));
     ASSERT_EQ(fh + 2, TestGetTickerCount(options, BLOCK_CACHE_FILTER_HIT));
     ASSERT_EQ(im + 3, TestGetTickerCount(options, BLOCK_CACHE_INDEX_MISS));
-    ASSERT_EQ(ih + 4, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
+    ASSERT_EQ(ih + 5, TestGetTickerCount(options, BLOCK_CACHE_INDEX_HIT));
   }
 }
 

--- a/db/manual_compaction_test.cc
+++ b/db/manual_compaction_test.cc
@@ -71,7 +71,7 @@ class LogCompactionFilter : public CompactionFilter {
 
   void Reset() { key_level_.clear(); }
 
-  int NumKeys() const { return key_level_.size(); }
+  size_t NumKeys() const { return key_level_.size(); }
 
   int KeyLevel(const Slice& key) {
     auto it = key_level_.find(key.ToString());

--- a/db/manual_compaction_test.cc
+++ b/db/manual_compaction_test.cc
@@ -250,7 +250,7 @@ TEST_F(ManualCompactionTest, SkipLevel) {
 
   {
     // L0: 1, 2
-    // L1: (4, 8)
+    // L1: [4, 8]
     // [5, 7] has no overlapped key in any file
     Slice start("5");
     Slice end("7");
@@ -261,8 +261,8 @@ TEST_F(ManualCompactionTest, SkipLevel) {
 
   {
     // L0: 1, 2
-    // L1: (4, 8)
-    // [-inf, 3] overlaps with 1, 2 in L0
+    // L1: [4, 8]
+    // (-inf, 3] overlaps with 1, 2 in L0
     Slice end("3");
     filter->Reset();
     db->CompactRange(CompactRangeOptions(), nullptr, &end);
@@ -275,8 +275,8 @@ TEST_F(ManualCompactionTest, SkipLevel) {
 
   {
     // L0:
-    // L1: (1, 2), (4, 8)
-    // [2, 5] overlaps with (1, 2) and (4, 8)
+    // L1: [1, 2], [4, 8]
+    // [2, 5] overlaps with [1, 2] and [4, 8)
     Slice start("2");
     Slice end("5");
     filter->Reset();

--- a/db/manual_compaction_test.cc
+++ b/db/manual_compaction_test.cc
@@ -4,8 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 // Test for issue 178: a manual compaction causes deleted data to reappear.
-#include <iostream>
-#include <sstream>
 #include <cstdlib>
 
 #include "port/port.h"
@@ -40,8 +38,8 @@ class ManualCompactionTest : public testing::Test {
  public:
   ManualCompactionTest() {
     // Get rid of any state from an old run.
-    dbname_ = ROCKSDB_NAMESPACE::test::PerThreadDBPath("rocksdb_cbug_test");
-    DestroyDB(dbname_, ROCKSDB_NAMESPACE::Options());
+    dbname_ = test::PerThreadDBPath("rocksdb_manual_compaction_test");
+    DestroyDB(dbname_, Options());
   }
 
   std::string dbname_;
@@ -60,6 +58,37 @@ class DestroyAllCompactionFilter : public CompactionFilter {
   const char* Name() const override { return "DestroyAllCompactionFilter"; }
 };
 
+class LogCompactionFilter : public CompactionFilter {
+ public:
+  const char* Name() const override { return "LogCompactionFilter"; }
+
+  bool Filter(int level, const Slice& key, const Slice& /*existing_value*/,
+              std::string* /*new_value*/,
+              bool* /*value_changed*/) const override {
+    key_level_[key.ToString()] = level;
+    return false;
+  }
+
+  void Reset() { key_level_.clear(); }
+
+  int NumKeys() const { return key_level_.size(); }
+
+  bool KeyExists(const Slice& key) {
+    return key_level_.find(key.ToString()) != key_level_.end();
+  }
+
+  int KeyLevel(const Slice& key) {
+    auto it = key_level_.find(key.ToString());
+    if (it == key_level_.end()) {
+      return -1;
+    }
+    return it->second;
+  }
+
+ private:
+  mutable std::map<std::string, int> key_level_;
+};
+
 TEST_F(ManualCompactionTest, CompactTouchesAllKeys) {
   for (int iter = 0; iter < 2; ++iter) {
     DB* db;
@@ -71,7 +100,7 @@ TEST_F(ManualCompactionTest, CompactTouchesAllKeys) {
       options.compaction_style = kCompactionStyleUniversal;
     }
     options.create_if_missing = true;
-    options.compression = ROCKSDB_NAMESPACE::kNoCompression;
+    options.compression = kNoCompression;
     options.compaction_filter = new DestroyAllCompactionFilter();
     ASSERT_OK(DB::Open(options, dbname_, &db));
 
@@ -100,46 +129,45 @@ TEST_F(ManualCompactionTest, Test) {
   // Open database.  Disable compression since it affects the creation
   // of layers and the code below is trying to test against a very
   // specific scenario.
-  ROCKSDB_NAMESPACE::DB* db;
-  ROCKSDB_NAMESPACE::Options db_options;
+  DB* db;
+  Options db_options;
   db_options.write_buffer_size = 1024;
   db_options.create_if_missing = true;
-  db_options.compression = ROCKSDB_NAMESPACE::kNoCompression;
-  ASSERT_OK(ROCKSDB_NAMESPACE::DB::Open(db_options, dbname_, &db));
+  db_options.compression = kNoCompression;
+  ASSERT_OK(DB::Open(db_options, dbname_, &db));
 
   // create first key range
-  ROCKSDB_NAMESPACE::WriteBatch batch;
+  WriteBatch batch;
   for (int i = 0; i < kNumKeys; i++) {
     batch.Put(Key1(i), "value for range 1 key");
   }
-  ASSERT_OK(db->Write(ROCKSDB_NAMESPACE::WriteOptions(), &batch));
+  ASSERT_OK(db->Write(WriteOptions(), &batch));
 
   // create second key range
   batch.Clear();
   for (int i = 0; i < kNumKeys; i++) {
     batch.Put(Key2(i), "value for range 2 key");
   }
-  ASSERT_OK(db->Write(ROCKSDB_NAMESPACE::WriteOptions(), &batch));
+  ASSERT_OK(db->Write(WriteOptions(), &batch));
 
   // delete second key range
   batch.Clear();
   for (int i = 0; i < kNumKeys; i++) {
     batch.Delete(Key2(i));
   }
-  ASSERT_OK(db->Write(ROCKSDB_NAMESPACE::WriteOptions(), &batch));
+  ASSERT_OK(db->Write(WriteOptions(), &batch));
 
   // compact database
   std::string start_key = Key1(0);
   std::string end_key = Key1(kNumKeys - 1);
-  ROCKSDB_NAMESPACE::Slice least(start_key.data(), start_key.size());
-  ROCKSDB_NAMESPACE::Slice greatest(end_key.data(), end_key.size());
+  Slice least(start_key.data(), start_key.size());
+  Slice greatest(end_key.data(), end_key.size());
 
   // commenting out the line below causes the example to work correctly
   db->CompactRange(CompactRangeOptions(), &least, &greatest);
 
   // count the keys
-  ROCKSDB_NAMESPACE::Iterator* iter =
-      db->NewIterator(ROCKSDB_NAMESPACE::ReadOptions());
+  Iterator* iter = db->NewIterator(ReadOptions());
   int num_keys = 0;
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     num_keys++;
@@ -149,7 +177,121 @@ TEST_F(ManualCompactionTest, Test) {
 
   // close database
   delete db;
-  DestroyDB(dbname_, ROCKSDB_NAMESPACE::Options());
+  DestroyDB(dbname_, Options());
+}
+
+TEST_F(ManualCompactionTest, SkipLevel) {
+  DB* db;
+  Options options;
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = INT_MAX;
+  options.compaction_style = kCompactionStyleLevel;
+  options.create_if_missing = true;
+  options.compression = kNoCompression;
+  LogCompactionFilter* filter = new LogCompactionFilter();
+  options.compaction_filter = filter;
+  ASSERT_OK(DB::Open(options, dbname_, &db));
+
+  // Keys: 1, 2, 4, 8
+  // Each key is flushed to a new SST file in L0
+  for (int k = 1; k <= 8; k <<= 1) {
+    db->Put(WriteOptions(), std::to_string(k), "");
+    db->Flush(FlushOptions());
+  }
+
+  {
+    // L0: 1, 2, 4, 8
+    // [5, 7] has no overlap with any file in any level.
+    Slice start("5");
+    Slice end("7");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, &end);
+    ASSERT_EQ(0, filter->NumKeys());
+  }
+
+  {
+    // L0: 1, 2, 4, 8
+    // [3, 7] overlaps with 4 in L0
+    Slice start("3");
+    Slice end("7");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, &end);
+    ASSERT_EQ(1, filter->NumKeys());
+    ASSERT_TRUE(filter->KeyExists("4"));
+    ASSERT_EQ(0, filter->KeyLevel("4"));
+  }
+
+  {
+    // L0: 1, 2, 8
+    // L1: 4
+    // [7, inf) overlaps with 8 in L0
+    Slice start("7");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, nullptr);
+    ASSERT_EQ(1, filter->NumKeys());
+    ASSERT_TRUE(filter->KeyExists("8"));
+    ASSERT_EQ(0, filter->KeyLevel("8"));
+  }
+
+  {
+    // L0: 1, 2
+    // L1: 4, 8
+    // [3, 9] overlaps with 4, 8 in L1
+    Slice start("3");
+    Slice end("9");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, &end);
+    ASSERT_EQ(2, filter->NumKeys());
+    ASSERT_TRUE(filter->KeyExists("4"));
+    ASSERT_EQ(1, filter->KeyLevel("4"));
+    ASSERT_TRUE(filter->KeyExists("8"));
+    ASSERT_EQ(1, filter->KeyLevel("8"));
+  }
+
+  {
+    // L0: 1, 2
+    // L1: (4, 8)
+    // [5, 7] has no overlapped key in any file
+    Slice start("5");
+    Slice end("7");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, &end);
+    ASSERT_EQ(0, filter->NumKeys());
+  }
+
+  {
+    // L0: 1, 2
+    // L1: (4, 8)
+    // [-inf, 3] overlaps with 1, 2 in L0
+    Slice end("3");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), nullptr, &end);
+    ASSERT_EQ(2, filter->NumKeys());
+    ASSERT_TRUE(filter->KeyExists("1"));
+    ASSERT_EQ(0, filter->KeyLevel("1"));
+    ASSERT_TRUE(filter->KeyExists("2"));
+    ASSERT_EQ(0, filter->KeyLevel("2"));
+  }
+
+  {
+    // L0:
+    // L1: (1, 2), (4, 8)
+    // [2, 5] overlaps with (1, 2) and (4, 8)
+    Slice start("2");
+    Slice end("5");
+    filter->Reset();
+    db->CompactRange(CompactRangeOptions(), &start, &end);
+    ASSERT_EQ(4, filter->NumKeys());
+    for (int k = 1; k <= 8; k <<= 1) {
+      auto key = std::to_string(k);
+      ASSERT_TRUE(filter->KeyExists(key));
+      ASSERT_EQ(1, filter->KeyLevel(key));
+    }
+  }
+
+  delete filter;
+  delete db;
+  DestroyDB(dbname_, options);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
In CompactRange, if there is no key in memtable falling in the specified range, then flush is skipped.
This PR extends this skipping logic to SST file levels: it starts compaction from the highest level (starting from L0) that has files with key falling in the specified range, instead of always starts from L0.

Test Plan:
A new test `ManualCompactionTest::SkipLevel` is added.

Also updated a test related to statistics of index block cache hit in `db_test2`, the index cache hit is increased by 1 in this PR because when checking overlap for the key range in L0, `OverlapWithLevelIterator` will do a seek in the table cache iterator, which will read from the cached index.

Also updated `db_compaction_test` and `db_test` to use correct range for full compaction.