### PR TITLE
Introduce BlobFileCache and add support for blob files to Get()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,7 @@ set(SOURCES
         db/arena_wrapped_db_iter.cc
         db/blob/blob_file_addition.cc
         db/blob/blob_file_builder.cc
+        db/blob/blob_file_cache.cc
         db/blob/blob_file_garbage.cc
         db/blob/blob_file_meta.cc
         db/blob/blob_file_reader.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1045,6 +1045,7 @@ if(WITH_TESTS)
         cache/lru_cache_test.cc
         db/blob/blob_file_addition_test.cc
         db/blob/blob_file_builder_test.cc
+        db/blob/blob_file_cache_test.cc
         db/blob/blob_file_garbage_test.cc
         db/blob/blob_file_reader_test.cc
         db/blob/db_blob_basic_test.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,6 +1047,7 @@ if(WITH_TESTS)
         db/blob/blob_file_builder_test.cc
         db/blob/blob_file_garbage_test.cc
         db/blob/blob_file_reader_test.cc
+        db/blob/db_blob_basic_test.cc
         db/blob/db_blob_index_test.cc
         db/column_family_test.cc
         db/compact_files_test.cc

--- a/Makefile
+++ b/Makefile
@@ -588,6 +588,7 @@ ifdef ASSERT_STATUS_CHECKED
 		crc32c_test \
 		dbformat_test \
 		db_basic_test \
+		db_blob_basic_test \
 		db_flush_test \
 		db_with_timestamp_basic_test \
 		db_with_timestamp_compaction_test \
@@ -687,6 +688,7 @@ endif
 # Not necessarily well thought out or up-to-date, but matches old list
 TESTS_PLATFORM_DEPENDENT := \
 	db_basic_test \
+	db_blob_basic_test \
 	db_with_timestamp_basic_test \
 	db_encryption_test \
 	db_test2 \
@@ -1460,6 +1462,9 @@ slice_transform_test: $(OBJ_DIR)/util/slice_transform_test.o $(TEST_LIBRARY) $(L
 	$(AM_LINK)
 
 db_basic_test: $(OBJ_DIR)/db/db_basic_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
+db_blob_basic_test: $(OBJ_DIR)/db/blob/db_blob_basic_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 db_with_timestamp_basic_test: $(OBJ_DIR)/db/db_with_timestamp_basic_test.o $(TEST_LIBRARY) $(LIBRARY)

--- a/Makefile
+++ b/Makefile
@@ -577,6 +577,7 @@ ifdef ASSERT_STATUS_CHECKED
 		lru_cache_test \
 		blob_file_addition_test \
 		blob_file_builder_test \
+		blob_file_cache_test \
 		blob_file_garbage_test \
 		blob_file_reader_test \
 		bloom_test \
@@ -1917,6 +1918,9 @@ blob_file_addition_test: $(OBJ_DIR)/db/blob/blob_file_addition_test.o $(TEST_LIB
 	$(AM_LINK)
 
 blob_file_builder_test: $(OBJ_DIR)/db/blob/blob_file_builder_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
+blob_file_cache_test: $(OBJ_DIR)/db/blob/blob_file_cache_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
 blob_file_garbage_test: $(OBJ_DIR)/db/blob/blob_file_garbage_test.o $(TEST_LIBRARY) $(LIBRARY)

--- a/TARGETS
+++ b/TARGETS
@@ -424,6 +424,7 @@ cpp_library(
         "db/arena_wrapped_db_iter.cc",
         "db/blob/blob_file_addition.cc",
         "db/blob/blob_file_builder.cc",
+        "db/blob/blob_file_cache.cc",
         "db/blob/blob_file_garbage.cc",
         "db/blob/blob_file_meta.cc",
         "db/blob/blob_file_reader.cc",

--- a/TARGETS
+++ b/TARGETS
@@ -135,6 +135,7 @@ cpp_library(
         "db/arena_wrapped_db_iter.cc",
         "db/blob/blob_file_addition.cc",
         "db/blob/blob_file_builder.cc",
+        "db/blob/blob_file_cache.cc",
         "db/blob/blob_file_garbage.cc",
         "db/blob/blob_file_meta.cc",
         "db/blob/blob_file_reader.cc",

--- a/TARGETS
+++ b/TARGETS
@@ -860,6 +860,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "blob_file_cache_test",
+        "db/blob/blob_file_cache_test.cc",
+        "serial",
+        [],
+        [],
+    ],
+    [
         "blob_file_garbage_test",
         "db/blob/blob_file_garbage_test.cc",
         "serial",

--- a/TARGETS
+++ b/TARGETS
@@ -1098,6 +1098,13 @@ ROCKS_TESTS = [
         [],
     ],
     [
+        "db_blob_basic_test",
+        "db/blob/db_blob_basic_test.cc",
+        "serial",
+        [],
+        [],
+    ],
+    [
         "db_blob_index_test",
         "db/blob/db_blob_index_test.cc",
         "serial",

--- a/cache/cache_helpers.h
+++ b/cache/cache_helpers.h
@@ -12,6 +12,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// Returns the cached value given a cache handle.
 template <typename T>
 T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
   assert(cache);
@@ -20,16 +21,21 @@ T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
   return static_cast<T*>(cache->Value(handle));
 }
 
+// Simple generic deleter for Cache (to be used with Cache::Insert).
 template <typename T>
 void DeleteEntry(const Slice& /* key */, void* value) {
   delete static_cast<T*>(value);
 }
 
+// Turns a T* into a Slice so it can be used as a key with Cache.
 template <typename T>
 Slice GetSlice(const T* t) {
   return Slice(reinterpret_cast<const char*>(t), sizeof(T));
 }
 
+// Generic resource management object for cache handles that releases the handle
+// when destroyed. Has unique ownership of the handle, so copying it is not
+// allowed, while moving it transfers ownership.
 template <typename T>
 class CacheHandleGuard {
  public:

--- a/cache/cache_helpers.h
+++ b/cache/cache_helpers.h
@@ -14,7 +14,7 @@ namespace ROCKSDB_NAMESPACE {
 
 // Returns the cached value given a cache handle.
 template <typename T>
-T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
+T* GetFromCacheHandle(Cache* cache, Cache::Handle* handle) {
   assert(cache);
   assert(handle);
 
@@ -23,7 +23,7 @@ T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
 
 // Simple generic deleter for Cache (to be used with Cache::Insert).
 template <typename T>
-void DeleteEntry(const Slice& /* key */, void* value) {
+void DeleteCacheEntry(const Slice& /* key */, void* value) {
   delete static_cast<T*>(value);
 }
 
@@ -44,7 +44,7 @@ class CacheHandleGuard {
   CacheHandleGuard(Cache* cache, Cache::Handle* handle)
       : cache_(cache),
         handle_(handle),
-        value_(GetFromHandle<T>(cache, handle)) {
+        value_(GetFromCacheHandle<T>(cache, handle)) {
     assert(cache_ && handle_ && value_);
   }
 

--- a/cache/cache_helpers.h
+++ b/cache/cache_helpers.h
@@ -21,7 +21,7 @@ T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
 }
 
 template <typename T>
-void DeleteEntry(const Slice& /*key*/, void* value) {
+void DeleteEntry(const Slice& /* key */, void* value) {
   delete static_cast<T*>(value);
 }
 

--- a/cache/cache_helpers.h
+++ b/cache/cache_helpers.h
@@ -1,0 +1,33 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cassert>
+
+#include "rocksdb/cache.h"
+#include "rocksdb/rocksdb_namespace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+template <typename T>
+T* GetFromHandle(Cache* cache, Cache::Handle* handle) {
+  assert(cache);
+  assert(handle);
+
+  return static_cast<T*>(cache->Value(handle));
+}
+
+template <typename T>
+void DeleteEntry(const Slice& /*key*/, void* value) {
+  delete static_cast<T*>(value);
+}
+
+template <typename T>
+Slice GetSlice(const T* t) {
+  return Slice(reinterpret_cast<const char*>(t), sizeof(T));
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -82,7 +82,7 @@ Status BlobFileCache::GetBlobFileReader(
     constexpr size_t charge = 1;
 
     const Status s = cache_->Insert(key, reader.get(), charge,
-                                    &DeleteEntry<BlobFileReader>, &handle);
+                                    &DeleteCacheEntry<BlobFileReader>, &handle);
     if (!s.ok()) {
       RecordTick(statistics, NO_FILE_ERRORS);
       return s;

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -61,8 +61,9 @@ Status BlobFileCache::GetBlobFileReader(
   }
 
   assert(immutable_cf_options_);
+  Statistics* const statistics = immutable_cf_options_->statistics;
 
-  RecordTick(immutable_cf_options_->statistics, NO_FILE_OPENS);
+  RecordTick(statistics, NO_FILE_OPENS);
 
   std::unique_ptr<BlobFileReader> reader;
 
@@ -72,7 +73,7 @@ Status BlobFileCache::GetBlobFileReader(
         *immutable_cf_options_, *file_options_, column_family_id_,
         blob_file_read_hist_, blob_file_number, &reader);
     if (!s.ok()) {
-      RecordTick(immutable_cf_options_->statistics, NO_FILE_ERRORS);
+      RecordTick(statistics, NO_FILE_ERRORS);
       return s;
     }
   }
@@ -83,7 +84,7 @@ Status BlobFileCache::GetBlobFileReader(
     const Status s = cache_->Insert(key, reader.get(), charge,
                                     &DeleteEntry<BlobFileReader>, &handle);
     if (!s.ok()) {
-      RecordTick(immutable_cf_options_->statistics, NO_FILE_ERRORS);
+      RecordTick(statistics, NO_FILE_ERRORS);
       return s;
     }
   }

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -12,6 +12,7 @@
 #include "options/cf_options.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/slice.h"
+#include "test_util/sync_point.h"
 #include "util/hash.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -47,6 +48,8 @@ Status BlobFileCache::GetBlobFileReader(
     *blob_file_reader = CacheHandleGuard<BlobFileReader>(cache_, handle);
     return Status::OK();
   }
+
+  TEST_SYNC_POINT("BlobFileCache::GetBlobFileReader:DoubleCheck");
 
   // Check again while holding mutex
   MutexLock lock(mutex_.get(key));

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -80,6 +80,7 @@ Status BlobFileCache::GetBlobFileReader(
     const Status s = cache_->Insert(key, reader.get(), charge,
                                     &DeleteEntry<BlobFileReader>, &handle);
     if (!s.ok()) {
+      RecordTick(immutable_cf_options_->statistics, NO_FILE_ERRORS);
       return s;
     }
   }

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -1,0 +1,113 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_file_cache.h"
+
+#include <cassert>
+#include <memory>
+
+#include "db/blob/blob_file_reader.h"
+#include "options/cf_options.h"
+#include "rocksdb/cache.h"
+#include "rocksdb/slice.h"
+#include "util/hash.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+BlobFileReader* GetBlobFileReaderFromHandle(Cache* cache,
+                                            Cache::Handle* handle) {
+  assert(cache);
+  assert(handle);
+
+  return static_cast<BlobFileReader*>(cache->Value(handle));
+}
+
+template <class T>
+void DeleteEntry(const Slice& /*key*/, void* value) {
+  delete static_cast<T*>(value);
+}
+
+Slice GetSliceForFileNumber(const uint64_t* file_number) {
+  return Slice(reinterpret_cast<const char*>(file_number),
+               sizeof(*file_number));
+}
+
+}  // anonymous namespace
+
+BlobFileCache::BlobFileCache(Cache* cache,
+                             const ImmutableCFOptions* immutable_cf_options,
+                             const FileOptions* file_options,
+                             uint32_t column_family_id,
+                             HistogramImpl* blob_file_read_hist)
+    : cache_(cache),
+      mutex_(128, GetSliceNPHash64),
+      immutable_cf_options_(immutable_cf_options),
+      file_options_(file_options),
+      column_family_id_(column_family_id),
+      blob_file_read_hist_(blob_file_read_hist) {
+  assert(cache_);
+  assert(immutable_cf_options_);
+  assert(file_options_);
+  assert(blob_file_read_hist_);
+}
+
+Status BlobFileCache::GetBlobFileReader(uint64_t blob_file_number,
+                                        BlobFileReader** blob_file_reader) {
+  assert(blob_file_reader);
+
+  const Slice key = GetSliceForFileNumber(&blob_file_number);
+
+  assert(cache_);
+
+  Cache::Handle* handle = cache_->Lookup(key);
+  if (handle) {
+    *blob_file_reader = GetBlobFileReaderFromHandle(cache_, handle);
+    return Status::OK();
+  }
+
+  // Check again while holding mutex
+  MutexLock lock(mutex_.get(key));
+
+  handle = cache_->Lookup(key);
+  if (handle) {
+    *blob_file_reader = GetBlobFileReaderFromHandle(cache_, handle);
+    return Status::OK();
+  }
+
+  assert(immutable_cf_options_);
+
+  RecordTick(immutable_cf_options_->statistics, NO_FILE_OPENS);
+
+  std::unique_ptr<BlobFileReader> reader;
+
+  {
+    assert(file_options_);
+    const Status s = BlobFileReader::Create(
+        *immutable_cf_options_, *file_options_, column_family_id_,
+        blob_file_read_hist_, blob_file_number, &reader);
+    if (!s.ok()) {
+      RecordTick(immutable_cf_options_->statistics, NO_FILE_ERRORS);
+      return s;
+    }
+  }
+
+  {
+    const Status s = cache_->Insert(key, reader.get(), 1,
+                                    &DeleteEntry<BlobFileReader>, &handle);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  reader.release();
+
+  *blob_file_reader = GetBlobFileReaderFromHandle(cache_, handle);
+
+  return Status::OK();
+}
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_cache.cc
+++ b/db/blob/blob_file_cache.cc
@@ -30,7 +30,6 @@ BlobFileCache::BlobFileCache(Cache* cache,
   assert(cache_);
   assert(immutable_cf_options_);
   assert(file_options_);
-  assert(blob_file_read_hist_);
 }
 
 Status BlobFileCache::GetBlobFileReader(

--- a/db/blob/blob_file_cache.h
+++ b/db/blob/blob_file_cache.h
@@ -1,0 +1,44 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <cinttypes>
+
+#include "rocksdb/rocksdb_namespace.h"
+#include "util/mutexlock.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class Cache;
+struct ImmutableCFOptions;
+struct FileOptions;
+class HistogramImpl;
+class Status;
+class BlobFileReader;
+class Slice;
+
+class BlobFileCache {
+ public:
+  BlobFileCache(Cache* cache, const ImmutableCFOptions* immutable_cf_options,
+                const FileOptions* file_options, uint32_t column_family_id,
+                HistogramImpl* blob_file_read_hist);
+
+  BlobFileCache(const BlobFileCache&) = delete;
+  BlobFileCache& operator=(const BlobFileCache&) = delete;
+
+  Status GetBlobFileReader(uint64_t blob_file_number,
+                           BlobFileReader** blob_file_reader);
+
+ private:
+  Cache* cache_;
+  Striped<port::Mutex, Slice> mutex_;
+  const ImmutableCFOptions* immutable_cf_options_;
+  const FileOptions* file_options_;
+  uint32_t column_family_id_;
+  HistogramImpl* blob_file_read_hist_;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_cache.h
+++ b/db/blob/blob_file_cache.h
@@ -40,6 +40,8 @@ class BlobFileCache {
   const FileOptions* file_options_;
   uint32_t column_family_id_;
   HistogramImpl* blob_file_read_hist_;
+
+  static constexpr size_t kNumberOfMutexStripes = 1 << 7;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/blob/blob_file_cache.h
+++ b/db/blob/blob_file_cache.h
@@ -7,6 +7,7 @@
 
 #include <cinttypes>
 
+#include "cache/cache_helpers.h"
 #include "rocksdb/rocksdb_namespace.h"
 #include "util/mutexlock.h"
 
@@ -30,7 +31,7 @@ class BlobFileCache {
   BlobFileCache& operator=(const BlobFileCache&) = delete;
 
   Status GetBlobFileReader(uint64_t blob_file_number,
-                           BlobFileReader** blob_file_reader);
+                           CacheHandleGuard<BlobFileReader>* blob_file_reader);
 
  private:
   Cache* cache_;

--- a/db/blob/blob_file_cache.h
+++ b/db/blob/blob_file_cache.h
@@ -35,6 +35,8 @@ class BlobFileCache {
 
  private:
   Cache* cache_;
+  // Note: mutex_ below is used to guard against multiple threads racing to open
+  // the same file.
   Striped<port::Mutex, Slice> mutex_;
   const ImmutableCFOptions* immutable_cf_options_;
   const FileOptions* file_options_;

--- a/db/blob/blob_file_cache_test.cc
+++ b/db/blob/blob_file_cache_test.cc
@@ -130,6 +130,8 @@ TEST_F(BlobFileCacheTest, GetBlobFileReader) {
   ASSERT_NE(second.GetValue(), nullptr);
   ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_OPENS), 1);
   ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_ERRORS), 0);
+
+  ASSERT_EQ(first.GetValue(), second.GetValue());
 }
 
 TEST_F(BlobFileCacheTest, GetBlobFileReader_Race) {

--- a/db/blob/blob_file_cache_test.cc
+++ b/db/blob/blob_file_cache_test.cc
@@ -1,0 +1,140 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_file_cache.h"
+
+#include <cassert>
+#include <string>
+
+#include "db/blob/blob_log_format.h"
+#include "db/blob/blob_log_writer.h"
+#include "env/mock_env.h"
+#include "file/filename.h"
+#include "file/read_write_util.h"
+#include "file/writable_file_writer.h"
+#include "options/cf_options.h"
+#include "rocksdb/cache.h"
+#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/options.h"
+#include "rocksdb/statistics.h"
+#include "test_util/sync_point.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+
+// Creates a test blob file with a single blob in it.
+void WriteBlobFile(uint32_t column_family_id,
+                   const ImmutableCFOptions& immutable_cf_options,
+                   uint64_t blob_file_number) {
+  assert(!immutable_cf_options.cf_paths.empty());
+
+  const std::string blob_file_path = BlobFileName(
+      immutable_cf_options.cf_paths.front().path, blob_file_number);
+
+  std::unique_ptr<FSWritableFile> file;
+  ASSERT_OK(NewWritableFile(immutable_cf_options.fs, blob_file_path, &file,
+                            FileOptions()));
+
+  std::unique_ptr<WritableFileWriter> file_writer(
+      new WritableFileWriter(std::move(file), blob_file_path, FileOptions(),
+                             immutable_cf_options.env));
+
+  constexpr Statistics* statistics = nullptr;
+  constexpr bool use_fsync = false;
+
+  BlobLogWriter blob_log_writer(std::move(file_writer),
+                                immutable_cf_options.env, statistics,
+                                blob_file_number, use_fsync);
+
+  constexpr bool has_ttl = false;
+  constexpr ExpirationRange expiration_range;
+
+  BlobLogHeader header(column_family_id, kNoCompression, has_ttl,
+                       expiration_range);
+
+  ASSERT_OK(blob_log_writer.WriteHeader(header));
+
+  constexpr char key[] = "key";
+  constexpr char blob[] = "blob";
+
+  std::string compressed_blob;
+  Slice blob_to_write;
+
+  uint64_t key_offset = 0;
+  uint64_t blob_offset = 0;
+
+  ASSERT_OK(blob_log_writer.AddRecord(key, blob, &key_offset, &blob_offset));
+
+  BlobLogFooter footer;
+  footer.blob_count = 1;
+  footer.expiration_range = expiration_range;
+
+  std::string checksum_method;
+  std::string checksum_value;
+
+  ASSERT_OK(
+      blob_log_writer.AppendFooter(footer, &checksum_method, &checksum_value));
+}
+
+}  // anonymous namespace
+
+class BlobFileCacheTest : public testing::Test {
+ protected:
+  BlobFileCacheTest() : mock_env_(Env::Default()) {}
+
+  MockEnv mock_env_;
+};
+
+TEST_F(BlobFileCacheTest, GetBlobFileReader) {
+  Options options;
+  options.env = &mock_env_;
+  options.statistics = CreateDBStatistics();
+  options.cf_paths.emplace_back(
+      test::PerThreadDBPath(&mock_env_, "BlobFileCacheTest_GetBlobFileReader"),
+      0);
+  options.enable_blob_files = true;
+
+  constexpr uint32_t column_family_id = 1;
+  ImmutableCFOptions immutable_cf_options(options);
+  constexpr uint64_t blob_file_number = 123;
+
+  WriteBlobFile(column_family_id, immutable_cf_options, blob_file_number);
+
+  constexpr size_t capacity = 10;
+  std::shared_ptr<Cache> backing_cache = NewLRUCache(capacity);
+
+  FileOptions file_options;
+  constexpr HistogramImpl* blob_file_read_hist = nullptr;
+
+  BlobFileCache blob_file_cache(backing_cache.get(), &immutable_cf_options,
+                                &file_options, column_family_id,
+                                blob_file_read_hist);
+
+  // First try: reader should be opened and put in cache
+  CacheHandleGuard<BlobFileReader> first;
+
+  ASSERT_OK(blob_file_cache.GetBlobFileReader(blob_file_number, &first));
+  ASSERT_NE(first.GetValue(), nullptr);
+  ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_OPENS), 1);
+  ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_ERRORS), 0);
+
+  // Second try: reader should be served from cache
+  CacheHandleGuard<BlobFileReader> second;
+
+  ASSERT_OK(blob_file_cache.GetBlobFileReader(blob_file_number, &second));
+  ASSERT_NE(second.GetValue(), nullptr);
+  ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_OPENS), 1);
+  ASSERT_EQ(options.statistics->getTickerCount(NO_FILE_ERRORS), 0);
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/blob/blob_file_reader_test.cc
+++ b/db/blob/blob_file_reader_test.cc
@@ -18,6 +18,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/options.h"
+#include "test_util/sync_point.h"
 #include "test_util/testharness.h"
 #include "util/compression.h"
 #include "utilities/fault_injection_env.h"

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -95,10 +95,6 @@ Status BlobLogFooter::DecodeFrom(Slice src) {
   return Status::OK();
 }
 
-uint64_t BlobLogRecord::CalculateAdjustmentForRecordHeader(uint64_t key_size) {
-  return key_size + kHeaderSize;
-}
-
 void BlobLogRecord::EncodeHeaderTo(std::string* dst) {
   assert(dst != nullptr);
   dst->clear();

--- a/db/blob/blob_log_format.h
+++ b/db/blob/blob_log_format.h
@@ -107,7 +107,9 @@ struct BlobLogRecord {
   // Note that the offset field of BlobIndex actually points to the blob value
   // as opposed to the start of the blob record. The following method can
   // be used to calculate the adjustment needed to read the blob record header.
-  static uint64_t CalculateAdjustmentForRecordHeader(uint64_t key_size);
+  static uint64_t CalculateAdjustmentForRecordHeader(uint64_t key_size) {
+    return key_size + kHeaderSize;
+  }
 
   uint64_t key_size = 0;
   uint64_t value_size = 0;

--- a/db/blob/blob_log_sequential_reader.cc
+++ b/db/blob/blob_log_sequential_reader.cc
@@ -6,8 +6,6 @@
 
 #include "db/blob/blob_log_sequential_reader.h"
 
-#include <algorithm>
-
 #include "file/random_access_file_reader.h"
 #include "monitoring/statistics.h"
 #include "util/stop_watch.h"

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -1,0 +1,116 @@
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "db/blob/blob_index.h"
+#include "db/db_test_util.h"
+#include "port/stack_trace.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class DBBlobBasicTest : public DBTestBase {
+ public:
+  DBBlobBasicTest()
+      : DBTestBase("/db_blob_basic_test", /* env_do_fsync */ false) {}
+};
+
+TEST_F(DBBlobBasicTest, GetBlob) {
+  Options options;
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.disable_auto_compactions = true;
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char blob_value[] = "blob_value";
+
+  ASSERT_OK(Put(key, blob_value));
+
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get(key), blob_value);
+
+  // Try again with no I/O allowed. The table and the necessary blocks should
+  // already be in their respective caches; however, the blob itself can only be
+  // read from the blob file, so the read should return Incomplete.
+  ReadOptions read_options;
+  read_options.read_tier = kBlockCacheTier;
+
+  PinnableSlice result;
+  ASSERT_TRUE(db_->Get(read_options, db_->DefaultColumnFamily(), key, &result)
+                  .IsIncomplete());
+}
+
+TEST_F(DBBlobBasicTest, GetBlob_InlinedTTLIndex) {
+  constexpr uint64_t min_blob_size = 10;
+
+  Options options;
+  options.enable_blob_files = true;
+  options.min_blob_size = min_blob_size;
+  options.disable_auto_compactions = true;
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char blob[] = "short";
+  static_assert(sizeof(short) - 1 < min_blob_size,
+                "Blob too long to be inlined");
+
+  // Fake an inlined TTL blob index.
+  std::string blob_index;
+
+  constexpr uint64_t expiration = 1234567890;
+
+  BlobIndex::EncodeInlinedTTL(&blob_index, expiration, blob);
+
+  WriteBatch batch;
+  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 0, key, blob_index));
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  ASSERT_OK(Flush());
+
+  PinnableSlice result;
+  ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
+                  .IsCorruption());
+}
+
+TEST_F(DBBlobBasicTest, GetBlob_IndexWithInvalidFileNumber) {
+  Options options;
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.disable_auto_compactions = true;
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+
+  // Fake a blob index referencing a non-existent blob file.
+  std::string blob_index;
+
+  constexpr uint64_t blob_file_number = 1000;
+  constexpr uint64_t offset = 1234;
+  constexpr uint64_t size = 5678;
+
+  BlobIndex::EncodeBlob(&blob_index, blob_file_number, offset, size,
+                        kNoCompression);
+
+  WriteBatch batch;
+  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 0, key, blob_index));
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  ASSERT_OK(Flush());
+
+  PinnableSlice result;
+  ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
+                  .IsCorruption());
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ROCKSDB_NAMESPACE::port::InstallStackTraceHandler();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -21,7 +21,6 @@ TEST_F(DBBlobBasicTest, GetBlob) {
   Options options;
   options.enable_blob_files = true;
   options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
 
   Reopen(options);
 
@@ -49,7 +48,6 @@ TEST_F(DBBlobBasicTest, GetBlob_CorruptIndex) {
   Options options;
   options.enable_blob_files = true;
   options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
 
   Reopen(options);
 
@@ -75,7 +73,6 @@ TEST_F(DBBlobBasicTest, GetBlob_InlinedTTLIndex) {
   Options options;
   options.enable_blob_files = true;
   options.min_blob_size = min_blob_size;
-  options.disable_auto_compactions = true;
 
   Reopen(options);
 
@@ -106,7 +103,6 @@ TEST_F(DBBlobBasicTest, GetBlob_IndexWithInvalidFileNumber) {
   Options options;
   options.enable_blob_files = true;
   options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
 
   Reopen(options);
 
@@ -154,7 +150,6 @@ TEST_P(DBBlobBasicIOErrorTest, GetBlob_IOError) {
   options.env = &fault_injection_env_;
   options.enable_blob_files = true;
   options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
 
   Reopen(options);
 

--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -157,7 +157,8 @@ TEST_F(DBBlobIndexTest, Write) {
 }
 
 // Get should be able to return blob index if is_blob_index is provided,
-// otherwise return Status::NotSupported status.
+// otherwise it should return Status::NotSupported (when reading from memtable)
+// or Status::Corruption (when reading from SST).
 TEST_F(DBBlobIndexTest, Get) {
   for (auto tier : kAllTiers) {
     DestroyAndReopen(GetTestOptions());
@@ -186,8 +187,8 @@ TEST_F(DBBlobIndexTest, Get) {
   }
 }
 
-// Get should NOT return Status::NotSupported if blob index is updated with
-// a normal value.
+// Get should NOT return Status::NotSupported/Status::Corruption if blob index
+// is updated with a normal value.
 TEST_F(DBBlobIndexTest, Updated) {
   for (auto tier : kAllTiers) {
     DestroyAndReopen(GetTestOptions());

--- a/db/blob/db_blob_index_test.cc
+++ b/db/blob/db_blob_index_test.cc
@@ -156,9 +156,13 @@ TEST_F(DBBlobIndexTest, Write) {
   }
 }
 
-// Get should be able to return blob index if is_blob_index is provided,
-// otherwise it should return Status::NotSupported (when reading from memtable)
-// or Status::Corruption (when reading from SST).
+// Note: the following test case pertains to the StackableDB-based BlobDB
+// implementation. Get should be able to return blob index if is_blob_index is
+// provided, otherwise it should return Status::NotSupported (when reading from
+// memtable) or Status::Corruption (when reading from SST). Reading from SST
+// returns Corruption because we can't differentiate between the application
+// accidentally opening the base DB of a stacked BlobDB and actual corruption
+// when using the integrated BlobDB.
 TEST_F(DBBlobIndexTest, Get) {
   for (auto tier : kAllTiers) {
     DestroyAndReopen(GetTestOptions());
@@ -187,8 +191,10 @@ TEST_F(DBBlobIndexTest, Get) {
   }
 }
 
-// Get should NOT return Status::NotSupported/Status::Corruption if blob index
-// is updated with a normal value.
+// Note: the following test case pertains to the StackableDB-based BlobDB
+// implementation. Get should NOT return Status::NotSupported/Status::Corruption
+// if blob index is updated with a normal value. See the test case above for
+// more details.
 TEST_F(DBBlobIndexTest, Updated) {
   for (auto tier : kAllTiers) {
     DestroyAndReopen(GetTestOptions());

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "db/blob/blob_file_cache.h"
 #include "db/compaction/compaction_picker.h"
 #include "db/compaction/compaction_picker_fifo.h"
 #include "db/compaction/compaction_picker_level.h"
@@ -559,6 +560,10 @@ ColumnFamilyData::ColumnFamilyData(
         new InternalStats(ioptions_.num_levels, db_options.env, this));
     table_cache_.reset(new TableCache(ioptions_, file_options, _table_cache,
                                       block_cache_tracer, io_tracer));
+    blob_file_cache_.reset(
+        new BlobFileCache(_table_cache, ioptions(), soptions(), id_,
+                          internal_stats_->GetBlobFileReadHist()));
+
     if (ioptions_.compaction_style == kCompactionStyleLevel) {
       compaction_picker_.reset(
           new LevelCompactionPicker(ioptions_, &internal_comparator_));

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -44,6 +44,7 @@ class LogBuffer;
 class InstrumentedMutex;
 class InstrumentedMutexLock;
 struct SuperVersionContext;
+class BlobFileCache;
 
 extern const double kIncSlowdownRatio;
 // This file contains a list of data structures for managing column family
@@ -381,6 +382,7 @@ class ColumnFamilyData {
                          SequenceNumber earliest_seq);
 
   TableCache* table_cache() const { return table_cache_.get(); }
+  BlobFileCache* blob_file_cache() const { return blob_file_cache_.get(); }
 
   // See documentation in compaction_picker.h
   // REQUIRES: DB mutex held
@@ -543,6 +545,7 @@ class ColumnFamilyData {
   const bool is_delete_range_supported_;
 
   std::unique_ptr<TableCache> table_cache_;
+  std::unique_ptr<BlobFileCache> blob_file_cache_;
 
   std::unique_ptr<InternalStats> internal_stats_;
 

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -3496,6 +3496,25 @@ INSTANTIATE_TEST_CASE_P(DBBasicTestDeadline, DBBasicTestDeadline,
                         ::testing::Values(std::make_tuple(true, false),
                                           std::make_tuple(false, true),
                                           std::make_tuple(true, true)));
+
+TEST_F(DBBasicTest, GetBlob) {
+  Options options;
+  options.enable_blob_files = true;
+  options.min_blob_size = 0;
+  options.disable_auto_compactions = true;
+
+  Reopen(options);
+
+  constexpr char key[] = "key";
+  constexpr char blob_value[] = "blob_value";
+
+  ASSERT_OK(Put(key, blob_value));
+
+  ASSERT_OK(Flush());
+
+  ASSERT_EQ(Get(key), blob_value);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 #ifdef ROCKSDB_UNITTESTS_WITH_CUSTOM_OBJECTS_FROM_STATIC_LIBS

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -3513,6 +3513,16 @@ TEST_F(DBBasicTest, GetBlob) {
   ASSERT_OK(Flush());
 
   ASSERT_EQ(Get(key), blob_value);
+
+  // Try again with no I/O allowed. The table and the necessary blocks should
+  // already be in their respective caches; however, the blob itself can only be
+  // read from the blob file, so the read should return Incomplete.
+  ReadOptions read_options;
+  read_options.read_tier = kBlockCacheTier;
+
+  PinnableSlice result;
+  ASSERT_TRUE(db_->Get(read_options, db_->DefaultColumnFamily(), key, &result)
+                  .IsIncomplete());
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <regex>
 
-#include "db/blob/blob_index.h"
 #include "db/db_test_util.h"
 #include "port/stack_trace.h"
 #include "rocksdb/merge_operator.h"
@@ -3497,99 +3496,6 @@ INSTANTIATE_TEST_CASE_P(DBBasicTestDeadline, DBBasicTestDeadline,
                         ::testing::Values(std::make_tuple(true, false),
                                           std::make_tuple(false, true),
                                           std::make_tuple(true, true)));
-
-TEST_F(DBBasicTest, GetBlob) {
-  Options options;
-  options.enable_blob_files = true;
-  options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
-
-  Reopen(options);
-
-  constexpr char key[] = "key";
-  constexpr char blob_value[] = "blob_value";
-
-  ASSERT_OK(Put(key, blob_value));
-
-  ASSERT_OK(Flush());
-
-  ASSERT_EQ(Get(key), blob_value);
-
-  // Try again with no I/O allowed. The table and the necessary blocks should
-  // already be in their respective caches; however, the blob itself can only be
-  // read from the blob file, so the read should return Incomplete.
-  ReadOptions read_options;
-  read_options.read_tier = kBlockCacheTier;
-
-  PinnableSlice result;
-  ASSERT_TRUE(db_->Get(read_options, db_->DefaultColumnFamily(), key, &result)
-                  .IsIncomplete());
-}
-
-TEST_F(DBBasicTest, GetBlob_InlinedTTLIndex) {
-  constexpr uint64_t min_blob_size = 10;
-
-  Options options;
-  options.enable_blob_files = true;
-  options.min_blob_size = min_blob_size;
-  options.disable_auto_compactions = true;
-
-  Reopen(options);
-
-  constexpr char key[] = "key";
-  constexpr char blob[] = "short";
-  static_assert(sizeof(short) - 1 < min_blob_size,
-                "Blob too long to be inlined");
-
-  // Fake an inlined TTL blob index.
-  std::string blob_index;
-
-  constexpr uint64_t expiration = 1234567890;
-
-  BlobIndex::EncodeInlinedTTL(&blob_index, expiration, blob);
-
-  WriteBatch batch;
-  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 0, key, blob_index));
-  ASSERT_OK(db_->Write(WriteOptions(), &batch));
-
-  ASSERT_OK(Flush());
-
-  PinnableSlice result;
-  ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
-                  .IsCorruption());
-}
-
-TEST_F(DBBasicTest, GetBlob_IndexWithInvalidFileNumber) {
-  Options options;
-  options.enable_blob_files = true;
-  options.min_blob_size = 0;
-  options.disable_auto_compactions = true;
-
-  Reopen(options);
-
-  constexpr char key[] = "key";
-
-  // Fake a blob index referencing a non-existent blob file.
-  std::string blob_index;
-
-  constexpr uint64_t blob_file_number = 1000;
-  constexpr uint64_t offset = 1234;
-  constexpr uint64_t size = 5678;
-
-  BlobIndex::EncodeBlob(&blob_index, blob_file_number, offset, size,
-                        kNoCompression);
-
-  WriteBatch batch;
-  ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 0, key, blob_index));
-  ASSERT_OK(db_->Write(WriteOptions(), &batch));
-
-  ASSERT_OK(Flush());
-
-  PinnableSlice result;
-  ASSERT_TRUE(db_->Get(ReadOptions(), db_->DefaultColumnFamily(), key, &result)
-                  .IsCorruption());
-}
-
 }  // namespace ROCKSDB_NAMESPACE
 
 #ifdef ROCKSDB_UNITTESTS_WITH_CUSTOM_OBJECTS_FROM_STATIC_LIBS

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -470,9 +470,7 @@ TEST_F(DBFlushTest, FlushWithBlob) {
   ASSERT_OK(Flush());
 
   ASSERT_EQ(Get("key1"), short_value);
-
-  // TODO: enable once Get support is implemented for blobs
-  // ASSERT_EQ(Get("key2"), long_value);
+  ASSERT_EQ(Get("key2"), long_value);
 
   VersionSet* const versions = dbfull()->TEST_GetVersionSet();
   assert(versions);

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -384,9 +384,7 @@ TEST_F(DBWALTest, RecoverWithBlob) {
   Reopen(options);
 
   ASSERT_EQ(Get("key1"), short_value);
-
-  // TODO: enable once Get support is implemented for blobs
-  // ASSERT_EQ(Get("key2"), long_value);
+  ASSERT_EQ(Get("key2"), long_value);
 
   VersionSet* const versions = dbfull()->TEST_GetVersionSet();
   assert(versions);

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -673,6 +673,8 @@ class InternalStats {
 
   HistogramImpl* GetFileReadHist(int /*level*/) { return nullptr; }
 
+  HistogramImpl* GetBlobFileReadHist() { return nullptr; }
+
   uint64_t GetBackgroundErrorCount() const { return 0; }
 
   uint64_t BumpAndGetBackgroundErrorCount() { return 0; }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1824,9 +1824,9 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
   }
 
   assert(blob_file_reader);
-  const Status s =
-      blob_file_reader->GetBlob(read_options, user_key, blob_index.offset(),
-                                blob_index.size(), get_context);
+  const Status s = blob_file_reader->GetBlob(
+      read_options, user_key, blob_index.offset(), blob_index.size(),
+      blob_index.compression(), get_context);
 
   return s;
 }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1889,7 +1889,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
       case GetContext::kCorrupt:
         *status = Status::Corruption("corrupted key for ", user_key);
         return;
-      case GetContext::kBlobIndex:
+      case GetContext::kUnexpectedBlobIndex:
         ROCKS_LOG_ERROR(info_log_, "Encounter unexpected blob index.");
         *status = Status::NotSupported(
             "Encounter unexpected blob index. Please open DB with "
@@ -2076,7 +2076,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
               Status::Corruption("corrupted key for ", iter->lkey->user_key());
           file_range.MarkKeyDone(iter);
           continue;
-        case GetContext::kBlobIndex:
+        case GetContext::kUnexpectedBlobIndex:
           ROCKS_LOG_ERROR(info_log_, "Encounter unexpected blob index.");
           *status = Status::NotSupported(
               "Encounter unexpected blob index. Please open DB with "

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1814,9 +1814,11 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
   {
     assert(cfd_);
     assert(cfd_->ioptions());
+    assert(cfd_->internal_stats());
 
     const Status s =
         BlobFileReader::Create(*cfd_->ioptions(), file_options_, cfd_->GetID(),
+                               cfd_->internal_stats()->GetBlobFileReadHist(),
                                blob_file_number, &blob_file_reader);
     if (!s.ok()) {
       return s;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1815,9 +1815,9 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     assert(cfd_);
     assert(cfd_->ioptions());
 
-    const Status s = BlobFileReader::Create(
-        read_options, *cfd_->ioptions(), file_options_, cfd_->GetID(),
-        blob_file_number, &blob_file_reader);
+    const Status s =
+        BlobFileReader::Create(*cfd_->ioptions(), file_options_, cfd_->GetID(),
+                               blob_file_number, &blob_file_reader);
     if (!s.ok()) {
       return s;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1809,17 +1809,15 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     return Status::Corruption("Invalid blob file number");
   }
 
-  assert(cfd_);
-
-  const ImmutableCFOptions* const ioptions = cfd_->ioptions();
-  assert(ioptions);
-
   std::unique_ptr<BlobFileReader> blob_file_reader;
 
   {
+    assert(cfd_);
+    assert(cfd_->ioptions());
+
     const Status s = BlobFileReader::Create(
-        read_options, *ioptions, file_options_, cfd_->GetID(), blob_file_number,
-        &blob_file_reader);
+        read_options, *cfd_->ioptions(), file_options_, cfd_->GetID(),
+        blob_file_number, &blob_file_reader);
     if (!s.ok()) {
       return s;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1759,6 +1759,7 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       db_statistics_((cfd_ == nullptr) ? nullptr
                                        : cfd_->ioptions()->statistics),
       table_cache_((cfd_ == nullptr) ? nullptr : cfd_->table_cache()),
+      blob_file_cache_(cfd_ ? cfd_->blob_file_cache() : nullptr),
       merge_operator_((cfd_ == nullptr) ? nullptr
                                         : cfd_->ioptions()->merge_operator),
       storage_info_(

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -22,8 +22,8 @@
 #include <vector>
 
 #include "compaction/compaction.h"
+#include "db/blob/blob_file_reader.h"
 #include "db/blob/blob_index.h"
-#include "db/blob/blob_log_format.h"
 #include "db/internal_stats.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
@@ -56,7 +56,6 @@
 #include "test_util/sync_point.h"
 #include "util/cast_util.h"
 #include "util/coding.h"
-#include "util/crc32c.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 #include "util/user_comparator_wrapper.h"
@@ -1783,15 +1782,18 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       version_number_(version_number),
       io_tracer_(io_tracer) {}
 
-Status Version::GetBlob(const ReadOptions& /* read_options */,
-                        const Slice& user_key, const Slice& index_entry,
+Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                        const Slice& index_entry,
                         GetContext* get_context) const {
   assert(get_context);
 
   BlobIndex blob_index;
-  Status s = blob_index.DecodeFrom(index_entry);
-  if (!s.ok()) {
-    return s;
+
+  {
+    Status s = blob_index.DecodeFrom(index_entry);
+    if (!s.ok()) {
+      return s;
+    }
   }
 
   if (blob_index.HasTTL() || blob_index.IsInlined()) {
@@ -1800,84 +1802,33 @@ Status Version::GetBlob(const ReadOptions& /* read_options */,
 
   const auto& blob_files = storage_info_.GetBlobFiles();
 
-  const auto it = blob_files.find(blob_index.file_number());
+  const uint64_t blob_file_number = blob_index.file_number();
+
+  const auto it = blob_files.find(blob_file_number);
   if (it == blob_files.end()) {
     return Status::Corruption("Invalid blob file number");
-  }
-
-  if (blob_index.offset() <
-      (BlobLogHeader::kSize + BlobLogRecord::kHeaderSize + user_key.size())) {
-    return Status::Corruption("Invalid blob offset");
   }
 
   const ImmutableCFOptions* const ioptions = cfd_->ioptions();
   assert(ioptions);
 
-  std::unique_ptr<FSRandomAccessFile> file;
-  const std::string blob_file_path =
-      BlobFileName(ioptions->cf_paths.front().path, blob_index.file_number());
+  std::unique_ptr<BlobFileReader> blob_file_reader;
 
-  assert(ioptions->fs);
-  s = ioptions->fs->NewRandomAccessFile(blob_file_path, file_options_, &file,
-                                        nullptr);
-  if (!s.ok()) {
-    return s;
+  {
+    const Status s =
+        BlobFileReader::Create(read_options, *ioptions, file_options_,
+                               blob_file_number, &blob_file_reader);
+    if (!s.ok()) {
+      return s;
+    }
   }
 
-  std::unique_ptr<RandomAccessFileReader> reader(new RandomAccessFileReader(
-      std::move(file), blob_file_path, nullptr /* env */, io_tracer_,
-      nullptr /* stats */, 0 /* hist_type */, nullptr /* file_read_hist */,
-      nullptr /* rate_limiter */, ioptions->listeners));
+  assert(blob_file_reader);
+  const Status s =
+      blob_file_reader->GetBlob(read_options, user_key, blob_index.offset(),
+                                blob_index.size(), get_context);
 
-  assert(blob_index.offset() >= user_key.size() + sizeof(uint32_t));
-  const uint64_t record_offset =
-      blob_index.offset() - user_key.size() - sizeof(uint32_t);
-  const uint64_t record_size =
-      sizeof(uint32_t) + user_key.size() + blob_index.size();
-
-  std::string buf;
-  AlignedBuf aligned_buf;
-
-  Slice blob_record;
-
-  if (reader->use_direct_io()) {
-    s = reader->Read(IOOptions(), record_offset,
-                     static_cast<size_t>(record_size), &blob_record, nullptr,
-                     &aligned_buf);
-  } else {
-    buf.reserve(static_cast<size_t>(record_size));
-    s = reader->Read(IOOptions(), record_offset,
-                     static_cast<size_t>(record_size), &blob_record, &buf[0],
-                     nullptr);
-  }
-
-  if (!s.ok()) {
-    return s;
-  }
-
-  if (blob_record.size() != record_size) {
-    return Status::Corruption("Failed to retrieve blob from blob index.");
-  }
-
-  Slice crc_slice(blob_record.data(), sizeof(uint32_t));
-  Slice blob_value(blob_record.data() + sizeof(uint32_t) + user_key.size(),
-                   static_cast<size_t>(blob_index.size()));
-
-  uint32_t crc_exp = 0;
-  if (!GetFixed32(&crc_slice, &crc_exp)) {
-    return Status::Corruption("Unable to decode checksum.");
-  }
-
-  uint32_t crc = crc32c::Value(blob_record.data() + sizeof(uint32_t),
-                               blob_record.size() - sizeof(uint32_t));
-  crc = crc32c::Mask(crc);
-  if (crc != crc_exp) {
-    return Status::Corruption("Corruption. Blob CRC mismatch");
-  }
-
-  get_context->SaveValue(blob_value, kMaxSequenceNumber);
-
-  return Status::OK();
+  return s;
 }
 
 void Version::Get(const ReadOptions& read_options, const LookupKey& k,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1802,12 +1802,19 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
       vset_->block_cache_tracer_->is_tracing_enabled()) {
     tracing_get_id = vset_->block_cache_tracer_->NextGetId();
   }
+
+  // Note: the old StackableDB-based BlobDB passes in
+  // GetImplOptions::is_blob_index; for the integrated BlobDB implementation, we
+  // need to provide it here.
+  bool is_blob_index = false;
+  bool* const is_blob_to_use = is_blob ? is_blob : &is_blob_index;
+
   GetContext get_context(
       user_comparator(), merge_operator_, info_log_, db_statistics_,
       status->ok() ? GetContext::kNotFound : GetContext::kMerge, user_key,
       do_merge ? value : nullptr, do_merge ? timestamp : nullptr, value_found,
       merge_context, do_merge, max_covering_tombstone_seq, this->env_, seq,
-      merge_operator_ ? &pinned_iters_mgr : nullptr, callback, is_blob,
+      merge_operator_ ? &pinned_iters_mgr : nullptr, callback, is_blob_to_use,
       tracing_get_id);
 
   // Pin blocks that we read to hold merge operands

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1809,15 +1809,17 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     return Status::Corruption("Invalid blob file number");
   }
 
+  assert(cfd_);
+
   const ImmutableCFOptions* const ioptions = cfd_->ioptions();
   assert(ioptions);
 
   std::unique_ptr<BlobFileReader> blob_file_reader;
 
   {
-    const Status s =
-        BlobFileReader::Create(read_options, *ioptions, file_options_,
-                               blob_file_number, &blob_file_reader);
+    const Status s = BlobFileReader::Create(
+        read_options, *ioptions, file_options_, cfd_->GetID(), blob_file_number,
+        &blob_file_reader);
     if (!s.ok()) {
       return s;
     }

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1810,7 +1810,7 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     return Status::Corruption("Invalid blob file number");
   }
 
-  BlobFileReader* blob_file_reader = nullptr;
+  CacheHandleGuard<BlobFileReader> blob_file_reader;
 
   {
     assert(blob_file_cache_);
@@ -1821,8 +1821,8 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     }
   }
 
-  assert(blob_file_reader);
-  const Status s = blob_file_reader->GetBlob(
+  assert(blob_file_reader.GetValue());
+  const Status s = blob_file_reader.GetValue()->GetBlob(
       read_options, user_key, blob_index.offset(), blob_index.size(),
       blob_index.compression(), value);
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -776,12 +776,12 @@ class Version {
     return storage_info_.user_comparator_;
   }
 
-  // Interprets index_entry as a blob reference, and (assuming the corresponding
+  // Interprets *value as a blob reference, and (assuming the corresponding
   // blob file is part of this Version) retrieves the blob and saves it in
-  // *get_context.
-  // REQUIRES: index_entry stores an encoded blob reference
+  // *value, replacing the blob reference.
+  // REQUIRES: *value stores an encoded blob reference
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 const Slice& index_entry, GetContext* get_context) const;
+                 PinnableSlice* value) const;
 
   // Returns true if the filter blocks in the specified level will not be
   // checked during read operations. In certain cases (trivial move or preload),

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -776,6 +776,13 @@ class Version {
     return storage_info_.user_comparator_;
   }
 
+  // Interprets index_entry as a blob reference, and (assuming the corresponding
+  // blob file is part of this Version) retrieves the blob and saves it in
+  // *get_context.
+  // REQUIRES: index_entry stores an encoded blob reference
+  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                 const Slice& index_entry, GetContext* get_context) const;
+
   // Returns true if the filter blocks in the specified level will not be
   // checked during read operations. In certain cases (trivial move or preload),
   // the filter block may already be cached, but we still do not access it such

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 
+#include "cache/cache_helpers.h"
 #include "db/blob/blob_file_meta.h"
 #include "db/column_family.h"
 #include "db/compaction/compaction.h"
@@ -1158,6 +1159,10 @@ class VersionSet {
   void GetLiveFilesMetaData(std::vector<LiveFileMetaData> *metadata);
 
   void AddObsoleteBlobFile(uint64_t blob_file_number, std::string path) {
+    assert(table_cache_);
+
+    table_cache_->Erase(GetSlice(&blob_file_number));
+
     obsolete_blob_files_.emplace_back(blob_file_number, std::move(path));
   }
 
@@ -1273,6 +1278,7 @@ class VersionSet {
   WalSet wals_;
 
   std::unique_ptr<ColumnFamilySet> column_family_set_;
+  Cache* table_cache_;
   Env* const env_;
   FileSystemPtr const fs_;
   const std::string dbname_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -807,6 +807,7 @@ class Version {
   Logger* info_log_;
   Statistics* db_statistics_;
   TableCache* table_cache_;
+  BlobFileCache* blob_file_cache_;
   const MergeOperator* merge_operator_;
 
   VersionStorageInfo storage_info_;

--- a/src.mk
+++ b/src.mk
@@ -359,6 +359,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/blob/blob_file_builder_test.cc                                     \
   db/blob/blob_file_garbage_test.cc                                     \
   db/blob/blob_file_reader_test.cc                                      \
+  db/blob/db_blob_basic_test.cc                                         \
   db/blob/db_blob_index_test.cc                                         \
   db/column_family_test.cc                                              \
   db/compact_files_test.cc                                              \

--- a/src.mk
+++ b/src.mk
@@ -357,6 +357,7 @@ TEST_MAIN_SOURCES =                                                     \
   cache/lru_cache_test.cc                                               \
   db/blob/blob_file_addition_test.cc                                    \
   db/blob/blob_file_builder_test.cc                                     \
+  db/blob/blob_file_cache_test.cc                                       \
   db/blob/blob_file_garbage_test.cc                                     \
   db/blob/blob_file_reader_test.cc                                      \
   db/blob/db_blob_basic_test.cc                                         \

--- a/src.mk
+++ b/src.mk
@@ -7,6 +7,7 @@ LIB_SOURCES =                                                   \
   db/arena_wrapped_db_iter.cc                                   \
   db/blob/blob_file_addition.cc                                 \
   db/blob/blob_file_builder.cc                                  \
+  db/blob/blob_file_cache.cc                                    \
   db/blob/blob_file_garbage.cc                                  \
   db/blob/blob_file_meta.cc                                     \
   db/blob/blob_file_reader.cc                                   \

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -245,7 +245,7 @@ bool GetContext::SaveValue(const ParsedInternalKey& parsed_key,
         assert(state_ == kNotFound || state_ == kMerge);
         if (type == kTypeBlobIndex && is_blob_index_ == nullptr) {
           // Blob value not supported. Stop.
-          state_ = kBlobIndex;
+          state_ = kUnexpectedBlobIndex;
           return false;
         }
         if (kNotFound == state_) {

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -96,11 +96,15 @@ void GetContext::MarkKeyMayExist() {
 }
 
 void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
-  assert(state_ == kNotFound);
+  assert(state_ == kNotFound || state_ == kFound);
   appendToReplayLog(replay_log_, kTypeValue, value);
 
   state_ = kFound;
   if (LIKELY(pinnable_val_ != nullptr)) {
+    if (pinnable_val_->IsPinned()) {
+      pinnable_val_->Reset();
+    }
+
     pinnable_val_->PinSelf(value);
   }
 }

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -96,10 +96,19 @@ void GetContext::MarkKeyMayExist() {
 }
 
 void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
-  assert(state_ == kNotFound || state_ == kFound);
+  assert(state_ == kNotFound);
   appendToReplayLog(replay_log_, kTypeValue, value);
 
   state_ = kFound;
+  if (LIKELY(pinnable_val_ != nullptr)) {
+    pinnable_val_->PinSelf(value);
+  }
+}
+
+void GetContext::SaveRealValue(const Slice& value) {
+  assert(state_ == kFound);
+  appendToReplayLog(replay_log_, kTypeValue, value);
+
   if (LIKELY(pinnable_val_ != nullptr)) {
     if (pinnable_val_->IsPinned()) {
       pinnable_val_->Reset();

--- a/table/get_context.cc
+++ b/table/get_context.cc
@@ -105,19 +105,6 @@ void GetContext::SaveValue(const Slice& value, SequenceNumber /*seq*/) {
   }
 }
 
-void GetContext::SaveRealValue(const Slice& value) {
-  assert(state_ == kFound);
-  appendToReplayLog(replay_log_, kTypeValue, value);
-
-  if (LIKELY(pinnable_val_ != nullptr)) {
-    if (pinnable_val_->IsPinned()) {
-      pinnable_val_->Reset();
-    }
-
-    pinnable_val_->PinSelf(value);
-  }
-}
-
 void GetContext::ReportCounters() {
   if (get_context_stats_.num_cache_hit > 0) {
     RecordTick(statistics_, BLOCK_CACHE_HIT, get_context_stats_.num_cache_hit);

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -71,7 +71,7 @@ class GetContext {
     kDeleted,
     kCorrupt,
     kMerge,  // saver contains the current merge result (the operands)
-    kBlobIndex,
+    kUnexpectedBlobIndex,
   };
   GetContextStats get_context_stats_;
 

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -136,6 +136,10 @@ class GetContext {
   // know that the operation is a Put.
   void SaveValue(const Slice& value, SequenceNumber seq);
 
+  // Another simplified version, used for replacing blob references with
+  // the real value (i.e. the retrieved blob).
+  void SaveRealValue(const Slice& value);
+
   GetState State() const { return state_; }
 
   SequenceNumber* max_covering_tombstone_seq() {

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -136,10 +136,6 @@ class GetContext {
   // know that the operation is a Put.
   void SaveValue(const Slice& value, SequenceNumber seq);
 
-  // Another simplified version, used for replacing blob references with
-  // the real value (i.e. the retrieved blob).
-  void SaveRealValue(const Slice& value);
-
   GetState State() const { return state_; }
 
   SequenceNumber* max_covering_tombstone_seq() {

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -1046,7 +1046,7 @@ TEST_F(BlobDBTest, MigrateFromPlainRocksDB) {
     if (data.count(key) == 0) {
       ASSERT_TRUE(s.IsNotFound());
     } else if (is_blob[i]) {
-      ASSERT_TRUE(s.IsNotSupported());
+      ASSERT_TRUE(s.IsCorruption());
     } else {
       ASSERT_OK(s);
       ASSERT_EQ(data[key], value);


### PR DESCRIPTION
Summary:
The patch adds blob file support to the `Get` API by extending `Version` so that
whenever a blob reference is read from a file, the blob is retrieved from the corresponding
blob file and passed back to the caller. (This is assuming the blob reference is valid
and the blob file is actually part of the given `Version`.) It also introduces a cache
of `BlobFileReader`s called `BlobFileCache` that enables sharing `BlobFileReader`s
between callers. `BlobFileCache` uses the same backing cache as `TableCache`, so
`max_open_files` (if specified) limits the total number of open (table + blob) files.

TODO: proactively open/cache blob files and pin the cache handles of the readers in the
metadata objects similarly to what `VersionBuilder::LoadTableHandlers` does for
table files.

Test Plan:
`make check`