### PR TITLE
Remove assertion which is incorrect when compression enabled

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1731,7 +1731,6 @@ void BlockBasedTable::RetrieveMultipleBlocks(
       // We allocated a buffer for this block. Give ownership of it to
       // BlockContents so it can free the memory
       assert(req.result.data() == req.scratch);
-      assert(req.result.size() == block_size(handle));
       assert(req_offset == 0);
       std::unique_ptr<char[]> raw_block(req.scratch);
       raw_block_contents = BlockContents(std::move(raw_block), handle.size());


### PR DESCRIPTION
In direct IO mode, the offset and length of the block request may be resized to be aligned, so req.result.size does not necessarily equal to the block size.

Test Plan:
make check