### PR TITLE
Fix potential size_t overflow in import_column_family

### DIFF
--- a/db/import_column_family_job.cc
+++ b/db/import_column_family_job.cc
@@ -62,7 +62,7 @@ Status ImportColumnFamilyJob::Prepare(uint64_t next_file_number,
                        info2->smallest_internal_key) < 0;
           });
 
-      for (size_t i = 0; i < sorted_files.size() - 1; i++) {
+      for (size_t i = 0; i + 1 < sorted_files.size(); i++) {
         if (cfd_->internal_comparator().Compare(
                 sorted_files[i]->largest_internal_key,
                 sorted_files[i + 1]->smallest_internal_key) >= 0) {


### PR DESCRIPTION
The issue is reported in #6753 . size_t is unsigned and if sorted_file.size() is 0, the end condition of i will be extremely large, cause segment fault in sorted_files[i] and sorted_files[i+1]. Added condition to fix it.

test plan: make asan_check