### PR TITLE
Fix up a VersionBuilder test case

### DIFF
--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -423,8 +423,18 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
   constexpr char smallest[] = "bar";
   constexpr char largest[] = "foo";
   constexpr uint64_t file_size = 10000;
+  constexpr uint32_t path_id = 0;
+  constexpr SequenceNumber smallest_seq = 100;
+  constexpr SequenceNumber largest_seq = 500;
+  constexpr uint64_t num_entries = 0;
+  constexpr uint64_t num_deletions = 0;
+  constexpr bool sampled = false;
+  constexpr SequenceNumber smallest_seqno = 1;
+  constexpr SequenceNumber largest_seqno = 1000;
 
-  Add(level, file_number, smallest, largest, file_size);
+  Add(level, file_number, smallest, largest, file_size, path_id, smallest_seq,
+      largest_seq, num_entries, num_deletions, sampled, smallest_seqno,
+      largest_seqno);
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -441,11 +451,6 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
 
   VersionEdit addition;
 
-  constexpr uint32_t path_id = 0;
-  constexpr SequenceNumber smallest_seq = 100;
-  constexpr SequenceNumber largest_seq = 100;
-  constexpr SequenceNumber smallest_seqno = 0;
-  constexpr SequenceNumber largest_seqno = 0;
   constexpr bool marked_for_compaction = false;
 
   addition.AddFile(level, file_number, path_id, file_size,

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -422,8 +422,9 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
   constexpr uint64_t file_number = 2345;
   constexpr char smallest[] = "bar";
   constexpr char largest[] = "foo";
+  constexpr uint64_t file_size = 10000;
 
-  Add(level, file_number, smallest, largest);
+  Add(level, file_number, smallest, largest, file_size);
 
   EnvOptions env_options;
   constexpr TableCache* table_cache = nullptr;
@@ -441,17 +442,18 @@ TEST_F(VersionBuilderTest, ApplyFileDeletionAndAddition) {
   VersionEdit addition;
 
   constexpr uint32_t path_id = 0;
-  constexpr uint64_t file_size = 10000;
-  constexpr SequenceNumber smallest_seqno = 100;
-  constexpr SequenceNumber largest_seqno = 1000;
+  constexpr SequenceNumber smallest_seq = 100;
+  constexpr SequenceNumber largest_seq = 100;
+  constexpr SequenceNumber smallest_seqno = 0;
+  constexpr SequenceNumber largest_seqno = 0;
   constexpr bool marked_for_compaction = false;
 
   addition.AddFile(level, file_number, path_id, file_size,
-                   GetInternalKey(smallest), GetInternalKey(largest),
-                   smallest_seqno, largest_seqno, marked_for_compaction,
-                   kInvalidBlobFileNumber, kUnknownOldestAncesterTime,
-                   kUnknownFileCreationTime, kUnknownFileChecksum,
-                   kUnknownFileChecksumFuncName);
+                   GetInternalKey(smallest, smallest_seq),
+                   GetInternalKey(largest, largest_seq), smallest_seqno,
+                   largest_seqno, marked_for_compaction, kInvalidBlobFileNumber,
+                   kUnknownOldestAncesterTime, kUnknownFileCreationTime,
+                   kUnknownFileChecksum, kUnknownFileChecksumFuncName);
 
   ASSERT_OK(builder.Apply(&addition));
 


### PR DESCRIPTION
Summary:
We currently do not have any validation that would ensure that the `FileMetaData`
objects are equivalent when a file gets deleted from the LSM tree and then re-added
(think trivial moves); however, if we did, this test case would be in violation. The patch
changes the values used in the test case so they are consistent.

Test Plan:
`make check`