### PR TITLE
WriteBatchWithIndex refactory: Allow third party index implementation

### DIFF
--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -12,6 +12,7 @@
 #include "rocksdb/comparator.h"
 #include "rocksdb/db.h"
 #include "rocksdb/utilities/stackable_db.h"
+#include "rocksdb/utilities/write_batch_with_index.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -29,6 +30,9 @@ struct OptimisticTransactionOptions {
   // Should be set if the DB has a non-default comparator.
   // See comment in WriteBatchWithIndex constructor.
   const Comparator* cmp = BytewiseComparator();
+
+  // Set index factory for WriteBatchWithIndex
+  const rocksdb::WriteBatchEntryIndexFactory* index_type = nullptr;
 };
 
 enum class OccValidationPolicy {

--- a/include/rocksdb/utilities/optimistic_transaction_db.h
+++ b/include/rocksdb/utilities/optimistic_transaction_db.h
@@ -32,7 +32,7 @@ struct OptimisticTransactionOptions {
   const Comparator* cmp = BytewiseComparator();
 
   // Set index factory for WriteBatchWithIndex
-  const rocksdb::WriteBatchEntryIndexFactory* index_type = nullptr;
+  const WriteBatchEntryIndexFactory* index_type = nullptr;
 };
 
 enum class OccValidationPolicy {

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -31,6 +31,7 @@ class DB;
 class ReadCallback;
 struct ReadOptions;
 struct DBOptions;
+class WriteBatchEntryIndexFactory;
 
 enum WriteType {
   kPutRecord,
@@ -42,12 +43,27 @@ enum WriteType {
   kXIDRecord,
 };
 
+// Singleton factory instance, DO NOT delete the returned pointer
+const WriteBatchEntryIndexFactory* skip_list_WriteBatchEntryIndexFactory();
+
 // an entry for Put, Merge, Delete, or SingleDelete entry for write batches.
 // Used in WBWIIterator.
 struct WriteEntry {
   WriteType type;
   Slice key;
   Slice value;
+};
+
+template<class T, size_t N>
+struct WBIteratorStorage {
+  ~WBIteratorStorage() {
+    if (iter != nullptr) {
+      iter->~T();
+    }
+  }
+  T* operator->() const { return iter; }
+  T* iter = nullptr;
+  uint8_t buffer[N];
 };
 
 // Iterator of one column family out of a WriteBatchWithIndex.
@@ -74,6 +90,8 @@ class WBWIIterator {
   virtual WriteEntry Entry() const = 0;
 
   virtual Status status() const = 0;
+
+  typedef WBIteratorStorage<WBWIIterator, 56> IteratorStorage;
 };
 
 // A WriteBatchWithIndex with a binary searchable index built for all the keys
@@ -94,10 +112,11 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // overwrite_key: if true, overwrite the key in the index when inserting
   //                the same key as previously, so iterator will never
   //                show two entries with the same key.
+  // index_factory: third-party entry index support, NOT take ownership
   explicit WriteBatchWithIndex(
       const Comparator* backup_index_comparator = BytewiseComparator(),
       size_t reserved_bytes = 0, bool overwrite_key = false,
-      size_t max_bytes = 0);
+      size_t max_bytes = 0, const WriteBatchEntryIndexFactory* = nullptr);
 
   ~WriteBatchWithIndex() override;
   WriteBatchWithIndex(WriteBatchWithIndex&&);
@@ -154,6 +173,9 @@ class WriteBatchWithIndex : public WriteBatchBase {
   //
   // The returned iterator should be deleted by the caller.
   WBWIIterator* NewIterator(ColumnFamilyHandle* column_family);
+  void NewIterator(ColumnFamilyHandle* column_family,
+                   WBWIIterator::IteratorStorage& storage,
+                   bool ephemeral = false);
   // Create an iterator of the default column family.
   WBWIIterator* NewIterator();
 

--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -54,7 +54,7 @@ struct WriteEntry {
   Slice value;
 };
 
-template<class T, size_t N>
+template <class T, size_t N>
 struct WBIteratorStorage {
   ~WBIteratorStorage() {
     if (iter != nullptr) {

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -19,14 +19,15 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-TransactionBaseImpl::TransactionBaseImpl(DB* db,
-                                         const WriteOptions& write_options)
+TransactionBaseImpl::TransactionBaseImpl(
+    DB* db, const WriteOptions& write_options,
+    const rocksdb::WriteBatchEntryIndexFactory* index_factory)
     : db_(db),
       dbimpl_(static_cast_with_check<DBImpl>(db)),
       write_options_(write_options),
       cmp_(GetColumnFamilyUserComparator(db->DefaultColumnFamily())),
       start_time_(db_->GetEnv()->NowMicros()),
-      write_batch_(cmp_, 0, true, 0),
+      write_batch_(cmp_, 0, true, 0, index_factory),
       indexing_enabled_(true) {
   assert(dynamic_cast<DBImpl*>(db_) != nullptr);
   log_number_ = 0;

--- a/utilities/transactions/transaction_base.cc
+++ b/utilities/transactions/transaction_base.cc
@@ -21,7 +21,7 @@ namespace ROCKSDB_NAMESPACE {
 
 TransactionBaseImpl::TransactionBaseImpl(
     DB* db, const WriteOptions& write_options,
-    const rocksdb::WriteBatchEntryIndexFactory* index_factory)
+    const WriteBatchEntryIndexFactory* index_factory)
     : db_(db),
       dbimpl_(static_cast_with_check<DBImpl>(db)),
       write_options_(write_options),

--- a/utilities/transactions/transaction_base.h
+++ b/utilities/transactions/transaction_base.h
@@ -27,7 +27,8 @@ namespace ROCKSDB_NAMESPACE {
 
 class TransactionBaseImpl : public Transaction {
  public:
-  TransactionBaseImpl(DB* db, const WriteOptions& write_options);
+  TransactionBaseImpl(DB* db, const WriteOptions& write_options,
+                      const WriteBatchEntryIndexFactory* = nullptr);
 
   virtual ~TransactionBaseImpl();
 

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -16,6 +16,7 @@
 #include "memory/arena.h"
 #include "memtable/skiplist.h"
 #include "options/db_options.h"
+#include "port/likely.h"
 #include "rocksdb/comparator.h"
 #include "rocksdb/iterator.h"
 #include "util/cast_util.h"
@@ -339,70 +340,43 @@ class BaseDeltaIterator : public Iterator {
   const Slice* iterate_upper_bound_;
 };
 
-typedef SkipList<WriteBatchIndexEntry*, const WriteBatchEntryComparator&>
-    WriteBatchEntrySkipList;
-
 class WBWIIteratorImpl : public WBWIIterator {
  public:
   WBWIIteratorImpl(uint32_t column_family_id,
-                   WriteBatchEntrySkipList* skip_list,
-                   const ReadableWriteBatch* write_batch)
-      : column_family_id_(column_family_id),
-        skip_list_iter_(skip_list),
-        write_batch_(write_batch) {}
+                   WriteBatchEntryIndex* entry_index,
+                   const ReadableWriteBatch* write_batch,
+                   bool ephemeral)
+    : column_family_id_(column_family_id),
+      write_batch_(write_batch) {
+    entry_index->NewIterator(iter_, ephemeral);
+  }
 
   ~WBWIIteratorImpl() override {}
 
-  bool Valid() const override {
-    if (!skip_list_iter_.Valid()) {
-      return false;
-    }
-    const WriteBatchIndexEntry* iter_entry = skip_list_iter_.key();
-    return (iter_entry != nullptr &&
-            iter_entry->column_family == column_family_id_);
-  }
+  bool Valid() const override { return iter_->Valid(); }
 
-  void SeekToFirst() override {
-    WriteBatchIndexEntry search_entry(
-        nullptr /* search_key */, column_family_id_,
-        true /* is_forward_direction */, true /* is_seek_to_first */);
-    skip_list_iter_.Seek(&search_entry);
-  }
+  void SeekToFirst() override { iter_->SeekToFirst(); }
 
-  void SeekToLast() override {
-    WriteBatchIndexEntry search_entry(
-        nullptr /* search_key */, column_family_id_ + 1,
-        true /* is_forward_direction */, true /* is_seek_to_first */);
-    skip_list_iter_.Seek(&search_entry);
-    if (!skip_list_iter_.Valid()) {
-      skip_list_iter_.SeekToLast();
-    } else {
-      skip_list_iter_.Prev();
-    }
-  }
+  void SeekToLast() override { iter_->SeekToLast(); }
 
   void Seek(const Slice& key) override {
-    WriteBatchIndexEntry search_entry(&key, column_family_id_,
-                                      true /* is_forward_direction */,
-                                      false /* is_seek_to_first */);
-    skip_list_iter_.Seek(&search_entry);
+    WriteBatchIndexEntry search_entry(&key, column_family_id_);
+    iter_->Seek(&search_entry);
   }
 
   void SeekForPrev(const Slice& key) override {
-    WriteBatchIndexEntry search_entry(&key, column_family_id_,
-                                      false /* is_forward_direction */,
-                                      false /* is_seek_to_first */);
-    skip_list_iter_.SeekForPrev(&search_entry);
+    WriteBatchIndexEntry search_entry(&key, column_family_id_);
+    iter_->SeekForPrev(&search_entry);
   }
 
-  void Next() override { skip_list_iter_.Next(); }
+  void Next() override { iter_->Next(); }
 
-  void Prev() override { skip_list_iter_.Prev(); }
+  void Prev() override { iter_->Prev(); }
 
   WriteEntry Entry() const override {
     WriteEntry ret;
     Slice blob, xid;
-    const WriteBatchIndexEntry* iter_entry = skip_list_iter_.key();
+    const WriteBatchIndexEntry* iter_entry = iter_->key();
     // this is guaranteed with Valid()
     assert(iter_entry != nullptr &&
            iter_entry->column_family == column_family_id_);
@@ -422,30 +396,54 @@ class WBWIIteratorImpl : public WBWIIterator {
   }
 
   const WriteBatchIndexEntry* GetRawEntry() const {
-    return skip_list_iter_.key();
+    return iter_->key();
   }
 
  private:
   uint32_t column_family_id_;
-  WriteBatchEntrySkipList::Iterator skip_list_iter_;
+  WBIteratorStorage<WriteBatchEntryIndex::Iterator, 24> iter_;
   const ReadableWriteBatch* write_batch_;
 };
 
 struct WriteBatchWithIndex::Rep {
   explicit Rep(const Comparator* index_comparator, size_t reserved_bytes = 0,
-               size_t max_bytes = 0, bool _overwrite_key = false)
+               size_t max_bytes = 0, bool _overwrite_key = false,
+               const WriteBatchEntryIndexFactory* _index_factory = nullptr)
       : write_batch(reserved_bytes, max_bytes),
-        comparator(index_comparator, &write_batch),
-        skip_list(comparator, &arena),
+        default_comparator(index_comparator),
+        index_factory(_index_factory == nullptr
+                          ? skip_list_WriteBatchEntryIndexFactory()
+                          : _index_factory),
         overwrite_key(_overwrite_key),
+        free_entry(nullptr),
         last_entry_offset(0),
         last_sub_batch_offset(0),
-        sub_batch_cnt(1) {}
+        sub_batch_cnt(1) {
+    factory_context = index_factory->NewContext(&arena);
+  }
+  ~Rep() {
+    for (auto& pair : entry_indices) {
+      if (pair.index != nullptr) {
+        pair.index->~WriteBatchEntryIndex();
+      }
+    }
+    if (factory_context != nullptr) {
+      factory_context->~WriteBatchEntryIndexContext();
+    }
+  }
+
   ReadableWriteBatch write_batch;
-  WriteBatchEntryComparator comparator;
+  const Comparator* default_comparator;
+  struct ComparatorIndexPair {
+    const Comparator* comparator = nullptr;
+    WriteBatchEntryIndex* index = nullptr;
+  };
+  std::vector<ComparatorIndexPair> entry_indices;
   Arena arena;
-  WriteBatchEntrySkipList skip_list;
+  const WriteBatchEntryIndexFactory* index_factory;
+  WriteBatchEntryIndexContext* factory_context;
   bool overwrite_key;
+  WriteBatchIndexEntry* free_entry;
   size_t last_entry_offset;
   // The starting offset of the last sub-batch. A sub-batch starts right before
   // inserting a key that is a duplicate of a key in the last sub-batch. Zero,
@@ -458,20 +456,20 @@ struct WriteBatchWithIndex::Rep {
   // the starting offset of the next record.
   void SetLastEntryOffset() { last_entry_offset = write_batch.GetDataSize(); }
 
-  // In overwrite mode, find the existing entry for the same key and update it
-  // to point to the current entry.
-  // Return true if the key is found and updated.
-  bool UpdateExistingEntry(ColumnFamilyHandle* column_family, const Slice& key);
-  bool UpdateExistingEntryWithCfId(uint32_t column_family_id, const Slice& key);
-
   // Add the recent entry to the update.
   // In overwrite mode, if key already exists in the index, update it.
-  void AddOrUpdateIndex(ColumnFamilyHandle* column_family, const Slice& key);
-  void AddOrUpdateIndex(const Slice& key);
+  void AddOrUpdateIndex(ColumnFamilyHandle* column_family);
+  void AddOrUpdateIndex(uint32_t column_family_id);
+  void AddOrUpdateIndex();
+  void AddOrUpdateIndex(uint32_t column_family_id,
+                        WriteBatchEntryIndex* entry_index);
 
-  // Allocate an index entry pointing to the last entry in the write batch and
-  // put it to skip list.
-  void AddNewEntry(uint32_t column_family_id);
+  // Get entry_index, create if missing
+  WriteBatchEntryIndex* GetEntryIndex(ColumnFamilyHandle* column_family);
+  WriteBatchEntryIndex* GetEntryIndexWithCfId(uint32_t column_family_id);
+
+  // Get comparator, nullptr if missing
+  const Comparator* GetComparator(ColumnFamilyHandle* column_family);
 
   // Clear all updates buffered in this batch.
   void Clear();
@@ -482,70 +480,90 @@ struct WriteBatchWithIndex::Rep {
   Status ReBuildIndex();
 };
 
-bool WriteBatchWithIndex::Rep::UpdateExistingEntry(
-    ColumnFamilyHandle* column_family, const Slice& key) {
-  uint32_t cf_id = GetColumnFamilyID(column_family);
-  return UpdateExistingEntryWithCfId(cf_id, key);
+void WriteBatchWithIndex::Rep::AddOrUpdateIndex(ColumnFamilyHandle* column_family) {
+  AddOrUpdateIndex(GetColumnFamilyID(column_family), GetEntryIndex(column_family));
 }
 
-bool WriteBatchWithIndex::Rep::UpdateExistingEntryWithCfId(
-    uint32_t column_family_id, const Slice& key) {
-  if (!overwrite_key) {
-    return false;
-  }
-
-  WBWIIteratorImpl iter(column_family_id, &skip_list, &write_batch);
-  iter.Seek(key);
-  if (!iter.Valid()) {
-    return false;
-  }
-  if (comparator.CompareKey(column_family_id, key, iter.Entry().key) != 0) {
-    return false;
-  }
-  WriteBatchIndexEntry* non_const_entry =
-      const_cast<WriteBatchIndexEntry*>(iter.GetRawEntry());
-  if (LIKELY(last_sub_batch_offset <= non_const_entry->offset)) {
-    last_sub_batch_offset = last_entry_offset;
-    sub_batch_cnt++;
-  }
-  non_const_entry->offset = last_entry_offset;
-  return true;
+void WriteBatchWithIndex::Rep::AddOrUpdateIndex(uint32_t column_family_id) {
+  AddOrUpdateIndex(column_family_id, GetEntryIndexWithCfId(column_family_id));
 }
 
-void WriteBatchWithIndex::Rep::AddOrUpdateIndex(
-    ColumnFamilyHandle* column_family, const Slice& key) {
-  if (!UpdateExistingEntry(column_family, key)) {
-    uint32_t cf_id = GetColumnFamilyID(column_family);
-    const auto* cf_cmp = GetColumnFamilyUserComparator(column_family);
-    if (cf_cmp != nullptr) {
-      comparator.SetComparatorForCF(cf_id, cf_cmp);
-    }
-    AddNewEntry(cf_id);
-  }
+void WriteBatchWithIndex::Rep::AddOrUpdateIndex() {
+  AddOrUpdateIndex(0, GetEntryIndex(nullptr));
 }
 
-void WriteBatchWithIndex::Rep::AddOrUpdateIndex(const Slice& key) {
-  if (!UpdateExistingEntryWithCfId(0, key)) {
-    AddNewEntry(0);
-  }
-}
-
-void WriteBatchWithIndex::Rep::AddNewEntry(uint32_t column_family_id) {
+void WriteBatchWithIndex::Rep::AddOrUpdateIndex(uint32_t column_family_id,
+                                                WriteBatchEntryIndex* entry_index) {
+  assert(entry_index == GetEntryIndexWithCfId(column_family_id));
   const std::string& wb_data = write_batch.Data();
   Slice entry_ptr = Slice(wb_data.data() + last_entry_offset,
                           wb_data.size() - last_entry_offset);
   // Extract key
   Slice key;
   bool success __attribute__((__unused__));
-  success =
-      ReadKeyFromWriteBatchEntry(&entry_ptr, &key, column_family_id != 0);
+  success = ReadKeyFromWriteBatchEntry(&entry_ptr, &key, column_family_id != 0);
   assert(success);
 
-  auto* mem = arena.Allocate(sizeof(WriteBatchIndexEntry));
+  void* mem = free_entry;
+  if (mem == nullptr) {
+    mem = arena.Allocate(sizeof(WriteBatchIndexEntry));
+  }
   auto* index_entry =
-      new (mem) WriteBatchIndexEntry(last_entry_offset, column_family_id,
-                                      key.data() - wb_data.data(), key.size());
-  skip_list.Insert(index_entry);
+          new (mem) WriteBatchIndexEntry(last_entry_offset, column_family_id,
+                                         key.data() - wb_data.data(), key.size());
+  if (!entry_index->Upsert(index_entry)) {
+    // overwrite key
+    if (LIKELY(last_sub_batch_offset <= index_entry->offset)) {
+      last_sub_batch_offset = last_entry_offset;
+      sub_batch_cnt++;
+    }
+    free_entry = index_entry;
+  } else {
+    free_entry = nullptr;
+  }
+}
+
+WriteBatchEntryIndex* WriteBatchWithIndex::Rep::GetEntryIndex(
+        ColumnFamilyHandle* column_family) {
+  uint32_t cf_id = GetColumnFamilyID(column_family);
+  if (cf_id >= entry_indices.size()) {
+    entry_indices.resize(cf_id + 1);
+  }
+  auto index = entry_indices[cf_id].index;
+  if (index == nullptr) {
+    const auto* cf_cmp = GetColumnFamilyUserComparator(column_family);
+    if (cf_cmp == nullptr) {
+      cf_cmp = default_comparator;
+    }
+    entry_indices[cf_id].comparator = cf_cmp;
+    entry_indices[cf_id].index = index =
+            index_factory->New(factory_context, WriteBatchKeyExtractor(&write_batch),
+                               cf_cmp, &arena, overwrite_key);
+  }
+  return index;
+}
+
+WriteBatchEntryIndex* WriteBatchWithIndex::Rep::GetEntryIndexWithCfId(
+        uint32_t column_family_id) {
+  assert(column_family_id < entry_indices.size());
+  auto index = entry_indices[column_family_id].index;
+  if (index == nullptr) {
+    const auto* cf_cmp = entry_indices[column_family_id].comparator;
+    assert(cf_cmp != nullptr);
+    entry_indices[column_family_id].index = index =
+            index_factory->New(factory_context, WriteBatchKeyExtractor(&write_batch),
+                               cf_cmp, &arena, overwrite_key);
+  }
+  return index;
+}
+
+const Comparator* WriteBatchWithIndex::Rep::GetComparator(
+        ColumnFamilyHandle* column_family) {
+  uint32_t cf_id = GetColumnFamilyID(column_family);
+  if (cf_id >= entry_indices.size()) {
+    return nullptr;
+  }
+  return entry_indices[cf_id].comparator;
 }
 
 void WriteBatchWithIndex::Rep::Clear() {
@@ -554,10 +572,19 @@ void WriteBatchWithIndex::Rep::Clear() {
 }
 
 void WriteBatchWithIndex::Rep::ClearIndex() {
-  skip_list.~WriteBatchEntrySkipList();
+  for (auto& pair : entry_indices) {
+    if (pair.index != nullptr) {
+      pair.index->~WriteBatchEntryIndex();
+      pair.index = nullptr;
+    }
+  }
+  if (factory_context != nullptr) {
+    factory_context->~WriteBatchEntryIndexContext();
+  }
   arena.~Arena();
   new (&arena) Arena();
-  new (&skip_list) WriteBatchEntrySkipList(comparator, &arena);
+  factory_context = index_factory->NewContext(&arena);
+  free_entry = nullptr;
   last_entry_offset = 0;
   last_sub_batch_offset = 0;
   sub_batch_cnt = 1;
@@ -604,9 +631,7 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
       case kTypeColumnFamilyMerge:
       case kTypeMerge:
         found++;
-        if (!UpdateExistingEntryWithCfId(column_family_id, key)) {
-          AddNewEntry(column_family_id);
-        }
+        AddOrUpdateIndex(column_family_id);
         break;
       case kTypeLogData:
       case kTypeBeginPrepareXID:
@@ -632,9 +657,10 @@ Status WriteBatchWithIndex::Rep::ReBuildIndex() {
 
 WriteBatchWithIndex::WriteBatchWithIndex(
     const Comparator* default_index_comparator, size_t reserved_bytes,
-    bool overwrite_key, size_t max_bytes)
+    bool overwrite_key, size_t max_bytes,
+    const WriteBatchEntryIndexFactory* index_factory)
     : rep(new Rep(default_index_comparator, reserved_bytes, max_bytes,
-                  overwrite_key)) {}
+                  overwrite_key, index_factory)) {}
 
 WriteBatchWithIndex::~WriteBatchWithIndex() {}
 
@@ -648,19 +674,32 @@ WriteBatch* WriteBatchWithIndex::GetWriteBatch() { return &rep->write_batch; }
 size_t WriteBatchWithIndex::SubBatchCnt() { return rep->sub_batch_cnt; }
 
 WBWIIterator* WriteBatchWithIndex::NewIterator() {
-  return new WBWIIteratorImpl(0, &(rep->skip_list), &rep->write_batch);
+  return new WBWIIteratorImpl(0, rep->GetEntryIndex(nullptr),
+                              &rep->write_batch, false);
 }
 
 WBWIIterator* WriteBatchWithIndex::NewIterator(
     ColumnFamilyHandle* column_family) {
-  return new WBWIIteratorImpl(GetColumnFamilyID(column_family),
-                              &(rep->skip_list), &rep->write_batch);
+  auto cf_id = GetColumnFamilyID(column_family);
+  return new WBWIIteratorImpl(cf_id, rep->GetEntryIndex(column_family),
+                              &rep->write_batch, false);
+}
+
+void WriteBatchWithIndex::NewIterator(ColumnFamilyHandle* column_family,
+                                      WBWIIterator::IteratorStorage& storage,
+                                      bool ephemeral) {
+  static_assert(sizeof(WBWIIteratorImpl) <= sizeof storage.buffer,
+                "Need larger buffer for WBWIIteratorImpl");
+  storage.iter = new (storage.buffer)
+          WBWIIteratorImpl(GetColumnFamilyID(column_family),
+                           rep->GetEntryIndex(column_family), &rep->write_batch,
+                           ephemeral);
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(
     ColumnFamilyHandle* column_family, Iterator* base_iterator,
     const ReadOptions* read_options) {
-  if (rep->overwrite_key == false) {
+  if (!rep->overwrite_key) {
     assert(false);
     return nullptr;
   }
@@ -670,13 +709,13 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
 }
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(Iterator* base_iterator) {
-  if (rep->overwrite_key == false) {
+  if (!rep->overwrite_key) {
     assert(false);
     return nullptr;
   }
   // default column family's comparator
   return new BaseDeltaIterator(base_iterator, NewIterator(),
-                               rep->comparator.default_comparator());
+                               rep->default_comparator);
 }
 
 Status WriteBatchWithIndex::Put(ColumnFamilyHandle* column_family,
@@ -684,7 +723,7 @@ Status WriteBatchWithIndex::Put(ColumnFamilyHandle* column_family,
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Put(column_family, key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key);
+    rep->AddOrUpdateIndex(column_family);
   }
   return s;
 }
@@ -693,7 +732,7 @@ Status WriteBatchWithIndex::Put(const Slice& key, const Slice& value) {
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Put(key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key);
+    rep->AddOrUpdateIndex();
   }
   return s;
 }
@@ -703,7 +742,7 @@ Status WriteBatchWithIndex::Delete(ColumnFamilyHandle* column_family,
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Delete(column_family, key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key);
+    rep->AddOrUpdateIndex(column_family);
   }
   return s;
 }
@@ -712,7 +751,7 @@ Status WriteBatchWithIndex::Delete(const Slice& key) {
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Delete(key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key);
+    rep->AddOrUpdateIndex();
   }
   return s;
 }
@@ -722,7 +761,7 @@ Status WriteBatchWithIndex::SingleDelete(ColumnFamilyHandle* column_family,
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.SingleDelete(column_family, key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key);
+    rep->AddOrUpdateIndex(column_family);
   }
   return s;
 }
@@ -731,7 +770,7 @@ Status WriteBatchWithIndex::SingleDelete(const Slice& key) {
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.SingleDelete(key);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key);
+    rep->AddOrUpdateIndex();
   }
   return s;
 }
@@ -741,7 +780,7 @@ Status WriteBatchWithIndex::Merge(ColumnFamilyHandle* column_family,
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Merge(column_family, key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(column_family, key);
+    rep->AddOrUpdateIndex(column_family);
   }
   return s;
 }
@@ -750,7 +789,7 @@ Status WriteBatchWithIndex::Merge(const Slice& key, const Slice& value) {
   rep->SetLastEntryOffset();
   auto s = rep->write_batch.Merge(key, value);
   if (s.ok()) {
-    rep->AddOrUpdateIndex(key);
+    rep->AddOrUpdateIndex();
   }
   return s;
 }
@@ -771,7 +810,7 @@ Status WriteBatchWithIndex::GetFromBatch(ColumnFamilyHandle* column_family,
   WriteBatchWithIndexInternal::Result result =
       WriteBatchWithIndexInternal::GetFromBatch(
           immuable_db_options, this, column_family, key, &merge_context,
-          &rep->comparator, value, rep->overwrite_key, &s);
+          rep->GetComparator(column_family), value, rep->overwrite_key, &s);
 
   switch (result) {
     case WriteBatchWithIndexInternal::Result::kFound:
@@ -855,7 +894,7 @@ Status WriteBatchWithIndex::GetFromBatchAndDB(
   WriteBatchWithIndexInternal::Result result =
       WriteBatchWithIndexInternal::GetFromBatch(
           immuable_db_options, this, column_family, key, &merge_context,
-          &rep->comparator, &batch_value, rep->overwrite_key, &s);
+          rep->GetComparator(column_family), &batch_value, rep->overwrite_key, &s);
 
   if (result == WriteBatchWithIndexInternal::Result::kFound) {
     pinnable_val->PinSelf();
@@ -868,7 +907,7 @@ Status WriteBatchWithIndex::GetFromBatchAndDB(
     return s;
   }
   if (result == WriteBatchWithIndexInternal::Result::kMergeInProgress &&
-      rep->overwrite_key == true) {
+      rep->overwrite_key) {
     // Since we've overwritten keys, we do not know what other operations are
     // in this batch for this key, so we cannot do a Merge to compute the
     // result.  Instead, we will simply return MergeInProgress.
@@ -956,7 +995,7 @@ void WriteBatchWithIndex::MultiGetFromBatchAndDB(
     WriteBatchWithIndexInternal::Result result =
         WriteBatchWithIndexInternal::GetFromBatch(
             immuable_db_options, this, column_family, keys[i], &merge_context,
-            &rep->comparator, &batch_value, rep->overwrite_key, s);
+            rep->GetComparator(column_family), &batch_value, rep->overwrite_key, s);
 
     if (result == WriteBatchWithIndexInternal::Result::kFound) {
       pinnable_val->PinSelf();

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -32,55 +32,26 @@ struct WriteBatchIndexEntry {
         key_size(ksz),
         search_key(nullptr) {}
   // Create a dummy entry as the search key. This index entry won't be backed
-  // by an entry from the write batch, but a pointer to the search key. Or a
-  // special flag of offset can indicate we are seek to first.
+  // by an entry from the write batch, but a pointer to the search key.
   // @_search_key: the search key
   // @_column_family: column family
-  // @is_forward_direction: true for Seek(). False for SeekForPrev()
-  // @is_seek_to_first: true if we seek to the beginning of the column family
-  //                    _search_key should be null in this case.
-  WriteBatchIndexEntry(const Slice* _search_key, uint32_t _column_family,
-                       bool is_forward_direction, bool is_seek_to_first)
-      // For SeekForPrev(), we need to make the dummy entry larger than any
-      // entry who has the same search key. Otherwise, we'll miss those entries.
-      : offset(is_forward_direction ? 0 : port::kMaxSizet),
+  WriteBatchIndexEntry(const Slice* _search_key, uint32_t _column_family)
+      : offset(0),
         column_family(_column_family),
         key_offset(0),
-        key_size(is_seek_to_first ? kFlagMinInCf : 0),
+        key_size(0),
         search_key(_search_key) {
-    assert(_search_key != nullptr || is_seek_to_first);
+    assert(_search_key != nullptr);
   }
 
-  // If this flag appears in the key_size, it indicates a
-  // key that is smaller than any other entry for the same column family.
-  static const size_t kFlagMinInCf = port::kMaxSizet;
-
-  bool is_min_in_cf() const {
-    assert(key_size != kFlagMinInCf ||
-           (key_offset == 0 && search_key == nullptr));
-    return key_size == kFlagMinInCf;
-  }
-
-  // offset of an entry in write batch's string buffer. If this is a dummy
-  // lookup key, in which case search_key != nullptr, offset is set to either
-  // 0 or max, only for comparison purpose. Because when entries have the same
-  // key, the entry with larger offset is larger, offset = 0 will make a seek
-  // key small or equal than all the entries with the seek key, so that Seek()
-  // will find all the entries of the same key. Similarly, offset = MAX will
-  // make the entry just larger than all entries with the search key so
-  // SeekForPrev() will see all the keys with the same key.
-  size_t offset;
-  uint32_t column_family;  // c1olumn family of the entry.
+  size_t offset;           // offset of an entry in write batch's string buffer.
+  uint32_t column_family;  // column family of the entry.
   size_t key_offset;       // offset of the key in write batch's string buffer.
-  size_t key_size;         // size of the key. kFlagMinInCf indicates
-                           // that this is a dummy look up entry for
-                           // SeekToFirst() to the beginning of the column
-                           // family. We use the flag here to save a boolean
-                           // in the struct.
+  size_t key_size;         // size of the key.
 
   const Slice* search_key;  // if not null, instead of reading keys from
-                            // write batch, use it to compare. This is used
-                            // for lookup key.
+  // write batch, use it to compare. This is used
+  // for lookup key.
 };
 
 class ReadableWriteBatch : public WriteBatch {
@@ -91,35 +62,6 @@ class ReadableWriteBatch : public WriteBatch {
   // the start offset of the write entry.
   Status GetEntryFromDataOffset(size_t data_offset, WriteType* type, Slice* Key,
                                 Slice* value, Slice* blob, Slice* xid) const;
-};
-
-class WriteBatchEntryComparator {
- public:
-  WriteBatchEntryComparator(const Comparator* _default_comparator,
-                            const ReadableWriteBatch* write_batch)
-      : default_comparator_(_default_comparator), write_batch_(write_batch) {}
-  // Compare a and b. Return a negative value if a is less than b, 0 if they
-  // are equal, and a positive value if a is greater than b
-  int operator()(const WriteBatchIndexEntry* entry1,
-                 const WriteBatchIndexEntry* entry2) const;
-
-  int CompareKey(uint32_t column_family, const Slice& key1,
-                 const Slice& key2) const;
-
-  void SetComparatorForCF(uint32_t column_family_id,
-                          const Comparator* comparator) {
-    if (column_family_id >= cf_comparators_.size()) {
-      cf_comparators_.resize(column_family_id + 1, nullptr);
-    }
-    cf_comparators_[column_family_id] = comparator;
-  }
-
-  const Comparator* default_comparator() { return default_comparator_; }
-
- private:
-  const Comparator* default_comparator_;
-  std::vector<const Comparator*> cf_comparators_;
-  const ReadableWriteBatch* write_batch_;
 };
 
 class WriteBatchWithIndexInternal {
@@ -137,8 +79,65 @@ class WriteBatchWithIndexInternal {
   static WriteBatchWithIndexInternal::Result GetFromBatch(
       const ImmutableDBOptions& ioptions, WriteBatchWithIndex* batch,
       ColumnFamilyHandle* column_family, const Slice& key,
-      MergeContext* merge_context, WriteBatchEntryComparator* cmp,
+      MergeContext* merge_context, const Comparator* cmp,
       std::string* value, bool overwrite_key, Status* s);
+};
+
+class WriteBatchKeyExtractor {
+ public:
+  WriteBatchKeyExtractor(const ReadableWriteBatch* write_batch)
+      : write_batch_(write_batch) {
+  }
+
+  Slice operator()(const WriteBatchIndexEntry* entry) const;
+
+ private:
+  const ReadableWriteBatch* write_batch_;
+};
+
+class WriteBatchEntryIndex {
+ public:
+  virtual ~WriteBatchEntryIndex() {}
+
+  class Iterator {
+   public:
+    virtual ~Iterator() {}
+    virtual bool Valid() const = 0;
+    virtual void SeekToFirst() = 0;
+    virtual void SeekToLast() = 0;
+    virtual void Seek(WriteBatchIndexEntry* target) = 0;
+    virtual void SeekForPrev(WriteBatchIndexEntry* target) = 0;
+    virtual void Next() = 0;
+    virtual void Prev() = 0;
+    virtual WriteBatchIndexEntry* key() const = 0;
+  };
+  typedef WBIteratorStorage<Iterator, 24> IteratorStorage;
+
+  virtual Iterator* NewIterator() = 0;
+  // sizeof(iterator) size must less or equal than 24
+  // INCLUDE virtual table pointer
+  virtual void NewIterator(IteratorStorage& storage, bool ephemeral) = 0;
+  // return true if insert success
+  // assign key->offset to exists entry's offset otherwise
+  virtual bool Upsert(WriteBatchIndexEntry* key) = 0;
+};
+
+class WriteBatchEntryIndexContext {
+ public:
+  virtual ~WriteBatchEntryIndexContext();
+};
+
+class WriteBatchEntryIndexFactory {
+ public:
+  // object MUST allocated from arena, allow return nullptr
+  // context will not delete, only by calling destructor
+  virtual WriteBatchEntryIndexContext* NewContext(Arena*) const;
+  virtual WriteBatchEntryIndex* New(WriteBatchEntryIndexContext* ctx,
+                                    WriteBatchKeyExtractor e,
+                                    const Comparator* c, Arena* a,
+                                    bool overwrite_key) const = 0;
+  virtual ~WriteBatchEntryIndexFactory();
+  virtual const char* Name() const = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -79,15 +79,14 @@ class WriteBatchWithIndexInternal {
   static WriteBatchWithIndexInternal::Result GetFromBatch(
       const ImmutableDBOptions& ioptions, WriteBatchWithIndex* batch,
       ColumnFamilyHandle* column_family, const Slice& key,
-      MergeContext* merge_context, const Comparator* cmp,
-      std::string* value, bool overwrite_key, Status* s);
+      MergeContext* merge_context, const Comparator* cmp, std::string* value,
+      bool overwrite_key, Status* s);
 };
 
 class WriteBatchKeyExtractor {
  public:
   WriteBatchKeyExtractor(const ReadableWriteBatch* write_batch)
-      : write_batch_(write_batch) {
-  }
+      : write_batch_(write_batch) {}
 
   Slice operator()(const WriteBatchIndexEntry* entry) const;
 

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -274,242 +274,235 @@ void TestValueAsSecondaryIndexHelper(std::vector<Entry> entries,
 }
 
 namespace {
-  const std::initializer_list<const WriteBatchEntryIndexFactory*>& all_index_types = {
-          skip_list_WriteBatchEntryIndexFactory(),
-  };
+const std::initializer_list<const WriteBatchEntryIndexFactory*>&
+    all_index_types = {
+        skip_list_WriteBatchEntryIndexFactory(),
+};
 }
 
 TEST_F(WriteBatchWithIndexTest, TestValueAsSecondaryIndex) {
-for (auto index_type : all_index_types) {
-  Entry entries[] = {
-      {"aaa", "0005", kPutRecord},
-      {"b", "0002", kPutRecord},
-      {"cdd", "0002", kMergeRecord},
-      {"aab", "00001", kPutRecord},
-      {"cc", "00005", kPutRecord},
-      {"cdd", "0002", kPutRecord},
-      {"aab", "0003", kPutRecord},
-      {"cc", "00005", kDeleteRecord},
-  };
-  std::vector<Entry> entries_list(entries, entries + 8);
+  for (auto index_type : all_index_types) {
+    Entry entries[] = {
+        {"aaa", "0005", kPutRecord},   {"b", "0002", kPutRecord},
+        {"cdd", "0002", kMergeRecord}, {"aab", "00001", kPutRecord},
+        {"cc", "00005", kPutRecord},   {"cdd", "0002", kPutRecord},
+        {"aab", "0003", kPutRecord},   {"cc", "00005", kDeleteRecord},
+    };
+    std::vector<Entry> entries_list(entries, entries + 8);
 
-  WriteBatchWithIndex batch(nullptr, 20, false, 0, index_type);
+    WriteBatchWithIndex batch(nullptr, 20, false, 0, index_type);
 
-  TestValueAsSecondaryIndexHelper(entries_list, &batch);
+    TestValueAsSecondaryIndexHelper(entries_list, &batch);
 
-  // Clear batch and re-run test with new values
-  batch.Clear();
+    // Clear batch and re-run test with new values
+    batch.Clear();
 
-  Entry new_entries[] = {
-      {"aaa", "0005", kPutRecord},
-      {"e", "0002", kPutRecord},
-      {"add", "0002", kMergeRecord},
-      {"aab", "00001", kPutRecord},
-      {"zz", "00005", kPutRecord},
-      {"add", "0002", kPutRecord},
-      {"aab", "0003", kPutRecord},
-      {"zz", "00005", kDeleteRecord},
-  };
+    Entry new_entries[] = {
+        {"aaa", "0005", kPutRecord},   {"e", "0002", kPutRecord},
+        {"add", "0002", kMergeRecord}, {"aab", "00001", kPutRecord},
+        {"zz", "00005", kPutRecord},   {"add", "0002", kPutRecord},
+        {"aab", "0003", kPutRecord},   {"zz", "00005", kDeleteRecord},
+    };
 
-  entries_list = std::vector<Entry>(new_entries, new_entries + 8);
+    entries_list = std::vector<Entry>(new_entries, new_entries + 8);
 
-  TestValueAsSecondaryIndexHelper(entries_list, &batch);
-}
+    TestValueAsSecondaryIndexHelper(entries_list, &batch);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, TestComparatorForCF) {
-for (auto index_type : all_index_types) {
-  ColumnFamilyHandleImplDummy cf1(6, nullptr);
-  ColumnFamilyHandleImplDummy reverse_cf(66, ReverseBytewiseComparator());
-  ColumnFamilyHandleImplDummy cf2(88, BytewiseComparator());
-  WriteBatchWithIndex batch(BytewiseComparator(), 20, false, 0, index_type);
+  for (auto index_type : all_index_types) {
+    ColumnFamilyHandleImplDummy cf1(6, nullptr);
+    ColumnFamilyHandleImplDummy reverse_cf(66, ReverseBytewiseComparator());
+    ColumnFamilyHandleImplDummy cf2(88, BytewiseComparator());
+    WriteBatchWithIndex batch(BytewiseComparator(), 20, false, 0, index_type);
 
-  batch.Put(&cf1, "ddd", "");
-  batch.Put(&cf2, "aaa", "");
-  batch.Put(&cf2, "eee", "");
-  batch.Put(&cf1, "ccc", "");
-  batch.Put(&reverse_cf, "a11", "");
-  batch.Put(&cf1, "bbb", "");
+    batch.Put(&cf1, "ddd", "");
+    batch.Put(&cf2, "aaa", "");
+    batch.Put(&cf2, "eee", "");
+    batch.Put(&cf1, "ccc", "");
+    batch.Put(&reverse_cf, "a11", "");
+    batch.Put(&cf1, "bbb", "");
 
-  Slice key_slices[] = {"a", "3", "3"};
-  Slice value_slice = "";
-  batch.Put(&reverse_cf, SliceParts(key_slices, 3),
-            SliceParts(&value_slice, 1));
-  batch.Put(&reverse_cf, "a22", "");
+    Slice key_slices[] = {"a", "3", "3"};
+    Slice value_slice = "";
+    batch.Put(&reverse_cf, SliceParts(key_slices, 3),
+              SliceParts(&value_slice, 1));
+    batch.Put(&reverse_cf, "a22", "");
 
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf1));
-    iter->Seek("");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("bbb", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("ccc", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("ddd", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf1));
+      iter->Seek("");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("bbb", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("ccc", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("ddd", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf2));
+      iter->Seek("");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("aaa", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("eee", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&reverse_cf));
+      iter->Seek("");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("z");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a33", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a22", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a11", iter->Entry().key.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("a22");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a22", iter->Entry().key.ToString());
+
+      iter->Seek("a13");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a11", iter->Entry().key.ToString());
+    }
   }
-
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf2));
-    iter->Seek("");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("aaa", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("eee", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-  }
-
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&reverse_cf));
-    iter->Seek("");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("z");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a33", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a22", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a11", iter->Entry().key.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("a22");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a22", iter->Entry().key.ToString());
-
-    iter->Seek("a13");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a11", iter->Entry().key.ToString());
-  }
-}
 }
 
 TEST_F(WriteBatchWithIndexTest, TestOverwriteKey) {
-for (auto index_type : all_index_types) {
-  ColumnFamilyHandleImplDummy cf1(6, nullptr);
-  ColumnFamilyHandleImplDummy reverse_cf(66, ReverseBytewiseComparator());
-  ColumnFamilyHandleImplDummy cf2(88, BytewiseComparator());
-  WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
+  for (auto index_type : all_index_types) {
+    ColumnFamilyHandleImplDummy cf1(6, nullptr);
+    ColumnFamilyHandleImplDummy reverse_cf(66, ReverseBytewiseComparator());
+    ColumnFamilyHandleImplDummy cf2(88, BytewiseComparator());
+    WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
 
-  batch.Put(&cf1, "ddd", "");
-  batch.Merge(&cf1, "ddd", "");
-  batch.Delete(&cf1, "ddd");
-  batch.Put(&cf2, "aaa", "");
-  batch.Delete(&cf2, "aaa");
-  batch.Put(&cf2, "aaa", "aaa");
-  batch.Put(&cf2, "eee", "eee");
-  batch.Put(&cf1, "ccc", "");
-  batch.Put(&reverse_cf, "a11", "");
-  batch.Delete(&cf1, "ccc");
-  batch.Put(&reverse_cf, "a33", "a33");
-  batch.Put(&reverse_cf, "a11", "a11");
-  Slice slices[] = {"a", "3", "3"};
-  batch.Delete(&reverse_cf, SliceParts(slices, 3));
+    batch.Put(&cf1, "ddd", "");
+    batch.Merge(&cf1, "ddd", "");
+    batch.Delete(&cf1, "ddd");
+    batch.Put(&cf2, "aaa", "");
+    batch.Delete(&cf2, "aaa");
+    batch.Put(&cf2, "aaa", "aaa");
+    batch.Put(&cf2, "eee", "eee");
+    batch.Put(&cf1, "ccc", "");
+    batch.Put(&reverse_cf, "a11", "");
+    batch.Delete(&cf1, "ccc");
+    batch.Put(&reverse_cf, "a33", "a33");
+    batch.Put(&reverse_cf, "a11", "a11");
+    Slice slices[] = {"a", "3", "3"};
+    batch.Delete(&reverse_cf, SliceParts(slices, 3));
 
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf1));
-    iter->Seek("");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("ccc", iter->Entry().key.ToString());
-    ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("ddd", iter->Entry().key.ToString());
-    ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf1));
+      iter->Seek("");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("ccc", iter->Entry().key.ToString());
+      ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("ddd", iter->Entry().key.ToString());
+      ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf2));
+      iter->SeekToLast();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("eee", iter->Entry().key.ToString());
+      ASSERT_EQ("eee", iter->Entry().value.ToString());
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("aaa", iter->Entry().key.ToString());
+      ASSERT_EQ("aaa", iter->Entry().value.ToString());
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToFirst();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("aaa", iter->Entry().key.ToString());
+      ASSERT_EQ("aaa", iter->Entry().value.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("eee", iter->Entry().key.ToString());
+      ASSERT_EQ("eee", iter->Entry().value.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    {
+      std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&reverse_cf));
+      iter->Seek("");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("z");
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a33", iter->Entry().key.ToString());
+      ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a11", iter->Entry().key.ToString());
+      ASSERT_EQ("a11", iter->Entry().value.ToString());
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToLast();
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a11", iter->Entry().key.ToString());
+      ASSERT_EQ("a11", iter->Entry().value.ToString());
+      iter->Prev();
+
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(iter->Valid());
+      ASSERT_EQ("a33", iter->Entry().key.ToString());
+      ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
+      iter->Prev();
+      ASSERT_TRUE(!iter->Valid());
+    }
   }
-
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&cf2));
-    iter->SeekToLast();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("eee", iter->Entry().key.ToString());
-    ASSERT_EQ("eee", iter->Entry().value.ToString());
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("aaa", iter->Entry().key.ToString());
-    ASSERT_EQ("aaa", iter->Entry().value.ToString());
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToFirst();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("aaa", iter->Entry().key.ToString());
-    ASSERT_EQ("aaa", iter->Entry().value.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("eee", iter->Entry().key.ToString());
-    ASSERT_EQ("eee", iter->Entry().value.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-  }
-
-  {
-    std::unique_ptr<WBWIIterator> iter(batch.NewIterator(&reverse_cf));
-    iter->Seek("");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("z");
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a33", iter->Entry().key.ToString());
-    ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a11", iter->Entry().key.ToString());
-    ASSERT_EQ("a11", iter->Entry().value.ToString());
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToLast();
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a11", iter->Entry().key.ToString());
-    ASSERT_EQ("a11", iter->Entry().value.ToString());
-    iter->Prev();
-
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(iter->Valid());
-    ASSERT_EQ("a33", iter->Entry().key.ToString());
-    ASSERT_TRUE(iter->Entry().type == WriteType::kDeleteRecord);
-    iter->Prev();
-    ASSERT_TRUE(!iter->Valid());
-  }
-}
 }
 
 namespace {
@@ -570,774 +563,774 @@ void AssertItersEqual(Iterator* iter1, Iterator* iter2) {
 }  // namespace
 
 TEST_F(WriteBatchWithIndexTest, TestRandomIteraratorWithBase) {
-for (auto index_type : all_index_types) {
-  std::vector<std::string> source_strings = {"a", "b", "c", "d", "e",
-                                             "f", "g", "h", "i", "j"};
-  for (int rand_seed = 301; rand_seed < 366; rand_seed++) {
-    Random rnd(rand_seed);
+  for (auto index_type : all_index_types) {
+    std::vector<std::string> source_strings = {"a", "b", "c", "d", "e",
+                                               "f", "g", "h", "i", "j"};
+    for (int rand_seed = 301; rand_seed < 366; rand_seed++) {
+      Random rnd(rand_seed);
 
-    ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
-    ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
-    ColumnFamilyHandleImplDummy cf3(8, BytewiseComparator());
+      ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+      ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
+      ColumnFamilyHandleImplDummy cf3(8, BytewiseComparator());
 
-    WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
+      WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
 
-    if (rand_seed % 2 == 0) {
-      batch.Put(&cf2, "zoo", "bar");
-    }
-    if (rand_seed % 4 == 1) {
-      batch.Put(&cf3, "zoo", "bar");
-    }
-
-    KVMap map;
-    KVMap merged_map;
-    for (auto key : source_strings) {
-      std::string value = key + key;
-      int type = rnd.Uniform(6);
-      switch (type) {
-        case 0:
-          // only base has it
-          map[key] = value;
-          merged_map[key] = value;
-          break;
-        case 1:
-          // only delta has it
-          batch.Put(&cf1, key, value);
-          map[key] = value;
-          merged_map[key] = value;
-          break;
-        case 2:
-          // both has it. Delta should win
-          batch.Put(&cf1, key, value);
-          map[key] = "wrong_value";
-          merged_map[key] = value;
-          break;
-        case 3:
-          // both has it. Delta is delete
-          batch.Delete(&cf1, key);
-          map[key] = "wrong_value";
-          break;
-        case 4:
-          // only delta has it. Delta is delete
-          batch.Delete(&cf1, key);
-          map[key] = "wrong_value";
-          break;
-        default:
-          // Neither iterator has it.
-          break;
+      if (rand_seed % 2 == 0) {
+        batch.Put(&cf2, "zoo", "bar");
       }
-    }
-
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
-    std::unique_ptr<Iterator> result_iter(new KVIter(&merged_map));
-
-    bool is_valid = false;
-    for (int i = 0; i < 128; i++) {
-      // Random walk and make sure iter and result_iter returns the
-      // same key and value
-      int type = rnd.Uniform(6);
-      ASSERT_OK(iter->status());
-      switch (type) {
-        case 0:
-          // Seek to First
-          iter->SeekToFirst();
-          result_iter->SeekToFirst();
-          break;
-        case 1:
-          // Seek to last
-          iter->SeekToLast();
-          result_iter->SeekToLast();
-          break;
-        case 2: {
-          // Seek to random key
-          auto key_idx = rnd.Uniform(static_cast<int>(source_strings.size()));
-          auto key = source_strings[key_idx];
-          iter->Seek(key);
-          result_iter->Seek(key);
-          break;
-        }
-        case 3: {
-          // SeekForPrev to random key
-          auto key_idx = rnd.Uniform(static_cast<int>(source_strings.size()));
-          auto key = source_strings[key_idx];
-          iter->SeekForPrev(key);
-          result_iter->SeekForPrev(key);
-          break;
-        }
-        case 4:
-          // Next
-          if (is_valid) {
-            iter->Next();
-            result_iter->Next();
-          } else {
-            continue;
-          }
-          break;
-        default:
-          assert(type == 5);
-          // Prev
-          if (is_valid) {
-            iter->Prev();
-            result_iter->Prev();
-          } else {
-            continue;
-          }
-          break;
+      if (rand_seed % 4 == 1) {
+        batch.Put(&cf3, "zoo", "bar");
       }
-      AssertItersEqual(iter.get(), result_iter.get());
-      is_valid = iter->Valid();
+
+      KVMap map;
+      KVMap merged_map;
+      for (auto key : source_strings) {
+        std::string value = key + key;
+        int type = rnd.Uniform(6);
+        switch (type) {
+          case 0:
+            // only base has it
+            map[key] = value;
+            merged_map[key] = value;
+            break;
+          case 1:
+            // only delta has it
+            batch.Put(&cf1, key, value);
+            map[key] = value;
+            merged_map[key] = value;
+            break;
+          case 2:
+            // both has it. Delta should win
+            batch.Put(&cf1, key, value);
+            map[key] = "wrong_value";
+            merged_map[key] = value;
+            break;
+          case 3:
+            // both has it. Delta is delete
+            batch.Delete(&cf1, key);
+            map[key] = "wrong_value";
+            break;
+          case 4:
+            // only delta has it. Delta is delete
+            batch.Delete(&cf1, key);
+            map[key] = "wrong_value";
+            break;
+          default:
+            // Neither iterator has it.
+            break;
+        }
+      }
+
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+      std::unique_ptr<Iterator> result_iter(new KVIter(&merged_map));
+
+      bool is_valid = false;
+      for (int i = 0; i < 128; i++) {
+        // Random walk and make sure iter and result_iter returns the
+        // same key and value
+        int type = rnd.Uniform(6);
+        ASSERT_OK(iter->status());
+        switch (type) {
+          case 0:
+            // Seek to First
+            iter->SeekToFirst();
+            result_iter->SeekToFirst();
+            break;
+          case 1:
+            // Seek to last
+            iter->SeekToLast();
+            result_iter->SeekToLast();
+            break;
+          case 2: {
+            // Seek to random key
+            auto key_idx = rnd.Uniform(static_cast<int>(source_strings.size()));
+            auto key = source_strings[key_idx];
+            iter->Seek(key);
+            result_iter->Seek(key);
+            break;
+          }
+          case 3: {
+            // SeekForPrev to random key
+            auto key_idx = rnd.Uniform(static_cast<int>(source_strings.size()));
+            auto key = source_strings[key_idx];
+            iter->SeekForPrev(key);
+            result_iter->SeekForPrev(key);
+            break;
+          }
+          case 4:
+            // Next
+            if (is_valid) {
+              iter->Next();
+              result_iter->Next();
+            } else {
+              continue;
+            }
+            break;
+          default:
+            assert(type == 5);
+            // Prev
+            if (is_valid) {
+              iter->Prev();
+              result_iter->Prev();
+            } else {
+              continue;
+            }
+            break;
+        }
+        AssertItersEqual(iter.get(), result_iter.get());
+        is_valid = iter->Valid();
+      }
     }
   }
-}
 }
 
 TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
-for (auto index_type : all_index_types) {
-  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
-  ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
-  WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
+  for (auto index_type : all_index_types) {
+    ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+    ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
+    WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
 
-  {
-    KVMap map;
-    map["a"] = "aa";
-    map["c"] = "cc";
-    map["e"] = "ee";
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+    {
+      KVMap map;
+      map["a"] = "aa";
+      map["c"] = "cc";
+      map["e"] = "ee";
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
 
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "e", "ee");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "e", "ee");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
 
-    iter->SeekToLast();
-    AssertIter(iter.get(), "e", "ee");
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Prev();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
+      iter->SeekToLast();
+      AssertIter(iter.get(), "e", "ee");
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Prev();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
 
-    iter->Seek("b");
-    AssertIter(iter.get(), "c", "cc");
+      iter->Seek("b");
+      AssertIter(iter.get(), "c", "cc");
 
-    iter->Prev();
-    AssertIter(iter.get(), "a", "aa");
+      iter->Prev();
+      AssertIter(iter.get(), "a", "aa");
 
-    iter->Seek("a");
-    AssertIter(iter.get(), "a", "aa");
+      iter->Seek("a");
+      AssertIter(iter.get(), "a", "aa");
+    }
+
+    // Test the case that there is one element in the write batch
+    batch.Put(&cf2, "zoo", "bar");
+    batch.Put(&cf1, "a", "aa");
+    {
+      KVMap empty_map;
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    batch.Delete(&cf1, "b");
+    batch.Put(&cf1, "c", "cc");
+    batch.Put(&cf1, "d", "dd");
+    batch.Delete(&cf1, "e");
+
+    {
+      KVMap map;
+      map["b"] = "";
+      map["cc"] = "cccc";
+      map["f"] = "ff";
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "cc", "cccc");
+      iter->Next();
+      AssertIter(iter.get(), "d", "dd");
+      iter->Next();
+      AssertIter(iter.get(), "f", "ff");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToLast();
+      AssertIter(iter.get(), "f", "ff");
+      iter->Prev();
+      AssertIter(iter.get(), "d", "dd");
+      iter->Prev();
+      AssertIter(iter.get(), "cc", "cccc");
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "cc", "cccc");
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Prev();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("c");
+      AssertIter(iter.get(), "c", "cc");
+
+      iter->Seek("cb");
+      AssertIter(iter.get(), "cc", "cccc");
+
+      iter->Seek("cc");
+      AssertIter(iter.get(), "cc", "cccc");
+      iter->Next();
+      AssertIter(iter.get(), "d", "dd");
+
+      iter->Seek("e");
+      AssertIter(iter.get(), "f", "ff");
+
+      iter->Prev();
+      AssertIter(iter.get(), "d", "dd");
+
+      iter->Next();
+      AssertIter(iter.get(), "f", "ff");
+    }
+
+    {
+      KVMap empty_map;
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "d", "dd");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToLast();
+      AssertIter(iter.get(), "d", "dd");
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Prev();
+      AssertIter(iter.get(), "a", "aa");
+
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("aa");
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "d", "dd");
+
+      iter->Seek("ca");
+      AssertIter(iter.get(), "d", "dd");
+
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+    }
   }
-
-  // Test the case that there is one element in the write batch
-  batch.Put(&cf2, "zoo", "bar");
-  batch.Put(&cf1, "a", "aa");
-  {
-    KVMap empty_map;
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
-
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-  }
-
-  batch.Delete(&cf1, "b");
-  batch.Put(&cf1, "c", "cc");
-  batch.Put(&cf1, "d", "dd");
-  batch.Delete(&cf1, "e");
-
-  {
-    KVMap map;
-    map["b"] = "";
-    map["cc"] = "cccc";
-    map["f"] = "ff";
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
-
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "cc", "cccc");
-    iter->Next();
-    AssertIter(iter.get(), "d", "dd");
-    iter->Next();
-    AssertIter(iter.get(), "f", "ff");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToLast();
-    AssertIter(iter.get(), "f", "ff");
-    iter->Prev();
-    AssertIter(iter.get(), "d", "dd");
-    iter->Prev();
-    AssertIter(iter.get(), "cc", "cccc");
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "cc", "cccc");
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Prev();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("c");
-    AssertIter(iter.get(), "c", "cc");
-
-    iter->Seek("cb");
-    AssertIter(iter.get(), "cc", "cccc");
-
-    iter->Seek("cc");
-    AssertIter(iter.get(), "cc", "cccc");
-    iter->Next();
-    AssertIter(iter.get(), "d", "dd");
-
-    iter->Seek("e");
-    AssertIter(iter.get(), "f", "ff");
-
-    iter->Prev();
-    AssertIter(iter.get(), "d", "dd");
-
-    iter->Next();
-    AssertIter(iter.get(), "f", "ff");
-  }
-
-  {
-    KVMap empty_map;
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
-
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "d", "dd");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToLast();
-    AssertIter(iter.get(), "d", "dd");
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Prev();
-    AssertIter(iter.get(), "a", "aa");
-
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("aa");
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "d", "dd");
-
-    iter->Seek("ca");
-    AssertIter(iter.get(), "d", "dd");
-
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-  }
-}
 }
 
 TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
