### PR TITLE
Log info about generated blob files in BlobFileBuilder

### DIFF
--- a/db/blob/blob_file_builder.cc
+++ b/db/blob/blob_file_builder.cc
@@ -28,21 +28,23 @@ BlobFileBuilder::BlobFileBuilder(
     VersionSet* versions, Env* env, FileSystem* fs,
     const ImmutableCFOptions* immutable_cf_options,
     const MutableCFOptions* mutable_cf_options, const FileOptions* file_options,
-    int job_id, uint32_t column_family_id, std::string column_family_name,
-    Env::IOPriority io_priority, Env::WriteLifeTimeHint write_hint,
+    int job_id, uint32_t column_family_id,
+    const std::string& column_family_name, Env::IOPriority io_priority,
+    Env::WriteLifeTimeHint write_hint,
     std::vector<BlobFileAddition>* blob_file_additions)
     : BlobFileBuilder([versions]() { return versions->NewFileNumber(); }, env,
                       fs, immutable_cf_options, mutable_cf_options,
                       file_options, job_id, column_family_id,
-                      std::move(column_family_name), io_priority, write_hint,
+                      column_family_name, io_priority, write_hint,
                       blob_file_additions) {}
 
 BlobFileBuilder::BlobFileBuilder(
     std::function<uint64_t()> file_number_generator, Env* env, FileSystem* fs,
     const ImmutableCFOptions* immutable_cf_options,
     const MutableCFOptions* mutable_cf_options, const FileOptions* file_options,
-    int job_id, uint32_t column_family_id, std::string column_family_name,
-    Env::IOPriority io_priority, Env::WriteLifeTimeHint write_hint,
+    int job_id, uint32_t column_family_id,
+    const std::string& column_family_name, Env::IOPriority io_priority,
+    Env::WriteLifeTimeHint write_hint,
     std::vector<BlobFileAddition>* blob_file_additions)
     : file_number_generator_(std::move(file_number_generator)),
       env_(env),
