### PR TITLE
Fix unused variable of r in release mode

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -610,10 +610,9 @@ IOStatus PosixRandomAccessFile::MultiRead(FSReadRequest* reqs,
                                           IODebugContext* dbg) {
   if (use_direct_io()) {
     for (size_t i = 0; i < num_reqs; i++) {
-      const FSReadRequest& r = reqs[i];
-      assert(IsSectorAligned(r.offset, GetRequiredBufferAlignment()));
-      assert(IsSectorAligned(r.len, GetRequiredBufferAlignment()));
-      assert(IsSectorAligned(r.scratch, GetRequiredBufferAlignment()));
+      assert(IsSectorAligned(reqs[i].offset, GetRequiredBufferAlignment()));
+      assert(IsSectorAligned(reqs[i].len, GetRequiredBufferAlignment()));
+      assert(IsSectorAligned(reqs[i].scratch, GetRequiredBufferAlignment()));
     }
   }
 


### PR DESCRIPTION
In release mode, asserts are not compiled, so `r` is not used, causing compiler warnings.

Test Plan:
make check under release mode