### PR TITLE
Allow MultiGet users to limit cumulative value size

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 ### New Feature
 * sst_dump to add a new --readahead_size argument. Users can specify read size when scanning the data. Sst_dump also tries to prefetch tail part of the SST files so usually some number of I/Os are saved there too.
 * Generate file checksum in SstFileWriter if Options.file_checksum_gen_factory is set. The checksum and checksum function name are stored in ExternalSstFileInfo after the sst file write is finished.
+* Add a value_size_soft_limit in read options which limits the cumulative value size of keys read in batches in MultiGet. Once the cumulative value size of found keys exceeds read_options.value_size_soft_limit, all the remaining keys are returned with status Abort without further finding their values. By default the value_size_soft_limit is std::numeric_limits<uint64_t>::max().
 
 ## 6.10 (5/2/2020)
 ### Bug Fixes

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1356,6 +1356,13 @@ struct ReadOptions {
   // processing a batch
   std::chrono::microseconds deadline;
 
+  // It limits the maximum cumulative value size of the keys in batch while
+  // reading through MultiGet. Once the cumulative value size exceeds this
+  // soft limit then all the remaining keys are returned with status Aborted.
+  //
+  // Default: std::numeric_limits<uint64_t>::max()
+  uint64_t value_size_soft_limit;
+
   ReadOptions();
   ReadOptions(bool cksum, bool cache);
 };

--- a/options/options.cc
+++ b/options/options.cc
@@ -608,7 +608,8 @@ ReadOptions::ReadOptions()
       iter_start_seqnum(0),
       timestamp(nullptr),
       iter_start_ts(nullptr),
-      deadline(std::chrono::microseconds::zero()) {}
+      deadline(std::chrono::microseconds::zero()),
+      value_size_soft_limit(std::numeric_limits<uint64_t>::max()) {}
 
 ReadOptions::ReadOptions(bool cksum, bool cache)
     : snapshot(nullptr),
@@ -630,6 +631,7 @@ ReadOptions::ReadOptions(bool cksum, bool cache)
       iter_start_seqnum(0),
       timestamp(nullptr),
       iter_start_ts(nullptr),
-      deadline(std::chrono::microseconds::zero()) {}
+      deadline(std::chrono::microseconds::zero()),
+      value_size_soft_limit(std::numeric_limits<uint64_t>::max()) {}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/multiget_context.h
+++ b/table/multiget_context.h
@@ -97,6 +97,7 @@ class MultiGetContext {
                   const ReadOptions& read_opts)
       : num_keys_(num_keys),
         value_mask_(0),
+        value_size_(0),
         lookup_key_ptr_(reinterpret_cast<LookupKey*>(lookup_key_stack_buf)) {
     if (num_keys > MAX_LOOKUP_KEYS_ON_STACK) {
       lookup_key_heap_buf.reset(new char[sizeof(LookupKey) * num_keys]);
@@ -127,6 +128,7 @@ class MultiGetContext {
   std::array<KeyContext*, MAX_BATCH_SIZE> sorted_keys_;
   size_t num_keys_;
   uint64_t value_mask_;
+  uint64_t value_size_;
   std::unique_ptr<char[]> lookup_key_heap_buf;
   LookupKey* lookup_key_ptr_;
 
@@ -242,6 +244,10 @@ class MultiGetContext {
       assert(ctx_ == other.ctx_);
       skip_mask_ |= other.skip_mask_;
     }
+
+    uint64_t GetValueSize() { return ctx_->value_size_; }
+
+    void AddValueSize(uint64_t value_size) { ctx_->value_size_ += value_size; }
 
    private:
     friend MultiGetContext;


### PR DESCRIPTION
Summary: 1. Add a value_size in read options which limits the cumulative value size of keys read in batches. Once the size exceeds read_options.value_size, all the remaining keys are returned with status Abort without further fetching any key.
2. Add a unit test case MultiGetBatchedValueSizeSimple the reads keys from memory and sst files.

Test Plan: 1. make check -j64
	   2. Add a new unit test case

Reviewers:

Subscribers:

Tasks: T64971827

Tags: