### PR TITLE
Fix clang anaylze warning caused by #6262

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -781,10 +781,12 @@ void BlockBasedTableBuilder::Flush() {
   if (r->data_block.empty()) return;
   if (r->compression_opts.parallel_threads > 1 &&
       r->state == Rep::State::kUnbuffered) {
-    ParallelCompressionRep::BlockRep* block_rep;
+    ParallelCompressionRep::BlockRep* block_rep = nullptr;
     r->pc_rep->block_rep_pool.pop(block_rep);
+    assert(block_rep != nullptr);
 
     r->data_block.Finish();
+    assert(block_rep->data);
     r->data_block.SwapAndReset(*(block_rep->data));
 
     block_rep->contents = *(block_rep->data);


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/6262 causes CLANG analyze to complain. Add assertion to suppress the warning.

Test Plan: Run "clang analyze" and make sure it passes.