### PR TITLE
Request for comments: ZenFS, a RocksDB FileSystem for Zoned Block Devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ rocksdb_undump
 db_test2
 trace_analyzer
 trace_analyzer_test
+zenfs
 block_cache_trace_analyzer
 .DS_Store
 .vs

--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,8 @@ VALGRIND_OPTS = --error-exitcode=$(VALGRIND_ERROR) --leak-check=full
 
 BENCHTOOLOBJECTS = $(BENCH_LIB_SOURCES:.cc=.o) $(LIBOBJECTS) $(TESTUTIL)
 
+ZENFSTOOLOBJECTS = $(ZENFS_LIB_SOURCES:.cc=.o) $(LIBOBJECTS) $(TESTUTIL)
+
 ANALYZETOOLOBJECTS = $(ANALYZER_LIB_SOURCES:.cc=.o)
 
 ifeq ($(DEBUG_LEVEL),0)
@@ -1299,6 +1301,9 @@ librocksdb_env_basic_test.a: env/env_basic_test.o $(LIBOBJECTS) $(TESTHARNESS)
 	$(AM_V_at)$(AR) $(ARFLAGS) $@ $^
 
 db_bench: tools/db_bench.o $(BENCHTOOLOBJECTS)
+	$(AM_LINK)
+
+zenfs: tools/zenfs.o $(ZENFSTOOLOBJECTS)
 	$(AM_LINK)
 
 trace_analyzer: tools/trace_analyzer.o $(ANALYZETOOLOBJECTS) $(LIBOBJECTS)

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -359,6 +359,19 @@ EOF
         fi
     fi
 
+    if ! test $ROCKSDB_DISABLE_LZBD; then
+        # Test whether libzbd is installed
+        $CXX $CFLAGS $COMMON_FLAGS -x c++ - -o /dev/null 2>/dev/null  <<EOF
+          #include <libzbd/zbd.h>
+          int main() {}
+EOF
+        if [ "$?" = 0 ]; then
+            COMMON_FLAGS="$COMMON_FLAGS -DLIBZBD"
+            PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -lzbd"
+            JAVA_LDFLAGS="$JAVA_LDFLAGS -lzbd"
+        fi
+    fi
+
     if ! test $ROCKSDB_DISABLE_NUMA; then
         # Test whether numa is available
         $CXX $CFLAGS -x c++ - -o /dev/null -lnuma 2>/dev/null  <<EOF

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -206,6 +206,7 @@ DECLARE_int32(compression_parallel_threads);
 DECLARE_string(checksum_type);
 DECLARE_string(hdfs);
 DECLARE_string(env_uri);
