### PR TITLE
Add missing Java API for boolean and numerical fields in DBOptions

### DIFF
--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1221,6 +1221,30 @@ void Java_org_rocksdb_Options_setWalSizeLimitMB(
 
 /*
  * Class:     org_rocksdb_Options
+ * Method:    setMaxWriteBatchGroupSizeBytes
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_Options_setMaxWriteBatchGroupSizeBytes
+  (JNIEnv *, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->max_write_batch_group_size_bytes =
+      static_cast<uint64_t>(jmax_write_batch_group_size_bytes);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    maxWriteBatchGroupSizeBytes
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Options_maxWriteBatchGroupSizeBytes
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jlong>(opt->max_write_batch_group_size_bytes);
+}
+
+
+/*
+ * Class:     org_rocksdb_Options
  * Method:    manifestPreallocationSize
  * Signature: (J)J
  */
@@ -1950,7 +1974,7 @@ jboolean Java_org_rocksdb_Options_skipStatsUpdateOnDbOpen(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_Options_setSkipCheckingSstFileSizesOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jboolean jskip_checking_sst_file_sizes_on_db_open) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->skip_checking_sst_file_sizes_on_db_open =
@@ -1963,7 +1987,7 @@ void Java_org_rocksdb_Options_setSkipCheckingSstFileSizesOnDbOpen(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_Options_skipCheckingSstFileSizesOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->skip_checking_sst_file_sizes_on_db_open);
 }
