### PR TITLE
Some fixes for gcc 4.8 and add to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -313,7 +313,7 @@ script:
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release $OPT && make -j4 rocksdb rocksdbjni
       ;;
     make-gcc4.8)
-      OPT=-DTRAVIS V=1 make -j4 all
+      OPT=-DTRAVIS V=1 SKIP_LINK=1 make -j4 all # Linking broken because libgflags compiled with newer ABI
       ;;
     status_checked)
       OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check_some

--- a/.travis.yml
+++ b/.travis.yml
@@ -313,7 +313,7 @@ script:
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release $OPT && make -j4 rocksdb rocksdbjni
       ;;
     make-gcc4.8)
-      OPT=-DTRAVIS V=1 SKIP_LINK=1 make -j4 all # Linking broken because libgflags compiled with newer ABI
+      OPT=-DTRAVIS V=1 SKIP_LINK=1 make -j4 all;# Linking broken because libgflags compiled with newer ABI
       ;;
     status_checked)
       OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check_some

--- a/.travis.yml
+++ b/.travis.yml
@@ -313,7 +313,7 @@ script:
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release $OPT && make -j4 rocksdb rocksdbjni
       ;;
     make-gcc4.8)
-      OPT=-DTRAVIS V=1 SKIP_LINK=1 make -j4 all;# Linking broken because libgflags compiled with newer ABI
+      OPT=-DTRAVIS V=1 SKIP_LINK=1 make -j4 all && [ "Linking broken because libgflags compiled with newer ABI" ]
       ;;
     status_checked)
       OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check_some

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ env:
   - JOB_NAME=cmake-gcc9 # 3-5 minutes
   - JOB_NAME=cmake-gcc9-c++20 # 3-5 minutes
   - JOB_NAME=cmake-mingw # 3 minutes
+  - JOB_NAME=make-gcc4.8
   - JOB_NAME=status_checked
 
 matrix:
@@ -66,15 +67,23 @@ matrix:
   - os: osx
     env: JOB_NAME=cmake-mingw
   - os: osx
+    env: JOB_NAME=make-gcc4.8
+  - os: osx
     arch: ppc64le
   - os: osx
     compiler: gcc
   - os : linux
     arch: arm64
     env: JOB_NAME=cmake-mingw
+  - os : linux
+    arch: arm64
+    env: JOB_NAME=make-gcc4.8
   - os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-mingw
+  - os: linux
+    arch: ppc64le
+    env: JOB_NAME=make-gcc4.8
   - os: linux
     compiler: clang
   # Exclude all but most unique cmake variants for pull requests, but build all in branches
@@ -225,6 +234,10 @@ install:
   - if [ "${JOB_NAME}" == cmake-mingw ]; then
       sudo apt-get install -y mingw-w64 ;
     fi
+  - if [ "${JOB_NAME}" == make-gcc4.8 ]; then
+      sudo apt-get install -y g++-4.8 ;
+      CC=gcc-4.8 && CXX=g++-4.8;
+    fi
   - if [[ "${JOB_NAME}" == cmake* ]] && [ "${TRAVIS_OS_NAME}" == linux ]; then
       CMAKE_DIST_URL="https://rocksdb-deps.s3-us-west-2.amazonaws.com/cmake/cmake-3.14.5-Linux-$(uname -m).tar.bz2";
       TAR_OPT="--strip-components=1 -xj";
@@ -298,6 +311,9 @@ script:
       esac
 
       mkdir build && cd build && cmake -DJNI=1 .. -DCMAKE_BUILD_TYPE=Release $OPT && make -j4 rocksdb rocksdbjni
+      ;;
+    make-gcc4.8)
+      OPT=-DTRAVIS V=1 make -j4 all
       ;;
     status_checked)
       OPT=-DTRAVIS V=1 ASSERT_STATUS_CHECKED=1 make -j4 check_some

--- a/Makefile
+++ b/Makefile
@@ -195,12 +195,16 @@ AM_V_CC = $(am__v_CC_$(V))
 am__v_CC_ = $(am__v_CC_$(AM_DEFAULT_VERBOSITY))
 am__v_CC_0 = @echo "  CC      " $@;
 am__v_CC_1 =
-CCLD = $(CC)
-LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+
 AM_V_CCLD = $(am__v_CCLD_$(V))
 am__v_CCLD_ = $(am__v_CCLD_$(AM_DEFAULT_VERBOSITY))
+ifneq ($(SKIP_LINK), 1)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 =
+else
+am__v_CCLD_0 = @echo "  !CCLD   " $@; true skip
+am__v_CCLD_1 = true skip
+endif
 AM_V_AR = $(am__v_AR_$(V))
 am__v_AR_ = $(am__v_AR_$(AM_DEFAULT_VERBOSITY))
 am__v_AR_0 = @echo "  AR      " $@;
@@ -212,6 +216,7 @@ LDFLAGS += -lrados
 endif
 
 AM_LINK = $(AM_V_CCLD)$(CXX) $^ $(EXEC_LDFLAGS) -o $@ $(LDFLAGS) $(COVERAGEFLAGS)
+
 # Detect what platform we're building on.
 # Export some common variables that might have been passed as Make variables
 # instead of environment variables.

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2188,11 +2188,11 @@ TEST_F(DBBasicTest, SkipWALIfMissingTableFiles) {
 class DBBasicTestMultiGet : public DBTestBase {
  public:
   DBBasicTestMultiGet(std::string test_dir, int num_cfs, bool compressed_cache,
-                      bool uncompressed_cache, bool compression_enabled,
-                      bool fill_cache, uint32_t compression_parallel_threads)
+                      bool uncompressed_cache, bool _compression_enabled,
+                      bool _fill_cache, uint32_t compression_parallel_threads)
       : DBTestBase(test_dir) {
-    compression_enabled_ = compression_enabled;
-    fill_cache_ = fill_cache;
+    compression_enabled_ = _compression_enabled;
+    fill_cache_ = _fill_cache;
 
     if (compressed_cache) {
       std::shared_ptr<Cache> cache = NewLRUCache(1048576);

--- a/file/random_access_file_reader_test.cc
+++ b/file/random_access_file_reader_test.cc
@@ -20,7 +20,7 @@ class RandomAccessFileReaderTest : public testing::Test {
     fs_ = FileSystem::Default();
     test_dir_ = test::PerThreadDBPath("random_access_file_reader_test");
     ASSERT_OK(fs_->CreateDir(test_dir_, IOOptions(), nullptr));
-    alignment_ = GetAlignment();
+    ComputeAndSetAlignment();
   }
 
   void TearDown() override {
@@ -63,14 +63,13 @@ class RandomAccessFileReaderTest : public testing::Test {
     return test_dir_ + "/" + fname;
   }
 
-  size_t GetAlignment() {
+  void ComputeAndSetAlignment() {
     std::string f = "get_alignment";
     Write(f, "");
     std::unique_ptr<RandomAccessFileReader> r;
     Read(f, FileOptions(), &r);
-    size_t alignment = r->file()->GetRequiredBufferAlignment();
+    alignment_ = r->file()->GetRequiredBufferAlignment();
     EXPECT_OK(fs_->DeleteFile(Path(f), IOOptions(), nullptr));
-    return alignment;
   }
 };
 


### PR DESCRIPTION
Summary: People keep breaking the gcc 4.8 compilation due to different
warnings for shadowing member functions with locals. Adding to Travis
to keep compatibility. (gcc 4.8 is default on CentOS 7.)

Test Plan: local and Travis