### PR TITLE
fix: release log handles to allow deletion

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -336,6 +336,12 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
     candidate_files.emplace_back(filename, dbname_);
   }
 
+  // release log handles so that logs can be deleted.
+  for (auto l : state.logs_to_free) {
+    delete l;
+  }
+  state.logs_to_free.clear();
+
   // dedup state.candidate_files so we don't try to delete the same
   // file twice
   std::sort(candidate_files.begin(), candidate_files.end(),


### PR DESCRIPTION
It is observed in tests on Windows that background compaction fails to clean log files in PurgeObsoleteFiles() because job_context still holds open handles. job_context.Clean() releases those handles but is called after PurgeObsoleteFiles(). This fix releases those log handles before trying to clean the log files.
