### PR TITLE
Update Travis config for broken snapd on ppc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,11 +100,11 @@ matrix:
     arch: amd64
     env: JOB_NAME=cmake-gcc9
   # Exclude most osx, arm64 and ppc64le tests for pull requests, but build in branches
-  # Temporarily disable ppc64le unit tests in PRs until Travis gets its act together (#6653)
+  # Temporarily disable ppc64le cmake test while snapd is broken
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: linux
     arch: ppc64le
-    env: TEST_GROUP=platform_dependent
+    env: JOB_NAME=cmake
   # NB: the cmake build is a partial java test
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx


### PR DESCRIPTION
Summary: snapd update has been failing on ppc for ~a week. Disabling it
for now in pull requests.

Also, #6653 seems to be fixed, so re-enabling standard unit tests for
PPC on pull requests.

Test Plan: CI