### PR TITLE
Fix/minimize mock_time_env.h dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,6 +731,7 @@ set(SOURCES
         table/table_factory.cc
         table/table_properties.cc
         table/two_level_iterator.cc
+        test_util/mock_time_env.cc
         test_util/sync_point.cc
         test_util/sync_point_impl.cc
         test_util/testutil.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,7 +731,6 @@ set(SOURCES
         table/table_factory.cc
         table/table_properties.cc
         table/two_level_iterator.cc
-        test_util/mock_time_env.cc
         test_util/sync_point.cc
         test_util/sync_point_impl.cc
         test_util/testutil.cc
@@ -1020,6 +1019,7 @@ option(WITH_ALL_TESTS "Build all test, rather than a small subset" ON)
 if(WITH_TESTS OR WITH_BENCHMARK_TOOLS)
   add_subdirectory(third-party/gtest-1.8.1/fused-src/gtest)
   add_library(testharness STATIC
+  test_util/mock_time_env.cc
   test_util/testharness.cc)
   target_link_libraries(testharness gtest)
 endif()

--- a/TARGETS
+++ b/TARGETS
@@ -294,6 +294,7 @@ cpp_library(
         "table/table_factory.cc",
         "table/table_properties.cc",
         "table/two_level_iterator.cc",
+        "test_util/mock_time_env.cc",
         "test_util/sync_point.cc",
         "test_util/sync_point_impl.cc",
         "test_util/transaction_test_util.cc",

--- a/TARGETS
+++ b/TARGETS
@@ -294,7 +294,6 @@ cpp_library(
         "table/table_factory.cc",
         "table/table_properties.cc",
         "table/two_level_iterator.cc",
-        "test_util/mock_time_env.cc",
         "test_util/sync_point.cc",
         "test_util/sync_point_impl.cc",
         "test_util/transaction_test_util.cc",
@@ -397,6 +396,7 @@ cpp_library(
     srcs = [
         "db/db_test_util.cc",
         "table/mock_table.cc",
+        "test_util/mock_time_env.cc",
         "test_util/testharness.cc",
         "test_util/testutil.cc",
         "tools/block_cache_analyzer/block_cache_trace_analyzer.cc",

--- a/src.mk
+++ b/src.mk
@@ -178,7 +178,6 @@ LIB_SOURCES =                                                   \
   table/table_factory.cc                                        \
   table/table_properties.cc                                     \
   table/two_level_iterator.cc                                   \
-  test_util/mock_time_env.cc                                    \
   test_util/sync_point.cc                                       \
   test_util/sync_point_impl.cc                                  \
   test_util/transaction_test_util.cc                            \
@@ -306,6 +305,7 @@ STRESS_LIB_SOURCES =                                            \
 
 TEST_LIB_SOURCES =                                              \
   db/db_test_util.cc                                            \
+  test_util/mock_time_env.cc                                    \
   test_util/testharness.cc                                      \
   test_util/testutil.cc                                         \
   utilities/cassandra/test_utils.cc                             \

--- a/src.mk
+++ b/src.mk
@@ -178,6 +178,7 @@ LIB_SOURCES =                                                   \
   table/table_factory.cc                                        \
   table/table_properties.cc                                     \
   table/two_level_iterator.cc                                   \
+  test_util/mock_time_env.cc                                    \
   test_util/sync_point.cc                                       \
   test_util/sync_point_impl.cc                                  \
   test_util/transaction_test_util.cc                            \

--- a/test_util/mock_time_env.cc
+++ b/test_util/mock_time_env.cc
@@ -13,9 +13,10 @@ namespace ROCKSDB_NAMESPACE {
 // for timedwait timeout. Ideally timedwait API should be moved to env.
 // details: PR #7101.
 void MockTimeEnv::InstallTimedWaitFixCallback() {
+#ifndef NDEBUG
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
-#if defined(OS_MACOSX) && !defined(NDEBUG)
+#ifdef OS_MACOSX
   // This is an alternate way (vs. SpecialEnv) of dealing with the fact
   // that on some platforms, pthread_cond_timedwait does not appear to
   // release the lock for other threads to operate if the deadline time
@@ -29,8 +30,9 @@ void MockTimeEnv::InstallTimedWaitFixCallback() {
           *reinterpret_cast<uint64_t*>(arg) = this->RealNowMicros() + 1000;
         }
       });
-#endif  // OS_MACOSX && !NDEBUG
+#endif  // OS_MACOSX
   SyncPoint::GetInstance()->EnableProcessing();
+#endif  // !NDEBUG
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/test_util/mock_time_env.cc
+++ b/test_util/mock_time_env.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "test_util/mock_time_env.h"
+
+#include "test_util/sync_point.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// TODO: this is a workaround for the different behavior on different platform
+// for timedwait timeout. Ideally timedwait API should be moved to env.
+// details: PR #7101.
+void MockTimeEnv::InstallTimedWaitFixCallback() {
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+#if defined(OS_MACOSX) && !defined(NDEBUG)
+  // This is an alternate way (vs. SpecialEnv) of dealing with the fact
+  // that on some platforms, pthread_cond_timedwait does not appear to
+  // release the lock for other threads to operate if the deadline time
+  // is already passed. (TimedWait calls are currently a bad abstraction
+  // because the deadline parameter is usually computed from Env time,
+  // but is interpreted in real clock time.)
+  SyncPoint::GetInstance()->SetCallBack(
+      "InstrumentedCondVar::TimedWaitInternal", [&](void* arg) {
+        uint64_t time_us = *reinterpret_cast<uint64_t*>(arg);
+        if (time_us < this->RealNowMicros()) {
+          *reinterpret_cast<uint64_t*>(arg) = this->RealNowMicros() + 1000;
+        }
+      });
+#endif  // OS_MACOSX && !NDEBUG
+  SyncPoint::GetInstance()->EnableProcessing();
+}
+
+}  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Summary: (a) own copy of kMicrosInSecond
(b) out-of-line sync point code

Test Plan: FB internal