-for (auto index_type : all_index_types) {
-  ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
-  ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());
-  WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
+  for (auto index_type : all_index_types) {
+    ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
+    ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());
+    WriteBatchWithIndex batch(BytewiseComparator(), 20, true, 0, index_type);
 
-  // Test the case that there is one element in the write batch
-  batch.Put(&cf2, "zoo", "bar");
-  batch.Put(&cf1, "a", "aa");
-  {
-    KVMap empty_map;
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+    // Test the case that there is one element in the write batch
+    batch.Put(&cf2, "zoo", "bar");
+    batch.Put(&cf1, "a", "aa");
+    {
+      KVMap empty_map;
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
 
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+    }
+
+    batch.Put(&cf1, "c", "cc");
+    {
+      KVMap map;
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Next();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToLast();
+      AssertIter(iter.get(), "a", "aa");
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("b");
+      AssertIter(iter.get(), "a", "aa");
+
+      iter->Prev();
+      AssertIter(iter.get(), "c", "cc");
+
+      iter->Seek("a");
+      AssertIter(iter.get(), "a", "aa");
+    }
+
+    // default column family
+    batch.Put("a", "b");
+    {
+      KVMap map;
+      map["b"] = "";
+      std::unique_ptr<Iterator> iter(
+          batch.NewIteratorWithBase(new KVIter(&map)));
+
+      iter->SeekToFirst();
+      AssertIter(iter.get(), "a", "b");
+      iter->Next();
+      AssertIter(iter.get(), "b", "");
+      iter->Next();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->SeekToLast();
+      AssertIter(iter.get(), "b", "");
+      iter->Prev();
+      AssertIter(iter.get(), "a", "b");
+      iter->Prev();
+      ASSERT_OK(iter->status());
+      ASSERT_TRUE(!iter->Valid());
+
+      iter->Seek("b");
+      AssertIter(iter.get(), "b", "");
+
+      iter->Prev();
+      AssertIter(iter.get(), "a", "b");
+
+      iter->Seek("0");
+      AssertIter(iter.get(), "a", "b");
+    }
   }
