### PR TITLE
MOD: allow to use hard link when creating the backup

### DIFF
--- a/env/env.cc
+++ b/env/env.cc
@@ -397,6 +397,7 @@ void AssignEnvOptions(EnvOptions* env_options, const DBOptions& options) {
       options.writable_file_max_buffer_size;
   env_options->allow_fallocate = options.allow_fallocate;
   env_options->strict_bytes_per_sync = options.strict_bytes_per_sync;
+  env_options->use_hardlink = options.use_hardlink;
   options.env->SanitizeEnvOptions(env_options);
 }
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -136,6 +136,9 @@ struct EnvOptions {
 
   // If not nullptr, write rate limiting is enabled for flush and compaction
   RateLimiter* rate_limiter = nullptr;
+
+  // If true, then try to use hard link to copy the file
+  bool use_hardlink = false;
 };
 
 class Env {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -794,6 +794,10 @@ struct DBOptions {
   // Default: false
   bool use_adaptive_mutex = false;
 
+  // If true, then use hardlink to create or copy the file
+  // Default: false
+  bool use_hardlink = false;
+
   // Create DBOptions with default values for all fields
   DBOptions();
   // Create DBOptions from Options

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -394,6 +394,10 @@ std::unordered_map<std::string, OptionTypeInfo>
             }
             return s;
           }}},
+        {"use_hardlink",
+         {offsetof(struct DBOptions, use_hardlink), OptionType::kBoolean,
+          OptionVerificationType::kNormal, OptionTypeFlags::kMutable,
+          offsetof(struct MutableDBOptions, use_hardlink)}},
 };
 #endif  // ROCKSDB_LITE
 
@@ -651,7 +655,8 @@ MutableDBOptions::MutableDBOptions()
       wal_bytes_per_sync(0),
       strict_bytes_per_sync(false),
       compaction_readahead_size(0),
-      max_background_flushes(-1) {}
+      max_background_flushes(-1),
+      use_hardlink(false) {}
 
 MutableDBOptions::MutableDBOptions(const DBOptions& options)
     : max_background_jobs(options.max_background_jobs),
@@ -672,7 +677,8 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
       wal_bytes_per_sync(options.wal_bytes_per_sync),
       strict_bytes_per_sync(options.strict_bytes_per_sync),
       compaction_readahead_size(options.compaction_readahead_size),
-      max_background_flushes(options.max_background_flushes) {}
+      max_background_flushes(options.max_background_flushes),
+      use_hardlink(options.use_hardlink) {}
 
 void MutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.max_background_jobs: %d",
@@ -716,7 +722,9 @@ void MutableDBOptions::Dump(Logger* log) const {
                    "      Options.compaction_readahead_size: %" ROCKSDB_PRIszt,
                    compaction_readahead_size);
   ROCKS_LOG_HEADER(log, "                 Options.max_background_flushes: %d",
-                          max_background_flushes);
+                   max_background_flushes);
+  ROCKS_LOG_HEADER(log, "                 Options.use_hardlink: %d",
+                   use_hardlink);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -116,6 +116,7 @@ struct MutableDBOptions {
   bool strict_bytes_per_sync;
   size_t compaction_readahead_size;
   int max_background_flushes;
+  bool use_hardlink;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -150,6 +150,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.max_bgerror_resume_count;
   options.bgerror_resume_retry_interval =
       immutable_db_options.bgerror_resume_retry_interval;
+  options.use_hardlink = mutable_db_options.use_hardlink;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -326,7 +326,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "write_dbid_to_manifest=false;"
                              "best_efforts_recovery=false;"
                              "max_bgerror_resume_count=2;"
-                             "bgerror_resume_retry_interval=1000000",
+                             "bgerror_resume_retry_interval=1000000;"
+                             "use_hardlink=false;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -1469,6 +1469,11 @@ Status BackupEngineImpl::CopyOrCreateFile(
   std::unique_ptr<SequentialFile> src_file;
   EnvOptions dst_env_options;
   dst_env_options.use_mmap_writes = false;
+
+  if (src_env_options.use_hardlink) {
+    s = src_env->LinkFile(src, dst);
+    if (s.ok()) return s;
+  }
   // TODO:(gzh) maybe use direct reads/writes here if possible
   if (size != nullptr) {
     *size = 0;


### PR DESCRIPTION
hi, does it make sense to allow us to use the hard link when copy file when the backup and DB dir in the same file system? we use the backup to replication in [https://github.com/bitleak/kvrocks](https://github.com/bitleak/kvrocks) and it may cause high io usage when creating the backup.