### PR TITLE
[Skinny] Add AppendWithVerify and PositionedAppendWithVerify to Env and FileSystem

### DIFF
--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -728,8 +728,8 @@ class LegacyWritableFileWrapper : public FSWritableFile {
     return status_to_io_status(target_->Append(data));
   }
   IOStatus Append(const Slice& data, const IOOptions& /*options*/,
-                  IODebugContext* /*dbg*/,
-                  const DataVerificationInfo& /*verification_info*/) override {
+                  const DataVerificationInfo& /*verification_info*/,
+                  IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->Append(data));
   }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
@@ -737,10 +737,10 @@ class LegacyWritableFileWrapper : public FSWritableFile {
                             IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->PositionedAppend(data, offset));
   }
-  IOStatus PositionedAppend(
-      const Slice& data, uint64_t offset, const IOOptions& /*options*/,
-      IODebugContext* /*dbg*/,
-      const DataVerificationInfo& /*verification_info*/) override {
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& /*options*/,
+                            const DataVerificationInfo& /*verification_info*/,
+                            IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->PositionedAppend(data, offset));
   }
   IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -115,25 +115,10 @@ class CompositeWritableFileWrapper : public WritableFile {
     IODebugContext dbg;
     return target_->Append(data, io_opts, &dbg);
   }
-  Status AppendWithVerify(
-      const Slice& data,
-      const DataVerificationInfo& verification_info) override {
-    IOOptions io_opts;
-    IODebugContext dbg;
-    return target_->AppendWithVerify(data, io_opts, &dbg, verification_info);
-  }
   Status PositionedAppend(const Slice& data, uint64_t offset) override {
     IOOptions io_opts;
     IODebugContext dbg;
     return target_->PositionedAppend(data, offset, io_opts, &dbg);
-  }
-  Status PositionedAppendWithVerify(
-      const Slice& data, uint64_t offset,
-      const DataVerificationInfo& verification_info) override {
-    IOOptions io_opts;
-    IODebugContext dbg;
-    return target_->PositionedAppendWithVerify(data, offset, io_opts, &dbg,
-                                               verification_info);
   }
   Status Truncate(uint64_t size) override {
     IOOptions io_opts;
@@ -742,23 +727,21 @@ class LegacyWritableFileWrapper : public FSWritableFile {
                   IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->Append(data));
   }
-  IOStatus AppendWithVerify(
-      const Slice& data, const IOOptions& /*options*/, IODebugContext* /*dbg*/,
-      const DataVerificationInfo& verification_info) override {
-    return status_to_io_status(
-        target_->AppendWithVerify(data, verification_info));
+  IOStatus Append(const Slice& data, const IOOptions& /*options*/,
+                  IODebugContext* /*dbg*/,
+                  const DataVerificationInfo& /*verification_info*/) override {
+    return status_to_io_status(target_->Append(data));
   }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& /*options*/,
                             IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->PositionedAppend(data, offset));
   }
