### PR TITLE
Remove 2019 from appveyor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,10 @@ jobs:
 
   build-windows:
     executor: windows-2xlarge
-    
+    parameters:
+      extra_cmake_opt:
+        default: ""
+        type: string
     environment:
       THIRDPARTY_HOME: C:/Users/circleci/thirdparty
       CMAKE_HOME: C:/Users/circleci/thirdparty/cmake-3.16.4-win64-x64
@@ -136,7 +139,7 @@ jobs:
           command: |
             mkdir build
             cd build
-            ${CMAKE_BIN} -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE=1 -DSNAPPY=1 -DJNI=1 ..
+            ${CMAKE_BIN} -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE=1 -DSNAPPY=1 -DJNI=1 << parameters.extra_cmake_opt >> ..
             cd ..
             msbuild.exe build/rocksdb.sln -maxCpuCount -property:Configuration=Debug -property:Platform=x64
       - run:
@@ -176,3 +179,7 @@ workflows:
   build-windows:
     jobs:
       - build-windows
+  build-windows-cxx20:
+    jobs:
+      - build-windows:
+          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,15 +24,6 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 Win64
       DEV_ENV: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.com
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      CMAKE_GENERATOR: Visual Studio 16
-      CMAKE_PLATEFORM_NAME: x64
-      DEV_ENV: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.com
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      CMAKE_GENERATOR: Visual Studio 16
-      CMAKE_PLATEFORM_NAME: x64
-      CMAKE_OPT: -DCMAKE_CXX_STANDARD=20
-      DEV_ENV: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.com
 
 install:
   - md %THIRDPARTY_HOME%


### PR DESCRIPTION
Summary:

VS2019 is covered in CircleCI. The only thing missing there is -DCMAKE_CXX_STANDARD=20 option. Add the option there and remove VS2019 build from Appveyor.

Test Plan: Watch build results.