+DECLARE_string(fs_uri);
 DECLARE_uint64(ops_per_thread);
 DECLARE_uint64(log2_keys_per_lock);
 DECLARE_uint64(max_manifest_file_size);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -596,10 +596,18 @@ DEFINE_string(bottommost_compression_type, "disable",
 
 DEFINE_string(checksum_type, "kCRC32c", "Algorithm to use to checksum blocks");
 
-DEFINE_string(hdfs, "", "Name of hdfs environment");
+DEFINE_string(hdfs, "",
+              "Name of hdfs environment. Mutually exclusive with"
+              " --env_uri and --fs_uri.");
 
-DEFINE_string(env_uri, "",
-              "URI for env lookup. Mutually exclusive with --hdfs");
+DEFINE_string(
+    env_uri, "",
+    "URI for env lookup. Mutually exclusive with --hdfs and --fs_uri");
+
+DEFINE_string(fs_uri, "",
+              "URI for registry Filesystem lookup. Mutually exclusive"
+              " with --hdfs and --env_uri."
+              " Creates a default environment with the specified filesystem.");
 
 DEFINE_uint64(ops_per_thread, 1200000, "Number of operations per thread.");
 static const bool FLAGS_ops_per_thread_dummy __attribute__((__unused__)) =

--- a/env/env.cc
+++ b/env/env.cc
@@ -476,6 +476,13 @@ const std::shared_ptr<FileSystem>& Env::GetFileSystem() const {
 std::unique_ptr<Env> NewCompositeEnv(std::shared_ptr<FileSystem> fs) {
   return std::unique_ptr<Env>(new CompositeEnvWrapper(Env::Default(), fs));
 }
+
+std::unique_ptr<Env> NewCompositeEnv(std::shared_ptr<FileSystem> fs,
+                                     std::shared_ptr<Env>* shared_env) {
+  assert(shared_env != nullptr);
+  if (!*shared_env) shared_env->reset(Env::Default());
+  return std::unique_ptr<Env>(new CompositeEnvWrapper(shared_env->get(), fs));
+}
 #endif
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -62,6 +62,7 @@
 #include "port/port.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
+#include "rocksdb/utilities/object_registry.h"
 #include "test_util/sync_point.h"
 #include "util/coding.h"
 #include "util/compression_context_cache.h"

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -56,6 +56,7 @@
 #include "port/port.h"
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
+#include "rocksdb/utilities/object_registry.h"
 #include "test_util/sync_point.h"
 #include "util/coding.h"
 #include "util/compression_context_cache.h"
@@ -1046,5 +1047,16 @@ std::shared_ptr<FileSystem> FileSystem::Default() {
       &default_fs, [](PosixFileSystem*) {});
   return default_fs_ptr;
 }
+
+#ifndef ROCKSDB_LITE
+static FactoryFunc<FileSystem> posix_filesystem_reg =
+    ObjectLibrary::Default()->Register<FileSystem>(
+        "posix://.*",
+        [](const std::string& /* uri */, std::unique_ptr<FileSystem>* f,
+           std::string* /* errmsg */) {
+          f->reset(new PosixFileSystem());
+          return f->get();
+        });
+#endif
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/fs_zenfs.cc
+++ b/env/fs_zenfs.cc
@@ -1,0 +1,763 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#if !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/utilities/object_registry.h"
+#include "util/crc32c.h"
+
+#include "env/fs_zenfs.h"
+
+#define DEFAULT_ZENV_LOG_PATH "/tmp/"
+
+namespace ROCKSDB_NAMESPACE {
+
+IOStatus ZenMetaLog::AddRecord(const Slice& slice) {
+  uint32_t record_sz = slice.size();
+  const char* data = slice.data();
+  size_t phys_sz;
+  uint32_t crc = 0;
+  char* buffer;
+  int ret;
+  IOStatus s;
+
+  phys_sz = record_sz + zMetaHeaderSize;
+
+  if (phys_sz % bs_) phys_sz += bs_ - phys_sz % bs_;
+
+  assert(data != nullptr);
+  assert((phys_sz % bs_) == 0);
+
+  ret = posix_memalign((void**)&buffer, bs_, phys_sz);
+  if (ret) return IOStatus::IOError("Failed to allocate memory");
+
+  memset(buffer, 0, phys_sz);
+
+  crc = crc32c::Extend(crc, (const char*)&record_sz, sizeof(uint32_t));
+  crc = crc32c::Extend(crc, data, record_sz);
+  crc = crc32c::Mask(crc);
+
+  EncodeFixed32(buffer, crc);
+  EncodeFixed32(buffer + sizeof(uint32_t), record_sz);
+  memcpy(buffer + sizeof(uint32_t) * 2, data, record_sz);
+
+  s = zone_->Append(buffer, phys_sz);
+
+  free(buffer);
+  return s;
+}
+
+IOStatus ZenMetaLog::Read(Slice* slice) {
+  int f = zbd_->GetReadFD();
+  const char* data = slice->data();
+  size_t read = 0;
+  size_t to_read = slice->size();
+  int ret;
+
+  if (read_pos_ >= zone_->wp_) {
+    // EOF
+    slice->clear();
+    return IOStatus::OK();
+  }
+
+  if ((read_pos_ + to_read) > (zone_->start_ + zone_->max_capacity_)) {
+    return IOStatus::IOError("Read across zone");
+  }
+
+  while (read < to_read) {
+    ret = pread(f, (void*)(data + read), to_read - read, read_pos_);
+
+    if (ret == -1 && errno == EINTR) continue;
+    if (ret < 0) return IOStatus::IOError("Read failed");
+
+    read += ret;
+    read_pos_ += ret;
+  }
+
+  return IOStatus::OK();
+}
+
+IOStatus ZenMetaLog::ReadRecord(Slice* record, std::string* scratch) {
+  Slice header;
+  uint32_t record_sz = 0;
+  uint32_t record_crc = 0;
+  uint32_t actual_crc;
+  IOStatus s;
+
+  /* TODO: discern different types of errors/corruption? */
+  scratch->clear();
+  record->clear();
+
+  scratch->append(zMetaHeaderSize, 0);
+  header = Slice(scratch->c_str(), zMetaHeaderSize);
+
+  s = Read(&header);
+  if (!s.ok()) return s;
+
+  // EOF?
+  if (header.size() == 0) {
+    record->clear();
+    return IOStatus::OK();
+  }
+
+  GetFixed32(&header, &record_crc);
+  GetFixed32(&header, &record_sz);
+
+  scratch->clear();
+  scratch->append(record_sz, 0);
+
+  *record = Slice(scratch->c_str(), record_sz);
+  s = Read(record);
+  if (!s.ok()) return s;
+
+  actual_crc = crc32c::Value((const char*)&record_sz, sizeof(uint32_t));
+  actual_crc = crc32c::Extend(actual_crc, record->data(), record->size());
+
+  if (actual_crc != crc32c::Unmask(record_crc)) {
+    return IOStatus::IOError("Not a valid record");
+  }
+
+  /* Next record starts on a block boundary */
+  if (read_pos_ % bs_) read_pos_ += bs_ - (read_pos_ % bs_);
+
+  return IOStatus::OK();
+}
+
+ZenFS::ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
+             std::shared_ptr<Logger> logger)
+    : FileSystemWrapper(aux_fs), zbd_(zbd), logger_(logger) {
+  Info(logger_, "ZenFS initializing");
+  Info(logger_, "ZenFS parameters: block device: %s, aux filesystem: %s",
+       zbd_->GetFilename().c_str(), target()->Name());
+
+  Info(logger_, "ZenFS initializing");
+  next_file_id_ = 1;
+  metadata_writer_.zenFS = this;
+}
+
+ZenFS::~ZenFS() {
+  Status s;
+  Info(logger_, "ZenFS shutting down");
+  zbd_->LogZoneUsage();
+  LogFiles();
+
+  meta_log_.reset(nullptr);
+  ClearFiles();
+  delete zbd_;
+}
+
+void ZenFS::LogFiles() {
+  std::map<std::string, ZoneFile*>::iterator it;
+  uint64_t total_size = 0;
+
+  Info(logger_, "  Files:\n");
+  for (it = files_.begin(); it != files_.end(); it++) {
+    ZoneFile* zFile = it->second;
+    std::vector<ZoneExtent*> extents = zFile->GetExtents();
+
+    Info(logger_, "    %-45s sz: %lu lh: %d", it->first.c_str(),
+         zFile->GetFileSize(), zFile->GetWriteLifeTimeHint());
+    for (unsigned int i = 0; i < extents.size(); i++) {
+      ZoneExtent* extent = extents[i];
+      Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%u} ", i,
+           extent->start_,
+           (uint32_t)(extent->zone_->start_ / zbd_->GetZoneSize()),
+           extent->length_);
+
+      total_size += extent->length_;
+    }
+  }
+  Info(logger_, "Sum of all files: %lu MB of data \n",
+       total_size / (1024 * 1024));
+}
+
+void ZenFS::ClearFiles() {
+  std::map<std::string, ZoneFile*>::iterator it;
+  for (it = files_.begin(); it != files_.end(); it++) delete it->second;
+  files_.clear();
+}
+
+IOStatus ZenFS::WriteSnapshot(ZenMetaLog* meta_log) {
+  std::string snapshot;
+
+  EncodeSnapshotTo(&snapshot);
+  return meta_log->AddRecord(snapshot);
+}
+
+IOStatus ZenFS::RollMetaZone() {
+  ZenMetaLog* new_meta_log;
+  Zone* new_meta_zone;
+  IOStatus s;
+
+  new_meta_zone = zbd_->AllocateMetaZone();
+  if (!new_meta_zone) {
+    assert(false);  // TMP
+    Error(logger_, "Out of metadata zones, we should go to read only now.");
+    return IOStatus::NoSpace("Out of metadata zones");
+  }
+
+  Info(logger_, "Rolling to metazone %d\n", (int)new_meta_zone->GetZoneNr());
+  new_meta_log = new ZenMetaLog(zbd_, new_meta_zone);
+  meta_log_.reset(new_meta_log);
+
+  std::string super_string;
+  superblock_->EncodeTo(&super_string);
+
+  s = meta_log_->AddRecord(super_string);
+  if (!s.ok()) {
+    Info(logger_, "Current meta zone full, rolling to next meta zone");
+    return IOStatus::IOError("Failed writing a new superblock");
+  }
+
+  return WriteSnapshot(meta_log_.get());
+}
+
+IOStatus ZenFS::PersistSnapshot(ZenMetaLog* meta_writer) {
+  IOStatus s;
+
+  files_mtx_.lock();
+  metadata_sync_mtx_.lock();
+
+  s = WriteSnapshot(meta_writer);
+  if (s == IOStatus::NoSpace()) {
+    Info(logger_, "Current meta zone full, rolling to next meta zone");
+    s = RollMetaZone();
+  }
+
+  if (!s.ok()) {
+    assert(false);  // TMP
+    Error(logger_,
+          "Failed persisting a snapshot, we should go to read only now!");
+  }
+
+  metadata_sync_mtx_.unlock();
+  files_mtx_.unlock();
+
+  return s;
+}
+
+IOStatus ZenFS::SyncFileMetadata(ZoneFile* /*zoneFile*/) {
+  /* Write a whole snapshot for now */
+  return PersistSnapshot(meta_log_.get());
+}
+
+ZoneFile* ZenFS::GetFile(std::string fname) {
+  ZoneFile* zoneFile = nullptr;
+  files_mtx_.lock();
+  if (files_.find(fname) != files_.end()) {
+    zoneFile = files_[fname];
+  }
+  files_mtx_.unlock();
+  return zoneFile;
+}
+
+bool ZenFS::DeleteFile(std::string fname) {
+  ZoneFile* zoneFile = nullptr;
+  files_mtx_.lock();
+  if (files_.find(fname) != files_.end()) {
+    zoneFile = files_[fname];
+    files_.erase(fname);
+    delete (zoneFile);
+  }
+  files_mtx_.unlock();
+  return (zoneFile != nullptr);
+}
+
+IOStatus ZenFS::NewSequentialFile(const std::string& fname,
+                                  const FileOptions& file_opts,
+                                  std::unique_ptr<FSSequentialFile>* result,
+                                  IODebugContext* /*dbg*/) {
+  ZoneFile* zoneFile = GetFile(fname);
+
+  Debug(logger_, "New sequential file: %s direct: %d\n", fname.c_str(),
+        file_opts.use_direct_reads);
+
+  if (zoneFile == nullptr) {
+    return IOStatus::IOError("File does not exist!\n");
+  }
+
+  result->reset(new ZonedSequentialFile(zoneFile));
+  return IOStatus::OK();
+}
+
+IOStatus ZenFS::NewRandomAccessFile(const std::string& fname,
+                                    const FileOptions& file_opts,
+                                    std::unique_ptr<FSRandomAccessFile>* result,
+                                    IODebugContext* /*dbg*/) {
+  ZoneFile* zoneFile = GetFile(fname);
+
+  Debug(logger_, "New random access file: %s direct: %d\n", fname.c_str(),
+        file_opts.use_direct_reads);
+
+  if (zoneFile == nullptr) {
+    return IOStatus::NotFound("File does not exist\n");
+  }
+
+  result->reset(new ZonedRandomAccessFile(files_[fname]));
+  return IOStatus::OK();
+}
+
+IOStatus ZenFS::NewWritableFile(const std::string& fname,
+                                const FileOptions& file_opts,
+                                std::unique_ptr<FSWritableFile>* result,
+                                IODebugContext* /*dbg*/) {
+  ZoneFile* zoneFile;
+  IOStatus s;
+  bool overwrites = false;
+
+  Debug(logger_, "New writable file: %s direct: %d\n", fname.c_str(),
+        file_opts.use_direct_writes);
+
+  overwrites = DeleteFile(fname);
+  zoneFile = new ZoneFile(zbd_, fname, next_file_id_++);
+
+  files_mtx_.lock();
+  files_.insert(std::make_pair(fname.c_str(), zoneFile));
+  files_mtx_.unlock();
+
+  result->reset(new ZonedWritableFile(zbd_, true, zoneFile, &metadata_writer_));
+
+  if (overwrites) {
+    if (!PersistSnapshot(meta_log_.get()).ok())
+      return IOStatus::IOError("Failed to persist file metadata\n");
+  }
+
+  return s;
+}
+
+IOStatus ZenFS::ReuseWritableFile(const std::string& fname,
+                                  const std::string& old_fname,
+                                  const FileOptions& file_opts,
+                                  std::unique_ptr<FSWritableFile>* result,
+                                  IODebugContext* dbg) {
+  Debug(logger_, "Reuse writable file: %s old name: %s\n", fname.c_str(),
+        old_fname.c_str());
+
+  if (!DeleteFile(old_fname))
+    return IOStatus::NotFound("Old file does not exist");
+
+  return NewWritableFile(fname, file_opts, result, dbg);
+}
+
+IOStatus ZenFS::FileExists(const std::string& fname, const IOOptions& options,
+                           IODebugContext* dbg) {
+  Debug(logger_, "FileExists: %s \n", fname.c_str());
+
+  if (GetFile(fname) == nullptr) {
+    return target()->FileExists(ToAuxPath(fname), options, dbg);
+  } else {
+    return IOStatus::OK();
+  }
+}
+
+IOStatus ZenFS::GetChildren(const std::string& dir, const IOOptions& options,
+                            std::vector<std::string>* result,
+                            IODebugContext* dbg) {
+  std::map<std::string, ZoneFile*>::iterator it;
+  std::vector<std::string> auxfiles;
+  IOStatus s;
+
+  Debug(logger_, "GetChildren: %s \n", dir.c_str());
+
+  target()->GetChildren(ToAuxPath(dir), options, &auxfiles, dbg);
+  for (const auto f : auxfiles) {
+    if (f != "." && f != "..") result->push_back(f);
+  }
+
+  files_mtx_.lock();
+  for (it = files_.begin(); it != files_.end(); it++) {
+    std::string fname = it->first;
+
+    if (fname.rfind(dir, 0) == 0) {
+      fname.erase(0, dir.length() + 1);
+      // Don't report grandchildren
+      if (fname.find("/") == std::string::npos) {
+        result->push_back(fname);
+      }
+    }
+  }
+  files_mtx_.unlock();
+
+  return s;
+}
+
+IOStatus ZenFS::DeleteFile(const std::string& fname, const IOOptions& options,
+                           IODebugContext* dbg) {
+  Debug(logger_, "Delete file: %s \n", fname.c_str());
+
+  if (!DeleteFile(fname)) {
+    return target()->DeleteFile(ToAuxPath(fname), options, dbg);
+  }
+
+  zbd_->LogZoneStats();
+
+  if (!PersistSnapshot(meta_log_.get()).ok())
+    return IOStatus::IOError("Failed to persist file metadata");
+
+  return IOStatus::OK();
+}
+
+IOStatus ZenFS::GetFileSize(const std::string& f, const IOOptions& /*options*/,
+                            uint64_t* size, IODebugContext* /*dbg*/) {
+  ZoneFile* zoneFile;
+  IOStatus s;
+
+  Debug(logger_, "GetFileSize: %s \n", f.c_str());
+
+  files_mtx_.lock();
+  if (files_.find(f) != files_.end()) {
+    zoneFile = files_[f];
+    *size = zoneFile->GetFileSize();
+  } else {
+    s = IOStatus::IOError("file does not exist\n");
+  }
+  files_mtx_.unlock();
+
+  return s;
+}
+
+IOStatus ZenFS::RenameFile(const std::string& f, const std::string& t,
+                           const IOOptions& options, IODebugContext* dbg) {
+  ZoneFile* zoneFile;
+  IOStatus s;
+
+  Debug(logger_, "Rename file: %s to : %s\n", f.c_str(), t.c_str());
+
+  files_mtx_.lock();
+  if (files_.find(f) != files_.end()) {
+    zoneFile = files_[f];
+    files_.erase(f);
+    zoneFile->Rename(t);
+    if (files_.find(t) != files_.end()) {
+      ZoneFile* to_delete = files_[t];
+
+      files_.erase(t);
+      delete to_delete;
+    }
+    files_.insert(std::make_pair(t, zoneFile));
+  } else {
+    s = target()->RenameFile(ToAuxPath(f), ToAuxPath(t), options, dbg);
+  }
+  files_mtx_.unlock();
+
+  if (!s.ok()) return s;
+
+  if (!PersistSnapshot(meta_log_.get()).ok())
+    return IOStatus::IOError("Failed to persist file metadata");
+
+  return IOStatus::OK();
+}
+
+void ZenFS::EncodeSnapshotTo(std::string* output) {
+  std::map<std::string, ZoneFile*>::iterator it;
+  std::string files_string;
+  PutFixed32(output, kCompleteFilesSnapshot);
+  for (it = files_.begin(); it != files_.end(); it++) {
+    std::string file_string;
+    ZoneFile* zFile = it->second;
+
+    zFile->EncodeTo(&file_string);
+    PutLengthPrefixedSlice(&files_string, Slice(file_string));
+  }
+  PutLengthPrefixedSlice(output, Slice(files_string));
+}
+
+Status ZenFS::DecodeSnapshotFrom(Slice* input) {
+  Slice slice;
+
+  assert(files_.size() == 0);
+
+  while (GetLengthPrefixedSlice(input, &slice)) {
+    ZoneFile* zoneFile = new ZoneFile(zbd_, "not_set", 0);
+    Status s = zoneFile->DecodeFrom(&slice);
+
+    if (!s.ok()) return s;
+
+    files_.insert(std::make_pair(zoneFile->GetFilename(), zoneFile));
+  }
+
+  return Status::OK();
+}
+
+Status ZenFS::RecoverFrom(ZenMetaLog* log) {
+  bool at_least_one_snapshot = false;
+  std::string scratch;
+  uint32_t tag = 0;
+  Slice record;
+  Slice data;
+  Status s;
+
+  while (1) {
+    IOStatus rs = log->ReadRecord(&record, &scratch);
+    if (!rs.ok()) {
+      Error(logger_, "Read recovery record failed with error: %s",
+            rs.ToString().c_str());
+      return Status::Corruption("ZenFS", "Metadata corruption");
+    }
+
+    if (!GetFixed32(&record, &tag)) break;
+
+    if (!GetLengthPrefixedSlice(&record, &data))
+      return Status::Corruption("ZenFS", "No recovery record data");
+
+    switch (tag) {
+      case kCompleteFilesSnapshot:
+
+        ClearFiles();
+        s = DecodeSnapshotFrom(&data);
+        if (!s.ok()) {
+          Warn(logger_, "Could not decode snapshot: %s", s.ToString().c_str());
+          return s;
+        }
+        at_least_one_snapshot = true;
+        break;
+      default:
+        Warn(logger_, "Unexpected metadata record tag: %u", tag);
+        return Status::Corruption("ZenFS", "Unexpected tag");
+    }
+  }
+
+  if (at_least_one_snapshot)
+    return Status::OK();
+  else
+    return Status::NotFound("ZenFS", "No snapshot found");
+}
+
+#define ZENV_URI_PATTERN "zenfs://"
+
+Status ZenFS::Mount() {
+  std::vector<Zone*> metazones = zbd_->GetMetaZones();
+  std::vector<std::unique_ptr<Superblock>> valid_superblocks;
+  std::vector<std::unique_ptr<ZenMetaLog>> valid_logs;
+  std::vector<Zone*> valid_zones;
+  std::vector<std::pair<uint32_t, uint32_t>> seq_map;
+
+  Status s;
+
+  /* We need a minimum of two non-offline meta data zones */
+  if (metazones.size() < 2) {
+    Error(logger_,
+          "Need at least two non-offline meta zones to open for write");
+    return Status::NotSupported();
+  }
+
+  /* Find all valid superblocks */
+  for (const auto z : metazones) {
+    std::unique_ptr<ZenMetaLog> log;
+    std::string scratch;
+    Slice super_record;
+
+    log.reset(new ZenMetaLog(zbd_, z));
+
+    if (!log->ReadRecord(&super_record, &scratch).ok()) continue;
+
+    if (super_record.size() == 0) continue;
+
+    std::unique_ptr<Superblock> super_block;
+
+    super_block.reset(new Superblock());
+    s = super_block->DecodeFrom(&super_record);
+    if (s.ok()) s = super_block->CompatibleWith(zbd_);
+    if (!s.ok()) return s;
+
+    Info(logger_, "Found OK superblock in zone %lu seq: %u\n", z->GetZoneNr(),
+         super_block->GetSeq());
+
+    seq_map.push_back(std::make_pair(super_block->GetSeq(), seq_map.size()));
+    valid_superblocks.push_back(std::move(super_block));
+    valid_logs.push_back(std::move(log));
+    valid_zones.push_back(z);
+  }
+
+  if (!seq_map.size()) return Status::NotFound("No valid superblock found");
+
+  /* Sort superblocks by descending sequence number */
+  std::sort(seq_map.begin(), seq_map.end(),
+            std::greater<std::pair<uint32_t, uint32_t>>());
+
+  bool recovery_ok = false;
+  unsigned int r = 0;
+
+  for (const auto sm : seq_map) {
+    uint32_t i = sm.second;
+    std::string scratch;
+    std::unique_ptr<ZenMetaLog> log = std::move(valid_logs[i]);
+
+    s = RecoverFrom(log.get());
+    if (!s.ok()) {
+      if (s.IsNotFound()) {
+        Warn(logger_,
+             "Did not find a valid snapshot, trying next meta zone. Error: %s",
+             s.ToString().c_str());
+        continue;
+      }
+
+      Error(logger_, "Metadata corruption. Error: %s", s.ToString().c_str());
+      return s;
+    }
+
+    r = i;
+    recovery_ok = true;
+    meta_log_ = std::move(log);
+    break;
+  }
+
+  if (!recovery_ok) {
+    return Status::IOError("Failed to mount filesystem");
+  }
+
+  Info(logger_, "Recovered from zone: %d", (int)valid_zones[r]->GetZoneNr());
+  superblock_ = std::move(valid_superblocks[r]);
+  zbd_->SetFinishTreshold(superblock_->GetFinishTreshold());
+
+  IOOptions foo;
+  IODebugContext bar;
+  s = target()->CreateDirIfMissing(superblock_->GetAuxFsPath(), foo, &bar);
+  if (!s.ok()) {
+    Error(logger_, "Failed to create aux filesystem directory.");
+    return s;
+  }
+
+  /* Free up old metadata zones, to get ready to roll */
+  for (const auto sm : seq_map) {
+    uint32_t i = sm.second;
+    if (i != r) {
+      valid_logs[i].reset();
+    }
+  }
+  s = RollMetaZone();
+  if (!s.ok()) {
+    Error(logger_, "Failed to roll metadata zone.");
+    return s;
+  }
+
+  Info(logger_, "Superblock sequence %d", (int)superblock_->GetSeq());
+  Info(logger_, "Finish threshold %u", superblock_->GetFinishTreshold());
+  Info(logger_, "Filesystem mount OK");
+  Info(logger_, "Resetting unused IO Zones..");
+  zbd_->ResetUnusedIOZones();
+  Info(logger_, "  Done");
+
+  LogFiles();
+
+  return Status::OK();
+}
+
+Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
+  std::vector<Zone*> metazones = zbd_->GetMetaZones();
+  std::unique_ptr<ZenMetaLog> log;
+  Zone* meta_zone = nullptr;
+  IOStatus s;
+
+  if (aux_fs_path.length() > 255) {
+    return Status::InvalidArgument(
+        "Aux filesystem path must be less than 256 bytes\n");
+  }
+
+  ClearFiles();
+
+  for (const auto mz : metazones) {
+    if (mz->Reset().ok()) {
+      if (!meta_zone) meta_zone = mz;
+    } else {
+      Warn(logger_, "Failed to reset meta zone\n");
+    }
+  }
+
+  if (!meta_zone) {
+    return Status::IOError("Not available meta zones\n");
+  }
+
+  log.reset(new ZenMetaLog(zbd_, meta_zone));
+
+  Superblock* super = new Superblock(zbd_, aux_fs_path, finish_threshold);
+  std::string super_string;
+  super->EncodeTo(&super_string);
+
+  s = log->AddRecord(super_string);
+  if (!s.ok()) return s;
+
+  /* Write an empty snapshot to make the metadata zone valid */
+  s = PersistSnapshot(log.get());
+  if (!s.ok()) {
+    Error(logger_, "Failed to persist snapshot: %s", s.ToString().c_str());
+    return Status::IOError("Failed persist snapshot");
+  }
+
+  Info(logger_, "Empty filesystem created");
+  return Status::OK();
+}
+
+static std::string GetLogFilename(std::string bdev) {
+  std::ostringstream ss;
+  time_t t = time(0);
+  struct tm* log_start = std::localtime(&t);
+  char buf[40];
+
+  std::strftime(buf, sizeof(buf), "%Y-%m-%d_%H:%M:%S.log", log_start);
+  ss << DEFAULT_ZENV_LOG_PATH << std::string("zenfs_") << bdev << "_" << buf;
+
+  return ss.str();
+}
+
+static FactoryFunc<FileSystem> zoned_reg =
+    ObjectLibrary::Default()->Register<FileSystem>(
+        ZENV_URI_PATTERN ".*",
+        [](const std::string& uri, std::unique_ptr<FileSystem>* env_guard,
+           std::string* errmsg) {
+          std::string bdev = uri;
+          std::string bdevname = uri;
+          std::shared_ptr<Logger> logger;
+          Status s;
+
+          bdevname.replace(0, strlen(ZENV_URI_PATTERN), "");
+          s = Env::Default()->NewLogger(GetLogFilename(bdevname), &logger);
+
+          if (!s.ok()) {
+            fprintf(stderr, "ZenFS: Could not create logger");
+          } else {
+#ifdef NDEBUG
+            logger->SetInfoLogLevel(INFO_LEVEL);
+#else
+            logger->SetInfoLogLevel(DEBUG_LEVEL);
+#endif
+          }
+
+          bdev.replace(0, strlen(ZENV_URI_PATTERN), "/dev/");
+
+          ZonedBlockDevice* zbd = new ZonedBlockDevice(bdev, logger);
+          IOStatus zbd_status = zbd->Open();
+          if (!zbd_status.ok()) {
+            Error(logger, "Failed to open zoned block device: %s",
+                  zbd_status.ToString().c_str());
+            *errmsg = zbd_status.ToString();
+            env_guard->reset(nullptr);
+            return env_guard->get();
+          }
+
+          ZenFS* zenFS = new ZenFS(zbd, FileSystem::Default(), logger);
+          s = zenFS->Mount();
+          if (!s.ok()) {
+            Error(logger, "Mount failed: %s", s.ToString().c_str());
+            *errmsg = s.ToString();
+            env_guard->reset(nullptr);
+          } else {
+            env_guard->reset(zenFS);
+          }
+
+          return env_guard->get();
+        });
+};  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)

