### PR TITLE
Fix result slice's  address for direct io read

### DIFF
--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -84,7 +84,7 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
         if (aligned_buf == nullptr) {
           buf.Read(scratch, offset_advance, res_len);
         } else {
-          scratch = buf.BufferStart();
+          scratch = buf.BufferStart() + offset_advance;
           aligned_buf->reset(buf.Release());
         }
       }


### PR DESCRIPTION
When aligned_buf is provided, the result slice's starting address should take offset advance into account.

Test Plan:
make random_access_file_reader_test && ./random_access_file_reader_test