### PR TITLE
lock_guard constructor is not const

### DIFF
--- a/util/channel.h
+++ b/util/channel.h
@@ -31,7 +31,7 @@ class channel {
     return buffer_.empty() && eof_;
   }
 
-  size_t size() const {
+  size_t size() {
     std::lock_guard<std::mutex> lk(lock_);
     return buffer_.size();
   }


### PR DESCRIPTION
May cause  `rocksdb/util/channel.h:35:33: error: no matching constructor for initialization of 'std::lock_guard<std::mutex>'`.