### PR TITLE
Do not track WAL in MANIFEST when fsync is disabled in a test

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -340,7 +340,9 @@ Options DBTestBase::GetDefaultOptions() const {
   options.wal_recovery_mode = WALRecoveryMode::kTolerateCorruptedTailRecords;
   options.compaction_pri = CompactionPri::kByCompensatedSize;
   options.env = env_;
-  options.track_and_verify_wals_in_manifest = true;
+  if (!env_->skip_fsync_) {
+    options.track_and_verify_wals_in_manifest = true;
+  }
   return options;
 }
 


### PR DESCRIPTION
If fsync is disabled in a unit test, then do not track WAL in MANIFEST, because on DB recovery, the WAL might be missing because the directory is not fsynced. For example, `db_test` disables fsync, in CircleCI tests, I do occasionally see tests fail with the "Corruption: Missing WAL" error reported during verifying the tracked WALs, though I never reproduced this kind of test failure on devserver.

I'll add another set of tests for WAL tracking with fsync enabled.

Test Plan:
Tests with fsync enabled should pass.