### PR TITLE
Remove a printf from db_stress that's not useful info

### DIFF
--- a/db_stress_tool/db_stress_stat.h
+++ b/db_stress_tool/db_stress_stat.h
@@ -204,8 +204,6 @@ class Stats {
             covered_by_range_deletions_);
 
     fprintf(stdout, "%-12s: Got errors %ld times\n", "", errors_);
-    fprintf(stdout, "%-12s: Got expected errors %ld times\n", "",
-            verified_errors_);
     fprintf(stdout, "%-12s: %ld CompactFiles() succeed\n", "",
             num_compact_files_succeed_);
     fprintf(stdout, "%-12s: %ld CompactFiles() did not succeed\n", "",

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -453,8 +453,7 @@ def whitebox_crash_main(args, unknown_args):
 
         stdoutdata = stdoutdata.lower()
         errorcount = (stdoutdata.count('error') -
-                      stdoutdata.count('got errors 0 times') -
-                      stdoutdata.count('got expected errors 0 times'))
+                      stdoutdata.count('got errors 0 times'))
         print("#times error occurred in output is " + str(errorcount) + "\n")
 
         if (errorcount > 0):


### PR DESCRIPTION
This was causing db_crashtest.py to wrongly assume an error by parsing the output. Hopefully this will stabilize the crash tests.

Test:
make blackbox_crash_test