### PR TITLE
Fix valgrind error by init memory region

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1317,10 +1317,10 @@ TEST_F(DBTest2, CompressionFailures) {
         if (curr_compression_failure_type == kTestDecompressionCorruption) {
           BlockContents* contents = static_cast<BlockContents*>(arg);
           // Ensure uncompressed data != original data
-          std::unique_ptr<char[]> fake_data(
-              new char[contents->data.size() + 1]);
-          *contents =
-              BlockContents(std::move(fake_data), contents->data.size() + 1);
+          const size_t len = contents->data.size() + 1;
+          std::unique_ptr<char[]> fake_data(new char[len]);
+          memset(fake_data.get(), 0, len);
+          *contents = BlockContents(std::move(fake_data), len);
         }
       });
 

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1318,8 +1318,7 @@ TEST_F(DBTest2, CompressionFailures) {
           BlockContents* contents = static_cast<BlockContents*>(arg);
           // Ensure uncompressed data != original data
           const size_t len = contents->data.size() + 1;
-          std::unique_ptr<char[]> fake_data(new char[len]);
-          memset(fake_data.get(), 0, len);
+          std::unique_ptr<char[]> fake_data(new char[len]());
           *contents = BlockContents(std::move(fake_data), len);
         }
       });


### PR DESCRIPTION
Summary:
As title. After allocating a memory buffer, initialize its content to 0s.
This fixes valgrind issue introduced in #6709.

Test Plan:
```
$make valgrind_test
$valgrind --tool=memcheck --track-origins=yes ./db_test2 --gtest_filter=DBTest2.CompressionFailures
```