### PR TITLE
Disable "compression_parallel_threads" in crash test for now

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -44,7 +44,9 @@ default_params = {
     "checksum_type" : lambda: random.choice(["kCRC32c", "kxxHash", "kxxHash64"]),
     "compression_max_dict_bytes": lambda: 16384 * random.randint(0, 1),
     "compression_zstd_max_train_bytes": lambda: 65536 * random.randint(0, 1),
-    "compression_parallel_threads": lambda: random.choice([1] * 9 + [4]),
+    # Disabled compression_parallel_threads as the feature is not stable
+    # lambda: random.choice([1] * 9 + [4])
+    "compression_parallel_threads": 1,
     "clear_column_family_one_in": 0,
     "compact_files_one_in": 1000000,
     "compact_range_one_in": 1000000,


### PR DESCRIPTION
Summary:
"compressio_parallel_threads" caused several test failure tests. To keep crash test clean, disable it for now.

Test Plan: "make crash_test" to make sure the python script doesn't break