### PR TITLE
IO Tracer Parsing tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,10 +712,12 @@ set(SOURCES
         test_util/transaction_test_util.cc
         tools/block_cache_analyzer/block_cache_trace_analyzer.cc
         tools/dump/db_dump_tool.cc
+        tools/io_tracer_parser_tool.cc
         tools/ldb_cmd.cc
         tools/ldb_tool.cc
         tools/sst_dump_tool.cc
         tools/trace_analyzer_tool.cc
+        trace_replay/io_tracer.cc
         trace_replay/trace_replay.cc
         trace_replay/block_cache_tracer.cc
         util/coding.cc
@@ -994,7 +996,7 @@ if(WITH_TESTS OR WITH_BENCHMARK_TOOLS)
   test_util/testharness.cc)
   target_link_libraries(testharness gtest)
 endif()
-  
+
 if(WITH_TESTS)
   set(TESTS
         db/db_basic_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1762,6 +1762,9 @@ testutil_test: $(OBJ_DIR)/test_util/testutil_test.o $(TEST_LIBRARY) $(LIBRARY)
 io_tracer_test: $(OBJ_DIR)/trace_replay/io_tracer_test.o $(OBJ_DIR)/trace_replay/io_tracer.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+io_tracer_parser: $(OBJ_DIR)/tools/io_tracer_parser.o $(TOOLS_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 #-------------------------------------------------
 # make install related stuff
 INSTALL_PATH ?= /usr/local

--- a/TARGETS
+++ b/TARGETS
@@ -292,6 +292,7 @@ cpp_library(
         "test_util/sync_point_impl.cc",
         "test_util/transaction_test_util.cc",
         "tools/dump/db_dump_tool.cc",
+        "tools/io_tracer_parser_tool.cc",
         "tools/ldb_cmd.cc",
         "tools/ldb_tool.cc",
         "tools/sst_dump_tool.cc",

--- a/include/rocksdb/io_tracer_parser_tool.h
+++ b/include/rocksdb/io_tracer_parser_tool.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+#ifndef ROCKSDB_LITE
+#pragma once
+
+#include <memory>
+
+#include "rocksdb/env.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+struct IOTraceHeader;
+struct IOTraceRecord;
+
+// IOTraceRecordParser class reads the IO trace file (in binary format) and
+// dumps the human readable records in output_file_.
+class IOTraceRecordParser {
+ public:
+  IOTraceRecordParser(const std::string& input_file,
+                      const std::string& output_file);
+
+  ~IOTraceRecordParser();
+
+  // ReadIOTraceRecords reads the binary trace file records one by one and
+  // invoke PrintHumanReadableIOTraceRecord to dump the records in output_file_.
+  int ReadIOTraceRecords();
+
+ private:
+  void PrintHumanReadableHeader(const IOTraceHeader& header);
+  void PrintHumanReadableIOTraceRecord(const IOTraceRecord& record);
+
+  // Binary file that contains IO trace records.
+  std::string input_file_;
+  // Output file where human readable records will be dumped.
+  std::string output_file_;
+  std::unique_ptr<WritableFile> trace_writer_;
+};
+
+class IOTracerParserTool {
+ public:
+  int run(int argc, char const* const* argv);
+};
+
+}  // namespace ROCKSDB_NAMESPACE
+#endif  // ROCKSDB_LITE

--- a/src.mk
+++ b/src.mk
@@ -269,6 +269,7 @@ LIB_SOURCES_C =
 endif
 
 TOOL_LIB_SOURCES =                                              \
+  tools/io_tracer_parser_tool.cc                                \
   tools/ldb_cmd.cc                                              \
   tools/ldb_tool.cc                                             \
   tools/sst_dump_tool.cc                                        \
@@ -315,6 +316,7 @@ TOOLS_MAIN_SOURCES =                                                    \
   tools/db_repl_stress.cc                                               \
   tools/db_sanity_test.cc                                               \
   tools/ldb.cc                                                          \
+  tools/io_tracer_parser.cc                                             \
   tools/sst_dump.cc                                                     \
   tools/write_stress.cc                                                 \
   tools/dump/rocksdb_dump.cc                                            \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,6 +11,7 @@ endforeach()
 
 if(WITH_TOOLS)
   set(TOOLS
+    io_tracer_parser.cc
     db_sanity_test.cc
     write_stress.cc
     db_repl_stress.cc

--- a/tools/io_tracer_parser.cc
+++ b/tools/io_tracer_parser.cc
@@ -1,0 +1,20 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+#ifndef ROCKSDB_LITE
+
+#include "rocksdb/io_tracer_parser_tool.h"
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::IOTracerParserTool tool;
+  return tool.run(argc, argv);
+}
+#else
+#include <stdio.h>
+int main(int /*argc*/, char** /*argv*/) {
+  fprintf(stderr, "Not supported in lite mode.\n");
+  return 1;
+}
+#endif  // ROCKSDB_LITE

--- a/tools/io_tracer_parser_tool.cc
+++ b/tools/io_tracer_parser_tool.cc
@@ -1,0 +1,147 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//    This source code is licensed under both the GPLv2 (found in the
+//    COPYING file in the root directory) and Apache 2.0 License
+//    (found in the LICENSE.Apache file in the root directory).
+
+#ifndef ROCKSDB_LITE
+
+#include "rocksdb/io_tracer_parser_tool.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+
+#include "port/lang.h"
+#include "rocksdb/env.h"
+#include "trace_replay/io_tracer.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+IOTraceRecordParser::IOTraceRecordParser(const std::string& input_file,
+                                         const std::string& output_file)
+    : input_file_(input_file), output_file_(output_file) {}
+
+IOTraceRecordParser::~IOTraceRecordParser() {
+  if (trace_writer_) {
+    trace_writer_->Flush();
+    trace_writer_->Close();
+  }
+}
+
+void IOTraceRecordParser::PrintHumanReadableHeader(
+    const IOTraceHeader& header) {
+  std::stringstream ss;
+  ss << "Start Time: " << header.start_time
+     << "\nRocksDB Major Version: " << header.rocksdb_major_version
+     << "\nRocksDB Minor Version: " << header.rocksdb_minor_version << "\n";
+  trace_writer_->Append(ss.str());
+}
+
+void IOTraceRecordParser::PrintHumanReadableIOTraceRecord(
+    const IOTraceRecord& record) {
+  std::stringstream ss;
+  ss << "Access Time : " << std::setw(17) << std::left
+     << record.access_timestamp << ", File Operation: " << std::setw(18)
+     << std::left << record.file_operation.c_str()
+     << ", Latency: " << std::setw(9) << std::left << record.latency
+     << ", IO Status: " << record.io_status.c_str();
+
+  switch (record.trace_type) {
+    case TraceType::kIOGeneral:
+      break;
+    case TraceType::kIOFileNameAndFileSize:
+      ss << ", File Size: " << record.file_size;
+      FALLTHROUGH_INTENDED;
+    case TraceType::kIOFileName: {
+      ss << ", File Name: ", record.file_name.c_str();
+      break;
+    }
+    case TraceType::kIOLenAndOffset:
+      ss << ", Offset: " << record.offset;
+      FALLTHROUGH_INTENDED;
+    case TraceType::kIOLen:
+      ss << ", Length: " << record.len;
+      break;
+    default:
+      assert(false);
+  }
+  ss << "\n";
+  trace_writer_->Append(ss.str());
+}
+
+int IOTraceRecordParser::ReadIOTraceRecords() {
+  Status status;
+  Env* env(Env::Default());
+  std::unique_ptr<TraceReader> trace_reader;
+  std::unique_ptr<IOTraceReader> io_trace_reader;
+
+  status = NewFileTraceReader(env, EnvOptions(), input_file_, &trace_reader);
+  if (!status.ok()) {
+    fprintf(stderr, "%s: %s\n", input_file_.c_str(), status.ToString().c_str());
+    return 1;
+  }
+  io_trace_reader.reset(new IOTraceReader(std::move(trace_reader)));
+
+  status = env->NewWritableFile(output_file_, &trace_writer_, EnvOptions());
+  if (!status.ok()) {
+    fprintf(stderr, "%s: %s\n", output_file_.c_str(),
+            status.ToString().c_str());
+    return 1;
+  }
+
+  // Read the header and dump it in a file.
+  IOTraceHeader header;
+  status = io_trace_reader->ReadHeader(&header);
+  if (!status.ok()) {
+    fprintf(stderr, "%s: %s\n", input_file_.c_str(), status.ToString().c_str());
+    return 1;
+  }
+  PrintHumanReadableHeader(header);
+
+  // Read the records one by one and print them in human readable format.
+  while (status.ok()) {
+    IOTraceRecord record;
+    status = io_trace_reader->ReadIOOp(&record);
+    // No way to differentiate if end of record or record is corrupted.
+    if (!status.ok()) {
+      break;
+    }
+    PrintHumanReadableIOTraceRecord(record);
+  }
+  return 0;
+}
+
+int IOTracerParserTool::run(int argc, char const* const* argv) {
+  std::string input_file;
+  std::string output_file;
+  for (int i = 1; i < argc; i++) {
+    if (strncmp(argv[i], "--input_file=", 13) == 0) {
+      input_file = argv[i] + 13;
+    } else if (strncmp(argv[i], "--output_file=", 14) == 0) {
+      output_file = argv[i] + 14;
+    } else {
+      fprintf(stderr, "Unrecognized argument '%s'\n\n", argv[i]);
+      return 1;
+    }
+  }
+
+  if (input_file.empty()) {
+    fprintf(stderr, "Specify IO trace file to be read with --input_file=\n\n");
+    return 1;
+  }
+
+  if (output_file.empty()) {
+    fprintf(stderr, "Specify IO trace file to be read with --output_file=\n\n");
+    return 1;
+  }
+
+  std::unique_ptr<IOTraceRecordParser> io_tracer_parser;
+  io_tracer_parser.reset(new IOTraceRecordParser(input_file, output_file));
+  return io_tracer_parser->ReadIOTraceRecords();
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+#endif  // ROCKSDB_LITE


### PR DESCRIPTION
Summary: Implement a parsing tool io_tracer_parser that takes input_file (binary file) with command line argument --input_file and output_file with --output_file and dumps the IO trace records in output_file in human readable form.

Test Plan: make check -j64

Reviewers:

Subscribers:

Tasks:

Tags: