### PR TITLE
Make env*_test work with ASSERT_STATUS_CHECKED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,7 @@ ifdef ASSERT_STATUS_CHECKED
 		slice_test \
 		statistics_test \
 		thread_local_test \
-		timed_env_test \
+		env_timed_test \
 		timer_queue_test \
 		timer_test \
 		util_merge_operators_test \

--- a/Makefile
+++ b/Makefile
@@ -561,9 +561,11 @@ ifdef ASSERT_STATUS_CHECKED
 		dbformat_test \
 		defer_test \
 		dynamic_bloom_test \
+		env_basic_test \
+		env_test \
+		env_logger_test \
 		event_logger_test \
 		file_indexer_test \
-		folly_synchronization_distributed_mutex_test \
 		hash_table_test \
 		hash_test \
 		heap_test \
@@ -585,12 +587,17 @@ ifdef ASSERT_STATUS_CHECKED
 		slice_test \
 		statistics_test \
 		thread_local_test \
+		timed_env_test \
 		timer_queue_test \
 		timer_test \
 		util_merge_operators_test \
 		version_edit_test \
 		work_queue_test \
 		write_controller_test \
+
+ifeq ($(USE_FOLLY_DISTRIBUTED_MUTEX),1)
+TESTS_PASSING_ASC += folly_synchronization_distributed_mutex_test
+endif
 
 	# Enable building all unit tests, but use check_some to run only tests
 	# known to pass ASC

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -190,7 +190,7 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
       // set of all files in the directory. We'll exclude files that are still
       // alive in the subsequent processings.
       std::vector<std::string> files;
-      env_->GetChildren(path, &files);  // Ignore errors
+      env_->GetChildren(path, &files).PermitUncheckedError();  // Ignore errors
       for (const std::string& file : files) {
         uint64_t number;
         FileType type;

--- a/env/env_basic_test.cc
+++ b/env/env_basic_test.cc
@@ -62,11 +62,13 @@ class EnvBasicTestWithParam : public testing::Test,
     test_dir_ = test::PerThreadDBPath(env_, "env_basic_test");
   }
 
