### PR TITLE
Add Support for saving CompressionOptions to Options File

### DIFF
--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -625,8 +625,65 @@ TEST_F(OptionsTest, CompressionOptionsFromString) {
   ASSERT_EQ(new_cf_opt.bottommost_compression_opts.parallel_threads,
             dflt.parallel_threads);
   ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled, false);
+
+  // Test as struct values
   ASSERT_OK(GetColumnFamilyOptionsFromString(
       config_options, ColumnFamilyOptions(),
+      "compression_opts={window_bits=5; level=6; strategy=7; max_dict_bytes=8;"
+      "zstd_max_train_bytes=9;parallel_threads=10;enabled=true}; "
+      "bottommost_compression_opts={window_bits=4; level=5; strategy=6;"
+      " max_dict_bytes=7;zstd_max_train_bytes=8;parallel_threads=9;"
+      "enabled=false}; ",
+      &new_cf_opt));
+  ASSERT_EQ(new_cf_opt.compression_opts.window_bits, 5);
+  ASSERT_EQ(new_cf_opt.compression_opts.level, 6);
+  ASSERT_EQ(new_cf_opt.compression_opts.strategy, 7);
+  ASSERT_EQ(new_cf_opt.compression_opts.max_dict_bytes, 8u);
+  ASSERT_EQ(new_cf_opt.compression_opts.zstd_max_train_bytes, 9u);
+  ASSERT_EQ(new_cf_opt.compression_opts.parallel_threads, 10u);
+  ASSERT_EQ(new_cf_opt.compression_opts.enabled, true);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.window_bits, 4);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.level, 5);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.strategy, 6);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.max_dict_bytes, 7u);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.zstd_max_train_bytes, 8u);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.parallel_threads, 9u);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled, false);
+
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, base_cf_opt,
+      "compression_opts={window_bits=4; strategy=5;};"
+      "bottommost_compression_opts={level=6; strategy=7;}",
+      &new_cf_opt));
+  ASSERT_EQ(new_cf_opt.compression_opts.window_bits, 4);
+  ASSERT_EQ(new_cf_opt.compression_opts.strategy, 5);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.level, 6);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.strategy, 7);
+
+  ASSERT_EQ(new_cf_opt.compression_opts.level,
+            base_cf_opt.compression_opts.level);
+  ASSERT_EQ(new_cf_opt.compression_opts.max_dict_bytes,
+            base_cf_opt.compression_opts.max_dict_bytes);
+  ASSERT_EQ(new_cf_opt.compression_opts.zstd_max_train_bytes,
+            base_cf_opt.compression_opts.zstd_max_train_bytes);
+  ASSERT_EQ(new_cf_opt.compression_opts.parallel_threads,
+            base_cf_opt.compression_opts.parallel_threads);
+  ASSERT_EQ(new_cf_opt.compression_opts.enabled,
+            base_cf_opt.compression_opts.enabled);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.window_bits,
+            base_cf_opt.bottommost_compression_opts.window_bits);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.max_dict_bytes,
+            base_cf_opt.bottommost_compression_opts.max_dict_bytes);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.zstd_max_train_bytes,
+            base_cf_opt.bottommost_compression_opts.zstd_max_train_bytes);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.parallel_threads,
+            base_cf_opt.bottommost_compression_opts.parallel_threads);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled,
+            base_cf_opt.bottommost_compression_opts.enabled);
+
+  // Test a few individual struct values
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, base_cf_opt,
       "compression_opts.enabled=false; "
       "bottommost_compression_opts.enabled=true; ",
       &new_cf_opt));

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -553,6 +553,115 @@ TEST_F(OptionsTest, GetColumnFamilyOptionsFromStringTest) {
   ASSERT_EQ(std::string(new_cf_opt.memtable_factory->Name()), "SkipListFactory");
 }
 
