### PR TITLE
Change HashMap::Insert()'s value to a const reference

### DIFF
--- a/util/hash_map.h
+++ b/util/hash_map.h
@@ -36,7 +36,7 @@ class HashMap {
     return it != bucket.end();
   }
 
-  void Insert(K key, V value) {
+  void Insert(K key, const V& value) {
     auto& bucket = table_[key % size];
     bucket.push_back({key, value});
   }


### PR DESCRIPTION
Summary:
When building RocksDB on VS2015, an error shows up with

hash_map.h(39): error C2719: 'value': formal parameter with requested alignment of 8 won't be aligned

Making the reference a reference can solve the problem, and there isn't a reason we can't do that, at least for the current use of the hash map.

Test Plan: See CI tests pass.