### PR TITLE
Improve atomic variable usage and check in BlockBasedTableBuilder in #6636

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ endif()
 
 option(WITH_TSAN "build with TSAN" OFF)
 if(WITH_TSAN)
+  add_definitions(-DROCKSDB_TSAN_RUN)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread -pie")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fPIC")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=thread -fPIC")

--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,8 @@ endif
 ifdef COMPILE_WITH_TSAN
 	DISABLE_JEMALLOC=1
 	EXEC_LDFLAGS += -fsanitize=thread
-	PLATFORM_CCFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD
-	PLATFORM_CXXFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD
+	PLATFORM_CCFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD -DROCKSDB_TSAN_RUN
+	PLATFORM_CXXFLAGS += -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD -DROCKSDB_TSAN_RUN
         # Turn off -pg when enabling TSAN testing, because that induces
         # a link failure.  TODO: find the root cause
 	PROFILING_FLAGS =


### PR DESCRIPTION
Summary:
#6636 wraps Rep::offset, ParallelCompressionRep::curr_compression_ratio
and ParallelCompressionRep::estimated_file_size in atomic variable. This
can be unnecessary because these variables are either blindly written or
updated single-threaded.

This commit:
1. Wraps curr_compression_ratio and estimated_file_size into getter/setter
instead of atomic variables.
2. Explicitly disables TSAN for getter/setters of variables mentioned above.
3. Minimizes get_offset/set_offset usage.
4. Uses EstimatedFileSize() when calling NotifyCollectTableCollectorsOnAdd
to be more accurate.
5. Also fixes TSAN error caused by ParallelCompressionRep::first_block.

Test Plan: Run all tests with TSAN.