### PR TITLE
WIP: Better GetDefaultCacheShardBits (possible performance improvement)

### DIFF
--- a/cache/cache_test.cc
+++ b/cache/cache_test.cc
@@ -734,17 +734,36 @@ TEST_P(CacheTest, ApplyToAllCacheEntiresTest) {
 TEST_P(CacheTest, DefaultShardBits) {
   // test1: set the flag to false. Insert more keys than capacity. See if they
   // all go through.
-  std::shared_ptr<Cache> cache = NewCache(16 * 1024L * 1024L);
-  ShardedCache* sc = dynamic_cast<ShardedCache*>(cache.get());
-  ASSERT_EQ(5, sc->GetNumShardBits());
+  std::shared_ptr<Cache> cache;
+  ShardedCache* sc;
 
-  cache = NewLRUCache(511 * 1024L, -1, true);
+  // 8 MiB
+  cache = NewCache(size_t{8} << 20);
   sc = dynamic_cast<ShardedCache*>(cache.get());
-  ASSERT_EQ(0, sc->GetNumShardBits());
+  EXPECT_EQ(4, sc->GetNumShardBits());
 
-  cache = NewLRUCache(1024L * 1024L * 1024L, -1, true);
+  // 16 MiB
+  cache = NewCache(size_t{16} << 20);
   sc = dynamic_cast<ShardedCache*>(cache.get());
-  ASSERT_EQ(6, sc->GetNumShardBits());
+  EXPECT_EQ(5, sc->GetNumShardBits());
+
+  // 511 KiB (used to be too small for > 1 shard, now considered ok)
+  cache = NewLRUCache(size_t{511} << 10, -1, true);
+  sc = dynamic_cast<ShardedCache*>(cache.get());
+  EXPECT_EQ(2, sc->GetNumShardBits());
+
+  // 1 GiB
+  cache = NewLRUCache(size_t{1} << 30, -1, true);
+  sc = dynamic_cast<ShardedCache*>(cache.get());
+  EXPECT_EQ(8, sc->GetNumShardBits());
+
+  if (sizeof(size_t) > 4) {
+    // 16 GiB
+    cache = NewLRUCache(size_t{16} << 30, -1, true);
+    sc = dynamic_cast<ShardedCache*>(cache.get());
+    // 1024 shards
+    EXPECT_EQ(10, sc->GetNumShardBits());
+  }
 }
 
 TEST_P(CacheTest, GetCharge) {

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -9,8 +9,10 @@
 
 #include "cache/sharded_cache.h"
 
+#include <algorithm>
 #include <string>
 
+#include "util/math.h"
 #include "util/mutexlock.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -147,16 +149,15 @@ std::string ShardedCache::GetPrintableOptions() const {
   return ret;
 }
 int GetDefaultCacheShardBits(size_t capacity) {
-  int num_shard_bits = 0;
-  size_t min_shard_size = 512L * 1024L;  // Every shard is at least 512KB.
-  size_t num_shards = capacity / min_shard_size;
-  while (num_shards >>= 1) {
-    if (++num_shard_bits >= 6) {
-      // No more than 6.
-      return num_shard_bits;
-    }
-  }
-  return num_shard_bits;
+  // The number of shards should not exceed roughly sqrt(cache entries)/2
+  // to minimize clustering effects and metadata overhead. For example,
+  // 4 shard bits (16 shards) for 8MiB block cache (long time defaults) and
+  // 10 shard bits (1024 shards) for 16GiB block cache.
+  // (Performance improvement has been seen with 1024 shards or more, due to
+  // less lock contention.)
+  // Estimate one cache entry per 4KB (2^12 bytes).
+  // In base-2 logs, /2 for sqrt, -1 for /2.
+  return std::max((FloorLog2(capacity) - 12) / 2 - 1, int{0});
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/hash_test.cc
+++ b/util/hash_test.cc
@@ -13,6 +13,7 @@
 #include "test_util/testharness.h"
 #include "util/coding.h"
 #include "util/hash.h"
+#include "util/math.h"
 
 using ROCKSDB_NAMESPACE::EncodeFixed32;
 using ROCKSDB_NAMESPACE::GetSliceHash64;
@@ -368,6 +369,31 @@ uint32_t fastrange32(uint32_t hash, uint32_t range) {
 // for inspection of disassembly
 size_t fastrange64(uint64_t hash, size_t range) {
   return ROCKSDB_NAMESPACE::fastrange64(hash, range);
+}
+
+// Tests of util/math.h here for now
+
+using ROCKSDB_NAMESPACE::FloorLog2;
+
+TEST(MathTest, FloorLog2Test) {
+  // Test everything up to 2^16, different types
+  for (uint16_t i = 1; /* wrap around */ i > 0; ++i) {
+    int floor_log2 = FloorLog2(i);
+    uint16_t floor_pow2 = static_cast<uint16_t>(1U << floor_log2);
+    EXPECT_EQ(floor_pow2 & i, floor_pow2);
+    EXPECT_LT(i / 2, floor_pow2);
+
+    EXPECT_EQ(floor_log2, FloorLog2(uint32_t{i}));
+    EXPECT_EQ(floor_log2, FloorLog2(unsigned{i}));
+    EXPECT_EQ(floor_log2, FloorLog2(uint64_t{i}));
+  }
+
+  // Test all 2^n and (2^n)-1 within 64 bits
+  EXPECT_EQ(FloorLog2(1U), 0);
+  for (int bit_pos = 1; bit_pos < 64; ++bit_pos) {
+    EXPECT_EQ(FloorLog2(uint64_t{1} << bit_pos), bit_pos);
+    EXPECT_EQ(FloorLog2((uint64_t{1} << bit_pos) - 1), bit_pos - 1);
+  }
 }
 
 int main(int argc, char** argv) {

--- a/util/math.h
+++ b/util/math.h
@@ -12,7 +12,7 @@
 #endif
 #include <type_traits>
 
-namespace rocksdb {
+namespace ROCKSDB_NAMESPACE {
 
 template <typename T>
 inline int FloorLog2(T v) {
@@ -40,4 +40,4 @@ inline int FloorLog2(T v) {
 #endif
 }
 
-}  // namespace rocksdb
+}  // namespace ROCKSDB_NAMESPACE

--- a/util/math.h
+++ b/util/math.h
@@ -1,0 +1,43 @@
+//  Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+namespace rocksdb {
+
+template <typename T>
+inline int FloorLog2(T v) {
+  static_assert(std::is_integral<T>::value, "non-integral type");
+  assert(v > 0);
+#ifdef _MSC_VER
+  static_assert(sizeof(T) >= sizeof(uint32_t), "type too small");
+  static_assert(sizeof(T) <= sizeof(uint64_t), "type too big");
+  unsigned long lz = 0;
+  if (sizeof(T) == sizeof(uint32_t)) {
+    _BitScanReverse(&lz, static_cast<uint32_t>(v));
+  } else {
+    _BitScanReverse64(&lz, static_cast<uint64_t>(v));
+  }
+  return 63 - static_cast<int>(lz);
+#else
+  static_assert(sizeof(T) >= sizeof(unsigned int), "type too small");
+  static_assert(sizeof(T) <= sizeof(unsigned long long), "type too big");
+  if (sizeof(T) == sizeof(unsigned int)) {
+    int lz = __builtin_clz(static_cast<unsigned int>(v));
+    return int{sizeof(unsigned int)} * 8 - 1 - lz;
+  } else {
+    int lz = __builtin_clzll(static_cast<unsigned long long>(v));
+    return int{sizeof(unsigned long long)} * 8 - 1 - lz;
+  }
+#endif
+}
+
+}  // namespace rocksdb

--- a/util/math.h
+++ b/util/math.h
@@ -10,27 +10,27 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
+#include <type_traits>
 
 namespace rocksdb {
 
 template <typename T>
 inline int FloorLog2(T v) {
   static_assert(std::is_integral<T>::value, "non-integral type");
+  static_assert(std::is_unsigned<T>::value, "must be unsigned");
   assert(v > 0);
 #ifdef _MSC_VER
-  static_assert(sizeof(T) >= sizeof(uint32_t), "type too small");
   static_assert(sizeof(T) <= sizeof(uint64_t), "type too big");
   unsigned long lz = 0;
-  if (sizeof(T) == sizeof(uint32_t)) {
+  if (sizeof(T) <= sizeof(uint32_t)) {
     _BitScanReverse(&lz, static_cast<uint32_t>(v));
   } else {
     _BitScanReverse64(&lz, static_cast<uint64_t>(v));
   }
   return 63 - static_cast<int>(lz);
 #else
-  static_assert(sizeof(T) >= sizeof(unsigned int), "type too small");
   static_assert(sizeof(T) <= sizeof(unsigned long long), "type too big");
-  if (sizeof(T) == sizeof(unsigned int)) {
+  if (sizeof(T) <= sizeof(unsigned int)) {
     int lz = __builtin_clz(static_cast<unsigned int>(v));
     return int{sizeof(unsigned int)} * 8 - 1 - lz;
   } else {


### PR DESCRIPTION
Summary: Production CPU profiles show a lot of time in
LRUHandleTable::FindPointer, though this appears to be speculative
execution while waiting for lock, confirmed by profiling db_bench
with varying -cache_numshardbits. Currently, the max inferred
num_shard_bits is 6 (64 shards), for any capacity over 32MB. And that
doesn't even pass the sniff test for a machine running 80 hardware
threads.

Presumably, the primary hazard of too many cache shards is "clustering,"
wherein a too-big combination of hot data ends up in a single shard.
IMHO, the best way to balance parallelism and clustering is using square
roots. If the number of shards is kept a bit below the square root of
the expected number of entries, you're unlikely to be burned by either.

Capacity: Old shard bits -> New shard bits
8MiB: 4 -> 4
1GiB: 6 -> 8
16GiB: 6 -> 10

Test Plan: Updated unit test, and with 16 threads, db_bench shows about
10% higher readrandom ops/s for 10 shard bits vs. 6.