### PR TITLE
Fix failure to write output in SpecialEnv::GetCurrentTime

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2511,9 +2511,8 @@ TEST_F(DBBasicTestMultiGetDeadline, MultiGetDeadlineExceeded) {
   std::shared_ptr<DBBasicTestMultiGetDeadline::DeadlineFS> fs(
       new DBBasicTestMultiGetDeadline::DeadlineFS(env_));
   std::unique_ptr<Env> env(new CompositeEnvWrapper(env_, fs));
-  env_->no_slowdown_ = true;
-  env_->time_elapse_only_sleep_.store(true);
   Options options = CurrentOptions();
+  env_->SetTimeElapseOnlySleep(&options);
 
   std::shared_ptr<Cache> cache = NewLRUCache(1048576);
   BlockBasedTableOptions table_options;

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -365,24 +365,16 @@ TEST_F(DBSSTTest, RateLimitedDelete) {
         env_->addon_time_.fetch_add(
             static_cast<uint64_t>(Random::GetTLSInstance()->Uniform(10)));
 
-        // Set wait until time to before (actual) current to force not to sleep
+        // Set wait until time to before (actual) current time to force not
+        // to sleep
         *abs_time_us = Env::Default()->NowMicros();
       });
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
-  env_->no_slowdown_ = true;
-  env_->time_elapse_only_sleep_ = true;
   Options options = CurrentOptions();
+  env_->SetTimeElapseOnlySleep(&options);
   options.disable_auto_compactions = true;
-  // Need to disable stats dumping and persisting which also use
-  // RepeatableThread, one of whose member variables is of type
-  // InstrumentedCondVar. The callback for
-  // InstrumentedCondVar::TimedWaitInternal can be triggered by stats dumping
-  // and persisting threads and cause time_spent_deleting measurement to become
-  // incorrect.
-  options.stats_dump_period_sec = 0;
-  options.stats_persist_period_sec = 0;
   options.env = env_;
 
   int64_t rate_bytes_per_sec = 1024 * 10;  // 10 Kbs / Sec

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -15,12 +15,12 @@
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
-int64_t MaybeCurrentTime(Env *env) {
-  int64_t time = 42; // fallback default
+int64_t MaybeCurrentTime(Env* env) {
+  int64_t time = 1337346000;  // arbitrary fallback default
   (void)env->GetCurrentTime(&time);
   return time;
 }
-}
+}  // namespace
 
 // Special Env used to delay background operations
 

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -14,10 +14,19 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+namespace {
+int64_t MaybeCurrentTime(Env *env) {
+  int64_t time = 42; // fallback default
+  (void)env->GetCurrentTime(&time);
+  return time;
+}
+}
+
 // Special Env used to delay background operations
 
 SpecialEnv::SpecialEnv(Env* base)
     : EnvWrapper(base),
+      maybe_starting_time_(MaybeCurrentTime(base)),
       rnd_(301),
       sleep_counter_(this),
       addon_time_(0),

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -535,15 +535,15 @@ class SpecialEnv : public EnvWrapper {
     return target()->DeleteFile(fname);
   }
 
-  void SetTimeElapseOnlySleep(Options *options) {
+  void SetTimeElapseOnlySleep(Options* options) {
     time_elapse_only_sleep_ = true;
     no_slowdown_ = true;
     // Need to disable stats dumping and persisting which also use
     // RepeatableThread, one of whose member variables is of type
     // InstrumentedCondVar. The callback for
     // InstrumentedCondVar::TimedWaitInternal can be triggered by stats dumping
-    // and persisting threads and cause time_spent_deleting measurement to become
-    // incorrect.
+    // and persisting threads and cause time_spent_deleting measurement to
+    // become incorrect.
     options->stats_dump_period_sec = 0;
     options->stats_persist_period_sec = 0;
   }

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -508,6 +508,8 @@ class SpecialEnv : public EnvWrapper {
       s = target()->GetCurrentTime(unix_time);
     }
     if (s.ok()) {
+      // FIXME: addon_time_ sometimes used to mean seconds (here) and
+      // sometimes microseconds
       *unix_time += addon_time_.load();
     }
     return s;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -502,7 +502,9 @@ class SpecialEnv : public EnvWrapper {
 
   virtual Status GetCurrentTime(int64_t* unix_time) override {
     Status s;
-    if (!time_elapse_only_sleep_) {
+    if (time_elapse_only_sleep_) {
+      *unix_time = maybe_starting_time_;
+    } else {
       s = target()->GetCurrentTime(unix_time);
     }
     if (s.ok()) {
@@ -530,6 +532,9 @@ class SpecialEnv : public EnvWrapper {
     delete_count_.fetch_add(1);
     return target()->DeleteFile(fname);
   }
+
+  // Something to return when mocking current time
+  const int64_t maybe_starting_time_;
 
   Random rnd_;
   port::Mutex rnd_mutex_;  // Lock to pretect rnd_

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -539,11 +539,9 @@ class SpecialEnv : public EnvWrapper {
     time_elapse_only_sleep_ = true;
     no_slowdown_ = true;
     // Need to disable stats dumping and persisting which also use
-    // RepeatableThread, one of whose member variables is of type
-    // InstrumentedCondVar. The callback for
-    // InstrumentedCondVar::TimedWaitInternal can be triggered by stats dumping
-    // and persisting threads and cause time_spent_deleting measurement to
-    // become incorrect.
+    // RepeatableThread, which uses InstrumentedCondVar::TimedWaitInternal.
+    // With time_elapse_only_sleep_, this can hang on some platforms.
+    // TODO: why? investigate/fix
     options->stats_dump_period_sec = 0;
     options->stats_persist_period_sec = 0;
   }

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -535,6 +535,19 @@ class SpecialEnv : public EnvWrapper {
     return target()->DeleteFile(fname);
   }
 
+  void SetTimeElapseOnlySleep(Options *options) {
+    time_elapse_only_sleep_ = true;
+    no_slowdown_ = true;
+    // Need to disable stats dumping and persisting which also use
+    // RepeatableThread, one of whose member variables is of type
+    // InstrumentedCondVar. The callback for
+    // InstrumentedCondVar::TimedWaitInternal can be triggered by stats dumping
+    // and persisting threads and cause time_spent_deleting measurement to become
+    // incorrect.
+    options->stats_dump_period_sec = 0;
+    options->stats_persist_period_sec = 0;
+  }
+
   // Something to return when mocking current time
   const int64_t maybe_starting_time_;
 


### PR DESCRIPTION
Summary: This very old test code bug was causing a new valgrind failure
in MultiGetDeadlineExceeded

Also fix hang in MultiGetDeadlineExceeded by unifying with some logic from another test.

Test Plan: run that unit test under valgrind, make check