### PR TITLE
Add missing ComputeCompactionScore() for a new universal manual compaction

### DIFF
--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -639,6 +639,7 @@ Compaction* CompactionPicker::CompactRange(
         compact_range_options.max_subcompactions, /* grandparents */ {},
         /* is manual */ true);
     RegisterCompaction(c);
+    vstorage->ComputeCompactionScore(ioptions_, mutable_cf_options);
     return c;
   }
 


### PR DESCRIPTION
Seems it's only causing assert failure during compaction pick, but in production code, the problematic compactions are excluded at a later step.