### PR TITLE
Fix assertion that can fail on sst corruption

### DIFF
--- a/table/format.cc
+++ b/table/format.cc
@@ -463,7 +463,7 @@ Status UncompressBlockContents(const UncompressionInfo& uncompression_info,
                                const ImmutableCFOptions& ioptions,
                                MemoryAllocator* allocator) {
   assert(data[n] != kNoCompression);
-  assert(data[n] == uncompression_info.type());
+  assert(data[n] == static_cast<char>(uncompression_info.type()));
   return UncompressBlockContentsForCompressionType(uncompression_info, data, n,
                                                    contents, format_version,
                                                    ioptions, allocator);


### PR DESCRIPTION
Summary: An assertion that a char == a CompressionType (unsigned char)
originally cast from a char can fail if the original value is negative,
due to numeric promotion.  The assertion should pass even if the value
is invalid CompressionType, because the callee
UncompressBlockContentsForCompressionType checks for that and reports
status appropriately.

Test Plan: Temporarily change kZSTD = 0x88 and see tests fail. Make this
change (in addition), and tests pass.