### PR TITLE
BaseDeltaIterator now adheres to ReadOptions iterate_upper_bound

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -245,6 +245,9 @@
 ### Others
 * Error in prefetching partitioned index blocks will not be swallowed. It will fail the query and return the IOError users.
 
+* Fixed an issue where the `BaseDeltaIterator` returned by `WriteBatchWithIndex::NewIteratorFromBase` did not correctly respect `ReadOptions::iterate_upper_bound`.
+
+
 ## 6.12 (2020-07-28)
 ### Public API Change
 * Encryption file classes now exposed for inheritance in env_encryption.h

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -68,6 +68,14 @@ class ArenaWrappedDBIter : public Iterator {
   bool IsBlob() const { return db_iter_->IsBlob(); }
 
   Status GetProperty(std::string prop_name, std::string* prop) override;
+  bool ChecksLowerBound() const override {
+    return db_iter_->ChecksLowerBound();
+  }
+  const Slice* lower_bound() const override { return db_iter_->lower_bound(); }
+  bool ChecksUpperBound() const override {
+    return db_iter_->ChecksUpperBound();
+  }
+  const Slice* upper_bound() const override { return db_iter_->upper_bound(); }
 
   Status Refresh() override;
 

--- a/db/arena_wrapped_db_iter.h
+++ b/db/arena_wrapped_db_iter.h
@@ -68,13 +68,7 @@ class ArenaWrappedDBIter : public Iterator {
   bool IsBlob() const { return db_iter_->IsBlob(); }
 
   Status GetProperty(std::string prop_name, std::string* prop) override;
-  bool ChecksLowerBound() const override {
-    return db_iter_->ChecksLowerBound();
-  }
   const Slice* lower_bound() const override { return db_iter_->lower_bound(); }
-  bool ChecksUpperBound() const override {
-    return db_iter_->ChecksUpperBound();
-  }
   const Slice* upper_bound() const override { return db_iter_->upper_bound(); }
 
   Status Refresh() override;

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -55,6 +55,10 @@ class KVIter : public Iterator {
   Slice key() const override { return iter_->first; }
   Slice value() const override { return iter_->second; }
   Status status() const override { return Status::OK(); }
+  bool ChecksLowerBound() const override { return false; }
+  const Slice* lower_bound() const override { return nullptr; }
+  bool ChecksUpperBound() const override { return false; }
+  const Slice* upper_bound() const override { return nullptr; }
 
  private:
   const stl_wrappers::KVMap* const map_;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -198,6 +198,10 @@ class DBIter final : public Iterator {
   }
 
   Status GetProperty(std::string prop_name, std::string* prop) override;
+  bool ChecksLowerBound() const override { return true; }
+  const Slice* lower_bound() const override { return iterate_lower_bound_; }
+  bool ChecksUpperBound() const override { return true; }
+  const Slice* upper_bound() const override { return iterate_upper_bound_; }
 
   void Next() final override;
   void Prev() final override;

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -198,9 +198,7 @@ class DBIter final : public Iterator {
   }
 
   Status GetProperty(std::string prop_name, std::string* prop) override;
-  bool ChecksLowerBound() const override { return true; }
   const Slice* lower_bound() const override { return iterate_lower_bound_; }
-  bool ChecksUpperBound() const override { return true; }
   const Slice* upper_bound() const override { return iterate_upper_bound_; }
 
   void Next() final override;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3104,6 +3104,11 @@ class ModelDB : public DB {
     Slice value() const override { return iter_->second; }
     Status status() const override { return Status::OK(); }
 
+    bool ChecksLowerBound() const override { return false; }
+    const Slice* lower_bound() const override { return nullptr; }
+    bool ChecksUpperBound() const override { return false; }
+    const Slice* upper_bound() const override { return nullptr; }
+
    private:
     const KVMap* const map_;
     const bool owned_;  // Do we own map_

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -115,6 +115,24 @@ class Iterator : public Cleanable {
     assert(false);
     return Slice();
   }
+
+  /**
+   * true if this iterator is already
+   * checking ReadOptions::iterate_lower_bound,
+   * false otherwise.
+   */
+  virtual bool has_lower_bound() const {
+    return false;
+  }
+
+  /**
+   * true if this iterator is already
+   * checking ReadOptions::iterate_upper_bound,
+   * false otherwise.
+   */
+  virtual bool has_upper_bound() const {
+    return false;
+  }
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -117,42 +117,22 @@ class Iterator : public Cleanable {
   }
 
   /**
-   * true if this iterator is already
-   * checking ReadOptions::iterate_lower_bound.
-   * false indicates that either the iterator does
-   * not check the lower bound, or that it does not
-   * report that it is performing the check.
-   */
-  virtual bool ChecksLowerBound() const = 0;
-
-  /**
    * Returns the lower bound if this iterator has a
    * ReadOptions::iterate_lower_bound set, else
    * returns nullptr.
    *
-   * Just because a lower bound is present, it does
-   * not mean that it is checked. This can however
-   * be determined by calling Iterator::ChecksLowerBound().
+   * If a lower bound is present, it should be assumed
+   * that the iterator adheres to it.
    */
   virtual const Slice* lower_bound() const = 0;
-
-  /**
-   * true if this iterator is already
-   * checking ReadOptions::iterate_upper_bound.
-   * false indicates that either the iterator does
-   * not check the upper bound, or that it does not
-   * report that it is performing the check.
-   */
-  virtual bool ChecksUpperBound() const = 0;
 
   /**
    * Returns the upper bound if this iterator has a
    * ReadOptions::iterate_upper_bound set, else
    * returns nullptr.
    *
-   * Just because an upper bound is present, it does
-   * not mean that it is checked. This can however
-   * be determined by calling Iterator::ChecksUpperBound().
+   * If an upper bound is present, it should be assumed
+   * that the iterator adheres to it.
    */
   virtual const Slice* upper_bound() const = 0;
 };

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -123,7 +123,7 @@ class Iterator : public Cleanable {
    * not check the lower bound, or that it does not
    * report that it is performing the check.
    */
-  virtual bool ChecksLowerBound() const { return false; }
+  virtual bool ChecksLowerBound() const = 0;
 
   /**
    * Returns the lower bound if this iterator has a
@@ -134,7 +134,7 @@ class Iterator : public Cleanable {
    * not mean that it is checked. This can however
    * be determined by calling Iterator::ChecksLowerBound().
    */
-  virtual const Slice* lower_bound() const { return nullptr; }
+  virtual const Slice* lower_bound() const = 0;
 
   /**
    * true if this iterator is already
@@ -143,7 +143,7 @@ class Iterator : public Cleanable {
    * not check the upper bound, or that it does not
    * report that it is performing the check.
    */
-  virtual bool ChecksUpperBound() const { return false; }
+  virtual bool ChecksUpperBound() const = 0;
 
   /**
    * Returns the upper bound if this iterator has a
@@ -154,7 +154,7 @@ class Iterator : public Cleanable {
    * not mean that it is checked. This can however
    * be determined by calling Iterator::ChecksUpperBound().
    */
-  virtual const Slice* upper_bound() const { return nullptr; }
+  virtual const Slice* upper_bound() const = 0;
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -121,7 +121,7 @@ class Iterator : public Cleanable {
    * checking ReadOptions::iterate_lower_bound,
    * false otherwise.
    */
-  virtual bool check_lower_bound() const { return false; }
+  virtual bool ChecksLowerBound() const { return false; }
 
   /**
    * Returns the lower bound if this iterator has a
@@ -130,16 +130,16 @@ class Iterator : public Cleanable {
    *
    * Just because a lower bound is present, it does
    * not mean that it is checked. This can however
-   * be determined by calling Iterator::check_lower_bound().
+   * be determined by calling Iterator::ChecksLowerBound().
    */
-  virtual const Slice* iterate_lower_bound() const { return nullptr; }
+  virtual const Slice* lower_bound() const { return nullptr; }
 
   /**
    * true if this iterator is already
    * checking ReadOptions::iterate_upper_bound,
    * false otherwise.
    */
-  virtual bool check_upper_bound() const { return false; }
+  virtual bool ChecksUpperBound() const { return false; }
 
   /**
    * Returns the upper bound if this iterator has a
@@ -148,9 +148,9 @@ class Iterator : public Cleanable {
    *
    * Just because an upper bound is present, it does
    * not mean that it is checked. This can however
-   * be determined by calling Iterator::check_upper_bound().
+   * be determined by calling Iterator::ChecksUpperBound().
    */
-  virtual const Slice* iterate_upper_bound() const { return nullptr; }
+  virtual const Slice* upper_bound() const { return nullptr; }
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -121,14 +121,36 @@ class Iterator : public Cleanable {
    * checking ReadOptions::iterate_lower_bound,
    * false otherwise.
    */
-  virtual bool has_lower_bound() const { return false; }
+  virtual bool check_lower_bound() const { return false; }
+
+  /**
+   * Returns the lower bound if this iterator has a
+   * ReadOptions::iterate_lower_bound set, else
+   * returns nullptr.
+   *
+   * Just because a lower bound is present, it does
+   * not mean that it is checked. This can however
+   * be determined by calling Iterator::check_lower_bound().
+   */
+  virtual const Slice* iterate_lower_bound() const { return nullptr; }
 
   /**
    * true if this iterator is already
    * checking ReadOptions::iterate_upper_bound,
    * false otherwise.
    */
-  virtual bool has_upper_bound() const { return false; }
+  virtual bool check_upper_bound() const { return false; }
+
+  /**
+   * Returns the upper bound if this iterator has a
+   * ReadOptions::iterate_upper_bound set, else
+   * returns nullptr.
+   *
+   * Just because an upper bound is present, it does
+   * not mean that it is checked. This can however
+   * be determined by calling Iterator::check_upper_bound().
+   */
+  virtual const Slice* iterate_upper_bound() const { return nullptr; }
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -121,18 +121,14 @@ class Iterator : public Cleanable {
    * checking ReadOptions::iterate_lower_bound,
    * false otherwise.
    */
-  virtual bool has_lower_bound() const {
-    return false;
-  }
+  virtual bool has_lower_bound() const { return false; }
 
   /**
    * true if this iterator is already
    * checking ReadOptions::iterate_upper_bound,
    * false otherwise.
    */
-  virtual bool has_upper_bound() const {
-    return false;
-  }
+  virtual bool has_upper_bound() const { return false; }
 };
 
 // Return an empty iterator (yields nothing).

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -47,7 +47,7 @@ class Iterator : public Cleanable {
   // Valid() after this call iff the source is not empty.
   virtual void SeekToLast() = 0;
 
-  // Position at the first key in the source that at or past target.
+  // Position at the first key in the source that is at or past target.
   // The iterator is Valid() after this call iff the source contains
   // an entry that comes at or past target.
   // All Seek*() methods clear any error status() that the iterator had prior to
@@ -56,7 +56,7 @@ class Iterator : public Cleanable {
   // Target does not contain timestamp.
   virtual void Seek(const Slice& target) = 0;
 
-  // Position at the last key in the source that at or before target.
+  // Position at the last key in the source that is at or before target.
   // The iterator is Valid() after this call iff the source contains
   // an entry that comes at or before target.
   // Target does not contain timestamp.

--- a/include/rocksdb/iterator.h
+++ b/include/rocksdb/iterator.h
@@ -118,8 +118,10 @@ class Iterator : public Cleanable {
 
   /**
    * true if this iterator is already
-   * checking ReadOptions::iterate_lower_bound,
-   * false otherwise.
+   * checking ReadOptions::iterate_lower_bound.
+   * false indicates that either the iterator does
+   * not check the lower bound, or that it does not
+   * report that it is performing the check.
    */
   virtual bool ChecksLowerBound() const { return false; }
 
@@ -136,8 +138,10 @@ class Iterator : public Cleanable {
 
   /**
    * true if this iterator is already
-   * checking ReadOptions::iterate_upper_bound,
-   * false otherwise.
+   * checking ReadOptions::iterate_upper_bound.
+   * false indicates that either the iterator does
+   * not check the upper bound, or that it does not
+   * report that it is performing the check.
    */
   virtual bool ChecksUpperBound() const { return false; }
 

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -126,6 +126,10 @@ class EmptyIterator : public Iterator {
     return Slice();
   }
   Status status() const override { return status_; }
+  bool ChecksLowerBound() const override { return false; }
+  const Slice* lower_bound() const override { return nullptr; }
+  bool ChecksUpperBound() const override { return false; }
+  const Slice* upper_bound() const override { return nullptr; }
 
  private:
   Status status_;

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -126,9 +126,7 @@ class EmptyIterator : public Iterator {
     return Slice();
   }
   Status status() const override { return status_; }
-  bool ChecksLowerBound() const override { return false; }
   const Slice* lower_bound() const override { return nullptr; }
-  bool ChecksUpperBound() const override { return false; }
   const Slice* upper_bound() const override { return nullptr; }
 
  private:

--- a/utilities/blob_db/blob_db_iterator.h
+++ b/utilities/blob_db/blob_db_iterator.h
@@ -117,6 +117,14 @@ class BlobDBIterator : public Iterator {
 
   // Iterator::Refresh() not supported.
 
+  bool ChecksLowerBound() const override { return iter_->ChecksLowerBound(); }
+
+  const Slice* lower_bound() const override { return iter_->lower_bound(); }
+
+  bool ChecksUpperBound() const override { return iter_->ChecksUpperBound(); }
+
+  const Slice* upper_bound() const override { return iter_->upper_bound(); }
+
  private:
   // Return true if caller should continue to next value.
   bool UpdateBlobValue() {

--- a/utilities/blob_db/blob_db_iterator.h
+++ b/utilities/blob_db/blob_db_iterator.h
@@ -117,11 +117,7 @@ class BlobDBIterator : public Iterator {
 
   // Iterator::Refresh() not supported.
 
-  bool ChecksLowerBound() const override { return iter_->ChecksLowerBound(); }
-
   const Slice* lower_bound() const override { return iter_->lower_bound(); }
-
-  bool ChecksUpperBound() const override { return iter_->ChecksUpperBound(); }
 
   const Slice* upper_bound() const override { return iter_->upper_bound(); }
 

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -146,6 +146,14 @@ class TtlIterator : public Iterator {
 
   Status status() const override { return iter_->status(); }
 
+  bool ChecksLowerBound() const override { return iter_->ChecksLowerBound(); }
+
+  const Slice* lower_bound() const override { return iter_->lower_bound(); }
+
+  bool ChecksUpperBound() const override { return iter_->ChecksUpperBound(); }
+
+  const Slice* upper_bound() const override { return iter_->upper_bound(); }
+
  private:
   Iterator* iter_;
 };

--- a/utilities/ttl/db_ttl_impl.h
+++ b/utilities/ttl/db_ttl_impl.h
@@ -146,11 +146,7 @@ class TtlIterator : public Iterator {
 
   Status status() const override { return iter_->status(); }
 
-  bool ChecksLowerBound() const override { return iter_->ChecksLowerBound(); }
-
   const Slice* lower_bound() const override { return iter_->lower_bound(); }
-
-  bool ChecksUpperBound() const override { return iter_->ChecksUpperBound(); }
 
   const Slice* upper_bound() const override { return iter_->upper_bound(); }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -30,8 +30,7 @@ BaseDeltaIterator::BaseDeltaIterator(Iterator* base_iterator,
       base_iterator_(base_iterator),
       delta_iterator_(delta_iterator),
       comparator_(comparator),
-      iterate_upper_bound_(read_options ? read_options->iterate_upper_bound
-                                        : nullptr) {}
+      read_options_(read_options) {}
 
 bool BaseDeltaIterator::Valid() const {
   return status_.ok() ? (current_at_base_ ? BaseValid() : DeltaValid()) : false;
@@ -273,8 +272,8 @@ void BaseDeltaIterator::UpdateCurrent() {
         // Finished
         return;
       }
-      if (iterate_upper_bound_) {
-        if (comparator_->Compare(delta_entry.key, *iterate_upper_bound_) >= 0) {
+      if (read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr) {
+        if (comparator_->Compare(delta_entry.key, *(read_options_->iterate_upper_bound)) >= 0) {
           // out of upper bound -> finished.
           return;
         }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -221,6 +221,18 @@ Status BaseDeltaIterator::status() const {
   return delta_iterator_->status();
 }
 
+bool BaseDeltaIterator::ChecksLowerBound() const { return false; }
+
+const Slice* BaseDeltaIterator::lower_bound() const {
+  return base_iterator_lower_bound();
+}
+
+bool BaseDeltaIterator::ChecksUpperBound() const { return true; }
+
+const Slice* BaseDeltaIterator::upper_bound() const {
+  return base_iterator_upper_bound();
+}
+
 void BaseDeltaIterator::Invalidate(Status s) { status_ = s; }
 
 void BaseDeltaIterator::AssertInvariants() {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -30,7 +30,47 @@ BaseDeltaIterator::BaseDeltaIterator(Iterator* base_iterator,
       base_iterator_(base_iterator),
       delta_iterator_(delta_iterator),
       comparator_(comparator),
-      read_options_(read_options) {}
+      read_options_(read_options) {
+
+  // We have to consider the upper_bound constraint of both
+  // the base_iterator and the read_options provdied
+  // to us. We use the tightest constraint, i.e. the
+  // lower of the two.
+  const Slice* base_iterator_upper_bound = base_iterator_->upper_bound();
+  const Slice* read_iterate_upper_bound = read_options == nullptr ? nullptr : read_options->iterate_upper_bound;
+  calc_bound(upper_bound_, upper_bound_equals_base_upper_bound_, base_iterator_upper_bound, read_iterate_upper_bound, [&comparator](const Slice* const base_upper, const Slice* const read_upper){
+    return comparator->Compare(*base_upper, *read_upper) <= 0;
+  });
+
+  // We have to consider the lower_bound constraint of both
+  // the base_iterator and the read_options provdied
+  // to us. We use the tightest constraint, i.e. the
+  // higher of the two.
+  const Slice* base_iterator_lower_bound = base_iterator_->lower_bound();
+  const Slice* read_iterate_lower_bound = read_options == nullptr ? nullptr : read_options->iterate_lower_bound;
+  calc_bound(lower_bound_, lower_bound_equals_base_lower_bound_, base_iterator_lower_bound, read_iterate_lower_bound, [&comparator](const Slice* const base_lower, const Slice* const read_lower){
+    return comparator->Compare(*base_lower, *read_lower) >= 0;
+  });
+}
+
+void BaseDeltaIterator::calc_bound(const Slice*& out_bound, bool& out_bound_equals_base_bound, const Slice* const base_iterator_bound, const Slice* const read_iterate_bound,
+    const std::function<bool(const Slice* const, const Slice* const)> use_base_bound) {
+  if (base_iterator_bound == nullptr) {
+    out_bound = read_iterate_bound;
+    out_bound_equals_base_bound = false;
+  } else if (read_iterate_bound == nullptr) {
+    out_bound = base_iterator_bound;
+    out_bound_equals_base_bound = true;
+  } else {
+    if (use_base_bound(base_iterator_bound, read_iterate_bound)) {
+      out_bound = base_iterator_bound;
+      out_bound_equals_base_bound = true;
+    } else {
+      out_bound = read_iterate_bound;
+      out_bound_equals_base_bound = false;
+    }
+  }
+}
 
 bool BaseDeltaIterator::Valid() const {
   return status_.ok() ? (current_at_base_ ? BaseValid() : DeltaValid()) : false;
@@ -45,13 +85,13 @@ void BaseDeltaIterator::SeekToFirst() {
 
 void BaseDeltaIterator::SeekToLast() {
   progress_ = Progress::SEEK_TO_LAST;
-  // is there an upper bound constraint on base_iterator_?
-  const Slice* base_upper_bound = base_iterator_upper_bound();
-  if (base_upper_bound != nullptr) {
-    // yes, and is base_iterator already constrained by an upper_bound?
-    if (!base_iterator_->ChecksUpperBound()) {
+
+  // is there an upper bound constraint?
+  if (upper_bound_ != nullptr) {
+    // yes, and is base_iterator already constrained by the same upper_bound?
+    if (!upper_bound_equals_base_upper_bound_) {
       // no, so we have to seek it to before base_upper_bound
-      base_iterator_->Seek(*(base_upper_bound));
+      base_iterator_->Seek(*upper_bound_);
       if (base_iterator_->Valid()) {
         base_iterator_->Prev();  // upper bound should be exclusive!
       } else {
@@ -60,7 +100,7 @@ void BaseDeltaIterator::SeekToLast() {
         base_iterator_->SeekToLast();
       }
     } else {
-      // yes, so the base_iterator will take care of base_upper_bound
+      // yes, so the base_iterator will take care of its own upper_bound
       base_iterator_->SeekToLast();
     }
   } else {
@@ -69,6 +109,7 @@ void BaseDeltaIterator::SeekToLast() {
   }
 
   // is there an upper bound constraint on delta_iterator_?
+  // TODO(AR) should we use the same upper_bound_ here?
   if (read_options_ != nullptr &&
       read_options_->iterate_upper_bound != nullptr) {
     // delta iterator does not itself support iterate_upper_bound,
@@ -219,16 +260,14 @@ Status BaseDeltaIterator::status() const {
   return delta_iterator_->status();
 }
 
-bool BaseDeltaIterator::ChecksLowerBound() const { return false; }
-
 const Slice* BaseDeltaIterator::lower_bound() const {
-  return base_iterator_lower_bound();
+  // NOTE: BaseDeltaIterator does not correctly check lower bound yet
+  // and so we can only return nullptr
+  return nullptr;
 }
 
-bool BaseDeltaIterator::ChecksUpperBound() const { return true; }
-
 const Slice* BaseDeltaIterator::upper_bound() const {
-  return base_iterator_upper_bound();
+  return upper_bound_;
 }
 
 void BaseDeltaIterator::Invalidate(Status s) { status_ = s; }
@@ -320,7 +359,7 @@ bool BaseDeltaIterator::BaseValid() const {
   // base_iterator if the base iterator has an
   // upper_bounds_check already
   return base_iterator_->Valid() &&
-         (base_iterator_->ChecksUpperBound() ? true : BaseIsWithinBounds());
+         (upper_bound_equals_base_upper_bound_ ? true : BaseIsWithinBounds());
 }
 
 bool BaseDeltaIterator::DeltaValid() const {
@@ -411,34 +450,16 @@ void BaseDeltaIterator::UpdateCurrent() {
 #endif  // __clang_analyzer__
 }
 
-inline const Slice* BaseDeltaIterator::base_iterator_upper_bound() const {
-  const Slice* upper = base_iterator_->upper_bound();
-  if (upper == nullptr && read_options_ != nullptr) {
-    return read_options_->iterate_upper_bound;
-  }
-  return upper;
-}
-
-inline const Slice* BaseDeltaIterator::base_iterator_lower_bound() const {
-  const Slice* lower = base_iterator_->lower_bound();
-  if (lower == nullptr && read_options_ != nullptr) {
-    return read_options_->iterate_lower_bound;
-  }
-  return lower;
-}
-
 bool BaseDeltaIterator::BaseIsWithinBounds() const {
   if (IsMovingBackward()) {
-    const Slice* lower = base_iterator_lower_bound();
-    if (lower != nullptr) {
-      return comparator_->Compare(base_iterator_->key(), *lower) >= 0;
+    if (lower_bound_ != nullptr) {
+      return comparator_->Compare(base_iterator_->key(), *lower_bound_) >= 0;
     }
   }
 
   if (IsMovingForward()) {
-    const Slice* upper = base_iterator_upper_bound();
-    if (upper != nullptr) {
-      return comparator_->Compare(base_iterator_->key(), *upper) < 0;
+    if (upper_bound_ != nullptr) {
+      return comparator_->Compare(base_iterator_->key(), *upper_bound_) < 0;
     }
   }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -460,7 +460,7 @@ bool BaseDeltaIterator::BaseIsWithinBounds() const {
   if (IsMovingBackward()) {
     const Slice* lower_bound;
     bool lower_bound_equals_base_lower_bound;
-    calc_upper_bound(&lower_bound, &lower_bound_equals_base_lower_bound);
+    calc_lower_bound(&lower_bound, &lower_bound_equals_base_lower_bound);
 
     if (lower_bound != nullptr) {
       return comparator_->Compare(base_iterator_->key(), *lower_bound) >= 0;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -49,7 +49,7 @@ void BaseDeltaIterator::SeekToLast() {
   const Slice* base_upper_bound = base_iterator_upper_bound();
   if (base_upper_bound != nullptr) {
     // yes, and is base_iterator already constrained by an upper_bound?
-    if (!base_iterator_->check_upper_bound()) {
+    if (!base_iterator_->ChecksUpperBound()) {
       // no, so we have to seek it to before base_upper_bound
       base_iterator_->Seek(*(base_upper_bound));
       if (base_iterator_->Valid()) {
@@ -310,7 +310,7 @@ bool BaseDeltaIterator::BaseValid() const {
   // base_iterator if the base iterator has an
   // upper_bounds_check already
   return base_iterator_->Valid() &&
-      (base_iterator_->check_upper_bound() ? true : BaseIsWithinBounds());
+      (base_iterator_->ChecksUpperBound() ? true : BaseIsWithinBounds());
 }
 
 bool BaseDeltaIterator::DeltaValid() const {
@@ -402,7 +402,7 @@ void BaseDeltaIterator::UpdateCurrent() {
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_upper_bound() const {
-  const Slice* upper_bound = base_iterator_->iterate_upper_bound();
+  const Slice* upper_bound = base_iterator_->upper_bound();
   if (upper_bound == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_upper_bound;
   }
@@ -410,7 +410,7 @@ inline const Slice* BaseDeltaIterator::base_iterator_upper_bound() const {
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_lower_bound() const {
-  const Slice* lower_bound = base_iterator_->iterate_lower_bound();
+  const Slice* lower_bound = base_iterator_->lower_bound();
   if (lower_bound == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_lower_bound;
   }

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -55,7 +55,8 @@ void BaseDeltaIterator::SeekToLast() {
       if (base_iterator_->Valid()) {
         base_iterator_->Prev();  // upper bound should be exclusive!
       } else {
-        // the base_upper_bound is beyond the base_iterator, so just SeekToLast()
+        // the base_upper_bound is beyond the base_iterator, so just
+        // SeekToLast()
         base_iterator_->SeekToLast();
       }
     } else {
@@ -68,9 +69,8 @@ void BaseDeltaIterator::SeekToLast() {
   }
 
   // is there an upper bound constraint on delta_iterator_?
-  if (read_options_ != nullptr
-      && read_options_->iterate_upper_bound != nullptr) {
-
+  if (read_options_ != nullptr &&
+      read_options_->iterate_upper_bound != nullptr) {
     // delta iterator does not itself support iterate_upper_bound,
     // so we have to seek it to before iterate_upper_bound
     delta_iterator_->Seek(*(read_options_->iterate_upper_bound));
@@ -127,7 +127,6 @@ void BaseDeltaIterator::Next() {
         delta_iterator_->SeekToFirst();
       }
     } else {
-
       progress_ = Progress::FORWARD;
       if (current_at_base_) {
         // Change delta from larger than base to smaller
@@ -139,7 +138,7 @@ void BaseDeltaIterator::Next() {
 
       if (DeltaValid() && BaseValid()) {
         if (comparator_->Equal(delta_iterator_->Entry().key,
-                              base_iterator_->key())) {
+                               base_iterator_->key())) {
           equal_keys_ = true;
         }
       }
@@ -176,16 +175,15 @@ void BaseDeltaIterator::Prev() {
         delta_iterator_->SeekToLast();
       }
     } else {
-
       progress_ = Progress::BACKWARD;
 
       if (current_at_base_) {
-          // Change delta from less advanced than base to more advanced
-          AdvanceDelta();
-        } else {
-          // Change base from less advanced than delta to more advanced
-          AdvanceBase();
-        }
+        // Change delta from less advanced than base to more advanced
+        AdvanceDelta();
+      } else {
+        // Change base from less advanced than delta to more advanced
+        AdvanceBase();
+      }
     }
 
     if (DeltaValid() && BaseValid()) {
@@ -322,12 +320,11 @@ bool BaseDeltaIterator::BaseValid() const {
   // base_iterator if the base iterator has an
   // upper_bounds_check already
   return base_iterator_->Valid() &&
-      (base_iterator_->ChecksUpperBound() ? true : BaseIsWithinBounds());
+         (base_iterator_->ChecksUpperBound() ? true : BaseIsWithinBounds());
 }
 
 bool BaseDeltaIterator::DeltaValid() const {
-  return delta_iterator_->Valid() &&
-      DeltaIsWithinBounds();
+  return delta_iterator_->Valid() && DeltaIsWithinBounds();
 }
 
 void BaseDeltaIterator::UpdateCurrent() {
@@ -360,8 +357,10 @@ void BaseDeltaIterator::UpdateCurrent() {
         return;
       }
 
-      if (read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr) {
-        if (comparator_->Compare(delta_entry.key, *(read_options_->iterate_upper_bound)) >= 0) {
+      if (read_options_ != nullptr &&
+          read_options_->iterate_upper_bound != nullptr) {
+        if (comparator_->Compare(delta_entry.key,
+                                 *(read_options_->iterate_upper_bound)) >= 0) {
           // out of upper bound -> finished.
           return;
         }
@@ -380,7 +379,6 @@ void BaseDeltaIterator::UpdateCurrent() {
       return;
 
     } else {
-
       // Base and Delta are both unfinished
 
       int compare =
@@ -433,7 +431,7 @@ bool BaseDeltaIterator::BaseIsWithinBounds() const {
   if (IsMovingBackward()) {
     const Slice* lower = base_iterator_lower_bound();
     if (lower != nullptr) {
-        return comparator_->Compare(base_iterator_->key(), *lower) >= 0;
+      return comparator_->Compare(base_iterator_->key(), *lower) >= 0;
     }
   }
 
@@ -451,12 +449,12 @@ bool BaseDeltaIterator::DeltaIsWithinBounds() const {
   if (read_options_ != nullptr) {
     if (IsMovingBackward() && read_options_->iterate_lower_bound != nullptr) {
       return comparator_->Compare(delta_iterator_->Entry().key,
-          *(read_options_->iterate_lower_bound)) >= 0;
+                                  *(read_options_->iterate_lower_bound)) >= 0;
     }
 
     if (IsMovingForward() && read_options_->iterate_upper_bound != nullptr) {
       return comparator_->Compare(delta_iterator_->Entry().key,
-          *(read_options_->iterate_upper_bound)) < 0;
+                                  *(read_options_->iterate_upper_bound)) < 0;
     }
   }
   return true;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -45,7 +45,7 @@ void BaseDeltaIterator::SeekToFirst() {
 
 void BaseDeltaIterator::SeekToLast() {
   progress_ = Progress::SEEK_TO_LAST;
-  // is there an upper bound constraint?
+  // is there an upper bound constraint on base_iterator_?
   const Slice* base_upper_bound = base_iterator_upper_bound();
   if (base_upper_bound != nullptr) {
     // yes, and is base_iterator already constrained by an upper_bound?
@@ -62,6 +62,14 @@ void BaseDeltaIterator::SeekToLast() {
       // yes, so the base_iterator will take care of base_upper_bound
       base_iterator_->SeekToLast();
     }
+  } else {
+    // no upper cound constraint, so just SeekToLast
+    base_iterator_->SeekToLast();
+  }
+
+  // is there an upper bound constraint on delta_iterator_?
+  if (read_options_ != nullptr
+      && read_options_->iterate_upper_bound != nullptr) {
 
     // delta iterator does not itself support iterate_upper_bound,
     // so we have to seek it to before iterate_upper_bound
@@ -74,8 +82,7 @@ void BaseDeltaIterator::SeekToLast() {
     }
 
   } else {
-    // no upper cound constraint, so just SeekToLast on both
-    base_iterator_->SeekToLast();
+    // no upper bound constraint, so just SeekToLast
     delta_iterator_->SeekToLast();
   }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -54,6 +54,9 @@ void BaseDeltaIterator::SeekToLast() {
       base_iterator_->Seek(*(base_upper_bound));
       if (base_iterator_->Valid()) {
         base_iterator_->Prev();  // upper bound should be exclusive!
+      } else {
+        // the base_upper_bound is beyond the base_iterator, so just SeekToLast()
+        base_iterator_->SeekToLast();
       }
     } else {
       // yes, so the base_iterator will take care of base_upper_bound
@@ -65,6 +68,9 @@ void BaseDeltaIterator::SeekToLast() {
     delta_iterator_->Seek(*(read_options_->iterate_upper_bound));
     if (delta_iterator_->Valid()) {
       delta_iterator_->Prev();  // upper bound should be exclusive!
+    } else {
+      // the upper_bound is beyond the delta_iterator, so just SeekToLast()
+      delta_iterator_->SeekToLast();
     }
 
   } else {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -395,19 +395,19 @@ void BaseDeltaIterator::UpdateCurrent() {
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_upper_bound() const {
-  const Slice* iterate_upper_bound = base_iterator_->iterate_upper_bound();
-  if (iterate_upper_bound == nullptr && read_options_ != nullptr) {
+  const Slice* upper_bound = base_iterator_->iterate_upper_bound();
+  if (upper_bound == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_upper_bound;
   }
-  return iterate_upper_bound;
+  return upper_bound;
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_lower_bound() const {
-  const Slice* iterate_lower_bound = base_iterator_->iterate_lower_bound();
-  if (iterate_lower_bound == nullptr && read_options_ != nullptr) {
+  const Slice* lower_bound = base_iterator_->iterate_lower_bound();
+  if (lower_bound == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_lower_bound;
   }
-  return iterate_lower_bound;
+  return lower_bound;
 }
 
 bool BaseDeltaIterator::BaseIsWithinBounds() const {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -414,33 +414,33 @@ void BaseDeltaIterator::UpdateCurrent() {
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_upper_bound() const {
-  const Slice* upper_bound = base_iterator_->upper_bound();
-  if (upper_bound == nullptr && read_options_ != nullptr) {
+  const Slice* upper = base_iterator_->upper_bound();
+  if (upper == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_upper_bound;
   }
-  return upper_bound;
+  return upper;
 }
 
 inline const Slice* BaseDeltaIterator::base_iterator_lower_bound() const {
-  const Slice* lower_bound = base_iterator_->lower_bound();
-  if (lower_bound == nullptr && read_options_ != nullptr) {
+  const Slice* lower = base_iterator_->lower_bound();
+  if (lower == nullptr && read_options_ != nullptr) {
     return read_options_->iterate_lower_bound;
   }
-  return lower_bound;
+  return lower;
 }
 
 bool BaseDeltaIterator::BaseIsWithinBounds() const {
   if (IsMovingBackward()) {
-    const Slice* lower_bound = base_iterator_lower_bound();
-    if (lower_bound != nullptr) {
-        return comparator_->Compare(base_iterator_->key(), *lower_bound) >= 0;
+    const Slice* lower = base_iterator_lower_bound();
+    if (lower != nullptr) {
+        return comparator_->Compare(base_iterator_->key(), *lower) >= 0;
     }
   }
 
   if (IsMovingForward()) {
-    const Slice* upper_bound = base_iterator_upper_bound();
-    if (upper_bound != nullptr) {
-      return comparator_->Compare(base_iterator_->key(), *upper_bound) < 0;
+    const Slice* upper = base_iterator_upper_bound();
+    if (upper != nullptr) {
+      return comparator_->Compare(base_iterator_->key(), *upper) < 0;
     }
   }
 

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -430,14 +430,18 @@ inline const Slice* BaseDeltaIterator::base_iterator_lower_bound() const {
 }
 
 bool BaseDeltaIterator::BaseIsWithinBounds() const {
-  const Slice* lower_bound = base_iterator_lower_bound();
-  if (IsMovingBackward() && lower_bound != nullptr) {
-      return comparator_->Compare(base_iterator_->key(), *lower_bound) >= 0;
+  if (IsMovingBackward()) {
+    const Slice* lower_bound = base_iterator_lower_bound();
+    if (lower_bound != nullptr) {
+        return comparator_->Compare(base_iterator_->key(), *lower_bound) >= 0;
+    }
   }
 
-  const Slice* upper_bound = base_iterator_upper_bound();
-  if (IsMovingForward() && upper_bound != nullptr) {
-    return comparator_->Compare(base_iterator_->key(), *upper_bound) < 0;
+  if (IsMovingForward()) {
+    const Slice* upper_bound = base_iterator_upper_bound();
+    if (upper_bound != nullptr) {
+      return comparator_->Compare(base_iterator_->key(), *upper_bound) < 0;
+    }
   }
 
   return true;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -45,8 +45,34 @@ void BaseDeltaIterator::SeekToFirst() {
 
 void BaseDeltaIterator::SeekToLast() {
   forward_ = false;
-  base_iterator_->SeekToLast();
-  delta_iterator_->SeekToLast();
+  // is there an upper bound constraint?
+  if (read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr) {
+
+    // yes, and is base_iterator already constrained by an upper_bound?
+    if (!base_iterator_->has_upper_bound()) {
+      // no, so we have to seek it to before iterate_upper_bound
+      base_iterator_->Seek(*(read_options_->iterate_upper_bound));
+      if (base_iterator_->Valid()) {
+        base_iterator_->Prev();  // upper bound should be exclusive!
+      }
+    } else {
+      // yes, so the base_iterator will take care of iterate_upper_bound for us
+      base_iterator_->SeekToLast();
+    }
+
+    // delta iterator does not itself support iterate_upper_bound,
+    // so we have to seek it to before iterate_upper_bound
+    delta_iterator_->Seek(*(read_options_->iterate_upper_bound));
+    if (delta_iterator_->Valid()) {
+      delta_iterator_->Prev();  // upper bound should be exclusive!
+    }
+
+  } else {
+    // no upper cound constraint, so just SeekToLast on both
+    base_iterator_->SeekToLast();
+    delta_iterator_->SeekToLast();
+  }
+
   UpdateCurrent();
 }
 
@@ -241,9 +267,18 @@ void BaseDeltaIterator::AdvanceBase() {
   }
 }
 
-bool BaseDeltaIterator::BaseValid() const { return base_iterator_->Valid(); }
+bool BaseDeltaIterator::BaseValid() const {
+  // NOTE: we don't need the bounds check on
+  // base_iterator if the base iterator has an
+  // upper_bounds_check already
+  return base_iterator_->Valid() &&
+      (base_iterator_->has_upper_bound() ? true : IsWithinBounds(base_iterator_->key()));
+}
 
-bool BaseDeltaIterator::DeltaValid() const { return delta_iterator_->Valid(); }
+bool BaseDeltaIterator::DeltaValid() const {
+  return delta_iterator_->Valid() &&
+      IsWithinBounds(delta_iterator_->Entry().key);
+}
 
 void BaseDeltaIterator::UpdateCurrent() {
 // Suppress false positive clang analyzer warnings.
@@ -259,7 +294,9 @@ void BaseDeltaIterator::UpdateCurrent() {
       current_at_base_ = false;
       return;
     }
+
     equal_keys_ = false;
+
     if (!BaseValid()) {
       if (!base_iterator_->status().ok()) {
         // Expose the error status and stop.
@@ -267,11 +304,12 @@ void BaseDeltaIterator::UpdateCurrent() {
         return;
       }
 
-      // Base has finished.
+      // Base and Delta have both finished.
       if (!DeltaValid()) {
         // Finished
         return;
       }
+
       if (read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr) {
         if (comparator_->Compare(delta_entry.key, *(read_options_->iterate_upper_bound)) >= 0) {
           // out of upper bound -> finished.
@@ -285,11 +323,16 @@ void BaseDeltaIterator::UpdateCurrent() {
         current_at_base_ = false;
         return;
       }
+
     } else if (!DeltaValid()) {
-      // Delta has finished.
+      // Base is unfinished, but Delta has finished.
       current_at_base_ = true;
       return;
+
     } else {
+
+      // Base and Delta are both unfinished
+
       int compare =
           (forward_ ? 1 : -1) *
           comparator_->Compare(delta_entry.key, base_iterator_->key());
@@ -302,11 +345,13 @@ void BaseDeltaIterator::UpdateCurrent() {
           current_at_base_ = false;
           return;
         }
+
         // Delta is less advanced and is delete.
         AdvanceDelta();
         if (equal_keys_) {
           AdvanceBase();
         }
+
       } else {
         current_at_base_ = true;
         return;
@@ -316,6 +361,21 @@ void BaseDeltaIterator::UpdateCurrent() {
 
   AssertInvariants();
 #endif  // __clang_analyzer__
+}
+
+bool BaseDeltaIterator::IsWithinBounds(const Slice& key) const {
+  if (read_options_ != nullptr) {
+    // TODO(AR) should this only be used when moving backward?
+    if (read_options_->iterate_lower_bound != nullptr) {
+      return comparator_->Compare(key, *(read_options_->iterate_lower_bound)) >= 0;
+    }
+
+    // TODO(AR) should this only be used when moving forward?
+    if (read_options_->iterate_upper_bound != nullptr) {
+      return comparator_->Compare(key, *(read_options_->iterate_upper_bound)) < 0;
+    }
+  }
+  return true;
 }
 
 class Env;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -23,7 +23,7 @@ BaseDeltaIterator::BaseDeltaIterator(Iterator* base_iterator,
                                      WBWIIterator* delta_iterator,
                                      const Comparator* comparator,
                                      const ReadOptions* read_options)
-    : forward_(true),
+    : progress_(Progress::TO_BE_DETERMINED),
       current_at_base_(true),
       equal_keys_(false),
       status_(Status::OK()),
@@ -37,14 +37,14 @@ bool BaseDeltaIterator::Valid() const {
 }
 
 void BaseDeltaIterator::SeekToFirst() {
-  forward_ = true;
+  progress_ = Progress::SEEK_TO_FIRST;
   base_iterator_->SeekToFirst();
   delta_iterator_->SeekToFirst();
   UpdateCurrent();
 }
 
 void BaseDeltaIterator::SeekToLast() {
-  forward_ = false;
+  progress_ = Progress::SEEK_TO_LAST;
   // is there an upper bound constraint?
   if (read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr) {
 
@@ -77,14 +77,14 @@ void BaseDeltaIterator::SeekToLast() {
 }
 
 void BaseDeltaIterator::Seek(const Slice& k) {
-  forward_ = true;
+  progress_ = Progress::SEEK;
   base_iterator_->Seek(k);
   delta_iterator_->Seek(k);
   UpdateCurrent();
 }
 
 void BaseDeltaIterator::SeekForPrev(const Slice& k) {
-  forward_ = false;
+  progress_ = Progress::SEEK_FOR_PREV;
   base_iterator_->SeekForPrev(k);
   delta_iterator_->SeekForPrev(k);
   UpdateCurrent();
@@ -96,33 +96,45 @@ void BaseDeltaIterator::Next() {
     return;
   }
 
-  if (!forward_) {
-    // Need to change direction
+  if (IsMovingBackward()) {
+    // currently moving backward, so we need to change direction
     // if our direction was backward and we're not equal, we have two states:
-    // * both iterators are valid: we're already in a good state (current
+    //     * both iterators are valid: we're already in a good state (current
     // shows to smaller)
-    // * only one iterator is valid: we need to advance that iterator
-    forward_ = true;
+    //     * only one iterator is valid: we need to advance that iterator
+
     equal_keys_ = false;
     if (!BaseValid()) {
       assert(DeltaValid());
-      base_iterator_->SeekToFirst();
+      if (progress_ != Progress::SEEK_TO_LAST) {
+        base_iterator_->SeekToFirst();
+      }
     } else if (!DeltaValid()) {
-      delta_iterator_->SeekToFirst();
-    } else if (current_at_base_) {
-      // Change delta from larger than base to smaller
-      AdvanceDelta();
+      if (progress_ != Progress::SEEK_TO_LAST) {
+        delta_iterator_->SeekToFirst();
+      }
     } else {
-      // Change base from larger than delta to smaller
-      AdvanceBase();
-    }
-    if (DeltaValid() && BaseValid()) {
-      if (comparator_->Equal(delta_iterator_->Entry().key,
-                             base_iterator_->key())) {
-        equal_keys_ = true;
+
+      progress_ = Progress::FORWARD;
+      if (current_at_base_) {
+        // Change delta from larger than base to smaller
+        AdvanceDelta();
+      } else {
+        // Change base from larger than delta to smaller
+        AdvanceBase();
+      }
+
+      if (DeltaValid() && BaseValid()) {
+        if (comparator_->Equal(delta_iterator_->Entry().key,
+                              base_iterator_->key())) {
+          equal_keys_ = true;
+        }
       }
     }
   }
+
+  progress_ = Progress::FORWARD;
+
   Advance();
 }
 
@@ -132,26 +144,37 @@ void BaseDeltaIterator::Prev() {
     return;
   }
 
-  if (forward_) {
-    // Need to change direction
-    // if our direction was backward and we're not equal, we have two states:
-    // * both iterators are valid: we're already in a good state (current
+  if (IsMovingForward()) {
+    // currently moving forward, so we need to change direction
+    // if our direction was forward and we're not equal, we have two states:
+    //     * both iterators are valid: we're already in a good state (current
     // shows to smaller)
-    // * only one iterator is valid: we need to advance that iterator
-    forward_ = false;
+    //     * only one iterator is valid: we need to advance that iterator
+
     equal_keys_ = false;
+
     if (!BaseValid()) {
       assert(DeltaValid());
-      base_iterator_->SeekToLast();
+      if (progress_ != Progress::SEEK_TO_FIRST) {
+        base_iterator_->SeekToLast();
+      }
     } else if (!DeltaValid()) {
-      delta_iterator_->SeekToLast();
-    } else if (current_at_base_) {
-      // Change delta from less advanced than base to more advanced
-      AdvanceDelta();
+      if (progress_ != Progress::SEEK_TO_FIRST) {
+        delta_iterator_->SeekToLast();
+      }
     } else {
-      // Change base from less advanced than delta to more advanced
-      AdvanceBase();
+
+      progress_ = Progress::BACKWARD;
+
+      if (current_at_base_) {
+          // Change delta from less advanced than base to more advanced
+          AdvanceDelta();
+        } else {
+          // Change base from less advanced than delta to more advanced
+          AdvanceBase();
+        }
     }
+
     if (DeltaValid() && BaseValid()) {
       if (comparator_->Equal(delta_iterator_->Entry().key,
                              base_iterator_->key())) {
@@ -159,6 +182,8 @@ void BaseDeltaIterator::Prev() {
       }
     }
   }
+
+  progress_ = Progress::BACKWARD;
 
   Advance();
 }
@@ -218,7 +243,7 @@ void BaseDeltaIterator::AssertInvariants() {
          delta_iterator_->Entry().type != kLogDataRecord);
   int compare =
       comparator_->Compare(delta_iterator_->Entry().key, base_iterator_->key());
-  if (forward_) {
+  if (IsMovingForward()) {
     // current_at_base -> compare < 0
     assert(!current_at_base_ || compare < 0);
     // !current_at_base -> compare <= 0
@@ -252,7 +277,7 @@ void BaseDeltaIterator::Advance() {
 }
 
 void BaseDeltaIterator::AdvanceDelta() {
-  if (forward_) {
+  if (IsMovingForward()) {
     delta_iterator_->Next();
   } else {
     delta_iterator_->Prev();
@@ -260,7 +285,7 @@ void BaseDeltaIterator::AdvanceDelta() {
 }
 
 void BaseDeltaIterator::AdvanceBase() {
-  if (forward_) {
+  if (IsMovingForward()) {
     base_iterator_->Next();
   } else {
     base_iterator_->Prev();
@@ -334,7 +359,7 @@ void BaseDeltaIterator::UpdateCurrent() {
       // Base and Delta are both unfinished
 
       int compare =
-          (forward_ ? 1 : -1) *
+          (IsMovingForward() ? 1 : -1) *
           comparator_->Compare(delta_entry.key, base_iterator_->key());
       if (compare <= 0) {  // delta bigger or equal
         if (compare == 0) {

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -59,6 +59,7 @@ class BaseDeltaIterator : public Iterator {
   bool BaseValid() const;
   bool DeltaValid() const;
   void UpdateCurrent();
+  bool IsWithinBounds(const Slice& key) const;
 
   bool forward_;
   bool current_at_base_;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -61,7 +61,27 @@ class BaseDeltaIterator : public Iterator {
   void UpdateCurrent();
   bool IsWithinBounds(const Slice& key) const;
 
-  bool forward_;
+  inline bool IsMovingForward() const {
+    return progress_ < Progress::BACKWARD;
+  }
+
+  inline bool IsMovingBackward() const {
+    return progress_ > Progress::FORWARD;
+  }
+
+  enum Progress {
+    TO_BE_DETERMINED = 0,
+
+    SEEK_TO_FIRST = 1,
+    SEEK = 2,
+    FORWARD = 3,
+
+    BACKWARD = 4,
+    SEEK_FOR_PREV = 5,
+    SEEK_TO_LAST = 6
+  };
+
+  Progress progress_;
   bool current_at_base_;
   bool equal_keys_;
   Status status_;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -86,13 +86,9 @@ class BaseDeltaIterator : public Iterator {
   bool BaseIsWithinBounds() const;
   bool DeltaIsWithinBounds() const;
 
-  inline bool IsMovingForward() const {
-    return progress_ < Progress::BACKWARD;
-  }
+  inline bool IsMovingForward() const { return progress_ < Progress::BACKWARD; }
 
-  inline bool IsMovingBackward() const {
-    return progress_ > Progress::FORWARD;
-  }
+  inline bool IsMovingBackward() const { return progress_ > Progress::FORWARD; }
 
   /**
    * Indicates the progression of the BaseDeltaIterator.

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -67,7 +67,7 @@ class BaseDeltaIterator : public Iterator {
   std::unique_ptr<Iterator> base_iterator_;
   std::unique_ptr<WBWIIterator> delta_iterator_;
   const Comparator* comparator_;  // not owned
-  const Slice* iterate_upper_bound_;
+  const ReadOptions* read_options_;  // not owned
 };
 
 // Key used by skip list, as the binary searchable index of WriteBatchWithIndex.

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -90,13 +90,27 @@ class BaseDeltaIterator : public Iterator {
     return progress_ > Progress::FORWARD;
   }
 
+  /**
+   * Indicates the progression of the BaseDeltaIterator.
+   *
+   * The numeric ordering of the enumerated values is
+   * important as it allows us to easily calculate
+   * whether a progression is considered to be generally
+   * Forward or Backward. For the logic see
+   * BaseDeltaIterator::IsMovingForward() and
+   * BaseDeltaIterator::IsMovingBackward().
+   */
   enum Progress {
+    // initial state, also considered
+    // to be a forward progression
     TO_BE_DETERMINED = 0,
 
+    // forward progressions
     SEEK_TO_FIRST = 1,
     SEEK = 2,
     FORWARD = 3,
 
+    // backward progressions
     BACKWARD = 4,
     SEEK_FOR_PREV = 5,
     SEEK_TO_LAST = 6

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -59,7 +59,28 @@ class BaseDeltaIterator : public Iterator {
   bool BaseValid() const;
   bool DeltaValid() const;
   void UpdateCurrent();
-  bool IsWithinBounds(const Slice& key) const;
+
+  /**
+   * Returns the upper bound for the base iterator,
+   * or nullptr if there is no upper bound.
+   *
+   * The base iterator may have its own upper bound,
+   * if not not we use the upper bound from this
+   * iterator's ReadOptions (if present).
+   */
+  inline const Slice* base_iterator_upper_bound() const;
+
+  /**
+   * Returns the lower bound for the base iterator,
+   * or nullptr if there is no lower bound.
+   *
+   * The base iterator may have its own lower bound,
+   * if not not we use the lower bound from this
+   * iterator's ReadOptions (if present).
+   */
+  inline const Slice* base_iterator_lower_bound() const;
+  bool BaseIsWithinBounds() const;
+  bool DeltaIsWithinBounds() const;
 
   inline bool IsMovingForward() const {
     return progress_ < Progress::BACKWARD;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -49,6 +49,10 @@ class BaseDeltaIterator : public Iterator {
   Slice key() const override;
   Slice value() const override;
   Status status() const override;
+  bool ChecksLowerBound() const override;
+  const Slice* lower_bound() const override;
+  bool ChecksUpperBound() const override;
+  const Slice* upper_bound() const override;
   void Invalidate(Status s);
 
  private:

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -561,25 +561,25 @@ class KVIter : public Iterator {
   Slice value() const override { return iter_->second; }
   Status status() const override { return Status::OK(); }
 
-  bool check_lower_bound() const override {
+  bool ChecksLowerBound() const override {
     return read_options_ != nullptr &&
            read_options_->iterate_lower_bound != nullptr;
   }
 
-  const Slice* iterate_lower_bound() const override {
-    if (check_lower_bound()) {
+  const Slice* lower_bound() const override {
+    if (ChecksLowerBound()) {
       return read_options_->iterate_lower_bound;
     }
     return nullptr;
   }
 
-  bool check_upper_bound() const override {
+  bool ChecksUpperBound() const override {
     return read_options_ != nullptr &&
            read_options_->iterate_upper_bound != nullptr;
   }
 
-  const Slice* iterate_upper_bound() const override {
-    if (check_upper_bound()) {
+  const Slice* upper_bound() const override {
+    if (ChecksUpperBound()) {
       return read_options_->iterate_upper_bound;
     }
     return nullptr;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -560,6 +560,14 @@ class KVIter : public Iterator {
   Slice value() const override { return iter_->second; }
   Status status() const override { return Status::OK(); }
 
+  bool has_lower_bound() const override {
+    return read_options_ != nullptr && read_options_->iterate_lower_bound != nullptr;
+  };
+
+  bool has_upper_bound() const override {
+    return read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr;
+  };
+
  private:
   const KVMap* const map_;
   KVMap::const_iterator iter_;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2341,6 +2341,103 @@ TEST_F(WriteBatchWithIndexTest,
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 }
 
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundOnBaseNoUpperBoundOnBatch) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
+
+  KVMap base;
+  base["k01"] = "v01";
+  base["k02"] = "v02";
+  base["k03"] = "v03";
+  base["k04"] = "v04";
+
+  batch.Put(&cf1, "k05", "v05");
+  batch.Put(&cf1, "k06", "v06");
+  batch.Put(&cf1, "k07", "v07");
+  batch.Put(&cf1, "k08", "v08");
+
+  Slice upper_bound_base("k03");
+  ReadOptions read_options_base;
+  read_options_base.iterate_upper_bound = &upper_bound_base;
+
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&base, BytewiseComparator(), &read_options_base),
+      nullptr));
+
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+  iter->Next();
+  // NOTE: k03 and k04 are skipped over on base
+  // due to read_options_base.iterate_upper_bound
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k06", "v06"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k07", "v07"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k08", "v08"));
+  iter->Next();
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+}
+
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseNoUpperBoundOnBaseUpperBoundOnBatch) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
+
+  KVMap base;
+  base["k01"] = "v01";
+  base["k02"] = "v02";
+  base["k03"] = "v03";
+  base["k04"] = "v04";
+
+  batch.Put(&cf1, "k05", "v05");
+  batch.Put(&cf1, "k06", "v06");
+  batch.Put(&cf1, "k07", "v07");
+  batch.Put(&cf1, "k08", "v08");
+
+  Slice upper_bound_batch("k07");
+
+  ReadOptions read_options_batch;
+  read_options_batch.iterate_upper_bound = &upper_bound_batch;
+
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&base, BytewiseComparator(), nullptr),
+      &read_options_batch));
+
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k06", "v06"));
+  iter->Next();
+  // NOTE: k07 and k08 are skipped over on batch
+  // due to read_options_batch.iterate_upper_bound
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+}
+
 TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2152,7 +2152,7 @@ TEST_F(WriteBatchWithIndexTest,
   Slice upper_bound_base("k04");
   read_options_base.iterate_upper_bound = &upper_bound_base;
 
-  // upper bound for base
+  // upper bound for batch
   ReadOptions read_options_batch;
   Slice upper_bound_batch("k08");
   read_options_batch.iterate_upper_bound = &upper_bound_batch;

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -521,11 +521,12 @@ class KVIter : public Iterator {
     } else {
       if (read_options_ != nullptr &&
           read_options_->iterate_upper_bound != nullptr) {
-
         // we can seek to before the iterate_upper_bound
 
-        // NOTE: std::map::lower_bound is equivalent to RocksDB's `iterate_upper_bound`
-        iter_ = map_->lower_bound(read_options_->iterate_upper_bound->ToString());
+        // NOTE: std::map::lower_bound is equivalent to RocksDB's
+        // `iterate_upper_bound`
+        iter_ =
+            map_->lower_bound(read_options_->iterate_upper_bound->ToString());
         if (iter_ != map_->begin()) {
           // lower_bound gives us the first element not
           // less than the `iterate_upper_bound` so we have
@@ -561,11 +562,13 @@ class KVIter : public Iterator {
   Status status() const override { return Status::OK(); }
 
   bool has_lower_bound() const override {
-    return read_options_ != nullptr && read_options_->iterate_lower_bound != nullptr;
+    return read_options_ != nullptr &&
+           read_options_->iterate_lower_bound != nullptr;
   };
 
   bool has_upper_bound() const override {
-    return read_options_ != nullptr && read_options_->iterate_upper_bound != nullptr;
+    return read_options_ != nullptr &&
+           read_options_->iterate_upper_bound != nullptr;
   };
 
  private:
@@ -578,24 +581,27 @@ class KVIter : public Iterator {
     if (read_options_ != nullptr) {
       // TODO(AR) should this only be used when moving backward?
       if (read_options_->iterate_lower_bound != nullptr) {
-        return comparator_->Compare(iter_->first, *(read_options_->iterate_lower_bound)) >= 0;
+        return comparator_->Compare(iter_->first,
+                                    *(read_options_->iterate_lower_bound)) >= 0;
       }
 
       // TODO(AR) should this only be used when moving forward?
       if (read_options_->iterate_upper_bound != nullptr) {
-        return comparator_->Compare(iter_->first, *(read_options_->iterate_upper_bound)) < 0;
+        return comparator_->Compare(iter_->first,
+                                    *(read_options_->iterate_upper_bound)) < 0;
       }
     }
-    
+
     return true;
   }
 };
 
-::testing::AssertionResult IterEquals(Iterator* iter,
-    const std::string& key,const std::string& value) {
+::testing::AssertionResult IterEquals(Iterator* iter, const std::string& key,
+                                      const std::string& value) {
   auto s = iter->status();
   if (!s.ok()) {
-    return ::testing::AssertionFailure() << "Iterator NOT OK; status is: " << s.ToString();
+    return ::testing::AssertionFailure()
+           << "Iterator NOT OK; status is: " << s.ToString();
   }
 
   if (!iter->Valid()) {
@@ -603,11 +609,15 @@ class KVIter : public Iterator {
   }
 
   if (key != iter->key()) {
-    return ::testing::AssertionFailure() << "Iterator::key(): '" << iter->key().ToString(false) << "' is not equal to '" << key << "'";
+    return ::testing::AssertionFailure()
+           << "Iterator::key(): '" << iter->key().ToString(false)
+           << "' is not equal to '" << key << "'";
   }
 
   if (value != iter->value()) {
-    return ::testing::AssertionFailure() << "Iterator::value(): '" << iter->value().ToString(false) << "' is not equal to '" << value << "'";
+    return ::testing::AssertionFailure()
+           << "Iterator::value(): '" << iter->value().ToString(false)
+           << "' is not equal to '" << value << "'";
   }
 
   return ::testing::AssertionSuccess();
@@ -1212,7 +1222,8 @@ TEST_F(WriteBatchWithIndexTest,
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 }
 
-TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBaseAndBatch) {
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseSeekToLastOnBaseAndBatch) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
 
@@ -1225,8 +1236,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBaseAndBatch) 
   batch.Put(&cf1, "k05", "v05");
   batch.Put(&cf1, "k06", "v06");
 
-  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
-      &cf1, new KVIter(&base, BytewiseComparator())));
+  std::unique_ptr<Iterator> iter(
+      batch.NewIteratorWithBase(&cf1, new KVIter(&base, BytewiseComparator())));
 
   ASSERT_OK(iter->status());
 
@@ -1308,7 +1319,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBaseAndBatch) 
   ASSERT_FALSE(iter->Valid()) << "Should have reached end";
 }
 
-TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBatchAndBase) {
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseSeekToLastOnBatchAndBase) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
 
@@ -1321,8 +1333,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBatchAndBase) 
   batch.Put(&cf1, "k02", "v02");
   batch.Put(&cf1, "k03", "v03");
 
-  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
-      &cf1, new KVIter(&base, BytewiseComparator())));
+  std::unique_ptr<Iterator> iter(
+      batch.NewIteratorWithBase(&cf1, new KVIter(&base, BytewiseComparator())));
 
   ASSERT_OK(iter->status());
 
@@ -1400,7 +1412,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseSeekToLastOnBatchAndBase) 
   ASSERT_TRUE(IterEquals(iter.get(), "k06", "v06"));
 }
 
-TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBaseWithoutBaseConstraint) {
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundOnBaseWithoutBaseConstraint) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
 
@@ -1417,10 +1430,10 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBaseWithoutBas
   ReadOptions read_options;
   read_options.iterate_upper_bound = &upper_bound;
 
-  // NOTE: read_options are NOT passed to KVIter, so WBWIIterator imposes iterate_upper_bound on base
+  // NOTE: read_options are NOT passed to KVIter, so WBWIIterator imposes
+  // iterate_upper_bound on base
   std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
-      &cf1, new KVIter(&base, BytewiseComparator()),
-      &read_options));
+      &cf1, new KVIter(&base, BytewiseComparator()), &read_options));
 
   ASSERT_OK(iter->status());
 
@@ -1461,7 +1474,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBaseWithoutBas
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 }
 
-TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBaseWithBaseConstraint) {
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundOnBaseWithBaseConstraint) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
 
@@ -1478,7 +1492,8 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBaseWithBaseCo
   ReadOptions read_options;
   read_options.iterate_upper_bound = &upper_bound;
 
-  // NOTE: read_options are also passed to KVIter, so KVIter imposes iterate_upper_bound on base
+  // NOTE: read_options are also passed to KVIter, so KVIter imposes
+  // iterate_upper_bound on base
   std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
       &cf1, new KVIter(&base, BytewiseComparator(), &read_options),
       &read_options));
@@ -1539,8 +1554,9 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseUpperBoundOnBatch) {
   read_options.iterate_upper_bound = &upper_bound;
 
   KVMap empty_map;
-  std::unique_ptr<Iterator> iter(
-      batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map, BytewiseComparator(), &read_options), &read_options));
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&empty_map, BytewiseComparator(), &read_options),
+      &read_options));
 
   ASSERT_OK(iter->status());
 

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2471,6 +2471,8 @@ TEST_F(WriteBatchWithIndexTest,
 
   ASSERT_OK(iter->status());
 
+  ASSERT_EQ(upper_bound_batch, *iter->upper_bound());
+
   iter->SeekToFirst();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
@@ -2533,6 +2535,8 @@ TEST_F(WriteBatchWithIndexTest,
 
   ASSERT_OK(iter->status());
 
+  ASSERT_EQ(upper_bound_batch, *iter->upper_bound());
+
   iter->SeekToFirst();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
@@ -2592,6 +2596,8 @@ TEST_F(WriteBatchWithIndexTest,
       &read_options_batch));
 
   ASSERT_OK(iter->status());
+
+  ASSERT_EQ(upper_bound_batch, *iter->upper_bound());
 
   iter->SeekToFirst();
   ASSERT_OK(iter->status());
@@ -2655,6 +2661,8 @@ TEST_F(WriteBatchWithIndexTest,
 
   ASSERT_OK(iter->status());
 
+  ASSERT_EQ(upper_bound_base, *iter->upper_bound());
+
   iter->SeekToFirst();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
@@ -2717,6 +2725,8 @@ TEST_F(WriteBatchWithIndexTest,
 
   ASSERT_OK(iter->status());
 
+  ASSERT_EQ(upper_bound_base, *iter->upper_bound());
+
   iter->SeekToFirst();
   ASSERT_OK(iter->status());
   ASSERT_TRUE(iter->Valid());
@@ -2776,6 +2786,8 @@ TEST_F(WriteBatchWithIndexTest,
       &read_options_batch));
 
   ASSERT_OK(iter->status());
+
+  ASSERT_EQ(upper_bound_base, *iter->upper_bound());
 
   iter->SeekToFirst();
   ASSERT_OK(iter->status());

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -2428,6 +2428,190 @@ TEST_F(WriteBatchWithIndexTest,
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 }
 
+/**
+ * Checks that when the Base Iterator has a higher
+ * upper bound than the WBWI Iterator upper bound,
+ * then values are only returned upto the lower of
+ * the two higher bounds.
+ * 
+ * Exercises the Base Iterator as all keys upto the bound will be in the base.
+ */
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundHigherOnBaseThanBatchBaseIterator) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
+
+  KVMap base;
+  base["k01"] = "v01";
+  base["k02"] = "v02";
+  base["k03"] = "v03";
+  base["k04"] = "v04";
+  base["k05"] = "v05";
+  base["k06"] = "v06";
+  base["k07"] = "v07";
+  base["k08"] = "v08";
+
+  batch.Put(&cf1, "k09", "v09");
+  batch.Put(&cf1, "k10", "v10");
+  batch.Put(&cf1, "k11", "v11");
+  batch.Put(&cf1, "k12", "v12");
+
+  Slice upper_bound_base("k07");   // higher than that for the batch
+  Slice upper_bound_batch("k06");  // lower than that for the base
+
+
+  ReadOptions read_options_base;
+  read_options_base.iterate_upper_bound = &upper_bound_base;
+  ReadOptions read_options_batch;
+  read_options_batch.iterate_upper_bound = &upper_bound_batch;
+
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&base, BytewiseComparator(), &read_options_base),
+      &read_options_batch));
+
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+  iter->Next();
+  // NOTE: k06 is the upper bound set on the batch
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+}
+
+/**
+ * Checks that when the Base Iterator has a higher
+ * upper bound than the WBWI Iterator upper bound,
+ * then values are only returned upto the lower of
+ * the two higher bounds.
+ * 
+ * Exercises the Delta Iterator as all keys upto the bound will be in the batch.
+ */
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundHigherOnBaseThanBatchDeltaIterator) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
+
+  KVMap base;
+  base["k09"] = "v09";
+  base["k10"] = "v10";
+  base["k11"] = "v11";
+  base["k12"] = "v12";
+
+  batch.Put(&cf1, "k01", "v01");
+  batch.Put(&cf1, "k02", "v02");
+  batch.Put(&cf1, "k03", "v03");
+  batch.Put(&cf1, "k04", "v04");
+  batch.Put(&cf1, "k05", "v05");
+  batch.Put(&cf1, "k06", "v06");
+  batch.Put(&cf1, "k07", "v07");
+  batch.Put(&cf1, "k08", "v08");
+
+  Slice upper_bound_base("k07");   // higher than that for the batch
+  Slice upper_bound_batch("k06");  // lower than that for the base
+
+
+  ReadOptions read_options_base;
+  read_options_base.iterate_upper_bound = &upper_bound_base;
+  ReadOptions read_options_batch;
+  read_options_batch.iterate_upper_bound = &upper_bound_batch;
+
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&base, BytewiseComparator(), &read_options_base),
+      &read_options_batch));
+
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+  iter->Next();
+  // NOTE: k06 is the upper bound set on the batch
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+}
+
+/**
+ * Checks that when the Base Iterator has a higher
+ * upper bound than the WBWI Iterator upper bound,
+ * then values are only returned upto the lower of
+ * the two higher bounds.
+ * 
+ * Exercises both Base and Delta Iterators as keys upto the bound will be split between base and batch.
+ */
+TEST_F(WriteBatchWithIndexTest,
+       TestIteraratorWithBaseUpperBoundHigherOnBaseThanBatchOverlappingIterators) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
+
+  KVMap base;
+  base["k01"] = "v01";
+  base["k02"] = "v02";
+  base["k03"] = "v03";
+  base["k04"] = "v04";
+
+  batch.Put(&cf1, "k03", "v03");
+  batch.Put(&cf1, "k04", "v04");
+  batch.Put(&cf1, "k05", "v05");
+  batch.Put(&cf1, "k06", "v06");
+  batch.Put(&cf1, "k07", "v07");
+  batch.Put(&cf1, "k08", "v08");
+
+  Slice upper_bound_base("k07");   // higher than that for the batch
+  Slice upper_bound_batch("k06");  // lower than that for the base
+
+
+  ReadOptions read_options_base;
+  read_options_base.iterate_upper_bound = &upper_bound_base;
+  ReadOptions read_options_batch;
+  read_options_batch.iterate_upper_bound = &upper_bound_batch;
+
+  std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
+      &cf1, new KVIter(&base, BytewiseComparator(), &read_options_base),
+      &read_options_batch));
+
+  ASSERT_OK(iter->status());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+  iter->Next();
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+  iter->Next();
+  // NOTE: k06 is the upper bound set on the batch
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+}
+
 TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBaseReverseCmp) {
   ColumnFamilyHandleImplDummy cf1(6, ReverseBytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, ReverseBytewiseComparator());

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -561,28 +561,18 @@ class KVIter : public Iterator {
   Slice value() const override { return iter_->second; }
   Status status() const override { return Status::OK(); }
 
-  bool ChecksLowerBound() const override {
-    return read_options_ != nullptr &&
-           read_options_->iterate_lower_bound != nullptr;
-  }
-
   const Slice* lower_bound() const override {
-    if (ChecksLowerBound()) {
-      return read_options_->iterate_lower_bound;
+    if (read_options_ == nullptr) {
+      return nullptr;
     }
-    return nullptr;
-  }
-
-  bool ChecksUpperBound() const override {
-    return read_options_ != nullptr &&
-           read_options_->iterate_upper_bound != nullptr;
+    return read_options_->iterate_lower_bound;
   }
 
   const Slice* upper_bound() const override {
-    if (ChecksUpperBound()) {
-      return read_options_->iterate_upper_bound;
+    if (read_options_ == nullptr) {
+      return nullptr;
     }
-    return nullptr;
+    return read_options_->iterate_upper_bound;
   }
 
  private:

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1891,6 +1891,43 @@ TEST_F(WriteBatchWithIndexTest,
   ASSERT_OK(iter->status());
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  iter->SeekForPrev("k04");
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  iter->SeekForPrev("k044");
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+
   // scan over batch
   // upper bound k09 is beyond the keys in the batch
   Slice upper_bound_batch("k09");
@@ -1933,6 +1970,63 @@ TEST_F(WriteBatchWithIndexTest,
   iter->Next();
   ASSERT_OK(iter->status());
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  iter->SeekForPrev("k08");
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k08", "v08"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k07", "v07"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k06", "v06"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k05", "v05"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k04", "v04"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k03", "v03"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k02", "v02"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k01", "v01"));
+
+  iter->Prev();
+  ASSERT_OK(iter->status());
+  ASSERT_FALSE(iter->Valid());
+
+  iter->SeekToFirst();
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+
+  iter->SeekForPrev("k09");
+  ASSERT_OK(iter->status());
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_TRUE(IterEquals(iter.get(), "k08", "v08"));
 }
 
 TEST_F(

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -1935,8 +1935,9 @@ TEST_F(WriteBatchWithIndexTest,
   ASSERT_FALSE(iter->Valid()) << "Should have reached upper_bound";
 }
 
-TEST_F(WriteBatchWithIndexTest,
-       TestIteraratorWithBaseOverUpperBoundOnBaseWithoutBaseConstraintAndBatch) {
+TEST_F(
+    WriteBatchWithIndexTest,
+    TestIteraratorWithBaseOverUpperBoundOnBaseWithoutBaseConstraintAndBatch) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 0, true);
 
@@ -1960,8 +1961,7 @@ TEST_F(WriteBatchWithIndexTest,
 
   // NOTE: KVIter DOES NOT have read_options::iterate_upper_bound constraint
   std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(
-      &cf1, new KVIter(&base, BytewiseComparator(), nullptr),
-      &read_options));
+      &cf1, new KVIter(&base, BytewiseComparator(), nullptr), &read_options));
 
   ASSERT_OK(iter->status());
 


### PR DESCRIPTION
Previously `iterate_upper_bound` set on a `BaseDeltaIterator` was not correctly respected.

There were no existing tests for this, so I added quite a lot of tests first.

As well as several fixes to `BaseDeltaIterator`, this introduces the functions `Iterator::ChecksLowerBound` and `Iterator::ChecksUpperBound` these can be used by a wrapping Iterator, such as `BaseDeltaIterator`, to prevent duplication the bounds check work. At present other wrapped iterators that do correct check bounds do not necessarily implement these, a future piece of work would be to have other bounds checking iterators (such as `ForwardIterator` and `ReverseIterator`) implement these.

Additionally, whilst this PR also has added much of the base work for correctly implementing `iterate_lower_bound` on `BaseDeltaIterator`, it's focus was that of the more commonly used `iterate_upper_bound`. The author makes no claims as to the correctness of `iterate_lower_bound`.
