### PR TITLE
Remove extraneous newline from ldb stderr

### DIFF
--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -124,7 +124,7 @@ int LDBCommandRunner::RunCommand(
 
   cmdObj->Run();
   LDBCommandExecuteResult ret = cmdObj->GetExecuteState();
-  fprintf(stderr, "%s\n", ret.ToString().c_str());
+  if (!ret.IsSucceed()) fprintf(stderr, "%s\n", ret.ToString().c_str());
   delete cmdObj;
 
   return ret.IsFailed() ? 1 : 0;

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -124,7 +124,9 @@ int LDBCommandRunner::RunCommand(
 
   cmdObj->Run();
   LDBCommandExecuteResult ret = cmdObj->GetExecuteState();
-  if (!ret.IsSucceed()) fprintf(stderr, "%s\n", ret.ToString().c_str());
+  if (!ret.IsSucceed()) {
+    fprintf(stderr, "%s\n", ret.ToString().c_str());
+  }
   delete cmdObj;
 
   return ret.IsFailed() ? 1 : 0;

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -124,7 +124,7 @@ int LDBCommandRunner::RunCommand(
 
   cmdObj->Run();
   LDBCommandExecuteResult ret = cmdObj->GetExecuteState();
-  if (!ret.IsSucceed()) {
+  if (!ret.ToString().empty()) {
     fprintf(stderr, "%s\n", ret.ToString().c_str());
   }
   delete cmdObj;


### PR DESCRIPTION
Summary: Remove the extraneous newline when using ldb tool. For example, the subcommand list_column_families will print an empty line to stderr even if there are no errors.

Test plan: Passed make check; manually tested a few ldb subcommands.