### PR TITLE
Fix double define in IO_tracer

### DIFF
--- a/trace_replay/io_tracer.cc
+++ b/trace_replay/io_tracer.cc
@@ -18,6 +18,10 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+namespace {
+const unsigned int kCharSize = 1;
+}  // namespace
+
 IOTraceWriter::IOTraceWriter(Env* env, const TraceOptions& trace_options,
                              std::unique_ptr<TraceWriter>&& trace_writer)
     : env_(env),

--- a/trace_replay/io_tracer.h
+++ b/trace_replay/io_tracer.h
@@ -16,10 +16,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-namespace {
-const unsigned int kCharSize = 1;
-}  // namespace
-
 struct IOTraceRecord {
   // Required fields for all accesses.
   uint64_t access_timestamp = 0;


### PR DESCRIPTION
Fix the following error

"./trace_replay/io_tracer.h:20:20: error: redefinition of ‘const unsigned int rocksdb::{anonymous}::kCharSize’
 const unsigned int kCharSize = 1;
                    ^~~~~~~~~
In file included from unity.cc:177:
trace_replay/block_cache_tracer.cc:22:20: note: ‘const unsigned int rocksdb::{anonymous}::kCharSize’ previously defined here
 const unsigned int kCharSize = 1;"