### PR TITLE
Pre-work of adding ExportColumnFamily and CreateColumnFamilyWithImport for Java

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -33,6 +33,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/ingest_external_file_options.cc
         rocksjni/iterator.cc
         rocksjni/jnicallback.cc
+        rocksjni/live_file_metadata.cc
         rocksjni/loggerjnicallback.cc
         rocksjni/lru_cache.cc
         rocksjni/memory_util.cc
@@ -53,6 +54,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/slice.cc
         rocksjni/snapshot.cc
         rocksjni/sst_file_manager.cc
+        rocksjni/sst_file_metadata.cc
         rocksjni/sst_file_writerjni.cc
         rocksjni/sst_file_readerjni.cc
         rocksjni/sst_file_reader_iterator.cc

--- a/java/Makefile
+++ b/java/Makefile
@@ -36,6 +36,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.HashLinkedListMemTableConfig\
 	org.rocksdb.HashSkipListMemTableConfig\
 	org.rocksdb.HdfsEnv\
+	org.rocksdb.LiveFileMetaData\
 	org.rocksdb.Logger\
 	org.rocksdb.LRUCache\
 	org.rocksdb.MemoryUsageType\
@@ -60,6 +61,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.SkipListMemTableConfig\
 	org.rocksdb.Slice\
 	org.rocksdb.SstFileManager\
+	org.rocksdb.SstFileMetaData\
 	org.rocksdb.SstFileWriter\
 	org.rocksdb.SstFileReader\
 	org.rocksdb.SstFileReaderIterator\
@@ -133,6 +135,7 @@ JAVA_TESTS = \
 	org.rocksdb.FlushTest\
 	org.rocksdb.InfoLogLevelTest\
 	org.rocksdb.KeyMayExistTest\
+	org.rocksdb.LiveFileMetaDataTest\
 	org.rocksdb.LoggerTest\
 	org.rocksdb.LRUCacheTest\
 	org.rocksdb.MemoryUtilTest\
@@ -162,6 +165,7 @@ JAVA_TESTS = \
 	org.rocksdb.SliceTest\
 	org.rocksdb.SnapshotTest\
 	org.rocksdb.SstFileManagerTest\
+	org.rocksdb.SstFileMetaDataTest\
 	org.rocksdb.SstFileWriterTest\
 	org.rocksdb.SstFileReaderTest\
 	org.rocksdb.TableFilterTest\

