### PR TITLE
API change: DB::OpenForReadOnly will not write to the file system unless create_if_missing is true

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 * BlobDB now explicitly disallows using the default column family's storage directories as blob directory.
 * DeleteRange now returns `Status::InvalidArgument` if the range's end key comes before its start key according to the user comparator. Previously the behavior was undefined.
 * ldb now uses options.force_consistency_checks = true by default and "--disable_consistency_checks" is added to disable it.
+* DB::OpenForReadOnly no longer creates files or directories if the named DB does not exist, unless create_if_missing is set to true.
 
 ### New Feature
 * sst_dump to add a new --readahead_size argument. Users can specify read size when scanning the data. Sst_dump also tries to prefetch tail part of the SST files so usually some number of I/Os are saved there too.

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -131,8 +131,21 @@ Status DBImplReadOnly::NewIterators(
 Status DB::OpenForReadOnly(const Options& options, const std::string& dbname,
                            DB** dbptr, bool /*error_if_log_file_exist*/) {
   if (access(dbname.c_str(), F_OK) == -1) {
-    // file does not exist
+    // directory does not exist
     return Status::NotFound("'" + dbname + "': No such file or directory");
+  } else {
+    std::string path_to_current = dbname;
+    if (!dbname.empty() && dbname.back() == '/') {
+      path_to_current += "CURRENT";
+    } else {
+      path_to_current += "/CURRENT";
+    }
+
+    if (access(path_to_current.c_str(), F_OK) == -1) {
+      // not a RocksDB
+      return Status::NotFound("'" + path_to_current +
+                              "': No such file or directory");
+    }
   }
 
   *dbptr = nullptr;

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -130,6 +130,11 @@ Status DBImplReadOnly::NewIterators(
 
 Status DB::OpenForReadOnly(const Options& options, const std::string& dbname,
                            DB** dbptr, bool /*error_if_log_file_exist*/) {
+  if (access(dbname.c_str(), F_OK) == -1) {
+    // file does not exist
+    return Status::NotFound("'" + dbname + "': No such file or directory");
+  }
+
   *dbptr = nullptr;
 
   // Try to first open DB as fully compacted DB

--- a/db/db_impl/db_impl_readonly.h
+++ b/db/db_impl/db_impl_readonly.h
@@ -130,6 +130,15 @@ class DBImplReadOnly : public DBImpl {
   }
 
  private:
+  // A "helper" function for DB::OpenForReadOnly without column families
+  // to reduce unnecessary I/O
+  // It has the same functionality as DB::OpenForReadOnly with column families
+  // but does not check the existence of dbname in the file system
+  static Status OpenForReadOnlyWithoutCheck(
+      const DBOptions& db_options, const std::string& dbname,
+      const std::vector<ColumnFamilyDescriptor>& column_families,
+      std::vector<ColumnFamilyHandle*>* handles, DB** dbptr,
+      bool error_if_log_file_exist = false);
   friend class DB;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -313,6 +313,8 @@ class Env {
   virtual Status CreateDirIfMissing(const std::string& dirname) = 0;
 
   // Delete the specified directory.
+  // Many implementations of this function will only delete a directory if it is
+  // empty.
   virtual Status DeleteDir(const std::string& dirname) = 0;
 
   // Store the size of fname in *file_size.

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2445,6 +2445,7 @@ void BatchPutCommand::Help(std::string& ret) {
   ret.append("  ");
   ret.append(BatchPutCommand::Name());
   ret.append(" <key> <value> [<key> <value>] [..]");
+  ret.append(" [--" + ARG_CREATE_IF_MISSING + "]");
   ret.append(" [--" + ARG_TTL + "]");
   ret.append("\n");
 }
@@ -2731,7 +2732,8 @@ PutCommand::PutCommand(const std::vector<std::string>& params,
 void PutCommand::Help(std::string& ret) {
   ret.append("  ");
   ret.append(PutCommand::Name());
-  ret.append(" <key> <value> ");
+  ret.append(" <key> <value>");
+  ret.append(" [--" + ARG_CREATE_IF_MISSING + "]");
   ret.append(" [--" + ARG_TTL + "]");
   ret.append("\n");
 }

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -424,15 +424,6 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("put x3 y3", "OK")
         dumpFilePath = os.path.join(self.TMP_DIR, "dump2")
         self.assertTrue(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
-        run_err_null("rm -rf %s" % dumpFilePath)
-        dbPath = dumpFilePath
-        dumpFilePath = os.path.join(self.TMP_DIR, "dump3")
-        self.assertFalse(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
-        dbPath = os.path.join(self.TMP_DIR, "not_db")
-        run_err_null("mkdir -p %s" % dbPath)
-        dumpFilePath = os.path.join(self.TMP_DIR, "dump4")
-        self.assertFalse(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
-
 
     def getManifests(self, directory):
         return glob.glob(directory + "/MANIFEST-*")

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -428,6 +428,11 @@ class LDBTestCase(unittest.TestCase):
         dbPath = dumpFilePath
         dumpFilePath = os.path.join(self.TMP_DIR, "dump3")
         self.assertFalse(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
+        dbPath = os.path.join(self.TMP_DIR, "not_db")
+        run_err_null("mkdir -p %s" % dbPath)
+        dumpFilePath = os.path.join(self.TMP_DIR, "dump4")
+        self.assertFalse(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
+
 
     def getManifests(self, directory):
         return glob.glob(directory + "/MANIFEST-*")

--- a/tools/ldb_test.py
+++ b/tools/ldb_test.py
@@ -424,6 +424,10 @@ class LDBTestCase(unittest.TestCase):
         self.assertRunOK("put x3 y3", "OK")
         dumpFilePath = os.path.join(self.TMP_DIR, "dump2")
         self.assertTrue(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
+        run_err_null("rm -rf %s" % dumpFilePath)
+        dbPath = dumpFilePath
+        dumpFilePath = os.path.join(self.TMP_DIR, "dump3")
+        self.assertFalse(self.dumpLiveFiles("--db=%s" % dbPath, dumpFilePath))
 
     def getManifests(self, directory):
         return glob.glob(directory + "/MANIFEST-*")


### PR DESCRIPTION
Summary: DB::OpenForReadOnly will not write anything to the file system (i.e., create directories or files for the DB) unless create_if_missing is true.

This change also fixes some subcommands of ldb, which write to the file system even if the purpose is for readonly.

Two tests for this updated behavior of DB::OpenForReadOnly are also added.

Other minor changes:
1. Updated HISTORY.md to include this API change of DB::OpenForReadOnly;
2. Updated the help information for the put and batchput subcommands of ldb with the option [--create_if_missing];
3. Updated the comment of Env::DeleteDir to emphasize that it returns OK only if the directory to be deleted is empty.

Test plan: Passed make check and some other manual tests.