### PR TITLE
Avoid Swallowing Some File Consistency Checking Bugs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 * Fix a bug caused by not including user timestamp in MultiGet LookupKey construction. This can lead to wrong query result since the trailing bytes of a user key, if not shorter than timestamp, will be mistaken for user timestamp.
 * Fix a bug caused by using wrong compare function when sorting the input keys of MultiGet with timestamps.
 * Upgraded version of bzip library (1.0.6 -> 1.0.8) used with RocksJava to address potential vulnerabilities if an attacker can manipulate compressed data saved and loaded by RocksDB (not normal). See issue #6703.
+* Fix consistency checking error swallowing in some cases when options.force_consistency_checks = true.
 
 ### Public API Change
 * Add a ConfigOptions argument to the APIs dealing with converting options to and from strings and files.  The ConfigOptions is meant to replace some of the options (such as input_strings_escaped and ignore_unknown_options) and allow for more parameters to be passed in the future without changing the function signature.

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -316,7 +316,10 @@ class VersionBuilder::Rep {
       }
     }
 
-    return Status::OK();
+    Status ret_s;
+    TEST_SYNC_POINT_CALLBACK("VersionBuilder::CheckConsistencyBeforeReturn",
+                             &ret_s);
+    return ret_s;
   }
 
   Status CheckConsistencyForDeletes(VersionEdit* /*edit*/, uint64_t number,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5970,8 +5970,7 @@ Status ReactiveVersionSet::Recover(
       Version* v = new Version(cfd, this, file_options_,
                                *cfd->GetLatestMutableCFOptions(),
                                current_version_number_++);
-      // Should handle it better
-      s = builder->SaveTo(v->storage_info());
+      builder->SaveTo(v->storage_info());
 
       // Install recovered version
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(),
@@ -6191,7 +6190,7 @@ Status ReactiveVersionSet::ApplyOneVersionEditToBuilder(
       auto version = new Version(cfd, this, file_options_,
                                  *cfd->GetLatestMutableCFOptions(),
                                  current_version_number_++);
-      s = builder->SaveTo(version->storage_info());
+      builder->SaveTo(version->storage_info());
       version->PrepareApply(*cfd->GetLatestMutableCFOptions(), true);
       AppendVersion(cfd, version);
       active_version_builders_.erase(builder_iter);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4594,7 +4594,11 @@ Status VersionSet::Recover(
       Version* v = new Version(cfd, this, file_options_,
                                *cfd->GetLatestMutableCFOptions(),
                                current_version_number_++);
-      builder->SaveTo(v->storage_info());
+      s = builder->SaveTo(v->storage_info());
+      if (!s.ok()) {
+        delete v;
+        return s;
+      }
 
       // Install recovered version
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(),
@@ -5145,7 +5149,7 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
       Version* v = new Version(cfd, this, file_options_,
                                *cfd->GetLatestMutableCFOptions(),
                                current_version_number_++);
-      builder->SaveTo(v->storage_info());
+      s = builder->SaveTo(v->storage_info());
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(), false);
 
       printf("--------------- Column family \"%s\"  (ID %" PRIu32
@@ -5966,7 +5970,8 @@ Status ReactiveVersionSet::Recover(
       Version* v = new Version(cfd, this, file_options_,
                                *cfd->GetLatestMutableCFOptions(),
                                current_version_number_++);
-      builder->SaveTo(v->storage_info());
+      // Should handle it better
+      s = builder->SaveTo(v->storage_info());
 
       // Install recovered version
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(),
@@ -6186,7 +6191,7 @@ Status ReactiveVersionSet::ApplyOneVersionEditToBuilder(
       auto version = new Version(cfd, this, file_options_,
                                  *cfd->GetLatestMutableCFOptions(),
                                  current_version_number_++);
-      builder->SaveTo(version->storage_info());
+      s = builder->SaveTo(version->storage_info());
       version->PrepareApply(*cfd->GetLatestMutableCFOptions(), true);
       AppendVersion(cfd, version);
       active_version_builders_.erase(builder_iter);

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -593,6 +593,7 @@ Options LDBCommand::PrepareOptionsForOpenDB() {
   } else {
     cf_opts = static_cast<ColumnFamilyOptions*>(&options_);
   }
+  cf_opts->force_consistency_checks = true;
   DBOptions* db_opts = static_cast<DBOptions*>(&options_);
   db_opts->create_if_missing = false;
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -593,7 +593,6 @@ Options LDBCommand::PrepareOptionsForOpenDB() {
   } else {
     cf_opts = static_cast<ColumnFamilyOptions*>(&options_);
   }
-  cf_opts->force_consistency_checks = true;
   DBOptions* db_opts = static_cast<DBOptions*>(&options_);
   db_opts->create_if_missing = false;
 


### PR DESCRIPTION
Summary:
We are swallowing some file consistency checking failures. This is not expected. We are fixing two cases: DB reopen and manifest dump.
More places are not fixed and need follow-up.

Error from CheckConsistencyForDeletes() is also swallowed, which is not fixed in this PR.

Test Plan: Add a unit test to cover the reopen case.