### PR TITLE
Fix handling of too-small filter partition size

### DIFF
--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -36,6 +36,25 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
       keys_added_to_partition_(0) {
   keys_per_partition_ =
       filter_bits_builder_->CalculateNumEntry(partition_size);
+  if (keys_per_partition_ < 1) {
+    // partition_size (minus buffer, ~10%) might be smaller than minimum
+    // filter size, sometimes based on cache line size. Try to find that
+    // minimum size without CalculateSpace (not necessarily available).
+    uint32_t larger = std::max(partition_size + 4, uint32_t{16});
+    for (;;) {
+      keys_per_partition_ =
+          filter_bits_builder_->CalculateNumEntry(larger);
+      if (keys_per_partition_ >= 1) {
+        break;
+      }
+      larger += larger / 4;
+      if (larger > 100000) {
+        // might be a broken implementation. substitute something reasonable:
+        // 1 key / byte.
+        keys_per_partition_ = partition_size;
+      }
+    }
+  }
 }
 
 PartitionedFilterBlockBuilder::~PartitionedFilterBlockBuilder() {}

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -52,6 +52,7 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
         // might be a broken implementation. substitute something reasonable:
         // 1 key / byte.
         keys_per_partition_ = partition_size;
+        break;
       }
     }
   }

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -42,8 +42,7 @@ PartitionedFilterBlockBuilder::PartitionedFilterBlockBuilder(
     // minimum size without CalculateSpace (not necessarily available).
     uint32_t larger = std::max(partition_size + 4, uint32_t{16});
     for (;;) {
-      keys_per_partition_ =
-          filter_bits_builder_->CalculateNumEntry(larger);
+      keys_per_partition_ = filter_bits_builder_->CalculateNumEntry(larger);
       if (keys_per_partition_ >= 1) {
         break;
       }


### PR DESCRIPTION
Summary: Because ARM and some other platforms have a larger cache line
size, they have a larger minimum filter size, which causes recently
added PartitionedMultiGet test in db_bloom_filter_test to fail on those
platforms. The code would actually end up using larger partitions,
because keys_per_partition_ would be 0 and never == number of keys
added.

The code now attempts to get as close as possible to the small target
size, while fully utilizing that filter size, if the target partition
size is smaller than the minimum filter size.

Also updated the test to break more uniformly across platforms

Test Plan: updated test, tested on ARM