### PR TITLE
minor fixes for stress/crash contruns

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -485,7 +485,6 @@ inline bool GetFirstIntValInPrefix(std::string big_endian_prefix,
   unsigned int pad = sizeof(uint64_t) - (size_key % sizeof(uint64_t));
   if (pad < sizeof(uint64_t)) {
     big_endian_prefix.append(pad, '\0');
-    size_key += pad;
   }
   return GetIntVal(std::move(big_endian_prefix), key_p);
 }

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -238,7 +238,8 @@ int db_stress_tool(int argc, char** argv) {
   }
   if (FLAGS_enable_compaction_filter &&
       (FLAGS_acquire_snapshot_one_in > 0 || FLAGS_compact_range_one_in > 0 ||
-       FLAGS_iterpercent > 0 || FLAGS_test_batches_snapshots > 0)) {
+       FLAGS_iterpercent > 0 || FLAGS_test_batches_snapshots ||
+       FLAGS_test_cf_consistency)) {
     fprintf(
         stderr,
         "Error: acquire_snapshot_one_in, compact_range_one_in, iterpercent, "

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -206,6 +206,9 @@ cf_consistency_params = {
     # more frequently
     "write_buffer_size": 1024 * 1024,
     "enable_pipelined_write": lambda: random.randint(0, 1),
+    # Snapshots are used heavily in this test mode, while they are incompatible
+    # with compaction filter.
+    "enable_compaction_filter": 0,
 }
 
 txn_params = {


### PR DESCRIPTION
Avoid using `cf_consistency` together with `enable_compaction_filter` as
the former heavily uses snapshots while the latter is incompatible with
snapshots.

Also fix a clang-analyze error for a write to a variable that is never
read.