### PR TITLE
Support injecting read errors for RandomAccessFile when using FaultInjectionTestEnv

### DIFF
--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1469,12 +1469,14 @@ TEST_F(BlobDBTest, UserCompactionFilter_BlobIOError) {
     auto s = blob_db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
     ASSERT_TRUE(s.IsIOError());
 
+    // Reactivate file system to allow test to verify and close DB.
+    fault_injection_env_->SetFilesystemActive(true);
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+
     // Verify full data set after compaction failure
     VerifyDB(data);
 
-    // Reactivate file system to allow test to close DB.
-    fault_injection_env_->SetFilesystemActive(true);
-    SyncPoint::GetInstance()->ClearAllCallBacks();
     delete options.compaction_filter;
     Destroy();
   }

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -47,6 +47,19 @@ struct FileState {
   Status DropRandomUnsyncedData(Env* env, Random* rand) const;
 };
 
+class TestRandomAccessFile : public RandomAccessFile {
+ public:
+  TestRandomAccessFile(std::unique_ptr<RandomAccessFile>&& target,
+                       FaultInjectionTestEnv* env);
+
+  Status Read(uint64_t offset, size_t n, Slice* result,
+              char* scratch) const override;
+
+ private:
+  std::unique_ptr<RandomAccessFile> target_;
+  FaultInjectionTestEnv* env_;
+};
+
 // A wrapper around WritableFileWriter* file
 // is written to or sync'ed.
 class TestWritableFile : public WritableFile {

--- a/utilities/fault_injection_env.h
+++ b/utilities/fault_injection_env.h
@@ -55,6 +55,10 @@ class TestRandomAccessFile : public RandomAccessFile {
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override;
 
+  Status Prefetch(uint64_t offset, size_t n) override;
+
+  Status MultiRead(ReadRequest* reqs, size_t num_reqs) override;
+
  private:
   std::unique_ptr<RandomAccessFile> target_;
   FaultInjectionTestEnv* env_;


### PR DESCRIPTION
Summary:
The patch adds support for injecting errors when reading from `RandomAccessFile`
using `FaultInjectionTestEnv`. (This functionality was curiously missing
w/r/t `RandomAccessFile`, even though it was implemented for `RandomRWFile`.)
The patch also fixes up a test case in `blob_db_test` which uses `FaultInjectionTestEnv`
but has so far relied on reads from `RandomAccessFile`s succeeding even after
deactivating the filesystem.

Test Plan:
`make check` 