### PR TITLE
Remove assertion from FaultInjectionTestFS::NewDirectory

### DIFF
--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -227,7 +227,6 @@ IOStatus FaultInjectionTestFS::NewDirectory(
     std::unique_ptr<FSDirectory>* result, IODebugContext* dbg) {
   std::unique_ptr<FSDirectory> r;
   IOStatus io_s = target()->NewDirectory(name, options, &r, dbg);
-  assert(io_s.ok());
   if (!io_s.ok()) {
     return io_s;
   }


### PR DESCRIPTION
Summary:
FaultInjectionTestFS::NewDirectory currently asserts that the directory
creation on the target filesystem succeeds. This is actually not
guaranteed since there might be a legitimate I/O error when creating the
directory. The patch removes this assertion.

Test Plan:
`make check`