### PR TITLE
skip direct I/O tests in rocksdb lite

### DIFF
--- a/file/random_access_file_reader_test.cc
+++ b/file/random_access_file_reader_test.cc
@@ -74,6 +74,9 @@ class RandomAccessFileReaderTest : public testing::Test {
   }
 };
 
+// Skip the following tests in lite mode since direct I/O is unsupported.
+#ifndef ROCKSDB_LITE
+
 TEST_F(RandomAccessFileReaderTest, ReadDirectIO) {
   std::string fname = "read-direct-io";
   Random rand(0);
@@ -246,6 +249,8 @@ TEST_F(RandomAccessFileReaderTest, MultiReadDirectIO) {
     AssertResult(content, reqs);
   }
 }
+
+#endif  // ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -221,15 +221,18 @@ TEST_P(BlockBasedTableReaderTest, MultiGet) {
 
 // Param 1: compression type
 // Param 2: whether to use direct reads
+#ifdef ROCKSDB_LITE
+// Skip direct I/O tests in lite mode since direct I/O is unsupported.
 INSTANTIATE_TEST_CASE_P(
     MultiGet, BlockBasedTableReaderTest,
     ::testing::Combine(::testing::ValuesIn(GetSupportedCompressions()),
-#ifdef ROCKSDB_LITE
-                       ::testing::Values(false)
+                       ::testing::Values(false)));
 #else   // ROCKSDB_LITE
-                       ::testing::Bool()
+INSTANTIATE_TEST_CASE_P(
+    MultiGet, BlockBasedTableReaderTest,
+    ::testing::Combine(::testing::ValuesIn(GetSupportedCompressions()),
+                       ::testing::Bool()));
 #endif  // ROCKSDB_LITE
-                           ));
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -224,7 +224,12 @@ TEST_P(BlockBasedTableReaderTest, MultiGet) {
 INSTANTIATE_TEST_CASE_P(
     MultiGet, BlockBasedTableReaderTest,
     ::testing::Combine(::testing::ValuesIn(GetSupportedCompressions()),
-                       ::testing::Bool()));
+#ifdef ROCKSDB_LITE
+                       ::testing::Values(false)
+#else   // ROCKSDB_LITE
+                       ::testing::Bool()
+#endif  // ROCKSDB_LITE
+                           ));
 
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/table/block_fetcher_test.cc
+++ b/table/block_fetcher_test.cc
@@ -339,6 +339,9 @@ class BlockFetcherTest : public testing::Test {
   }
 };
 
+// Skip the following tests in lite mode since direct I/O is unsupported.
+#ifndef ROCKSDB_LITE
+
 // Fetch index block under both direct IO and non-direct IO.
 // Expects:
 // the index block contents are the same for both read modes.
@@ -436,6 +439,8 @@ TEST_F(BlockFetcherTest, FetchAndUncompressCompressedDataBlock) {
   TestFetchDataBlock("FetchAndUncompressCompressedDataBlock", true, true,
                      expected_non_direct_io_stats, expected_direct_io_stats);
 }
+
+#endif  // ROCKSDB_LITE
 
 }  // namespace
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Fix a couple places where direct I/O was used even though it is
unsupported in lite builds.

Test plan:
`LITE=1 make check -j48`