### PR TITLE
Fix wrong starting address of Read's result

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -84,7 +84,7 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
         if (aligned_buf == nullptr) {
           buf.Read(scratch, offset_advance, res_len);
         } else {
-          scratch = buf.BufferStart();
+          scratch = buf.BufferStart() + offset_advance;
           aligned_buf->reset(buf.Release());
         }
       }


### PR DESCRIPTION
The starting address of Read's result slice in direct IO mode is wrong.

Test Plan:
make check