### PR TITLE
Flag CompressionOptions::parallel_threads to be experimental

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,7 +16,7 @@
 * Add IsDirectory to Env and FS to indicate if a path is a directory.
 
 ### New Features
-* Added support for pipelined & parallel compression optimization for `BlockBasedTableBuilder`. This optimization makes block building, block compression and block appending a pipeline, and uses multiple threads to accelerate block compression. Users can set `CompressionOptions::parallel_threads` greater than 1 to enable compression parallelism.
+* Added support for pipelined & parallel compression optimization for `BlockBasedTableBuilder`. This optimization makes block building, block compression and block appending a pipeline, and uses multiple threads to accelerate block compression. Users can set `CompressionOptions::parallel_threads` greater than 1 to enable compression parallelism. This feature is experimental for now.
 * Provide an allocator for memkind to be used with block cache. This is to work with memory technologies (Intel DCPMM is one such technology currently available) that require different libraries for allocation and management (such as PMDK and memkind). The high capacities available make it possible to provision large caches (up to several TBs in size) beyond what is achievable with DRAM.
 * Option `max_background_flushes` can be set dynamically using DB::SetDBOptions().
 * Added functionality in sst_dump tool to check the compressed file size for different compression levels and print the time spent on compressing files with each compression type. Added arguments `--compression_level_from` and `--compression_level_to` to report size of all compression levels and one compression_type must be specified with it so that it will report compressed sizes of one compression type with different levels.

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -119,6 +119,7 @@ struct CompressionOptions {
 
   // Number of threads for parallel compression.
   // Parallel compression is enabled only if threads > 1.
+  // THE FEATURE IS STILL EXPERIMENTAL
   //
   // This option is valid only when BlockBasedTable is used.
   //

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -123,12 +123,10 @@ struct CompressionOptions {
   //
   // This option is valid only when BlockBasedTable is used.
   //
-  // When parallel compression is enabled, SST size estimation becomes less
-  // accurate, because block building and compression are pipelined, and there
-  // might be inflight blocks being compressed and not finally written, when
-  // current SST size is fetched. This brings inflation of final output file
-  // size.
-  // To be more accurate, this inflation is also estimated by using historical
+  // When parallel compression is enabled, SST size file sizes might be
+  // more inflated compared to the target size, because more data of unknown
+  // compressed size is in flight when compression is parallelized. To be
+  // reasonably accurate, this inflation is also estimated by using historical
   // compression ratio and current bytes inflight.
   //
   // Default: 1.


### PR DESCRIPTION
Summary: The feature of CompressionOptions::parallel_threads is still not yet mature. Mention it to be experimental in the comments for now.