### PR TITLE
Keep track of obsolete blob files in VersionSet

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -86,9 +86,9 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
 
   // Get obsolete files.  This function will also update the list of
   // pending files in VersionSet().
-  versions_->GetObsoleteFiles(&job_context->sst_delete_files,
-                              &job_context->manifest_delete_files,
-                              job_context->min_pending_output);
+  versions_->GetObsoleteFiles(
+      &job_context->sst_delete_files, &job_context->blob_delete_files,
+      &job_context->manifest_delete_files, job_context->min_pending_output);
 
   // Mark the elements in job_context->sst_delete_files as grabbedForPurge
   // so that other threads calling FindObsoleteFiles with full_scan=true

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -146,8 +146,8 @@ struct JobContext {
   // a list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;
 
-  // list of blob files that we need to delete
-  std::vector<uint64_t> blob_delete_files;
+  // the list of blob files that we need to delete
+  std::vector<ObsoleteBlobFileInfo> blob_delete_files;
 
   // a list of log files that we need to delete
   std::vector<uint64_t> log_delete_files;

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -102,9 +102,9 @@ struct SuperVersionContext {
 
 struct JobContext {
   inline bool HaveSomethingToDelete() const {
-    return !full_scan_candidate_files.empty() || !sst_delete_files.empty() ||
-           !blob_delete_files.empty() || !log_delete_files.empty() ||
-           !manifest_delete_files.empty();
+    return !(full_scan_candidate_files.empty() && sst_delete_files.empty() &&
+             blob_delete_files.empty() && log_delete_files.empty() &&
+             manifest_delete_files.empty());
   }
 
   inline bool HaveSomethingToClean() const {

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -102,8 +102,9 @@ struct SuperVersionContext {
 
 struct JobContext {
   inline bool HaveSomethingToDelete() const {
-    return full_scan_candidate_files.size() || sst_delete_files.size() ||
-           log_delete_files.size() || manifest_delete_files.size();
+    return !full_scan_candidate_files.empty() || !sst_delete_files.empty() ||
+           !blob_delete_files.empty() || !log_delete_files.empty() ||
+           !manifest_delete_files.empty();
   }
 
   inline bool HaveSomethingToClean() const {
@@ -144,6 +145,9 @@ struct JobContext {
 
   // a list of sst files that we need to delete
   std::vector<ObsoleteFileInfo> sst_delete_files;
+
+  // list of blob files that we need to delete
+  std::vector<uint64_t> blob_delete_files;
 
   // a list of log files that we need to delete
   std::vector<uint64_t> log_delete_files;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -395,10 +395,16 @@ class VersionBuilder::Rep {
     // Note: in C++14, this could be done in a more elegant way using
     // generalized lambda capture.
     VersionSet* const vs = version_set_;
-    auto deleter = [vs](SharedBlobFileMetaData* shared_meta) {
+    const ImmutableCFOptions* const ioptions = ioptions_;
+
+    auto deleter = [vs, ioptions](SharedBlobFileMetaData* shared_meta) {
       if (vs) {
+        assert(ioptions);
+        assert(!ioptions->cf_paths.empty());
         assert(shared_meta);
-        vs->AddObsoleteBlobFile(shared_meta->GetBlobFileNumber());
+
+        vs->AddObsoleteBlobFile(shared_meta->GetBlobFileNumber(),
+                                ioptions->cf_paths.front().path);
       }
 
       delete shared_meta;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -87,7 +87,7 @@ class VersionBuilder::Rep {
   };
 
   const FileOptions& file_options_;
-  const ImmutableCFOptions* ioptions_;
+  const ImmutableCFOptions* const ioptions_;
   TableCache* table_cache_;
   VersionStorageInfo* base_vstorage_;
   VersionSet* version_set_;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -392,8 +392,8 @@ class VersionBuilder::Rep {
       return Status::Corruption("VersionBuilder", oss.str());
     }
 
-    // Note: in C++14, this could be done in a more elegant way using
-    // generalized lambda capture.
+    // Note: we use C++11 for now but in C++14, this could be done in a more
+    // elegant way using generalized lambda capture.
     VersionSet* const vs = version_set_;
     const ImmutableCFOptions* const ioptions = ioptions_;
 

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -32,7 +32,7 @@ class VersionBuilder {
  public:
   VersionBuilder(const FileOptions& file_options, TableCache* table_cache,
                  VersionStorageInfo* base_vstorage, VersionSet* version_set,
-                 Logger* info_log = nullptr);
+                 Logger* info_log);
   ~VersionBuilder();
 
   bool CheckConsistencyForNumLevels();

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -22,6 +22,7 @@ class VersionEdit;
 struct FileMetaData;
 class InternalStats;
 class Version;
+class VersionSet;
 class ColumnFamilyData;
 
 // A helper class so we can efficiently apply a whole sequence
@@ -30,7 +31,8 @@ class ColumnFamilyData;
 class VersionBuilder {
  public:
   VersionBuilder(const FileOptions& file_options, TableCache* table_cache,
-                 VersionStorageInfo* base_vstorage, Logger* info_log = nullptr);
+                 VersionStorageInfo* base_vstorage, VersionSet* version_set,
+                 Logger* info_log = nullptr);
   ~VersionBuilder();
 
   bool CheckConsistencyForNumLevels();

--- a/db/version_builder.h
+++ b/db/version_builder.h
@@ -16,6 +16,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+struct ImmutableCFOptions;
 class TableCache;
 class VersionStorageInfo;
 class VersionEdit;
@@ -30,9 +31,9 @@ class ColumnFamilyData;
 // Versions that contain full copies of the intermediate state.
 class VersionBuilder {
  public:
-  VersionBuilder(const FileOptions& file_options, TableCache* table_cache,
-                 VersionStorageInfo* base_vstorage, VersionSet* version_set,
-                 Logger* info_log);
+  VersionBuilder(const FileOptions& file_options,
+                 const ImmutableCFOptions* ioptions, TableCache* table_cache,
+                 VersionStorageInfo* base_vstorage, VersionSet* version_set);
   ~VersionBuilder();
 
   bool CheckConsistencyForNumLevels();

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -152,8 +152,11 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   version_edit.DeleteFile(3, 27U);
 
   EnvOptions env_options;
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
 
-  VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
+                                 version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -190,8 +193,11 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   version_edit.DeleteFile(0, 88U);
 
   EnvOptions env_options;
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
 
-  VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
+                                 version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -233,8 +239,11 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
   version_edit.DeleteFile(4, 8U);
 
   EnvOptions env_options;
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
 
-  VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
+                                 version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -279,8 +288,11 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
                        kUnknownFileChecksumFuncName);
 
   EnvOptions env_options;
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
 
-  VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
+                                 version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -296,7 +308,12 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   UpdateVersionStorageInfo();
 
   EnvOptions env_options;
-  VersionBuilder version_builder(env_options, nullptr, &vstorage_);
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
+                                 version_set);
+
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
 
@@ -353,7 +370,9 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
 TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -406,7 +425,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -423,7 +444,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyApplied) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -463,7 +486,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -505,7 +530,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit addition;
 
@@ -558,7 +585,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -591,7 +620,9 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -681,7 +712,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {
   // new table file--blob file pair.
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   VersionEdit edit;
 
@@ -739,7 +772,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesNotInVersion) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;
@@ -776,7 +811,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbage) {
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
-  VersionBuilder builder(env_options, table_cache, &vstorage_);
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -154,10 +154,9 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set, info_log);
+  VersionBuilder version_builder(env_options, &ioptions_, table_cache,
+                                 &vstorage_, version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -196,10 +195,9 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set, info_log);
+  VersionBuilder version_builder(env_options, &ioptions_, table_cache,
+                                 &vstorage_, version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -243,10 +241,9 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set, info_log);
+  VersionBuilder version_builder(env_options, &ioptions_, table_cache,
+                                 &vstorage_, version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -293,10 +290,9 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set, info_log);
+  VersionBuilder version_builder(env_options, &ioptions_, table_cache,
+                                 &vstorage_, version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -314,10 +310,9 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set, info_log);
+  VersionBuilder version_builder(env_options, &ioptions_, table_cache,
+                                 &vstorage_, version_set);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -376,10 +371,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -433,10 +427,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -454,10 +447,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyApplied) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -498,10 +490,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -544,10 +535,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit addition;
 
@@ -601,10 +591,9 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -638,10 +627,9 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -732,10 +720,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   VersionEdit edit;
 
@@ -794,10 +781,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesNotInVersion) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;
@@ -835,10 +821,9 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbage) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
-  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
-                         info_log);
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -154,9 +154,10 @@ TEST_F(VersionBuilderTest, ApplyAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
   VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set);
+                                 version_set, info_log);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -195,9 +196,10 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
   VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set);
+                                 version_set, info_log);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -241,9 +243,10 @@ TEST_F(VersionBuilderTest, ApplyAndSaveToDynamic2) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
   VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set);
