### PR TITLE
Use function objects as deleters in the block cache

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -337,8 +337,7 @@ bool LRUCacheShard::Release(Cache::Handle* handle, bool force_erase) {
 }
 
 Status LRUCacheShard::Insert(const Slice& key, uint32_t hash, void* value,
-                             size_t charge,
-                             void (*deleter)(const Slice& key, void* value),
+                             size_t charge, Deleter* deleter,
                              Cache::Handle** handle, Cache::Priority priority) {
   // Allocate the memory here outside of the mutex
   // If the cache is full, we'll have to release it

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -48,8 +48,10 @@ namespace ROCKSDB_NAMESPACE {
 // (to move into state 3).
 
 struct LRUHandle {
+  using Deleter = Cache::Deleter;
+
   void* value;
-  void (*deleter)(const Slice&, void* value);
+  Deleter* deleter;
   LRUHandle* next_hash;
   LRUHandle* next;
   LRUHandle* prev;
@@ -209,9 +211,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
 
   // Like Cache methods, but with an extra "hash" parameter.
   virtual Status Insert(const Slice& key, uint32_t hash, void* value,
-                        size_t charge,
-                        void (*deleter)(const Slice& key, void* value),
-                        Cache::Handle** handle,
+                        size_t charge, Deleter* deleter, Cache::Handle** handle,
                         Cache::Priority priority) override;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) override;
   virtual bool Ref(Cache::Handle* handle) override;

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -44,8 +44,8 @@ void ShardedCache::SetStrictCapacityLimit(bool strict_capacity_limit) {
 }
 
 Status ShardedCache::Insert(const Slice& key, void* value, size_t charge,
-                            void (*deleter)(const Slice& key, void* value),
-                            Handle** handle, Priority priority) {
+                            Deleter* deleter, Handle** handle,
+                            Priority priority) {
   uint32_t hash = HashSlice(key);
   return GetShard(Shard(hash))
       ->Insert(key, hash, value, charge, deleter, handle, priority);

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -21,13 +21,14 @@ namespace ROCKSDB_NAMESPACE {
 // Single cache shard interface.
 class CacheShard {
  public:
+  using Deleter = Cache::Deleter;
+
   CacheShard() = default;
   virtual ~CacheShard() = default;
 
   virtual Status Insert(const Slice& key, uint32_t hash, void* value,
-                        size_t charge,
-                        void (*deleter)(const Slice& key, void* value),
-                        Cache::Handle** handle, Cache::Priority priority) = 0;
+                        size_t charge, Deleter* deleter, Cache::Handle** handle,
+                        Cache::Priority priority) = 0;
   virtual Cache::Handle* Lookup(const Slice& key, uint32_t hash) = 0;
   virtual bool Ref(Cache::Handle* handle) = 0;
   virtual bool Release(Cache::Handle* handle, bool force_erase = false) = 0;
@@ -70,8 +71,8 @@ class ShardedCache : public Cache {
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) override;
 
   virtual Status Insert(const Slice& key, void* value, size_t charge,
-                        void (*deleter)(const Slice& key, void* value),
-                        Handle** handle, Priority priority) override;
+                        Deleter* deleter, Handle** handle,
+                        Priority priority) override;
   virtual Handle* Lookup(const Slice& key, Statistics* stats) override;
   virtual bool Ref(Handle* handle) override;
   virtual bool Release(Handle* handle, bool force_erase = false) override;

--- a/cache/simple_deleter.h
+++ b/cache/simple_deleter.h
@@ -1,0 +1,47 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/cache.h"
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+template <typename T>
+class SimpleDeleter : public Cache::Deleter {
+ public:
+  static SimpleDeleter* GetInstance() {
+    static auto deleter = new SimpleDeleter;
+    return deleter;
+  }
+
+  void operator()(const Slice& /* key */, void* value) override {
+    T* const t = static_cast<T*>(value);
+    delete t;
+  }
+
+ private:
+  SimpleDeleter() = default;
+};
+
+template <typename T>
+class SimpleDeleter<T[]> : public Cache::Deleter {
+ public:
+  static SimpleDeleter* GetInstance() {
+    static auto deleter = new SimpleDeleter;
+    return deleter;
+  }
+
+  void operator()(const Slice& /* key */, void* value) override {
+    T* const t = static_cast<T*>(value);
+    delete[] t;
+  }
+
+ private:
+  SimpleDeleter() = default;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2053,8 +2053,7 @@ class DBBasicTestWithParallelIO
     virtual const char* Name() const override { return "MyBlockCache"; }
 
     virtual Status Insert(const Slice& key, void* value, size_t charge,
-                          void (*deleter)(const Slice& key, void* value),
-                          Handle** handle = nullptr,
+                          Deleter* deleter, Handle** handle = nullptr,
                           Priority priority = Priority::LOW) override {
       num_inserts_++;
       return target_->Insert(key, value, charge, deleter, handle, priority);

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -443,9 +443,8 @@ class MockCache : public LRUCache {
                  false /*strict_capacity_limit*/, 0.0 /*high_pri_pool_ratio*/) {
   }
 
-  Status Insert(const Slice& key, void* value, size_t charge,
-                void (*deleter)(const Slice& key, void* value), Handle** handle,
-                Priority priority) override {
+  Status Insert(const Slice& key, void* value, size_t charge, Deleter* deleter,
+                Handle** handle, Priority priority) override {
     if (priority == Priority::LOW) {
       low_pri_insert_count++;
     } else {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -9,6 +9,7 @@
 
 #include "db/table_cache.h"
 
+#include "cache/simple_deleter.h"
 #include "db/dbformat.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/snapshot_impl.h"
@@ -32,12 +33,6 @@
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
-
-template <class T>
-static void DeleteEntry(const Slice& /*key*/, void* value) {
-  T* typed_value = reinterpret_cast<T*>(value);
-  delete typed_value;
-}
 
 static void UnrefEntry(void* arg1, void* arg2) {
   Cache* cache = reinterpret_cast<Cache*>(arg1);
@@ -166,8 +161,8 @@ Status TableCache::FindTable(const FileOptions& file_options,
       // We do not cache error results so that if the error is transient,
       // or somebody repairs the file, we recover automatically.
     } else {
-      s = cache_->Insert(key, table_reader.get(), 1, &DeleteEntry<TableReader>,
-                         handle);
+      s = cache_->Insert(key, table_reader.get(), 1,
+                         SimpleDeleter<TableReader>::GetInstance(), handle);
       if (s.ok()) {
         // Release ownership of table reader.
         table_reader.release();
@@ -425,7 +420,7 @@ Status TableCache::Get(const ReadOptions& options,
         row_cache_key.Size() + row_cache_entry->size() + sizeof(std::string);
     void* row_ptr = new std::string(std::move(*row_cache_entry));
     ioptions_.row_cache->Insert(row_cache_key.GetUserKey(), row_ptr, charge,
-                                &DeleteEntry<std::string>);
+                                SimpleDeleter<std::string>::GetInstance());
   }
 #endif  // ROCKSDB_LITE
 
@@ -545,7 +540,7 @@ Status TableCache::MultiGet(const ReadOptions& options,
             row_cache_key.Size() + row_cache_entry.size() + sizeof(std::string);
         void* row_ptr = new std::string(std::move(row_cache_entry));
         ioptions_.row_cache->Insert(row_cache_key.GetUserKey(), row_ptr, charge,
-                                    &DeleteEntry<std::string>);
+                                    SimpleDeleter<std::string>::GetInstance());
       }
     }
   }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -132,6 +132,13 @@ extern std::shared_ptr<Cache> NewClockCache(
         kDefaultCacheMetadataChargePolicy);
 class Cache {
  public:
+  class Deleter {
+   public:
+    virtual ~Deleter() = default;
+
+    virtual void operator()(const Slice& key, void* value) = 0;
+  };
+
   // Depending on implementation, cache entries with high priority could be less
   // likely to get evicted than low priority entries.
   enum class Priority { HIGH, LOW };
@@ -168,10 +175,10 @@ class Cache {
   // insert. In case of error value will be cleanup.
   //
   // When the inserted entry is no longer needed, the key and
-  // value will be passed to "deleter".
+  // value will be passed to "deleter". It is the caller's responsibility to
+  // ensure that the deleter outlives the cache entries referring to it.
   virtual Status Insert(const Slice& key, void* value, size_t charge,
-                        void (*deleter)(const Slice& key, void* value),
-                        Handle** handle = nullptr,
+                        Deleter* deleter, Handle** handle = nullptr,
                         Priority priority = Priority::LOW) = 0;
 
   // If the cache has no mapping for "key", returns nullptr.

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -7,6 +7,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #include "table/block_based/partitioned_index_reader.h"
+
+#include "cache/simple_deleter.h"
 #include "table/block_based/partitioned_index_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -168,19 +168,15 @@ class SimCacheImpl : public SimCache {
     cache_->SetStrictCapacityLimit(strict_capacity_limit);
   }
 
-  Status Insert(const Slice& key, void* value, size_t charge,
-                void (*deleter)(const Slice& key, void* value), Handle** handle,
-                Priority priority) override {
+  Status Insert(const Slice& key, void* value, size_t charge, Deleter* deleter,
+                Handle** handle, Priority priority) override {
     // The handle and value passed in are for real cache, so we pass nullptr
-    // to key_only_cache_ for both instead. Also, the deleter function pointer
-    // will be called by user to perform some external operation which should
-    // be applied only once. Thus key_only_cache accepts an empty function.
-    // *Lambda function without capture can be assgined to a function pointer
+    // to key_only_cache_ for both instead. Also, the deleter should be invoked
+    // only once (on the actual value), so we pass nullptr to key_only_cache for
+    // that one as well.
     Handle* h = key_only_cache_->Lookup(key);
     if (h == nullptr) {
-      key_only_cache_->Insert(key, nullptr, charge,
-                              [](const Slice& /*k*/, void* /*v*/) {}, nullptr,
-                              priority);
+      key_only_cache_->Insert(key, nullptr, charge, nullptr, nullptr, priority);
     } else {
       key_only_cache_->Release(h);
     }


### PR DESCRIPTION
Summary:
As the first step of reintroducing eviction statistics for the block
cache, the patch switches from using simple function pointers as deleters
to function objects implementing an interface. This will enable using
deleters that have state, like a smart pointer to the statistics object
that is to be updated when an entry is removed from the cache. For now,
the patch adds a deleter template class `SimpleDeleter`, which simply
casts the `value` pointer to its original type and calls `delete` or
`delete[]` on it as appropriate. Note: to prevent object lifecycle
issues, deleters must outlive the cache entries referring to them;
`SimpleDeleter` ensures this by using the ("leaky") Meyers singleton
pattern.

Test Plan:
`make asan_check`