### PR TITLE
Give instructions instead of broken 2to3 for clang-format-diff.py

### DIFF
--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -75,17 +75,15 @@ else
       exit 129
     fi
     # Unfortunately, some machines have a Python2 clang-format-diff.py
-    # installed but only a Python3 interpreter installed. Rather than trying
-    # different Python versions that might be installed, we can try migrating
-    # the code to Python3 if it looks like Python2
+    # installed but only a Python3 interpreter installed. Unfortunately,
+    # automatic 2to3 migration is insufficient, so suggest downloading latest.
     if grep -q "print '" "$CFD_PATH" && \
        ${PYTHON:-python3} --version | grep -q 'ython 3'; then
-      if [ ! -f "$REPO_ROOT/.py3/clang-format-diff.py" ]; then
-        echo "Migrating $CFD_PATH to Python3 in a hidden file"
-        mkdir -p "$REPO_ROOT/.py3"
-        ${PYTHON:-python3} -m lib2to3 -w -n -o "$REPO_ROOT/.py3" "$CFD_PATH" > /dev/null || exit 128
-      fi
-      CFD_PATH="$REPO_ROOT/.py3/clang-format-diff.py"
+      echo "You have clang-format-diff.py for Python 2 but are using a Python 3"
+      echo "interpreter (${PYTHON:-python3})."
+      echo "You can download clang-format-diff.py for Python 3 by running: "
+      echo "    curl --location http://goo.gl/iUW1u2 -o ${REPO_ROOT}/clang-format-diff.py"
+      exit 130
     fi
     CLANG_FORMAT_DIFF="${PYTHON:-python3} $CFD_PATH"
     # This had better work after all those checks


### PR DESCRIPTION
Summary: My previous change to use lib2to3 to migrate clang-format-diff.py
for Python 2 only works if there's nothing to reformat. Instead, give
instructions to download to REPO_ROOT.

Test Plan: Try the instructions on a fresh CentOS 8 devserver