### PR TITLE
Fix a few bugs in db_stress fault injection

### DIFF
--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -164,6 +164,7 @@ bool FullFilterBlockReader::MayMatch(
   const Status s =
       GetOrReadFilterBlock(no_io, get_context, lookup_context, &filter_block);
   if (!s.ok()) {
+    TEST_SYNC_POINT("FilterReadError");
     return true;
   }
 
@@ -221,6 +222,7 @@ void FullFilterBlockReader::MayMatch(
   const Status s = GetOrReadFilterBlock(no_io, range->begin()->get_context,
                                         lookup_context, &filter_block);
   if (!s.ok()) {
+    TEST_SYNC_POINT("FilterReadError");
     return;
   }
 

--- a/test_util/fault_injection_test_fs.h
+++ b/test_util/fault_injection_test_fs.h
@@ -165,7 +165,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
       : FileSystemWrapper(base),
         filesystem_active_(true),
         filesystem_writable_(false),
-        thread_local_error_(new ThreadLocalPtr(nullptr)) {}
+        thread_local_error_(
+            new ThreadLocalPtr(DeleteThreadLocalErrorContext)) {}
   virtual ~FaultInjectionTestFS() {}
 
   const char* Name() const override { return "FaultInjectionTestFS"; }
@@ -297,6 +298,11 @@ class FaultInjectionTestFS : public FileSystemWrapper {
     }
     ctx->one_in = one_in;
     ctx->count = 0;
+  }
+
+  static void DeleteThreadLocalErrorContext(void *p) {
+    ErrorContext* ctx = static_cast<ErrorContext*>(p);
+    delete ctx;
   }
 
   // Inject an error. For a READ operation, a status of IOError(), a

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -453,7 +453,8 @@ def whitebox_crash_main(args, unknown_args):
 
         stdoutdata = stdoutdata.lower()
         errorcount = (stdoutdata.count('error') -
-                      stdoutdata.count('got errors 0 times'))
+                      stdoutdata.count('got errors 0 times') -
+                      stdoutdata.count('got expected errors 0 times'))
         print("#times error occurred in output is " + str(errorcount) + "\n")
 
         if (errorcount > 0):


### PR DESCRIPTION
Summary:
Fix the following issues -
1. Output parsing error in db_crashtest.py
2. Memory leak on exit
3. False alarm on filter block read error

Test Plan:
asan_crash