### PR TITLE
Fix some errors showing up in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,134 +87,134 @@ matrix:
   - os: linux
     compiler: clang
   # Exclude all but most unique cmake variants for pull requests, but build all in branches
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: amd64
     env: JOB_NAME=cmake
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: amd64
     env: JOB_NAME=cmake-gcc8
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: amd64
     env: JOB_NAME=cmake-gcc9
   # Exclude most osx, arm64 and ppc64le tests for pull requests, but build in branches
   # Temporarily disable ppc64le unit tests in PRs until Travis gets its act together (#6653)
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: TEST_GROUP=platform_dependent
   # NB: the cmake build is a partial java test
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx
     env: TEST_GROUP=1
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=1
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: TEST_GROUP=1
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx
     env: TEST_GROUP=2
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=2
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: TEST_GROUP=2
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx
     env: TEST_GROUP=3
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=3
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: TEST_GROUP=3
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx
     env: TEST_GROUP=4
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=4
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: TEST_GROUP=4
-  - if: type = pull_request AND commit_message !~ /java/
+  - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
     os : osx
     env: JOB_NAME=java_test
-  - if: type = pull_request AND commit_message !~ /java/
+  - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
     os : linux
     arch: arm64
     env: JOB_NAME=java_test
-  - if: type = pull_request AND commit_message !~ /java/
+  - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
     os: linux
     arch: ppc64le
     env: JOB_NAME=java_test
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : osx
     env: JOB_NAME=lite_build
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=lite_build
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=lite_build
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : osx
     env: JOB_NAME=examples
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=examples
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=examples
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=cmake-gcc8
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc8
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=cmake-gcc9
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc9
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=cmake-gcc9-c++20
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc9-c++20
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : osx
     env: JOB_NAME=status_checked
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=status_checked
-  - if: type = pull_request
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
     env: JOB_NAME=status_checked

--- a/Makefile
+++ b/Makefile
@@ -2150,13 +2150,6 @@ rocksdbjavageneratepom:
 jl/%.o: %.cc
 	$(AM_V_CC)mkdir -p $(@D) && $(CXX) $(CXXFLAGS) -fPIC -c $< -o $@ $(COVERAGEFLAGS)
 
-jl/crc32c_ppc.o: util/crc32c_ppc.c
-	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
-
-jl/crc32c_ppc_asm.o: util/crc32c_ppc_asm.S
-	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
-
-
 rocksdbjava: $(LIB_OBJECTS)
 	$(AM_V_GEN)cd java;$(MAKE) javalib;
 	$(AM_V_at)rm -f ./java/target/$(ROCKSDBJNILIB)
@@ -2219,7 +2212,7 @@ ifeq ($(HAVE_POWER8),1)
 $(OBJ_DIR)/util/crc32c_ppc.o: util/crc32c_ppc.c
 	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
 
-+$(OBJ_DIR)/util/crc32c_ppc_asm.o: util/crc32c_ppc_asm.S
+$(OBJ_DIR)/util/crc32c_ppc_asm.o: util/crc32c_ppc_asm.S
 	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
 endif
 $(OBJ_DIR)/%.o: %.cc
@@ -2265,7 +2258,7 @@ $(OBJ_DIR)/%.c.d: %.c
 	@$(CXX) $(CXXFLAGS) $(PLATFORM_SHARED_CFLAGS) \
 	  -MM -MT'$@' -MT'$(<:.c=.o)' "$<" -o '$@'
 
-+$(OBJ_DIR)/%.S.d: %.S
+$(OBJ_DIR)/%.S.d: %.S
 	@$(CXX) $(CXXFLAGS) $(PLATFORM_SHARED_CFLAGS) \
 	  -MM -MT'$@' -MT'$(<:.S=.o)' "$<" -o '$@'
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5394,18 +5394,11 @@ class Benchmark {
   // based on the hotness of the prefix and also the key hotness distribution.
   class GenerateTwoTermExpKeys {
    public:
-    int64_t keyrange_rand_max_;
-    int64_t keyrange_size_;
-    int64_t keyrange_num_;
-    bool initiated_;
+    // Avoid uninitialized warning-as-error in some compilers
+    int64_t keyrange_rand_max_ = 0;
+    int64_t keyrange_size_ = 0;
+    int64_t keyrange_num_ = 0;
     std::vector<KeyrangeUnit> keyrange_set_;
-
-    GenerateTwoTermExpKeys() {
-      keyrange_rand_max_ = FLAGS_num;
-      initiated_ = false;
-    }
-
-    ~GenerateTwoTermExpKeys() {}
 
     // Initiate the KeyrangeUnit vector and calculate the size of each
     // KeyrangeUnit.
@@ -5414,7 +5407,6 @@ class Benchmark {
                                    double prefix_d) {
       int64_t amplify = 0;
       int64_t keyrange_start = 0;
-      initiated_ = true;
       if (FLAGS_keyrange_num <= 0) {
         keyrange_num_ = 1;
       } else {


### PR DESCRIPTION
Summary: Also enables a pull request to trigger all the Travis
configurations by writing FULL_CI in the commit message. (See what I did
there?)

First issue

    make: *** No rule to make target 'jl/util/crc32c_ppc_asm.o', needed by 'rocksdbjava'.  Stop.

Second issue

    tools/db_bench_tool.cc:5514:38: error: ‘gen_exp.rocksdb::Benchmark::GenerateTwoTermExpKeys::keyrange_size_’ may be used uninitialized in this function

Test Plan: CI