### PR TITLE
Fix potential deadlock in TestMultiGet in stress test

### DIFF
--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -268,7 +268,10 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 #endif
     for (size_t i = 0; i < num_keys; ++i) {
-      std::string key = txn->GetName() + "-" + Key(rand_keys[i]);
+      std::string key = Key(rand_keys[i]);
+      if (use_txn) {
+        key = txn->GetName() + "-" + key;
+      }
       key_str.emplace_back(key);
       keys.emplace_back(key_str.back());
 #ifndef ROCKSDB_LITE

--- a/db_stress_tool/no_batched_ops_stress.cc
+++ b/db_stress_tool/no_batched_ops_stress.cc
@@ -268,7 +268,8 @@ class NonBatchedOpsStressTest : public StressTest {
     }
 #endif
     for (size_t i = 0; i < num_keys; ++i) {
-      key_str.emplace_back(Key(rand_keys[i]));
+      std::string key = txn->GetName() + "-" + Key(rand_keys[i]);
+      key_str.emplace_back(key);
       keys.emplace_back(key_str.back());
 #ifndef ROCKSDB_LITE
       if (use_txn) {


### PR DESCRIPTION
`TestMultiGet` creates a transaction, then does put/merge/delete on a set of random keys in the transaction.

If multiple `TestMultiGet`s are run concurrently, and there are overlaps in the random keys, then there might be transaction deadlocks, which causes lock timeout.

This PR tries to solve this problem by adding transaction name as the key's prefix, so that keys in different transactions do not have overlap.

Test Plan:
Without this PR, ```./db_stress --acquire_snapshot_one_in=10000 --allow_concurrent_memtable_write=1 --avoid_flush_during_recovery=0 --avoid_unnecessary_blocking_io=1 --block_size=16384 --bloom_bits=8 --bottommost_compression_type=disable --cache_index_and_filter_blocks=0 --cache_size=1048576 --checkpoint_one_in=0 --checksum_type=kCRC32c --clear_column_family_one_in=0 --compact_files_one_in=1000000 --compact_range_one_in=1000000 --compaction_style=1 --compaction_ttl=0 --compression_max_dict_bytes=16384 --compression_parallel_threads=1 --compression_type=zstd --compression_zstd_max_train_bytes=0 --continuous_verification_interval=0 --db=/dev/shm/rocksdb/rocksdb_crashtest_whitebox --db_write_buffer_size=0 --delpercent=5 --delrangepercent=0 --destroy_db_initially=0 --disable_wal=0 --enable_pipelined_write=0 --flush_one_in=1000000 --format_version=2 --get_current_wal_file_one_in=0 --get_live_files_one_in=1000000 --get_sorted_wal_files_one_in=0 --index_block_restart_interval=11 --index_type=2 --key_len_percent_dist=1,30,69 --level_compaction_dynamic_level_bytes=True --log2_keys_per_lock=10 --long_running_snapshots=1 --max_background_compactions=20 --max_bytes_for_level_base=10485760 --max_key=100000000 --max_key_len=3 --max_manifest_file_size=1073741824 --max_write_batch_group_size_bytes=1048576 --max_write_buffer_number=3 --memtablerep=skip_list --mmap_read=0 --mock_direct_io=True --nooverwritepercent=1 --open_files=100 --ops_per_thread=200000 --partition_filters=1 --pause_background_one_in=1000000 --periodic_compaction_seconds=0 --prefixpercent=5 --progress_reports=0 --read_fault_one_in=1000 --readpercent=45 --recycle_log_file_num=1 --reopen=20 --snapshot_hold_ops=100000 --subcompactions=3 --sync=0 --sync_fault_injection=False --target_file_size_base=2097152 --target_file_size_multiplier=2 --test_batches_snapshots=0 --txn_write_policy=1 --unordered_write=1 --use_block_based_filter=0 --use_direct_io_for_flush_and_compaction=1 --use_direct_reads=1 --use_full_merge_v1=1 --use_merge=1 --use_multiget=1 --use_txn=1 --verify_checksum=1 --verify_checksum_one_in=1000000 --verify_db_one_in=100000 --write_buffer_size=4194304 --write_dbid_to_manifest=1 --writepercent=35``` fails with `Transaction put: Operation timed out: Timeout waiting to lock key
terminate called without an active exception`.
