### PR TITLE
Circle CI's clang build to really use clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,9 @@ jobs:
     resource_class: 2xlarge
     steps:
       - checkout # check out the code in the project directory
-      - run: USE_CLANG=1 make all -j32
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y clang
+      - run: CC=clang CXX=clang++ V=1 USE_CLANG=1 make all -j32
 
   build-linux-cmake:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout # check out the code in the project directory
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y clang
-      - run: CC=clang CXX=clang++ V=1 USE_CLANG=1 make all -j32
+      - run: CC=clang CXX=clang++ V=1 USE_CLANG=1 PORTABLE=1 make all -j32
 
   build-linux-cmake:
     machine:


### PR DESCRIPTION
Summary: The CircleCI's Clang flavor has a bug that doesn't really use CLANG. Fix it.

Test Plan: See CI results.