-  IOStatus PositionedAppendWithVerify(
+  IOStatus PositionedAppend(
       const Slice& data, uint64_t offset, const IOOptions& /*options*/,
       IODebugContext* /*dbg*/,
-      const DataVerificationInfo& verification_info) override {
-    return status_to_io_status(
-        target_->PositionedAppendWithVerify(data, offset, verification_info));
+      const DataVerificationInfo& /*verification_info*/) override {
+    return status_to_io_status(target_->PositionedAppend(data, offset));
   }
   IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override {

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -115,10 +115,25 @@ class CompositeWritableFileWrapper : public WritableFile {
     IODebugContext dbg;
     return target_->Append(data, io_opts, &dbg);
   }
+  Status AppendWithVerify(
+      const Slice& data,
+      const DataVerificationInfo& verification_info) override {
+    IOOptions io_opts;
+    IODebugContext dbg;
+    return target_->AppendWithVerify(data, io_opts, &dbg, verification_info);
+  }
   Status PositionedAppend(const Slice& data, uint64_t offset) override {
     IOOptions io_opts;
     IODebugContext dbg;
     return target_->PositionedAppend(data, offset, io_opts, &dbg);
+  }
+  Status PositionedAppendWithVerify(
+      const Slice& data, uint64_t offset,
+      const DataVerificationInfo& verification_info) override {
+    IOOptions io_opts;
+    IODebugContext dbg;
+    return target_->PositionedAppendWithVerify(data, offset, io_opts, &dbg,
+                                               verification_info);
   }
   Status Truncate(uint64_t size) override {
     IOOptions io_opts;
@@ -727,10 +742,23 @@ class LegacyWritableFileWrapper : public FSWritableFile {
                   IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->Append(data));
   }
+  IOStatus AppendWithVerify(
+      const Slice& data, const IOOptions& /*options*/, IODebugContext* /*dbg*/,
+      const DataVerificationInfo& verification_info) override {
+    return status_to_io_status(
+        target_->AppendWithVerify(data, verification_info));
+  }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& /*options*/,
                             IODebugContext* /*dbg*/) override {
     return status_to_io_status(target_->PositionedAppend(data, offset));
+  }
+  IOStatus PositionedAppendWithVerify(
+      const Slice& data, uint64_t offset, const IOOptions& /*options*/,
+      IODebugContext* /*dbg*/,
+      const DataVerificationInfo& verification_info) override {
+    return status_to_io_status(
+        target_->PositionedAppendWithVerify(data, offset, verification_info));
   }
   IOStatus Truncate(uint64_t size, const IOOptions& /*options*/,
                     IODebugContext* /*dbg*/) override {

--- a/env/file_system_tracer.h
+++ b/env/file_system_tracer.h
@@ -244,10 +244,21 @@ class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
 
   IOStatus Append(const Slice& data, const IOOptions& options,
                   IODebugContext* dbg) override;
+  IOStatus Append(const Slice& data, const IOOptions& options,
+                  IODebugContext* dbg,
+                  const DataVerificationInfo& /*verification_info*/) override {
+    return Append(data, options, dbg);
+  }
 
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& options,
                             IODebugContext* dbg) override;
+  IOStatus PositionedAppend(
+      const Slice& data, uint64_t offset, const IOOptions& options,
+      IODebugContext* dbg,
+      const DataVerificationInfo& /*verification_info*/) override {
+    return PositionedAppend(data, offset, options, dbg);
+  }
 
   IOStatus Truncate(uint64_t size, const IOOptions& options,
                     IODebugContext* dbg) override;

--- a/env/file_system_tracer.h
+++ b/env/file_system_tracer.h
@@ -245,18 +245,18 @@ class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
   IOStatus Append(const Slice& data, const IOOptions& options,
                   IODebugContext* dbg) override;
   IOStatus Append(const Slice& data, const IOOptions& options,
-                  IODebugContext* dbg,
-                  const DataVerificationInfo& /*verification_info*/) override {
+                  const DataVerificationInfo& /*verification_info*/,
+                  IODebugContext* dbg) override {
     return Append(data, options, dbg);
   }
 
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& options,
                             IODebugContext* dbg) override;
