### PR TITLE
cmake: add option WITH_CORE_TOOLS to exclude tools except ldb and sst_dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1177,9 +1177,15 @@ if(WITH_BENCHMARK_TOOLS)
     ${ROCKSDB_LIB})
 endif()
 
+option(WITH_CORE_TOOLS "build with ldb and sst_dump" ON)
 option(WITH_TOOLS "build with tools" ON)
-if(WITH_TOOLS)
+if(WITH_CORE_TOOLS OR WITH_TOOLS)
   add_subdirectory(tools)
+  add_custom_target(core_tools
+    DEPENDS ${core_tool_deps})
+endif()
+
+if(WITH_TOOLS)
   add_subdirectory(db_stress_tool)
   add_custom_target(tools
     DEPENDS ${tool_deps})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,21 +1,30 @@
-set(TOOLS
+set(CORE_TOOLS
   sst_dump.cc
-  db_sanity_test.cc
-  write_stress.cc
-  ldb.cc
-  db_repl_stress.cc
-  dump/rocksdb_dump.cc
-  dump/rocksdb_undump.cc)
-foreach(src ${TOOLS})
+  ldb.cc)
+foreach(src ${CORE_TOOLS})
   get_filename_component(exename ${src} NAME_WE)
   add_executable(${exename}${ARTIFACT_SUFFIX}
     ${src})
   target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${ROCKSDB_LIB})
-  list(APPEND tool_deps ${exename})
+  list(APPEND core_tool_deps ${exename})
 endforeach()
 
-list(APPEND tool_deps)
+if(WITH_TOOLS)
+  set(TOOLS
+    db_sanity_test.cc
+    write_stress.cc
+    db_repl_stress.cc
+    dump/rocksdb_dump.cc
+    dump/rocksdb_undump.cc)
+  foreach(src ${TOOLS})
+    get_filename_component(exename ${src} NAME_WE)
+    add_executable(${exename}${ARTIFACT_SUFFIX}
+      ${src})
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${ROCKSDB_LIB})
+    list(APPEND tool_deps ${exename})
+  endforeach()
 
-add_custom_target(ldb_tests
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/ldb_tests.py
-  DEPENDS ldb)
+  add_custom_target(ldb_tests
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/ldb_tests.py
+    DEPENDS ldb)
+endif()


### PR DESCRIPTION
Summary:
ldb and sst_dump are most important tools and they don't dependend on gflags. In cmake, we don't have an way to only build these two tools and exclude other tools. This is inconvenient if the environment has a problem with gflags. Add such an option WITH_CORE_TOOLS.

Test Plan: cmake and build with "cmake -DWITH_CORE_TOOLS=On" and without.