### PR TITLE
Disable a few timer tests

### DIFF
--- a/util/timer_test.cc
+++ b/util/timer_test.cc
@@ -115,7 +115,7 @@ TEST_F(TimerTest, MultipleScheduleOnceTest) {
   ASSERT_EQ(5, count2);
 }
 
-TEST_F(TimerTest, SingleScheduleRepeatedlyTest) {
+TEST_F(TimerTest, DISABLED_SingleScheduleRepeatedlyTest) {
   const uint64_t kSecond = 1000000;  // 1sec = 1000000us
   const int kIterations = 5;
   uint64_t time_counter = 0;
@@ -153,7 +153,7 @@ TEST_F(TimerTest, SingleScheduleRepeatedlyTest) {
   ASSERT_EQ(5, count);
 }
 
-TEST_F(TimerTest, MultipleScheduleRepeatedlyTest) {
+TEST_F(TimerTest, DISABLED_MultipleScheduleRepeatedlyTest) {
   const uint64_t kSecond = 1000000;  // 1sec = 1000000us
   uint64_t time_counter = 0;
   mock_env_->set_current_time(0);


### PR DESCRIPTION
Disable `TimerTest.SingleScheduleRepeatedlyTest` and `TimerTest.MultipleScheduleRepeatedlyTest`. This is to help people to not hit any hangs (#6698) during their development process while I investigate further; I could not reproduce the issue on my dev machine yet. Note that timer is not being utilized anywhere yet.

Test Plan:
```
svemuri@devbig187 ~/rocksdb (timer-disable-test) $ TEST_TMPDIR=/dev/shm ./timer_test
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TimerTest
[ RUN      ] TimerTest.SingleScheduleOnceTest
[       OK ] TimerTest.SingleScheduleOnceTest (1 ms)
[ RUN      ] TimerTest.MultipleScheduleOnceTest
[       OK ] TimerTest.MultipleScheduleOnceTest (0 ms)
[----------] 2 tests from TimerTest (1 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 2 tests.

  YOU HAVE 2 DISABLED TESTS
```