### PR TITLE
Add zstd_max_train_bytes to c interop

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -2381,7 +2381,8 @@ void rocksdb_options_set_bottommost_compression_options(rocksdb_options_t* opt,
 
 void rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
     rocksdb_options_t* opt, int zstd_max_train_bytes, unsigned char enabled) {
-  opt->rep.bottommost_compression_opts.zstd_max_train_bytes = zstd_max_train_bytes;
+  opt->rep.bottommost_compression_opts.zstd_max_train_bytes =
+      zstd_max_train_bytes;
   opt->rep.bottommost_compression_opts.enabled = enabled;
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -1466,11 +1466,24 @@ void rocksdb_writebatch_delete(
   b->rep.Delete(Slice(key, klen));
 }
 
+void rocksdb_writebatch_singledelete(
+    rocksdb_writebatch_t* b, const char* key,
+    size_t klen) {
+  b->rep.SingleDelete(Slice(key, klen));
+}
+
 void rocksdb_writebatch_delete_cf(
     rocksdb_writebatch_t* b,
     rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen) {
   b->rep.Delete(column_family->rep, Slice(key, klen));
+}
+
+void rocksdb_writebatch_singledelete_cf(
+    rocksdb_writebatch_t* b,
+    rocksdb_column_family_handle_t* column_family,
+    const char* key, size_t klen) {
+  b->rep.SingleDelete(column_family->rep, Slice(key, klen));
 }
 
 void rocksdb_writebatch_deletev(

--- a/db/c.cc
+++ b/db/c.cc
@@ -1734,11 +1734,22 @@ void rocksdb_writebatch_wi_delete(
   b->rep->Delete(Slice(key, klen));
 }
 
+void rocksdb_writebatch_wi_singledelete(rocksdb_writebatch_wi_t* b,
+                                         const char* key, size_t klen) {
+  b->rep->SingleDelete(Slice(key, klen));
+}
+
 void rocksdb_writebatch_wi_delete_cf(
     rocksdb_writebatch_wi_t* b,
     rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen) {
   b->rep->Delete(column_family->rep, Slice(key, klen));
+}
+
+void rocksdb_writebatch_wi_singledelete_cf(
+    rocksdb_writebatch_wi_t* b, rocksdb_column_family_handle_t* column_family,
+    const char* key, size_t klen) {
+  b->rep->SingleDelete(column_family->rep, Slice(key, klen));
 }
 
 void rocksdb_writebatch_wi_deletev(

--- a/db/c.cc
+++ b/db/c.cc
@@ -2371,7 +2371,7 @@ void rocksdb_options_set_bottommost_compression_options(rocksdb_options_t* opt,
                                                         int w_bits, int level,
                                                         int strategy,
                                                         int max_dict_bytes,
-                                                        bool enabled) {
+                                                        unsigned char enabled) {
   opt->rep.bottommost_compression_opts.window_bits = w_bits;
   opt->rep.bottommost_compression_opts.level = level;
   opt->rep.bottommost_compression_opts.strategy = strategy;
@@ -2380,7 +2380,7 @@ void rocksdb_options_set_bottommost_compression_options(rocksdb_options_t* opt,
 }
 
 void rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
-    rocksdb_options_t* opt, int zstd_max_train_bytes, bool enabled) {
+    rocksdb_options_t* opt, int zstd_max_train_bytes, unsigned char enabled) {
   opt->rep.bottommost_compression_opts.zstd_max_train_bytes = zstd_max_train_bytes;
   opt->rep.bottommost_compression_opts.enabled = enabled;
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -1466,9 +1466,8 @@ void rocksdb_writebatch_delete(
   b->rep.Delete(Slice(key, klen));
 }
 
-void rocksdb_writebatch_singledelete(
-    rocksdb_writebatch_t* b, const char* key,
-    size_t klen) {
+void rocksdb_writebatch_singledelete(rocksdb_writebatch_t* b, const char* key,
+                                     size_t klen) {
   b->rep.SingleDelete(Slice(key, klen));
 }
 
@@ -1480,8 +1479,7 @@ void rocksdb_writebatch_delete_cf(
 }
 
 void rocksdb_writebatch_singledelete_cf(
-    rocksdb_writebatch_t* b,
-    rocksdb_column_family_handle_t* column_family,
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen) {
   b->rep.SingleDelete(column_family->rep, Slice(key, klen));
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -1735,7 +1735,7 @@ void rocksdb_writebatch_wi_delete(
 }
 
 void rocksdb_writebatch_wi_singledelete(rocksdb_writebatch_wi_t* b,
-                                         const char* key, size_t klen) {
+                                        const char* key, size_t klen) {
   b->rep->SingleDelete(Slice(key, klen));
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -2379,6 +2379,12 @@ void rocksdb_options_set_bottommost_compression_options(rocksdb_options_t* opt,
   opt->rep.bottommost_compression_opts.enabled = enabled;
 }
 
+void rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
+    rocksdb_options_t* opt, int zstd_max_train_bytes, bool enabled) {
+  opt->rep.bottommost_compression_opts.zstd_max_train_bytes = zstd_max_train_bytes;
+  opt->rep.bottommost_compression_opts.enabled = enabled;
+}
+
 void rocksdb_options_set_compression_options(rocksdb_options_t* opt, int w_bits,
                                              int level, int strategy,
                                              int max_dict_bytes) {
@@ -2386,6 +2392,11 @@ void rocksdb_options_set_compression_options(rocksdb_options_t* opt, int w_bits,
   opt->rep.compression_opts.level = level;
   opt->rep.compression_opts.strategy = strategy;
   opt->rep.compression_opts.max_dict_bytes = max_dict_bytes;
+}
+
+void rocksdb_options_set_compression_options_zstd_max_train_bytes(
+    rocksdb_options_t* opt, int zstd_max_train_bytes) {
+  opt->rep.compression_opts.zstd_max_train_bytes = zstd_max_train_bytes;
 }
 
 void rocksdb_options_set_prefix_extractor(

--- a/db/c.cc
+++ b/db/c.cc
@@ -2357,6 +2357,10 @@ void rocksdb_options_set_compression(rocksdb_options_t* opt, int t) {
   opt->rep.compression = static_cast<CompressionType>(t);
 }
 
+void rocksdb_options_set_bottommost_compression(rocksdb_options_t* opt, int t) {
+  opt->rep.bottommost_compression = static_cast<CompressionType>(t);
+}
+
 void rocksdb_options_set_compression_per_level(rocksdb_options_t* opt,
                                                int* level_values,
                                                size_t num_levels) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -829,6 +829,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options(
     rocksdb_options_t*, int, int, int, int);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options_zstd_max_train_bytes(
     rocksdb_options_t*, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_bottommost_compression_options(
+    rocksdb_options_t*, int, int, int, int, unsigned char);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
+    rocksdb_options_t*, int, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_prefix_extractor(
     rocksdb_options_t*, rocksdb_slicetransform_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_num_levels(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -827,11 +827,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_total_wal_size(
     rocksdb_options_t* opt, uint64_t n);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options(
     rocksdb_options_t*, int, int, int, int);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options_zstd_max_train_bytes(
-    rocksdb_options_t*, int);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_bottommost_compression_options(
-    rocksdb_options_t*, int, int, int, int, unsigned char);
-extern ROCKSDB_LIBRARY_API void rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_compression_options_zstd_max_train_bytes(rocksdb_options_t*,
+                                                             int);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_bottommost_compression_options(rocksdb_options_t*, int, int,
+                                                   int, int, unsigned char);
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_set_bottommost_compression_options_zstd_max_train_bytes(
     rocksdb_options_t*, int, unsigned char);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_prefix_extractor(
     rocksdb_options_t*, rocksdb_slicetransform_t*);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -495,8 +495,13 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_mergev_cf(
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete(rocksdb_writebatch_t*,
                                                           const char* key,
                                                           size_t klen);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_singledelete(
+    rocksdb_writebatch_t* b, const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_delete_cf(
     rocksdb_writebatch_t*, rocksdb_column_family_handle_t* column_family,
+    const char* key, size_t klen);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_singledelete_cf(
+    rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_deletev(
     rocksdb_writebatch_t* b, int num_keys, const char* const* keys_list,

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -588,7 +588,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_mergev_cf(
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_delete(rocksdb_writebatch_wi_t*,
                                                           const char* key,
                                                           size_t klen);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_singledelete(
+    rocksdb_writebatch_wi_t*, const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_delete_cf(
+    rocksdb_writebatch_wi_t*, rocksdb_column_family_handle_t* column_family,
+    const char* key, size_t klen);
+extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_singledelete_cf(
     rocksdb_writebatch_wi_t*, rocksdb_column_family_handle_t* column_family,
     const char* key, size_t klen);
 extern ROCKSDB_LIBRARY_API void rocksdb_writebatch_wi_deletev(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -827,6 +827,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_max_total_wal_size(
     rocksdb_options_t* opt, uint64_t n);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options(
     rocksdb_options_t*, int, int, int, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_options_zstd_max_train_bytes(
+    rocksdb_options_t*, int);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_prefix_extractor(
     rocksdb_options_t*, rocksdb_slicetransform_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_num_levels(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1038,6 +1038,8 @@ enum {
 };
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression(
     rocksdb_options_t*, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_bottommost_compression(
+    rocksdb_options_t*, int);
 
 enum {
   rocksdb_level_compaction = 0,


### PR DESCRIPTION
Added setting of zstd_max_train_bytes compression option parameter to c interop.

rocksdb_options_set_bottommost_compression_options was using bool parameter and thus not exported, updated it to unsigned char and added to c.h as well.

