### PR TITLE
Disallow using the base DB's storage directory as blob_dir in BlobDB

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 * Add NewFileChecksumGenCrc32cFactory to the file checksum public API, such that the builtin Crc32c based file checksum generator factory can be used by applications.
 * Add IsDirectory to Env and FS to indicate if a path is a directory.
 * Flush(..., column_family) may return Status::ColumnFamilyDropped() instead of Status::InvalidArgument() if column_family is dropped while processing the flush request.
+* BlobDB now explicitly disallows using the default column family's storage directories as blob directory.
 
 ### New Features
 * Added support for pipelined & parallel compression optimization for `BlockBasedTableBuilder`. This optimization makes block building, block compression and block appending a pipeline, and uses multiple threads to accelerate block compression. Users can set `CompressionOptions::parallel_threads` greater than 1 to enable compression parallelism. This feature is experimental for now.

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -25,8 +25,9 @@ namespace blob_db {
 // users to use blob DB.
 
 struct BlobDBOptions {
-  // name of the directory under main db, where blobs will be stored.
-  // default is "blob_dir"
+  // Name of the directory under the base DB where blobs will be stored. Using
+  // a directory where the base DB stores its SST files is not supported.
+  // Default is "blob_dir"
   std::string blob_dir = "blob_dir";
 
   // whether the blob_dir path is relative or absolute.

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -211,6 +211,33 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   }
   db_impl_ = static_cast_with_check<DBImpl>(db_->GetRootDB());
 
+  // Sanitize the blob_dir provided. Using the same directory where the
+  // base DB stores its files for the default CF is not supported.
+  const ColumnFamilyData* const cfd =
+      static_cast<ColumnFamilyHandleImpl*>(DefaultColumnFamily())->cfd();
+  assert(cfd);
+
+  const ImmutableCFOptions* const ioptions = cfd->ioptions();
+  assert(ioptions);
+
+  assert(!ioptions->cf_paths.empty());
+  const std::string& cf_dir = ioptions->cf_paths.front().path;
+
+  assert(env_);
+  bool blob_dir_same_as_cf_dir = false;
+  s = env_->AreFilesSame(blob_dir_, cf_dir, &blob_dir_same_as_cf_dir);
+  if (!s.ok()) {
+    ROCKS_LOG_ERROR(db_options_.info_log,
+                    "Error while sanitizing blob_dir %s, status: %s",
+                    blob_dir_.c_str(), s.ToString().c_str());
+    return s;
+  }
+
+  if (blob_dir_same_as_cf_dir) {
+    return Status::NotSupported(
+        "Using the base DB's directory to store blob files is not supported.");
+  }
+
   // Initialize SST file <-> oldest blob file mapping if garbage collection
   // is enabled.
   if (bdb_options_.enable_garbage_collection) {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -220,8 +220,9 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
   const ImmutableCFOptions* const ioptions = cfd->ioptions();
   assert(ioptions);
 
+  assert(env_);
+
   for (const auto& cf_path : ioptions->cf_paths) {
-    assert(env_);
     bool blob_dir_same_as_cf_dir = false;
     s = env_->AreFilesSame(blob_dir_, cf_path.path, &blob_dir_same_as_cf_dir);
     if (!s.ok()) {

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -233,7 +233,7 @@ Status BlobDBImpl::Open(std::vector<ColumnFamilyHandle*>* handles) {
 
     if (blob_dir_same_as_cf_dir) {
       return Status::NotSupported(
-          "Using the base DB's directory to store blob files is not "
+          "Using the base DB's storage directories for BlobDB files is not "
           "supported.");
     }
   }


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/6807 extends the logic that
identifies and purges obsolete files to blob files handled by RocksDB
itself. In order to prevent that from interfering with the current BlobDB code,
we need to make sure that `BlobDBOptions::blob_dir` is different from
the storage directories used by the base DB. (Note: this is true by default.)
The patch adds a check that explicitly disallows this configuration and
returns `Status::NotSupported` from `BlobDB::Open` in such cases.

Test Plan:
Tested using the BlobDB mode of `db_bench`.