### PR TITLE
fix doc about kTolerateCorruptedTailRecords recovery

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -303,8 +303,18 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
 
 enum class WALRecoveryMode : char {
   // Original levelDB recovery
-  // We tolerate incomplete record in trailing data on all logs
-  // Use case : This is legacy behavior
+  //
+  // We tolerate one incomplete record caused by crash in the trailing data of
+  // any log. Zeroed bytes from preallocation are also tolerated in the trailing
+  // data of any log.
+  //
+  // Use case : Applications for which updates, once applied, must not be rolled
+  // back even after a crash-recovery. By default RocksDB guarantees this as
+  // long as `WritableFile::Append()` writes are durable. In case the user needs
+  // the guarantee in more situations (e.g., when `WritableFile::Append()`
+  // writes to page cache, but the user desires this guarantee in face of power-
+  // loss crash-recovery), RocksDB offers various mechanisms to additionally
+  // invoke `WritableFile::Sync()` in order to strengthen the guarantee.
   kTolerateCorruptedTailRecords = 0x00,
   // Recover from clean shutdown
   // We don't expect to find any corruption in the WAL

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -315,6 +315,11 @@ enum class WALRecoveryMode : char {
   // writes to page cache, but the user desires this guarantee in face of power-
   // loss crash-recovery), RocksDB offers various mechanisms to additionally
   // invoke `WritableFile::Sync()` in order to strengthen the guarantee.
+  //
+  // This differs from kPointInTimeRecovery in that, in case a corruption is
+  // detected during recovery, this mode will refuse to open the DB. Whereas,
+  // kPointInTimeRecovery will stop recovery just before the corruption since
+  // that is a valid point-in-time to which to recover.
   kTolerateCorruptedTailRecords = 0x00,
   // Recover from clean shutdown
   // We don't expect to find any corruption in the WAL

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -304,21 +304,22 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
 enum class WALRecoveryMode : char {
   // Original levelDB recovery
   //
-  // We tolerate one incomplete record caused by crash in the trailing data of
-  // any log. Zeroed bytes from preallocation are also tolerated in the trailing
-  // data of any log.
+  // We tolerate the last record in any log to be incomplete due to a crash
+  // while writing it. Zeroed bytes from preallocation are also tolerated in the
+  // trailing data of any log.
   //
-  // Use case : Applications for which updates, once applied, must not be rolled
-  // back even after a crash-recovery. By default RocksDB guarantees this as
-  // long as `WritableFile::Append()` writes are durable. In case the user needs
-  // the guarantee in more situations (e.g., when `WritableFile::Append()`
-  // writes to page cache, but the user desires this guarantee in face of power-
-  // loss crash-recovery), RocksDB offers various mechanisms to additionally
-  // invoke `WritableFile::Sync()` in order to strengthen the guarantee.
+  // Use case: Applications for which updates, once applied, must not be rolled
+  // back even after a crash-recovery. In this recovery mode, RocksDB guarantees
+  // this as long as `WritableFile::Append()` writes are durable. In case the
+  // user needs the guarantee in more situations (e.g., when
+  // `WritableFile::Append()` writes to page cache, but the user desires this
+  // guarantee in face of power-loss crash-recovery), RocksDB offers various
+  // mechanisms to additionally invoke `WritableFile::Sync()` in order to
+  // strengthen the guarantee.
   //
-  // This differs from kPointInTimeRecovery in that, in case a corruption is
+  // This differs from `kPointInTimeRecovery` in that, in case a corruption is
   // detected during recovery, this mode will refuse to open the DB. Whereas,
-  // kPointInTimeRecovery will stop recovery just before the corruption since
+  // `kPointInTimeRecovery` will stop recovery just before the corruption since
   // that is a valid point-in-time to which to recover.
   kTolerateCorruptedTailRecords = 0x00,
   // Recover from clean shutdown


### PR DESCRIPTION
- Made it clear only one record in the tail is allowed to have a problem
- Added detail about the valid use case instead of calling it legacy behavior

