### PR TITLE
Create a thread in DeleteScheduler only when rate limit enabled

### DIFF
--- a/file/delete_scheduler.cc
+++ b/file/delete_scheduler.cc
@@ -32,13 +32,13 @@ DeleteScheduler::DeleteScheduler(Env* env, FileSystem* fs,
       bytes_max_delete_chunk_(bytes_max_delete_chunk),
       closing_(false),
       cv_(&mu_),
+      bg_thread_(nullptr),
       info_log_(info_log),
       sst_file_manager_(sst_file_manager),
       max_trash_db_ratio_(max_trash_db_ratio) {
   assert(sst_file_manager != nullptr);
   assert(max_trash_db_ratio >= 0);
-  bg_thread_.reset(
-      new port::Thread(&DeleteScheduler::BackgroundEmptyTrash, this));
+  MaybeCreateBackgroundThread();
 }
 
 DeleteScheduler::~DeleteScheduler() {
@@ -349,6 +349,13 @@ void DeleteScheduler::WaitForEmptyTrash() {
   InstrumentedMutexLock l(&mu_);
   while (pending_files_ > 0 && !closing_) {
     cv_.Wait();
+  }
+}
+
+void DeleteScheduler::MaybeCreateBackgroundThread() {
+  if(bg_thread_ == nullptr && rate_bytes_per_sec_.load() > 0) {
+    bg_thread_.reset(
+        new port::Thread(&DeleteScheduler::BackgroundEmptyTrash, this));
   }
 }
 

--- a/file/delete_scheduler.h
+++ b/file/delete_scheduler.h
@@ -45,6 +45,7 @@ class DeleteScheduler {
   // Set delete rate limit in bytes per second
   void SetRateBytesPerSecond(int64_t bytes_per_sec) {
     rate_bytes_per_sec_.store(bytes_per_sec);
+    MaybeCreateBackgroundThread();
   }
 
   // Mark file as trash directory and schedule it's deletion. If force_bg is
@@ -90,6 +91,8 @@ class DeleteScheduler {
                          uint64_t* deleted_bytes, bool* is_complete);
 
   void BackgroundEmptyTrash();
+
+  void MaybeCreateBackgroundThread();
 
   Env* env_;
   FileSystem* fs_;


### PR DESCRIPTION
Summary: Create a thread in DeleteScheduler only when delete rate limit is set
	 because when there is no rate limit on deletion, a thread per DeleteScheduler
	 consumes unnecessary resources.

Task Id: T64154614

Test Plan: make -j64 check