### PR TITLE
remove `DeleteFile()` from public API and language bindings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 ### Public API Change
 * Expose kTypeDeleteWithTimestamp in EntryType and update GetEntryType() accordingly.
 * Added file_checksum and file_checksum_func_name to TableFileCreationInfo, which can pass the table file checksum information through the OnTableFileCreated callback during flush and compaction.
+* `DB::DeleteFile()` is removed.
 
 ### Behavior Changes
 * File abstraction `FSRandomAccessFile.Prefetch()` default return status is changed from `OK` to `NotSupported`. If the user inherited file doesn't implement prefetch, RocksDB will create internal prefetch buffer to improve read performance.

--- a/db/c.cc
+++ b/db/c.cc
@@ -1237,12 +1237,6 @@ void rocksdb_approximate_sizes_cf(
   delete[] ranges;
 }
 
-void rocksdb_delete_file(
-    rocksdb_t* db,
-    const char* name) {
-  db->rep->DeleteFile(name);
-}
-
 const rocksdb_livefiles_t* rocksdb_livefiles(
     rocksdb_t* db) {
   rocksdb_livefiles_t* result = new rocksdb_livefiles_t;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3036,8 +3036,6 @@ class ModelDB : public DB {
     return Status::NotSupported();
   }
 
-  Status DeleteFile(std::string /*name*/) override { return Status::OK(); }
-
   Status GetUpdatesSince(
       ROCKSDB_NAMESPACE::SequenceNumber,
       std::unique_ptr<ROCKSDB_NAMESPACE::TransactionLogIterator>*,

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -172,15 +172,15 @@ TEST_F(DeleteFileTest, AddKeysAndQueryLevels) {
   ASSERT_EQ(level1keycount, 50000);
   ASSERT_EQ(level2keycount, 50000);
 
-  Status status = db_->DeleteFile("0.sst");
+  Status status = dbfull()->DeleteFile("0.sst");
   ASSERT_TRUE(status.IsInvalidArgument());
 
   // intermediate level files cannot be deleted.
-  status = db_->DeleteFile(level1file);
+  status = dbfull()->DeleteFile(level1file);
   ASSERT_TRUE(status.IsInvalidArgument());
 
   // Lowest level file deletion should succeed.
-  ASSERT_OK(db_->DeleteFile(level2file));
+  ASSERT_OK(dbfull()->DeleteFile(level2file));
 }
 
 TEST_F(DeleteFileTest, PurgeObsoleteFilesTest) {
@@ -429,7 +429,7 @@ TEST_F(DeleteFileTest, DeleteFileWithIterator) {
     level2file = metadata[0].name;
   }
 
-  Status status = db_->DeleteFile(level2file);
+  Status status = dbfull()->DeleteFile(level2file);
   fprintf(stdout, "Deletion status %s: %s\n",
           level2file.c_str(), status.ToString().c_str());
   ASSERT_TRUE(status.ok());
@@ -461,7 +461,7 @@ TEST_F(DeleteFileTest, DeleteLogFiles) {
   ASSERT_OK(env_->FileExists(wal_dir_ + "/" + alive_log->PathName()));
   fprintf(stdout, "Deleting alive log file %s\n",
           alive_log->PathName().c_str());
-  ASSERT_TRUE(!db_->DeleteFile(alive_log->PathName()).ok());
+  ASSERT_TRUE(!dbfull()->DeleteFile(alive_log->PathName()).ok());
   ASSERT_OK(env_->FileExists(wal_dir_ + "/" + alive_log->PathName()));
   logfiles.clear();
 
@@ -479,7 +479,7 @@ TEST_F(DeleteFileTest, DeleteLogFiles) {
   ASSERT_OK(env_->FileExists(wal_dir_ + "/" + archived_log->PathName()));
   fprintf(stdout, "Deleting archived log file %s\n",
           archived_log->PathName().c_str());
-  ASSERT_OK(db_->DeleteFile(archived_log->PathName()));
+  ASSERT_OK(dbfull()->DeleteFile(archived_log->PathName()));
   ASSERT_EQ(Status::NotFound(),
             env_->FileExists(wal_dir_ + "/" + archived_log->PathName()));
 }
@@ -515,8 +515,8 @@ TEST_F(DeleteFileTest, DeleteNonDefaultColumnFamily) {
   auto new_file = metadata[0].smallest_seqno > metadata[1].smallest_seqno
                       ? metadata[0].name
                       : metadata[1].name;
-  ASSERT_TRUE(db_->DeleteFile(new_file).IsInvalidArgument());
-  ASSERT_OK(db_->DeleteFile(old_file));
+  ASSERT_TRUE(dbfull()->DeleteFile(new_file).IsInvalidArgument());
+  ASSERT_OK(dbfull()->DeleteFile(old_file));
 
   {
     std::unique_ptr<Iterator> itr(db_->NewIterator(ReadOptions(), handles_[1]));

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1342,13 +1342,6 @@ class DB {
       const TransactionLogIterator::ReadOptions& read_options =
           TransactionLogIterator::ReadOptions()) = 0;
 
-// Windows API macro interference
-#undef DeleteFile
-  // Delete the file name from the db directory and update the internal state to
-  // reflect that. Supports deletion of sst and log files only. 'name' must be
-  // path relative to the db directory. eg. 000001.sst, /archive/000003.log
-  virtual Status DeleteFile(std::string name) = 0;
-
   // Returns a list of all table files with their level, start key
   // and end key
   virtual void GetLiveFilesMetaData(

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -397,10 +397,6 @@ class StackableDB : public DB {
     return db_->GetCreationTimeOfOldestFile(creation_time);
   }
 
-  virtual Status DeleteFile(std::string name) override {
-    return db_->DeleteFile(name);
-  }
-
   virtual Status GetDbIdentity(std::string& identity) const override {
     return db_->GetDbIdentity(identity);
   }

--- a/java/rocksjni/rocksjni.cc
+++ b/java/rocksjni/rocksjni.cc
@@ -3022,24 +3022,6 @@ jlong Java_org_rocksdb_RocksDB_getUpdatesSince(
 
 /*
  * Class:     org_rocksdb_RocksDB
- * Method:    deleteFile
- * Signature: (JLjava/lang/String;)V
- */
-void Java_org_rocksdb_RocksDB_deleteFile(
-    JNIEnv* env, jobject, jlong jdb_handle, jstring jname) {
-  auto* db = reinterpret_cast<ROCKSDB_NAMESPACE::DB*>(jdb_handle);
-  jboolean has_exception = JNI_FALSE;
-  std::string name =
-      ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jname, &has_exception);
-  if (has_exception == JNI_TRUE) {
-    // exception occurred
-    return;
-  }
-  db->DeleteFile(name);
-}
-
-/*
- * Class:     org_rocksdb_RocksDB
  * Method:    getLiveFilesMetaData
  * Signature: (J)[Lorg/rocksdb/LiveFileMetaData;
  */

--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -3989,19 +3989,6 @@ public class RocksDB extends RocksObject {
   }
 
   /**
-   * Delete the file name from the db directory and update the internal state to
-   * reflect that. Supports deletion of sst and log files only. 'name' must be
-   * path relative to the db directory. eg. 000001.sst, /archive/000003.log
-   *
-   * @param name the file name
-   *
-   * @throws RocksDBException if an error occurs whilst deleting the file
-   */
-  public void deleteFile(final String name) throws RocksDBException {
-    deleteFile(nativeHandle_, name);
-  }
-
-  /**
    * Gets a list of all table files metadata.
    *
    * @return table files metadata.
@@ -4630,8 +4617,6 @@ public class RocksDB extends RocksObject {
       throws RocksDBException;
   private native long getUpdatesSince(final long handle,
       final long sequenceNumber) throws RocksDBException;
-  private native void deleteFile(final long handle, final String name)
-      throws RocksDBException;
   private native LiveFileMetaData[] getLiveFilesMetaData(final long handle);
   private native ColumnFamilyMetaData getColumnFamilyMetaData(
       final long handle, final long columnFamilyHandle);

--- a/java/src/test/java/org/rocksdb/RocksDBTest.java
+++ b/java/src/test/java/org/rocksdb/RocksDBTest.java
@@ -1481,16 +1481,6 @@ public class RocksDBTest {
   }
 
   @Test
-  public void deleteFile() throws RocksDBException {
-    try (final Options options = new Options().setCreateIfMissing(true)) {
-      final String dbPath = dbFolder.getRoot().getAbsolutePath();
-      try (final RocksDB db = RocksDB.open(options, dbPath)) {
-        db.deleteFile("unknown");
-      }
-    }
-  }
-
-  @Test
   public void getLiveFilesMetaData() throws RocksDBException {
     try (final Options options = new Options().setCreateIfMissing(true)) {
       final String dbPath = dbFolder.getRoot().getAbsolutePath();


### PR DESCRIPTION
At the risk of stating the obvious, `DeleteFile()` is not the proper level of abstraction for a key-value store. While it appears at first glance analogous to `AddFile()` (now called `IngestExternalFile()`), it is actually not. File ingestion adds a bunch of updates as the newest component in the LSM, and the outcome is fully deterministic. `DeleteFile()`, on the other hand, removes some subset of the oldest component in the LSM. The data in the oldest component is totally non-deterministic and depends on what compactions have happened. Besides that, the restrictions on what files can be deleted was entirely undocumented.