### PR TITLE
Fix the MultiGet testing failure in  Circleci

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -7,8 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <iostream>
-
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1768,13 +1766,7 @@ class DBBasicTestWithParallelIO
       compression_types = GetSupportedCompressions();
       // Not every platform may have compression libraries available, so
       // dynamically pick based on what's available
-      std::cout<<"compression_type size: "<<compression_types.size()<<"\n";
-      for (auto c:compression_types) {
-        std::cout<<CompressionTypeToString(c)<<"\n";
-      }
-      if (compression_types.size() == 0 ||
-          (compression_types.size() == 1 &&
-           compression_types[0] == kNoCompression)) {
+      if (compression_types.size() == 0) {
         compression_enabled_ = false;
       } else {
         CompressionType tmp_type = kNoCompression;
@@ -1999,7 +1991,6 @@ class DBBasicTestWithParallelIO
 };
 
 // TODO: fails on CircleCI's Windows env
-//#ifndef OS_WIN
 TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   std::vector<std::string> key_data(10);
   std::vector<Slice> keys;
@@ -2122,7 +2113,6 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
     }
   }
 }
-//#endif // OS_WIN
 
 TEST_P(DBBasicTestWithParallelIO, MultiGetWithChecksumMismatch) {
   std::vector<std::string> key_data(10);

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1766,21 +1766,17 @@ class DBBasicTestWithParallelIO
       compression_types = GetSupportedCompressions();
       // Not every platform may have compression libraries available, so
       // dynamically pick based on what's available
-      if (compression_types.size() == 0) {
-        compression_enabled_ = false;
+      CompressionType tmp_type = kNoCompression;
+      for (auto c_type : compression_types) {
+        if (c_type != kNoCompression) {
+          tmp_type = c_type;
+          break;
+        }
+      }
+      if (tmp_type != kNoCompression) {
+        options.compression = tmp_type;
       } else {
-        CompressionType tmp_type = kNoCompression;
-        for (auto c_type:compression_types) {
-          if (c_type != kNoCompression) {
-            tmp_type = c_type;
-            break;
-          }
-        }
-        if (tmp_type != kNoCompression) {
-          options.compression = tmp_type;
-        } else {
-          compression_enabled_ = false;
-        }
+        compression_enabled_ = false;
       }
     }
 #else
@@ -1990,7 +1986,6 @@ class DBBasicTestWithParallelIO
   bool fill_cache_;
 };
 
-// TODO: fails on CircleCI's Windows env
 TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   std::vector<std::string> key_data(10);
   std::vector<Slice> keys;

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1777,7 +1777,18 @@ class DBBasicTestWithParallelIO
            compression_types[0] == kNoCompression)) {
         compression_enabled_ = false;
       } else {
-        options.compression = compression_types[0];
+        CompressionType tmp_type = kNoCompression;
+        for (auto c_type:compression_types) {
+          if (c_type != kNoCompression) {
+            tmp_type = c_type;
+            break;
+          }
+        }
+        if (tmp_type != kNoCompression) {
+          options.compression = tmp_type;
+        } else {
+          compression_enabled_ = false;
+        }
       }
     }
 #else

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -1765,7 +1765,9 @@ class DBBasicTestWithParallelIO
       compression_types = GetSupportedCompressions();
       // Not every platform may have compression libraries available, so
       // dynamically pick based on what's available
-      if (compression_types.size() == 0) {
+      if (compression_types.size() == 0 ||
+          (compression_types.size() == 1 &&
+           compression_types[0] == kNoCompression)) {
         compression_enabled_ = false;
       } else {
         options.compression = compression_types[0];
@@ -1979,7 +1981,7 @@ class DBBasicTestWithParallelIO
 };
 
 // TODO: fails on CircleCI's Windows env
-#ifndef OS_WIN
+//#ifndef OS_WIN
 TEST_P(DBBasicTestWithParallelIO, MultiGet) {
   std::vector<std::string> key_data(10);
   std::vector<Slice> keys;
@@ -2102,7 +2104,7 @@ TEST_P(DBBasicTestWithParallelIO, MultiGet) {
     }
   }
 }
-#endif // OS_WIN
+//#endif // OS_WIN
 
 TEST_P(DBBasicTestWithParallelIO, MultiGetWithChecksumMismatch) {
   std::vector<std::string> key_data(10);

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -6,6 +6,9 @@
 // Copyright (c) 2011 The LevelDB Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <iostream>
+
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/perf_context.h"
@@ -1765,6 +1768,10 @@ class DBBasicTestWithParallelIO
       compression_types = GetSupportedCompressions();
       // Not every platform may have compression libraries available, so
       // dynamically pick based on what's available
+      std::cout<<"compression_type size: "<<compression_types.size()<<"\n";
+      for (auto c:compression_types) {
+        std::cout<<CompressionTypeToString(c)<<"\n";
+      }
       if (compression_types.size() == 0 ||
           (compression_types.size() == 1 &&
            compression_types[0] == kNoCompression)) {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -13,6 +13,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
@@ -809,6 +810,7 @@ Status BlockBasedTable::ReadPropertiesBlock(
       rep_->blocks_maybe_compressed =
           rep_->table_properties->compression_name !=
           CompressionTypeToString(kNoCompression);
+      std::cout<<"table_properties->compression_name: "<<rep_->table_properties->compression_name<<"\n";
       rep_->blocks_definitely_zstd_compressed =
           (rep_->table_properties->compression_name ==
                CompressionTypeToString(kZSTD) ||
@@ -1579,6 +1581,11 @@ void BlockBasedTable::RetrieveMultipleBlocks(
   size_t prev_len = 0;
   autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_idx_for_block;
   autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_offset_for_block;
+  if (scratch != nullptr) {
+    std::cout<<"read combine is triggered\n";
+  } else {
+    std::cout<<"read combine is NOT triggered\n";
+  }
   for (auto mget_iter = batch->begin(); mget_iter != batch->end();
        ++mget_iter, ++idx_in_batch) {
     const BlockHandle& handle = (*handles)[idx_in_batch];

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -13,7 +13,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
@@ -810,7 +809,6 @@ Status BlockBasedTable::ReadPropertiesBlock(
       rep_->blocks_maybe_compressed =
           rep_->table_properties->compression_name !=
           CompressionTypeToString(kNoCompression);
-      std::cout<<"table_properties->compression_name: "<<rep_->table_properties->compression_name<<"\n";
       rep_->blocks_definitely_zstd_compressed =
           (rep_->table_properties->compression_name ==
                CompressionTypeToString(kZSTD) ||
@@ -1581,11 +1579,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
   size_t prev_len = 0;
   autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_idx_for_block;
   autovector<size_t, MultiGetContext::MAX_BATCH_SIZE> req_offset_for_block;
-  if (scratch != nullptr) {
-    std::cout<<"read combine is triggered\n";
-  } else {
-    std::cout<<"read combine is NOT triggered\n";
-  }
   for (auto mget_iter = batch->begin(); mget_iter != batch->end();
        ++mget_iter, ++idx_in_batch) {
     const BlockHandle& handle = (*handles)[idx_in_batch];


### PR DESCRIPTION
The MultiGet test in db_basic_test fails in CircleCI vs2019. The reason is that even Snappy compression is enabled, the first compression type is still kNoCompression. This PR checks the list and ensure that only when compression is enable and the compression type is valid, compression will be enabled. Such that, it will not fail the combined read test in MultiGet.

Test plan: make check, db_basic_test.