--- a/env/fs_zenfs.h
+++ b/env/fs_zenfs.h
@@ -1,0 +1,388 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#if !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)
+
+#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/status.h"
+#include "util/coding.h"
+
+#include "env/io_zenfs.h"
+#include "env/zbd_zenfs.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Superblock {
+  uint32_t magic_ = 0;
+  char uuid_[37] = {0};
+  uint32_t sequence_ = 0;
+  uint32_t version_ = 0;
+  uint32_t flags_ = 0;
+  uint32_t block_size_ = 0; /* in bytes */
+  uint32_t zone_size_ = 0;  /* in blocks */
+  uint32_t nr_zones_ = 0;
+  char aux_fs_path_[256] = {0};
+  uint32_t finish_treshold_ = 0;
+  char reserved_[187] = {0};
+
+ public:
+  const uint32_t MAGIC = 0x5a454e46; /* ZENF */
+  const uint32_t ENCODED_SIZE = 512;
+  const uint32_t CURRENT_VERSION = 0; /* Experimental version */
+  const uint32_t DEFAULT_FLAGS = 0;
+
+  Superblock() {}
+
+  /* Create a superblock for a filesystem covering the entire zoned block device
+   */
+  Superblock(ZonedBlockDevice* zbd, std::string aux_fs_path = "",
+             uint32_t finish_threshold = 0) {
+    std::string uuid = Env::Default()->GenerateUniqueId();
+    assert(uuid.length() == sizeof(uuid_));
+    magic_ = MAGIC;
+    memcpy((void*)uuid_, uuid.c_str(), sizeof(uuid_));
+    version_ = CURRENT_VERSION;
+    flags_ = DEFAULT_FLAGS;
+    finish_treshold_ = finish_threshold;
+
+    block_size_ = zbd->GetBlockSize();
+    zone_size_ = zbd->GetZoneSize() / block_size_;
+    nr_zones_ = zbd->GetNrZones();
+
+    assert(aux_fs_path.length() < sizeof(aux_fs_path_));
+    strcpy(aux_fs_path_, aux_fs_path.c_str());
+  }
+
+  Status DecodeFrom(Slice* input) {
+    if (input->size() != ENCODED_SIZE) {
+      return Status::Corruption("ZenFS Superblock",
+                                "Error: Superblock size missmatch");
+    }
+
+    GetFixed32(input, &magic_);
+    memcpy(&uuid_, input->data(), sizeof(uuid_));
+    input->remove_prefix(sizeof(uuid_));
+    GetFixed32(input, &sequence_);
+    GetFixed32(input, &version_);
+    GetFixed32(input, &flags_);
+    GetFixed32(input, &block_size_);
+    GetFixed32(input, &zone_size_);
+    GetFixed32(input, &nr_zones_);
+    GetFixed32(input, &finish_treshold_);
+    memcpy(&aux_fs_path_, input->data(), sizeof(aux_fs_path_));
+    input->remove_prefix(sizeof(aux_fs_path_));
+    memcpy(&reserved_, input->data(), sizeof(reserved_));
+    input->remove_prefix(sizeof(reserved_));
+    assert(input->size() == 0);
+
+    if (magic_ != MAGIC)
+      return Status::Corruption("ZenFS Superblock", "Error: Magic missmatch");
+    if (version_ != CURRENT_VERSION)
+      return Status::Corruption("ZenFS Superblock", "Error: Version missmatch");
+
+    return Status::OK();
+  }
+
+  void EncodeTo(std::string* output) {
+    sequence_++; /* Ensure that this superblock representation is unique */
+    output->clear();
+    PutFixed32(output, magic_);
+    output->append(uuid_, sizeof(uuid_));
+    PutFixed32(output, sequence_);
+    PutFixed32(output, version_);
+    PutFixed32(output, flags_);
+    PutFixed32(output, block_size_);
+    PutFixed32(output, zone_size_);
+    PutFixed32(output, nr_zones_);
+    PutFixed32(output, finish_treshold_);
+    output->append(aux_fs_path_, sizeof(aux_fs_path_));
+    output->append(reserved_, sizeof(reserved_));
+    assert(output->length() == ENCODED_SIZE);
+  }
+
+  Status CompatibleWith(ZonedBlockDevice* zbd) {
+    if (block_size_ != zbd->GetBlockSize())
+      return Status::Corruption("ZenFS Superblock",
+                                "Error: block size missmatch");
+    if (zone_size_ != (zbd->GetZoneSize() / block_size_))
+      return Status::Corruption("ZenFS Superblock",
+                                "Error: zone size missmatch");
+    if (nr_zones_ > zbd->GetNrZones())
+      return Status::Corruption("ZenFS Superblock",
+                                "Error: nr of zones missmatch");
+
+    return Status::OK();
+  }
+
+  uint32_t GetSeq() { return sequence_; }
+  std::string GetAuxFsPath() { return std::string(aux_fs_path_); }
+  uint32_t GetFinishTreshold() { return finish_treshold_; }
+};
+
+class ZenMetaLog {
+  uint64_t read_pos_;
+  Zone* zone_;
+  ZonedBlockDevice* zbd_;
+  size_t bs_;
+
+  /* Every meta log record is prefixed with a CRC(32 bits) and record length (32
+   * bits) */
+  const size_t zMetaHeaderSize = sizeof(uint32_t) * 2;
+
+ public:
+  ZenMetaLog(ZonedBlockDevice* zbd, Zone* zone) {
+    zbd_ = zbd;
+    zone_ = zone;
+    zone_->open_for_write_ = true;
+    bs_ = zbd_->GetBlockSize();
+    read_pos_ = zone->start_;
+  }
+
+  virtual ~ZenMetaLog() { zone_->open_for_write_ = false; }
+
+  IOStatus AddRecord(const Slice& slice);
+  IOStatus ReadRecord(Slice* record, std::string* scratch);
+
+ private:
+  IOStatus Read(Slice* slice);
+};
+
+class ZenFS : public FileSystemWrapper {
+  ZonedBlockDevice* zbd_;
+  std::map<std::string, ZoneFile*> files_;
+  std::mutex files_mtx_;
+  std::shared_ptr<Logger> logger_;
+  std::atomic<uint64_t> next_file_id_;
+
+  Zone* cur_meta_zone_ = nullptr;
+  std::unique_ptr<ZenMetaLog> meta_log_;
+  std::mutex metadata_sync_mtx_;
+  std::unique_ptr<Superblock> superblock_;
+
+  std::shared_ptr<Logger> GetLogger() { return logger_; }
+
+  struct MetadataWriter : public ZonedWritableFile::MetadataWriter {
+    ZenFS* zenFS;
+    IOStatus Persist(ZoneFile* zoneFile) {
+      Debug(zenFS->GetLogger(), "Syncing metadata for: %s",
+            zoneFile->GetFilename().c_str());
+      return zenFS->SyncFileMetadata(zoneFile);
+    }
+  };
+
+  MetadataWriter metadata_writer_;
+
+  enum ZenFSTag : uint32_t {
+    kCompleteFilesSnapshot = 1,
+  };
+
+  void LogFiles();
+  void ClearFiles();
+  IOStatus WriteSnapshot(ZenMetaLog* meta_log);
+  IOStatus RollMetaZone();
+  IOStatus PersistSnapshot(ZenMetaLog* meta_writer);
+  IOStatus SyncFileMetadata(ZoneFile* zoneFile);
+
+  void EncodeSnapshotTo(std::string* output);
+  Status DecodeSnapshotFrom(Slice* input);
+  Status RecoverFrom(ZenMetaLog* log);
+
+  std::string ToAuxPath(std::string path) {
+    return superblock_->GetAuxFsPath() + path;
+  }
+
+  std::string ToZenFSPath(std::string aux_path) {
+    std::string path = aux_path;
+    path.erase(0, superblock_->GetAuxFsPath().length());
+    return path;
+  }
+
+  ZoneFile* GetFile(std::string fname);
+  bool DeleteFile(std::string fname);
+
+ public:
+  explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
+                 std::shared_ptr<Logger> logger);
+  virtual ~ZenFS();
+
+  Status Mount();
+  Status MkFS(std::string aux_fs_path, uint32_t finish_threshold);
+
+  const char* Name() const override {
+    return "ZenFS - The Zoned-enabled File System";
+  }
+
+  virtual IOStatus NewSequentialFile(const std::string& fname,
+                                     const FileOptions& file_opts,
+                                     std::unique_ptr<FSSequentialFile>* result,
+                                     IODebugContext* dbg) override;
+  virtual IOStatus NewRandomAccessFile(
+      const std::string& fname, const FileOptions& file_opts,
+      std::unique_ptr<FSRandomAccessFile>* result,
+      IODebugContext* dbg) override;
+  virtual IOStatus NewWritableFile(const std::string& fname,
+                                   const FileOptions& file_opts,
+                                   std::unique_ptr<FSWritableFile>* result,
+                                   IODebugContext* dbg) override;
+  virtual IOStatus ReuseWritableFile(const std::string& fname,
+                                     const std::string& old_fname,
+                                     const FileOptions& file_opts,
+                                     std::unique_ptr<FSWritableFile>* result,
+                                     IODebugContext* dbg) override;
+  virtual IOStatus FileExists(const std::string& fname,
+                              const IOOptions& options,
+                              IODebugContext* dbg) override;
+  virtual IOStatus GetChildren(const std::string& dir, const IOOptions& options,
+                               std::vector<std::string>* result,
+                               IODebugContext* dbg) override;
+  virtual IOStatus DeleteFile(const std::string& fname,
+                              const IOOptions& options,
+                              IODebugContext* dbg) override;
+  IOStatus GetFileSize(const std::string& f, const IOOptions& options,
+                       uint64_t* size, IODebugContext* dbg) override;
+  IOStatus RenameFile(const std::string& f, const std::string& t,
+                      const IOOptions& options, IODebugContext* dbg) override;
+
+  IOStatus GetFreeSpace(const std::string& /*path*/,
+                        const IOOptions& /*options*/, uint64_t* diskfree,
+                        IODebugContext* /*dbg*/) override {
+    *diskfree = zbd_->GetFreeSpace();
+    return IOStatus::OK();
+  }
+
+  // The directory structure is stored in the aux file system
+  IOStatus NewDirectory(const std::string& name, const IOOptions& io_opts,
+                        std::unique_ptr<FSDirectory>* result,
+                        IODebugContext* dbg) override {
+    Debug(logger_, "NewDirectory: %s to aux: %s\n", name.c_str(),
+          ToAuxPath(name).c_str());
+    return target()->NewDirectory(ToAuxPath(name), io_opts, result, dbg);
+  }
+
+  IOStatus CreateDir(const std::string& d, const IOOptions& options,
+                     IODebugContext* dbg) override {
+    Debug(logger_, "CreatDir: %s to aux: %s\n", d.c_str(),
+          ToAuxPath(d).c_str());
+    return target()->CreateDir(ToAuxPath(d), options, dbg);
+  }
+
+  IOStatus CreateDirIfMissing(const std::string& d, const IOOptions& options,
+                              IODebugContext* dbg) override {
+    Debug(logger_, "CreatDirIfMissing: %s to aux: %s\n", d.c_str(),
+          ToAuxPath(d).c_str());
+    return target()->CreateDirIfMissing(ToAuxPath(d), options, dbg);
+  }
+
+  IOStatus DeleteDir(const std::string& d, const IOOptions& options,
+                     IODebugContext* dbg) override {
+    std::vector<std::string> children;
+    IOStatus s;
+
+    Debug(logger_, "DeleteDir: %s aux: %s\n", d.c_str(), ToAuxPath(d).c_str());
+
+    s = GetChildren(d, options, &children, dbg);
+    if (children.size() != 0)
+      return IOStatus::IOError("Directory has children");
+
+    return target()->DeleteDir(ToAuxPath(d), options, dbg);
+  }
+
+  // We might want to override these in the future
+  IOStatus GetAbsolutePath(const std::string& db_path, const IOOptions& options,
+                           std::string* output_path,
+                           IODebugContext* dbg) override {
+    return target()->GetAbsolutePath(db_path, options, output_path, dbg);
+  }
+
+  IOStatus LockFile(const std::string& f, const IOOptions& options,
+                    FileLock** l, IODebugContext* dbg) override {
+    return target()->LockFile(ToAuxPath(f), options, l, dbg);
+  }
+
+  IOStatus UnlockFile(FileLock* l, const IOOptions& options,
+                      IODebugContext* dbg) override {
+    return target()->UnlockFile(l, options, dbg);
+  }
+
+  IOStatus GetTestDirectory(const IOOptions& options, std::string* path,
+                            IODebugContext* dbg) override {
+    *path = "/rocksdbtest";
+    Debug(logger_, "GetTestDirectory: %s aux: %s\n", path->c_str(),
+          ToAuxPath(*path).c_str());
+    return target()->CreateDirIfMissing(ToAuxPath(*path), options, dbg);
+  }
+
+  IOStatus NewLogger(const std::string& fname, const IOOptions& options,
+                     std::shared_ptr<Logger>* result,
+                     IODebugContext* dbg) override {
+    return target()->NewLogger(ToAuxPath(fname), options, result, dbg);
+  }
+
+  // Not supported (at least not yet)
+  IOStatus Truncate(const std::string& /*fname*/, size_t /*size*/,
+                    const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+    return IOStatus::NotSupported("Truncate is not implemented in ZenFS");
+    return IOStatus::OK();
+  }
+
+  virtual IOStatus ReopenWritableFile(
+      const std::string& /*fname*/, const FileOptions& /*options*/,
+      std::unique_ptr<FSWritableFile>* /*result*/, IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported(
+        "ReopenWritableFile is not implemented in ZenFS");
+  }
+
+  virtual IOStatus NewRandomRWFile(const std::string& /*fname*/,
+                                   const FileOptions& /*options*/,
+                                   std::unique_ptr<FSRandomRWFile>* /*result*/,
+                                   IODebugContext* /*dbg*/) override {
+    return IOStatus::NotSupported("RandomRWFile is not implemented in ZenFS");
+  }
+
+  virtual IOStatus NewMemoryMappedFileBuffer(
+      const std::string& /*fname*/,
+      std::unique_ptr<MemoryMappedFileBuffer>* /*result*/) override {
+    return IOStatus::NotSupported(
+        "MemoryMappedFileBuffer is not implemented in ZenFS");
+  }
+
+  IOStatus GetFileModificationTime(const std::string& /*fname*/,
+                                   const IOOptions& /*options*/,
+                                   uint64_t* /*file_mtime*/,
+                                   IODebugContext* /*dbg*/) override {
+    return IOStatus::NotSupported(
+        "GetFileModificationTime is not implemented in ZenFS");
+  }
+
+  virtual IOStatus LinkFile(const std::string& /*src*/,
+                            const std::string& /*target*/,
+                            const IOOptions& /*options*/,
+                            IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported("LinkFile is not supported in ZenFS");
+  }
+
+  virtual IOStatus NumFileLinks(const std::string& /*fname*/,
+                                const IOOptions& /*options*/,
+                                uint64_t* /*count*/, IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported(
+        "Getting number of file links is not supported in ZenFS");
+  }
+
+  virtual IOStatus AreFilesSame(const std::string& /*first*/,
+                                const std::string& /*second*/,
+                                const IOOptions& /*options*/, bool* /*res*/,
+                                IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
+  }
+};
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)

