### PR TITLE
Fix multiple CF replay failure in db_bench replay

### DIFF
--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -321,6 +321,7 @@ Status Replayer::MultiThreadReplay(uint32_t threads_num) {
     if (!s.ok()) {
       break;
     }
+    ra->cf_map = &cf_map_;
     ra->woptions = woptions;
     ra->roptions = roptions;
 
@@ -407,6 +408,7 @@ Status Replayer::ReadTrace(Trace* trace) {
 void Replayer::BGWorkGet(void* arg) {
   std::unique_ptr<ReplayerWorkerArg> ra(
       reinterpret_cast<ReplayerWorkerArg*>(arg));
+  assert(ra != nullptr);
   auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
       ra->cf_map);
   uint32_t cf_id = 0;
@@ -429,6 +431,7 @@ void Replayer::BGWorkGet(void* arg) {
 void Replayer::BGWorkWriteBatch(void* arg) {
   std::unique_ptr<ReplayerWorkerArg> ra(
       reinterpret_cast<ReplayerWorkerArg*>(arg));
+  assert(ra != nullptr);
   WriteBatch batch(ra->trace_entry.payload);
   ra->db->Write(ra->woptions, &batch);
   return;
@@ -437,6 +440,7 @@ void Replayer::BGWorkWriteBatch(void* arg) {
 void Replayer::BGWorkIterSeek(void* arg) {
   std::unique_ptr<ReplayerWorkerArg> ra(
       reinterpret_cast<ReplayerWorkerArg*>(arg));
+  assert(ra != nullptr);
   auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
       ra->cf_map);
   uint32_t cf_id = 0;
@@ -461,6 +465,7 @@ void Replayer::BGWorkIterSeek(void* arg) {
 void Replayer::BGWorkIterSeekForPrev(void* arg) {
   std::unique_ptr<ReplayerWorkerArg> ra(
       reinterpret_cast<ReplayerWorkerArg*>(arg));
+  assert(ra != nullptr);
   auto cf_map = static_cast<std::unordered_map<uint32_t, ColumnFamilyHandle*>*>(
       ra->cf_map);
   uint32_t cf_id = 0;


### PR DESCRIPTION
The multiple CF hash map is not passed to the multi-thread worker. When using multi-thread replay for multiple CFs, it will cause segment fault. Pass the cf_map to the argument.

Test plan: pass trace replay test.