### PR TITLE
Only check for python location once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@
 BASH_EXISTS := $(shell which bash)
 SHELL := $(shell which bash)
 # Default to python3. Some distros like CentOS 8 do not have `python`.
-PYTHON?=$(shell which python3 || which python || echo python3)
+ifeq ($(origin PYTHON), undefined)
+	PYTHON := $(shell which python3 || which python || echo python3)
+endif
 export PYTHON
 
 CLEAN_FILES = # deliberately empty, so we can append below.


### PR DESCRIPTION
This fixes an issue introduced in 0c56fc4 whereby the location of Python is evaluated many times and leads to excessive logging of unknown python locations of CentOS 6.

The location is now only checked once.