--- a/env/io_zenfs.cc
+++ b/env/io_zenfs.cc
@@ -1,0 +1,585 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#if !defined(ROCKSDB_LITE) && !defined(OS_WIN) && defined(LIBZBD)
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libzbd/zbd.h>
+#include <linux/blkzoned.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/env.h"
+#include "util/coding.h"
+
+#include "io_zenfs.h"
+#include "zbd_zenfs.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status ZoneExtent::DecodeFrom(Slice* input) {
+  if (input->size() != (sizeof(start_) + sizeof(length_)))
+    return Status::Corruption("ZoneExtent", "Error: length missmatch");
+
+  GetFixed64(input, &start_);
+  GetFixed32(input, &length_);
+  return Status::OK();
+}
+
+void ZoneExtent::EncodeTo(std::string* output) {
+  PutFixed64(output, start_);
+  PutFixed32(output, length_);
+}
+
+enum ZoneFileTag : uint32_t {
+  kFileID = 1,
+  kFileName = 2,
+  kFileSize = 3,
+  kWriteLifeTimeHint = 4,
+  kExtent = 5,
+};
+
+void ZoneFile::EncodeTo(std::string* output) {
+  PutFixed32(output, kFileID);
+  PutFixed64(output, file_id_);
+
+  PutFixed32(output, kFileName);
+  PutLengthPrefixedSlice(output, Slice(filename_));
+
+  PutFixed32(output, kFileSize);
+  PutFixed64(output, fileSize);
+
+  for (const auto e : extents_) {
+    std::string extent_str;
+
+    PutFixed32(output, kExtent);
+    e->EncodeTo(&extent_str);
+    PutLengthPrefixedSlice(output, Slice(extent_str));
+  }
+
+  /* We're not encoding active zone and extent start
+   * as files will always be read-only after mount */
+}
+
+Status ZoneFile::DecodeFrom(Slice* input) {
+  uint32_t tag = 0;
+
+  GetFixed32(input, &tag);
+  if (tag != kFileID || !GetFixed64(input, &file_id_))
+    return Status::Corruption("ZoneFile", "File ID missing");
+
+  while (true) {
+    Slice slice;
+    ZoneExtent* extent;
+    Status s;
+
+    if (!GetFixed32(input, &tag)) break;
+
+    switch (tag) {
+      case kFileID:
+        if (!GetFixed64(input, &file_id_))
+          return Status::Corruption("zonefile", "missing file ID");
+        break;
+      case kFileName:
+        if (!GetLengthPrefixedSlice(input, &slice))
+          return Status::Corruption("ZoneFile", "Filename missing");
+        filename_ = slice.ToString();
+        if (filename_.length() == 0)
+          return Status::Corruption("ZoneFile", "Zero length filename");
+        break;
+      case kFileSize:
+        if (!GetFixed64(input, &fileSize))
+          return Status::Corruption("zonefile", "missing file size");
+        break;
+      case kExtent:
+        extent = new ZoneExtent(0, 0, nullptr);
+        GetLengthPrefixedSlice(input, &slice);
+        s = extent->DecodeFrom(&slice);
+        if (!s.ok()) {
+          delete extent;
+          return s;
+        }
+        extent->zone_ = zbd_->GetIOZone(extent->start_);
+        if (!extent->zone_)
+          return Status::Corruption("ZoneFile", "Invalid zone extent");
+        extent->zone_->used_capacity_ += extent->length_;
+        extents_.push_back(extent);
+        break;
+      default:
+        return Status::Corruption("ZoneFile", "Unexpected tag");
+    }
+  }
+
+  return Status::OK();
+}
+
+ZoneFile::ZoneFile(ZonedBlockDevice* zbd, std::string filename,
+                   uint64_t file_id)
+    : zbd_(zbd),
+      active_zone_(NULL),
+      extent_start_(0),
+      extent_filepos_(0),
+      lifetime_(Env::WLTH_NOT_SET),
+      openforwrite_(false),
+      fileSize(0),
+      filename_(filename),
+      file_id_(file_id) {}
+
+std::string ZoneFile::GetFilename() { return filename_; }
+
+void ZoneFile::Rename(std::string name) { filename_ = name; }
+
+uint64_t ZoneFile::GetFileSize() { return fileSize; }
+void ZoneFile::SetFileSize(uint64_t sz) { fileSize = sz; }
+
+ZoneFile::~ZoneFile() {
+  for (auto e = std::begin(extents_); e != std::end(extents_); ++e) {
+    Zone* zone = (*e)->zone_;
+
+    assert(zone && zone->used_capacity_ >= (*e)->length_);
+    zone->used_capacity_ -= (*e)->length_;
+    delete *e;
+  }
+}
+
+IOStatus ZoneFile::OpenWR() {
+  openforwrite_ = true;
+
+  return IOStatus::OK();
+}
+
+IOStatus ZoneFile::CloseWR() {
+  if (!openforwrite_) return IOStatus::OK();
+
+  if (active_zone_) {
+    /* Release zone */
+    active_zone_->open_for_write_ = false;
+    active_zone_ = NULL;
+  }
+
+  openforwrite_ = false;
+
+  return IOStatus::OK();
+}
+
+ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
+  for (unsigned int i = 0; i < extents_.size(); i++) {
+    if (file_offset < extents_[i]->length_) {
+      *dev_offset = extents_[i]->start_ + file_offset;
+      return extents_[i];
+    } else {
+      file_offset -= extents_[i]->length_;
+    }
+  }
+
+  return NULL;
+}
+
+IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
+                                  char* scratch) {
+  int f = zbd_->GetReadFD();
+  char* ptr;
+  uint64_t r_off;
+  size_t r_sz;
+  ssize_t r = 0;
+  size_t read = 0;
+  ZoneExtent* extent;
+  uint64_t extent_end;
+  IOStatus s;
+
+  if (offset >= fileSize) {
+    *result = Slice(scratch, 0);
+    return IOStatus::OK();
+  }
+
+  r_off = 0;
+  extent = GetExtent(offset, &r_off);
+  if (!extent) {
+    /* read start beyond end of (synced) file data*/
+    *result = Slice(scratch, 0);
+    return s;
+  }
+  extent_end = extent->start_ + extent->length_;
+
+  /* Limit read size to end of file */
+  if ((offset + n) > fileSize)
+    r_sz = fileSize - offset;
+  else
+    r_sz = n;
+
+  ptr = scratch;
+
+  while (read != r_sz) {
+    size_t pread_sz = r_sz - read;
+
+    if ((pread_sz + r_off) > extent_end) pread_sz = extent_end - r_off;
+
+    r = pread(f, ptr, pread_sz, r_off);
+
+    if (r <= 0) {
+      if (r == -1 && errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+
+    pread_sz = (size_t)r;
+
+    ptr += pread_sz;
+    read += pread_sz;
+    r_off += pread_sz;
+
+    if (read != r_sz && r_off == extent_end) {
+      extent = GetExtent(offset + read, &r_off);
+      if (!extent) {
+        /* read beyond end of (synced) file data */
+        break;
+      }
+      r_off = extent->start_;
+      extent_end = extent->start_ + extent->length_;
+      assert(((size_t)r_off % zbd_->GetBlockSize()) == 0);
+    }
+  }
+
+  if (r < 0) {
+    s = IOStatus::IOError("pread error\n");
+    read = 0;
+  }
+
+  *result = Slice((char*)scratch, read);
+  return s;
+}
+
+void ZoneFile::PushExtent() {
+  uint64_t length;
+
+  assert(fileSize >= extent_filepos_);
+
+  if (!active_zone_) return;
+
+  length = fileSize - extent_filepos_;
+  if (length == 0) return;
+
+  assert(length <= (active_zone_->wp_ - extent_start_));
+  extents_.push_back(new ZoneExtent(extent_start_, length, active_zone_));
+
+  active_zone_->used_capacity_ += length;
+  extent_start_ = active_zone_->wp_;
+  extent_filepos_ = fileSize;
+}
+
+/* Assumes that data and size are block aligned */
+IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
+  uint32_t left = data_size;
+  uint32_t wr_size, offset = 0;
+  IOStatus s;
+
+  //  assert(((uint64_t)data_size % zbd_->GetBlockSize()) == 0);
+  //  assert(((uint64_t)data % zbd_->GetBlockSize()) == 0);
+
+  if (active_zone_ == NULL) {
+    active_zone_ = zbd_->AllocateZone(lifetime_);
+    if (!active_zone_) {
+      return IOStatus::NoSpace("Zone allocation failure\n");
+    }
+    extent_start_ = active_zone_->wp_;
+    extent_filepos_ = fileSize;
+  }
+
+  while (left) {
+    if (active_zone_->capacity_ == 0) {
+      PushExtent();
+
+      /* Release zone */
+      active_zone_->open_for_write_ = false;
+      active_zone_ = zbd_->AllocateZone(lifetime_);
+      if (!active_zone_) {
+        return IOStatus::NoSpace("Zone allocation failure\n");
+      }
+      extent_start_ = active_zone_->wp_;
+      extent_filepos_ = fileSize;
+    }
+
+    wr_size = left;
+    if (wr_size > active_zone_->capacity_) wr_size = active_zone_->capacity_;
+
+    s = active_zone_->Append((char*)data + offset, wr_size);
+    if (!s.ok()) return s;
+
+    fileSize += wr_size;
+    left -= wr_size;
+    offset += wr_size;
+  }
+
+  fileSize -= (data_size - valid_size);
+  return IOStatus::OK();
+}
+
+IOStatus ZoneFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime) {
+  lifetime_ = lifetime;
+  return IOStatus::OK();
+}
+
+ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
+                                     ZoneFile* zoneFile,
+                                     MetadataWriter* metadata_writer) {
+  wp = zoneFile->GetFileSize();
+  assert(wp == 0);
+
+  buffered = _buffered;
+  block_sz = zbd->GetBlockSize();
+  buffer_sz = block_sz * 256;
+  buffer_pos = 0;
+
+  zoneFile_ = zoneFile;
+  zoneFile_->OpenWR();
+
+  if (buffered) {
+    int ret = posix_memalign((void**)&buffer, block_sz, buffer_sz);
+
+    if (ret) buffer = nullptr;
+
+    assert(buffer != nullptr);
+  }
+
+  metadata_writer_ = metadata_writer;
+}
+
+ZonedWritableFile::~ZonedWritableFile() {
+  zoneFile_->CloseWR();
+  if (buffered) free(buffer);
+};
+
+ZonedWritableFile::MetadataWriter::~MetadataWriter() {}
+
+IOStatus ZonedWritableFile::Truncate(uint64_t size,
+                                     const IOOptions& /*options*/,
+                                     IODebugContext* /*dbg*/) {
+  zoneFile_->SetFileSize(size);
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
+                                  IODebugContext* /*dbg*/) {
+  IOStatus s;
+
+  s = FlushBuffer();
+  if (!s.ok()) {
+    return s;
+  }
+  zoneFile_->PushExtent();
+
+  return metadata_writer_->Persist(zoneFile_);
+}
+
+IOStatus ZonedWritableFile::Sync(const IOOptions& options,
+                                 IODebugContext* dbg) {
+  return Fsync(options, dbg);
+}
+
+IOStatus ZonedWritableFile::Flush(const IOOptions& /*options*/,
+                                  IODebugContext* /*dbg*/) {
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::RangeSync(uint64_t offset, uint64_t nbytes,
+                                      const IOOptions& options,
+                                      IODebugContext* dbg) {
+  if (wp < offset + nbytes) return Fsync(options, dbg);
+
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::Close(const IOOptions& options,
+                                  IODebugContext* dbg) {
+  Fsync(options, dbg);
+  zoneFile_->CloseWR();
+
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::FlushBuffer() {
+  uint32_t align, pad_sz = 0, wr_sz;
+  IOStatus s;
+
+  if (!buffer_pos) return IOStatus::OK();
+
+  align = buffer_pos % block_sz;
+  if (align) pad_sz = block_sz - align;
+
+  if (pad_sz) memset((char*)buffer + buffer_pos, 0x0, pad_sz);
+
+  wr_sz = buffer_pos + pad_sz;
+  s = zoneFile_->Append((char*)buffer, wr_sz, buffer_pos);
+  if (!s.ok()) {
+    return s;
+  }
+
+  wp += buffer_pos;
+  buffer_pos = 0;
+
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::BufferedWrite(const Slice& slice) {
+  uint32_t buffer_left = buffer_sz - buffer_pos;
+  uint32_t data_left = slice.size();
+  char* data = (char*)slice.data();
+  uint32_t tobuffer;
+  int blocks, aligned_sz;
+  int ret;
+  void* alignbuf;
+  IOStatus s;
+
+  if (buffer_pos || data_left <= buffer_left) {
+    if (data_left < buffer_left) {
+      tobuffer = data_left;
+    } else {
+      tobuffer = buffer_left;
+    }
+
+    memcpy(buffer + buffer_pos, data, tobuffer);
+    buffer_pos += tobuffer;
+    data_left -= tobuffer;
+
+    if (!data_left) return IOStatus::OK();
+
+    data += tobuffer;
+  }
+
+  if (buffer_pos == buffer_sz) {
+    s = FlushBuffer();
+    if (!s.ok()) return s;
+  }
+
+  if (data_left >= buffer_sz) {
+    blocks = data_left / block_sz;
+    aligned_sz = block_sz * blocks;
+
+    ret = posix_memalign(&alignbuf, block_sz, aligned_sz);
+    if (ret) {
+      return IOStatus::IOError("failed allocating alignment write buffer\n");
+    }
+
+    memcpy(alignbuf, data, aligned_sz);
+    s = zoneFile_->Append(alignbuf, aligned_sz, aligned_sz);
+    free(alignbuf);
+
+    if (!s.ok()) {
+      return IOStatus::IOError("append failed when writing aligned buffer\n");
+    }
+
+    wp += aligned_sz;
+    data_left -= aligned_sz;
+    data += aligned_sz;
+  }
+
+  if (data_left) {
+    memcpy(buffer, data, data_left);
+    buffer_pos = data_left;
+  }
+
+  return IOStatus::OK();
+}
+
+IOStatus ZonedWritableFile::Append(const Slice& data,
+                                   const IOOptions& /*options*/,
+                                   IODebugContext* /*dbg*/) {
+  IOStatus s;
+
+  if (buffered) {
+    s = BufferedWrite(data);
+  } else {
+    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    if (s.ok()) wp += data.size();
+  }
+
+  return s;
+}
+
+IOStatus ZonedWritableFile::PositionedAppend(const Slice& data, uint64_t offset,
+                                             const IOOptions& /*options*/,
+                                             IODebugContext* /*dbg*/) {
+  IOStatus s;
+
+  if (offset != wp) {
+    assert(false);
+    return IOStatus::IOError("positioned append not at write pointer");
+  }
+
+  if (buffered) {
+    s = BufferedWrite(data);
+  } else {
+    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    if (s.ok()) wp += data.size();
+  }
+
+  return s;
+}
+
+void ZonedWritableFile::PrepareWrite(size_t /*offset*/, size_t /*len*/,
+                                     const IOOptions& /*options*/,
+                                     IODebugContext* /*dbg*/) {
+  /* TODO: implement or remove */
+}
+
+IOStatus ZonedWritableFile::Allocate(uint64_t /*offset*/, uint64_t /*len*/,
+                                     const IOOptions& /*options*/,
+                                     IODebugContext* /*dbg*/) {
+  return IOStatus::OK();
+}
+
+void ZonedWritableFile::SetPreallocationBlockSize(size_t /*size*/) {
+  /* TODO: implement or remove */
+}
+
+void ZonedWritableFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) {
+  zoneFile_->SetWriteLifeTimeHint(hint);
+}
+
+IOStatus ZonedSequentialFile::Read(size_t n, const IOOptions& /*options*/,
+                                   Slice* result, char* scratch,
+                                   IODebugContext* /*dbg*/) {
+  IOStatus s;
+
+  s = zoneFile_->PositionedRead(rp, n, result, scratch);
+  if (s.ok()) rp += result->size();
+
+  return s;
+}
+
+IOStatus ZonedSequentialFile::Skip(uint64_t n) {
+  if (rp + n >= zoneFile_->GetFileSize())
+    return IOStatus::InvalidArgument("Skip beyond end of file");
+  rp += n;
+  return IOStatus::OK();
+}
+
+IOStatus ZonedSequentialFile::PositionedRead(uint64_t offset, size_t n,
+                                             const IOOptions& /*options*/,
+                                             Slice* result, char* scratch,
+                                             IODebugContext* /*dbg*/) {
+  return zoneFile_->PositionedRead(offset, n, result, scratch);
+}
+
+IOStatus ZonedRandomAccessFile::Read(uint64_t offset, size_t n,
+                                     const IOOptions& /*options*/,
+                                     Slice* result, char* scratch,
+                                     IODebugContext* /*dbg*/) const {
+  return zoneFile_->PositionedRead(offset, n, result, scratch);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && !defined(OS_WIN) && defined(LIBZBD)

--- a/env/io_zenfs.h
+++ b/env/io_zenfs.h
@@ -1,0 +1,225 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#if !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/file_system.h"
+#include "zbd_zenfs.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class ZoneExtent {
+ public:
+  uint64_t start_;
+  uint32_t length_;
+  Zone* zone_;
+
+  explicit ZoneExtent(uint64_t start, uint32_t length, Zone* zone);
+  Status DecodeFrom(Slice* input);
+  void EncodeTo(std::string* output);
+};
+
+class ZoneFile {
+ protected:
+  ZonedBlockDevice* zbd_;
+  std::vector<ZoneExtent*> extents_;
+  Zone* active_zone_;
+  uint64_t extent_start_;
+  uint64_t extent_filepos_;
+
+  Env::WriteLifeTimeHint lifetime_;
+  bool openforwrite_;
+  uint64_t fileSize;
+  std::string filename_;
+  uint64_t file_id_;
+
+ public:
+  /* Constructor for data files */
+  explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
+                    uint64_t file_id_);
+
+  virtual ~ZoneFile();
+
+  IOStatus OpenWR();
+  IOStatus CloseWR();
+  IOStatus Append(void* data, int data_size, int valid_size);
+  IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
+  std::string GetFilename();
+  void Rename(std::string name);
+  uint64_t GetFileSize();
+  void SetFileSize(uint64_t sz);
+
+  uint32_t GetBlockSize() { return zbd_->GetBlockSize(); }
+  std::vector<ZoneExtent*> GetExtents() { return extents_; }
+  Env::WriteLifeTimeHint GetWriteLifeTimeHint() { return lifetime_; }
+
+  IOStatus PositionedRead(uint64_t offset, size_t n, Slice* result,
+                          char* scratch);
+  ZoneExtent* GetExtent(uint64_t file_offset, uint64_t* dev_offset);
+  void PushExtent();
+
+  void EncodeTo(std::string* output);
+  Status DecodeFrom(Slice* input);
+
+  uint64_t GetID() { return file_id_; }
+};
+
+class ZonedWritableFile : public FSWritableFile {
+ public:
+  /* Interface for persisting metadata for files */
+  class MetadataWriter {
+   public:
+    virtual ~MetadataWriter();
+    virtual IOStatus Persist(ZoneFile* zoneFile) = 0;
+  };
+
+  explicit ZonedWritableFile(ZonedBlockDevice* zbd, bool buffered,
+                             ZoneFile* zoneFile,
+                             MetadataWriter* metadata_writer = nullptr);
+  virtual ~ZonedWritableFile();
+
+  virtual IOStatus Append(const Slice& data, const IOOptions& options,
+                          IODebugContext* dbg) override;
+  virtual IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                                    const IOOptions& options,
+                                    IODebugContext* dbg) override;
+
+  virtual IOStatus Truncate(uint64_t size, const IOOptions& options,
+                            IODebugContext* dbg) override;
+
+  virtual IOStatus Close(const IOOptions& options,
+                         IODebugContext* dbg) override;
+  virtual IOStatus Flush(const IOOptions& options,
+                         IODebugContext* dbg) override;
+  virtual IOStatus Sync(const IOOptions& options, IODebugContext* dbg) override;
+
+  virtual IOStatus RangeSync(uint64_t offset, uint64_t nbytes,
+                             const IOOptions& options,
+                             IODebugContext* dbg) override;
+
+  virtual IOStatus Fsync(const IOOptions& options,
+                         IODebugContext* dbg) override;
+
+  void SetPreallocationBlockSize(size_t size) override;
+  IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
+                    IODebugContext* dbg) override;
+  void PrepareWrite(size_t offset, size_t len, const IOOptions& options,
+                    IODebugContext* dbg) override;
+
+  bool use_direct_io() const override { return !buffered; }
+  size_t GetRequiredBufferAlignment() const override {
+    return zoneFile_->GetBlockSize();
+  }
+
+  void SetWriteLifeTimeHint(Env::WriteLifeTimeHint hint) override;
+
+ private:
+  IOStatus BufferedWrite(const Slice& data);
+  IOStatus FlushBuffer();
+
+  bool buffered;
+  char* buffer;
+  size_t buffer_sz;
+  uint32_t block_sz;
+  uint32_t buffer_pos;
+  uint64_t wp;
+  int write_temp;
+
+  ZoneFile* zoneFile_;
+  MetadataWriter* metadata_writer_;
+};
+
+class ZonedSequentialFile : public FSSequentialFile {
+ private:
+  ZoneFile* zoneFile_;
+  uint64_t rp;
+
+ public:
+  explicit ZonedSequentialFile(ZoneFile* zoneFile)
+      : zoneFile_(zoneFile), rp(0) {}
+
+  IOStatus Read(size_t n, const IOOptions& options, Slice* result,
+                char* scratch, IODebugContext* dbg) override;
+  IOStatus PositionedRead(uint64_t offset, size_t n, const IOOptions& options,
+                          Slice* result, char* scratch,
+                          IODebugContext* dbg) override;
+  IOStatus Skip(uint64_t n);
+
+  bool use_direct_io() const override { /*return target_->use_direct_io(); */
+    return true;
+  }
+
+  size_t GetRequiredBufferAlignment() const override {
+    return zoneFile_->GetBlockSize();
+  }
+
+  IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+    /* TODO: Implement ?*/
+    return IOStatus::OK();
+  }
+};
+
+class ZonedRandomAccessFile : public FSRandomAccessFile {
+ private:
+  ZoneFile* zoneFile_;
+
+ public:
+  explicit ZonedRandomAccessFile(ZoneFile* zoneFile) : zoneFile_(zoneFile) {}
+
+  IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
+                Slice* result, char* scratch,
+                IODebugContext* dbg) const override;
+
+  IOStatus MultiRead(FSReadRequest* /*reqs*/, size_t /*num_reqs*/,
+                     const IOOptions& /*options*/,
+                     IODebugContext* /*dbg*/) override {
+    return IOStatus::IOError("Not implemented");
+  }
+
+  IOStatus Prefetch(uint64_t /*offset*/, size_t /*n*/,
+                    const IOOptions& /*options*/,
+                    IODebugContext* /*dbg*/) override {
+    /* TODO: Implement ?*/
+    return IOStatus::OK();
+  }
+
+  size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const override {
+    return 0; /* TODO: implement - dev inode + file inode should be good enough
+               */
+  };
+
+  void Hint(AccessPattern /*pattern*/) override { /* TODO: Implement ? */
+  }
+
+  bool use_direct_io() const override { return true; }
+
+  size_t GetRequiredBufferAlignment() const override {
+    return zoneFile_->GetBlockSize();
+  }
+
+  IOStatus InvalidateCache(size_t /*offset*/, size_t /*length*/) override {
+    /* TODO: Implement ?*/
+    return IOStatus::OK();
+  }
+};
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)

