### PR TITLE
Add NewFileChecksumGenCrc32cFactory to file checksum

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 * Fix wrong result being read from ingested file. May happen when a key in the file happen to be prefix of another key also in the file. The issue can further cause more data corruption. The issue exists with rocksdb >= 5.0.0 since DB::IngestExternalFile() was introduced.
 
+### Public API Change
+* Add NewFileChecksumGenCrc32cFactory to the file checksum public API, such that the build-in Crc32c based file checksum generator factory can be used by applications.
+
 ### New Features
 * Added support for pipelined & parallel compression optimization for `BlockBasedTableBuilder`. This optimization makes block building, block compression and block appending a pipeline, and uses multiple threads to accelerate block compression. Users can set `CompressionOptions::parallel_threads` greater than 1 to enable compression parallelism.
 * Provide an allocator for memkind to be used with block cache. This is to work with memory technologies (Intel DCPMM is one such technology currently available) that require different libraries for allocation and management (such as PMDK and memkind). The high capacities available make it possible to provision large caches (up to several TBs in size) beyond what is achievable with DRAM.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 * Fix wrong result being read from ingested file. May happen when a key in the file happen to be prefix of another key also in the file. The issue can further cause more data corruption. The issue exists with rocksdb >= 5.0.0 since DB::IngestExternalFile() was introduced.
 
 ### Public API Change
-* Add NewFileChecksumGenCrc32cFactory to the file checksum public API, such that the build-in Crc32c based file checksum generator factory can be used by applications.
+* Add NewFileChecksumGenCrc32cFactory to the file checksum public API, such that the builtin Crc32c based file checksum generator factory can be used by applications.
 
 ### New Features
 * Added support for pipelined & parallel compression optimization for `BlockBasedTableBuilder`. This optimization makes block building, block compression and block appending a pipeline, and uses multiple threads to accelerate block compression. Users can set `CompressionOptions::parallel_threads` greater than 1 to enable compression parallelism.

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -97,8 +97,10 @@ class FileChecksumList {
 // Create a new file checksum list.
 extern FileChecksumList* NewFileChecksumList();
 
-// Create a buildin Crc32 based file checksum generatory factory object, which
-// can be shared to create the Crc32c based checksum generator object.
-extern FileChecksumGenFactory* NewFileChecksumGenCrc32cFactory();
+// Return a shared_ptr of the builtin Crc32 based file checksum generatory
+// factory object, which can be shared to create the Crc32c based checksum
+// generator object.
+extern std::shared_ptr<FileChecksumGenFactory>
+GetFileChecksumGenCrc32cFactory();
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/file_checksum.h
+++ b/include/rocksdb/file_checksum.h
@@ -97,4 +97,8 @@ class FileChecksumList {
 // Create a new file checksum list.
 extern FileChecksumList* NewFileChecksumList();
 
+// Create a buildin Crc32 based file checksum generatory factory object, which
+// can be shared to create the Crc32c based checksum generator object.
+extern FileChecksumGenFactory* NewFileChecksumGenCrc32cFactory();
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -344,9 +344,7 @@ TEST_F(LdbCmdTest, DumpFileChecksumCRC32) {
   Options opts;
   opts.env = env.get();
   opts.create_if_missing = true;
-  FileChecksumGenCrc32cFactory* file_checksum_gen_factory =
-      new FileChecksumGenCrc32cFactory();
-  opts.file_checksum_gen_factory.reset(file_checksum_gen_factory);
+  opts.file_checksum_gen_factory.reset(NewFileChecksumGenCrc32cFactory());
 
   DB* db = nullptr;
   std::string dbname = test::TmpDir();

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -344,7 +344,7 @@ TEST_F(LdbCmdTest, DumpFileChecksumCRC32) {
   Options opts;
   opts.env = env.get();
   opts.create_if_missing = true;
-  opts.file_checksum_gen_factory.reset(NewFileChecksumGenCrc32cFactory());
+  opts.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();
 
   DB* db = nullptr;
   std::string dbname = test::TmpDir();

--- a/util/file_checksum_helper.cc
+++ b/util/file_checksum_helper.cc
@@ -77,8 +77,10 @@ FileChecksumList* NewFileChecksumList() {
   return checksum_list;
 }
 
-FileChecksumGenFactory* NewFileChecksumGenCrc32cFactory() {
-  return new FileChecksumGenCrc32cFactory();
+std::shared_ptr<FileChecksumGenFactory> GetFileChecksumGenCrc32cFactory() {
+  static std::shared_ptr<FileChecksumGenFactory> default_crc32c_gen_factory(
+      new FileChecksumGenCrc32cFactory());
+  return default_crc32c_gen_factory;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/file_checksum_helper.cc
+++ b/util/file_checksum_helper.cc
@@ -77,4 +77,8 @@ FileChecksumList* NewFileChecksumList() {
   return checksum_list;
 }
 
+FileChecksumGenFactory* NewFileChecksumGenCrc32cFactory() {
+  return new FileChecksumGenCrc32cFactory();
+}
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Add NewFileChecksumGenCrc32cFactory to file checksum public interface such that applications can use the build in crc32 checksum factory.

Test plan: pass make asan_check