### PR TITLE
Introduce a blob file reader class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,7 @@ set(SOURCES
         db/blob/blob_file_builder.cc
         db/blob/blob_file_garbage.cc
         db/blob/blob_file_meta.cc
+        db/blob/blob_file_reader.cc
         db/blob/blob_log_format.cc
         db/blob/blob_log_reader.cc
         db/blob/blob_log_writer.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1045,6 +1045,7 @@ if(WITH_TESTS)
         db/blob/blob_file_addition_test.cc
         db/blob/blob_file_builder_test.cc
         db/blob/blob_file_garbage_test.cc
+        db/blob/blob_file_reader_test.cc
         db/blob/db_blob_index_test.cc
         db/column_family_test.cc
         db/compact_files_test.cc

--- a/Makefile
+++ b/Makefile
@@ -578,6 +578,7 @@ ifdef ASSERT_STATUS_CHECKED
 		blob_file_addition_test \
 		blob_file_builder_test \
 		blob_file_garbage_test \
+		blob_file_reader_test \
 		bloom_test \
 		cassandra_format_test \
 		cassandra_row_merge_test \
@@ -1908,6 +1909,9 @@ blob_file_builder_test: $(OBJ_DIR)/db/blob/blob_file_builder_test.o $(TEST_LIBRA
 	$(AM_LINK)
 
 blob_file_garbage_test: $(OBJ_DIR)/db/blob/blob_file_garbage_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
+blob_file_reader_test: $(OBJ_DIR)/db/blob/blob_file_reader_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 timer_test: $(OBJ_DIR)/util/timer_test.o $(TEST_LIBRARY) $(LIBRARY)

--- a/TARGETS
+++ b/TARGETS
@@ -137,6 +137,7 @@ cpp_library(
         "db/blob/blob_file_builder.cc",
         "db/blob/blob_file_garbage.cc",
         "db/blob/blob_file_meta.cc",
+        "db/blob/blob_file_reader.cc",
         "db/blob/blob_log_format.cc",
         "db/blob/blob_log_reader.cc",
         "db/blob/blob_log_writer.cc",

--- a/TARGETS
+++ b/TARGETS
@@ -864,6 +864,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "blob_file_reader_test",
+        "db/blob/blob_file_reader_test.cc",
+        "serial",
+        [],
+        [],
+    ],
+    [
         "block_based_filter_block_test",
         "table/block_based/block_based_filter_block_test.cc",
         "serial",

--- a/TARGETS
+++ b/TARGETS
@@ -425,6 +425,7 @@ cpp_library(
         "db/blob/blob_file_builder.cc",
         "db/blob/blob_file_garbage.cc",
         "db/blob/blob_file_meta.cc",
+        "db/blob/blob_file_reader.cc",
         "db/blob/blob_log_format.cc",
         "db/blob/blob_log_reader.cc",
         "db/blob/blob_log_writer.cc",

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -384,7 +384,7 @@ Status BlobFileReader::UncompressBlobIfNeeded(const Slice& value_slice,
   assert(value);
 
   if (compression_type == kNoCompression) {
-    SaveValue(value, value_slice);
+    SaveValue(value_slice, value);
 
     return Status::OK();
   }
@@ -408,12 +408,12 @@ Status BlobFileReader::UncompressBlobIfNeeded(const Slice& value_slice,
     return Status::Corruption("Unable to uncompress blob");
   }
 
-  SaveValue(value, Slice(output.get(), uncompressed_size));
+  SaveValue(Slice(output.get(), uncompressed_size), value);
 
   return Status::OK();
 }
 
-void BlobFileReader::SaveValue(PinnableSlice* dst, const Slice& src) {
+void BlobFileReader::SaveValue(const Slice& src, PinnableSlice* dst) {
   assert(dst);
 
   if (dst->IsPinned()) {

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -1,0 +1,159 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_file_reader.h"
+
+#include <cassert>
+#include <string>
+
+#include "db/blob/blob_log_format.h"
+#include "file/file_util.h"
+#include "file/filename.h"
+#include "file/random_access_file_reader.h"
+#include "options/cf_options.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/status.h"
+#include "table/get_context.h"
+#include "util/crc32c.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status BlobFileReader::Create(
+    const ReadOptions& read_options,
+    const ImmutableCFOptions& immutable_cf_options,
+    const FileOptions& file_options, uint64_t blob_file_number,
+    std::unique_ptr<BlobFileReader>* blob_file_reader) {
+  assert(blob_file_reader);
+  assert(!*blob_file_reader);
+
+  Env* const env = immutable_cf_options.env;
+  assert(env);
+
+  FileOptions file_opts(file_options);
+
+  {
+    const Status s =
+        PrepareIOFromReadOptions(read_options, env, file_opts.io_options);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  FileSystem* const fs = immutable_cf_options.fs;
+  assert(fs);
+
+  const auto& cf_paths = immutable_cf_options.cf_paths;
+  assert(!cf_paths.empty());
+
+  const std::string blob_file_path =
+      BlobFileName(cf_paths.front().path, blob_file_number);
+  std::unique_ptr<FSRandomAccessFile> file;
+  constexpr IODebugContext* dbg = nullptr;
+
+  {
+    const Status s =
+        fs->NewRandomAccessFile(blob_file_path, file_opts, &file, dbg);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  assert(file);
+
+  if (immutable_cf_options.advise_random_on_open) {
+    file->Hint(FSRandomAccessFile::kRandom);
+  }
+
+  // TODO
+  constexpr IOTracer* io_tracer = nullptr;
+  constexpr HistogramImpl* file_read_hist = nullptr;
+
+  std::unique_ptr<RandomAccessFileReader> file_reader(
+      new RandomAccessFileReader(
+          std::move(file), blob_file_path, env,
+          std::shared_ptr<IOTracer>(io_tracer), immutable_cf_options.statistics,
+          BLOB_DB_BLOB_FILE_READ_MICROS, file_read_hist,
+          immutable_cf_options.rate_limiter, immutable_cf_options.listeners));
+
+  // TODO: read header and retrieve compression etc.
+
+  blob_file_reader->reset(new BlobFileReader(std::move(file_reader)));
+
+  return Status::OK();
+}
+
+BlobFileReader::BlobFileReader(
+    std::unique_ptr<RandomAccessFileReader>&& file_reader)
+    : file_reader_(std::move(file_reader)) {
+  assert(file_reader_);
+}
+
+BlobFileReader::~BlobFileReader() = default;
+
+Status BlobFileReader::GetBlob(const ReadOptions& /* TODO read_options */,
+                               const Slice& user_key, uint64_t offset,
+                               uint64_t size, GetContext* get_context) const {
+  assert(get_context);
+
+  if (offset <
+      (BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + user_key.size())) {
+    return Status::Corruption("Invalid blob offset");
+  }
+
+  assert(offset >= user_key.size() + sizeof(uint32_t));
+  const uint64_t record_offset = offset - user_key.size() - sizeof(uint32_t);
+  const uint64_t record_size = sizeof(uint32_t) + user_key.size() + size;
+
+  std::string buf;
+  AlignedBuf aligned_buf;
+
+  Slice blob_record;
+
+  assert(file_reader_);
+
+  Status s;
+
+  if (file_reader_->use_direct_io()) {
+    s = file_reader_->Read(IOOptions(), record_offset,
+                           static_cast<size_t>(record_size), &blob_record,
+                           nullptr, &aligned_buf);
+  } else {
+    buf.reserve(static_cast<size_t>(record_size));
+    s = file_reader_->Read(IOOptions(), record_offset,
+                           static_cast<size_t>(record_size), &blob_record,
+                           &buf[0], nullptr);
+  }
+
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (blob_record.size() != record_size) {
+    return Status::Corruption("Failed to retrieve blob from blob index.");
+  }
+
+  Slice crc_slice(blob_record.data(), sizeof(uint32_t));
+  Slice blob_value(blob_record.data() + sizeof(uint32_t) + user_key.size(),
+                   static_cast<size_t>(size));
+
+  uint32_t crc_exp = 0;
+  if (!GetFixed32(&crc_slice, &crc_exp)) {
+    return Status::Corruption("Unable to decode checksum.");
+  }
+
+  uint32_t crc = crc32c::Value(blob_record.data() + sizeof(uint32_t),
+                               blob_record.size() - sizeof(uint32_t));
+  crc = crc32c::Mask(crc);
+  if (crc != crc_exp) {
+    return Status::Corruption("Corruption. Blob CRC mismatch");
+  }
+
+  get_context->SaveValue(blob_value, kMaxSequenceNumber);
+
+  return Status::OK();
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -8,7 +8,6 @@
 #include <cassert>
 
 #include "db/blob/blob_log_format.h"
-#include "file/file_util.h"
 #include "file/filename.h"
 #include "options/cf_options.h"
 #include "rocksdb/file_system.h"

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -146,6 +146,9 @@ Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
     if (!s.ok()) {
       return s;
     }
+
+    TEST_SYNC_POINT_CALLBACK("BlobFileReader::ReadHeader:TamperWithResult",
+                             &header_slice);
   }
 
   BlobLogHeader header;
@@ -192,6 +195,9 @@ Status BlobFileReader::ReadFooter(uint64_t file_size,
     if (!s.ok()) {
       return s;
     }
+
+    TEST_SYNC_POINT_CALLBACK("BlobFileReader::ReadFooter:TamperWithResult",
+                             &footer_slice);
   }
 
   BlobLogFooter footer;
@@ -301,6 +307,9 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
     if (!s.ok()) {
       return s;
     }
+
+    TEST_SYNC_POINT_CALLBACK("BlobFileReader::GetBlob:TamperWithResult",
+                             &record_slice);
   }
 
   if (read_options.verify_checksums) {

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -384,7 +384,7 @@ Status BlobFileReader::UncompressBlobIfNeeded(const Slice& value_slice,
       UncompressData(info, value_slice.data(), value_slice.size(),
                      &uncompressed_size, compression_format_version, allocator);
   if (!output) {
-    return Status::Corruption("Unable to decompress blob");
+    return Status::Corruption("Unable to uncompress blob");
   }
 
   get_context->SaveValue(Slice(output.get(), uncompressed_size),

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -206,6 +206,7 @@ BlobFileReader::~BlobFileReader() = default;
 Status BlobFileReader::GetBlob(const ReadOptions& read_options,
                                const Slice& user_key, uint64_t offset,
                                uint64_t value_size,
+                               CompressionType compression_type,
                                GetContext* get_context) const {
   assert(get_context);
 
@@ -213,6 +214,10 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
 
   if (!IsValidBlobOffset(offset, key_size)) {
     return Status::Corruption("Invalid blob offset");
+  }
+
+  if (compression_type != compression_type_) {
+    return Status::Corruption("Compression type mismatch when reading blob");
   }
 
   // Note: if verify_checksum is set, we read the entire blob record to be able

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -60,7 +60,7 @@ Status BlobFileReader::Create(
   }
 
   blob_file_reader->reset(
-      new BlobFileReader(std::move(file_reader), compression_type));
+      new BlobFileReader(std::move(file_reader), file_size, compression_type));
 
   return Status::OK();
 }
@@ -255,9 +255,10 @@ Status BlobFileReader::ReadFromFile(RandomAccessFileReader* file_reader,
 }
 
 BlobFileReader::BlobFileReader(
-    std::unique_ptr<RandomAccessFileReader>&& file_reader,
+    std::unique_ptr<RandomAccessFileReader>&& file_reader, uint64_t file_size,
     CompressionType compression_type)
     : file_reader_(std::move(file_reader)),
+      file_size_(file_size),
       compression_type_(compression_type) {
   assert(file_reader_);
 }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -365,6 +365,9 @@ Status BlobFileReader::VerifyBlob(const Slice& record_slice,
   record.value = Slice(record.key.data() + key_size, value_size);
 
   {
+    TEST_SYNC_POINT_CALLBACK("BlobFileReader::VerifyBlob:CheckBlobCRC",
+                             &record);
+
     const Status s = record.CheckBlobCRC();
     if (!s.ok()) {
       return s;

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -50,7 +50,7 @@ Status BlobFileReader::Create(
 
   assert(file_reader);
 
-  CompressionType compression_type;
+  CompressionType compression_type = kNoCompression;
 
   {
     const Status s = ReadHeader(file_reader.get(), file_opts.io_options,

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -211,7 +211,7 @@ Status BlobFileReader::ReadFromFile(RandomAccessFileReader* file_reader,
 
 Status BlobFileReader::VerifyBlob(const Slice& record_slice,
                                   const Slice& user_key, uint64_t key_size,
-                                  uint64_t value_size) const {
+                                  uint64_t value_size) {
   assert(user_key.size() == key_size);
 
   BlobLogRecord record;

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -15,6 +15,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "table/get_context.h"
+#include "test_util/sync_point.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
 
@@ -85,6 +86,8 @@ Status BlobFileReader::OpenFile(
   constexpr IODebugContext* dbg = nullptr;
 
   {
+    TEST_SYNC_POINT("BlobFileReader::OpenFile:GetFileSize");
+
     const Status s =
         fs->GetFileSize(blob_file_path, IOOptions(), file_size, dbg);
     if (!s.ok()) {
@@ -99,6 +102,8 @@ Status BlobFileReader::OpenFile(
   std::unique_ptr<FSRandomAccessFile> file;
 
   {
+    TEST_SYNC_POINT("BlobFileReader::OpenFile:NewRandomAccessFile");
+
     const Status s =
         fs->NewRandomAccessFile(blob_file_path, file_opts, &file, dbg);
     if (!s.ok()) {
@@ -132,6 +137,8 @@ Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
   AlignedBuf aligned_buf;
 
   {
+    TEST_SYNC_POINT("BlobFileReader::ReadHeader:ReadFromFile");
+
     constexpr uint64_t read_offset = 0;
     constexpr size_t read_size = BlobLogHeader::kSize;
 
@@ -176,6 +183,8 @@ Status BlobFileReader::ReadFooter(uint64_t file_size,
   AlignedBuf aligned_buf;
 
   {
+    TEST_SYNC_POINT("BlobFileReader::ReadFooter:ReadFromFile");
+
     const uint64_t read_offset = file_size - BlobLogFooter::kSize;
     constexpr size_t read_size = BlobLogFooter::kSize;
 
@@ -282,6 +291,8 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
   AlignedBuf aligned_buf;
 
   {
+    TEST_SYNC_POINT("BlobFileReader::GetBlob:ReadFromFile");
+
     const uint64_t record_offset = offset - adjustment;
     const uint64_t record_size = value_size + adjustment;
 

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -97,7 +97,7 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
                                GetContext* get_context) const {
   assert(get_context);
 
-  const size_t key_size = user_key.size();
+  const uint64_t key_size = user_key.size();
 
   if (!IsValidBlobOffset(offset, key_size)) {
     return Status::Corruption("Invalid blob offset");
@@ -107,7 +107,7 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
   // to perform the verification; otherwise, we just read the blob itself. Since
   // the offset in BlobIndex actually points to the blob value, we need to make
   // an adjustment in the former case.
-  const size_t adjustment =
+  const uint64_t adjustment =
       read_options.verify_checksums
           ? BlobLogRecord::CalculateAdjustmentForRecordHeader(key_size)
           : 0;

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -274,7 +274,7 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
 
   const uint64_t key_size = user_key.size();
 
-  if (!IsValidBlobOffset(offset, key_size)) {
+  if (!IsValidBlobOffset(offset, key_size, value_size, file_size_)) {
     return Status::Corruption("Invalid blob offset");
   }
 

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -21,7 +21,6 @@
 namespace ROCKSDB_NAMESPACE {
 
 Status BlobFileReader::Create(
-    const ReadOptions& read_options,
     const ImmutableCFOptions& immutable_cf_options,
     const FileOptions& file_options, uint32_t column_family_id,
     uint64_t blob_file_number,
@@ -29,21 +28,11 @@ Status BlobFileReader::Create(
   assert(blob_file_reader);
   assert(!*blob_file_reader);
 
-  FileOptions file_opts(file_options);
-
-  {
-    const Status s = PrepareIOFromReadOptions(
-        read_options, immutable_cf_options.env, file_opts.io_options);
-    if (!s.ok()) {
-      return s;
-    }
-  }
-
   std::unique_ptr<RandomAccessFileReader> file_reader;
 
   {
-    const Status s = OpenFile(immutable_cf_options, file_opts, blob_file_number,
-                              &file_reader);
+    const Status s = OpenFile(immutable_cf_options, file_options,
+                              blob_file_number, &file_reader);
     if (!s.ok()) {
       return s;
     }
@@ -54,8 +43,8 @@ Status BlobFileReader::Create(
   CompressionType compression_type = kNoCompression;
 
   {
-    const Status s = ReadHeader(file_reader.get(), file_opts.io_options,
-                                column_family_id, &compression_type);
+    const Status s =
+        ReadHeader(file_reader.get(), column_family_id, &compression_type);
     if (!s.ok()) {
       return s;
     }
@@ -112,7 +101,6 @@ Status BlobFileReader::OpenFile(
 }
 
 Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
-                                  const IOOptions& io_options,
                                   uint32_t column_family_id,
                                   CompressionType* compression_type) {
   assert(file_reader);
@@ -126,8 +114,8 @@ Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
     constexpr uint64_t read_offset = 0;
     constexpr size_t read_size = BlobLogHeader::kSize;
 
-    const Status s = ReadFromFile(file_reader, io_options, read_offset,
-                                  read_size, &header_slice, &buf, &aligned_buf);
+    const Status s = ReadFromFile(file_reader, read_offset, read_size,
+                                  &header_slice, &buf, &aligned_buf);
     if (!s.ok()) {
       return s;
     }
@@ -158,7 +146,6 @@ Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
 }
 
 Status BlobFileReader::ReadFromFile(RandomAccessFileReader* file_reader,
-                                    const IOOptions& io_options,
                                     uint64_t read_offset, size_t read_size,
                                     Slice* slice, std::string* buf,
                                     AlignedBuf* aligned_buf) {
@@ -173,14 +160,14 @@ Status BlobFileReader::ReadFromFile(RandomAccessFileReader* file_reader,
   if (file_reader->use_direct_io()) {
     constexpr char* scratch = nullptr;
 
-    s = file_reader->Read(io_options, read_offset, read_size, slice, scratch,
+    s = file_reader->Read(IOOptions(), read_offset, read_size, slice, scratch,
                           aligned_buf);
   } else {
     buf->reserve(read_size);
     constexpr AlignedBuf* aligned_scratch = nullptr;
 
-    s = file_reader->Read(io_options, read_offset, read_size, slice, &(*buf)[0],
-                          aligned_scratch);
+    s = file_reader->Read(IOOptions(), read_offset, read_size, slice,
+                          &(*buf)[0], aligned_scratch);
   }
 
   if (!s.ok()) {
@@ -233,22 +220,12 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
   const uint64_t record_offset = offset - adjustment;
   const uint64_t record_size = value_size + adjustment;
 
-  IOOptions io_options;
-
-  {
-    const Status s =
-        PrepareIOFromReadOptions(read_options, file_reader_->env(), io_options);
-    if (!s.ok()) {
-      return s;
-    }
-  }
-
   Slice record_slice;
   std::string buf;
   AlignedBuf aligned_buf;
 
   {
-    const Status s = ReadFromFile(file_reader_.get(), io_options, record_offset,
+    const Status s = ReadFromFile(file_reader_.get(), record_offset,
                                   static_cast<size_t>(record_size),
                                   &record_slice, &buf, &aligned_buf);
     if (!s.ok()) {

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -310,7 +310,7 @@ Status BlobFileReader::UncompressBlobIfNeeded(const Slice& value_slice,
   UncompressionInfo info(context, UncompressionDict::GetEmptyDict(),
                          compression_type);
 
-  int uncompressed_size = 0;
+  size_t uncompressed_size = 0;
   constexpr uint32_t compression_format_version = 2;
   constexpr MemoryAllocator* allocator = nullptr;
 

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -22,7 +22,8 @@ namespace ROCKSDB_NAMESPACE {
 Status BlobFileReader::Create(
     const ReadOptions& read_options,
     const ImmutableCFOptions& immutable_cf_options,
-    const FileOptions& file_options, uint64_t blob_file_number,
+    const FileOptions& file_options, uint32_t column_family_id,
+    uint64_t blob_file_number,
     std::unique_ptr<BlobFileReader>* blob_file_reader) {
   assert(blob_file_reader);
   assert(!*blob_file_reader);
@@ -106,7 +107,9 @@ Status BlobFileReader::Create(
     return Status::Corruption("Unexpected TTL blob file");
   }
 
-  // column_family_id_ = header.column_family_id;
+  if (header.column_family_id != column_family_id) {
+    return Status::Corruption("Column family ID mismatch");
+  }
   // compression_ = header.compression;
 
   blob_file_reader->reset(new BlobFileReader(std::move(file_reader)));

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -121,8 +121,9 @@ Status BlobFileReader::GetBlob(const ReadOptions& read_options,
   AlignedBuf aligned_buf;
 
   {
-    const Status s = ReadBlobFromFile(record_offset, record_size, &record_slice,
-                                      &buf, &aligned_buf);
+    const Status s =
+        ReadBlobFromFile(record_offset, static_cast<size_t>(record_size),
+                         &record_slice, &buf, &aligned_buf);
     if (!s.ok()) {
       return s;
     }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -135,7 +135,7 @@ Status BlobFileReader::GetBlob(const ReadOptions& /* TODO read_options */,
   }
 
   if (blob_record.size() != record_size) {
-    return Status::Corruption("Failed to retrieve blob from blob index.");
+    return Status::Corruption("Failed to retrieve blob from blob index");
   }
 
   Slice crc_slice(blob_record.data(), sizeof(uint32_t));
@@ -144,14 +144,14 @@ Status BlobFileReader::GetBlob(const ReadOptions& /* TODO read_options */,
 
   uint32_t crc_exp = 0;
   if (!GetFixed32(&crc_slice, &crc_exp)) {
-    return Status::Corruption("Unable to decode checksum.");
+    return Status::Corruption("Unable to decode checksum");
   }
 
   uint32_t crc = crc32c::Value(blob_record.data() + sizeof(uint32_t),
                                blob_record.size() - sizeof(uint32_t));
   crc = crc32c::Mask(crc);
   if (crc != crc_exp) {
-    return Status::Corruption("Corruption. Blob CRC mismatch");
+    return Status::Corruption("Blob CRC mismatch");
   }
 
   get_context->SaveValue(blob_value, kMaxSequenceNumber);

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -399,6 +399,10 @@ Status BlobFileReader::UncompressBlobIfNeeded(const Slice& value_slice,
   CacheAllocationPtr output =
       UncompressData(info, value_slice.data(), value_slice.size(),
                      &uncompressed_size, compression_format_version, allocator);
+
+  TEST_SYNC_POINT_CALLBACK(
+      "BlobFileReader::UncompressBlobIfNeeded:TamperWithResult", &output);
+
   if (!output) {
     return Status::Corruption("Unable to uncompress blob");
   }

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -110,16 +110,18 @@ Status BlobFileReader::Create(
   if (header.column_family_id != column_family_id) {
     return Status::Corruption("Column family ID mismatch");
   }
-  // compression_ = header.compression;
 
-  blob_file_reader->reset(new BlobFileReader(std::move(file_reader)));
+  blob_file_reader->reset(
+      new BlobFileReader(std::move(file_reader), header.compression));
 
   return Status::OK();
 }
 
 BlobFileReader::BlobFileReader(
-    std::unique_ptr<RandomAccessFileReader>&& file_reader)
-    : file_reader_(std::move(file_reader)) {
+    std::unique_ptr<RandomAccessFileReader>&& file_reader,
+    CompressionType compression_type)
+    : file_reader_(std::move(file_reader)),
+      compression_type_(compression_type) {
   assert(file_reader_);
 }
 

--- a/db/blob/blob_file_reader.cc
+++ b/db/blob/blob_file_reader.cc
@@ -124,7 +124,7 @@ Status BlobFileReader::OpenFile(
   return Status::OK();
 }
 
-Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
+Status BlobFileReader::ReadHeader(const RandomAccessFileReader* file_reader,
                                   uint32_t column_family_id,
                                   CompressionType* compression_type) {
   assert(file_reader);
@@ -175,7 +175,7 @@ Status BlobFileReader::ReadHeader(RandomAccessFileReader* file_reader,
 }
 
 Status BlobFileReader::ReadFooter(uint64_t file_size,
-                                  RandomAccessFileReader* file_reader) {
+                                  const RandomAccessFileReader* file_reader) {
   assert(file_size >= BlobLogHeader::kSize + BlobLogFooter::kSize);
   assert(file_reader);
 
@@ -217,7 +217,7 @@ Status BlobFileReader::ReadFooter(uint64_t file_size,
   return Status::OK();
 }
 
-Status BlobFileReader::ReadFromFile(RandomAccessFileReader* file_reader,
+Status BlobFileReader::ReadFromFile(const RandomAccessFileReader* file_reader,
                                     uint64_t read_offset, size_t read_size,
                                     Slice* slice, std::string* buf,
                                     AlignedBuf* aligned_buf) {

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -22,6 +22,7 @@ struct FileOptions;
 class Slice;
 class GetContext;
 class RandomAccessFileReader;
+struct IOOptions;
 
 class BlobFileReader {
  public:
@@ -45,8 +46,8 @@ class BlobFileReader {
                  CompressionType compression_type);
 
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
-                             uint64_t read_offset, size_t read_size,
-                             Slice* slice, std::string* buf,
+                             const IOOptions& io_options, uint64_t read_offset,
+                             size_t read_size, Slice* slice, std::string* buf,
                              AlignedBuf* aligned_buf);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -22,7 +22,6 @@ struct FileOptions;
 class HistogramImpl;
 class Slice;
 class PinnableSlice;
-class RandomAccessFileReader;
 
 class BlobFileReader {
  public:

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -52,14 +52,14 @@ class BlobFileReader {
                          uint64_t blob_file_number, uint64_t* file_size,
                          std::unique_ptr<RandomAccessFileReader>* file_reader);
 
-  static Status ReadHeader(RandomAccessFileReader* file_reader,
+  static Status ReadHeader(const RandomAccessFileReader* file_reader,
                            uint32_t column_family_id,
                            CompressionType* compression_type);
 
   static Status ReadFooter(uint64_t file_size,
-                           RandomAccessFileReader* file_reader);
+                           const RandomAccessFileReader* file_reader);
 
-  static Status ReadFromFile(RandomAccessFileReader* file_reader,
+  static Status ReadFromFile(const RandomAccessFileReader* file_reader,
                              uint64_t read_offset, size_t read_size,
                              Slice* slice, std::string* buf,
                              AlignedBuf* aligned_buf);

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -45,6 +45,11 @@ class BlobFileReader {
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
                  CompressionType compression_type);
 
+  static Status OpenFile(const ImmutableCFOptions& immutable_cf_options,
+                         const FileOptions& file_opts,
+                         uint64_t blob_file_number,
+                         std::unique_ptr<RandomAccessFileReader>* file_reader);
+
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
                              const IOOptions& io_options, uint64_t read_offset,
                              size_t read_size, Slice* slice, std::string* buf,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "file/random_access_file_reader.h"
+#include "rocksdb/compression_type.h"
 #include "rocksdb/rocksdb_namespace.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -40,8 +41,8 @@ class BlobFileReader {
                  GetContext* get_context) const;
 
  private:
-  explicit BlobFileReader(
-      std::unique_ptr<RandomAccessFileReader>&& file_reader);
+  BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
+                 CompressionType compression_type);
 
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
                              uint64_t read_offset, size_t read_size,
@@ -52,6 +53,7 @@ class BlobFileReader {
                            uint64_t key_size, uint64_t value_size);
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
+  CompressionType compression_type_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -7,7 +7,9 @@
 
 #include <cinttypes>
 #include <memory>
+#include <string>
 
+#include "file/random_access_file_reader.h"
 #include "rocksdb/rocksdb_namespace.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -40,6 +42,10 @@ class BlobFileReader {
  private:
   explicit BlobFileReader(
       std::unique_ptr<RandomAccessFileReader>&& file_reader);
+
+  Status ReadBlobFromFile(uint64_t record_offset, size_t record_size,
+                          Slice* record_slice, std::string* buf,
+                          AlignedBuf* aligned_buf) const;
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
 };

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -43,8 +43,10 @@ class BlobFileReader {
   explicit BlobFileReader(
       std::unique_ptr<RandomAccessFileReader>&& file_reader);
 
-  Status ReadFromFile(uint64_t read_offset, size_t read_size, Slice* slice,
-                      std::string* buf, AlignedBuf* aligned_buf) const;
+  static Status ReadFromFile(RandomAccessFileReader* file_reader,
+                             uint64_t read_offset, size_t read_size,
+                             Slice* slice, std::string* buf,
+                             AlignedBuf* aligned_buf);
 
   Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
                     uint64_t key_size, uint64_t value_size) const;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -44,7 +44,7 @@ class BlobFileReader {
 
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
-                 CompressionType compression_type);
+                 uint64_t file_size, CompressionType compression_type);
 
   static Status OpenFile(const ImmutableCFOptions& immutable_cf_options,
                          const FileOptions& file_opts,
@@ -74,6 +74,7 @@ class BlobFileReader {
   static void SaveValue(PinnableSlice* dst, const Slice& src);
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
+  uint64_t file_size_;
   CompressionType compression_type_;
 };
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -21,7 +21,7 @@ struct ImmutableCFOptions;
 struct FileOptions;
 class HistogramImpl;
 class Slice;
-class GetContext;
+class PinnableSlice;
 class RandomAccessFileReader;
 
 class BlobFileReader {
@@ -40,8 +40,7 @@ class BlobFileReader {
 
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
                  uint64_t offset, uint64_t value_size,
-                 CompressionType compression_type,
-                 GetContext* get_context) const;
+                 CompressionType compression_type, PinnableSlice* value) const;
 
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,
@@ -70,7 +69,9 @@ class BlobFileReader {
 
   static Status UncompressBlobIfNeeded(const Slice& value_slice,
                                        CompressionType compression_type,
-                                       GetContext* get_context);
+                                       PinnableSlice* value);
+
+  static void SaveValue(PinnableSlice* dst, const Slice& src);
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   CompressionType compression_type_;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -64,6 +64,10 @@ class BlobFileReader {
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
                            uint64_t key_size, uint64_t value_size);
 
+  static Status UncompressBlobIfNeeded(const Slice& value_slice,
+                                       CompressionType compression_type,
+                                       GetContext* get_context);
+
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   CompressionType compression_type_;
 };

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -47,6 +47,9 @@ class BlobFileReader {
                           Slice* record_slice, std::string* buf,
                           AlignedBuf* aligned_buf) const;
 
+  Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
+                    uint64_t key_size, uint64_t value_size) const;
+
   std::unique_ptr<RandomAccessFileReader> file_reader_;
 };
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -65,7 +65,7 @@ class BlobFileReader {
                              AlignedBuf* aligned_buf);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
-                           uint64_t key_size, uint64_t value_size);
+                           uint64_t value_size);
 
   static Status UncompressBlobIfNeeded(const Slice& value_slice,
                                        CompressionType compression_type,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -39,6 +39,7 @@ class BlobFileReader {
 
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
                  uint64_t offset, uint64_t value_size,
+                 CompressionType compression_type,
                  GetContext* get_context) const;
 
  private:

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -27,7 +27,7 @@ class BlobFileReader {
   static Status Create(const ReadOptions& read_options,
                        const ImmutableCFOptions& immutable_cf_options,
                        const FileOptions& file_options,
-                       uint64_t blob_file_number,
+                       uint32_t column_family_id, uint64_t blob_file_number,
                        std::unique_ptr<BlobFileReader>* reader);
 
   BlobFileReader(const BlobFileReader&) = delete;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -50,14 +50,14 @@ class BlobFileReader {
   static Status OpenFile(const ImmutableCFOptions& immutable_cf_options,
                          const FileOptions& file_opts,
                          HistogramImpl* blob_file_read_hist,
-                         uint64_t blob_file_number,
+                         uint64_t blob_file_number, uint64_t* file_size,
                          std::unique_ptr<RandomAccessFileReader>* file_reader);
 
   static Status ReadHeader(RandomAccessFileReader* file_reader,
                            uint32_t column_family_id,
                            CompressionType* compression_type);
 
-  static Status ReadFooter(const ImmutableCFOptions& immutable_cf_options,
+  static Status ReadFooter(uint64_t file_size,
                            RandomAccessFileReader* file_reader);
 
   static Status ReadFromFile(RandomAccessFileReader* file_reader,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -16,10 +16,10 @@
 namespace ROCKSDB_NAMESPACE {
 
 class Status;
-struct ReadOptions;
 struct ImmutableCFOptions;
 struct FileOptions;
 class HistogramImpl;
+struct ReadOptions;
 class Slice;
 class PinnableSlice;
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -43,9 +43,8 @@ class BlobFileReader {
   explicit BlobFileReader(
       std::unique_ptr<RandomAccessFileReader>&& file_reader);
 
-  Status ReadBlobFromFile(uint64_t record_offset, size_t record_size,
-                          Slice* record_slice, std::string* buf,
-                          AlignedBuf* aligned_buf) const;
+  Status ReadFromFile(uint64_t read_offset, size_t read_size, Slice* slice,
+                      std::string* buf, AlignedBuf* aligned_buf) const;
 
   Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
                     uint64_t key_size, uint64_t value_size) const;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -71,7 +71,7 @@ class BlobFileReader {
                                        CompressionType compression_type,
                                        PinnableSlice* value);
 
-  static void SaveValue(PinnableSlice* dst, const Slice& src);
+  static void SaveValue(const Slice& src, PinnableSlice* dst);
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
   uint64_t file_size_;

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -7,7 +7,6 @@
 
 #include <cinttypes>
 #include <memory>
-#include <string>
 
 #include "file/random_access_file_reader.h"
 #include "rocksdb/compression_type.h"
@@ -58,9 +57,11 @@ class BlobFileReader {
   static Status ReadFooter(uint64_t file_size,
                            const RandomAccessFileReader* file_reader);
 
+  using Buffer = std::unique_ptr<char[]>;
+
   static Status ReadFromFile(const RandomAccessFileReader* file_reader,
                              uint64_t read_offset, size_t read_size,
-                             Slice* slice, std::string* buf,
+                             Slice* slice, Buffer* buf,
                              AlignedBuf* aligned_buf);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -19,6 +19,7 @@ class Status;
 struct ReadOptions;
 struct ImmutableCFOptions;
 struct FileOptions;
+class HistogramImpl;
 class Slice;
 class GetContext;
 class RandomAccessFileReader;
@@ -27,7 +28,9 @@ class BlobFileReader {
  public:
   static Status Create(const ImmutableCFOptions& immutable_cf_options,
                        const FileOptions& file_options,
-                       uint32_t column_family_id, uint64_t blob_file_number,
+                       uint32_t column_family_id,
+                       HistogramImpl* blob_file_read_hist,
+                       uint64_t blob_file_number,
                        std::unique_ptr<BlobFileReader>* reader);
 
   BlobFileReader(const BlobFileReader&) = delete;
@@ -46,6 +49,7 @@ class BlobFileReader {
 
   static Status OpenFile(const ImmutableCFOptions& immutable_cf_options,
                          const FileOptions& file_opts,
+                         HistogramImpl* blob_file_read_hist,
                          uint64_t blob_file_number,
                          std::unique_ptr<RandomAccessFileReader>* file_reader);
 

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -48,8 +48,8 @@ class BlobFileReader {
                              Slice* slice, std::string* buf,
                              AlignedBuf* aligned_buf);
 
-  Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
-                    uint64_t key_size, uint64_t value_size) const;
+  static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,
+                           uint64_t key_size, uint64_t value_size);
 
   std::unique_ptr<RandomAccessFileReader> file_reader_;
 };

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -22,12 +22,10 @@ struct FileOptions;
 class Slice;
 class GetContext;
 class RandomAccessFileReader;
-struct IOOptions;
 
 class BlobFileReader {
  public:
-  static Status Create(const ReadOptions& read_options,
-                       const ImmutableCFOptions& immutable_cf_options,
+  static Status Create(const ImmutableCFOptions& immutable_cf_options,
                        const FileOptions& file_options,
                        uint32_t column_family_id, uint64_t blob_file_number,
                        std::unique_ptr<BlobFileReader>* reader);
@@ -52,13 +50,12 @@ class BlobFileReader {
                          std::unique_ptr<RandomAccessFileReader>* file_reader);
 
   static Status ReadHeader(RandomAccessFileReader* file_reader,
-                           const IOOptions& io_options,
                            uint32_t column_family_id,
                            CompressionType* compression_type);
 
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
-                             const IOOptions& io_options, uint64_t read_offset,
-                             size_t read_size, Slice* slice, std::string* buf,
+                             uint64_t read_offset, size_t read_size,
+                             Slice* slice, std::string* buf,
                              AlignedBuf* aligned_buf);
 
   static Status VerifyBlob(const Slice& record_slice, const Slice& user_key,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -53,6 +53,9 @@ class BlobFileReader {
                            uint32_t column_family_id,
                            CompressionType* compression_type);
 
+  static Status ReadFooter(const ImmutableCFOptions& immutable_cf_options,
+                           RandomAccessFileReader* file_reader);
+
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
                              uint64_t read_offset, size_t read_size,
                              Slice* slice, std::string* buf,

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -1,0 +1,46 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cinttypes>
+#include <memory>
+
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Status;
+struct ReadOptions;
+struct ImmutableCFOptions;
+struct FileOptions;
+class Slice;
+class GetContext;
+class RandomAccessFileReader;
+
+class BlobFileReader {
+ public:
+  static Status Create(const ReadOptions& read_options,
+                       const ImmutableCFOptions& immutable_cf_options,
+                       const FileOptions& file_options,
+                       uint64_t blob_file_number,
+                       std::unique_ptr<BlobFileReader>* reader);
+
+  BlobFileReader(const BlobFileReader&) = delete;
+  BlobFileReader& operator=(const BlobFileReader&) = delete;
+
+  ~BlobFileReader();
+
+  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                 uint64_t offset, uint64_t size, GetContext* get_context) const;
+
+ private:
+  explicit BlobFileReader(
+      std::unique_ptr<RandomAccessFileReader>&& file_reader);
+
+  std::unique_ptr<RandomAccessFileReader> file_reader_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -34,7 +34,8 @@ class BlobFileReader {
   ~BlobFileReader();
 
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 uint64_t offset, uint64_t size, GetContext* get_context) const;
+                 uint64_t offset, uint64_t value_size,
+                 GetContext* get_context) const;
 
  private:
   explicit BlobFileReader(

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -50,6 +50,11 @@ class BlobFileReader {
                          uint64_t blob_file_number,
                          std::unique_ptr<RandomAccessFileReader>* file_reader);
 
+  static Status ReadHeader(RandomAccessFileReader* file_reader,
+                           const IOOptions& io_options,
+                           uint32_t column_family_id,
+                           CompressionType* compression_type);
+
   static Status ReadFromFile(RandomAccessFileReader* file_reader,
                              const IOOptions& io_options, uint64_t read_offset,
                              size_t read_size, Slice* slice, std::string* buf,

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -191,20 +191,6 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
   }
 }
 
-class BlobFileReaderIOErrorTest
-    : public testing::Test,
-      public testing::WithParamInterface<std::string> {
- protected:
-  BlobFileReaderIOErrorTest()
-      : mock_env_(Env::Default()),
-        fault_injection_env_(&mock_env_),
-        sync_point_(GetParam()) {}
-
-  MockEnv mock_env_;
-  FaultInjectionTestEnv fault_injection_env_;
-  std::string sync_point_;
-};
-
 TEST_F(BlobFileReaderTest, TTL) {
   Options options;
   options.env = &mock_env_;
@@ -347,6 +333,20 @@ TEST_F(BlobFileReaderTest, IncorrectColumnFamily) {
                                      &reader)
                   .IsCorruption());
 }
+
+class BlobFileReaderIOErrorTest
+    : public testing::Test,
+      public testing::WithParamInterface<std::string> {
+ protected:
+  BlobFileReaderIOErrorTest()
+      : mock_env_(Env::Default()),
+        fault_injection_env_(&mock_env_),
+        sync_point_(GetParam()) {}
+
+  MockEnv mock_env_;
+  FaultInjectionTestEnv fault_injection_env_;
+  std::string sync_point_;
+};
 
 INSTANTIATE_TEST_CASE_P(BlobFileReaderTest, BlobFileReaderIOErrorTest,
                         ::testing::ValuesIn(std::vector<std::string>{

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -109,24 +109,10 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
                                    column_family_id, blob_file_read_hist,
                                    blob_file_number, &reader));
 
-  constexpr const MergeOperator* merge_operator = nullptr;
-  constexpr Logger* logger = nullptr;
-  constexpr Statistics* statistics = nullptr;
-  constexpr bool* value_found = nullptr;
-  constexpr MergeContext* merge_context = nullptr;
-  constexpr bool do_merge = true;
-  constexpr SequenceNumber* max_covering_tombstone_seq = nullptr;
-  constexpr Env* env = nullptr;
-
   PinnableSlice value;
 
-  GetContext get_context(options.comparator, merge_operator, logger, statistics,
-                         GetContext::kFound, key, &value, value_found,
-                         merge_context, do_merge, max_covering_tombstone_seq,
-                         env);
-
   ASSERT_OK(reader->GetBlob(ReadOptions(), key, blob_offset, sizeof(blob) - 1,
-                            kNoCompression, &get_context));
+                            kNoCompression, &value));
   ASSERT_EQ(value, blob);
 }
 
@@ -197,25 +183,11 @@ TEST_P(BlobFileReaderIOErrorTest, IOError) {
   } else {
     ASSERT_OK(s);
 
-    constexpr const MergeOperator* merge_operator = nullptr;
-    constexpr Logger* logger = nullptr;
-    constexpr Statistics* statistics = nullptr;
-    constexpr bool* value_found = nullptr;
-    constexpr MergeContext* merge_context = nullptr;
-    constexpr bool do_merge = true;
-    constexpr SequenceNumber* max_covering_tombstone_seq = nullptr;
-    constexpr Env* env = nullptr;
-
     PinnableSlice value;
-
-    GetContext get_context(options.comparator, merge_operator, logger,
-                           statistics, GetContext::kFound, key, &value,
-                           value_found, merge_context, do_merge,
-                           max_covering_tombstone_seq, env);
 
     ASSERT_TRUE(reader
                     ->GetBlob(ReadOptions(), key, blob_offset, sizeof(blob) - 1,
-                              kNoCompression, &get_context)
+                              kNoCompression, &value)
                     .IsIOError());
   }
 

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -121,7 +121,6 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
   {
     PinnableSlice value;
 
-
     ASSERT_OK(reader->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
                               kNoCompression, &value));
     ASSERT_EQ(value, blob);
@@ -332,6 +331,58 @@ TEST_F(BlobFileReaderTest, IncorrectColumnFamily) {
                                      blob_file_read_hist, blob_file_number,
                                      &reader)
                   .IsCorruption());
+}
+
+TEST_F(BlobFileReaderTest, BlobCRCError) {
+  Options options;
+  options.env = &mock_env_;
+  options.cf_paths.emplace_back(
+      test::PerThreadDBPath(&mock_env_, "BlobFileReaderTest_BlobCRCError"), 0);
+  options.enable_blob_files = true;
+
+  ImmutableCFOptions immutable_cf_options(options);
+
+  constexpr uint32_t column_family_id = 1;
+  constexpr uint64_t blob_file_number = 1;
+  constexpr char key[] = "key";
+  constexpr char blob[] = "blob";
+
+  uint64_t blob_offset = 0;
+
+  constexpr bool has_ttl = false;
+  constexpr ExpirationRange expiration_range;
+
+  WriteBlobFile(immutable_cf_options, column_family_id, has_ttl,
+                expiration_range, expiration_range, blob_file_number, key, blob,
+                &blob_offset);
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "BlobFileReader::VerifyBlob:CheckBlobCRC", [](void* arg) {
+        BlobLogRecord* const record = static_cast<BlobLogRecord*>(arg);
+        assert(record);
+
+        record->blob_crc = 0xfaceb00c;
+      });
+
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  constexpr HistogramImpl* blob_file_read_hist = nullptr;
+
+  std::unique_ptr<BlobFileReader> reader;
+
+  ASSERT_OK(BlobFileReader::Create(immutable_cf_options, FileOptions(),
+                                   column_family_id, blob_file_read_hist,
+                                   blob_file_number, &reader));
+
+  PinnableSlice value;
+
+  ASSERT_TRUE(reader
+                  ->GetBlob(ReadOptions(), key, blob_offset, sizeof(blob) - 1,
+                            kNoCompression, &value)
+                  .IsCorruption());
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 class BlobFileReaderIOErrorTest

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -6,7 +6,6 @@
 #include "db/blob/blob_file_reader.h"
 
 #include <cassert>
-#include <cinttypes>
 #include <string>
 
 #include "db/blob/blob_log_format.h"

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -116,21 +116,21 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
 
   // Make sure the blob can be retrieved with and without checksum verification
   ReadOptions read_options;
+  read_options.verify_checksums = false;
 
   {
     PinnableSlice value;
 
-    read_options.verify_checksums = false;
 
     ASSERT_OK(reader->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
                               kNoCompression, &value));
     ASSERT_EQ(value, blob);
   }
 
+  read_options.verify_checksums = true;
+
   {
     PinnableSlice value;
-
-    read_options.verify_checksums = true;
 
     ASSERT_OK(reader->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
                               kNoCompression, &value));

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -114,11 +114,28 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
                                    column_family_id, blob_file_read_hist,
                                    blob_file_number, &reader));
 
-  PinnableSlice value;
+  // Make sure the blob can be retrieved with and without checksum verification
+  ReadOptions read_options;
 
-  ASSERT_OK(reader->GetBlob(ReadOptions(), key, blob_offset, sizeof(blob) - 1,
-                            kNoCompression, &value));
-  ASSERT_EQ(value, blob);
+  {
+    PinnableSlice value;
+
+    read_options.verify_checksums = false;
+
+    ASSERT_OK(reader->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
+                              kNoCompression, &value));
+    ASSERT_EQ(value, blob);
+  }
+
+  {
+    PinnableSlice value;
+
+    read_options.verify_checksums = true;
+
+    ASSERT_OK(reader->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
+                              kNoCompression, &value));
+    ASSERT_EQ(value, blob);
+  }
 }
 
 class BlobFileReaderIOErrorTest

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -386,6 +386,14 @@ TEST_F(BlobFileReaderTest, BlobCRCError) {
                 expiration_range, expiration_range, blob_file_number, key, blob,
                 kNoCompression, &blob_offset, &blob_size);
 
+  constexpr HistogramImpl* blob_file_read_hist = nullptr;
+
+  std::unique_ptr<BlobFileReader> reader;
+
+  ASSERT_OK(BlobFileReader::Create(immutable_cf_options, FileOptions(),
+                                   column_family_id, blob_file_read_hist,
+                                   blob_file_number, &reader));
+
   SyncPoint::GetInstance()->SetCallBack(
       "BlobFileReader::VerifyBlob:CheckBlobCRC", [](void* arg) {
         BlobLogRecord* const record = static_cast<BlobLogRecord*>(arg);
@@ -395,14 +403,6 @@ TEST_F(BlobFileReaderTest, BlobCRCError) {
       });
 
   SyncPoint::GetInstance()->EnableProcessing();
-
-  constexpr HistogramImpl* blob_file_read_hist = nullptr;
-
-  std::unique_ptr<BlobFileReader> reader;
-
-  ASSERT_OK(BlobFileReader::Create(immutable_cf_options, FileOptions(),
-                                   column_family_id, blob_file_read_hist,
-                                   blob_file_number, &reader));
 
   PinnableSlice value;
 

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -1,0 +1,124 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_file_reader.h"
+
+#include <cassert>
+#include <cinttypes>
+#include <string>
+
+#include "db/blob/blob_log_format.h"
+#include "db/blob/blob_log_writer.h"
+#include "env/mock_env.h"
+#include "file/filename.h"
+#include "file/read_write_util.h"
+#include "file/writable_file_writer.h"
+#include "options/cf_options.h"
+#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/options.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class BlobFileReaderTest : public testing::Test {
+ protected:
+  BlobFileReaderTest()
+      : mock_env_(Env::Default()), fs_(mock_env_.GetFileSystem().get()) {
+    assert(fs_);
+  }
+
+  MockEnv mock_env_;
+  FileSystem* fs_;
+  FileOptions file_options_;
+};
+
+TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
+  Options options;
+  options.env = &mock_env_;
+  options.cf_paths.emplace_back(
+      test::PerThreadDBPath(&mock_env_,
+                            "BlobFileReaderTest_CreateReaderAndGetBlob"),
+      0);
+  options.enable_blob_files = true;
+
+  ImmutableCFOptions immutable_cf_options(options);
+
+  constexpr uint64_t blob_file_number = 1;
+
+  const std::string blob_file_path = BlobFileName(
+      immutable_cf_options.cf_paths.front().path, blob_file_number);
+
+  std::unique_ptr<FSWritableFile> file;
+  ASSERT_OK(NewWritableFile(fs_, blob_file_path, &file, file_options_));
+
+  std::unique_ptr<WritableFileWriter> file_writer(new WritableFileWriter(
+      std::move(file), blob_file_path, file_options_, &mock_env_));
+
+  constexpr Statistics* statistics = nullptr;
+  constexpr bool use_fsync = false;
+
+  std::unique_ptr<BlobLogWriter> blob_log_writer(
+      new BlobLogWriter(std::move(file_writer), &mock_env_, statistics,
+                        blob_file_number, use_fsync));
+
+  constexpr uint32_t column_family_id = 1;
+  constexpr bool has_ttl = false;
+  constexpr ExpirationRange expiration_range;
+
+  BlobLogHeader header(column_family_id, kNoCompression, has_ttl,
+                       expiration_range);
+
+  ASSERT_OK(blob_log_writer->WriteHeader(header));
+
+  constexpr char key[] = "key";
+  constexpr char blob[] = "blob";
+  uint64_t key_offset = 0;
+  uint64_t blob_offset = 0;
+
+  ASSERT_OK(blob_log_writer->AddRecord(key, blob, &key_offset, &blob_offset));
+
+  BlobLogFooter footer;
+  footer.blob_count = 1;
+
+  std::string checksum_method;
+  std::string checksum_value;
+
+  ASSERT_OK(
+      blob_log_writer->AppendFooter(footer, &checksum_method, &checksum_value));
+
+  constexpr HistogramImpl* blob_file_read_hist = nullptr;
+
+  std::unique_ptr<BlobFileReader> reader;
+
+  ASSERT_OK(BlobFileReader::Create(immutable_cf_options, file_options_,
+                                   column_family_id, blob_file_read_hist,
+                                   blob_file_number, &reader));
+
+  constexpr const MergeOperator* merge_operator = nullptr;
+  constexpr Logger* logger = nullptr;
+  constexpr bool* value_found = nullptr;
+  constexpr MergeContext* merge_context = nullptr;
+  constexpr bool do_merge = true;
+  constexpr SequenceNumber* max_covering_tombstone_seq = nullptr;
+  constexpr Env* env = nullptr;
+
+  PinnableSlice value;
+
+  GetContext get_context(options.comparator, merge_operator, logger, statistics,
+                         GetContext::kFound, key, &value, value_found,
+                         merge_context, do_merge, max_covering_tombstone_seq,
+                         env);
+  ASSERT_OK(reader->GetBlob(ReadOptions(), key, blob_offset, sizeof(blob) - 1,
+                            kNoCompression, &get_context));
+  ASSERT_EQ(value, blob);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -26,6 +26,9 @@ namespace ROCKSDB_NAMESPACE {
 
 namespace {
 
+// Creates a test blob file with a single blob in it. Note: this method
+// makes it possible to test various corner cases by allowing the caller
+// to specify the contents of various blob file header/footer fields.
 void WriteBlobFile(const ImmutableCFOptions& immutable_cf_options,
                    uint32_t column_family_id, bool has_ttl,
                    const ExpirationRange& expiration_range_header,

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -164,12 +164,22 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
     ASSERT_EQ(value, blob);
   }
 
-  // Invalid offset
+  // Invalid offset (too close to start of file)
   {
     PinnableSlice value;
 
     ASSERT_TRUE(reader
                     ->GetBlob(read_options, key, blob_offset - 1, blob_size,
+                              kNoCompression, &value)
+                    .IsCorruption());
+  }
+
+  // Invalid offset (too close to end of file)
+  {
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, key, blob_offset + 1, blob_size,
                               kNoCompression, &value)
                     .IsCorruption());
   }

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -157,6 +157,18 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
                     .IsCorruption());
   }
 
+  // Incorrect key size
+  {
+    constexpr char shorter_key[] = "k";
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, shorter_key,
+                              blob_offset - (sizeof(key) - sizeof(shorter_key)),
+                              sizeof(blob) - 1, kNoCompression, &value)
+                    .IsCorruption());
+  }
+
   // Incorrect key
   {
     constexpr char incorrect_key[] = "foo";

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -136,6 +136,47 @@ TEST_F(BlobFileReaderTest, CreateReaderAndGetBlob) {
                               kNoCompression, &value));
     ASSERT_EQ(value, blob);
   }
+
+  // Invalid offset
+  {
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, key, blob_offset - 1,
+                              sizeof(blob) - 1, kNoCompression, &value)
+                    .IsCorruption());
+  }
+
+  // Incorrect compression type
+  {
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, key, blob_offset, sizeof(blob) - 1,
+                              kZSTD, &value)
+                    .IsCorruption());
+  }
+
+  // Incorrect key
+  {
+    constexpr char incorrect_key[] = "foo";
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, incorrect_key, blob_offset,
+                              sizeof(blob) - 1, kNoCompression, &value)
+                    .IsCorruption());
+  }
+
+  // Incorrect value size
+  {
+    PinnableSlice value;
+
+    ASSERT_TRUE(reader
+                    ->GetBlob(read_options, key, blob_offset, sizeof(blob),
+                              kNoCompression, &value)
+                    .IsCorruption());
+  }
 }
 
 class BlobFileReaderIOErrorTest

--- a/db/blob/blob_index.h
+++ b/db/blob/blob_index.h
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <string>
 
-#include "rocksdb/options.h"
+#include "rocksdb/compression_type.h"
 #include "util/coding.h"
 #include "util/string_util.h"
 
@@ -82,6 +82,11 @@ class BlobIndex {
     return size_;
   }
 
+  CompressionType compression() const {
+    assert(!IsInlined());
+    return compression_;
+  }
+
   Status DecodeFrom(Slice slice) {
     static const std::string kErrorMessage = "Error while decoding blob index";
     assert(slice.size() > 0);
@@ -117,7 +122,7 @@ class BlobIndex {
       oss << "[inlined blob] value:" << value_.ToString(output_hex);
     } else {
       oss << "[blob ref] file:" << file_number_ << " offset:" << offset_
-          << " size:" << size_;
+          << " size:" << size_ << " compression: " << compression_;
     }
 
     if (HasTTL()) {

--- a/db/blob/blob_index.h
+++ b/db/blob/blob_index.h
@@ -9,6 +9,7 @@
 
 #include "rocksdb/compression_type.h"
 #include "util/coding.h"
+#include "util/compression.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -122,7 +123,8 @@ class BlobIndex {
       oss << "[inlined blob] value:" << value_.ToString(output_hex);
     } else {
       oss << "[blob ref] file:" << file_number_ << " offset:" << offset_
-          << " size:" << size_ << " compression: " << compression_;
+          << " size:" << size_
+          << " compression: " << CompressionTypeToString(compression_);
     }
 
     if (HasTTL()) {

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -95,8 +95,8 @@ Status BlobLogFooter::DecodeFrom(Slice src) {
   return Status::OK();
 }
 
-size_t BlobLogRecord::CalculateAdjustmentForRecordHeader(size_t key_size) {
-  return kHeaderSize + key_size;
+uint64_t BlobLogRecord::CalculateAdjustmentForRecordHeader(uint64_t key_size) {
+  return key_size + kHeaderSize;
 }
 
 void BlobLogRecord::EncodeHeaderTo(std::string* dst) {

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -95,10 +95,8 @@ Status BlobLogFooter::DecodeFrom(Slice src) {
   return Status::OK();
 }
 
-size_t BlobLogRecord::CalculateAdjustmentForBlobCRC(size_t key_size) {
-  constexpr size_t crc_size = sizeof(uint32_t);
-
-  return crc_size + key_size;
+size_t BlobLogRecord::CalculateAdjustmentForRecordHeader(size_t key_size) {
+  return kHeaderSize + key_size;
 }
 
 void BlobLogRecord::EncodeHeaderTo(std::string* dst) {

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -95,6 +95,12 @@ Status BlobLogFooter::DecodeFrom(Slice src) {
   return Status::OK();
 }
 
+size_t BlobLogRecord::CalculateAdjustmentForBlobCRC(size_t key_size) {
+  constexpr size_t crc_size = sizeof(uint32_t);
+
+  return crc_size + key_size;
+}
+
 void BlobLogRecord::EncodeHeaderTo(std::string* dst) {
   assert(dst != nullptr);
   dst->clear();

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -129,9 +129,18 @@ struct BlobLogRecord {
 };
 
 // Checks whether a blob offset is potentially valid or not.
-inline bool IsValidBlobOffset(uint64_t value_offset, uint64_t key_size) {
-  return value_offset >=
-         BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + key_size;
+inline bool IsValidBlobOffset(uint64_t value_offset, uint64_t key_size,
+                              uint64_t value_size, uint64_t file_size) {
+  if (value_offset <
+      BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + key_size) {
+    return false;
+  }
+
+  if (value_offset + value_size + BlobLogFooter::kSize > file_size) {
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -104,6 +104,11 @@ struct BlobLogRecord {
   // header include fields up to blob CRC
   static constexpr size_t kHeaderSize = 32;
 
+  // Note that the offset field of BlobIndex actually points to the blob value
+  // as opposed to the start of the blob record. The following method can
+  // be used to calculate the adjustment needed to read the blob CRC field.
+  static size_t CalculateAdjustmentForBlobCRC(size_t key_size);
+
   uint64_t key_size = 0;
   uint64_t value_size = 0;
   uint64_t expiration = 0;
@@ -122,5 +127,11 @@ struct BlobLogRecord {
 
   Status CheckBlobCRC() const;
 };
+
+// Checks whether a blob offset is potentially valid or not.
+inline bool IsValidBlobOffset(uint64_t value_offset, size_t key_size) {
+  return value_offset >=
+         BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + key_size;
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -107,7 +107,7 @@ struct BlobLogRecord {
   // Note that the offset field of BlobIndex actually points to the blob value
   // as opposed to the start of the blob record. The following method can
   // be used to calculate the adjustment needed to read the blob CRC field.
-  static size_t CalculateAdjustmentForBlobCRC(size_t key_size);
+  static size_t CalculateAdjustmentForRecordHeader(size_t key_size);
 
   uint64_t key_size = 0;
   uint64_t value_size = 0;

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -106,7 +106,7 @@ struct BlobLogRecord {
 
   // Note that the offset field of BlobIndex actually points to the blob value
   // as opposed to the start of the blob record. The following method can
-  // be used to calculate the adjustment needed to read the blob CRC field.
+  // be used to calculate the adjustment needed to read the blob record header.
   static uint64_t CalculateAdjustmentForRecordHeader(uint64_t key_size);
 
   uint64_t key_size = 0;

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -107,7 +107,7 @@ struct BlobLogRecord {
   // Note that the offset field of BlobIndex actually points to the blob value
   // as opposed to the start of the blob record. The following method can
   // be used to calculate the adjustment needed to read the blob CRC field.
-  static size_t CalculateAdjustmentForRecordHeader(size_t key_size);
+  static uint64_t CalculateAdjustmentForRecordHeader(uint64_t key_size);
 
   uint64_t key_size = 0;
   uint64_t value_size = 0;
@@ -129,7 +129,7 @@ struct BlobLogRecord {
 };
 
 // Checks whether a blob offset is potentially valid or not.
-inline bool IsValidBlobOffset(uint64_t value_offset, size_t key_size) {
+inline bool IsValidBlobOffset(uint64_t value_offset, uint64_t key_size) {
   return value_offset >=
          BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + key_size;
 }

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <limits>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1386,21 +1387,26 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
 }
 
 void InternalStats::DumpCFFileHistogram(std::string* value) {
-  char buf[2000];
-  snprintf(buf, sizeof(buf),
-           "\n** File Read Latency Histogram By Level [%s] **\n",
-           cfd_->GetName().c_str());
-  value->append(buf);
+  assert(value);
+  assert(cfd_);
+
+  std::ostringstream oss;
+  oss << "\n** File Read Latency Histogram By Level [" << cfd_->GetName()
+      << "] **\n";
 
   for (int level = 0; level < number_levels_; level++) {
     if (!file_read_latency_[level].Empty()) {
-      char buf2[5000];
-      snprintf(buf2, sizeof(buf2),
-               "** Level %d read latency histogram (micros):\n%s\n", level,
-               file_read_latency_[level].ToString().c_str());
-      value->append(buf2);
+      oss << "** Level " << level << " read latency histogram (micros):\n"
+          << file_read_latency_[level].ToString() << '\n';
     }
   }
+
+  if (!blob_file_read_latency_.Empty()) {
+    oss << "** Blob file read latency histogram (micros):\n"
+        << blob_file_read_latency_.ToString() << '\n';
+  }
+
+  *value = oss.str();
 }
 
 #else

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -335,6 +335,7 @@ class InternalStats {
     for (auto& h : file_read_latency_) {
       h.Clear();
     }
+    blob_file_read_latency_.Clear();
     cf_stats_snapshot_.Clear();
     db_stats_snapshot_.Clear();
     bg_error_count_ = 0;
@@ -374,6 +375,8 @@ class InternalStats {
   HistogramImpl* GetFileReadHist(int level) {
     return &file_read_latency_[level];
   }
+
+  HistogramImpl* GetBlobFileReadHist() { return &blob_file_read_latency_; }
 
   uint64_t GetBackgroundErrorCount() const { return bg_error_count_; }
 
@@ -426,6 +429,7 @@ class InternalStats {
   std::vector<CompactionStats> comp_stats_;
   std::vector<CompactionStats> comp_stats_by_pri_;
   std::vector<HistogramImpl> file_read_latency_;
+  HistogramImpl blob_file_read_latency_;
 
   // Used to compute per-interval statistics
   struct CFStatsSnapshot {

--- a/src.mk
+++ b/src.mk
@@ -357,6 +357,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/blob/blob_file_addition_test.cc                                    \
   db/blob/blob_file_builder_test.cc                                     \
   db/blob/blob_file_garbage_test.cc                                     \
+  db/blob/blob_file_reader_test.cc                                      \
   db/blob/db_blob_index_test.cc                                         \
   db/column_family_test.cc                                              \
   db/compact_files_test.cc                                              \

--- a/src.mk
+++ b/src.mk
@@ -9,6 +9,7 @@ LIB_SOURCES =                                                   \
   db/blob/blob_file_builder.cc                                  \
   db/blob/blob_file_garbage.cc                                  \
   db/blob/blob_file_meta.cc                                     \
+  db/blob/blob_file_reader.cc                                   \
   db/blob/blob_log_format.cc                                    \
   db/blob/blob_log_reader.cc                                    \
   db/blob/blob_log_writer.cc                                    \


### PR DESCRIPTION
Summary:
The patch adds a class called `BlobFileReader` that can be used to retrieve blobs
using the information available in blob references (e.g. blob file number, offset, and
size). This will come in handy when implementing blob support for `Get`, `MultiGet`,
and iterators, and also for compaction/garbage collection.

When a `BlobFileReader` object is created (using the factory method `Create`),
it first checks whether the specified file is potentially valid by comparing the file
size against the combined size of the blob file header and footer (files smaller than
the threshold are considered malformed). Then, it opens the file, and reads and verifies
the header and footer. The verification involves magic number/CRC checks
as well as checking for unexpected header/footer fields, e.g. incorrect column family ID
or TTL blob files.

Blobs can be retrieved using `GetBlob`. `GetBlob` validates the offset and compression
type passed by the caller (because of the presence of the header and footer, the
specified offset cannot be too close to the start/end of the file; also, the compression type
has to match the one in the blob file header), and retrieves and potentially verifies and
uncompresses the blob. In particular, when `ReadOptions::verify_checksums` is set,
`BlobFileReader` reads the blob record header as well (as opposed to just the blob itself)
and verifies the key/value size, the key itself, as well as the CRC of the blob record header
and the key/value pair.

In addition, the patch exposes the compression type from `BlobIndex` (both using an
accessor and via `DebugString`), and adds a blob file read latency histogram to
`InternalStats` that can be used with `BlobFileReader`.

Test Plan:
`make check`