### PR TITLE
Avoid skipping a test in db_wal_test

### DIFF
--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1699,7 +1699,7 @@ TEST_F(DBWALTest, TruncateLastLogAfterRecoverWithoutFlush) {
   options.env = env_;
   options.avoid_flush_during_recovery = true;
   if (mem_env_) {
-    ROCKSDB_GTEST_SKIP("Test requires default environment");
+    ROCKSDB_GTEST_SKIP("Test requires non-mem environment");
     return;
   }
   // Test fallocate support of running file system.

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1697,10 +1697,7 @@ TEST_F(DBWALTest, TruncateLastLogAfterRecoverWithoutFlush) {
   constexpr size_t kKB = 1024;
   Options options = CurrentOptions();
   options.avoid_flush_during_recovery = true;
-  if (options.env != Env::Default()) {
-    ROCKSDB_GTEST_SKIP("Test requires default environment");
-    return;
-  }
+  options.env = env_;
   // Test fallocate support of running file system.
   // Skip this test if fallocate is not supported.
   std::string fname_test_fallocate = dbname_ + "/preallocate_testfile";

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1696,8 +1696,12 @@ TEST_F(DBWALTest, RestoreTotalLogSizeAfterRecoverWithoutFlush) {
 TEST_F(DBWALTest, TruncateLastLogAfterRecoverWithoutFlush) {
   constexpr size_t kKB = 1024;
   Options options = CurrentOptions();
-  options.avoid_flush_during_recovery = true;
   options.env = env_;
+  options.avoid_flush_during_recovery = true;
+  if (mem_env_) {
+    ROCKSDB_GTEST_SKIP("Test requires default environment");
+    return;
+  }
   // Test fallocate support of running file system.
   // Skip this test if fallocate is not supported.
   std::string fname_test_fallocate = dbname_ + "/preallocate_testfile";


### PR DESCRIPTION
Recent test report shows that some tests have been skipped.

For DBWALTest that inherits from DBTestBase, the following will always be
true, since `env_` is an instance of `SpecialEnv`, not `Env::Default()`. Thus the test
will always be skipped.

```
if (options.env != Env::Default()) {
  ROCKSDB_GTEST_SKIP("Test requires default environment");
  return;
}
```

Test plan:
./db_wal_test --gtest_filter=DBWALTest.TruncateLastLogAfterRecoverWithoutFlush
MEM_ENV=1 ./db_wal_test --gtest_filter=DBWALTest.TruncateLastLogAfterRecoverWithoutFlush
make check