-
-  batch.Put(&cf1, "c", "cc");
-  {
-    KVMap map;
-    std::unique_ptr<Iterator> iter(
-        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
-
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Next();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToLast();
-    AssertIter(iter.get(), "a", "aa");
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("b");
-    AssertIter(iter.get(), "a", "aa");
-
-    iter->Prev();
-    AssertIter(iter.get(), "c", "cc");
-
-    iter->Seek("a");
-    AssertIter(iter.get(), "a", "aa");
-  }
-
-  // default column family
-  batch.Put("a", "b");
-  {
-    KVMap map;
-    map["b"] = "";
-    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
-
-    iter->SeekToFirst();
-    AssertIter(iter.get(), "a", "b");
-    iter->Next();
-    AssertIter(iter.get(), "b", "");
-    iter->Next();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->SeekToLast();
-    AssertIter(iter.get(), "b", "");
-    iter->Prev();
-    AssertIter(iter.get(), "a", "b");
-    iter->Prev();
-    ASSERT_OK(iter->status());
-    ASSERT_TRUE(!iter->Valid());
-
-    iter->Seek("b");
-    AssertIter(iter.get(), "b", "");
-
-    iter->Prev();
-    AssertIter(iter.get(), "a", "b");
-
-    iter->Seek("0");
-    AssertIter(iter.get(), "a", "b");
-  }
-}
 }
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatch) {
-for (auto index_type : all_index_types) {
-  Options options;
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  Status s;
-  std::string value;
+  for (auto index_type : all_index_types) {
+    Options options;
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    Status s;
+    std::string value;
 
-  s = batch.GetFromBatch(options, "b", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(options, "b", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  batch.Put("a", "a");
-  batch.Put("b", "b");
-  batch.Put("c", "c");
-  batch.Put("a", "z");
-  batch.Delete("c");
-  batch.Delete("d");
-  batch.Delete("e");
-  batch.Put("e", "e");
+    batch.Put("a", "a");
+    batch.Put("b", "b");
+    batch.Put("c", "c");
+    batch.Put("a", "z");
+    batch.Delete("c");
+    batch.Delete("d");
+    batch.Delete("e");
+    batch.Put("e", "e");
 
-  s = batch.GetFromBatch(options, "b", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("b", value);
+    s = batch.GetFromBatch(options, "b", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("b", value);
 
-  s = batch.GetFromBatch(options, "a", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("z", value);
+    s = batch.GetFromBatch(options, "a", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("z", value);
 
-  s = batch.GetFromBatch(options, "c", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(options, "c", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = batch.GetFromBatch(options, "d", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(options, "d", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = batch.GetFromBatch(options, "x", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(options, "x", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = batch.GetFromBatch(options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e", value);
-
-  batch.Merge("z", "z");
-
-  s = batch.GetFromBatch(options, "z", &value);
-  ASSERT_NOK(s);  // No merge operator specified.
-
-  s = batch.GetFromBatch(options, "b", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("b", value);
-}
-}
-
-TEST_F(WriteBatchWithIndexTest, TestGetFromBatchMerge) {
-for (auto index_type : all_index_types) {
-  DB* db;
-  Options options;
-  options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
-  options.create_if_missing = true;
-
-  std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
-
-  DestroyDB(dbname, options);
-  Status s = DB::Open(options, dbname, &db);
-  ASSERT_OK(s);
-
-  ColumnFamilyHandle* column_family = db->DefaultColumnFamily();
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  std::string value;
-
-  s = batch.GetFromBatch(options, "x", &value);
-  ASSERT_TRUE(s.IsNotFound());
-
-  batch.Put("x", "X");
-  std::string expected = "X";
-
-  for (int i = 0; i < 5; i++) {
-    batch.Merge("x", ToString(i));
-    expected = expected + "," + ToString(i);
-
-    if (i % 2 == 0) {
-      batch.Put("y", ToString(i / 2));
-    }
+    s = batch.GetFromBatch(options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e", value);
 
     batch.Merge("z", "z");
 
-    s = batch.GetFromBatch(column_family, options, "x", &value);
-    ASSERT_OK(s);
-    ASSERT_EQ(expected, value);
+    s = batch.GetFromBatch(options, "z", &value);
+    ASSERT_NOK(s);  // No merge operator specified.
 
-    s = batch.GetFromBatch(column_family, options, "y", &value);
+    s = batch.GetFromBatch(options, "b", &value);
     ASSERT_OK(s);
-    ASSERT_EQ(ToString(i / 2), value);
-
-    s = batch.GetFromBatch(column_family, options, "z", &value);
-    ASSERT_TRUE(s.IsMergeInProgress());
+    ASSERT_EQ("b", value);
   }
-
-  delete db;
-  DestroyDB(dbname, options);
 }
+
+TEST_F(WriteBatchWithIndexTest, TestGetFromBatchMerge) {
+  for (auto index_type : all_index_types) {
+    DB* db;
+    Options options;
+    options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
+    options.create_if_missing = true;
+
+    std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
+
+    DestroyDB(dbname, options);
+    Status s = DB::Open(options, dbname, &db);
+    ASSERT_OK(s);
+
+    ColumnFamilyHandle* column_family = db->DefaultColumnFamily();
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    std::string value;
+
+    s = batch.GetFromBatch(options, "x", &value);
+    ASSERT_TRUE(s.IsNotFound());
+
+    batch.Put("x", "X");
+    std::string expected = "X";
+
+    for (int i = 0; i < 5; i++) {
+      batch.Merge("x", ToString(i));
+      expected = expected + "," + ToString(i);
+
+      if (i % 2 == 0) {
+        batch.Put("y", ToString(i / 2));
+      }
+
+      batch.Merge("z", "z");
+
+      s = batch.GetFromBatch(column_family, options, "x", &value);
+      ASSERT_OK(s);
+      ASSERT_EQ(expected, value);
+
+      s = batch.GetFromBatch(column_family, options, "y", &value);
+      ASSERT_OK(s);
+      ASSERT_EQ(ToString(i / 2), value);
+
+      s = batch.GetFromBatch(column_family, options, "z", &value);
+      ASSERT_TRUE(s.IsMergeInProgress());
+    }
+
+    delete db;
+    DestroyDB(dbname, options);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatchMerge2) {
-for (auto index_type : all_index_types) {
-  DB* db;
-  Options options;
-  options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
-  options.create_if_missing = true;
+  for (auto index_type : all_index_types) {
+    DB* db;
+    Options options;
+    options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
+    options.create_if_missing = true;
 
-  std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
+    std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
 
-  DestroyDB(dbname, options);
-  Status s = DB::Open(options, dbname, &db);
-  ASSERT_OK(s);
+    DestroyDB(dbname, options);
+    Status s = DB::Open(options, dbname, &db);
+    ASSERT_OK(s);
 
-  ColumnFamilyHandle* column_family = db->DefaultColumnFamily();
+    ColumnFamilyHandle* column_family = db->DefaultColumnFamily();
 
-  // Test batch with overwrite_key=true
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
-  std::string value;
+    // Test batch with overwrite_key=true
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
+    std::string value;
 
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  batch.Put(column_family, "X", "x");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("x", value);
+    batch.Put(column_family, "X", "x");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("x", value);
 
-  batch.Put(column_family, "X", "x2");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("x2", value);
+    batch.Put(column_family, "X", "x2");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("x2", value);
 
-  batch.Merge(column_family, "X", "aaa");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    batch.Merge(column_family, "X", "aaa");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  batch.Merge(column_family, "X", "bbb");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    batch.Merge(column_family, "X", "bbb");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  batch.Put(column_family, "X", "x3");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("x3", value);
+    batch.Put(column_family, "X", "x3");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("x3", value);
 
-  batch.Merge(column_family, "X", "ccc");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    batch.Merge(column_family, "X", "ccc");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  batch.Delete(column_family, "X");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    batch.Delete(column_family, "X");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  batch.Merge(column_family, "X", "ddd");
-  s = batch.GetFromBatch(column_family, options, "X", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    batch.Merge(column_family, "X", "ddd");
+    s = batch.GetFromBatch(column_family, options, "X", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  delete db;
-  DestroyDB(dbname, options);
-}
+    delete db;
+    DestroyDB(dbname, options);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatchAndDB) {
-for (auto index_type : all_index_types) {
-  DB* db;
-  Options options;
-  options.create_if_missing = true;
-  std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
+  for (auto index_type : all_index_types) {
+    DB* db;
+    Options options;
+    options.create_if_missing = true;
+    std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
 
-  DestroyDB(dbname, options);
-  Status s = DB::Open(options, dbname, &db);
-  ASSERT_OK(s);
+    DestroyDB(dbname, options);
+    Status s = DB::Open(options, dbname, &db);
+    ASSERT_OK(s);
 
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  ReadOptions read_options;
-  WriteOptions write_options;
-  std::string value;
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    ReadOptions read_options;
+    WriteOptions write_options;
+    std::string value;
 
-  s = db->Put(write_options, "a", "a");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "a", "a");
+    ASSERT_OK(s);
 
-  s = db->Put(write_options, "b", "b");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "b", "b");
+    ASSERT_OK(s);
 
-  s = db->Put(write_options, "c", "c");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "c", "c");
+    ASSERT_OK(s);
 
-  batch.Put("a", "batch.a");
-  batch.Delete("b");
+    batch.Put("a", "batch.a");
+    batch.Delete("b");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("batch.a", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("batch.a", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "b", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "b", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("c", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("c", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  db->Delete(write_options, "x");
+    db->Delete(write_options, "x");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  delete db;
-  DestroyDB(dbname, options);
-}
+    delete db;
+    DestroyDB(dbname, options);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatchAndDBMerge) {
-for (auto index_type : all_index_types) {
-  DB* db;
-  Options options;
+  for (auto index_type : all_index_types) {
+    DB* db;
+    Options options;
 
-  options.create_if_missing = true;
-  std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
+    options.create_if_missing = true;
+    std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
 
-  options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
+    options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
 
-  DestroyDB(dbname, options);
-  Status s = DB::Open(options, dbname, &db);
-  assert(s.ok());
+    DestroyDB(dbname, options);
+    Status s = DB::Open(options, dbname, &db);
+    assert(s.ok());
 
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  ReadOptions read_options;
-  WriteOptions write_options;
-  std::string value;
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    ReadOptions read_options;
+    WriteOptions write_options;
+    std::string value;
 
-  s = db->Put(write_options, "a", "a0");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "a", "a0");
+    ASSERT_OK(s);
 
-  s = db->Put(write_options, "b", "b0");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "b", "b0");
+    ASSERT_OK(s);
 
-  s = db->Merge(write_options, "b", "b1");
-  ASSERT_OK(s);
+    s = db->Merge(write_options, "b", "b1");
+    ASSERT_OK(s);
 
-  s = db->Merge(write_options, "c", "c0");
-  ASSERT_OK(s);
+    s = db->Merge(write_options, "c", "c0");
+    ASSERT_OK(s);
 
-  s = db->Merge(write_options, "d", "d0");
-  ASSERT_OK(s);
+    s = db->Merge(write_options, "d", "d0");
+    ASSERT_OK(s);
 
-  batch.Merge("a", "a1");
-  batch.Merge("a", "a2");
-  batch.Merge("b", "b2");
-  batch.Merge("d", "d1");
-  batch.Merge("e", "e0");
+    batch.Merge("a", "a1");
+    batch.Merge("a", "a2");
+    batch.Merge("b", "b2");
+    batch.Merge("d", "d1");
+    batch.Merge("e", "e0");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("a0,a1,a2", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("a0,a1,a2", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "b", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("b0,b1,b2", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "b", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("b0,b1,b2", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("c0", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("c0", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "d", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("d0,d1", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "d", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("d0,d1", value);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e0", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e0", value);
 
-  s = db->Delete(write_options, "x");
-  ASSERT_OK(s);
+    s = db->Delete(write_options, "x");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "x", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  const Snapshot* snapshot = db->GetSnapshot();
-  ReadOptions snapshot_read_options;
-  snapshot_read_options.snapshot = snapshot;
+    const Snapshot* snapshot = db->GetSnapshot();
+    ReadOptions snapshot_read_options;
+    snapshot_read_options.snapshot = snapshot;
 
-  s = db->Delete(write_options, "a");
-  ASSERT_OK(s);
+    s = db->Delete(write_options, "a");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("a1,a2", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("a1,a2", value);
 
-  s = batch.GetFromBatchAndDB(db, snapshot_read_options, "a", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("a0,a1,a2", value);
+    s = batch.GetFromBatchAndDB(db, snapshot_read_options, "a", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("a0,a1,a2", value);
 
-  batch.Delete("a");
+    batch.Delete("a");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "a", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = batch.GetFromBatchAndDB(db, snapshot_read_options, "a", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, snapshot_read_options, "a", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  s = db->Merge(write_options, "c", "c1");
-  ASSERT_OK(s);
+    s = db->Merge(write_options, "c", "c1");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("c0,c1", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "c", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("c0,c1", value);
 
-  s = batch.GetFromBatchAndDB(db, snapshot_read_options, "c", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("c0", value);
+    s = batch.GetFromBatchAndDB(db, snapshot_read_options, "c", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("c0", value);
 
-  s = db->Put(write_options, "e", "e1");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "e", "e1");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e1,e0", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e1,e0", value);
 
-  s = batch.GetFromBatchAndDB(db, snapshot_read_options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e0", value);
+    s = batch.GetFromBatchAndDB(db, snapshot_read_options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e0", value);
 
-  s = db->Delete(write_options, "e");
-  ASSERT_OK(s);
+    s = db->Delete(write_options, "e");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e0", value);
+    s = batch.GetFromBatchAndDB(db, read_options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e0", value);
 
-  s = batch.GetFromBatchAndDB(db, snapshot_read_options, "e", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("e0", value);
+    s = batch.GetFromBatchAndDB(db, snapshot_read_options, "e", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("e0", value);
 
-  db->ReleaseSnapshot(snapshot);
-  delete db;
-  DestroyDB(dbname, options);
-}
+    db->ReleaseSnapshot(snapshot);
+    delete db;
+    DestroyDB(dbname, options);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatchAndDBMerge2) {
-for (auto index_type : all_index_types) {
-  DB* db;
-  Options options;
+  for (auto index_type : all_index_types) {
+    DB* db;
+    Options options;
 
-  options.create_if_missing = true;
-  std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
+    options.create_if_missing = true;
+    std::string dbname = test::PerThreadDBPath("write_batch_with_index_test");
 
-  options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
+    options.merge_operator = MergeOperators::CreateFromStringId("stringappend");
 
-  DestroyDB(dbname, options);
-  Status s = DB::Open(options, dbname, &db);
-  assert(s.ok());
+    DestroyDB(dbname, options);
+    Status s = DB::Open(options, dbname, &db);
+    assert(s.ok());
 
-  // Test batch with overwrite_key=true
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
+    // Test batch with overwrite_key=true
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
 
-  ReadOptions read_options;
-  WriteOptions write_options;
-  std::string value;
+    ReadOptions read_options;
+    WriteOptions write_options;
+    std::string value;
 
-  s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  batch.Merge("A", "xxx");
+    batch.Merge("A", "xxx");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  batch.Merge("A", "yyy");
+    batch.Merge("A", "yyy");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  s = db->Put(write_options, "A", "a0");
-  ASSERT_OK(s);
+    s = db->Put(write_options, "A", "a0");
+    ASSERT_OK(s);
 
-  s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
-  ASSERT_TRUE(s.IsMergeInProgress());
+    s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
+    ASSERT_TRUE(s.IsMergeInProgress());
 
-  batch.Delete("A");
+    batch.Delete("A");
 
-  s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatchAndDB(db, read_options, "A", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  delete db;
-  DestroyDB(dbname, options);
+    delete db;
+    DestroyDB(dbname, options);
+  }
 }
-}
-
 
 TEST_F(WriteBatchWithIndexTest, TestGetFromBatchAndDBMerge3) {
   DB* db;
@@ -1383,41 +1376,41 @@ void AssertValue(std::string value, WBWIIterator* iter) {
 // Tests that we can write to the WBWI while we iterate (from a single thread).
 // iteration should see the newest writes
 TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingCorrectnessTest) {
-for (auto index_type : all_index_types) {
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
-  for (char c = 'a'; c <= 'z'; ++c) {
-    batch.Put(std::string(1, c), std::string(1, c));
+  for (auto index_type : all_index_types) {
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
+    for (char c = 'a'; c <= 'z'; ++c) {
+      batch.Put(std::string(1, c), std::string(1, c));
+    }
+
+    std::unique_ptr<WBWIIterator> iter(batch.NewIterator());
+    iter->Seek("k");
+    AssertKey("k", iter.get());
+    iter->Next();
+    AssertKey("l", iter.get());
+    batch.Put("ab", "cc");
+    iter->Next();
+    AssertKey("m", iter.get());
+    batch.Put("mm", "kk");
+    iter->Next();
+    AssertKey("mm", iter.get());
+    AssertValue("kk", iter.get());
+    batch.Delete("mm");
+
+    iter->Next();
+    AssertKey("n", iter.get());
+    iter->Prev();
+    AssertKey("mm", iter.get());
+    ASSERT_EQ(kDeleteRecord, iter->Entry().type);
+
+    iter->Seek("ab");
+    AssertKey("ab", iter.get());
+    batch.Delete("x");
+    iter->Seek("x");
+    AssertKey("x", iter.get());
+    ASSERT_EQ(kDeleteRecord, iter->Entry().type);
+    iter->Prev();
+    AssertKey("w", iter.get());
   }
-
-  std::unique_ptr<WBWIIterator> iter(batch.NewIterator());
-  iter->Seek("k");
-  AssertKey("k", iter.get());
-  iter->Next();
-  AssertKey("l", iter.get());
-  batch.Put("ab", "cc");
-  iter->Next();
-  AssertKey("m", iter.get());
-  batch.Put("mm", "kk");
-  iter->Next();
-  AssertKey("mm", iter.get());
-  AssertValue("kk", iter.get());
-  batch.Delete("mm");
-
-  iter->Next();
-  AssertKey("n", iter.get());
-  iter->Prev();
-  AssertKey("mm", iter.get());
-  ASSERT_EQ(kDeleteRecord, iter->Entry().type);
-
-  iter->Seek("ab");
-  AssertKey("ab", iter.get());
-  batch.Delete("x");
-  iter->Seek("x");
-  AssertKey("x", iter.get());
-  ASSERT_EQ(kDeleteRecord, iter->Entry().type);
-  iter->Prev();
-  AssertKey("w", iter.get());
-}
 }
 
 void AssertIterKey(std::string key, Iterator* iter) {
@@ -1432,128 +1425,126 @@ void AssertIterValue(std::string value, Iterator* iter) {
 
 // same thing as above, but testing IteratorWithBase
 TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseCorrectnessTest) {
-for (auto index_type : all_index_types) {
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
-  for (char c = 'a'; c <= 'z'; ++c) {
-    batch.Put(std::string(1, c), std::string(1, c));
+  for (auto index_type : all_index_types) {
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
+    for (char c = 'a'; c <= 'z'; ++c) {
+      batch.Put(std::string(1, c), std::string(1, c));
+    }
+
+    KVMap map;
+    map["aa"] = "aa";
+    map["cc"] = "cc";
+    map["ee"] = "ee";
+    map["em"] = "me";
+
+    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
+    iter->Seek("k");
+    AssertIterKey("k", iter.get());
+    iter->Next();
+    AssertIterKey("l", iter.get());
+    batch.Put("ab", "cc");
+    iter->Next();
+    AssertIterKey("m", iter.get());
+    batch.Put("mm", "kk");
+    iter->Next();
+    AssertIterKey("mm", iter.get());
+    AssertIterValue("kk", iter.get());
+    batch.Delete("mm");
+    iter->Next();
+    AssertIterKey("n", iter.get());
+    iter->Prev();
+    // "mm" is deleted, so we're back at "m"
+    AssertIterKey("m", iter.get());
+
+    iter->Seek("ab");
+    AssertIterKey("ab", iter.get());
+    iter->Prev();
+    AssertIterKey("aa", iter.get());
+    iter->Prev();
+    AssertIterKey("a", iter.get());
+    batch.Delete("aa");
+    iter->Next();
+    AssertIterKey("ab", iter.get());
+    iter->Prev();
+    AssertIterKey("a", iter.get());
+
+    batch.Delete("x");
+    iter->Seek("x");
+    AssertIterKey("y", iter.get());
+    iter->Next();
+    AssertIterKey("z", iter.get());
+    iter->Prev();
+    iter->Prev();
+    AssertIterKey("w", iter.get());
+
+    batch.Delete("e");
+    iter->Seek("e");
+    AssertIterKey("ee", iter.get());
+    AssertIterValue("ee", iter.get());
+    batch.Put("ee", "xx");
+    // still the same value
+    AssertIterValue("ee", iter.get());
+    iter->Next();
+    AssertIterKey("em", iter.get());
+    iter->Prev();
+    // new value
+    AssertIterValue("xx", iter.get());
   }
-
-  KVMap map;
-  map["aa"] = "aa";
-  map["cc"] = "cc";
-  map["ee"] = "ee";
-  map["em"] = "me";
-
-  std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(new KVIter(&map)));
-  iter->Seek("k");
-  AssertIterKey("k", iter.get());
-  iter->Next();
-  AssertIterKey("l", iter.get());
-  batch.Put("ab", "cc");
-  iter->Next();
-  AssertIterKey("m", iter.get());
-  batch.Put("mm", "kk");
-  iter->Next();
-  AssertIterKey("mm", iter.get());
-  AssertIterValue("kk", iter.get());
-  batch.Delete("mm");
-  iter->Next();
-  AssertIterKey("n", iter.get());
-  iter->Prev();
-  // "mm" is deleted, so we're back at "m"
-  AssertIterKey("m", iter.get());
-
-  iter->Seek("ab");
-  AssertIterKey("ab", iter.get());
-  iter->Prev();
-  AssertIterKey("aa", iter.get());
-  iter->Prev();
-  AssertIterKey("a", iter.get());
-  batch.Delete("aa");
-  iter->Next();
-  AssertIterKey("ab", iter.get());
-  iter->Prev();
-  AssertIterKey("a", iter.get());
-
-  batch.Delete("x");
-  iter->Seek("x");
-  AssertIterKey("y", iter.get());
-  iter->Next();
-  AssertIterKey("z", iter.get());
-  iter->Prev();
-  iter->Prev();
-  AssertIterKey("w", iter.get());
-
-  batch.Delete("e");
-  iter->Seek("e");
-  AssertIterKey("ee", iter.get());
-  AssertIterValue("ee", iter.get());
-  batch.Put("ee", "xx");
-  // still the same value
-  AssertIterValue("ee", iter.get());
-  iter->Next();
-  AssertIterKey("em", iter.get());
-  iter->Prev();
-  // new value
-  AssertIterValue("xx", iter.get());
-}
 }
 
 // stress testing mutations with IteratorWithBase
 TEST_F(WriteBatchWithIndexTest, MutateWhileIteratingBaseStressTest) {
-for (auto index_type : all_index_types) {
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
-  for (char c = 'a'; c <= 'z'; ++c) {
-    batch.Put(std::string(1, c), std::string(1, c));
-  }
+  for (auto index_type : all_index_types) {
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, true, 0, index_type);
+    for (char c = 'a'; c <= 'z'; ++c) {
+      batch.Put(std::string(1, c), std::string(1, c));
+    }
 
-  KVMap map;
-  for (char c = 'a'; c <= 'z'; ++c) {
-    map[std::string(2, c)] = std::string(2, c);
-  }
+    KVMap map;
+    for (char c = 'a'; c <= 'z'; ++c) {
+      map[std::string(2, c)] = std::string(2, c);
+    }
 
-  std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(new KVIter(&map)));
+    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
 
-  Random rnd(301);
-  for (int i = 0; i < 1000000; ++i) {
-    int random = rnd.Uniform(8);
-    char c = static_cast<char>(rnd.Uniform(26) + 'a');
-    switch (random) {
-      case 0:
-        batch.Put(std::string(1, c), "xxx");
-        break;
-      case 1:
-        batch.Put(std::string(2, c), "xxx");
-        break;
-      case 2:
-        batch.Delete(std::string(1, c));
-        break;
-      case 3:
-        batch.Delete(std::string(2, c));
-        break;
-      case 4:
-        iter->Seek(std::string(1, c));
-        break;
-      case 5:
-        iter->Seek(std::string(2, c));
-        break;
-      case 6:
-        if (iter->Valid()) {
-          iter->Next();
-        }
-        break;
-      case 7:
-        if (iter->Valid()) {
-          iter->Prev();
-        }
-        break;
-      default:
-        assert(false);
+    Random rnd(301);
+    for (int i = 0; i < 1000000; ++i) {
+      int random = rnd.Uniform(8);
+      char c = static_cast<char>(rnd.Uniform(26) + 'a');
+      switch (random) {
+        case 0:
+          batch.Put(std::string(1, c), "xxx");
+          break;
+        case 1:
+          batch.Put(std::string(2, c), "xxx");
+          break;
+        case 2:
+          batch.Delete(std::string(1, c));
+          break;
+        case 3:
+          batch.Delete(std::string(2, c));
+          break;
+        case 4:
+          iter->Seek(std::string(1, c));
+          break;
+        case 5:
+          iter->Seek(std::string(2, c));
+          break;
+        case 6:
+          if (iter->Valid()) {
+            iter->Next();
+          }
+          break;
+        case 7:
+          if (iter->Valid()) {
+            iter->Prev();
+          }
+          break;
+        default:
+          assert(false);
+      }
     }
   }
-}
 }
 
 static std::string PrintContents(WriteBatchWithIndex* batch,
@@ -1631,243 +1622,249 @@ static std::string PrintContents(WriteBatchWithIndex* batch, KVMap* base_map,
 }
 
 TEST_F(WriteBatchWithIndexTest, SavePointTest) {
-for (auto index_type : all_index_types) {
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  ColumnFamilyHandleImplDummy cf1(1, BytewiseComparator());
-  Status s;
+  for (auto index_type : all_index_types) {
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    ColumnFamilyHandleImplDummy cf1(1, BytewiseComparator());
+    Status s;
 
-  batch.Put("A", "a");
-  batch.Put("B", "b");
-  batch.Put("A", "aa");
-  batch.Put(&cf1, "A", "a1");
-  batch.Delete(&cf1, "B");
-  batch.Put(&cf1, "C", "c1");
-  batch.Put(&cf1, "E", "e1");
+    batch.Put("A", "a");
+    batch.Put("B", "b");
+    batch.Put("A", "aa");
+    batch.Put(&cf1, "A", "a1");
+    batch.Delete(&cf1, "B");
+    batch.Put(&cf1, "C", "c1");
+    batch.Put(&cf1, "E", "e1");
 
-  batch.SetSavePoint();  // 1
+    batch.SetSavePoint();  // 1
 
-  batch.Put("C", "cc");
-  batch.Put("B", "bb");
-  batch.Delete("A");
-  batch.Put(&cf1, "B", "b1");
-  batch.Delete(&cf1, "A");
-  batch.SingleDelete(&cf1, "E");
-  batch.SetSavePoint();  // 2
+    batch.Put("C", "cc");
+    batch.Put("B", "bb");
+    batch.Delete("A");
+    batch.Put(&cf1, "B", "b1");
+    batch.Delete(&cf1, "A");
+    batch.SingleDelete(&cf1, "E");
+    batch.SetSavePoint();  // 2
 
-  batch.Put("A", "aaa");
-  batch.Put("A", "xxx");
-  batch.Delete("B");
-  batch.Put(&cf1, "B", "b2");
-  batch.Delete(&cf1, "C");
-  batch.SetSavePoint();  // 3
-  batch.SetSavePoint();  // 4
-  batch.SingleDelete("D");
-  batch.Delete(&cf1, "D");
-  batch.Delete(&cf1, "E");
+    batch.Put("A", "aaa");
+    batch.Put("A", "xxx");
+    batch.Delete("B");
+    batch.Put(&cf1, "B", "b2");
+    batch.Delete(&cf1, "C");
+    batch.SetSavePoint();  // 3
+    batch.SetSavePoint();  // 4
+    batch.SingleDelete("D");
+    batch.Delete(&cf1, "D");
+    batch.Delete(&cf1, "E");
 
-  ASSERT_EQ(
-      "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,DEL("
-      "B)"
-      ",PUT(C):cc,SINGLE-DEL(D),",
-      PrintContents(&batch, nullptr));
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,"
+        "DEL("
+        "B)"
+        ",PUT(C):cc,SINGLE-DEL(D),",
+        PrintContents(&batch, nullptr));
 
-  ASSERT_EQ(
-      "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
-      "DEL(D),PUT(E):e1,SINGLE-DEL(E),DEL(E),",
-      PrintContents(&batch, &cf1));
+    ASSERT_EQ(
+        "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
+        "DEL(D),PUT(E):e1,SINGLE-DEL(E),DEL(E),",
+        PrintContents(&batch, &cf1));
 
-  ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 4
-  ASSERT_EQ(
-      "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,DEL("
-      "B)"
-      ",PUT(C):cc,",
-      PrintContents(&batch, nullptr));
+    ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 4
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,"
+        "DEL("
+        "B)"
+        ",PUT(C):cc,",
+        PrintContents(&batch, nullptr));
 
-  ASSERT_EQ(
-      "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
-      "PUT(E):e1,SINGLE-DEL(E),",
-      PrintContents(&batch, &cf1));
+    ASSERT_EQ(
+        "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
+        "PUT(E):e1,SINGLE-DEL(E),",
+        PrintContents(&batch, &cf1));
 
-  ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 3
-  ASSERT_EQ(
-      "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,DEL("
-      "B)"
-      ",PUT(C):cc,",
-      PrintContents(&batch, nullptr));
+    ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 3
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):aa,DEL(A),PUT(A):aaa,PUT(A):xxx,PUT(B):b,PUT(B):bb,"
+        "DEL("
+        "B)"
+        ",PUT(C):cc,",
+        PrintContents(&batch, nullptr));
 
-  ASSERT_EQ(
-      "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
-      "PUT(E):e1,SINGLE-DEL(E),",
-      PrintContents(&batch, &cf1));
+    ASSERT_EQ(
+        "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(B):b2,PUT(C):c1,DEL(C),"
+        "PUT(E):e1,SINGLE-DEL(E),",
+        PrintContents(&batch, &cf1));
 
-  ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 2
-  ASSERT_EQ("PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,",
-            PrintContents(&batch, nullptr));
+    ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 2
+    ASSERT_EQ("PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,",
+              PrintContents(&batch, nullptr));
 
-  ASSERT_EQ(
-      "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(C):c1,"
-      "PUT(E):e1,SINGLE-DEL(E),",
-      PrintContents(&batch, &cf1));
+    ASSERT_EQ(
+        "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(C):c1,"
+        "PUT(E):e1,SINGLE-DEL(E),",
+        PrintContents(&batch, &cf1));
 
-  batch.SetSavePoint();  // 5
-  batch.Put("X", "x");
+    batch.SetSavePoint();  // 5
+    batch.Put("X", "x");
 
-  ASSERT_EQ("PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,PUT(X):x,",
-            PrintContents(&batch, nullptr));
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,PUT(X):x,",
+        PrintContents(&batch, nullptr));
 
-  ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 5
-  ASSERT_EQ("PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,",
-            PrintContents(&batch, nullptr));
+    ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 5
+    ASSERT_EQ("PUT(A):a,PUT(A):aa,DEL(A),PUT(B):b,PUT(B):bb,PUT(C):cc,",
+              PrintContents(&batch, nullptr));
 
-  ASSERT_EQ(
-      "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(C):c1,"
-      "PUT(E):e1,SINGLE-DEL(E),",
-      PrintContents(&batch, &cf1));
+    ASSERT_EQ(
+        "PUT(A):a1,DEL(A),DEL(B),PUT(B):b1,PUT(C):c1,"
+        "PUT(E):e1,SINGLE-DEL(E),",
+        PrintContents(&batch, &cf1));
 
-  ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 1
-  ASSERT_EQ("PUT(A):a,PUT(A):aa,PUT(B):b,", PrintContents(&batch, nullptr));
+    ASSERT_OK(batch.RollbackToSavePoint());  // rollback to 1
+    ASSERT_EQ("PUT(A):a,PUT(A):aa,PUT(B):b,", PrintContents(&batch, nullptr));
 
-  ASSERT_EQ("PUT(A):a1,DEL(B),PUT(C):c1,PUT(E):e1,",
-            PrintContents(&batch, &cf1));
+    ASSERT_EQ("PUT(A):a1,DEL(B),PUT(C):c1,PUT(E):e1,",
+              PrintContents(&batch, &cf1));
 
-  s = batch.RollbackToSavePoint();  // no savepoint found
-  ASSERT_TRUE(s.IsNotFound());
-  ASSERT_EQ("PUT(A):a,PUT(A):aa,PUT(B):b,", PrintContents(&batch, nullptr));
+    s = batch.RollbackToSavePoint();  // no savepoint found
+    ASSERT_TRUE(s.IsNotFound());
+    ASSERT_EQ("PUT(A):a,PUT(A):aa,PUT(B):b,", PrintContents(&batch, nullptr));
 
-  ASSERT_EQ("PUT(A):a1,DEL(B),PUT(C):c1,PUT(E):e1,",
-            PrintContents(&batch, &cf1));
+    ASSERT_EQ("PUT(A):a1,DEL(B),PUT(C):c1,PUT(E):e1,",
+              PrintContents(&batch, &cf1));
 
-  batch.SetSavePoint();  // 6
+    batch.SetSavePoint();  // 6
 
-  batch.Clear();
-  ASSERT_EQ("", PrintContents(&batch, nullptr));
-  ASSERT_EQ("", PrintContents(&batch, &cf1));
+    batch.Clear();
+    ASSERT_EQ("", PrintContents(&batch, nullptr));
+    ASSERT_EQ("", PrintContents(&batch, &cf1));
 
-  s = batch.RollbackToSavePoint();  // rollback to 6
-  ASSERT_TRUE(s.IsNotFound());
-}
+    s = batch.RollbackToSavePoint();  // rollback to 6
+    ASSERT_TRUE(s.IsNotFound());
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, SingleDeleteTest) {
-for (auto index_type : all_index_types) {
-  WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
-  Status s;
-  std::string value;
-  DBOptions db_options;
+  for (auto index_type : all_index_types) {
+    WriteBatchWithIndex batch(BytewiseComparator(), 0, false, 0, index_type);
+    Status s;
+    std::string value;
+    DBOptions db_options;
 
-  batch.SingleDelete("A");
+    batch.SingleDelete("A");
 
-  s = batch.GetFromBatch(db_options, "A", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  s = batch.GetFromBatch(db_options, "B", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  value = PrintContents(&batch, nullptr);
-  ASSERT_EQ("SINGLE-DEL(A),", value);
+    s = batch.GetFromBatch(db_options, "A", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "B", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    value = PrintContents(&batch, nullptr);
+    ASSERT_EQ("SINGLE-DEL(A),", value);
 
-  batch.Clear();
-  batch.Put("A", "a");
-  batch.Put("A", "a2");
-  batch.Put("B", "b");
-  batch.SingleDelete("A");
+    batch.Clear();
+    batch.Put("A", "a");
+    batch.Put("A", "a2");
+    batch.Put("B", "b");
+    batch.SingleDelete("A");
 
-  s = batch.GetFromBatch(db_options, "A", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  s = batch.GetFromBatch(db_options, "B", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("b", value);
+    s = batch.GetFromBatch(db_options, "A", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "B", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("b", value);
 
-  value = PrintContents(&batch, nullptr);
-  ASSERT_EQ("PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(B):b,", value);
+    value = PrintContents(&batch, nullptr);
+    ASSERT_EQ("PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(B):b,", value);
 
-  batch.Put("C", "c");
-  batch.Put("A", "a3");
-  batch.Delete("B");
-  batch.SingleDelete("B");
-  batch.SingleDelete("C");
+    batch.Put("C", "c");
+    batch.Put("A", "a3");
+    batch.Delete("B");
+    batch.SingleDelete("B");
+    batch.SingleDelete("C");
 
-  s = batch.GetFromBatch(db_options, "A", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("a3", value);
-  s = batch.GetFromBatch(db_options, "B", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  s = batch.GetFromBatch(db_options, "C", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  s = batch.GetFromBatch(db_options, "D", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "A", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("a3", value);
+    s = batch.GetFromBatch(db_options, "B", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "C", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "D", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  value = PrintContents(&batch, nullptr);
-  ASSERT_EQ(
-      "PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(A):a3,PUT(B):b,DEL(B),SINGLE-DEL(B)"
-      ",PUT(C):c,SINGLE-DEL(C),",
-      value);
+    value = PrintContents(&batch, nullptr);
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(A):a3,PUT(B):b,DEL(B),SINGLE-DEL("
+        "B)"
+        ",PUT(C):c,SINGLE-DEL(C),",
+        value);
 
-  batch.Put("B", "b4");
-  batch.Put("C", "c4");
-  batch.Put("D", "d4");
-  batch.SingleDelete("D");
-  batch.SingleDelete("D");
-  batch.Delete("A");
+    batch.Put("B", "b4");
+    batch.Put("C", "c4");
+    batch.Put("D", "d4");
+    batch.SingleDelete("D");
+    batch.SingleDelete("D");
+    batch.Delete("A");
 
-  s = batch.GetFromBatch(db_options, "A", &value);
-  ASSERT_TRUE(s.IsNotFound());
-  s = batch.GetFromBatch(db_options, "B", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("b4", value);
-  s = batch.GetFromBatch(db_options, "C", &value);
-  ASSERT_OK(s);
-  ASSERT_EQ("c4", value);
-  s = batch.GetFromBatch(db_options, "D", &value);
-  ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "A", &value);
+    ASSERT_TRUE(s.IsNotFound());
+    s = batch.GetFromBatch(db_options, "B", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("b4", value);
+    s = batch.GetFromBatch(db_options, "C", &value);
+    ASSERT_OK(s);
+    ASSERT_EQ("c4", value);
+    s = batch.GetFromBatch(db_options, "D", &value);
+    ASSERT_TRUE(s.IsNotFound());
 
-  value = PrintContents(&batch, nullptr);
-  ASSERT_EQ(
-      "PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(A):a3,DEL(A),PUT(B):b,DEL(B),"
-      "SINGLE-DEL(B),PUT(B):b4,PUT(C):c,SINGLE-DEL(C),PUT(C):c4,PUT(D):d4,"
-      "SINGLE-DEL(D),SINGLE-DEL(D),",
-      value);
-}
+    value = PrintContents(&batch, nullptr);
+    ASSERT_EQ(
+        "PUT(A):a,PUT(A):a2,SINGLE-DEL(A),PUT(A):a3,DEL(A),PUT(B):b,DEL(B),"
+        "SINGLE-DEL(B),PUT(B):b4,PUT(C):c,SINGLE-DEL(C),PUT(C):c4,PUT(D):d4,"
+        "SINGLE-DEL(D),SINGLE-DEL(D),",
+        value);
+  }
 }
 
 TEST_F(WriteBatchWithIndexTest, SingleDeleteDeltaIterTest) {
-for (auto index_type : all_index_types) {
-  Status s;
-  std::string value;
-  DBOptions db_options;
-  WriteBatchWithIndex batch(BytewiseComparator(), 20, true /* overwrite_key */, 0, index_type);
-  batch.Put("A", "a");
-  batch.Put("A", "a2");
-  batch.Put("B", "b");
-  batch.SingleDelete("A");
-  batch.Delete("B");
+  for (auto index_type : all_index_types) {
+    Status s;
+    std::string value;
+    DBOptions db_options;
+    WriteBatchWithIndex batch(BytewiseComparator(), 20,
+                              true /* overwrite_key */, 0, index_type);
+    batch.Put("A", "a");
+    batch.Put("A", "a2");
+    batch.Put("B", "b");
+    batch.SingleDelete("A");
+    batch.Delete("B");
 
-  KVMap map;
-  value = PrintContents(&batch, &map, nullptr);
-  ASSERT_EQ("", value);
+    KVMap map;
+    value = PrintContents(&batch, &map, nullptr);
+    ASSERT_EQ("", value);
 
-  map["A"] = "aa";
-  map["C"] = "cc";
-  map["D"] = "dd";
+    map["A"] = "aa";
+    map["C"] = "cc";
+    map["D"] = "dd";
 
-  batch.SingleDelete("B");
-  batch.SingleDelete("C");
-  batch.SingleDelete("Z");
+    batch.SingleDelete("B");
+    batch.SingleDelete("C");
+    batch.SingleDelete("Z");
 
-  value = PrintContents(&batch, &map, nullptr);
-  ASSERT_EQ("D:dd,", value);
+    value = PrintContents(&batch, &map, nullptr);
+    ASSERT_EQ("D:dd,", value);
 
-  batch.Put("A", "a3");
-  batch.Put("B", "b3");
-  batch.SingleDelete("A");
-  batch.SingleDelete("A");
-  batch.SingleDelete("D");
-  batch.SingleDelete("D");
-  batch.Delete("D");
+    batch.Put("A", "a3");
+    batch.Put("B", "b3");
+    batch.SingleDelete("A");
+    batch.SingleDelete("A");
+    batch.SingleDelete("D");
+    batch.SingleDelete("D");
+    batch.Delete("D");
 
-  map["E"] = "ee";
+    map["E"] = "ee";
 
-  value = PrintContents(&batch, &map, nullptr);
-  ASSERT_EQ("B:b3,E:ee,", value);
-}
+    value = PrintContents(&batch, &map, nullptr);
+    ASSERT_EQ("B:b3,E:ee,", value);
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
WriteBatchWithIndex hard coded `SkipList` as index implementation, this PR refactory the interface to allow third party index implementation, `SkipList` is used as default.