### PR TITLE
Move away from direct TmpDir() call in some tests

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -3566,7 +3566,7 @@ TEST_F(DBTest2, TraceAndReplay) {
 
   // Open another db, replay, and verify the data
   std::string value;
-  std::string dbname2 = test::TmpDir(env_) + "/db_replay";
+  std::string dbname2 = test::PerThreadDBPath(env_, "/db_replay");
   ASSERT_OK(DestroyDB(dbname2, options));
 
   // Using a different name than db2, to pacify infer's use-after-lifetime
@@ -3640,7 +3640,7 @@ TEST_F(DBTest2, TraceWithLimit) {
   ASSERT_OK(Put(0, "c", "1"));
   ASSERT_OK(db_->EndTrace());
 
-  std::string dbname2 = test::TmpDir(env_) + "/db_replay2";
+  std::string dbname2 = test::PerThreadDBPath(env_, "/db_replay2");
   std::string value;
   ASSERT_OK(DestroyDB(dbname2, options));
 
@@ -3709,7 +3709,7 @@ TEST_F(DBTest2, TraceWithSampling) {
   ASSERT_OK(Put(0, "e", "5"));
   ASSERT_OK(db_->EndTrace());
 
-  std::string dbname2 = test::TmpDir(env_) + "/db_replay_sampling";
+  std::string dbname2 = test::PerThreadDBPath(env_, "/db_replay_sampling");
   std::string value;
   ASSERT_OK(DestroyDB(dbname2, options));
 

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1602,9 +1602,10 @@ TEST_P(EnvPosixTestWithParam, ConsistentChildrenAttributes) {
   const int kNumChildren = 10;
 
   std::string data;
+  std::string test_base_dir = test::PerThreadDBPath(env_, "env_test_chr_attr");
+  env_->CreateDir(test_base_dir);
   for (int i = 0; i < kNumChildren; ++i) {
-    const std::string path =
-        test::TmpDir(env_) + "/" + "testfile_" + std::to_string(i);
+    const std::string path = test_base_dir + "/testfile_" + std::to_string(i);
     std::unique_ptr<WritableFile> file;
 #if !defined(OS_MACOSX) && !defined(OS_WIN) && !defined(OS_SOLARIS) && !defined(OS_AIX) && !defined(OS_OPENBSD) && !defined(OS_FREEBSD)
       if (soptions.use_direct_writes) {
@@ -1623,10 +1624,10 @@ TEST_P(EnvPosixTestWithParam, ConsistentChildrenAttributes) {
   }
 
     std::vector<Env::FileAttributes> file_attrs;
-    ASSERT_OK(env_->GetChildrenFileAttributes(test::TmpDir(env_), &file_attrs));
+    ASSERT_OK(env_->GetChildrenFileAttributes(test_base_dir, &file_attrs));
     for (int i = 0; i < kNumChildren; ++i) {
       const std::string name = "testfile_" + std::to_string(i);
-      const std::string path = test::TmpDir(env_) + "/" + name;
+      const std::string path = test_base_dir + "/" + name;
 
       auto file_attrs_iter = std::find_if(
           file_attrs.begin(), file_attrs.end(),

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -94,7 +94,7 @@ TEST_F(LdbCmdTest, MemEnv) {
   opts.create_if_missing = true;
 
   DB* db = nullptr;
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
   ASSERT_OK(DB::Open(opts, dbname, &db));
 
   WriteOptions wopts;
@@ -274,7 +274,7 @@ TEST_F(LdbCmdTest, DumpFileChecksumNoChecksum) {
   opts.create_if_missing = true;
 
   DB* db = nullptr;
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
   ASSERT_OK(DB::Open(opts, dbname, &db));
 
   WriteOptions wopts;
@@ -359,7 +359,7 @@ TEST_F(LdbCmdTest, DumpFileChecksumCRC32) {
   opts.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();
 
   DB* db = nullptr;
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
   ASSERT_OK(DB::Open(opts, dbname, &db));
 
   WriteOptions wopts;
@@ -482,7 +482,7 @@ TEST_F(LdbCmdTest, ListFileTombstone) {
   opts.create_if_missing = true;
 
   DB* db = nullptr;
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
   ASSERT_OK(DB::Open(opts, dbname, &db));
 
   WriteOptions wopts;
@@ -571,7 +571,7 @@ TEST_F(LdbCmdTest, DisableConsistencyChecks) {
   opts.env = env.get();
   opts.create_if_missing = true;
 
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
 
   {
     DB* db = nullptr;
@@ -663,7 +663,7 @@ TEST_F(LdbCmdTest, TestBadDbPath) {
   opts.env = env.get();
   opts.create_if_missing = true;
 
-  std::string dbname = test::TmpDir();
+  std::string dbname = test::PerThreadDBPath(env.get(), "ldb_cmd_test");
   char arg1[] = "./ldb";
   char arg2[1024];
   snprintf(arg2, sizeof(arg2), "--db=%s/.no_such_dir", dbname.c_str());

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -68,7 +68,7 @@ class CheckpointTest : public testing::Test {
     EXPECT_OK(DestroyDB(snapshot_tmp_name, options));
     env_->DeleteDir(snapshot_tmp_name);
     Reopen(options);
-    export_path_ = test::TmpDir(env_) + "/export";
+    export_path_ = test::PerThreadDBPath("/export");
     test::DestroyDir(env_, export_path_);
     cfh_reverse_comp_ = nullptr;
     metadata_ = nullptr;


### PR DESCRIPTION
Summary:
Some tests directly uses TmpDir() as temporary directory without adding any randomize factor. This would cause failures when tests run in parallel. Fix it by moving some of them to test::PerThreadDBPath()

Test Plan: Watch existing tests pass