### PR TITLE
Move kNoExpiration to blob_db.h

### DIFF
--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -9,7 +9,6 @@
 
 #ifndef ROCKSDB_LITE
 
-#include <limits>
 #include <memory>
 #include <utility>
 
@@ -23,7 +22,6 @@ namespace blob_db {
 
 constexpr uint32_t kMagicNumber = 2395959;  // 0x00248f37
 constexpr uint32_t kVersion1 = 1;
-constexpr uint64_t kNoExpiration = std::numeric_limits<uint64_t>::max();
 
 using ExpirationRange = std::pair<uint64_t, uint64_t>;
 

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -8,6 +8,7 @@
 #ifndef ROCKSDB_LITE
 
 #include <functional>
+#include <limits>
 #include <string>
 #include <vector>
 #include "rocksdb/db.h"
@@ -23,6 +24,8 @@ namespace blob_db {
 //
 // The factory needs to be moved to include/rocksdb/utilities to allow
 // users to use blob DB.
+
+constexpr uint64_t kNoExpiration = std::numeric_limits<uint64_t>::max();
 
 struct BlobDBOptions {
   // Name of the directory under the base DB where blobs will be stored. Using

--- a/utilities/blob_db/blob_db.h
+++ b/utilities/blob_db/blob_db.h
@@ -11,6 +11,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+
 #include "rocksdb/db.h"
 #include "rocksdb/status.h"
 #include "rocksdb/utilities/stackable_db.h"


### PR DESCRIPTION
Summary:
The constant `kNoExpiration` is currently defined in an
internal/implementation header (`blob_log_format.h`); the patch moves it
to the public header `blob_db.h` so it is accessible to users.

Test Plan:
`make check`