### PR TITLE
Check alignment of MultiRead requests in direct IO mode

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -608,6 +608,15 @@ IOStatus PosixRandomAccessFile::MultiRead(FSReadRequest* reqs,
                                           size_t num_reqs,
                                           const IOOptions& options,
                                           IODebugContext* dbg) {
+  if (use_direct_io()) {
+    for (size_t i = 0; i < num_reqs; i++) {
+      const FSReadRequest& r = reqs[i];
+      assert(IsSectorAligned(r.offset, GetRequiredBufferAlignment()));
+      assert(IsSectorAligned(r.len, GetRequiredBufferAlignment()));
+      assert(IsSectorAligned(r.scratch, GetRequiredBufferAlignment()));
+    }
+  }
+
 #if defined(ROCKSDB_IOURING_PRESENT)
   struct io_uring* iu = nullptr;
   if (thread_local_io_urings_) {


### PR DESCRIPTION
Add assertions to check direct IO's alignment requirements in MultiRead.

Test Plan:
make check