### PR TITLE
Enable paranoid_file_checks in crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -134,8 +134,7 @@ default_params = {
     "read_fault_one_in": lambda: random.choice([0, 1000]),
     "sync_fault_injection": False,
     "get_property_one_in": 1000000,
-    # paranoid_file_checks has a bug so it's not yet passed.
-    "paranoid_file_checks": 0,
+    "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'
@@ -200,8 +199,7 @@ simple_default_params = {
     "test_batches_snapshots": 0,
     "write_buffer_size": 32 * 1024 * 1024,
     "level_compaction_dynamic_level_bytes": False,
-    # "paranoid_file_checks" has a bug so it's not yet passed.
-    "paranoid_file_checks": 0,
+    "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
 }
 
 blackbox_simple_default_params = {


### PR DESCRIPTION
Summary:
Cover paranoid_file_checks in crash test.

Test Plan: Run crash tests for hours and didn't see any failure.