### PR TITLE
Remove some dead code from BlobLogWriter

### DIFF
--- a/db/blob/blob_log_writer.cc
+++ b/db/blob/blob_log_writer.cc
@@ -20,15 +20,12 @@ namespace ROCKSDB_NAMESPACE {
 
 BlobLogWriter::BlobLogWriter(std::unique_ptr<WritableFileWriter>&& dest,
                              Env* env, Statistics* statistics,
-                             uint64_t log_number, uint64_t bpsync, bool use_fs,
-                             uint64_t boffset)
+                             uint64_t log_number, bool use_fs, uint64_t boffset)
     : dest_(std::move(dest)),
       env_(env),
       statistics_(statistics),
       log_number_(log_number),
       block_offset_(boffset),
-      bytes_per_sync_(bpsync),
-      next_sync_offset_(0),
       use_fsync_(use_fs),
       last_elem_type_(kEtNone) {}
 

--- a/db/blob/blob_log_writer.h
+++ b/db/blob/blob_log_writer.h
@@ -35,8 +35,8 @@ class BlobLogWriter {
   // "*dest" must be initially empty.
   // "*dest" must remain live while this BlobLogWriter is in use.
   BlobLogWriter(std::unique_ptr<WritableFileWriter>&& dest, Env* env,
-                Statistics* statistics, uint64_t log_number, uint64_t bpsync,
-                bool use_fsync, uint64_t boffset = 0);
+                Statistics* statistics, uint64_t log_number, bool use_fsync,
+                uint64_t boffset = 0);
   // No copying allowed
   BlobLogWriter(const BlobLogWriter&) = delete;
   BlobLogWriter& operator=(const BlobLogWriter&) = delete;
@@ -66,11 +66,7 @@ class BlobLogWriter {
 
   uint64_t get_log_number() const { return log_number_; }
 
-  bool ShouldSync() const { return block_offset_ > next_sync_offset_; }
-
   Status Sync();
-
-  void ResetSyncPointer() { next_sync_offset_ += bytes_per_sync_; }
 
  private:
   std::unique_ptr<WritableFileWriter> dest_;
@@ -78,8 +74,6 @@ class BlobLogWriter {
   Statistics* statistics_;
   uint64_t log_number_;
   uint64_t block_offset_;  // Current offset in block
-  uint64_t bytes_per_sync_;
-  uint64_t next_sync_offset_;
   bool use_fsync_;
 
  public:

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -756,7 +756,7 @@ Status BlobDBImpl::CreateWriterLocked(const std::shared_ptr<BlobFile>& bfile) {
 
   bfile->log_writer_ = std::make_shared<BlobLogWriter>(
       std::move(fwriter), env_, statistics_, bfile->file_number_,
-      bdb_options_.bytes_per_sync, db_options_.use_fsync, boffset);
+      db_options_.use_fsync, boffset);
   bfile->log_writer_->last_elem_type_ = et;
 
   return s;


### PR DESCRIPTION
Summary:
Periodic syncing of blob files is performed by `WritableFileWriter`;
`bytes_per_sync_` and `next_sync_offset_` in `BlobLogWriter` are
actually unused (or more precisely, only used by methods that are
themselves unused). The patch removes all this dead code.

Test Plan:
`make check`