### PR TITLE
Avoid skipping a test in db_test2

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -3990,7 +3990,7 @@ TEST_F(DBTest2, TraceWithFilter) {
 TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   Options options = CurrentOptions();
   options.env = env_;
-  if (options.env != Env::Default()) {
+  if (!IsMemoryMappedAccessSupported()) {
     ROCKSDB_GTEST_SKIP("Test requires default environment");
     return;
   }


### PR DESCRIPTION
Summary:
Test report shows that this test has been skipped recently due to
a condition that will never meet. `env_` is not equal to
`Env::Default()` for DBTest2 that inherits from DBTestBase.

Test Plan:
make check
./db_test2 --gtest_filter=DBTest2.PinnableSliceAndMmapReads