### PR TITLE
Remove the status.PermitUncheckedError() from WriteGroup Destructor

### DIFF
--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -75,7 +75,6 @@ class WriteThread {
   struct Writer;
 
   struct WriteGroup {
-    ~WriteGroup() { status.PermitUncheckedError(); }
     Writer* leader = nullptr;
     Writer* last_writer = nullptr;
     SequenceNumber last_sequence;


### PR DESCRIPTION
test plan: ASSERT_STATUS_CHECKED=1 make -j48 error_handler_fs_test