### PR TITLE
fix comparison count for format_version=3 indexes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 * Fix a bug when making options.bottommost_compression, options.compression_opts and options.bottommost_compression_opts dynamically changeable: the modified values are not written to option files or returned back to users when being queried.
+* Fix a bug where index key comparisons were unaccounted in `PerfContext::user_key_comparison_count` for lookups in files written with `format_version >= 3`.
 
 ## 6.9.0 (03/29/2020)
 ### Behavior changes

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -502,9 +502,14 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
                   SequenceNumber global_seqno, BlockPrefixIndex* prefix_index,
                   bool have_first_key, bool key_includes_seq,
                   bool value_is_full, bool block_contents_pinned) {
-    InitializeBase(key_includes_seq ? comparator : user_comparator, data,
-                   restarts, num_restarts, kDisableGlobalSequenceNumber,
-                   block_contents_pinned);
+    if (!key_includes_seq) {
+      user_comparator_wrapper_ = std::unique_ptr<UserComparatorWrapper>(
+          new UserComparatorWrapper(user_comparator));
+    }
+    InitializeBase(
+        key_includes_seq ? comparator : user_comparator_wrapper_.get(), data,
+        restarts, num_restarts, kDisableGlobalSequenceNumber,
+        block_contents_pinned);
     key_includes_seq_ = key_includes_seq;
     key_.SetIsUserKey(!key_includes_seq_);
     prefix_index_ = prefix_index;
@@ -573,6 +578,7 @@ class IndexBlockIter final : public BlockIter<IndexValue> {
   }
 
  private:
+  std::unique_ptr<UserComparatorWrapper> user_comparator_wrapper_;
   // Key is in InternalKey format
   bool key_includes_seq_;
   bool value_delta_encoded_;


### PR DESCRIPTION
Summary: In index blocks since `format_version=3`, user keys are written
rather than internal keys. When reading such blocks, the comparator is
obtained via `InternalKeyComparator::user_comparator()`. We need to
wrap that function's result in a `UserComparatorWrapper` in order for
its comparisons to be counted in `PerfContext::user_key_comparison_count`.

Test Plan: ran db_bench and verified
`PerfContext::user_key_comparison_count` became larger.