@@ -54,7 +56,7 @@ BlobFileBuilder::BlobFileBuilder(
       file_options_(file_options),
       job_id_(job_id),
       column_family_id_(column_family_id),
-      column_family_name_(std::move(column_family_name)),
+      column_family_name_(column_family_name),
       io_priority_(io_priority),
       write_hint_(write_hint),
       blob_file_additions_(blob_file_additions),

--- a/db/blob/blob_file_builder.cc
+++ b/db/blob/blob_file_builder.cc
@@ -15,6 +15,7 @@
 #include "file/filename.h"
 #include "file/read_write_util.h"
 #include "file/writable_file_writer.h"
+#include "logging/logging.h"
 #include "options/cf_options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
@@ -27,20 +28,21 @@ BlobFileBuilder::BlobFileBuilder(
     VersionSet* versions, Env* env, FileSystem* fs,
     const ImmutableCFOptions* immutable_cf_options,
     const MutableCFOptions* mutable_cf_options, const FileOptions* file_options,
-    uint32_t column_family_id, Env::IOPriority io_priority,
-    Env::WriteLifeTimeHint write_hint,
+    int job_id, uint32_t column_family_id, std::string column_family_name,
+    Env::IOPriority io_priority, Env::WriteLifeTimeHint write_hint,
     std::vector<BlobFileAddition>* blob_file_additions)
     : BlobFileBuilder([versions]() { return versions->NewFileNumber(); }, env,
                       fs, immutable_cf_options, mutable_cf_options,
-                      file_options, column_family_id, io_priority, write_hint,
+                      file_options, job_id, column_family_id,
+                      std::move(column_family_name), io_priority, write_hint,
                       blob_file_additions) {}
 
 BlobFileBuilder::BlobFileBuilder(
     std::function<uint64_t()> file_number_generator, Env* env, FileSystem* fs,
     const ImmutableCFOptions* immutable_cf_options,
     const MutableCFOptions* mutable_cf_options, const FileOptions* file_options,
-    uint32_t column_family_id, Env::IOPriority io_priority,
-    Env::WriteLifeTimeHint write_hint,
+    int job_id, uint32_t column_family_id, std::string column_family_name,
+    Env::IOPriority io_priority, Env::WriteLifeTimeHint write_hint,
     std::vector<BlobFileAddition>* blob_file_additions)
     : file_number_generator_(std::move(file_number_generator)),
       env_(env),
@@ -50,7 +52,9 @@ BlobFileBuilder::BlobFileBuilder(
       blob_file_size_(mutable_cf_options->blob_file_size),
       blob_compression_type_(mutable_cf_options->blob_compression_type),
       file_options_(file_options),
+      job_id_(job_id),
       column_family_id_(column_family_id),
+      column_family_name_(std::move(column_family_name)),
       io_priority_(io_priority),
       write_hint_(write_hint),
       blob_file_additions_(blob_file_additions),
@@ -267,6 +271,13 @@ Status BlobFileBuilder::CloseBlobFile() {
   blob_file_additions_->emplace_back(blob_file_number, blob_count_, blob_bytes_,
                                      std::move(checksum_method),
                                      std::move(checksum_value));
+
+  assert(immutable_cf_options_);
+  ROCKS_LOG_INFO(immutable_cf_options_->info_log,
+                 "[%s] [JOB %d] Generated blob file #%" PRIu64 ": %" PRIu64
+                 " total blobs, %" PRIu64 " total bytes",
+                 column_family_name_.c_str(), job_id_, blob_file_number,
+                 blob_count_, blob_bytes_);
 
   writer_.reset();
   blob_count_ = 0;

--- a/db/blob/blob_file_builder.h
+++ b/db/blob/blob_file_builder.h
@@ -32,7 +32,8 @@ class BlobFileBuilder {
                   const ImmutableCFOptions* immutable_cf_options,
                   const MutableCFOptions* mutable_cf_options,
                   const FileOptions* file_options, int job_id,
-                  uint32_t column_family_id, std::string column_family_name,
+                  uint32_t column_family_id,
+                  const std::string& column_family_name,
                   Env::IOPriority io_priority,
                   Env::WriteLifeTimeHint write_hint,
                   std::vector<BlobFileAddition>* blob_file_additions);
@@ -42,7 +43,8 @@ class BlobFileBuilder {
                   const ImmutableCFOptions* immutable_cf_options,
                   const MutableCFOptions* mutable_cf_options,
                   const FileOptions* file_options, int job_id,
-                  uint32_t column_family_id, std::string column_family_name,
+                  uint32_t column_family_id,
+                  const std::string& column_family_name,
                   Env::IOPriority io_priority,
                   Env::WriteLifeTimeHint write_hint,
                   std::vector<BlobFileAddition>* blob_file_additions);

--- a/db/blob/blob_file_builder.h
+++ b/db/blob/blob_file_builder.h
@@ -31,7 +31,8 @@ class BlobFileBuilder {
   BlobFileBuilder(VersionSet* versions, Env* env, FileSystem* fs,
                   const ImmutableCFOptions* immutable_cf_options,
                   const MutableCFOptions* mutable_cf_options,
-                  const FileOptions* file_options, uint32_t column_family_id,
+                  const FileOptions* file_options, int job_id,
+                  uint32_t column_family_id, std::string column_family_name,
                   Env::IOPriority io_priority,
                   Env::WriteLifeTimeHint write_hint,
                   std::vector<BlobFileAddition>* blob_file_additions);
@@ -40,7 +41,8 @@ class BlobFileBuilder {
                   FileSystem* fs,
                   const ImmutableCFOptions* immutable_cf_options,
                   const MutableCFOptions* mutable_cf_options,
-                  const FileOptions* file_options, uint32_t column_family_id,
+                  const FileOptions* file_options, int job_id,
+                  uint32_t column_family_id, std::string column_family_name,
                   Env::IOPriority io_priority,
                   Env::WriteLifeTimeHint write_hint,
                   std::vector<BlobFileAddition>* blob_file_additions);
@@ -70,7 +72,9 @@ class BlobFileBuilder {
   uint64_t blob_file_size_;
   CompressionType blob_compression_type_;
   const FileOptions* file_options_;
+  int job_id_;
   uint32_t column_family_id_;
+  std::string column_family_name_;
   Env::IOPriority io_priority_;
   Env::WriteLifeTimeHint write_hint_;
   std::vector<BlobFileAddition>* blob_file_additions_;

--- a/db/blob/blob_file_builder_test.cc
+++ b/db/blob/blob_file_builder_test.cc
@@ -131,16 +131,18 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckOneFile) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   std::vector<std::pair<std::string, std::string>> expected_key_value_pairs(
       number_of_blobs);
@@ -202,16 +204,18 @@ TEST_F(BlobFileBuilderTest, BuildAndCheckMultipleFiles) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   std::vector<std::pair<std::string, std::string>> expected_key_value_pairs(
       number_of_blobs);
@@ -276,16 +280,18 @@ TEST_F(BlobFileBuilderTest, InlinedValues) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   for (size_t i = 0; i < number_of_blobs; ++i) {
     const std::string key = std::to_string(i);
@@ -323,16 +329,18 @@ TEST_F(BlobFileBuilderTest, Compression) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   const std::string key("1");
   const std::string uncompressed_value(value_size, 'x');
@@ -393,16 +401,18 @@ TEST_F(BlobFileBuilderTest, CompressionError) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   SyncPoint::GetInstance()->SetCallBack("CompressData:TamperWithReturnValue",
                                         [](void* arg) {
@@ -457,16 +467,18 @@ TEST_F(BlobFileBuilderTest, Checksum) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
   std::vector<BlobFileAddition> blob_file_additions;
 
-  BlobFileBuilder builder(TestFileNumberGenerator(), &mock_env_, &fs_,
-                          &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+  BlobFileBuilder builder(
+      TestFileNumberGenerator(), &mock_env_, &fs_, &immutable_cf_options,
+      &mutable_cf_options, &file_options_, job_id, column_family_id,
+      column_family_name, io_priority, write_hint, &blob_file_additions);
 
   const std::string key("1");
   const std::string value("deadbeef");
@@ -543,7 +555,9 @@ TEST_P(BlobFileBuilderIOErrorTest, IOError) {
   ImmutableCFOptions immutable_cf_options(options);
   MutableCFOptions mutable_cf_options(options);
 
+  constexpr int job_id = 1;
   constexpr uint32_t column_family_id = 123;
+  constexpr char column_family_name[] = "foobar";
   constexpr Env::IOPriority io_priority = Env::IO_HIGH;
   constexpr Env::WriteLifeTimeHint write_hint = Env::WLTH_MEDIUM;
 
@@ -551,8 +565,9 @@ TEST_P(BlobFileBuilderIOErrorTest, IOError) {
 
   BlobFileBuilder builder(TestFileNumberGenerator(), &fault_injection_env_,
                           &fs_, &immutable_cf_options, &mutable_cf_options,
-                          &file_options_, column_family_id, io_priority,
-                          write_hint, &blob_file_additions);
+                          &file_options_, job_id, column_family_id,
+                          column_family_name, io_priority, write_hint,
+                          &blob_file_additions);
 
   SyncPoint::GetInstance()->SetCallBack(sync_point_, [this](void* /* arg */) {
     fault_injection_env_.SetFilesystemActive(false,


### PR DESCRIPTION
Summary:
The patch adds a log message to `BlobFileBuilder` that is logged upon
generating a blob file, similarly to how we log the generation of table files
during flush and compaction. The log message contains the column family
name, job id, blob file number, and the number and total size of blobs in
the new file.

Test Plan:
Ran `make check` and checked the actual log messages using a custom `db_bench`.