### PR TITLE
Pick FIFO compaction based on file flush timestamp

### DIFF
--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -383,8 +383,7 @@ Status FlushJob::WriteLevel0Table() {
           mutable_cf_options_.paranoid_file_checks, cfd_->internal_stats(),
           TableFileCreationReason::kFlush, event_logger_, job_context_->job_id,
           Env::IO_HIGH, &table_properties_, 0 /* level */,
-          meta_.oldest_ancester_time, oldest_key_time, write_hint,
-          current_time);
+          meta_.file_creation_time, oldest_key_time, write_hint, current_time);
       LogFlush(db_options_.info_log);
     }
     ROCKS_LOG_INFO(db_options_.info_log,


### PR DESCRIPTION
Summary:
In FiFO compaction with TTL, a file should be picked only if the latest
(newest) key time is older than TTL. To avoid maintaining an atomic variable
newest_timestamp_ for each memtable, we use flush timestamp to approximate.

Test Plan:
make check