### PR TITLE
Misc things for ASSERT_STATUS_CHECKED, also gcc 4.8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -300,7 +300,7 @@ script:
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release $OPT && make -j4 rocksdb rocksdbjni
       ;;
     status_checked)
-      OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check
+      OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check_some
       ;;
     esac
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -633,10 +633,6 @@ TESTS = \
 	timer_test \
 	db_with_timestamp_compaction_test \
 
-ifeq ($(USE_FOLLY_DISTRIBUTED_MUTEX),1)
-	TESTS += folly_synchronization_distributed_mutex_test
-endif
-
 PARALLEL_TEST = \
 	backupable_db_test \
 	db_bloom_filter_test \
@@ -659,6 +655,11 @@ PARALLEL_TEST = \
 	transaction_lock_mgr_test \
 	write_prepared_transaction_test \
 	write_unprepared_transaction_test \
+
+ifeq ($(USE_FOLLY_DISTRIBUTED_MUTEX),1)
+	TESTS += folly_synchronization_distributed_mutex_test
+	PARALLEL_TEST += folly_synchronization_distributed_mutex_test
+endif
 
 # options_settable_test doesn't pass with UBSAN as we use hack in the test
 ifdef COMPILE_WITH_UBSAN
@@ -1034,8 +1035,10 @@ check: all
 ifneq ($(PLATFORM), OS_AIX)
 	$(PYTHON) tools/check_all_python.py
 ifeq ($(filter -DROCKSDB_LITE,$(OPT)),)
+ifndef ASSERT_STATUS_CHECKED # not yet working with these tests
 	$(PYTHON) tools/ldb_test.py
 	sh tools/rocksdb_dump_test.sh
+endif
 endif
 endif
 	$(MAKE) check-format

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -62,13 +62,13 @@ class RandomAccessFileReader {
  public:
   explicit RandomAccessFileReader(
       std::unique_ptr<FSRandomAccessFile>&& raf, const std::string& _file_name,
-      Env* env = nullptr, Statistics* stats = nullptr, uint32_t hist_type = 0,
+      Env* _env = nullptr, Statistics* stats = nullptr, uint32_t hist_type = 0,
       HistogramImpl* file_read_hist = nullptr,
       RateLimiter* rate_limiter = nullptr,
       const std::vector<std::shared_ptr<EventListener>>& listeners = {})
       : file_(std::move(raf)),
         file_name_(std::move(_file_name)),
-        env_(env),
+        env_(_env),
         stats_(stats),
         hist_type_(hist_type),
         file_read_hist_(file_read_hist),

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1122,17 +1122,18 @@ Status OptionTypeInfo::ParseStruct(
     // This option represents the entire struct
     std::unordered_map<std::string, std::string> opt_map;
     status = StringToMap(opt_value, &opt_map);
-    if (status.ok()) {
-      for (const auto& map_iter : opt_map) {
-        const auto iter = struct_map->find(map_iter.first);
-        if (iter != struct_map->end()) {
-          status = iter->second.Parse(config_options, map_iter.first,
-                                      map_iter.second,
-                                      opt_addr + iter->second.offset_);
-        } else {
-          return Status::InvalidArgument("Unrecognized option: ",
+    for (const auto& map_iter : opt_map) {
+      if (!status.ok()) {
+        break;
+      }
+      const auto iter = struct_map->find(map_iter.first);
+      if (iter != struct_map->end()) {
+        status =
+            iter->second.Parse(config_options, map_iter.first, map_iter.second,
+                               opt_addr + iter->second.offset_);
+      } else {
+        status = Status::InvalidArgument("Unrecognized option: ",
                                          struct_name + "." + map_iter.first);
-        }
       }
     }
   } else if (StartsWith(opt_name, struct_name + ".")) {

--- a/third-party/folly/folly/lang/Align.h
+++ b/third-party/folly/folly/lang/Align.h
@@ -22,6 +22,15 @@
 #include <folly/Portability.h>
 #include <folly/ConstexprMath.h>
 
+// Work around bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56019
+#ifdef __GNUC__
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9)
+namespace std {
+using ::max_align_t;
+}
+#endif
+#endif
+
 namespace folly {
 
 //  has_extended_alignment


### PR DESCRIPTION
Summary:
* Print stack trace on status checked failure
* Make folly_synchronization_distributed_mutex_test a parallel test
* Disable ldb_test.py and rocksdb_dump_test.sh with
  ASSERT_STATUS_CHECKED (broken)
* Fix shadow warning in random_access_file_reader.h reported by gcc
  4.8.5 (ROCKSDB_NO_FBCODE), also #6866
* Work around compiler bug on max_align_t for gcc < 4.9
* Remove an apparently wrong comment in status.h
* Use check_some in Travis config (for proper diagnostic output)
* Fix ignored Status in loop in options_helper.cc

Test Plan: manual, CI