### PR TITLE
[WIP] Track WAL in MANIFEST

### DIFF
--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -734,16 +734,15 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         }
         break;
 
-      case kNewWal:
+      case kNewWal: {
         AddedWal wal;
-        {
-          Status s = wal.DecodeFrom(&input);
-          if (!s.ok()) return s;
-        }
+        Status s = wal.DecodeFrom(&input);
+        if (!s.ok()) return s;
         new_wals_.push_back(wal);
         break;
+      }
 
-      case kArchivedWal:
+      case kArchivedWal: {
         WalNumber log_number;
         if (GetVarint64(&input, &log_number)) {
           archived_wals_.push_back(log_number);
@@ -753,15 +752,15 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
           }
         }
         break;
+      }
 
-      case kDeletedWal:
-        DeletedWal deleted_wal;
-        {
-          Status s = deleted_wal.DecodeFrom(&input);
-          if (!s.ok()) return s;
-        }
-        deleted_wals_.push_back(deleted_wal);
+      case kDeletedWal: {
+        DeletedWal wal;
+        Status s = wal.DecodeFrom(&input);
+        if (!s.ok()) return s;
+        deleted_wals_.push_back(wal);
         break;
+      }
 
       default:
         if (tag & kTagSafeIgnoreMask) {

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -9,9 +9,6 @@
 
 #include "db/version_edit.h"
 
-#include <ostream>
-#include <sstream>
-
 #include "db/blob/blob_index.h"
 #include "db/version_set.h"
 #include "logging/event_logger.h"
@@ -134,18 +131,19 @@ Status DeletedWal::DecodeFrom(Slice* src) {
   if (!GetVarint32(src, &archived)) {
     return Status::Corruption(class_name, "Error decoding WAL archive status");
   }
-  archived_ = static_cast<bool>(archived);
+  archived_ = archived == 1;
   return Status::OK();
 }
 
 std::ostream& operator<<(std::ostream& os, const DeletedWal& wal) {
   os << "log_number: " << wal.GetLogNumber()
-     << " archived: " << wal.IsArchived();
+     << " is_archived: " << (wal.IsArchived() ? "true" : "false");
   return os;
 }
 
 JSONWriter& operator<<(JSONWriter& jw, const DeletedWal& wal) {
-  jw << "LogNumber" << wal.GetLogNumber() << "IsArchived" << wal.IsArchived();
+  jw << "LogNumber" << wal.GetLogNumber() << "IsArchived"
+     << (wal.IsArchived() ? "true" : "false");
   return jw;
 }
 
@@ -1023,9 +1021,7 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
     jw << "ArchivedWals";
     jw.StartArray();
     for (const WalNumber log_number : archived_wals_) {
-      jw.StartArrayedObject();
       jw << log_number;
-      jw.EndArrayedObject();
     }
     jw.EndArray();
   }

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -309,6 +309,26 @@ TEST_F(VersionEditTest, BlobFileAdditionAndGarbage) {
   TestEncodeDecode(edit);
 }
 
+TEST_F(VersionEditTest, WAL) {
+  VersionEdit edit;
+
+  for (uint64_t log_number = 1; log_number <= 20; log_number++) {
+    switch (log_number % 3) {
+      case 0:
+        edit.AddWal(AddedWal(log_number, rand() % 100));
+        break;
+      case 1:
+        edit.ArchiveWal(log_number);
+        break;
+      case 2:
+        edit.DeleteWal(DeletedWal(log_number, rand() % 2 == 0));
+        break;
+    }
+  }
+
+  TestEncodeDecode(edit);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR adds WAL lifecycle related information to VersionEdit.
When a WAL is closed because the corresponding memtable is flushed, the WAL's log number and size are tracked in VersionEdit. When a WAL is archived or deleted, the event is also tracked in VersionEdit.

An alternative design is to track WAL's file path, instead of the log number. This PR prefers to track log number to save disk space occupied by MANIFEST.

Another design choice is to just track added WAL and deleted WAL, for archived WAL, treat is as deleting the old WAL and adding a new WAL in the archive directory. This PR prefers to introduce a specific entry for archived WAL, because it only needs to track the log number in one entry instead of two entries (delete and add), which saves disk space of MANIFEST.

Follow up PRs will:
1. apply the WAL related VersionEdits to MANIFEST.
2. create WAL related VersionEdits in relevant code paths of WAL's lifecycle.
3. compute and track checksum of the WALs.

Test Plan:
A set of new unit tests are added to version_edit_test.cc.