### PR TITLE
Add "max_write_buffer_size_to_maintain" to crash test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -137,6 +137,8 @@ default_params = {
     "sync_fault_injection": False,
     "get_property_one_in": 1000000,
     "paranoid_file_checks": lambda: random.choice([0, 1, 1, 1]),
+    "max_write_buffer_size_to_maintain": lambda: random.choice(
+        [0, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 8 * 1024 * 1024]),
 }
 
 _TEST_DIR_ENV_VAR = 'TEST_TMPDIR'


### PR DESCRIPTION
Summary: Add "max_write_buffer_size_to_maintain" to crash test

Test Plan: make crash_test -j64

Reviewers:

Subscribers:

Tasks: T74089368

Tags: