### PR TITLE
Destroy DB at the end of each test in db_logical_block_size_cache_test

### DIFF
--- a/db/db_logical_block_size_cache_test.cc
+++ b/db/db_logical_block_size_cache_test.cc
@@ -90,6 +90,7 @@ TEST_F(DBLogicalBlockSizeCacheTest, OpenClose) {
     ASSERT_EQ(0, cache_->Size());
     delete db;
   }
+  ASSERT_OK(DestroyDB(dbname_, options, {}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, OpenDelete) {
@@ -118,6 +119,7 @@ TEST_F(DBLogicalBlockSizeCacheTest, OpenDelete) {
     delete db;
     ASSERT_EQ(0, cache_->Size());
   }
+  ASSERT_OK(DestroyDB(dbname_, options, {}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, CreateColumnFamily) {
@@ -163,6 +165,7 @@ TEST_F(DBLogicalBlockSizeCacheTest, CreateColumnFamily) {
 
   delete db;
   ASSERT_EQ(0, cache_->Size());
+  ASSERT_OK(DestroyDB(dbname_, options, {{"cf", cf_options}}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, CreateColumnFamilies) {
@@ -216,6 +219,8 @@ TEST_F(DBLogicalBlockSizeCacheTest, CreateColumnFamilies) {
 
   delete db;
   ASSERT_EQ(0, cache_->Size());
+  ASSERT_OK(DestroyDB(dbname_, options,
+      {{"cf1", cf_options}, {"cf2", cf_options}}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, OpenWithColumnFamilies) {
@@ -303,6 +308,8 @@ TEST_F(DBLogicalBlockSizeCacheTest, OpenWithColumnFamilies) {
     delete db;
     ASSERT_EQ(0, cache_->Size());
   }
+  ASSERT_OK(DestroyDB(dbname_, options,
+      {{"cf1", cf_options}, {"cf2", cf_options}}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, DestroyColumnFamilyHandle) {
@@ -376,6 +383,7 @@ TEST_F(DBLogicalBlockSizeCacheTest, DestroyColumnFamilyHandle) {
     delete db;
     ASSERT_EQ(0, cache_->Size());
   }
+  ASSERT_OK(DestroyDB(dbname_, options, {{"cf", cf_options}}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithDifferentPaths) {
@@ -384,6 +392,8 @@ TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithDifferentPaths) {
   Options options;
   options.create_if_missing = true;
   options.env = env_.get();
+
+  ASSERT_OK(env_->CreateDirIfMissing(dbname_));
 
   DB* db0;
   ASSERT_OK(DB::Open(options, data_path_0_, &db0));
@@ -431,10 +441,12 @@ TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithDifferentPaths) {
   ASSERT_EQ(1, cache_->GetRefCount(data_path_1_));
   ASSERT_TRUE(cache_->Contains(cf_path_1_));
   ASSERT_EQ(1, cache_->GetRefCount(cf_path_1_));
+  ASSERT_OK(DestroyDB(data_path_0_, options, {{"cf", cf_options0}}));
 
   db1->DestroyColumnFamilyHandle(cf1);
   delete db1;
   ASSERT_EQ(0, cache_->Size());
+  ASSERT_OK(DestroyDB(data_path_1_, options, {{"cf", cf_options1}}));
 }
 
 TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithSamePaths) {
@@ -446,6 +458,8 @@ TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithSamePaths) {
   options.db_paths = {{data_path_0_, 1024}};
   ColumnFamilyOptions cf_options;
   cf_options.cf_paths = {{cf_path_0_, 1024}};
+
+  ASSERT_OK(env_->CreateDirIfMissing(dbname_));
 
   DB* db0;
   ASSERT_OK(DB::Open(options, dbname_ + "/db0", &db0));
@@ -484,10 +498,12 @@ TEST_F(DBLogicalBlockSizeCacheTest, MultiDBWithSamePaths) {
   ASSERT_EQ(1, cache_->GetRefCount(data_path_0_));
   ASSERT_TRUE(cache_->Contains(cf_path_0_));
   ASSERT_EQ(1, cache_->GetRefCount(cf_path_0_));
+  ASSERT_OK(DestroyDB(dbname_ + "/db0", options, {{"cf", cf_options}}));
 
   db1->DestroyColumnFamilyHandle(cf1);
   delete db1;
   ASSERT_EQ(0, cache_->Size());
+  ASSERT_OK(DestroyDB(dbname_ + "/db1", options, {{"cf", cf_options}}));
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
If DB is not deleted, in concurrent test, the tests might fail because of the previously existing DB.

Test Plan:
make clean && make -j24 LITE=1  db_logical_block_size_cache_test && ./db_logical_block_size_cache_test
make clean && make -j24 db_logical_block_size_cache_test && ./db_logical_block_size_cache_test