### PR TITLE
Make options length longer for sst_dump_test

### DIFF
--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -22,7 +22,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-const uint32_t kOptLength = 100;
+const uint32_t kOptLength = 1024;
 
 namespace {
 static std::string MakeKey(int i) {


### PR DESCRIPTION
Under MacOS when running with make -j 8 check, the temporary directory generated was > 100 characters.  This caused the tests to do nothing under MacOS.  Most of them still reported success for doing nothing, but ReadaheadSize was expecting the test to run.

By making the option name longer, the tests will no run successfully (and do something!)