### PR TITLE
Remove duplicate colon in Status message

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -1501,7 +1501,7 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
               break;
             }
           } else {
-            s = Status::InvalidArgument("Column family not found: ", cf.name);
+            s = Status::InvalidArgument("Column family not found", cf.name);
             break;
           }
         }

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -218,7 +218,7 @@ Status DBImplReadOnly::OpenForReadOnlyWithoutCheck(
       auto cfd =
           impl->versions_->GetColumnFamilySet()->GetColumnFamily(cf.name);
       if (cfd == nullptr) {
-        s = Status::InvalidArgument("Column family not found: ", cf.name);
+        s = Status::InvalidArgument("Column family not found", cf.name);
         break;
       }
       handles->push_back(new ColumnFamilyHandleImpl(cfd, impl, &impl->mutex_));

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -623,7 +623,7 @@ Status DB::OpenAsSecondary(
       auto cfd =
           impl->versions_->GetColumnFamilySet()->GetColumnFamily(cf.name);
       if (nullptr == cfd) {
-        s = Status::InvalidArgument("Column family not found: ", cf.name);
+        s = Status::InvalidArgument("Column family not found", cf.name);
         break;
       }
       handles->push_back(new ColumnFamilyHandleImpl(cfd, impl, &impl->mutex_));

--- a/env/env.cc
+++ b/env/env.cc
@@ -44,7 +44,7 @@ Status Env::LoadEnv(const std::string& value, Env** result) {
 #ifndef ROCKSDB_LITE
   s = ObjectRegistry::NewInstance()->NewStaticObject<Env>(value, &env);
 #else
-  s = Status::NotSupported("Cannot load environment in LITE mode: ", value);
+  s = Status::NotSupported("Cannot load environment in LITE mode", value);
 #endif
   if (s.ok()) {
     *result = env;
@@ -77,7 +77,7 @@ Status Env::LoadEnv(const std::string& value, Env** result,
 #else
   (void)result;
   (void)guard;
-  s = Status::NotSupported("Cannot load environment in LITE mode: ", value);
+  s = Status::NotSupported("Cannot load environment in LITE mode", value);
 #endif
   return s;
 }

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -21,7 +21,7 @@ Status FileSystem::Load(const std::string& value,
   s = ObjectRegistry::NewInstance()->NewSharedObject<FileSystem>(value, result);
 #else
   (void)result;
-  s = Status::NotSupported("Cannot load FileSystem in LITE mode: ", value);
+  s = Status::NotSupported("Cannot load FileSystem in LITE mode", value);
 #endif
   return s;
 }

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1040,7 +1040,7 @@ Status OptionTypeInfo::Parse(const ConfigOptions& config_options,
   }
   try {
     if (opt_addr == nullptr) {
-      return Status::NotFound("Could not find option: ", opt_name);
+      return Status::NotFound("Could not find option", opt_name);
     } else if (parse_func_ != nullptr) {
       return parse_func_(config_options, opt_name, opt_value, opt_addr);
     } else if (ParseOptionHelper(opt_addr, type_, opt_value)) {
@@ -1077,7 +1077,7 @@ Status OptionTypeInfo::ParseStruct(
             iter->second.Parse(config_options, map_iter.first, map_iter.second,
                                opt_addr + iter->second.offset_);
       } else {
-        status = Status::InvalidArgument("Unrecognized option: ",
+        status = Status::InvalidArgument("Unrecognized option",
                                          struct_name + "." + map_iter.first);
       }
     }
@@ -1090,7 +1090,7 @@ Status OptionTypeInfo::ParseStruct(
       status = opt_info->Parse(config_options, elem_name, opt_value,
                                opt_addr + opt_info->offset_);
     } else {
-      status = Status::InvalidArgument("Unrecognized option: ", opt_name);
+      status = Status::InvalidArgument("Unrecognized option", opt_name);
     }
   } else {
     // This option represents a field in the struct (e.g. field)
@@ -1100,7 +1100,7 @@ Status OptionTypeInfo::ParseStruct(
       status = opt_info->Parse(config_options, elem_name, opt_value,
                                opt_addr + opt_info->offset_);
     } else {
-      status = Status::InvalidArgument("Unrecognized option: ",
+      status = Status::InvalidArgument("Unrecognized option",
                                        struct_name + "." + opt_name);
     }
   }
@@ -1117,7 +1117,7 @@ Status OptionTypeInfo::Serialize(const ConfigOptions& config_options,
     if (serialize_func_ != nullptr) {
       return serialize_func_(config_options, opt_name, opt_addr, opt_value);
     } else if (!SerializeSingleOptionHelper(opt_addr, type_, opt_value)) {
-      return Status::InvalidArgument("Cannot serialize option: ", opt_name);
+      return Status::InvalidArgument("Cannot serialize option", opt_name);
     }
   }
   return Status::OK();
@@ -1160,14 +1160,14 @@ Status OptionTypeInfo::SerializeStruct(
       status = opt_info->Serialize(config_options, elem_name,
                                    opt_addr + opt_info->offset_, value);
     } else {
-      status = Status::InvalidArgument("Unrecognized option: ", opt_name);
+      status = Status::InvalidArgument("Unrecognized option", opt_name);
     }
   } else {
     // This option represents a field in the struct (e.g. field)
     std::string elem_name;
     const auto opt_info = Find(opt_name, *struct_map, &elem_name);
     if (opt_info == nullptr) {
-      status = Status::InvalidArgument("Unrecognized option: ", opt_name);
+      status = Status::InvalidArgument("Unrecognized option", opt_name);
     } else if (opt_info->ShouldSerialize()) {
       status = opt_info->Serialize(config_options, opt_name + "." + elem_name,
                                    opt_addr + opt_info->offset_, value);


### PR DESCRIPTION
A colon will be added after 'msg' automatically when invoke function Status(Code _code, const Slice& msg, const Slice& msg2),
it's not needed to append a colon explicitly to 'msg'.