### PR TITLE
Revert an uncessary status code check skipping

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1836,8 +1836,6 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
         GetPerfLevel() >= PerfLevel::kEnableTimeExceptForMutex &&
         get_perf_context()->per_level_perf_context_enabled;
     StopWatchNano timer(env_, timer_enabled /* auto_start */);
-    // Something feels not right here. Should investigate more.
-    status->PermitUncheckedError();
     *status = table_cache_->Get(
         read_options, *internal_comparator(), *f->file_metadata, ikey,
         &get_context, mutable_cf_options_.prefix_extractor.get(),


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/7452 added an uncessary skip for status code checking. Revert it.

Test Plan: Watch CI to finish