+                                 version_set, info_log);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -290,9 +293,10 @@ TEST_F(VersionBuilderTest, ApplyMultipleAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
   VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set);
+                                 version_set, info_log);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -310,9 +314,10 @@ TEST_F(VersionBuilderTest, ApplyDeleteAndSaveTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
   VersionBuilder version_builder(env_options, table_cache, &vstorage_,
-                                 version_set);
+                                 version_set, info_log);
 
   VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
                                   kCompactionStyleLevel, nullptr, false);
@@ -371,8 +376,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -426,8 +433,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -445,8 +454,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyApplied) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -487,8 +498,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -531,8 +544,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit addition;
 
@@ -586,8 +601,10 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -621,8 +638,10 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -713,8 +732,10 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   VersionEdit edit;
 
@@ -773,8 +794,10 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesNotInVersion) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;
@@ -812,8 +835,10 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbage) {
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
   constexpr VersionSet* version_set = nullptr;
+  constexpr Logger* info_log = nullptr;
 
-  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set);
+  VersionBuilder builder(env_options, table_cache, &vstorage_, version_set,
+                         info_log);
 
   // Save to a new version in order to trigger consistency checks.
   constexpr bool force_consistency_checks = true;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5725,7 +5725,7 @@ void VersionSet::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
 }
 
 void VersionSet::GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
