### PR TITLE
Remove gtest dependency in non-test code under utilities/cassandra

### DIFF
--- a/utilities/cassandra/cassandra_format_test.cc
+++ b/utilities/cassandra/cassandra_format_test.cc
@@ -184,6 +184,8 @@ TEST(TombstoneTest, Tombstone) {
       == 0);
 }
 
+class RowValueTest : public testing::Test {};
+
 TEST(RowValueTest, RowTombstone) {
   int32_t local_deletion_time = 1494022807;
   int64_t marked_for_delete_at = 1494022807044;
@@ -327,10 +329,13 @@ TEST(RowValueTest, PurgeTtlShouldRemvoeAllColumnsExpired) {
   bool changed = false;
   auto purged = row_value.RemoveExpiredColumns(&changed);
   EXPECT_TRUE(changed);
-  EXPECT_EQ(purged.columns_.size(), 3);
-  VerifyRowValueColumns(purged.columns_, 0, kColumn, 0, ToMicroSeconds(now));
-  VerifyRowValueColumns(purged.columns_, 1, kExpiringColumn, 2, ToMicroSeconds(now));
-  VerifyRowValueColumns(purged.columns_, 2, kTombstone, 3, ToMicroSeconds(now));
+  EXPECT_EQ(purged.get_columns().size(), 3);
+  VerifyRowValueColumns(purged.get_columns(), 0, kColumn, 0,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(purged.get_columns(), 1, kExpiringColumn, 2,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(purged.get_columns(), 2, kTombstone, 3,
+                        ToMicroSeconds(now));
 
   purged.RemoveExpiredColumns(&changed);
   EXPECT_FALSE(changed);
@@ -349,11 +354,15 @@ TEST(RowValueTest, ExpireTtlShouldConvertExpiredColumnsToTombstones) {
   bool changed = false;
   auto compacted = row_value.ConvertExpiredColumnsToTombstones(&changed);
   EXPECT_TRUE(changed);
-  EXPECT_EQ(compacted.columns_.size(), 4);
-  VerifyRowValueColumns(compacted.columns_, 0, kColumn, 0, ToMicroSeconds(now));
-  VerifyRowValueColumns(compacted.columns_, 1, kTombstone, 1, ToMicroSeconds(now - 10));
-  VerifyRowValueColumns(compacted.columns_, 2, kExpiringColumn, 2, ToMicroSeconds(now));
-  VerifyRowValueColumns(compacted.columns_, 3, kTombstone, 3, ToMicroSeconds(now));
+  EXPECT_EQ(compacted.get_columns().size(), 4);
+  VerifyRowValueColumns(compacted.get_columns(), 0, kColumn, 0,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(compacted.get_columns(), 1, kTombstone, 1,
+                        ToMicroSeconds(now - 10));
+  VerifyRowValueColumns(compacted.get_columns(), 2, kExpiringColumn, 2,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(compacted.get_columns(), 3, kTombstone, 3,
+                        ToMicroSeconds(now));
 
   compacted.ConvertExpiredColumnsToTombstones(&changed);
   EXPECT_FALSE(changed);

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -164,12 +164,17 @@ TEST_F(CassandraFunctionalTest, SimpleMergeTest) {
 
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
-  EXPECT_EQ(merged.columns_.size(), 5);
-  VerifyRowValueColumns(merged.columns_, 0, kExpiringColumn, 0, ToMicroSeconds(now + 6));
-  VerifyRowValueColumns(merged.columns_, 1, kColumn, 1, ToMicroSeconds(now + 8));
-  VerifyRowValueColumns(merged.columns_, 2, kTombstone, 2, ToMicroSeconds(now + 7));
-  VerifyRowValueColumns(merged.columns_, 3, kExpiringColumn, 7, ToMicroSeconds(now + 17));
-  VerifyRowValueColumns(merged.columns_, 4, kTombstone, 11, ToMicroSeconds(now + 11));
+  EXPECT_EQ(merged.get_columns().size(), 5);
+  VerifyRowValueColumns(merged.get_columns(), 0, kExpiringColumn, 0,
+                        ToMicroSeconds(now + 6));
+  VerifyRowValueColumns(merged.get_columns(), 1, kColumn, 1,
+                        ToMicroSeconds(now + 8));
+  VerifyRowValueColumns(merged.get_columns(), 2, kTombstone, 2,
+                        ToMicroSeconds(now + 7));
+  VerifyRowValueColumns(merged.get_columns(), 3, kExpiringColumn, 7,
+                        ToMicroSeconds(now + 17));
+  VerifyRowValueColumns(merged.get_columns(), 4, kTombstone, 11,
+                        ToMicroSeconds(now + 11));
 }
 
 TEST_F(CassandraFunctionalTest,
@@ -196,11 +201,15 @@ TEST_F(CassandraFunctionalTest,
   auto ret = store.Get("k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
-  EXPECT_EQ(merged.columns_.size(), 4);
-  VerifyRowValueColumns(merged.columns_, 0, kTombstone, 0, ToMicroSeconds(now - 10));
-  VerifyRowValueColumns(merged.columns_, 1, kExpiringColumn, 1, ToMicroSeconds(now - kTtl + 10));
-  VerifyRowValueColumns(merged.columns_, 2, kColumn, 2, ToMicroSeconds(now));
-  VerifyRowValueColumns(merged.columns_, 3, kTombstone, 3, ToMicroSeconds(now));
+  EXPECT_EQ(merged.get_columns().size(), 4);
+  VerifyRowValueColumns(merged.get_columns(), 0, kTombstone, 0,
+                        ToMicroSeconds(now - 10));
+  VerifyRowValueColumns(merged.get_columns(), 1, kExpiringColumn, 1,
+                        ToMicroSeconds(now - kTtl + 10));
+  VerifyRowValueColumns(merged.get_columns(), 2, kColumn, 2,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(merged.get_columns(), 3, kTombstone, 3,
+                        ToMicroSeconds(now));
 }
 
 
@@ -229,10 +238,13 @@ TEST_F(CassandraFunctionalTest,
   auto ret = store.Get("k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& merged = std::get<1>(ret);
-  EXPECT_EQ(merged.columns_.size(), 3);
-  VerifyRowValueColumns(merged.columns_, 0, kExpiringColumn, 1, ToMicroSeconds(now));
-  VerifyRowValueColumns(merged.columns_, 1, kColumn, 2, ToMicroSeconds(now));
-  VerifyRowValueColumns(merged.columns_, 2, kTombstone, 3, ToMicroSeconds(now));
+  EXPECT_EQ(merged.get_columns().size(), 3);
+  VerifyRowValueColumns(merged.get_columns(), 0, kExpiringColumn, 1,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(merged.get_columns(), 1, kColumn, 2,
+                        ToMicroSeconds(now));
+  VerifyRowValueColumns(merged.get_columns(), 2, kTombstone, 3,
+                        ToMicroSeconds(now));
 }
 
 TEST_F(CassandraFunctionalTest,
@@ -284,8 +296,8 @@ TEST_F(CassandraFunctionalTest,
   auto ret = store.Get("k1");
   ASSERT_TRUE(std::get<0>(ret));
   RowValue& gced = std::get<1>(ret);
-  EXPECT_EQ(gced.columns_.size(), 1);
-  VerifyRowValueColumns(gced.columns_, 0, kColumn, 1, ToMicroSeconds(now));
+  EXPECT_EQ(gced.get_columns().size(), 1);
+  VerifyRowValueColumns(gced.get_columns(), 0, kColumn, 1, ToMicroSeconds(now));
 }
 
 TEST_F(CassandraFunctionalTest, CompactionShouldRemoveTombstoneFromPut) {

--- a/utilities/cassandra/cassandra_row_merge_test.cc
+++ b/utilities/cassandra/cassandra_row_merge_test.cc
@@ -11,6 +11,8 @@
 namespace ROCKSDB_NAMESPACE {
 namespace cassandra {
 
+class RowValueMergeTest : public testing::Test {};
+
 TEST(RowValueMergeTest, Merge) {
   std::vector<RowValue> row_values;
   row_values.push_back(
@@ -41,12 +43,12 @@ TEST(RowValueMergeTest, Merge) {
 
   RowValue merged = RowValue::Merge(std::move(row_values));
   EXPECT_FALSE(merged.IsTombstone());
-  EXPECT_EQ(merged.columns_.size(), 5);
-  VerifyRowValueColumns(merged.columns_, 0, kExpiringColumn, 0, 6);
-  VerifyRowValueColumns(merged.columns_, 1, kColumn, 1, 8);
-  VerifyRowValueColumns(merged.columns_, 2, kTombstone, 2, 7);
-  VerifyRowValueColumns(merged.columns_, 3, kExpiringColumn, 7, 17);
-  VerifyRowValueColumns(merged.columns_, 4, kTombstone, 11, 11);
+  EXPECT_EQ(merged.get_columns().size(), 5);
+  VerifyRowValueColumns(merged.get_columns(), 0, kExpiringColumn, 0, 6);
+  VerifyRowValueColumns(merged.get_columns(), 1, kColumn, 1, 8);
+  VerifyRowValueColumns(merged.get_columns(), 2, kTombstone, 2, 7);
+  VerifyRowValueColumns(merged.get_columns(), 3, kExpiringColumn, 7, 17);
+  VerifyRowValueColumns(merged.get_columns(), 4, kTombstone, 11, 11);
 }
 
 TEST(RowValueMergeTest, MergeWithRowTombstone) {
@@ -83,10 +85,10 @@ TEST(RowValueMergeTest, MergeWithRowTombstone) {
 
   RowValue merged = RowValue::Merge(std::move(row_values));
   EXPECT_FALSE(merged.IsTombstone());
-  EXPECT_EQ(merged.columns_.size(), 3);
-  VerifyRowValueColumns(merged.columns_, 0, kColumn, 3, 12);
-  VerifyRowValueColumns(merged.columns_, 1, kColumn, 4, 13);
-  VerifyRowValueColumns(merged.columns_, 2, kColumn, 5, 14);
+  EXPECT_EQ(merged.get_columns().size(), 3);
+  VerifyRowValueColumns(merged.get_columns(), 0, kColumn, 3, 12);
+  VerifyRowValueColumns(merged.get_columns(), 1, kColumn, 4, 13);
+  VerifyRowValueColumns(merged.get_columns(), 2, kColumn, 5, 14);
 
   // If the tombstone's timestamp is the latest, then it returns a
   // row tombstone.

--- a/utilities/cassandra/format.h
+++ b/utilities/cassandra/format.h
@@ -60,7 +60,6 @@
 #include <vector>
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/slice.h"
-#include "test_util/testharness.h"
 
 namespace ROCKSDB_NAMESPACE {
 namespace cassandra {
@@ -172,25 +171,13 @@ public:
   // Merge multiple rows according to their timestamp.
   static RowValue Merge(std::vector<RowValue>&& values);
 
-private:
+  const Columns& get_columns() { return columns_; }
+
+ private:
   int32_t local_deletion_time_;
   int64_t marked_for_delete_at_;
   Columns columns_;
   int64_t last_modified_time_;
-
-  FRIEND_TEST(RowValueTest, PurgeTtlShouldRemvoeAllColumnsExpired);
-  FRIEND_TEST(RowValueTest, ExpireTtlShouldConvertExpiredColumnsToTombstones);
-  FRIEND_TEST(RowValueMergeTest, Merge);
-  FRIEND_TEST(RowValueMergeTest, MergeWithRowTombstone);
-  FRIEND_TEST(CassandraFunctionalTest, SimpleMergeTest);
-  FRIEND_TEST(
-    CassandraFunctionalTest, CompactionShouldConvertExpiredColumnsToTombstone);
-  FRIEND_TEST(
-    CassandraFunctionalTest, CompactionShouldPurgeExpiredColumnsIfPurgeTtlIsOn);
-  FRIEND_TEST(
-    CassandraFunctionalTest, CompactionShouldRemoveRowWhenAllColumnExpiredIfPurgeTtlIsOn);
-  FRIEND_TEST(CassandraFunctionalTest,
-              CompactionShouldRemoveTombstoneExceedingGCGracePeriod);
 };
 
 } // namepsace cassandrda

--- a/utilities/cassandra/test_utils.cc
+++ b/utilities/cassandra/test_utils.cc
@@ -53,12 +53,9 @@ RowValue CreateRowTombstone(int64_t timestamp) {
 }
 
 void VerifyRowValueColumns(
-  std::vector<std::shared_ptr<ColumnBase>> &columns,
-  std::size_t index_of_vector,
-  int8_t expected_mask,
-  int8_t expected_index,
-  int64_t expected_timestamp
-) {
+    const std::vector<std::shared_ptr<ColumnBase>> &columns,
+    std::size_t index_of_vector, int8_t expected_mask, int8_t expected_index,
+    int64_t expected_timestamp) {
   EXPECT_EQ(expected_timestamp, columns[index_of_vector]->Timestamp());
   EXPECT_EQ(expected_mask, columns[index_of_vector]->Mask());
   EXPECT_EQ(expected_index, columns[index_of_vector]->Index());

--- a/utilities/cassandra/test_utils.h
+++ b/utilities/cassandra/test_utils.h
@@ -33,12 +33,9 @@ RowValue CreateTestRowValue(
 RowValue CreateRowTombstone(int64_t timestamp);
 
 void VerifyRowValueColumns(
-  std::vector<std::shared_ptr<ColumnBase>> &columns,
-  std::size_t index_of_vector,
-  int8_t expected_mask,
-  int8_t expected_index,
-  int64_t expected_timestamp
-);
+    const std::vector<std::shared_ptr<ColumnBase>> &columns,
+    std::size_t index_of_vector, int8_t expected_mask, int8_t expected_index,
+    int64_t expected_timestamp);
 
 int64_t ToMicroSeconds(int64_t seconds);
 int32_t ToSeconds(int64_t microseconds);


### PR DESCRIPTION
Summary:
production code under utilities/cassandra depends on gtest.h. Remove them.

Test Plan: Run all existing tests.