### PR TITLE
Add Java API for rocksdb::CancelAllBackgroundWork()

### DIFF
--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -2612,6 +2612,17 @@ jobjectArray Java_org_rocksdb_RocksDB_compactFiles(
 
 /*
  * Class:     org_rocksdb_RocksDB
+ * Method:    cancelAllBackgroundWork
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_RocksDB_cancelAllBackgroundWork(
+        JNIEnv*, jobject, jlong jdb_handle, jboolean jwait) {
+    auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
+    rocksdb::CancelAllBackgroundWork(db, jwait);
+}
+
+/*
+ * Class:     org_rocksdb_RocksDB
  * Method:    pauseBackgroundWork
  * Signature: (J)V
  */

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -3480,6 +3480,17 @@ public class RocksDB extends RocksObject {
   }
 
   /**
+   * This function will cancel all currently running background processes.
+   *
+   * @param wait if true, wait for all background work to be cancelled before
+   *   returning.
+   *
+   */
+  public void cancelAllBackgroundWork(boolean wait) {
+    cancelAllBackgroundWork(nativeHandle_, wait);
+  }
+
+  /**
    * This function will wait until all currently running background processes
    * finish. After it returns, no background process will be run until
    * {@link #continueBackgroundWork()} is called
@@ -4457,6 +4468,8 @@ public class RocksDB extends RocksObject {
       final int outputLevel,
       final int outputPathId,
       final long compactionJobInfoHandle) throws RocksDBException;
+  private native void cancelAllBackgroundWork(final long handle,
+      final boolean wait);
   private native void pauseBackgroundWork(final long handle)
       throws RocksDBException;
   private native void continueBackgroundWork(final long handle)

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1086,6 +1086,8 @@ public class RocksDBTest {
 
   @Test
   public void continueBackgroundWorkAfterCancelAllBackgroundWork() throws RocksDBException {
+    final int KEY_SIZE = 20;
+    final int VALUE_SIZE = 300;
     try (final DBOptions opt = new DBOptions().
         setCreateIfMissing(true).
         setCreateMissingColumnFamilies(true);
@@ -1106,9 +1108,10 @@ public class RocksDBTest {
         try {
           db.cancelAllBackgroundWork(true);
           try {
-            db.continueBackgroundWork();
-            fail("Expected RocksDBException to be thrown if we attempt to continue background " +
-                "work after all background work is cancelled.");
+            db.put(new byte[KEY_SIZE], new byte[VALUE_SIZE]);
+            db.flush(new FlushOptions().setWaitForFlush(true));
+            fail("Expected RocksDBException to be thrown if we attempt to trigger a flush after" +
+                " all background work is cancelled.");
           } catch (RocksDBException ignored) { }
         } finally {
           for (final ColumnFamilyHandle handle : columnFamilyHandles) {


### PR DESCRIPTION
Adding a Java API for rocksdb::CancelAllBackgroundWork() so that the user can call this (when required) before closing the DB. This is to **prevent the crashes when manual compaction is running and the user decides to close the DB**.

Calling CancelAllBackgroundWork() seems to be the recommended way to make sure that it's safe to close the DB (according to RocksDB FAQ: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ#basic-readwrite).