### PR TITLE
Fix cmake  build on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1224,9 +1224,8 @@ if(WITH_TESTS)
 
   if(ROCKSDB_LIB_FOR_C)
     set(C_TESTS db/c_test.c)
-    # C executables must link to a shared object
     add_executable(c_test db/c_test.c)
-    target_link_libraries(c_test ${ROCKSDB_SHARED_LIB} testharness)
+    target_link_libraries(c_test ${ROCKSDB_LIB_FOR_C} testharness)
     add_test(NAME c_test COMMAND c_test${ARTIFACT_SUFFIX})
     add_dependencies(check c_test)
   endif()

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -587,8 +587,7 @@ TEST_F(PrefixTest, DynamicPrefixIterator) {
     }
 
     if (FLAGS_random_prefix) {
-      std::random_device rd;
-      std::shuffle(prefixes.begin(), prefixes.end(), std::mt19937(rd()));
+      RandomShuffle(prefixes.begin(), prefixes.end());
     }
 
     HistogramImpl hist_put_time;

--- a/db/prefix_test.cc
+++ b/db/prefix_test.cc
@@ -587,7 +587,8 @@ TEST_F(PrefixTest, DynamicPrefixIterator) {
     }
 
     if (FLAGS_random_prefix) {
-      std::random_shuffle(prefixes.begin(), prefixes.end());
+      std::random_device rd;
+      std::shuffle(prefixes.begin(), prefixes.end(), std::mt19937(rd()));
     }
 
     HistogramImpl hist_put_time;

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -500,8 +500,7 @@ void ReadKeys(uint64_t num, uint32_t batch_size) {
   for (uint64_t i = 0; i < num; ++i) {
     keys.push_back(2 * i);
   }
-  std::random_device rd;
-  std::shuffle(keys.begin(), keys.end(), std::mt19937(rd()));
+  RandomShuffle(keys.begin(), keys.end());
 
   PinnableSlice value;
   // Assume only the fast path is triggered

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -500,7 +500,8 @@ void ReadKeys(uint64_t num, uint32_t batch_size) {
   for (uint64_t i = 0; i < num; ++i) {
     keys.push_back(2 * i);
   }
-  std::random_shuffle(keys.begin(), keys.end());
+  std::random_device rd;
+  std::shuffle(keys.begin(), keys.end(), std::mt19937(rd()));
 
   PinnableSlice value;
   // Assume only the fast path is triggered


### PR DESCRIPTION
1. `std::random_shuffle` is deprecated and now we can use `std::shuffle`
```
/rocksdb/db/prefix_test.cc:590:12: error: 'random_shuffle<std::__1::__wrap_iter<unsigned long long *> >'
      is deprecated [-Werror,-Wdeprecated-declarations]
      std::random_shuffle(prefixes.begin(), prefixes.end());
           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2982:1: note:
      'random_shuffle<std::__1::__wrap_iter<unsigned long long *> >' has been explicitly marked deprecated here
_LIBCPP_DEPRECATED_IN_CXX14 void
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:1107:39: note: expanded from macro
      '_LIBCPP_DEPRECATED_IN_CXX14'
#  define _LIBCPP_DEPRECATED_IN_CXX14 _LIBCPP_DEPRECATED
                                      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:1090:48: note: expanded from macro
      '_LIBCPP_DEPRECATED'
#    define _LIBCPP_DEPRECATED __attribute__ ((deprecated))
```
2. `c_test` link error with `-DROCKSDB_BUILD_SHARED=OFF`:
```
[  7%] Linking CXX executable c_test
ld: library not found for -lrocksdb-shared
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[5]: *** [c_test] Error 1
make[4]: *** [CMakeFiles/c_test.dir/all] Error 2
make[4]: *** Waiting for unfinished jobs....
```