### PR TITLE
Fix InternalStats::DumpCFStats

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -1406,7 +1406,7 @@ void InternalStats::DumpCFFileHistogram(std::string* value) {
         << blob_file_read_latency_.ToString() << '\n';
   }
 
-  *value = oss.str();
+  value->append(oss.str());
 }
 
 #else


### PR DESCRIPTION
Summary:
https://github.com/facebook/rocksdb/pull/7461 accidentally broke
`InternalStats::DumpCFStats` by making `DumpCFFileHistogram` overwrite
the output of `DumpCFStatsNoFileHistogram` instead of appending to it,
resulting in only the file histogram related information getting logged.
The patch fixes this by reverting to appending in `DumpCFFileHistogram`.

Fixes https://github.com/facebook/rocksdb/issues/7664 .

Test Plan:
Ran `make check` and checked the info log of `db_bench`.