@@ -2110,6 +2134,161 @@ jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(
     JNIEnv*, jobject, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_recovery);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setAvoidUnnecessaryBlockingIO
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setAvoidUnnecessaryBlockingIO
+  (JNIEnv *, jclass, jlong jhandle, jboolean avoid_blocking_io) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->avoid_unnecessary_blocking_io =
+      static_cast<bool>(avoid_blocking_io);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    avoidUnnecessaryBlockingIO
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_avoidUnnecessaryBlockingIO
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jboolean>(opt->avoid_unnecessary_blocking_io);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setPersistStatsToDisk
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setPersistStatsToDisk
+  (JNIEnv *, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->persist_stats_to_disk = static_cast<bool>(persist_stats_to_disk);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    persistStatsToDisk
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_persistStatsToDisk
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jboolean>(opt->persist_stats_to_disk);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setWriteDbidToManifest
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setWriteDbidToManifest
+  (JNIEnv *, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->write_dbid_to_manifest = static_cast<bool>(jwrite_dbid_to_manifest);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    writeDbidToManifest
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_writeDbidToManifest
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jboolean>(opt->write_dbid_to_manifest);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setLogReadaheadSize
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_Options_setLogReadaheadSize
+  (JNIEnv *, jclass, jlong jhandle, jlong jlog_readahead_size) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->log_readahead_size = static_cast<size_t>(jlog_readahead_size);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    logReasaheadSize
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Options_logReadaheadSize
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jlong>(opt->log_readahead_size);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setBestEffortsRecovery
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_Options_setBestEffortsRecovery
+  (JNIEnv *, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->best_efforts_recovery = static_cast<bool>(jbest_efforts_recovery);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    bestEffortsRecovery
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_Options_bestEffortsRecovery
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jlong>(opt->best_efforts_recovery);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setMaxBgErrorResumeCount
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_Options_setMaxBgErrorResumeCount
+  (JNIEnv *, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->max_bgerror_resume_count = static_cast<int>(jmax_bgerror_resume_count);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    maxBgerrorResumeCount
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_Options_maxBgerrorResumeCount
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jint>(opt->max_bgerror_resume_count);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    setBgerrorResumeRetryInterval
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_Options_setBgerrorResumeRetryInterval
+  (JNIEnv *, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  opt->bgerror_resume_retry_interval = static_cast<uint64_t>(jbgerror_resume_retry_interval);
+}
+
+/*
+ * Class:     org_rocksdb_Options
+ * Method:    bgerrorResumeRetryInterval
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_Options_bgerrorResumeRetryInterval
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
+  return static_cast<jlong>(opt->bgerror_resume_retry_interval);
 }
 
 /*
@@ -5853,6 +6032,29 @@ jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(
 
 /*
  * Class:     org_rocksdb_DBOptions
+ * Method:    setMaxWriteBatchGroupSizeBytes
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_DBOptions_setMaxWriteBatchGroupSizeBytes
+  (JNIEnv *, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->max_write_batch_group_size_bytes =
+      static_cast<uint64_t>(jmax_write_batch_group_size_bytes);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    maxWriteBatchGroupSizeBytes
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_DBOptions_maxWriteBatchGroupSizeBytes
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jlong>(opt->max_write_batch_group_size_bytes);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
  * Method:    setManifestPreallocationSize
  * Signature: (JJ)V
  */
@@ -6553,7 +6755,7 @@ jboolean Java_org_rocksdb_DBOptions_skipStatsUpdateOnDbOpen(
  * Signature: (JZ)V
  */
 void Java_org_rocksdb_DBOptions_setSkipCheckingSstFileSizesOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle,
+    JNIEnv*, jclass, jlong jhandle,
     jboolean jskip_checking_sst_file_sizes_on_db_open) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->skip_checking_sst_file_sizes_on_db_open =
@@ -6566,7 +6768,7 @@ void Java_org_rocksdb_DBOptions_setSkipCheckingSstFileSizesOnDbOpen(
  * Signature: (J)Z
  */
 jboolean Java_org_rocksdb_DBOptions_skipCheckingSstFileSizesOnDbOpen(
-    JNIEnv*, jobject, jlong jhandle) {
+    JNIEnv*, jclass, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->skip_checking_sst_file_sizes_on_db_open);
 }
@@ -6844,6 +7046,161 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(
     JNIEnv*, jobject, jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_flush_during_shutdown);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setAvoidUnnecessaryBlockingIO
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_DBOptions_setAvoidUnnecessaryBlockingIO
+  (JNIEnv *, jclass, jlong jhandle, jboolean avoid_blocking_io) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->avoid_unnecessary_blocking_io =
+      static_cast<bool>(avoid_blocking_io);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    avoidUnnecessaryBlockingIO
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_DBOptions_avoidUnnecessaryBlockingIO
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jboolean>(opt->avoid_unnecessary_blocking_io);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setPersistStatsToDisk
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_DBOptions_setPersistStatsToDisk
+  (JNIEnv *, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->persist_stats_to_disk = static_cast<bool>(persist_stats_to_disk);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    persistStatsToDisk
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_DBOptions_persistStatsToDisk
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jboolean>(opt->persist_stats_to_disk);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setWriteDbidToManifest
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_DBOptions_setWriteDbidToManifest
+  (JNIEnv *, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->write_dbid_to_manifest = static_cast<bool>(jwrite_dbid_to_manifest);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    writeDbidToManifest
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_DBOptions_writeDbidToManifest
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jboolean>(opt->write_dbid_to_manifest);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setLogReadaheadSize
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_DBOptions_setLogReadaheadSize
+  (JNIEnv *, jclass, jlong jhandle, jlong jlog_readahead_size) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->log_readahead_size = static_cast<size_t>(jlog_readahead_size);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    logReasaheadSize
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_DBOptions_logReadaheadSize
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jlong>(opt->log_readahead_size);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setBestEffortsRecovery
+ * Signature: (JZ)V
+ */
+void Java_org_rocksdb_DBOptions_setBestEffortsRecovery
+  (JNIEnv *, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->best_efforts_recovery = static_cast<bool>(jbest_efforts_recovery);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    bestEffortsRecovery
+ * Signature: (J)Z
+ */
+jboolean Java_org_rocksdb_DBOptions_bestEffortsRecovery
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jlong>(opt->best_efforts_recovery);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setMaxBgErrorResumeCount
+ * Signature: (JI)V
+ */
+void Java_org_rocksdb_DBOptions_setMaxBgErrorResumeCount
+  (JNIEnv *, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->max_bgerror_resume_count = static_cast<int>(jmax_bgerror_resume_count);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    maxBgerrorResumeCount
+ * Signature: (J)I
+ */
+jint Java_org_rocksdb_DBOptions_maxBgerrorResumeCount
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jint>(opt->max_bgerror_resume_count);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    setBgerrorResumeRetryInterval
+ * Signature: (JJ)V
+ */
+void Java_org_rocksdb_DBOptions_setBgerrorResumeRetryInterval
+  (JNIEnv *, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  opt->bgerror_resume_retry_interval = static_cast<uint64_t>(jbgerror_resume_retry_interval);
+}
+
+/*
+ * Class:     org_rocksdb_DBOptions
+ * Method:    bgerrorResumeRetryInterval
+ * Signature: (J)J
+ */
+jlong Java_org_rocksdb_DBOptions_bgerrorResumeRetryInterval
+  (JNIEnv *, jclass, jlong jhandle) {
+  auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
+  return static_cast<jlong>(opt->bgerror_resume_retry_interval);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -1224,8 +1224,8 @@ void Java_org_rocksdb_Options_setWalSizeLimitMB(
  * Method:    setMaxWriteBatchGroupSizeBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setMaxWriteBatchGroupSizeBytes
-  (JNIEnv *, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
+void Java_org_rocksdb_Options_setMaxWriteBatchGroupSizeBytes(
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->max_write_batch_group_size_bytes =
       static_cast<uint64_t>(jmax_write_batch_group_size_bytes);
@@ -1236,12 +1236,11 @@ void Java_org_rocksdb_Options_setMaxWriteBatchGroupSizeBytes
  * Method:    maxWriteBatchGroupSizeBytes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_maxWriteBatchGroupSizeBytes
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_Options_maxWriteBatchGroupSizeBytes(JNIEnv*, jclass,
+                                                           jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->max_write_batch_group_size_bytes);
 }
-
 
 /*
  * Class:     org_rocksdb_Options
@@ -2141,11 +2140,10 @@ jboolean Java_org_rocksdb_Options_avoidFlushDuringRecovery(
  * Method:    setAvoidUnnecessaryBlockingIO
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setAvoidUnnecessaryBlockingIO
-  (JNIEnv *, jclass, jlong jhandle, jboolean avoid_blocking_io) {
+void Java_org_rocksdb_Options_setAvoidUnnecessaryBlockingIO(
+    JNIEnv*, jclass, jlong jhandle, jboolean avoid_blocking_io) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
-  opt->avoid_unnecessary_blocking_io =
-      static_cast<bool>(avoid_blocking_io);
+  opt->avoid_unnecessary_blocking_io = static_cast<bool>(avoid_blocking_io);
 }
 
 /*
@@ -2153,8 +2151,8 @@ void Java_org_rocksdb_Options_setAvoidUnnecessaryBlockingIO
  * Method:    avoidUnnecessaryBlockingIO
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_avoidUnnecessaryBlockingIO
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_avoidUnnecessaryBlockingIO(JNIEnv*, jclass,
+                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->avoid_unnecessary_blocking_io);
 }
@@ -2164,8 +2162,8 @@ jboolean Java_org_rocksdb_Options_avoidUnnecessaryBlockingIO
  * Method:    setPersistStatsToDisk
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setPersistStatsToDisk
-  (JNIEnv *, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
+void Java_org_rocksdb_Options_setPersistStatsToDisk(
+    JNIEnv*, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->persist_stats_to_disk = static_cast<bool>(persist_stats_to_disk);
 }
@@ -2175,8 +2173,8 @@ void Java_org_rocksdb_Options_setPersistStatsToDisk
  * Method:    persistStatsToDisk
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_persistStatsToDisk
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_persistStatsToDisk(JNIEnv*, jclass,
+                                                     jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->persist_stats_to_disk);
 }
@@ -2186,8 +2184,8 @@ jboolean Java_org_rocksdb_Options_persistStatsToDisk
  * Method:    setWriteDbidToManifest
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setWriteDbidToManifest
-  (JNIEnv *, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
+void Java_org_rocksdb_Options_setWriteDbidToManifest(
+    JNIEnv*, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->write_dbid_to_manifest = static_cast<bool>(jwrite_dbid_to_manifest);
 }
@@ -2197,8 +2195,8 @@ void Java_org_rocksdb_Options_setWriteDbidToManifest
  * Method:    writeDbidToManifest
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_writeDbidToManifest
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_writeDbidToManifest(JNIEnv*, jclass,
+                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jboolean>(opt->write_dbid_to_manifest);
 }
@@ -2208,8 +2206,9 @@ jboolean Java_org_rocksdb_Options_writeDbidToManifest
  * Method:    setLogReadaheadSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setLogReadaheadSize
-  (JNIEnv *, jclass, jlong jhandle, jlong jlog_readahead_size) {
+void Java_org_rocksdb_Options_setLogReadaheadSize(JNIEnv*, jclass,
+                                                  jlong jhandle,
+                                                  jlong jlog_readahead_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->log_readahead_size = static_cast<size_t>(jlog_readahead_size);
 }
@@ -2219,8 +2218,8 @@ void Java_org_rocksdb_Options_setLogReadaheadSize
  * Method:    logReasaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_logReadaheadSize
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_Options_logReadaheadSize(JNIEnv*, jclass,
+                                                jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->log_readahead_size);
 }
@@ -2230,8 +2229,8 @@ jlong Java_org_rocksdb_Options_logReadaheadSize
  * Method:    setBestEffortsRecovery
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_Options_setBestEffortsRecovery
-  (JNIEnv *, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
+void Java_org_rocksdb_Options_setBestEffortsRecovery(
+    JNIEnv*, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->best_efforts_recovery = static_cast<bool>(jbest_efforts_recovery);
 }
@@ -2241,8 +2240,8 @@ void Java_org_rocksdb_Options_setBestEffortsRecovery
  * Method:    bestEffortsRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_Options_bestEffortsRecovery
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_Options_bestEffortsRecovery(JNIEnv*, jclass,
+                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->best_efforts_recovery);
 }
@@ -2252,8 +2251,8 @@ jboolean Java_org_rocksdb_Options_bestEffortsRecovery
  * Method:    setMaxBgErrorResumeCount
  * Signature: (JI)V
  */
-void Java_org_rocksdb_Options_setMaxBgErrorResumeCount
-  (JNIEnv *, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
+void Java_org_rocksdb_Options_setMaxBgErrorResumeCount(
+    JNIEnv*, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   opt->max_bgerror_resume_count = static_cast<int>(jmax_bgerror_resume_count);
 }
@@ -2263,8 +2262,8 @@ void Java_org_rocksdb_Options_setMaxBgErrorResumeCount
  * Method:    maxBgerrorResumeCount
  * Signature: (J)I
  */
-jint Java_org_rocksdb_Options_maxBgerrorResumeCount
-  (JNIEnv *, jclass, jlong jhandle) {
+jint Java_org_rocksdb_Options_maxBgerrorResumeCount(JNIEnv*, jclass,
+                                                    jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jint>(opt->max_bgerror_resume_count);
 }
@@ -2274,10 +2273,11 @@ jint Java_org_rocksdb_Options_maxBgerrorResumeCount
  * Method:    setBgerrorResumeRetryInterval
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_Options_setBgerrorResumeRetryInterval
-  (JNIEnv *, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
+void Java_org_rocksdb_Options_setBgerrorResumeRetryInterval(
+    JNIEnv*, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
-  opt->bgerror_resume_retry_interval = static_cast<uint64_t>(jbgerror_resume_retry_interval);
+  opt->bgerror_resume_retry_interval =
+      static_cast<uint64_t>(jbgerror_resume_retry_interval);
 }
 
 /*
@@ -2285,8 +2285,8 @@ void Java_org_rocksdb_Options_setBgerrorResumeRetryInterval
  * Method:    bgerrorResumeRetryInterval
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_Options_bgerrorResumeRetryInterval
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_Options_bgerrorResumeRetryInterval(JNIEnv*, jclass,
+                                                          jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
   return static_cast<jlong>(opt->bgerror_resume_retry_interval);
 }
@@ -6035,8 +6035,8 @@ jlong Java_org_rocksdb_DBOptions_walSizeLimitMB(
  * Method:    setMaxWriteBatchGroupSizeBytes
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setMaxWriteBatchGroupSizeBytes
-  (JNIEnv *, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
+void Java_org_rocksdb_DBOptions_setMaxWriteBatchGroupSizeBytes(
+    JNIEnv*, jclass, jlong jhandle, jlong jmax_write_batch_group_size_bytes) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->max_write_batch_group_size_bytes =
       static_cast<uint64_t>(jmax_write_batch_group_size_bytes);
@@ -6047,8 +6047,8 @@ void Java_org_rocksdb_DBOptions_setMaxWriteBatchGroupSizeBytes
  * Method:    maxWriteBatchGroupSizeBytes
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_maxWriteBatchGroupSizeBytes
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_maxWriteBatchGroupSizeBytes(JNIEnv*, jclass,
+                                                             jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->max_write_batch_group_size_bytes);
 }
@@ -7053,11 +7053,10 @@ jboolean Java_org_rocksdb_DBOptions_avoidFlushDuringShutdown(
  * Method:    setAvoidUnnecessaryBlockingIO
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setAvoidUnnecessaryBlockingIO
-  (JNIEnv *, jclass, jlong jhandle, jboolean avoid_blocking_io) {
+void Java_org_rocksdb_DBOptions_setAvoidUnnecessaryBlockingIO(
+    JNIEnv*, jclass, jlong jhandle, jboolean avoid_blocking_io) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
-  opt->avoid_unnecessary_blocking_io =
-      static_cast<bool>(avoid_blocking_io);
+  opt->avoid_unnecessary_blocking_io = static_cast<bool>(avoid_blocking_io);
 }
 
 /*
@@ -7065,8 +7064,8 @@ void Java_org_rocksdb_DBOptions_setAvoidUnnecessaryBlockingIO
  * Method:    avoidUnnecessaryBlockingIO
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_avoidUnnecessaryBlockingIO
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_avoidUnnecessaryBlockingIO(JNIEnv*, jclass,
+                                                               jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->avoid_unnecessary_blocking_io);
 }
@@ -7076,8 +7075,8 @@ jboolean Java_org_rocksdb_DBOptions_avoidUnnecessaryBlockingIO
  * Method:    setPersistStatsToDisk
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setPersistStatsToDisk
-  (JNIEnv *, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
+void Java_org_rocksdb_DBOptions_setPersistStatsToDisk(
+    JNIEnv*, jclass, jlong jhandle, jboolean persist_stats_to_disk) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->persist_stats_to_disk = static_cast<bool>(persist_stats_to_disk);
 }
@@ -7087,8 +7086,8 @@ void Java_org_rocksdb_DBOptions_setPersistStatsToDisk
  * Method:    persistStatsToDisk
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_persistStatsToDisk
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_persistStatsToDisk(JNIEnv*, jclass,
+                                                       jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->persist_stats_to_disk);
 }
@@ -7098,8 +7097,8 @@ jboolean Java_org_rocksdb_DBOptions_persistStatsToDisk
  * Method:    setWriteDbidToManifest
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setWriteDbidToManifest
-  (JNIEnv *, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
+void Java_org_rocksdb_DBOptions_setWriteDbidToManifest(
+    JNIEnv*, jclass, jlong jhandle, jboolean jwrite_dbid_to_manifest) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->write_dbid_to_manifest = static_cast<bool>(jwrite_dbid_to_manifest);
 }
@@ -7109,8 +7108,8 @@ void Java_org_rocksdb_DBOptions_setWriteDbidToManifest
  * Method:    writeDbidToManifest
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_writeDbidToManifest
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_writeDbidToManifest(JNIEnv*, jclass,
+                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jboolean>(opt->write_dbid_to_manifest);
 }
@@ -7120,8 +7119,9 @@ jboolean Java_org_rocksdb_DBOptions_writeDbidToManifest
  * Method:    setLogReadaheadSize
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setLogReadaheadSize
-  (JNIEnv *, jclass, jlong jhandle, jlong jlog_readahead_size) {
+void Java_org_rocksdb_DBOptions_setLogReadaheadSize(JNIEnv*, jclass,
+                                                    jlong jhandle,
+                                                    jlong jlog_readahead_size) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->log_readahead_size = static_cast<size_t>(jlog_readahead_size);
 }
@@ -7131,8 +7131,8 @@ void Java_org_rocksdb_DBOptions_setLogReadaheadSize
  * Method:    logReasaheadSize
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_logReadaheadSize
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_logReadaheadSize(JNIEnv*, jclass,
+                                                  jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->log_readahead_size);
 }
@@ -7142,8 +7142,8 @@ jlong Java_org_rocksdb_DBOptions_logReadaheadSize
  * Method:    setBestEffortsRecovery
  * Signature: (JZ)V
  */
-void Java_org_rocksdb_DBOptions_setBestEffortsRecovery
-  (JNIEnv *, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
+void Java_org_rocksdb_DBOptions_setBestEffortsRecovery(
+    JNIEnv*, jclass, jlong jhandle, jboolean jbest_efforts_recovery) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->best_efforts_recovery = static_cast<bool>(jbest_efforts_recovery);
 }
@@ -7153,8 +7153,8 @@ void Java_org_rocksdb_DBOptions_setBestEffortsRecovery
  * Method:    bestEffortsRecovery
  * Signature: (J)Z
  */
-jboolean Java_org_rocksdb_DBOptions_bestEffortsRecovery
-  (JNIEnv *, jclass, jlong jhandle) {
+jboolean Java_org_rocksdb_DBOptions_bestEffortsRecovery(JNIEnv*, jclass,
+                                                        jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->best_efforts_recovery);
 }
@@ -7164,8 +7164,8 @@ jboolean Java_org_rocksdb_DBOptions_bestEffortsRecovery
  * Method:    setMaxBgErrorResumeCount
  * Signature: (JI)V
  */
-void Java_org_rocksdb_DBOptions_setMaxBgErrorResumeCount
-  (JNIEnv *, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
+void Java_org_rocksdb_DBOptions_setMaxBgErrorResumeCount(
+    JNIEnv*, jclass, jlong jhandle, jint jmax_bgerror_resume_count) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   opt->max_bgerror_resume_count = static_cast<int>(jmax_bgerror_resume_count);
 }
@@ -7175,8 +7175,8 @@ void Java_org_rocksdb_DBOptions_setMaxBgErrorResumeCount
  * Method:    maxBgerrorResumeCount
  * Signature: (J)I
  */
-jint Java_org_rocksdb_DBOptions_maxBgerrorResumeCount
-  (JNIEnv *, jclass, jlong jhandle) {
+jint Java_org_rocksdb_DBOptions_maxBgerrorResumeCount(JNIEnv*, jclass,
+                                                      jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jint>(opt->max_bgerror_resume_count);
 }
@@ -7186,10 +7186,11 @@ jint Java_org_rocksdb_DBOptions_maxBgerrorResumeCount
  * Method:    setBgerrorResumeRetryInterval
  * Signature: (JJ)V
  */
-void Java_org_rocksdb_DBOptions_setBgerrorResumeRetryInterval
-  (JNIEnv *, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
+void Java_org_rocksdb_DBOptions_setBgerrorResumeRetryInterval(
+    JNIEnv*, jclass, jlong jhandle, jlong jbgerror_resume_retry_interval) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
-  opt->bgerror_resume_retry_interval = static_cast<uint64_t>(jbgerror_resume_retry_interval);
+  opt->bgerror_resume_retry_interval =
+      static_cast<uint64_t>(jbgerror_resume_retry_interval);
 }
 
 /*
@@ -7197,8 +7198,8 @@ void Java_org_rocksdb_DBOptions_setBgerrorResumeRetryInterval
  * Method:    bgerrorResumeRetryInterval
  * Signature: (J)J
  */
-jlong Java_org_rocksdb_DBOptions_bgerrorResumeRetryInterval
-  (JNIEnv *, jclass, jlong jhandle) {
+jlong Java_org_rocksdb_DBOptions_bgerrorResumeRetryInterval(JNIEnv*, jclass,
+                                                            jlong jhandle) {
   auto* opt = reinterpret_cast<ROCKSDB_NAMESPACE::DBOptions*>(jhandle);
   return static_cast<jlong>(opt->bgerror_resume_retry_interval);
 }

--- a/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyOptionsInterface.java
@@ -487,9 +487,13 @@ public interface ColumnFamilyOptionsInterface<T extends ColumnFamilyOptionsInter
    * partitioning of sst files. This helps compaction to split the files
    * on interesting boundaries (key prefixes) to make propagation of sst
    * files less write amplifying (covering the whole key space).
+   *
+   * Default: nullptr
+   *
    * @param factory The factory reference
    * @return the reference of the current options.
    */
+  @Experimental("Caution: this option is experimental")
   T setSstPartitionerFactory(SstPartitionerFactory factory);
 
   /**
@@ -497,6 +501,7 @@ public interface ColumnFamilyOptionsInterface<T extends ColumnFamilyOptionsInter
    *
    * @return SST partitioner factory
    */
+  @Experimental("Caution: this option is experimental")
   SstPartitionerFactory sstPartitionerFactory();
 
   /**

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -573,13 +573,15 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setMaxWriteBatchGroupSizeBytes(long maxWriteBatchGroupSizeBytes) {
-    return null;
+  public DBOptions setMaxWriteBatchGroupSizeBytes(final long maxWriteBatchGroupSizeBytes) {
+    setMaxWriteBatchGroupSizeBytes(nativeHandle_, maxWriteBatchGroupSizeBytes);
+    return this;
   }
 
   @Override
   public long maxWriteBatchGroupSizeBytes() {
-    return 0;
+    assert(isOwningHandle());
+    return maxWriteBatchGroupSizeBytes(nativeHandle_);
   }
 
   @Override
@@ -1021,13 +1023,15 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setSkipCheckingSstFileSizesOnDbOpen(boolean skipCheckingSstFileSizesOnDbOpen) {
-    return null;
+  public DBOptions setSkipCheckingSstFileSizesOnDbOpen(final boolean skipCheckingSstFileSizesOnDbOpen) {
+    setSkipCheckingSstFileSizesOnDbOpen(nativeHandle_, skipCheckingSstFileSizesOnDbOpen);
+    return this;
   }
 
   @Override
   public boolean skipCheckingSstFileSizesOnDbOpen() {
-    return false;
+    assert(isOwningHandle());
+    return skipCheckingSstFileSizesOnDbOpen(nativeHandle_);
   }
 
   @Override
@@ -1200,7 +1204,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setAvoidUnnecessaryBlockingIO(boolean avoidUnnecessaryBlockingIO) {
+  public DBOptions setAvoidUnnecessaryBlockingIO(final boolean avoidUnnecessaryBlockingIO) {
     setAvoidUnnecessaryBlockingIO(nativeHandle_, avoidUnnecessaryBlockingIO);
     return this;
   }
@@ -1212,7 +1216,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setPersistStatsToDisk(boolean persistStatsToDisk) {
+  public DBOptions setPersistStatsToDisk(final boolean persistStatsToDisk) {
     setPersistStatsToDisk(nativeHandle_, persistStatsToDisk);
     return this;
   }
@@ -1224,7 +1228,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setWriteDbidToManifest(boolean writeDbidToManifest) {
+  public DBOptions setWriteDbidToManifest(final boolean writeDbidToManifest) {
     setWriteDbidToManifest(nativeHandle_, writeDbidToManifest);
     return this;
   }
@@ -1236,7 +1240,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setLogReadaheadSize(long logReadaheadSize) {
+  public DBOptions setLogReadaheadSize(final long logReadaheadSize) {
     setLogReadaheadSize(nativeHandle_, logReadaheadSize);
     return this;
   }
@@ -1244,11 +1248,11 @@ public class DBOptions extends RocksObject
   @Override
   public long logReadaheadSize() {
     assert(isOwningHandle());
-    return logReasaheadSize(nativeHandle_);
+    return logReadaheadSize(nativeHandle_);
   }
 
   @Override
-  public DBOptions setBestEffortsRecovery(boolean bestEffortsRecovery) {
+  public DBOptions setBestEffortsRecovery(final boolean bestEffortsRecovery) {
     setBestEffortsRecovery(nativeHandle_, bestEffortsRecovery);
     return this;
   }
@@ -1260,8 +1264,8 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
-    setMaxBgerrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
+  public DBOptions setMaxBgErrorResumeCount(final int maxBgerrorResumeCount) {
+    setMaxBgErrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
     return this;
   }
 
@@ -1272,7 +1276,7 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setBgerrorResumeRetryInterval(long bgerrorResumeRetryInterval) {
+  public DBOptions setBgerrorResumeRetryInterval(final long bgerrorResumeRetryInterval) {
     setBgerrorResumeRetryInterval(nativeHandle_, bgerrorResumeRetryInterval);
     return this;
   }
@@ -1385,6 +1389,9 @@ public class DBOptions extends RocksObject
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
+  private static native void setMaxWriteBatchGroupSizeBytes(final long handle,
+                                                            final long maxWriteBatchGroupSizeBytes);
+  private static native long maxWriteBatchGroupSizeBytes(final long handle);
   private native void setManifestPreallocationSize(
       long handle, long size) throws IllegalArgumentException;
   private native long manifestPreallocationSize(long handle);
@@ -1477,6 +1484,9 @@ public class DBOptions extends RocksObject
   private native void setSkipStatsUpdateOnDbOpen(final long handle,
       final boolean skipStatsUpdateOnDbOpen);
   private native boolean skipStatsUpdateOnDbOpen(final long handle);
+  private static native void setSkipCheckingSstFileSizesOnDbOpen(final long handle,
+                                                                 final boolean skipChecking);
+  private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
   private native void setWalRecoveryMode(final long handle,
       final byte walRecoveryMode);
   private native byte walRecoveryMode(final long handle);
@@ -1525,11 +1535,11 @@ public class DBOptions extends RocksObject
   private static native boolean writeDbidToManifest(final long handle);
   private static native void setLogReadaheadSize(final long handle,
                                                  final long logReadaheadSize);
-  private static native long logReasaheadSize(final long handle);
+  private static native long logReadaheadSize(final long handle);
   private static native void setBestEffortsRecovery(final long handle,
                                                     final boolean bestEffortsRecovery);
   private static native boolean bestEffortsRecovery(final long handle);
-  private static native void setMaxBgerrorResumeCount(final long handle,
+  private static native void setMaxBgErrorResumeCount(final long handle,
                                                       final int maxBgerrorRecumeCount);
   private static native int maxBgerrorResumeCount(final long handle);
   private static native void setBgerrorResumeRetryInterval(final long handle,

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -573,6 +573,16 @@ public class DBOptions extends RocksObject
   }
 
   @Override
+  public DBOptions setMaxWriteBatchGroupSizeBytes(long maxWriteBatchGroupSizeBytes) {
+    return null;
+  }
+
+  @Override
+  public long maxWriteBatchGroupSizeBytes() {
+    return 0;
+  }
+
+  @Override
   public DBOptions setManifestPreallocationSize(
       final long size) {
     assert(isOwningHandle());
@@ -1011,6 +1021,16 @@ public class DBOptions extends RocksObject
   }
 
   @Override
+  public DBOptions setSkipCheckingSstFileSizesOnDbOpen(boolean skipCheckingSstFileSizesOnDbOpen) {
+    return null;
+  }
+
+  @Override
+  public boolean skipCheckingSstFileSizesOnDbOpen() {
+    return false;
+  }
+
+  @Override
   public DBOptions setWalRecoveryMode(final WALRecoveryMode walRecoveryMode) {
     assert(isOwningHandle());
     setWalRecoveryMode(nativeHandle_, walRecoveryMode.getValue());
@@ -1177,6 +1197,76 @@ public class DBOptions extends RocksObject
   @Override
   public boolean atomicFlush() {
     return atomicFlush(nativeHandle_);
+  }
+
+  @Override
+  public DBOptions setAvoidUnnecessaryBlockingIO(boolean avoidUnnecessaryBlockingIO) {
+    return null;
+  }
+
+  @Override
+  public boolean avoidUnnecessaryBlockingIO() {
+    return false;
+  }
+
+  @Override
+  public DBOptions setPersistStatsToDisk(boolean persistStatsToDisk) {
+    return null;
+  }
+
+  @Override
+  public boolean persistStatsToDisk() {
+    return false;
+  }
+
+  @Override
+  public DBOptions setWriteDbidToManifest(boolean writeDbidToManifest) {
+    return null;
+  }
+
+  @Override
+  public boolean writeDbidToManifest() {
+    return false;
+  }
+
+  @Override
+  public DBOptions setLogReadaheadSize(long logReadaheadSize) {
+    return null;
+  }
+
+  @Override
+  public long logReadaheadSize() {
+    return 0;
+  }
+
+  @Override
+  public DBOptions setBestEffortsRecovery(boolean bestEffortsRecovery) {
+    return null;
+  }
+
+  @Override
+  public boolean bestEffortsRecovery() {
+    return false;
+  }
+
+  @Override
+  public DBOptions setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
+    return null;
+  }
+
+  @Override
+  public int maxBgerrorResumeCount() {
+    return 0;
+  }
+
+  @Override
+  public DBOptions setBgerrorResumeRetryInterval(long bgerrorResumeRetryInterval) {
+    return null;
+  }
+
+  @Override
+  public long bgerrorResumeRetryInterval() {
+    return 0;
   }
 
   static final int DEFAULT_NUM_SHARD_BITS = -1;

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -1201,72 +1201,86 @@ public class DBOptions extends RocksObject
 
   @Override
   public DBOptions setAvoidUnnecessaryBlockingIO(boolean avoidUnnecessaryBlockingIO) {
-    return null;
+    setAvoidUnnecessaryBlockingIO(nativeHandle_, avoidUnnecessaryBlockingIO);
+    return this;
   }
 
   @Override
   public boolean avoidUnnecessaryBlockingIO() {
-    return false;
+    assert(isOwningHandle());
+    return avoidUnnecessaryBlockingIO(nativeHandle_);
   }
 
   @Override
   public DBOptions setPersistStatsToDisk(boolean persistStatsToDisk) {
-    return null;
+    setPersistStatsToDisk(nativeHandle_, persistStatsToDisk);
+    return this;
   }
 
   @Override
   public boolean persistStatsToDisk() {
-    return false;
+    assert(isOwningHandle());
+    return persistStatsToDisk(nativeHandle_);
   }
 
   @Override
   public DBOptions setWriteDbidToManifest(boolean writeDbidToManifest) {
-    return null;
+    setWriteDbidToManifest(nativeHandle_, writeDbidToManifest);
+    return this;
   }
 
   @Override
   public boolean writeDbidToManifest() {
-    return false;
+    assert(isOwningHandle());
+    return writeDbidToManifest(nativeHandle_);
   }
 
   @Override
   public DBOptions setLogReadaheadSize(long logReadaheadSize) {
-    return null;
+    setLogReadaheadSize(nativeHandle_, logReadaheadSize);
+    return this;
   }
 
   @Override
   public long logReadaheadSize() {
-    return 0;
+    assert(isOwningHandle());
+    return logReasaheadSize(nativeHandle_);
   }
 
   @Override
   public DBOptions setBestEffortsRecovery(boolean bestEffortsRecovery) {
-    return null;
+    setBestEffortsRecovery(nativeHandle_, bestEffortsRecovery);
+    return this;
   }
 
   @Override
   public boolean bestEffortsRecovery() {
-    return false;
+    assert(isOwningHandle());
+    return bestEffortsRecovery(nativeHandle_);
   }
 
   @Override
   public DBOptions setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
-    return null;
+    setMaxBgerrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
+    return this;
   }
 
   @Override
   public int maxBgerrorResumeCount() {
-    return 0;
+    assert(isOwningHandle());
+    return maxBgerrorResumeCount(nativeHandle_);
   }
 
   @Override
   public DBOptions setBgerrorResumeRetryInterval(long bgerrorResumeRetryInterval) {
-    return null;
+    setBgerrorResumeRetryInterval(nativeHandle_, bgerrorResumeRetryInterval);
+    return this;
   }
 
   @Override
   public long bgerrorResumeRetryInterval() {
-    return 0;
+    assert(isOwningHandle());
+    return bgerrorResumeRetryInterval(nativeHandle_);
   }
 
   static final int DEFAULT_NUM_SHARD_BITS = -1;
@@ -1500,6 +1514,27 @@ public class DBOptions extends RocksObject
   private native void setAtomicFlush(final long handle,
       final boolean atomicFlush);
   private native boolean atomicFlush(final long handle);
+  private static native void setAvoidUnnecessaryBlockingIO(final long handle,
+                                                           final boolean avoidBlockingIO);
+  private static native boolean avoidUnnecessaryBlockingIO(final long handle);
+  private static native void setPersistStatsToDisk(final long handle,
+                                                   final boolean persistStatsToDisk);
+  private static native boolean persistStatsToDisk(final long handle);
+  private static native void setWriteDbidToManifest(final long handle,
+                                                    final boolean writeDbidToManifest);
+  private static native boolean writeDbidToManifest(final long handle);
+  private static native void setLogReadaheadSize(final long handle,
+                                                 final long logReadaheadSize);
+  private static native long logReasaheadSize(final long handle);
+  private static native void setBestEffortsRecovery(final long handle,
+                                                    final boolean bestEffortsRecovery);
+  private static native boolean bestEffortsRecovery(final long handle);
+  private static native void setMaxBgerrorResumeCount(final long handle,
+                                                      final int maxBgerrorRecumeCount);
+  private static native int maxBgerrorResumeCount(final long handle);
+  private static native void setBgerrorResumeRetryInterval(final long handle,
+                                                           final long bgerrorResumeRetryInterval);
+  private static native long bgerrorResumeRetryInterval(final long handle);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!

--- a/java/src/main/java/org/rocksdb/DBOptions.java
+++ b/java/src/main/java/org/rocksdb/DBOptions.java
@@ -580,7 +580,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public long maxWriteBatchGroupSizeBytes() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return maxWriteBatchGroupSizeBytes(nativeHandle_);
   }
 
@@ -1023,14 +1023,15 @@ public class DBOptions extends RocksObject
   }
 
   @Override
-  public DBOptions setSkipCheckingSstFileSizesOnDbOpen(final boolean skipCheckingSstFileSizesOnDbOpen) {
+  public DBOptions setSkipCheckingSstFileSizesOnDbOpen(
+      final boolean skipCheckingSstFileSizesOnDbOpen) {
     setSkipCheckingSstFileSizesOnDbOpen(nativeHandle_, skipCheckingSstFileSizesOnDbOpen);
     return this;
   }
 
   @Override
   public boolean skipCheckingSstFileSizesOnDbOpen() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return skipCheckingSstFileSizesOnDbOpen(nativeHandle_);
   }
 
@@ -1211,7 +1212,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public boolean avoidUnnecessaryBlockingIO() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return avoidUnnecessaryBlockingIO(nativeHandle_);
   }
 
@@ -1223,7 +1224,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public boolean persistStatsToDisk() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return persistStatsToDisk(nativeHandle_);
   }
 
@@ -1235,7 +1236,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public boolean writeDbidToManifest() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return writeDbidToManifest(nativeHandle_);
   }
 
@@ -1247,7 +1248,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public long logReadaheadSize() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return logReadaheadSize(nativeHandle_);
   }
 
@@ -1259,7 +1260,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public boolean bestEffortsRecovery() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return bestEffortsRecovery(nativeHandle_);
   }
 
@@ -1271,7 +1272,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public int maxBgerrorResumeCount() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return maxBgerrorResumeCount(nativeHandle_);
   }
 
@@ -1283,7 +1284,7 @@ public class DBOptions extends RocksObject
 
   @Override
   public long bgerrorResumeRetryInterval() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return bgerrorResumeRetryInterval(nativeHandle_);
   }
 
@@ -1389,8 +1390,8 @@ public class DBOptions extends RocksObject
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
-  private static native void setMaxWriteBatchGroupSizeBytes(final long handle,
-                                                            final long maxWriteBatchGroupSizeBytes);
+  private static native void setMaxWriteBatchGroupSizeBytes(
+      final long handle, final long maxWriteBatchGroupSizeBytes);
   private static native long maxWriteBatchGroupSizeBytes(final long handle);
   private native void setManifestPreallocationSize(
       long handle, long size) throws IllegalArgumentException;
@@ -1484,8 +1485,8 @@ public class DBOptions extends RocksObject
   private native void setSkipStatsUpdateOnDbOpen(final long handle,
       final boolean skipStatsUpdateOnDbOpen);
   private native boolean skipStatsUpdateOnDbOpen(final long handle);
-  private static native void setSkipCheckingSstFileSizesOnDbOpen(final long handle,
-                                                                 final boolean skipChecking);
+  private static native void setSkipCheckingSstFileSizesOnDbOpen(
+      final long handle, final boolean skipChecking);
   private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
   private native void setWalRecoveryMode(final long handle,
       final byte walRecoveryMode);
@@ -1524,26 +1525,25 @@ public class DBOptions extends RocksObject
   private native void setAtomicFlush(final long handle,
       final boolean atomicFlush);
   private native boolean atomicFlush(final long handle);
-  private static native void setAvoidUnnecessaryBlockingIO(final long handle,
-                                                           final boolean avoidBlockingIO);
+  private static native void setAvoidUnnecessaryBlockingIO(
+      final long handle, final boolean avoidBlockingIO);
   private static native boolean avoidUnnecessaryBlockingIO(final long handle);
-  private static native void setPersistStatsToDisk(final long handle,
-                                                   final boolean persistStatsToDisk);
+  private static native void setPersistStatsToDisk(
+      final long handle, final boolean persistStatsToDisk);
   private static native boolean persistStatsToDisk(final long handle);
-  private static native void setWriteDbidToManifest(final long handle,
-                                                    final boolean writeDbidToManifest);
+  private static native void setWriteDbidToManifest(
+      final long handle, final boolean writeDbidToManifest);
   private static native boolean writeDbidToManifest(final long handle);
-  private static native void setLogReadaheadSize(final long handle,
-                                                 final long logReadaheadSize);
+  private static native void setLogReadaheadSize(final long handle, final long logReadaheadSize);
   private static native long logReadaheadSize(final long handle);
-  private static native void setBestEffortsRecovery(final long handle,
-                                                    final boolean bestEffortsRecovery);
+  private static native void setBestEffortsRecovery(
+      final long handle, final boolean bestEffortsRecovery);
   private static native boolean bestEffortsRecovery(final long handle);
-  private static native void setMaxBgErrorResumeCount(final long handle,
-                                                      final int maxBgerrorRecumeCount);
+  private static native void setMaxBgErrorResumeCount(
+      final long handle, final int maxBgerrorRecumeCount);
   private static native int maxBgerrorResumeCount(final long handle);
-  private static native void setBgerrorResumeRetryInterval(final long handle,
-                                                           final long bgerrorResumeRetryInterval);
+  private static native void setBgerrorResumeRetryInterval(
+      final long handle, final long bgerrorResumeRetryInterval);
   private static native long bgerrorResumeRetryInterval(final long handle);
 
   // instance variables

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1621,7 +1621,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * and will instead schedule a background job to do it.
    * Use it if you're latency-sensitive.
    * If set to true, takes precedence over
-   * {@code ReadOptions::background_purge_on_iterator_cleanup}.
+   * {@link ReadOptions#setBackgroundPurgeOnIteratorCleanup(boolean)}.
    *
    * @param avoidUnnecessaryBlockingIO If true, working thread may avoid doing unnecessary operation.
    * @return the reference to the current options.
@@ -1634,7 +1634,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * and will instead schedule a background job to do it.
    * Use it if you're latency-sensitive.
    * If set to true, takes precedence over
-   * {@code ReadOptions::background_purge_on_iterator_cleanup}.
+   * {@link ReadOptions#setBackgroundPurgeOnIteratorCleanup(boolean)}.
    *
    * @return true, if working thread may avoid doing unnecessary operation.
    */
@@ -1769,7 +1769,7 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * @param maxBgerrorResumeCount maximum number of times db resume should be called when IO Error happens.
    * @return the instance of the current object.
    */
-  T setMaxBgerrorResumeCount(final int maxBgerrorResumeCount);
+  T setMaxBgErrorResumeCount(final int maxBgerrorResumeCount);
 
   /**
    * It defines how many times db resume is called by a separate thread when

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -1623,7 +1623,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * If set to true, takes precedence over
    * {@link ReadOptions#setBackgroundPurgeOnIteratorCleanup(boolean)}.
    *
-   * @param avoidUnnecessaryBlockingIO If true, working thread may avoid doing unnecessary operation.
+   * @param avoidUnnecessaryBlockingIO If true, working thread may avoid doing unnecessary
+   *     operation.
    * @return the reference to the current options.
    */
   T setAvoidUnnecessaryBlockingIO(final boolean avoidUnnecessaryBlockingIO);
@@ -1766,7 +1767,8 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    *
    * Default: INT_MAX
    *
-   * @param maxBgerrorResumeCount maximum number of times db resume should be called when IO Error happens.
+   * @param maxBgerrorResumeCount maximum number of times db resume should be called when IO Error
+   *     happens.
    * @return the instance of the current object.
    */
   T setMaxBgErrorResumeCount(final int maxBgerrorResumeCount);

--- a/java/src/main/java/org/rocksdb/DBOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/DBOptionsInterface.java
@@ -704,6 +704,29 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
   long walSizeLimitMB();
 
   /**
+   * The maximum limit of number of bytes that are written in a single batch
+   * of WAL or memtable write. It is followed when the leader write size
+   * is larger than 1/8 of this limit.
+   *
+   * Default: 1 MB
+   *
+   * @param maxWriteBatchGroupSizeBytes the maximum limit of number of bytes, see description.
+   * @return the instance of the current object.
+   */
+  T setMaxWriteBatchGroupSizeBytes(final long maxWriteBatchGroupSizeBytes);
+
+  /**
+   * The maximum limit of number of bytes that are written in a single batch
+   * of WAL or memtable write. It is followed when the leader write size
+   * is larger than 1/8 of this limit.
+   *
+   * Default: 1 MB
+   *
+   * @return the maximum limit of number of bytes, see description.
+   */
+  long maxWriteBatchGroupSizeBytes();
+
+  /**
    * Number of bytes to preallocate (via fallocate) the manifest
    * files.  Default is 4mb, which is reasonable to reduce random IO
    * as well as prevent overallocation for mounts that preallocate
@@ -1279,6 +1302,36 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
   boolean skipStatsUpdateOnDbOpen();
 
   /**
+   * If true, then {@link RocksDB#open(String)} will not fetch and check sizes of all sst files.
+   * This may significantly speed up startup if there are many sst files,
+   * especially when using non-default Env with expensive GetFileSize().
+   * We'll still check that all required sst files exist.
+   * If {@code paranoid_checks} is false, this option is ignored, and sst files are
+   * not checked at all.
+   *
+   * Default: false
+   *
+   * @param skipCheckingSstFileSizesOnDbOpen if true, then SST file sizes will not be checked
+   *                                         when calling {@link RocksDB#open(String)}.
+   * @return the reference to the current options.
+   */
+  T setSkipCheckingSstFileSizesOnDbOpen(final boolean skipCheckingSstFileSizesOnDbOpen);
+
+  /**
+   * If true, then {@link RocksDB#open(String)} will not fetch and check sizes of all sst files.
+   * This may significantly speed up startup if there are many sst files,
+   * especially when using non-default Env with expensive GetFileSize().
+   * We'll still check that all required sst files exist.
+   * If {@code paranoid_checks} is false, this option is ignored, and sst files are
+   * not checked at all.
+   *
+   * Default: false
+   *
+   * @return true, if file sizes will not be checked when calling {@link RocksDB#open(String)}.
+   */
+  boolean skipCheckingSstFileSizesOnDbOpen();
+
+  /**
    * Recovery mode to control the consistency while replaying WAL
    *
    * Default: {@link WALRecoveryMode#PointInTimeRecovery}
@@ -1561,4 +1614,197 @@ public interface DBOptionsInterface<T extends DBOptionsInterface<T>> {
    * @return true if atomic flush is enabled.
    */
   boolean atomicFlush();
+
+  /**
+   * If true, working thread may avoid doing unnecessary and long-latency
+   * operation (such as deleting obsolete files directly or deleting memtable)
+   * and will instead schedule a background job to do it.
+   * Use it if you're latency-sensitive.
+   * If set to true, takes precedence over
+   * {@code ReadOptions::background_purge_on_iterator_cleanup}.
+   *
+   * @param avoidUnnecessaryBlockingIO If true, working thread may avoid doing unnecessary operation.
+   * @return the reference to the current options.
+   */
+  T setAvoidUnnecessaryBlockingIO(final boolean avoidUnnecessaryBlockingIO);
+
+  /**
+   * If true, working thread may avoid doing unnecessary and long-latency
+   * operation (such as deleting obsolete files directly or deleting memtable)
+   * and will instead schedule a background job to do it.
+   * Use it if you're latency-sensitive.
+   * If set to true, takes precedence over
+   * {@code ReadOptions::background_purge_on_iterator_cleanup}.
+   *
+   * @return true, if working thread may avoid doing unnecessary operation.
+   */
+  boolean avoidUnnecessaryBlockingIO();
+
+  /**
+   * If true, automatically persist stats to a hidden column family (column
+   * family name: ___rocksdb_stats_history___) every
+   * stats_persist_period_sec seconds; otherwise, write to an in-memory
+   * struct. User can query through `GetStatsHistory` API.
+   * If user attempts to create a column family with the same name on a DB
+   * which have previously set persist_stats_to_disk to true, the column family
+   * creation will fail, but the hidden column family will survive, as well as
+   * the previously persisted statistics.
+   * When peristing stats to disk, the stat name will be limited at 100 bytes.
+   * Default: false
+   *
+   * @param persistStatsToDisk true if stats should be persisted to hidden column family.
+   * @return the instance of the current object.
+   */
+  T setPersistStatsToDisk(final boolean persistStatsToDisk);
+
+  /**
+   * If true, automatically persist stats to a hidden column family (column
+   * family name: ___rocksdb_stats_history___) every
+   * stats_persist_period_sec seconds; otherwise, write to an in-memory
+   * struct. User can query through `GetStatsHistory` API.
+   * If user attempts to create a column family with the same name on a DB
+   * which have previously set persist_stats_to_disk to true, the column family
+   * creation will fail, but the hidden column family will survive, as well as
+   * the previously persisted statistics.
+   * When peristing stats to disk, the stat name will be limited at 100 bytes.
+   * Default: false
+   *
+   * @return true if stats should be persisted to hidden column family.
+   */
+  boolean persistStatsToDisk();
+
+  /**
+   * Historically DB ID has always been stored in Identity File in DB folder.
+   * If this flag is true, the DB ID is written to Manifest file in addition
+   * to the Identity file. By doing this 2 problems are solved
+   * 1. We don't checksum the Identity file where as Manifest file is.
+   * 2. Since the source of truth for DB is Manifest file DB ID will sit with
+   *    the source of truth. Previously the Identity file could be copied
+   *    independent of Manifest and that can result in wrong DB ID.
+   * We recommend setting this flag to true.
+   * Default: false
+   *
+   * @param writeDbidToManifest if true, then DB ID will be written to Manifest file.
+   * @return the instance of the current object.
+   */
+  T setWriteDbidToManifest(final boolean writeDbidToManifest);
+
+  /**
+   * Historically DB ID has always been stored in Identity File in DB folder.
+   * If this flag is true, the DB ID is written to Manifest file in addition
+   * to the Identity file. By doing this 2 problems are solved
+   * 1. We don't checksum the Identity file where as Manifest file is.
+   * 2. Since the source of truth for DB is Manifest file DB ID will sit with
+   *    the source of truth. Previously the Identity file could be copied
+   *    independent of Manifest and that can result in wrong DB ID.
+   * We recommend setting this flag to true.
+   * Default: false
+   *
+   * @return true, if DB ID will be written to Manifest file.
+   */
+  boolean writeDbidToManifest();
+
+  /**
+   * The number of bytes to prefetch when reading the log. This is mostly useful
+   * for reading a remotely located log, as it can save the number of
+   * round-trips. If 0, then the prefetching is disabled.
+   *
+   * Default: 0
+   *
+   * @param logReadaheadSize the number of bytes to prefetch when reading the log.
+   * @return the instance of the current object.
+   */
+  T setLogReadaheadSize(final long logReadaheadSize);
+
+  /**
+   * The number of bytes to prefetch when reading the log. This is mostly useful
+   * for reading a remotely located log, as it can save the number of
+   * round-trips. If 0, then the prefetching is disabled.
+   *
+   * Default: 0
+   *
+   * @return the number of bytes to prefetch when reading the log.
+   */
+  long logReadaheadSize();
+
+  /**
+   * By default, RocksDB recovery fails if any table file referenced in
+   * MANIFEST are missing after scanning the MANIFEST.
+   * Best-efforts recovery is another recovery mode that
+   * tries to restore the database to the most recent point in time without
+   * missing file.
+   * Currently not compatible with atomic flush. Furthermore, WAL files will
+   * not be used for recovery if best_efforts_recovery is true.
+   * Default: false
+   *
+   * @param bestEffortsRecovery if true, RocksDB will use best-efforts mode when recovering.
+   * @return the instance of the current object.
+   */
+  T setBestEffortsRecovery(final boolean bestEffortsRecovery);
+
+  /**
+   * By default, RocksDB recovery fails if any table file referenced in
+   * MANIFEST are missing after scanning the MANIFEST.
+   * Best-efforts recovery is another recovery mode that
+   * tries to restore the database to the most recent point in time without
+   * missing file.
+   * Currently not compatible with atomic flush. Furthermore, WAL files will
+   * not be used for recovery if best_efforts_recovery is true.
+   * Default: false
+   *
+   * @return true, if RocksDB uses best-efforts mode when recovering.
+   */
+  boolean bestEffortsRecovery();
+
+  /**
+   * It defines how many times db resume is called by a separate thread when
+   * background retryable IO Error happens. When background retryable IO
+   * Error happens, SetBGError is called to deal with the error. If the error
+   * can be auto-recovered (e.g., retryable IO Error during Flush or WAL write),
+   * then db resume is called in background to recover from the error. If this
+   * value is 0 or negative, db resume will not be called.
+   *
+   * Default: INT_MAX
+   *
+   * @param maxBgerrorResumeCount maximum number of times db resume should be called when IO Error happens.
+   * @return the instance of the current object.
+   */
+  T setMaxBgerrorResumeCount(final int maxBgerrorResumeCount);
+
+  /**
+   * It defines how many times db resume is called by a separate thread when
+   * background retryable IO Error happens. When background retryable IO
+   * Error happens, SetBGError is called to deal with the error. If the error
+   * can be auto-recovered (e.g., retryable IO Error during Flush or WAL write),
+   * then db resume is called in background to recover from the error. If this
+   * value is 0 or negative, db resume will not be called.
+   *
+   * Default: INT_MAX
+   *
+   * @return maximum number of times db resume should be called when IO Error happens.
+   */
+  int maxBgerrorResumeCount();
+
+  /**
+   * If max_bgerror_resume_count is &ge; 2, db resume is called multiple times.
+   * This option decides how long to wait to retry the next resume if the
+   * previous resume fails and satisfy redo resume conditions.
+   *
+   * Default: 1000000 (microseconds).
+   *
+   * @param bgerrorResumeRetryInterval how many microseconds to wait between DB resume attempts.
+   * @return the instance of the current object.
+   */
+  T setBgerrorResumeRetryInterval(final long bgerrorResumeRetryInterval);
+
+  /**
+   * If max_bgerror_resume_count is &ge; 2, db resume is called multiple times.
+   * This option decides how long to wait to retry the next resume if the
+   * previous resume fails and satisfy redo resume conditions.
+   *
+   * Default: 1000000 (microseconds).
+   *
+   * @return the instance of the current object.
+   */
+  long bgerrorResumeRetryInterval();
 }

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -669,7 +669,7 @@ public class Options extends RocksObject
 
   @Override
   public long maxWriteBatchGroupSizeBytes() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return maxWriteBatchGroupSizeBytes(nativeHandle_);
   }
 
@@ -1086,7 +1086,7 @@ public class Options extends RocksObject
 
   @Override
   public boolean skipCheckingSstFileSizesOnDbOpen() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return skipCheckingSstFileSizesOnDbOpen(nativeHandle_);
   }
 
@@ -1892,7 +1892,7 @@ public class Options extends RocksObject
 
   @Override
   public boolean avoidUnnecessaryBlockingIO() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return avoidUnnecessaryBlockingIO(nativeHandle_);
   }
 
@@ -1904,7 +1904,7 @@ public class Options extends RocksObject
 
   @Override
   public boolean persistStatsToDisk() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return persistStatsToDisk(nativeHandle_);
   }
 
@@ -1916,7 +1916,7 @@ public class Options extends RocksObject
 
   @Override
   public boolean writeDbidToManifest() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return writeDbidToManifest(nativeHandle_);
   }
 
@@ -1928,7 +1928,7 @@ public class Options extends RocksObject
 
   @Override
   public long logReadaheadSize() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return logReadaheadSize(nativeHandle_);
   }
 
@@ -1940,7 +1940,7 @@ public class Options extends RocksObject
 
   @Override
   public boolean bestEffortsRecovery() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return bestEffortsRecovery(nativeHandle_);
   }
 
@@ -1952,7 +1952,7 @@ public class Options extends RocksObject
 
   @Override
   public int maxBgerrorResumeCount() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return maxBgerrorResumeCount(nativeHandle_);
   }
 
@@ -1964,7 +1964,7 @@ public class Options extends RocksObject
 
   @Override
   public long bgerrorResumeRetryInterval() {
-    assert(isOwningHandle());
+    assert (isOwningHandle());
     return bgerrorResumeRetryInterval(nativeHandle_);
   }
 
@@ -2082,8 +2082,8 @@ public class Options extends RocksObject
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
-  private static native void setMaxWriteBatchGroupSizeBytes(final long handle,
-                                                            final long maxWriteBatchGroupSizeBytes);
+  private static native void setMaxWriteBatchGroupSizeBytes(
+      final long handle, final long maxWriteBatchGroupSizeBytes);
   private static native long maxWriteBatchGroupSizeBytes(final long handle);
   private native void setManifestPreallocationSize(
       long handle, long size) throws IllegalArgumentException;
@@ -2177,8 +2177,8 @@ public class Options extends RocksObject
   private native void setSkipStatsUpdateOnDbOpen(final long handle,
       final boolean skipStatsUpdateOnDbOpen);
   private native boolean skipStatsUpdateOnDbOpen(final long handle);
-  private static native void setSkipCheckingSstFileSizesOnDbOpen(final long handle,
-                                                                 final boolean skipChecking);
+  private static native void setSkipCheckingSstFileSizesOnDbOpen(
+      final long handle, final boolean skipChecking);
   private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
   private native void setWalRecoveryMode(final long handle,
       final byte walRecoveryMode);
@@ -2380,26 +2380,25 @@ public class Options extends RocksObject
   private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long newLimiterHandle);
-  private static native void setAvoidUnnecessaryBlockingIO(final long handle,
-                                                           final boolean avoidBlockingIO);
+  private static native void setAvoidUnnecessaryBlockingIO(
+      final long handle, final boolean avoidBlockingIO);
   private static native boolean avoidUnnecessaryBlockingIO(final long handle);
-  private static native void setPersistStatsToDisk(final long handle,
-                                                   final boolean persistStatsToDisk);
+  private static native void setPersistStatsToDisk(
+      final long handle, final boolean persistStatsToDisk);
   private static native boolean persistStatsToDisk(final long handle);
-  private static native void setWriteDbidToManifest(final long handle,
-                                                    final boolean writeDbidToManifest);
+  private static native void setWriteDbidToManifest(
+      final long handle, final boolean writeDbidToManifest);
   private static native boolean writeDbidToManifest(final long handle);
-  private static native void setLogReadaheadSize(final long handle,
-                                                 final long logReadaheadSize);
+  private static native void setLogReadaheadSize(final long handle, final long logReadaheadSize);
   private static native long logReadaheadSize(final long handle);
-  private static native void setBestEffortsRecovery(final long handle,
-                                                    final boolean bestEffortsRecovery);
+  private static native void setBestEffortsRecovery(
+      final long handle, final boolean bestEffortsRecovery);
   private static native boolean bestEffortsRecovery(final long handle);
-  private static native void setMaxBgErrorResumeCount(final long handle,
-                                                      final int maxBgerrorRecumeCount);
+  private static native void setMaxBgErrorResumeCount(
+      final long handle, final int maxBgerrorRecumeCount);
   private static native int maxBgerrorResumeCount(final long handle);
-  private static native void setBgerrorResumeRetryInterval(final long handle,
-                                                           final long bgerrorResumeRetryInterval);
+  private static native void setBgerrorResumeRetryInterval(
+      final long handle, final long bgerrorResumeRetryInterval);
   private static native long bgerrorResumeRetryInterval(final long handle);
 
   // instance variables

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -1882,72 +1882,86 @@ public class Options extends RocksObject
 
   @Override
   public Options setAvoidUnnecessaryBlockingIO(boolean avoidUnnecessaryBlockingIO) {
-    return null;
+    setAvoidUnnecessaryBlockingIO(nativeHandle_, avoidUnnecessaryBlockingIO);
+    return this;
   }
 
   @Override
   public boolean avoidUnnecessaryBlockingIO() {
-    return false;
+    assert(isOwningHandle());
+    return avoidUnnecessaryBlockingIO(nativeHandle_);
   }
 
   @Override
   public Options setPersistStatsToDisk(boolean persistStatsToDisk) {
-    return null;
+    setPersistStatsToDisk(nativeHandle_, persistStatsToDisk);
+    return this;
   }
 
   @Override
   public boolean persistStatsToDisk() {
-    return false;
+    assert(isOwningHandle());
+    return persistStatsToDisk(nativeHandle_);
   }
 
   @Override
   public Options setWriteDbidToManifest(boolean writeDbidToManifest) {
-    return null;
+    setWriteDbidToManifest(nativeHandle_, writeDbidToManifest);
+    return this;
   }
 
   @Override
   public boolean writeDbidToManifest() {
-    return false;
+    assert(isOwningHandle());
+    return writeDbidToManifest(nativeHandle_);
   }
 
   @Override
   public Options setLogReadaheadSize(long logReadaheadSize) {
-    return null;
+    setLogReadaheadSize(nativeHandle_, logReadaheadSize);
+    return this;
   }
 
   @Override
   public long logReadaheadSize() {
-    return 0;
+    assert(isOwningHandle());
+    return logReasaheadSize(nativeHandle_);
   }
 
   @Override
   public Options setBestEffortsRecovery(boolean bestEffortsRecovery) {
-    return null;
+    setBestEffortsRecovery(nativeHandle_, bestEffortsRecovery);
+    return this;
   }
 
   @Override
   public boolean bestEffortsRecovery() {
-    return false;
+    assert(isOwningHandle());
+    return bestEffortsRecovery(nativeHandle_);
   }
 
   @Override
   public Options setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
-    return null;
+    setMaxBgerrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
+    return this;
   }
 
   @Override
   public int maxBgerrorResumeCount() {
-    return 0;
+    assert(isOwningHandle());
+    return maxBgerrorResumeCount(nativeHandle_);
   }
 
   @Override
   public Options setBgerrorResumeRetryInterval(long bgerrorResumeRetryInterval) {
-    return null;
+    setBgerrorResumeRetryInterval(nativeHandle_, bgerrorResumeRetryInterval);
+    return this;
   }
 
   @Override
   public long bgerrorResumeRetryInterval() {
-    return 0;
+    assert(isOwningHandle());
+    return bgerrorResumeRetryInterval(nativeHandle_);
   }
 
   @Override
@@ -2356,6 +2370,27 @@ public class Options extends RocksObject
   private native void setSstPartitionerFactory(long nativeHandle_, long newFactoryHandle);
   private static native void setCompactionThreadLimiter(
       final long nativeHandle_, final long newLimiterHandle);
+  private static native void setAvoidUnnecessaryBlockingIO(final long handle,
+                                                           final boolean avoidBlockingIO);
+  private static native boolean avoidUnnecessaryBlockingIO(final long handle);
+  private static native void setPersistStatsToDisk(final long handle,
+                                                   final boolean persistStatsToDisk);
+  private static native boolean persistStatsToDisk(final long handle);
+  private static native void setWriteDbidToManifest(final long handle,
+                                                    final boolean writeDbidToManifest);
+  private static native boolean writeDbidToManifest(final long handle);
+  private static native void setLogReadaheadSize(final long handle,
+                                                 final long logReadaheadSize);
+  private static native long logReasaheadSize(final long handle);
+  private static native void setBestEffortsRecovery(final long handle,
+                                                    final boolean bestEffortsRecovery);
+  private static native boolean bestEffortsRecovery(final long handle);
+  private static native void setMaxBgerrorResumeCount(final long handle,
+                                                      final int maxBgerrorRecumeCount);
+  private static native int maxBgerrorResumeCount(final long handle);
+  private static native void setBgerrorResumeRetryInterval(final long handle,
+                                                           final long bgerrorResumeRetryInterval);
+  private static native long bgerrorResumeRetryInterval(final long handle);
 
   // instance variables
   // NOTE: If you add new member variables, please update the copy constructor above!

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -663,12 +663,14 @@ public class Options extends RocksObject
 
   @Override
   public Options setMaxWriteBatchGroupSizeBytes(long maxWriteBatchGroupSizeBytes) {
-    return null;
+    setMaxWriteBatchGroupSizeBytes(nativeHandle_, maxWriteBatchGroupSizeBytes);
+    return this;
   }
 
   @Override
   public long maxWriteBatchGroupSizeBytes() {
-    return 0;
+    assert(isOwningHandle());
+    return maxWriteBatchGroupSizeBytes(nativeHandle_);
   }
 
   @Override
@@ -1078,12 +1080,14 @@ public class Options extends RocksObject
 
   @Override
   public Options setSkipCheckingSstFileSizesOnDbOpen(boolean skipCheckingSstFileSizesOnDbOpen) {
-    return null;
+    setSkipCheckingSstFileSizesOnDbOpen(nativeHandle_, skipCheckingSstFileSizesOnDbOpen);
+    return this;
   }
 
   @Override
   public boolean skipCheckingSstFileSizesOnDbOpen() {
-    return false;
+    assert(isOwningHandle());
+    return skipCheckingSstFileSizesOnDbOpen(nativeHandle_);
   }
 
   @Override
@@ -1925,7 +1929,7 @@ public class Options extends RocksObject
   @Override
   public long logReadaheadSize() {
     assert(isOwningHandle());
-    return logReasaheadSize(nativeHandle_);
+    return logReadaheadSize(nativeHandle_);
   }
 
   @Override
@@ -1941,8 +1945,8 @@ public class Options extends RocksObject
   }
 
   @Override
-  public Options setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
-    setMaxBgerrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
+  public Options setMaxBgErrorResumeCount(int maxBgerrorResumeCount) {
+    setMaxBgErrorResumeCount(nativeHandle_, maxBgerrorResumeCount);
     return this;
   }
 
@@ -2078,6 +2082,9 @@ public class Options extends RocksObject
   private native long walTtlSeconds(long handle);
   private native void setWalSizeLimitMB(long handle, long sizeLimitMB);
   private native long walSizeLimitMB(long handle);
+  private static native void setMaxWriteBatchGroupSizeBytes(final long handle,
+                                                            final long maxWriteBatchGroupSizeBytes);
+  private static native long maxWriteBatchGroupSizeBytes(final long handle);
   private native void setManifestPreallocationSize(
       long handle, long size) throws IllegalArgumentException;
   private native long manifestPreallocationSize(long handle);
@@ -2170,6 +2177,9 @@ public class Options extends RocksObject
   private native void setSkipStatsUpdateOnDbOpen(final long handle,
       final boolean skipStatsUpdateOnDbOpen);
   private native boolean skipStatsUpdateOnDbOpen(final long handle);
+  private static native void setSkipCheckingSstFileSizesOnDbOpen(final long handle,
+                                                                 final boolean skipChecking);
+  private static native boolean skipCheckingSstFileSizesOnDbOpen(final long handle);
   private native void setWalRecoveryMode(final long handle,
       final byte walRecoveryMode);
   private native byte walRecoveryMode(final long handle);
@@ -2381,11 +2391,11 @@ public class Options extends RocksObject
   private static native boolean writeDbidToManifest(final long handle);
   private static native void setLogReadaheadSize(final long handle,
                                                  final long logReadaheadSize);
-  private static native long logReasaheadSize(final long handle);
+  private static native long logReadaheadSize(final long handle);
   private static native void setBestEffortsRecovery(final long handle,
                                                     final boolean bestEffortsRecovery);
   private static native boolean bestEffortsRecovery(final long handle);
-  private static native void setMaxBgerrorResumeCount(final long handle,
+  private static native void setMaxBgErrorResumeCount(final long handle,
                                                       final int maxBgerrorRecumeCount);
   private static native int maxBgerrorResumeCount(final long handle);
   private static native void setBgerrorResumeRetryInterval(final long handle,

--- a/java/src/main/java/org/rocksdb/Options.java
+++ b/java/src/main/java/org/rocksdb/Options.java
@@ -662,6 +662,16 @@ public class Options extends RocksObject
   }
 
   @Override
+  public Options setMaxWriteBatchGroupSizeBytes(long maxWriteBatchGroupSizeBytes) {
+    return null;
+  }
+
+  @Override
+  public long maxWriteBatchGroupSizeBytes() {
+    return 0;
+  }
+
+  @Override
   public Options setWalSizeLimitMB(final long sizeLimitMB) {
     assert(isOwningHandle());
     setWalSizeLimitMB(nativeHandle_, sizeLimitMB);
@@ -1064,6 +1074,16 @@ public class Options extends RocksObject
   public boolean skipStatsUpdateOnDbOpen() {
     assert(isOwningHandle());
     return skipStatsUpdateOnDbOpen(nativeHandle_);
+  }
+
+  @Override
+  public Options setSkipCheckingSstFileSizesOnDbOpen(boolean skipCheckingSstFileSizesOnDbOpen) {
+    return null;
+  }
+
+  @Override
+  public boolean skipCheckingSstFileSizesOnDbOpen() {
+    return false;
   }
 
   @Override
@@ -1858,6 +1878,76 @@ public class Options extends RocksObject
   @Override
   public boolean atomicFlush() {
     return atomicFlush(nativeHandle_);
+  }
+
+  @Override
+  public Options setAvoidUnnecessaryBlockingIO(boolean avoidUnnecessaryBlockingIO) {
+    return null;
+  }
+
+  @Override
+  public boolean avoidUnnecessaryBlockingIO() {
+    return false;
+  }
+
+  @Override
+  public Options setPersistStatsToDisk(boolean persistStatsToDisk) {
+    return null;
+  }
+
+  @Override
+  public boolean persistStatsToDisk() {
+    return false;
+  }
+
+  @Override
+  public Options setWriteDbidToManifest(boolean writeDbidToManifest) {
+    return null;
+  }
+
+  @Override
+  public boolean writeDbidToManifest() {
+    return false;
+  }
+
+  @Override
+  public Options setLogReadaheadSize(long logReadaheadSize) {
+    return null;
+  }
+
+  @Override
+  public long logReadaheadSize() {
+    return 0;
+  }
+
+  @Override
+  public Options setBestEffortsRecovery(boolean bestEffortsRecovery) {
+    return null;
+  }
+
+  @Override
+  public boolean bestEffortsRecovery() {
+    return false;
+  }
+
+  @Override
+  public Options setMaxBgerrorResumeCount(int maxBgerrorResumeCount) {
+    return null;
+  }
+
+  @Override
+  public int maxBgerrorResumeCount() {
+    return 0;
+  }
+
+  @Override
+  public Options setBgerrorResumeRetryInterval(long bgerrorResumeRetryInterval) {
+    return null;
+  }
+
+  @Override
+  public long bgerrorResumeRetryInterval() {
+    return 0;
   }
 
   @Override

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -810,4 +810,89 @@ public class DBOptionsTest {
       assertThat(stats).isNotNull();
     }
   }
+
+  @Test
+  public void avoidUnnecessaryBlockingIO() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(false);
+      assertThat(options.setAvoidUnnecessaryBlockingIO(true)).isEqualTo(options);
+      assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void persistStatsToDisk() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.persistStatsToDisk()).isEqualTo(false);
+      assertThat(options.setPersistStatsToDisk(true)).isEqualTo(options);
+      assertThat(options.persistStatsToDisk()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void writeDbidToManifest() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.writeDbidToManifest()).isEqualTo(false);
+      assertThat(options.setWriteDbidToManifest(true)).isEqualTo(options);
+      assertThat(options.writeDbidToManifest()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void logReadaheadSize() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.logReadaheadSize()).isEqualTo(0);
+      final int size = 1024 * 1024 * 100;
+      assertThat(options.setLogReadaheadSize(size)).isEqualTo(options);
+      assertThat(options.logReadaheadSize()).isEqualTo(size);
+    }
+  }
+
+  @Test
+  public void bestEffortsRecovery() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.bestEffortsRecovery()).isEqualTo(false);
+      assertThat(options.setBestEffortsRecovery(true)).isEqualTo(options);
+      assertThat(options.bestEffortsRecovery()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void maxBgerrorResumeCount() {
+    try(final DBOptions options = new DBOptions()) {
+      final int INT_MAX = 2147483647;
+      assertThat(options.maxBgerrorResumeCount()).isEqualTo(INT_MAX);
+      assertThat(options.setMaxBgErrorResumeCount(-1)).isEqualTo(options);
+      assertThat(options.maxBgerrorResumeCount()).isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void bgerrorResumeRetryInterval() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(1000000);
+      final long newRetryInterval = 24 * 3600 * 1000000L;
+      assertThat(options.setBgerrorResumeRetryInterval(newRetryInterval)).isEqualTo(options);
+      assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(newRetryInterval);
+    }
+  }
+
+  @Test
+  public void maxWriteBatchGroupSizeBytes() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(1024 * 1024);
+      final long size = 1024 * 1024 * 1024 * 10L;
+      assertThat(options.setMaxWriteBatchGroupSizeBytes(size)).isEqualTo(options);
+      assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(size);
+    }
+  }
+
+  @Test
+  public void skipCheckingSstFileSizesOnDbOpen() {
+    try(final DBOptions options = new DBOptions()) {
+      assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(false);
+      assertThat(options.setSkipCheckingSstFileSizesOnDbOpen(true)).isEqualTo(options);
+      assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(true);
+    }
+  }
 }

