### PR TITLE
Fix status message size assert

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -134,7 +134,7 @@ std::string Status::ToString() const {
   std::string result(type);
   if (subcode_ != kNone) {
     uint32_t index = static_cast<int32_t>(subcode_);
-    assert(sizeof(msgs) > index);
+    assert(sizeof(msgs) / sizeof(msgs[0]) > index);
     result.append(msgs[index]);
   }
 


### PR DESCRIPTION
In status.cc, the assert is `assert(sizeof(msgs) > index)`; msgs is a const char* array, sizeof(msgs) is the array size*char* size, which will make the assert pass all the time. Change it to sizeof(msgs)/sizeof(char*) > index.

test plan: pass make check