### PR TITLE
Update buckifier to unblock future internal release

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -94,9 +94,6 @@ is_opt_mode = build_mode.startswith("opt")
 # -DNDEBUG is added by default in opt mode in fbcode. But adding it twice
 # doesn't harm and avoid forgetting to add it.
 ROCKSDB_COMPILER_FLAGS += (["-DNDEBUG"] if is_opt_mode else [])
-ROCKSDB_STRESS_DEPS = (
-        [":rocksdb_lib", ":rocksdb_test_lib"] if not is_opt_mode else [":rocksdb_lib"]
-)
 
 sanitizer = read_config("fbcode", "sanitizer")
 
@@ -207,6 +204,7 @@ cpp_library(
         "memory/arena.cc",
         "memory/concurrent_arena.cc",
         "memory/jemalloc_nodump_allocator.cc",
+        "memory/memkind_kmem_allocator.cc",
         "memtable/alloc_tracker.cc",
         "memtable/hash_linklist_rep.cc",
         "memtable/hash_skiplist_rep.cc",
@@ -439,7 +437,36 @@ cpp_library(
     os_deps = ROCKSDB_OS_DEPS,
     os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
     preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
-    deps = ROCKSDB_STRESS_DEPS,
+    deps = [":rocksdb_lib"],
+    external_deps = ROCKSDB_EXTERNAL_DEPS,
+)
+
+cpp_library(
+    name = "rocksdb_stress_lib_dbg",
+    srcs = [
+        "db_stress_tool/batched_ops_stress.cc",
+        "db_stress_tool/cf_consistency_stress.cc",
+        "db_stress_tool/db_stress_common.cc",
+        "db_stress_tool/db_stress_driver.cc",
+        "db_stress_tool/db_stress_gflags.cc",
+        "db_stress_tool/db_stress_shared_state.cc",
+        "db_stress_tool/db_stress_test_base.cc",
+        "db_stress_tool/db_stress_tool.cc",
+        "db_stress_tool/no_batched_ops_stress.cc",
+        "test_util/testutil.cc",
+        "tools/block_cache_analyzer/block_cache_trace_analyzer.cc",
+        "tools/trace_analyzer_tool.cc",
+    ],
+    auto_headers = AutoHeaders.RECURSIVE_GLOB,
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    os_deps = ROCKSDB_OS_DEPS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    deps = [
+        ":rocksdb_lib",
+        ":rocksdb_test_lib",
+    ],
     external_deps = ROCKSDB_EXTERNAL_DEPS,
 )
 
@@ -1183,6 +1210,13 @@ ROCKS_TESTS = [
         "manual_compaction_test",
         "db/manual_compaction_test.cc",
         "parallel",
+        [],
+        [],
+    ],
+    [
+        "memkind_kmem_allocator_test",
+        "memory/memkind_kmem_allocator_test.cc",
+        "serial",
         [],
         [],
     ],

--- a/TARGETS
+++ b/TARGETS
@@ -437,32 +437,6 @@ cpp_library(
     os_deps = ROCKSDB_OS_DEPS,
     os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
     preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
-    deps = [":rocksdb_lib"],
-    external_deps = ROCKSDB_EXTERNAL_DEPS,
-)
-
-cpp_library(
-    name = "rocksdb_stress_lib_dbg",
-    srcs = [
-        "db_stress_tool/batched_ops_stress.cc",
-        "db_stress_tool/cf_consistency_stress.cc",
-        "db_stress_tool/db_stress_common.cc",
-        "db_stress_tool/db_stress_driver.cc",
-        "db_stress_tool/db_stress_gflags.cc",
-        "db_stress_tool/db_stress_shared_state.cc",
-        "db_stress_tool/db_stress_test_base.cc",
-        "db_stress_tool/db_stress_tool.cc",
-        "db_stress_tool/no_batched_ops_stress.cc",
-        "test_util/testutil.cc",
-        "tools/block_cache_analyzer/block_cache_trace_analyzer.cc",
-        "tools/trace_analyzer_tool.cc",
-    ],
-    auto_headers = AutoHeaders.RECURSIVE_GLOB,
-    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
-    compiler_flags = ROCKSDB_COMPILER_FLAGS,
-    os_deps = ROCKSDB_OS_DEPS,
-    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
-    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
     deps = [
         ":rocksdb_lib",
         ":rocksdb_test_lib",

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -173,15 +173,7 @@ def generate_targets(repo_path, deps_map):
         src_mk.get("ANALYZER_LIB_SOURCES", [])
         + src_mk.get('STRESS_LIB_SOURCES', [])
         + ["test_util/testutil.cc"],
-        [":rocksdb_lib"])
-    # rocksdb_stress_lib_dbg
-    TARGETS.add_library(
-        "rocksdb_stress_lib_dbg",
-        src_mk.get("ANALYZER_LIB_SOURCES", [])
-        + src_mk.get('STRESS_LIB_SOURCES', [])
-        + ["test_util/testutil.cc"],
         [":rocksdb_lib", ":rocksdb_test_lib"])
-
 
     print("Extra dependencies:\n{0}".format(str(deps_map)))
     # test for every test we found in the Makefile

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -174,6 +174,14 @@ def generate_targets(repo_path, deps_map):
         + src_mk.get('STRESS_LIB_SOURCES', [])
         + ["test_util/testutil.cc"],
         [":rocksdb_lib"])
+    # rocksdb_stress_lib_dbg
+    TARGETS.add_library(
+        "rocksdb_stress_lib_dbg",
+        src_mk.get("ANALYZER_LIB_SOURCES", [])
+        + src_mk.get('STRESS_LIB_SOURCES', [])
+        + ["test_util/testutil.cc"],
+        [":rocksdb_lib", ":rocksdb_test_lib"])
+
 
     print("Extra dependencies:\n{0}".format(str(deps_map)))
     # test for every test we found in the Makefile


### PR DESCRIPTION
Summary:
Some recent PRs added new source files or modified TARGETS file manually.
During next internal release, executing the following command will revert the
manual changes.
Update buckifier so that the following command
```
python buckfier/buckify_rocksdb.py
```
does not change TARGETS file.

Test Plan:
```
python buckifier/buckify_rocksdb.py
```