### PR TITLE
Add skip_memtable_flush in IngestExternalFileOptions

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4255,6 +4255,10 @@ Status DBImpl::IngestExternalFiles(
             "cannot ingest an external file into a dropped CF");
         break;
       }
+      if (args[i].options.skip_memtable_flush) {
+        need_flush[i] = false;
+        continue;
+      }
       bool tmp = false;
       status = ingestion_jobs[i].NeedsFlush(&tmp, cfd->GetSuperVersion());
       need_flush[i] = tmp;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1584,6 +1584,11 @@ struct IngestExternalFileOptions {
   // ingestion. However, if no checksum information is provided with the
   // ingested files, DB will generate the checksum and store in the Manifest.
   bool verify_file_checksum = true;
+  // Set to true if you are sure although the key ranges may overlap,
+  // the memtable and the file being ingested do not have the same keys,
+  // or not care about that.
+  // The memtable flushing may block for hundreds of milliseconds.
+  bool skip_memtable_flush = false;
 };
 
 enum TraceFilterType : uint64_t {


### PR DESCRIPTION
Summary:
Set to true if you are sure although the key ranges may overlap, the memtable and the file being ingested
do not have the same keys, or not care about that.
The memtable flushing may block for hundreds of milliseconds.

Test Plan: make check