### PR TITLE
Refactor the blob file related logic in VersionBuilder

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -86,6 +86,28 @@ class VersionBuilder::Rep {
     std::unordered_map<uint64_t, FileMetaData*> added_files;
   };
 
+  class BlobFileChanges {
+   public:
+    BlobFileChanges()
+        : additional_garbage_count_(0), additional_garbage_bytes_(0) {}
+
+    uint64_t AdditionalGarbageCount() const {
+      return additional_garbage_count_;
+    }
+    uint64_t AdditionalGarbageBytes() const {
+      return additional_garbage_bytes_;
+    }
+
+    void AddGarbage(uint64_t count, uint64_t bytes) {
+      additional_garbage_count_ += count;
+      additional_garbage_bytes_ += bytes;
+    }
+
+   private:
+    uint64_t additional_garbage_count_;
+    uint64_t additional_garbage_bytes_;
+  };
+
   const FileOptions& file_options_;
   const ImmutableCFOptions* const ioptions_;
   TableCache* table_cache_;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -189,9 +189,10 @@ class VersionBuilder::Rep {
       const auto& delta = delta_it->second;
 
       auto shared_meta = delta.GetSharedMeta();
-      assert(shared_meta);
 
-      return shared_meta;
+      if (shared_meta) {
+        return shared_meta;
+      }
     }
 
     assert(base_vstorage_);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -91,12 +91,19 @@ class VersionBuilder::Rep {
     BlobFileMetaDataDelta()
         : additional_garbage_count_(0), additional_garbage_bytes_(0) {}
 
+    bool IsEmpty() const {
+      return !shared_meta_ && !additional_garbage_count_ &&
+             !additional_garbage_bytes_;
+    }
+
     std::shared_ptr<SharedBlobFileMetaData> GetSharedMeta() const {
       return shared_meta_;
     }
+
     uint64_t GetAdditionalGarbageCount() const {
       return additional_garbage_count_;
     }
+
     uint64_t GetAdditionalGarbageBytes() const {
       return additional_garbage_bytes_;
     }
@@ -107,6 +114,7 @@ class VersionBuilder::Rep {
 
       shared_meta_ = std::move(shared_meta);
     }
+
     void AddGarbage(uint64_t count, uint64_t bytes) {
       additional_garbage_count_ += count;
       additional_garbage_bytes_ += bytes;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -615,6 +615,12 @@ class VersionBuilder::Rep {
       const uint64_t base_blob_file_number = base_it->first;
       const uint64_t delta_blob_file_number = delta_it->first;
 
+      // Note: blob file numbers are strictly increasing over time and
+      // once blob files get marked obsolete, they never reappear. Thus,
+      // the case delta_blob_file_number < base_blob_file_number is not
+      // possible here.
+      assert(base_blob_file_number <= delta_blob_file_number);
+
       if (base_blob_file_number < delta_blob_file_number) {
         const auto& base_meta = base_it->second;
         assert(base_meta);
@@ -624,14 +630,6 @@ class VersionBuilder::Rep {
         vstorage->AddBlobFile(base_meta);
 
         ++base_it;
-      } else if (delta_blob_file_number < base_blob_file_number) {
-        const auto& delta = delta_it->second;
-
-        auto meta = CreateMetaDataForNewBlobFile(delta);
-
-        AddBlobFileIfNeeded(vstorage, meta);
-
-        ++delta_it;
       } else {
         assert(base_blob_file_number == delta_blob_file_number);
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -615,12 +615,6 @@ class VersionBuilder::Rep {
       const uint64_t base_blob_file_number = base_it->first;
       const uint64_t delta_blob_file_number = delta_it->first;
 
-      // Note: blob file numbers are strictly increasing over time and
-      // once blob files get marked obsolete, they never reappear. Thus,
-      // the case delta_blob_file_number < base_blob_file_number is not
-      // possible here.
-      assert(base_blob_file_number <= delta_blob_file_number);
-
       if (base_blob_file_number < delta_blob_file_number) {
         const auto& base_meta = base_it->second;
         assert(base_meta);
@@ -630,6 +624,13 @@ class VersionBuilder::Rep {
         vstorage->AddBlobFile(base_meta);
 
         ++base_it;
+      } else if (delta_blob_file_number < base_blob_file_number) {
+        // Note: blob file numbers are strictly increasing over time and
+        // once blob files get marked obsolete, they never reappear. Thus,
+        // this case is not possible.
+        assert(false);
+
+        ++delta_it;
       } else {
         assert(base_blob_file_number == delta_blob_file_number);
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -88,9 +88,6 @@ class VersionBuilder::Rep {
 
   class BlobFileMetaDataDelta {
    public:
-    BlobFileMetaDataDelta()
-        : additional_garbage_count_(0), additional_garbage_bytes_(0) {}
-
     bool IsEmpty() const {
       return !shared_meta_ && !additional_garbage_count_ &&
              !additional_garbage_bytes_;
@@ -122,8 +119,8 @@ class VersionBuilder::Rep {
 
    private:
     std::shared_ptr<SharedBlobFileMetaData> shared_meta_;
-    uint64_t additional_garbage_count_;
-    uint64_t additional_garbage_bytes_;
+    uint64_t additional_garbage_count_ = 0;
+    uint64_t additional_garbage_bytes_ = 0;
   };
 
   const FileOptions& file_options_;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -86,9 +86,9 @@ class VersionBuilder::Rep {
     std::unordered_map<uint64_t, FileMetaData*> added_files;
   };
 
-  class BlobFileChanges {
+  class BlobFileMetaDataDelta {
    public:
-    BlobFileChanges()
+    BlobFileMetaDataDelta()
         : additional_garbage_count_(0), additional_garbage_bytes_(0) {}
 
     uint64_t AdditionalGarbageCount() const {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -190,9 +190,7 @@ class VersionBuilder::Rep {
   bool IsBlobFileInVersion(uint64_t blob_file_number) const {
     auto delta_it = blob_file_meta_deltas_.find(blob_file_number);
     if (delta_it != blob_file_meta_deltas_.end()) {
-      const auto& delta = delta_it->second;
-
-      if (delta.GetSharedMeta()) {
+      if (delta_it->second.GetSharedMeta()) {
         return true;
       }
     }
@@ -203,9 +201,8 @@ class VersionBuilder::Rep {
 
     auto base_it = base_blob_files.find(blob_file_number);
     if (base_it != base_blob_files.end()) {
-      const auto& meta = base_it->second;
-      assert(meta);
-      assert(meta->GetSharedMeta());
+      assert(base_it->second);
+      assert(base_it->second->GetSharedMeta());
 
       return true;
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -91,6 +91,9 @@ class VersionBuilder::Rep {
     BlobFileMetaDataDelta()
         : additional_garbage_count_(0), additional_garbage_bytes_(0) {}
 
+    std::shared_ptr<SharedBlobFileMetaData> GetSharedMeta() const {
+      return shared_meta_;
+    }
     uint64_t AdditionalGarbageCount() const {
       return additional_garbage_count_;
     }
@@ -98,12 +101,19 @@ class VersionBuilder::Rep {
       return additional_garbage_bytes_;
     }
 
+    void SetSharedMeta(std::shared_ptr<SharedBlobFileMetaData> shared_meta) {
+      assert(!shared_meta_);
+      assert(shared_meta);
+
+      shared_meta_ = std::move(shared_meta);
+    }
     void AddGarbage(uint64_t count, uint64_t bytes) {
       additional_garbage_count_ += count;
       additional_garbage_bytes_ += bytes;
     }
 
    private:
+    std::shared_ptr<SharedBlobFileMetaData> shared_meta_;
     uint64_t additional_garbage_count_;
     uint64_t additional_garbage_bytes_;
   };


### PR DESCRIPTION
Summary:
This patch is groundwork for an upcoming change to store the set of
linked SSTs in `BlobFileMetaData`. With the current code, a new
`BlobFileMetaData` object is created each time a `VersionEdit` touches
a certain blob file. This is fine as long as these objects are lightweight
and cheap to create; however, with the addition of the linked SST set, it would
be very inefficient since the set would have to be copied over and over again.
Note that this is the same kind of problem that `VersionBuilder` is solving
w/r/t `Version`s and files, and we can apply the same solution; that is, we can
accumulate the changes in a different mutable object, and apply the delta in
one shot when the changes are committed. The patch does exactly that by
adding a new `BlobFileMetaDataDelta` class to `VersionBuilder`. In addition,
it turns the existing `GetBlobFileMetaData` helper into `IsBlobFileInVersion`
(which is fine since that's the only thing the method's clients care about now),
and adds a couple of helper methods that can create a `BlobFileMetaData`
object from the `BlobFileMetaData` in the base (if applicable) and the delta
when the `Version` is saved.

Test Plan:
`make check`