### PR TITLE
Fix for stress test failure

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -134,6 +134,9 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
                      for_compaction);
       }
       if (!s.ok()) {
+#ifndef NDEBUG
+        IGNORE_STATUS_IF_ERROR(s);
+#endif
         return false;
       }
       readahead_size_ = std::min(max_readahead_size_, readahead_size_ * 2);

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -612,6 +612,10 @@ Status BlockBasedTable::Open(
     s = PrefetchTail(ro, file.get(), file_size, force_direct_prefetch,
                      tail_prefetch_stats, prefetch_all, preload_all,
                      &prefetch_buffer);
+    // Return error in prefetch path to users.
+    if (!s.ok()) {
+      return s;
+    }
   } else {
     // Should not prefetch for mmap mode.
     prefetch_buffer.reset(new FilePrefetchBuffer(


### PR DESCRIPTION
Summary:  Ignore read error in 'FilePrefetchBuffer::TryReadFromCache' as status is ignored
and  bool value is returned. Return error if prefetch fails in
'PrefetchTail' as we have planned to return Prefetch failures to users.

Test Plan: make check -j64,
python -u tools/db_crashtest.py blackbox

Reviewers:

Subscribers:

Tasks:

Tags: