### PR TITLE
Clean up blob files based on the linked SST set

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -729,14 +729,16 @@ class VersionBuilder::Rep {
     assert(meta);
     assert(found_first_non_empty);
 
-    if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount() &&
-        meta->GetLinkedSsts().empty()) {
-      return;
+    if (!(*found_first_non_empty)) {
+      if (!meta->GetLinkedSsts().empty()) {
+        (*found_first_non_empty) = true;
+      } else {
+        return;
+      }
     }
 
-    (*found_first_non_empty) |= !meta->GetLinkedSsts().empty();
-
-    if (!(*found_first_non_empty)) {
+    if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount() &&
+        meta->GetLinkedSsts().empty()) {
       return;
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -729,16 +729,11 @@ class VersionBuilder::Rep {
     assert(meta);
     assert(found_first_non_empty);
 
-    if (meta->GetLinkedSsts().empty()) {
-      if (!(*found_first_non_empty)) {
-        return;
-      }
-
-      if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount()) {
-        return;
-      }
-    } else {
+    if (!meta->GetLinkedSsts().empty()) {
       (*found_first_non_empty) = true;
+    } else if (!(*found_first_non_empty) ||
+               meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount()) {
+      return;
     }
 
     vstorage->AddBlobFile(meta);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -729,17 +729,16 @@ class VersionBuilder::Rep {
     assert(meta);
     assert(found_first_non_empty);
 
-    if (!(*found_first_non_empty)) {
-      if (!meta->GetLinkedSsts().empty()) {
-        (*found_first_non_empty) = true;
-      } else {
+    if (meta->GetLinkedSsts().empty()) {
+      if (!(*found_first_non_empty)) {
         return;
       }
-    }
 
-    if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount() &&
-        meta->GetLinkedSsts().empty()) {
-      return;
+      if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount()) {
+        return;
+      }
+    } else {
+      (*found_first_non_empty) = true;
     }
 
     vstorage->AddBlobFile(meta);

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -722,16 +722,25 @@ class VersionBuilder::Rep {
     return meta;
   }
 
-  void AddBlobFileIfNeeded(
-      VersionStorageInfo* vstorage,
-      const std::shared_ptr<BlobFileMetaData>& meta) const {
+  void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
+                           const std::shared_ptr<BlobFileMetaData>& meta,
+                           bool* found_first_non_empty) const {
     assert(vstorage);
     assert(meta);
+    assert(found_first_non_empty);
 
-    if (meta->GetGarbageBlobCount() < meta->GetTotalBlobCount() ||
-        !meta->GetLinkedSsts().empty()) {
-      vstorage->AddBlobFile(meta);
+    if (meta->GetGarbageBlobCount() >= meta->GetTotalBlobCount() &&
+        meta->GetLinkedSsts().empty()) {
+      return;
     }
+
+    (*found_first_non_empty) |= !meta->GetLinkedSsts().empty();
+
+    if (!(*found_first_non_empty)) {
+      return;
+    }
+
+    vstorage->AddBlobFile(meta);
   }
 
   // Merge the blob file metadata from the base version with the changes (edits)
@@ -739,6 +748,8 @@ class VersionBuilder::Rep {
   void SaveBlobFilesTo(VersionStorageInfo* vstorage) const {
     assert(base_vstorage_);
     assert(vstorage);
+
+    bool found_first_non_empty = false;
 
     const auto& base_blob_files = base_vstorage_->GetBlobFiles();
     auto base_it = base_blob_files.begin();
@@ -757,7 +768,7 @@ class VersionBuilder::Rep {
         assert(base_meta->GetGarbageBlobCount() <
                base_meta->GetTotalBlobCount());
 
-        vstorage->AddBlobFile(base_meta);
+        AddBlobFileIfNeeded(vstorage, base_meta, &found_first_non_empty);
 
         ++base_it;
       } else if (delta_blob_file_number < base_blob_file_number) {
@@ -775,7 +786,7 @@ class VersionBuilder::Rep {
 
         auto meta = GetOrCreateMetaDataForExistingBlobFile(base_meta, delta);
 
-        AddBlobFileIfNeeded(vstorage, meta);
+        AddBlobFileIfNeeded(vstorage, meta, &found_first_non_empty);
 
         ++base_it;
         ++delta_it;
@@ -787,7 +798,7 @@ class VersionBuilder::Rep {
       assert(base_meta);
       assert(base_meta->GetGarbageBlobCount() < base_meta->GetTotalBlobCount());
 
-      vstorage->AddBlobFile(base_meta);
+      AddBlobFileIfNeeded(vstorage, base_meta, &found_first_non_empty);
       ++base_it;
     }
 
@@ -796,7 +807,7 @@ class VersionBuilder::Rep {
 
       auto meta = CreateMetaDataForNewBlobFile(delta);
 
-      AddBlobFileIfNeeded(vstorage, meta);
+      AddBlobFileIfNeeded(vstorage, meta, &found_first_non_empty);
 
       ++delta_it;
     }

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -765,9 +765,6 @@ class VersionBuilder::Rep {
 
       if (base_blob_file_number < delta_blob_file_number) {
         const auto& base_meta = base_it->second;
-        assert(base_meta);
-        assert(base_meta->GetGarbageBlobCount() <
-               base_meta->GetTotalBlobCount());
 
         AddBlobFileIfNeeded(vstorage, base_meta, &found_first_non_empty);
 
@@ -796,10 +793,9 @@ class VersionBuilder::Rep {
 
     while (base_it != base_it_end) {
       const auto& base_meta = base_it->second;
-      assert(base_meta);
-      assert(base_meta->GetGarbageBlobCount() < base_meta->GetTotalBlobCount());
 
       AddBlobFileIfNeeded(vstorage, base_meta, &found_first_non_empty);
+
       ++base_it;
     }
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -722,6 +722,11 @@ class VersionBuilder::Rep {
     return meta;
   }
 
+  // Add the blob file specified by meta to *vstorage if it is determined to
+  // contain valid data (blobs). We make this decision based on the amount
+  // of garbage in the file, and whether the file or any lower-numbered blob
+  // files have any linked SSTs. The latter condition is tracked using the
+  // flag *found_first_non_empty.
   void AddBlobFileIfNeeded(VersionStorageInfo* vstorage,
                            const std::shared_ptr<BlobFileMetaData>& meta,
                            bool* found_first_non_empty) const {

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -693,6 +693,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileAddition) {
             BlobFileMetaData::LinkedSsts{table_file_number});
   ASSERT_EQ(new_meta->GetGarbageBlobCount(), 0);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(), 0);
+
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, ApplyBlobFileAdditionAlreadyInBase) {
@@ -820,6 +822,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileInBase) {
             garbage_blob_count + new_garbage_blob_count);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(),
             garbage_blob_bytes + new_garbage_blob_bytes);
+
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
@@ -881,6 +885,8 @@ TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileAdditionApplied) {
             BlobFileMetaData::LinkedSsts{table_file_number});
   ASSERT_EQ(new_meta->GetGarbageBlobCount(), garbage_blob_count);
   ASSERT_EQ(new_meta->GetGarbageBlobBytes(), garbage_blob_bytes);
+
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, ApplyBlobFileGarbageFileNotFound) {
@@ -1017,6 +1023,9 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   const auto newer_meta1 = GetBlobFileMetaData(newer_blob_files, 1);
 
   ASSERT_EQ(newer_meta1, nullptr);
+
+  UnrefFilesInVersion(&newer_vstorage);
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 TEST_F(VersionBuilderTest, CheckConsistencyForBlobFiles) {

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -940,13 +940,15 @@ TEST_F(VersionBuilderTest, SaveBlobFilesTo) {
   // Add some garbage to the second and third blob files. The second blob file
   // remains valid since it does not consist entirely of garbage yet. The third
   // blob file is all garbage after the edit and will not be part of the new
-  // version.
+  // version. The corresponding dummy table file is also removed for
+  // consistency.
   edit.AddBlobFileGarbage(/* blob_file_number */ 2,
                           /* garbage_blob_count */ 200,
                           /* garbage_blob_bytes */ 100000);
   edit.AddBlobFileGarbage(/* blob_file_number */ 3,
                           /* garbage_blob_count */ 2700,
                           /* garbage_blob_bytes */ 2940000);
+  edit.DeleteFile(/* level */ 0, /* file_number */ 3);
 
   // Add a fourth blob file.
   edit.AddBlobFile(/* blob_file_number */ 4, /* total_blob_count */ 4000,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1161,6 +1161,14 @@ class VersionSet {
   // Get the IO Status returned by written Manifest.
   const IOStatus& io_status() const { return io_status_; }
 
+  void TEST_CreateAndAppendVersion(ColumnFamilyData* cfd) {
+    assert(cfd);
+
+    Version* const version = new Version(cfd, this, file_options_,
+                                         *cfd->GetLatestMutableCFOptions());
+    AppendVersion(cfd, version);
+  }
+
  protected:
   using VersionBuilderMap =
       std::unordered_map<uint32_t,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1164,8 +1164,12 @@ class VersionSet {
   void TEST_CreateAndAppendVersion(ColumnFamilyData* cfd) {
     assert(cfd);
 
-    Version* const version = new Version(cfd, this, file_options_,
-                                         *cfd->GetLatestMutableCFOptions());
+    const auto& mutable_cf_options = *cfd->GetLatestMutableCFOptions();
+    Version* const version =
+        new Version(cfd, this, file_options_, mutable_cf_options);
+
+    constexpr bool update_stats = false;
+    version->PrepareApply(mutable_cf_options, update_stats);
     AppendVersion(cfd, version);
   }
 

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1030,7 +1030,7 @@ TEST_F(VersionSetTest, AddLiveBlobFiles) {
       std::move(first_shared_meta), BlobFileMetaData::LinkedSsts(),
       garbage_blob_count, garbage_blob_bytes);
 
-  first_storage_info->AddBlobFile(std::move(first_meta));
+  first_storage_info->AddBlobFile(first_meta);
 
   // Reference the version so it stays alive even after the following version
   // edit.
@@ -1045,7 +1045,7 @@ TEST_F(VersionSetTest, AddLiveBlobFiles) {
   ASSERT_EQ(version_blob_files.size(), 1);
   ASSERT_EQ(version_blob_files[0], first_blob_file_number);
 
-  // Create a new version containing a different blob file.
+  // Create a new version containing an additional blob file.
   versions_->TEST_CreateAndAppendVersion(cfd);
 
   Version* const second_version = cfd->current();
@@ -1070,6 +1070,7 @@ TEST_F(VersionSetTest, AddLiveBlobFiles) {
       std::move(second_shared_meta), BlobFileMetaData::LinkedSsts(),
       garbage_blob_count, garbage_blob_bytes);
 
+  second_storage_info->AddBlobFile(std::move(first_meta));
   second_storage_info->AddBlobFile(std::move(second_meta));
 
   // Get all live files from version set. Note that the result contains


### PR DESCRIPTION
Summary:
The earlier `VersionBuilder` code only cleaned up blob files that were
marked as entirely consisting of garbage using `VersionEdits` with
`BlobFileGarbage`. This covers the cases when table files go through
regular compaction, where we iterate through the KVs and thus have an
opportunity to calculate the amount of garbage (that is, most cases).
However, it does not help when table files are simply dropped (e.g. deletion
compactions or the `DeleteFile` API). To deal with such cases, the patch
adds logic that cleans up all blob files at the head of the list until the first
one with linked SSTs is found. (As an example, let's assume we have blob files
with numbers 1..10, and the first one with any linked SSTs is number 8.
This means that SSTs in the `Version` only rely on blob files with numbers >= 8,
and thus 1..7 are no longer needed.)

The code change itself is pretty small; however, changing the logic like this
necessitated changes to some tests that have been added recently (namely
to the ones that use blob files in isolation, i.e. without any table files referring
to them). Some of these cases were fixed by bypassing `VersionBuilder` altogether
in order to keep the tests simple (which actually makes them more proper unit tests
as well), while the `VersionBuilder` unit tests were fixed by adding dummy table
files to the test cases as needed.

Test Plan:
`make check`