### PR TITLE
Update "ReadOptions.value_size_soft_limit" to also include keys size.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 
 ### Public API Change
 * Deprecate `BlockBasedTableOptions::pin_l0_filter_and_index_blocks_in_cache` and `BlockBasedTableOptions::pin_top_level_index_and_filter`. These options still take effect until users migrate to the replacement APIs in `BlockBasedTableOptions::metadata_cache_options`. Migration guidance can be found in the API comments on the deprecated options.
+* Update "ReadOptions.value_size_soft_limit" to include keys size (keys that are found) along with their value size in the cumulative size (which initially included size of values only). The MultiGet is Aborted once the total cumulative size exceeds "value_size_soft_limit".
 
 ## 6.14 (10/09/2020)
 ### Bug fixes

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1907,7 +1907,7 @@ std::vector<Status> DBImpl::MultiGet(
     if (s.ok()) {
       bytes_read += value->size();
       num_found++;
-      curr_value_size += value->size();
+      curr_value_size += (value->size() + keys[keys_read].size());
       if (curr_value_size > read_options.value_size_soft_limit) {
         while (++keys_read < num_keys) {
           stat_list[keys_read] = Status::Aborted();

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -953,7 +953,7 @@ void MemTable::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
 
     if (found_final_value) {
       iter->value->PinSelf();
-      range->AddValueSize(iter->value->size());
+      range->AddValueSize(iter->value->size() + iter->lkey->user_key().size());
       range->MarkKeyDone(iter);
       RecordTick(moptions_.statistics, MEMTABLE_HIT);
       if (range->GetValueSize() > read_options.value_size_soft_limit) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2124,7 +2124,8 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
           }
           PERF_COUNTER_BY_LEVEL_ADD(user_key_return_count, 1,
                                     fp.GetHitFileLevel());
-          file_range.AddValueSize(iter->value->size());
+          file_range.AddValueSize(iter->value->size() +
+                                  iter->lkey->user_key().size());
           file_range.MarkKeyDone(iter);
           if (file_range.GetValueSize() > read_options.value_size_soft_limit) {
             s = Status::Aborted();
@@ -2200,7 +2201,7 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
           nullptr /* result_operand */, true);
       if (LIKELY(iter->value != nullptr)) {
         iter->value->PinSelf();
-        range->AddValueSize(iter->value->size());
+        range->AddValueSize(iter->value->size() + user_key.size());
         range->MarkKeyDone(iter);
         if (range->GetValueSize() > read_options.value_size_soft_limit) {
           s = Status::Aborted();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1421,6 +1421,7 @@ struct ReadOptions {
   // It limits the maximum cumulative value size of the keys in batch while
   // reading through MultiGet. Once the cumulative value size exceeds this
   // soft limit then all the remaining keys are returned with status Aborted.
+  // value_size_soft_limit includes the size of keys (found) and their values.
   //
   // Default: std::numeric_limits<uint64_t>::max()
   uint64_t value_size_soft_limit;


### PR DESCRIPTION
Summary: Update "ReadOptions.value_size_soft_limit" to include keys size
(keys found) along with size of their values.
Initally this option considered only the size of values.

Test Plan: make check -j64,
           Tests related to value_size_soft_limit

Reviewers:

Subscribers:

Tasks: T77798449

Tags: