### PR TITLE
Update clang-format-diff.py

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Download clang-format-diff.py
       uses: wei/wget@v1
       with:
-        args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
+        args: https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -52,15 +52,15 @@ else
     else
       echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
       echo "You can download clang-format-diff.py by running: "
-      echo "    curl --location http://goo.gl/iUW1u2 -o ${CLANG_FORMAT_DIFF}"
+      echo "    curl --location https://tinyurl.com/y2kvokof -o ${REPO_ROOT}/clang-format-diff.py"
       echo "You can download clang-format by running:"
       echo "    brew install clang-format"
       echo "  Or"
       echo "    apt install clang-format"
       echo "  This might work too:"
       echo "    yum install git-clang-format"
-      echo "Then, move both files (i.e. ${CLANG_FORMAT_DIFF} and clang-format) to some directory within PATH=${PATH}"
-      echo "and make sure ${CLANG_FORMAT_DIFF} is executable."
+      echo "Then make sure clang-format is available and executable from \$PATH:"
+      echo "    clang-format --version"
       exit 128
     fi
     # Check argparse pre-req on interpreter, or it will fail
@@ -82,7 +82,7 @@ else
       echo "You have clang-format-diff.py for Python 2 but are using a Python 3"
       echo "interpreter (${PYTHON:-python3})."
       echo "You can download clang-format-diff.py for Python 3 by running: "
-      echo "    curl --location http://goo.gl/iUW1u2 -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location https://tinyurl.com/y2kvokof -o ${REPO_ROOT}/clang-format-diff.py"
       exit 130
     fi
     CLANG_FORMAT_DIFF="${PYTHON:-python3} $CFD_PATH"


### PR DESCRIPTION
`llvm-mirror/clang` is archived. Get the `clang-format-diff.py` file from the active source.