### PR TITLE
Reduce memory copy in block fetcher in direct IO

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -84,7 +84,7 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
         if (aligned_buf == nullptr) {
           buf.Read(scratch, offset_advance, res_len);
         } else {
-          scratch = buf.BufferStart();
+          scratch = buf.BufferStart() + offset_advance;
           aligned_buf->reset(buf.Release());
         }
       }

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -22,7 +22,7 @@ namespace ROCKSDB_NAMESPACE {
 class Statistics;
 class HistogramImpl;
 
-using AlignedBuf = std::unique_ptr<const char[]>;
+using AlignedBuf = std::unique_ptr<char[]>;
 
 // RandomAccessFileReader is a wrapper on top of Env::RnadomAccessFile. It is
 // responsible for:

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -90,7 +90,7 @@ class BlockFetcher {
   CacheAllocationPtr compressed_buf_;
   char stack_buf_[kDefaultStackBufferSize];
   bool got_from_prefetch_buffer_ = false;
-  ROCKSDB_NAMESPACE::CompressionType compression_type_;
+  CompressionType compression_type_;
   bool for_compaction_ = false;
 
   // return true if found

--- a/table/format.cc
+++ b/table/format.cc
@@ -293,7 +293,7 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
   }
 
   std::string footer_buf;
-  std::unique_ptr<const char[]> internal_buf;
+  AlignedBuf internal_buf;
   Slice footer_input;
   size_t read_offset =
       (file_size > Footer::kMaxEncodedLength)


### PR DESCRIPTION
In direct IO mode, there is no need to copy the block from RandomAccessFileReader::Read's internal buffer to block fetcher's buffer.

Test Plan:
make check