### PR TITLE
Windows: disable operator new / delete when jemalloc 5 is detected

### DIFF
--- a/port/win/win_jemalloc.cc
+++ b/port/win/win_jemalloc.cc
@@ -46,6 +46,8 @@ void jemalloc_aligned_free(void* p) ROCKSDB_NOEXCEPT { je_free(p); }
 }  // namespace port
 }  // namespace ROCKSDB_NAMESPACE
 
+#if (JEMALLOC_VERSION_MAJOR < 5)
+
 void* operator new(size_t size) {
   void* p = je_malloc(size);
   if (!p) {
@@ -73,3 +75,5 @@ void operator delete[](void* p) {
     je_free(p);
   }
 }
+
+#endif  // (JEMALLOC_VERSION_MAJOR < 5)


### PR DESCRIPTION
Jemalloc 5 added its own `operator new` / `delete` which conflict with the rocksdb ones.

See https://github.com/jemalloc/jemalloc/releases/tag/5.0.0

> Add C++ new/delete operator bindings. (@djwatson)

https://github.com/jemalloc/jemalloc/commit/2319152d9f5d9b33eebc36a50ccf4239f31c1ad9