### PR TITLE
Supress an error with parallel compression + dictionary compression

### DIFF
--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -856,6 +856,9 @@ void BlockBasedTableBuilder::Flush() {
     if (r->first_key_in_next_block == nullptr) {
       block_rep->first_key_in_next_block.reset(nullptr);
     } else {
+      if (!block_rep->first_key_in_next_block) {
+        block_rep->first_key_in_next_block.reset(new td::string());
+      }
       block_rep->first_key_in_next_block->assign(
           r->first_key_in_next_block->data(),
           r->first_key_in_next_block->size());


### PR DESCRIPTION
Summary:
Stress tests occassionally fail with something like:

table/block_based/block_based_table_builder.cc:859:43: runtime error: member call on null pointer of type 'std::__cxx11::basic_string<char>'***

It's not completely clear why this can happen, but while we are investigating it, prevent this from happening by simply allocating a string if it is null. It's not clear whether it can fix a root cause, or even make the failure go away. Just a try to fix the stress test to be clean so that we can catch other bugs.

Test Plan: Run existing tests and make sure it doesn't break.