### PR TITLE
Basic MultiGet support for partitioned filters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,9 @@
 * Fix a bug when making options.bottommost_compression, options.compression_opts and options.bottommost_compression_opts dynamically changeable: the modified values are not written to option files or returned back to users when being queried.
 * Fix a bug where index key comparisons were unaccounted in `PerfContext::user_key_comparison_count` for lookups in files written with `format_version >= 3`.
 
+### Performance Improvements
+* Improve performance of batch MultiGet with partitioned filters, by sharing block cache lookups to applicable filter blocks.
+
 ## 6.9.0 (03/29/2020)
 ### Behavior changes
 * Since RocksDB 6.8, ttl-based FIFO compaction can drop a file whose oldest key becomes older than options.ttl while others have not. This fix reverts this and makes ttl-based FIFO compaction use the file's flush time as the criterion. This fix also requires that max_open_files = -1 and compaction_options_fifo.allow_compaction = false to function properly.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 ### Bug Fixes
 * Fix a bug when making options.bottommost_compression, options.compression_opts and options.bottommost_compression_opts dynamically changeable: the modified values are not written to option files or returned back to users when being queried.
 * Fix a bug where index key comparisons were unaccounted in `PerfContext::user_key_comparison_count` for lookups in files written with `format_version >= 3`.
+* Fix many bloom.filter statistics not being updated in batch MultiGet.
 
 ### Performance Improvements
 * Improve performance of batch MultiGet with partitioned filters, by sharing block cache lookups to applicable filter blocks.

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -24,8 +24,6 @@ using BFP = BloomFilterPolicy;
 class DBBloomFilterTest : public DBTestBase {
  public:
   DBBloomFilterTest() : DBTestBase("/db_bloom_filter_test") {}
-
-  static std::string UKey(uint32_t i) { return Key(static_cast<int>(i)); }
 };
 
 class DBBloomFilterTestWithParam : public DBTestBase,
@@ -146,172 +144,6 @@ TEST_P(DBBloomFilterTestDefFormatVersion, KeyMayExist) {
     // by plain table format.
   } while (
       ChangeOptions(kSkipPlainTable | kSkipHashIndex | kSkipFIFOCompaction));
