### PR TITLE
Prevent uninitialized load in `IndexBlockIter`

### DIFF
--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -376,13 +376,13 @@ bool DataBlockIter::SeekForGetImpl(const Slice& target) {
 
 void IndexBlockIter::Seek(const Slice& target) {
   TEST_SYNC_POINT("IndexBlockIter::Seek:0");
-  Slice seek_key = target;
-  if (!key_includes_seq_) {
-    seek_key = ExtractUserKey(target);
-  }
   PERF_TIMER_GUARD(block_seek_nanos);
   if (data_ == nullptr) {  // Not init yet
     return;
+  }
+  Slice seek_key = target;
+  if (!key_includes_seq_) {
+    seek_key = ExtractUserKey(target);
   }
   status_ = Status::OK();
   uint32_t index = 0;


### PR DESCRIPTION
When index block is empty or an error happens while reading it,
`Invalidate()` is called rather than `Initialize()`. So `Seek()` must
not refer to member variables that are only initialized in
`Initialize()` until it is sure `Initialize()` has been called.