### PR TITLE
Make CompactRange and GetApproximateSizes work with timestamp

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@
 * Fixed the logic of populating native data structure for `read_amp_bytes_per_bit` during OPTIONS file parsing on big-endian architecture. Without this fix, original code introduced in PR7659, when running on big-endian machine, can mistakenly store read_amp_bytes_per_bit (an uint32) in little endian format. Future access to `read_amp_bytes_per_bit` will give wrong values. Little endian architecture is not affected.
 * Fixed prefix extractor with timestamp issues.
 
+### New Features
+* User defined timestamp feature supports `CompactRange` and `GetApproximateSizes`.
+
 ## 6.15.0 (11/13/2020)
 ### Bug Fixes
 * Fixed a bug in the following combination of features: indexes with user keys (`format_version >= 3`), indexes are partitioned (`index_type == kTwoLevelIndexSearch`), and some index partitions are pinned in memory (`BlockBasedTableOptions::pin_l0_filter_and_index_blocks_in_cache`). The bug could cause keys to be truncated when read from the index leading to wrong read results or other unexpected behavior.

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3418,10 +3418,11 @@ Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
     // Add timestamp if needed
     std::string start_with_ts, limit_with_ts;
     if (ts_sz > 0) {
-      // Append a minimal timestamp as the range limit is exclusive:
+      // Maximum timestamp means including all key with any timestamp
+      AppendKeyWithMaxTimestamp(&start_with_ts, start, ts_sz);
+      // Append a maximum timestamp as the range limit is exclusive:
       // [start, limit)
-      AppendKeyWithMinTimestamp(&start_with_ts, start, ts_sz);
-      AppendKeyWithMinTimestamp(&limit_with_ts, limit, ts_sz);
+      AppendKeyWithMaxTimestamp(&limit_with_ts, limit, ts_sz);
       start = start_with_ts;
       limit = limit_with_ts;
     }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3397,20 +3397,26 @@ void DBImpl::GetApproximateMemTableStats(ColumnFamilyHandle* column_family,
 Status DBImpl::GetApproximateSizes(const SizeApproximationOptions& options,
                                    ColumnFamilyHandle* column_family,
                                    const Range* range, int n, uint64_t* sizes) {
-  auto ts_sz = column_family->GetComparator()->timestamp_size();
+  const Comparator* const ucmp = column_family->GetComparator();
+  assert(ucmp);
+  size_t ts_sz = ucmp->timestamp_size();
   if (ts_sz == 0) {
     return GetApproximateSizesInternal(options, column_family, range, n, sizes);
-  } else {
-    std::string start_str;
-    std::string limit_str;
-    AppendKeyWithMinTimestamp(&start_str, range->start, ts_sz);
+  }
+
+  std::string start_str[n];
+  std::string limit_str[n];
+  Range range_with_ts[n];
+  for (int i = 0; i < n; i++) {
+    AppendKeyWithMinTimestamp(&start_str[i], range[i].start, ts_sz);
     // Append a minimal timestamp as the range limit is exclusive:
     // [start, limit)
-    AppendKeyWithMinTimestamp(&limit_str, range->limit, ts_sz);
-    Range range_with_ts(start_str, limit_str);
-    return GetApproximateSizesInternal(options, column_family, &range_with_ts,
-                                       n, sizes);
+    AppendKeyWithMinTimestamp(&limit_str[i], range[i].limit, ts_sz);
+    range_with_ts[i].start = start_str[i];
+    range_with_ts[i].limit = limit_str[i];
   }
+  return GetApproximateSizesInternal(options, column_family, range_with_ts, n,
+                                     sizes);
 }
 
 Status DBImpl::GetApproximateSizesInternal(

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1110,6 +1110,10 @@ class DBImpl : public DB {
   // If need_enter_write_thread = false, the method will enter write thread.
   Status WriteOptionsFile(bool need_mutex_lock, bool need_enter_write_thread);
 
+  Status CompactRangeInternal(const CompactRangeOptions& options,
+                              ColumnFamilyHandle* column_family,
+                              const Slice* begin, const Slice* end);
+
   // The following two functions can only be called when:
   // 1. WriteThread::Writer::EnterUnbatched() is used.
   // 2. db_mutex is NOT held

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1114,6 +1114,11 @@ class DBImpl : public DB {
                               ColumnFamilyHandle* column_family,
                               const Slice* begin, const Slice* end);
 
+  Status GetApproximateSizesInternal(const SizeApproximationOptions& options,
+                                     ColumnFamilyHandle* column_family,
+                                     const Range* range, int n,
+                                     uint64_t* sizes);
+
   // The following two functions can only be called when:
   // 1. WriteThread::Writer::EnterUnbatched() is used.
   // 2. db_mutex is NOT held

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -783,29 +783,29 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
                             ColumnFamilyHandle* column_family,
                             const Slice* begin_without_ts,
                             const Slice* end_without_ts) {
-  auto ts_sz = column_family->GetComparator()->timestamp_size();
+  size_t ts_sz = column_family->GetComparator()->timestamp_size();
   if (ts_sz == 0) {
     return CompactRangeInternal(options, column_family, begin_without_ts,
                                 end_without_ts);
-  } else {
-    std::string begin_str;
-    std::string end_str;
-
-    if (begin_without_ts != nullptr) {
-      AppendKeyWithMinTimestamp(&begin_str, *begin_without_ts, ts_sz);
-    }
-    if (end_without_ts != nullptr) {
-      AppendKeyWithMaxTimestamp(&end_str, *end_without_ts, ts_sz);
-    }
-    Slice begin(begin_str);
-    Slice end(end_str);
-
-    Slice* begin_with_ts = begin_without_ts ? &begin : nullptr;
-    Slice* end_with_ts = end_without_ts ? &end : nullptr;
-
-    return CompactRangeInternal(options, column_family, begin_with_ts,
-                                end_with_ts);
   }
+
+  std::string begin_str;
+  std::string end_str;
+
+  if (begin_without_ts != nullptr) {
+    AppendKeyWithMinTimestamp(&begin_str, *begin_without_ts, ts_sz);
+  }
+  if (end_without_ts != nullptr) {
+    AppendKeyWithMaxTimestamp(&end_str, *end_without_ts, ts_sz);
+  }
+  Slice begin(begin_str);
+  Slice end(end_str);
+
+  Slice* begin_with_ts = begin_without_ts ? &begin : nullptr;
+  Slice* end_with_ts = end_without_ts ? &end : nullptr;
+
+  return CompactRangeInternal(options, column_family, begin_with_ts,
+                              end_with_ts);
 }
 
 Status DBImpl::CompactRangeInternal(const CompactRangeOptions& options,

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -783,7 +783,9 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
                             ColumnFamilyHandle* column_family,
                             const Slice* begin_without_ts,
                             const Slice* end_without_ts) {
-  size_t ts_sz = column_family->GetComparator()->timestamp_size();
+  const Comparator* const ucmp = column_family->GetComparator();
+  assert(ucmp);
+  size_t ts_sz = ucmp->timestamp_size();
   if (ts_sz == 0) {
     return CompactRangeInternal(options, column_family, begin_without_ts,
                                 end_without_ts);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -794,11 +794,14 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
   std::string begin_str;
   std::string end_str;
 
+  // CompactRange compact all keys: [begin, end] inclusively. Add maximum
+  // timestamp to include all `begin` keys, and add minimal timestamp to include
+  // all `end` keys.
   if (begin_without_ts != nullptr) {
-    AppendKeyWithMinTimestamp(&begin_str, *begin_without_ts, ts_sz);
+    AppendKeyWithMaxTimestamp(&begin_str, *begin_without_ts, ts_sz);
   }
   if (end_without_ts != nullptr) {
-    AppendKeyWithMaxTimestamp(&end_str, *end_without_ts, ts_sz);
+    AppendKeyWithMinTimestamp(&end_str, *end_without_ts, ts_sz);
   }
   Slice begin(begin_str);
   Slice end(end_str);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -280,6 +280,25 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_EQ(size, 0);
 
+  // Test range boundaries
+  ASSERT_OK(db_->Put(write_opts, Key(1000), rnd.RandomString(1024)));
+  // Should include start key
+  start = Key(1000);
+  end = Key(1100);
+  r = Range(start, end);
+  ASSERT_OK(
+      db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
+  ASSERT_GT(size, 0);
+
+  // Should exclude end key
+  start = Key(900);
+  end = Key(1000);
+  r = Range(start, end);
+  ASSERT_OK(
+      db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
+  ASSERT_EQ(size, 0);
+  std::cout << size << std::endl;
+
   Close();
 }
 

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -266,7 +266,7 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   uint64_t ranges_size;
   ASSERT_OK(db_->GetApproximateSizes(size_approx_options, default_cf, ranges, 2,
                                      &ranges_size));
-  ASSERT_LE(ranges_size, size);
+  ASSERT_GE(ranges_size, size);
 
   // Zero if not including mem table
   db_->GetApproximateSizes(&r, 1, &size);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -258,14 +258,14 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   ASSERT_LT(size, 204800);
 
   // test multiple ranges
-  Range ranges[2];
-  ranges[0].start = Key(10);
-  ranges[0].limit = Key(20);
-  ranges[1].start = Key(50);
-  ranges[1].limit = Key(60);
+  std::vector<Range> ranges;
+  std::string start_tmp = Key(10);
+  std::string end_tmp = Key(20);
+  ranges.emplace_back(Range(start_tmp, end_tmp));
+  ranges.emplace_back(Range(start, end));
   uint64_t range_sizes[2];
-  ASSERT_OK(db_->GetApproximateSizes(size_approx_options, default_cf, ranges, 2,
-                                     range_sizes));
+  ASSERT_OK(db_->GetApproximateSizes(size_approx_options, default_cf,
+                                     ranges.data(), 2, range_sizes));
 
   ASSERT_EQ(range_sizes[1], size);
 

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -256,6 +256,18 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
       db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_GT(size, 6000);
   ASSERT_LT(size, 204800);
+
+  // test multiple ranges
+  Range ranges[2];
+  ranges[0].start = Key(10);
+  ranges[0].limit = Key(20);
+  ranges[1].start = Key(50);
+  ranges[1].limit = Key(60);
+  uint64_t ranges_size;
+  ASSERT_OK(db_->GetApproximateSizes(size_approx_options, default_cf, ranges, 2,
+                                     &ranges_size));
+  ASSERT_LE(ranges_size, size);
+
   // Zero if not including mem table
   db_->GetApproximateSizes(&r, 1, &size);
   ASSERT_EQ(size, 0);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -210,10 +210,10 @@ TEST_F(DBBasicTestWithTimestamp, CompactRangeWithSpecifiedRange) {
   write_opts.timestamp = &ts;
 
   ASSERT_OK(db_->Put(write_opts, "foo1", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ASSERT_OK(db_->Put(write_opts, "foo2", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   std::string start_str = "foo";
   std::string end_str = "foo2";
@@ -371,16 +371,16 @@ TEST_F(DBBasicTestWithTimestamp, SeekWithPrefixLessThanKey) {
   write_opts.timestamp = &ts;
 
   ASSERT_OK(db_->Put(write_opts, "foo1", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ASSERT_OK(db_->Put(write_opts, "foo2", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   // Move sst file to next level
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
   ASSERT_OK(db_->Put(write_opts, "foo3", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ReadOptions read_opts;
   std::string read_ts = Timestamp(1, 0);
@@ -426,16 +426,16 @@ TEST_F(DBBasicTestWithTimestamp, SeekWithPrefixLargerThanKey) {
   write_opts.timestamp = &ts;
 
   ASSERT_OK(db_->Put(write_opts, "foo1", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ASSERT_OK(db_->Put(write_opts, "foo2", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   // Move sst file to next level
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
 
   ASSERT_OK(db_->Put(write_opts, "foo3", "bar"));
-  Flush();
+  ASSERT_OK(Flush());
 
   ReadOptions read_opts;
   std::string read_ts = Timestamp(2, 0);

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -252,7 +252,8 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   SizeApproximationOptions size_approx_options;
   size_approx_options.include_memtabtles = true;
   size_approx_options.include_files = true;
-  db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size);
+  ASSERT_OK(
+      db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_GT(size, 6000);
   ASSERT_LT(size, 204800);
   // Zero if not including mem table
@@ -262,7 +263,8 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   start = Key(500);
   end = Key(600);
   r = Range(start, end);
-  db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size);
+  ASSERT_OK(
+      db_->GetApproximateSizes(size_approx_options, default_cf, &r, 1, &size));
   ASSERT_EQ(size, 0);
 
   Close();

--- a/db/db_with_timestamp_basic_test.cc
+++ b/db/db_with_timestamp_basic_test.cc
@@ -263,10 +263,11 @@ TEST_F(DBBasicTestWithTimestamp, GetApproximateSizes) {
   ranges[0].limit = Key(20);
   ranges[1].start = Key(50);
   ranges[1].limit = Key(60);
-  uint64_t ranges_size;
+  uint64_t range_sizes[2];
   ASSERT_OK(db_->GetApproximateSizes(size_approx_options, default_cf, ranges, 2,
-                                     &ranges_size));
-  ASSERT_GE(ranges_size, size);
+                                     range_sizes));
+
+  ASSERT_EQ(range_sizes[1], size);
 
   // Zero if not including mem table
   db_->GetApproximateSizes(&r, 1, &size);

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -78,6 +78,22 @@ void AppendInternalKeyFooter(std::string* result, SequenceNumber s,
   PutFixed64(result, PackSequenceAndType(s, t));
 }
 
+void AppendKeyWithMinTimestamp(std::string* result, const Slice& key,
+                               size_t ts_sz) {
+  assert(ts_sz > 0);
+  const std::string kTsMin(ts_sz, static_cast<char>(0));
+  result->append(key.data(), key.size());
+  result->append(kTsMin.data(), ts_sz);
+}
+
+void AppendKeyWithMaxTimestamp(std::string* result, const Slice& key,
+                               size_t ts_sz) {
+  assert(ts_sz > 0);
+  const std::string kTsMax(ts_sz, static_cast<char>(0xff));
+  result->append(key.data(), key.size());
+  result->append(kTsMax.data(), ts_sz);
+}
+
 std::string ParsedInternalKey::DebugString(bool log_err_key, bool hex) const {
   std::string result = "'";
   if (log_err_key) {

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -81,7 +81,7 @@ void AppendInternalKeyFooter(std::string* result, SequenceNumber s,
 void AppendKeyWithMinTimestamp(std::string* result, const Slice& key,
                                size_t ts_sz) {
   assert(ts_sz > 0);
-  const std::string kTsMin(ts_sz, static_cast<char>(0));
+  const std::string kTsMin(ts_sz, static_cast<unsigned char>(0));
   result->append(key.data(), key.size());
   result->append(kTsMin.data(), ts_sz);
 }
@@ -89,7 +89,7 @@ void AppendKeyWithMinTimestamp(std::string* result, const Slice& key,
 void AppendKeyWithMaxTimestamp(std::string* result, const Slice& key,
                                size_t ts_sz) {
   assert(ts_sz > 0);
-  const std::string kTsMax(ts_sz, static_cast<char>(0xff));
+  const std::string kTsMax(ts_sz, static_cast<unsigned char>(0xff));
   result->append(key.data(), key.size());
   result->append(kTsMax.data(), ts_sz);
 }

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -167,6 +167,14 @@ extern void AppendInternalKeyWithDifferentTimestamp(
 extern void AppendInternalKeyFooter(std::string* result, SequenceNumber s,
                                     ValueType t);
 
+// Append the key and a minimal timestamp to *result
+extern void AppendKeyWithMinTimestamp(std::string* result, const Slice& key,
+                                      size_t ts_sz);
+
+// Append the key and a maximal timestamp to *result
+extern void AppendKeyWithMaxTimestamp(std::string* result, const Slice& key,
+                                      size_t ts_sz);
+
 // Attempt to parse an internal key from "internal_key".  On success,
 // stores the parsed data in "*result", and returns true.
 //

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1032,7 +1032,8 @@ class DB {
         (include_flags & SizeApproximationFlags::INCLUDE_MEMTABLES) != 0;
     options.include_files =
         (include_flags & SizeApproximationFlags::INCLUDE_FILES) != 0;
-    GetApproximateSizes(options, column_family, ranges, n, sizes);
+    Status s = GetApproximateSizes(options, column_family, ranges, n, sizes);
+    s.PermitUncheckedError();
   }
   virtual void GetApproximateSizes(const Range* ranges, int n, uint64_t* sizes,
                                    uint8_t include_flags = INCLUDE_FILES) {


### PR DESCRIPTION
Add timestamp to the `CompactRange()` and `GetApproximateSizes` range keys if needed.

Test plan: make check