### PR TITLE
[CodeMod] Remove unused includes

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -11,7 +11,6 @@
 
 #include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string>
 
 #include "util/mutexlock.h"

--- a/db/c.cc
+++ b/db/c.cc
@@ -60,7 +60,6 @@ using ROCKSDB_NAMESPACE::ColumnFamilyDescriptor;
 using ROCKSDB_NAMESPACE::ColumnFamilyHandle;
 using ROCKSDB_NAMESPACE::ColumnFamilyOptions;
 using ROCKSDB_NAMESPACE::CompactionFilter;
-using ROCKSDB_NAMESPACE::CompactionFilterContext;
 using ROCKSDB_NAMESPACE::CompactionFilterFactory;
 using ROCKSDB_NAMESPACE::CompactionOptionsFIFO;
 using ROCKSDB_NAMESPACE::CompactRangeOptions;
@@ -82,7 +81,6 @@ using ROCKSDB_NAMESPACE::LiveFileMetaData;
 using ROCKSDB_NAMESPACE::Logger;
 using ROCKSDB_NAMESPACE::MemoryUtil;
 using ROCKSDB_NAMESPACE::MergeOperator;
-using ROCKSDB_NAMESPACE::MergeOperators;
 using ROCKSDB_NAMESPACE::NewBloomFilterPolicy;
 using ROCKSDB_NAMESPACE::NewGenericRateLimiter;
 using ROCKSDB_NAMESPACE::NewLRUCache;
@@ -115,10 +113,8 @@ using ROCKSDB_NAMESPACE::WriteBatch;
 using ROCKSDB_NAMESPACE::WriteBatchWithIndex;
 using ROCKSDB_NAMESPACE::WriteOptions;
 
-using std::shared_ptr;
 using std::vector;
 using std::unordered_set;
