### PR TITLE
Status check enforcement for io_posix_test and options_settable_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,7 +668,9 @@ ifdef ASSERT_STATUS_CHECKED
 	# This is a new check for which we will add support incrementally. The
 	# whitelist can be removed once support is fully added.
         TESTS_WHITELIST = \
-		options_test
+		options_test \
+		options_settable_test \
+		io_posix_test
         TESTS := $(filter $(TESTS_WHITELIST),$(TESTS))
         PARALLEL_TEST := $(filter $(TESTS_WHITELIST),$(PARALLEL_TEST))
 endif

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -416,7 +416,7 @@ Status LogicalBlockSizeCache::RefAndCacheLogicalBlockSize(
       v.size = dir_size->second;
     }
   }
-  return Status::OK();
+  return s;
 }
 
 void LogicalBlockSizeCache::UnrefAndTryRemoveCachedLogicalBlockSize(

--- a/env/io_posix_test.cc
+++ b/env/io_posix_test.cc
@@ -67,7 +67,7 @@ TEST_F(LogicalBlockSizeCacheTest, Cache) {
   ASSERT_EQ(3, cache.GetLogicalBlockSize("/db2/sst2", 7));
   ASSERT_EQ(8, ncall);
 
-  cache.RefAndCacheLogicalBlockSize({"/db"});
+  ASSERT_OK(cache.RefAndCacheLogicalBlockSize({"/db"}));
   ASSERT_EQ(4, cache.Size());
   ASSERT_TRUE(cache.Contains("/"));
   ASSERT_TRUE(cache.Contains("/db1"));
@@ -104,7 +104,7 @@ TEST_F(LogicalBlockSizeCacheTest, Ref) {
   ASSERT_EQ(1, cache.GetLogicalBlockSize("/db/sst0", 1));
   ASSERT_EQ(1, ncall);
 
-  cache.RefAndCacheLogicalBlockSize({"/db"});
+  ASSERT_OK(cache.RefAndCacheLogicalBlockSize({"/db"}));
   ASSERT_EQ(2, ncall);
   ASSERT_EQ(1, cache.GetRefCount("/db"));
   // Block size for /db is cached. Ref count = 1.
@@ -112,7 +112,7 @@ TEST_F(LogicalBlockSizeCacheTest, Ref) {
   ASSERT_EQ(2, ncall);
 
   // Ref count = 2, but won't recompute the cached buffer size.
-  cache.RefAndCacheLogicalBlockSize({"/db"});
+  ASSERT_OK(cache.RefAndCacheLogicalBlockSize({"/db"}));
   ASSERT_EQ(2, cache.GetRefCount("/db"));
   ASSERT_EQ(2, ncall);
 


### PR DESCRIPTION
Summary: Added status check enforcement for io_posix_test and options_settable_test

Test Plan: ASSERT_STATUS_CHECKED=1 make -j48 check

Reviewers:

Subscribers:

Tasks:

Tags: