### PR TITLE
Make examples work on Windows

### DIFF
--- a/examples/c_simple_example.c
+++ b/examples/c_simple_example.c
@@ -10,18 +10,35 @@
 
 #include "rocksdb/c.h"
 
+#if defined(OS_WIN)
+#include <Windows.h>
+#else
 #include <unistd.h>  // sysconf() - get CPU count
+#endif
 
-const char DBPath[] = "/tmp/rocksdb_simple_example";
-const char DBBackupPath[] = "/tmp/rocksdb_simple_example_backup";
+#if defined(OS_WIN)
+const char DBPath[] = "C:\\Windows\\TEMP\\rocksdb_c_simple_example";
+const char DBBackupPath[] =
+    "C:\\Windows\\TEMP\\rocksdb_c_simple_example_backup";
+#else
+const char DBPath[] = "/tmp/rocksdb_c_simple_example";
+const char DBBackupPath[] = "/tmp/rocksdb_c_simple_example_backup";
+#endif
 
 int main(int argc, char **argv) {
   rocksdb_t *db;
   rocksdb_backup_engine_t *be;
   rocksdb_options_t *options = rocksdb_options_create();
   // Optimize RocksDB. This is the easiest way to
-  // get RocksDB to perform well
-  long cpus = sysconf(_SC_NPROCESSORS_ONLN);  // get # of online cores
+  // get RocksDB to perform well.
+#if defined(OS_WIN)
+  SYSTEM_INFO system_info;
+  GetSystemInfo(&system_info);
+  long cpus = system_info.dwNumberOfProcessors;
+#else
+  long cpus = sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+  // Set # of online cores
   rocksdb_options_increase_parallelism(options, (int)(cpus));
   rocksdb_options_optimize_level_style_compaction(options, 0);
   // create the DB if it's not already present

--- a/examples/column_families_example.cc
+++ b/examples/column_families_example.cc
@@ -12,7 +12,11 @@
 
 using namespace ROCKSDB_NAMESPACE;
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_column_families_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_column_families_example";
+#endif
 
 int main() {
   // open DB

--- a/examples/compact_files_example.cc
+++ b/examples/compact_files_example.cc
@@ -13,7 +13,13 @@
 #include "rocksdb/options.h"
 
 using namespace ROCKSDB_NAMESPACE;
+
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_compact_files_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_compact_files_example";
+#endif
+
 struct CompactionTask;
 
 // This is an example interface of external-compaction algorithm.

--- a/examples/compaction_filter_example.cc
+++ b/examples/compaction_filter_example.cc
@@ -54,22 +54,30 @@ class MyFilter : public ROCKSDB_NAMESPACE::CompactionFilter {
   mutable int merge_count_ = 0;
 };
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksmergetest";
+std::string kRemoveDirCommand = "rmdir /Q /S ";
+#else
+std::string kDBPath = "/tmp/rocksmergetest";
+std::string kRemoveDirCommand = "rm -rf ";
+#endif
+
 int main() {
   ROCKSDB_NAMESPACE::DB* raw_db;
   ROCKSDB_NAMESPACE::Status status;
 
   MyFilter filter;
 
-  int ret = system("rm -rf /tmp/rocksmergetest");
+  std::string rm_cmd = kRemoveDirCommand + kDBPath;
+  int ret = system(rm_cmd.c_str());
   if (ret != 0) {
-    fprintf(stderr, "Error deleting /tmp/rocksmergetest, code: %d\n", ret);
-    return ret;
+    fprintf(stderr, "Error deleting %s, code: %d\n", kDBPath.c_str(), ret);
   }
   ROCKSDB_NAMESPACE::Options options;
   options.create_if_missing = true;
   options.merge_operator.reset(new MyMerge);
   options.compaction_filter = &filter;
-  status = ROCKSDB_NAMESPACE::DB::Open(options, "/tmp/rocksmergetest", &raw_db);
+  status = ROCKSDB_NAMESPACE::DB::Open(options, kDBPath, &raw_db);
   assert(status.ok());
   std::unique_ptr<ROCKSDB_NAMESPACE::DB> db(raw_db);
 

--- a/examples/multi_processes_example.cc
+++ b/examples/multi_processes_example.cc
@@ -23,6 +23,8 @@
 #include <thread>
 #include <vector>
 
+// TODO: port this example to other systems. It should be straightforward for
+// POSIX-compliant systems.
 #if defined(OS_LINUX)
 #include <dirent.h>
 #include <signal.h>
@@ -30,7 +32,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#endif  // !OS_LINUX
 
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
@@ -136,9 +137,6 @@ static Slice GenerateRandomValue(const size_t max_length, char scratch[]) {
 
 static bool ShouldCloseDB() { return true; }
 
-// TODO: port this example to other systems. It should be straightforward for
-// POSIX-compliant systems.
-#if defined(OS_LINUX)
 void CreateDB() {
   long my_pid = static_cast<long>(getpid());
   Options options;
@@ -389,7 +387,7 @@ int main(int argc, char** argv) {
 }
 #else   // OS_LINUX
 int main() {
-  fpritnf(stderr, "Not implemented.\n");
+  fprintf(stderr, "Not implemented.\n");
   return 0;
 }
 #endif  // !OS_LINUX

--- a/examples/optimistic_transaction_example.cc
+++ b/examples/optimistic_transaction_example.cc
@@ -13,7 +13,11 @@
 
 using namespace ROCKSDB_NAMESPACE;
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_transaction_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_transaction_example";
+#endif
 
 int main() {
   // open DB

--- a/examples/options_file_example.cc
+++ b/examples/options_file_example.cc
@@ -20,7 +20,11 @@
 
 using namespace ROCKSDB_NAMESPACE;
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_options_file_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_options_file_example";
+#endif
 
 namespace {
 // A dummy compaction filter

--- a/examples/simple_example.cc
+++ b/examples/simple_example.cc
@@ -12,7 +12,11 @@
 
 using namespace ROCKSDB_NAMESPACE;
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_simple_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_simple_example";
+#endif
 
 int main() {
   DB* db;

--- a/examples/transaction_example.cc
+++ b/examples/transaction_example.cc
@@ -13,7 +13,11 @@
 
 using namespace ROCKSDB_NAMESPACE;
 
+#if defined(OS_WIN)
+std::string kDBPath = "C:\\Windows\\TEMP\\rocksdb_transaction_example";
+#else
 std::string kDBPath = "/tmp/rocksdb_transaction_example";
+#endif
 
 int main() {
   // open DB


### PR DESCRIPTION
Quick fixes to examples to make it easier to get familiar with RocksDB for Windows users:

- Set proper temporary directory path on Windows for all examples (with C++17 we should start using std::filesystem)
- Fixed typo and got rid of warnings treated as errors in multi_processes_example.cc
- Get number of available cores on Windows in c_simple_example.c
- Add command to remove DB directory for Windows in compaction_filter_example.cc (print error, but carry on with example upon error, because error code is returned if there is no such directory on Windows)