### PR TITLE
[cmake] db_bench should be linked with thirdparty libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1245,7 +1245,7 @@ if(WITH_BENCHMARK_TOOLS)
     tools/db_bench.cc
     tools/db_bench_tool.cc)
   target_link_libraries(db_bench
-    ${ROCKSDB_LIB} ${GFLAGS_LIB})
+    ${ROCKSDB_LIB} ${THIRDPARTY_LIBS})
 
   add_executable(cache_bench
     cache/cache_bench.cc)


### PR DESCRIPTION
`db_bench` is not linked with thirdparty libs in cmake, even `-DWITH_*`
is specified.

Test Plan:
`$ mkdir build; cd build; cmake .. -DWITH_SNAPPY=1; make db_bench; ./db_bench`
`$ cmake .. -DWITH_SNAPPY=1 -DWITH_LZ4; make db_bench; ./db_bench -compression_type=lz4`