### PR TITLE
Fix compile error for old gcc-4.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - checkout
       - run: pyenv global 3.5.2
       - run: sudo apt-get update -y && sudo apt-get install gcc-4.8 g++-4.8 libgflags-dev
-      - run: CC=gcc-4.8 CXX=g++-4.8 V=1 SKIP_LINK=1 make -j32 all | .circleci/cat_ignore_eagain # Linking broken because libgflags compiled with newer ABI
+      - run: CC=gcc-4.8 CXX=g++-4.8 V=1 SKIP_LINK=1 make -j4 all | .circleci/cat_ignore_eagain # Linking broken because libgflags compiled with newer ABI
 
   build-windows:
     executor: windows-2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - checkout
       - run: pyenv global 3.5.2
       - run: sudo apt-get update -y && sudo apt-get install gcc-4.8 g++-4.8 libgflags-dev
-      - run: CC=gcc-4.8 CXX=g++-4.8 V=1 SKIP_LINK=1 make -j32 all | .circleci/cat_ignore_eagain
+      - run: CC=gcc-4.8 CXX=g++-4.8 V=1 SKIP_LINK=1 make -j32 all | .circleci/cat_ignore_eagain # Linking broken because libgflags compiled with newer ABI
 
   build-windows:
     executor: windows-2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,16 @@ jobs:
       - run: apt-get update -y && apt-get install -y libgflags-dev
       - run: TEST_TMPDIR=/dev/shm && make V=1 -j16 unity_test | .circleci/cat_ignore_eagain
 
+  build-linux-gcc-4-8:
+    machine:
+      image: ubuntu-1604:201903-01
+    resource_class: large
+    steps:
+      - checkout
+      - run: pyenv global 3.5.2
+      - run: sudo apt-get update -y && sudo apt-get install gcc-4.8 g++-4.8 libgflags-dev
+      - run: CC=gcc-4.8 CXX=g++-4.8 V=1 SKIP_LINK=1 make -j32 all | .circleci/cat_ignore_eagain
+
   build-windows:
     executor: windows-2xlarge
     parameters:
@@ -360,3 +370,6 @@ workflows:
       - build-linux-non-shm:
           start_test: "compact_on_deletion_collector_test" # make sure unique in src.mk
           end_test: ""
+  build-linux-gcc-4-8:
+    jobs:
+      - build-linux-gcc-4-8

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -3180,7 +3180,7 @@ Status BlockBasedTable::GetKVPairsFromDataBlocks(
 }
 
 Status BlockBasedTable::DumpTable(WritableFile* out_file) {
-  auto out_file_wrapper = WritableFileStringStreamAdapter(out_file);
+  WritableFileStringStreamAdapter out_file_wrapper(out_file);
   std::ostream out_stream(&out_file_wrapper);
   // Output Footer
   out_stream << "Footer Details:\n"

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -93,7 +93,7 @@ class SSTDumpToolTest : public testing::Test {
   }
 
   void createSST(const Options& opts, const std::string& file_name) {
-    Env* env = opts.env;
+    Env* test_env = opts.env;
     EnvOptions env_options(opts);
     ReadOptions read_options;
     const ImmutableCFOptions imoptions(opts);
@@ -102,7 +102,7 @@ class SSTDumpToolTest : public testing::Test {
     std::unique_ptr<TableBuilder> tb;
 
     std::unique_ptr<WritableFile> file;
-    ASSERT_OK(env->NewWritableFile(file_name, &file, env_options));
+    ASSERT_OK(test_env->NewWritableFile(file_name, &file, env_options));
 
     std::vector<std::unique_ptr<IntTblPropCollectorFactory> >
         int_tbl_prop_collector_factories;


### PR DESCRIPTION
gcc-4.8 returns error when using the constructor. Not sure if it's a compiler bug/limitation or code issue:
```
table/block_based/block_based_table_reader.cc:3183:67: error: use of deleted function ‘rocksdb::WritableFileStringStreamAdapter::WritableFileStringStreamAdapter(rocksdb::WritableFileStringStreamAdapter&&)’
```
Workaround this by set the `WritableFile` separately.