### PR TITLE
Minor renaming to make gcc 4.8 happy

### DIFF
--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2188,11 +2188,11 @@ TEST_F(DBBasicTest, SkipWALIfMissingTableFiles) {
 class DBBasicTestMultiGet : public DBTestBase {
  public:
   DBBasicTestMultiGet(std::string test_dir, int num_cfs, bool compressed_cache,
-                      bool uncompressed_cache, bool compression_enabled,
-                      bool fill_cache, uint32_t compression_parallel_threads)
+                      bool uncompressed_cache, bool _compression_enabled,
+                      bool _fill_cache, uint32_t compression_parallel_threads)
       : DBTestBase(test_dir) {
-    compression_enabled_ = compression_enabled;
-    fill_cache_ = fill_cache;
+    compression_enabled_ = _compression_enabled;
+    fill_cache_ = _fill_cache;
 
     if (compressed_cache) {
       std::shared_ptr<Cache> cache = NewLRUCache(1048576);

--- a/file/random_access_file_reader_test.cc
+++ b/file/random_access_file_reader_test.cc
@@ -68,9 +68,9 @@ class RandomAccessFileReaderTest : public testing::Test {
     Write(f, "");
     std::unique_ptr<RandomAccessFileReader> r;
     Read(f, FileOptions(), &r);
-    size_t alignment = r->file()->GetRequiredBufferAlignment();
+    size_t _alignment = r->file()->GetRequiredBufferAlignment();
     EXPECT_OK(fs_->DeleteFile(Path(f), IOOptions(), nullptr));
-    return alignment;
+    return _alignment;
   }
 };
 


### PR DESCRIPTION
Summary: GCC 4.8 fails with some warnings. Rename variables for it.

Test Plan: See existing tests pass.