### PR TITLE
Add a compact option max_compaction_bytes

### DIFF
--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -775,6 +775,11 @@ Compaction* CompactionPicker::CompactRange(
     return nullptr;
   }
 
+  auto max_compaction_bytes = mutable_cf_options.max_compaction_bytes;
+  if (compact_range_options.max_compaction_bytes > 0) {
+    max_compaction_bytes = compact_range_options.max_compaction_bytes;
+  }
+
   std::vector<FileMetaData*> grandparents;
   GetGrandparents(vstorage, inputs, output_level_inputs, &grandparents);
   Compaction* compaction = new Compaction(
@@ -783,8 +788,7 @@ Compaction* CompactionPicker::CompactRange(
       MaxFileSizeForLevel(mutable_cf_options, output_level,
                           ioptions_.compaction_style, vstorage->base_level(),
                           ioptions_.level_compaction_dynamic_level_bytes),
-      mutable_cf_options.max_compaction_bytes,
-      compact_range_options.target_path_id,
+      max_compaction_bytes, compact_range_options.target_path_id,
       GetCompressionType(ioptions_, vstorage, mutable_cf_options, output_level,
                          vstorage->base_level()),
       GetCompressionOptions(mutable_cf_options, vstorage, output_level),

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1500,6 +1500,8 @@ struct CompactRangeOptions {
   bool allow_write_stall = false;
   // If > 0, it will replace the option in the DBOptions for this compaction.
   uint32_t max_subcompactions = 0;
+  // If > 0, it will replace the option in the CFOptions for this compaction.
+  uint64_t max_compaction_bytes = 0;
 };
 
 // IngestExternalFileOptions is used by IngestExternalFile()


### PR DESCRIPTION
I found that manual compact sometimes picks some very large compactions. I haven't figure out why but using a small `max_compaction_bytes` can prevent it. I think it is reasonable to add `max_compaction_bytes` as a manual compact option too.