### PR TITLE
Fix crash in JNI getApproximateSizes

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -2277,10 +2277,11 @@ jlongArray Java_org_rocksdb_RocksDB_getApproximateSizes(
 
   auto ranges = std::unique_ptr<ROCKSDB_NAMESPACE::Range[]>(
       new ROCKSDB_NAMESPACE::Range[range_count]);
+  size_t range_offset = 0;
   for (jsize i = 0; i < jlen; ++i) {
     auto* start = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jranges[i]);
     auto* limit = reinterpret_cast<ROCKSDB_NAMESPACE::Slice*>(jranges[++i]);
-    ranges.get()[i] = ROCKSDB_NAMESPACE::Range(*start, *limit);
+    ranges.get()[range_offset++] = ROCKSDB_NAMESPACE::Range(*start, *limit);
   }
 
   auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1170,7 +1170,6 @@ public class RocksDBTest {
     }
   }
 
-  @Ignore("This test crashes. Re-enable after fixing.")
   @Test
   public void getApproximateSizes() throws RocksDBException {
     final byte key1[] = "key1".getBytes(UTF_8);
@@ -1185,7 +1184,7 @@ public class RocksDBTest {
 
         final long[] sizes = db.getApproximateSizes(
             Arrays.asList(
-                new Range(new Slice(key1), new Slice(key2)),
+                new Range(new Slice(key1), new Slice(key1)),
                 new Range(new Slice(key2), new Slice(key3))
             ),
             SizeApproximationFlag.INCLUDE_FILES,


### PR DESCRIPTION
This change is fixing a crash happening in getApproximateSizes JNI implementation. It also reenables Java test that was crashing most likelly because if this bug.