### PR TITLE
Adding Memkind Persistent Memory Allocator

### DIFF
--- a/include/rocksdb/memory_allocator.h
+++ b/include/rocksdb/memory_allocator.h
@@ -74,4 +74,21 @@ extern Status NewJemallocNodumpAllocator(
     JemallocAllocatorOptions& options,
     std::shared_ptr<MemoryAllocator>* memory_allocator);
 
+// PersistentMemoryAllocator is an interface that a client can implement to
+// supply custom persistent memory allocation, deallocation, initialization and
+// finlization functions. All methods should be thread-safe.
+class PersistentMemoryAllocator : public MemoryAllocator {
+ public:
+  virtual ~PersistentMemoryAllocator() = default;
+
+  // Initialize the persistent memory allocator. Typically setting up
+  // memory-mapped files in DAX-enabled file systems and/or recover existing
+  // heap(s).
+  virtual int Init() = 0;
+
+  // Finilization of persistent memory allocator. Typically finish writing back
+  // or flushing to NVM, and close the file.
+  virtual int Finalize() = 0;
+};
+
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary:
With byte-addressable non-volatile main memory available, we want to explore the possibility of residing (compressed) block cache in it, as block cache is designed for byte-addressable main memory, and (compressed) cache can likely make use of persistent storage media to drastically reduce recovery overhead.
Since Memkind is officially supported in RocksDB, we want to test its PMEM allocation on both simulated and real NVM in preparation for the goal above.

Test plan:
Adapt the test for memkind kmem allocator to this pmem callocator.