-                                  std::vector<uint64_t>* blob_files,
+                                  std::vector<ObsoleteBlobFileInfo>* blob_files,
                                   std::vector<std::string>* manifest_filenames,
                                   uint64_t min_pending_output) {
   assert(files);
@@ -5745,12 +5745,12 @@ void VersionSet::GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
   }
   obsolete_files_.swap(pending_files);
 
-  std::vector<uint64_t> pending_blob_files;
-  for (const auto& blob_file : obsolete_blob_files_) {
-    if (blob_file < min_pending_output) {
-      blob_files->emplace_back(blob_file);
+  std::vector<ObsoleteBlobFileInfo> pending_blob_files;
+  for (auto& blob_file : obsolete_blob_files_) {
+    if (blob_file.GetBlobFileNumber() < min_pending_output) {
+      blob_files->emplace_back(std::move(blob_file));
     } else {
-      pending_blob_files.emplace_back(blob_file);
+      pending_blob_files.emplace_back(std::move(blob_file));
     }
   }
   obsolete_blob_files_.swap(pending_blob_files);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5725,19 +5725,37 @@ void VersionSet::GetLiveFilesMetaData(std::vector<LiveFileMetaData>* metadata) {
 }
 
 void VersionSet::GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
+                                  std::vector<uint64_t>* blob_files,
                                   std::vector<std::string>* manifest_filenames,
                                   uint64_t min_pending_output) {
+  assert(files);
+  assert(blob_files);
+  assert(manifest_filenames);
+  assert(files->empty());
+  assert(blob_files->empty());
   assert(manifest_filenames->empty());
-  obsolete_manifests_.swap(*manifest_filenames);
+
   std::vector<ObsoleteFileInfo> pending_files;
   for (auto& f : obsolete_files_) {
     if (f.metadata->fd.GetNumber() < min_pending_output) {
-      files->push_back(std::move(f));
+      files->emplace_back(std::move(f));
     } else {
-      pending_files.push_back(std::move(f));
+      pending_files.emplace_back(std::move(f));
     }
   }
   obsolete_files_.swap(pending_files);
+
+  std::vector<uint64_t> pending_blob_files;
+  for (auto& blob_file : obsolete_blob_files_) {
+    if (blob_file < min_pending_output) {
+      blob_files->emplace_back(blob_file);
+    } else {
+      pending_blob_files.emplace_back(blob_file);
+    }
+  }
+  obsolete_blob_files_.swap(pending_blob_files);
+
+  obsolete_manifests_.swap(*manifest_filenames);
 }
 
 ColumnFamilyData* VersionSet::CreateColumnFamily(

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5746,7 +5746,7 @@ void VersionSet::GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
   obsolete_files_.swap(pending_files);
 
   std::vector<uint64_t> pending_blob_files;
-  for (auto& blob_file : obsolete_blob_files_) {
+  for (const auto& blob_file : obsolete_blob_files_) {
     if (blob_file < min_pending_output) {
       blob_files->emplace_back(blob_file);
     } else {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1061,6 +1061,7 @@ class VersionSet {
   void GetLiveFilesMetaData(std::vector<LiveFileMetaData> *metadata);
 
   void GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
+                        std::vector<uint64_t>* blob_files,
                         std::vector<std::string>* manifest_filenames,
                         uint64_t min_pending_output);
 
@@ -1194,6 +1195,7 @@ class VersionSet {
   uint64_t manifest_file_size_;
 
   std::vector<ObsoleteFileInfo> obsolete_files_;
+  std::vector<uint64_t> obsolete_blob_files_;
   std::vector<std::string> obsolete_manifests_;
 
   // env options for all reads and writes except compactions

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -789,6 +789,19 @@ struct ObsoleteFileInfo {
   }
 };
 
+class ObsoleteBlobFileInfo {
+ public:
+  ObsoleteBlobFileInfo(uint64_t blob_file_number, std::string path)
+      : blob_file_number_(blob_file_number), path_(std::move(path)) {}
+
+  uint64_t GetBlobFileNumber() const { return blob_file_number_; }
+  const std::string& GetPath() const { return path_; }
+
+ private:
+  uint64_t blob_file_number_;
+  std::string path_;
+};
+
 class BaseReferencedVersionBuilder;
 
 class AtomicGroupReadBuffer {
@@ -1060,12 +1073,12 @@ class VersionSet {
   // This function doesn't support leveldb SST filenames
   void GetLiveFilesMetaData(std::vector<LiveFileMetaData> *metadata);
 
-  void AddObsoleteBlobFile(uint64_t blob_file_number) {
-    obsolete_blob_files_.emplace_back(blob_file_number);
+  void AddObsoleteBlobFile(uint64_t blob_file_number, std::string path) {
+    obsolete_blob_files_.emplace_back(blob_file_number, std::move(path));
   }
 
   void GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
-                        std::vector<uint64_t>* blob_files,
+                        std::vector<ObsoleteBlobFileInfo>* blob_files,
                         std::vector<std::string>* manifest_filenames,
                         uint64_t min_pending_output);
 
@@ -1199,7 +1212,7 @@ class VersionSet {
   uint64_t manifest_file_size_;
 
   std::vector<ObsoleteFileInfo> obsolete_files_;
-  std::vector<uint64_t> obsolete_blob_files_;
+  std::vector<ObsoleteBlobFileInfo> obsolete_blob_files_;
   std::vector<std::string> obsolete_manifests_;
 
   // env options for all reads and writes except compactions

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1060,6 +1060,10 @@ class VersionSet {
   // This function doesn't support leveldb SST filenames
   void GetLiveFilesMetaData(std::vector<LiveFileMetaData> *metadata);
 
+  void AddObsoleteBlobFile(uint64_t blob_file_number) {
+    obsolete_blob_files_.emplace_back(blob_file_number);
+  }
+
   void GetObsoleteFiles(std::vector<ObsoleteFileInfo>* files,
                         std::vector<uint64_t>* blob_files,
                         std::vector<std::string>* manifest_filenames,

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -999,7 +999,22 @@ TEST_F(VersionSetTest, ObsoleteBlobFile) {
 
   ASSERT_OK(s);
 
-  // Make sure the blob file is returned as obsolete.
+  // Pretend for a moment that the blob file is in the pending range, and make
+  // sure it is not returned as obsolete.
+  {
+    std::vector<ObsoleteFileInfo> table_files;
+    std::vector<ObsoleteBlobFileInfo> blob_files;
+    std::vector<std::string> manifest_files;
+    constexpr uint64_t min_pending_output = blob_file_number;
+
+    versions_->GetObsoleteFiles(&table_files, &blob_files, &manifest_files,
+                                min_pending_output);
+
+    ASSERT_TRUE(blob_files.empty());
+  }
+
+  // Make sure the blob file is returned as obsolete if it's not in the pending
+  // range.
   {
     std::vector<ObsoleteFileInfo> table_files;
     std::vector<ObsoleteBlobFileInfo> blob_files;
@@ -1013,12 +1028,12 @@ TEST_F(VersionSetTest, ObsoleteBlobFile) {
     ASSERT_EQ(blob_files[0].GetBlobFileNumber(), blob_file_number);
   }
 
-  // Make sure blob files in the pending range are not returned as obsolete.
+  // Make sure it's not returned a second time.
   {
     std::vector<ObsoleteFileInfo> table_files;
     std::vector<ObsoleteBlobFileInfo> blob_files;
     std::vector<std::string> manifest_files;
-    constexpr uint64_t min_pending_output = blob_file_number;
+    constexpr uint64_t min_pending_output = 0;
 
     versions_->GetObsoleteFiles(&table_files, &blob_files, &manifest_files,
                                 min_pending_output);

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -960,6 +960,73 @@ TEST_F(VersionSetTest, PersistBlobFileStateInNewManifest) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
+TEST_F(VersionSetTest, ObsoleteBlobFile) {
+  // Initialize the database and add a blob file (with no garbage just yet).
+  NewDB();
+
+  VersionEdit addition;
+
+  constexpr uint64_t blob_file_number = 234;
+  constexpr uint64_t total_blob_count = 555;
+  constexpr uint64_t total_blob_bytes = 66666;
+  constexpr char checksum_method[] = "CRC32";
+  constexpr char checksum_value[] = "3d87ff57";
+
+  addition.AddBlobFile(blob_file_number, total_blob_count, total_blob_bytes,
+                       checksum_method, checksum_value);
+
+  assert(versions_);
+  assert(versions_->GetColumnFamilySet());
+
+  mutex_.Lock();
+  Status s =
+      versions_->LogAndApply(versions_->GetColumnFamilySet()->GetDefault(),
+                             mutable_cf_options_, &addition, &mutex_);
+  mutex_.Unlock();
+
+  ASSERT_OK(s);
+
+  // Mark the entire blob file garbage.
+  VersionEdit garbage;
+
+  garbage.AddBlobFileGarbage(blob_file_number, total_blob_count,
+                             total_blob_bytes);
+
+  mutex_.Lock();
+  s = versions_->LogAndApply(versions_->GetColumnFamilySet()->GetDefault(),
+                             mutable_cf_options_, &garbage, &mutex_);
+  mutex_.Unlock();
+
+  ASSERT_OK(s);
+
+  // Make sure the blob file is returned as obsolete.
+  {
+    std::vector<ObsoleteFileInfo> table_files;
+    std::vector<ObsoleteBlobFileInfo> blob_files;
+    std::vector<std::string> manifest_files;
+    constexpr uint64_t min_pending_output = blob_file_number + 1;
+
+    versions_->GetObsoleteFiles(&table_files, &blob_files, &manifest_files,
+                                min_pending_output);
+
+    ASSERT_EQ(blob_files.size(), 1);
+    ASSERT_EQ(blob_files[0].GetBlobFileNumber(), blob_file_number);
+  }
+
+  // Make sure blob files in the pending range are not returned as obsolete.
+  {
+    std::vector<ObsoleteFileInfo> table_files;
+    std::vector<ObsoleteBlobFileInfo> blob_files;
+    std::vector<std::string> manifest_files;
+    constexpr uint64_t min_pending_output = blob_file_number;
+
+    versions_->GetObsoleteFiles(&table_files, &blob_files, &manifest_files,
+                                min_pending_output);
+
+    ASSERT_TRUE(blob_files.empty());
+  }
+}
+
 class VersionSetAtomicGroupTest : public VersionSetTestBase,
                                   public testing::Test {
  public:

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -999,8 +999,8 @@ TEST_F(VersionSetTest, ObsoleteBlobFile) {
 
   ASSERT_OK(s);
 
-  // Pretend for a moment that the blob file is in the pending range, and make
-  // sure it is not returned as obsolete.
+  // Make sure blob files from the pending number range are not returned
+  // as obsolete.
   {
     std::vector<ObsoleteFileInfo> table_files;
     std::vector<ObsoleteBlobFileInfo> blob_files;
@@ -1033,7 +1033,7 @@ TEST_F(VersionSetTest, ObsoleteBlobFile) {
     std::vector<ObsoleteFileInfo> table_files;
     std::vector<ObsoleteBlobFileInfo> blob_files;
     std::vector<std::string> manifest_files;
-    constexpr uint64_t min_pending_output = 0;
+    constexpr uint64_t min_pending_output = blob_file_number + 1;
 
     versions_->GetObsoleteFiles(&table_files, &blob_files, &manifest_files,
                                 min_pending_output);


### PR DESCRIPTION
Summary:
The patch adds logic to keep track of obsolete blob files. A blob file becomes
obsolete when the last `shared_ptr` that points to the corresponding
`SharedBlobFileMetaData` object goes away, which, in turn, happens when the
last `Version` that contains the blob file is destroyed. No longer needed blob
files are added to the obsolete list in `VersionSet` using a custom deleter to
avoid unnecessary coupling between `SharedBlobFileMetaData` and `VersionSet`.
Obsolete blob files are returned by `VersionSet::GetObsoleteFiles` and stored
in `JobContext`.

Test Plan:
`make check`