+TEST_F(OptionsTest, CompressionOptionsFromString) {
+  ColumnFamilyOptions base_cf_opt;
+  ColumnFamilyOptions new_cf_opt;
+  ConfigOptions config_options;
+  std::string opts_str;
+  config_options.ignore_unknown_options = false;
+  CompressionOptions dflt;
+  // Test with some optional values removed....
+  ASSERT_OK(
+      GetColumnFamilyOptionsFromString(config_options, ColumnFamilyOptions(),
+                                       "compression_opts=3:4:5; "
+                                       "bottommost_compression_opts=4:5:6:7",
+                                       &base_cf_opt));
+  ASSERT_EQ(base_cf_opt.compression_opts.window_bits, 3);
+  ASSERT_EQ(base_cf_opt.compression_opts.level, 4);
+  ASSERT_EQ(base_cf_opt.compression_opts.strategy, 5);
+  ASSERT_EQ(base_cf_opt.compression_opts.max_dict_bytes, dflt.max_dict_bytes);
+  ASSERT_EQ(base_cf_opt.compression_opts.zstd_max_train_bytes,
+            dflt.zstd_max_train_bytes);
+  ASSERT_EQ(base_cf_opt.compression_opts.parallel_threads,
+            dflt.parallel_threads);
+  ASSERT_EQ(base_cf_opt.compression_opts.enabled, dflt.enabled);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.window_bits, 4);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.level, 5);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.strategy, 6);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.max_dict_bytes, 7u);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.zstd_max_train_bytes,
+            dflt.zstd_max_train_bytes);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.parallel_threads,
+            dflt.parallel_threads);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.enabled, dflt.enabled);
+
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(),
+      "compression_opts=4:5:6:7:8:9:true; "
+      "bottommost_compression_opts=5:6:7:8:9:false",
+      &base_cf_opt));
+  ASSERT_EQ(base_cf_opt.compression_opts.window_bits, 4);
+  ASSERT_EQ(base_cf_opt.compression_opts.level, 5);
+  ASSERT_EQ(base_cf_opt.compression_opts.strategy, 6);
+  ASSERT_EQ(base_cf_opt.compression_opts.max_dict_bytes, 7u);
+  ASSERT_EQ(base_cf_opt.compression_opts.zstd_max_train_bytes, 8u);
+  ASSERT_EQ(base_cf_opt.compression_opts.parallel_threads, 9u);
+  ASSERT_EQ(base_cf_opt.compression_opts.enabled, true);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.window_bits, 5);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.level, 6);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.strategy, 7);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.max_dict_bytes, 8u);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.zstd_max_train_bytes, 9u);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.parallel_threads,
+            dflt.parallel_threads);
+  ASSERT_EQ(base_cf_opt.bottommost_compression_opts.enabled, false);
+
+  ASSERT_OK(
+      GetStringFromColumnFamilyOptions(config_options, base_cf_opt, &opts_str));
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(), opts_str, &new_cf_opt));
+  ASSERT_EQ(new_cf_opt.compression_opts.window_bits, 4);
+  ASSERT_EQ(new_cf_opt.compression_opts.level, 5);
+  ASSERT_EQ(new_cf_opt.compression_opts.strategy, 6);
+  ASSERT_EQ(new_cf_opt.compression_opts.max_dict_bytes, 7u);
+  ASSERT_EQ(new_cf_opt.compression_opts.zstd_max_train_bytes, 8u);
+  ASSERT_EQ(new_cf_opt.compression_opts.parallel_threads, 9u);
+  ASSERT_EQ(new_cf_opt.compression_opts.enabled, true);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.window_bits, 5);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.level, 6);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.strategy, 7);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.max_dict_bytes, 8u);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.zstd_max_train_bytes, 9u);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.parallel_threads,
+            dflt.parallel_threads);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled, false);
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(),
+      "compression_opts.enabled=false; "
+      "bottommost_compression_opts.enabled=true; ",
+      &new_cf_opt));
+  ASSERT_EQ(new_cf_opt.compression_opts.enabled, false);
+  ASSERT_EQ(new_cf_opt.bottommost_compression_opts.enabled, true);
+
+  // Now test some illegal values
+  ConfigOptions ignore;
+  ignore.ignore_unknown_options = true;
+  ASSERT_NOK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(),
+      "compression_opts=5:6:7:8:9:x:false", &base_cf_opt));
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      ignore, ColumnFamilyOptions(), "compression_opts=5:6:7:8:9:x:false",
+      &base_cf_opt));
+  ASSERT_NOK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(),
+      "compression_opts=1:2:3:4:5:6:true:8", &base_cf_opt));
+  ASSERT_OK(GetColumnFamilyOptionsFromString(
+      ignore, ColumnFamilyOptions(), "compression_opts=1:2:3:4:5:6:true:8",
+      &base_cf_opt));
+  ASSERT_NOK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(), "compression_opts={unknown=bad;}",
+      &base_cf_opt));
+  ASSERT_OK(GetColumnFamilyOptionsFromString(ignore, ColumnFamilyOptions(),
+                                             "compression_opts={unknown=bad;}",
+                                             &base_cf_opt));
+  ASSERT_NOK(GetColumnFamilyOptionsFromString(
+      config_options, ColumnFamilyOptions(), "compression_opts.unknown=bad",
+      &base_cf_opt));
+  ASSERT_OK(GetColumnFamilyOptionsFromString(ignore, ColumnFamilyOptions(),
+                                             "compression_opts.unknown=bad",
+                                             &base_cf_opt));
+}
+
 TEST_F(OptionsTest, OldInterfaceTest) {
   ColumnFamilyOptions base_cf_opt;
   ColumnFamilyOptions new_cf_opt;


### PR DESCRIPTION
This PR does a few things:
- The "compression_opts" and "bottom_compression_opts" can now be read/written as name/value pairs of options (instead of only a colon-separated list;
- These options can now be read/written to the Options file;
- The parallel_threads value can now be set (either in the colon or name-value format).

The compression options are now stored and treated as a OptionTypeInfo::Struct by the options system, meaning they can be read and written like the other structs.  This change allows them to be read/written easily to the options file.

Additionally, the colon-format was extended to allow support for setting parallel threads.  Tests were added to test all of the option settings via the optional parameters in the colon format.