### PR TITLE
Add unsafe remove sst file command for ldb

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -380,7 +380,7 @@ class DBImpl : public DB {
       SequenceNumber seq_number, std::unique_ptr<TransactionLogIterator>* iter,
       const TransactionLogIterator::ReadOptions& read_options =
           TransactionLogIterator::ReadOptions()) override;
-  virtual Status DeleteFile(std::string name) override;
+  virtual Status DeleteFile(std::string name, bool force = false) override;
   Status DeleteFilesInRanges(ColumnFamilyHandle* column_family,
                              const RangePtr* ranges, size_t n,
                              bool include_end = true);

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2952,7 +2952,9 @@ class ModelDB : public DB {
     return Status::NotSupported();
   }
 
-  Status DeleteFile(std::string /*name*/) override { return Status::OK(); }
+  Status DeleteFile(std::string /*name*/, bool = false /*force*/) override {
+    return Status::OK();
+  }
 
   Status GetUpdatesSince(
       ROCKSDB_NAMESPACE::SequenceNumber,

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1329,7 +1329,7 @@ class DB {
   // Delete the file name from the db directory and update the internal state to
   // reflect that. Supports deletion of sst and log files only. 'name' must be
   // path relative to the db directory. eg. 000001.sst, /archive/000003.log
-  virtual Status DeleteFile(std::string name) = 0;
+  virtual Status DeleteFile(std::string name, bool force = false) = 0;
 
   // Returns a list of all table files with their level, start key
   // and end key

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -392,8 +392,8 @@ class StackableDB : public DB {
     return db_->GetCreationTimeOfOldestFile(creation_time);
   }
 
-  virtual Status DeleteFile(std::string name) override {
-    return db_->DeleteFile(name);
+  virtual Status DeleteFile(std::string name, bool force = false) override {
+    return db_->DeleteFile(name, force);
   }
 
   virtual Status GetDbIdentity(std::string& identity) const override {

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -625,4 +625,22 @@ class ListFileRangeDeletesCommand : public LDBCommand {
   int max_keys_ = 1000;
 };
 
+// Command that remove the SST file forcibly in manifest.
+class UnsafeRemoveSstFileCommand : public LDBCommand {
+ public:
+  static std::string Name() { return "unsafe_remove_sst_file"; }
+  UnsafeRemoveSstFileCommand(const std::vector<std::string>& params,
+                             const std::map<std::string, std::string>& options,
+                             const std::vector<std::string>& flags);
+
+  virtual void DoCommand() override;
+
+  virtual Options PrepareOptionsForOpenDB() override;
+
+  static void Help(std::string& ret);
+
+ private:
+  std::string file_;
+};
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -96,6 +96,7 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   CheckPointCommand::Help(ret);
   WriteExternalSstFilesCommand::Help(ret);
   IngestExternalSstFilesCommand::Help(ret);
+  UnsafeRemoveSstFileCommand::Help(ret);
 
   fprintf(stderr, "%s\n", ret.c_str());
 }


### PR DESCRIPTION
The SST file may be corrupted due to file system or other kinds of reasons, so Rocksdb will fail to start due to the corruption. In some cases, we tolerate data loss. To make it still provide the service, we need to remove the corrupted SST file forcibly by writing a delete record in the manifest.

This PR adds a `unsafe_remove_sst_file` command to do that.
```
usage: ldb --db=<path/to/db> unsafe_remove_sst_file <xxx.sst>
```

Test:
run it manually
