### PR TITLE
Fix the bug that compressed cache is disabled in read-only DBs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ### Behavior Changes
 * Best-efforts recovery ignores CURRENT file completely. If CURRENT file is missing during recovery, best-efforts recovery still proceeds with MANIFEST file(s).
 * In best-efforts recovery, an error that is not Corruption or IOError::kNotFound or IOError::kPathNotFound will be overwritten silently. Fix this by checking all non-ok cases and return early.
+### Bug fixes
+* Compressed block cache was automatically disabled with read-only DBs by mistake. Now it is fixed: compressed block cache will be in effective with read-only DB too.
 
 ## 6.11 (6/12/2020)
 ### Bug Fixes

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -92,8 +92,7 @@ class TestReadOnlyWithCompressedCache
       public testing::WithParamInterface<std::tuple<int, bool>> {
  public:
   TestReadOnlyWithCompressedCache()
-      : DBTestBase("/test_readonly_with_compressed_cache") {}
-  void SetUp() override {
+      : DBTestBase("/test_readonly_with_compressed_cache") {
     max_open_files_ = std::get<0>(GetParam());
     use_mmap_ = std::get<1>(GetParam());
   }
@@ -109,43 +108,42 @@ TEST_P(TestReadOnlyWithCompressedCache, ReadOnlyWithCompressedCache) {
   ASSERT_OK(Put("foo2", "barbarbarbarbarbarbarbar"));
   ASSERT_OK(Flush());
 
-      DB* db_ptr = nullptr;
-      Options options = CurrentOptions();
-      options.allow_mmap_reads = use_mmap_;
-      options.max_open_files = max_open_files_;
-      options.compression = kSnappyCompression;
-      BlockBasedTableOptions table_options;
-      table_options.block_cache_compressed = NewLRUCache(8 * 1024 * 1024);
-      table_options.no_block_cache = true;
-      options.table_factory.reset(NewBlockBasedTableFactory(table_options));
-      options.statistics = CreateDBStatistics();
+  DB* db_ptr = nullptr;
+  Options options = CurrentOptions();
+  options.allow_mmap_reads = use_mmap_;
+  options.max_open_files = max_open_files_;
+  options.compression = kSnappyCompression;
+  BlockBasedTableOptions table_options;
+  table_options.block_cache_compressed = NewLRUCache(8 * 1024 * 1024);
+  table_options.no_block_cache = true;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  options.statistics = CreateDBStatistics();
 
-      ASSERT_OK(DB::OpenForReadOnly(options, dbname_, &db_ptr));
+  ASSERT_OK(DB::OpenForReadOnly(options, dbname_, &db_ptr));
 
-      std::string v;
-      ASSERT_OK(db_ptr->Get(ReadOptions(), "foo", &v));
-      ASSERT_EQ("bar", v);
+  std::string v;
+  ASSERT_OK(db_ptr->Get(ReadOptions(), "foo", &v));
+  ASSERT_EQ("bar", v);
+  ASSERT_EQ(0, options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
+  ASSERT_OK(db_ptr->Get(ReadOptions(), "foo", &v));
+  ASSERT_EQ("bar", v);
+  if (Snappy_Supported()) {
+    if (use_mmap_) {
       ASSERT_EQ(0,
                 options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
-      ASSERT_OK(db_ptr->Get(ReadOptions(), "foo", &v));
-      ASSERT_EQ("bar", v);
-      if (Snappy_Supported()) {
-        if (use_mmap_) {
-          ASSERT_EQ(0, options.statistics->getTickerCount(
-                           BLOCK_CACHE_COMPRESSED_HIT));
-        } else {
-          ASSERT_EQ(1, options.statistics->getTickerCount(
-                           BLOCK_CACHE_COMPRESSED_HIT));
-        }
-      }
+    } else {
+      ASSERT_EQ(1,
+                options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
+    }
+  }
 
-      delete db_ptr;
+  delete db_ptr;
 }
 
-INSTANTIATE_TEST_CASE_P(
-    TestReadOnlyWithCompressedCache, TestReadOnlyWithCompressedCache,
-    ::testing::Values(std::make_tuple(-1, false), std::make_tuple(100, false),
-                      std::make_tuple(-1, true), std::make_tuple(100, false)));
+INSTANTIATE_TEST_CASE_P(TestReadOnlyWithCompressedCache,
+                        TestReadOnlyWithCompressedCache,
+                        ::testing::Combine(::testing::Values(-1, 100),
+                                           ::testing::Bool()));
 #endif  // ROCKSDB_LITE
 
 class PrefixFullBloomWithReverseComparator

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -101,6 +101,7 @@ TEST_F(DBTest2, ReadOnlyWithCompresedCache) {
       Options options = CurrentOptions();
       options.allow_mmap_reads = use_mmap;
       options.max_open_files = max_open_files;
+      options.compression = kSnappyCompression;
       BlockBasedTableOptions table_options;
       table_options.block_cache_compressed = NewLRUCache(8 * 1024 * 1024);
       table_options.no_block_cache = true;
@@ -116,12 +117,14 @@ TEST_F(DBTest2, ReadOnlyWithCompresedCache) {
                 options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
       ASSERT_OK(db_ptr->Get(ReadOptions(), "foo", &v));
       ASSERT_EQ("bar", v);
-      if (use_mmap) {
-        ASSERT_EQ(
-            0, options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
-      } else {
-        ASSERT_EQ(
-            1, options.statistics->getTickerCount(BLOCK_CACHE_COMPRESSED_HIT));
+      if (Snappy_Supported()) {
+        if (use_mmap) {
+          ASSERT_EQ(0, options.statistics->getTickerCount(
+                           BLOCK_CACHE_COMPRESSED_HIT));
+        } else {
+          ASSERT_EQ(1, options.statistics->getTickerCount(
+                           BLOCK_CACHE_COMPRESSED_HIT));
+        }
       }
 
       delete db_ptr;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1403,10 +1403,8 @@ Status BlockBasedTable::MaybeReadBlockAndLoadToCache(
   assert(block_entry != nullptr);
   const bool no_io = (ro.read_tier == kBlockCacheTier);
   Cache* block_cache = rep_->table_options.block_cache.get();
-  // No point to cache compressed blocks if it never goes away
   Cache* block_cache_compressed =
-      rep_->immortal_table ? nullptr
-                           : rep_->table_options.block_cache_compressed.get();
+      rep_->table_options.block_cache_compressed.get();
 
   // First, try to get the block from the cache
   //


### PR DESCRIPTION
Summary:
Compressed block cache is disabled in https://github.com/facebook/rocksdb/pull/4650 for no good reason. Re-enable it.

Test Plan: Add a unit test to make sure a general function works with read-only DB + compressed block cache.