### PR TITLE
Add Github Action for some basic sanity test of PR

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -14,9 +14,6 @@ jobs:
       run: |
         git remote add upstream https://github.com/facebook/rocksdb.git && git fetch upstream
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v2
-
     - name: Where am I
       run: |
         echo git status && git status

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -30,19 +30,8 @@ jobs:
       with:
         args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
 
-    - name: Compute merge base between PR and upstream/master
-      id: merge_base
-      run: |
-        echo "::set-output name=MERGE_BASE::$(git merge-base upstream/master HEAD)"
-
-    - name: Format diff
-      id: format_diff
-      run: |
-        echo "::set-output name=FORMAT_DIFF_OUTPUT::$(git diff -U0 ${{steps.merge_base.outputs.MERGE_BASE}} | python clang-format-diff.py -p 1 | head -n 1)"
-
     - name: Check format
-      run: |
-        if [ -z "${{steps.format_diff.outputs.FORMAT_DIFF_OUTPUT}}" ]; then exit 0; else exit 1; fi
+      run: make check-format
 
     - name: Compare buckify output
       run: make check-buck-targets

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -30,6 +30,10 @@ jobs:
       with:
         args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
 
+    - name: Check format 1
+      run: |
+        build_tools/format-diff.sh -c
+
     - name: Check format
       run: make check-format
 

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -15,6 +15,8 @@ jobs:
     - name: Where am I
       run: |
         echo git status && git status
+        echo "git remote -v" && git remote -v
+        echo git branch && git branch
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -17,6 +17,7 @@ jobs:
         echo git status && git status
         echo "git remote -v" && git remote -v
         echo git branch && git branch
+        git merge-base upstream/master HEAD
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
 
+    - name: Found merge base
+      run: git merge-base upstream/master HEAD
+
     - name: Check format 1
       run: |
         build_tools/format-diff.sh -c

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -13,6 +13,9 @@ jobs:
         git remote add upstream https://github.com/facebook/rocksdb.git && git fetch upstream
         git fetch origin
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v2
+
     - name: Where am I
       run: |
         echo git status && git status

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -13,7 +13,6 @@ jobs:
     - name: Fetch from upstream
       run: |
         git remote add upstream https://github.com/facebook/rocksdb.git && git fetch upstream
-        git fetch origin
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v2
@@ -23,7 +22,6 @@ jobs:
         echo git status && git status
         echo "git remote -v" && git remote -v
         echo git branch && git branch
-        GIT_CURL_VERBOSE=1 GIT_TRACE=1 git merge-base origin/master HEAD
 
     - name: Setup Python
       uses: actions/setup-python@v1
@@ -38,13 +36,6 @@ jobs:
       uses: wei/wget@v1
       with:
         args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
-
-    - name: Found merge base
-      run: git merge-base upstream/master HEAD
-
-    - name: Check format 1
-      run: |
-        build_tools/format-diff.sh -c
 
     - name: Check format
       run: make check-format

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -17,7 +17,7 @@ jobs:
         echo git status && git status
         echo "git remote -v" && git remote -v
         echo git branch && git branch
