### PR TITLE
Add VS2015 and VS2017 to CircleCI Runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,17 +132,31 @@ jobs:
       extra_cmake_opt:
         default: ""
         type: string
+      vs_year:
+        default: "2019"
+        type: string
+      cmake_generator:
+        default: "Visual Studio 16 2019"
+        type: string
     environment:
       THIRDPARTY_HOME: C:/Users/circleci/thirdparty
       CMAKE_HOME: C:/Users/circleci/thirdparty/cmake-3.16.4-win64-x64
       CMAKE_BIN: C:/Users/circleci/thirdparty/cmake-3.16.4-win64-x64/bin/cmake.exe
-      CMAKE_GENERATOR: Visual Studio 16 2019
       SNAPPY_HOME: C:/Users/circleci/thirdparty/snappy-1.1.7
       SNAPPY_INCLUDE: C:/Users/circleci/thirdparty/snappy-1.1.7;C:/Users/circleci/thirdparty/snappy-1.1.7/build
       SNAPPY_LIB_DEBUG: C:/Users/circleci/thirdparty/snappy-1.1.7/build/Debug/snappy.lib
-
+      VS_YEAR: <<parameters.vs_year>>
+      CMAKE_GENERATOR: <<parameters.cmake_generator>>
     steps:
       - checkout
+      - run:
+          name: "Setup VS"
+          command: |
+            if [[ "${VS_YEAR}" == "2017" ]]; then
+              powershell .circleci/vs2017_install.ps1
+            elif [[ "${VS_YEAR}" == "2015" ]]; then
+              powershell .circleci/vs2015_install.ps1
+            fi
       - run:
           name: "Install thirdparty dependencies"
           command: |
@@ -210,6 +224,16 @@ workflows:
   build-windows:
     jobs:
       - build-windows
+  build-windows-vs2017:
+    jobs:
+      - build-windows:
+          vs_year: "2017"
+          cmake_generator: "Visual Studio 15 Win64"
+  build-windows-vs2015:
+    jobs:
+      - build-windows:
+          vs_year: "2015"
+          cmake_generator: "Visual Studio 14 Win64"
   build-windows-cxx20:
     jobs:
       - build-windows:

--- a/.circleci/vs2015_install.ps1
+++ b/.circleci/vs2015_install.ps1
@@ -1,0 +1,23 @@
+$VS_DOWNLOAD_LINK = "https://go.microsoft.com/fwlink/?LinkId=691126"
+$COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
+curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
+if ($LASTEXITCODE -ne 0) {
+    echo "Download of the VS 2015 installer failed"
+    exit 1
+}
+$VS_INSTALL_ARGS = @("/Quiet", "/NoRestart")
+$process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARGS -NoNewWindow -Wait -PassThru
+Remove-Item -Path vs_installer.exe -Force
+$exitCode = $process.ExitCode
+if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
+    echo "VS 2017 installer exited with code $exitCode, which should be one of [0, 3010]."
+    curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
+    if ($LASTEXITCODE -ne 0) {
+        echo "Download of the VS Collect tool failed."
+        exit 1
+    }
+    Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
+    New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
+    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    exit 1
+}

--- a/.circleci/vs2017_install.ps1
+++ b/.circleci/vs2017_install.ps1
@@ -1,0 +1,34 @@
+$VS_DOWNLOAD_LINK = "https://aka.ms/vs/15/release/vs_buildtools.exe"
+$COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
+$VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Tools.14.13",
+                                                     "--add Microsoft.Component.MSBuild",
+                                                     "--add Microsoft.VisualStudio.Component.Roslyn.Compiler",
+                                                     "--add Microsoft.VisualStudio.Component.TextTemplating",
+                                                     "--add Microsoft.VisualStudio.Component.VC.CoreIde",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                                                     "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81")
+
+curl.exe --retry 3 -kL $VS_DOWNLOAD_LINK --output vs_installer.exe
+if ($LASTEXITCODE -ne 0) {
+    echo "Download of the VS 2017 installer failed"
+    exit 1
+}
+
+$process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_INSTALL_ARGS -NoNewWindow -Wait -PassThru
+Remove-Item -Path vs_installer.exe -Force
+$exitCode = $process.ExitCode
+if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
+    echo "VS 2017 installer exited with code $exitCode, which should be one of [0, 3010]."
+    curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
+    if ($LASTEXITCODE -ne 0) {
+        echo "Download of the VS Collect tool failed."
+        exit 1
+    }
+    Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
+    New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
+    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    exit 1
+}


### PR DESCRIPTION
Summary: It's desirable to move all Windows builds to CircleCI so that we can eventually deprecate Appveyor.

Test Plan: Watch CI results.
