### PR TITLE
Find/purge obsolete blob files

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1939,7 +1939,7 @@ class DBImpl : public DB {
   std::unordered_map<uint64_t, PurgeFileInfo> purge_files_;
 
   // A vector to store the file numbers that have been assigned to certain
-  // JobContext. Current implementation tracks ssts only.
+  // JobContext. Current implementation tracks table and blob files only.
   std::unordered_set<uint64_t> files_grabbed_for_purge_;
 
   // A queue to store log writers to close

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -973,6 +973,10 @@ class DBImpl : public DB {
   size_t TEST_EstimateInMemoryStatsHistorySize() const;
 
   VersionSet* TEST_GetVersionSet() const { return versions_.get(); }
+
+  const std::unordered_set<uint64_t>& TEST_GetFilesGrabbedForPurge() const {
+    return files_grabbed_for_purge_;
+  }
 #endif  // NDEBUG
 
  protected:

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -924,6 +924,8 @@ class DBImpl : public DB {
   void TEST_GetFilesMetaData(ColumnFamilyHandle* column_family,
                              std::vector<std::vector<FileMetaData>>* metadata);
 
+  InstrumentedMutex* TEST_GetMutex() const { return &mutex_; }
+
   void TEST_LockMutex();
 
   void TEST_UnlockMutex();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -924,8 +924,6 @@ class DBImpl : public DB {
   void TEST_GetFilesMetaData(ColumnFamilyHandle* column_family,
                              std::vector<std::vector<FileMetaData>>* metadata);
 
-  InstrumentedMutex* TEST_GetMutex() const { return &mutex_; }
-
   void TEST_LockMutex();
 
   void TEST_UnlockMutex();

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -441,6 +441,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
         // TODO(yhchiang): carefully modify the third condition to safely
         //                 remove the temp options files.
         keep = (sst_live_set.find(number) != sst_live_set.end()) ||
+               (blob_live_set.find(number) != blob_live_set.end()) ||
                (number == state.pending_manifest_file_number) ||
                (to_delete.find(kOptionsFileNamePrefix) != std::string::npos);
         break;

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -261,7 +261,7 @@ void DBImpl::DeleteObsoleteFileImpl(int job_id, const std::string& fname,
                            const_cast<std::string*>(&fname));
 
   Status file_deletion_status;
-  if (type == kTableFile || type == kLogFile) {
+  if (type == kTableFile || type == kBlobFile || type == kLogFile) {
     file_deletion_status =
         DeleteDBFile(&immutable_db_options_, fname, path_to_sync,
                      /*force_bg=*/false, /*force_fg=*/!wal_in_db_path_);

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -257,6 +257,9 @@ bool CompareCandidateFile(const JobContext::CandidateFileInfo& first,
 void DBImpl::DeleteObsoleteFileImpl(int job_id, const std::string& fname,
                                     const std::string& path_to_sync,
                                     FileType type, uint64_t number) {
+  TEST_SYNC_POINT_CALLBACK("DBImpl::DeleteObsoleteFileImpl::BeforeDeletion",
+                           const_cast<std::string*>(&fname));
+
   Status file_deletion_status;
   if (type == kTableFile || type == kLogFile) {
     file_deletion_status =
@@ -328,8 +331,8 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
   }
 
   for (const auto& blob_file : state.blob_delete_files) {
-    candidate_files.emplace_back(
-        BlobFileName(blob_file.GetBlobFileNumber()), blob_file.GetPath());
+    candidate_files.emplace_back(BlobFileName(blob_file.GetBlobFileNumber()),
+                                 blob_file.GetPath());
   }
 
   for (auto file_num : state.log_delete_files) {

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -479,6 +479,9 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
       TableCache::Evict(table_cache_.get(), number);
       fname = MakeTableFileName(candidate_file.file_path, number);
       dir_to_sync = candidate_file.file_path;
+    } else if (type == kBlobFile) {
+      // TODO: fname ???
+      dir_to_sync = candidate_file.file_path;
     } else {
       dir_to_sync =
           (type == kLogFile) ? immutable_db_options_.wal_dir : dbname_;

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -329,7 +329,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
 
   for (const auto& blob_file : state.blob_delete_files) {
     candidate_files.emplace_back(
-        BlobFileName("", blob_file.GetBlobFileNumber()), blob_file.GetPath());
+        BlobFileName(blob_file.GetBlobFileNumber()), blob_file.GetPath());
   }
 
   for (auto file_num : state.log_delete_files) {

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -480,7 +480,7 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
       fname = MakeTableFileName(candidate_file.file_path, number);
       dir_to_sync = candidate_file.file_path;
     } else if (type == kBlobFile) {
-      // TODO: fname ???
+      fname = BlobFileName(candidate_file.file_path, number);
       dir_to_sync = candidate_file.file_path;
     } else {
       dir_to_sync =

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -258,6 +258,9 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
 
   dbfull()->PurgeObsoleteFiles(job_context);
   job_context.Clean();
+
+  ASSERT_EQ(files_grabbed_for_purge.find(first_blob_file_number),
+            files_grabbed_for_purge.end());
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -229,7 +229,7 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
 
   dbfull()->TEST_LockMutex();
   Status s = versions->LogAndApply(cfd, *cfd->GetLatestMutableCFOptions(),
-                                   &edit, dbfull()->TEST_GetMutex());
+                                   &edit, dbfull()->mutex());
   dbfull()->TEST_UnlockMutex();
 
   ASSERT_OK(s);

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -10,6 +10,7 @@
 #ifndef ROCKSDB_LITE
 
 #include <stdlib.h>
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
@@ -256,11 +257,59 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
   ASSERT_EQ(job_context.blob_live.size(), 1);
   ASSERT_EQ(job_context.blob_live[0], second_blob_file_number);
 
+  // Hack the job context a bit by adding a few files to the full scan
+  // list and adjusting the pending file number. We add the two files
+  // above as well as two additional ones, where one is old
+  // and should be cleaned up, and the other is still pending.
+  assert(cfd->ioptions());
+  assert(!cfd->ioptions()->cf_paths.empty());
+  const std::string& path = cfd->ioptions()->cf_paths.front().path;
+
+  constexpr uint64_t old_blob_file_number = 123;
+  constexpr uint64_t pending_blob_file_number = 567;
+
+  job_context.full_scan_candidate_files.emplace_back(
+      BlobFileName(old_blob_file_number), path);
+  job_context.full_scan_candidate_files.emplace_back(
+      BlobFileName(first_blob_file_number), path);
+  job_context.full_scan_candidate_files.emplace_back(
+      BlobFileName(second_blob_file_number), path);
+  job_context.full_scan_candidate_files.emplace_back(
+      BlobFileName(pending_blob_file_number), path);
+
+  job_context.min_pending_output = pending_blob_file_number;
+
+  // Purge obsolete files and make sure we purge the old file and the first file
+  // (and keep the second file and the pending file).
+  std::vector<std::string> deleted_files;
+  SyncPoint::GetInstance()->SetCallBack(
+      "DBImpl::DeleteObsoleteFileImpl::BeforeDeletion", [&](void* arg) {
+        const std::string* file = static_cast<std::string*>(arg);
+        assert(file);
+
+        constexpr char blob_extension[] = ".blob";
+
+        if (file->find(blob_extension) != std::string::npos) {
+          deleted_files.emplace_back(*file);
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
   dbfull()->PurgeObsoleteFiles(job_context);
   job_context.Clean();
 
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+
   ASSERT_EQ(files_grabbed_for_purge.find(first_blob_file_number),
             files_grabbed_for_purge.end());
+
+  std::sort(deleted_files.begin(), deleted_files.end());
+  const std::vector<std::string> expected_deleted_files{
+      BlobFileName(path, old_blob_file_number),
+      BlobFileName(path, first_blob_file_number)};
+
+  ASSERT_EQ(deleted_files, expected_deleted_files);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -244,7 +244,7 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
   dbfull()->TEST_UnlockMutex();
 
   ASSERT_TRUE(job_context.HaveSomethingToDelete());
-  ASSERT_FALSE(job_context.blob_delete_files.empty());
+  ASSERT_EQ(job_context.blob_delete_files.size(), 1);
   ASSERT_EQ(job_context.blob_delete_files[0].GetBlobFileNumber(),
             first_blob_file_number);
 
@@ -253,7 +253,7 @@ TEST_F(ObsoleteFilesTest, BlobFiles) {
   ASSERT_NE(files_grabbed_for_purge.find(first_blob_file_number),
             files_grabbed_for_purge.end());
 
-  ASSERT_FALSE(job_context.blob_live.empty());
+  ASSERT_EQ(job_context.blob_live.size(), 1);
   ASSERT_EQ(job_context.blob_live[0], second_blob_file_number);
 
   dbfull()->PurgeObsoleteFiles(job_context);

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -79,6 +79,11 @@ std::string LogFileName(uint64_t number) {
   return MakeFileName(number, "log");
 }
 
+std::string BlobFileName(uint64_t number) {
+  assert(number > 0);
+  return MakeFileName(number, kRocksDBBlobFileExt.c_str());
+}
+
 std::string BlobFileName(const std::string& blobdirname, uint64_t number) {
   assert(number > 0);
   return MakeFileName(blobdirname, number, kRocksDBBlobFileExt.c_str());

--- a/file/filename.h
+++ b/file/filename.h
@@ -56,6 +56,8 @@ extern std::string LogFileName(const std::string& dbname, uint64_t number);
 
 extern std::string LogFileName(uint64_t number);
 
+extern std::string BlobFileName(uint64_t number);
+
 extern std::string BlobFileName(const std::string& bdirname, uint64_t number);
 
 extern std::string BlobFileName(const std::string& dbname,


### PR DESCRIPTION
Summary:
The patch extends `FindObsoleteFiles` and `PurgeObsoleteFiles` with
support for blob files. The behavior is analogous to SST files: obsolete
blob files are put on the "candidates for deletion" list, while live (and pending)
files are preserved.

Test Plan:
`make check`