-        git merge-base upstream/master HEAD
+        GIT_CURL_VERBOSE=1 GIT_TRACE=1 git merge-base upstream/master HEAD
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -1,0 +1,48 @@
+name: Check buck targets and code format
+on: [push, pull_request]
+jobs:
+  check:
+    name: Check TARGETS file and code format
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout feature branch
+      uses: actions/checkout@v2
+
+    - name: Fetch from upstream
+      run: |
+        git remote add upstream https://github.com/facebook/rocksdb.git && git fetch upstream
+
+    - name: Where am I
+      run: |
+        echo git status && git status
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+
+    - name: Install Dependencies
+      run: python -m pip install --upgrade pip
+
+    - name: Install argparse
+      run: pip install argparse
+
+    - name: Download clang-format-diff.py
+      uses: wei/wget@v1
+      with:
+        args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
+
+    - name: Compute merge base between PR and upstream/master
+      id: merge_base
+      run: |
+        echo "::set-output name=MERGE_BASE::$(git merge-base upstream/master HEAD)"
+
+    - name: Format diff
+      id: format_diff
+      run: |
+        echo "::set-output name=FORMAT_DIFF_OUTPUT::$(git diff -U0 ${{steps.merge_base.outputs.MERGE_BASE}} | python clang-format-diff.py -p 1 | head -n 1)"
+
+    - name: Check format
+      run: |
+        if [ -z "${{steps.format_diff.outputs.FORMAT_DIFF_OUTPUT}}" ]; then exit 0; else exit 1; fi
+
+    - name: Compare buckify output
+      run: make check-buck-targets

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout feature branch
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Fetch from upstream
       run: |

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -17,7 +17,7 @@ jobs:
         echo git status && git status
         echo "git remote -v" && git remote -v
         echo git branch && git branch
-        GIT_CURL_VERBOSE=1 GIT_TRACE=1 git merge-base upstream/master HEAD
+        GIT_CURL_VERBOSE=1 GIT_TRACE=1 git merge-base origin/master HEAD
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -11,6 +11,7 @@ jobs:
     - name: Fetch from upstream
       run: |
         git remote add upstream https://github.com/facebook/rocksdb.git && git fetch upstream
+        git fetch origin
 
     - name: Where am I
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1202,8 +1202,6 @@ check-buck-targets: buck-targets
 	@if [ -z "$(TMP)" ]; then \
 		exit 0; \
 	else \
-		echo You need to run make buck-targets to update the TARGETS file
-		echo Do not modify TARGETS file manually.
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1187,6 +1187,19 @@ tags0:
 format:
 	build_tools/format-diff.sh
 
+buck-targets:
+	python buckifier/buckify_rocksdb.py
+
+check-buck-targets: buck-targets
+	$(eval TMP=$(shell bash -c "git diff TARGETS | head -n 1"))
+	@echo Running git diff on TARGETS, and the first line of output is...
+	@echo $(TMP)
+	@if [ -z "$(TMP)" ]; then \
+		exit 0; \
+	else \
+		exit 1; \
+	fi
+
 package:
 	bash build_tools/make_package.sh $(SHARED_MAJOR).$(SHARED_MINOR)
 

--- a/Makefile
+++ b/Makefile
@@ -1192,20 +1192,8 @@ format:
 check-format:
 	build_tools/format-diff.sh -c
 
-buck-targets:
-	python buckifier/buckify_rocksdb.py
-
-check-buck-targets: buck-targets
-	$(eval TMP=$(shell bash -c "git diff TARGETS | head -n 1"))
-	@echo Running git diff on TARGETS, and the first line of output is...
-	@echo $(TMP)
-	@if [ -z "$(TMP)" ]; then \
-		exit 0; \
-	else \
-		echo "Please run 'make buck-targets' to update TARGETS file."; \
-		echo "Do not manually update TARGETS file."; \
-		exit 1; \
-	fi
+check-buck-targets:
+	buckifier/check_buck_targets.sh
 
 package:
 	bash build_tools/make_package.sh $(SHARED_MAJOR).$(SHARED_MINOR)

--- a/Makefile
+++ b/Makefile
@@ -1202,6 +1202,8 @@ check-buck-targets: buck-targets
 	@if [ -z "$(TMP)" ]; then \
 		exit 0; \
 	else \
+		echo "Please run 'make buck-targets' to update TARGETS file."; \
+		echo "Do not manually update TARGETS file."; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -967,6 +967,8 @@ ifeq ($(filter -DROCKSDB_LITE,$(OPT)),)
 	sh tools/rocksdb_dump_test.sh
 endif
 endif
+	$(MAKE) check-format
+	$(MAKE) check-buck-targets
 
 # TODO add ldb_tests
 check_some: $(SUBSET)
