### PR TITLE
Fix initializer syntax for old Xcode compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,6 @@ matrix:
     arch: ppc64le
     env: TEST_GROUP=2
   - if: type = pull_request
-    os: osx
-    env: TEST_GROUP=3
-  - if: type = pull_request
     os : linux
     arch: arm64
     env: TEST_GROUP=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,9 @@ matrix:
     arch: ppc64le
     env: TEST_GROUP=2
   - if: type = pull_request
+    os: osx
+    env: TEST_GROUP=3
+  - if: type = pull_request
     os : linux
     arch: arm64
     env: TEST_GROUP=3

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -181,8 +181,8 @@ TEST_F(FlushJobTest, NonEmpty) {
   // Note: the first two blob references will not be considered when resolving
   // the oldest blob file referenced (the first one is inlined TTL, while the
   // second one is TTL and thus points to a TTL blob file).
-  constexpr std::array<uint64_t, 6> blob_file_numbers{
-      kInvalidBlobFileNumber, 5, 103, 17, 102, 101};
+  constexpr std::array<uint64_t, 6> blob_file_numbers{{
+      kInvalidBlobFileNumber, 5, 103, 17, 102, 101}};
   for (size_t i = 0; i < blob_file_numbers.size(); ++i) {
     std::string key(ToString(i + 10001));
     std::string blob_index;

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -181,8 +181,8 @@ TEST_F(FlushJobTest, NonEmpty) {
   // Note: the first two blob references will not be considered when resolving
   // the oldest blob file referenced (the first one is inlined TTL, while the
   // second one is TTL and thus points to a TTL blob file).
-  constexpr std::array<uint64_t, 6> blob_file_numbers = {
-      kInvalidBlobFileNumber, 5, 103, 17, 102, 101};
+  constexpr std::array<uint64_t, 6> blob_file_numbers{{
+      kInvalidBlobFileNumber, 5, 103, 17, 102, 101}};
   for (size_t i = 0; i < blob_file_numbers.size(); ++i) {
     std::string key(ToString(i + 10001));
     std::string blob_index;

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -181,8 +181,8 @@ TEST_F(FlushJobTest, NonEmpty) {
   // Note: the first two blob references will not be considered when resolving
   // the oldest blob file referenced (the first one is inlined TTL, while the
   // second one is TTL and thus points to a TTL blob file).
-  constexpr std::array<uint64_t, 6> blob_file_numbers{{
-      kInvalidBlobFileNumber, 5, 103, 17, 102, 101}};
+  constexpr std::array<uint64_t, 6> blob_file_numbers = {
+      kInvalidBlobFileNumber, 5, 103, 17, 102, 101};
   for (size_t i = 0; i < blob_file_numbers.size(); ++i) {
     std::string key(ToString(i + 10001));
     std::string blob_index;


### PR DESCRIPTION
Summary: Example compiler output, from OSX TEST_GROUP=3:

db/flush_job_test.cc:185:7: error: suggest braces around initialization
of subobject [-Werror,-Wmissing-braces]
      kInvalidBlobFileNumber, 5, 103, 17, 102, 101};

Apparently permitted in newer version, but worth working around.
https://stackoverflow.com/questions/31555584/why-is-clang-warning-suggest-braces-around-initialization-of-subobject-wmis

Test Plan: CI (temporarily including OSX TEST_GROUP=3 in Travis)