### PR TITLE
Allow optimization level to be set in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ else
 	OPTIMIZE_LEVEL ?= -Os
 endif
 endif
+# `OPTIMIZE_LEVEL` is empty when the user does not set it and `DEBUG_LEVEL=2`.
+# In that case, the compiler default (`-O0` for gcc and clang) will be used.
 OPT += $(OPTIMIZE_LEVEL)
 
 # compile with -O2 if debug level is not 2

--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,12 @@ endif
 # Figure out optimize level.
 ifneq ($(DEBUG_LEVEL), 2)
 ifeq ($(LITE), 0)
-	OPT += -O2
+	OPTIMIZE_LEVEL ?= -O2
 else
-	OPT += -Os
+	OPTIMIZE_LEVEL ?= -Os
 endif
 endif
+OPT += $(OPTIMIZE_LEVEL)
 
 # compile with -O2 if debug level is not 2
 ifneq ($(DEBUG_LEVEL), 2)


### PR DESCRIPTION
`-O3` is already adopted widely, so we should make it easier to configure
for development/open source. This PR adds an `OPTIMIZE_LEVEL` variable
that users can set to override the `-O` flag chosen in the Makefile.

Test Plan: built a few different ways and verified correct value is passed for `-O` flag