### PR TITLE
Fix the status overwrite in block based table builder in 6.9.fb

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Rocksdb Change Log
 ## Unreleased
+### Bug Fixes
+* Fix a bug caused by overwrite the status with io status in block based table builder when writing data blocks. If status stores the error message (e.g., failure of verify block compression), the bug will make the io status overwrite the status.
 
 ## 6.9.3 (04/28/2020)
 ### Bug Fixes

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -788,7 +788,9 @@ void BlockBasedTableBuilder::WriteRawBlock(const Slice& block_contents,
       }
     }
   }
-  r->status = r->io_status;
+  if (r->status.ok()) {
+    r->status = r->io_status;
+  }
 }
 
 Status BlockBasedTableBuilder::status() const { return rep_->status; }
@@ -1064,7 +1066,9 @@ void BlockBasedTableBuilder::WriteFooter(BlockHandle& metaindex_block_handle,
   if (r->io_status.ok()) {
     r->offset += footer_encoding.size();
   }
-  r->status = r->io_status;
+  if (r->status.ok()) {
+    r->status = r->io_status;
+  }
 }
 
 void BlockBasedTableBuilder::EnterUnbuffered() {


### PR DESCRIPTION
In #6487 , the status returned from IO functions are replaced with IO Status. A new status was introduced to store the IO status specifically in the write path. IO status should be a subset of status. However, in #6487 , the status for block based table builder are directly overwritten by io status without check, which may swallow the error status stored in the status.

The bug was fixed in master by #6262 but still exist in 6.9.fb

test plan: make asan_check