### PR TITLE
Fix wrong result read from ingested file from iterator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 * Fix corruption caused by enabling delete triggered compaction (NewCompactOnDeletionCollectorFactory) in universal compaction mode, along with parallel compactions. The bug can result in two parallel compactions picking the same input files, resulting in the DB resurrecting older and deleted versions of some keys.
 * Fix a use-after-free bug in best-efforts recovery. column_family_memtables_ needs to point to valid ColumnFamilySet.
 * Let best-efforts recovery ignore corrupted files during table loading.
+* Fix wrong result being read from ingested file when calling Next() follow by Prev() or SeekForPrev() on an iterator.
 
 ### Public API Change
 * Flush(..., column_family) may return Status::ColumnFamilyDropped() instead of Status::InvalidArgument() if column_family is dropped while processing the flush request.

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -437,7 +437,7 @@ class IterKey {
   // Update the sequence number in the internal key.  Guarantees not to
   // invalidate slices to the key (and the user key).
   void UpdateInternalKey(uint64_t seq, ValueType t) {
-    // assert(!IsKeyPinned());
+    assert(!IsKeyPinned());
     assert(key_size_ >= 8);
     uint64_t newval = (seq << 8) | t;
     EncodeFixed64(&buf_[key_size_ - 8], newval);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -437,7 +437,7 @@ class IterKey {
   // Update the sequence number in the internal key.  Guarantees not to
   // invalidate slices to the key (and the user key).
   void UpdateInternalKey(uint64_t seq, ValueType t) {
-    assert(!IsKeyPinned());
+    // assert(!IsKeyPinned());
     assert(key_size_ >= 8);
     uint64_t newval = (seq << 8) | t;
     EncodeFixed64(&buf_[key_size_ - 8], newval);

--- a/table/block_based/block.h
+++ b/table/block_based/block.h
@@ -449,12 +449,16 @@ class DataBlockIter final : public BlockIter<Slice> {
   mutable uint32_t last_bitmap_offset_;
   struct CachedPrevEntry {
     explicit CachedPrevEntry(uint32_t _offset, const char* _key_ptr,
-                             size_t _key_offset, size_t _key_size, Slice _value)
+                             size_t _key_offset, size_t _key_size, Slice _value,
+                             SequenceNumber _stored_seqno,
+                             ValueType _stored_value_type)
         : offset(_offset),
           key_ptr(_key_ptr),
           key_offset(_key_offset),
           key_size(_key_size),
-          value(_value) {}
+          value(_value),
+          stored_seqno(_stored_seqno),
+          stored_value_type(_stored_value_type) {}
 
     // offset of entry in block
     uint32_t offset;
@@ -466,6 +470,11 @@ class DataBlockIter final : public BlockIter<Slice> {
     size_t key_size;
     // value slice pointing to data in block
     Slice value;
+    // Original seqno stored in block, if replaced by global seqno.
+    SequenceNumber stored_seqno = 0;
+    // Original value type stored in block, if seqno is replaced by global
+    // seqno.
+    ValueType stored_value_type = kMaxValue;
   };
   std::string prev_entries_keys_buff_;
   std::vector<CachedPrevEntry> prev_entries_;


### PR DESCRIPTION
Summary:
Fix issue introduced in #6669. The patch doesn't handle the case for `Prev()`, where results are cached in a local buffer. As a result, `DataBlockIter::ParseNextDataKey()` can restore to a wrong value type when restore the original seqno replaced by global seqno. This can cause wrong result being returned from iterators when issue `Next()` after `Prev()` or `SeekForPrev()`.

Test Plan:
Add new unit test. The test will fail on the `!IsKeyPinned()` assert in `IterKey::UpdateInternalKey()`. After comment out the assert the test will fail with iterator returning wrong result.

Signed-off-by: Yi Wu <yiwu@pingcap.com>