### PR TITLE
[WON'T LAND TO MASTER] Use file creation time for FIFO compaction

### DIFF
--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -74,7 +74,7 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
       if (f->fd.table_reader != nullptr &&
           f->fd.table_reader->GetTableProperties() != nullptr) {
         auto creation_time =
-            f->fd.table_reader->GetTableProperties()->creation_time;
+            f->fd.table_reader->GetTableProperties()->file_creation_time;
         if (creation_time == 0 ||
             creation_time >= (current_time - mutable_cf_options.ttl)) {
           break;
@@ -96,11 +96,12 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
   }
 
   for (const auto& f : inputs[0].files) {
-    ROCKS_LOG_BUFFER(log_buffer,
-                     "[%s] FIFO compaction: picking file %" PRIu64
-                     " with creation time %" PRIu64 " for deletion",
-                     cf_name.c_str(), f->fd.GetNumber(),
-                     f->fd.table_reader->GetTableProperties()->creation_time);
+    ROCKS_LOG_BUFFER(
+        log_buffer,
+        "[%s] FIFO compaction: picking file %" PRIu64
+        " with creation time %" PRIu64 " for deletion",
+        cf_name.c_str(), f->fd.GetNumber(),
+        f->fd.table_reader->GetTableProperties()->file_creation_time);
   }
 
   Compaction* c = new Compaction(


### PR DESCRIPTION
Use file_creation_time when picking a file for ttl-based FIFO compaction.
Cannot use oldest_key_time since the SST may have keys newer than TTL while oldest_key_time may be older than TTL.

Test plan:
make check