### PR TITLE
[cmake] tests need linked with third_party libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1230,7 +1230,7 @@ if(WITH_TESTS)
         EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
         OUTPUT_NAME ${exename}${ARTIFACT_SUFFIX}
       )
-      target_link_libraries(${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} testharness gtest ${GFLAGS_LIB} ${ROCKSDB_LIB})
+      target_link_libraries(${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} testharness gtest ${THIRDPARTY_LIBS} ${ROCKSDB_LIB})
       if(NOT "${exename}" MATCHES "db_sanity_test")
         add_test(NAME ${exename} COMMAND ${exename}${ARTIFACT_SUFFIX})
         add_dependencies(check ${CMAKE_PROJECT_NAME}_${exename}${ARTIFACT_SUFFIX})


### PR DESCRIPTION
To fix the cmake build with third_party libs, like:
`mkdir build && cd build && cmake .. -DWITH_SNAPPY=1 && make`

Error:
```
Undefined symbols for architecture x86_64:
  "snappy::RawCompress(char const*, unsigned long, char*, unsigned long*)"
```