### PR TITLE
Generate and install a pkg-config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 make_config.mk
+rocksdb.pc
 
 *.a
 *.arc

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ dummy := $(shell (export ROCKSDB_ROOT="$(CURDIR)"; \
 include make_config.mk
 
 export JAVAC_ARGS
-CLEAN_FILES += make_config.mk
+CLEAN_FILES += make_config.mk rocksdb.pc
 
 ifeq ($(V), 1)
 $(info $(shell uname -a))
@@ -725,7 +725,7 @@ endif  # PLATFORM_SHARED_EXT
 
 .PHONY: blackbox_crash_test check clean coverage crash_test ldb_tests package \
 	release tags tags0 valgrind_check whitebox_crash_test format static_lib shared_lib all \
-	dbg rocksdbjavastatic rocksdbjava install install-static install-shared uninstall \
+	dbg rocksdbjavastatic rocksdbjava gen-pc install install-static install-shared uninstall \
 	analyze tools tools_lib \
 	blackbox_crash_test_with_atomic_flush whitebox_crash_test_with_atomic_flush  \
 	blackbox_crash_test_with_txn whitebox_crash_test_with_txn \
@@ -1824,16 +1824,19 @@ uninstall:
 	  $(INSTALL_PATH)/lib/$(SHARED4) \
 	  $(INSTALL_PATH)/lib/$(SHARED3) \
 	  $(INSTALL_PATH)/lib/$(SHARED2) \
-	  $(INSTALL_PATH)/lib/$(SHARED1)
+	  $(INSTALL_PATH)/lib/$(SHARED1) \
+	  $(INSTALL_PATH)/lib/pkgconfig/rocksdb.pc
 
-install-headers:
+install-headers: gen-pc
 	install -d $(INSTALL_PATH)/lib
+	install -d $(INSTALL_PATH)/lib/pkgconfig
 	for header_dir in `$(FIND) "include/rocksdb" -type d`; do \
 		install -d $(INSTALL_PATH)/$$header_dir; \
 	done
 	for header in `$(FIND) "include/rocksdb" -type f -name *.h`; do \
 		install -C -m 644 $$header $(INSTALL_PATH)/$$header; \
 	done
+	install -C -m 644 rocksdb.pc $(INSTALL_PATH)/lib/pkgconfig/rocksdb.pc
 
 install-static: install-headers $(LIBRARY)
 	install -C -m 755 $(LIBRARY) $(INSTALL_PATH)/lib
@@ -1847,6 +1850,20 @@ install-shared: install-headers $(SHARED4)
 # install static by default + install shared if it exists
 install: install-static
 	[ -e $(SHARED4) ] && $(MAKE) install-shared || :
+
+# Generate the pkg-config file
+gen-pc:
+	-echo 'prefix=$(INSTALL_PATH)' > rocksdb.pc
+	-echo 'exec_prefix=$${prefix}' >> rocksdb.pc
+	-echo 'includedir=$${prefix}/include' >> rocksdb.pc
+	-echo 'libdir=$${exec_prefix}/lib' >> rocksdb.pc
+	-echo '' >> rocksdb.pc
+	-echo 'Name: rocksdb' >> rocksdb.pc
+	-echo 'Description: An embeddable persistent key-value store for fast storage' >> rocksdb.pc
+	-echo Version: $(shell ./build_tools/version.sh full) >> rocksdb.pc
+	-echo 'Libs: -L$${libdir} $(EXEC_LDFLAGS) -lrocksdb' >> rocksdb.pc
+	-echo 'Libs.private: $(PLATFORM_LDFLAGS)' >> rocksdb.pc
+	-echo 'Cflags: -I$${includedir} $(PLATFORM_CXXFLAGS)' >> rocksdb.pc
 
 #-------------------------------------------------
 


### PR DESCRIPTION
pkg-config files are quite useful for communicating to users of a
library how to compile against them. This commit generates and installs
a pkg-config file that can be used for both static and dynamic builds
against the RocksDB library. This should make life easier for developers
of client programs, language bindings, etc.

Example usage:

```
g++ `pkg-config --cflags rocksdb` -o simple_example simple_example.cc `pkg-config --libs rocksdb`

g++ `pkg-config --cflags --static rocksdb` -static \
   -o simple_example simple_example.cc `pkg-config --libs --static rocksdb`
```

The commit also adds the generated file to .gitignore, to the uninstall
target, and to clean.

No additional dependencies are added to RocksDB itself, and this does
not make RocksDB use pkg-config as part of its build process.

Resolves https://github.com/facebook/rocksdb/issues/4452