@@ -1187,6 +1189,9 @@ tags0:
 format:
 	build_tools/format-diff.sh
 
+check-format:
+	build_tools/format-diff.sh -c
+
 buck-targets:
 	python buckifier/buckify_rocksdb.py
 
@@ -1197,6 +1202,8 @@ check-buck-targets: buck-targets
 	@if [ -z "$(TMP)" ]; then \
 		exit 0; \
 	else \
+		echo You need to run make buck-targets to update the TARGETS file
+		echo Do not modify TARGETS file manually.
 		exit 1; \
 	fi
 

--- a/buckifier/check_buck_targets.sh
+++ b/buckifier/check_buck_targets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+# If clang_format_diff.py command is not specfied, we assume we are able to
+# access directly without any path.
+
+TGT_DIFF=`git diff TARGETS | head -n 1`
+
+if [ ! -z "$TGT_DIFF" ]
+then
+  echo "TARGETS file has uncommitted changes. Skip this check."
+  exit 0
+fi
+
+echo Backup original TARGETS file.
+
+cp TARGETS TARGETS.bkp
+
+python buckifier/buckify_rocksdb.py
+
+TGT_DIFF=`git diff TARGETS | head -n 1`
+
+if [ -z "$TGT_DIFF" ]
+then
+  mv TARGETS.bkp TARGETS
+  exit 0
+else
+  echo "Please run 'python buckifier/buckify_rocksdb.py' to update TARGETS file."
+  echo "Do not manually update TARGETS file."
+  mv TARGETS.bkp TARGETS
+  exit 1
+fi

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -119,6 +119,7 @@ then
   # Get the common ancestor with that remote branch. Everything after that
   # common ancestor would be considered the contents of a pull request, so
   # should be relevant for formatting fixes.
+  git merge-base "$FORMAT_UPSTREAM" HEAD
   FORMAT_UPSTREAM_MERGE_BASE="$(git merge-base "$FORMAT_UPSTREAM" HEAD)"
   echo FORMAT_UPSTREAM_MERGE_BASE is $FORMAT_UPSTREAM_MERGE_BASE
   # Get the differences

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -102,26 +102,14 @@ if [ -z "$uncommitted_code" ]
 then
   # Attempt to get name of facebook/rocksdb.git remote.
   [ "$FORMAT_REMOTE" ] || FORMAT_REMOTE="$(git remote -v | grep 'facebook/rocksdb.git' | head -n 1 | cut -f 1)"
-  echo FORMAT_REMOTE is $FORMAT_REMOTE
   # Fall back on 'origin' if that fails
   [ "$FORMAT_REMOTE" ] || FORMAT_REMOTE=origin
-  echo FORMAT_REMOTE is $FORMAT_REMOTE
   # Use master branch from that remote
   [ "$FORMAT_UPSTREAM" ] || FORMAT_UPSTREAM="$FORMAT_REMOTE/master"
-  echo FORMAT_UPSTREAM is $FORMAT_UPSTREAM
-  echo CLANG_FORMAT_DIFF is $CLANG_FORMAT_DIFF
-  if [ -f ./clang-format-diff.py ]
-  then
-    echo found file
-  else
-    echo not found
-  fi
   # Get the common ancestor with that remote branch. Everything after that
   # common ancestor would be considered the contents of a pull request, so
   # should be relevant for formatting fixes.
-  git merge-base "$FORMAT_UPSTREAM" HEAD
   FORMAT_UPSTREAM_MERGE_BASE="$(git merge-base "$FORMAT_UPSTREAM" HEAD)"
-  echo FORMAT_UPSTREAM_MERGE_BASE is $FORMAT_UPSTREAM_MERGE_BASE
   # Get the differences
   diffs=$(git diff -U0 "$FORMAT_UPSTREAM_MERGE_BASE" | $CLANG_FORMAT_DIFF -p 1)
 else

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -32,7 +32,7 @@ CLANG_FORMAT_DIFF="clang-format-diff.py"
 fi
 
 # Check clang-format-diff.py
