### PR TITLE
Build blob file reader/writer classes in LITE mode as well

### DIFF
--- a/db/blob/blob_index.h
+++ b/db/blob/blob_index.h
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
-#ifndef ROCKSDB_LITE
 
 #include <sstream>
 #include <string>
@@ -176,4 +175,3 @@ class BlobIndex {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -3,8 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
-#ifndef ROCKSDB_LITE
-
 #include "db/blob/blob_log_format.h"
 
 #include "util/coding.h"
@@ -144,4 +142,3 @@ Status BlobLogRecord::CheckBlobCRC() const {
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -3,6 +3,7 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
+
 #include "db/blob/blob_log_format.h"
 
 #include "util/coding.h"

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifndef ROCKSDB_LITE
-
 #include <memory>
 #include <utility>
 
@@ -126,4 +124,3 @@ struct BlobLogRecord {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_reader.cc
+++ b/db/blob/blob_log_reader.cc
@@ -3,7 +3,6 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
-#ifndef ROCKSDB_LITE
 
 #include "db/blob/blob_log_reader.h"
 
@@ -102,4 +101,3 @@ Status BlobLogReader::ReadRecord(BlobLogRecord* record, ReadLevel level,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_reader.h
+++ b/db/blob/blob_log_reader.h
@@ -5,8 +5,6 @@
 //
 #pragma once
 
-#ifndef ROCKSDB_LITE
-
 #include <memory>
 #include <string>
 
@@ -77,4 +75,3 @@ class BlobLogReader {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_writer.cc
+++ b/db/blob/blob_log_writer.cc
@@ -2,6 +2,7 @@
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
+
 #include "db/blob/blob_log_writer.h"
 
 #include <cstdint>

--- a/db/blob/blob_log_writer.cc
+++ b/db/blob/blob_log_writer.cc
@@ -2,8 +2,6 @@
 //  This source code is licensed under both the GPLv2 (found in the
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
-#ifndef ROCKSDB_LITE
-
 #include "db/blob/blob_log_writer.h"
 
 #include <cstdint>
@@ -139,4 +137,3 @@ Status BlobLogWriter::EmitPhysicalRecord(const std::string& headerbuf,
 }
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/blob/blob_log_writer.h
+++ b/db/blob/blob_log_writer.h
@@ -4,8 +4,6 @@
 //  (found in the LICENSE.Apache file in the root directory).
 #pragma once
 
-#ifndef ROCKSDB_LITE
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -82,4 +80,3 @@ class BlobLogWriter {
 };
 
 }  // namespace ROCKSDB_NAMESPACE
-#endif  // ROCKSDB_LITE

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -179,7 +179,6 @@ TEST_F(FlushJobTest, NonEmpty) {
     inserted_keys.insert({internal_key.Encode().ToString(), "9999a"});
   }
 
-#ifndef ROCKSDB_LITE
   // Note: the first two blob references will not be considered when resolving
   // the oldest blob file referenced (the first one is inlined TTL, while the
   // second one is TTL and thus points to a TTL blob file).
@@ -208,7 +207,6 @@ TEST_F(FlushJobTest, NonEmpty) {
     inserted_keys.emplace_hint(inserted_keys.end(),
                                internal_key.Encode().ToString(), blob_index);
   }
-#endif
 
   autovector<MemTable*> to_delete;
   cfd->imm()->Add(new_mem, &to_delete);
@@ -239,12 +237,8 @@ TEST_F(FlushJobTest, NonEmpty) {
   ASSERT_EQ(ToString(0), file_meta.smallest.user_key().ToString());
   ASSERT_EQ("9999a", file_meta.largest.user_key().ToString());
   ASSERT_EQ(1, file_meta.fd.smallest_seqno);
-#ifndef ROCKSDB_LITE
   ASSERT_EQ(10006, file_meta.fd.largest_seqno);
   ASSERT_EQ(17, file_meta.oldest_blob_file_number);
-#else
-  ASSERT_EQ(10000, file_meta.fd.largest_seqno);
-#endif
   mock_table_factory_->AssertSingleFile(inserted_keys);
   job_context.Clean();
 }

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -38,7 +38,6 @@ void FileMetaData::UpdateBoundaries(const Slice& key, const Slice& value,
   fd.smallest_seqno = std::min(fd.smallest_seqno, seqno);
   fd.largest_seqno = std::max(fd.largest_seqno, seqno);
 
-#ifndef ROCKSDB_LITE
   if (value_type == kTypeBlobIndex) {
     BlobIndex blob_index;
     const Status s = blob_index.DecodeFrom(value);
@@ -65,10 +64,6 @@ void FileMetaData::UpdateBoundaries(const Slice& key, const Slice& value,
       oldest_blob_file_number = blob_index.file_number();
     }
   }
-#else
-  (void)value;
-  (void)value_type;
-#endif
 }
 
 void VersionEdit::Clear() {


### PR DESCRIPTION
Summary:
The patch makes sure that the functionality required for the new integrated
BlobDB implementation (most importantly, the classes related to reading and
writing blob files) is also built in LITE mode by removing the corresponding
`#ifndef`s.

Test Plan:
Ran `make check` in both regular and LITE mode.