### PR TITLE
Fix data racing of BlockBasedTableBuilder::ParallelCompressionRep::first_block

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -816,6 +816,9 @@ void BlockBasedTableBuilder::Flush() {
             new_blocks_inflight * kBlockTrailerSize,
         std::memory_order_relaxed);
 
+    // Read out first_block here to avoid data race with BGWorkWriteRawBlock
+    bool first_block = r->pc_rep->first_block;
+
     assert(block_rep->status.ok());
     if (!r->pc_rep->write_queue.push(block_rep->slot.get())) {
       return;
@@ -824,7 +827,7 @@ void BlockBasedTableBuilder::Flush() {
       return;
     }
 
-    if (r->pc_rep->first_block) {
+    if (first_block) {
       std::unique_lock<std::mutex> lock(r->pc_rep->first_block_mutex);
       r->pc_rep->first_block_cond.wait(lock,
                                        [=] { return !r->pc_rep->first_block; });
@@ -1138,7 +1141,7 @@ void BlockBasedTableBuilder::BGWorkWriteRawBlock() {
     }
 
     if (r->pc_rep->first_block) {
-      std::unique_lock<std::mutex> lock(r->pc_rep->first_block_mutex);
+      std::lock_guard<std::mutex> lock(r->pc_rep->first_block_mutex);
       r->pc_rep->first_block = false;
       r->pc_rep->first_block_cond.notify_one();
     }


### PR DESCRIPTION
Summary:
BlockBasedTableBuilder::ParallelCompressionRep::first_block can be read in
Flush() and written in BGWorkWriteRawBlock() concurrently. This commit fixes
the issue by reading first_block out before pushing the block to compression
and write.

Test Plan: Run all tests concurrently with TSAN.