### PR TITLE
Add default FileOptions::operator=

### DIFF
--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -105,6 +105,8 @@ struct FileOptions : EnvOptions {
 
   FileOptions(const FileOptions& opts)
     : EnvOptions(opts), io_options(opts.io_options) {}
+
+  FileOptions& operator=(const FileOptions&) = default;
 };
 
 // A structure to pass back some debugging information from the FileSystem


### PR DESCRIPTION
Generation of an implicitly defined copy assignment operator is deprecated
in the presence of a user declared copy constructor.  Therefore, explicitly
add the default operator= to FileOptions.

Signed-off-by: Derrick Pallas <derrick@pallas.us>