### PR TITLE
Update  option "allow_data_in_errors" in BuildOptions

### DIFF
--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -167,6 +167,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.bgerror_resume_retry_interval =
       immutable_db_options.bgerror_resume_retry_interval;
   options.db_host_id = immutable_db_options.db_host_id;
+  options.allow_data_in_errors = immutable_db_options.allow_data_in_errors;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -334,7 +334,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "best_efforts_recovery=false;"
                              "max_bgerror_resume_count=2;"
                              "bgerror_resume_retry_interval=1000000"
-                             "db_host_id=hostname",
+                             "db_host_id=hostname;"
+                             "allow_data_in_errors=false",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),


### PR DESCRIPTION
Summary: "allow_data_in_errors" is not updated in BuildOptions. So it
would assume default value when BuildOptions is called.

Test Plan: make check -j64

Reviewers:

Subscribers:

Tasks:

Tags: