### PR TITLE
Maintain the set of linked SSTs in BlobFileMetaData

### DIFF
--- a/db/blob/blob_file_meta.cc
+++ b/db/blob/blob_file_meta.cc
@@ -38,8 +38,15 @@ std::string BlobFileMetaData::DebugString() const {
 std::ostream& operator<<(std::ostream& os, const BlobFileMetaData& meta) {
   const auto& shared_meta = meta.GetSharedMeta();
   assert(shared_meta);
+  os << (*shared_meta);
 
-  os << (*shared_meta) << " garbage_blob_count: " << meta.GetGarbageBlobCount()
+  os << " linked_ssts: {";
+  for (uint64_t file_number : meta.GetLinkedSsts()) {
+    os << ' ' << file_number;
+  }
+  os << " }";
+
+  os << " garbage_blob_count: " << meta.GetGarbageBlobCount()
      << " garbage_blob_bytes: " << meta.GetGarbageBlobBytes();
 
   return os;

--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -11,6 +11,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -90,11 +91,15 @@ std::ostream& operator<<(std::ostream& os,
 
 class BlobFileMetaData {
  public:
+  using LinkedSsts = std::unordered_set<uint64_t>;
+
   static std::shared_ptr<BlobFileMetaData> Create(
       std::shared_ptr<SharedBlobFileMetaData> shared_meta,
-      uint64_t garbage_blob_count, uint64_t garbage_blob_bytes) {
-    return std::shared_ptr<BlobFileMetaData>(new BlobFileMetaData(
-        std::move(shared_meta), garbage_blob_count, garbage_blob_bytes));
+      LinkedSsts linked_ssts, uint64_t garbage_blob_count,
+      uint64_t garbage_blob_bytes) {
+    return std::shared_ptr<BlobFileMetaData>(
+        new BlobFileMetaData(std::move(shared_meta), std::move(linked_ssts),
+                             garbage_blob_count, garbage_blob_bytes));
   }
 
   BlobFileMetaData(const BlobFileMetaData&) = delete;
@@ -128,6 +133,8 @@ class BlobFileMetaData {
     return shared_meta_->GetChecksumValue();
   }
 
+  const LinkedSsts& GetLinkedSsts() const { return linked_ssts_; }
+
   uint64_t GetGarbageBlobCount() const { return garbage_blob_count_; }
   uint64_t GetGarbageBlobBytes() const { return garbage_blob_bytes_; }
 
@@ -135,8 +142,10 @@ class BlobFileMetaData {
 
  private:
   BlobFileMetaData(std::shared_ptr<SharedBlobFileMetaData> shared_meta,
-                   uint64_t garbage_blob_count, uint64_t garbage_blob_bytes)
+                   LinkedSsts linked_ssts, uint64_t garbage_blob_count,
+                   uint64_t garbage_blob_bytes)
       : shared_meta_(std::move(shared_meta)),
+        linked_ssts_(std::move(linked_ssts)),
         garbage_blob_count_(garbage_blob_count),
         garbage_blob_bytes_(garbage_blob_bytes) {
     assert(shared_meta_);
@@ -145,6 +154,7 @@ class BlobFileMetaData {
   }
 
   std::shared_ptr<SharedBlobFileMetaData> shared_meta_;
+  LinkedSsts linked_ssts_;
   uint64_t garbage_blob_count_;
   uint64_t garbage_blob_bytes_;
 };

--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -5,13 +5,13 @@
 
 #pragma once
 
-#include "rocksdb/rocksdb_namespace.h"
-
 #include <cassert>
 #include <iosfwd>
 #include <memory>
 #include <string>
 #include <unordered_set>
+
+#include "rocksdb/rocksdb_namespace.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -648,16 +648,16 @@ class VersionBuilder::Rep {
     // appears on both lists (trivial move), it is still there after the
     // updates are done.
 
-    for (uint64_t blob_file : newly_unlinked) {
-      assert(result.find(blob_file) != result.end());
+    for (uint64_t sst_file_number : newly_unlinked) {
+      assert(result.find(sst_file_number) != result.end());
 
-      result.erase(blob_file);
+      result.erase(sst_file_number);
     }
 
-    for (uint64_t blob_file : newly_linked) {
-      assert(result.find(blob_file) == result.end());
+    for (uint64_t sst_file_number : newly_linked) {
+      assert(result.find(sst_file_number) == result.end());
 
-      result.emplace(blob_file);
+      result.emplace(sst_file_number);
     }
 
     return result;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -556,6 +556,22 @@ class VersionBuilder::Rep {
       }
     }
 
+    // Add new blob files
+    for (const auto& blob_file_addition : edit->GetBlobFileAdditions()) {
+      const Status s = ApplyBlobFileAddition(blob_file_addition);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
+    // Increase the amount of garbage for blob files affected by GC
+    for (const auto& blob_file_garbage : edit->GetBlobFileGarbages()) {
+      const Status s = ApplyBlobFileGarbage(blob_file_garbage);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+
     // Delete files
     for (const auto& deleted_file : edit->GetDeletedFiles()) {
       const int level = deleted_file.first;
@@ -585,22 +601,6 @@ class VersionBuilder::Rep {
         // TODO: check that blob file exists in version
         blob_file_meta_deltas_[meta.oldest_blob_file_number].LinkSst(
             meta.fd.GetNumber());
-      }
-    }
-
-    // Add new blob files
-    for (const auto& blob_file_addition : edit->GetBlobFileAdditions()) {
-      const Status s = ApplyBlobFileAddition(blob_file_addition);
-      if (!s.ok()) {
-        return s;
-      }
-    }
-
-    // Increase the amount of garbage for blob files affected by GC
-    for (const auto& blob_file_garbage : edit->GetBlobFileGarbages()) {
-      const Status s = ApplyBlobFileGarbage(blob_file_garbage);
-      if (!s.ok()) {
-        return s;
       }
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -565,6 +565,10 @@ class VersionBuilder::Rep {
       if (!s.ok()) {
         return s;
       }
+
+      // TODO: if there is a blob file associated with the table file
+      // (which can be determined from FileMetaData), check if the blob file
+      // exists in the version (it should), and if so, unlink the SST from it
     }
 
     // Add new files
@@ -575,6 +579,12 @@ class VersionBuilder::Rep {
       const Status s = ApplyFileAddition(level, meta);
       if (!s.ok()) {
         return s;
+      }
+
+      if (meta.oldest_blob_file_number != kInvalidBlobFileNumber) {
+        // TODO: check that blob file exists in version
+        blob_file_meta_deltas_[meta.oldest_blob_file_number].LinkSst(
+            meta.fd.GetNumber());
       }
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -505,6 +505,14 @@ class VersionBuilder::Rep {
       return Status::OK();
     }
 
+    const uint64_t blob_file_number =
+        GetBlobFileNumberForTableFile(level, file_number);
+
+    if (blob_file_number != kInvalidBlobFileNumber &&
+        IsBlobFileInVersion(blob_file_number)) {
+      blob_file_meta_deltas_[blob_file_number].UnlinkSst(file_number);
+    }
+
     auto& level_state = levels_[level];
 
     auto& add_files = level_state.added_files;
@@ -635,16 +643,6 @@ class VersionBuilder::Rep {
       const Status s = ApplyFileDeletion(level, file_number);
       if (!s.ok()) {
         return s;
-      }
-
-      if (level < num_levels_) {
-        const uint64_t blob_file_number =
-            GetBlobFileNumberForTableFile(level, file_number);
-
-        if (blob_file_number != kInvalidBlobFileNumber &&
-            IsBlobFileInVersion(blob_file_number)) {
-          blob_file_meta_deltas_[blob_file_number].UnlinkSst(file_number);
-        }
       }
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -688,12 +688,10 @@ class VersionBuilder::Rep {
     auto shared_meta = delta.GetSharedMeta();
     assert(shared_meta);
 
-    auto linked_ssts = ApplyLinkedSstChanges(BlobFileMetaData::LinkedSsts(),
-                                             delta.GetNewlyLinkedSsts(),
-                                             delta.GetNewlyUnlinkedSsts());
+    assert(delta.GetNewlyUnlinkedSsts().empty());
 
     auto meta = BlobFileMetaData::Create(
-        std::move(shared_meta), std::move(linked_ssts),
+        std::move(shared_meta), delta.GetNewlyLinkedSsts(),
         delta.GetAdditionalGarbageCount(), delta.GetAdditionalGarbageBytes());
 
     return meta;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -575,7 +575,8 @@ class VersionBuilder::Rep {
 
     table_file_levels_[file_number] = level;
 
-    if (meta.oldest_blob_file_number != kInvalidBlobFileNumber) {
+    if (meta.oldest_blob_file_number != kInvalidBlobFileNumber &&
+        IsBlobFileInVersion(meta.oldest_blob_file_number)) {
       // TODO: check that blob file exists in version
       blob_file_meta_deltas_[meta.oldest_blob_file_number].LinkSst(
           meta.fd.GetNumber());

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -731,7 +731,8 @@ class VersionBuilder::Rep {
     assert(vstorage);
     assert(meta);
 
-    if (meta->GetGarbageBlobCount() < meta->GetTotalBlobCount()) {
+    if (meta->GetGarbageBlobCount() < meta->GetTotalBlobCount() ||
+        !meta->GetLinkedSsts().empty()) {
       vstorage->AddBlobFile(meta);
     }
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -579,6 +579,8 @@ class VersionBuilder::Rep {
 
   uint64_t GetBlobFileNumberForTableFile(int level,
                                          uint64_t table_file_number) {
+    assert(level < num_levels_);
+
     const auto& added_files = levels_[level].added_files;
 
     auto it = added_files.find(table_file_number);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -583,9 +583,9 @@ class VersionBuilder::Rep {
     auto shared_meta = delta.GetSharedMeta();
     assert(shared_meta);
 
-    auto meta = BlobFileMetaData::Create(std::move(shared_meta),
-                                         delta.GetAdditionalGarbageCount(),
-                                         delta.GetAdditionalGarbageBytes());
+    auto meta = BlobFileMetaData::Create(
+        std::move(shared_meta), BlobFileMetaData::LinkedSsts(),
+        delta.GetAdditionalGarbageCount(), delta.GetAdditionalGarbageBytes());
 
     return meta;
   }
@@ -605,7 +605,7 @@ class VersionBuilder::Rep {
     assert(shared_meta);
 
     auto meta = BlobFileMetaData::Create(
-        std::move(shared_meta),
+        std::move(shared_meta), BlobFileMetaData::LinkedSsts(),
         base_meta->GetGarbageBlobCount() + delta.GetAdditionalGarbageCount(),
         base_meta->GetGarbageBlobBytes() + delta.GetAdditionalGarbageBytes());
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -472,7 +472,8 @@ class VersionBuilder::Rep {
     return base_vstorage_->GetFileLocation(file_number).GetLevel();
   }
 
-  uint64_t GetBlobFileNumberForTableFile(int level, uint64_t file_number) {
+  uint64_t GetOldestBlobFileNumberForTableFile(int level,
+                                               uint64_t file_number) const {
     assert(level < num_levels_);
 
     const auto& added_files = levels_[level].added_files;
@@ -527,7 +528,7 @@ class VersionBuilder::Rep {
     }
 
     const uint64_t blob_file_number =
-        GetBlobFileNumberForTableFile(level, file_number);
+        GetOldestBlobFileNumberForTableFile(level, file_number);
 
     if (blob_file_number != kInvalidBlobFileNumber &&
         IsBlobFileInVersion(blob_file_number)) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -588,7 +588,7 @@ class VersionBuilder::Rep {
         return s;
       }
 
-      {
+      if (level < num_levels_) {
         uint64_t blob_file_number = kInvalidBlobFileNumber;
 
         const auto& base_files = base_vstorage_->LevelFiles(level);
@@ -602,16 +602,14 @@ class VersionBuilder::Rep {
         }
 
         if (blob_file_number == kInvalidBlobFileNumber) {
-          if (level < num_levels_) {
-            const auto& added_files = levels_[level].added_files;
+          const auto& added_files = levels_[level].added_files;
 
-            auto it = added_files.find(number);
-            if (it != added_files.end()) {
-              const FileMetaData* const meta = it->second;
-              assert(meta);
+          auto it = added_files.find(number);
+          if (it != added_files.end()) {
+            const FileMetaData* const meta = it->second;
+            assert(meta);
 
-              blob_file_number = meta->oldest_blob_file_number;
-            }
+            blob_file_number = meta->oldest_blob_file_number;
           }
         }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -485,15 +485,9 @@ class VersionBuilder::Rep {
       return meta->oldest_blob_file_number;
     }
 
-    const auto location = base_vstorage_->GetFileLocation(file_number);
-    assert(location.IsValid());
-    assert(location.GetLevel() == level);
-    assert(location.GetLevel() < base_vstorage_->num_levels());
-
-    const auto& level_files = base_vstorage_->LevelFiles(location.GetLevel());
-    assert(location.GetPosition() < level_files.size());
-
-    const FileMetaData* const meta = level_files[location.GetPosition()];
+    assert(base_vstorage_);
+    const FileMetaData* const meta =
+        base_vstorage_->GetFileMetaDataByNumber(file_number);
     assert(meta);
 
     return meta->oldest_blob_file_number;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -595,14 +595,14 @@ class VersionBuilder::Rep {
     assert(add_files.find(file_number) == add_files.end());
     add_files.emplace(file_number, f);
 
-    table_file_levels_[file_number] = level;
-
-    const uint64_t blob_file_number = meta.oldest_blob_file_number;
+    const uint64_t blob_file_number = f->oldest_blob_file_number;
 
     if (blob_file_number != kInvalidBlobFileNumber &&
         IsBlobFileInVersion(blob_file_number)) {
       blob_file_meta_deltas_[blob_file_number].LinkSst(file_number);
     }
+
+    table_file_levels_[file_number] = level;
 
     return Status::OK();
   }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -628,7 +628,7 @@ class VersionBuilder::Rep {
       }
     }
 
-    // Delete files
+    // Delete table files
     for (const auto& deleted_file : edit->GetDeletedFiles()) {
       const int level = deleted_file.first;
       const uint64_t file_number = deleted_file.second;
@@ -649,7 +649,7 @@ class VersionBuilder::Rep {
       }
     }
 
-    // Add new files
+    // Add new table files
     for (const auto& new_file : edit->GetNewFiles()) {
       const int level = new_file.first;
       const FileMetaData& meta = new_file.second;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -616,6 +616,10 @@ class VersionBuilder::Rep {
       }
     }
 
+    // Note: we process the blob file related changes first because the
+    // table file addition/deletion logic depends on the blob files
+    // already being there.
+
     // Add new blob files
     for (const auto& blob_file_addition : edit->GetBlobFileAdditions()) {
       const Status s = ApplyBlobFileAddition(blob_file_addition);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -90,7 +90,8 @@ class VersionBuilder::Rep {
    public:
     bool IsEmpty() const {
       return !shared_meta_ && !additional_garbage_count_ &&
-             !additional_garbage_bytes_;
+             !additional_garbage_bytes_ && newly_linked_ssts_.empty() &&
+             newly_unlinked_ssts_.empty();
     }
 
     std::shared_ptr<SharedBlobFileMetaData> GetSharedMeta() const {
@@ -105,6 +106,14 @@ class VersionBuilder::Rep {
       return additional_garbage_bytes_;
     }
 
+    const std::vector<uint64_t>& GetNewlyLinkedSsts() const {
+      return newly_linked_ssts_;
+    }
+
+    const std::vector<uint64_t>& GetNewlyUnlinkedSsts() const {
+      return newly_unlinked_ssts_;
+    }
+
     void SetSharedMeta(std::shared_ptr<SharedBlobFileMetaData> shared_meta) {
       assert(!shared_meta_);
       assert(shared_meta);
@@ -117,10 +126,20 @@ class VersionBuilder::Rep {
       additional_garbage_bytes_ += bytes;
     }
 
+    void LinkSst(uint64_t sst_file_number) {
+      newly_linked_ssts_.emplace_back(sst_file_number);
+    }
+
+    void UnlinkSst(uint64_t sst_file_number) {
+      newly_unlinked_ssts_.emplace_back(sst_file_number);
+    }
+
    private:
     std::shared_ptr<SharedBlobFileMetaData> shared_meta_;
     uint64_t additional_garbage_count_ = 0;
     uint64_t additional_garbage_bytes_ = 0;
+    std::vector<uint64_t> newly_linked_ssts_;
+    std::vector<uint64_t> newly_unlinked_ssts_;
   };
 
   const FileOptions& file_options_;

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -588,9 +588,6 @@ class VersionBuilder::Rep {
         return s;
       }
 
-      // TODO: if there is a blob file associated with the table file
-      // (which can be determined from FileMetaData), check if the blob file
-      // exists in the version (it should), and if so, unlink the SST from it
       {
         uint64_t blob_file_number = kInvalidBlobFileNumber;
 
@@ -618,7 +615,8 @@ class VersionBuilder::Rep {
           }
         }
 
-        if (blob_file_number != kInvalidBlobFileNumber) {
+        if (blob_file_number != kInvalidBlobFileNumber &&
+            IsBlobFileInVersion(blob_file_number)) {
           blob_file_meta_deltas_[blob_file_number].UnlinkSst(number);
         }
       }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -639,11 +639,11 @@ class VersionBuilder::Rep {
 
       if (level < num_levels_) {
         const uint64_t blob_file_number =
-            GetBlobFileNumberForTableFile(level, number);
+            GetBlobFileNumberForTableFile(level, file_number);
 
         if (blob_file_number != kInvalidBlobFileNumber &&
             IsBlobFileInVersion(blob_file_number)) {
-          blob_file_meta_deltas_[blob_file_number].UnlinkSst(number);
+          blob_file_meta_deltas_[blob_file_number].UnlinkSst(file_number);
         }
       }
     }

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -86,7 +86,8 @@ class VersionBuilderTest : public testing::Test {
         blob_file_number, total_blob_count, total_blob_bytes,
         std::move(checksum_method), std::move(checksum_value));
     auto meta = BlobFileMetaData::Create(
-        std::move(shared_meta), garbage_blob_count, garbage_blob_bytes);
+        std::move(shared_meta), BlobFileMetaData::LinkedSsts(),
+        garbage_blob_count, garbage_blob_bytes);
 
     vstorage_.AddBlobFile(std::move(meta));
   }

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -1144,41 +1144,78 @@ TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobs) {
     }
   }
 
-  EnvOptions env_options;
-  constexpr TableCache* table_cache = nullptr;
-  constexpr VersionSet* version_set = nullptr;
-  constexpr bool force_consistency_checks = true;
+  VersionEdit edit;
 
-  // Simulate a flush where the SST does not reference any blob files.
-
-  VersionEdit flush_no_blob;
-
-  flush_no_blob.AddFile(
-      /* level */ 0, /* file_number */ 21, /* path_id */ 0,
+  // Add an SST that references a blob file.
+  edit.AddFile(
+      /* level */ 1, /* file_number */ 21, /* path_id */ 0,
       /* file_size */ 100, /* smallest */ GetInternalKey("21", 2100),
       /* largest */ GetInternalKey("21", 2100), /* smallest_seqno */ 2100,
       /* largest_seqno */ 2100, /* marked_for_compaction */ false,
+      /* oldest_blob_file_number */ 1, kUnknownOldestAncesterTime,
+      kUnknownFileCreationTime, kUnknownFileChecksum,
+      kUnknownFileChecksumFuncName);
+
+  // Add an SST that does not reference any blob files.
+  edit.AddFile(
+      /* level */ 1, /* file_number */ 22, /* path_id */ 0,
+      /* file_size */ 100, /* smallest */ GetInternalKey("22", 2200),
+      /* largest */ GetInternalKey("22", 2200), /* smallest_seqno */ 2200,
+      /* largest_seqno */ 2200, /* marked_for_compaction */ false,
       kInvalidBlobFileNumber, kUnknownOldestAncesterTime,
       kUnknownFileCreationTime, kUnknownFileChecksum,
       kUnknownFileChecksumFuncName);
 
-  VersionBuilder flush_no_blob_builder(env_options, &ioptions_, table_cache,
-                                       &vstorage_, version_set);
+  // Delete a file that references a blob file.
+  edit.DeleteFile(/* level */ 1, /* file_number */ 6);
 
-  ASSERT_OK(flush_no_blob_builder.Apply(&flush_no_blob));
+  // Delete a file that does not reference any blob files.
+  edit.DeleteFile(/* level */ 1, /* file_number */ 16);
 
-  VersionStorageInfo flush_no_blob_vstorage(&icmp_, ucmp_, options_.num_levels,
-                                            kCompactionStyleLevel, &vstorage_,
-                                            force_consistency_checks);
+  // Trivially move a file that references a blob file.
+  edit.DeleteFile(/* level */ 1, /* file_number */ 3);
+  edit.AddFile(/* level */ 2, /* file_number */ 3, /* path_id */ 0,
+               /* file_size */ 100, /* smallest */ GetInternalKey("03", 300),
+               /* largest */ GetInternalKey("03", 300),
+               /* smallest_seqno */ 300,
+               /* largest_seqno */ 300, /* marked_for_compaction */ false,
+               /* oldest_blob_file_number */ 3, kUnknownOldestAncesterTime,
+               kUnknownFileCreationTime, kUnknownFileChecksum,
+               kUnknownFileChecksumFuncName);
 
-  ASSERT_OK(flush_no_blob_builder.SaveTo(&flush_no_blob_vstorage));
+  // Trivially move a file that does not reference any blob files.
+  edit.DeleteFile(/* level */ 1, /* file_number */ 13);
+  edit.AddFile(/* level */ 2, /* file_number */ 13, /* path_id */ 0,
+               /* file_size */ 100, /* smallest */ GetInternalKey("13", 1300),
+               /* largest */ GetInternalKey("13", 1300),
+               /* smallest_seqno */ 1300,
+               /* largest_seqno */ 1300, /* marked_for_compaction */ false,
+               kInvalidBlobFileNumber, kUnknownOldestAncesterTime,
+               kUnknownFileCreationTime, kUnknownFileChecksum,
+               kUnknownFileChecksumFuncName);
+
+  EnvOptions env_options;
+  constexpr TableCache* table_cache = nullptr;
+  constexpr VersionSet* version_set = nullptr;
+
+  VersionBuilder builder(env_options, &ioptions_, table_cache, &vstorage_,
+                         version_set);
+
+  ASSERT_OK(builder.Apply(&edit));
+
+  constexpr bool force_consistency_checks = true;
+  VersionStorageInfo new_vstorage(&icmp_, ucmp_, options_.num_levels,
+                                  kCompactionStyleLevel, &vstorage_,
+                                  force_consistency_checks);
+
+  ASSERT_OK(builder.SaveTo(&new_vstorage));
 
   {
-    const auto& blob_files = flush_no_blob_vstorage.GetBlobFiles();
+    const auto& blob_files = new_vstorage.GetBlobFiles();
     ASSERT_EQ(blob_files.size(), 5);
 
     const std::vector<BlobFileMetaData::LinkedSsts> expected_linked_ssts{
-        {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
+        {1, 21}, {2, 7}, {3, 8}, {4, 9}, {5, 10}};
 
     for (size_t i = 0; i < 5; ++i) {
       const auto meta =
@@ -1188,111 +1225,7 @@ TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobs) {
     }
   }
 
-  // Simulate a flush where the SST references a blob file.
-  VersionEdit flush_blob;
-
-  flush_blob.AddFile(
-      /* level */ 0, /* file_number */ 22, /* path_id */ 0,
-      /* file_size */ 100, /* smallest */ GetInternalKey("22", 2200),
-      /* largest */ GetInternalKey("22", 2200), /* smallest_seqno */ 2200,
-      /* largest_seqno */ 2200, /* marked_for_compaction */ false,
-      /* oldest_blob_file_number */ 6, kUnknownOldestAncesterTime,
-      kUnknownFileCreationTime, kUnknownFileChecksum,
-      kUnknownFileChecksumFuncName);
-  flush_blob.AddBlobFile(/* blob_file_number */ 6, /* total_blob_count */ 2000,
-                         /* total_blob_bytes */ 2000000,
-                         /* checksum_method */ std::string(),
-                         /* checksum_value */ std::string());
-
-  VersionBuilder flush_blob_builder(env_options, &ioptions_, table_cache,
-                                    &flush_no_blob_vstorage, version_set);
-
-  ASSERT_OK(flush_blob_builder.Apply(&flush_blob));
-
-  VersionStorageInfo flush_blob_vstorage(
-      &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
-      &flush_no_blob_vstorage, force_consistency_checks);
-
-  ASSERT_OK(flush_blob_builder.SaveTo(&flush_blob_vstorage));
-
-  {
-    const auto& blob_files = flush_blob_vstorage.GetBlobFiles();
-    ASSERT_EQ(blob_files.size(), 6);
-
-    const std::vector<BlobFileMetaData::LinkedSsts> expected_linked_ssts{
-        {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}, {22}};
-
-    for (size_t i = 0; i < 6; ++i) {
-      const auto meta =
-          GetBlobFileMetaData(blob_files, /* blob_file_number */ i + 1);
-      ASSERT_NE(meta, nullptr);
-      ASSERT_EQ(meta->GetLinkedSsts(), expected_linked_ssts[i]);
-    }
-  }
-
-  // Simulate a compaction. Some inputs and outputs have blob file references,
-  // some don't. There is also a trivial move.
-  VersionEdit compaction;
-
-  compaction.DeleteFile(/* level */ 1, /* file_number */ 1);
-  compaction.DeleteFile(/* level */ 1, /* file_number */ 2);
-  compaction.DeleteFile(/* level */ 1, /* file_number */ 6);
-  compaction.DeleteFile(/* level */ 1, /* file_number */ 11);
-  compaction.DeleteFile(/* level */ 0, /* file_number */ 22);
-  compaction.AddFile(
-      /* level */ 1, /* file_number */ 22, /* path_id */ 0,
-      /* file_size */ 100, /* smallest */ GetInternalKey("22", 2200),
-      /* largest */ GetInternalKey("22", 2200), /* smallest_seqno */ 2200,
-      /* largest_seqno */ 2200, /* marked_for_compaction */ false,
-      /* oldest_blob_file_number */ 6, kUnknownOldestAncesterTime,
-      kUnknownFileCreationTime, kUnknownFileChecksum,
-      kUnknownFileChecksumFuncName);
-  compaction.AddFile(
-      /* level */ 2, /* file_number */ 23, /* path_id */ 0,
-      /* file_size */ 100, /* smallest */ GetInternalKey("23", 2300),
-      /* largest */ GetInternalKey("23", 2300), /* smallest_seqno */ 2300,
-      /* largest_seqno */ 2300, /* marked_for_compaction */ false,
-      /* oldest_blob_file_number */ 3, kUnknownOldestAncesterTime,
-      kUnknownFileCreationTime, kUnknownFileChecksum,
-      kUnknownFileChecksumFuncName);
-  compaction.AddFile(
-      /* level */ 2, /* file_number */ 24, /* path_id */ 0,
-      /* file_size */ 100, /* smallest */ GetInternalKey("24", 2400),
-      /* largest */ GetInternalKey("24", 2400), /* smallest_seqno */ 2400,
-      /* largest_seqno */ 2400, /* marked_for_compaction */ false,
-      kInvalidBlobFileNumber, kUnknownOldestAncesterTime,
-      kUnknownFileCreationTime, kUnknownFileChecksum,
-      kUnknownFileChecksumFuncName);
-
-  VersionBuilder compaction_builder(env_options, &ioptions_, table_cache,
-                                    &flush_blob_vstorage, version_set);
-
-  ASSERT_OK(compaction_builder.Apply(&compaction));
-
-  VersionStorageInfo compaction_vstorage(
-      &icmp_, ucmp_, options_.num_levels, kCompactionStyleLevel,
-      &flush_blob_vstorage, force_consistency_checks);
-
-  ASSERT_OK(compaction_builder.SaveTo(&compaction_vstorage));
-
-  {
-    const auto& blob_files = compaction_vstorage.GetBlobFiles();
-    ASSERT_EQ(blob_files.size(), 6);
-
-    const std::vector<BlobFileMetaData::LinkedSsts> expected_linked_ssts{
-        {}, {7}, {3, 8, 23}, {4, 9}, {5, 10}, {22}};
-
-    for (size_t i = 0; i < 6; ++i) {
-      const auto meta =
-          GetBlobFileMetaData(blob_files, /* blob_file_number */ i + 1);
-      ASSERT_NE(meta, nullptr);
-      ASSERT_EQ(meta->GetLinkedSsts(), expected_linked_ssts[i]);
-    }
-  }
-
-  UnrefFilesInVersion(&compaction_vstorage);
-  UnrefFilesInVersion(&flush_blob_vstorage);
-  UnrefFilesInVersion(&flush_no_blob_vstorage);
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, CheckConsistencyForFileDeletedTwice) {

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+
 #include "db/version_edit.h"
 #include "db/version_set.h"
 #include "logging/logging.h"

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -644,6 +644,7 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
   ASSERT_EQ(new_meta->GetTotalBlobBytes(), total_blob_bytes);
   ASSERT_EQ(new_meta->GetChecksumMethod(), checksum_method);
   ASSERT_EQ(new_meta->GetChecksumValue(), checksum_value);
+  ASSERT_TRUE(new_meta->GetLinkedSsts().empty());
   ASSERT_EQ(new_meta->GetGarbageBlobCount(), 0);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(), 0);
 }
@@ -763,6 +764,7 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
   ASSERT_EQ(new_meta->GetTotalBlobBytes(), total_blob_bytes);
   ASSERT_EQ(new_meta->GetChecksumMethod(), checksum_method);
   ASSERT_EQ(new_meta->GetChecksumValue(), checksum_value);
+  ASSERT_TRUE(new_meta->GetLinkedSsts().empty());
   ASSERT_EQ(new_meta->GetGarbageBlobCount(),
             garbage_blob_count + new_garbage_blob_count);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(),
@@ -820,6 +822,7 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
   ASSERT_EQ(new_meta->GetTotalBlobBytes(), total_blob_bytes);
   ASSERT_EQ(new_meta->GetChecksumMethod(), checksum_method);
   ASSERT_EQ(new_meta->GetChecksumValue(), checksum_value);
+  ASSERT_TRUE(new_meta->GetLinkedSsts().empty());
   ASSERT_EQ(new_meta->GetGarbageBlobCount(), garbage_blob_count);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(), garbage_blob_bytes);
 }

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -1085,7 +1085,7 @@ TEST_F(VersionBuilderTest, CheckConsistencyForBlobFilesAllGarbage) {
   UnrefFilesInVersion(&new_vstorage);
 }
 
-TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobs) {
+TEST_F(VersionBuilderTest, MaintainLinkedSstsForBlobFiles) {
   // Initialize base version. Table files 1..10 are linked to blob files 1..5,
   // while table files 11..20 are not linked to any blob files.
 


### PR DESCRIPTION
Summary:
The `FileMetaData` objects associated with table files already contain the
number of the oldest blob file referenced by the SST in question. This patch
adds the inverse mapping to `BlobFileMetaData`, namely the set of table file
numbers for which the oldest blob file link points to the given blob file (these
are referred to as *linked SSTs*). This mapping will be used by the GC logic.

Implementation-wise, the patch builds on the `BlobFileMetaDataDelta`
functionality introduced in https://github.com/facebook/rocksdb/pull/6835: newly linked/unlinked SSTs are
accumulated in `BlobFileMetaDataDelta`, and the changes to the linked SST set
are applied in one shot when the new `Version` is saved. The patch also reworks
the blob file related consistency checks in `VersionBuilder` so they validate the
consistency of the forward table file -> blob file links and the backward blob file ->
table file links for blob files that are part of the `Version`.

Test Plan:
`make check`