### PR TITLE
fix read_amp_bytes_per_bit field size

### DIFF
--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -359,7 +359,7 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"read_amp_bytes_per_bit",
          {offsetof(struct BlockBasedTableOptions, read_amp_bytes_per_bit),
-          OptionType::kSizeT, OptionVerificationType::kNormal,
+          OptionType::kUInt32T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"enable_index_compression",
          {offsetof(struct BlockBasedTableOptions, enable_index_compression),


### PR DESCRIPTION
The field in BlockBasedTableOptions is 4 bytes:
  // Default: 0 (disabled)
  uint32_t read_amp_bytes_per_bit = 0;