### PR TITLE
Fix a bug in crash_test_with_txn

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -366,7 +366,7 @@ class NonBatchedOpsStressTest : public StressTest {
         if (use_txn) {
 #ifndef ROCKSDB_LITE
           tmp_s = txn->Get(readoptionscopy, cfh, keys[i], &value);
-#endif // ROCKSDB_LITE
+#endif  // ROCKSDB_LITE
         } else {
           tmp_s = db_->Get(readoptionscopy, cfh, keys[i], &value);
         }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -364,7 +364,9 @@ class NonBatchedOpsStressTest : public StressTest {
         std::string value;
 
         if (use_txn) {
+#ifndef ROCKSDB_LITE
           tmp_s = txn->Get(readoptionscopy, cfh, keys[i], &value);
+#endif // ROCKSDB_LITE
         } else {
           tmp_s = db_->Get(readoptionscopy, cfh, keys[i], &value);
         }

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -363,7 +363,11 @@ class NonBatchedOpsStressTest : public StressTest {
         Status tmp_s;
         std::string value;
 
-        tmp_s = db_->Get(readoptionscopy, cfh, keys[i], &value);
+        if (use_txn) {
+          tmp_s = txn->Get(readoptionscopy, cfh, keys[i], &value);
+        } else {
+          tmp_s = db_->Get(readoptionscopy, cfh, keys[i], &value);
+        }
         if (!tmp_s.ok() && !tmp_s.IsNotFound()) {
           fprintf(stderr, "Get error: %s\n", s.ToString().c_str());
           is_consistent = false;


### PR DESCRIPTION
In NoBatchedOpsStress::TestMultiGet, call txn->Get() when transactions
are in use.

Test:
make crash_test_with_txn