### PR TITLE
Track WAL in MANIFEST: track obsolete WALs in MANIFEST during flush

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -21,11 +21,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 uint64_t DBImpl::MinLogNumberToKeep() {
-  if (allow_2pc()) {
-    return versions_->min_log_number_to_keep_2pc();
-  } else {
-    return versions_->MinLogNumberWithUnflushedData();
-  }
+  return versions_->MinLogNumberToKeep();
 }
 
 uint64_t DBImpl::MinObsoleteSstNumberToKeep() {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1107,6 +1107,17 @@ class VersionSet {
   uint64_t MinLogNumberWithUnflushedData() const {
     return PreComputeMinLogNumberWithUnflushedData(nullptr);
   }
+
+  // In either 2PC or non-2PC mode, logs with number smaller than the
+  // returned value can be deleted.
+  uint64_t MinLogNumberToKeep() const {
+    if (db_options_->allow_2pc) {
+      return min_log_number_to_keep_2pc();
+    } else {
+      return MinLogNumberWithUnflushedData();
+    }
+  }
+
   // Returns the minimum log number which still has data not flushed to any SST
   // file, except data from `cfd_to_skip`.
   uint64_t PreComputeMinLogNumberWithUnflushedData(


### PR DESCRIPTION
After flushing a column family, compute the WALs that can be ignored and track them in MANIFEST.

So the WAL information in MANIFEST is the source of truth for logically alive WALs. If a WAL is obsolete, it will be deleted from `VersionSet::wals_`, but the actual archival or deletion of the WAL is asynchronous and might not happen immediately.

Test Plan:
will add tests after merging #7256.