### PR TITLE
PS-6966: fix gcc-9 and clang-10 compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,9 @@ if(WIN32)
   set(SYSTEM_LIBS ${SYSTEM_LIBS} shlwapi.lib rpcrt4.lib)
 else()
   set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
+  if(UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(SYSTEM_LIBS ${SYSTEM_LIBS} atomic)
+  endif()
 endif()
 
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES})
@@ -1187,10 +1190,12 @@ if(WITH_BENCHMARK_TOOLS)
   target_link_libraries(range_del_aggregator_bench
     ${ROCKSDB_LIB})
 
-  add_executable(table_reader_bench
-    table/table_reader_bench.cc)
-  target_link_libraries(table_reader_bench
-    ${ROCKSDB_LIB} testharness)
+  if(WITH_TESTS)
+    add_executable(table_reader_bench
+      table/table_reader_bench.cc)
+    target_link_libraries(table_reader_bench
+      ${ROCKSDB_LIB} testharness)
+  endif()
 
   add_executable(filter_bench
     util/filter_bench.cc)

--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -97,7 +97,8 @@ struct StressTestIterator : public InternalIterator {
 
   bool MaybeFail() {
     if (rnd->Next() >=
-        std::numeric_limits<uint64_t>::max() * error_probability) {
+        static_cast<float>(std::numeric_limits<uint64_t>::max()) *
+            error_probability) {
       return false;
     }
     if (rnd->Next() % 2) {
@@ -114,7 +115,8 @@ struct StressTestIterator : public InternalIterator {
 
   void MaybeMutate() {
     if (rnd->Next() >=
-        std::numeric_limits<uint64_t>::max() * mutation_probability) {
+        static_cast<float>(std::numeric_limits<uint64_t>::max()) *
+            mutation_probability) {
       return;
     }
     do {
@@ -126,8 +128,9 @@ struct StressTestIterator : public InternalIterator {
       if (data->hidden.empty()) {
         hide_probability = 1;
       }
-      bool do_hide =
-          rnd->Next() < std::numeric_limits<uint64_t>::max() * hide_probability;
+      bool do_hide = rnd->Next() <
+                     static_cast<float>(std::numeric_limits<uint64_t>::max()) *
+                         hide_probability;
       if (do_hide) {
         // Hide a random entry.
         size_t idx = rnd->Next() % data->entries.size();

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -37,7 +37,7 @@ class DBOptionsTest : public DBTestBase {
     std::unordered_map<std::string, std::string> options_map;
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
-    for (const auto opt : db_options_type_info) {
+    for (const auto& opt : db_options_type_info) {
       if (opt.second.IsMutable() && !opt.second.IsDeprecated()) {
         mutable_map[opt.first] = options_map[opt.first];
       }
@@ -52,7 +52,7 @@ class DBOptionsTest : public DBTestBase {
     std::unordered_map<std::string, std::string> options_map;
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
-    for (const auto opt : cf_options_type_info) {
+    for (const auto& opt : cf_options_type_info) {
       if (opt.second.IsMutable() && !opt.second.IsDeprecated()) {
         mutable_map[opt.first] = options_map[opt.first];
       }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1046,7 +1046,7 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
 
     // Collect and check whether the IDs are unique.
     std::unordered_set<std::string> ids;
-    for (const std::string fname : fnames) {
+    for (const std::string& fname : fnames) {
       std::unique_ptr<RandomAccessFile> file;
       std::string unique_id;
       ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
@@ -1060,7 +1060,7 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
     }
 
     // Delete the files
-    for (const std::string fname : fnames) {
+    for (const std::string& fname : fnames) {
       ASSERT_OK(env_->DeleteFile(fname));
     }
 

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -95,6 +95,8 @@ struct FileOptions : EnvOptions {
   // to be issued for the file open/creation
   IOOptions io_options;
 
+  FileOptions& operator=(const FileOptions& opts) = default;
+
   FileOptions() : EnvOptions() {}
 
   FileOptions(const DBOptions& opts)

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1011,7 +1011,7 @@ Status GetStringFromStruct(
     const std::string& delimiter) {
   assert(opt_string);
   opt_string->clear();
-  for (const auto iter : type_info) {
+  for (const auto& iter : type_info) {
     const auto& opt_info = iter.second;
     if (opt_info.IsDeprecated()) {
       // If the option is no longer used in rocksdb and marked as deprecated,

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -228,7 +228,7 @@ class BlockConstructor: public Constructor {
     block_ = nullptr;
     BlockBuilder builder(table_options.block_restart_interval);
 
-    for (const auto kv : kv_map) {
+    for (const auto& kv : kv_map) {
       builder.Add(kv.first, kv.second);
     }
     // Open the block
@@ -352,7 +352,7 @@ class TableConstructor: public Constructor {
         TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
         file_writer_.get()));
 
-    for (const auto kv : kv_map) {
+    for (const auto& kv : kv_map) {
       if (convert_to_internal_key_) {
         ParsedInternalKey ikey(kv.first, kMaxSequenceNumber, kTypeValue);
         std::string encoded;
@@ -486,7 +486,7 @@ class MemTableConstructor: public Constructor {
                              kMaxSequenceNumber, 0 /* column_family_id */);
     memtable_->Ref();
     int seq = 1;
-    for (const auto kv : kv_map) {
+    for (const auto& kv : kv_map) {
       memtable_->Add(seq, kTypeValue, kv.first, kv.second);
       seq++;
     }
@@ -547,7 +547,7 @@ class DBConstructor: public Constructor {
     delete db_;
     db_ = nullptr;
     NewDB();
-    for (const auto kv : kv_map) {
+    for (const auto& kv : kv_map) {
       WriteBatch batch;
       batch.Put(kv.first, kv.second);
       EXPECT_TRUE(db_->Write(WriteOptions(), &batch).ok());
@@ -1223,7 +1223,7 @@ class FileChecksumTestHelper {
   }
 
   Status WriteKVAndFlushTable() {
-    for (const auto kv : kv_map_) {
+    for (const auto& kv : kv_map_) {
       if (convert_to_internal_key_) {
         ParsedInternalKey ikey(kv.first, kMaxSequenceNumber, kTypeValue);
         std::string encoded;

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -64,7 +64,7 @@ TEST_F(LdbCmdTest, HexToStringBadInputs) {
   const vector<string> badInputs = {
       "0xZZ", "123", "0xx5", "0x111G", "0x123", "Ox12", "0xT", "0x1Q1",
   };
-  for (const auto badInput : badInputs) {
+  for (const auto& badInput : badInputs) {
     try {
       ROCKSDB_NAMESPACE::LDBCommand::HexToString(badInput);
       std::cerr << "Should fail on bad hex value: " << badInput << "\n";


### PR DESCRIPTION
1. Fix gcc-9 compilation issues with `CC=gcc-9 CXX=g++-9 cmake .. -DCMAKE_BUILD_TYPE=Debug`
```
/data/rocksdb/db/db_impl/db_impl.cc: In member function ‘virtual rocksdb::Status rocksdb::DBImpl::SetDBOptions(const std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&)’:
/data/rocksdb/db/db_impl/db_impl.cc:1082:64: error: implicitly-declared ‘rocksdb::FileOptions& rocksdb::FileOptions::operator=(const rocksdb::FileOptions&)’ is deprecated [-Werror=deprecated-copy]
 1082 |       file_options_for_compaction_ = FileOptions(new_db_options);
```

2. Fix gcc-9 compilation issues with `CC=gcc-9 CXX=g++-9 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo`
```
/usr/bin/ld: cannot find -ltestharness
collect2: error: ld returned 1 exit status
CMakeFiles/table_reader_bench.dir/build.make:96: recipe for target 'table_reader_bench' failed
make[2]: *** [table_reader_bench] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/table_reader_bench.dir/all' failed
make[1]: *** [CMakeFiles/table_reader_bench.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs...
```

3. Fix clang-10 compilation issues with `CC=clang-10 CXX=clang++-10 cmake .. -DCMAKE_BUILD_TYPE=Debug`
```
CMakeFiles/db_stress.dir/db_stress_driver.cc.o: In function `rocksdb::SharedState::SharedState(rocksdb::Env*, rocksdb::StressTest*)':
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/atomic_base.h:377: undefined reference to `__atomic_is_lock_free'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
```
/data/rocksdb/options/options_helper.cc:1014:19: error: loop variable 'iter' of type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo>' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo>' [-Werror,-Wrange-loop-construct]
  for (const auto iter : type_info) {
/data/rocksdb/options/options_helper.cc:1014:8: note: use reference type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo> &' to prevent copying
  for (const auto iter : type_info) {
```
```
/data/rocksdb/tools/ldb_cmd_test.cc:67:19: error: loop variable 'badInput' of type 'const std::__cxx11::basic_string<char>' creates a copy from type 'const std::__cxx11::basic_string<char>' [-Werror,-Wrange-loop-construct]
  for (const auto badInput : badInputs) {
/data/rocksdb/tools/ldb_cmd_test.cc:67:8: note: use reference type 'const std::__cxx11::basic_string<char> &' to prevent copying
  for (const auto badInput : badInputs) {
```
```
/data/rocksdb/db/db_options_test.cc:40:21: error: loop variable 'opt' of type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo>' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo>' [-Werror,-Wrange-loop-construct]
    for (const auto opt : db_options_type_info) {
/data/rocksdb/db/db_options_test.cc:40:10: note: use reference type 'const std::pair<const std::__cxx11::basic_string<char>, rocksdb::OptionTypeInfo> &' to prevent copying
    for (const auto opt : db_options_type_info) {
```
```
/data/rocksdb/db/db_iter_stress_test.cc:100:9: error: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]
        std::numeric_limits<uint64_t>::max() * error_probability) {
```
```
/data/rocksdb/table/table_test.cc:231:21: error: loop variable 'kv' of type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >' [-Werror,-Wrange-loop-construct]
    for (const auto kv : kv_map) {
/data/rocksdb/table/table_test.cc:231:10: note: use reference type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > &' to prevent copying
    for (const auto kv : kv_map) {
```
```
/data/rocksdb/env/env_test.cc:1049:28: error: loop variable 'fname' of type 'const std::string' (aka 'const basic_string<char>') creates a copy from type 'const std::string' [-Werror,-Wrange-loop-construct]
    for (const std::string fname : fnames) {
/data/rocksdb/env/env_test.cc:1049:10: note: use reference type 'const std::string &' (aka 'const basic_string<char> &') to prevent copying
    for (const std::string fname : fnames) {
```