### PR TITLE
Fix the memory leak in Env_basic_test

### DIFF
--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -97,8 +97,11 @@ static ROT13BlockCipher encrypt_block_rot13(32);
 
 static CTREncryptionProvider encrypt_provider_ctr(encrypt_block_rot13);
 
-static std::unique_ptr<Env> encrypt_env(new NormalizingEnvWrapper(
-    NewEncryptedEnv(Env::Default(), &encrypt_provider_ctr)));
+static std::unique_ptr<Env> ecpt_env(NewEncryptedEnv(Env::Default(),
+                                                     &encrypt_provider_ctr));
+
+static std::unique_ptr<Env> encrypt_env(
+    new NormalizingEnvWrapper(ecpt_env.get()));
 INSTANTIATE_TEST_CASE_P(EncryptedEnv, EnvBasicTestWithParam,
                         ::testing::Values(encrypt_env.get()));
 INSTANTIATE_TEST_CASE_P(EncryptedEnv, EnvMoreTestWithParam,


### PR DESCRIPTION
Fix the memory leak broken asan and other test introduced by #6830 

test plan: pass asan_check