### PR TITLE
Revert pr 6455

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -88,7 +88,7 @@ Status FilePrefetchBuffer::Prefetch(RandomAccessFileReader* reader,
   Slice result;
   s = reader->Read(rounddown_offset + chunk_len,
                    static_cast<size_t>(roundup_len - chunk_len), &result,
-                   buffer_.BufferStart() + chunk_len, nullptr, for_compaction);
+                   buffer_.BufferStart() + chunk_len, for_compaction);
   if (s.ok()) {
     buffer_offset_ = rounddown_offset;
     buffer_.Size(static_cast<size_t>(chunk_len) + result.size());

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -22,13 +22,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
-<<<<<<< HEAD
-                                    char* scratch, AlignedBuf* aligned_buf,
-                                    bool for_compaction) const {
-  (void)aligned_buf;
-=======
                                     char* scratch, bool for_compaction) const {
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   Status s;
   uint64_t elapsed = 0;
   {
@@ -84,18 +78,8 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
       }
       size_t res_len = 0;
       if (s.ok() && offset_advance < buf.CurrentSize()) {
-<<<<<<< HEAD
-        res_len = std::min(buf.CurrentSize() - offset_advance, n);
-        if (aligned_buf == nullptr) {
-          buf.Read(scratch, offset_advance, res_len);
-        } else {
-          scratch = buf.BufferStart();
-          aligned_buf->reset(buf.Release());
-        }
-=======
         res_len = buf.Read(scratch, offset_advance,
                            std::min(buf.CurrentSize() - offset_advance, n));
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
       }
       *result = Slice(scratch, res_len);
 #endif  // !ROCKSDB_LITE

--- a/file/random_access_file_reader.cc
+++ b/file/random_access_file_reader.cc
@@ -22,9 +22,13 @@
 namespace ROCKSDB_NAMESPACE {
 
 Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
+<<<<<<< HEAD
                                     char* scratch, AlignedBuf* aligned_buf,
                                     bool for_compaction) const {
   (void)aligned_buf;
+=======
+                                    char* scratch, bool for_compaction) const {
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   Status s;
   uint64_t elapsed = 0;
   {
@@ -80,6 +84,7 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
       }
       size_t res_len = 0;
       if (s.ok() && offset_advance < buf.CurrentSize()) {
+<<<<<<< HEAD
         res_len = std::min(buf.CurrentSize() - offset_advance, n);
         if (aligned_buf == nullptr) {
           buf.Read(scratch, offset_advance, res_len);
@@ -87,6 +92,10 @@ Status RandomAccessFileReader::Read(uint64_t offset, size_t n, Slice* result,
           scratch = buf.BufferStart();
           aligned_buf->reset(buf.Release());
         }
+=======
+        res_len = buf.Read(scratch, offset_advance,
+                           std::min(buf.CurrentSize() - offset_advance, n));
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
       }
       *result = Slice(scratch, res_len);
 #endif  // !ROCKSDB_LITE

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -104,19 +104,8 @@ class RandomAccessFileReader {
   RandomAccessFileReader(const RandomAccessFileReader&) = delete;
   RandomAccessFileReader& operator=(const RandomAccessFileReader&) = delete;
 
-<<<<<<< HEAD
-  // In non-direct IO mode,
-  // 1. if using mmap, result is stored in a buffer other than scratch;
-  // 2. if not using mmap, result is stored in the buffer starting from scratch.
-  //
-  // In direct IO mode, an aligned buffer is allocated internally.
-  // 1. If aligned_buf is null, then results are copied to the buffer
-  // starting from scratch;
-  // 2. Otherwise, scratch is not used and can be null, the aligned_buf owns
-  // the internally allocated buffer on return, and the result refers to a
-  // region in aligned_buf.
   Status Read(uint64_t offset, size_t n, Slice* result, char* scratch,
-              AlignedBuf* aligned_buf, bool for_compaction = false) const;
+              bool for_compaction = false) const;
 
   // REQUIRES:
   // num_reqs > 0, reqs do not overlap, and offsets in reqs are increasing.
@@ -125,12 +114,6 @@ class RandomAccessFileReader {
   // MultiRead, the result Slices in reqs refer to aligned_buf.
   Status MultiRead(FSReadRequest* reqs, size_t num_reqs,
                    AlignedBuf* aligned_buf) const;
-=======
-  Status Read(uint64_t offset, size_t n, Slice* result, char* scratch,
-              bool for_compaction = false) const;
-
-  Status MultiRead(FSReadRequest* reqs, size_t num_reqs) const;
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
 
   Status Prefetch(uint64_t offset, size_t n) const {
     return file_->Prefetch(offset, n, IOOptions(), nullptr);

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -104,6 +104,7 @@ class RandomAccessFileReader {
   RandomAccessFileReader(const RandomAccessFileReader&) = delete;
   RandomAccessFileReader& operator=(const RandomAccessFileReader&) = delete;
 
+<<<<<<< HEAD
   // In non-direct IO mode,
   // 1. if using mmap, result is stored in a buffer other than scratch;
   // 2. if not using mmap, result is stored in the buffer starting from scratch.
@@ -124,6 +125,12 @@ class RandomAccessFileReader {
   // MultiRead, the result Slices in reqs refer to aligned_buf.
   Status MultiRead(FSReadRequest* reqs, size_t num_reqs,
                    AlignedBuf* aligned_buf) const;
+=======
+  Status Read(uint64_t offset, size_t n, Slice* result, char* scratch,
+              bool for_compaction = false) const;
+
+  Status MultiRead(FSReadRequest* reqs, size_t num_reqs) const;
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
 
   Status Prefetch(uint64_t offset, size_t n) const {
     return file_->Prefetch(offset, n, IOOptions(), nullptr);

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -216,7 +216,7 @@ Status BlockFetcher::ReadBlockContents() {
       PERF_TIMER_GUARD(block_read_time);
       // Actual file read
       status_ = file_->Read(handle_.offset(), block_size_ + kBlockTrailerSize,
-                            &slice_, used_buf_, nullptr, for_compaction_);
+                            &slice_, used_buf_, for_compaction_);
     }
     PERF_COUNTER_ADD(block_read_count, 1);
 

--- a/table/cuckoo/cuckoo_table_builder_test.cc
+++ b/table/cuckoo/cuckoo_table_builder_test.cc
@@ -114,7 +114,7 @@ class CuckooBuilderTest : public testing::Test {
     for (uint32_t i = 0; i < table_size + cuckoo_block_size - 1; ++i) {
       Slice read_slice;
       ASSERT_OK(file_reader->Read(i * bucket_size, bucket_size, &read_slice,
-                                  nullptr, nullptr));
+                                  nullptr));
       size_t key_idx =
           std::find(expected_locations.begin(), expected_locations.end(), i) -
           expected_locations.begin();

--- a/table/cuckoo/cuckoo_table_reader.cc
+++ b/table/cuckoo/cuckoo_table_reader.cc
@@ -137,8 +137,7 @@ CuckooTableReader::CuckooTableReader(
   cuckoo_block_size_ = *reinterpret_cast<const uint32_t*>(
       cuckoo_block_size->second.data());
   cuckoo_block_bytes_minus_one_ = cuckoo_block_size_ * bucket_length_ - 1;
-  status_ = file_->Read(0, static_cast<size_t>(file_size), &file_data_, nullptr,
-                        nullptr);
+  status_ = file_->Read(0, static_cast<size_t>(file_size), &file_data_, nullptr);
 }
 
 Status CuckooTableReader::Get(const ReadOptions& /*readOptions*/,

--- a/table/format.cc
+++ b/table/format.cc
@@ -292,8 +292,7 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
                               file->file_name());
   }
 
-  std::string footer_buf;
-  std::unique_ptr<const char[]> internal_buf;
+  char footer_space[Footer::kMaxEncodedLength];
   Slice footer_input;
   size_t read_offset =
       (file_size > Footer::kMaxEncodedLength)
@@ -303,14 +302,8 @@ Status ReadFooterFromFile(RandomAccessFileReader* file,
   if (prefetch_buffer == nullptr ||
       !prefetch_buffer->TryReadFromCache(read_offset, Footer::kMaxEncodedLength,
                                          &footer_input)) {
-    if (file->use_direct_io()) {
-      s = file->Read(read_offset, Footer::kMaxEncodedLength, &footer_input,
-                    nullptr, &internal_buf);
-    } else {
-      footer_buf.reserve(Footer::kMaxEncodedLength);
-      s = file->Read(read_offset, Footer::kMaxEncodedLength, &footer_input,
-                    &footer_buf[0], nullptr);
-    }
+    s = file->Read(read_offset, Footer::kMaxEncodedLength, &footer_input,
+                   footer_space);
     if (!s.ok()) return s;
   }
 

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -114,7 +114,7 @@ uint32_t MockTableFactory::GetAndWriteNextID(WritableFileWriter* file) const {
 uint32_t MockTableFactory::GetIDFromFile(RandomAccessFileReader* file) const {
   char buf[4];
   Slice result;
-  file->Read(0, 4, &result, buf, nullptr);
+  file->Read(0, 4, &result, buf);
   assert(result.size() == 4);
   return DecodeFixed32(buf);
 }

--- a/table/plain/plain_table_key_coding.cc
+++ b/table/plain/plain_table_key_coding.cc
@@ -211,7 +211,7 @@ bool PlainTableFileReader::ReadNonMmap(uint32_t file_offset, uint32_t len,
   }
   Slice read_result;
   Status s = file_info_->file->Read(file_offset, size_to_read, &read_result,
-                                    new_buffer->buf.get(), nullptr);
+                                    new_buffer->buf.get());
   if (!s.ok()) {
     status_ = s;
     return false;

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -288,8 +288,7 @@ void PlainTableReader::FillBloom(const std::vector<uint32_t>& prefix_hashes) {
 Status PlainTableReader::MmapDataIfNeeded() {
   if (file_info_.is_mmap_mode) {
     // Get mmapped memory.
-    return file_info_.file->Read(0, static_cast<size_t>(file_size_),
-                                 &file_info_.file_data, nullptr, nullptr);
+    return file_info_.file->Read(0, static_cast<size_t>(file_size_), &file_info_.file_data, nullptr);
   }
   return Status::OK();
 }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1264,16 +1264,14 @@ class FileChecksumTestHelper {
     Slice result;
     uint64_t offset = 0;
     Status s;
-    s = file_reader_->Read(offset, 2048, &result, scratch.get(), nullptr,
-                           false);
+    s = file_reader_->Read(offset, 2048, &result, scratch.get(), false);
     if (!s.ok()) {
       return s;
     }
     while (result.size() != 0) {
       file_checksum_generator->Update(scratch.get(), result.size());
       offset += static_cast<uint64_t>(result.size());
-      s = file_reader_->Read(offset, 2048, &result, scratch.get(), nullptr,
-                             false);
+      s = file_reader_->Read(offset, 2048, &result, scratch.get(), false);
       if (!s.ok()) {
         return s;
       }

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -116,6 +116,13 @@ public:
     cursize_ = 0;
   }
 
+  char* Release() {
+    cursize_ = 0;
+    capacity_ = 0;
+    bufstart_ = nullptr;
+    return buf_.release();
+  }
+
   void Alignment(size_t alignment) {
     assert(alignment > 0);
     assert((alignment & (alignment - 1)) == 0);

--- a/util/aligned_buffer.h
+++ b/util/aligned_buffer.h
@@ -116,13 +116,6 @@ public:
     cursize_ = 0;
   }
 
-  char* Release() {
-    cursize_ = 0;
-    capacity_ = 0;
-    bufstart_ = nullptr;
-    return buf_.release();
-  }
-
   void Alignment(size_t alignment) {
     assert(alignment > 0);
     assert((alignment & (alignment - 1)) == 0);

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1482,14 +1482,20 @@ Status BlobDBImpl::GetRawBlobFromFile(const Slice& key, uint64_t file_number,
   const uint64_t record_size = sizeof(uint32_t) + key.size() + size;
 
   // Allocate the buffer. This is safe in C++11
+<<<<<<< HEAD
   std::string buf;
   AlignedBuf aligned_buf;
+=======
+  std::string buffer_str(static_cast<size_t>(record_size), static_cast<char>(0));
+  char* buffer = &buffer_str[0];
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
 
   // A partial blob record contain checksum, key and value.
   Slice blob_record;
 
   {
     StopWatch read_sw(env_, statistics_, BLOB_DB_BLOB_FILE_READ_MICROS);
+<<<<<<< HEAD
     if (reader->use_direct_io()) {
       s = reader->Read(record_offset, static_cast<size_t>(record_size),
                        &blob_record, nullptr, &aligned_buf);
@@ -1498,6 +1504,9 @@ Status BlobDBImpl::GetRawBlobFromFile(const Slice& key, uint64_t file_number,
       s = reader->Read(record_offset, static_cast<size_t>(record_size),
                        &blob_record, &buf[0], nullptr);
     }
+=======
+    s = reader->Read(record_offset, static_cast<size_t>(record_size), &blob_record, buffer);
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
     RecordTick(statistics_, BLOB_DB_BLOB_FILE_BYTES_READ, blob_record.size());
   }
 

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1482,31 +1482,15 @@ Status BlobDBImpl::GetRawBlobFromFile(const Slice& key, uint64_t file_number,
   const uint64_t record_size = sizeof(uint32_t) + key.size() + size;
 
   // Allocate the buffer. This is safe in C++11
-<<<<<<< HEAD
-  std::string buf;
-  AlignedBuf aligned_buf;
-=======
   std::string buffer_str(static_cast<size_t>(record_size), static_cast<char>(0));
   char* buffer = &buffer_str[0];
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
 
   // A partial blob record contain checksum, key and value.
   Slice blob_record;
 
   {
     StopWatch read_sw(env_, statistics_, BLOB_DB_BLOB_FILE_READ_MICROS);
-<<<<<<< HEAD
-    if (reader->use_direct_io()) {
-      s = reader->Read(record_offset, static_cast<size_t>(record_size),
-                       &blob_record, nullptr, &aligned_buf);
-    } else {
-      buf.reserve(static_cast<size_t>(record_size));
-      s = reader->Read(record_offset, static_cast<size_t>(record_size),
-                       &blob_record, &buf[0], nullptr);
-    }
-=======
     s = reader->Read(record_offset, static_cast<size_t>(record_size), &blob_record, buffer);
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
     RecordTick(statistics_, BLOB_DB_BLOB_FILE_BYTES_READ, blob_record.size());
   }
 

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -101,7 +101,7 @@ Status BlobDumpTool::Read(uint64_t offset, size_t size, Slice* result) {
     }
     buffer_.reset(new char[buffer_size_]);
   }
-  Status s = reader_->Read(offset, size, result, buffer_.get(), nullptr);
+  Status s = reader_->Read(offset, size, result, buffer_.get());
   if (!s.ok()) {
     return s;
   }

--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -138,6 +138,7 @@ Status BlobFile::ReadFooter(BlobLogFooter* bf) {
   assert(ra_file_reader_);
 
   Slice result;
+<<<<<<< HEAD
   std::string buf;
   AlignedBuf aligned_buf;
   Status s;
@@ -149,6 +150,11 @@ Status BlobFile::ReadFooter(BlobLogFooter* bf) {
     s = ra_file_reader_->Read(footer_offset, BlobLogFooter::kSize, &result,
                               &buf[0], nullptr);
   }
+=======
+  char scratch[BlobLogFooter::kSize + 10];
+  Status s = ra_file_reader_->Read(footer_offset, BlobLogFooter::kSize, &result,
+                                   scratch);
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) return s;
   if (result.size() != BlobLogFooter::kSize) {
     // should not happen
@@ -262,6 +268,7 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
                                  PathName()));
 
   // Read file header.
+<<<<<<< HEAD
   std::string header_buf;
   AlignedBuf aligned_buf;
   Slice header_slice;
@@ -273,6 +280,11 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
     s = file_reader->Read(0, BlobLogHeader::kSize, &header_slice,
                           &header_buf[0], nullptr);
   }
+=======
+  char header_buf[BlobLogHeader::kSize];
+  Slice header_slice;
+  s = file_reader->Read(0, BlobLogHeader::kSize, &header_slice, header_buf);
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) {
     ROCKS_LOG_ERROR(info_log_,
                     "Failed to read header of blob file %" PRIu64
@@ -303,8 +315,9 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
     assert(!footer_valid_);
     return Status::OK();
   }
-  std::string footer_buf;
+  char footer_buf[BlobLogFooter::kSize];
   Slice footer_slice;
+<<<<<<< HEAD
   if (file_reader->use_direct_io()) {
     s = file_reader->Read(file_size - BlobLogFooter::kSize,
                           BlobLogFooter::kSize, &footer_slice, nullptr,
@@ -315,6 +328,10 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
                           BlobLogFooter::kSize, &footer_slice, &footer_buf[0],
                           nullptr);
   }
+=======
+  s = file_reader->Read(file_size - BlobLogFooter::kSize, BlobLogFooter::kSize,
+                        &footer_slice, footer_buf);
+>>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) {
     ROCKS_LOG_ERROR(info_log_,
                     "Failed to read footer of blob file %" PRIu64

--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -138,23 +138,9 @@ Status BlobFile::ReadFooter(BlobLogFooter* bf) {
   assert(ra_file_reader_);
 
   Slice result;
-<<<<<<< HEAD
-  std::string buf;
-  AlignedBuf aligned_buf;
-  Status s;
-  if (ra_file_reader_->use_direct_io()) {
-    s = ra_file_reader_->Read(footer_offset, BlobLogFooter::kSize, &result,
-                              nullptr, &aligned_buf);
-  } else {
-    buf.reserve(BlobLogFooter::kSize + 10);
-    s = ra_file_reader_->Read(footer_offset, BlobLogFooter::kSize, &result,
-                              &buf[0], nullptr);
-  }
-=======
   char scratch[BlobLogFooter::kSize + 10];
   Status s = ra_file_reader_->Read(footer_offset, BlobLogFooter::kSize, &result,
                                    scratch);
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) return s;
   if (result.size() != BlobLogFooter::kSize) {
     // should not happen
@@ -268,23 +254,9 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
                                  PathName()));
 
   // Read file header.
-<<<<<<< HEAD
-  std::string header_buf;
-  AlignedBuf aligned_buf;
-  Slice header_slice;
-  if (file_reader->use_direct_io()) {
-    s = file_reader->Read(0, BlobLogHeader::kSize, &header_slice, nullptr,
-                          &aligned_buf);
-  } else {
-    header_buf.reserve(BlobLogHeader::kSize);
-    s = file_reader->Read(0, BlobLogHeader::kSize, &header_slice,
-                          &header_buf[0], nullptr);
-  }
-=======
   char header_buf[BlobLogHeader::kSize];
   Slice header_slice;
   s = file_reader->Read(0, BlobLogHeader::kSize, &header_slice, header_buf);
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) {
     ROCKS_LOG_ERROR(info_log_,
                     "Failed to read header of blob file %" PRIu64
@@ -317,21 +289,8 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
   }
   char footer_buf[BlobLogFooter::kSize];
   Slice footer_slice;
-<<<<<<< HEAD
-  if (file_reader->use_direct_io()) {
-    s = file_reader->Read(file_size - BlobLogFooter::kSize,
-                          BlobLogFooter::kSize, &footer_slice, nullptr,
-                          &aligned_buf);
-  } else {
-    footer_buf.reserve(BlobLogFooter::kSize);
-    s = file_reader->Read(file_size - BlobLogFooter::kSize,
-                          BlobLogFooter::kSize, &footer_slice, &footer_buf[0],
-                          nullptr);
-  }
-=======
   s = file_reader->Read(file_size - BlobLogFooter::kSize, BlobLogFooter::kSize,
                         &footer_slice, footer_buf);
->>>>>>> parent of 0a0151fb9... Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)
   if (!s.ok()) {
     ROCKS_LOG_ERROR(info_log_,
                     "Failed to read footer of blob file %" PRIu64

--- a/utilities/blob_db/blob_log_reader.cc
+++ b/utilities/blob_db/blob_log_reader.cc
@@ -26,8 +26,7 @@ Reader::Reader(std::unique_ptr<RandomAccessFileReader>&& file_reader, Env* env,
 
 Status Reader::ReadSlice(uint64_t size, Slice* slice, char* buf) {
   StopWatch read_sw(env_, statistics_, BLOB_DB_BLOB_FILE_READ_MICROS);
-  Status s =
-      file_->Read(next_byte_, static_cast<size_t>(size), slice, buf, nullptr);
+  Status s = file_->Read(next_byte_, static_cast<size_t>(size), slice, buf);
   next_byte_ += size;
   if (!s.ok()) {
     return s;

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -235,7 +235,7 @@ bool RandomAccessCacheFile::Read(const LBA& lba, Slice* key, Slice* val,
   }
 
   Slice result;
-  Status s = freader_->Read(lba.off_, lba.size_, &result, scratch, nullptr);
+  Status s = freader_->Read(lba.off_, lba.size_, &result, scratch);
   if (!s.ok()) {
     Error(log_, "Error reading from file %s. %s", Path().c_str(),
           s.ToString().c_str());

--- a/utilities/trace/file_trace_reader_writer.cc
+++ b/utilities/trace/file_trace_reader_writer.cc
@@ -33,8 +33,7 @@ Status FileTraceReader::Close() {
 
 Status FileTraceReader::Read(std::string* data) {
   assert(file_reader_ != nullptr);
-  Status s = file_reader_->Read(offset_, kTraceMetadataSize, &result_, buffer_,
-                                nullptr);
+  Status s = file_reader_->Read(offset_, kTraceMetadataSize, &result_, buffer_);
   if (!s.ok()) {
     return s;
   }
@@ -58,7 +57,7 @@ Status FileTraceReader::Read(std::string* data) {
   unsigned int to_read =
       bytes_to_read > kBufferSize ? kBufferSize : bytes_to_read;
   while (to_read > 0) {
-    s = file_reader_->Read(offset_, to_read, &result_, buffer_, nullptr);
+    s = file_reader_->Read(offset_, to_read, &result_, buffer_);
     if (!s.ok()) {
       return s;
     }


### PR DESCRIPTION
Reverts "Remove memcpy from RandomAccessFileReader::Read in direct IO mode (#6455)".
This reverts commit 0a0151f.
The optimization has not been applied to all targeted code paths, so it doesn't bring too much benefit for release 6.9, should be better to target for 6.10 with more code paths coverage and more thorough tests.

Test Plan:
make check