### PR TITLE
Mark dependencies as PRIVATE and fix missing dependencies in tools.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,12 +839,12 @@ else()
 endif()
 
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES})
-target_link_libraries(${ROCKSDB_STATIC_LIB}
+target_link_libraries(${ROCKSDB_STATIC_LIB} PRIVATE
   ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
 if(ROCKSDB_BUILD_SHARED)
   add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
-  target_link_libraries(${ROCKSDB_SHARED_LIB}
+  target_link_libraries(${ROCKSDB_SHARED_LIB} PRIVATE
     ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
   if(WIN32)

--- a/db_stress_tool/CMakeLists.txt
+++ b/db_stress_tool/CMakeLists.txt
@@ -10,5 +10,5 @@ add_executable(db_stress${ARTIFACT_SUFFIX}
   db_stress_gflags.cc
   db_stress_tool.cc
   no_batched_ops_stress.cc)
-target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${ROCKSDB_LIB})
+target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})
 list(APPEND tool_deps db_stress)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WITH_TOOLS)
     get_filename_component(exename ${src} NAME_WE)
     add_executable(${exename}${ARTIFACT_SUFFIX}
       ${src})
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${ROCKSDB_LIB})
+    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})
     list(APPEND tool_deps ${exename})
   endforeach()
 


### PR DESCRIPTION
Tools were mistakenly using leaked (PUBLIC) dependencies from main lib.