--- a/env/zbd_zenfs.cc
+++ b/env/zbd_zenfs.cc
@@ -1,0 +1,400 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#if !defined(ROCKSDB_LITE) && !defined(OS_WIN) && defined(LIBZBD)
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libzbd/zbd.h>
+#include <linux/blkzoned.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "io_zenfs.h"
+#include "rocksdb/env.h"
+#include "zbd_zenfs.h"
+
+/* Number of reserved zones for metadata
+ * Two non-offline meta zones are needed to be able
+ * to roll the metadata log safely. One extra
+ * is allocated to cover for one zone going offline.
+ */
+#define ZENFS_META_ZONES (3)
+
+/* Minimum of number of zones that makes sense */
+#define ZENFS_MIN_ZONES (32)
+
+namespace ROCKSDB_NAMESPACE {
+
+Zone::Zone(ZonedBlockDevice *zbd, struct zbd_zone *z)
+    : zbd_(zbd),
+      start_(zbd_zone_start(z)),
+      max_capacity_(zbd_zone_capacity(z)),
+      wp_(zbd_zone_wp(z)),
+      open_for_write_(false) {
+  lifetime_ = Env::WLTH_NOT_SET;
+  used_capacity_ = 0;
+
+  capacity_ = 0;
+  if (!(zbd_zone_full(z) || zbd_zone_offline(z) || zbd_zone_rdonly(z)))
+    capacity_ = zbd_zone_capacity(z) - (zbd_zone_wp(z) - zbd_zone_start(z));
+}
+
+bool Zone::IsUsed() { return (used_capacity_ > 0) || open_for_write_; }
+
+uint64_t Zone::GetCapacityLeft() { return capacity_; }
+
+bool Zone::IsFull() { return (capacity_ == 0); }
+
+bool Zone::IsEmpty() { return (wp_ == start_); }
+
+uint64_t Zone::GetZoneNr() { return start_ / zbd_->GetZoneSize(); }
+
+IOStatus Zone::Reset() {
+  size_t zone_sz = zbd_->GetZoneSize();
+  int fd = zbd_->GetWriteFD();
+  unsigned int reported = 0;
+  struct zbd_zone z;
+  int ret;
+
+  assert(!IsUsed());
+
+  ret = zbd_reset_zones(fd, start_, zone_sz);
+  if (ret) return IOStatus::IOError("Zone reset failed\n");
+
+  ret = zbd_report_zones(fd, start_, zone_sz, ZBD_RO_ALL, &z, &reported);
+
+  if (ret || (reported != 1)) return IOStatus::IOError("Zone report failed\n");
+
+  if (zbd_zone_offline(&z))
+    capacity_ = 0;
+  else
+    max_capacity_ = capacity_ = zbd_zone_capacity(&z);
+
+  wp_ = start_;
+  lifetime_ = Env::WLTH_NOT_SET;
+
+  return IOStatus::OK();
+}
+
+IOStatus Zone::Finish() {
+  size_t zone_sz = zbd_->GetZoneSize();
+  int fd = zbd_->GetWriteFD();
+  int ret;
+
+  assert(!open_for_write_);
+
+  ret = zbd_finish_zones(fd, start_, zone_sz);
+  if (ret) return IOStatus::IOError("Zone finish failed\n");
+
+  capacity_ = 0;
+  wp_ = start_ + zone_sz;
+
+  return IOStatus::OK();
+}
+
+IOStatus Zone::Append(char *data, uint32_t size) {
+  char *ptr = data;
+  uint32_t left = size;
+  int fd = zbd_->GetWriteFD();
+  int ret;
+
+  if (capacity_ < size)
+    return IOStatus::NoSpace("Not enough capacity for append");
+
+  assert((size % zbd_->GetBlockSize()) == 0);
+
+  while (left) {
+    ret = pwrite(fd, ptr, size, wp_);
+    if (ret < 0) return IOStatus::IOError("Write failed");
+
+    ptr += ret;
+    wp_ += ret;
+    capacity_ -= ret;
+    left -= ret;
+  }
+
+  return IOStatus::OK();
+}
+
+ZoneExtent::ZoneExtent(uint64_t start, uint32_t length, Zone *zone)
+    : start_(start), length_(length), zone_(zone) {}
+Zone *ZonedBlockDevice::GetIOZone(uint64_t offset) {
+  /* Yes, this is silly. TODO: make this smarter */
+  for (const auto z : io_zones)
+    if (z->start_ <= offset && offset < (z->start_ + zone_sz_)) return z;
+
+  return nullptr;
+}
+
+ZonedBlockDevice::ZonedBlockDevice(std::string filename,
+                                   std::shared_ptr<Logger> logger)
+    : filename_(filename), logger_(logger) {
+  Info(logger_, "New Zoned Block Device: %s", filename.c_str());
+};
+
+IOStatus ZonedBlockDevice::Open() {
+  struct zbd_zone *zone_rep;
+  unsigned int reported_zones;
+  size_t addr_space_sz;
+  zbd_info info;
+  Status s;
+  uint64_t i = 0;
+  uint64_t m = 0;
+  int ret;
+
+  read_f_ = zbd_open(filename_.c_str(), O_RDONLY, &info);
+  if (read_f_ < 0) {
+    return IOStatus::InvalidArgument("Failed to open zoned block device");
+  }
+
+  write_f_ = zbd_open(filename_.c_str(), O_WRONLY | O_DIRECT, &info);
+  if (write_f_ < 0) {
+    return IOStatus::InvalidArgument("Failed to open zoned block device");
+  }
+
+  if (info.model != ZBD_DM_HOST_MANAGED) {
+    return IOStatus::NotSupported("Not a host managed block device");
+  }
+
+  if (info.nr_zones < ZENFS_MIN_ZONES) {
+    return IOStatus::NotSupported(
+        "To few zones on zoned block device (32 required)");
+  }
+
+  block_sz_ = info.pblock_size;
+  zone_sz_ = info.zone_size;
+  nr_zones_ = info.nr_zones;
+  addr_space_sz = (uint64_t)nr_zones_ * zone_sz_;
+
+  ret = zbd_list_zones(write_f_, 0, addr_space_sz, ZBD_RO_ALL, &zone_rep,
+                       &reported_zones);
+
+  if (ret || reported_zones != nr_zones_) {
+    Error(logger_, "Failed to list zones, err: %d", ret);
+    return IOStatus::IOError("Failed to list zones");
+  }
+
+  while (m < ZENFS_META_ZONES && i < reported_zones) {
+    struct zbd_zone *z = &zone_rep[i++];
+    /* Only use sequential write required zones */
+    if (zbd_zone_type(z) == ZBD_ZONE_TYPE_SWR) {
+      if (!zbd_zone_offline(z)) {
+        meta_zones.push_back(new Zone(this, z));
+      }
+      m++;
+    }
+  }
+
+  for (; i < reported_zones; i++) {
+    struct zbd_zone *z = &zone_rep[i];
+    /* Only use sequential write required zones */
+    if (zbd_zone_type(z) == ZBD_ZONE_TYPE_SWR) {
+      if (!zbd_zone_offline(z)) {
+        io_zones.push_back(new Zone(this, z));
+      }
+    }
+  }
+
+  free(zone_rep);
+  start_time_ = time(NULL);
+
+  return IOStatus::OK();
+}
+
+#define KB (1024)
+#define MB (1024 * KB)
+
+uint64_t ZonedBlockDevice::GetFreeSpace() {
+  uint64_t free = 0;
+  for (const auto z : io_zones) {
+    free += z->capacity_;
+  }
+
+  return free;
+}
+
+void ZonedBlockDevice::LogZoneStats() {
+  uint64_t used_capacity = 0;
+  uint64_t reclaimable_capacity = 0;
+  uint64_t reclaimables_max_capacity = 0;
+  uint64_t active = 0;
+  io_zones_mtx.lock();
+
+  for (const auto z : io_zones) {
+    used_capacity += z->used_capacity_;
+
+    if (z->used_capacity_) {
+      reclaimable_capacity += z->max_capacity_ - z->used_capacity_;
+      reclaimables_max_capacity += z->max_capacity_;
+    }
+
+    if (!(z->IsFull() || z->IsEmpty())) active++;
+  }
+
+  if (reclaimables_max_capacity == 0) reclaimables_max_capacity = 1;
+
+  Info(logger_,
+       "[Zonestats:time(s),used_cap(MB),reclaimable_cap(MB), "
+       "avg_reclaimable(%%), active(#)] %ld %lu %lu %lu %lu\n",
+       time(NULL) - start_time_, used_capacity / MB, reclaimable_capacity / MB,
+       100 * reclaimable_capacity / reclaimables_max_capacity, active);
+
+  io_zones_mtx.unlock();
+}
+
+void ZonedBlockDevice::LogZoneUsage() {
+  for (const auto z : io_zones) {
+    int64_t used = z->used_capacity_;
+
+    if (used > 0) {
+      Debug(logger_, "Zone 0x%lX used capacity: %ld bytes (%ld MB)\n",
+            z->start_, used, used / MB);
+    }
+  }
+}
+
+ZonedBlockDevice::~ZonedBlockDevice() {
+  for (const auto z : meta_zones) {
+    delete z;
+  }
+
+  for (const auto z : io_zones) {
+    delete z;
+  }
+
+  zbd_close(read_f_);
+  zbd_close(write_f_);
+}
+
+#define LIFETIME_DIFF_NOT_GOOD (100)
+
+unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime,
+                             Env::WriteLifeTimeHint file_lifetime) {
+  assert(file_lifetime <= Env::WLTH_EXTREME);
+
+  if ((file_lifetime == Env::WLTH_NOT_SET) ||
+      (file_lifetime == Env::WLTH_NONE)) {
+    if (file_lifetime == zone_lifetime) {
+      return 0;
+    } else {
+      return LIFETIME_DIFF_NOT_GOOD;
+    }
+  }
+
+  if (zone_lifetime > file_lifetime) return zone_lifetime - file_lifetime;
+
+  return LIFETIME_DIFF_NOT_GOOD;
+}
+
+Zone *ZonedBlockDevice::AllocateMetaZone() {
+  for (const auto z : meta_zones) {
+    /* If the zone is not used, reset and use it */
+    if (!z->IsUsed()) {
+      if (!z->IsEmpty()) {
+        if (!z->Reset().ok()) {
+          Warn(logger_, "Failed resetting zone!");
+          continue;
+        }
+      }
+      return z;
+    }
+  }
+  return nullptr;
+}
+
+void ZonedBlockDevice::ResetUnusedIOZones() {
+  /* Reset any unused zones */
+  for (const auto z : io_zones) {
+    if (!z->IsUsed() && !z->IsFull()) {
+      if (!z->Reset().ok()) Warn(logger_, "Failed reseting zone");
+    }
+  }
+}
+
+Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime) {
+  Zone *allocated_zone = nullptr;
+  unsigned int best_diff = LIFETIME_DIFF_NOT_GOOD;
+  int new_zone = 0;
+  Status s;
+
+  io_zones_mtx.lock();
+
+  /* Reset any unused zones and finish used zones under capacity treshold*/
+  for (const auto z : io_zones) {
+    if (!z->IsUsed() && z->IsFull()) {
+      s = z->Reset();
+      if (!s.ok()) {
+        Debug(logger_, "Failed resetting zone !");
+      }
+      continue;
+    }
+
+    if ((z->used_capacity_ > 0 && !z->open_for_write_) &&
+        (z->capacity_ < (z->max_capacity_ * finish_threshold_ / 100))) {
+      /* If there is less than finish_threshold_% remaining capacity in a
+       * non-open-zone, finish the zone */
+      s = z->Finish();
+      if (!s.ok()) {
+        Debug(logger_, "Failed finishing zone");
+      }
+    }
+  }
+
+  /* Try to fill an already open zone */
+  for (const auto z : io_zones) {
+    if ((!z->open_for_write_) && (z->used_capacity_ > 0) &&
+        (z->capacity_ > 0)) {
+      unsigned int diff = GetLifeTimeDiff(z->lifetime_, file_lifetime);
+      if (diff <= best_diff) {
+        allocated_zone = z;
+        best_diff = diff;
+      }
+    }
+  }
+
+  /* If we did not find a good match, allocate an empty one */
+  if (best_diff >= LIFETIME_DIFF_NOT_GOOD) {
+    for (const auto z : io_zones) {
+      if ((!z->open_for_write_) && (z->capacity_ > 0) &&
+          (z->used_capacity_ == 0)) {
+        z->lifetime_ = file_lifetime;
+        allocated_zone = z;
+        new_zone = 1;
+        break;
+      }
+    }
+  }
+
+  if (allocated_zone) {
+    assert(!allocated_zone->open_for_write_);
+    allocated_zone->open_for_write_ = true;
+    Debug(logger_,
+          "Allocating zone(new=%d) start: 0x%lx wp: 0x%lx lt: %d file lt: %d\n",
+          new_zone, allocated_zone->start_, allocated_zone->wp_,
+          allocated_zone->lifetime_, file_lifetime);
+  }
+
+  io_zones_mtx.unlock();
+  LogZoneStats();
+
+  return allocated_zone;
+}
+
+std::string ZonedBlockDevice::GetFilename() { return filename_; }
+
+uint32_t ZonedBlockDevice::GetBlockSize() { return block_sz_; }
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && !defined(OS_WIN) && defined(LIBZBD)