--- a/java/rocksjni/live_file_metadata.cc
+++ b/java/rocksjni/live_file_metadata.cc
@@ -1,0 +1,145 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ for LiveFileMetaData
+
+#include <jni.h>
+
+#include "include/org_rocksdb_LiveFileMetaData.h"
+#include "rocksdb/metadata.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    newLiveFileMetaData
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_LiveFileMetaData_newLiveFileMetaData__(JNIEnv*, jclass) {
+  auto* metadata = new ROCKSDB_NAMESPACE::LiveFileMetaData();
+  return reinterpret_cast<jlong>(metadata);
+}
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    newLiveFileMetaData
+ * Signature: ([BIILjava/lang/String;Ljava/lang/String;JJJ[BI[BIJZJJ)J
+ */
+jlong Java_org_rocksdb_LiveFileMetaData_newLiveFileMetaData___3BIILjava_lang_String_2Ljava_lang_String_2JJJ_3BI_3BIJZJJ(
+    JNIEnv* env, jclass, jbyteArray jcolumn_family_name,
+    jint jcolumn_family_name_len, jint jlevel, jstring jfile_name,
+    jstring jpath, jlong jfile_size, jlong jsmallest_seqno,
+    jlong jlargest_seqno, jbyteArray jsmallest_key, jint jsmallest_key_len,
+    jbyteArray jlargest_key, jint jlargest_key_len, jlong jnum_reads_sampled,
+    jboolean jbeing_compacted, jlong jnum_entries, jlong jnum_deletions) {
+  auto* metadata = new ROCKSDB_NAMESPACE::LiveFileMetaData();
+
+  jboolean has_exception = JNI_FALSE;
+  const std::string column_family_name =
+      ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+          env, jcolumn_family_name, jcolumn_family_name_len,
+          [](const char* str, const size_t len) {
+            return std::string(str, len);
+          },
+          &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  std::string file_name = ROCKSDB_NAMESPACE::JniUtil::copyStdString(
+      env, jfile_name, &has_exception);
+  if (has_exception == JNI_TRUE) {
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(
+        env, "Could not copy jstring to std::string");
+    return 0;
+  }
+
+  std::string path =
+      ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jpath, &has_exception);
+  if (has_exception == JNI_TRUE) {
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(
+        env, "Could not copy jstring to std::string");
+    return 0;
+  }
+
+  const std::string smallestkey =
+      ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+          env, jsmallest_key, jsmallest_key_len,
+          [](const char* str, const size_t len) {
+            return std::string(str, len);
+          },
+          &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  const std::string largestkey =
+      ROCKSDB_NAMESPACE::JniUtil::byteString<std::string>(
+          env, jlargest_key, jlargest_key_len,
+          [](const char* str, const size_t len) {
+            return std::string(str, len);
+          },
+          &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  metadata->column_family_name = column_family_name;
+  metadata->level = static_cast<int>(jlevel);
+  metadata->name = file_name;
+  metadata->db_path = path;
+  metadata->size = static_cast<size_t>(jfile_size);
+  metadata->smallest_seqno =
+      static_cast<ROCKSDB_NAMESPACE::SequenceNumber>(jsmallest_seqno);
+  metadata->largest_seqno =
+      static_cast<ROCKSDB_NAMESPACE::SequenceNumber>(jlargest_seqno);
+  metadata->smallestkey = smallestkey;
+  metadata->largestkey = largestkey;
+  metadata->num_reads_sampled = static_cast<uint64_t>(jnum_reads_sampled);
+  metadata->being_compacted = (jbeing_compacted == JNI_TRUE);
+  metadata->num_entries = static_cast<uint64_t>(jnum_entries);
+  metadata->num_deletions = static_cast<uint64_t>(jnum_deletions);
+
+  return reinterpret_cast<jlong>(metadata);
+}
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_LiveFileMetaData_disposeInternal(JNIEnv*, jobject,
+                                                       jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(jhandle);
+  delete metadata;
+}
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    columnFamilyName
+ * Signature: (J)[B
+ */
+jbyteArray Java_org_rocksdb_LiveFileMetaData_columnFamilyName(JNIEnv* env,
+                                                              jobject,
+                                                              jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::copyBytes(env,
+                                               metadata->column_family_name);
+}
+
+/*
+ * Class:     org_rocksdb_LiveFileMetaData
+ * Method:    level
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_LiveFileMetaData_level(JNIEnv*, jobject, jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(jhandle);
+  return static_cast<jint>(metadata->level);
+}

--- a/java/rocksjni/portal.h
+++ b/java/rocksjni/portal.h
@@ -6943,88 +6943,14 @@ class LiveFileMetaDataJni : public JavaClass {
       return nullptr;
     }
 
-    jmethodID mid = env->GetMethodID(jclazz, "<init>", "([BILjava/lang/String;Ljava/lang/String;JJJ[B[BJZJJ)V");
+    jmethodID mid = env->GetMethodID(jclazz, "<init>", "(J)V");
     if (mid == nullptr) {
       // exception thrown: NoSuchMethodException or OutOfMemoryError
       return nullptr;
     }
 
-    jbyteArray jcolumn_family_name = ROCKSDB_NAMESPACE::JniUtil::copyBytes(
-        env, live_file_meta_data->column_family_name);
-    if (jcolumn_family_name == nullptr) {
-      // exception occurred creating java byte array
-      return nullptr;
-    }
-
-    jstring jfile_name = ROCKSDB_NAMESPACE::JniUtil::toJavaString(
-        env, &live_file_meta_data->name, true);
-    if (env->ExceptionCheck()) {
-      // exception occurred creating java string
-      env->DeleteLocalRef(jcolumn_family_name);
-      return nullptr;
-    }
-
-    jstring jpath = ROCKSDB_NAMESPACE::JniUtil::toJavaString(
-        env, &live_file_meta_data->db_path, true);
-    if (env->ExceptionCheck()) {
-      // exception occurred creating java string
-      env->DeleteLocalRef(jcolumn_family_name);
-      env->DeleteLocalRef(jfile_name);
-      return nullptr;
-    }
-
-    jbyteArray jsmallest_key = ROCKSDB_NAMESPACE::JniUtil::copyBytes(
-        env, live_file_meta_data->smallestkey);
-    if (jsmallest_key == nullptr) {
-      // exception occurred creating java byte array
-      env->DeleteLocalRef(jcolumn_family_name);
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      return nullptr;
-    }
-
-    jbyteArray jlargest_key = ROCKSDB_NAMESPACE::JniUtil::copyBytes(
-        env, live_file_meta_data->largestkey);
-    if (jlargest_key == nullptr) {
-      // exception occurred creating java byte array
-      env->DeleteLocalRef(jcolumn_family_name);
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      env->DeleteLocalRef(jsmallest_key);
-      return nullptr;
-    }
-
-    jobject jlive_file_meta_data = env->NewObject(jclazz, mid,
-        jcolumn_family_name,
-        static_cast<jint>(live_file_meta_data->level),
-        jfile_name,
-        jpath,
-        static_cast<jlong>(live_file_meta_data->size),
-        static_cast<jlong>(live_file_meta_data->smallest_seqno),
-        static_cast<jlong>(live_file_meta_data->largest_seqno),
-        jsmallest_key,
-        jlargest_key,
-        static_cast<jlong>(live_file_meta_data->num_reads_sampled),
-        static_cast<jboolean>(live_file_meta_data->being_compacted),
-        static_cast<jlong>(live_file_meta_data->num_entries),
-        static_cast<jlong>(live_file_meta_data->num_deletions)
-    );
-
-    if (env->ExceptionCheck()) {
-      env->DeleteLocalRef(jcolumn_family_name);
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      env->DeleteLocalRef(jsmallest_key);
-      env->DeleteLocalRef(jlargest_key);
-      return nullptr;
-    }
-
-    // cleanup
-    env->DeleteLocalRef(jcolumn_family_name);
-    env->DeleteLocalRef(jfile_name);
-    env->DeleteLocalRef(jpath);
-    env->DeleteLocalRef(jsmallest_key);
-    env->DeleteLocalRef(jlargest_key);
+    jobject jlive_file_meta_data = env->NewObject(
+        jclazz, mid, reinterpret_cast<jlong>(live_file_meta_data));
 
     return jlive_file_meta_data;
   }
@@ -7054,73 +6980,14 @@ class SstFileMetaDataJni : public JavaClass {
       return nullptr;
     }
 
-    jmethodID mid = env->GetMethodID(jclazz, "<init>", "(Ljava/lang/String;Ljava/lang/String;JJJ[B[BJZJJ)V");
+    jmethodID mid = env->GetMethodID(jclazz, "<init>", "(J)V");
     if (mid == nullptr) {
       // exception thrown: NoSuchMethodException or OutOfMemoryError
       return nullptr;
     }
 
-    jstring jfile_name = ROCKSDB_NAMESPACE::JniUtil::toJavaString(
-        env, &sst_file_meta_data->name, true);
-    if (jfile_name == nullptr) {
-      // exception occurred creating java byte array
-      return nullptr;
-    }
-
-    jstring jpath = ROCKSDB_NAMESPACE::JniUtil::toJavaString(
-        env, &sst_file_meta_data->db_path, true);
-    if (jpath == nullptr) {
-      // exception occurred creating java byte array
-      env->DeleteLocalRef(jfile_name);
-      return nullptr;
-    }
-
-    jbyteArray jsmallest_key = ROCKSDB_NAMESPACE::JniUtil::copyBytes(
-        env, sst_file_meta_data->smallestkey);
-    if (jsmallest_key == nullptr) {
-      // exception occurred creating java byte array
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      return nullptr;
-    }
-
-    jbyteArray jlargest_key = ROCKSDB_NAMESPACE::JniUtil::copyBytes(
-        env, sst_file_meta_data->largestkey);
-    if (jlargest_key == nullptr) {
-      // exception occurred creating java byte array
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      env->DeleteLocalRef(jsmallest_key);
-      return nullptr;
-    }
-
-    jobject jsst_file_meta_data = env->NewObject(jclazz, mid,
-        jfile_name,
-        jpath,
-        static_cast<jlong>(sst_file_meta_data->size),
-        static_cast<jint>(sst_file_meta_data->smallest_seqno),
-        static_cast<jlong>(sst_file_meta_data->largest_seqno),
-        jsmallest_key,
-        jlargest_key,
-        static_cast<jlong>(sst_file_meta_data->num_reads_sampled),
-        static_cast<jboolean>(sst_file_meta_data->being_compacted),
-        static_cast<jlong>(sst_file_meta_data->num_entries),
-        static_cast<jlong>(sst_file_meta_data->num_deletions)
-    );
-
-    if (env->ExceptionCheck()) {
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      env->DeleteLocalRef(jsmallest_key);
-      env->DeleteLocalRef(jlargest_key);
-      return nullptr;
-    }
-
-    // cleanup
-      env->DeleteLocalRef(jfile_name);
-      env->DeleteLocalRef(jpath);
-      env->DeleteLocalRef(jsmallest_key);
-      env->DeleteLocalRef(jlargest_key);
+    jobject jsst_file_meta_data = env->NewObject(
+        jclazz, mid, reinterpret_cast<jlong>(sst_file_meta_data));
 
     return jsst_file_meta_data;
   }

--- a/java/rocksjni/sst_file_metadata.cc
+++ b/java/rocksjni/sst_file_metadata.cc
@@ -1,0 +1,166 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ for SstFileMetaData
+
+#include <jni.h>
+
+#include "include/org_rocksdb_SstFileMetaData.h"
+#include "rocksdb/metadata.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    newSstFileMetaData
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_newSstFileMetaData(JNIEnv*, jclass) {
+  auto* metadata = new ROCKSDB_NAMESPACE::SstFileMetaData();
+  return reinterpret_cast<jlong>(metadata);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_SstFileMetaData_disposeInternal(JNIEnv*, jobject,
+                                                      jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  delete metadata;
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    fileName
+ * Signature: (J)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_SstFileMetaData_fileName(JNIEnv* env, jobject,
+                                                  jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::toJavaString(env, &metadata->name, false);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    path
+ * Signature: (J)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_SstFileMetaData_path(JNIEnv* env, jobject,
+                                              jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::toJavaString(env, &metadata->db_path,
+                                                  false);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    size
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_size(JNIEnv*, jobject, jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->size);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    smallestSeqno
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_smallestSeqno(JNIEnv*, jobject,
+                                                     jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->smallest_seqno);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    largestSeqno
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_largestSeqno(JNIEnv*, jobject,
+                                                    jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->largest_seqno);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    smallestKey
+ * Signature: (J)[B
+ */
+jbyteArray Java_org_rocksdb_SstFileMetaData_smallestKey(JNIEnv* env, jobject,
+                                                        jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::copyBytes(env, metadata->smallestkey);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    largestKey
+ * Signature: (J)[B
+ */
+jbyteArray Java_org_rocksdb_SstFileMetaData_largestKey(JNIEnv* env, jobject,
+                                                       jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::copyBytes(env, metadata->largestkey);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    numReadsSampled
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_numReadsSampled(JNIEnv*, jobject,
+                                                       jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->num_reads_sampled);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    beingCompacted
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_SstFileMetaData_beingCompacted(JNIEnv*, jobject,
+                                                         jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jboolean>(metadata->being_compacted);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    numEntries
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_numEntries(JNIEnv*, jobject,
+                                                  jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->num_entries);
+}
+
+/*
+ * Class:     org_rocksdb_SstFileMetaData
+ * Method:    numDeletions
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_SstFileMetaData_numDeletions(JNIEnv*, jobject,
+                                                    jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::SstFileMetaData*>(jhandle);
+  return static_cast<jlong>(metadata->num_deletions);
+}

--- a/java/src/main/java/org/rocksdb/LiveFileMetaData.java
+++ b/java/src/main/java/org/rocksdb/LiveFileMetaData.java
@@ -9,30 +9,40 @@ package org.rocksdb;
  * The full set of metadata associated with each SST file.
  */
 public class LiveFileMetaData extends SstFileMetaData {
-  private final byte[] columnFamilyName;
-  private final int level;
 
   /**
    * Called from JNI C++
    */
-  private LiveFileMetaData(
-      final byte[] columnFamilyName,
-      final int level,
-      final String fileName,
-      final String path,
-      final long size,
-      final long smallestSeqno,
-      final long largestSeqno,
-      final byte[] smallestKey,
-      final byte[] largestKey,
-      final long numReadsSampled,
-      final boolean beingCompacted,
-      final long numEntries,
-      final long numDeletions) {
-    super(fileName, path, size, smallestSeqno, largestSeqno, smallestKey,
-        largestKey, numReadsSampled, beingCompacted, numEntries, numDeletions);
-    this.columnFamilyName = columnFamilyName;
-    this.level = level;
+  private LiveFileMetaData(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  public LiveFileMetaData() {
+    super(newLiveFileMetaData());
+  }
+
+  /**
+   * @param columnFamilyName the name of the column family
+   * @param level the level at which the file resides
+   * @param fileName the file name
+   * @param path the file path
+   * @param size the size of the file
+   * @param smallestSeqno the smallest sequence number
+   * @param largestSeqno the largest sequence number
+   * @param smallestKey the smallest key
+   * @param largestKey the largest key
+   * @param numReadsSampled the number of reads sampled
+   * @param beingCompacted true if the file is being compacted, false otherwise
+   * @param numEntries the number of entries
+   * @param numDeletions the number of deletions
+   */
+  public LiveFileMetaData(final byte[] columnFamilyName, final int level, final String fileName,
+      final String path, final long size, final long smallestSeqno, final long largestSeqno,
+      final byte[] smallestKey, final byte[] largestKey, final long numReadsSampled,
+      final boolean beingCompacted, final long numEntries, final long numDeletions) {
+    super(newLiveFileMetaData(columnFamilyName, columnFamilyName.length, level, fileName, path,
+        size, smallestSeqno, largestSeqno, smallestKey, smallestKey.length, largestKey,
+        largestKey.length, numReadsSampled, beingCompacted, numEntries, numDeletions));
   }
 
   /**
@@ -41,7 +51,7 @@ public class LiveFileMetaData extends SstFileMetaData {
    * @return the name of the column family
    */
   public byte[] columnFamilyName() {
-    return columnFamilyName;
+    return columnFamilyName(nativeHandle_);
   }
 
   /**
@@ -50,6 +60,18 @@ public class LiveFileMetaData extends SstFileMetaData {
    * @return the level at which the file resides.
    */
   public int level() {
-    return level;
+    return level(nativeHandle_);
   }
+
+  private static native long newLiveFileMetaData();
+  private static native long newLiveFileMetaData(final byte[] columnFamilyName,
+      final int columnFamilyNameLen, final int level, final String fileName, final String path,
+      final long size, final long smallestSeqno, final long largestSeqno, final byte[] smallestKey,
+      final int smallestKeyLen, final byte[] largestKey, final int largestKeyLen,
+      final long numReadsSampled, final boolean beingCompacted, final long numEntries,
+      final long numDeletions);
+  @Override protected native void disposeInternal(final long handle);
+
+  private native byte[] columnFamilyName(final long handle);
+  private native int level(final long handle);
 }

--- a/java/src/main/java/org/rocksdb/SstFileMetaData.java
+++ b/java/src/main/java/org/rocksdb/SstFileMetaData.java
@@ -8,57 +8,17 @@ package org.rocksdb;
 /**
  * The metadata that describes a SST file.
  */
-public class SstFileMetaData {
-  private final String fileName;
-  private final String path;
-  private final long size;
-  private final long smallestSeqno;
-  private final long largestSeqno;
-  private final byte[] smallestKey;
-  private final byte[] largestKey;
-  private final long numReadsSampled;
-  private final boolean beingCompacted;
-  private final long numEntries;
-  private final long numDeletions;
-
+public class SstFileMetaData extends RocksObject {
   /**
-   * Called from JNI C++
-   *
-   * @param fileName the file name
-   * @param path the file path
-   * @param size the size of the file
-   * @param smallestSeqno the smallest sequence number
-   * @param largestSeqno the largest sequence number
-   * @param smallestKey the smallest key
-   * @param largestKey the largest key
-   * @param numReadsSampled the number of reads sampled
-   * @param beingCompacted true if the file is being compacted, false otherwise
-   * @param numEntries the number of entries
-   * @param numDeletions the number of deletions
+   * Called from JNI C++ or subclass
+   * @param nativeHandle pointer to the C++ object
    */
-  protected SstFileMetaData(
-      final String fileName,
-      final String path,
-      final long size,
-      final long smallestSeqno,
-      final long largestSeqno,
-      final byte[] smallestKey,
-      final byte[] largestKey,
-      final long numReadsSampled,
-      final boolean beingCompacted,
-      final long numEntries,
-      final long numDeletions) {
-    this.fileName = fileName;
-    this.path = path;
-    this.size = size;
-    this.smallestSeqno = smallestSeqno;
-    this.largestSeqno = largestSeqno;
-    this.smallestKey = smallestKey;
-    this.largestKey = largestKey;
-    this.numReadsSampled = numReadsSampled;
-    this.beingCompacted = beingCompacted;
-    this.numEntries = numEntries;
-    this.numDeletions = numDeletions;
+  public SstFileMetaData(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  public SstFileMetaData() {
+    super(newSstFileMetaData());
   }
 
   /**
@@ -67,7 +27,7 @@ public class SstFileMetaData {
    * @return the name of the file.
    */
   public String fileName() {
-    return fileName;
+    return fileName(nativeHandle_);
   }
 
   /**
@@ -76,7 +36,7 @@ public class SstFileMetaData {
    * @return the full path
    */
   public String path() {
-    return path;
+    return path(nativeHandle_);
   }
 
   /**
@@ -85,7 +45,7 @@ public class SstFileMetaData {
    * @return file size
    */
   public long size() {
-    return size;
+    return size(nativeHandle_);
   }
 
   /**
@@ -94,7 +54,7 @@ public class SstFileMetaData {
    * @return the smallest sequence number
    */
   public long smallestSeqno() {
-    return smallestSeqno;
+    return smallestSeqno(nativeHandle_);
   }
 
   /**
@@ -103,7 +63,7 @@ public class SstFileMetaData {
    * @return the largest sequence number
    */
   public long largestSeqno() {
-    return largestSeqno;
+    return largestSeqno(nativeHandle_);
   }
 
   /**
@@ -112,7 +72,7 @@ public class SstFileMetaData {
    * @return the smallest user defined key
    */
   public byte[] smallestKey() {
-    return smallestKey;
+    return smallestKey(nativeHandle_);
   }
 
   /**
@@ -121,7 +81,7 @@ public class SstFileMetaData {
    * @return the largest user defined key
    */
   public byte[] largestKey() {
-    return largestKey;
+    return largestKey(nativeHandle_);
   }
 
   /**
@@ -130,7 +90,7 @@ public class SstFileMetaData {
    * @return the number of times the file has been read
    */
   public long numReadsSampled() {
-    return numReadsSampled;
+    return numReadsSampled(nativeHandle_);
   }
 
   /**
@@ -139,7 +99,7 @@ public class SstFileMetaData {
    * @return true if the file is currently being compacted, false otherwise.
    */
   public boolean beingCompacted() {
-    return beingCompacted;
+    return beingCompacted(nativeHandle_);
   }
 
   /**
@@ -148,7 +108,7 @@ public class SstFileMetaData {
    * @return the number of entries.
    */
   public long numEntries() {
-    return numEntries;
+    return numEntries(nativeHandle_);
   }
 
   /**
@@ -157,6 +117,21 @@ public class SstFileMetaData {
    * @return the number of deletions.
    */
   public long numDeletions() {
-    return numDeletions;
+    return numDeletions(nativeHandle_);
   }
+
+  private static native long newSstFileMetaData();
+  @Override protected native void disposeInternal(final long handle);
+
+  private native String fileName(final long handle);
+  private native String path(final long handle);
+  private native long size(final long handle);
+  private native long smallestSeqno(final long handle);
+  private native long largestSeqno(final long handle);
+  private native byte[] smallestKey(final long handle);
+  private native byte[] largestKey(final long handle);
+  private native long numReadsSampled(final long handle);
+  private native boolean beingCompacted(final long handle);
+  private native long numEntries(final long handle);
+  private native long numDeletions(final long handle);
 }

--- a/java/src/test/java/org/rocksdb/LiveFileMetaDataTest.java
+++ b/java/src/test/java/org/rocksdb/LiveFileMetaDataTest.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class LiveFileMetaDataTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  public static final Random rand = PlatformRandomHelper.getPlatformSpecificRandomFactory();
+
+  @Test
+  public void createLiveFileMetaDataWithoutParameters() {
+    try (final LiveFileMetaData metadata = new LiveFileMetaData()) {
+      assertThat(metadata).isNotNull();
+    }
+  }
+
+  @Test
+  public void createLiveFileMetaDataWithParameters() throws UnsupportedEncodingException {
+    final byte[] columnFamilyName = "testColumnFamilyName".getBytes("UTF-8");
+    final int level = rand.nextInt();
+    final String fileName = "testFileName";
+    final String path = "testPath";
+    final long size = rand.nextInt();
+    final long smallestSeqno = rand.nextLong();
+    final long largestSeqno = rand.nextLong();
+    final byte[] smallestKey = "testSmallestKey".getBytes("UTF-8");
+    final byte[] largestKey = "testLargestKey".getBytes("UTF-8");
+    final long numReadsSampled = rand.nextLong();
+    final boolean beingCompacted = rand.nextBoolean();
+    final long numEntries = rand.nextLong();
+    final long numDeletions = rand.nextLong();
+
+    try (final LiveFileMetaData metadata = new LiveFileMetaData(columnFamilyName, level, fileName,
+             path, size, smallestSeqno, largestSeqno, smallestKey, largestKey, numReadsSampled,
+             beingCompacted, numEntries, numDeletions)) {
+      assertThat(metadata).isNotNull();
+      assertThat(new String(metadata.columnFamilyName(), "UTF-8"))
+          .isEqualTo(new String(columnFamilyName, "UTF-8"));
+      assertThat(metadata.level()).isEqualTo(level);
+      assertThat(metadata.fileName()).isEqualTo(fileName);
+      assertThat(metadata.path()).isEqualTo(path);
+      assertThat(metadata.size()).isEqualTo(size);
+      assertThat(metadata.smallestSeqno()).isEqualTo(smallestSeqno);
+      assertThat(metadata.largestSeqno()).isEqualTo(largestSeqno);
+      assertThat(new String(metadata.smallestKey(), "UTF-8"))
+          .isEqualTo(new String(smallestKey, "UTF-8"));
+      assertThat(new String(metadata.largestKey(), "UTF-8"))
+          .isEqualTo(new String(largestKey, "UTF-8"));
+      assertThat(metadata.numReadsSampled()).isEqualTo(numReadsSampled);
+      assertThat(metadata.beingCompacted()).isEqualTo(beingCompacted);
+      assertThat(metadata.numEntries()).isEqualTo(numEntries);
+      assertThat(metadata.numDeletions()).isEqualTo(numDeletions);
+    }
+  }
+}

--- a/java/src/test/java/org/rocksdb/SstFileMetaDataTest.java
+++ b/java/src/test/java/org/rocksdb/SstFileMetaDataTest.java
@@ -1,0 +1,104 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SstFileMetaDataTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  public static final Random rand = PlatformRandomHelper.getPlatformSpecificRandomFactory();
+
+  @Test
+  public void createSstFileMetaDataWithoutParameters() {
+    try (final SstFileMetaData metadata = new SstFileMetaData()) {
+      assertThat(metadata).isNotNull();
+    }
+  }
+
+  @Test
+  public void fileName() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.fileName()).isEqualTo("");
+    }
+  }
+
+  @Test
+  public void path() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.path()).isEqualTo("");
+    }
+  }
+
+  @Test
+  public void size() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.size()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void smallestSeqno() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.smallestSeqno()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void largestSeqno() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.largestSeqno()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void smallestKey() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.smallestKey()).isEmpty();
+    }
+  }
+
+  @Test
+  public void largestKey() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.largestKey()).isEmpty();
+    }
+  }
+
+  @Test
+  public void numReadsSampled() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.numReadsSampled()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void beingCompacted() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.beingCompacted()).isEqualTo(false);
+    }
+  }
+
+  @Test
+  public void numEntries() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.numEntries()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void numDeletions() {
+    try (final SstFileMetaData sstFileMetaData = new SstFileMetaData()) {
+      assertThat(sstFileMetaData.numDeletions()).isEqualTo(0);
+    }
+  }
+}

