### PR TITLE
riscv64 need -latomic as library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,11 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   endif(HAS_ARMV8_CRC)
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+  string(APPEND CMAKE_C_STANDARD_LIBRARIES " -latomic")
+  string(APPEND CMAKE_CXX_STANDARD_LIBRARIES " -latomic")
+endif()
+
 option(PORTABLE "build a portable binary" OFF)
 option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 if(PORTABLE)

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ OPT += -momit-leaf-frame-pointer
 endif
 endif
 
+ifneq ($(findstring riscv64, $(MACHINE)),)
+LDFLAGS += -latomic
+endif
+
 ifeq (,$(shell $(CXX) -fsyntax-only -maltivec -xc /dev/null 2>&1))
 CXXFLAGS += -DHAS_ALTIVEC
 CFLAGS += -DHAS_ALTIVEC


### PR DESCRIPTION
note may not be the best way to add a library, and maybe it needs to be more general than just Linux.

riscv64 architecture specificly chosen to include atomics per https://www.sifive.com/blog/all-aboard-part-1-compiler-args

Compile error per bug reports:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=933151
https://jira.mariadb.org/browse/MDEV-23051

Per Debian bug -latomic is needed which is consistent with
build_detect_platform code which include atomic (though only for
clang).

Tested with https://toolchains.bootlin.com/releases_riscv64.html
( riscv64--glibc--bleeding-edge-2020.02-2)

cmake -DCMAKE_TOOLCHAIN_FILE=../rocks-riscv64-toolchain.cmake -DPORTABLE=TRUE ../rocksdb

rocks-riscv64-toolchain.cmake:
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR riscv64)

set(tools /home/dan/repos/riscv64--glibc--bleeding-edge-2020.02-2)
set(CMAKE_C_COMPILER ${tools}/bin/riscv64-buildroot-linux-gnu-gcc)
set(CMAKE_CXX_COMPILER ${tools}/bin/riscv64-buildroot-linux-gnu-g++)

set(CMAKE_C_FLAGS "-march=rv64iafd")
set(CMAKE_CXX_FLAGS "-march=rv64iafd")
set(WITH_GFLAGS OFF)

set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

closes #7051