### PR TITLE
Fix  warning when O_CLOEXEC is not defined

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -122,6 +122,8 @@ int cloexec_flags(int flags, const EnvOptions* options) {
   if (options == nullptr || options->set_fd_cloexec) {
     flags |= O_CLOEXEC;
   }
+#else
+  (void)options;
 #endif
   return flags;
 }


### PR DESCRIPTION
Compilation fails on systems that do not support O_CLOEXEC. Fix it.

Test Plan:
compile without O_CLOEXEC support