-}
-
-TEST_F(DBBloomFilterTest, PartitionedMultiGet) {
-  for (bool use_prefix : {false, true}) {
-    Options options = CurrentOptions();
-    if (use_prefix) {
-      // Entire key from UKey()
-      options.prefix_extractor.reset(NewCappedPrefixTransform(9));
-    }
-    options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-    BlockBasedTableOptions bbto;
-    bbto.filter_policy.reset(NewBloomFilterPolicy(20));
-    bbto.partition_filters = true;
-    bbto.index_type = BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
-    bbto.whole_key_filtering = !use_prefix;
-    bbto.metadata_block_size = 128;
-    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
-    DestroyAndReopen(options);
-    ReadOptions ropts;
-
-    constexpr uint32_t N = 10000;
-    // Add N/2 evens
-    for (uint32_t i = 0; i < N; i += 2) {
-      ASSERT_OK(Put(UKey(i), UKey(i)));
-    }
-    ASSERT_OK(Flush());
-    ASSERT_EQ(TotalTableFiles(), 1);
-
-    constexpr uint32_t Q = 29;
-    // MultiGet In
-    std::array<std::string, Q> keys;
-    std::array<Slice, Q> key_slices;
-    std::array<ColumnFamilyHandle*, Q> column_families;
-    // MultiGet Out
-    std::array<Status, Q> statuses;
-    std::array<PinnableSlice, Q> values;
-
-    TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT);
-    TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
-    TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_USEFUL);
-    TestGetAndResetTickerCount(options, BLOOM_FILTER_USEFUL);
-    TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_CHECKED);
-    TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_POSITIVE);
-    TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE);
-
-    // Check that initial clump of keys only loads one partition filter from
-    // block cache.
-    // And that spread out keys load many partition filters.
-    // In both cases, mix present vs. not present keys.
-    for (uint32_t stride : {uint32_t{1}, (N / Q) | 1}) {
-      for (uint32_t i = 0; i < Q; ++i) {
-        keys[i] = UKey(i * stride);
-        key_slices[i] = Slice(keys[i]);
-        column_families[i] = db_->DefaultColumnFamily();
-        statuses[i] = Status();
-        values[i] = PinnableSlice();
-      }
-
-      db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
-                    /*timestamps=*/nullptr, &statuses[0], true);
-
-      // Confirm correct status results
-      uint32_t number_not_found = 0;
-      for (uint32_t i = 0; i < Q; ++i) {
-        if ((i * stride % 2) == 0) {
-          ASSERT_OK(statuses[i]);
-        } else {
-          ASSERT_TRUE(statuses[i].IsNotFound());
-          ++number_not_found;
-        }
-      }
-
-      // Confirm correct Bloom stats (no FPs)
-      uint64_t filter_useful = TestGetAndResetTickerCount(
-          options,
-          use_prefix ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
-      uint64_t filter_checked =
-          TestGetAndResetTickerCount(options,
-                                     use_prefix ? BLOOM_FILTER_PREFIX_CHECKED
-                                                : BLOOM_FILTER_FULL_POSITIVE) +
-          (use_prefix ? 0 : filter_useful);
-      EXPECT_EQ(filter_useful, number_not_found);
-      EXPECT_EQ(filter_checked, Q);
-      if (!use_prefix) {
-        EXPECT_EQ(TestGetAndResetTickerCount(options,
-                                             BLOOM_FILTER_FULL_TRUE_POSITIVE),
-                  Q - number_not_found);
-      }
-
-      // Confirm no duplicate loading same filter partition
-      uint64_t filter_accesses =
-          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
-          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
-      if (stride == 1) {
-        EXPECT_EQ(filter_accesses, 1);
-      } else {
-        // for large stride
-        EXPECT_GE(filter_accesses, Q / 2 + 1);
-      }
-    }
-
-    // Check that a clump of keys (present and not) works when spanning
-    // two partitions
-    int found_spanning = 0;
-    for (uint32_t start = 0; start < N / 2;) {
-      for (uint32_t i = 0; i < Q; ++i) {
-        keys[i] = UKey(start + i);
-        key_slices[i] = Slice(keys[i]);
-        column_families[i] = db_->DefaultColumnFamily();
-        statuses[i] = Status();
-        values[i] = PinnableSlice();
-      }
-
-      db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
-                    /*timestamps=*/nullptr, &statuses[0], true);
-
-      // Confirm correct status results
-      uint32_t number_not_found = 0;
-      for (uint32_t i = 0; i < Q; ++i) {
-        if (((start + i) % 2) == 0) {
-          ASSERT_OK(statuses[i]);
-        } else {
-          ASSERT_TRUE(statuses[i].IsNotFound());
-          ++number_not_found;
-        }
-      }
-
-      // Confirm correct Bloom stats (might see some FPs)
-      uint64_t filter_useful = TestGetAndResetTickerCount(
-          options,
-          use_prefix ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
-      uint64_t filter_checked =
-          TestGetAndResetTickerCount(options,
-                                     use_prefix ? BLOOM_FILTER_PREFIX_CHECKED
-                                                : BLOOM_FILTER_FULL_POSITIVE) +
-          (use_prefix ? 0 : filter_useful);
-      EXPECT_GE(filter_useful, number_not_found - 2);  // possible FP
-      EXPECT_EQ(filter_checked, Q);
-      if (!use_prefix) {
-        EXPECT_EQ(TestGetAndResetTickerCount(options,
-                                             BLOOM_FILTER_FULL_TRUE_POSITIVE),
-                  Q - number_not_found);
-      }
-
-      // Confirm no duplicate loading of same filter partition
-      uint64_t filter_accesses =
-          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
-          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
-      if (filter_accesses == 2) {
-        // Spanned across partitions.
-        ++found_spanning;
-        if (found_spanning >= 2) {
-          break;
-        } else {
-          // Ensure that at least once we have at least one present and
-          // one non-present key on both sides of partition boundary.
-          start += 2;
-        }
-      } else {
-        EXPECT_EQ(filter_accesses, 1);
-        // See explanation at "start += 2"
-        start += Q - 4;
-      }
-    }
-    EXPECT_TRUE(found_spanning >= 2);
-  }
 }
 
 TEST_F(DBBloomFilterTest, GetFilterByPrefixBloomCustomPrefixExtractor) {
@@ -1197,6 +1029,204 @@ TEST_F(DBBloomFilterTest, MemtablePrefixBloomOutOfDomain) {
   ASSERT_TRUE(iter->Valid());
   ASSERT_EQ(kKey, iter->key());
 }
+
+class DBBloomFilterTestVaryPrefixAndFormatVer
+    : public DBTestBase,
+      public testing::WithParamInterface<std::tuple<bool, uint32_t>> {
+ protected:
+  bool use_prefix_;
+  uint32_t format_version_;
+
+ public:
+  DBBloomFilterTestVaryPrefixAndFormatVer()
+      : DBTestBase("/db_bloom_filter_tests") {}
+
+  ~DBBloomFilterTestVaryPrefixAndFormatVer() override {}
+
+  void SetUp() override {
+    use_prefix_ = std::get<0>(GetParam());
+    format_version_ = std::get<1>(GetParam());
+  }
+
+  static std::string UKey(uint32_t i) { return Key(static_cast<int>(i)); }
+};
+
+TEST_P(DBBloomFilterTestVaryPrefixAndFormatVer, PartitionedMultiGet) {
+  Options options = CurrentOptions();
+  if (use_prefix_) {
+    // Entire key from UKey()
+    options.prefix_extractor.reset(NewCappedPrefixTransform(9));
+  }
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  BlockBasedTableOptions bbto;
+  bbto.filter_policy.reset(NewBloomFilterPolicy(20));
+  bbto.partition_filters = true;
+  bbto.index_type = BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+  bbto.whole_key_filtering = !use_prefix_;
+  bbto.metadata_block_size = 128;
+  options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+  DestroyAndReopen(options);
+  ReadOptions ropts;
+
+  constexpr uint32_t N = 10000;
+  // Add N/2 evens
+  for (uint32_t i = 0; i < N; i += 2) {
+    ASSERT_OK(Put(UKey(i), UKey(i)));
+  }
+  ASSERT_OK(Flush());
+  ASSERT_EQ(TotalTableFiles(), 1);
+
+  constexpr uint32_t Q = 29;
+  // MultiGet In
+  std::array<std::string, Q> keys;
+  std::array<Slice, Q> key_slices;
+  std::array<ColumnFamilyHandle*, Q> column_families;
+  // MultiGet Out
+  std::array<Status, Q> statuses;
+  std::array<PinnableSlice, Q> values;
+
+  TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT);
+  TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+  TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_USEFUL);
+  TestGetAndResetTickerCount(options, BLOOM_FILTER_USEFUL);
+  TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_CHECKED);
+  TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_POSITIVE);
+  TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE);
+
+  // Check that initial clump of keys only loads one partition filter from
+  // block cache.
+  // And that spread out keys load many partition filters.
+  // In both cases, mix present vs. not present keys.
+  for (uint32_t stride : {uint32_t{1}, (N / Q) | 1}) {
+    for (uint32_t i = 0; i < Q; ++i) {
+      keys[i] = UKey(i * stride);
+      key_slices[i] = Slice(keys[i]);
+      column_families[i] = db_->DefaultColumnFamily();
+      statuses[i] = Status();
+      values[i] = PinnableSlice();
+    }
+
+    db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
+                  /*timestamps=*/nullptr, &statuses[0], true);
+
+    // Confirm correct status results
+    uint32_t number_not_found = 0;
+    for (uint32_t i = 0; i < Q; ++i) {
+      if ((i * stride % 2) == 0) {
+        ASSERT_OK(statuses[i]);
+      } else {
+        ASSERT_TRUE(statuses[i].IsNotFound());
+        ++number_not_found;
+      }
+    }
+
+    // Confirm correct Bloom stats (no FPs)
+    uint64_t filter_useful = TestGetAndResetTickerCount(
+        options,
+        use_prefix_ ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
+    uint64_t filter_checked =
+        TestGetAndResetTickerCount(options, use_prefix_
+                                                ? BLOOM_FILTER_PREFIX_CHECKED
+                                                : BLOOM_FILTER_FULL_POSITIVE) +
+        (use_prefix_ ? 0 : filter_useful);
+    EXPECT_EQ(filter_useful, number_not_found);
+    EXPECT_EQ(filter_checked, Q);
+    if (!use_prefix_) {
+      EXPECT_EQ(
+          TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE),
+          Q - number_not_found);
+    }
+
+    // Confirm no duplicate loading same filter partition
+    uint64_t filter_accesses =
+        TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
+        TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+    if (stride == 1) {
+      EXPECT_EQ(filter_accesses, 1);
+    } else {
+      // for large stride
+      EXPECT_GE(filter_accesses, Q / 2 + 1);
+    }
+  }
+
+  // Check that a clump of keys (present and not) works when spanning
+  // two partitions
+  int found_spanning = 0;
+  for (uint32_t start = 0; start < N / 2;) {
+    for (uint32_t i = 0; i < Q; ++i) {
+      keys[i] = UKey(start + i);
+      key_slices[i] = Slice(keys[i]);
+      column_families[i] = db_->DefaultColumnFamily();
+      statuses[i] = Status();
+      values[i] = PinnableSlice();
+    }
+
+    db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
+                  /*timestamps=*/nullptr, &statuses[0], true);
+
+    // Confirm correct status results
+    uint32_t number_not_found = 0;
+    for (uint32_t i = 0; i < Q; ++i) {
+      if (((start + i) % 2) == 0) {
+        ASSERT_OK(statuses[i]);
+      } else {
+        ASSERT_TRUE(statuses[i].IsNotFound());
+        ++number_not_found;
+      }
+    }
+
+    // Confirm correct Bloom stats (might see some FPs)
+    uint64_t filter_useful = TestGetAndResetTickerCount(
+        options,
+        use_prefix_ ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
+    uint64_t filter_checked =
+        TestGetAndResetTickerCount(options, use_prefix_
+                                                ? BLOOM_FILTER_PREFIX_CHECKED
+                                                : BLOOM_FILTER_FULL_POSITIVE) +
+        (use_prefix_ ? 0 : filter_useful);
+    EXPECT_GE(filter_useful, number_not_found - 2);  // possible FP
+    EXPECT_EQ(filter_checked, Q);
+    if (!use_prefix_) {
+      EXPECT_EQ(
+          TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE),
+          Q - number_not_found);
+    }
+
+    // Confirm no duplicate loading of same filter partition
+    uint64_t filter_accesses =
+        TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
+        TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+    if (filter_accesses == 2) {
+      // Spanned across partitions.
+      ++found_spanning;
+      if (found_spanning >= 2) {
+        break;
+      } else {
+        // Ensure that at least once we have at least one present and
+        // one non-present key on both sides of partition boundary.
+        start += 2;
+      }
+    } else {
+      EXPECT_EQ(filter_accesses, 1);
+      // See explanation at "start += 2"
+      start += Q - 4;
+    }
+  }
+  EXPECT_TRUE(found_spanning >= 2);
+}
+
+INSTANTIATE_TEST_CASE_P(DBBloomFilterTestVaryPrefixAndFormatVer,
+                        DBBloomFilterTestVaryPrefixAndFormatVer,
+                        ::testing::Values(
+                            // (use_prefix, format_version)
+                            std::make_tuple(false, 2),
+                            std::make_tuple(false, 3),
+                            std::make_tuple(false, 4),
+                            std::make_tuple(false, 5),
+                            std::make_tuple(true, 2),
+                            std::make_tuple(true, 3),
+                            std::make_tuple(true, 4),
+                            std::make_tuple(true, 5)));
 
 #ifndef ROCKSDB_LITE
 namespace {

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -25,9 +25,7 @@ class DBBloomFilterTest : public DBTestBase {
  public:
   DBBloomFilterTest() : DBTestBase("/db_bloom_filter_test") {}
 
-  static std::string UKey(uint32_t i) {
-    return Key(static_cast<int>(i));
-  }
+  static std::string UKey(uint32_t i) { return Key(static_cast<int>(i)); }
 };
 
 class DBBloomFilterTestWithParam : public DBTestBase,

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -153,7 +153,6 @@ TEST_F(DBBloomFilterTest, PartitionedMultiGet) {
       options.prefix_extractor.reset(NewCappedPrefixTransform(9));
     }
     options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-    get_perf_context()->EnablePerLevelPerfContext();
     BlockBasedTableOptions bbto;
     bbto.filter_policy.reset(NewBloomFilterPolicy(20));
     bbto.partition_filters = true;

--- a/db/db_bloom_filter_test.cc
+++ b/db/db_bloom_filter_test.cc
@@ -145,6 +145,173 @@ TEST_P(DBBloomFilterTestDefFormatVersion, KeyMayExist) {
       ChangeOptions(kSkipPlainTable | kSkipHashIndex | kSkipFIFOCompaction));
 }
 
