### PR TITLE
Remove CircleCI clang build's verbose output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout # check out the code in the project directory
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y clang
-      - run: CC=clang CXX=clang++ V=1 USE_CLANG=1 PORTABLE=1 make all -j32
+      - run: CC=clang CXX=clang++ USE_CLANG=1 PORTABLE=1 make all -j32
 
   build-linux-cmake:
     machine:


### PR DESCRIPTION
Summary:
As CirclrCI build's clang build is stable, verbose flag is less useful. On the other hand, the long outputs might create other problems. A non-reproducible failure "make: write error: stdout" might be related to it.

Test Plan: Watch the run