### PR TITLE
Improve consistency checks in VersionBuilder

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -134,7 +134,7 @@ class VersionBuilder::Rep {
   // storing them in levels_ to avoid regression in case there are no files
   // on invalid levels. The version is not consistent if in the end the files
   // on invalid levels don't cancel out.
-  std::unordered_map<int, int> invalid_level_sizes_;
+  std::unordered_map<int, size_t> invalid_level_sizes_;
   // Whether there are invalid new files or invalid deletion on levels larger
   // than num_levels_.
   bool has_invalid_levels_;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -455,7 +455,17 @@ class VersionBuilder::Rep {
         has_invalid_levels_ = true;
       }
 
-      return Status::Corruption();  // TODO: message
+      std::ostringstream oss;
+      oss << "Cannot delete table file #" << file_number << " from level "
+          << level << " since it is ";
+      if (current_level ==
+          VersionStorageInfo::FileLocation::Invalid().GetLevel()) {
+        oss << "not in the LSM tree";
+      } else {
+        oss << "on level " << current_level;
+      }
+
+      return Status::Corruption("VersionBuilder", oss.str());
     }
 
     if (level >= num_levels_) {
@@ -500,7 +510,10 @@ class VersionBuilder::Rep {
         has_invalid_levels_ = true;
       }
 
-      return Status::Corruption();  // TODO: message
+      std::ostringstream oss;
+      oss << "Cannot add table file #" << file_number << " to level " << level
+          << " since it is already in the LSM tree on level " << current_level;
+      return Status::Corruption("VersionBuilder", oss.str());
     }
 
     if (level >= num_levels_) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -446,7 +446,7 @@ class VersionBuilder::Rep {
   }
 
   Status ApplyFileDeletion(int level, uint64_t file_number) {
-    assert(level >= 0);
+    assert(level != VersionStorageInfo::FileLocation::Invalid().GetLevel());
 
     const int current_level = GetCurrentLevelForTableFile(file_number);
 
@@ -498,7 +498,7 @@ class VersionBuilder::Rep {
   }
 
   Status ApplyFileAddition(int level, const FileMetaData& meta) {
-    assert(level >= 0);
+    assert(level != VersionStorageInfo::FileLocation::Invalid().GetLevel());
 
     const uint64_t file_number = meta.fd.GetNumber();
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -504,6 +504,7 @@ class VersionBuilder::Rep {
     auto& level_state = levels_[level];
 
     auto& add_files = level_state.added_files;
+    // TODO: the file cannot be on any other level either
     if (add_files.find(file_number) != add_files.end()) {
       return Status::Corruption();  // TODO: message
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -488,7 +488,7 @@ class VersionBuilder::Rep {
     } else {
       auto& del_files = level_state.deleted_files;
       assert(del_files.find(file_number) == del_files.end());
-      del_files.insert(file_number);
+      del_files.emplace(file_number);
     }
 
     table_file_levels_[file_number] =
@@ -535,7 +535,7 @@ class VersionBuilder::Rep {
 
       auto& add_files = level_state.added_files;
       assert(add_files.find(file_number) == add_files.end());
-      add_files[file_number] = f;
+      add_files.emplace(file_number, f);
     }
 
     table_file_levels_[file_number] = level;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -362,7 +362,7 @@ class VersionBuilder::Rep {
     return ret_s;
   }
 
-  bool CheckConsistencyForNumLevels() {
+  bool CheckConsistencyForNumLevels() const {
     // Make sure there are no files on or beyond num_levels().
     if (has_invalid_levels_) {
       return false;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -474,11 +474,11 @@ class VersionBuilder::Rep {
     if (add_it != add_files.end()) {
       UnrefFile(add_it->second);
       add_files.erase(add_it);
+    } else {
+      auto& del_files = level_state.deleted_files;
+      assert(del_files.find(file_number) == del_files.end());
+      del_files.insert(file_number);
     }
-
-    auto& del_files = level_state.deleted_files;
-    assert(del_files.find(file_number) == del_files.end());
-    del_files.insert(file_number);
 
     table_file_levels_[file_number] = -1;
 
@@ -513,15 +513,14 @@ class VersionBuilder::Rep {
     auto del_it = del_files.find(file_number);
     if (del_it != del_files.end()) {
       del_files.erase(del_it);
+    } else {
+      FileMetaData* const f = new FileMetaData(meta);
+      f->refs = 1;
+
+      auto& add_files = level_state.added_files;
+      assert(add_files.find(file_number) == add_files.end());
+      add_files[file_number] = f;
     }
-
-    FileMetaData* const f = new FileMetaData(meta);
-    f->refs = 1;
-
-    auto& add_files = level_state.added_files;
-    assert(add_files.find(file_number) == add_files.end());
-    add_files.insert(std::unordered_map<uint64_t, FileMetaData*>::value_type(
-        file_number, f));
 
     table_file_levels_[file_number] = level;
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -462,7 +462,8 @@ class VersionBuilder::Rep {
       assert(invalid_level_sizes_[level] > 0);
       --invalid_level_sizes_[level];
 
-      table_file_levels_[file_number] = -1;
+      table_file_levels_[file_number] =
+          VersionStorageInfo::FileLocation::Invalid().GetLevel();
 
       return Status::OK();
     }
@@ -480,7 +481,8 @@ class VersionBuilder::Rep {
       del_files.insert(file_number);
     }
 
-    table_file_levels_[file_number] = -1;
+    table_file_levels_[file_number] =
+        VersionStorageInfo::FileLocation::Invalid().GetLevel();
 
     return Status::OK();
   }
@@ -492,7 +494,8 @@ class VersionBuilder::Rep {
 
     const int current_level = GetCurrentLevelForTableFile(file_number);
 
-    if (current_level >= 0) {
+    if (current_level !=
+        VersionStorageInfo::FileLocation::Invalid().GetLevel()) {
       if (level >= num_levels_) {
         has_invalid_levels_ = true;
       }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -446,15 +446,9 @@ class VersionBuilder::Rep {
   }
 
   Status ApplyFileDeletion(int level, uint64_t file_number) {
+    assert(level >= 0);
+
     const int current_level = GetCurrentLevelForTableFile(file_number);
-
-    if (current_level < 0) {
-      if (level >= num_levels_) {
-        has_invalid_levels_ = true;
-      }
-
-      return Status::Corruption();  // TODO: message
-    }
 
     if (level != current_level) {
       if (level >= num_levels_) {
@@ -492,9 +486,13 @@ class VersionBuilder::Rep {
   }
 
   Status ApplyFileAddition(int level, const FileMetaData& meta) {
+    assert(level >= 0);
+
     const uint64_t file_number = meta.fd.GetNumber();
 
-    if (GetCurrentLevelForTableFile(file_number) >= 0) {
+    const int current_level = GetCurrentLevelForTableFile(file_number);
+
+    if (current_level >= 0) {
       if (level >= num_levels_) {
         has_invalid_levels_ = true;
       }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -529,9 +529,11 @@ class VersionBuilder::Rep {
 
   // Apply all of the edits in *edit to the current state.
   Status Apply(VersionEdit* edit) {
-    Status s = CheckConsistency(base_vstorage_);
-    if (!s.ok()) {
-      return s;
+    {
+      const Status s = CheckConsistency(base_vstorage_);
+      if (!s.ok()) {
+        return s;
+      }
     }
 
     // Delete files
@@ -539,7 +541,7 @@ class VersionBuilder::Rep {
       const int level = deleted_file.first;
       const uint64_t file_number = deleted_file.second;
 
-      s = ApplyFileDeletion(level, file_number);
+      const Status s = ApplyFileDeletion(level, file_number);
       if (!s.ok()) {
         return s;
       }
@@ -550,7 +552,7 @@ class VersionBuilder::Rep {
       const int level = new_file.first;
       const FileMetaData& meta = new_file.second;
 
-      s = ApplyFileAddition(level, meta);
+      const Status s = ApplyFileAddition(level, meta);
       if (!s.ok()) {
         return s;
       }
@@ -558,7 +560,7 @@ class VersionBuilder::Rep {
 
     // Add new blob files
     for (const auto& blob_file_addition : edit->GetBlobFileAdditions()) {
-      s = ApplyBlobFileAddition(blob_file_addition);
+      const Status s = ApplyBlobFileAddition(blob_file_addition);
       if (!s.ok()) {
         return s;
       }
@@ -566,13 +568,13 @@ class VersionBuilder::Rep {
 
     // Increase the amount of garbage for blob files affected by GC
     for (const auto& blob_file_garbage : edit->GetBlobFileGarbages()) {
-      s = ApplyBlobFileGarbage(blob_file_garbage);
+      const Status s = ApplyBlobFileGarbage(blob_file_garbage);
       if (!s.ok()) {
         return s;
       }
     }
 
-    return s;
+    return Status::OK();
   }
 
   static std::shared_ptr<BlobFileMetaData> CreateMetaDataForNewBlobFile(

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -54,7 +54,7 @@ class VersionBuilderTest : public testing::Test {
     return InternalKey(ukey, smallest_seq, kTypeValue);
   }
 
-  void Add(int level, uint32_t file_number, const char* smallest,
+  void Add(int level, uint64_t file_number, const char* smallest,
            const char* largest, uint64_t file_size = 0, uint32_t path_id = 0,
            SequenceNumber smallest_seq = 100, SequenceNumber largest_seq = 100,
            uint64_t num_entries = 0, uint64_t num_deletions = 0,


### PR DESCRIPTION
Summary:
The patch cleans up the code and improves the consistency checks around
adding/deleting table files in `VersionBuilder`. Namely, it makes the checks
stricter and improves them in the following ways:
1) A table file can now only be deleted from the LSM tree using the level it
resides on. Earlier, there was some unnecessary wiggle room for
trivially moved files (they could be deleted using a lower level number than
the actual one).
2) A table file cannot be added to the tree if it is already present in the tree
on any level (not just the target level). The earlier code only had an assertion
(which is a no-op in release builds) that the newly added file is not already
present on the target level.
3) The above consistency checks around state transitions are now mandatory,
as opposed to the earlier `CheckConsistencyForDeletes`, which was a no-op
in release mode unless `force_consistency_checks` was set to `true`. The rationale
here is that assuming that the initial state is consistent, a valid transition leads to a
next state that is also consistent; however, an *invalid* transition offers no such
guarantee. Hence it makes sense to validate the transitions unconditionally,
and save `force_consistency_checks` for the paranoid checks that re-validate
the entire state.
4) The new checks build on the mechanism introduced in https://github.com/facebook/rocksdb/pull/6862,
which enables us to efficiently look up the location (level and position within level)
of files in a `Version` by file number. This makes the consistency checks much more
efficient than the earlier `CheckConsistencyForDeletes`, which essentially
performed a linear search.

Test Plan:
Extended the unit tests and ran:

`make check`
`make whitebox_crash_test`