### PR TITLE
Size Check to avoid segfault

### DIFF
--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -62,6 +62,9 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
                                            info2->smallest_internal_key) < 0;
                 });
 
+      if (sorted_files.size() <= 1) {
+        continue;
+      }
       for (size_t i = 0; i < sorted_files.size() - 1; i++) {
         if (sstableKeyCompare(ucmp, sorted_files[i]->largest_internal_key,
                               sorted_files[i + 1]->smallest_internal_key) >=


### PR DESCRIPTION
Hi Team, 
  I am from Cohesity while I was trying rocksdb6.4.6 APIs I found that if the size of the sorted_files is 0  it will lead to a SEG FAULT as in the for loop it's checking if i <  sorted_files.size() -1 .
If  sorted_files.size() ==0 then  sorted_files.size()-1 is a positive number as it is of the type size_t which is unsigned. Hence to avoid this I have added a safer continue option to continue when a  sorted_files.size() is less than or equal to 1.