### PR TITLE
Added the safe-to-ignore tag to version_edit

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -60,7 +60,7 @@ enum Tag : uint32_t {
   kBlobFileAddition,
   kBlobFileGarbage,
   kStateUponManifestSwitch,
-  kManifestSwitchFinished,
+  kManifestSwitched,
 };
 
 enum NewFileCustomTag : uint32_t {
@@ -163,7 +163,7 @@ void VersionEdit::Clear() {
   is_in_atomic_group_ = false;
   remaining_entries_ = 0;
   state_upon_manifest_switch_ = false;
-  manifest_switch_finished_ = false;
+  manifest_switched_ = false;
 }
 
 bool VersionEdit::EncodeTo(std::string* dst) const {
@@ -301,8 +301,8 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
     PutVarint32(dst, kStateUponManifestSwitch);
   }
 
-  if (manifest_switch_finished_) {
-    PutVarint32(dst, kManifestSwitchFinished);
+  if (manifest_switched_) {
+    PutVarint32(dst, kManifestSwitched);
   }
 
   if (is_column_family_add_) {
@@ -651,8 +651,8 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         state_upon_manifest_switch_ = true;
         break;
 
-      case kManifestSwitchFinished:
-        manifest_switch_finished_ = true;
+      case kManifestSwitched:
+        manifest_switched_ = true;
         break;
 
       case kInAtomicGroup:

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -423,8 +423,18 @@ class VersionEdit {
   std::string DebugString(bool hex_key = false) const;
   std::string DebugJSON(int edit_num, bool hex_key = false) const;
 
-  void SetSafeToIgnoreTag(bool tag) { safe_to_ignore_ = tag; }
-  bool GetSafeToIgnoreTag() const { return safe_to_ignore_; }
+  void SetStateUponManifestSwitchTag(bool tag) {
+    state_upon_manifest_switch_ = tag;
+  }
+  bool GetStateUponManifestSwitchTag() const {
+    return state_upon_manifest_switch_;
+  }
+  void SetManifestSwitchFinishedTag(bool tag) {
+    manifest_switch_finished_ = tag;
+  }
+  bool GetManifestSwitchFinishedTag() const {
+    return manifest_switch_finished_;
+  }
 
  private:
   friend class ReactiveVersionSet;
@@ -475,7 +485,11 @@ class VersionEdit {
   uint32_t remaining_entries_ = 0;
   // To distinguish the version edit written by WriteCurrentStateToManifest
   // and other redgular writes. Default is false.
-  bool safe_to_ignore_ = false;
+  bool state_upon_manifest_switch_ = false;
+  // To indicate when WriteCurrentStateToManifest is successful. When both
+  // state_upon_manifest_switch and manifest_switch_finished are true, it can
+  // ensure the manifest switch is finished.
+  bool manifest_switch_finished_ = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -423,6 +423,9 @@ class VersionEdit {
   std::string DebugString(bool hex_key = false) const;
   std::string DebugJSON(int edit_num, bool hex_key = false) const;
 
+  void SetSafeToIgnoreTag(bool tag) { safe_to_ignore_ = tag; }
+  bool GetSafeToIgnoreTag() const { return safe_to_ignore_; }
+
  private:
   friend class ReactiveVersionSet;
   friend class VersionSet;
@@ -470,6 +473,9 @@ class VersionEdit {
 
   bool is_in_atomic_group_ = false;
   uint32_t remaining_entries_ = 0;
+  // To distinguish the version edit written by WriteCurrentStateToManifest
+  // and other redgular writes. Default is false.
+  bool safe_to_ignore_ = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -423,17 +423,17 @@ class VersionEdit {
   std::string DebugString(bool hex_key = false) const;
   std::string DebugJSON(int edit_num, bool hex_key = false) const;
 
-  void SetStateUponManifestSwitchTag(bool tag) {
+  void SetStateUponManifestSwitch(bool tag) {
     state_upon_manifest_switch_ = tag;
   }
-  bool GetStateUponManifestSwitchTag() const {
+  bool GetStateUponManifestSwitch() const {
     return state_upon_manifest_switch_;
   }
-  void SetManifestSwitchFinishedTag(bool tag) {
-    manifest_switch_finished_ = tag;
+  void SetManifestSwitched(bool tag) {
+    manifest_switched_ = tag;
   }
-  bool GetManifestSwitchFinishedTag() const {
-    return manifest_switch_finished_;
+  bool GetManifestSwitched() const {
+    return manifest_switched_;
   }
 
  private:
@@ -484,12 +484,12 @@ class VersionEdit {
   bool is_in_atomic_group_ = false;
   uint32_t remaining_entries_ = 0;
   // To distinguish the version edit written by WriteCurrentStateToManifest
-  // and other redgular writes. Default is false.
+  // and other regular writes. Default is false.
   bool state_upon_manifest_switch_ = false;
   // To indicate when WriteCurrentStateToManifest is successful. When both
   // state_upon_manifest_switch and manifest_switch_finished are true, it can
   // ensure the manifest switch is finished.
-  bool manifest_switch_finished_ = false;
+  bool manifest_switched_ = false;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -46,7 +46,7 @@ TEST_F(VersionEditTest, EncodeDecode) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
-  edit.SetStateUponManifestSwitchTag(true);
+  edit.SetStateUponManifestSwitch(true);
   TestEncodeDecode(edit);
 }
 
@@ -81,7 +81,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
-  edit.SetStateUponManifestSwitchTag(true);
+  edit.SetStateUponManifestSwitch(true);
   TestEncodeDecode(edit);
 
   std::string encoded, encoded2;
@@ -105,7 +105,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   ASSERT_EQ(kInvalidBlobFileNumber,
             new_files[2].second.oldest_blob_file_number);
   ASSERT_EQ(1001, new_files[3].second.oldest_blob_file_number);
-  ASSERT_TRUE(parsed.GetStateUponManifestSwitchTag());
+  ASSERT_TRUE(parsed.GetStateUponManifestSwitch());
 }
 
 TEST_F(VersionEditTest, ForwardCompatibleNewFile4) {
@@ -284,32 +284,32 @@ TEST_F(VersionEditTest, DbId) {
 
 TEST_F(VersionEditTest, ManifestSwitchTag) {
   VersionEdit edit1, decode1;
-  edit1.SetStateUponManifestSwitchTag(true);
+  edit1.SetStateUponManifestSwitch(true);
   TestEncodeDecode(edit1);
   std::string encoded1;
   edit1.EncodeTo(&encoded1);
   ASSERT_OK(decode1.DecodeFrom(encoded1));
-  ASSERT_TRUE(decode1.GetStateUponManifestSwitchTag());
-  ASSERT_TRUE(!decode1.GetManifestSwitchFinishedTag());
+  ASSERT_TRUE(decode1.GetStateUponManifestSwitch());
+  ASSERT_TRUE(!decode1.GetManifestSwitched());
 
   VersionEdit edit2, decode2;
-  edit2.SetManifestSwitchFinishedTag(true);
+  edit2.SetManifestSwitched(true);
   TestEncodeDecode(edit2);
   std::string encoded2;
   edit2.EncodeTo(&encoded2);
   ASSERT_OK(decode2.DecodeFrom(encoded2));
-  ASSERT_TRUE(!decode2.GetStateUponManifestSwitchTag());
-  ASSERT_TRUE(decode2.GetManifestSwitchFinishedTag());
+  ASSERT_TRUE(!decode2.GetStateUponManifestSwitch());
+  ASSERT_TRUE(decode2.GetManifestSwitched());
 
   VersionEdit edit3, decode3;
-  edit3.SetStateUponManifestSwitchTag(true);
-  edit3.SetManifestSwitchFinishedTag(true);
+  edit3.SetStateUponManifestSwitch(true);
+  edit3.SetManifestSwitched(true);
   TestEncodeDecode(edit3);
   std::string encoded3;
   edit3.EncodeTo(&encoded3);
   ASSERT_OK(decode3.DecodeFrom(encoded3));
-  ASSERT_TRUE(decode3.GetStateUponManifestSwitchTag());
-  ASSERT_TRUE(decode3.GetManifestSwitchFinishedTag());
+  ASSERT_TRUE(decode3.GetStateUponManifestSwitch());
+  ASSERT_TRUE(decode3.GetManifestSwitched());
 
 
 }

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -46,6 +46,7 @@ TEST_F(VersionEditTest, EncodeDecode) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
+  edit.SetSafeToIgnoreTag(true);
   TestEncodeDecode(edit);
 }
 
@@ -80,6 +81,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
+  edit.SetSafeToIgnoreTag(true);
   TestEncodeDecode(edit);
 
   std::string encoded, encoded2;
@@ -103,6 +105,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   ASSERT_EQ(kInvalidBlobFileNumber,
             new_files[2].second.oldest_blob_file_number);
   ASSERT_EQ(1001, new_files[3].second.oldest_blob_file_number);
+  ASSERT_TRUE(parsed.GetSafeToIgnoreTag());
 }
 
 TEST_F(VersionEditTest, ForwardCompatibleNewFile4) {

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -46,7 +46,7 @@ TEST_F(VersionEditTest, EncodeDecode) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
-  edit.SetSafeToIgnoreTag(true);
+  edit.SetStateUponManifestSwitchTag(true);
   TestEncodeDecode(edit);
 }
 
@@ -81,7 +81,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   edit.SetLogNumber(kBig + 100);
   edit.SetNextFile(kBig + 200);
   edit.SetLastSequence(kBig + 1000);
-  edit.SetSafeToIgnoreTag(true);
+  edit.SetStateUponManifestSwitchTag(true);
   TestEncodeDecode(edit);
 
   std::string encoded, encoded2;
@@ -105,7 +105,7 @@ TEST_F(VersionEditTest, EncodeDecodeNewFile4) {
   ASSERT_EQ(kInvalidBlobFileNumber,
             new_files[2].second.oldest_blob_file_number);
   ASSERT_EQ(1001, new_files[3].second.oldest_blob_file_number);
-  ASSERT_TRUE(parsed.GetSafeToIgnoreTag());
+  ASSERT_TRUE(parsed.GetStateUponManifestSwitchTag());
 }
 
 TEST_F(VersionEditTest, ForwardCompatibleNewFile4) {
@@ -280,6 +280,38 @@ TEST_F(VersionEditTest, DbId) {
   edit.Clear();
   edit.SetDBId("34ba-cd12-435f-er01");
   TestEncodeDecode(edit);
+}
+
+TEST_F(VersionEditTest, ManifestSwitchTag) {
+  VersionEdit edit1, decode1;
+  edit1.SetStateUponManifestSwitchTag(true);
+  TestEncodeDecode(edit1);
+  std::string encoded1;
+  edit1.EncodeTo(&encoded1);
+  ASSERT_OK(decode1.DecodeFrom(encoded1));
+  ASSERT_TRUE(decode1.GetStateUponManifestSwitchTag());
+  ASSERT_TRUE(!decode1.GetManifestSwitchFinishedTag());
+
+  VersionEdit edit2, decode2;
+  edit2.SetManifestSwitchFinishedTag(true);
+  TestEncodeDecode(edit2);
+  std::string encoded2;
+  edit2.EncodeTo(&encoded2);
+  ASSERT_OK(decode2.DecodeFrom(encoded2));
+  ASSERT_TRUE(!decode2.GetStateUponManifestSwitchTag());
+  ASSERT_TRUE(decode2.GetManifestSwitchFinishedTag());
+
+  VersionEdit edit3, decode3;
+  edit3.SetStateUponManifestSwitchTag(true);
+  edit3.SetManifestSwitchFinishedTag(true);
+  TestEncodeDecode(edit3);
+  std::string encoded3;
+  edit3.EncodeTo(&encoded3);
+  ASSERT_OK(decode3.DecodeFrom(encoded3));
+  ASSERT_TRUE(decode3.GetStateUponManifestSwitchTag());
+  ASSERT_TRUE(decode3.GetManifestSwitchFinishedTag());
+
+
 }
 
 TEST_F(VersionEditTest, BlobFileAdditionAndGarbage) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5003,6 +5003,7 @@ Status VersionSet::WriteCurrentStateToManifest(
     VersionEdit edit_for_db_id;
     assert(!db_id_.empty());
     edit_for_db_id.SetDBId(db_id_);
+    edit_for_db_id.SetSafeToIgnoreTag(true);
     std::string db_id_record;
     if (!edit_for_db_id.EncodeTo(&db_id_record)) {
       return Status::Corruption("Unable to Encode VersionEdit:" +
@@ -5028,6 +5029,7 @@ Status VersionSet::WriteCurrentStateToManifest(
         edit.AddColumnFamily(cfd->GetName());
         edit.SetColumnFamily(cfd->GetID());
       }
+      edit.SetSafeToIgnoreTag(true);
       edit.SetComparatorName(
           cfd->internal_comparator().user_comparator()->Name());
       std::string record;
@@ -5045,6 +5047,7 @@ Status VersionSet::WriteCurrentStateToManifest(
       // Save files
       VersionEdit edit;
       edit.SetColumnFamily(cfd->GetID());
+      edit.SetSafeToIgnoreTag(true);
 
       for (int level = 0; level < cfd->NumberLevels(); level++) {
         for (const auto& f :

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5003,7 +5003,7 @@ Status VersionSet::WriteCurrentStateToManifest(
     VersionEdit edit_for_db_id;
     assert(!db_id_.empty());
     edit_for_db_id.SetDBId(db_id_);
-    edit_for_db_id.SetStateUponManifestSwitchTag(true);
+    edit_for_db_id.SetStateUponManifestSwitch(true);
     std::string db_id_record;
     if (!edit_for_db_id.EncodeTo(&db_id_record)) {
       return Status::Corruption("Unable to Encode VersionEdit:" +
@@ -5029,7 +5029,7 @@ Status VersionSet::WriteCurrentStateToManifest(
         edit.AddColumnFamily(cfd->GetName());
         edit.SetColumnFamily(cfd->GetID());
       }
-      edit.SetStateUponManifestSwitchTag(true);
+      edit.SetStateUponManifestSwitch(true);
       edit.SetComparatorName(
           cfd->internal_comparator().user_comparator()->Name());
       std::string record;
@@ -5047,7 +5047,7 @@ Status VersionSet::WriteCurrentStateToManifest(
       // Save files
       VersionEdit edit;
       edit.SetColumnFamily(cfd->GetID());
-      edit.SetStateUponManifestSwitchTag(true);
+      edit.SetStateUponManifestSwitch(true);
 
       for (int level = 0; level < cfd->NumberLevels(); level++) {
         for (const auto& f :
@@ -5076,18 +5076,15 @@ Status VersionSet::WriteCurrentStateToManifest(
     }
   }
   VersionEdit end_flag;
-  end_flag.SetStateUponManifestSwitchTag(true);
-  end_flag.SetManifestSwitchFinishedTag(true);
+  end_flag.SetStateUponManifestSwitch(true);
+  end_flag.SetManifestSwitched(true);
   std::string end_record;
   if (!end_flag.EncodeTo(&end_record)) {
     return Status::Corruption("Unable to Encode VersionEdit:" +
                               end_flag.DebugString(true));
   }
   Status s_end_record = log->AddRecord(end_record);
-  if (!s_end_record.ok()) {
-    return s_end_record;
-  }
-  return Status::OK();
+  return  s_end_record;
 }
 
 // TODO(aekmekji): in CompactionJob::GenSubcompactionBoundaries(), this


### PR DESCRIPTION
Each time RocksDB switches to a new MANIFEST file from old one, it calls WriteCurrentStateToManifest() which writes a 'snapshot' of the current in-memory state of versions to the beginning of the new manifest as a bunch of version edits. We can distinguish these version edits from other version edits written during normal operations with a custom, safe-to-ignore tag.

Test plan: added test to version_edit_test, pass make asan_check