### PR TITLE
[FB Internal] Find the correct gcov

### DIFF
--- a/coverage/coverage_test.sh
+++ b/coverage/coverage_test.sh
@@ -12,7 +12,7 @@ fi
 ROOT=".."
 # Fetch right version of gcov
 if [ -d /mnt/gvfs/third-party -a -z "$CXX" ]; then
-  source $ROOT/build_tools/fbcode_config.sh
+  source $ROOT/build_tools/fbcode_config_platform007.sh
   GCOV=$GCC_BASE/bin/gcov
 else
   GCOV=$(which gcov)


### PR DESCRIPTION
Summary:
Right now in FB environment, wrong gcov is used. Fix it.

Test Plan: "make coverage" and watch results.