### PR TITLE
Avoid to suppress status code in ~BlockBasedTableBuilder

### DIFF
--- a/file/filename.cc
+++ b/file/filename.cc
@@ -414,7 +414,7 @@ Status SetIdentityFile(Env* env, const std::string& dbname,
     s = env->RenameFile(tmp, IdentityFileName(dbname));
   }
   if (!s.ok()) {
-    env->DeleteFile(tmp);
+    env->DeleteFile(tmp).PermitUncheckedError();
   }
   return s;
 }

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -496,13 +496,6 @@ struct BlockBasedTableBuilder::Rep {
   Rep(const Rep&) = delete;
   Rep& operator=(const Rep&) = delete;
 
-  ~Rep() {
-    // They are supposed to be passed back to users through Finish()
-    // if the file finishes.
-    status.PermitUncheckedError();
-    io_status.PermitUncheckedError();
-  }
-
  private:
   Status status;
   IOStatus io_status;
@@ -1708,6 +1701,8 @@ void BlockBasedTableBuilder::Abandon() {
     rep_->pc_rep->finished = true;
   }
   rep_->state = Rep::State::kClosed;
+  rep_->GetStatus().PermitUncheckedError();
+  rep_->GetIOStatus().PermitUncheckedError();
 }
 
 uint64_t BlockBasedTableBuilder::NumEntries() const {


### PR DESCRIPTION
Summary:
We just used a hacky way to fix db_basic_test: suppress status code in ~BlockBasedTableBuilder. Rather, we should pass them back in Finish() and suppress them in Abandon().

Test Plan: Watch existing tests to succeed.