### PR TITLE
add StartTrace and EndTrace to stackable_db

### DIFF
--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -377,9 +377,8 @@ class StackableDB : public DB {
   Status EndIOTrace() override { return db_->EndIOTrace(); }
 
   using DB::StartTrace;
-  Status StartTrace(
-      const TraceOptions& options,
-      std::unique_ptr<TraceWriter>&& trace_writer) override {
+  Status StartTrace(const TraceOptions& options,
+                    std::unique_ptr<TraceWriter>&& trace_writer) override {
     return db_->StartTrace(options, std::move(trace_writer));
   }
 

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -376,6 +376,16 @@ class StackableDB : public DB {
   using DB::EndIOTrace;
   Status EndIOTrace() override { return db_->EndIOTrace(); }
 
+  using DB::StartTrace;
+  Status StartTrace(
+      const TraceOptions& options,
+      std::unique_ptr<TraceWriter>&& trace_writer) override {
+    return db_->StartTrace(options, std::move(trace_writer));
+  }
+
+  using DB::EndTrace;
+  Status EndTrace() override { return db_->EndTrace(); }
+
 #endif  // ROCKSDB_LITE
 
   virtual Status GetLiveFiles(std::vector<std::string>& vec, uint64_t* mfs,


### PR DESCRIPTION
In addition to trace block cache access, we want to support trace queries on MySQL. To achieve that StartTrace and EndTrace need to be added to the stackable_db.h