### PR TITLE
Implement IOTracing 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,7 @@ set(SOURCES
         env/env_encryption.cc
         env/env_hdfs.cc
         env/file_system.cc
+        env/file_system_tracer.cc
         env/mock_env.cc
         file/delete_scheduler.cc
         file/file_prefetch_buffer.cc
@@ -718,6 +719,7 @@ set(SOURCES
         tools/trace_analyzer_tool.cc
         trace_replay/trace_replay.cc
         trace_replay/block_cache_tracer.cc
+        trace_replay/io_tracer.cc
         util/coding.cc
         util/compaction_job_stats_impl.cc
         util/comparator.cc
@@ -1111,6 +1113,7 @@ if(WITH_TESTS)
         table/table_test.cc
         table/block_fetcher_test.cc
         test_util/testutil_test.cc
+        trace_replay/io_tracer_test.cc
         tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
         tools/ldb_cmd_test.cc
         tools/reduce_levels_test.cc

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -67,7 +67,7 @@ TableBuilder* NewTableBuilder(
 }
 
 Status BuildTable(
-    const std::string& dbname, Env* env, FileSystem* fs,
+    const std::string& dbname, Env* env, const FileSystemPtr* fs,
     const ImmutableCFOptions& ioptions,
     const MutableCFOptions& mutable_cf_options, const FileOptions& file_options,
     TableCache* table_cache, InternalIterator* iter,
@@ -140,8 +140,9 @@ Status BuildTable(
       file->SetWriteLifeTimeHint(write_hint);
 
       file_writer.reset(new WritableFileWriter(
-          std::move(file), fname, file_options, env, ioptions.statistics,
-          ioptions.listeners, ioptions.file_checksum_gen_factory));
+          std::move(file), fname, file_options, ioptions.io_tracer, env,
+          ioptions.statistics, ioptions.listeners,
+          ioptions.file_checksum_gen_factory));
 
       builder = NewTableBuilder(
           ioptions, mutable_cf_options, internal_comparator,
@@ -269,7 +270,7 @@ Status BuildTable(
   }
 
   if (!s.ok() || meta->fd.GetFileSize() == 0) {
-    fs->DeleteFile(fname, IOOptions(), nullptr);
+    (*fs)->DeleteFile(fname, IOOptions(), nullptr);
   }
 
   if (meta->fd.GetFileSize() == 0) {

--- a/db/builder.h
+++ b/db/builder.h
@@ -63,7 +63,7 @@ TableBuilder* NewTableBuilder(
 // @param column_family_name Name of the column family that is also identified
 //    by column_family_id, or empty string if unknown.
 extern Status BuildTable(
-    const std::string& dbname, Env* env, FileSystem* fs,
+    const std::string& dbname, Env* env, const FileSystemPtr* fs,
     const ImmutableCFOptions& options,
     const MutableCFOptions& mutable_cf_options, const FileOptions& file_options,
     TableCache* table_cache, InternalIterator* iter,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -323,7 +323,7 @@ CompactionJob::CompactionJob(
       env_(db_options.env),
       fs_(db_options.fs.get()),
       file_options_for_read_(
-          fs_->OptimizeForCompactionTableRead(file_options, db_options_)),
+          (*fs_)->OptimizeForCompactionTableRead(file_options, db_options_)),
       versions_(versions),
       shutting_down_(shutting_down),
       manual_compaction_paused_(manual_compaction_paused),
@@ -1552,10 +1552,10 @@ Status CompactionJob::OpenCompactionOutputFile(
       sub_compact->compaction->OutputFilePreallocationSize()));
   const auto& listeners =
       sub_compact->compaction->immutable_cf_options()->listeners;
-  sub_compact->outfile.reset(
-      new WritableFileWriter(std::move(writable_file), fname, file_options_,
-                             env_, db_options_.statistics.get(), listeners,
-                             db_options_.file_checksum_gen_factory.get()));
+  sub_compact->outfile.reset(new WritableFileWriter(
+      std::move(writable_file), fname, file_options_, db_options_.io_tracer,
+      env_, db_options_.statistics.get(), listeners,
+      db_options_.file_checksum_gen_factory.get()));
 
   // If the Column family flag is to only optimize filters for hits,
   // we can skip creating filters if this is the bottommost_level where

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -160,7 +160,7 @@ class CompactionJob {
   const FileOptions file_options_;
 
   Env* env_;
-  FileSystem* fs_;
+  FileSystemPtr* fs_;
   // env_option optimized for compaction table reads
   FileOptions file_options_for_read_;
   VersionSet* versions_;

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -72,7 +72,6 @@ class CompactionJobTest : public testing::Test {
  public:
   CompactionJobTest()
       : env_(Env::Default()),
-        fs_(std::make_shared<LegacyFileSystemWrapper>(env_)),
         dbname_(test::PerThreadDBPath("compaction_job_test")),
         db_options_(),
         mutable_cf_options_(cf_options_),
@@ -86,6 +85,9 @@ class CompactionJobTest : public testing::Test {
         preserve_deletes_seqnum_(0),
         mock_table_factory_(new mock::MockTableFactory()),
         error_handler_(nullptr, db_options_, &mutex_) {
+    std::shared_ptr<FileSystem> fs_wrap =
+        std::make_shared<LegacyFileSystemWrapper>(env_);
+    fs_ = std::make_shared<FileSystemPtr>(fs_wrap);
     EXPECT_OK(env_->CreateDirIfMissing(dbname_));
     db_options_.env = env_;
     db_options_.fs = fs_;
@@ -271,8 +273,9 @@ class CompactionJobTest : public testing::Test {
     Status s = env_->NewWritableFile(
         manifest, &file, env_->OptimizeForManifestWrite(env_options_));
     ASSERT_OK(s);
-    std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-        NewLegacyWritableFileWrapper(std::move(file)), manifest, env_options_));
+    std::unique_ptr<WritableFileWriter> file_writer(
+        new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
+                               manifest, env_options_, nullptr /* IOTracer */));
     {
       log::Writer log(std::move(file_writer), 0, false);
       std::string record;
@@ -364,7 +367,7 @@ class CompactionJobTest : public testing::Test {
   }
 
   Env* env_;
-  std::shared_ptr<FileSystem> fs_;
+  std::shared_ptr<FileSystemPtr> fs_;
   std::string dbname_;
   EnvOptions env_options_;
   ImmutableDBOptions db_options_;

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -511,7 +511,7 @@ TEST_F(CorruptionTest, RangeDeletionCorrupted) {
   ASSERT_OK(options_.env->NewRandomAccessFile(filename, &file, EnvOptions()));
   std::unique_ptr<RandomAccessFileReader> file_reader(
       new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
-                                 filename));
+                                 filename, options_.io_tracer));
 
   uint64_t file_size;
   ASSERT_OK(options_.env->GetFileSize(filename, &file_size));

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -82,7 +82,7 @@ struct MemTableInfo;
 // Class to maintain directories for all database paths other than main one.
 class Directories {
  public:
-  IOStatus SetDirectories(FileSystem* fs, const std::string& dbname,
+  IOStatus SetDirectories(const FileSystemPtr* fs, const std::string& dbname,
                           const std::string& wal_dir,
                           const std::vector<DbPath>& data_paths);
 
@@ -325,7 +325,7 @@ class DBImpl : public DB {
       ColumnFamilyHandle* column_family) override;
   virtual const std::string& GetName() const override;
   virtual Env* GetEnv() const override;
-  virtual FileSystem* GetFileSystem() const override;
+  virtual FileSystemPtr* GetFileSystemPtr() const override;
   using DB::GetOptions;
   virtual Options GetOptions(ColumnFamilyHandle* column_family) const override;
   using DB::GetDBOptions;
@@ -862,7 +862,7 @@ class DBImpl : public DB {
                      const bool seq_per_batch, const bool batch_per_txn);
 
   static IOStatus CreateAndNewDirectory(
-      FileSystem* fs, const std::string& dirname,
+      const FileSystemPtr* fs, const std::string& dirname,
       std::unique_ptr<FSDirectory>* directory);
 
   // find stats map from stats_history_ with smallest timestamp in
@@ -997,15 +997,16 @@ class DBImpl : public DB {
   bool own_info_log_;
   const DBOptions initial_db_options_;
   Env* const env_;
-  std::shared_ptr<FileSystem> fs_;
   const ImmutableDBOptions immutable_db_options_;
   MutableDBOptions mutable_db_options_;
+  std::shared_ptr<FileSystemPtr> fs_;
   Statistics* stats_;
   std::unordered_map<std::string, RecoveredTransaction*>
       recovered_transactions_;
   std::unique_ptr<Tracer> tracer_;
   InstrumentedMutex trace_mutex_;
   BlockCacheTracer block_cache_tracer_;
+  std::shared_ptr<IOTracer> io_tracer_;
 
   // State below is protected by mutex_
   // With two_write_queues enabled, some of the variables that accessed during

--- a/db/db_impl/db_impl_readonly.cc
+++ b/db/db_impl/db_impl_readonly.cc
@@ -137,7 +137,8 @@ Status OpenForReadOnlyCheckExistence(const DBOptions& db_options,
   Status s;
   if (!db_options.create_if_missing) {
     // Attempt to read "CURRENT" file
-    const std::shared_ptr<FileSystem>& fs = db_options.env->GetFileSystem();
+    const std::shared_ptr<FileSystemPtr> fs =
+        std::make_shared<FileSystemPtr>(db_options.env->GetFileSystem());
     std::string manifest_path;
     uint64_t manifest_file_number;
     s = VersionSet::GetCurrentManifestPath(dbname, fs.get(), &manifest_path,

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -145,15 +145,15 @@ Status DBImplSecondary::MaybeInitLogReader(
     std::unique_ptr<SequentialFileReader> file_reader;
     {
       std::unique_ptr<FSSequentialFile> file;
-      Status status = fs_->NewSequentialFile(
-          fname, fs_->OptimizeForLogRead(file_options_), &file,
-          nullptr);
+      Status status = (*fs_)->NewSequentialFile(
+          fname, (*fs_)->OptimizeForLogRead(file_options_), &file, nullptr);
       if (!status.ok()) {
         *log_reader = nullptr;
         return status;
       }
       file_reader.reset(new SequentialFileReader(
-          std::move(file), fname, immutable_db_options_.log_readahead_size));
+          std::move(file), fname, immutable_db_options_.log_readahead_size,
+          immutable_db_options_.io_tracer));
     }
 
     // Create the log reader.

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -950,8 +950,9 @@ class RecoveryTestHelper {
       std::string fname = LogFileName(test->dbname_, current_log_number);
       std::unique_ptr<WritableFile> file;
       ASSERT_OK(db_options.env->NewWritableFile(fname, &file, env_options));
-      std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-          NewLegacyWritableFileWrapper(std::move(file)), fname, env_options));
+      std::unique_ptr<WritableFileWriter> file_writer(
+          new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
+                                 fname, env_options, nullptr /* IOTracer */));
       current_log_writer.reset(
           new log::Writer(std::move(file_writer), current_log_number,
                           db_options.recycle_log_file_num > 0));

--- a/db/external_sst_file_ingestion_job.h
+++ b/db/external_sst_file_ingestion_job.h
@@ -167,7 +167,7 @@ class ExternalSstFileIngestionJob {
   Status SyncIngestedFile(TWritableFile* file);
 
   Env* env_;
-  FileSystem* fs_;
+  FileSystemPtr* fs_;
   VersionSet* versions_;
   ColumnFamilyData* cfd_;
   const ImmutableDBOptions& db_options_;

--- a/db/import_column_family_job.h
+++ b/db/import_column_family_job.h
@@ -61,7 +61,7 @@ class ImportColumnFamilyJob {
   VersionSet* versions_;
   ColumnFamilyData* cfd_;
   const ImmutableDBOptions& db_options_;
-  FileSystem* fs_;
+  FileSystemPtr* fs_;
   const EnvOptions& env_options_;
   autovector<IngestedFileInfo> files_to_import_;
   VersionEdit edit_;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -759,7 +759,7 @@ class RetriableLogTest : public ::testing::TestWithParam<int> {
     if (s.ok()) {
       writer_.reset(new WritableFileWriter(
           NewLegacyWritableFileWrapper(std::move(writable_file)), log_file_,
-          env_options_));
+          env_options_, nullptr /* IOTracer */));
       assert(writer_ != nullptr);
     }
     std::unique_ptr<SequentialFile> seq_file;
@@ -767,8 +767,9 @@ class RetriableLogTest : public ::testing::TestWithParam<int> {
       s = env_->NewSequentialFile(log_file_, &seq_file, env_options_);
     }
     if (s.ok()) {
-      reader_.reset(new SequentialFileReader(
-          NewLegacySequentialFileWrapper(seq_file), log_file_));
+      reader_.reset(
+          new SequentialFileReader(NewLegacySequentialFileWrapper(seq_file),
+                                   log_file_, nullptr /* IOTracer */));
       assert(reader_ != nullptr);
       log_reader_.reset(new FragmentBufferedReader(
           nullptr, std::move(reader_), &report_, true /* checksum */,

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -352,8 +352,9 @@ class Repairer {
     if (!status.ok()) {
       return status;
     }
+
     std::unique_ptr<SequentialFileReader> lfile_reader(new SequentialFileReader(
-        NewLegacySequentialFileWrapper(lfile), logname));
+        NewLegacySequentialFileWrapper(lfile), logname, db_options_.io_tracer));
 
     // Create the log reader.
     LogReporter reporter;
@@ -426,7 +427,10 @@ class Repairer {
         range_del_iters.emplace_back(range_del_iter);
       }
 
-      LegacyFileSystemWrapper fs(env_);
+      std::shared_ptr<FileSystem> fs_wrap =
+          std::make_shared<LegacyFileSystemWrapper>(env_);
+      FileSystemPtr fs(fs_wrap);
+
       IOStatus io_s;
       status = BuildTable(
           dbname_, env_, &fs, *cfd->ioptions(),

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -75,7 +75,9 @@ TEST_F(RepairTest, CorruptManifest) {
   Close();
   ASSERT_OK(env_->FileExists(manifest_path));
 
-  LegacyFileSystemWrapper fs(env_);
+  std::shared_ptr<FileSystem> fs_wrap =
+      std::make_shared<LegacyFileSystemWrapper>(env_);
+  FileSystemPtr fs(fs_wrap);
   CreateFile(&fs, manifest_path, "blah", false /* use_fsync */);
   ASSERT_OK(RepairDB(dbname_, CurrentOptions()));
   Reopen(CurrentOptions());
@@ -156,7 +158,9 @@ TEST_F(RepairTest, CorruptSst) {
   auto sst_path = GetFirstSstPath();
   ASSERT_FALSE(sst_path.empty());
 
-  LegacyFileSystemWrapper fs(env_);
+  std::shared_ptr<FileSystem> fs_wrap =
+      std::make_shared<LegacyFileSystemWrapper>(env_);
+  FileSystemPtr fs(fs_wrap);
   CreateFile(&fs, sst_path, "blah", false /* use_fsync */);
 
   Close();

--- a/db/table_properties_collector_test.cc
+++ b/db/table_properties_collector_test.cc
@@ -48,9 +48,9 @@ void MakeBuilder(const Options& options, const ImmutableCFOptions& ioptions,
                  std::unique_ptr<WritableFileWriter>* writable,
                  std::unique_ptr<TableBuilder>* builder) {
   std::unique_ptr<WritableFile> wf(new test::StringSink);
-  writable->reset(
-      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(wf)),
-                             "" /* don't care */, EnvOptions()));
+  writable->reset(new WritableFileWriter(
+      NewLegacyWritableFileWrapper(std::move(wf)), "" /* don't care */,
+      EnvOptions(), nullptr /* IOTracer */));
   int unknown_level = -1;
   builder->reset(NewTableBuilder(
       ioptions, moptions, internal_comparator, int_tbl_prop_collector_factories,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -757,7 +757,6 @@ class Version {
 
  private:
   Env* env_;
-  FileSystem* fs_;
   friend class ReactiveVersionSet;
   friend class VersionSet;
   friend class VersionEditHandler;
@@ -951,7 +950,7 @@ class VersionSet {
       const ColumnFamilyOptions* new_cf_options = nullptr);
 
   static Status GetCurrentManifestPath(const std::string& dbname,
-                                       FileSystem* fs,
+                                       const FileSystemPtr* fs,
                                        std::string* manifest_filename,
                                        uint64_t* manifest_file_number);
 
@@ -976,7 +975,8 @@ class VersionSet {
   // Reads a manifest file and returns a list of column families in
   // column_families.
   static Status ListColumnFamilies(std::vector<std::string>* column_families,
-                                   const std::string& dbname, FileSystem* fs);
+                                   const std::string& dbname,
+                                   const FileSystemPtr* fs);
 
 #ifndef ROCKSDB_LITE
   // Try to reduce the number of levels. This call is valid when
@@ -1265,7 +1265,7 @@ class VersionSet {
 
   std::unique_ptr<ColumnFamilySet> column_family_set_;
   Env* const env_;
-  FileSystem* const fs_;
+  FileSystemPtr* const fs_;
   const std::string dbname_;
   std::string db_id_;
   const ImmutableDBOptions* const db_options_;

--- a/db/wal_manager.cc
+++ b/db/wal_manager.cc
@@ -463,11 +463,10 @@ Status WalManager::ReadFirstLine(const std::string& fname,
   };
 
   std::unique_ptr<FSSequentialFile> file;
-  Status status = fs_->NewSequentialFile(fname,
-                                         fs_->OptimizeForLogRead(file_options_),
-                                         &file, nullptr);
+  Status status = (*fs_)->NewSequentialFile(
+      fname, (*fs_)->OptimizeForLogRead(file_options_), &file, nullptr);
   std::unique_ptr<SequentialFileReader> file_reader(
-      new SequentialFileReader(std::move(file), fname));
+      new SequentialFileReader(std::move(file), fname, db_options_.io_tracer));
 
   if (!status.ok()) {
     return status;

--- a/db/wal_manager.h
+++ b/db/wal_manager.h
@@ -91,7 +91,7 @@ class WalManager {
   const ImmutableDBOptions& db_options_;
   const FileOptions file_options_;
   Env* env_;
-  FileSystem* fs_;
+  FileSystemPtr* fs_;
 
   // ------- WalManager state -------
   // cache for ReadFirstRecord() calls

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -613,6 +613,11 @@ class CompositeEnvWrapper : public Env {
     return file_system_->OptimizeForCompactionTableRead(
         FileOptions(env_options), db_options);
   }
+
+  // This seems to clash with a macro on Windows, so #undef it here
+#ifdef GetFreeSpace
+#undef GetFreeSpace
+#endif
   Status GetFreeSpace(const std::string& path, uint64_t* diskfree) override {
     IOOptions io_opts;
     IODebugContext dbg;
@@ -1089,6 +1094,11 @@ class LegacyFileSystemWrapper : public FileSystem {
       const ImmutableDBOptions& db_options) const override {
     return target_->OptimizeForCompactionTableRead(file_options, db_options);
   }
+
+  // This seems to clash with a macro on Windows, so #undef it here
+#ifdef GetFreeSpace
+#undef GetFreeSpace
+#endif
   IOStatus GetFreeSpace(const std::string& path, const IOOptions& /*options*/,
                         uint64_t* diskfree, IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->GetFreeSpace(path, diskfree));

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -2187,7 +2187,8 @@ TEST_F(EnvTest, IsDirectory) {
     ASSERT_OK(s);
     std::unique_ptr<WritableFileWriter> fwriter;
     fwriter.reset(new WritableFileWriter(std::move(wfile), test_file_path,
-                                         FileOptions(), Env::Default()));
+                                         FileOptions(), nullptr /* IOTracer */,
+                                         Env::Default()));
     constexpr char buf[] = "test";
     s = fwriter->Append(buf);
     ASSERT_OK(s);

--- a/env/file_system_tracer.cc
+++ b/env/file_system_tracer.cc
@@ -9,6 +9,8 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+FileSystemTracingWrapper::~FileSystemTracingWrapper() {}
+
 IOStatus FileSystemTracingWrapper::NewWritableFile(
     const std::string& fname, const FileOptions& file_opts,
     std::unique_ptr<FSWritableFile>* result, IODebugContext* dbg) {
@@ -16,8 +18,8 @@ IOStatus FileSystemTracingWrapper::NewWritableFile(
   timer.Start();
   IOStatus s = target()->NewWritableFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(elapsed, TraceType::kIOFileName, __func__, elapsed,
-                          s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
+                          elapsed, s.ToString(), fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -271,7 +273,7 @@ uint64_t FSWritableFileTracingWrapper::GetFileSize(const IOOptions& options,
   uint64_t file_size = target()->GetFileSize(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileNameAndFileSize,
-                          "GetFileSize", elapsed, "" /* file_name */,
+                          "GetFileSize", elapsed, "OK", "" /* file_name */,
                           file_size);
   io_tracer_->WriteIOOp(io_record);
   return file_size;

--- a/file/delete_scheduler.h
+++ b/file/delete_scheduler.h
@@ -23,6 +23,7 @@ namespace ROCKSDB_NAMESPACE {
 class Env;
 class Logger;
 class SstFileManagerImpl;
+class FileSystemPtr;
 
 // DeleteScheduler allows the DB to enforce a rate limit on file deletion,
 // Instead of deleteing files immediately, files are marked as trash
@@ -33,7 +34,7 @@ class SstFileManagerImpl;
 // case DeleteScheduler will delete files immediately.
 class DeleteScheduler {
  public:
-  DeleteScheduler(Env* env, FileSystem* fs, int64_t rate_bytes_per_sec,
+  DeleteScheduler(Env* env, FileSystemPtr* fs, int64_t rate_bytes_per_sec,
                   Logger* info_log, SstFileManagerImpl* sst_file_manager,
                   double max_trash_db_ratio, uint64_t bytes_max_delete_chunk);
 
@@ -100,7 +101,7 @@ class DeleteScheduler {
   void MaybeCreateBackgroundThread();
 
   Env* env_;
-  FileSystem* fs_;
+  FileSystemPtr* fs_;
 
   // total size of trash files
   std::atomic<uint64_t> total_trash_size_;

--- a/file/delete_scheduler_test.cc
+++ b/file/delete_scheduler_test.cc
@@ -98,8 +98,9 @@ class DeleteSchedulerTest : public testing::Test {
     // 25%)
     std::shared_ptr<FileSystem>
                 fs(std::make_shared<LegacyFileSystemWrapper>(env_));
+    std::shared_ptr<FileSystemPtr> fsptr = std::make_shared<FileSystemPtr>(fs);
     sst_file_mgr_.reset(
-        new SstFileManagerImpl(env_, fs, nullptr, rate_bytes_per_sec_,
+        new SstFileManagerImpl(env_, fsptr, nullptr, rate_bytes_per_sec_,
                                /* max_trash_db_ratio= */ 1.1, 128 * 1024));
     delete_scheduler_ = sst_file_mgr_->delete_scheduler();
     sst_file_mgr_->SetStatisticsPtr(stats_);

--- a/file/file_util.h
+++ b/file/file_util.h
@@ -17,11 +17,12 @@
 namespace ROCKSDB_NAMESPACE {
 // use_fsync maps to options.use_fsync, which determines the way that
 // the file is synced after copying.
-extern IOStatus CopyFile(FileSystem* fs, const std::string& source,
+extern IOStatus CopyFile(const FileSystemPtr* fs, const std::string& source,
                          const std::string& destination, uint64_t size,
                          bool use_fsync);
 
-extern IOStatus CreateFile(FileSystem* fs, const std::string& destination,
+extern IOStatus CreateFile(const FileSystemPtr* fs,
+                           const std::string& destination,
                            const std::string& contents, bool use_fsync);
 
 extern Status DeleteDBFile(const ImmutableDBOptions* db_options,
@@ -32,7 +33,7 @@ extern Status DeleteDBFile(const ImmutableDBOptions* db_options,
 extern bool IsWalDirSameAsDBPath(const ImmutableDBOptions* db_options);
 
 extern IOStatus GenerateOneFileChecksum(
-    FileSystem* fs, const std::string& file_path,
+    const FileSystemPtr* fs, const std::string& file_path,
     FileChecksumGenFactory* checksum_factory, std::string* file_checksum,
     std::string* file_checksum_func_name,
     size_t verify_checksums_readahead_size, bool allow_mmap_reads);

--- a/file/filename.h
+++ b/file/filename.h
@@ -171,7 +171,8 @@ extern bool ParseFileName(const std::string& filename, uint64_t* number,
 
 // Make the CURRENT file point to the descriptor file with the
 // specified number.
-extern IOStatus SetCurrentFile(FileSystem* fs, const std::string& dbname,
+extern IOStatus SetCurrentFile(const FileSystemPtr* fs,
+                               const std::string& dbname,
                                uint64_t descriptor_number,
                                FSDirectory* directory_to_fsync);
 

--- a/file/random_access_file_reader_test.cc
+++ b/file/random_access_file_reader_test.cc
@@ -40,7 +40,8 @@ class RandomAccessFileReaderTest : public testing::Test {
     std::string fpath = Path(fname);
     std::unique_ptr<FSRandomAccessFile> f;
     ASSERT_OK(fs_->NewRandomAccessFile(fpath, opts, &f, nullptr));
-    (*reader).reset(new RandomAccessFileReader(std::move(f), fpath, env_));
+    (*reader).reset(new RandomAccessFileReader(std::move(f), fpath,
+                                               nullptr /* IOTracer */, env_));
   }
 
   void AssertResult(const std::string& content,

--- a/file/read_write_util.cc
+++ b/file/read_write_util.cc
@@ -14,10 +14,10 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-IOStatus NewWritableFile(FileSystem* fs, const std::string& fname,
+IOStatus NewWritableFile(const FileSystemPtr* fs, const std::string& fname,
                          std::unique_ptr<FSWritableFile>* result,
                          const FileOptions& options) {
-  IOStatus s = fs->NewWritableFile(fname, options, result, nullptr);
+  IOStatus s = (*fs)->NewWritableFile(fname, options, result, nullptr);
   TEST_KILL_RANDOM("NewWritableFile:0", rocksdb_kill_odds * REDUCE_ODDS2);
   return s;
 }

--- a/file/read_write_util.h
+++ b/file/read_write_util.h
@@ -9,6 +9,8 @@
 
 #pragma once
 #include <atomic>
+
+#include "env/file_system_tracer.h"
 #include "file/sequence_file_reader.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
@@ -20,7 +22,8 @@ namespace ROCKSDB_NAMESPACE {
 // fname   : the file name.
 // result  : output arg. A WritableFile based on `fname` returned.
 // options : the Env Options.
-extern IOStatus NewWritableFile(FileSystem* fs, const std::string& fname,
+extern IOStatus NewWritableFile(const FileSystemPtr* fs,
+                                const std::string& fname,
                                 std::unique_ptr<FSWritableFile>* result,
                                 const FileOptions& options);
 

--- a/file/sst_file_manager_impl.h
+++ b/file/sst_file_manager_impl.h
@@ -27,7 +27,7 @@ class Logger;
 // All SstFileManager public functions are thread-safe.
 class SstFileManagerImpl : public SstFileManager {
  public:
-  explicit SstFileManagerImpl(Env* env, std::shared_ptr<FileSystem> fs,
+  explicit SstFileManagerImpl(Env* env, std::shared_ptr<FileSystemPtr> fs,
                               std::shared_ptr<Logger> logger,
                               int64_t rate_bytes_per_sec,
                               double max_trash_db_ratio,
@@ -153,7 +153,7 @@ class SstFileManagerImpl : public SstFileManager {
   }
 
   Env* env_;
-  std::shared_ptr<FileSystem> fs_;
+  std::shared_ptr<FileSystemPtr> fs_;
   std::shared_ptr<Logger> logger_;
   // Mutex to protect tracked_files_, total_files_size_
   port::Mutex mu_;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -10,11 +10,13 @@
 
 #include <stdint.h>
 #include <stdio.h>
+
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "rocksdb/iterator.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/metadata.h"
@@ -57,7 +59,7 @@ class TraceWriter;
 #ifdef ROCKSDB_LITE
 class CompactionJobInfo;
 #endif
-class FileSystem;
+class FileSystemPtr;
 
 extern const std::string kDefaultColumnFamilyName;
 extern const std::string kPersistentStatsColumnFamilyName;
@@ -1201,7 +1203,7 @@ class DB {
   // Get Env object from the DB
   virtual Env* GetEnv() const = 0;
 
-  virtual FileSystem* GetFileSystem() const;
+  virtual FileSystemPtr* GetFileSystemPtr() const;
 
   // Get DB Options that we use.  During the process of opening the
   // column family, the options provided when calling DB::Open() or

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <stdint.h>
+
 #include <cstdarg>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "rocksdb/status.h"
 #include "rocksdb/thread_status.h"
 
@@ -58,6 +60,7 @@ class RateLimiter;
 class ThreadStatusUpdater;
 struct ThreadStatus;
 class FileSystem;
+class FileSystemPtr;
 
 const size_t kDefaultPageSize = 4 * 1024;
 

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -43,6 +43,7 @@ class Slice;
 struct ImmutableDBOptions;
 struct MutableDBOptions;
 class RateLimiter;
+class FileSystemPtr;
 
 using AccessPattern = RandomAccessFile::AccessPattern;
 using FileAttributes = Env::FileAttributes;
@@ -1412,12 +1413,12 @@ class FSDirectoryWrapper : public FSDirectory {
 };
 
 // A utility routine: write "data" to the named file.
-extern IOStatus WriteStringToFile(FileSystem* fs, const Slice& data,
+extern IOStatus WriteStringToFile(const FileSystemPtr* fs, const Slice& data,
                                   const std::string& fname,
                                   bool should_sync = false);
 
 // A utility routine: read contents of named file into *data
-extern IOStatus ReadFileToString(FileSystem* fs, const std::string& fname,
-                                 std::string* data);
+extern IOStatus ReadFileToString(const FileSystemPtr* fs,
+                                 const std::string& fname, std::string* data);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -50,6 +50,7 @@ class Statistics;
 class InternalKeyComparator;
 class WalFilter;
 class FileSystem;
+class IOTracer;
 
 // DB contents are stored in a set of blocks, each of which holds a
 // sequence of key,value pairs.  Each block may be compressed before
@@ -1154,6 +1155,12 @@ struct DBOptions {
   //
   // Default: 1000000 (microseconds).
   uint64_t bgerror_resume_retry_interval = 1000000;
+
+  // IOTracer is to used trace the I/O operations in a trace_file (binary
+  // format) provided by user.
+  //
+  // Default: nullptr
+  std::shared_ptr<IOTracer> io_tracer = nullptr;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/sst_file_manager.h
+++ b/include/rocksdb/sst_file_manager.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "env/file_system_tracer.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
@@ -122,7 +123,8 @@ extern SstFileManager* NewSstFileManager(
     const std::string& trash_dir = "", int64_t rate_bytes_per_sec = 0,
     bool delete_existing_trash = true, Status* status = nullptr,
     double max_trash_db_ratio = 0.25,
-    uint64_t bytes_max_delete_chunk = 64 * 1024 * 1024);
+    uint64_t bytes_max_delete_chunk = 64 * 1024 * 1024,
+    std::shared_ptr<IOTracer> io_tracer = nullptr);
 
 // Same as above, but takes a pointer to a legacy Env object, instead of
 // Env and FileSystem objects
@@ -131,6 +133,7 @@ extern SstFileManager* NewSstFileManager(
     std::string trash_dir = "", int64_t rate_bytes_per_sec = 0,
     bool delete_existing_trash = true, Status* status = nullptr,
     double max_trash_db_ratio = 0.25,
-    uint64_t bytes_max_delete_chunk = 64 * 1024 * 1024);
+    uint64_t bytes_max_delete_chunk = 64 * 1024 * 1024,
+    std::shared_ptr<IOTracer> io_tracer = nullptr);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -299,8 +299,8 @@ class StackableDB : public DB {
 
   virtual Env* GetEnv() const override { return db_->GetEnv(); }
 
-  virtual FileSystem* GetFileSystem() const override {
-    return db_->GetFileSystem();
+  virtual FileSystemPtr* GetFileSystemPtr() const override {
+    return db_->GetFileSystemPtr();
   }
 
   using DB::GetOptions;

--- a/logging/env_logger.h
+++ b/logging/env_logger.h
@@ -31,7 +31,8 @@ class EnvLogger : public Logger {
             const std::string& fname, const EnvOptions& options, Env* env,
             InfoLogLevel log_level = InfoLogLevel::ERROR_LEVEL)
       : Logger(log_level),
-        file_(std::move(writable_file), fname, options, env),
+        file_(std::move(writable_file), fname, options, nullptr /* IOTracer */,
+              env),
         last_flush_micros_(0),
         env_(env),
         flush_pending_(false) {}

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -689,7 +689,8 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
           cf_options.memtable_insert_with_hint_prefix_extractor.get()),
       cf_paths(cf_options.cf_paths),
       compaction_thread_limiter(cf_options.compaction_thread_limiter),
-      file_checksum_gen_factory(db_options.file_checksum_gen_factory.get()) {}
+      file_checksum_gen_factory(db_options.file_checksum_gen_factory.get()),
+      io_tracer(db_options.io_tracer) {}
 
 // Multiple two operands. If they overflow, return op1.
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2) {

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -61,7 +61,7 @@ struct ImmutableCFOptions {
 
   Env* env;
 
-  FileSystem* fs;
+  FileSystemPtr* fs;
 
   // Allow the OS to mmap file for reading sst tables. Default: false
   bool allow_mmap_reads;
@@ -121,6 +121,8 @@ struct ImmutableCFOptions {
   std::shared_ptr<ConcurrentTaskLimiter> compaction_thread_limiter;
 
   FileChecksumGenFactory* file_checksum_gen_factory;
+
+  std::shared_ptr<IOTracer> io_tracer;
 };
 
 struct MutableCFOptions {

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -404,7 +404,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       error_if_exists(options.error_if_exists),
       paranoid_checks(options.paranoid_checks),
       env(options.env),
-      fs(options.env->GetFileSystem()),
+      fs(std::make_shared<FileSystemPtr>(options.env->GetFileSystem(),
+                                         options.io_tracer)),
       rate_limiter(options.rate_limiter),
       sst_file_manager(options.sst_file_manager),
       info_log(options.info_log),
@@ -475,7 +476,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       file_checksum_gen_factory(options.file_checksum_gen_factory),
       best_efforts_recovery(options.best_efforts_recovery),
       max_bgerror_resume_count(options.max_bgerror_resume_count),
-      bgerror_resume_retry_interval(options.bgerror_resume_retry_interval) {
+      bgerror_resume_retry_interval(options.bgerror_resume_retry_interval),
+      io_tracer(options.io_tracer) {
 }
 
 void ImmutableDBOptions::Dump(Logger* log) const {
@@ -488,7 +490,7 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "                                    Options.env: %p",
                    env);
   ROCKS_LOG_HEADER(log, "                                     Options.fs: %s",
-                   fs->Name());
+                   (*fs)->Name());
   ROCKS_LOG_HEADER(log, "                               Options.info_log: %p",
                    info_log.get());
   ROCKS_LOG_HEADER(log, "               Options.max_file_opening_threads: %d",
@@ -634,6 +636,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "           Options.bgerror_resume_retry_interval: %" PRIu64,
                    bgerror_resume_retry_interval);
+  ROCKS_LOG_HEADER(log, "                Options.io_tracer: %p",
+                   io_tracer.get());
 }
 
 MutableDBOptions::MutableDBOptions()

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -23,7 +23,7 @@ struct ImmutableDBOptions {
   bool error_if_exists;
   bool paranoid_checks;
   Env* env;
-  std::shared_ptr<FileSystem> fs;
+  std::shared_ptr<FileSystemPtr> fs;
   std::shared_ptr<RateLimiter> rate_limiter;
   std::shared_ptr<SstFileManager> sst_file_manager;
   std::shared_ptr<Logger> info_log;
@@ -90,6 +90,7 @@ struct ImmutableDBOptions {
   bool best_efforts_recovery;
   int max_bgerror_resume_count;
   uint64_t bgerror_resume_retry_interval;
+  std::shared_ptr<IOTracer> io_tracer;
 };
 
 struct MutableDBOptions {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -150,6 +150,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.max_bgerror_resume_count;
   options.bgerror_resume_retry_interval =
       immutable_db_options.bgerror_resume_retry_interval;
+  options.io_tracer = immutable_db_options.io_tracer;
   return options;
 }
 

--- a/options/options_parser.h
+++ b/options/options_parser.h
@@ -36,12 +36,14 @@ static const std::string opt_section_titles[] = {
 Status PersistRocksDBOptions(const DBOptions& db_opt,
                              const std::vector<std::string>& cf_names,
                              const std::vector<ColumnFamilyOptions>& cf_opts,
-                             const std::string& file_name, FileSystem* fs);
+                             const std::string& file_name,
+                             const FileSystemPtr* fs);
 Status PersistRocksDBOptions(const ConfigOptions& config_options,
                              const DBOptions& db_opt,
                              const std::vector<std::string>& cf_names,
                              const std::vector<ColumnFamilyOptions>& cf_opts,
-                             const std::string& file_name, FileSystem* fs);
+                             const std::string& file_name,
+                             const FileSystemPtr* fs);
 
 class RocksDBOptionsParser {
  public:
@@ -51,11 +53,11 @@ class RocksDBOptionsParser {
 
   // `file_readahead_size` is used for readahead for the option file.
   // If 0 is given, a default value will be used.
-  Status Parse(const std::string& file_name, FileSystem* fs,
+  Status Parse(const std::string& file_name, const FileSystemPtr* fs,
                bool ignore_unknown_options, size_t file_readahead_size);
 
   Status Parse(const ConfigOptions& config_options,
-               const std::string& file_name, FileSystem* fs);
+               const std::string& file_name, const FileSystemPtr* fs);
 
   static std::string TrimAndRemoveComment(const std::string& line,
                                           const bool trim_only = false);
@@ -79,7 +81,7 @@ class RocksDBOptionsParser {
       const ConfigOptions& config_options, const DBOptions& db_opt,
       const std::vector<std::string>& cf_names,
       const std::vector<ColumnFamilyOptions>& cf_opts,
-      const std::string& file_name, FileSystem* fs);
+      const std::string& file_name, const FileSystemPtr* fs);
   static Status VerifyDBOptions(
       const ConfigOptions& config_options, const DBOptions& base_opt,
       const DBOptions& new_opt,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -221,7 +221,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, wal_filter), sizeof(const WalFilter*)},
       {offsetof(struct DBOptions, file_checksum_gen_factory),
        sizeof(std::shared_ptr<FileChecksumGenFactory>)},
-  };
+      {offsetof(struct DBOptions, io_tracer),
+       sizeof(std::shared_ptr<IOTracer>)}};
 
   char* options_ptr = new char[sizeof(DBOptions)];
 

--- a/src.mk
+++ b/src.mk
@@ -77,6 +77,7 @@ LIB_SOURCES =                                                   \
   env/env_hdfs.cc                                               \
   env/env_posix.cc                                              \
   env/file_system.cc                                            \
+  env/file_system_tracer.cc                                     \
   env/fs_posix.cc                                               \
   env/file_system_tracer.cc                                     \
   env/io_posix.cc                                               \

--- a/src.mk
+++ b/src.mk
@@ -79,7 +79,6 @@ LIB_SOURCES =                                                   \
   env/file_system.cc                                            \
   env/file_system_tracer.cc                                     \
   env/fs_posix.cc                                               \
-  env/file_system_tracer.cc                                     \
   env/io_posix.cc                                               \
   env/mock_env.cc                                               \
   file/delete_scheduler.cc                                      \

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -124,7 +124,8 @@ class BlockBasedTableReaderTest
     FileOptions foptions;
     std::unique_ptr<FSWritableFile> file;
     ASSERT_OK(fs_->NewWritableFile(path, foptions, &file, nullptr));
-    writer->reset(new WritableFileWriter(std::move(file), path, env_options));
+    writer->reset(new WritableFileWriter(std::move(file), path, env_options,
+                                         nullptr /* IOTracer */));
   }
 
   void NewFileReader(const std::string& filename, const FileOptions& opt,
@@ -132,7 +133,8 @@ class BlockBasedTableReaderTest
     std::string path = Path(filename);
     std::unique_ptr<FSRandomAccessFile> f;
     ASSERT_OK(fs_->NewRandomAccessFile(path, opt, &f, nullptr));
-    reader->reset(new RandomAccessFileReader(std::move(f), path, env_));
+    reader->reset(new RandomAccessFileReader(std::move(f), path,
+                                             nullptr /* IOTracer */, env_));
   }
 
   std::string ToInternalKey(const std::string& key) {

--- a/table/block_fetcher_test.cc
+++ b/table/block_fetcher_test.cc
@@ -251,8 +251,9 @@ class BlockFetcherTest : public testing::Test {
     EnvOptions env_options;
     std::unique_ptr<WritableFile> file;
     ASSERT_OK(env_->NewWritableFile(path, &file, env_options));
-    writer->reset(new WritableFileWriter(
-        NewLegacyWritableFileWrapper(std::move(file)), path, env_options));
+    writer->reset(
+        new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
+                               path, env_options, nullptr /* IOTracer */));
   }
 
   void NewFileReader(const std::string& filename, const FileOptions& opt,
@@ -260,7 +261,8 @@ class BlockFetcherTest : public testing::Test {
     std::string path = Path(filename);
     std::unique_ptr<FSRandomAccessFile> f;
     ASSERT_OK(fs_->NewRandomAccessFile(path, opt, &f, nullptr));
-    reader->reset(new RandomAccessFileReader(std::move(f), path, env_));
+    reader->reset(new RandomAccessFileReader(std::move(f), path,
+                                             nullptr /* IOTracer */, env_));
   }
 
   void NewTableReader(const ImmutableCFOptions& ioptions,

--- a/table/cuckoo/cuckoo_table_builder_test.cc
+++ b/table/cuckoo/cuckoo_table_builder_test.cc
@@ -65,7 +65,7 @@ class CuckooBuilderTest : public testing::Test {
     TableProperties* props = nullptr;
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                   fname));
+                                   fname, nullptr /* IOTracer */));
     ASSERT_OK(ReadTableProperties(file_reader.get(), read_file_size,
                                   kCuckooTableMagicNumber, ioptions,
                                   &props, true /* compression_type_missing */));
@@ -167,7 +167,7 @@ TEST_F(CuckooBuilderTest, SuccessWithEmptyFile) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, 4, 100,
                              BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -210,7 +210,7 @@ TEST_F(CuckooBuilderTest, WriteSuccessNoCollisionFullKey) {
     ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
     std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
         NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-        EnvOptions()));
+        EnvOptions(), nullptr /* IOTracer */));
     CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                                100, BytewiseComparator(), 1, false, false,
                                GetSliceHash, 0 /* column_family_id */,
@@ -260,7 +260,7 @@ TEST_F(CuckooBuilderTest, WriteSuccessWithCollisionFullKey) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -310,7 +310,7 @@ TEST_F(CuckooBuilderTest, WriteSuccessWithCollisionAndCuckooBlock) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(
       file_writer.get(), kHashTableRatio, num_hash_fun, 100,
       BytewiseComparator(), cuckoo_block_size, false, false, GetSliceHash,
@@ -364,7 +364,7 @@ TEST_F(CuckooBuilderTest, WithCollisionPathFullKey) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -415,7 +415,7 @@ TEST_F(CuckooBuilderTest, WithCollisionPathFullKeyAndCuckooBlock) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 2, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -459,7 +459,7 @@ TEST_F(CuckooBuilderTest, WriteSuccessNoCollisionUserKey) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -504,7 +504,7 @@ TEST_F(CuckooBuilderTest, WriteSuccessWithCollisionUserKey) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -551,7 +551,7 @@ TEST_F(CuckooBuilderTest, WithCollisionPathUserKey) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              2, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -597,7 +597,7 @@ TEST_F(CuckooBuilderTest, FailWhenCollisionPathTooLong) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              2, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,
@@ -626,7 +626,7 @@ TEST_F(CuckooBuilderTest, FailWhenSameKeyInserted) {
   ASSERT_OK(env_->NewWritableFile(fname, &writable_file, env_options_));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      EnvOptions()));
+      EnvOptions(), nullptr /* IOTracer */));
   CuckooTableBuilder builder(file_writer.get(), kHashTableRatio, num_hash_fun,
                              100, BytewiseComparator(), 1, false, false,
                              GetSliceHash, 0 /* column_family_id */,

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -93,7 +93,7 @@ class CuckooReaderTest : public testing::Test {
     ASSERT_OK(env->NewWritableFile(fname, &writable_file, env_options));
     std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
         NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-        env_options));
+        env_options, nullptr /* IOTracer */));
 
     CuckooTableBuilder builder(
         file_writer.get(), 0.9, kNumHashFunc, 100, ucomp, 2, false, false,
@@ -114,7 +114,7 @@ class CuckooReaderTest : public testing::Test {
     ASSERT_OK(env->NewRandomAccessFile(fname, &read_file, env_options));
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                   fname));
+                                   fname, nullptr /* IOTrace */));
     const ImmutableCFOptions ioptions(options);
     CuckooTableReader reader(ioptions, std::move(file_reader), file_size, ucomp,
                              GetSliceHash);
@@ -144,7 +144,7 @@ class CuckooReaderTest : public testing::Test {
     ASSERT_OK(env->NewRandomAccessFile(fname, &read_file, env_options));
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                   fname));
+                                   fname, nullptr /* IOTrace */));
     const ImmutableCFOptions ioptions(options);
     CuckooTableReader reader(ioptions, std::move(file_reader), file_size, ucomp,
                              GetSliceHash);
@@ -335,7 +335,7 @@ TEST_F(CuckooReaderTest, WhenKeyNotFound) {
   ASSERT_OK(env->NewRandomAccessFile(fname, &read_file, env_options));
   std::unique_ptr<RandomAccessFileReader> file_reader(
       new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                 fname));
+                                 fname, nullptr /* IOTrace */));
   const ImmutableCFOptions ioptions(options);
   CuckooTableReader reader(ioptions, std::move(file_reader), file_size, ucmp,
                            GetSliceHash);
@@ -424,7 +424,7 @@ void WriteFile(const std::vector<std::string>& keys,
   ASSERT_OK(env->NewWritableFile(fname, &writable_file, env_options));
   std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(writable_file)), fname,
-      env_options));
+      env_options, nullptr /* IOTracer */));
   CuckooTableBuilder builder(
       file_writer.get(), hash_ratio, 64, 1000, test::Uint64Comparator(), 5,
       false, FLAGS_identity_as_first_hash, nullptr, 0 /* column_family_id */,
@@ -446,7 +446,7 @@ void WriteFile(const std::vector<std::string>& keys,
   ASSERT_OK(env->NewRandomAccessFile(fname, &read_file, env_options));
   std::unique_ptr<RandomAccessFileReader> file_reader(
       new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                 fname));
+                                 fname, nullptr /*IOTracer */));
 
   const ImmutableCFOptions ioptions(options);
   CuckooTableReader reader(ioptions, std::move(file_reader), file_size,
@@ -479,7 +479,7 @@ void ReadKeys(uint64_t num, uint32_t batch_size) {
   ASSERT_OK(env->NewRandomAccessFile(fname, &read_file, env_options));
   std::unique_ptr<RandomAccessFileReader> file_reader(
       new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(read_file),
-                                 fname));
+                                 fname, nullptr /* IOTracer */));
 
   const ImmutableCFOptions ioptions(options);
   CuckooTableReader reader(ioptions, std::move(file_reader), file_size,

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -97,7 +97,7 @@ Status MockTableFactory::CreateMockTable(Env* env, const std::string& fname,
   }
 
   WritableFileWriter file_writer(NewLegacyWritableFileWrapper(std::move(file)),
-                                 fname, EnvOptions());
+                                 fname, EnvOptions(), nullptr /* IOTracer */);
 
   uint32_t id = GetAndWriteNextID(&file_writer);
   file_system_.files.insert({id, std::move(file_contents)});

--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -94,7 +94,7 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
   }
 
   file_.reset(new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
-                                         file_path));
+                                         file_path, options_.io_tracer));
 
   FilePrefetchBuffer prefetch_buffer(nullptr, 0, 0, true /* enable */,
                                      false /* track_min_offset */);
@@ -120,8 +120,9 @@ Status SstFileDumper::GetTableReader(const std::string& file_path) {
         magic_number == kLegacyPlainTableMagicNumber) {
       soptions_.use_mmap_reads = true;
       options_.env->NewRandomAccessFile(file_path, &file, soptions_);
-      file_.reset(new RandomAccessFileReader(
-          NewLegacyRandomAccessFileWrapper(file), file_path));
+      file_.reset(
+          new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
+                                     file_path, options_.io_tracer));
     }
     options_.comparator = &internal_comparator_;
     // For old sst format, ReadTableProperties might fail but file can be read
@@ -191,7 +192,7 @@ uint64_t SstFileDumper::CalculateCompressedTableSize(
   std::unique_ptr<WritableFileWriter> dest_writer;
   dest_writer.reset(
       new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(out_file)),
-                             testFileName, soptions_));
+                             testFileName, soptions_, ioptions_.io_tracer));
   BlockBasedTableOptions table_options;
   table_options.block_size = block_size;
   BlockBasedTableFactory block_based_tf(table_options);

--- a/table/sst_file_reader.cc
+++ b/table/sst_file_reader.cc
@@ -48,8 +48,9 @@ Status SstFileReader::Open(const std::string& file_path) {
     s = r->options.env->NewRandomAccessFile(file_path, &file, r->soptions);
   }
   if (s.ok()) {
-    file_reader.reset(new RandomAccessFileReader(
-        NewLegacyRandomAccessFileWrapper(file), file_path));
+    file_reader.reset(
+        new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
+                                   file_path, r->options.io_tracer));
   }
   if (s.ok()) {
     TableReaderOptions t_opt(r->ioptions, r->moptions.prefix_extractor.get(),

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -255,8 +255,9 @@ Status SstFileWriter::Open(const std::string& file_path) {
       0 /* file_creation_time */, "SST Writer" /* db_id */, db_session_id);
   r->file_writer.reset(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(sst_file)), file_path,
-      r->env_options, r->ioptions.env, nullptr /* stats */,
-      r->ioptions.listeners, r->ioptions.file_checksum_gen_factory));
+      r->env_options, r->ioptions.io_tracer, r->ioptions.env,
+      nullptr /* stats */, r->ioptions.listeners,
+      r->ioptions.file_checksum_gen_factory));
 
   // TODO(tec) : If table_factory is using compressed block cache, we will
   // be adding the external sst file blocks into it, which is wasteful.

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -95,8 +95,9 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
     std::vector<std::unique_ptr<IntTblPropCollectorFactory> >
         int_tbl_prop_collector_factories;
 
-    file_writer.reset(new WritableFileWriter(
-        NewLegacyWritableFileWrapper(std::move(file)), file_name, env_options));
+    file_writer.reset(
+        new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
+                               file_name, env_options, ioptions.io_tracer));
     int unknown_level = -1;
     tb = opts.table_factory->NewTableBuilder(
         TableBuilderOptions(
@@ -140,7 +141,7 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
     env->GetFileSize(file_name, &file_size);
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(raf),
-                                   file_name));
+                                   file_name, ioptions.io_tracer));
     s = opts.table_factory->NewTableReader(
         TableReaderOptions(ioptions, moptions.prefix_extractor.get(),
                            env_options, ikc),

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -174,19 +174,21 @@ WritableFileWriter* GetWritableFileWriter(WritableFile* wf,
                                           const std::string& fname) {
   std::unique_ptr<WritableFile> file(wf);
   return new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
-                                fname, EnvOptions());
+                                fname, EnvOptions(), nullptr /* IOTracer */);
 }
 
 RandomAccessFileReader* GetRandomAccessFileReader(RandomAccessFile* raf) {
   std::unique_ptr<RandomAccessFile> file(raf);
   return new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
-                                    "[test RandomAccessFileReader]");
+                                    "[test RandomAccessFileReader]",
+                                    nullptr /*IOTracer */);
 }
 
 SequentialFileReader* GetSequentialFileReader(SequentialFile* se,
                                               const std::string& fname) {
   std::unique_ptr<SequentialFile> file(se);
-  return new SequentialFileReader(NewLegacySequentialFileWrapper(file), fname);
+  return new SequentialFileReader(NewLegacySequentialFileWrapper(file), fname,
+                                  nullptr /*IOTrace*/);
 }
 
 void CorruptKeyType(InternalKey* ikey) {

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -2217,7 +2217,7 @@ void DumpWalFile(Options options, std::string wal_file, bool print_header,
     status = env->NewSequentialFile(wal_file, &file, soptions);
     if (status.ok()) {
       wal_file_reader.reset(new SequentialFileReader(
-          NewLegacySequentialFileWrapper(file), wal_file));
+          NewLegacySequentialFileWrapper(file), wal_file, options.io_tracer));
     }
   }
   if (!status.ok()) {

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -53,8 +53,9 @@ void createSST(const Options& opts, const std::string& file_name) {
 
   std::vector<std::unique_ptr<IntTblPropCollectorFactory> >
       int_tbl_prop_collector_factories;
-  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
-      NewLegacyWritableFileWrapper(std::move(file)), file_name, EnvOptions()));
+  std::unique_ptr<WritableFileWriter> file_writer(
+      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
+                             file_name, EnvOptions(), nullptr /* IOTracer */));
   std::string column_family_name;
   int unknown_level = -1;
   tb.reset(opts.table_factory->NewTableBuilder(

--- a/tools/trace_analyzer_test.cc
+++ b/tools/trace_analyzer_test.cc
@@ -133,7 +133,8 @@ class TraceAnalyzerTest : public testing::Test {
     std::unique_ptr<FSSequentialFile> file =
         NewLegacySequentialFileWrapper(f_ptr);
     SequentialFileReader sf_reader(std::move(file), file_path,
-                                   4096 /* filereadahead_size */);
+                                   4096 /* filereadahead_size */,
+                                   nullptr /* IOTracer */);
 
     for (count = 0; ReadOneLine(&iss, &sf_reader, &get_line, &has_data, &s);
          ++count) {

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -1066,7 +1066,8 @@ Status TraceAnalyzer::ReProcessing() {
         size_t kTraceFileReadaheadSize = 2 * 1024 * 1024;
         SequentialFileReader sf_reader(
             std::move(file), whole_key_path,
-            kTraceFileReadaheadSize /* filereadahead_size */);
+            kTraceFileReadaheadSize /* filereadahead_size */,
+            nullptr /*IOTracer*/);
         for (cfs_[cf_id].w_count = 0;
              ReadOneLine(&iss, &sf_reader, &get_key, &has_data, &s);
              ++cfs_[cf_id].w_count) {

--- a/trace_replay/io_tracer.cc
+++ b/trace_replay/io_tracer.cc
@@ -52,7 +52,7 @@ Status IOTraceWriter::WriteIOOp(const IOTraceRecord& record) {
       PutFixed64(&trace.payload, record.offset);
       FALLTHROUGH_INTENDED;
     case TraceType::kIOLen:
-      trace.payload.push_back(record.len);
+      PutFixed64(&trace.payload, record.len);
       break;
     default:
       assert(false);
@@ -177,13 +177,10 @@ Status IOTraceReader::ReadIOOp(IOTraceRecord* record) {
       }
       FALLTHROUGH_INTENDED;
     case TraceType::kIOLen: {
-      if (enc_slice.empty()) {
+      if (!GetFixed64(&enc_slice, &record->len)) {
         return Status::Incomplete(
             "Incomplete access record: Failed to read length.");
       }
-      record->len = static_cast<size_t>(enc_slice[0]);
-      const unsigned int kCharSize = 1;
-      enc_slice.remove_prefix(kCharSize);
       break;
     }
     default:

--- a/trace_replay/io_tracer.h
+++ b/trace_replay/io_tracer.h
@@ -25,7 +25,7 @@ struct IOTraceRecord {
   std::string io_status;
   // Required fields for read.
   std::string file_name;
-  size_t len = 0;
+  uint64_t len = 0;
   uint64_t offset = 0;
   uint64_t file_size = 0;
 

--- a/trace_replay/io_tracer_test.cc
+++ b/trace_replay/io_tracer_test.cc
@@ -31,7 +31,7 @@ class IOTracerTest : public testing::Test {
     EXPECT_OK(env_->DeleteDir(test_path_));
   }
 
-  std::string GetFileOperation(uint32_t id) {
+  std::string GetFileOperation(uint64_t id) {
     id = id % 4;
     switch (id) {
       case 0:
@@ -42,13 +42,15 @@ class IOTracerTest : public testing::Test {
         return "FileSize";
       case 3:
         return "DeleteDir";
+      default:
+        assert(false);
     }
-    assert(false);
+    return "";
   }
 
-  void WriteIOOp(IOTraceWriter* writer, uint32_t nrecords) {
+  void WriteIOOp(IOTraceWriter* writer, uint64_t nrecords) {
     assert(writer);
-    for (uint32_t i = 0; i < nrecords; i++) {
+    for (uint64_t i = 0; i < nrecords; i++) {
       IOTraceRecord record;
       record.trace_type = TraceType::kIOLenAndOffset;
       record.file_operation = GetFileOperation(i);
@@ -60,9 +62,9 @@ class IOTracerTest : public testing::Test {
     }
   }
 
-  void VerifyIOOp(IOTraceReader* reader, uint32_t nrecords) {
+  void VerifyIOOp(IOTraceReader* reader, uint64_t nrecords) {
     assert(reader);
-    for (uint32_t i = 0; i < nrecords; i++) {
+    for (uint64_t i = 0; i < nrecords; i++) {
       IOTraceRecord record;
       ASSERT_OK(reader->ReadIOOp(&record));
       ASSERT_EQ(record.file_operation, GetFileOperation(i));
@@ -100,8 +102,8 @@ TEST_F(IOTracerTest, AtomicWrite) {
     IOTraceReader reader(std::move(trace_reader));
     IOTraceHeader header;
     ASSERT_OK(reader.ReadHeader(&header));
-    ASSERT_EQ(kMajorVersion, header.rocksdb_major_version);
-    ASSERT_EQ(kMinorVersion, header.rocksdb_minor_version);
+    ASSERT_EQ(kMajorVersion, static_cast<int>(header.rocksdb_major_version));
+    ASSERT_EQ(kMinorVersion, static_cast<int>(header.rocksdb_minor_version));
     // Read record and verify data.
     IOTraceRecord access_record;
     ASSERT_OK(reader.ReadIOOp(&access_record));
@@ -162,8 +164,8 @@ TEST_F(IOTracerTest, AtomicNoWriteAfterEndTrace) {
     IOTraceReader reader(std::move(trace_reader));
     IOTraceHeader header;
     ASSERT_OK(reader.ReadHeader(&header));
-    ASSERT_EQ(kMajorVersion, header.rocksdb_major_version);
-    ASSERT_EQ(kMinorVersion, header.rocksdb_minor_version);
+    ASSERT_EQ(kMajorVersion, static_cast<int>(header.rocksdb_major_version));
+    ASSERT_EQ(kMinorVersion, static_cast<int>(header.rocksdb_minor_version));
 
     IOTraceRecord access_record;
     ASSERT_OK(reader.ReadIOOp(&access_record));
@@ -196,8 +198,9 @@ TEST_F(IOTracerTest, AtomicMultipleWrites) {
     IOTraceReader reader(std::move(trace_reader));
     IOTraceHeader header;
     ASSERT_OK(reader.ReadHeader(&header));
-    ASSERT_EQ(kMajorVersion, header.rocksdb_major_version);
-    ASSERT_EQ(kMinorVersion, header.rocksdb_minor_version);
+    ASSERT_EQ(kMajorVersion, static_cast<int>(header.rocksdb_major_version));
+    ASSERT_EQ(kMinorVersion, static_cast<int>(header.rocksdb_minor_version));
+
     // Read 10 records.
     VerifyIOOp(&reader, 10);
     // Read one more and record and it should report error.

--- a/util/file_reader_writer_test.cc
+++ b/util/file_reader_writer_test.cc
@@ -76,9 +76,9 @@ TEST_F(WritableFileWriterTest, RangeSync) {
   EnvOptions env_options;
   env_options.bytes_per_sync = kMb;
   std::unique_ptr<FakeWF> wf(new FakeWF);
-  std::unique_ptr<WritableFileWriter> writer(
-      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(wf)),
-                             "" /* don't care */, env_options));
+  std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
+      NewLegacyWritableFileWrapper(std::move(wf)), "" /* don't care */,
+      env_options, nullptr /* IOTracer */));
   Random r(301);
   std::unique_ptr<char[]> large_buf(new char[10 * kMb]);
   for (int i = 0; i < 1000; i++) {
@@ -159,9 +159,9 @@ TEST_F(WritableFileWriterTest, IncrementalBuffer) {
                                           false,
 #endif
                                           no_flush));
-    std::unique_ptr<WritableFileWriter> writer(
-        new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(wf)),
-                               "" /* don't care */, env_options));
+    std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
+        NewLegacyWritableFileWrapper(std::move(wf)), "" /* don't care */,
+        env_options, nullptr /* IOTracer */));
 
     std::string target;
     for (int i = 0; i < 20; i++) {
@@ -213,9 +213,9 @@ TEST_F(WritableFileWriterTest, AppendStatusReturn) {
   };
   std::unique_ptr<FakeWF> wf(new FakeWF());
   wf->Setuse_direct_io(true);
-  std::unique_ptr<WritableFileWriter> writer(
-      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(wf)),
-                             "" /* don't care */, EnvOptions()));
+  std::unique_ptr<WritableFileWriter> writer(new WritableFileWriter(
+      NewLegacyWritableFileWrapper(std::move(wf)), "" /* don't care */,
+      EnvOptions(), nullptr /* IOTracer */));
 
   ASSERT_OK(writer->Append(std::string(2 * kMb, 'a')));
 
@@ -348,7 +348,8 @@ class ReadaheadSequentialFileTest : public testing::Test,
     auto read_holder = std::unique_ptr<SequentialFile>(
         new test::SeqStringSource(str, &seq_read_count_));
     test_read_holder_.reset(new SequentialFileReader(
-        NewLegacySequentialFileWrapper(read_holder), "test", readahead_size_));
+        NewLegacySequentialFileWrapper(read_holder), "test", readahead_size_,
+        nullptr /* IOTracer */));
   }
   size_t GetReadaheadSize() const { return readahead_size_; }
 

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1476,13 +1476,14 @@ Status BackupEngineImpl::CopyOrCreateFile(
     return s;
   }
 
-  std::unique_ptr<WritableFileWriter> dest_writer(new WritableFileWriter(
-      NewLegacyWritableFileWrapper(std::move(dst_file)), dst, dst_env_options));
+  std::unique_ptr<WritableFileWriter> dest_writer(
+      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(dst_file)),
+                             dst, dst_env_options, nullptr /* IOTrace */));
   std::unique_ptr<SequentialFileReader> src_reader;
   std::unique_ptr<char[]> buf;
   if (!src.empty()) {
     src_reader.reset(new SequentialFileReader(
-        NewLegacySequentialFileWrapper(src_file), src));
+        NewLegacySequentialFileWrapper(src_file), src, nullptr /* IOTracer */));
     buf.reset(new char[copy_file_buffer_size_]);
   }
 
@@ -1777,8 +1778,8 @@ Status BackupEngineImpl::CalculateChecksum(const std::string& src, Env* src_env,
     return s;
   }
 
-  std::unique_ptr<SequentialFileReader> src_reader(
-      new SequentialFileReader(NewLegacySequentialFileWrapper(src_file), src));
+  std::unique_ptr<SequentialFileReader> src_reader(new SequentialFileReader(
+      NewLegacySequentialFileWrapper(src_file), src, nullptr));
   std::unique_ptr<char[]> buf(new char[copy_file_buffer_size_]);
   Slice data;
 
@@ -2080,7 +2081,7 @@ Status BackupEngineImpl::BackupMeta::LoadFromFile(
 
   std::unique_ptr<SequentialFileReader> backup_meta_reader(
       new SequentialFileReader(NewLegacySequentialFileWrapper(backup_meta_file),
-                               meta_filename_));
+                               meta_filename_, nullptr));
   std::unique_ptr<char[]> buf(new char[max_backup_meta_file_size_ + 1]);
   Slice data;
   s = backup_meta_reader->Read(max_backup_meta_file_size_, &data, buf.get());

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -732,8 +732,9 @@ Status BlobDBImpl::CreateWriterLocked(const std::shared_ptr<BlobFile>& bfile) {
   }
 
   std::unique_ptr<WritableFileWriter> fwriter;
-  fwriter.reset(new WritableFileWriter(
-      NewLegacyWritableFileWrapper(std::move(wfile)), fpath, env_options_));
+  fwriter.reset(
+      new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(wfile)),
+                             fpath, env_options_, db_options_.io_tracer));
 
   uint64_t boffset = bfile->GetFileSize();
   if (debug_level_ >= 2 && boffset) {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -660,7 +660,9 @@ TEST_F(BlobDBTest, SstFileManagerRestart) {
   Close();
 
   // Create 3 dummy trash files under the blob_dir
-  LegacyFileSystemWrapper fs(db_options.env);
+  std::shared_ptr<FileSystem> fs_wrap =
+      std::make_shared<LegacyFileSystemWrapper>(db_options.env);
+  FileSystemPtr fs(fs_wrap);
   CreateFile(&fs, blob_dir + "/000666.blob.trash", "", false);
   CreateFile(&fs, blob_dir + "/000888.blob.trash", "", true);
   CreateFile(&fs, blob_dir + "/something_not_match.trash", "", false);

--- a/utilities/blob_db/blob_dump_tool.cc
+++ b/utilities/blob_db/blob_dump_tool.cc
@@ -51,8 +51,9 @@ Status BlobDumpTool::Run(const std::string& filename, DisplayType show_key,
   if (file_size == 0) {
     return Status::Corruption("File is empty.");
   }
-  reader_.reset(new RandomAccessFileReader(
-      NewLegacyRandomAccessFileWrapper(file), filename));
+  reader_.reset(
+      new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
+                                 filename, nullptr /* IOTracer */));
   uint64_t offset = 0;
   uint64_t footer_offset = 0;
   CompressionType compression = kNoCompression;

--- a/utilities/blob_db/blob_file.cc
+++ b/utilities/blob_db/blob_file.cc
@@ -75,8 +75,9 @@ std::shared_ptr<BlobLogReader> BlobFile::OpenRandomAccessReader(
   sfile = NewReadaheadRandomAccessFile(std::move(sfile), kReadaheadSize);
 
   std::unique_ptr<RandomAccessFileReader> sfile_reader;
-  sfile_reader.reset(new RandomAccessFileReader(
-      NewLegacyRandomAccessFileWrapper(sfile), path_name));
+  sfile_reader.reset(
+      new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(sfile),
+                                 path_name, db_options.io_tracer));
 
   std::shared_ptr<BlobLogReader> log_reader = std::make_shared<BlobLogReader>(
       std::move(sfile_reader), db_options.env, db_options.statistics.get());
@@ -211,7 +212,8 @@ Status BlobFile::GetReader(Env* env, const EnvOptions& env_options,
   }
 
   ra_file_reader_ = std::make_shared<RandomAccessFileReader>(
-      NewLegacyRandomAccessFileWrapper(rfile), PathName());
+      NewLegacyRandomAccessFileWrapper(rfile), PathName(),
+      nullptr /* IOTracer */);
   *reader = ra_file_reader_;
   *fresh_open = true;
   return s;
@@ -250,7 +252,7 @@ Status BlobFile::ReadMetadata(Env* env, const EnvOptions& env_options) {
   }
   std::unique_ptr<RandomAccessFileReader> file_reader(
       new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file),
-                                 PathName()));
+                                 PathName(), nullptr /* IOTracer */));
 
   // Read file header.
   std::string header_buf;

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -114,22 +114,22 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
         [&](const std::string& src_dirname, const std::string& fname,
             FileType) {
           ROCKS_LOG_INFO(db_options.info_log, "Hard Linking %s", fname.c_str());
-          return db_->GetFileSystem()->LinkFile(src_dirname + fname,
-                                                full_private_path + fname,
-                                                IOOptions(), nullptr);
+          return (*(db_->GetFileSystemPtr()))
+              ->LinkFile(src_dirname + fname, full_private_path + fname,
+                         IOOptions(), nullptr);
         } /* link_file_cb */,
         [&](const std::string& src_dirname, const std::string& fname,
             uint64_t size_limit_bytes, FileType,
             const std::string& /* checksum_func_name */,
             const std::string& /* checksum_val */) {
           ROCKS_LOG_INFO(db_options.info_log, "Copying %s", fname.c_str());
-          return CopyFile(db_->GetFileSystem(), src_dirname + fname,
+          return CopyFile(db_->GetFileSystemPtr(), src_dirname + fname,
                           full_private_path + fname, size_limit_bytes,
                           db_options.use_fsync);
         } /* copy_file_cb */,
         [&](const std::string& fname, const std::string& contents, FileType) {
           ROCKS_LOG_INFO(db_options.info_log, "Creating %s", fname.c_str());
-          return CreateFile(db_->GetFileSystem(), full_private_path + fname,
+          return CreateFile(db_->GetFileSystemPtr(), full_private_path + fname,
                             contents, db_options.use_fsync);
         } /* create_file_cb */,
         &sequence_number, log_size_for_flush);
@@ -417,7 +417,7 @@ Status CheckpointImpl::ExportColumnFamily(
           [&](const std::string& src_dirname, const std::string& fname) {
             ROCKS_LOG_INFO(db_options.info_log, "[%s] Copying %s",
                            cf_name.c_str(), fname.c_str());
-            return CopyFile(db_->GetFileSystem(), src_dirname + fname,
+            return CopyFile(db_->GetFileSystemPtr(), src_dirname + fname,
                             tmp_export_dir + fname, 0, db_options.use_fsync);
           } /*copy_file_cb*/);
 

--- a/utilities/options/options_util.cc
+++ b/utilities/options/options_util.cc
@@ -8,6 +8,7 @@
 #include "rocksdb/utilities/options_util.h"
 
 #include "env/composite_env_wrapper.h"
+#include "env/file_system_tracer.h"
 #include "file/filename.h"
 #include "options/options_parser.h"
 #include "rocksdb/convenience.h"
@@ -34,7 +35,9 @@ Status LoadOptionsFromFile(const ConfigOptions& config_options,
                            std::vector<ColumnFamilyDescriptor>* cf_descs,
                            std::shared_ptr<Cache>* cache) {
   RocksDBOptionsParser parser;
-  LegacyFileSystemWrapper fs(config_options.env);
+  std::shared_ptr<FileSystem> fs_wrap =
+      std::make_shared<LegacyFileSystemWrapper>(config_options.env);
+  FileSystemPtr fs(fs_wrap);
   Status s = parser.Parse(config_options, file_name, &fs);
   if (!s.ok()) {
     return s;
@@ -143,10 +146,10 @@ Status CheckOptionsCompatibility(
     cf_opts.push_back(cf_desc.options);
   }
 
-  LegacyFileSystemWrapper fs(config_options.env);
-
+  std::shared_ptr<FileSystem> fs_wrap =
+      std::make_shared<LegacyFileSystemWrapper>(config_options.env);
+  FileSystemPtr fs(fs_wrap);
   return RocksDBOptionsParser::VerifyRocksDBOptionsFromFile(
-
       config_options, db_options, cf_names, cf_opts,
       dbpath + "/" + options_file_name, &fs);
 }

--- a/utilities/options/options_util_test.cc
+++ b/utilities/options/options_util_test.cc
@@ -11,6 +11,7 @@
 #include <cinttypes>
 #include <unordered_map>
 
+#include "env/file_system_tracer.h"
 #include "options/options_parser.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
@@ -32,13 +33,15 @@ class OptionsUtilTest : public testing::Test {
  public:
   OptionsUtilTest() : rnd_(0xFB) {
     env_.reset(new test::StringEnv(Env::Default()));
-    fs_.reset(new LegacyFileSystemWrapper(env_.get()));
+    std::shared_ptr<FileSystem> fs_wrap =
+        std::make_shared<LegacyFileSystemWrapper>(env_.get());
+    fs_.reset(new FileSystemPtr(fs_wrap));
     dbname_ = test::PerThreadDBPath("options_util_test");
   }
 
  protected:
   std::unique_ptr<test::StringEnv> env_;
-  std::unique_ptr<LegacyFileSystemWrapper> fs_;
+  std::unique_ptr<FileSystemPtr> fs_;
   std::string dbname_;
   Random rnd_;
 };

--- a/utilities/persistent_cache/block_cache_tier_file.cc
+++ b/utilities/persistent_cache/block_cache_tier_file.cc
@@ -218,8 +218,9 @@ bool RandomAccessCacheFile::OpenImpl(const bool enable_direct_reads) {
           status.ToString().c_str());
     return false;
   }
-  freader_.reset(new RandomAccessFileReader(
-      NewLegacyRandomAccessFileWrapper(file), Path(), env_));
+  freader_.reset(
+      new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(file), Path(),
+                                 nullptr /* IOTracer */, env_));
 
   return true;
 }

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -4,8 +4,11 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include "rocksdb/utilities/sim_cache.h"
+
 #include <atomic>
+
 #include "env/composite_env_wrapper.h"
+#include "env/file_system_tracer.h"
 #include "file/writable_file_writer.h"
 #include "monitoring/statistics.h"
 #include "port/port.h"
@@ -49,7 +52,7 @@ class CacheActivityLogger {
     }
     file_writer_.reset(new WritableFileWriter(
         NewLegacyWritableFileWrapper(std::move(log_file)), activity_log_file,
-        env_opts));
+        env_opts, nullptr /* IOTracer */));
 
     max_logging_size_ = max_logging_size;
     activity_logging_enabled_.store(true);

