### PR TITLE
Revamp cache_bench to resemble a real workload

### DIFF
--- a/cache/cache_bench.cc
+++ b/cache/cache_bench.cc
@@ -151,7 +151,7 @@ struct KeyGen {
 
 char* createValue(Random64& rnd) {
   char* rv = new char[FLAGS_value_bytes];
-  // And fill with some filler data
+  // Fill with some filler data, and take some CPU time
   for (uint32_t i = 0; i < FLAGS_value_bytes; i += 8) {
     EncodeFixed64(rv + i, rnd.Next());
   }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -1076,8 +1076,9 @@ void BlockBasedTableBuilder::WriteRawBlock(const Slice& block_contents,
                                          1;
           r->pc_rep->estimated_file_size =
               r->offset +
-              static_cast<uint64_t>(static_cast<double>(new_raw_bytes_inflight) *
-                                    r->pc_rep->curr_compression_ratio) +
+              static_cast<uint64_t>(
+                  static_cast<double>(new_raw_bytes_inflight) *
+                  r->pc_rep->curr_compression_ratio) +
               new_blocks_inflight * kBlockTrailerSize;
         } else {
           r->pc_rep->estimated_file_size = r->offset;

--- a/util/work_queue.h
+++ b/util/work_queue.h
@@ -17,7 +17,6 @@
 #include <cassert>
 #include <condition_variable>
 #include <cstddef>
-#include <cstddef>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -146,4 +145,4 @@ class WorkQueue {
     }
   }
 };
-}
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: I suspect LRUCache could use some optimization, and to support
such an effort, a good benchmarking tool is needed. The existing
cache_bench was heavily skewed toward insertion and lookup misses, and
did not saturate memory with other work. This change should improve
those things to better resemble a real workload.

(All below using clang compiler, for some consistency, but not
necessarily same version and settings.)

The real workload is from production MySQL on RocksDB, filtering stacks
containing "LRU", "ShardedCache" or "CacheShard."
Lookup inclusive: 66%
Insert inclusive: 17%
Release inclusive: 15%

An alternate simulated workload is MySQL running a LinkBench read test:
Lookup inclusive: 54%
Insert inclusive: 24%
Release inclusive: 21%

cache_bench default settings, prior to this change:
Lookup inclusive: 35.8%
Insert inclusive: 63.6%
Release inclusive: 0%

cache_bench after this change (intended as somewhat "tighter" workload
than average production, more like LinkBench):
Lookup inclusive: 52%
Insert inclusive: 20%
Release inclusive: 26%

And top exclusive stacks (portion of stack samples as filtered above):
Production MySQL:
LRUHandleTable::FindPointer: 25.3%
rocksdb::operator==: 15.1%  <-- Slice ==
LRUCacheShard::LRU_Remove: 13.8%
ShardedCache::Lookup: 8.9%
__pthread_mutex_lock: 7.1%
LRUCacheShard::LRU_Insert: 6.3%
MurmurHash64A: 4.8%  <-- Since upgraded to XXH3p
...

Old cache_bench:
LRUHandleTable::FindPointer: 23.6%
__pthread_mutex_lock: 15.0%
__pthread_mutex_unlock_usercnt: 11.7%
__lll_lock_wait: 8.6%
__lll_unlock_wake: 6.8%
LRUCacheShard::LRU_Insert: 6.0%
ShardedCache::Lookup: 4.4%
LRUCacheShard::LRU_Remove: 2.8%
...
rocksdb::operator==: 0.2%  <-- Slice ==
...

New cache_bench:
LRUHandleTable::FindPointer: 22.8%
__pthread_mutex_unlock_usercnt: 14.3%
rocksdb::operator==: 10.5%  <-- Slice ==
LRUCacheShard::LRU_Insert: 9.0%
__pthread_mutex_lock: 5.9%
LRUCacheShard::LRU_Remove: 5.0%
...
ShardedCache::Lookup: 2.9%
...

So there's a bit more lock contention in the benchmark than in
production, but otherwise looks similar enough to me. At least it's a
big improvement over the existing code.

Test Plan: No production code changes, ran cache_bench with ASAN