### PR TITLE
Fix for Regression failure

### DIFF
--- a/build_tools/rocksdb-lego-determinator
+++ b/build_tools/rocksdb-lego-determinator
@@ -1101,6 +1101,7 @@ run_regression()
   strip librocksdb.a
   send_size_to_ods static_lib_stripped $(stat --printf="%s" librocksdb.a)
 
+  make clean
   make -j$(nproc) shared_lib
   send_size_to_ods shared_lib $(stat --printf="%s" `readlink -f librocksdb.so`)
   strip `readlink -f librocksdb.so`
@@ -1113,6 +1114,7 @@ run_regression()
   strip librocksdb.a
   send_size_to_ods static_lib_lite_stripped $(stat --printf="%s" librocksdb.a)
 
+  make clean
   make LITE=1 -j$(nproc) shared_lib
   send_size_to_ods shared_lib_lite $(stat --printf="%s" `readlink -f librocksdb.so`)
   strip `readlink -f librocksdb.so`


### PR DESCRIPTION
Summary: RocksDb regression commands are exiting with error
/usr/bin/ar: creating
librocksdb.a
/usr/bin/ld: ./cache/cache.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC

Bug: It tries to link the static code into a shared lib.
Fix: Added make clean before building shared_lib

Test Plan: make clean
           make -j$(nproc) static_lib
           make -j$(nproc) shared_lib

Reviewers:

Subscribers:

Tasks:

Tags: