### PR TITLE
Flush info log for warning and higher severity

### DIFF
--- a/env/env.cc
+++ b/env/env.cc
@@ -208,6 +208,14 @@ void Logger::Logv(const InfoLogLevel log_level, const char* format, va_list ap) 
       kInfoLogLevelNames[log_level], format);
     Logv(new_format, ap);
   }
+
+  if (log_level >= InfoLogLevel::WARN_LEVEL &&
+      log_level != InfoLogLevel::HEADER_LEVEL) {
+    // Log messages with severity of warning or higher should be rare and are
+    // sometimes followed by an unclean crash. We want to be sure important
+    // messages are not lost in an application buffer when that happens.
+    Flush();
+  }
 }
 
 static void Logv(const InfoLogLevel log_level, Logger *info_log, const char *format, va_list ap) {


### PR DESCRIPTION
After unclean crash, the tail of the log could look as follows due to block buffering, even when the call to `ROCKSDB_LOG_ERROR()` finished.

```
2020/09/29-13:54:39.596710 7f67025fe700 [ERROR] [/db_impl/db_impl_compaction_flush.cc:2500] Waiting after background compaction err
```

This PR forces the flush while logging warning severity or higher to prevent that case.