### PR TITLE
Suppress UBSAN warning in CRC32 ARM

### DIFF
--- a/util/crc32c_arm64.cc
+++ b/util/crc32c_arm64.cc
@@ -44,6 +44,13 @@ uint32_t crc32c_runtime_check(void) {
 #endif
 }
 
+#ifdef ROCKSDB_UBSAN_RUN
+#if defined(__clang__)
+__attribute__((__no_sanitize__("alignment")))
+#elif defined(__GNUC__)
+__attribute__((__no_sanitize_undefined__))
+#endif
+#endif
 uint32_t crc32c_arm64(uint32_t crc, unsigned char const *data,
                              unsigned len) {
   const uint8_t *buf8;


### PR DESCRIPTION
Summary:
UBSAN shows following warning:

util/crc32c_arm64.cc:111:11: runtime error: load of misaligned address 0x00001afcda86 for type 'const uint64_t', which requires 8 byte alignment
0x00001afcda86: note: pointer points here
cc c1 2d 00 01 81  40 24 30 66 39 66 30 37  30 63 2d 32 36 63 34 2d  34 62 61 61 2d 38 35 33  31 2d
^

Suppress it just as what we do in x86 CRC.

Test Plan: Run the same UBSAN and see it to pass now.