### PR TITLE
Support limiting write rate on range sync operation

### DIFF
--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -346,8 +346,8 @@ IOStatus WritableFileWriter::IncrementalSync() {
       }
       s = RangeSync(pos, allowed);
       if (s.ok()) {
-        last_sync_size_ = pos;
         pos += allowed;
+        last_sync_size_ = pos;
       } else {
         break;
       }

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -345,10 +345,9 @@ IOStatus WritableFileWriter::IncrementalSync() {
         allowed = offset_sync_to - pos;
       }
       s = RangeSync(pos, allowed);
-      if (s.ok()) {
-        pos += allowed;
-        last_sync_size_ = pos;
-      } else {
+      pos += allowed;
+      last_sync_size_ = pos;
+      if (!s.ok()) {
         break;
       }
     }

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -65,7 +65,7 @@ IOStatus WritableFileWriter::Append(const Slice& data) {
     if (left > 0) {
       s = Flush();
       if (!s.ok()) {
-        break;
+        return s;
       }
     }
     if (!use_direct_io() && left >= buf_.Capacity()) {
@@ -240,7 +240,7 @@ IOStatus WritableFileWriter::Flush() {
   }
 
   if (!use_direct_io()) {
-    IncrementalSync();
+    s = IncrementalSync();
   }
 
   return s;

--- a/file/writable_file_writer.cc
+++ b/file/writable_file_writer.cc
@@ -41,7 +41,8 @@ IOStatus WritableFileWriter::Append(const Slice& data) {
   }
 
   // See whether we need to enlarge the buffer to avoid the flush
-  if (buf_.Capacity() - buf_.CurrentSize() < left) {
+  size_t total = left + buf_.CurrentSize();
+  if (buf_.Capacity() < total && max_buffer_size_ >= total) {
     for (size_t cap = buf_.Capacity();
          cap < max_buffer_size_;  // There is still room to increase
          cap *= 2) {
@@ -56,37 +57,25 @@ IOStatus WritableFileWriter::Append(const Slice& data) {
     }
   }
 
-  // Flush only when buffered I/O
-  if (!use_direct_io() && (buf_.Capacity() - buf_.CurrentSize()) < left) {
-    if (buf_.CurrentSize() > 0) {
+  while (left > 0) {
+    size_t appended = buf_.Append(src, left);
+    left -= appended;
+    src += appended;
+
+    if (left > 0) {
       s = Flush();
       if (!s.ok()) {
-        return s;
+        break;
       }
     }
-    assert(buf_.CurrentSize() == 0);
-  }
-
-  // We never write directly to disk with direct I/O on.
-  // or we simply use it for its original purpose to accumulate many small
-  // chunks
-  if (use_direct_io() || (buf_.Capacity() >= left)) {
-    while (left > 0) {
-      size_t appended = buf_.Append(src, left);
-      left -= appended;
-      src += appended;
-
-      if (left > 0) {
-        s = Flush();
-        if (!s.ok()) {
-          break;
-        }
+    if (!use_direct_io() && left >= buf_.Capacity()) {
+      assert(buf_.CurrentSize() == 0);
+      s = WriteBuffered(src, left);
+      if (s.ok()) {
+        s = IncrementalSync();
       }
+      left = 0;
     }
-  } else {
-    // Writing directly to file bypassing the buffer
-    assert(buf_.CurrentSize() == 0);
-    s = WriteBuffered(src, left);
   }
 
   TEST_KILL_RANDOM("WritableFileWriter::Append:1", rocksdb_kill_odds);
@@ -250,31 +239,8 @@ IOStatus WritableFileWriter::Flush() {
     return s;
   }
 
-  // sync OS cache to disk for every bytes_per_sync_
-  // TODO: give log file and sst file different options (log
-  // files could be potentially cached in OS for their whole
-  // life time, thus we might not want to flush at all).
-
-  // We try to avoid sync to the last 1MB of data. For two reasons:
-  // (1) avoid rewrite the same page that is modified later.
-  // (2) for older version of OS, write can block while writing out
-  //     the page.
-  // Xfs does neighbor page flushing outside of the specified ranges. We
-  // need to make sure sync range is far from the write offset.
-  if (!use_direct_io() && bytes_per_sync_) {
-    const uint64_t kBytesNotSyncRange =
-        1024 * 1024;                                // recent 1MB is not synced.
-    const uint64_t kBytesAlignWhenSync = 4 * 1024;  // Align 4KB.
-    if (filesize_ > kBytesNotSyncRange) {
-      uint64_t offset_sync_to = filesize_ - kBytesNotSyncRange;
-      offset_sync_to -= offset_sync_to % kBytesAlignWhenSync;
-      assert(offset_sync_to >= last_sync_size_);
-      if (offset_sync_to > 0 &&
-          offset_sync_to - last_sync_size_ >= bytes_per_sync_) {
-        s = RangeSync(last_sync_size_, offset_sync_to - last_sync_size_);
-        last_sync_size_ = offset_sync_to;
-      }
-    }
+  if (!use_direct_io()) {
+    IncrementalSync();
   }
 
   return s;
@@ -352,6 +318,33 @@ IOStatus WritableFileWriter::SyncInternal(bool use_fsync) {
   }
 #endif
   SetPerfLevel(prev_perf_level);
+  return s;
+}
+
+IOStatus WritableFileWriter::IncrementalSync() {
+  // TODO: give log file and sst file different options (log
+  // files could be potentially cached in OS for their whole
+  // life time, thus we might not want to flush at all).
+
+  // We try to avoid sync to the last 1MB of data. For two reasons:
+  // (1) avoid rewrite the same page that is modified later.
+  // (2) for older version of OS, write can block while writing out
+  //     the page.
+  // Xfs does neighbor page flushing outside of the specified ranges. We
+  // need to make sure sync range is far from the write offset.
+  const uint64_t kBytesNotSyncRange = 1024 * 1024;  // recent 1MB is not synced.
+  const uint64_t kBytesAlignWhenSync = 4 * 1024;    // Align 4KB.
+  IOStatus s;
+  if (bytes_per_sync_ && filesize_ > kBytesNotSyncRange) {
+    uint64_t offset_sync_to = filesize_ - kBytesNotSyncRange;
+    offset_sync_to -= offset_sync_to % kBytesAlignWhenSync;
+    assert(offset_sync_to >= last_sync_size_);
+    if (offset_sync_to > 0 &&
+        offset_sync_to - last_sync_size_ >= bytes_per_sync_) {
+      s = RangeSync(last_sync_size_, offset_sync_to - last_sync_size_);
+      last_sync_size_ = offset_sync_to;
+    }
+  }
   return s;
 }
 

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -135,6 +135,7 @@ class WritableFileWriter {
   uint64_t last_sync_size_;
   uint64_t bytes_per_sync_;
   RateLimiter* rate_limiter_;
+  bool strict_write_limit_;
   Statistics* stats_;
   std::vector<std::shared_ptr<EventListener>> listeners_;
   std::unique_ptr<FileChecksumGenerator> checksum_generator_;
@@ -160,6 +161,7 @@ class WritableFileWriter {
         last_sync_size_(0),
         bytes_per_sync_(options.bytes_per_sync),
         rate_limiter_(options.rate_limiter),
+        strict_write_limit_(options.strict_write_limit),
         stats_(stats),
         listeners_(),
         checksum_generator_(nullptr),

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -242,6 +242,8 @@ class WritableFileWriter {
 #endif  // !ROCKSDB_LITE
   // Normal write
   IOStatus WriteBuffered(const char* data, size_t size);
+  // sync OS cache to disk for every bytes_per_sync_
+  IOStatus IncrementalSync();
   IOStatus RangeSync(uint64_t offset, uint64_t nbytes);
   IOStatus SyncInternal(bool use_fsync);
 };

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -136,6 +136,11 @@ struct EnvOptions {
 
   // If not nullptr, write rate limiting is enabled for flush and compaction
   RateLimiter* rate_limiter = nullptr;
+
+  // If true, rate limiter (if provided) is applied to file sync operation.
+  // If false, it's applied to buffered write operation.
+  // Default: false
+  bool strict_write_limit = false;
 };
 
 class Env {


### PR DESCRIPTION
In our production environment in use of RocksDB, existing rate limiter occasionally fails to regulate disk IO flow and causes performance jitter. To address this issue, this PR directly applies rate limiter to periodical file synchronization instead of buffered `write()` operation. This change partially breaks the guarantee from `bytes_per_sync` option, since now sync size is determined by token size of rate limiter.

P.S. code is based on a previous [PR](https://github.com/facebook/rocksdb/pull/7221)  which includes some bugfix for existing range sync logic.