### PR TITLE
Use DestroyColumnFamilyHandle instead of directly deleting column family handle

### DIFF
--- a/examples/column_families_example.cc
+++ b/examples/column_families_example.cc
@@ -28,7 +28,8 @@ int main() {
   assert(s.ok());
 
   // close DB
-  db->DestroyColumnFamilyHandle(cf);
+  s = db->DestroyColumnFamilyHandle(cf);
+  assert(s.ok());
   delete db;
 
   // open DB with two column families
@@ -64,7 +65,8 @@ int main() {
 
   // close db
   for (auto handle : handles) {
-    db->DestroyColumnFamilyHandle(handle);
+    s = db->DestroyColumnFamilyHandle(handle);
+    assert(s.ok());
   }
   delete db;
 

--- a/examples/column_families_example.cc
+++ b/examples/column_families_example.cc
@@ -28,7 +28,7 @@ int main() {
   assert(s.ok());
 
   // close DB
-  delete cf;
+  db->DestroyColumnFamilyHandle(cf);
   delete db;
 
   // open DB with two column families
@@ -64,7 +64,7 @@ int main() {
 
   // close db
   for (auto handle : handles) {
-    delete handle;
+    db->DestroyColumnFamilyHandle(handle);
   }
   delete db;
 


### PR DESCRIPTION
Update example usage of closing column family.

Test Plan:
make check