### PR TITLE
Use correct Env for DestroyDB in stress test

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -41,6 +41,7 @@ StressTest::StressTest()
     }
 
     Options options;
+    options.env = db_stress_env;
     // Remove files without preserving manfiest files
 #ifndef ROCKSDB_LITE
     const Status s = !FLAGS_use_blob_db


### PR DESCRIPTION
Summary:
When using custom Env, trying to call DestroyDB() with default Options will
fail.

Test Plan:
./db_stress