### PR TITLE
Add a new int64 subtract merge operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,6 +745,7 @@ set(SOURCES
         utilities/leveldb_options/leveldb_options.cc
         utilities/memory/memory_util.cc
         utilities/merge_operators/bytesxor.cc
+        utilities/merge_operators/int64subtract.cc
         utilities/merge_operators/max.cc
         utilities/merge_operators/put.cc
         utilities/merge_operators/sortlist.cc
@@ -1114,6 +1115,7 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_serialize_test.cc
         utilities/checkpoint/checkpoint_test.cc
         utilities/memory/memory_test.cc
+        utilities/merge_operators/int64subtract_test.cc
         utilities/merge_operators/string_append/stringappend_test.cc
         utilities/object_registry_test.cc
         utilities/option_change_migration/option_change_migration_test.cc

--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,7 @@ TESTS = \
 	prefix_test \
 	skiplist_test \
 	write_buffer_manager_test \
+	int64subtract_test \
 	stringappend_test \
 	cassandra_format_test \
 	cassandra_functional_test \
@@ -1366,6 +1367,9 @@ random_test: util/random_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 option_change_migration_test: utilities/option_change_migration/option_change_migration_test.o db/db_test_util.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+int64subtract_test: utilities/merge_operators/int64subtract_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 stringappend_test: utilities/merge_operators/string_append/stringappend_test.o $(LIBOBJECTS) $(TESTHARNESS)

--- a/src.mk
+++ b/src.mk
@@ -212,6 +212,7 @@ LIB_SOURCES =                                                   \
   utilities/env_timed.cc                                        \
   utilities/leveldb_options/leveldb_options.cc                  \
   utilities/memory/memory_util.cc                               \
+  utilities/merge_operators/int64subtract.cc                    \
   utilities/merge_operators/max.cc                              \
   utilities/merge_operators/put.cc                              \
   utilities/merge_operators/sortlist.cc                  		    \
@@ -465,6 +466,7 @@ MAIN_SOURCES =                                                          \
   utilities/cassandra/cassandra_serialize_test.cc                       \
   utilities/checkpoint/checkpoint_test.cc                               \
   utilities/memory/memory_test.cc                                       \
+  utilities/merge_operators/int64subtract_test.cc                       \
   utilities/merge_operators/string_append/stringappend_test.cc          \
   utilities/object_registry_test.cc                                     \
   utilities/option_change_migration/option_change_migration_test.cc     \

--- a/utilities/merge_operators.h
+++ b/utilities/merge_operators.h
@@ -18,6 +18,7 @@ class MergeOperators {
   static std::shared_ptr<MergeOperator> CreatePutOperator();
   static std::shared_ptr<MergeOperator> CreateDeprecatedPutOperator();
   static std::shared_ptr<MergeOperator> CreateUInt64AddOperator();
+  static std::shared_ptr<MergeOperator> CreateInt64SubtractOperator();
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator();
   static std::shared_ptr<MergeOperator> CreateStringAppendOperator(char delim_char);
   static std::shared_ptr<MergeOperator> CreateStringAppendTESTOperator();
@@ -35,6 +36,8 @@ class MergeOperators {
       return CreateDeprecatedPutOperator();
     } else if ( name == "uint64add") {
       return CreateUInt64AddOperator();
+    } else if (name == "int64subtract") {
+      return CreateInt64SubtractOperator();
     } else if (name == "stringappend") {
       return CreateStringAppendOperator();
     } else if (name == "stringappendtest") {

--- a/utilities/merge_operators/int64subtract.cc
+++ b/utilities/merge_operators/int64subtract.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <memory>
+
+#include "logging/logging.h"
+#include "rocksdb/env.h"
+#include "rocksdb/merge_operator.h"
+#include "rocksdb/slice.h"
+#include "util/coding.h"
+#include "utilities/merge_operators.h"
+
+using namespace ROCKSDB_NAMESPACE;
+
+namespace {  // anonymous namespace
+
+// A 'model' merge operator with int64 subtraction semantics
+// operands and database value should be variable length encoded
+// int64_t values, as encoded/decoded by `util/coding.h`.
+class Int64SubtractMergeOperator : public AssociativeMergeOperator {
+ public:
+  bool Merge(const Slice&, const Slice* existing_value, const Slice& value,
+             std::string* new_value, Logger* logger) const override {
+    int64_t orig_value = 0;
+    if (existing_value) {
+      Slice ev(*existing_value);
+      if (!GetVarsignedint64(&ev, &orig_value)) {
+        ROCKS_LOG_ERROR(logger,
+                        "int64 value corruption, size: %" ROCKSDB_PRIszt,
+                        existing_value->size());
+        return false;
+      }
+    }
+
+    int64_t operand = 0;
+    Slice v(value);
+    if (!GetVarsignedint64(&v, &operand)) {
+      ROCKS_LOG_ERROR(logger,
+                      "int64 operand corruption, size: %" ROCKSDB_PRIszt,
+                      value.size());
+      return false;
+    }
+
+    assert(new_value);
+    new_value->clear();
+    const int64_t new_number = orig_value - operand;
+    PutVarsignedint64(new_value, new_number);
+
+    return true;
+  }
+
+  const char* Name() const override { return "Int64SubtractMergeOperator"; }
+};
+
+}  // namespace
+
+namespace ROCKSDB_NAMESPACE {
+
+std::shared_ptr<MergeOperator> MergeOperators::CreateInt64SubtractOperator() {
+  return std::make_shared<Int64SubtractMergeOperator>();
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/utilities/merge_operators/int64subtract_test.cc
+++ b/utilities/merge_operators/int64subtract_test.cc
@@ -1,0 +1,257 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#ifndef ROCKSDB_LITE
+
+#include "port/stack_trace.h"
+#include "rocksdb/db.h"
+#include "test_util/testharness.h"
+#include "util/coding.h"
+#include "utilities/merge_operators.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Int64SubtractMergeOperatorTest : public testing::Test {
+ public:
+  Int64SubtractMergeOperatorTest() {
+    options_.merge_operator =
+        MergeOperators::CreateFromStringId("int64subtract");
+    options_.create_if_missing = true;
+    dbname_ = test::PerThreadDBPath("write_batch_with_index_test");
+    DestroyDB(dbname_, options_);
+  }
+
+  ~Int64SubtractMergeOperatorTest() {
+    if (db_ != nullptr) {
+      delete db_;
+      DestroyDB(dbname_, options_);
+    }
+  }
+
+  Status OpenDB() { return DB::Open(options_, dbname_, &db_); }
+
+ public:
+  DB* db_;
+  std::string dbname_;
+  Options options_;
+  WriteOptions write_opts_;
+  ReadOptions read_opts_;
+};
+
+class EmptyDbTest : public Int64SubtractMergeOperatorTest,
+                    public testing::WithParamInterface<int64_t> {
+ public:
+  EmptyDbTest() : Int64SubtractMergeOperatorTest() {}
+};
+
+class NonEmptyDbTest
+    : public Int64SubtractMergeOperatorTest,
+      public testing::WithParamInterface<std::tuple<int64_t, int64_t>> {
+ public:
+  NonEmptyDbTest() : Int64SubtractMergeOperatorTest() {}
+};
+
+TEST_P(EmptyDbTest, MergeEmptyDb) {
+  const int64_t merge_num = GetParam();
+
+  std::string value;
+
+  ASSERT_OK(OpenDB());
+
+  PutVarsignedint64(&value, merge_num);
+  Status s =
+      db_->Merge(write_opts_, "key", value);  // Merging merge_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  s = db_->Get(read_opts_, "key", &value);
+  ASSERT_OK(s);
+  Slice read_slice(value);
+  int64_t read_value = 0;
+  const bool read_ok = GetVarsignedint64(&read_slice, &read_value);
+
+  ASSERT_TRUE(read_ok);
+  const int64_t expected = 0 - GetParam();
+  ASSERT_EQ(read_value,
+            expected);  // Merge operators should have been applied on empty db,
+                        // i.e. 0 and then subtracted merge_num.
+}
+
+TEST_P(EmptyDbTest, MergeEmptyDbCf) {
+  const int64_t merge_num = GetParam();
+
+  std::string value;
+
+  ASSERT_OK(OpenDB());
+  ColumnFamilyOptions cf_opts;
+  cf_opts.merge_operator = options_.merge_operator;
+  ColumnFamilyHandle* cf1;
+  Status s = db_->CreateColumnFamily(cf_opts, "cf1", &cf1);
+
+  PutVarsignedint64(&value, merge_num);
+  s = db_->Merge(write_opts_, cf1, "key",
+                 value);  // Merging merge_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  s = db_->Get(read_opts_, cf1, "key", &value);
+  ASSERT_OK(s);
+  Slice read_slice(value);
+  int64_t read_value = 0;
+  const bool read_ok = GetVarsignedint64(&read_slice, &read_value);
+
+  db_->DropColumnFamily(cf1);
+  db_->DestroyColumnFamilyHandle(cf1);
+
+  ASSERT_TRUE(read_ok);
+  const int64_t expected = 0 - GetParam();
+  ASSERT_EQ(read_value,
+            expected);  // Merge operators should have been applied on empty db,
+                        // i.e. 0 and then subtracted merge_num.
+}
+
+TEST_P(NonEmptyDbTest, MergeNonEmptyDb) {
+  const int64_t initial_db_num = std::get<0>(GetParam());
+  const int64_t merge_num = std::get<1>(GetParam());
+
+  std::string value;
+
+  ASSERT_OK(OpenDB());
+
+  PutVarsignedint64(&value, initial_db_num);
+  Status s =
+      db_->Put(write_opts_, "key", value);  // Put initial_db_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  PutVarsignedint64(&value, merge_num);
+  s = db_->Merge(write_opts_, "key", value);  // Merging merge_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  s = db_->Get(read_opts_, "key", &value);
+  ASSERT_OK(s);
+  Slice read_slice(value);
+  int64_t read_value = 0;
+  const bool read_ok = GetVarsignedint64(&read_slice, &read_value);
+
+  ASSERT_TRUE(read_ok);
+  const int64_t expected = initial_db_num - merge_num;
+  ASSERT_EQ(read_value,
+            expected);  // Merge operators should have been applied on non-empty
+                        // db, and then merge subtracted merge_num.
+}
+
+TEST_P(NonEmptyDbTest, MergeNonEmptyDbCf) {
+  const int64_t initial_db_num = std::get<0>(GetParam());
+  const int64_t merge_num = std::get<1>(GetParam());
+
+  std::string value;
+
+  ASSERT_OK(OpenDB());
+  ColumnFamilyOptions cf_opts;
+  cf_opts.merge_operator = options_.merge_operator;
+  ColumnFamilyHandle* cf1;
+  Status s = db_->CreateColumnFamily(cf_opts, "cf1", &cf1);
+
+  PutVarsignedint64(&value, initial_db_num);
+  s = db_->Put(write_opts_, cf1, "key", value);  // Put initial_db_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  PutVarsignedint64(&value, merge_num);
+  s = db_->Merge(write_opts_, cf1, "key",
+                 value);  // Merging merge_num under key
+  ASSERT_OK(s);
+
+  value.clear();
+
+  s = db_->Get(read_opts_, cf1, "key", &value);
+  ASSERT_OK(s);
+  Slice read_slice(value);
+  int64_t read_value = 0;
+  const bool read_ok = GetVarsignedint64(&read_slice, &read_value);
+
+  db_->DropColumnFamily(cf1);
+  db_->DestroyColumnFamilyHandle(cf1);
+
+  ASSERT_TRUE(read_ok);
+  const int64_t expected = initial_db_num - merge_num;
+  ASSERT_EQ(read_value,
+            expected);  // Merge operators should have been applied on non-empty
+                        // db, and then merge subtracted merge_num.
+}
+
+TEST_F(Int64SubtractMergeOperatorTest, MergeMultipleValues) {
+  std::string value;
+
+  ASSERT_OK(OpenDB());
+
+  PutVarsignedint64(&value, 123);
+  Status s = db_->Merge(write_opts_, "key", value);  // Merging 123 under key
+  ASSERT_OK(s);
+  value.clear();
+
+  PutVarsignedint64(&value, -1234);
+  s = db_->Merge(write_opts_, "key", value);  // Merging -1234 under key
+  ASSERT_OK(s);
+  value.clear();
+
+  PutVarsignedint64(&value, 99);
+  s = db_->Merge(write_opts_, "key", value);  // Merging 99 under key
+  ASSERT_OK(s);
+  value.clear();
+
+  PutVarsignedint64(&value, -101);
+  s = db_->Merge(write_opts_, "key", value);  // Merging -101 under key
+  ASSERT_OK(s);
+  value.clear();
+
+  s = db_->Get(read_opts_, "key", &value);
+  ASSERT_OK(s);
+  Slice read_slice(value);
+  int64_t read_value = 0;
+  const bool read_ok = GetVarsignedint64(&read_slice, &read_value);
+
+  ASSERT_TRUE(read_ok);
+  const int64_t expected = 0 - 123 - (-1234) - 99 - (-101);
+  ASSERT_EQ(read_value,
+            expected);  // Merge operators should have been applied on non-empty
+                        // db, and then merge subtracted merge_num.
+}
+
+INSTANTIATE_TEST_CASE_P(Int64SubtractMergeOperatorTest, EmptyDbTest,
+                        testing::Values(-255, -2, -1, 0, 1, 2, 255));
+INSTANTIATE_TEST_CASE_P(
+    Int64SubtractMergeOperatorTest, NonEmptyDbTest,
+    testing::Combine(testing::Values(-255, -2, -1, 0, 1, 2, 255),
+                     testing::Values(-255, -2, -1, 0, 1, 2, 255)));
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+#else
+#include <stdio.h>
+
+int main() {
+  fprintf(stderr, "SKIPPED\n");
+  return 0;
+}
+
+#endif  // !ROCKSDB_LITE


### PR DESCRIPTION
This merge operator subtracts `uint64_t` values. My use-case for this is testing the Merge operator on `WBWI` and `BaseDeltaIterator`. This merge operator has an advantage over the other available merge operators, in that a Get after a Merge will not return the same value that was passed to the Merge if the merge operator was executed. The same is not true of the other merge operators, for example:

UInt64AddOperator -> WBWI.Merge(K1, 19) -> WBWI.Get(K1) == 19. However you cannot tell if the merge operator was called or not... If the merge operator was called, the value will be 19, if it was not called, the value is also 19!

At a cursory glance, this may appear similar to `UInt64AddOperator`, but this merge operator handles signed numbers.

This merge operator may also add value for general use by others that want a decrementing counter or similar. However, that is not my use-case. I need this for further testing and making improvements to Merge in WBWI scenarios.