### PR TITLE
Fix GetFileDbIdentities

### DIFF
--- a/table/sst_file_dumper.cc
+++ b/table/sst_file_dumper.cc
@@ -45,11 +45,12 @@ SstFileDumper::SstFileDumper(const Options& options,
                              const std::string& file_path,
                              size_t readahead_size, bool verify_checksum,
                              bool output_hex, bool decode_blob_index,
-                             bool silent)
+                             const EnvOptions& soptions, bool silent)
     : file_name_(file_path),
       read_num_(0),
       output_hex_(output_hex),
       decode_blob_index_(decode_blob_index),
+      soptions_(soptions),
       silent_(silent),
       options_(options),
       ioptions_(options_),

--- a/table/sst_file_dumper.h
+++ b/table/sst_file_dumper.h
@@ -18,6 +18,7 @@ class SstFileDumper {
   explicit SstFileDumper(const Options& options, const std::string& file_name,
                          size_t readahead_size, bool verify_checksum,
                          bool output_hex, bool decode_blob_index,
+                         const EnvOptions& soptions = EnvOptions(),
                          bool silent = false);
 
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,


### PR DESCRIPTION
Summary:
Although PR #7032 fixes the construction of the `SstFileDumper` in `GetFileDbIdentities` by setting a proper `Env` of the `Options` passed in the constructor, the file path was not corrected accordingly. This actually disables backup engine to use db session ids in the file names since the `db_session_id` is always empty.

Now it is fixed by setting the correct path in the construction of `SstFileDumper`. Furthermore, to preserve the Direct IO property that backup engine already has, parameter `EnvOptions` is added to `GetFileDbIdentities` and `SstFileDumper`.

The `BackupUsingDirectIO` test is updated accordingly.

Test plan:
backupable_db_test and some manual tests.