--- a/env/zbd_zenfs.h
+++ b/env/zbd_zenfs.h
@@ -1,0 +1,103 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#if !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rocksdb/env.h"
+#include "rocksdb/io_status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class ZonedBlockDevice;
+
+class Zone {
+  ZonedBlockDevice *zbd_;
+
+ public:
+  explicit Zone(ZonedBlockDevice *zbd, struct zbd_zone *z);
+
+  uint64_t start_;
+  uint64_t capacity_; /* remaining capacity */
+  uint64_t max_capacity_;
+  uint64_t wp_;
+  bool open_for_write_;
+  Env::WriteLifeTimeHint lifetime_;
+  std::atomic<long> used_capacity_;
+
+  IOStatus Reset();
+  IOStatus Finish();
+  IOStatus Append(char *data, uint32_t size);
+  bool IsUsed();
+  bool IsFull();
+  bool IsEmpty();
+  uint64_t GetZoneNr();
+  uint64_t GetCapacityLeft();
+};
+
+class ZonedBlockDevice {
+ private:
+  std::string filename_;
+  uint32_t block_sz_;
+  uint32_t zone_sz_;
+  uint32_t nr_zones_;
+  std::vector<Zone *> io_zones;
+  std::mutex io_zones_mtx;
+  std::vector<Zone *> meta_zones;
+  int read_f_;
+  int write_f_;
+  time_t start_time_;
+  std::shared_ptr<Logger> logger_;
+  uint32_t finish_threshold_ = 0;
+
+ public:
+  explicit ZonedBlockDevice(std::string filename,
+                            std::shared_ptr<Logger> logger);
+  virtual ~ZonedBlockDevice();
+
+  IOStatus Open();
+
+  Zone *GetIOZone(uint64_t offset);
+
+  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime);
+  Zone *AllocateMetaZone();
+
+  uint64_t GetFreeSpace();
+  std::string GetFilename();
+  uint32_t GetBlockSize();
+
+  Status ResetZone(Zone *z);
+
+  void ResetUnusedIOZones();
+  void LogZoneStats();
+  void LogZoneUsage();
+
+  int GetReadFD() { return read_f_; }
+  int GetWriteFD() { return write_f_; }
+
+  uint32_t GetZoneSize() { return zone_sz_; }
+  uint32_t GetNrZones() { return nr_zones_; }
+  std::vector<Zone *> GetMetaZones() { return meta_zones; }
+
+  void SetFinishTreshold(uint32_t threshold) { finish_threshold_ = threshold; }
+};
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX) && defined(LIBZBD)

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1629,5 +1629,7 @@ Status NewEnvLogger(const std::string& fname, Env* env,
                     std::shared_ptr<Logger>* result);
 
 std::unique_ptr<Env> NewCompositeEnv(std::shared_ptr<FileSystem> fs);
+std::unique_ptr<Env> NewCompositeEnv(std::shared_ptr<FileSystem> fs,
+                                     std::shared_ptr<Env>* shared_env);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/src.mk
+++ b/src.mk
@@ -284,6 +284,9 @@ MOCK_LIB_SOURCES =                                              \
 BENCH_LIB_SOURCES =                                             \
   tools/db_bench_tool.cc                                        \
 
+ZENFS_LIB_SOURCES =                                             \
+  tools/zenfs_tool.cc                                           \
+
 STRESS_LIB_SOURCES =                                            \
   db_stress_tool/batched_ops_stress.cc                         \
   db_stress_tool/cf_consistency_stress.cc                      \

--- a/src.mk
+++ b/src.mk
@@ -76,6 +76,9 @@ LIB_SOURCES =                                                   \
   env/file_system.cc                                            \
   env/fs_posix.cc                                           	  \
   env/io_posix.cc                                               \
+  env/fs_zenfs.cc                                               \
+  env/io_zenfs.cc                                               \
+  env/zbd_zenfs.cc                                              \
   env/mock_env.cc                                               \
   file/delete_scheduler.cc                                      \
   file/file_prefetch_buffer.cc                                  \

--- a/tools/zenfs.cc
+++ b/tools/zenfs.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <cstdio>
+#ifdef ROCKSDB_LITE
+int main() {
+  fprintf("Not supported in lite mode.\n");
+  return 1;
+}
+#else
+#ifdef GFLAGS
+#ifdef LIBZBD
+int zenfs_tool(int argc, char** argv);
+int main(int argc, char** argv) { return zenfs_tool(argc, argv); }
+#else
+int main() {
+  fprintf(stderr, "Please install libzbd to run the zenfs tool\n");
+  return 1;
+}
+#endif  // LIBZBD
+#else
+int main() {
+  fprintf(stderr, "Please install gflags to run rocksdb tools\n");
+  return 1;
+}
+#endif  // GFLAGS
+#endif  // ROCKSDB_LITE

