### PR TITLE
Reduce dependency on gtest dependency in release code

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -17,7 +17,6 @@
 #include "monitoring/iostats_context_imp.h"
 #include "port/port.h"
 #include "test_util/sync_point.h"
-#include "test_util/testharness.h"
 #include "util/random.h"
 #include "util/rate_limiter.h"
 

--- a/table/block_based/block_based_filter_block.cc
+++ b/table/block_based/block_based_filter_block.cc
@@ -14,7 +14,6 @@
 #include "monitoring/perf_context_imp.h"
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block_based_table_reader.h"
-#include "test_util/testharness.h"
 #include "util/coding.h"
 #include "util/string_util.h"
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -55,7 +55,6 @@
 #include "table/sst_file_writer_collectors.h"
 #include "table/two_level_iterator.h"
 
-#include "test_util/testharness.h"
 #include "monitoring/perf_context_imp.h"
 #include "port/lang.h"
 #include "test_util/sync_point.h"

--- a/table/block_based/full_filter_block.cc
+++ b/table/block_based/full_filter_block.cc
@@ -11,7 +11,6 @@
 #include "port/port.h"
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block_based_table_reader.h"
-#include "test_util/testharness.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/table/block_based/partitioned_filter_block.cc
+++ b/table/block_based/partitioned_filter_block.cc
@@ -13,7 +13,6 @@
 #include "rocksdb/filter_policy.h"
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_reader.h"
-#include "test_util/testharness.h"
 #include "util/coding.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/table/block_based/partitioned_index_reader.cc
+++ b/table/block_based/partitioned_index_reader.cc
@@ -8,7 +8,6 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #include "table/block_based/partitioned_index_reader.h"
 #include "table/block_based/partitioned_index_iterator.h"
-#include "test_util/testharness.h"
 
 namespace ROCKSDB_NAMESPACE {
 Status PartitionIndexReader::Create(

--- a/test_util/sync_point.h
+++ b/test_util/sync_point.h
@@ -142,3 +142,17 @@ class SyncPoint {
 #define INIT_SYNC_POINT_SINGLETONS() \
   (void)ROCKSDB_NAMESPACE::SyncPoint::GetInstance();
 #endif  // NDEBUG
+
+// Callback sync point for any read IO errors that should be ignored by
+// the fault injection framework
+// Disable in release mode
+#ifdef NDEBUG
+#define IGNORE_STATUS_IF_ERROR(_status_)
+#else
+#define IGNORE_STATUS_IF_ERROR(_status_)            \
+  {                                                 \
+    if (!_status_.ok()) {                           \
+      TEST_SYNC_POINT("FaultInjectionIgnoreError"); \
+    }                                               \
+  }
+#endif  // NDEBUG

--- a/test_util/testharness.h
+++ b/test_util/testharness.h
@@ -43,18 +43,4 @@ int RandomSeed();
   EXPECT_PRED_FORMAT1(ROCKSDB_NAMESPACE::test::AssertStatus, s)
 #define EXPECT_NOK(s) EXPECT_FALSE((s).ok())
 }  // namespace test
-
-// Callback sync point for any read IO errors that should be ignored by
-// the fault injection framework
-#ifdef NDEBUG
-// Disable in release mode
-#define IGNORE_STATUS_IF_ERROR(_status_)
-#else
-#define IGNORE_STATUS_IF_ERROR(_status_)          \
-{                                                 \
-  if (!_status_.ok()) {                           \
-    TEST_SYNC_POINT("FaultInjectionIgnoreError"); \
-  }                                               \
-}
-#endif // NDEBUG
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:
Release code now depends on gtest, indirectly through including "test_util/testharness.h". This creates multiple problems. One important reason is the definition of IGNORE_STATUS_IF_ERROR() in test_util/testharness.h. Move it to sync_point.h instead.
Note that utilities/cassandra/format.h still depends on "test_util/testharness.h". This will be resolved in a separate diff.

Test Plan: Run all existing tests.