### PR TITLE
Reset refitting_level_ flag to false in error paths

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1329,12 +1329,14 @@ Status DBImpl::ReFitLevel(ColumnFamilyData* cfd, int level, int target_level) {
   if (to_level != level) {
     if (to_level > level) {
       if (level == 0) {
+        refitting_level_ = false;
         return Status::NotSupported(
             "Cannot change from level 0 to other levels.");
       }
       // Check levels are empty for a trivial move
       for (int l = level + 1; l <= to_level; l++) {
         if (vstorage->NumLevelFiles(l) > 0) {
+          refitting_level_ = false;
           return Status::NotSupported(
               "Levels between source and target are not empty for a move.");
         }
@@ -1344,6 +1346,7 @@ Status DBImpl::ReFitLevel(ColumnFamilyData* cfd, int level, int target_level) {
       // Check levels are empty for a trivial move
       for (int l = to_level; l < level; l++) {
         if (vstorage->NumLevelFiles(l) > 0) {
+          refitting_level_ = false;
           return Status::NotSupported(
               "Levels between source and target are not empty for a move.");
         }


### PR DESCRIPTION
Summary:
Reset refitting_level_ flag to false in error paths in
DBImpl::ReFitLevel()

Test Plan:
make -j64 all check

Reviewers:
Andrew

Subscribers:

Tasks:

Tags: