### PR TITLE
Rebuild SST file tool that can be used to fix checksum error.

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -252,13 +252,6 @@ extern Status CheckCFPathsSupported(const DBOptions& db_options,
 
 extern ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
                                            const ColumnFamilyOptions& src);
-// Wrap user defined table proproties collector factories `from cf_options`
-// into internal ones in int_tbl_prop_collector_factories. Add a system internal
-// one too.
-extern void GetIntTblPropCollectorFactory(
-    const ImmutableCFOptions& ioptions,
-    std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
-        int_tbl_prop_collector_factories);
 
 class ColumnFamilySet;
 

--- a/db/table_properties_collector.h
+++ b/db/table_properties_collector.h
@@ -104,4 +104,14 @@ class UserKeyTablePropertiesCollectorFactory
   std::shared_ptr<TablePropertiesCollectorFactory> user_collector_factory_;
 };
 
+struct ImmutableCFOptions;
+
+// Wrap user defined table proproties collector factories `from cf_options`
+// into internal ones in int_tbl_prop_collector_factories. Add a system internal
+// one too.
+extern void GetIntTblPropCollectorFactory(
+    const ImmutableCFOptions& ioptions,
+    std::vector<std::unique_ptr<IntTblPropCollectorFactory>>*
+        int_tbl_prop_collector_factories);
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -173,6 +173,9 @@ class BlockBasedTable : public TableReader {
   // convert SST file to a human readable form
   Status DumpTable(WritableFile* out_file) override;
 
+  Status RebuildTable(WritableFileWriter* out_file,
+                      const Options& options) override;
+
   Status VerifyChecksum(const ReadOptions& readOptions,
                         TableReaderCaller caller) override;
 

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -135,6 +135,12 @@ class TableReader {
     return Status::NotSupported("DumpTable() not supported");
   }
 
+  // convert db file to a human readable form
+  virtual Status RebuildTable(WritableFileWriter* /*out_file*/,
+                              const Options& /*options*/) {
+    return Status::NotSupported("RebuildTable() not supported");
+  }
+
   // check whether there is corruption in this db file
   virtual Status VerifyChecksum(const ReadOptions& /*read_options*/,
                                 TableReaderCaller /*caller*/) {

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -33,6 +33,9 @@ class SstFileDumper {
 
   Status VerifyChecksum();
   Status DumpTable(const std::string& out_filename);
+  Status RebuildTable(const std::string& out_filename,
+                      const std::string& manifest_filename,
+                      const std::string& out_manifest_filename);
   Status getStatus() { return init_result_; }
 
   int ShowAllCompressionSizes(


### PR DESCRIPTION
I have extended sst_dump tool to be able to repair broken sst file. It tries to copy:
- Table properties
- Column family ID
- All entries in blocks that does not have checksum error. It skips all entries in broken blocks.
- Range deletions

One can also specify compression algorithm (default is no compression). Because SST is changed manifest also needs to be updated (file size) so one need to pass manifest file name as well.

Example:
```
./sst_dump --file=4230207.sst --command=rebuild --rebuild_manifest=MANIFEST-4161457 --rebuild_compression=kZSTD
from [] to []
Process 4230207.sst
Sst file format: block-based
Data rebuilt into the file 4230207_rebuilt.sst
Manifest rebuilt into the file MANIFEST-4161457_rebuild
```

User than just replace files with files that were generated.


