### PR TITLE
Make DestroyDir destroy directories recursively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,7 +1090,7 @@ if(WITH_TESTS)
         table/sst_file_reader_test.cc
         table/table_test.cc
         table/block_fetcher_test.cc
-        testutil/testutil_test.cc
+        test_util/testutil_test.cc
         tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
         tools/ldb_cmd_test.cc
         tools/reduce_levels_test.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,6 +1090,7 @@ if(WITH_TESTS)
         table/sst_file_reader_test.cc
         table/table_test.cc
         table/block_fetcher_test.cc
+        testutil/testutil_test.cc
         tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
         tools/ldb_cmd_test.cc
         tools/reduce_levels_test.cc

--- a/Makefile
+++ b/Makefile
@@ -639,6 +639,7 @@ TESTS = \
 	blob_file_garbage_test \
 	timer_test \
 	db_with_timestamp_compaction_test \
+	testutil_test \
 
 PARALLEL_TEST = \
 	backupable_db_test \
@@ -1864,6 +1865,9 @@ blob_file_garbage_test: db/blob/blob_file_garbage_test.o $(LIBOBJECTS) $(TESTHAR
 	$(AM_LINK)
 
 timer_test: util/timer_test.o $(LIBOBJECTS) $(TESTHARNESS)
+	$(AM_LINK)
+
+testutil_test: test_util/testutil_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_LINK)
 
 #-------------------------------------------------

--- a/TARGETS
+++ b/TARGETS
@@ -1486,6 +1486,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "testutil_test",
+        "test_util/testutil_test.cc",
+        "serial",
+        [],
+        [],
+    ],
+    [
         "thread_list_test",
         "util/thread_list_test.cc",
         "serial",

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -464,7 +464,16 @@ Status DestroyDir(Env* env, const std::string& dir) {
       if (file_in_dir == "." || file_in_dir == "..") {
         continue;
       }
-      s = env->DeleteFile(dir + "/" + file_in_dir);
+      std::string path = dir + "/" + file_in_dir;
+      bool is_dir = false;
+      s = env->IsDirectory(path, &is_dir);
+      if (s.ok()) {
+        if (is_dir) {
+          s = DestroyDir(env, path);
+        } else {
+          s = env->DeleteFile(path);
+        }
+      }
       if (!s.ok()) {
         break;
       }

--- a/test_util/testutil_test.cc
+++ b/test_util/testutil_test.cc
@@ -1,0 +1,41 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "port/port.h"
+#include "port/stack_trace.h"
+#include "test_util/testharness.h"
+#include "test_util/testutil.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+void CreateFile(Env* env, const std::string& path) {
+  std::unique_ptr<WritableFile> f;
+  ASSERT_OK(env->NewWritableFile(path, &f, EnvOptions()));
+  f->Close();
+}
+
+TEST(TestUtil, DestroyDirRecursively) {
+  auto env = Env::Default();
+  // test_util/file
+  //          /dir
+  //          /dir/file
+  std::string test_dir = test::PerThreadDBPath("test_util");
+  ASSERT_OK(env->CreateDir(test_dir));
+  CreateFile(env, test_dir + "/file");
+  ASSERT_OK(env->CreateDir(test_dir + "/dir"));
+  CreateFile(env, test_dir + "/dir/file");
+
+  ASSERT_OK(test::DestroyDir(env, test_dir));
+  auto s = env->FileExists(test_dir);
+  ASSERT_TRUE(s.IsNotFound());
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test_util/testutil_test.cc
+++ b/test_util/testutil_test.cc
@@ -3,10 +3,11 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#include "test_util/testutil.h"
+
 #include "port/port.h"
 #include "port/stack_trace.h"
 #include "test_util/testharness.h"
-#include "test_util/testutil.h"
 
 namespace ROCKSDB_NAMESPACE {
 


### PR DESCRIPTION
Currently, `DeleteDir` only deletes the directory if there are no other directories under the target dir. This PR makes it delete directories recursively.

Test Plan:
Added a new unit test in testutil_test.cc.
`make testutil_test`