### PR TITLE
Keep building RocksJava on all architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,17 +118,6 @@ matrix:
     env: TEST_GROUP=4
   - if: type = pull_request
     os : osx
-    env: JOB_NAME=java_test
-  - if: type = pull_request
-    os : linux
-    arch: arm64
-    env: JOB_NAME=java_test
-  - if: type = pull_request
-    os: linux
-    arch: ppc64le
-    env: JOB_NAME=java_test
-  - if: type = pull_request
-    os : osx
     env: JOB_NAME=lite_build
   - if: type = pull_request
     os : linux


### PR DESCRIPTION
Adding solid support for multiple architectures was initially triggered by RocksJava users. As such I would like to keep the CI for RocksJava on all architectures, to ensure we don't break backwards compatibility.

@pdillinger okay let's see how long it takes to complete Travis-CI with this one...