### PR TITLE
mark frequently used classes in `Get()` as final

### DIFF
--- a/table/block_based/binary_search_index_reader.h
+++ b/table/block_based/binary_search_index_reader.h
@@ -13,7 +13,8 @@ namespace ROCKSDB_NAMESPACE {
 // Index that allows binary search lookup for the first key of each block.
 // This class can be viewed as a thin wrapper for `Block` class which already
 // supports binary search.
-class BinarySearchIndexReader : public BlockBasedTable::IndexReaderCommon {
+class BinarySearchIndexReader final
+    : public BlockBasedTable::IndexReaderCommon {
  public:
   // Read index from the file and create an intance for
   // `BinarySearchIndexReader`.

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -53,7 +53,11 @@ typedef std::vector<std::pair<std::string, std::string>> KVPairBlock;
 // memory, and finally search that record within the block. Of course, to avoid
 // frequent reads of the same block, we introduced the block cache to keep the
 // loaded blocks in the memory.
-class BlockBasedTable : public TableReader {
+class BlockBasedTable
+#ifdef NDEBUG
+    final
+#endif  // NDEBUG
+    : public TableReader {
  public:
   static const std::string kFilterBlockPrefix;
   static const std::string kFullFilterBlockPrefix;

--- a/table/block_based/hash_index_reader.h
+++ b/table/block_based/hash_index_reader.h
@@ -13,7 +13,7 @@
 namespace ROCKSDB_NAMESPACE {
 // Index that leverages an internal hash table to quicken the lookup for a given
 // key.
-class HashIndexReader : public BlockBasedTable::IndexReaderCommon {
+class HashIndexReader final : public BlockBasedTable::IndexReaderCommon {
  public:
   static Status Create(const BlockBasedTable* table,
                        FilePrefetchBuffer* prefetch_buffer,

--- a/table/block_based/partitioned_index_reader.h
+++ b/table/block_based/partitioned_index_reader.h
@@ -11,7 +11,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 // Index that allows binary search lookup in a two-level index structure.
-class PartitionIndexReader : public BlockBasedTable::IndexReaderCommon {
+class PartitionIndexReader final : public BlockBasedTable::IndexReaderCommon {
  public:
   // Read the partition index from the file and create an instance for
   // `PartitionIndexReader`.

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -18,7 +18,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
-class BytewiseComparatorImpl : public Comparator {
+class BytewiseComparatorImpl final : public Comparator {
  public:
   BytewiseComparatorImpl() { }
 
@@ -132,7 +132,7 @@ class BytewiseComparatorImpl : public Comparator {
   }
 };
 
-class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
+class ReverseBytewiseComparatorImpl final : public Comparator {
  public:
   ReverseBytewiseComparatorImpl() { }
 
@@ -143,6 +143,8 @@ class ReverseBytewiseComparatorImpl : public BytewiseComparatorImpl {
   int Compare(const Slice& a, const Slice& b) const override {
     return -a.compare(b);
   }
+
+  bool Equal(const Slice& a, const Slice& b) const override { return a == b; }
 
   void FindShortestSeparator(std::string* start,
                              const Slice& limit) const override {


### PR DESCRIPTION
Summary: Using PGO and LTO, virtual function callsites that usually
have the same target can be devirtualized and inlined. However it is
only possible as long as the target function belongs to a final class.
This PR makes the classes final that show up high in `Get()` profiles.

Test Plan:

measured readrandom with PGO, LTO, and this PR. Throughput increased ~17% on a small cached ~1GB database, which exaggerates the overhead of RocksDB’s abstractions.

- compiler: gcc-8
- benchmark setup:
```
$ TEST_TMPDIR=/dev/shm/dbbench ./db_bench -benchmarks=filluniquerandom,compact -write_buffer_size=1048576 -target_file_size_base=1048576 -max_bytes_for_level_base=4194304 -max_background_jobs=12 -level_compaction_dynamic_level_bytes=true -num=10000000  -compression_type=none
```
- rebuild with PGO and LTO:
```
$ EXTRA_CXXFLAGS="-fprofile-generate -flto" EXTRA_LDFLAGS="-fprofile-generate -O2 -flto" ROCKSDB_NO_FBCODE=1 DEBUG_LEVEL=0 make -j48 db_bench
$ TEST_TMPDIR=/dev/shm/dbbench ./db_bench -use_existing_db=true -benchmarks=readrandom -disable_auto_compactions=true -num=10000000  -compression_type=none -reads=10000000 -cache_size=10485760000 -compression_type=none
$ EXTRA_CXXFLAGS="-fprofile-use -fprofile-correction -flto" EXTRA_LDFLAGS="-fprofile-use -fprofile-correction -O2 -flto" ROCKSDB_NO_FBCODE=1 DEBUG_LEVEL=0 make -j48 db_bench
```
- benchmark command:
```
$ TEST_TMPDIR=/dev/shm/dbbench ./db_bench -use_existing_db=true -benchmarks=readrandom -disable_auto_compactions=true -num=10000000  -compression_type=none -reads=100000000 -cache_size=10485760000
```
- throughput before (without PGO, LTO, or this patch): 41.6, 32.9, **39.8** MB/s
- throughput after (with PGO, LTO, and this patch): 50.5, 45.9, **46.5** MB/s