### PR TITLE
Move CompressionType to its own header file

### DIFF
--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "rocksdb/compression_type.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/universal_compaction.h"
 
@@ -17,7 +18,6 @@ namespace ROCKSDB_NAMESPACE {
 
 class Slice;
 class SliceTransform;
-enum CompressionType : unsigned char;
 class TablePropertiesCollectorFactory;
 class TableFactory;
 struct Options;

--- a/include/rocksdb/compression_type.h
+++ b/include/rocksdb/compression_type.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// DB contents are stored in a set of blocks, each of which holds a
+// sequence of key,value pairs.  Each block may be compressed before
+// being stored in a file.  The following enum describes which
+// compression method (if any) is used to compress a block.
+
+enum CompressionType : unsigned char {
+  // NOTE: do not change the values of existing entries, as these are
+  // part of the persistent format on disk.
+  kNoCompression = 0x0,
+  kSnappyCompression = 0x1,
+  kZlibCompression = 0x2,
+  kBZip2Compression = 0x3,
+  kLZ4Compression = 0x4,
+  kLZ4HCCompression = 0x5,
+  kXpressCompression = 0x6,
+  kZSTD = 0x7,
+
+  // Only use kZSTDNotFinalCompression if you have to use ZSTD lib older than
+  // 0.8.0 or consider a possibility of downgrading the service or copying
+  // the database files to another service running with an older version of
+  // RocksDB that doesn't have kZSTD. Otherwise, you should use kZSTD. We will
+  // eventually remove the option from the public API.
+  kZSTDNotFinalCompression = 0x40,
+
+  // kDisableCompressionOption is used to disable some compression options.
+  kDisableCompressionOption = 0xff,
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "rocksdb/compression_type.h"
 #include "rocksdb/db.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "rocksdb/compaction_job_stats.h"
 #include "rocksdb/compression_type.h"
 #include "rocksdb/status.h"

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 #include "rocksdb/compaction_job_stats.h"
+#include "rocksdb/compression_type.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table_properties.h"
 
@@ -24,7 +25,6 @@ class DB;
 class ColumnFamilyHandle;
 class Status;
 struct CompactionJobStats;
-enum CompressionType : unsigned char;
 
 enum class TableFileCreationReason {
   kFlush,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -19,6 +19,7 @@
 
 #include "rocksdb/advanced_options.h"
 #include "rocksdb/comparator.h"
+#include "rocksdb/compression_type.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/listener.h"
@@ -52,33 +53,6 @@ class Statistics;
 class InternalKeyComparator;
 class WalFilter;
 class FileSystem;
-
-// DB contents are stored in a set of blocks, each of which holds a
-// sequence of key,value pairs.  Each block may be compressed before
-// being stored in a file.  The following enum describes which
-// compression method (if any) is used to compress a block.
-enum CompressionType : unsigned char {
-  // NOTE: do not change the values of existing entries, as these are
-  // part of the persistent format on disk.
-  kNoCompression = 0x0,
-  kSnappyCompression = 0x1,
-  kZlibCompression = 0x2,
-  kBZip2Compression = 0x3,
-  kLZ4Compression = 0x4,
-  kLZ4HCCompression = 0x5,
-  kXpressCompression = 0x6,
-  kZSTD = 0x7,
-
-  // Only use kZSTDNotFinalCompression if you have to use ZSTD lib older than
-  // 0.8.0 or consider a possibility of downgrading the service or copying
-  // the database files to another service running with an older version of
-  // RocksDB that doesn't have kZSTD. Otherwise, you should use kZSTD. We will
-  // eventually remove the option from the public API.
-  kZSTDNotFinalCompression = 0x40,
-
-  // kDisableCompressionOption is used to disable some compression options.
-  kDisableCompressionOption = 0xff,
-};
 
 struct Options;
 struct DbPath;

--- a/include/rocksdb/utilities/leveldb_options.h
+++ b/include/rocksdb/utilities/leveldb_options.h
@@ -11,6 +11,7 @@
 
 #include <stddef.h>
 
+#include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -22,8 +23,6 @@ class FilterPolicy;
 class Logger;
 struct Options;
 class Snapshot;
-
-enum CompressionType : unsigned char;
 
 // Options to control the behavior of a database (passed to
 // DB::Open). A LevelDBOptions object can be initialized as though


### PR DESCRIPTION
Summary:
The patch moves `CompressionType` to its own header file and makes sure
all other public headers include this new header directly, as opposed to
relying on transitive includes or forward declarations.

Test Plan:
`make check`