### PR TITLE
Initialize scratch to nullptr explicitly to make clang analyzer happy

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -163,6 +163,7 @@ FSReadRequest Align(const FSReadRequest& r, size_t alignment) {
   req.offset = static_cast<uint64_t>(
     TruncateToPageBoundary(alignment, static_cast<size_t>(r.offset)));
   req.len = Roundup(End(r), alignment) - req.offset;
+  req.scratch = nullptr;
   return req;
 }
 


### PR DESCRIPTION
`scratch` is not initialized in `Align` because it will be set outside of it. But clang analyzer is strict on initializing it before return.

Test Plan:
make analyze