### PR TITLE
Add a new EntryType for deletion with timestamp

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,9 @@
 ### Performance Improvements
 * Reduce thread number for multiple DB instances by re-using one global thread for statistics dumping and persisting.
 
+### Public API Change
+* Expose kTypeDeleteWithTimestamp in EntryType and update GetEntryType() accordingly.
+
 ## 6.12 (2020-07-28)
 ### Public API Change
 * Encryption file classes now exposed for inheritance in env_encryption.h

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -32,6 +32,8 @@ EntryType GetEntryType(ValueType value_type) {
       return kEntryPut;
     case kTypeDeletion:
       return kEntryDelete;
+    case kTypeDeletionWithTimestamp:
+      return kEntryDeleteWithTimestamp;
     case kTypeSingleDeletion:
       return kEntrySingleDelete;
     case kTypeMerge:

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -18,14 +18,15 @@ typedef uint64_t SequenceNumber;
 const SequenceNumber kMinUnCommittedSeq = 1;  // 0 is always committed
 
 // User-oriented representation of internal key types.
+// Ordering of this enum entries should not change.
 enum EntryType {
   kEntryPut,
   kEntryDelete,
-  kEntryDeleteWithTimestamp,
   kEntrySingleDelete,
   kEntryMerge,
   kEntryRangeDeletion,
   kEntryBlobIndex,
+  kEntryDeleteWithTimestamp,
   kEntryOther,
 };
 

--- a/include/rocksdb/types.h
+++ b/include/rocksdb/types.h
@@ -21,6 +21,7 @@ const SequenceNumber kMinUnCommittedSeq = 1;  // 0 is always committed
 enum EntryType {
   kEntryPut,
   kEntryDelete,
+  kEntryDeleteWithTimestamp,
   kEntrySingleDelete,
   kEntryMerge,
   kEntryRangeDeletion,


### PR DESCRIPTION
Add `kEntryDeleteWithTimestamp` to `EntryType` which is a public API.

Test plan:
make check