### PR TITLE
[FB Internal] Fix test in buck test

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -449,6 +449,25 @@ cpp_library(
     external_deps = ROCKSDB_EXTERNAL_DEPS,
 )
 
+cpp_binary(
+    name = "c_test_bin",
+    srcs = ["db/c_test.c"],
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    deps = [":rocksdb_test_lib"],
+)
+
+custom_unittest(
+    "c_test",
+    command = [
+        native.package_name() + "/buckifier/rocks_test_runner.sh",
+        "$(location :{})".format("c_test_bin"),
+    ],
+    type = "simple",
+)
+
 cpp_library(
     name = "env_basic_test_lib",
     srcs = ["env/env_basic_test.cc"],
@@ -558,13 +577,6 @@ ROCKS_TESTS = [
     [
         "bloom_test",
         "util/bloom_test.cc",
-        "serial",
-        [],
-        [],
-    ],
-    [
-        "c_test",
-        "db/c_test.c",
         "serial",
         [],
         [],

--- a/buckifier/buckify_rocksdb.py
+++ b/buckifier/buckify_rocksdb.py
@@ -166,9 +166,17 @@ def generate_targets(repo_path, deps_map):
     # Dictionary test executable name -> relative source file path
     test_source_map = {}
     print(src_mk)
-    test_main_sources = src_mk.get("TEST_MAIN_SOURCES", []) + \
-        src_mk.get("TEST_MAIN_SOURCES_C", [])
-    for test_src in test_main_sources:
+
+    # c_test.c is added through TARGETS.add_c_test(). If there
+    # are more than one .c test file, we need to extend
+    # TARGETS.add_c_test() to include other C tests too.
+    for test_src in src_mk.get("TEST_MAIN_SOURCES_C", []):
+        if test_src != 'db/c_test.c':
+            print("Don't know how to deal with " + test_src)
+            return False
+    TARGETS.add_c_test()
+
+    for test_src in src_mk.get("TEST_MAIN_SOURCES", []):
         test = test_src.split('.c')[0].strip().split('/')[-1].strip()
         test_source_map[test] = test_src
         print("" + test + " " + test_src)

--- a/buckifier/targets_builder.py
+++ b/buckifier/targets_builder.py
@@ -76,6 +76,28 @@ class TARGETSBuilder(object):
             pretty_list(deps)))
         self.total_bin = self.total_bin + 1
 
+    def add_c_test(self):
+        self.targets_file.write("""
+cpp_binary(
+    name = "c_test_bin",
+    srcs = ["db/c_test.c"],
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    deps = [":rocksdb_test_lib"],
+)
+
+custom_unittest(
+    "c_test",
+    command = [
+        native.package_name() + "/buckifier/rocks_test_runner.sh",
+        "$(location :{})".format("c_test_bin"),
+    ],
+    type = "simple",
+)
+""")
+
     def register_test(self,
                       test_name,
                       src,


### PR DESCRIPTION
Summary:
This is to fix special logic to run tests inside FB.
Buck test is broken after moving to cpp_unittest(). Move c_test back to the previous approach.

Test Plan: Watch the Sandcastle run