### PR TITLE
Skip swaths of keys covered by range tombstones (2020 edition)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,9 @@
 * Introduce options.check_flush_compaction_key_order with default value to be true. With this option, during flush and compaction, key order will be checked when writing to each SST file. If the order is violated, the flush or compaction will fail.
 * Added is_full_compaction to CompactionJobStats, so that the information is available through the EventListener interface.
 
+### Performance Improvements
+* Upon encountering a range tombstone in forward or reverse iteration, seek directly to the end or beginning key, respectively, in LSM components older than the range tombstone. This saves key comparisons.
+
 ## 6.13 (09/12/2020)
 ### Bug fixes
 * Fix a performance regression introduced in 6.4 that makes a upper bound check for every Next() even if keys are within a data block that is within the upper bound.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1496,7 +1496,8 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
   MergeIteratorBuilder merge_iter_builder(
       &cfd->internal_comparator(), arena,
       !read_options.total_order_seek &&
-          super_version->mutable_cf_options.prefix_extractor != nullptr);
+          super_version->mutable_cf_options.prefix_extractor != nullptr,
+      range_del_agg);
   // Collect iterator for mutable mem
   merge_iter_builder.AddIterator(
       super_version->mem->NewIterator(read_options, arena));

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -1223,9 +1223,8 @@ void DBIter::Seek(const Slice& target) {
     PERF_TIMER_GUARD(seek_internal_seek_time);
 
     SetSavedKeyToSeekTarget(target);
-    iter_.Seek(saved_key_.GetInternalKey());
-
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.Seek(saved_key_.GetInternalKey());
     RecordTick(statistics_, NUMBER_DB_SEEK);
   }
   if (!iter_.Valid()) {
@@ -1292,8 +1291,8 @@ void DBIter::SeekForPrev(const Slice& target) {
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
     SetSavedKeyToSeekForPrevTarget(target);
-    iter_.SeekForPrev(saved_key_.GetInternalKey());
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekForPrev(saved_key_.GetInternalKey());
     RecordTick(statistics_, NUMBER_DB_SEEK);
   }
   if (!iter_.Valid()) {
@@ -1349,8 +1348,8 @@ void DBIter::SeekToFirst() {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.SeekToFirst();
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekToFirst();
   }
 
   RecordTick(statistics_, NUMBER_DB_SEEK);
@@ -1409,8 +1408,8 @@ void DBIter::SeekToLast() {
 
   {
     PERF_TIMER_GUARD(seek_internal_seek_time);
-    iter_.SeekToLast();
     range_del_agg_.InvalidateRangeDelMapPositions();
+    iter_.SeekToLast();
   }
   PrevInternal(nullptr);
   if (statistics_ != nullptr) {

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -968,7 +968,6 @@ TEST_F(DBRangeDelTest, IteratorRangeTombstoneOverlapsSstable) {
       uint64_t range_del_reseeks =
           get_perf_context()->internal_range_del_reseek_count;
       ASSERT_LT(prev_range_del_reseeks, range_del_reseeks);
-      prev_range_del_reseeks = range_del_reseeks;
     }
   }
 }

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -304,7 +304,8 @@ void ReverseRangeDelIterator::Invalidate() {
   inactive_iters_.clear();
 }
 
-void RangeDelAggregator::StripeRep::MoveForward(const ParsedInternalKey& parsed) {
+void RangeDelAggregator::StripeRep::MoveForward(
+    const ParsedInternalKey& parsed) {
   InvalidateReverseIter();
 
   // Pick up previously unseen iterators.
@@ -315,7 +316,8 @@ void RangeDelAggregator::StripeRep::MoveForward(const ParsedInternalKey& parsed)
   }
 }
 
-void RangeDelAggregator::StripeRep::MoveBackward(const ParsedInternalKey& parsed) {
+void RangeDelAggregator::StripeRep::MoveBackward(
+    const ParsedInternalKey& parsed) {
   InvalidateForwardIter();
 
   // Pick up previously unseen iterators.

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -349,7 +349,7 @@ bool RangeDelAggregator::StripeRep::ShouldDelete(
 PartialRangeTombstoneEndpoint RangeDelAggregator::StripeRep::GetEndpoint(
     const Slice& key, RangeDelPositioningMode mode) {
   ParsedInternalKey parsed_key;
-  if (!ParseInternalKey(key, &parsed_key)) {
+  if (!ParseInternalKey(key, &parsed_key).ok()) {
     assert(false);
     return PartialRangeTombstoneEndpoint(
         nullptr, static_cast<RangeDelPositioningMode>(0), 0);

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -16,7 +16,6 @@
 #include "db/compaction/compaction_iteration_stats.h"
 #include "db/dbformat.h"
 #include "db/pinned_iterators_manager.h"
-#include "db/range_del_aggregator.h"
 #include "db/range_tombstone_fragmenter.h"
 #include "db/version_edit.h"
 #include "rocksdb/comparator.h"

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -187,9 +187,8 @@ void VerifyGetEndpoint(ReadRangeDelAggregator* range_del_agg,
         test_case.result.endpoint, RangeDelPositioningMode::kForwardTraversal,
         test_case.result.seqno);
     VerifyPartialTombstonesEq(
-        expected,
-        range_del_agg->GetEndpoint(key,
-                                   RangeDelPositioningMode::kForwardTraversal));
+        expected, range_del_agg->GetEndpoint(
+                      key, RangeDelPositioningMode::kForwardTraversal));
   }
   for (auto it = test_cases.rbegin(); it != test_cases.rend(); ++it) {
     const auto& test_case = *it;
@@ -200,9 +199,8 @@ void VerifyGetEndpoint(ReadRangeDelAggregator* range_del_agg,
         RangeDelPositioningMode::kBackwardTraversal,
         test_case.reverse_result.seqno);
     VerifyPartialTombstonesEq(
-        expected,
-        range_del_agg->GetEndpoint(
-            key, RangeDelPositioningMode::kBackwardTraversal));
+        expected, range_del_agg->GetEndpoint(
+                      key, RangeDelPositioningMode::kBackwardTraversal));
   }
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1109,7 +1109,7 @@ void LevelIterator::Seek(const Slice& target) {
 
 void LevelIterator::SeekIfSeqnoSmaller(const Slice& target,
                                        SequenceNumber limit) {
-  uint32_t prev_file_index = flevel_->num_files;
+  size_t prev_file_index = flevel_->num_files;
   while (Valid() && prev_file_index != file_index_ &&
          flevel_->files[file_index_].fd.largest_seqno < limit) {
     prev_file_index = file_index_;
@@ -1137,7 +1137,7 @@ void LevelIterator::SeekForPrev(const Slice& target) {
 
 void LevelIterator::SeekForPrevIfSeqnoSmaller(const Slice& target,
                                               SequenceNumber limit) {
-  uint32_t prev_file_index = flevel_->num_files;
+  size_t prev_file_index = flevel_->num_files;
   while (Valid() && prev_file_index != file_index_ &&
          flevel_->files[file_index_].fd.largest_seqno < limit) {
     prev_file_index = file_index_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1113,7 +1113,7 @@ void LevelIterator::SeekIfSeqnoSmaller(const Slice& target,
   while (Valid() && prev_file_index != file_index_ &&
          flevel_->files[file_index_].fd.largest_seqno < limit) {
     prev_file_index = file_index_;
-    file_iter_.Seek(target);
+    file_iter_.SeekIfSeqnoSmaller(target, limit);
     SkipEmptyFileForward();
   }
   // Unlike the `Seek*()` APIs exposed to users, the iterator should not be
@@ -1141,7 +1141,7 @@ void LevelIterator::SeekForPrevIfSeqnoSmaller(const Slice& target,
   while (Valid() && prev_file_index != file_index_ &&
          flevel_->files[file_index_].fd.largest_seqno < limit) {
     prev_file_index = file_index_;
-    file_iter_.SeekForPrev(target);
+    file_iter_.SeekForPrevIfSeqnoSmaller(target, limit);
     SkipEmptyFileBackward();
     if (!Valid()) {
       break;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1359,7 +1359,8 @@ enum {
   rocksdb_env_lock_file_nanos,
   rocksdb_env_unlock_file_nanos,
   rocksdb_env_new_logger_nanos,
-  rocksdb_total_metric_count = 68
+  rocksdb_internal_range_del_reseek_count,
+  rocksdb_total_metric_count = 69
 };
 
 extern ROCKSDB_LIBRARY_API void rocksdb_set_perf_level(int);

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -114,6 +114,10 @@ struct PerfContext {
   // How many values were fed into merge operator by iterators.
   //
   uint64_t internal_merge_count;
+  // Number of times we reseeked inside a table iterator, specifically to skip
+  // after or before a range of keys covered by a range deletion in a newer LSM
+  // component.
+  uint64_t internal_range_del_reseek_count;
 
   uint64_t get_snapshot_time;        // total nanos spent on getting snapshot
   uint64_t get_from_memtable_time;   // total nanos spent on querying memtables

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -179,9 +179,15 @@ enum Tickers : uint32_t {
   BLOOM_FILTER_PREFIX_CHECKED,
   BLOOM_FILTER_PREFIX_USEFUL,
 
-  // Number of times we had to reseek inside an iteration to skip
-  // over large number of keys with same userkey.
+  // Number of times we had to reseek inside an iteration. This could be due to
+  // range deletion (see below stat), or seeking over many versions of the same
+  // user key.
   NUMBER_OF_RESEEKS_IN_ITERATION,
+
+  // Number of times we had to reseek inside an iteration, specifically to skip
+  // after or before a range of keys covered by a range deletion in a newer LSM
+  // component.
+  NUMBER_OF_RANGE_DEL_RESEEKS_IN_ITERATION,
 
   // Record the number of calls to GetUpadtesSince. Useful to keep track of
   // transaction log iterator refreshes

--- a/include/rocksdb/statistics.h
+++ b/include/rocksdb/statistics.h
@@ -184,11 +184,6 @@ enum Tickers : uint32_t {
   // user key.
   NUMBER_OF_RESEEKS_IN_ITERATION,
 
-  // Number of times we had to reseek inside an iteration, specifically to skip
-  // after or before a range of keys covered by a range deletion in a newer LSM
-  // component.
-  NUMBER_OF_RANGE_DEL_RESEEKS_IN_ITERATION,
-
   // Record the number of calls to GetUpadtesSince. Useful to keep track of
   // transaction log iterator refreshes
   GET_UPDATES_SINCE_CALLS,

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -60,6 +60,7 @@ PerfContext::PerfContext(const PerfContext& other) {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -157,6 +158,7 @@ PerfContext::PerfContext(PerfContext&& other) noexcept {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -256,6 +258,7 @@ PerfContext& PerfContext::operator=(const PerfContext& other) {
   internal_delete_skipped_count = other.internal_delete_skipped_count;
   internal_recent_skipped_count = other.internal_recent_skipped_count;
   internal_merge_count = other.internal_merge_count;
+  internal_range_del_reseek_count = other.internal_range_del_reseek_count;
   write_wal_time = other.write_wal_time;
   get_snapshot_time = other.get_snapshot_time;
   get_from_memtable_time = other.get_from_memtable_time;
@@ -352,6 +355,7 @@ void PerfContext::Reset() {
   internal_delete_skipped_count = 0;
   internal_recent_skipped_count = 0;
   internal_merge_count = 0;
+  internal_range_del_reseek_count = 0;
   write_wal_time = 0;
 
   get_snapshot_time = 0;
@@ -472,6 +476,7 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(internal_delete_skipped_count);
   PERF_CONTEXT_OUTPUT(internal_recent_skipped_count);
   PERF_CONTEXT_OUTPUT(internal_merge_count);
+  PERF_CONTEXT_OUTPUT(internal_range_del_reseek_count);
   PERF_CONTEXT_OUTPUT(write_wal_time);
   PERF_CONTEXT_OUTPUT(get_snapshot_time);
   PERF_CONTEXT_OUTPUT(get_from_memtable_time);

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -432,12 +432,11 @@ Status BlockBasedTableFactory::NewTableReader(
   return BlockBasedTable::Open(
       ro, table_reader_options.ioptions, table_reader_options.env_options,
       table_options_, table_reader_options.internal_comparator, std::move(file),
-      file_size, table_reader, table_reader_options.prefix_extractor,
-      prefetch_index_and_filter_in_cache, table_reader_options.skip_filters,
-      table_reader_options.level, table_reader_options.immortal,
-      table_reader_options.largest_seqno,
-      table_reader_options.force_direct_prefetch, &tail_prefetch_stats_,
-      table_reader_options.block_cache_tracer,
+      file_size, table_reader, table_reader_options.largest_seqno,
+      table_reader_options.prefix_extractor, prefetch_index_and_filter_in_cache,
+      table_reader_options.skip_filters, table_reader_options.level,
+      table_reader_options.immortal, table_reader_options.force_direct_prefetch,
+      &tail_prefetch_stats_, table_reader_options.block_cache_tracer,
       table_reader_options.max_file_size_for_l0_meta_pin);
 }
 

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -14,7 +14,7 @@ void BlockBasedTableIterator::Seek(const Slice& target) { SeekImpl(&target); }
 void BlockBasedTableIterator::SeekIfSeqnoSmaller(const Slice& target,
                                                  SequenceNumber limit) {
   if (largest_seqno_ < limit) {
-    SeekImpl(&target);
+    Seek(target);
   }
 }
 
@@ -164,6 +164,13 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
   CheckDataBlockWithinUpperBound();
   assert(!block_iter_.Valid() ||
          icomp_.Compare(target, block_iter_.key()) >= 0);
+}
+
+void BlockBasedTableIterator::SeekForPrevIfSeqnoSmaller(const Slice& target,
+                                                        SequenceNumber limit) {
+  if (largest_seqno_ < limit) {
+    SeekForPrev(target);
+  }
 }
 
 void BlockBasedTableIterator::SeekToLast() {

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -11,6 +11,13 @@
 namespace ROCKSDB_NAMESPACE {
 void BlockBasedTableIterator::Seek(const Slice& target) { SeekImpl(&target); }
 
+void BlockBasedTableIterator::SeekIfSeqnoSmaller(const Slice& target,
+                                                 SequenceNumber limit) {
+  if (largest_seqno_ < limit) {
+    SeekImpl(&target);
+  }
+}
+
 void BlockBasedTableIterator::SeekToFirst() { SeekImpl(nullptr); }
 
 void BlockBasedTableIterator::SeekImpl(const Slice* target) {

--- a/table/block_based/block_based_table_iterator.cc
+++ b/table/block_based/block_based_table_iterator.cc
@@ -14,6 +14,7 @@ void BlockBasedTableIterator::Seek(const Slice& target) { SeekImpl(&target); }
 void BlockBasedTableIterator::SeekIfSeqnoSmaller(const Slice& target,
                                                  SequenceNumber limit) {
   if (largest_seqno_ < limit) {
+    PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
     Seek(target);
   }
 }
@@ -169,6 +170,7 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
 void BlockBasedTableIterator::SeekForPrevIfSeqnoSmaller(const Slice& target,
                                                         SequenceNumber limit) {
   if (largest_seqno_ < limit) {
+    PERF_COUNTER_ADD(internal_range_del_reseek_count, 1);
     SeekForPrev(target);
   }
 }

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -26,8 +26,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
       std::unique_ptr<InternalIteratorBase<IndexValue>>&& index_iter,
       bool check_filter, bool need_upper_bound_check,
       const SliceTransform* prefix_extractor, TableReaderCaller caller,
-      SequenceNumber largest_seqno,
-      size_t compaction_readahead_size = 0, bool allow_unprepared_value = false)
+      SequenceNumber largest_seqno, size_t compaction_readahead_size = 0,
+      bool allow_unprepared_value = false)
       : table_(table),
         read_options_(read_options),
         icomp_(icomp),

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -46,8 +46,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   ~BlockBasedTableIterator() {}
 
   void Seek(const Slice& target) override;
-  void SeekForPrev(const Slice& target) override;
   void SeekIfSeqnoSmaller(const Slice& target, SequenceNumber limit) override;
+  void SeekForPrev(const Slice& target) override;
   void SeekForPrevIfSeqnoSmaller(const Slice& target,
                                  SequenceNumber limit) override;
   void SeekToFirst() override;

--- a/table/block_based/block_based_table_iterator.h
+++ b/table/block_based/block_based_table_iterator.h
@@ -48,6 +48,8 @@ class BlockBasedTableIterator : public InternalIteratorBase<Slice> {
   void Seek(const Slice& target) override;
   void SeekForPrev(const Slice& target) override;
   void SeekIfSeqnoSmaller(const Slice& target, SequenceNumber limit) override;
+  void SeekForPrevIfSeqnoSmaller(const Slice& target,
+                                 SequenceNumber limit) override;
   void SeekToFirst() override;
   void SeekToLast() override;
   void Next() final override;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -94,11 +94,11 @@ class BlockBasedTable : public TableReader {
                      std::unique_ptr<RandomAccessFileReader>&& file,
                      uint64_t file_size,
                      std::unique_ptr<TableReader>* table_reader,
+                     const SequenceNumber largest_seqno,
                      const SliceTransform* prefix_extractor = nullptr,
                      bool prefetch_index_and_filter_in_cache = true,
                      bool skip_filters = false, int level = -1,
                      const bool immortal_table = false,
-                     const SequenceNumber largest_seqno = 0,
                      bool force_direct_prefetch = false,
                      TailPrefetchStats* tail_prefetch_stats = nullptr,
                      BlockCacheTracer* const block_cache_tracer = nullptr,
@@ -508,7 +508,8 @@ struct BlockBasedTable::Rep {
   Rep(const ImmutableCFOptions& _ioptions, const EnvOptions& _env_options,
       const BlockBasedTableOptions& _table_opt,
       const InternalKeyComparator& _internal_comparator, bool skip_filters,
-      uint64_t _file_size, int _level, const bool _immortal_table)
+      uint64_t _file_size, int _level, const bool _immortal_table,
+      const SequenceNumber _largest_seqno)
       : ioptions(_ioptions),
         env_options(_env_options),
         table_options(_table_opt),
@@ -520,6 +521,7 @@ struct BlockBasedTable::Rep {
         whole_key_filtering(_table_opt.whole_key_filtering),
         prefix_filtering(true),
         global_seqno(kDisableGlobalSequenceNumber),
+        largest_seqno(_largest_seqno),
         file_size(_file_size),
         level(_level),
         immortal_table(_immortal_table) {}
@@ -577,6 +579,8 @@ struct BlockBasedTable::Rep {
   // A value of kDisableGlobalSequenceNumber means that this feature is disabled
   // and every key have it's own seqno.
   SequenceNumber global_seqno;
+
+  const SequenceNumber largest_seqno;
 
   // Size of the table file on disk
   uint64_t file_size;

--- a/table/block_based/block_based_table_reader_test.cc
+++ b/table/block_based/block_based_table_reader_test.cc
@@ -98,7 +98,8 @@ class BlockBasedTableReaderTest
     ASSERT_NE(table_options, nullptr);
     ASSERT_OK(BlockBasedTable::Open(ro, ioptions, EnvOptions(), *table_options,
                                     comparator, std::move(file), file_size,
-                                    &table_reader));
+                                    &table_reader,
+                                    kMaxSequenceNumber /* largest_seqno */));
 
     table->reset(reinterpret_cast<BlockBasedTable*>(table_reader.release()));
   }

--- a/table/block_based/mock_block_based_table.h
+++ b/table/block_based/mock_block_based_table.h
@@ -39,7 +39,8 @@ class MockBlockBasedTableTester {
     constexpr bool immortal_table = false;
     table_.reset(new MockBlockBasedTable(new BlockBasedTable::Rep(
         ioptions_, env_options_, table_options_, icomp_, skip_filters,
-        12345 /*file_size*/, kMockLevel, immortal_table)));
+        12345 /*file_size*/, kMockLevel, immortal_table,
+        kMaxSequenceNumber /* largest_seqno */)));
   }
 
   FilterBitsBuilder* GetBuilder() const {

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -149,7 +149,8 @@ class PartitionedFilterBlockTest
     table_.reset(new MockedBlockBasedTable(
         new BlockBasedTable::Rep(ioptions_, env_options_, table_options_,
                                  icomp_, skip_filters, file_size, level,
-                                 immortal_table),
+                                 immortal_table,
+                                 kMaxSequenceNumber /* largest_seqno */),
         pib));
     BlockContents contents(slice);
     CachableEntry<Block> block(

--- a/table/block_fetcher_test.cc
+++ b/table/block_fetcher_test.cc
@@ -281,7 +281,8 @@ class BlockFetcherTest : public testing::Test {
     ASSERT_NE(table_options, nullptr);
     ASSERT_OK(BlockBasedTable::Open(ro, ioptions, EnvOptions(), *table_options,
                                     comparator, std::move(file), file_size,
-                                    &table_reader));
+                                    &table_reader,
+                                    kMaxSequenceNumber /* largest_seqno */));
 
     table->reset(reinterpret_cast<BlockBasedTable*>(table_reader.release()));
   }

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -63,10 +63,15 @@ class InternalIteratorBase : public Cleanable {
   // 'target' contains user timestamp if timestamp is enabled.
   virtual void Seek(const Slice& target) = 0;
 
-  // Seek forwards as far as the first key in the source at or after `target`,
-  // only skipping over keys with seqnos strictly less than `limit`. The
-  // implementation can be a no-op or seek only part of the way forward to
-  // the largest allowed key.
+  // Seek all underlying iterators forwards as far as the first key in the
+  // source at or after `target`, only skipping over keys with seqnos strictly
+  // less than `limit`.  The implementation can be a no-op or seek only part of
+  // the way forward to the largest allowed key.
+  //
+  // N.B.: after calling this function, the forward scan is no longer required
+  // to return all keys until passing `target`. In case of a composite iterator,
+  // underlying iterators may seek forward by varying distances, resulting in a
+  // subset of keys visible to an ensuing forward scan.
   //
   // REQUIRES: The iterator is `Valid()` before this call.
   virtual void SeekIfSeqnoSmaller(const Slice& /* target */,
@@ -77,10 +82,15 @@ class InternalIteratorBase : public Cleanable {
   // an entry that comes at or before target.
   virtual void SeekForPrev(const Slice& target) = 0;
 
-  // Seek backwards as far as the last key in the source at or before `target`,
-  // only skipping over keys with seqnos strictly less than `limit`. The
-  // implementation can be a no-op or seek only part of the way backward to
-  // the smallest allowed key.
+  // Seek all underlying iterators backwards as far as the last key in the
+  // source at or before `target`, only skipping over keys with seqnos strictly
+  // less than `limit`.  The implementation can be a no-op or seek only part of
+  // the way backward to the smallest allowed key.
+  //
+  // N.B.: after calling this function, the backward scan is no longer required
+  // to return all keys until passing `target`. In case of a composite iterator,
+  // underlying iterators may seek backward by varying distances, resulting in a
+  // subset of keys visible to an ensuing backward scan.
   //
   // REQUIRES: The iterator is `Valid()` before this call.
   virtual void SeekForPrevIfSeqnoSmaller(const Slice& /* target */,

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -63,14 +63,12 @@ class InternalIteratorBase : public Cleanable {
   // 'target' contains user timestamp if timestamp is enabled.
   virtual void Seek(const Slice& target) = 0;
 
-  // Position at the first key in the source at or past `target` if all keys
-  // visible to this iterator are known to have seqnos strictly less than
-  // `limit`. It is ok to be a no-op if that condition is unknown.
+  // Seek forwards as far as the first key in the source at or after `target`,
+  // only skipping over keys with seqnos strictly less than `limit`. The
+  // implementation can be a no-op or seek only part of the way forward to
+  // the largest allowed key.
   //
   // REQUIRES: The iterator is `Valid()` before this call.
-  //
-  // The iterator is `Valid()` after this call if no seek occurred, or if a seek
-  // occurred and the source contains an entry that comes at or past `target`.
   virtual void SeekIfSeqnoSmaller(const Slice& /* target */,
                                   SequenceNumber /* limit */) {}
 
@@ -79,14 +77,12 @@ class InternalIteratorBase : public Cleanable {
   // an entry that comes at or before target.
   virtual void SeekForPrev(const Slice& target) = 0;
 
-  // Position at the last key in the source at or before `target` if all keys
-  // visible to this iterator are known to have seqnos strictly less than
-  // `limit`. It is ok to be a no-op if that condition is unknown.
+  // Seek backwards as far as the last key in the source at or before `target`,
+  // only skipping over keys with seqnos strictly less than `limit`. The
+  // implementation can be a no-op or seek only part of the way backward to
+  // the smallest allowed key.
   //
   // REQUIRES: The iterator is `Valid()` before this call.
-  //
-  // The iterator is `Valid()` after this call if no seek occurred, or if a seek
-  // occurred and the source contains an entry that comes at or before `target`.
   virtual void SeekForPrevIfSeqnoSmaller(const Slice& /* target */,
                                          SequenceNumber /* limit */) {}
 

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -63,6 +63,17 @@ class InternalIteratorBase : public Cleanable {
   // 'target' contains user timestamp if timestamp is enabled.
   virtual void Seek(const Slice& target) = 0;
 
+  // Position at the first key in the source at or past `target` if all keys
+  // visible to this iterator are known to have seqnos strictly less than
+  // `limit`. It is ok to be a no-op if that condition is unknown.
+  //
+  // REQUIRES: The iterator is `Valid()` before this call.
+  //
+  // The iterator is `Valid()` after this call if no seek occurred, or if a seek
+  // occurred and the source contains an entry that comes at or past target.
+  virtual void SeekIfSeqnoSmaller(const Slice& /* target */,
+                                  SequenceNumber /* limit */) {}
+
   // Position at the first key in the source that at or before target
   // The iterator is Valid() after this call iff the source contains
   // an entry that comes at or before target.

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -63,6 +63,13 @@ class InternalIteratorBase : public Cleanable {
   // 'target' contains user timestamp if timestamp is enabled.
   virtual void Seek(const Slice& target) = 0;
 
+  // TODO(ajkr): This interface is temporarily needed for pushing info about the
+  // the current global range tombstone down to the sub-iterators, who use the
+  // info to potentially skip forwards. Once we disaggregate the range
+  // tombstones by sorted run, we can simply call `Seek()` on sorted runs
+  // beneath a range tombstone, relying on the LSM invariant that the skipped
+  // keys must be older.
+  //
   // Seek all underlying iterators forwards as far as the first key in the
   // source at or after `target`, only skipping over keys with seqnos strictly
   // less than `limit`.  The implementation can be a no-op or seek only part of
@@ -82,6 +89,13 @@ class InternalIteratorBase : public Cleanable {
   // an entry that comes at or before target.
   virtual void SeekForPrev(const Slice& target) = 0;
 
+  // TODO(ajkr): This interface is temporarily needed for pushing info about the
+  // the current global range tombstone down to the sub-iterators, who use the
+  // info to potentially skip backwards. Once we disaggregate the range
+  // tombstones by sorted run, we can simply call `SeekForPrev()` on sorted runs
+  // beneath a range tombstone, relying on the LSM invariant that the skipped
+  // keys must be older.
+  //
   // Seek all underlying iterators backwards as far as the last key in the
   // source at or before `target`, only skipping over keys with seqnos strictly
   // less than `limit`.  The implementation can be a no-op or seek only part of

--- a/table/internal_iterator.h
+++ b/table/internal_iterator.h
@@ -70,7 +70,7 @@ class InternalIteratorBase : public Cleanable {
   // REQUIRES: The iterator is `Valid()` before this call.
   //
   // The iterator is `Valid()` after this call if no seek occurred, or if a seek
-  // occurred and the source contains an entry that comes at or past target.
+  // occurred and the source contains an entry that comes at or past `target`.
   virtual void SeekIfSeqnoSmaller(const Slice& /* target */,
                                   SequenceNumber /* limit */) {}
 
@@ -78,6 +78,17 @@ class InternalIteratorBase : public Cleanable {
   // The iterator is Valid() after this call iff the source contains
   // an entry that comes at or before target.
   virtual void SeekForPrev(const Slice& target) = 0;
+
+  // Position at the last key in the source at or before `target` if all keys
+  // visible to this iterator are known to have seqnos strictly less than
+  // `limit`. It is ok to be a no-op if that condition is unknown.
+  //
+  // REQUIRES: The iterator is `Valid()` before this call.
+  //
+  // The iterator is `Valid()` after this call if no seek occurred, or if a seek
+  // occurred and the source contains an entry that comes at or before `target`.
+  virtual void SeekForPrevIfSeqnoSmaller(const Slice& /* target */,
+                                         SequenceNumber /* limit */) {}
 
   // Moves to the next entry in the source.  After this call, Valid() is
   // true iff the iterator was not positioned at the last entry in the source.

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -106,9 +106,19 @@ class IteratorWrapperBase {
     iter_->Seek(k);
     Update();
   }
+  void SeekIfSeqnoSmaller(const Slice& k, SequenceNumber limit) {
+    assert(iter_);
+    iter_->SeekIfSeqnoSmaller(k, limit);
+    Update();
+  }
   void SeekForPrev(const Slice& k) {
     assert(iter_);
     iter_->SeekForPrev(k);
+    Update();
+  }
+  void SeekForPrevIfSeqnoSmaller(const Slice& k, SequenceNumber limit) {
+    assert(iter_);
+    iter_->SeekForPrevIfSeqnoSmaller(k, limit);
     Update();
   }
   void SeekToFirst() {

--- a/table/merging_iterator.h
+++ b/table/merging_iterator.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "db/dbformat.h"
+#include "db/range_del_aggregator.h"
 #include "rocksdb/types.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -41,7 +42,8 @@ class MergeIteratorBuilder {
   // comparator: the comparator used in merging comparator
   // arena: where the merging iterator needs to be allocated from.
   explicit MergeIteratorBuilder(const InternalKeyComparator* comparator,
-                                Arena* arena, bool prefix_seek_mode = false);
+                                Arena* arena, bool prefix_seek_mode = false,
+                                RangeDelAggregator* range_del_agg = nullptr);
   ~MergeIteratorBuilder();
 
   // Add iter to the merging iterator.

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -36,11 +36,11 @@ struct TableReaderOptions {
                      bool _force_direct_prefetch = false, int _level = -1,
                      BlockCacheTracer* const _block_cache_tracer = nullptr,
                      size_t _max_file_size_for_l0_meta_pin = 0)
-      : TableReaderOptions(_ioptions, _prefix_extractor, _env_options,
-                           _internal_comparator, _skip_filters, _immortal,
-                           _force_direct_prefetch, _level,
-                           0 /* _largest_seqno */, _block_cache_tracer,
-                           _max_file_size_for_l0_meta_pin) {}
+      : TableReaderOptions(
+            _ioptions, _prefix_extractor, _env_options, _internal_comparator,
+            _skip_filters, _immortal, _force_direct_prefetch, _level,
+            kMaxSequenceNumber /* largest_seqno */, _block_cache_tracer,
+            _max_file_size_for_l0_meta_pin) {}
 
   // @param skip_filters Disables loading/accessing the filter block
   TableReaderOptions(const ImmutableCFOptions& _ioptions,

--- a/table/table_reader_bench.cc
+++ b/table/table_reader_bench.cc
@@ -143,7 +143,8 @@ void TableReaderBenchmark(Options& opts, EnvOptions& env_options,
                                    file_name));
     s = opts.table_factory->NewTableReader(
         TableReaderOptions(ioptions, moptions.prefix_extractor.get(),
-                           env_options, ikc),
+                           env_options, ikc,
+                           kMaxSequenceNumber /* largest_seqno */),
         std::move(file_reader), file_size, &table_reader);
     if (!s.ok()) {
       fprintf(stderr, "Open Table Error: %s\n", s.ToString().c_str());

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4765,6 +4765,25 @@ TEST_P(BlockBasedTableTest, SeekIfSeqnoSmaller) {
     ASSERT_TRUE(iter->Valid());
     ASSERT_EQ("k0", ExtractUserKey(iter->key()).ToString());
   }
+
+  iter->SeekToLast();
+  {
+    InternalKey internal_key("k1", kMaxSequenceNumber, kValueTypeForSeek);
+    std::string encoded_key = internal_key.Encode().ToString();
+    iter->SeekForPrevIfSeqnoSmaller(encoded_key, kNumKeys /* limit */);
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ("k0", ExtractUserKey(iter->key()).ToString());
+  }
+
+  iter->SeekToLast();
+  {
+    InternalKey internal_key("k1", kMaxSequenceNumber, kValueTypeForSeek);
+    std::string encoded_key = internal_key.Encode().ToString();
+    iter->SeekForPrevIfSeqnoSmaller(encoded_key, kNumKeys - 1 /* limit */);
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ("k" + std::to_string(kNumKeys - 1),
+              ExtractUserKey(iter->key()).ToString());
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Similar to #5506, but moved range tombstone aware logic from `BlockBasedTableIterator` into `MergingIterator` since `RangeDelAggregator` has the same scope as `MergingIterator`. Now the optimized seek only happens during forward/backward scan, not during any user seek. Besides that, there are a few minor fixes/improvements:

- Fixed a bug where `GetEndpoint()` was getting its endpoint from the `active_seqnums_` heap. While it's an endpoint representing a valid tombstone, it's better to get the endpoint from the `active_iters_` heap in case a tombstone with a newer seqno shows up before the current newest one ends.
- Added `PerfContext::internal_range_del_reseek_count` to count how many times optimized seek happened.
- Got rid of endpoint caching in the iterator. It risked missing seek opportunities when files in higher levels would be opened and covering tombstones would be added, but the table iterator wouldn't notice because it had cached some distant endpoint.

But, this has not been heavily tested or benchmarked. One TODO is reduce calls to the optimized seek functions -- we should only call them upon noticing the endpoint has changed.