### PR TITLE
Fix a couple of bugs in FaultInjectionTestFS

### DIFF
--- a/test_util/fault_injection_test_fs.h
+++ b/test_util/fault_injection_test_fs.h
@@ -309,7 +309,8 @@ class FaultInjectionTestFS : public FileSystemWrapper {
   // corruption in the contents of scratch, or truncation of slice
   // are the types of error with equal probability. For OPEN,
   // its always an IOError.
-  IOStatus InjectError(ErrorOperation op, Slice* slice, char* scratch);
+  IOStatus InjectError(ErrorOperation op, Slice* slice,
+                       bool direct_io, char* scratch);
 
   // Get the count of how many times we injected since the previous call
   int GetAndResetErrorCount() {


### PR DESCRIPTION
Summary:
Fix the following cases that can cause false alarms in db_stress when read fault injection is 
 enabled -
1. Turn off corruption/truncation when direct IO is enabled. Since the actual IO size is larger than block size due to alignment requirements, the corruption may not result in a detectable error.
2. Handle the case when the randomly generated string to overwrite the original block is identical to the original. 

Tests:
Run db_stress w/ and wo/ direct IO and fault injection turned on