### PR TITLE
Suppress file deletion error message in FaultInjectionTestFS

### DIFF
--- a/test_util/fault_injection_test_fs.cc
+++ b/test_util/fault_injection_test_fs.cc
@@ -335,10 +335,6 @@ IOStatus FaultInjectionTestFS::DeleteFile(const std::string& f,
     return GetError();
   }
   IOStatus io_s = FileSystemWrapper::DeleteFile(f, options, dbg);
-  if (!io_s.ok()) {
-    fprintf(stderr, "Cannot delete file %s: %s\n", f.c_str(),
-            io_s.ToString().c_str());
-  }
   if (io_s.ok()) {
     UntrackFile(f);
   }


### PR DESCRIPTION
Summary:
The error message is causing problems in the crash tests due to the
error parsing logic in db_crashtest.py.