### PR TITLE
Add `find_dependency()` in cmake config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,8 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
 
   install(DIRECTORY include/rocksdb COMPONENT devel DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+  install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/modules" COMPONENT devel DESTINATION ${package_config_destination})
+
   install(
     TARGETS ${ROCKSDB_STATIC_LIB}
     EXPORT RocksDBTargets

--- a/cmake/RocksDBConfig.cmake.in
+++ b/cmake/RocksDBConfig.cmake.in
@@ -1,3 +1,54 @@
 @PACKAGE_INIT@
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+
+include(CMakeFindDependencyMacro)
+
+set(GFLAGS_USE_TARGET_NAMESPACE @GFLAGS_USE_TARGET_NAMESPACE@)
+
+if(@WITH_JEMALLOC@)
+  find_dependency(JeMalloc)
+endif()
+
+if(@WITH_GFLAGS@)
+  find_dependency(gflags CONFIG)
+  if(NOT gflags_FOUND)
+    find_dependency(gflags)
+  endif()
+endif()
+
+if(@WITH_SNAPPY@)
+  find_dependency(Snappy CONFIG)
+  if(NOT Snappy_FOUND)
+    find_dependency(Snappy)
+  endif()
+endif()
+
+if(@WITH_ZLIB@)
+  find_dependency(ZLIB)
+endif()
+
+if(@WITH_BZ2@)
+  find_dependency(BZip2)
+endif()
+
+if(@WITH_LZ4@)
+  find_dependency(lz4)
+endif()
+
+if(@WITH_ZSTD@)
+  find_dependency(zstd)
+endif()
+
+if(@WITH_NUMA@)
+  find_dependency(NUMA)
+endif()
+
+if(@WITH_TBB@)
+  find_dependency(TBB)
+endif()
+
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/RocksDBTargets.cmake")
 check_required_components(RocksDB)


### PR DESCRIPTION
Currently when building PyTorch with latest RocksDB we get errors like "missing target Snappy::snappy", because they are simply not there.
With old `${VAR}` approach we essentially hard-code the abs path found during RocksDB build, which is:
 - Not relocatable.
 - Doesn't work when changed to modern target-based design because that requires target to present when used for expansion.

This fix allows cmake to setup imported target, if enabled during RocksDB build, when downstream uses `find_package(RocksDB)`.

This is for https://github.com/facebook/rocksdb/issues/6179
@tchaikov Please help review, thanks!