-  void SetUp() override { env_->CreateDirIfMissing(test_dir_); }
+  void SetUp() override {
+    env_->CreateDirIfMissing(test_dir_).PermitUncheckedError();
+  }
 
   void TearDown() override {
     std::vector<std::string> files;
-    env_->GetChildren(test_dir_, &files);
+    env_->GetChildren(test_dir_, &files).PermitUncheckedError();
     for (const auto& file : files) {
       // don't know whether it's file or directory, try both. The tests must
       // only create files or empty directories, so one must succeed, else the
@@ -209,13 +211,12 @@ TEST_P(EnvBasicTestWithParam, Basics) {
                                        soptions_)
                    .ok());
   ASSERT_TRUE(!seq_file);
-  ASSERT_TRUE(!env_->NewRandomAccessFile(test_dir_ + "/non_existent",
-                                         &rand_file, soptions_)
-                   .ok());
+  ASSERT_NOK(env_->NewRandomAccessFile(test_dir_ + "/non_existent", &rand_file,
+                                       soptions_));
   ASSERT_TRUE(!rand_file);
 
   // Check that deleting works.
-  ASSERT_TRUE(!env_->DeleteFile(test_dir_ + "/non_existent").ok());
+  ASSERT_NOK(env_->DeleteFile(test_dir_ + "/non_existent"));
   ASSERT_OK(env_->DeleteFile(test_dir_ + "/g"));
   ASSERT_EQ(Status::NotFound(), env_->FileExists(test_dir_ + "/g"));
   ASSERT_OK(env_->GetChildren(test_dir_, &children));
@@ -346,14 +347,14 @@ TEST_P(EnvMoreTestWithParam, GetChildren) {
   ASSERT_EQ(3U, children.size());
   ASSERT_EQ(3U, childAttr.size());
   for (auto each : children) {
-    env_->DeleteDir(test_dir_ + "/" + each);
+    env_->DeleteDir(test_dir_ + "/" + each).PermitUncheckedError();
   }  // necessary for default POSIX env
 
   // non-exist directory returns IOError
   ASSERT_OK(env_->DeleteDir(test_dir_));
-  ASSERT_TRUE(!env_->FileExists(test_dir_).ok());
-  ASSERT_TRUE(!env_->GetChildren(test_dir_, &children).ok());
-  ASSERT_TRUE(!env_->GetChildrenFileAttributes(test_dir_, &childAttr).ok());
+  ASSERT_NOK(env_->FileExists(test_dir_));
+  ASSERT_NOK(env_->GetChildren(test_dir_, &children));
+  ASSERT_NOK(env_->GetChildrenFileAttributes(test_dir_, &childAttr));
 
   // if dir is a file, returns IOError
   ASSERT_OK(env_->CreateDir(test_dir_));
@@ -362,7 +363,7 @@ TEST_P(EnvMoreTestWithParam, GetChildren) {
       env_->NewWritableFile(test_dir_ + "/file", &writable_file, soptions_));
   ASSERT_OK(writable_file->Close());
   writable_file.reset();
-  ASSERT_TRUE(!env_->GetChildren(test_dir_ + "/file", &children).ok());
+  ASSERT_NOK(env_->GetChildren(test_dir_ + "/file", &children));
   ASSERT_EQ(0U, children.size());
 }
 

--- a/env/env_chroot.cc
+++ b/env/env_chroot.cc
@@ -256,8 +256,7 @@ class ChrootEnv : public EnvWrapper {
     *path = buf;
 
     // Directory may already exist, so ignore return
-    CreateDir(*path);
-    return Status::OK();
+    return CreateDirIfMissing(*path);
   }
 
   Status NewLogger(const std::string& fname,

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -472,11 +472,14 @@ class EncryptedEnv : public EnvWrapper {
       // Initialize prefix
       prefixBuf.Alignment(underlying->GetRequiredBufferAlignment());
       prefixBuf.AllocateNewBuffer(prefixLength);
-      provider_->CreateNewPrefix(fname, prefixBuf.BufferStart(), prefixLength);
-      prefixBuf.Size(prefixLength);
-      prefixSlice = Slice(prefixBuf.BufferStart(), prefixBuf.CurrentSize());
-      // Write prefix
-      status = underlying->Append(prefixSlice);
+      status = provider_->CreateNewPrefix(fname, prefixBuf.BufferStart(),
+                                          prefixLength);
+      if (status.ok()) {
+        prefixBuf.Size(prefixLength);
+        prefixSlice = Slice(prefixBuf.BufferStart(), prefixBuf.CurrentSize());
+        // Write prefix
+        status = underlying->Append(prefixSlice);
+      }
       if (!status.ok()) {
         return status;
       }

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -167,7 +167,6 @@ class PosixEnv : public CompositeEnvWrapper {
   // provided by the search path
   Status LoadLibrary(const std::string& name, const std::string& path,
                      std::shared_ptr<DynamicLibrary>* result) override {
-    Status status;
     assert(result != nullptr);
     if (name.empty()) {
       void* hndl = dlopen(NULL, RTLD_NOW);

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -990,7 +990,8 @@ PosixMmapFile::PosixMmapFile(const std::string& fname, int fd, size_t page_size,
 
 PosixMmapFile::~PosixMmapFile() {
   if (fd_ >= 0) {
-    PosixMmapFile::Close(IOOptions(), nullptr);
+    IOStatus s = PosixMmapFile::Close(IOOptions(), nullptr);
+    s.PermitUncheckedError();
   }
 }
 
@@ -1152,7 +1153,8 @@ PosixWritableFile::PosixWritableFile(const std::string& fname, int fd,
 
 PosixWritableFile::~PosixWritableFile() {
   if (fd_ >= 0) {
-    PosixWritableFile::Close(IOOptions(), nullptr);
+    IOStatus s = PosixWritableFile::Close(IOOptions(), nullptr);
+    s.PermitUncheckedError();
   }
 }
 
@@ -1394,7 +1396,8 @@ PosixRandomRWFile::PosixRandomRWFile(const std::string& fname, int fd,
 
 PosixRandomRWFile::~PosixRandomRWFile() {
   if (fd_ >= 0) {
-    Close(IOOptions(), nullptr);
+    IOStatus s = Close(IOOptions(), nullptr);
+    s.PermitUncheckedError();
   }
 }
 

--- a/env/mock_env.cc
+++ b/env/mock_env.cc
@@ -600,7 +600,7 @@ Status MockEnv::CreateDir(const std::string& dirname) {
 }
 
 Status MockEnv::CreateDirIfMissing(const std::string& dirname) {
-  CreateDir(dirname);
+  CreateDir(dirname).PermitUncheckedError();
   return Status::OK();
 }
 

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -509,7 +509,7 @@ SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<FileSystem> fs,
 
   // trash_dir is deprecated and not needed anymore, but if user passed it
   // we will still remove files in it.
-  Status s;
+  Status s = Status::OK();
   if (delete_existing_trash && trash_dir != "") {
     std::vector<std::string> files_in_trash;
     s = fs->GetChildren(trash_dir, IOOptions(), &files_in_trash, nullptr);
@@ -532,6 +532,9 @@ SstFileManager* NewSstFileManager(Env* env, std::shared_ptr<FileSystem> fs,
 
   if (status) {
     *status = s;
+  } else {
+    // No one passed us a Status, so they must not care about the error...
+    s.PermitUncheckedError();
   }
 
   return res;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -869,7 +869,8 @@ class FSWritableFile {
       size_t num_spanned_blocks =
           new_last_preallocated_block - last_preallocated_block_;
       Allocate(block_size * last_preallocated_block_,
-               block_size * num_spanned_blocks, options, dbg);
+               block_size * num_spanned_blocks, options, dbg)
+          .PermitUncheckedError();
       last_preallocated_block_ = new_last_preallocated_block;
     }
   }

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -26,7 +26,7 @@ namespace test {
 std::string TmpDir(Env* env) {
   std::string dir;
   Status s = env->GetTestDirectory(&dir);
-  EXPECT_TRUE(s.ok()) << s.ToString();
+  EXPECT_OK(s);
   return dir;
 }
 

--- a/utilities/env_timed_test.cc
+++ b/utilities/env_timed_test.cc
@@ -21,7 +21,7 @@ TEST_F(TimedEnvTest, BasicTest) {
   std::unique_ptr<Env> mem_env(NewMemEnv(Env::Default()));
   std::unique_ptr<Env> timed_env(NewTimedEnv(mem_env.get()));
   std::unique_ptr<WritableFile> writable_file;
-  timed_env->NewWritableFile("f", &writable_file, EnvOptions());
+  ASSERT_OK(timed_env->NewWritableFile("f", &writable_file, EnvOptions()));
 
   ASSERT_GT(get_perf_context()->env_new_writable_file_nanos, 0);
 }

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -157,13 +157,13 @@ class TestFSDirectory : public FSDirectory {
 
 class FaultInjectionTestFS : public FileSystemWrapper {
  public:
-  explicit FaultInjectionTestFS(std::shared_ptr<FileSystem> base)
+  explicit FaultInjectionTestFS(const std::shared_ptr<FileSystem>& base)
       : FileSystemWrapper(base),
         filesystem_active_(true),
         filesystem_writable_(false),
-        thread_local_error_(
-            new ThreadLocalPtr(DeleteThreadLocalErrorContext)) {}
-  virtual ~FaultInjectionTestFS() {}
+        thread_local_error_(new ThreadLocalPtr(DeleteThreadLocalErrorContext)) {
+  }
+  virtual ~FaultInjectionTestFS() { error_.PermitUncheckedError(); }
 
   const char* Name() const override { return "FaultInjectionTestFS"; }
 


### PR DESCRIPTION
Make (most of) the env*_test pass when ASSERT_STATUS_CHECKED is enabled.  

One test that opens a database is currently disabled in this mode, as there are many errors that need revisited for DB tests and status checks.