### PR TITLE
Using Read/Write Lock guard in all corresponding places

### DIFF
--- a/memtable/vectorrep.cc
+++ b/memtable/vectorrep.cc
@@ -4,18 +4,17 @@
 //  (found in the LICENSE.Apache file in the root directory).
 //
 #ifndef ROCKSDB_LITE
-#include "rocksdb/memtablerep.h"
-
-#include <unordered_set>
-#include <set>
-#include <memory>
 #include <algorithm>
+#include <memory>
+#include <set>
 #include <type_traits>
+#include <unordered_set>
 
 #include "db/memtable.h"
 #include "memory/arena.h"
 #include "memtable/stl_wrappers.h"
 #include "port/port.h"
+#include "rocksdb/memtablerep.h"
 #include "util/mutexlock.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -50,13 +49,14 @@ class VectorRep : public MemTableRep {
     std::shared_ptr<std::vector<const char*>> bucket_;
     std::vector<const char*>::const_iterator mutable cit_;
     const KeyComparator& compare_;
-    std::string tmp_;       // For passing to EncodeKey
+    std::string tmp_;  // For passing to EncodeKey
     bool mutable sorted_;
     void DoSort() const;
+
    public:
     explicit Iterator(class VectorRep* vrep,
-      std::shared_ptr<std::vector<const char*>> bucket,
-      const KeyComparator& compare);
+                      std::shared_ptr<std::vector<const char*>> bucket,
+                      const KeyComparator& compare);
 
     // Initialize an iterator over the specified collection.
     // The returned iterator is not valid.
@@ -125,12 +125,10 @@ void VectorRep::MarkReadOnly() {
 }
 
 size_t VectorRep::ApproximateMemoryUsage() {
-  return
-    sizeof(bucket_) + sizeof(*bucket_) +
-    bucket_->size() *
-    sizeof(
-      std::remove_reference<decltype(*bucket_)>::type::value_type
-    );
+  return sizeof(bucket_) + sizeof(*bucket_) +
+         bucket_->size() *
+             sizeof(
+                 std::remove_reference<decltype(*bucket_)>::type::value_type);
 }
 
 VectorRep::VectorRep(const KeyComparator& compare, Allocator* allocator,
@@ -144,13 +142,13 @@ VectorRep::VectorRep(const KeyComparator& compare, Allocator* allocator,
 }
 
 VectorRep::Iterator::Iterator(class VectorRep* vrep,
-                   std::shared_ptr<std::vector<const char*>> bucket,
-                   const KeyComparator& compare)
-: vrep_(vrep),
-  bucket_(bucket),
-  cit_(bucket_->end()),
-  compare_(compare),
-  sorted_(false) { }
+                              std::shared_ptr<std::vector<const char*>> bucket,
+                              const KeyComparator& compare)
+    : vrep_(vrep),
+      bucket_(bucket),
+      cit_(bucket_->end()),
+      compare_(compare),
+      sorted_(false) {}
 
 void VectorRep::Iterator::DoSort() const {
   // vrep is non-null means that we are working on an immutable memtable
@@ -216,12 +214,11 @@ void VectorRep::Iterator::Seek(const Slice& user_key,
   // Do binary search to find first value not less than the target
   const char* encoded_key =
       (memtable_key != nullptr) ? memtable_key : EncodeKey(&tmp_, user_key);
-  cit_ = std::equal_range(bucket_->begin(),
-                          bucket_->end(),
-                          encoded_key,
-                          [this] (const char* a, const char* b) {
+  cit_ = std::equal_range(bucket_->begin(), bucket_->end(), encoded_key,
+                          [this](const char* a, const char* b) {
                             return compare_(a, b) < 0;
-                          }).first;
+                          })
+             .first;
 }
 
 // Advance to the first entry with a key <= target
@@ -249,20 +246,27 @@ void VectorRep::Iterator::SeekToLast() {
 
 void VectorRep::Get(const LookupKey& k, void* callback_args,
                     bool (*callback_func)(void* arg, const char* entry)) {
-  rwlock_.ReadLock();
-  VectorRep* vector_rep;
-  std::shared_ptr<Bucket> bucket;
-  if (immutable_) {
-    vector_rep = this;
-  } else {
-    vector_rep = nullptr;
-    bucket.reset(new Bucket(*bucket_));  // make a copy
-  }
-  VectorRep::Iterator iter(vector_rep, immutable_ ? bucket_ : bucket, compare_);
-  rwlock_.ReadUnlock();
+  std::unique_ptr<VectorRep::Iterator> iter{};
 
-  for (iter.Seek(k.user_key(), k.memtable_key().data());
-       iter.Valid() && callback_func(callback_args, iter.key()); iter.Next()) {
+  {
+    ReadLock aReadLock(&rwlock_);
+    VectorRep* vector_rep;
+    std::shared_ptr<Bucket> bucket;
+
+    if (immutable_) {
+      vector_rep = this;
+    } else {
+      vector_rep = nullptr;
+      bucket = std::make_shared<Bucket>(*bucket_);  // make a copy
+    }
+
+    iter.reset(new VectorRep::Iterator(
+        vector_rep, immutable_ ? bucket_ : bucket, compare_));
+  }
+
+  for (iter->Seek(k.user_key(), k.memtable_key().data());
+       iter->Valid() && callback_func(callback_args, iter->key());
+       iter->Next()) {
   }
 }
 
@@ -281,8 +285,8 @@ MemTableRep::Iterator* VectorRep::GetIterator(Arena* arena) {
       return new (mem) Iterator(this, bucket_, compare_);
     }
   } else {
-    std::shared_ptr<Bucket> tmp;
-    tmp.reset(new Bucket(*bucket_)); // make a copy
+    std::shared_ptr<Bucket> tmp =
+        std::make_shared<Bucket>(*bucket_);  // make a copy
     if (arena == nullptr) {
       return new Iterator(nullptr, tmp, compare_);
     } else {
@@ -290,7 +294,7 @@ MemTableRep::Iterator* VectorRep::GetIterator(Arena* arena) {
     }
   }
 }
-} // anon namespace
+}  // namespace
 
 MemTableRep* VectorRepFactory::CreateMemTableRep(
     const MemTableRep::KeyComparator& compare, Allocator* allocator,


### PR DESCRIPTION
The problem in many places is that RocksDB uses Read/Write locks in non safe mode.

This PR protects corresponding places with corresponding guards.