### PR TITLE
db_stress: uses the testutillib directly so needs to link

### DIFF
--- a/db_stress_tool/CMakeLists.txt
+++ b/db_stress_tool/CMakeLists.txt
@@ -10,5 +10,5 @@ add_executable(db_stress${ARTIFACT_SUFFIX}
   db_stress_gflags.cc
   db_stress_tool.cc
   no_batched_ops_stress.cc)
-target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})
+target_link_libraries(db_stress${ARTIFACT_SUFFIX} ${ROCKSDB_LIB} ${THIRDPARTY_LIBS} ${TESTUTILLIB})
 list(APPEND tool_deps db_stress)


### PR DESCRIPTION
The compile error below occurs on FreeBSD-12.1 without this patch:

cd /home/dan/build-rocksdb/db_stress_tool && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/db_stress.dir/link.txt --verbose=1
/usr/bin/c++   -W -Wextra -Wall -Wsign-compare -Wshadow -Wno-unused-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-strict-aliasing -march=native -Werror -g -DROCKSDB_USE_RTTI   CMakeFiles/db_stress.dir/db_stress.cc.o CMakeFiles/db_stress.dir/db_stress_tool.cc.o CMakeFiles/db_stress.dir/batched_ops_stress.cc.o CMakeFiles/db_stress.dir/cf_consistency_stress.cc.o CMakeFiles/db_stress.dir/db_stress_common.cc.o CMakeFiles/db_stress.dir/db_stress_driver.cc.o CMakeFiles/db_stress.dir/db_stress_test_base.cc.o CMakeFiles/db_stress.dir/db_stress_shared_state.cc.o CMakeFiles/db_stress.dir/db_stress_gflags.cc.o CMakeFiles/db_stress.dir/no_batched_ops_stress.cc.o  -o db_stress  -Wl,-rpath,/home/dan/build-rocksdb:/usr/local/lib ../librocksdb.so.6.11.0 /usr/local/lib/libgflags.so.2.2.2 -pthread
ld: error: undefined symbol: vtable for rocksdb::FaultInjectionTestFS
>>> referenced by fault_injection_test_fs.h:169 (/home/dan/rocksdb/test_util/fault_injection_test_fs.h:169)
>>>               CMakeFiles/db_stress.dir/db_stress_tool.cc.o:(rocksdb::FaultInjectionTestFS::FaultInjectionTestFS(std::__1::shared_ptr<rocksdb::FileSystem>))
the vtable symbol may be undefined because the class is missing its key function (see https://lld.llvm.org/missingkeyfunction)

ld: error: undefined symbol: rocksdb::FaultInjectionTestFS::PrintFaultBacktrace()
>>> referenced by no_batched_ops_stress.cc:205 (/home/dan/rocksdb/db_stress_tool/no_batched_ops_stress.cc:205)
>>>               CMakeFiles/db_stress.dir/no_batched_ops_stress.cc.o:(rocksdb::NonBatchedOpsStressTest::TestGet(rocksdb::ThreadState*, rocksdb::ReadOptions const&, std::__1::vector<int, std::__1::allocator<int> > const&, std::__1::vector<long, std::__1::allocator<long> > const&))

ld: error: undefined symbol: rocksdb::FaultInjectionTestFS::PrintFaultBacktrace()
>>> referenced by no_batched_ops_stress.cc:347 (/home/dan/rocksdb/db_stress_tool/no_batched_ops_stress.cc:347)
>>>               CMakeFiles/db_stress.dir/no_batched_ops_stress.cc.o:(rocksdb::NonBatchedOpsStressTest::TestMultiGet(rocksdb::ThreadState*, rocksdb::ReadOptions const&, std::__1::vector<int, std::__1::allocator<int> > const&, std::__1::vector<long, std::__1::allocator<long> > const&))
c++: error: linker command failed with exit code 1 (use -v to see invocation)