--- a/java/src/test/java/org/rocksdb/DBOptionsTest.java
+++ b/java/src/test/java/org/rocksdb/DBOptionsTest.java
@@ -813,7 +813,7 @@ public class DBOptionsTest {
 
   @Test
   public void avoidUnnecessaryBlockingIO() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(false);
       assertThat(options.setAvoidUnnecessaryBlockingIO(true)).isEqualTo(options);
       assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(true);
@@ -822,7 +822,7 @@ public class DBOptionsTest {
 
   @Test
   public void persistStatsToDisk() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.persistStatsToDisk()).isEqualTo(false);
       assertThat(options.setPersistStatsToDisk(true)).isEqualTo(options);
       assertThat(options.persistStatsToDisk()).isEqualTo(true);
@@ -831,7 +831,7 @@ public class DBOptionsTest {
 
   @Test
   public void writeDbidToManifest() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.writeDbidToManifest()).isEqualTo(false);
       assertThat(options.setWriteDbidToManifest(true)).isEqualTo(options);
       assertThat(options.writeDbidToManifest()).isEqualTo(true);
@@ -840,7 +840,7 @@ public class DBOptionsTest {
 
   @Test
   public void logReadaheadSize() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.logReadaheadSize()).isEqualTo(0);
       final int size = 1024 * 1024 * 100;
       assertThat(options.setLogReadaheadSize(size)).isEqualTo(options);
@@ -850,7 +850,7 @@ public class DBOptionsTest {
 
   @Test
   public void bestEffortsRecovery() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.bestEffortsRecovery()).isEqualTo(false);
       assertThat(options.setBestEffortsRecovery(true)).isEqualTo(options);
       assertThat(options.bestEffortsRecovery()).isEqualTo(true);
@@ -859,7 +859,7 @@ public class DBOptionsTest {
 
   @Test
   public void maxBgerrorResumeCount() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       final int INT_MAX = 2147483647;
       assertThat(options.maxBgerrorResumeCount()).isEqualTo(INT_MAX);
       assertThat(options.setMaxBgErrorResumeCount(-1)).isEqualTo(options);
@@ -869,7 +869,7 @@ public class DBOptionsTest {
 
   @Test
   public void bgerrorResumeRetryInterval() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(1000000);
       final long newRetryInterval = 24 * 3600 * 1000000L;
       assertThat(options.setBgerrorResumeRetryInterval(newRetryInterval)).isEqualTo(options);
@@ -879,7 +879,7 @@ public class DBOptionsTest {
 
   @Test
   public void maxWriteBatchGroupSizeBytes() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(1024 * 1024);
       final long size = 1024 * 1024 * 1024 * 10L;
       assertThat(options.setMaxWriteBatchGroupSizeBytes(size)).isEqualTo(options);
@@ -889,7 +889,7 @@ public class DBOptionsTest {
 
   @Test
   public void skipCheckingSstFileSizesOnDbOpen() {
-    try(final DBOptions options = new DBOptions()) {
+    try (final DBOptions options = new DBOptions()) {
       assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(false);
       assertThat(options.setSkipCheckingSstFileSizesOnDbOpen(true)).isEqualTo(options);
       assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(true);

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1342,13 +1342,98 @@ public class OptionsTest {
   }
 
   @Test
-  public void cfPaths() throws IOException {
+  public void cfPaths() {
     try (final Options options = new Options()) {
       final List<DbPath> paths = Arrays.asList(
           new DbPath(Paths.get("test1"), 2 << 25), new DbPath(Paths.get("/test2/path"), 2 << 25));
       assertThat(options.cfPaths()).isEqualTo(Collections.emptyList());
       assertThat(options.setCfPaths(paths)).isEqualTo(options);
       assertThat(options.cfPaths()).isEqualTo(paths);
+    }
+  }
+
+  @Test
+  public void avoidUnnecessaryBlockingIO() {
+    try (final Options options = new Options()) {
+      assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(false);
+      assertThat(options.setAvoidUnnecessaryBlockingIO(true)).isEqualTo(options);
+      assertThat(options.avoidUnnecessaryBlockingIO()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void persistStatsToDisk() {
+    try (final Options options = new Options()) {
+      assertThat(options.persistStatsToDisk()).isEqualTo(false);
+      assertThat(options.setPersistStatsToDisk(true)).isEqualTo(options);
+      assertThat(options.persistStatsToDisk()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void writeDbidToManifest() {
+    try(final Options options = new Options()) {
+      assertThat(options.writeDbidToManifest()).isEqualTo(false);
+      assertThat(options.setWriteDbidToManifest(true)).isEqualTo(options);
+      assertThat(options.writeDbidToManifest()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void logReadaheadSize() {
+    try(final Options options = new Options()) {
+      assertThat(options.logReadaheadSize()).isEqualTo(0);
+      final int size = 1024 * 1024 * 100;
+      assertThat(options.setLogReadaheadSize(size)).isEqualTo(options);
+      assertThat(options.logReadaheadSize()).isEqualTo(size);
+    }
+  }
+
+  @Test
+  public void bestEffortsRecovery() {
+    try(final Options options = new Options()) {
+      assertThat(options.bestEffortsRecovery()).isEqualTo(false);
+      assertThat(options.setBestEffortsRecovery(true)).isEqualTo(options);
+      assertThat(options.bestEffortsRecovery()).isEqualTo(true);
+    }
+  }
+
+  @Test
+  public void maxBgerrorResumeCount() {
+    try(final Options options = new Options()) {
+      final int INT_MAX = 2147483647;
+      assertThat(options.maxBgerrorResumeCount()).isEqualTo(INT_MAX);
+      assertThat(options.setMaxBgErrorResumeCount(-1)).isEqualTo(options);
+      assertThat(options.maxBgerrorResumeCount()).isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void bgerrorResumeRetryInterval() {
+    try(final Options options = new Options()) {
+      assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(1000000);
+      final long newRetryInterval = 24 * 3600 * 1000000L;
+      assertThat(options.setBgerrorResumeRetryInterval(newRetryInterval)).isEqualTo(options);
+      assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(newRetryInterval);
+    }
+  }
+
+  @Test
+  public void maxWriteBatchGroupSizeBytes() {
+    try(final Options options = new Options()) {
+      assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(1024 * 1024);
+      final long size = 1024 * 1024 * 1024 * 10L;
+      assertThat(options.setMaxWriteBatchGroupSizeBytes(size)).isEqualTo(options);
+      assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(size);
+    }
+  }
+
+  @Test
+  public void skipCheckingSstFileSizesOnDbOpen() {
+    try(final Options options = new Options()) {
+      assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(false);
+      assertThat(options.setSkipCheckingSstFileSizesOnDbOpen(true)).isEqualTo(options);
+      assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(true);
     }
   }
 }

--- a/java/src/test/java/org/rocksdb/OptionsTest.java
+++ b/java/src/test/java/org/rocksdb/OptionsTest.java
@@ -1372,7 +1372,7 @@ public class OptionsTest {
 
   @Test
   public void writeDbidToManifest() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.writeDbidToManifest()).isEqualTo(false);
       assertThat(options.setWriteDbidToManifest(true)).isEqualTo(options);
       assertThat(options.writeDbidToManifest()).isEqualTo(true);
@@ -1381,7 +1381,7 @@ public class OptionsTest {
 
   @Test
   public void logReadaheadSize() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.logReadaheadSize()).isEqualTo(0);
       final int size = 1024 * 1024 * 100;
       assertThat(options.setLogReadaheadSize(size)).isEqualTo(options);
@@ -1391,7 +1391,7 @@ public class OptionsTest {
 
   @Test
   public void bestEffortsRecovery() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.bestEffortsRecovery()).isEqualTo(false);
       assertThat(options.setBestEffortsRecovery(true)).isEqualTo(options);
       assertThat(options.bestEffortsRecovery()).isEqualTo(true);
@@ -1400,7 +1400,7 @@ public class OptionsTest {
 
   @Test
   public void maxBgerrorResumeCount() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       final int INT_MAX = 2147483647;
       assertThat(options.maxBgerrorResumeCount()).isEqualTo(INT_MAX);
       assertThat(options.setMaxBgErrorResumeCount(-1)).isEqualTo(options);
@@ -1410,7 +1410,7 @@ public class OptionsTest {
 
   @Test
   public void bgerrorResumeRetryInterval() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.bgerrorResumeRetryInterval()).isEqualTo(1000000);
       final long newRetryInterval = 24 * 3600 * 1000000L;
       assertThat(options.setBgerrorResumeRetryInterval(newRetryInterval)).isEqualTo(options);
@@ -1420,7 +1420,7 @@ public class OptionsTest {
 
   @Test
   public void maxWriteBatchGroupSizeBytes() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.maxWriteBatchGroupSizeBytes()).isEqualTo(1024 * 1024);
       final long size = 1024 * 1024 * 1024 * 10L;
       assertThat(options.setMaxWriteBatchGroupSizeBytes(size)).isEqualTo(options);
@@ -1430,7 +1430,7 @@ public class OptionsTest {
 
   @Test
   public void skipCheckingSstFileSizesOnDbOpen() {
-    try(final Options options = new Options()) {
+    try (final Options options = new Options()) {
       assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(false);
       assertThat(options.setSkipCheckingSstFileSizesOnDbOpen(true)).isEqualTo(options);
       assertThat(options.skipCheckingSstFileSizesOnDbOpen()).isEqualTo(true);


### PR DESCRIPTION
Exposes the following previously missing DBOptions fields in the RocksJava API:
- persist_stats_to_disk
- max_write_batch_group_size_bytes
- skip_checking_sst_file_sizes_on_db_open
- avoid_unnecessary_blocking_io
- write_dbid_to_manifest
- log_readahead_size
- best_efforts_recovery
- max_bgerror_resume_count
- bgerror_resume_retry_interval