### PR TITLE
Fix potential memory leak in table_test

### DIFF
--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1190,6 +1190,8 @@ class FileChecksumTestHelper {
   void SetFileChecksumGenerator(FileChecksumGenerator* checksum_generator) {
     if (file_writer_ != nullptr) {
       file_writer_->TEST_SetFileChecksumGenerator(checksum_generator);
+    } else {
+      delete checksum_generator;
     }
   }
 


### PR DESCRIPTION
The checksum generator should be released if file_writer fails to reset the pointer.

Test: pass make asan_check