### PR TITLE
Add ExportColumnFamily for Java

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -29,6 +29,7 @@ set(JNI_NATIVE_SOURCES
         rocksjni/config_options.cc
         rocksjni/env.cc
         rocksjni/env_options.cc
+        rocksjni/export_import_files_metadata.cc
         rocksjni/filter.cc
         rocksjni/ingest_external_file_options.cc
         rocksjni/iterator.cc
@@ -139,6 +140,7 @@ set(JAVA_MAIN_CLASSES
   src/main/java/org/rocksdb/Env.java
   src/main/java/org/rocksdb/EnvOptions.java
   src/main/java/org/rocksdb/Experimental.java
+  src/main/java/org/rocksdb/ExportImportFilesMetaData.java
   src/main/java/org/rocksdb/Filter.java
   src/main/java/org/rocksdb/FlushOptions.java
   src/main/java/org/rocksdb/HashLinkedListMemTableConfig.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -30,6 +30,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.DirectSlice\
 	org.rocksdb.Env\
 	org.rocksdb.EnvOptions\
+	org.rocksdb.ExportImportFilesMetaData\
 	org.rocksdb.FlushOptions\
 	org.rocksdb.Filter\
 	org.rocksdb.IngestExternalFileOptions\
@@ -125,6 +126,8 @@ JAVA_TESTS = \
 	org.rocksdb.DirectSliceTest\
 	org.rocksdb.util.EnvironmentTest\
 	org.rocksdb.EnvOptionsTest\
+	org.rocksdb.ExportImportColumnFamilyTest\
+	org.rocksdb.ExportImportFilesMetaDataTest\
 	org.rocksdb.HdfsEnvTest\
 	org.rocksdb.IngestExternalFileOptionsTest\
 	org.rocksdb.util.IntComparatorTest\

--- a/java/rocksjni/checkpoint.cc
+++ b/java/rocksjni/checkpoint.cc
@@ -66,3 +66,38 @@ void Java_org_rocksdb_Checkpoint_createCheckpoint(JNIEnv* env, jobject /*jobj*/,
     ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
   }
 }
+
+/*
+ * Class:     org_rocksdb_ExportColumnFamily
+ * Method:    exportColumnFamily
+ * Signature: (JJLjava/lang/String;)J
+ */
+jlong Java_org_rocksdb_Checkpoint_exportColumnFamily(JNIEnv* env, jobject,
+                                                     jlong jcheckpoint_handle,
+                                                     jlong jcf_handle,
+                                                     jstring jexport_dir) {
+  const char* export_dir = env->GetStringUTFChars(jexport_dir, nullptr);
+  if (export_dir == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return 0;
+  }
+
+  auto* checkpoint =
+      reinterpret_cast<ROCKSDB_NAMESPACE::Checkpoint*>(jcheckpoint_handle);
+  auto* cfh =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyHandle*>(jcf_handle);
+
+  ROCKSDB_NAMESPACE::ExportImportFilesMetaData* export_import_files_metadata =
+      nullptr;
+
+  ROCKSDB_NAMESPACE::Status s = checkpoint->ExportColumnFamily(
+      cfh, export_dir, &export_import_files_metadata);
+
+  env->ReleaseStringUTFChars(jexport_dir, export_dir);
+
+  if (!s.ok()) {
+    ROCKSDB_NAMESPACE::RocksDBExceptionJni::ThrowNew(env, s);
+  }
+
+  return reinterpret_cast<jlong>(export_import_files_metadata);
+}

--- a/java/rocksjni/export_import_files_metadata.cc
+++ b/java/rocksjni/export_import_files_metadata.cc
@@ -1,0 +1,131 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// This file implements the "bridge" between Java and C++ for
+// ExportImportFilesMetaData
+
+#include <jni.h>
+
+#include "include/org_rocksdb_ExportImportFilesMetaData.h"
+#include "rocksdb/metadata.h"
+#include "rocksjni/portal.h"
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    newExportImportFilesMetaData
+ * Signature: ()J
+ */
+jlong Java_org_rocksdb_ExportImportFilesMetaData_newExportImportFilesMetaData__(
+    JNIEnv*, jclass) {
+  auto* metadata = new ROCKSDB_NAMESPACE::ExportImportFilesMetaData();
+  return reinterpret_cast<jlong>(metadata);
+}
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    setDbComparatorName
+ * Signature: (Ljava/lang/String;[J)J
+ */
+jlong Java_org_rocksdb_ExportImportFilesMetaData_newExportImportFilesMetaData__Ljava_lang_String_2_3J(
+    JNIEnv* env, jclass, jstring jdb_comparator_name,
+    jlongArray jfile_handles) {
+  auto* metadata = new ROCKSDB_NAMESPACE::ExportImportFilesMetaData();
+
+  jboolean has_exception = JNI_FALSE;
+  std::string db_comparator_name = ROCKSDB_NAMESPACE::JniUtil::copyStdString(
+      env, jdb_comparator_name, &has_exception);
+  if (has_exception == JNI_TRUE) {
+    // exception occurred
+    return 0;
+  }
+
+  metadata->db_comparator_name = db_comparator_name;
+
+  jlong* jfh = env->GetLongArrayElements(jfile_handles, nullptr);
+  if (jfh == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return 0;
+  }
+
+  const jsize jlen = env->GetArrayLength(jfile_handles);
+  for (jsize i = 0; i < jlen; i++) {
+    auto* file_handle =
+        reinterpret_cast<ROCKSDB_NAMESPACE::LiveFileMetaData*>(jfh[i]);
+    metadata->files.push_back(*file_handle);
+  }
+  env->ReleaseLongArrayElements(jfile_handles, jfh, JNI_ABORT);
+
+  return reinterpret_cast<jlong>(metadata);
+}
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    disposeInternal
+ * Signature: (J)V
+ */
+void Java_org_rocksdb_ExportImportFilesMetaData_disposeInternal(JNIEnv*,
+                                                                jobject,
+                                                                jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ExportImportFilesMetaData*>(jhandle);
+  delete metadata;
+}
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    dbComparatorName
+ * Signature: (J)Ljava/lang/String;
+ */
+jstring Java_org_rocksdb_ExportImportFilesMetaData_dbComparatorName(
+    JNIEnv* env, jobject, jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ExportImportFilesMetaData*>(jhandle);
+  return ROCKSDB_NAMESPACE::JniUtil::toJavaString(
+      env, &metadata->db_comparator_name, false);
+}
+
+/*
+ * Class:     org_rocksdb_ExportImportFilesMetaData
+ * Method:    files
+ * Signature: (J)[Lorg/rocksdb/LiveFileMetaData;
+ */
+jobjectArray Java_org_rocksdb_ExportImportFilesMetaData_files(JNIEnv* env,
+                                                              jobject,
+                                                              jlong jhandle) {
+  auto* metadata =
+      reinterpret_cast<ROCKSDB_NAMESPACE::ExportImportFilesMetaData*>(jhandle);
+
+  const jsize jlen = static_cast<jsize>(metadata->files.size());
+  jobjectArray jfiles = env->NewObjectArray(
+      jlen, ROCKSDB_NAMESPACE::LiveFileMetaDataJni::getJClass(env), nullptr);
+  if (jfiles == nullptr) {
+    // exception thrown: OutOfMemoryError
+    return nullptr;
+  }
+
+  jsize i = 0;
+  for (auto it = metadata->files.begin(); it != metadata->files.end(); ++it) {
+    jobject jfile =
+        ROCKSDB_NAMESPACE::LiveFileMetaDataJni::fromCppLiveFileMetaData(env,
+                                                                        &(*it));
+    if (jfile == nullptr) {
+      // exception occurred
+      env->DeleteLocalRef(jfiles);
+      return nullptr;
+    }
+
+    env->SetObjectArrayElement(jfiles, i++, jfile);
+    if (env->ExceptionCheck()) {
+      // exception occurred
+      env->DeleteLocalRef(jfile);
+      env->DeleteLocalRef(jfiles);
+      return nullptr;
+    }
+
+    env->DeleteLocalRef(jfile);
+  }
+
+  return jfiles;
+}

--- a/java/src/main/java/org/rocksdb/Checkpoint.java
+++ b/java/src/main/java/org/rocksdb/Checkpoint.java
@@ -51,6 +51,26 @@ public class Checkpoint extends RocksObject {
     createCheckpoint(nativeHandle_, checkpointPath);
   }
 
+  /**
+   * <p>Exports all live SST files of a specified Column Family onto exportDir,
+   * returning SST files information in metadata. SST files will be created as
+   * hard links when the directory specified is in the same partition as the db
+   * directory, copied otherwise. exportDir should not already exist and will be
+   * created by this API. Always triggers a flush </p>
+   *
+   * @param columnFamilyHandle {@link org.rocksdb.ColumnFamilyHandle}
+   *     instance
+   * @param exportDir all live SST files of a specified Column Family is going
+   *     to be stored.
+   * @throws RocksDBException thrown if an error occurs within the native
+   *     part of the library.
+   */
+  public ExportImportFilesMetaData exportColumnFamily(
+      final ColumnFamilyHandle columnFamilyHandle, final String exportDir) throws RocksDBException {
+    return new ExportImportFilesMetaData(
+        exportColumnFamily(nativeHandle_, columnFamilyHandle.nativeHandle_, exportDir));
+  }
+
   private Checkpoint(final RocksDB db) {
     super(newCheckpoint(db.nativeHandle_));
     this.db_ = db;
@@ -63,4 +83,7 @@ public class Checkpoint extends RocksObject {
 
   private native void createCheckpoint(long handle, String checkpointPath)
       throws RocksDBException;
+
+  private native long exportColumnFamily(final long handle, final long columnFamilyHandle,
+      final String exportDir) throws RocksDBException;
 }

--- a/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
+++ b/java/src/main/java/org/rocksdb/ExportImportFilesMetaData.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Metadata returned as output from ExportColumnFamily() and used as input to
+ * CreateColumnFamiliesWithImport().
+ */
+public class ExportImportFilesMetaData extends RocksObject {
+  public ExportImportFilesMetaData() {
+    super(newExportImportFilesMetaData());
+  }
+
+  public ExportImportFilesMetaData(
+      final String dbComparatorName, final List<LiveFileMetaData> files) {
+    super(newExportImportFilesMetaData(dbComparatorName, getFileHandles(files)));
+  }
+
+  public ExportImportFilesMetaData(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  private static long[] getFileHandles(final List<LiveFileMetaData> files) {
+    long fileHandles[] = new long[files.size()];
+    for (int i = 0; i < files.size(); i++) {
+      fileHandles[i] = files.get(i).nativeHandle_;
+    }
+    return fileHandles;
+  }
+
+  /**
+   * Get the name of the db comparator.
+   *
+   * @return the name of the db comparator
+   */
+  public String dbComparatorName() {
+    return dbComparatorName(nativeHandle_);
+  }
+
+  /**
+   * Get the list of LiveFileMetaData.
+   *
+   * @return the list of LiveFileMetaData.
+   */
+  public List<LiveFileMetaData> files() {
+    return Arrays.asList(files(nativeHandle_));
+  }
+
+  private static native long newExportImportFilesMetaData();
+  private static native long newExportImportFilesMetaData(
+      final String dbComparatorName, final long[] fileHandles);
+  @Override protected native void disposeInternal(final long handle);
+
+  private native String dbComparatorName(final long handle);
+  private native LiveFileMetaData[] files(final long handle);
+}

--- a/java/src/test/java/org/rocksdb/ExportImportColumnFamilyTest.java
+++ b/java/src/test/java/org/rocksdb/ExportImportColumnFamilyTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ExportImportColumnFamilyTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  @Rule public TemporaryFolder dbFolder = new TemporaryFolder();
+
+  @Rule public TemporaryFolder exportFolder = new TemporaryFolder();
+
+  @Test
+  public void exportColumnFamily() throws RocksDBException {
+    try (final Options options = new Options().setCreateIfMissing(true);
+         final RocksDB db = RocksDB.open(options, dbFolder.getRoot().getAbsolutePath())) {
+      db.put("key".getBytes(), "value".getBytes());
+
+      try (
+          final Checkpoint checkpoint = Checkpoint.create(db);
+          final ExportImportFilesMetaData metadata = checkpoint.exportColumnFamily(
+              db.getDefaultColumnFamily(), exportFolder.getRoot().getAbsolutePath() + "/export1")) {
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.files().size()).isEqualTo(1);
+      }
+    }
+  }
+}

--- a/java/src/test/java/org/rocksdb/ExportImportFilesMetaDataTest.java
+++ b/java/src/test/java/org/rocksdb/ExportImportFilesMetaDataTest.java
@@ -1,0 +1,84 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+package org.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ExportImportFilesMetaDataTest {
+  @ClassRule
+  public static final RocksNativeLibraryResource ROCKS_NATIVE_LIBRARY_RESOURCE =
+      new RocksNativeLibraryResource();
+
+  public static final Random rand = PlatformRandomHelper.getPlatformSpecificRandomFactory();
+
+  @Test
+  public void createExportImportFilesMetaDataWithoutParameters() {
+    try (final ExportImportFilesMetaData metadata = new ExportImportFilesMetaData()) {
+      assertThat(metadata).isNotNull();
+    }
+  }
+
+  @Test
+  public void createExportImportFilesMetaDataWithParameters() throws UnsupportedEncodingException {
+    final String dbComparatorName = "testDbComparatorName";
+    final List<LiveFileMetaData> files = new ArrayList<>();
+
+    final String columnFamilyName = "testColumnFamilyName";
+    final int level = rand.nextInt();
+    final String fileName = "testFileName";
+    final String path = "testPath";
+    final long size = rand.nextInt();
+    final long smallestSeqno = rand.nextLong();
+    final long largestSeqno = rand.nextLong();
+    final String smallestKey = "testSmallestKey";
+    final String largestKey = "testLargestKey";
+    final long numReadsSampled = rand.nextLong();
+    final boolean beingCompacted = rand.nextBoolean();
+    final long numEntries = rand.nextLong();
+    final long numDeletions = rand.nextLong();
+
+    for (int i = 0; i < 2; i++) {
+      LiveFileMetaData file = new LiveFileMetaData((columnFamilyName + i).getBytes("UTF-8"),
+          level + i, fileName + i, path + i, size + i, smallestSeqno + i, largestSeqno + i,
+          (smallestKey + i).getBytes("UTF-8"), (largestKey + i).getBytes("UTF-8"),
+          numReadsSampled + i, beingCompacted, numEntries + i, numDeletions + i);
+
+      files.add(file);
+    }
+
+    try (final ExportImportFilesMetaData metadata =
+             new ExportImportFilesMetaData(dbComparatorName, files)) {
+      assertThat(metadata).isNotNull();
+      assertThat(metadata.dbComparatorName()).isEqualTo(dbComparatorName);
+      assertThat(metadata.files().size()).isEqualTo(files.size());
+
+      for (int i = 0; i < metadata.files().size(); i++) {
+        LiveFileMetaData file = metadata.files().get(i);
+
+        assertThat(new String(file.columnFamilyName(), "UTF-8")).isEqualTo(columnFamilyName + i);
+        assertThat(file.level()).isEqualTo(level + i);
+        assertThat(file.fileName()).isEqualTo(fileName + i);
+        assertThat(file.path()).isEqualTo(path + i);
+        assertThat(file.size()).isEqualTo(size + i);
+        assertThat(file.smallestSeqno()).isEqualTo(smallestSeqno + i);
+        assertThat(file.largestSeqno()).isEqualTo(largestSeqno + i);
+        assertThat(new String(file.smallestKey(), "UTF-8")).isEqualTo(smallestKey + i);
+        assertThat(new String(file.largestKey(), "UTF-8")).isEqualTo(largestKey + i);
+        assertThat(file.numReadsSampled()).isEqualTo(numReadsSampled + i);
+        assertThat(file.beingCompacted()).isEqualTo(beingCompacted);
+        assertThat(file.numEntries()).isEqualTo(numEntries + i);
+        assertThat(file.numDeletions()).isEqualTo(numDeletions + i);
+      }
+    }
+  }
+}

--- a/src.mk
+++ b/src.mk
@@ -501,6 +501,7 @@ JNI_NATIVE_SOURCES =                                          \
   java/rocksjni/config_options.cc                             \
   java/rocksjni/env.cc                                        \
   java/rocksjni/env_options.cc                                \
+  java/rocksjni/export_import_files_metadata.cc               \
   java/rocksjni/ingest_external_file_options.cc               \
   java/rocksjni/filter.cc                                     \
   java/rocksjni/iterator.cc                                   \


### PR DESCRIPTION
This depends on the PR: [Pre-work of adding ExportColumnFamily and CreateColumnFamilyWithImport for Java](https://github.com/facebook/rocksdb/pull/6894).