### PR TITLE
Remove some more dead code around syncing blob files

### DIFF
--- a/utilities/blob_db/blob_file.h
+++ b/utilities/blob_db/blob_file.h
@@ -98,9 +98,6 @@ class BlobFile {
   // time when the random access reader was last created.
   std::atomic<std::int64_t> last_access_{-1};
 
-  // last time file was fsync'd/fdatasyncd
-  std::atomic<uint64_t> last_fsync_{0};
-
   bool header_valid_{false};
 
   bool footer_valid_{false};
@@ -183,9 +180,6 @@ class BlobFile {
     assert(Obsolete());
     return obsolete_sequence_;
   }
-
-  // we will assume this is atomic
-  bool NeedsFsync(bool hard, uint64_t bytes_per_sync) const;
 
   Status Fsync();
 


### PR DESCRIPTION
Summary:
Periodic syncing of blob files is handled by a lower layer, namely by
`WritableFileWriter`; the `NeedsFsync` method of `BlobFile` and the
`last_fsync_` member variable are actually unused and thus can be
removed. See also https://github.com/facebook/rocksdb/pull/7125 .

Test Plan:
`make check`