### PR TITLE
folly: Use SYS_futex for syscall

### DIFF
--- a/third-party/folly/folly/detail/Futex.cpp
+++ b/third-party/folly/folly/detail/Futex.cpp
@@ -48,9 +48,15 @@ namespace {
 #define FUTEX_CLOCK_REALTIME 256
 #endif
 
+/// Newer 32bit CPUs eg. RISCV-32 are defaulting to 64bit time_t from get go and
+/// therefore do not define __NR_futex
+#if !defined(SYS_futex) && defined(SYS_futex_time64)
+# define SYS_futex SYS_futex_time64
+#endif
+
 int nativeFutexWake(const void* addr, int count, uint32_t wakeMask) {
   long rv = syscall(
-      __NR_futex,
+      SYS_futex,
       addr, /* addr1 */
       FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG, /* op */
       count, /* val */
@@ -112,7 +118,7 @@ FutexResult nativeFutexWaitImpl(
   // Unlike FUTEX_WAIT, FUTEX_WAIT_BITSET requires an absolute timeout
   // value - http://locklessinc.com/articles/futex_cheat_sheet/
   long rv = syscall(
-      __NR_futex,
+      SYS_futex,
       addr, /* addr1 */
       op, /* op */
       expected, /* val */


### PR DESCRIPTION
glibc defines SYS_futex and on newer 32bit CPUs like RISCV-32, arc there
is no 32bit time_t therefore define SYS_futex in terms of SYS_futex_time64

Signed-off-by: Khem Raj <raj.khem@gmail.com>