### PR TITLE
Timer should run scheduled function without mutex

### DIFF
--- a/util/timer.h
+++ b/util/timer.h
@@ -36,11 +36,7 @@ namespace ROCKSDB_NAMESPACE {
 class Timer {
  public:
   Timer(Env* env)
-      : env_(env),
-        mutex_(env),
-        cond_var_(&mutex_),
-        running_(false) {
-  }
+      : env_(env), mutex_(env), cond_var_(&mutex_), running_(false) {}
 
   ~Timer() {}
 
@@ -67,6 +63,7 @@ class Timer {
     auto it = map_.find(fn_name);
     if (it != map_.end()) {
       if (it->second) {
+        WaitForTaskCompleteIfNecessary(*(it->second));
         it->second->Cancel();
       }
     }
@@ -129,8 +126,13 @@ class Timer {
       }
 
       if (current_fn->next_run_time_us <= env_->NowMicros()) {
+        current_fn->executing = true;
+        mutex_.Unlock();
         // Execute the work
         current_fn->fn();
+        mutex_.Lock();
+        current_fn->executing = false;
+        cond_var_.Signal();
 
         // Remove the work from the heap once it is done executing.
         // Note that we are just removing the pointer from the heap. Its
@@ -157,6 +159,8 @@ class Timer {
     }
 
     while (!heap_.empty()) {
+      const FunctionInfo& top = *(heap_.top());
+      WaitForTaskCompleteIfNecessary(top);
       heap_.pop();
     }
 
@@ -178,25 +182,34 @@ class Timer {
     // A function is valid upon construction and until someone explicitly
     // calls `Cancel()`.
     bool valid;
+    // Whether this function is being executed now.
+    bool executing;
 
-    FunctionInfo(std::function<void()>&& _fn,
-                 const std::string& _name,
-                 const uint64_t _next_run_time_us,
-                 uint64_t _repeat_every_us)
-      : fn(std::move(_fn)),
-        name(_name),
-        next_run_time_us(_next_run_time_us),
-        repeat_every_us(_repeat_every_us),
-        valid(true) {}
+    FunctionInfo(std::function<void()>&& _fn, const std::string& _name,
+                 const uint64_t _next_run_time_us, uint64_t _repeat_every_us)
+        : fn(std::move(_fn)),
+          name(_name),
+          next_run_time_us(_next_run_time_us),
+          repeat_every_us(_repeat_every_us),
+          valid(true),
+          executing(false) {}
 
     void Cancel() {
       valid = false;
     }
 
-    bool IsValid() {
-      return valid;
-    }
+    bool IsValid() const { return valid; }
+
+    bool IsExecuting() const { return executing; }
   };
+
+  void WaitForTaskCompleteIfNecessary(const FunctionInfo& fn) {
+    mutex_.AssertHeld();
+    while (fn.executing) {
+      TEST_SYNC_POINT("Timer::WaitForTaskCompleteIfNecessary:TaskExecuting");
+      cond_var_.Wait();
+    }
+  }
 
   struct RunTimeOrder {
     bool operator()(const FunctionInfo* f1,
@@ -212,7 +225,6 @@ class Timer {
   InstrumentedCondVar cond_var_;
   std::unique_ptr<port::Thread> thread_;
   bool running_;
-
 
   std::priority_queue<FunctionInfo*,
                       std::vector<FunctionInfo*>,

--- a/util/timer.h
+++ b/util/timer.h
@@ -35,7 +35,7 @@ namespace ROCKSDB_NAMESPACE {
 // A map from a function name to the function keeps track of all the functions.
 class Timer {
  public:
-  Timer(Env* env)
+  explicit Timer(Env* env)
       : env_(env),
         mutex_(env),
         cond_var_(&mutex_),
@@ -96,8 +96,8 @@ class Timer {
       return false;
     }
 
-    thread_.reset(new port::Thread(&Timer::Run, this));
     running_ = true;
+    thread_.reset(new port::Thread(&Timer::Run, this));
     return true;
   }
 

--- a/util/timer.h
+++ b/util/timer.h
@@ -158,6 +158,7 @@ class Timer {
 
         // current_fn may be cancelled already.
         if (current_fn->IsValid() && current_fn->repeat_every_us > 0) {
+          assert(running_);
           current_fn->next_run_time_us = env_->NowMicros() +
               current_fn->repeat_every_us;
 

--- a/util/timer_test.cc
+++ b/util/timer_test.cc
@@ -283,6 +283,42 @@ TEST_F(TimerTest, AddAfterStartTest) {
   ASSERT_EQ(kIterations, count);
 }
 
+TEST_F(TimerTest, CancelRunningTask) {
+  constexpr char kTestFuncName[] = "test_func";
+  mock_env_->set_current_time(0);
+  Timer timer(mock_env_.get());
+  ASSERT_TRUE(timer.Start());
+  int* value = new int;
+  ASSERT_NE(nullptr, value);  // make linter happy
+  *value = 0;
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({
+      {"TimerTest::CancelRunningTask:test_func:0",
+       "TimerTest::CancelRunningTask:BeforeCancel"},
+      {"Timer::WaitForTaskCompleteIfNecessary:TaskExecuting",
+       "TimerTest::CancelRunningTask:test_func:1"},
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+  timer.Add(
+      [&]() {
+        *value = 1;
+        TEST_SYNC_POINT("TimerTest::CancelRunningTask:test_func:0");
+        TEST_SYNC_POINT("TimerTest::CancelRunningTask:test_func:1");
+      },
+      kTestFuncName, 0, 1 * kSecond);
+  port::Thread control_thr([&]() {
+    TEST_SYNC_POINT("TimerTest::CancelRunningTask:BeforeCancel");
+    timer.Cancel(kTestFuncName);
+    // Verify that *value has been set to 1.
+    ASSERT_EQ(1, *value);
+    delete value;
+    value = nullptr;
+  });
+  mock_env_->set_current_time(1);
+  control_thr.join();
+  ASSERT_TRUE(timer.Shutdown());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
Timer (defined in timer.h) schedules and runs user-specified fuctions
regularly. Current implementation holds the mutex while running user
function, which will lead to contention and waiting.
To fix, Timer::Run releases mutex before running user function, and
re-acquires it afterwards.
This fix will impact how we can cancel a task. If the task is running,
it is not holding the mutex. The thread calling Cancel() should wait
until the current task finishes.

Test Plan (devserver):
make check
COMPILE_WITH_ASAN=1 make check