### PR TITLE
Make sure (Shared)BlobFileMetaData are owned by shared_ptrs

### DIFF
--- a/db/blob/blob_file_meta.cc
+++ b/db/blob/blob_file_meta.cc
@@ -10,10 +10,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-SharedBlobFileMetaData::~SharedBlobFileMetaData() {
-  // TODO: add the blob file to the list of obsolete files here
-}
-
 std::string SharedBlobFileMetaData::DebugString() const {
   std::ostringstream oss;
   oss << (*this);

--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -34,10 +34,11 @@ class SharedBlobFileMetaData {
     assert(checksum_method_.empty() == checksum_value_.empty());
   }
 
-  ~SharedBlobFileMetaData() = default;
-
   SharedBlobFileMetaData(const SharedBlobFileMetaData&) = delete;
   SharedBlobFileMetaData& operator=(const SharedBlobFileMetaData&) = delete;
+
+  SharedBlobFileMetaData(SharedBlobFileMetaData&&) = delete;
+  SharedBlobFileMetaData& operator=(SharedBlobFileMetaData&&) = delete;
 
   uint64_t GetBlobFileNumber() const { return blob_file_number_; }
   uint64_t GetTotalBlobCount() const { return total_blob_count_; }
@@ -78,10 +79,11 @@ class BlobFileMetaData {
     assert(garbage_blob_bytes_ <= shared_meta_->GetTotalBlobBytes());
   }
 
-  ~BlobFileMetaData() = default;
-
   BlobFileMetaData(const BlobFileMetaData&) = delete;
   BlobFileMetaData& operator=(const BlobFileMetaData&) = delete;
+
+  BlobFileMetaData(BlobFileMetaData&&) = delete;
+  BlobFileMetaData& operator=(BlobFileMetaData&&) = delete;
 
   const std::shared_ptr<SharedBlobFileMetaData>& GetSharedMeta() const {
     return shared_meta_;

--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -34,7 +34,7 @@ class SharedBlobFileMetaData {
     assert(checksum_method_.empty() == checksum_value_.empty());
   }
 
-  ~SharedBlobFileMetaData();
+  ~SharedBlobFileMetaData() = default;
 
   SharedBlobFileMetaData(const SharedBlobFileMetaData&) = delete;
   SharedBlobFileMetaData& operator=(const SharedBlobFileMetaData&) = delete;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -388,7 +388,7 @@ class VersionBuilder::Rep {
       return Status::Corruption("VersionBuilder", oss.str());
     }
 
-    auto shared_meta = std::make_shared<SharedBlobFileMetaData>(
+    auto shared_meta = SharedBlobFileMetaData::Create(
         blob_file_number, blob_file_addition.GetTotalBlobCount(),
         blob_file_addition.GetTotalBlobBytes(),
         blob_file_addition.GetChecksumMethod(),
@@ -396,7 +396,7 @@ class VersionBuilder::Rep {
 
     constexpr uint64_t garbage_blob_count = 0;
     constexpr uint64_t garbage_blob_bytes = 0;
-    auto new_meta = std::make_shared<BlobFileMetaData>(
+    auto new_meta = BlobFileMetaData::Create(
         std::move(shared_meta), garbage_blob_count, garbage_blob_bytes);
 
     changed_blob_files_.emplace(blob_file_number, std::move(new_meta));
@@ -417,7 +417,7 @@ class VersionBuilder::Rep {
 
     assert(meta->GetBlobFileNumber() == blob_file_number);
 
-    auto new_meta = std::make_shared<BlobFileMetaData>(
+    auto new_meta = BlobFileMetaData::Create(
         meta->GetSharedMeta(),
         meta->GetGarbageBlobCount() + blob_file_garbage.GetGarbageBlobCount(),
         meta->GetGarbageBlobBytes() + blob_file_garbage.GetGarbageBlobBytes());

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -82,10 +82,10 @@ class VersionBuilderTest : public testing::Test {
                uint64_t total_blob_bytes, std::string checksum_method,
                std::string checksum_value, uint64_t garbage_blob_count,
                uint64_t garbage_blob_bytes) {
-    auto shared_meta = std::make_shared<SharedBlobFileMetaData>(
+    auto shared_meta = SharedBlobFileMetaData::Create(
         blob_file_number, total_blob_count, total_blob_bytes,
         std::move(checksum_method), std::move(checksum_value));
-    auto meta = std::make_shared<BlobFileMetaData>(
+    auto meta = BlobFileMetaData::Create(
         std::move(shared_meta), garbage_blob_count, garbage_blob_bytes);
 
     vstorage_.AddBlobFile(std::move(meta));


### PR DESCRIPTION
Summary:
The patch makes a couple of small cleanups to `SharedBlobFileMetaData` and `BlobFileMetaData`:
* It makes the constructors private and introduces factory methods to ensure these objects are always owned by `shared_ptr`s. Note that `SharedBlobFileMetaData` has an additional factory that takes a deleter object; we can utilize this to e.g. notify `VersionSet` when a blob file becomes obsolete (which is exactly when `SharedBlobFileMetaData` is destroyed).
* It disables move operations explicitly instead of relying on them being suppressed because of a user-declared destructor.

Test Plan:
`make check`