### PR TITLE
Update format check script

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -34,6 +34,12 @@ jobs:
       with:
         args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
 
+    # Uncomment the following to setup interactive session.
+    # https://github.com/marketplace/actions/debugging-with-tmate?version=v2
+    # DEBUG ONLY, DO NOT COMMIT.
+    #- name: Setup tmate session
+    #  uses: mxschmitt/action-tmate@v2
+
     - name: Check format
       run: make check-format
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ buckifier/*.pyc
 buckifier/__pycache__
 
 compile_commands.json
+clang-format-diff.py

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -123,6 +123,8 @@ then
   exit 0
 elif [ $CHECK_ONLY ]
 then
+  echo Checking format.
+  echo "$diffs"
   echo "Your change has unformatted code. Please run make format!"
   exit 1
 fi


### PR DESCRIPTION
Update format check script so that unformatted code can be printed in the log of GH Action.

Test plan:
Watch for GH Action.