### PR TITLE
Fix LITE mode test failure in DBOptionsTest.ChangeCompression

### DIFF
--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -859,8 +859,6 @@ TEST_F(DBOptionsTest, FIFOTtlBackwardCompatible) {
   ASSERT_EQ(dbfull()->GetOptions().ttl, 191);
 }
 
-#endif  // ROCKSDB_LITE
-
 TEST_F(DBOptionsTest, ChangeCompression) {
   if (!Snappy_Supported() || !LZ4_Supported()) {
     return;
@@ -920,6 +918,8 @@ TEST_F(DBOptionsTest, ChangeCompression) {
 
   SyncPoint::GetInstance()->DisableProcessing();
 }
+
+#endif  // ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE
 


### PR DESCRIPTION
This failure was introduced in #6262 