### PR TITLE
add find_prev_user_entry_time to PerfContext

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -3498,6 +3498,8 @@ uint64_t rocksdb_perfcontext_metric(rocksdb_perfcontext_t* context,
       return rep->seek_internal_seek_time;
     case rocksdb_find_next_user_entry_time:
       return rep->find_next_user_entry_time;
+    case rocksdb_find_prev_user_entry_time:
+      return rep->find_prev_user_entry_time;
     case rocksdb_write_wal_time:
       return rep->write_wal_time;
     case rocksdb_write_memtable_time:

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -697,6 +697,7 @@ bool DBIter::ReverseToBackward() {
 }
 
 void DBIter::PrevInternal(const Slice* prefix) {
+  PERF_TIMER_GUARD(find_prev_user_entry_time);
   while (iter_.Valid()) {
     saved_key_.SetUserKey(
         ExtractUserKey(iter_.key()),

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1419,6 +1419,7 @@ enum {
   rocksdb_seek_max_heap_time,
   rocksdb_seek_internal_seek_time,
   rocksdb_find_next_user_entry_time,
+  rocksdb_find_prev_user_entry_time,
   rocksdb_write_wal_time,
   rocksdb_write_memtable_time,
   rocksdb_write_delay_time,

--- a/include/rocksdb/perf_context.h
+++ b/include/rocksdb/perf_context.h
@@ -140,6 +140,8 @@ struct PerfContext {
   uint64_t seek_internal_seek_time;
   // total nanos spent on iterating internal entries to find the next user entry
   uint64_t find_next_user_entry_time;
+  // total nanos spent on iterating internal entries to find the prev user entry
+  uint64_t find_prev_user_entry_time;
 
   // This group of stats provide a breakdown of time spent by Write().
   // May be inaccurate when 2PC, two_write_queues or enable_pipelined_write

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -172,6 +172,7 @@ PerfContext::PerfContext(PerfContext&& other) noexcept {
   seek_min_heap_time = other.seek_min_heap_time;
   seek_internal_seek_time = other.seek_internal_seek_time;
   find_next_user_entry_time = other.find_next_user_entry_time;
+  find_prev_user_entry_time = other.find_prev_user_entry_time;
   write_pre_and_post_process_time = other.write_pre_and_post_process_time;
   write_memtable_time = other.write_memtable_time;
   write_delay_time = other.write_delay_time;
@@ -271,6 +272,7 @@ PerfContext& PerfContext::operator=(const PerfContext& other) {
   seek_min_heap_time = other.seek_min_heap_time;
   seek_internal_seek_time = other.seek_internal_seek_time;
   find_next_user_entry_time = other.find_next_user_entry_time;
+  find_prev_user_entry_time = other.find_prev_user_entry_time;
   write_pre_and_post_process_time = other.write_pre_and_post_process_time;
   write_memtable_time = other.write_memtable_time;
   write_delay_time = other.write_delay_time;
@@ -368,6 +370,7 @@ void PerfContext::Reset() {
   seek_min_heap_time = 0;
   seek_internal_seek_time = 0;
   find_next_user_entry_time = 0;
+  find_prev_user_entry_time = 0;
   write_pre_and_post_process_time = 0;
   write_memtable_time = 0;
   write_delay_time = 0;
@@ -487,6 +490,7 @@ std::string PerfContext::ToString(bool exclude_zero_counters) const {
   PERF_CONTEXT_OUTPUT(seek_min_heap_time);
   PERF_CONTEXT_OUTPUT(seek_internal_seek_time);
   PERF_CONTEXT_OUTPUT(find_next_user_entry_time);
+  PERF_CONTEXT_OUTPUT(find_prev_user_entry_time);
   PERF_CONTEXT_OUTPUT(write_pre_and_post_process_time);
   PERF_CONTEXT_OUTPUT(write_memtable_time);
   PERF_CONTEXT_OUTPUT(write_thread_wait_nanos);


### PR DESCRIPTION
add find_prev_user_entry_time to perf context, to track time cost in PrevInternal