### PR TITLE
Add GetStringFromBlockBasedTableOptions APIs in convenience.h

### DIFF
--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -433,11 +433,20 @@ Status GetStringFromColumnFamilyOptions(std::string* opts_str,
 Status GetStringFromCompressionType(std::string* compression_str,
                                     CompressionType compression_type);
 
+Status GetStringFromBlockBasedTableOptions(
+    const ConfigOptions& config_options,
+    const BlockBasedTableOptions& bbt_options, std::string* opts_str);
+
+Status GetStringFromBlockBasedTableOptions(
+    std::string* opt_string, const BlockBasedTableOptions& bbtf_options,
+    const std::string& delimiter);
+
 std::vector<CompressionType> GetSupportedCompressions();
 
 Status GetBlockBasedTableOptionsFromString(
     const BlockBasedTableOptions& table_options, const std::string& opts_str,
     BlockBasedTableOptions* new_table_options);
+
 Status GetBlockBasedTableOptionsFromString(
     const ConfigOptions& config_options,
     const BlockBasedTableOptions& table_options, const std::string& opts_str,

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -454,7 +454,8 @@ void BlockBasedTableFactory::InitializeOptions() {
   }
   if (table_options_.index_type == BlockBasedTableOptions::kHashSearch &&
       table_options_.index_block_restart_interval != 1) {
-    // Currently kHashSearch is incompatible with index_block_restart_interval > 1
+    // Currently kHashSearch is incompatible with index_block_restart_interval >
+    // 1
     table_options_.index_block_restart_interval = 1;
   }
   if (table_options_.partition_filters &&
@@ -815,6 +816,22 @@ Status GetBlockBasedTableOptionsFromMap(
     *new_table_options = table_options;
   }
   return s;
+}
+
+Status GetStringFromBlockBasedTableOptions(
+    std::string* opt_string, const BlockBasedTableOptions& bbtf_options,
+    const std::string& delimiter) {
+  ConfigOptions config_options;
+  config_options.delimiter = delimiter;
+  return GetStringFromBlockBasedTableOptions(config_options, bbtf_options,
+                                             opt_string);
+}
+
+Status GetStringFromBlockBasedTableOptions(
+    const ConfigOptions& config_options,
+    const BlockBasedTableOptions& bbtf_options, std::string* opt_string) {
+  BlockBasedTableFactory bbtf(bbtf_options);
+  return bbtf.GetOptionString(config_options, opt_string);
 }
 #endif  // !ROCKSDB_LITE
 

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -703,6 +703,8 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd);
 // cf_opt->compaction_filter.
 void RandomInitCFOptions(ColumnFamilyOptions* cf_opt, DBOptions&, Random* rnd);
 
+BlockBasedTableOptions RandomBlockBasedTableOptions(Random* rnd);
+
 // A dummy merge operator which can change its name
 class ChanglingMergeOperator : public MergeOperator {
  public:


### PR DESCRIPTION
Summary: Add GetStringFromBlockBasedTableOptions APIs to get string of
BlockBasedTableOptions. The behavior of these APIs is similar to
GetStringFromDBOptions and GetStringFromColumnFamilyOptions.

Test Plan: Add new unit test cases.

Reviewers:

Subscribers:

Tasks:

Tags: