### PR TITLE
Remove duplicate close

### DIFF
--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -87,7 +87,6 @@ class ColumnFamilyTestBase : public testing::Test {
 #endif  // ROCKSDB_LITE
       column_families.push_back(cfdescriptor);
     }
-    Close();
     ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
     Destroy(column_families);
     delete env_;


### PR DESCRIPTION
Because `Close()` have called in `Destroy()`