--- a/tools/zenfs_tool.cc
+++ b/tools/zenfs_tool.cc
@@ -1,0 +1,153 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#if defined(GFLAGS) && !defined(ROCKSDB_LITE) && defined(LIBZBD)
+
+#include <cstdio>
+#include "env/fs_zenfs.h"
+#include "util/gflags_compat.h"
+
+using GFLAGS_NAMESPACE::ParseCommandLineFlags;
+using GFLAGS_NAMESPACE::RegisterFlagValidator;
+using GFLAGS_NAMESPACE::SetUsageMessage;
+
+DEFINE_string(zbd, "", "Path to a zoned block device.");
+DEFINE_string(aux_path, "",
+              "Path for auxiliary file storage (log and lock files).");
+DEFINE_bool(force, false, "Force file system creation.");
+DEFINE_string(path, "", "Path to directory to list files under");
+DEFINE_int32(finish_threshold, 0, "Finish used zones if less than x% left");
+
+namespace ROCKSDB_NAMESPACE {
+
+ZonedBlockDevice *zbd_open() {
+  ZonedBlockDevice *zbd = new ZonedBlockDevice(FLAGS_zbd, nullptr);
+  IOStatus open_status = zbd->Open();
+
+  if (!open_status.ok()) {
+    fprintf(stderr, "Failed to open zoned block device: %s, error: %s\n",
+            FLAGS_zbd.c_str(), open_status.ToString().c_str());
+    delete zbd;
+    return nullptr;
+  }
+
+  return zbd;
+}
+
+Status zenfs_mount(ZonedBlockDevice *zbd, ZenFS **zenFS) {
+  Status s;
+
+  *zenFS = new ZenFS(zbd, FileSystem::Default(), nullptr);
+  s = (*zenFS)->Mount();
+  if (!s.ok()) {
+    delete *zenFS;
+    *zenFS = nullptr;
+  }
+
+  return s;
+}
+
+int zenfs_tool_mkfs() {
+  Status s;
+
+  if (FLAGS_aux_path.empty()) {
+    fprintf(stderr, "You need to specify --aux_path\n");
+    return 1;
+  }
+
+  ZonedBlockDevice *zbd = zbd_open();
+  if (zbd == nullptr) return 1;
+
+  ZenFS *zenFS;
+  s = zenfs_mount(zbd, &zenFS);
+  if ((s.ok() || !s.IsNotFound()) && !FLAGS_force) {
+    fprintf(
+        stderr,
+        "Existing filesystem found, use --force if you want to replace it.\n");
+    return 1;
+  }
+
+  if (zenFS != nullptr) delete zenFS;
+
+  zbd = zbd_open();
+  zenFS = new ZenFS(zbd, FileSystem::Default(), nullptr);
+
+  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to create file system, error: %s\n",
+            s.ToString().c_str());
+    delete zenFS;
+    return 1;
+  }
+
+  fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",
+          zbd->GetFreeSpace() / (1024 * 1024));
+
+  delete zenFS;
+  return 0;
+}
+
+void list_children(ZenFS *zenFS, std::string path) {
+  IOOptions opts;
+  IODebugContext dbg;
+  std::vector<std::string> result;
+  IOStatus io_status = zenFS->GetChildren(path, opts, &result, &dbg);
+
+  if (!io_status.ok()) return;
+
+  for (const auto f : result) {
+    fprintf(stdout, "%s/%s\n", path.c_str(), f.c_str());
+  }
+}
+
+int zenfs_tool_list() {
+  Status s;
+
+  ZonedBlockDevice *zbd = zbd_open();
+  if (zbd == nullptr) return 1;
+
+  ZenFS *zenFS;
+  s = zenfs_mount(zbd, &zenFS);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to mount filesystem, error: %s\n",
+            s.ToString().c_str());
+    return 1;
+  }
+
+  list_children(zenFS, FLAGS_path);
+
+  return 0;
+}
+}  // namespace ROCKSDB_NAMESPACE
+
+int zenfs_tool(int argc, char **argv) {
+  SetUsageMessage(std::string("\nUSAGE:\n") + std::string(argv[0]) +
+                  +" <command> [OPTIONS]...\nCommands: mkfs, list");
+  if (argc < 2) {
+    fprintf(stderr, "You need to specify a command.\n");
+    return 1;
+  }
+
+  std::string subcmd(argv[1]);
+  ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_zbd.empty()) {
+    fprintf(stderr, "You need to specify a zoned block device using --zbd\n");
+    return 1;
+  }
+  if (subcmd == "mkfs") {
+    return ROCKSDB_NAMESPACE::zenfs_tool_mkfs();
+  } else if (subcmd == "list") {
+    return ROCKSDB_NAMESPACE::zenfs_tool_list();
+  } else {
+    fprintf(stderr, "Subcommand not recognized: %s\n", subcmd.c_str());
+    return 1;
+  }
+
+  return 0;
+}
+
+#endif  // defined(GFLAGS) && !defined(ROCKSDB_LITE) && defined(LIBZBD)


### PR DESCRIPTION
This is a request for comments for a new file system for zoned block devices.

The pull request based on top of another open pull request : #6878 that enables db_bench and db_stress to be used with custom file systems.

With this pull request I am mainly asking for comments on the high-level architecture and feedback on the following:

**What applicable testing is available?**
I have mainly run smoke testing using db_bench and db_stress up till now and looking for ways to do i.e. recovery/crash/power fail testing.

**Would a completely self-contained file system be preferable?**
Currently ZenFS stores logs and lock files on the default file system. The reason for this if to avoid duplicating already working code and for easy access to the log files.

**What kind of workloads are most interesting to optimize for?**

Looking forward to feedback as I finish up my laundry list of todos and optimizations.

Thanks!

## Overview

ZenFS is a simple file system that utilizes RockDBs FileSystem interface to place files into zones on a raw zoned block device. By separating files into zones and utilizing the write life time hints to co-locate data of similar life times, the system write amplification is greatly reduced(compared to conventional block devices) while keeping the ZenFS capacity overhead at a very reasonable level.

ZenFS is designed to work with host-managed zoned spinning disks as well as NVME SSDs with Zoned Namespaces.

Some of the ideas and concepts in ZenFS are based on earlier work done by Abutalib Aghayev and Marc Acosta.

### Dependencies

ZenFS depends on[ libzbd ](https://github.com/westerndigitalcorporation/libzbd) and Linux kernel 5.4 or later to perform zone management operations.

## Architecture overview
![zenfs stack](https://user-images.githubusercontent.com/447288/84152469-fa3d6300-aa64-11ea-87c4-8a6653bb9d22.png)

ZenFS implements the FileSystem API, and stores all data files on to a raw zoned block device. Log and lock files are stored on the default file system under a configurable directory. Zone management is done through libzbd and zenfs io is done through normal pread/pwrite calls.

Optimizing the IO path is on the TODO list.

## Example usage

This example issues 100 million random inserts followed by as many overwrites on a 100G memory backed zoned null block device. Target file sizes are set up to align with zone size.

```
make db_bench zenfs

DEV=nullb1
ZONE_SZ_SECS=$(cat /sys/class/block/$DEV/queue/chunk_sectors)
FUZZ=5
ZONE_CAP=$((ZONE_SZ_SECS * 512))
BASE_FZ=$(($ZONE_CAP  * (100 - $FUZZ) / 100))
WB_SIZE=$(($BASE_FZ * 2))

TARGET_FZ_BASE=$WB_SIZE
TARGET_FILE_SIZE_MULTIPLIER=2
MAX_BYTES_FOR_LEVEL_BASE=$((2 * $TARGET_FZ_BASE))

./zenfs mkfs --zbd=/dev/$DEV --aux_path=/tmp/zenfs_$DEV --finish_threshold=$FUZZ --force

./db_bench --fs_uri=zenfs://$DEV --key_size=16 --value_size=800 --target_file_size_base=$TARGET_FZ_BASE --write_buffer_size=$WB_SIZE --max_bytes_for_level_base=$MAX_BYTES_FOR_LEVEL_BASE --max_bytes_for_level_multiplier=4 --use_direct_io_for_flush_and_compaction --max_background_jobs=$(nproc) --num=100000000 --benchmarks=fillrandom,overwrite
```

This graph below shows the capacity usage over time.
As ZenFS does not do any garbage collection the write amplification is 1.

![zenfs_capacity](https://user-images.githubusercontent.com/447288/84157574-2c51c380-aa6b-11ea-89e2-def4a4d658af.png)


## File system implementation

Files are mapped into into a set of extents:

* Extents are block-aligned, continious regions on the block device
* Extents do not span across zones
* A zone may contain more than one extent
* Extents from different files may share zones

### Reclaim 
ZenFS is exceptionally lazy at current state of implementation and does not do any garbage collection whatsoever. As files gets deleted, the used capacity zone counters drops and when
it reaches zero, a zone can be reset and reused.

###  Metadata 
Metadata is stored in a rolling log in the first zones of the block device.

Each valid meta data zone contains:

* A superblock with the current sequence number and global file system metadata
* At least one snapshot of all files in the file system
    
**The metadata format is currently experimental.** More extensive testing is needed and support for differential updates is planned to be implemented before bumping up the version to 1.0.
