### PR TITLE
Expose Cache statistics in JNI

### DIFF
--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -282,10 +282,13 @@ class ClockCacheShard final : public CacheShard {
   bool EraseAndConfirm(const Slice& key, uint32_t hash,
                        CleanupContext* context);
   size_t GetUsage() const override;
+  size_t GetHighPriorityPoolUsage() const override;
   size_t GetPinnedUsage() const override;
   void EraseUnRefEntries() override;
   void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                               bool thread_safe) override;
+
+  size_t GetEntries() const override;
 
  private:
   static const uint32_t kInCacheBit = 1;
@@ -400,9 +403,13 @@ size_t ClockCacheShard::GetUsage() const {
   return usage_.load(std::memory_order_relaxed);
 }
 
+size_t ClockCacheShard::GetHighPriorityPoolUsage() const { return 0; }
+
 size_t ClockCacheShard::GetPinnedUsage() const {
   return pinned_usage_.load(std::memory_order_relaxed);
 }
+
+size_t ClockCacheShard::GetEntries() const { return table_.size(); }
 
 void ClockCacheShard::ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                              bool thread_safe) {

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -95,6 +95,8 @@ void LRUHandleTable::Resize() {
   length_ = new_length;
 }
 
+size_t LRUHandleTable::GetEntries() const { return elems_; }
+
 LRUCacheShard::LRUCacheShard(size_t capacity, bool strict_capacity_limit,
                              double high_pri_pool_ratio,
                              bool use_adaptive_mutex,
@@ -448,10 +450,20 @@ size_t LRUCacheShard::GetUsage() const {
   return usage_;
 }
 
+size_t LRUCacheShard::GetHighPriorityPoolUsage() const {
+  MutexLock l(&mutex_);
+  return high_pri_pool_usage_;
+}
+
 size_t LRUCacheShard::GetPinnedUsage() const {
   MutexLock l(&mutex_);
   assert(usage_ >= lru_usage_);
   return usage_ - lru_usage_;
+}
+
+size_t LRUCacheShard::GetEntries() const {
+  MutexLock l(&mutex_);
+  return table_.GetEntries();
 }
 
 std::string LRUCacheShard::GetPrintableOptions() const {

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -160,6 +160,9 @@ class LRUHandleTable {
   LRUHandle* Insert(LRUHandle* h);
   LRUHandle* Remove(const Slice& key, uint32_t hash);
 
+  // Returns number of elements in the table
+  size_t GetEntries() const;
+
   template <typename T>
   void ApplyToAllCacheEntries(T func) {
     for (uint32_t i = 0; i < length_; i++) {
@@ -224,7 +227,9 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   // protect them with mutex_.
 
   virtual size_t GetUsage() const override;
+  virtual size_t GetHighPriorityPoolUsage() const override;
   virtual size_t GetPinnedUsage() const override;
+  virtual size_t GetEntries() const override;
 
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) override;

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -95,6 +95,16 @@ size_t ShardedCache::GetUsage() const {
   return usage;
 }
 
+size_t ShardedCache::GetHighPriorityPoolUsage() const {
+  // We will not lock the cache when getting the usage from shards.
+  int num_shards = 1 << num_shard_bits_;
+  size_t usage = 0;
+  for (int s = 0; s < num_shards; s++) {
+    usage += GetShard(s)->GetHighPriorityPoolUsage();
+  }
+  return usage;
+}
+
 size_t ShardedCache::GetUsage(Handle* handle) const {
   return GetCharge(handle);
 }
@@ -105,6 +115,16 @@ size_t ShardedCache::GetPinnedUsage() const {
   size_t usage = 0;
   for (int s = 0; s < num_shards; s++) {
     usage += GetShard(s)->GetPinnedUsage();
+  }
+  return usage;
+}
+
+size_t ShardedCache::GetEntries() const {
+  // We will not lock the cache when getting the usage from shards.
+  int num_shards = 1 << num_shard_bits_;
+  size_t usage = 0;
+  for (int s = 0; s < num_shards; s++) {
+    usage += GetShard(s)->GetEntries();
   }
   return usage;
 }

--- a/cache/sharded_cache.h
+++ b/cache/sharded_cache.h
@@ -35,7 +35,9 @@ class CacheShard {
   virtual void SetCapacity(size_t capacity) = 0;
   virtual void SetStrictCapacityLimit(bool strict_capacity_limit) = 0;
   virtual size_t GetUsage() const = 0;
+  virtual size_t GetHighPriorityPoolUsage() const = 0;
   virtual size_t GetPinnedUsage() const = 0;
+  virtual size_t GetEntries() const = 0;
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) = 0;
   virtual void EraseUnRefEntries() = 0;
@@ -80,8 +82,10 @@ class ShardedCache : public Cache {
   virtual size_t GetCapacity() const override;
   virtual bool HasStrictCapacityLimit() const override;
   virtual size_t GetUsage() const override;
+  virtual size_t GetHighPriorityPoolUsage() const override;
   virtual size_t GetUsage(Handle* handle) const override;
   virtual size_t GetPinnedUsage() const override;
+  virtual size_t GetEntries() const override;
   virtual void ApplyToAllCacheEntries(void (*callback)(void*, size_t),
                                       bool thread_safe) override;
   virtual void EraseUnRefEntries() override;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -710,6 +710,12 @@ class CacheWrapper : public Cache {
 
   size_t GetUsage() const override { return target_->GetUsage(); }
 
+  size_t GetHighPriorityPoolUsage() const override {
+    return target_->GetHighPriorityPoolUsage();
+  }
+
+  size_t GetEntries() const override { return target_->GetEntries(); }
+
   size_t GetUsage(Handle* handle) const override {
     return target_->GetUsage(handle);
   }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -255,11 +255,18 @@ class Cache {
   // returns the memory size for the entries residing in the cache.
   virtual size_t GetUsage() const = 0;
 
+  // returns the memory size for the high priority entries residing in the
+  // cache.
+  virtual size_t GetHighPriorityPoolUsage() const = 0;
+
   // returns the memory size for a specific entry in the cache.
   virtual size_t GetUsage(Handle* handle) const = 0;
 
   // returns the memory size for the entries in use by the system
   virtual size_t GetPinnedUsage() const = 0;
+
+  // returns the number of entries in the cache
+  virtual size_t GetEntries() const = 0;
 
   // returns the charge for the specific entry in the cache.
   virtual size_t GetCharge(Handle* handle) const = 0;

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -421,6 +421,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.11.4" OR (${Java_VERSION_MINOR} STREQUAL "7"
           org.rocksdb.HdfsEnv
           org.rocksdb.IngestExternalFileOptions
           org.rocksdb.Logger
+          org.rocksdb.Cache
           org.rocksdb.LRUCache
           org.rocksdb.MemoryUtil
           org.rocksdb.MemTableConfig

--- a/java/Makefile
+++ b/java/Makefile
@@ -12,6 +12,7 @@ NATIVE_JAVA_CLASSES = \
 	org.rocksdb.BlockBasedTableConfig\
 	org.rocksdb.BloomFilter\
 	org.rocksdb.Checkpoint\
+	org.rocksdb.Cache\
 	org.rocksdb.ClockCache\
 	org.rocksdb.CassandraCompactionFilter\
 	org.rocksdb.CassandraValueMergeOperator\

--- a/java/rocksjni/lru_cache.cc
+++ b/java/rocksjni/lru_cache.cc
@@ -6,9 +6,11 @@
 // This file implements the "bridge" between Java and C++ for
 // ROCKSDB_NAMESPACE::LRUCache.
 
+#include "cache/lru_cache.h"
+
 #include <jni.h>
 
-#include "cache/lru_cache.h"
+#include "include/org_rocksdb_Cache.h"
 #include "include/org_rocksdb_LRUCache.h"
 
 /*
@@ -40,4 +42,60 @@ void Java_org_rocksdb_LRUCache_disposeInternal(JNIEnv* /*env*/,
   auto* sptr_lru_cache =
       reinterpret_cast<std::shared_ptr<ROCKSDB_NAMESPACE::Cache>*>(jhandle);
   delete sptr_lru_cache;  // delete std::shared_ptr
+}
+
+/*
+ * Class:     org_rocksdb_Cache
+ * Method:    getCapacity
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Cache_getCapacity(JNIEnv* /*env*/, jobject /*jobj*/,
+                                         jlong jhandle) {
+  auto* cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
+  return cache->get()->GetCapacity();
+}
+
+/*
+ * Class:     org_rocksdb_Cache
+ * Method:    getUsage
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Cache_getUsage(JNIEnv* /*env*/, jobject /*jobj*/,
+                                      jlong jhandle) {
+  auto* cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
+  return cache->get()->GetUsage();
+}
+
+/*
+ * Class:     org_rocksdb_Cache
+ * Method:    getUsage
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Cache_getHighPriorityPoolUsage(JNIEnv* /*env*/,
+                                                      jobject /*jobj*/,
+                                                      jlong jhandle) {
+  auto* cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
+  return cache->get()->GetHighPriorityPoolUsage();
+}
+
+/*
+ * Class:     org_rocksdb_Cache
+ * Method:    getPinnedUsage
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Cache_getPinnedUsage(JNIEnv* /*env*/, jobject /*jobj*/,
+                                            jlong jhandle) {
+  auto* cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
+  return cache->get()->GetPinnedUsage();
+}
+
+/*
+ * Class:     org_rocksdb_Cache
+ * Method:    getEntries
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Cache_getEntries(JNIEnv* /*env*/, jobject /*jobj*/,
+                                        jlong jhandle) {
+  auto* cache = reinterpret_cast<std::shared_ptr<rocksdb::Cache>*>(jhandle);
+  return cache->get()->GetEntries();
 }

--- a/java/src/main/java/org/rocksdb/Cache.java
+++ b/java/src/main/java/org/rocksdb/Cache.java
@@ -10,4 +10,50 @@ public abstract class Cache extends RocksObject {
   protected Cache(final long nativeHandle) {
     super(nativeHandle);
   }
+
+  /**
+   * @return the maximum configured capacity of the cache
+   * @throws RocksDBException
+   */
+  public long getCapacity() throws RocksDBException {
+    return getCapacity(nativeHandle_);
+  }
+
+  /**
+   * @return the memory size for the entries residing in the cache
+   * @throws RocksDBException
+   */
+  public long getUsage() throws RocksDBException {
+    return getUsage(nativeHandle_);
+  }
+
+  /**
+   * @return the memory size for the entries residing in the cache
+   * @throws RocksDBException
+   */
+  public long getHighPriorityPoolUsage() throws RocksDBException {
+    return getHighPriorityPoolUsage(nativeHandle_);
+  }
+
+  /**
+   * @return the memory size for the entries in use by the system
+   * @throws RocksDBException
+   */
+  public long getPinnedUsage() throws RocksDBException {
+    return getPinnedUsage(nativeHandle_);
+  }
+
+  /**
+   * @return the number of entries in the cache
+   * @throws RocksDBException
+   */
+  public long getEntries() throws RocksDBException {
+    return getEntries(nativeHandle_);
+  }
+
+  private native long getCapacity(final long handle) throws RocksDBException;
+  private native long getUsage(final long handle) throws RocksDBException;
+  private native long getHighPriorityPoolUsage(final long handle) throws RocksDBException;
+  private native long getPinnedUsage(final long handle) throws RocksDBException;
+  private native long getEntries(final long handle) throws RocksDBException;
 }

--- a/java/src/test/java/org/rocksdb/LRUCacheTest.java
+++ b/java/src/test/java/org/rocksdb/LRUCacheTest.java
@@ -5,6 +5,8 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 public class LRUCacheTest {
@@ -14,14 +16,18 @@ public class LRUCacheTest {
   }
 
   @Test
-  public void newLRUCache() {
+  public void newLRUCache() throws RocksDBException {
     final long capacity = 1000;
     final int numShardBits = 16;
     final boolean strictCapacityLimit = true;
-    final double highPriPoolRatio = 5;
+    final double highPriPoolRatio = 0.5;
     try(final Cache lruCache = new LRUCache(capacity,
         numShardBits, strictCapacityLimit, highPriPoolRatio)) {
-      //no op
+      assertThat(lruCache.getCapacity()).isEqualTo(capacity);
+      assertThat(lruCache.getEntries()).isEqualTo(0);
+      assertThat(lruCache.getUsage()).isEqualTo(0);
+      assertThat(lruCache.getHighPriorityPoolUsage()).isEqualTo(0);
+      assertThat(lruCache.getPinnedUsage()).isEqualTo(0);
     }
   }
 }

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -232,6 +232,10 @@ class SimCacheImpl : public SimCache {
 
   size_t GetUsage() const override { return cache_->GetUsage(); }
 
+  size_t GetHighPriorityPoolUsage() const override {
+    return cache_->GetHighPriorityPoolUsage();
+  }
+
   size_t GetUsage(Handle* handle) const override {
     return cache_->GetUsage(handle);
   }
@@ -241,6 +245,8 @@ class SimCacheImpl : public SimCache {
   }
 
   size_t GetPinnedUsage() const override { return cache_->GetPinnedUsage(); }
+
+  size_t GetEntries() const override { return cache_->GetEntries(); }
 
   void DisownData() override {
     cache_->DisownData();


### PR DESCRIPTION
This PR exposes basic getters of LRU cache in Java. It allows us to do better monitoring.
```java
long getCapacity() throws RocksDBException;
long getUsage() throws RocksDBException;
long getHighPriorityPoolUsage() throws RocksDBException;
long getPinnedUsage() throws RocksDBException;
long getEntries() throws RocksDBException;
```