-  IOStatus PositionedAppend(
-      const Slice& data, uint64_t offset, const IOOptions& options,
-      IODebugContext* dbg,
-      const DataVerificationInfo& /*verification_info*/) override {
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& options,
+                            const DataVerificationInfo& /*verification_info*/,
+                            IODebugContext* dbg) override {
     return PositionedAppend(data, offset, options, dbg);
   }
 

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -242,9 +242,9 @@ class PosixWritableFile : public FSWritableFile {
   virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Append(const Slice& data, const IOOptions& opts,
                           IODebugContext* dbg) override;
-  virtual IOStatus Append(
-      const Slice& data, const IOOptions& opts, IODebugContext* dbg,
-      const DataVerificationInfo& /* verification_info */) override {
+  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
+                          const DataVerificationInfo& /* verification_info */,
+                          IODebugContext* dbg) override {
     return Append(data, opts, dbg);
   }
   virtual IOStatus PositionedAppend(const Slice& data, uint64_t offset,
@@ -252,8 +252,8 @@ class PosixWritableFile : public FSWritableFile {
                                     IODebugContext* dbg) override;
   virtual IOStatus PositionedAppend(
       const Slice& data, uint64_t offset, const IOOptions& opts,
-      IODebugContext* dbg,
-      const DataVerificationInfo& /* verification_info */) override {
+      const DataVerificationInfo& /* verification_info */,
+      IODebugContext* dbg) override {
     return PositionedAppend(data, offset, opts, dbg);
   }
   virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
@@ -342,9 +342,9 @@ class PosixMmapFile : public FSWritableFile {
   virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Append(const Slice& data, const IOOptions& opts,
                           IODebugContext* dbg) override;
-  virtual IOStatus Append(
-      const Slice& data, const IOOptions& opts, IODebugContext* dbg,
-      const DataVerificationInfo& /* verification_info */) override {
+  virtual IOStatus Append(const Slice& data, const IOOptions& opts,
+                          const DataVerificationInfo& /* verification_info */,
+                          IODebugContext* dbg) override {
     return Append(data, opts, dbg);
   }
   virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -242,9 +242,20 @@ class PosixWritableFile : public FSWritableFile {
   virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Append(const Slice& data, const IOOptions& opts,
                           IODebugContext* dbg) override;
+  virtual IOStatus Append(
+      const Slice& data, const IOOptions& opts, IODebugContext* dbg,
+      const DataVerificationInfo& /* verification_info */) override {
+    return Append(data, opts, dbg);
+  }
   virtual IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                                     const IOOptions& opts,
                                     IODebugContext* dbg) override;
+  virtual IOStatus PositionedAppend(
+      const Slice& data, uint64_t offset, const IOOptions& opts,
+      IODebugContext* dbg,
+      const DataVerificationInfo& /* verification_info */) override {
+    return PositionedAppend(data, offset, opts, dbg);
+  }
   virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;
@@ -331,6 +342,11 @@ class PosixMmapFile : public FSWritableFile {
   virtual IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Append(const Slice& data, const IOOptions& opts,
                           IODebugContext* dbg) override;
+  virtual IOStatus Append(
+      const Slice& data, const IOOptions& opts, IODebugContext* dbg,
+      const DataVerificationInfo& /* verification_info */) override {
+    return Append(data, opts, dbg);
+  }
   virtual IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
   virtual IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -740,6 +740,14 @@ class RandomAccessFile {
   // RandomAccessFileWrapper too.
 };
 
+// A data structure brings the data verification information, which is
+// used togther with data being written to a file.
+struct DataVerificationInfo {
+  DataVerificationInfo(const std::string& checksum_) : checksum(checksum_) {}
+  // checksum of the data being written.
+  Slice checksum;
+};
+
 // A file abstraction for sequential writing.  The implementation
 // must provide buffering since callers may append small fragments
 // at a time to the file.
@@ -769,6 +777,12 @@ class WritableFile {
   // PositionedAppend, so the users cannot mix the two.
   virtual Status Append(const Slice& data) = 0;
 
+  // Append data with verification information
+  virtual Status AppendWithVerify(
+      const Slice& data, const DataVerificationInfo& /* verification_info */) {
+    return Append(data);
+  }
+
   // PositionedAppend data to the specified offset. The new EOF after append
   // must be larger than the previous EOF. This is to be used when writes are
   // not backed by OS buffers and hence has to always start from the start of
@@ -791,6 +805,14 @@ class WritableFile {
   // required is queried via GetRequiredBufferAlignment()
   virtual Status PositionedAppend(const Slice& /* data */,
                                   uint64_t /* offset */) {
+    return Status::NotSupported(
+        "WritableFile::PositionedAppend() not supported.");
+  }
+
+  // PositionedAppend data with verification information.
+  virtual Status PositionedAppendWithVerify(
+      const Slice& /* data */, uint64_t /* offset */,
+      const DataVerificationInfo& /* verification_info */) {
     return Status::NotSupported(
         "WritableFile::PositionedAppend() not supported.");
   }
@@ -1497,8 +1519,18 @@ class WritableFileWrapper : public WritableFile {
   explicit WritableFileWrapper(WritableFile* t) : target_(t) {}
 
   Status Append(const Slice& data) override { return target_->Append(data); }
+  Status AppendWithVerify(
+      const Slice& data,
+      const DataVerificationInfo& verification_info) override {
+    return target_->AppendWithVerify(data, verification_info);
+  }
   Status PositionedAppend(const Slice& data, uint64_t offset) override {
     return target_->PositionedAppend(data, offset);
+  }
+  Status PositionedAppendWithVerify(
+      const Slice& data, uint64_t offset,
+      const DataVerificationInfo& verification_info) override {
+    return target_->PositionedAppendWithVerify(data, offset, verification_info);
   }
   Status Truncate(uint64_t size) override { return target_->Truncate(size); }
   Status Close() override { return target_->Close(); }

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -702,6 +702,13 @@ class FSRandomAccessFile {
   // RandomAccessFileWrapper too.
 };
 
+// A data structure brings the data verification information, which is
+// used togther with data being written to a file.
+struct DataVerificationInfo {
+  // checksum of the data being written.
+  Slice checksum;
+};
+
 // A file abstraction for sequential writing.  The implementation
 // must provide buffering since callers may append small fragments
 // at a time to the file.
@@ -751,9 +758,11 @@ class FSWritableFile {
   // required is queried via GetRequiredBufferAlignment()
 
   // Append data with verification information
-  virtual IOStatus AppendWithVerify(
-      const Slice& data, const IOOptions& options, IODebugContext* dbg,
-      const DataVerificationInfo& /* verification_info */) {
+  // Note that this API change is experimental and it might be changed in
+  // the future. Currently, RocksDB does not use this API.
+  virtual IOStatus Append(const Slice& data, const IOOptions& options,
+                          IODebugContext* dbg,
+                          const DataVerificationInfo& /* verification_info */) {
     return Append(data, options, dbg);
   }
 
@@ -765,7 +774,9 @@ class FSWritableFile {
   }
 
   // PositionedAppend data with verification information.
-  virtual IOStatus PositionedAppendWithVerify(
+  // Note that this API change is experimental and it might be changed in
+  // the future. Currently, RocksDB does not use this API.
+  virtual IOStatus PositionedAppend(
       const Slice& /* data */, uint64_t /* offset */,
       const IOOptions& /*options*/, IODebugContext* /*dbg*/,
       const DataVerificationInfo& /* verification_info */) {
@@ -1302,22 +1313,22 @@ class FSWritableFileWrapper : public FSWritableFile {
                   IODebugContext* dbg) override {
     return target_->Append(data, options, dbg);
   }
-  IOStatus AppendWithVerify(
-      const Slice& data, const IOOptions& options, IODebugContext* dbg,
-      const DataVerificationInfo& verification_info) override {
-    return target_->AppendWithVerify(data, options, dbg, verification_info);
+  IOStatus Append(const Slice& data, const IOOptions& options,
+                  IODebugContext* dbg,
+                  const DataVerificationInfo& verification_info) override {
+    return target_->Append(data, options, dbg, verification_info);
   }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& options,
                             IODebugContext* dbg) override {
     return target_->PositionedAppend(data, offset, options, dbg);
   }
-  IOStatus PositionedAppendWithVerify(
+  IOStatus PositionedAppend(
       const Slice& data, uint64_t offset, const IOOptions& options,
       IODebugContext* dbg,
       const DataVerificationInfo& verification_info) override {
-    return target_->PositionedAppendWithVerify(data, offset, options, dbg,
-                                               verification_info);
+    return target_->PositionedAppend(data, offset, options, dbg,
+                                     verification_info);
   }
   IOStatus Truncate(uint64_t size, const IOOptions& options,
                     IODebugContext* dbg) override {

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -749,10 +749,26 @@ class FSWritableFile {
   //
   // PositionedAppend() requires aligned buffer to be passed in. The alignment
   // required is queried via GetRequiredBufferAlignment()
+
+  // Append data with verification information
+  virtual IOStatus AppendWithVerify(
+      const Slice& data, const IOOptions& options, IODebugContext* dbg,
+      const DataVerificationInfo& /* verification_info */) {
+    return Append(data, options, dbg);
+  }
+
   virtual IOStatus PositionedAppend(const Slice& /* data */,
                                     uint64_t /* offset */,
                                     const IOOptions& /*options*/,
                                     IODebugContext* /*dbg*/) {
+    return IOStatus::NotSupported();
+  }
+
+  // PositionedAppend data with verification information.
+  virtual IOStatus PositionedAppendWithVerify(
+      const Slice& /* data */, uint64_t /* offset */,
+      const IOOptions& /*options*/, IODebugContext* /*dbg*/,
+      const DataVerificationInfo& /* verification_info */) {
     return IOStatus::NotSupported();
   }
 
@@ -1286,10 +1302,22 @@ class FSWritableFileWrapper : public FSWritableFile {
                   IODebugContext* dbg) override {
     return target_->Append(data, options, dbg);
   }
+  IOStatus AppendWithVerify(
+      const Slice& data, const IOOptions& options, IODebugContext* dbg,
+      const DataVerificationInfo& verification_info) override {
+    return target_->AppendWithVerify(data, options, dbg, verification_info);
+  }
   IOStatus PositionedAppend(const Slice& data, uint64_t offset,
                             const IOOptions& options,
                             IODebugContext* dbg) override {
     return target_->PositionedAppend(data, offset, options, dbg);
+  }
+  IOStatus PositionedAppendWithVerify(
+      const Slice& data, uint64_t offset, const IOOptions& options,
+      IODebugContext* dbg,
+      const DataVerificationInfo& verification_info) override {
+    return target_->PositionedAppendWithVerify(data, offset, options, dbg,
+                                               verification_info);
   }
   IOStatus Truncate(uint64_t size, const IOOptions& options,
                     IODebugContext* dbg) override {

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -64,9 +64,9 @@ class TestFSWritableFile : public FSWritableFile {
   virtual ~TestFSWritableFile();
   virtual IOStatus Append(const Slice& data, const IOOptions&,
                           IODebugContext*) override;
-  virtual IOStatus Append(
-      const Slice& data, const IOOptions& options, IODebugContext* dbg,
-      const DataVerificationInfo& /*verification_info*/) override {
+  virtual IOStatus Append(const Slice& data, const IOOptions& options,
+                          const DataVerificationInfo& /*verification_info*/,
+                          IODebugContext* dbg) override {
     return Append(data, options, dbg);
   }
   virtual IOStatus Truncate(uint64_t size, const IOOptions& options,
@@ -83,10 +83,10 @@ class TestFSWritableFile : public FSWritableFile {
                                     IODebugContext* dbg) override {
     return target_->PositionedAppend(data, offset, options, dbg);
   }
-  IOStatus PositionedAppend(
-      const Slice& data, uint64_t offset, const IOOptions& options,
-      IODebugContext* dbg,
-      const DataVerificationInfo& /*verification_info*/) override {
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& options,
+                            const DataVerificationInfo& /*verification_info*/,
+                            IODebugContext* dbg) override {
     return PositionedAppend(data, offset, options, dbg);
   }
   virtual size_t GetRequiredBufferAlignment() const override {

--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -64,6 +64,11 @@ class TestFSWritableFile : public FSWritableFile {
   virtual ~TestFSWritableFile();
   virtual IOStatus Append(const Slice& data, const IOOptions&,
                           IODebugContext*) override;
+  virtual IOStatus Append(
+      const Slice& data, const IOOptions& options, IODebugContext* dbg,
+      const DataVerificationInfo& /*verification_info*/) override {
+    return Append(data, options, dbg);
+  }
   virtual IOStatus Truncate(uint64_t size, const IOOptions& options,
                             IODebugContext* dbg) override {
     return target_->Truncate(size, options, dbg);
@@ -77,6 +82,12 @@ class TestFSWritableFile : public FSWritableFile {
                                     const IOOptions& options,
                                     IODebugContext* dbg) override {
     return target_->PositionedAppend(data, offset, options, dbg);
+  }
+  IOStatus PositionedAppend(
+      const Slice& data, uint64_t offset, const IOOptions& options,
+      IODebugContext* dbg,
+      const DataVerificationInfo& /*verification_info*/) override {
+    return PositionedAppend(data, offset, options, dbg);
   }
   virtual size_t GetRequiredBufferAlignment() const override {
     return target_->GetRequiredBufferAlignment();


### PR DESCRIPTION
Add new AppendWithVerify and PositionedAppendWithVerify APIs to Env and FileSystem to bring the data verification information (data checksum information) from upper layer (e.g., WritableFileWriter) to the storage layer. This PR only include the API definition, no functional codes are added to unblock other developers which depend on these APIs.

Test plan: make -j32