### PR TITLE
Change Status() to be marked as checked

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1326,6 +1326,7 @@ void DBImpl::NotifyOnCompactionCompleted(
     for (auto listener : immutable_db_options_.listeners) {
       listener->OnCompactionCompleted(this, info);
     }
+    info.status.PermitUncheckedError();
   }
   mutex_.Lock();
   current->Unref();
@@ -2970,10 +2971,8 @@ Status DBImpl::BackgroundCompaction(bool* made_progress,
                              c->column_family_data());
   }
 
-  if (status.ok() && !io_s.ok()) {
+  if (!io_s.ok() && status.ok()) {
     status = io_s;
-  } else {
-    io_s.PermitUncheckedError();
   }
 
   if (c != nullptr) {

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -31,9 +31,6 @@ class ErrorHandler {
                 InstrumentedMutex* db_mutex)
        : db_(db),
          db_options_(db_options),
-         bg_error_(Status::OK()),
-         recovery_error_(Status::OK()),
-         recovery_io_error_(IOStatus::OK()),
          cv_(db_mutex),
          end_recovery_(false),
          recovery_thread_(nullptr),
@@ -50,13 +47,14 @@ class ErrorHandler {
                                      Status::Code code,
                                      Status::SubCode subcode);
 
-   Status SetBGError(const Status& bg_err, BackgroundErrorReason reason);
+   const Status& SetBGError(const Status& bg_err, BackgroundErrorReason reason);
 
-   Status SetBGError(const IOStatus& bg_io_err, BackgroundErrorReason reason);
+   const Status& SetBGError(const IOStatus& bg_io_err,
+                            BackgroundErrorReason reason);
 
-   Status GetBGError() { return bg_error_; }
+   const Status& GetBGError() const { return bg_error_; }
 
-   Status GetRecoveryError() { return recovery_error_; }
+   const Status& GetRecoveryError() const { return recovery_error_; }
 
    Status ClearBGError();
 
@@ -107,9 +105,9 @@ class ErrorHandler {
     // Used to store the context for recover, such as flush reason.
     DBRecoverContext recover_context_;
 
-    Status OverrideNoSpaceError(Status bg_error, bool* auto_recovery);
+    Status OverrideNoSpaceError(const Status& bg_error, bool* auto_recovery);
     void RecoverFromNoSpace();
-    Status StartRecoverFromRetryableBGIOError(IOStatus io_error);
+    const Status& StartRecoverFromRetryableBGIOError(const IOStatus& io_error);
     void RecoverFromRetryableBGIOError();
 };
 

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -42,9 +42,6 @@ class ErrorHandler {
          recovery_in_prog_(false),
          soft_error_no_bg_work_(false) {}
    ~ErrorHandler() {
-     bg_error_.PermitUncheckedError();
-     recovery_error_.PermitUncheckedError();
-     recovery_io_error_.PermitUncheckedError();
    }
 
    void EnableAutoRecovery() { auto_recovery_ = true; }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -130,7 +130,6 @@ FlushJob::FlushJob(
 }
 
 FlushJob::~FlushJob() {
-  io_status_.PermitUncheckedError();
   ThreadStatusUtil::ResetThreadStatus();
 }
 

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -34,7 +34,6 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
     pinned_bounds_.emplace_back();
     auto& parsed_smallest = pinned_bounds_.back();
     Status pikStatus = ParseInternalKey(smallest->Encode(), &parsed_smallest);
-    pikStatus.PermitUncheckedError();
     assert(pikStatus.ok());
 
     smallest_ = &parsed_smallest;
@@ -44,7 +43,6 @@ TruncatedRangeDelIterator::TruncatedRangeDelIterator(
     auto& parsed_largest = pinned_bounds_.back();
 
     Status pikStatus = ParseInternalKey(largest->Encode(), &parsed_largest);
-    pikStatus.PermitUncheckedError();
     assert(pikStatus.ok());
 
     if (parsed_largest.type == kTypeRangeDeletion &&

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3576,6 +3576,7 @@ struct VersionSet::ManifestWriter {
         cfd(_cfd),
         mutable_cf_options(cf_options),
         edit_list(e) {}
+
   ~ManifestWriter() { status.PermitUncheckedError(); }
 };
 
@@ -3666,7 +3667,6 @@ VersionSet::~VersionSet() {
     file.DeleteMetadata();
   }
   obsolete_files_.clear();
-  io_status_.PermitUncheckedError();
 }
 
 void VersionSet::Reset() {
@@ -4219,6 +4219,7 @@ Status VersionSet::LogAndApply(
 #ifndef NDEBUG
     for (const auto& writer : writers) {
       assert(writer.done);
+      writer.status.PermitUncheckedError();  // Ignore all but the first
     }
 #endif /* !NDEBUG */
     return first_writer.status;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -340,9 +340,10 @@ uint32_t WriteBatch::ComputeContentFlags() const {
   auto rv = content_flags_.load(std::memory_order_relaxed);
   if ((rv & ContentFlags::DEFERRED) != 0) {
     BatchContentClassifier classifier;
-    // Should we handle status here?
+    // TODO: Should we handle status here?  Sometimes this returns a bad
+    // status...
     Status s = Iterate(&classifier);
-    assert(s.ok());
+    s.PermitUncheckedError();
     rv = classifier.content_flags;
 
     // this method is conceptually const, because it is performing a lazy

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -341,7 +341,8 @@ uint32_t WriteBatch::ComputeContentFlags() const {
   if ((rv & ContentFlags::DEFERRED) != 0) {
     BatchContentClassifier classifier;
     // Should we handle status here?
-    Iterate(&classifier).PermitUncheckedError();
+    Status s = Iterate(&classifier);
+    assert(s.ok());
     rv = classifier.content_flags;
 
     // this method is conceptually const, because it is performing a lazy

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -179,8 +179,6 @@ class WriteThread {
         StateMutex().~mutex();
         StateCV().~condition_variable();
       }
-      status.PermitUncheckedError();
-      callback_status.PermitUncheckedError();
     }
 
     bool CheckCallback(DB* db) {

--- a/file/sst_file_manager_impl.cc
+++ b/file/sst_file_manager_impl.cc
@@ -43,7 +43,6 @@ SstFileManagerImpl::SstFileManagerImpl(Env* env, std::shared_ptr<FileSystem> fs,
 
 SstFileManagerImpl::~SstFileManagerImpl() {
   Close();
-  bg_err_.PermitUncheckedError();
 }
 
 void SstFileManagerImpl::Close() {

--- a/include/rocksdb/io_status.h
+++ b/include/rocksdb/io_status.h
@@ -36,7 +36,12 @@ class IOStatus : public Status {
   };
 
   // Create a success status.
-  IOStatus() : IOStatus(kOk, kNone) {}
+  IOStatus()
+      : Status(),
+        retryable_(false),
+        data_loss_(false),
+        scope_(kIOErrorScopeFileSystem) {}
+
   ~IOStatus() {}
 
   // Copy the specified status.

--- a/include/rocksdb/io_status.h
+++ b/include/rocksdb/io_status.h
@@ -69,7 +69,7 @@ class IOStatus : public Status {
   IOErrorScope GetScope() const { return scope_; }
 
   // Return a success status.
-  static IOStatus OK() { return IOStatus(); }
+  static IOStatus OK() { return IOStatus(kOk, kNone); }
 
   static IOStatus NotSupported(const Slice& msg, const Slice& msg2 = Slice()) {
     return IOStatus(kNotSupported, msg, msg2);

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -250,7 +250,6 @@ struct CompactionFileInfo {
 };
 
 struct CompactionJobInfo {
-  ~CompactionJobInfo() { status.PermitUncheckedError(); }
   // the id of the column family where the compaction happened.
   uint32_t cf_id;
   // the name of the column family where the compaction happened.

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -67,6 +67,10 @@ class Status {
   bool operator==(const Status& rhs) const;
   bool operator!=(const Status& rhs) const;
 
+#ifdef ROCKSDB_ASSERT_STATUS_CHECKED
+  inline bool Checked() const { return checked_; }
+#endif  // ROCKSDB_ASSERT_STATUS_CHECKED
+
   // In case of intentionally swallowing an error, user must explicitly call
   // this function. That way we are easily able to search the code to find where
   // error swallowing occurs.
@@ -155,7 +159,7 @@ class Status {
   }
 
   // Return a success status.
-  static Status OK() { return Status(); }
+  static Status OK() { return Status(kOk, kNone); }
 
   // Successful, though an existing something was overwritten
   // Note: using variants of OK status for program logic is discouraged,

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -34,7 +34,12 @@ namespace ROCKSDB_NAMESPACE {
 class Status {
  public:
   // Create a success status.
-  Status() : code_(kOk), subcode_(kNone), sev_(kNoError), state_(nullptr) {}
+  Status() : code_(kOk), subcode_(kNone), sev_(kNoError), state_(nullptr) {
+#ifdef ROCKSDB_ASSERT_STATUS_CHECKED
+    checked_ = true;
+#endif  // ROCKSDB_ASSERT_STATUS_CHECKED
+  }
+
   ~Status() {
 #ifdef ROCKSDB_ASSERT_STATUS_CHECKED
     if (!checked_) {

--- a/logging/auto_roll_logger.h
+++ b/logging/auto_roll_logger.h
@@ -71,7 +71,6 @@ class AutoRollLogger : public Logger {
     if (logger_ && !closed_) {
       logger_->Close().PermitUncheckedError();
     }
-    status_.PermitUncheckedError();
   }
 
   using Logger::GetInfoLogLevel;

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -496,12 +496,6 @@ struct BlockBasedTableBuilder::Rep {
   Rep(const Rep&) = delete;
   Rep& operator=(const Rep&) = delete;
 
-  ~Rep() {
-    // They are supposed to be passed back to users through Finish()
-    // if the file finishes.
-    status.PermitUncheckedError();
-    io_status.PermitUncheckedError();
-  }
 
  private:
   Status status;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2442,7 +2442,6 @@ void BlockBasedTable::MultiGet(const ReadOptions& read_options,
 
       CachableEntry<UncompressionDict> uncompression_dict;
       Status uncompression_dict_status;
-      uncompression_dict_status.PermitUncheckedError();
       bool uncompression_dict_inited = false;
       size_t total_len = 0;
       ReadOptions ro = read_options;

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -523,7 +523,6 @@ struct BlockBasedTable::Rep {
         file_size(_file_size),
         level(_level),
         immortal_table(_immortal_table) {}
-  ~Rep() { status.PermitUncheckedError(); }
   const ImmutableCFOptions& ioptions;
   const EnvOptions& env_options;
   const BlockBasedTableOptions table_options;

--- a/table/merging_iterator.cc
+++ b/table/merging_iterator.cc
@@ -79,7 +79,6 @@ class MergingIterator : public InternalIterator {
     for (auto& child : children_) {
       child.DeleteIter(is_arena_mode_);
     }
-    status_.PermitUncheckedError();
   }
 
   bool Valid() const override { return current_ != nullptr && status_.ok(); }

--- a/table/plain/plain_table_builder.cc
+++ b/table/plain/plain_table_builder.cc
@@ -118,8 +118,6 @@ PlainTableBuilder::PlainTableBuilder(
 PlainTableBuilder::~PlainTableBuilder() {
   // They are supposed to have been passed to users through Finish()
   // if the file succeeds.
-  status_.PermitUncheckedError();
-  io_status_.PermitUncheckedError();
 }
 
 void PlainTableBuilder::Add(const Slice& key, const Slice& value) {

--- a/table/plain/plain_table_key_coding.h
+++ b/table/plain/plain_table_key_coding.h
@@ -69,10 +69,6 @@ class PlainTableFileReader {
   explicit PlainTableFileReader(const PlainTableReaderFileInfo* _file_info)
       : file_info_(_file_info), num_buf_(0) {}
 
-  ~PlainTableFileReader() {
-    // Should fix.
-    status_.PermitUncheckedError();
-  }
 
   // In mmaped mode, the results point to mmaped area of the file, which
   // means it is always valid before closing the file.

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -26,7 +26,6 @@ class CacheActivityLogger {
     MutexLock l(&mutex_);
 
     StopLoggingInternal();
-    bg_status_.PermitUncheckedError();
   }
 
   Status StartLogging(const std::string& activity_log_file, Env* env,


### PR DESCRIPTION
Change the default constructor of a Status and IOStatus to be marked as checked.  This change means that classes that have a Status in them should not need to call PermitUncheckedError on destruction.

Cleaned up (most of*) the destructors that were calling PermitUncheckedError, as it is no longer needed.  Did not fix VersionSet::ManifestWriter or the BlockIter as they were more involved, but did the rest.