--- a/utilities/trace/file_trace_reader_writer.cc
+++ b/utilities/trace/file_trace_reader_writer.cc
@@ -99,8 +99,9 @@ Status NewFileTraceReader(Env* env, const EnvOptions& env_options,
   }
 
   std::unique_ptr<RandomAccessFileReader> file_reader;
-  file_reader.reset(new RandomAccessFileReader(
-      NewLegacyRandomAccessFileWrapper(trace_file), trace_filename));
+  file_reader.reset(
+      new RandomAccessFileReader(NewLegacyRandomAccessFileWrapper(trace_file),
+                                 trace_filename, nullptr /* IOTracer */));
   trace_reader->reset(new FileTraceReader(std::move(file_reader)));
   return s;
 }
@@ -117,7 +118,7 @@ Status NewFileTraceWriter(Env* env, const EnvOptions& env_options,
   std::unique_ptr<WritableFileWriter> file_writer;
   file_writer.reset(new WritableFileWriter(
       NewLegacyWritableFileWrapper(std::move(trace_file)), trace_filename,
-      env_options));
+      env_options, nullptr /* IOTrace */));
   trace_writer->reset(new FileTraceWriter(std::move(file_writer)));
   return s;
 }


### PR DESCRIPTION
Summary: As part of IOTracing project, this PR contains following changes.
1. Changed the code to cache "FileSystemPtr" pointer(wrapper class that returns file system pointer based on tracing enabled) instead of "FileSystem" pointer.
2. Add IOTrace in Options.
3. "FileSystemPtr" pointer is created in db_impl.cc and Options.env->GetFileSystem() and Options.io_tracer are passed as arguments.
4. "ImmutableDBOptions.fs" is used in the code to get the "FileSystemPtr" pointer.
5. In "SequentialFileReader" class, "FSSequentialFilePtr" (wrapper class) ptr is created and that pointer is used to call underlying file system based on tracing enabled/disabled.
6. For "FSRandomAccessFile" and  "FSWritableFile" as well, their Reader/Writer classes create a wrapper class pointer and io_tracer pointer is passed to the Reader/Writer classes for creation of wrapper class pointers.

Test Plan: make check -j64
           COMPILE_WITH_TSAN=1 make check -j64

Reviewers:

Subscribers:

Tasks:

Tags: