### PR TITLE
filelock_test: add freebsd headers for waitpid

### DIFF
--- a/util/filelock_test.cc
+++ b/util/filelock_test.cc
@@ -7,6 +7,10 @@
 #include "rocksdb/env.h"
 
 #include <fcntl.h>
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
 #include <vector>
 #include "test_util/testharness.h"
 #include "util/coding.h"


### PR DESCRIPTION
Per manual https://www.unix.com/man-page/FreeBSD/2/waitpid