### PR TITLE
Suppress file deletion error message in FaultInjectionTestEnv

### DIFF
--- a/test_util/fault_injection_test_env.cc
+++ b/test_util/fault_injection_test_env.cc
@@ -305,10 +305,6 @@ Status FaultInjectionTestEnv::DeleteFile(const std::string& f) {
     return GetError();
   }
   Status s = EnvWrapper::DeleteFile(f);
-  if (!s.ok()) {
-    fprintf(stderr, "Cannot delete file %s: %s\n", f.c_str(),
-            s.ToString().c_str());
-  }
   if (s.ok()) {
     UntrackFile(f);
   }


### PR DESCRIPTION
The error message is causing problems in the crash tests due to the
error parsing logic in db_crashtest.py.

This is a follow up PR for https://github.com/facebook/rocksdb/pull/6694.

Test Plan:
make check