### PR TITLE
fix typo: paraniod -> paranoid

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -270,7 +270,7 @@ Status BuildTable(
         }
         s = it->status();
         if (s.ok() && check_hash != paranoid_hash) {
-          s = Status::Corruption("Paraniod checksums do not match");
+          s = Status::Corruption("Paranoid checksums do not match");
         }
       }
     }

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -700,7 +700,7 @@ Status CompactionJob::Run() {
           }
           s = iter->status();
           if (s.ok() && hash != files_output[file_idx]->paranoid_hash) {
-            s = Status::Corruption("Paraniod checksums do not match");
+            s = Status::Corruption("Paranoid checksums do not match");
           }
         }
 

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -565,7 +565,7 @@ static const auto& corruption_modes = {mock::MockTableFactory::kCorruptNone,
                                        mock::MockTableFactory::kCorruptKey,
                                        mock::MockTableFactory::kCorruptValue};
 
-TEST_F(CorruptionTest, ParaniodFileChecksOnFlush) {
+TEST_F(CorruptionTest, ParanoidFileChecksOnFlush) {
   Options options;
   options.paranoid_file_checks = true;
   options.create_if_missing = true;
@@ -588,7 +588,7 @@ TEST_F(CorruptionTest, ParaniodFileChecksOnFlush) {
   }
 }
 
-TEST_F(CorruptionTest, ParaniodFileChecksOnCompact) {
+TEST_F(CorruptionTest, ParanoidFileChecksOnCompact) {
   Options options;
   options.paranoid_file_checks = true;
   options.create_if_missing = true;


### PR DESCRIPTION
Rename "paraniod" to "paranoid" in a few places.