### PR TITLE
Add unity build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run: pyenv global 3.5.2
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y libgflags-dev
+      - run: gcc -v
       - run: SKIP_FORMAT_BUCK_CHECKS=1 PRINT_PARALLEL_OUTPUTS=1 make J=32 all check -j32
 
   build-linux-release:
@@ -64,6 +65,15 @@ jobs:
     steps:
       - checkout # check out the code in the project directory
       - run: mkdir build && cd build && cmake -DWITH_GFLAGS=0 .. && make -j32
+
+  build-linux-unity:
+    docker: # executor type
+      - image: gcc:latest
+    resource_class: xlarge
+    steps:
+      - run: gcc -v
+      - checkout # check out the code in the project directory
+      - run: TEST_TMPDIR=/dev/shm && make unity_test -j
 
   build-windows:
     executor: windows-2xlarge
@@ -128,6 +138,9 @@ workflows:
   build-linux-cmake:
     jobs:
       - build-linux-cmake
+  build-linux-unity:
+    jobs:
+      - build-linux-unity
   build-windows:
     jobs:
       - build-windows

--- a/Makefile
+++ b/Makefile
@@ -1255,7 +1255,7 @@ unity.a: unity.o
 
 TOOLLIBOBJECTS = $(TOOL_LIB_SOURCES:.cc=.o)
 # try compiling db_test with unity
-unity_test: db/db_test.o db/db_test_util.o $(TESTHARNESS) $(TOOLLIBOBJECTS) unity.a
+unity_test: db/db_basic_test.o db/db_test_util.o $(TESTHARNESS) $(TOOLLIBOBJECTS) unity.a
 	$(AM_LINK)
 	./unity_test
 

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -641,8 +641,9 @@ static bool SaveValue(void* arg, const char* entry) {
   // Check that it belongs to same user key.  We do not check the
   // sequence number since the Seek() call above should have skipped
   // all entries with overly large sequence numbers.
-  uint32_t key_length;
+  uint32_t key_length = 0;
   const char* key_ptr = GetVarint32Ptr(entry, entry + 5, &key_length);
+  assert(key_length >= 8);
   Slice user_key_slice = Slice(key_ptr, key_length - 8);
   const Comparator* user_comparator =
       s->mem->GetInternalKeyComparator().user_comparator();

--- a/table/block_based/filter_policy.cc
+++ b/table/block_based/filter_policy.cc
@@ -183,7 +183,7 @@ class FastLocalBloomBitsBuilder : public BuiltinFilterBitsBuilder {
         // storage on disk.
         // Nothing to do, except assert that the result is accurate about
         // the usable size. (Assignment never used.)
-        assert(tmpbuf[usable - 1] = 'x');
+        assert((tmpbuf[usable - 1] = 'x'));
       } else if (usable > requested) {
         // Adjust for reasonably larger usable size
         size_t usable_len = (usable - kExtraPadding - /* metadata */ 5);

--- a/table/plain/plain_table_reader.cc
+++ b/table/plain/plain_table_reader.cc
@@ -448,7 +448,7 @@ Status PlainTableReader::GetOffset(PlainTableKeyDecoder* decoder,
   }
 
   // point to sub-index, need to do a binary search
-  uint32_t upper_bound;
+  uint32_t upper_bound = 0;
   const char* base_ptr =
       index_.GetSubIndexBasePtrAndUpperBound(prefix_index_offset, &upper_bound);
   uint32_t low = 0;


### PR DESCRIPTION
We are still keeping unity build working. So it's a good idea to add to a pre-commit CI.
A latest GCC docker image just to get a little bit more coverage. Fix three small issues to make it pass.
Also make unity_test to run db_basic_test rather than db_test to cut the test time. There is no point to run expensive tests here. It was set to run db_test before db_basic_test was separated out.

Test Plan: watch tests to pass.