### PR TITLE
Fix clang analyze error

### DIFF
--- a/db/compaction/compaction_picker_fifo.cc
+++ b/db/compaction/compaction_picker_fifo.cc
@@ -71,6 +71,7 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
   if (current_time > mutable_cf_options.ttl) {
     for (auto ritr = level_files.rbegin(); ritr != level_files.rend(); ++ritr) {
       FileMetaData* f = *ritr;
+      assert(f);
       if (f->fd.table_reader && f->fd.table_reader->GetTableProperties()) {
         uint64_t creation_time =
             f->fd.table_reader->GetTableProperties()->creation_time;
@@ -96,7 +97,8 @@ Compaction* FIFOCompactionPicker::PickTTLCompaction(
 
   for (const auto& f : inputs[0].files) {
     uint64_t creation_time = 0;
-    if (f && f->fd.table_reader && f->fd.table_reader->GetTableProperties()) {
+    assert(f);
+    if (f->fd.table_reader && f->fd.table_reader->GetTableProperties()) {
       creation_time = f->fd.table_reader->GetTableProperties()->creation_time;
     }
     ROCKS_LOG_BUFFER(log_buffer,


### PR DESCRIPTION
Summary:
As title. #6612 caused clang analyze to fail with the error:
```
db/compaction/compaction_picker_fifo.cc:105:39: warning: Called C++ object pointer is null
                     cf_name.c_str(), f->fd.GetNumber(), creation_time);
                                      ^~~~~~~~~~~~~~~~~
./logging/logging.h:59:36: note: expanded from macro 'ROCKS_LOG_BUFFER'
                                 ##__VA_ARGS__)
                                   ^~~~~~~~~~~
1 warning generated.
```

Test Plan (devserver):
USE_CLANG=1 make analyze