### PR TITLE
Add skip_memtable_flush in IngestExternalFileOptions

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4253,6 +4253,10 @@ Status DBImpl::IngestExternalFiles(
             "cannot ingest an external file into a dropped CF");
         break;
       }
+      if (args[i].options.skip_memtable_flush) {
+          need_flush[i] = false;
+          continue;
+      }
       bool tmp = false;
       status = ingestion_jobs[i].NeedsFlush(&tmp, cfd->GetSuperVersion());
       need_flush[i] = tmp;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1571,6 +1571,11 @@ struct IngestExternalFileOptions {
   // Using a large readahead size (> 2MB) can typically improve the performance
   // of forward iteration on spinning disks.
   size_t verify_checksums_readahead_size = 0;
+  // Set to true if you are sure although the key ranges may overlap, 
+  // the memtable and the file being ingested
+  // do not have the same keys, or not care about that.
+  // The memtable flushing may block for hundreds of milliseconds.
+  bool skip_memtable_flush = false;
 };
 
 enum TraceFilterType : uint64_t {


### PR DESCRIPTION
Summary:
Set to true if you are sure although the key ranges may overlap, the memtable and the file being ingested
do not have the same keys, or not care about that.
The memtable flushing may block for hundreds of milliseconds.

Test Plan: make check