### PR TITLE
Add convenience method GetFileMetaDataByNumber

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -325,6 +325,17 @@ class VersionStorageInfo {
   }
 
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
+  FileMetaData* GetFileMetaDataByNumber(uint64_t file_number) const {
+    auto location = GetFileLocation(file_number);
+
+    if (!location.IsValid()) {
+      return nullptr;
+    }
+
+    return files_[location.GetLevel()][location.GetPosition()];
+  }
+
+  // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   using BlobFiles = std::map<uint64_t, std::shared_ptr<BlobFileMetaData>>;
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -421,7 +421,7 @@ TEST_F(VersionStorageInfoTest, GetOverlappingInputs) {
       1, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}));
 }
 
-TEST_F(VersionStorageInfoTest, FileLocation) {
+TEST_F(VersionStorageInfoTest, FileLocationAndMetaDataByNumber) {
   Add(0, 11U, "1", "2", 5000U);
   Add(0, 12U, "1", "2", 5000U);
 
@@ -429,13 +429,18 @@ TEST_F(VersionStorageInfoTest, FileLocation) {
 
   ASSERT_EQ(vstorage_.GetFileLocation(11U),
             VersionStorageInfo::FileLocation(0, 0));
+  ASSERT_NE(vstorage_.GetFileMetaDataByNumber(11U), nullptr);
+
   ASSERT_EQ(vstorage_.GetFileLocation(12U),
             VersionStorageInfo::FileLocation(0, 1));
+  ASSERT_NE(vstorage_.GetFileMetaDataByNumber(12U), nullptr);
 
   ASSERT_EQ(vstorage_.GetFileLocation(7U),
             VersionStorageInfo::FileLocation(2, 0));
+  ASSERT_NE(vstorage_.GetFileMetaDataByNumber(7U), nullptr);
 
   ASSERT_FALSE(vstorage_.GetFileLocation(999U).IsValid());
+  ASSERT_EQ(vstorage_.GetFileMetaDataByNumber(999U), nullptr);
 }
 
 class VersionStorageInfoTimestampTest : public VersionStorageInfoTestBase {


### PR DESCRIPTION
Summary:
The patch adds a convenience method `GetFileMetaDataByNumber` that
builds on the `FileLocation` functionality introduced recently (see
https://github.com/facebook/rocksdb/pull/6862). This method makes it possible to retrieve the `FileMetaData`
directly as opposed to having to go through `LevelFiles` and friends.

Test Plan:
`make check`