### PR TITLE
Remove redundant consistency check from VersionStorageInfo::AddFile

### DIFF
--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -989,8 +989,7 @@ class VersionBuilder::Rep {
       if (add_it != add_files.end() && add_it->second != f) {
         vstorage->RemoveCurrentStats(f);
       } else {
-        assert(ioptions_);
-        vstorage->AddFile(level, f, ioptions_->info_log);
+        vstorage->AddFile(level, f);
       }
     }
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -119,7 +119,7 @@ class VersionStorageInfo {
 
   void Reserve(int level, size_t size) { files_[level].reserve(size); }
 
-  void AddFile(int level, FileMetaData* f, Logger* info_log = nullptr);
+  void AddFile(int level, FileMetaData* f);
 
   void AddBlobFile(std::shared_ptr<BlobFileMetaData> blob_file_meta);
 


### PR DESCRIPTION
Summary:
`VersionStorageInfo::AddFile` currently has a debug-mode consistency
check to make sure the newly added file does not overlap with the
previous one (for levels below L0). Considering that
`VersionBuilder::CheckConsistency` also performs similar checks (in
fact, those checks are more comprehensive and cover L0 as well), this
check is redundant. The patch removes it and also cleans up `AddFile` a
little.

Test Plan:
`make check`