### PR TITLE
Running ./ldb without any extra arg print usage

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -464,7 +464,7 @@ Status StressTest::NewTxn(WriteOptions& write_opts, Transaction** txn) {
   }
   static std::atomic<uint64_t> txn_id = {0};
   TransactionOptions txn_options;
-  txn_options.lock_timeout = 60000; // 1min
+  txn_options.lock_timeout = 60000;  // 1min
   txn_options.deadlock_detect = true;
   *txn = txn_db_->BeginTransaction(write_opts, txn_options);
   auto istr = std::to_string(txn_id.fetch_add(1));

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -107,7 +107,10 @@ int LDBCommandRunner::RunCommand(
     const LDBOptions& ldb_options,
     const std::vector<ColumnFamilyDescriptor>* column_families) {
   if (argc <= 2) {
-    if (std::string(argv[1]) == "--version") {
+    if (argc <= 1) {
+      PrintHelp(ldb_options, argv[0], /*to_stderr*/ true);
+      return 1;
+    } else if (std::string(argv[1]) == "--version") {
       printf("ldb from RocksDB %d.%d.%d\n", ROCKSDB_MAJOR, ROCKSDB_MINOR,
              ROCKSDB_PATCH);
       return 0;


### PR DESCRIPTION
Summary:
as title.

Test Plan:
make ldb && ./ldb