### PR TITLE
Clean up VersionBuilder a bit

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -507,16 +507,7 @@ VersionBuilder::VersionBuilder(const FileOptions& file_options,
                                Logger* info_log)
     : rep_(new Rep(file_options, info_log, table_cache, base_vstorage)) {}
 
-VersionBuilder::~VersionBuilder() { delete rep_; }
-
-Status VersionBuilder::CheckConsistency(VersionStorageInfo* vstorage) {
-  return rep_->CheckConsistency(vstorage);
-}
-
-Status VersionBuilder::CheckConsistencyForDeletes(VersionEdit* edit,
-                                                  uint64_t number, int level) {
-  return rep_->CheckConsistencyForDeletes(edit, number, level);
-}
+VersionBuilder::~VersionBuilder() = default;
 
 bool VersionBuilder::CheckConsistencyForNumLevels() {
   return rep_->CheckConsistencyForNumLevels();
@@ -535,11 +526,6 @@ Status VersionBuilder::LoadTableHandlers(
   return rep_->LoadTableHandlers(internal_stats, max_threads,
                                  prefetch_index_and_filter_in_cache,
                                  is_initial_load, prefix_extractor);
-}
-
-void VersionBuilder::MaybeAddFile(VersionStorageInfo* vstorage, int level,
-                                  FileMetaData* f) {
-  rep_->MaybeAddFile(vstorage, level, f);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -8,6 +8,9 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
 #pragma once
+
+#include <memory>
+
 #include "rocksdb/file_system.h"
 #include "rocksdb/slice_transform.h"
 
@@ -27,9 +30,7 @@ class VersionBuilder {
   VersionBuilder(const FileOptions& file_options, TableCache* table_cache,
                  VersionStorageInfo* base_vstorage, Logger* info_log = nullptr);
   ~VersionBuilder();
-  Status CheckConsistency(VersionStorageInfo* vstorage);
-  Status CheckConsistencyForDeletes(VersionEdit* edit, uint64_t number,
-                                    int level);
+
   bool CheckConsistencyForNumLevels();
   Status Apply(VersionEdit* edit);
   Status SaveTo(VersionStorageInfo* vstorage);
@@ -37,11 +38,10 @@ class VersionBuilder {
                            bool prefetch_index_and_filter_in_cache,
                            bool is_initial_load,
                            const SliceTransform* prefix_extractor);
-  void MaybeAddFile(VersionStorageInfo* vstorage, int level, FileMetaData* f);
 
  private:
   class Rep;
-  Rep* rep_;
+  std::unique_ptr<Rep> rep_;
 };
 
 extern bool NewestFirstBySeqNo(FileMetaData* a, FileMetaData* b);


### PR DESCRIPTION
Summary:
The whole point of the pimpl idiom is to hide implementation details.
Internal helper methods like `CheckConsistency`, `CheckConsistencyForDeletes`,
and `MaybeAddFile` do not belong in the public interface of the class.
In addition, the patch switches to `unique_ptr` for the implementation
object instead of using a raw `delete`.

Test Plan:
`make check`