+TEST_F(DBBloomFilterTest, PartitionedMultiGet) {
+  for (bool use_prefix : {false, true}) {
+    Options options = CurrentOptions();
+    if (use_prefix) {
+      // Entire key from Key()
+      options.prefix_extractor.reset(NewCappedPrefixTransform(9));
+    }
+    options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+    get_perf_context()->EnablePerLevelPerfContext();
+    BlockBasedTableOptions bbto;
+    bbto.filter_policy.reset(NewBloomFilterPolicy(20));
+    bbto.partition_filters = true;
+    bbto.index_type = BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+    bbto.whole_key_filtering = !use_prefix;
+    bbto.metadata_block_size = 128;
+    options.table_factory.reset(NewBlockBasedTableFactory(bbto));
+    DestroyAndReopen(options);
+    ReadOptions ropts;
+
+    constexpr size_t N = 10000;
+    // Add N/2 evens
+    for (size_t i = 0; i < N; i += 2) {
+      ASSERT_OK(Put(Key(i), Key(i)));
+    }
+    ASSERT_OK(Flush());
+    ASSERT_EQ(TotalTableFiles(), 1);
+
+    constexpr size_t Q = 29;
+    // MultiGet In
+    std::array<std::string, Q> keys;
+    std::array<Slice, Q> key_slices;
+    std::array<ColumnFamilyHandle*, Q> column_families;
+    // MultiGet Out
+    std::array<Status, Q> statuses;
+    std::array<PinnableSlice, Q> values;
+
+    TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT);
+    TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+    TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_USEFUL);
+    TestGetAndResetTickerCount(options, BLOOM_FILTER_USEFUL);
+    TestGetAndResetTickerCount(options, BLOOM_FILTER_PREFIX_CHECKED);
+    TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_POSITIVE);
+    TestGetAndResetTickerCount(options, BLOOM_FILTER_FULL_TRUE_POSITIVE);
+
+    // Check that initial clump of keys only loads one partition filter from
+    // block cache.
+    // And that spread out keys load many partition filters.
+    // In both cases, mix present vs. not present keys.
+    for (size_t stride : {size_t{1}, (N / Q) | 1}) {
+      for (size_t i = 0; i < Q; ++i) {
+        keys[i] = Key(i * stride);
+        key_slices[i] = Slice(keys[i]);
+        column_families[i] = db_->DefaultColumnFamily();
+        statuses[i] = Status();
+        values[i] = PinnableSlice();
+      }
+
+      db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
+                    /*timestamps=*/nullptr, &statuses[0], true);
+
+      // Confirm correct status results
+      size_t number_not_found = 0;
+      for (size_t i = 0; i < Q; ++i) {
+        if ((i * stride % 2) == 0) {
+          ASSERT_OK(statuses[i]);
+        } else {
+          ASSERT_TRUE(statuses[i].IsNotFound());
+          ++number_not_found;
+        }
+      }
+
+      // Confirm correct Bloom stats (no FPs)
+      uint64_t filter_useful = TestGetAndResetTickerCount(
+          options,
+          use_prefix ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
+      uint64_t filter_checked =
+          TestGetAndResetTickerCount(options,
+                                     use_prefix ? BLOOM_FILTER_PREFIX_CHECKED
+                                                : BLOOM_FILTER_FULL_POSITIVE) +
+          (use_prefix ? 0 : filter_useful);
+      EXPECT_EQ(filter_useful, number_not_found);
+      EXPECT_EQ(filter_checked, Q);
+      if (!use_prefix) {
+        EXPECT_EQ(TestGetAndResetTickerCount(options,
+                                             BLOOM_FILTER_FULL_TRUE_POSITIVE),
+                  Q - number_not_found);
+      }
+
+      // Confirm no duplicate loading same filter partition
+      uint64_t filter_accesses =
+          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
+          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+      if (stride == 1) {
+        EXPECT_EQ(filter_accesses, 1);
+      } else {
+        // for large stride
+        EXPECT_GE(filter_accesses, Q / 2 + 1);
+      }
+    }
+
+    // Check that a clump of keys (present and not) works when spanning
+    // two partitions
+    int found_spanning = 0;
+    for (size_t start = 0; start < N / 2;) {
+      for (size_t i = 0; i < Q; ++i) {
+        keys[i] = Key(start + i);
+        key_slices[i] = Slice(keys[i]);
+        column_families[i] = db_->DefaultColumnFamily();
+        statuses[i] = Status();
+        values[i] = PinnableSlice();
+      }
+
+      db_->MultiGet(ropts, Q, &column_families[0], &key_slices[0], &values[0],
+                    /*timestamps=*/nullptr, &statuses[0], true);
+
+      // Confirm correct status results
+      size_t number_not_found = 0;
+      for (size_t i = 0; i < Q; ++i) {
+        if (((start + i) % 2) == 0) {
+          ASSERT_OK(statuses[i]);
+        } else {
+          ASSERT_TRUE(statuses[i].IsNotFound());
+          ++number_not_found;
+        }
+      }
+
+      // Confirm correct Bloom stats (might see some FPs)
+      uint64_t filter_useful = TestGetAndResetTickerCount(
+          options,
+          use_prefix ? BLOOM_FILTER_PREFIX_USEFUL : BLOOM_FILTER_USEFUL);
+      uint64_t filter_checked =
+          TestGetAndResetTickerCount(options,
+                                     use_prefix ? BLOOM_FILTER_PREFIX_CHECKED
+                                                : BLOOM_FILTER_FULL_POSITIVE) +
+          (use_prefix ? 0 : filter_useful);
+      EXPECT_GE(filter_useful, number_not_found - 2);  // possible FP
+      EXPECT_EQ(filter_checked, Q);
+      if (!use_prefix) {
+        EXPECT_EQ(TestGetAndResetTickerCount(options,
+                                             BLOOM_FILTER_FULL_TRUE_POSITIVE),
+                  Q - number_not_found);
+      }
+
+      // Confirm no duplicate loading of same filter partition
+      uint64_t filter_accesses =
+          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_HIT) +
+          TestGetAndResetTickerCount(options, BLOCK_CACHE_FILTER_MISS);
+      if (filter_accesses == 2) {
+        // Spanned across partitions.
+        ++found_spanning;
+        if (found_spanning >= 2) {
+          break;
+        } else {
+          // Ensure that at least once we have at least one present and
+          // one non-present key on both sides of partition boundary.
+          start += 2;
+        }
+      } else {
+        EXPECT_EQ(filter_accesses, 1);
+        // See explanation at "start += 2"
+        start += Q - 4;
+      }
+    }
+    EXPECT_TRUE(found_spanning >= 2);
+  }
+}
+
 TEST_F(DBBloomFilterTest, GetFilterByPrefixBloomCustomPrefixExtractor) {
   for (bool partition_filters : {true, false}) {
     Options options = last_options_;

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -190,7 +190,6 @@ void FullFilterBlockReader::KeysMayMatch(
     uint64_t block_offset, const bool no_io,
     BlockCacheLookupContext* lookup_context) {
 #ifdef NDEBUG
-  (void)range;
   (void)block_offset;
 #endif
   assert(block_offset == kNotValid);
@@ -207,7 +206,6 @@ void FullFilterBlockReader::PrefixesMayMatch(
     uint64_t block_offset, const bool no_io,
     BlockCacheLookupContext* lookup_context) {
 #ifdef NDEBUG
-  (void)range;
   (void)block_offset;
 #endif
   assert(block_offset == kNotValid);

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -170,13 +170,25 @@ bool PartitionedFilterBlockReader::KeyMayMatch(
                   &FullFilterBlockReader::KeyMayMatch);
 }
 
+void PartitionedFilterBlockReader::KeysMayMatch(
+    MultiGetRange* range, const SliceTransform* prefix_extractor,
+    uint64_t block_offset, const bool no_io,
+    BlockCacheLookupContext* lookup_context) {
+  assert(block_offset == kNotValid);
+  if (!whole_key_filtering()) {
+    return;  // Any/all may match
+  }
+
+  MayMatch(
+      range, prefix_extractor, block_offset, no_io,
+      lookup_context,
+      &FullFilterBlockReader::KeysMayMatch);
+}
+
 bool PartitionedFilterBlockReader::PrefixMayMatch(
     const Slice& prefix, const SliceTransform* prefix_extractor,
     uint64_t block_offset, const bool no_io, const Slice* const const_ikey_ptr,
     GetContext* get_context, BlockCacheLookupContext* lookup_context) {
-#ifdef NDEBUG
-  (void)block_offset;
-#endif
   assert(const_ikey_ptr != nullptr);
   assert(block_offset == kNotValid);
   if (!table_prefix_extractor() && !prefix_extractor) {
@@ -186,6 +198,19 @@ bool PartitionedFilterBlockReader::PrefixMayMatch(
   return MayMatch(prefix, prefix_extractor, block_offset, no_io, const_ikey_ptr,
                   get_context, lookup_context,
                   &FullFilterBlockReader::PrefixMayMatch);
+}
+
+void PartitionedFilterBlockReader::PrefixesMayMatch(
+    MultiGetRange* range, const SliceTransform* prefix_extractor,
+    uint64_t block_offset, const bool no_io,
+    BlockCacheLookupContext* lookup_context) {
+  assert(block_offset == kNotValid);
+  if (!table_prefix_extractor() && !prefix_extractor) {
+    return;  // Any/all may match
+  }
+
+  MayMatch(range, prefix_extractor, block_offset, no_io, lookup_context,
+           &FullFilterBlockReader::PrefixesMayMatch);
 }
 
 BlockHandle PartitionedFilterBlockReader::GetFilterPartitionHandle(
@@ -281,6 +306,73 @@ bool PartitionedFilterBlockReader::MayMatch(
   return (filter_partition.*filter_function)(
       slice, prefix_extractor, block_offset, no_io, const_ikey_ptr, get_context,
       lookup_context);
+}
+
+void PartitionedFilterBlockReader::MayMatch(
+    MultiGetRange* range, const SliceTransform* prefix_extractor,
+    uint64_t block_offset, bool no_io, BlockCacheLookupContext* lookup_context,
+    FilterManyFunction filter_function) const {
+  CachableEntry<Block> filter_block;
+  Status s = GetOrReadFilterBlock(no_io, range->begin()->get_context,
+                                  lookup_context, &filter_block);
+  if (UNLIKELY(!s.ok())) {
+    TEST_SYNC_POINT("FilterReadError");
+    return;  // Any/all may match
+  }
+
+  if (UNLIKELY(filter_block.GetValue()->size() == 0)) {
+    return;  // Any/all may match
+  }
+
+  auto start_iter_same_handle = range->begin();
+  BlockHandle prev_filter_handle = BlockHandle::NullBlockHandle();
+
+  for (auto iter = start_iter_same_handle; iter != range->end(); ++iter) {
+    BlockHandle this_filter_handle =
+        GetFilterPartitionHandle(filter_block, iter->ikey);
+    if (!prev_filter_handle.IsNull() &&
+        this_filter_handle != prev_filter_handle) {
+      MultiGetRange subrange(*range, start_iter_same_handle, iter);
+      MayMatchPartition(&subrange, prefix_extractor, block_offset,
+                        prev_filter_handle, no_io, lookup_context,
+                        filter_function);
+      range->AddSkipsFrom(subrange);
+      start_iter_same_handle = iter;
+    }
+    if (UNLIKELY(this_filter_handle.size() == 0)) {  // key is out of range
+      range->SkipKey(iter);
+      prev_filter_handle = BlockHandle();
+    } else {
+      prev_filter_handle = this_filter_handle;
+    }
+  }
+  if (!prev_filter_handle.IsNull()) {
+    MultiGetRange subrange(*range, start_iter_same_handle, range->end());
+    MayMatchPartition(&subrange, prefix_extractor, block_offset,
+                      prev_filter_handle, no_io, lookup_context,
+                      filter_function);
+    range->AddSkipsFrom(subrange);
+  }
+}
+
+void PartitionedFilterBlockReader::MayMatchPartition(
+    MultiGetRange* range, const SliceTransform* prefix_extractor,
+    uint64_t block_offset, BlockHandle filter_handle, bool no_io,
+    BlockCacheLookupContext* lookup_context,
+    FilterManyFunction filter_function) const {
+  CachableEntry<ParsedFullFilterBlock> filter_partition_block;
+  Status s = GetFilterPartitionBlock(
+      nullptr /* prefetch_buffer */, filter_handle, no_io,
+      range->begin()->get_context, lookup_context, &filter_partition_block);
+  if (UNLIKELY(!s.ok())) {
+    TEST_SYNC_POINT("FilterReadError");
+    return;  // Any/all may match
+  }
+
+  FullFilterBlockReader filter_partition(table(),
+                                         std::move(filter_partition_block));
+  (filter_partition.*filter_function)(range, prefix_extractor, block_offset,
+                                      no_io, lookup_context);
 }
 
 size_t PartitionedFilterBlockReader::ApproximateMemoryUsage() const {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -181,10 +181,8 @@ void PartitionedFilterBlockReader::KeysMayMatch(
     return;  // Any/all may match
   }
 
-  MayMatch(
-      range, prefix_extractor, block_offset, no_io,
-      lookup_context,
-      &FullFilterBlockReader::KeysMayMatch);
+  MayMatch(range, prefix_extractor, block_offset, no_io, lookup_context,
+           &FullFilterBlockReader::KeysMayMatch);
 }
 
 bool PartitionedFilterBlockReader::PrefixMayMatch(

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -316,7 +316,7 @@ void PartitionedFilterBlockReader::MayMatch(
   Status s = GetOrReadFilterBlock(no_io, range->begin()->get_context,
                                   lookup_context, &filter_block);
   if (UNLIKELY(!s.ok())) {
-    TEST_SYNC_POINT("FilterReadError");
+    IGNORE_STATUS_IF_ERROR(s);
     return;  // Any/all may match
   }
 
@@ -371,7 +371,7 @@ void PartitionedFilterBlockReader::MayMatchPartition(
       nullptr /* prefetch_buffer */, filter_handle, no_io,
       range->begin()->get_context, lookup_context, &filter_partition_block);
   if (UNLIKELY(!s.ok())) {
-    TEST_SYNC_POINT("FilterReadError");
+    IGNORE_STATUS_IF_ERROR(s);
     return;  // Any/all may match
   }
 

--- a/table/block_based/partitioned_filter_block.h
+++ b/table/block_based/partitioned_filter_block.h
@@ -80,12 +80,21 @@ class PartitionedFilterBlockReader : public FilterBlockReaderCommon<Block> {
                    uint64_t block_offset, const bool no_io,
                    const Slice* const const_ikey_ptr, GetContext* get_context,
                    BlockCacheLookupContext* lookup_context) override;
+  void KeysMayMatch(MultiGetRange* range,
+                    const SliceTransform* prefix_extractor,
+                    uint64_t block_offset, const bool no_io,
+                    BlockCacheLookupContext* lookup_context) override;
+
   bool PrefixMayMatch(const Slice& prefix,
                       const SliceTransform* prefix_extractor,
                       uint64_t block_offset, const bool no_io,
                       const Slice* const const_ikey_ptr,
                       GetContext* get_context,
                       BlockCacheLookupContext* lookup_context) override;
+  void PrefixesMayMatch(MultiGetRange* range,
+                        const SliceTransform* prefix_extractor,
+                        uint64_t block_offset, const bool no_io,
+                        BlockCacheLookupContext* lookup_context) override;
 
   size_t ApproximateMemoryUsage() const override;
 
@@ -108,6 +117,19 @@ class PartitionedFilterBlockReader : public FilterBlockReaderCommon<Block> {
                 GetContext* get_context,
                 BlockCacheLookupContext* lookup_context,
                 FilterFunction filter_function) const;
+  using FilterManyFunction = void (FullFilterBlockReader::*)(
+      MultiGetRange* range, const SliceTransform* prefix_extractor,
+      uint64_t block_offset, const bool no_io,
+      BlockCacheLookupContext* lookup_context);
+  void MayMatch(MultiGetRange* range, const SliceTransform* prefix_extractor,
+                uint64_t block_offset, bool no_io,
+                BlockCacheLookupContext* lookup_context,
+                FilterManyFunction filter_function) const;
+  void MayMatchPartition(MultiGetRange* range,
+                         const SliceTransform* prefix_extractor,
+                         uint64_t block_offset, BlockHandle filter_handle,
+                         bool no_io, BlockCacheLookupContext* lookup_context,
+                         FilterManyFunction filter_function) const;
   void CacheDependencies(bool pin) override;
 
   const InternalKeyComparator* internal_comparator() const;

--- a/table/format.h
+++ b/table/format.h
@@ -38,6 +38,8 @@ const int kMagicNumberLengthByte = 8;
 // block or a meta block.
 class BlockHandle {
  public:
+  // Creates a block handle with special values indicating "uninitialized,"
+  // distinct from the "null" block handle.
   BlockHandle();
   BlockHandle(uint64_t offset, uint64_t size);
 
@@ -64,6 +66,13 @@ class BlockHandle {
 
   // Maximum encoding length of a BlockHandle
   enum { kMaxEncodedLength = 10 + 10 };
+
+  inline bool operator==(const BlockHandle& rhs) const {
+    return offset_ == rhs.offset_ && size_ == rhs.size_;
+  }
+  inline bool operator!=(const BlockHandle& rhs) const {
+    return !(*this == rhs);
+  }
 
  private:
   uint64_t offset_;

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -13,6 +13,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/types.h"
 #include "util/autovector.h"
+#include "util/math.h"
 
 namespace ROCKSDB_NAMESPACE {
 class GetContext;
@@ -156,7 +157,7 @@ class MultiGetContext {
       Iterator(const Range* range, size_t idx)
           : range_(range), ctx_(range->ctx_), index_(idx) {
         while (index_ < range_->end_ &&
-               (1ull << index_) &
+               (uint64_t{1} << index_) &
                    (range_->ctx_->value_mask_ | range_->skip_mask_))
           index_++;
       }
@@ -166,7 +167,7 @@ class MultiGetContext {
 
       Iterator& operator++() {
         while (++index_ < range_->end_ &&
-               (1ull << index_) &
+               (uint64_t{1} << index_) &
                    (range_->ctx_->value_mask_ | range_->skip_mask_))
           ;
         return *this;
@@ -208,6 +209,8 @@ class MultiGetContext {
       start_ = first.index_;
       end_ = last.index_;
       skip_mask_ = mget_range.skip_mask_;
+      assert(start_ < 64);
+      assert(end_ < 64);
     }
 
     Range() = default;
@@ -216,31 +219,27 @@ class MultiGetContext {
 
     Iterator end() const { return Iterator(this, end_); }
 
-    bool empty() {
-      return (((1ull << end_) - 1) & ~((1ull << start_) - 1) &
-              ~(ctx_->value_mask_ | skip_mask_)) == 0;
-    }
+    bool empty() { return RemainingMask() == 0; }
 
-    void SkipKey(const Iterator& iter) { skip_mask_ |= 1ull << iter.index_; }
+    void SkipKey(const Iterator& iter) {
+      skip_mask_ |= uint64_t{1} << iter.index_;
+    }
 
     // Update the value_mask_ in MultiGetContext so its
     // immediately reflected in all the Range Iterators
     void MarkKeyDone(Iterator& iter) {
-      ctx_->value_mask_ |= (1ull << iter.index_);
+      ctx_->value_mask_ |= (uint64_t{1} << iter.index_);
     }
 
     bool CheckKeyDone(Iterator& iter) {
-      return ctx_->value_mask_ & (1ull << iter.index_);
+      return ctx_->value_mask_ & (uint64_t{1} << iter.index_);
     }
 
-    uint64_t KeysLeft() {
-      uint64_t new_val = skip_mask_ | ctx_->value_mask_;
-      uint64_t count = 0;
-      while (new_val) {
-        new_val = new_val & (new_val - 1);
-        count++;
-      }
-      return end_ - count;
+    uint64_t KeysLeft() { return BitsSetToOne(RemainingMask()); }
+
+    void AddSkipsFrom(const Range& other) {
+      assert(ctx_ == other.ctx_);
+      skip_mask_ |= other.skip_mask_;
     }
 
    private:
@@ -251,7 +250,14 @@ class MultiGetContext {
     uint64_t skip_mask_;
 
     Range(MultiGetContext* ctx, size_t num_keys)
-        : ctx_(ctx), start_(0), end_(num_keys), skip_mask_(0) {}
+        : ctx_(ctx), start_(0), end_(num_keys), skip_mask_(0) {
+      assert(num_keys < 64);
+    }
+
+    uint64_t RemainingMask() {
+      return (((uint64_t{1} << end_) - 1) & ~((uint64_t{1} << start_) - 1) &
+              ~(ctx_->value_mask_ | skip_mask_));
+    }
   };
 
   // Return the initial range that encompasses all the keys in the batch

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -219,7 +219,7 @@ class MultiGetContext {
 
     Iterator end() const { return Iterator(this, end_); }
 
-    bool empty() { return RemainingMask() == 0; }
+    bool empty() const { return RemainingMask() == 0; }
 
     void SkipKey(const Iterator& iter) {
       skip_mask_ |= uint64_t{1} << iter.index_;
@@ -231,11 +231,11 @@ class MultiGetContext {
       ctx_->value_mask_ |= (uint64_t{1} << iter.index_);
     }
 
-    bool CheckKeyDone(Iterator& iter) {
+    bool CheckKeyDone(Iterator& iter) const {
       return ctx_->value_mask_ & (uint64_t{1} << iter.index_);
     }
 
-    uint64_t KeysLeft() { return BitsSetToOne(RemainingMask()); }
+    uint64_t KeysLeft() const { return BitsSetToOne(RemainingMask()); }
 
     void AddSkipsFrom(const Range& other) {
       assert(ctx_ == other.ctx_);
@@ -254,7 +254,7 @@ class MultiGetContext {
       assert(num_keys < 64);
     }
 
-    uint64_t RemainingMask() {
+    uint64_t RemainingMask() const {
       return (((uint64_t{1} << end_) - 1) & ~((uint64_t{1} << start_) - 1) &
               ~(ctx_->value_mask_ | skip_mask_));
     }

--- a/util/math.h
+++ b/util/math.h
@@ -19,9 +19,9 @@ inline int BitsSetToOne(T v) {
 #ifdef _MSC_VER
   static_assert(sizeof(T) <= sizeof(uint64_t), "type too big");
   if (sizeof(T) > sizeof(uint32_t)) {
-    return static_cast<int>(__popcnt64(static_cast<uint64_t>(v)) );
+    return static_cast<int>(__popcnt64(static_cast<uint64_t>(v)));
   } else {
-    return static_cast<int>(__popcnt(static_cast<uint32_t>(v)) );
+    return static_cast<int>(__popcnt(static_cast<uint32_t>(v)));
   }
 #else
   static_assert(sizeof(T) <= sizeof(unsigned long long), "type too big");

--- a/util/math.h
+++ b/util/math.h
@@ -1,0 +1,38 @@
+//  Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+namespace ROCKSDB_NAMESPACE {
+
+template <typename T>
+inline int BitsSetToOne(T v) {
+  static_assert(std::is_integral<T>::value, "non-integral type");
+#ifdef _MSC_VER
+  static_assert(sizeof(T) <= sizeof(uint64_t), "type too big");
+  if (sizeof(T) > sizeof(uint32_t)) {
+    return static_cast<int>(__popcnt64(static_cast<uint64_t>(v)) );
+  } else {
+    return static_cast<int>(__popcnt(static_cast<uint32_t>(v)) );
+  }
+#else
+  static_assert(sizeof(T) <= sizeof(unsigned long long), "type too big");
+  if (sizeof(T) > sizeof(unsigned long)) {
+    return __builtin_popcountll(static_cast<unsigned long long>(v));
+  } else if (sizeof(T) > sizeof(unsigned int)) {
+    return __builtin_popcountl(static_cast<unsigned long>(v));
+  } else {
+    return __builtin_popcount(static_cast<unsigned int>(v));
+  }
+#endif
+}
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: In MultiGet, access each applicable filter partition only once
per batch, rather than for each applicable key. Also,

* Fix Bloom stats for MultiGet
* Fix/refactor MultiGetContext::Range::KeysLeft, including
* Add efficient BitsSetToOne implementation
* Assert that MultiGetContext::Range does not go beyond shift range

Performance test: Generate db:

    $ ./db_bench --benchmarks=fillrandom --num=15000000 --cache_index_and_filter_blocks -bloom_bits=10 -partition_index_and_filters=true
    ...

Before (middle performing run of three; note some missing Bloom stats):

    $ ./db_bench --use-existing-db --benchmarks=multireadrandom --num=15000000 --cache_index_and_filter_blocks --bloom_bits=10 --threads=16 --cache_size=20000000 -partition_index_and_filters -batch_size=32 -multiread_batched -statistics --duration=20 2>&1 | egrep 'micros/op|block.cache.filter.hit|bloom.filter.(full|use)|number.multiget'
    multireadrandom :      26.403 micros/op 597517 ops/sec; (548427 of 671968 found)
    rocksdb.block.cache.filter.hit COUNT : 83443275
    rocksdb.bloom.filter.useful COUNT : 0
    rocksdb.bloom.filter.full.positive COUNT : 0
    rocksdb.bloom.filter.full.true.positive COUNT : 7931450
    rocksdb.number.multiget.get COUNT : 385984
    rocksdb.number.multiget.keys.read COUNT : 12351488
    rocksdb.number.multiget.bytes.read COUNT : 793145000
    rocksdb.number.multiget.keys.found COUNT : 7931450

After (middle performing run of three):

    $ ./db_bench_new --use-existing-db --benchmarks=multireadrandom --num=15000000 --cache_index_and_filter_blocks --bloom_bits=10 --threads=16 --cache_size=20000000 -partition_index_and_filters -batch_size=32 -multiread_batched -statistics --duration=20 2>&1 | egrep 'micros/op|block.cache.filter.hit|bloom.filter.(full|use)|number.multiget'
    multireadrandom :      21.024 micros/op 752963 ops/sec; (705188 of 863968 found)
    rocksdb.block.cache.filter.hit COUNT : 49856682
    rocksdb.bloom.filter.useful COUNT : 45684579
    rocksdb.bloom.filter.full.positive COUNT : 10395458
    rocksdb.bloom.filter.full.true.positive COUNT : 9908456
    rocksdb.number.multiget.get COUNT : 481984
    rocksdb.number.multiget.keys.read COUNT : 15423488
    rocksdb.number.multiget.bytes.read COUNT : 990845600
    rocksdb.number.multiget.keys.found COUNT : 9908456

So that's about 25% higher throughput even for random keys

Test Plan: unit test included