### PR TITLE
Fix more defects reported by Coverity Scan

### DIFF
--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -30,10 +30,10 @@ struct PerfContextByLevel {
 
   // total number of user key returned (only include keys that are found, does
   // not include keys that are deleted or merged without a final put
-  uint64_t user_key_return_count;
+  uint64_t user_key_return_count = 0;
 
   // total nanos spent on reading data from SST files
-  uint64_t get_from_table_nanos;
+  uint64_t get_from_table_nanos = 0;
 
   uint64_t block_cache_hit_count = 0;   // total number of block cache hits
   uint64_t block_cache_miss_count = 0;  // total number of block cache misses

--- a/memtable/memtablerep_bench.cc
+++ b/memtable/memtablerep_bench.cc
@@ -452,8 +452,8 @@ class Benchmark {
   MemTableRep* table_;
   KeyGenerator* key_gen_;
   uint64_t* sequence_;
-  uint64_t num_write_ops_per_thread_;
-  uint64_t num_read_ops_per_thread_;
+  uint64_t num_write_ops_per_thread_ = 0;
+  uint64_t num_read_ops_per_thread_ = 0;
   const uint32_t num_threads_;
 };
 

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -124,7 +124,7 @@ class Mutex {
   friend class CondVar;
   pthread_mutex_t mu_;
 #ifndef NDEBUG
-  bool locked_;
+  bool locked_ = false;
 #endif
 };
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -1189,11 +1189,11 @@ class FileChecksumTestHelper {
  public:
   FileChecksumTestHelper(bool convert_to_internal_key = false)
       : convert_to_internal_key_(convert_to_internal_key) {
-    sink_ = new test::StringSink();
   }
   ~FileChecksumTestHelper() {}
 
   void CreateWriteableFile() {
+    sink_ = new test::StringSink();
     file_writer_.reset(test::GetWritableFileWriter(sink_, "" /* don't care */));
   }
 
@@ -1291,7 +1291,7 @@ class FileChecksumTestHelper {
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   std::unique_ptr<TableBuilder> table_builder_;
   stl_wrappers::KVMap kv_map_;
-  test::StringSink* sink_;
+  test::StringSink* sink_ = nullptr;
 
   static uint64_t checksum_uniq_id_;
 };

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1851,7 +1851,7 @@ class CombinedStats;
 class Stats {
  private:
   int id_;
-  uint64_t start_;
+  uint64_t start_ = 0;
   uint64_t sine_interval_;
   uint64_t finish_;
   double seconds_;

--- a/trace_replay/block_cache_tracer.h
+++ b/trace_replay/block_cache_tracer.h
@@ -220,7 +220,7 @@ class BlockCacheHumanReadableTraceWriter {
 class BlockCacheTraceReader {
  public:
   BlockCacheTraceReader(std::unique_ptr<TraceReader>&& reader);
-  ~BlockCacheTraceReader() = default;
+  virtual ~BlockCacheTraceReader() = default;
   // No copy and move.
   BlockCacheTraceReader(const BlockCacheTraceReader&) = delete;
   BlockCacheTraceReader& operator=(const BlockCacheTraceReader&) = delete;

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -538,6 +538,7 @@ Status BackupEngine::Open(const BackupableDBOptions& options, Env* env,
 BackupEngineImpl::BackupEngineImpl(const BackupableDBOptions& options,
                                    Env* db_env, bool read_only)
     : initialized_(false),
+      threads_cpu_priority_(),
       latest_backup_id_(0),
       latest_valid_backup_id_(0),
       stop_backup_(false),


### PR DESCRIPTION
Summary: Mostly uninitialized values: some probably written before use, but some seem like bugs. Also, destructor needs to be virtual, and possible use-after-free in test

Test Plan: make check