### PR TITLE
Fix write_unprepared_transaction_test crash on debug version.

### DIFF
--- a/utilities/transactions/write_unprepared_transaction_test.cc
+++ b/utilities/transactions/write_unprepared_transaction_test.cc
@@ -182,8 +182,8 @@ TEST_P(WriteUnpreparedStressTest, ReadYourOwnWriteStress) {
     ReadOptions read_options;
 
     for (uint32_t i = 0; i < kNumIter; i++) {
-      std::set<std::string> owned_keys(&keys[id * kNumKeys],
-                                       &keys[(id + 1) * kNumKeys]);
+      std::set<std::string> owned_keys(keys.begin() + id * kNumKeys,
+                                       keys.begin() + (id + 1) * kNumKeys);
       // Add unowned keys to make the workload more interesting, but this
       // increases row lock contention, so just do it sometimes.
       if (rnd.OneIn(2)) {


### PR DESCRIPTION
The last key may hit index of out bound exception when id = 9.