### PR TITLE
Add full_history_ts_low_ to CompactionJob

### DIFF
--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -78,7 +78,8 @@ class CompactionJob {
       const std::string& dbname, CompactionJobStats* compaction_job_stats,
       Env::Priority thread_pri, const std::shared_ptr<IOTracer>& io_tracer,
       const std::atomic<int>* manual_compaction_paused = nullptr,
-      const std::string& db_id = "", const std::string& db_session_id = "");
+      const std::string& db_id = "", const std::string& db_session_id = "",
+      std::string full_history_ts_low = "");
 
   ~CompactionJob();
 
@@ -201,6 +202,7 @@ class CompactionJob {
   Env::WriteLifeTimeHint write_hint_;
   Env::Priority thread_pri_;
   IOStatus io_status_;
+  std::string full_history_ts_low_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1124,7 +1124,7 @@ TEST_F(CompactionJobTimestampTest, GCDisabled) {
        {KeyStr("b", 7, ValueType::kTypeDeletionWithTimestamp, 97), ""},
        {KeyStr("c", 6, ValueType::kTypeDeletionWithTimestamp, 96), ""},
        {KeyStr("c", 5, ValueType::kTypeValue, 95), "c5"}});
-  auto files = cfd_->current()->storage_info()->LevelFiles(0);
+  const auto& files = cfd_->current()->storage_info()->LevelFiles(0);
   RunCompaction({files}, expected_results);
 }
 
@@ -1150,7 +1150,7 @@ TEST_F(CompactionJobTimestampTest, NoKeyExpired) {
                           {KeyStr("b", 7, ValueType::kTypeValue, 101), "b7"},
                           {KeyStr("c", 5, ValueType::kTypeValue, 99), "c5"},
                           {KeyStr("c", 3, ValueType::kTypeValue, 97), "c3"}});
-  auto files = cfd_->current()->storage_info()->LevelFiles(0);
+  const auto& files = cfd_->current()->storage_info()->LevelFiles(0);
 
   full_history_ts_low_ = encode_u64_ts_(0);
   RunCompaction({files}, expected_results);
@@ -1174,7 +1174,7 @@ TEST_F(CompactionJobTimestampTest, AllKeysExpired) {
 
   auto expected_results =
       mock::MakeMockFile({{KeyStr("b", 0, ValueType::kTypeValue, 0), "b6"}});
-  auto files = cfd_->current()->storage_info()->LevelFiles(0);
+  const auto& files = cfd_->current()->storage_info()->LevelFiles(0);
 
   full_history_ts_low_ = encode_u64_ts_(std::numeric_limits<uint64_t>::max());
   RunCompaction({files}, expected_results);
@@ -1199,7 +1199,7 @@ TEST_F(CompactionJobTimestampTest, SomeKeysExpired) {
   auto expected_results =
       mock::MakeMockFile({{KeyStr("a", 5, ValueType::kTypeValue, 50), "a5"},
                           {KeyStr("b", 6, ValueType::kTypeValue, 49), "b6"}});
-  auto files = cfd_->current()->storage_info()->LevelFiles(0);
+  const auto& files = cfd_->current()->storage_info()->LevelFiles(0);
 
   full_history_ts_low_ = encode_u64_ts_(49);
   RunCompaction({files}, expected_results);

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -18,8 +18,8 @@ namespace mock {
 
 KVVector MakeMockFile(std::initializer_list<KVPair> l) { return KVVector(l); }
 
-void SortKVVector(KVVector* kv_vector) {
-  InternalKeyComparator icmp(BytewiseComparator());
+void SortKVVector(KVVector* kv_vector, const Comparator* ucmp) {
+  InternalKeyComparator icmp(ucmp);
   std::sort(kv_vector->begin(), kv_vector->end(),
             [icmp](KVPair a, KVPair b) -> bool {
               return icmp.Compare(a.first, b.first) < 0;

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -31,7 +31,8 @@ using KVPair = std::pair<std::string, std::string>;
 using KVVector = std::vector<KVPair>;
 
 KVVector MakeMockFile(std::initializer_list<KVPair> l = {});
-void SortKVVector(KVVector* kv_vector);
+void SortKVVector(KVVector* kv_vector,
+                  const Comparator* ucmp = BytewiseComparator());
 
 struct MockTableFileSystem {
   port::Mutex mutex;


### PR DESCRIPTION
#7556 enables `CompactionIterator` to perform garbage collection during compaction according
to a lower bound (user-defined) timestamp `full_history_ts_low_`.

This PR adds a data member `full_history_ts_low_` of type `std::string` to `CompactionJob`, and
`full_history_ts_low_` does not change during compaction. `CompactionJob` will pass a pointer to this
data member to the `CompactionIterator` used during compaction.

Also refactored compaction_job_test.cc to re-use some existing code, which is actually the majority of this PR.

Test plan:
make check