-if [ ! which $CLANG_FORMAT_DIFF &> /dev/null ]
+if ! which $CLANG_FORMAT_DIFF &> /dev/null
 then
   if [ ! -f ./clang-format-diff.py ]
   then
@@ -49,7 +49,7 @@ then
     echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
     exit 128
   else
-    if [ -x ./clang-format-diff.py]
+    if [ -x ./clang-format-diff.py ]
     then
       PATH=$PATH:.
     else

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -109,6 +109,11 @@ then
   # Use master branch from that remote
   [ "$FORMAT_UPSTREAM" ] || FORMAT_UPSTREAM="$FORMAT_REMOTE/master"
   echo FORMAT_UPSTREAM is $FORMAT_UPSTREAM
+  echo CLANG_FORMAT_DIFF is $CLANG_FORMAT_DIFF
+  if [ -f ./clang-format-diff.py]
+  then
+    echo found file
+  fi
   # Get the common ancestor with that remote branch. Everything after that
   # common ancestor would be considered the contents of a pull request, so
   # should be relevant for formatting fixes.

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -2,26 +2,60 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # If clang_format_diff.py command is not specfied, we assume we are able to
 # access directly without any path.
+
+print_usage () {
+  echo "Usage:"
+  echo "format-diff.sh [OPTIONS]"
+  echo "-c: check only."
+  echo "-h: print this message."
+}
+
+while getopts ':ch' OPTION; do
+  case "$OPTION" in
+    c)
+      CHECK_ONLY=1
+      ;;
+    h)
+      print_usage
+      exit 1
+      ;;
+    ?)
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z $CLANG_FORMAT_DIFF ]
 then
 CLANG_FORMAT_DIFF="clang-format-diff.py"
 fi
 
 # Check clang-format-diff.py
-if ! which $CLANG_FORMAT_DIFF &> /dev/null
+if [ ! which $CLANG_FORMAT_DIFF &> /dev/null ]
 then
-  echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
-  echo "You can download clang-format-diff.py by running: "
-  echo "    curl --location http://goo.gl/iUW1u2 -o ${CLANG_FORMAT_DIFF}"
-  echo "You can download clang-format by running:"
-  echo "    brew install clang-format"
-  echo "  Or"
-  echo "    apt install clang-format"
-  echo "  This might work too:"
-  echo "    yum install git-clang-format"
-  echo "Then, move both files (i.e. ${CLANG_FORMAT_DIFF} and clang-format) to some directory within PATH=${PATH}"
-  echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
-  exit 128
+  if [ ! -f ./clang-format-diff.py ]
+  then
+    echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
+    echo "You can download clang-format-diff.py by running: "
+    echo "    curl --location http://goo.gl/iUW1u2 -o ${CLANG_FORMAT_DIFF}"
+    echo "You can download clang-format by running:"
+    echo "    brew install clang-format"
+    echo "  Or"
+    echo "    apt install clang-format"
+    echo "  This might work too:"
+    echo "    yum install git-clang-format"
+    echo "Then, move both files (i.e. ${CLANG_FORMAT_DIFF} and clang-format) to some directory within PATH=${PATH}"
+    echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
+    exit 128
+  else
+    if [ -x ./clang-format-diff.py]
+    then
+      PATH=$PATH:.
+    else
+      CLANG_FORMAT_DIFF="python ./clang-format-diff.py"
+    fi
+  fi
 fi
 
 # Check argparse, a library that clang-format-diff.py requires.
@@ -87,6 +121,10 @@ if [ -z "$diffs" ]
 then
   echo "Nothing needs to be reformatted!"
   exit 0
