### PR TITLE
Update comments to remove out-of-date information

### DIFF
--- a/include/rocksdb/table.h
+++ b/include/rocksdb/table.h
@@ -163,7 +163,7 @@ struct BlockBasedTableOptions {
   // Approximate size of user data packed per block.  Note that the
   // block size specified here corresponds to uncompressed data.  The
   // actual size of the unit read from disk may be smaller if
-  // compression is enabled.  This parameter can be changed dynamically.
+  // compression is enabled.
   size_t block_size = 4 * 1024;
 
   // This is used to close a block before it reaches the configured
@@ -174,9 +174,8 @@ struct BlockBasedTableOptions {
   int block_size_deviation = 10;
 
   // Number of keys between restart points for delta encoding of keys.
-  // This parameter can be changed dynamically.  Most clients should
-  // leave this parameter alone.  The minimum value allowed is 1.  Any smaller
-  // value will be silently overwritten with 1.
+  // Most clients should leave this parameter alone. The minimum value allowed
+  // is 1. Any smaller value will be silently overwritten with 1.
   int block_restart_interval = 16;
 
   // Same as block_restart_interval but used for the index block.


### PR DESCRIPTION
`BlockBasedTableOptions` is no longger mutable. It's used by
`BlockBasedTableFactory` for `options.table_factory`, seems not easy to
make it dynamically changeable:
https://github.com/facebook/rocksdb/blob/b9bb59d49df264363d7250ceba59213706b3bb61/options/cf_options.cc#L511-L514

Test Plan:
```
dbfull()->SetOptions({{"block_based_table_factory", "{block_size=7k;}"}});
// get error: Invalid argument: Option not changeable: block_based_table_factory
```