-using std::map;
 
 extern "C" {
 

--- a/db/compaction/compaction_job_stats_test.cc
+++ b/db/compaction/compaction_job_stats_test.cc
@@ -24,7 +24,6 @@
 #include "db/write_batch_internal.h"
 #include "env/mock_env.h"
 #include "file/filename.h"
-#include "logging/logging.h"
 #include "memtable/hash_linklist_rep.h"
 #include "monitoring/statistics.h"
 #include "monitoring/thread_status_util.h"

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -12,7 +12,6 @@
 #include "db/compaction/compaction_picker_level.h"
 #include "db/compaction/compaction_picker_universal.h"
 
-#include "logging/logging.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/string_util.h"

--- a/db/comparator_db_test.cc
+++ b/db/comparator_db_test.cc
@@ -17,7 +17,6 @@
 #include "util/string_util.h"
 #include "utilities/merge_operators.h"
 
-using std::unique_ptr;
 
 namespace ROCKSDB_NAMESPACE {
 namespace {

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -9,7 +9,6 @@
 
 #ifndef ROCKSDB_LITE
 
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -8,7 +8,6 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "db/dbformat.h"
-#include "logging/logging.h"
 #include "test_util/testharness.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -16,7 +16,6 @@
 #include "db/version_set.h"
 #include "env/mock_env.h"
 #include "file/filename.h"
-#include "logging/logging.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"

--- a/db/filename_test.cc
+++ b/db/filename_test.cc
@@ -10,7 +10,6 @@
 #include "file/filename.h"
 
 #include "db/dbformat.h"
-#include "logging/logging.h"
 #include "port/port.h"
 #include "test_util/testharness.h"
 

--- a/db/listener_test.cc
+++ b/db/listener_test.cc
@@ -10,7 +10,6 @@
 #include "db/version_set.h"
 #include "db/write_batch_internal.h"
 #include "file/filename.h"
-#include "logging/logging.h"
 #include "memtable/hash_linklist_rep.h"
 #include "monitoring/statistics.h"
 #include "rocksdb/cache.h"

--- a/db/obsolete_files_test.cc
+++ b/db/obsolete_files_test.cc
@@ -28,10 +28,6 @@
 #include "test_util/testutil.h"
 #include "util/string_util.h"
 
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::flush;
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/db/periodic_work_scheduler.cc
+++ b/db/periodic_work_scheduler.cc
@@ -6,7 +6,6 @@
 #include "db/periodic_work_scheduler.h"
 
 #include "db/db_impl/db_impl.h"
-#include "util/cast_util.h"
 
 #ifndef ROCKSDB_LITE
 namespace ROCKSDB_NAMESPACE {

--- a/db/plain_table_db_test.cc
+++ b/db/plain_table_db_test.cc
@@ -16,7 +16,6 @@
 #include "db/version_set.h"
 #include "db/write_batch_internal.h"
 #include "file/filename.h"
-#include "logging/logging.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/db.h"
@@ -39,7 +38,6 @@
 #include "util/string_util.h"
 #include "utilities/merge_operators.h"
 
-using std::unique_ptr;
 
 namespace ROCKSDB_NAMESPACE {
 class PlainTableKeyDecoderTest : public testing::Test {};

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -11,7 +11,6 @@
 
 #include "db/version_edit.h"
 #include "db/version_set.h"
-#include "logging/logging.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/string_util.h"

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -11,7 +11,7 @@
 
 #include "db/db_impl/db_impl.h"
 #include "db/log_writer.h"
-#include "logging/logging.h"
+#include "env/mock_env.h"
 #include "table/block_based/block_based_table_factory.h"
 #include "table/mock_table.h"
 #include "test_util/testharness.h"

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -11,7 +11,6 @@
 
 #include "db/db_impl/db_impl.h"
 #include "db/log_writer.h"
-#include "env/mock_env.h"
 #include "table/block_based/block_based_table_factory.h"
 #include "table/mock_table.h"
 #include "test_util/testharness.h"

--- a/env/env.cc
+++ b/env/env.cc
@@ -15,7 +15,6 @@
 #include "memory/arena.h"
 #include "options/db_options.h"
 #include "port/port.h"
-#include "port/sys_time.h"
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "util/autovector.h"

--- a/env/env.cc
+++ b/env/env.cc
@@ -15,6 +15,7 @@
 #include "memory/arena.h"
 #include "options/db_options.h"
 #include "port/port.h"
+#include "port/sys_time.h"
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "util/autovector.h"

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -16,8 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#if defined(OS_LINUX)
-#endif
 #if defined(ROCKSDB_IOURING_PRESENT)
 #include <liburing.h>
 #endif

--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 
 #if defined(OS_LINUX)
-#include <linux/fs.h>
 #endif
 #if defined(ROCKSDB_IOURING_PRESENT)
 #include <liburing.h>
@@ -27,13 +26,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #if defined(OS_LINUX) || defined(OS_SOLARIS) || defined(OS_ANDROID)
 #include <sys/statfs.h>
-#include <sys/syscall.h>
-#include <sys/sysmacros.h>
 #endif
 #include <sys/statvfs.h>
 #include <sys/time.h>
@@ -58,7 +54,6 @@
 
 #include "env/composite_env_wrapper.h"
 #include "env/io_posix.h"
-#include "logging/logging.h"
 #include "logging/posix_logger.h"
 #include "monitoring/iostats_context_imp.h"
 #include "monitoring/thread_status_updater.h"

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -16,8 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#if defined(OS_LINUX)
-#endif
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 
 #if defined(OS_LINUX)
-#include <linux/fs.h>
 #endif
 #include <pthread.h>
 #include <signal.h>
@@ -29,7 +28,6 @@
 #include <sys/stat.h>
 #if defined(OS_LINUX) || defined(OS_SOLARIS) || defined(OS_ANDROID)
 #include <sys/statfs.h>
-#include <sys/syscall.h>
 #include <sys/sysmacros.h>
 #endif
 #include <sys/statvfs.h>
@@ -52,7 +50,6 @@
 
 #include "env/composite_env_wrapper.h"
 #include "env/io_posix.h"
-#include "logging/logging.h"
 #include "logging/posix_logger.h"
 #include "monitoring/iostats_context_imp.h"
 #include "monitoring/thread_status_updater.h"

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #ifdef OS_LINUX
 #include <sys/statfs.h>
-#include <sys/syscall.h>
 #include <sys/sysmacros.h>
 #endif
 #include "monitoring/iostats_context_imp.h"

--- a/file/filename.cc
+++ b/file/filename.cc
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <vector>
 #include "file/writable_file_writer.h"
-#include "logging/logging.h"
 #include "rocksdb/env.h"
 #include "test_util/sync_point.h"
 #include "util/stop_watch.h"

--- a/logging/auto_roll_logger_test.cc
+++ b/logging/auto_roll_logger_test.cc
@@ -7,7 +7,6 @@
 #ifndef ROCKSDB_LITE
 
 #include "logging/auto_roll_logger.h"
-#include <errno.h>
 #include <sys/stat.h>
 #include <algorithm>
 #include <cmath>

--- a/logging/event_logger.cc
+++ b/logging/event_logger.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <string>
 
-#include "logging/logging.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/monitoring/persistent_stats_history.cc
+++ b/monitoring/persistent_stats_history.cc
@@ -12,7 +12,6 @@
 #include <string>
 #include <utility>
 #include "db/db_impl/db_impl.h"
-#include "port/likely.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstdio>
-#include "port/likely.h"
 #include "rocksdb/statistics.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -13,6 +13,7 @@
 
 #include <assert.h>
 #if defined(__i386__) || defined(__x86_64__)
+#include <cpuid.h>
 #endif
 #include <errno.h>
 #include <sched.h>

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -13,7 +13,6 @@
 
 #include <assert.h>
 #if defined(__i386__) || defined(__x86_64__)
-#include <cpuid.h>
 #endif
 #include <errno.h>
 #include <sched.h>
@@ -21,11 +20,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/resource.h>
-#include <sys/syscall.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <cstdlib>
-#include "logging/logging.h"
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/table/block_based/block.cc
+++ b/table/block_based/block.cc
@@ -15,7 +15,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "logging/logging.h"
 #include "monitoring/perf_context_imp.h"
 #include "port/port.h"
 #include "port/stack_trace.h"

--- a/table/block_based/block_based_table_builder.cc
+++ b/table/block_based/block_based_table_builder.cc
@@ -21,7 +21,6 @@
 
 #include "db/dbformat.h"
 #include "index_builder.h"
-#include "port/lang.h"
 
 #include "rocksdb/cache.h"
 #include "rocksdb/comparator.h"
@@ -56,7 +55,6 @@ namespace ROCKSDB_NAMESPACE {
 extern const std::string kHashIndexPrefixesBlock;
 extern const std::string kHashIndexPrefixesMetadataBlock;
 
-typedef BlockBasedTableOptions::IndexType IndexType;
 
 // Without anonymous namespace here, we fail the warning -Wmissing-prototypes
 namespace {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -62,7 +62,6 @@
 #include "util/crc32c.h"
 #include "util/stop_watch.h"
 #include "util/string_util.h"
-#include "util/xxhash.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -70,7 +69,6 @@ extern const uint64_t kBlockBasedTableMagicNumber;
 extern const std::string kHashIndexPrefixesBlock;
 extern const std::string kHashIndexPrefixesMetadataBlock;
 
-typedef BlockBasedTable::IndexReader IndexReader;
 
 // Found that 256 KB readahead size provides the best performance, based on
 // experiments, for auto readahead. Experiment data is in PR #3282.

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -12,7 +12,6 @@
 #include "table/block_based/filter_policy_internal.h"
 
 #include "index_builder.h"
-#include "logging/logging.h"
 #include "test_util/testharness.h"
 #include "test_util/testutil.h"
 #include "util/coding.h"

--- a/table/cuckoo/cuckoo_table_reader_test.cc
+++ b/table/cuckoo/cuckoo_table_reader_test.cc
@@ -31,7 +31,6 @@ int main() {
 #include "util/string_util.h"
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
-using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(file_dir, "", "Directory where the files will be created"
     " for benchmark. Added for using tmpfs.");

--- a/table/format.cc
+++ b/table/format.cc
@@ -14,7 +14,6 @@
 
 #include "block_fetcher.h"
 #include "file/random_access_file_reader.h"
-#include "logging/logging.h"
 #include "memory/memory_allocator.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/statistics.h"

--- a/test_util/sync_point.cc
+++ b/test_util/sync_point.cc
@@ -6,7 +6,6 @@
 #include "test_util/sync_point.h"
 
 #include <fcntl.h>
-#include <sys/stat.h>
 
 #include "test_util/sync_point_impl.h"
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -10,7 +10,6 @@
 #ifdef GFLAGS
 #ifdef NUMA
 #include <numa.h>
-#include <numaif.h>
 #endif
 #ifndef OS_WIN
 #include <unistd.h>

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -24,7 +24,6 @@
 #include "db/write_batch_internal.h"
 #include "env/composite_env_wrapper.h"
 #include "file/filename.h"
-#include "port/port_dirent.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/file_checksum.h"
 #include "rocksdb/table_properties.h"

--- a/tools/trace_analyzer_tool.cc
+++ b/tools/trace_analyzer_tool.cc
@@ -9,7 +9,6 @@
 #ifdef GFLAGS
 #ifdef NUMA
 #include <numa.h>
-#include <numaif.h>
 #endif
 #ifndef OS_WIN
 #include <unistd.h>
@@ -50,8 +49,6 @@
 #include "util/string_util.h"
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
-using GFLAGS_NAMESPACE::RegisterFlagValidator;
-using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(trace_path, "", "The trace file path.");
 DEFINE_string(output_dir, "", "The directory to store the output files.");

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -19,7 +19,6 @@ int main() {
 #include <cmath>
 #include <vector>
 
-#include "logging/logging.h"
 #include "memory/arena.h"
 #include "port/jemalloc_helper.h"
 #include "rocksdb/filter_policy.h"

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -11,7 +11,6 @@
 #include <stdint.h>
 #include <algorithm>
 #include <memory>
-#include "logging/logging.h"
 #include "port/port.h"
 #include "rocksdb/slice.h"
 

--- a/util/dynamic_bloom_test.cc
+++ b/util/dynamic_bloom_test.cc
@@ -20,7 +20,6 @@ int main() {
 #include <vector>
 
 #include "dynamic_bloom.h"
-#include "logging/logging.h"
 #include "memory/arena.h"
 #include "port/port.h"
 #include "test_util/testharness.h"

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -6,7 +6,6 @@
 #include "util/string_util.h"
 
 #include <errno.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <algorithm>
@@ -17,7 +16,6 @@
 #include <utility>
 #include <vector>
 #include "port/port.h"
-#include "port/sys_time.h"
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/util/string_util.cc
+++ b/util/string_util.cc
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 #include "port/port.h"
+#include "port/sys_time.h"
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/util/xxhash.cc
+++ b/util/xxhash.cc
@@ -1151,7 +1151,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 *  New generation hash designed for speed on small keys and vectorization
 ************************************************************************ */
 
-
+#include "xxh3p.h" /* XXH3 preview for RocksDB */
 
 #endif  /* XXH_NO_LONG_LONG */
 

--- a/util/xxhash.cc
+++ b/util/xxhash.cc
@@ -218,7 +218,6 @@ static xxh_u32 XXH_read32(const void* memPtr)
 
 
 /* ===   Endianess   === */
-typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
 
 /* XXH_CPU_LITTLE_ENDIAN can be defined externally, for example on the compiler command line */
 #ifndef XXH_CPU_LITTLE_ENDIAN
@@ -1152,7 +1151,6 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 *  New generation hash designed for speed on small keys and vectorization
 ************************************************************************ */
 
-#include "xxh3p.h" /* XXH3 preview for RocksDB */
 
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -26,7 +26,6 @@
 #include "rocksdb/utilities/debug.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
-#include "util/cast_util.h"
 #include "util/random.h"
 #include "util/string_util.h"
 #include "utilities/blob_db/blob_db_impl.h"

--- a/utilities/cassandra/cassandra_format_test.cc
+++ b/utilities/cassandra/cassandra_format_test.cc
@@ -10,7 +10,6 @@
 #include "utilities/cassandra/serialize.h"
 #include "utilities/cassandra/test_utils.h"
 
-using namespace ROCKSDB_NAMESPACE::cassandra;
 
 namespace ROCKSDB_NAMESPACE {
 namespace cassandra {

--- a/utilities/cassandra/cassandra_functional_test.cc
+++ b/utilities/cassandra/cassandra_functional_test.cc
@@ -17,7 +17,6 @@
 #include "utilities/cassandra/test_utils.h"
 #include "utilities/merge_operators.h"
 
-using namespace ROCKSDB_NAMESPACE;
 
 namespace ROCKSDB_NAMESPACE {
 namespace cassandra {

--- a/utilities/cassandra/cassandra_serialize_test.cc
+++ b/utilities/cassandra/cassandra_serialize_test.cc
@@ -6,7 +6,6 @@
 #include "test_util/testharness.h"
 #include "utilities/cassandra/serialize.h"
 
-using namespace ROCKSDB_NAMESPACE::cassandra;
 
 namespace ROCKSDB_NAMESPACE {
 namespace cassandra {

--- a/utilities/merge_operators/sortlist.cc
+++ b/utilities/merge_operators/sortlist.cc
@@ -7,9 +7,6 @@
 #include "rocksdb/slice.h"
 #include "utilities/merge_operators.h"
 
-using ROCKSDB_NAMESPACE::Logger;
-using ROCKSDB_NAMESPACE::MergeOperator;
-using ROCKSDB_NAMESPACE::Slice;
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/utilities/merge_operators/string_append/stringappend_test.cc
+++ b/utilities/merge_operators/string_append/stringappend_test.cc
@@ -27,7 +27,6 @@
 #include "utilities/merge_operators.h"
 #include "utilities/merge_operators/string_append/stringappend2.h"
 
-using namespace ROCKSDB_NAMESPACE;
 
 namespace ROCKSDB_NAMESPACE {
 

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -10,7 +10,6 @@
 #include <thread>
 
 #include "db/db_impl/db_impl.h"
-#include "logging/logging.h"
 #include "port/port.h"
 #include "rocksdb/db.h"
 #include "rocksdb/perf_context.h"


### PR DESCRIPTION
This is a PR generated **semi-automatically** by an internal tool to remove unused includes and `using` statements.

Test plan:
make check