+elif [ $CHECK_ONLY ]
+then
+  echo "Your change has unformatted code. Please run make format!"
+  exit 1
 fi
 
 # Highlight the insertion/deletion from the clang-format-diff.py's output

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -117,8 +117,6 @@ else
   diffs=$(git diff -U0 HEAD | $CLANG_FORMAT_DIFF -p 1)
 fi
 
-diffs_line_one=$($diffs | head -n 1)
-echo $diffs_line_one
 if [ -z "$diffs" ]
 then
   echo "Nothing needs to be reformatted!"

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -102,14 +102,18 @@ if [ -z "$uncommitted_code" ]
 then
   # Attempt to get name of facebook/rocksdb.git remote.
   [ "$FORMAT_REMOTE" ] || FORMAT_REMOTE="$(git remote -v | grep 'facebook/rocksdb.git' | head -n 1 | cut -f 1)"
+  echo FORMAT_REMOTE is $FORMAT_REMOTE
   # Fall back on 'origin' if that fails
   [ "$FORMAT_REMOTE" ] || FORMAT_REMOTE=origin
+  echo FORMAT_REMOTE is $FORMAT_REMOTE
   # Use master branch from that remote
   [ "$FORMAT_UPSTREAM" ] || FORMAT_UPSTREAM="$FORMAT_REMOTE/master"
+  echo FORMAT_UPSTREAM is $FORMAT_UPSTREAM
   # Get the common ancestor with that remote branch. Everything after that
   # common ancestor would be considered the contents of a pull request, so
   # should be relevant for formatting fixes.
   FORMAT_UPSTREAM_MERGE_BASE="$(git merge-base "$FORMAT_UPSTREAM" HEAD)"
+  echo FORMAT_UPSTREAM_MERGE_BASE is $FORMAT_UPSTREAM_MERGE_BASE
   # Get the differences
   diffs=$(git diff -U0 "$FORMAT_UPSTREAM_MERGE_BASE" | $CLANG_FORMAT_DIFF -p 1)
 else
@@ -117,6 +121,8 @@ else
   diffs=$(git diff -U0 HEAD | $CLANG_FORMAT_DIFF -p 1)
 fi
 
+diffs_line_one=$($diffs | head -n 1)
+echo $diffs_line_one
 if [ -z "$diffs" ]
 then
   echo "Nothing needs to be reformatted!"

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -110,9 +110,11 @@ then
   [ "$FORMAT_UPSTREAM" ] || FORMAT_UPSTREAM="$FORMAT_REMOTE/master"
   echo FORMAT_UPSTREAM is $FORMAT_UPSTREAM
   echo CLANG_FORMAT_DIFF is $CLANG_FORMAT_DIFF
-  if [ -f ./clang-format-diff.py]
+  if [ -f ./clang-format-diff.py ]
   then
     echo found file
+  else
+    echo not found
   fi
   # Get the common ancestor with that remote branch. Everything after that
   # common ancestor would be considered the contents of a pull request, so


### PR DESCRIPTION
Summary:
Add Github Action to perform some basic sanity check for PR, inclding the
following.
1) Buck TARGETS file.
On the one hand, The TARGETS file is used for internal buck, and we do not
manually update it. On the other hand, we need to run the buckifier scripts to
update TARGETS whenever new files are added, etc. With this Github Action, we
make sure that every PR does not forget this step. The GH Action uses
a Makefile target called check-buck-targets. Users can manually run `make
check-buck-targets` on local machine.

2) Code format
We use clang-format-diff.py to format our code. The GH Action in this PR makes
sure this step is not skipped. The checking script build_tools/format-diff.sh assumes that `clang-format-diff.py` is executable.
On host running GH Action, it is difficult to download `clang-format-diff.py` and make it
executable. Therefore, we modified build_tools/format-diff.sh to handle the case in which there is a non-executable clang-format-diff.py file in the top-level rocksdb repo directory.

Test Plan (Github and devserver):
Watch for Github Action result in the `Checks` tab.
On dev server
```
make check-format
make check-buck-targets
make check
```