### PR TITLE
Check iterator status BlockBasedTableReader::VerifyChecksumInBlocks() 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Fix corrupt key read from ingested file when iterator direction switches from reverse to forward at a key that is a prefix of another key in the same file. It is only possible in files with a non-zero global seqno.
 * Fix abnormally large estimate from GetApproximateSizes when a range starts near the end of one SST file and near the beginning of another. Now GetApproximateSizes consistently and fairly includes the size of SST metadata in addition to data blocks, attributing metadata proportionally among the data blocks based on their size.
 * Fix potential file descriptor leakage in PosixEnv's IsDirectory() and NewRandomAccessFile().
+* Fix false negative from the VerifyChecksum() API when there is a checksum mismatch in an index partition block in a BlockBasedTable format table file (index_type is kTwoLevelIndexSearch).
 
 ### Public API Change
 * Flush(..., column_family) may return Status::ColumnFamilyDropped() instead of Status::InvalidArgument() if column_family is dropped while processing the flush request.

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2837,6 +2837,9 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
       break;
     }
   }
+  if (s.ok()) {
+    s = index_iter->status();
+  }
   return s;
 }
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2838,6 +2838,9 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
     }
   }
   if (s.ok()) {
+    // In the case of two level indexes, we would have exited the above loop
+    // by checking index_iter->Valid(), but Valid() might have returned false
+    // due to an IO error. So check the index_iter status
     s = index_iter->status();
   }
   return s;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -255,7 +255,7 @@ class BlockBasedTable : public TableReader {
 
  private:
   friend class MockedBlockBasedTable;
-  friend class BlockBasedTableReaderTest_VerifyChecksum_Test;
+  friend class BlockBasedTableReaderTestVerifyChecksum_ChecksumMismatch_Test;
   static std::atomic<uint64_t> next_cache_key_id_;
   BlockCacheTracer* const block_cache_tracer_;
 

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -255,6 +255,7 @@ class BlockBasedTable : public TableReader {
 
  private:
   friend class MockedBlockBasedTable;
+  friend class BlockBasedTableReaderTest_VerifyChecksum_Test;
   static std::atomic<uint64_t> next_cache_key_id_;
   BlockCacheTracer* const block_cache_tracer_;
 

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -331,7 +331,7 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Values(BlockBasedTableOptions::IndexType::kBinarySearch),
         ::testing::Values(false)));
 #endif  // ROCKSDB_LITE
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     VerifyChecksum, BlockBasedTableReaderTestVerifyChecksum,
     ::testing::Combine(
         ::testing::ValuesIn(GetSupportedCompressions()),

--- a/table/block_based/partitioned_index_iterator.h
+++ b/table/block_based/partitioned_index_iterator.h
@@ -122,7 +122,7 @@ class ParititionedIndexIterator : public InternalIteratorBase<IndexValue> {
   }
 
  private:
-  friend class BlockBasedTableReaderTest_VerifyChecksum_Test;
+  friend class BlockBasedTableReaderTestVerifyChecksum_ChecksumMismatch_Test;
   const BlockBasedTable* table_;
   const ReadOptions read_options_;
 #ifndef NDEBUG

--- a/table/block_based/partitioned_index_iterator.h
+++ b/table/block_based/partitioned_index_iterator.h
@@ -122,6 +122,7 @@ class ParititionedIndexIterator : public InternalIteratorBase<IndexValue> {
   }
 
  private:
+  friend class BlockBasedTableReaderTest_VerifyChecksum_Test;
   const BlockBasedTable* table_;
   const ReadOptions read_options_;
 #ifndef NDEBUG

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -528,7 +528,6 @@ void SetupSyncPointsToMockDirectIO() {
 #endif
 }
 
-#ifndef ROCKSDB_LITE
 void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
   struct stat sbuf;
   if (stat(fname.c_str(), &sbuf) != 0) {
@@ -563,9 +562,10 @@ void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
   assert(s.ok());
   Options options;
   EnvOptions env_options;
+#ifndef ROCKSDB_LITE
   assert(!VerifySstFileChecksum(options, env_options, fname).ok());
-}
 #endif
+}
 
 }  // namespace test
 }  // namespace ROCKSDB_NAMESPACE

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -10,6 +10,7 @@
 #include "test_util/testutil.h"
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <array>
 #include <cctype>
 #include <fstream>
@@ -525,6 +526,43 @@ void SetupSyncPointsToMockDirectIO() {
       });
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 #endif
+}
+
+void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
+  struct stat sbuf;
+  if (stat(fname.c_str(), &sbuf) != 0) {
+    const char* msg = strerror(errno);
+    fprintf(stderr, "%s:%s\n", fname.c_str(), msg);
+    assert(false);
+  }
+
+  if (offset < 0) {
+    // Relative to end of file; make it absolute
+    if (-offset > sbuf.st_size) {
+      offset = 0;
+    } else {
+      offset = static_cast<int>(sbuf.st_size + offset);
+    }
+  }
+  if (offset > sbuf.st_size) {
+    offset = static_cast<int>(sbuf.st_size);
+  }
+  if (offset + bytes_to_corrupt > sbuf.st_size) {
+    bytes_to_corrupt = static_cast<int>(sbuf.st_size - offset);
+  }
+
+  // Do it
+  std::string contents;
+  Status s = ReadFileToString(Env::Default(), fname, &contents);
+  assert(s.ok());
+  for (int i = 0; i < bytes_to_corrupt; i++) {
+    contents[i + offset] ^= 0x80;
+  }
+  s = WriteStringToFile(Env::Default(), contents, fname);
+  assert(s.ok());
+  Options options;
+  EnvOptions env_options;
+  assert(!VerifySstFileChecksum(options, env_options, fname).ok());
 }
 
 }  // namespace test

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -528,6 +528,7 @@ void SetupSyncPointsToMockDirectIO() {
 #endif
 }
 
+#ifndef ROCKSDB_LITE
 void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
   struct stat sbuf;
   if (stat(fname.c_str(), &sbuf) != 0) {
@@ -564,6 +565,7 @@ void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
   EnvOptions env_options;
   assert(!VerifySstFileChecksum(options, env_options, fname).ok());
 }
+#endif
 
 }  // namespace test
 }  // namespace ROCKSDB_NAMESPACE

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -531,6 +531,8 @@ void SetupSyncPointsToMockDirectIO() {
 void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
   struct stat sbuf;
   if (stat(fname.c_str(), &sbuf) != 0) {
+    // strerror is not thread-safe so should not be used in the "passing" path
+    // of unit tests (sometimes parallelized) but is OK here where test fails
     const char* msg = strerror(errno);
     fprintf(stderr, "%s:%s\n", fname.c_str(), msg);
     assert(false);

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -812,5 +812,7 @@ void ResetTmpDirForDirectIO();
 // to the file system.
 void SetupSyncPointsToMockDirectIO();
 
+void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt);
+
 }  // namespace test
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
The ```for``` loop in ```VerifyChecksumInBlocks``` only checks ```index_iter->Valid()``` which could be ```false``` either due to reaching the end of the index or, in case of partitioned index, it could be due to a checksum mismatch error when reading a 2nd level index block. Instead of throwing away the index iterator status, we need to return any errors back to the caller.

Tests:
Add a test in block_based_table_reader_test.cc.