--- a/src.mk
+++ b/src.mk
@@ -505,6 +505,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/filter.cc                                     \
   java/rocksjni/iterator.cc                                   \
   java/rocksjni/jnicallback.cc                                \
+  java/rocksjni/live_file_metadata.cc                         \
   java/rocksjni/loggerjnicallback.cc                          \
   java/rocksjni/lru_cache.cc                                  \
   java/rocksjni/memtablejni.cc                                \
@@ -527,6 +528,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/slice.cc                                      \
   java/rocksjni/snapshot.cc                                   \
   java/rocksjni/sst_file_manager.cc                           \
+  java/rocksjni/sst_file_metadata.cc                          \
   java/rocksjni/sst_file_writerjni.cc                         \
   java/rocksjni/sst_file_readerjni.cc                         \
   java/rocksjni/sst_file_reader_iterator.cc                   \


### PR DESCRIPTION
1. This is the Pre-work of [Add ExportColumnFamily for Java](https://github.com/facebook/rocksdb/pull/6895), and Add CreateColumnFamilyWithImport for Java.
2. `ExportImportFilesMetaData` not only as a result returned by API `ExportColumnFamily`, but also as a parameter to API `CreateColumnFamilyWithImport`. 

3. Define of `ExportImportFilesMetaData`:
```
struct ExportImportFilesMetaData {
   std::string db_comparator_name;       // Used to safety check at import.
   std::vector<LiveFileMetaData> files;  // Vector of file metadata.
 };
```

4. So `LiveFileMetaData` and it's parent class `SstFileMetaData` should not only support transforming from C++ to Java, but also support transforming from Java to C++