### PR TITLE
Fix Java test for uint64add merge operator

### DIFF
--- a/java/src/test/java/org/rocksdb/MergeTest.java
+++ b/java/src/test/java/org/rocksdb/MergeTest.java
@@ -5,17 +5,17 @@
 
 package org.rocksdb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ArrayList;
-
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MergeTest {
 
@@ -46,13 +46,13 @@ public class MergeTest {
   }
 
   private byte[] longToByteArray(long l) {
-    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
+    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN);
     buf.putLong(l);
     return buf.array();
   }
 
   private long longFromByteArray(byte[] a) {
-    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
+    ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.LITTLE_ENDIAN);
     buf.put(a);
     buf.flip();
     return buf.getLong();
@@ -144,14 +144,13 @@ public class MergeTest {
           // writing (long)100 under key
           db.put(columnFamilyHandleList.get(1),
               "cfkey".getBytes(), longToByteArray(100));
-          // merge (long)1 under key
-          db.merge(columnFamilyHandleList.get(1),
-              "cfkey".getBytes(), longToByteArray(1));
+          // merge (long)157 under key
+          db.merge(columnFamilyHandleList.get(1), "cfkey".getBytes(), longToByteArray(157));
 
           byte[] value = db.get(columnFamilyHandleList.get(1),
               "cfkey".getBytes());
           long longValue = longFromByteArray(value);
-          assertThat(longValue).isEqualTo(101);
+          assertThat(longValue).isEqualTo(257);
         } finally {
           for (final ColumnFamilyHandle handle : columnFamilyHandleList) {
             handle.close();


### PR DESCRIPTION
The PR fixes a Java test for Merge operator `uint64add`.

The current implementation uses wrong byte order for long serialization, but fails to catch this error because the merge sum is lower than `256`.

The PR makes this test case more representative (i.e. it fails with wrong byte order) and changes the byte order to little endian.

Some background: RocksDB uses LittleEndian byte order for integer serialization across all platforms. `MergeTest` uses `ByteBuffer` that defaults to BigEndian byte order.

This test case might probably be used as a sample of `MergeOperator` usage in Java.