### PR TITLE
Makefile support subset/individual valgrind tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,13 +629,13 @@ endif
 
 	# Enable building all unit tests, but use check_some to run only tests
 	# known to pass ASC (ASSERT_STATUS_CHECKED)
-	SUBSET := $(TESTS_PASSING_ASC)
+	ROCKSDBTESTS_SUBSET ?= $(TESTS_PASSING_ASC)
 	# Alternate: only build unit tests known to pass ASC, and run them
 	# with make check
 	#TESTS := $(filter $(TESTS_PASSING_ASC),$(TESTS))
 	#PARALLEL_TEST := $(filter $(TESTS_PASSING_ASC),$(PARALLEL_TEST))
 else
-	SUBSET := $(TESTS)
+	ROCKSDBTESTS_SUBSET ?= $(TESTS)
 endif
 # Not necessarily well thought out or up-to-date, but matches old list
 TESTS_PLATFORM_DEPENDENT := \
@@ -665,26 +665,22 @@ TESTS_PLATFORM_DEPENDENT := \
 	iostats_context_test \
 	db_wal_test \
 
-# Sort SUBSET for filtering, except db_test is special (expensive) so
-# is placed first (out-of-order)
-SUBSET := $(filter db_test, $(SUBSET)) $(sort $(filter-out db_test, $(SUBSET)))
+# Sort ROCKSDBTESTS_SUBSET for filtering, except db_test is special (expensive)
+# so is placed first (out-of-order)
+ROCKSDBTESTS_SUBSET := $(filter db_test, $(ROCKSDBTESTS_SUBSET)) $(sort $(filter-out db_test, $(ROCKSDBTESTS_SUBSET)))
 
 ifdef ROCKSDBTESTS_START
-        SUBSET := $(shell echo $(SUBSET) | sed 's/^.*$(ROCKSDBTESTS_START)/$(ROCKSDBTESTS_START)/')
+        ROCKSDBTESTS_SUBSET := $(shell echo $(ROCKSDBTESTS_SUBSET) | sed 's/^.*$(ROCKSDBTESTS_START)/$(ROCKSDBTESTS_START)/')
 endif
 
 ifdef ROCKSDBTESTS_END
-        SUBSET := $(shell echo $(SUBSET) | sed 's/$(ROCKSDBTESTS_END).*//')
-endif
-
-ifdef ROCKSDBTESTS_ONLY
-        SUBSET := $(filter $(ROCKSDBTESTS_ONLY), $(SUBSET))
+        ROCKSDBTESTS_SUBSET := $(shell echo $(ROCKSDBTESTS_SUBSET) | sed 's/$(ROCKSDBTESTS_END).*//')
 endif
 
 ifeq ($(ROCKSDBTESTS_PLATFORM_DEPENDENT), only)
-        SUBSET := $(filter $(TESTS_PLATFORM_DEPENDENT), $(SUBSET))
+        ROCKSDBTESTS_SUBSET := $(filter $(TESTS_PLATFORM_DEPENDENT), $(ROCKSDBTESTS_SUBSET))
 else ifeq ($(ROCKSDBTESTS_PLATFORM_DEPENDENT), exclude)
-        SUBSET := $(filter-out $(TESTS_PLATFORM_DEPENDENT), $(SUBSET))
+        ROCKSDBTESTS_SUBSET := $(filter-out $(TESTS_PLATFORM_DEPENDENT), $(ROCKSDBTESTS_SUBSET))
 endif
 
 # bench_tool_analyer main is in bench_tool_analyzer_tool, or this would be simpler...
@@ -786,7 +782,7 @@ endif  # PLATFORM_SHARED_EXT
 
 all: $(LIBRARY) $(BENCHMARKS) tools tools_lib test_libs $(TESTS)
 
-all_but_some_tests: $(LIBRARY) $(BENCHMARKS) tools tools_lib test_libs $(SUBSET)
+all_but_some_tests: $(LIBRARY) $(BENCHMARKS) tools tools_lib test_libs $(ROCKSDBTESTS_SUBSET)
 
 static_lib: $(STATIC_LIBRARY)
 
@@ -1004,8 +1000,8 @@ ifndef SKIP_FORMAT_BUCK_CHECKS
 endif
 
 # TODO add ldb_tests
-check_some: $(SUBSET)
-	for t in $(SUBSET); do echo "===== Running $$t (`date`)"; ./$$t || exit 1; done
+check_some: $(ROCKSDBTESTS_SUBSET)
+	for t in $(ROCKSDBTESTS_SUBSET); do echo "===== Running $$t (`date`)"; ./$$t || exit 1; done
 
 .PHONY: ldb_tests
 ldb_tests: ldb
@@ -1130,8 +1126,8 @@ valgrind_check: $(TESTS)
 		done; \
 	fi
 
-valgrind_check_some: $(SUBSET)
-	for t in $(SUBSET); do \
+valgrind_check_some: $(ROCKSDBTESTS_SUBSET)
+	for t in $(ROCKSDBTESTS_SUBSET); do \
 		$(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
 		ret_code=$$?; \
 		if [ $$ret_code -ne 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -677,6 +677,10 @@ ifdef ROCKSDBTESTS_END
         SUBSET := $(shell echo $(SUBSET) | sed 's/$(ROCKSDBTESTS_END).*//')
 endif
 
+ifdef ROCKSDBTESTS_ONLY
+        SUBSET := $(filter $(ROCKSDBTESTS_ONLY), $(SUBSET))
+endif
+
 ifeq ($(ROCKSDBTESTS_PLATFORM_DEPENDENT), only)
         SUBSET := $(filter $(TESTS_PLATFORM_DEPENDENT), $(SUBSET))
 else ifeq ($(ROCKSDBTESTS_PLATFORM_DEPENDENT), exclude)
@@ -1105,6 +1109,9 @@ ubsan_crash_test_with_best_efforts_recovery: clean
 valgrind_test:
 	ROCKSDB_VALGRIND_RUN=1 DISABLE_JEMALLOC=1 $(MAKE) valgrind_check
 
+valgrind_test_some:
+	ROCKSDB_VALGRIND_RUN=1 DISABLE_JEMALLOC=1 $(MAKE) valgrind_check_some
+
 valgrind_check: $(TESTS)
 	$(MAKE) DRIVER="$(VALGRIND_VER) $(VALGRIND_OPTS)" gen_parallel_tests
 	$(AM_V_GEN)if test "$(J)" != 1                                  \
@@ -1123,6 +1130,14 @@ valgrind_check: $(TESTS)
 		done; \
 	fi
 
+valgrind_check_some: $(SUBSET)
+	for t in $(SUBSET); do \
+		$(VALGRIND_VER) $(VALGRIND_OPTS) ./$$t; \
+		ret_code=$$?; \
+		if [ $$ret_code -ne 0 ]; then \
+			exit $$ret_code; \
+		fi; \
+	done
 
 ifneq ($(PAR_TEST),)
 parloop:


### PR DESCRIPTION
Introduced `valgrind_check_some`, which is analogous to the `check_some` target for non-valgrind tests. It simplifies the process for running a single valgrind test or subset of valgrind tests when trying to repro a failure.

I also added a `ROCKSDBTESTS_ONLY` parameter, which simplifies selecting a single test to run. Previously the user would have to use `ROCKSDBTESTS_START` and `ROCKSDBTESTS_END`, but it was difficult to determine the end variable since it is an exclusive endpoint and must match an actual test name.