### PR TITLE
Fix potential memory leak

### DIFF
--- a/util/timer_test.cc
+++ b/util/timer_test.cc
@@ -289,7 +289,6 @@ TEST_F(TimerTest, CancelRunningTask) {
   Timer timer(mock_env_.get());
   ASSERT_TRUE(timer.Start());
   int* value = new int;
-  ASSERT_NE(nullptr, value);  // make linter happy
   *value = 0;
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->LoadDependency({
@@ -337,7 +336,6 @@ TEST_F(TimerTest, ShutdownRunningTask) {
   ASSERT_TRUE(timer.Start());
 
   int* value = new int;
-  ASSERT_NE(nullptr, value);
   *value = 0;
   timer.Add(
       [&]() {


### PR DESCRIPTION
```
int* value = new int;
ASSERT_NE(nullptr, value);
```
`ASSERT_NE` can expand the expression such that a memory leak is
reported by clang analyzer.
We can remove this ASSERT_NE since we can assume the memory allocation
must succeed. Otherwise a bad alloc exception will be thrown and the
process will be killed anyway.

Test plan (dev server):
```
USE_CLANG=1 make analyze
```