### PR TITLE
Include more information in file lock failure

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 
 ### New Features
 * Basic support for user timestamp in iterator. Seek/SeekToFirst/Next and lower/upper bounds are supported. Reverse iteration is not supported. Merge is not considered.
+* When file lock failure when the lock is held by the current process, return acquiring time and thread ID in the error message.
 
 ## 6.8.0 (02/24/2020)
 ### Java API Changes

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -326,8 +326,10 @@ TEST_F(DBBasicTest, CheckLock) {
     // second open should fail
     Status s = DB::Open(options, dbname_, &localdb);
     ASSERT_NOK(s);
+#ifdef OS_LINUX
     ASSERT_TRUE(s.ToString().find("lock hold by current process") !=
                 std::string::npos);
+#endif  // OS_LINUX
   } while (ChangeCompactOptions());
 }
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -324,7 +324,10 @@ TEST_F(DBBasicTest, CheckLock) {
     ASSERT_OK(TryReopen(options));
 
     // second open should fail
-    ASSERT_TRUE(!(DB::Open(options, dbname_, &localdb)).ok());
+    Status s = DB::Open(options, dbname_, &localdb);
+    ASSERT_NOK(s);
+    ASSERT_TRUE(s.ToString().find("lock hold by current process") !=
+                std::string::npos);
   } while (ChangeCompactOptions());
 }
 

--- a/util/filelock_test.cc
+++ b/util/filelock_test.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include "test_util/testharness.h"
 #include "util/coding.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -120,7 +121,11 @@ TEST_F(LockTest, LockBySameThread) {
   ASSERT_TRUE( AssertFileIsLocked() );
 
   // re-acquire the lock on the same file. This should fail.
-  ASSERT_TRUE(LockFile(&lock2).IsIOError());
+  Status s = LockFile(&lock2);
+  ASSERT_TRUE(s.IsIOError());
+  // Validate that error message contains current thread ID.
+  ASSERT_TRUE(s.ToString().find(ToString(Env::Default()->GetThreadID())) !=
+              std::string::npos);
 
   // check the file is locked
   ASSERT_TRUE( AssertFileIsLocked() );


### PR DESCRIPTION
Summary:
When users fail to open a DB with file lock failure, it is sometimes hard for users to debug. We now include the time the lock is acquired and the thread ID that acquired the lock, to help users debug problems like this. Default Env's thread ID is used.

Since type of lockedFiles is changed, rename it to follow naming convention too.

Test Plan: Add a unit test and improve an existing test to validate the case.