### PR TITLE
pin image version in circle CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   windows-2xlarge:
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: 'windows-server-2019-vs2019:201908-06'
       resource_class: windows.2xlarge
       shell: bash.exe
 


### PR DESCRIPTION
somehow the windows-server-2019-vs2019 image changed in a way that made
VS 14 2015 the default. This caused an error when we specify VS 16 2019
as the cmake generator. I could not figure out the right arguments/env
vars to get the latest VS working so pinned the image to the previous
version instead.