### PR TITLE
Update channel.h

### DIFF
--- a/util/channel.h
+++ b/util/channel.h
@@ -31,7 +31,7 @@ class channel {
     return buffer_.empty() && eof_;
   }
 
-  size_t size() const {
+  size_t size() {
     std::lock_guard<std::mutex> lk(lock_);
     return buffer_.size();
   }


### PR DESCRIPTION
Compiling this on FreeBSD with CLang fails due to:
```In file included from /usr/ports/net/ceph15/work/ceph-15.2.4/src/rocksdb/utilities/backupable/backupable_db.cc:16:
/usr/ports/net/ceph15/work/ceph-15.2.4/src/rocksdb/util/channel.h:35:33: error: no matching constructor for initialization of 'std::lock_guard<std::mutex>'
    std::lock_guard<std::mutex> lk(lock_);
                                ^  ~~~~~
/usr/include/c++/v1/__mutex_base:90:14: note: candidate constructor not viable: 1st argument ('const std::mutex') would lose const qualifier
    explicit lock_guard(mutex_type& __m) _LIBCPP_THREAD_SAFETY_ANNOTATION(acquire_capability(__m))
             ^
/usr/include/c++/v1/__mutex_base:100:5: note: candidate constructor not viable: no known conversion from 'const std::mutex' to 'const std::__1::lock_guard<std::__1::mutex>' for 1st argument
    lock_guard(lock_guard const&) _LIBCPP_EQUAL_DELETE;
    ^
/usr/include/c++/v1/__mutex_base:94:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    lock_guard(mutex_type& __m, adopt_lock_t) _LIBCPP_THREAD_SAFETY_ANNOTATION(requires_capability(__m))
    ^
1 error generated.
```