### PR TITLE
Fix prefix_test for status check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,6 +611,7 @@ ifdef ASSERT_STATUS_CHECKED
 		merger_test \
 		mock_env_test \
 		object_registry_test \
+		prefix_test \
 		repair_test \
 		configurable_test \
 		options_settable_test \

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -846,6 +846,7 @@ bool DBIter::FindValueForCurrentKey() {
   }
 
   Status s;
+  s.PermitUncheckedError();
   is_blob_ = false;
   switch (last_key_entry_type) {
     case kTypeDeletion:


### PR DESCRIPTION
Summary:
Fix prefix_test so that it passes when ASSERT_STATUS_CHECKED=1

Test Plan: Run the test with the option