### PR TITLE
Handling misuse of snprintf return value

### DIFF
--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -61,6 +61,7 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
                            const std::string& group_by) {
   int written_size =
       snprintf(buf, len, "\n** Compaction Stats [%s] **\n", cf_name.c_str());
+  written_size = std::min(written_size, static_cast<int>(len));
   auto hdr = [](LevelStatType t) {
     return InternalStats::compaction_level_stats.at(t).header_name.c_str();
   };
@@ -80,6 +81,7 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
       hdr(LevelStatType::KEY_DROP));
 
   written_size += line_size;
+  written_size = std::min(written_size, static_cast<int>(len));
   snprintf(buf + written_size, len - written_size, "%s\n",
            std::string(line_size, '-').c_str());
 }

--- a/utilities/backupable/backupable_db.cc
+++ b/utilities/backupable/backupable_db.cc
@@ -2245,32 +2245,25 @@ Status BackupEngineImpl::BackupMeta::StoreToFile(bool sync) {
     return s;
   }
 
-  std::string buf;
-  buf += std::to_string(timestamp_);
-  buf += "\n";
-  buf += std::to_string(sequence_number_);
-  buf += "\n";
+  std::ostringstream buf;
+  buf << timestamp_ << "\n";
+  buf << sequence_number_ << "\n";
 
   if (!app_metadata_.empty()) {
     std::string hex_encoded_metadata =
         Slice(app_metadata_).ToString(/* hex */ true);
-    buf += kMetaDataPrefix.ToString();
-    buf += hex_encoded_metadata;
-    buf += "\n";
+    buf << kMetaDataPrefix.ToString() << hex_encoded_metadata << "\n";
   }
-  buf += std::to_string(files_.size());
-  buf += "\n";
+  buf << files_.size() << "\n";
 
   for (const auto& file : files_) {
     // use crc32c for now, switch to something else if needed
     // WART: The checksums are crc32c, not original crc32
-    buf += file->filename;
-    buf += " crc32 ";
-    buf += std::to_string(ChecksumHexToInt32(file->checksum_hex));
-    buf += "\n";
+    buf << file->filename << " crc32 " << ChecksumHexToInt32(file->checksum_hex)
+        << "\n";
   }
 
-  s = backup_meta_file->Append(Slice(buf));
+  s = backup_meta_file->Append(Slice(buf.str()));
   if (s.ok() && sync) {
     s = backup_meta_file->Sync();
   }

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1692,6 +1692,11 @@ std::pair<bool, int64_t> BlobDBImpl::SanityCheck(bool aborted) {
                        ", blob count %" PRIu64 ", immutable %d",
                        blob_file->BlobFileNumber(), blob_file->GetFileSize(),
                        blob_file->BlobCount(), blob_file->Immutable());
+    if (pos >= static_cast<int>(sizeof(buf))) {
+      pos = sizeof(buf);
+      ROCKS_LOG_WARN(db_options_.info_log,
+                     "Buffer too small for sanity check.");
+    }
     if (blob_file->HasTTL()) {
       ExpirationRange expiration_range;
 
@@ -1703,15 +1708,31 @@ std::pair<bool, int64_t> BlobDBImpl::SanityCheck(bool aborted) {
       pos += snprintf(buf + pos, sizeof(buf) - pos,
                       ", expiration range (%" PRIu64 ", %" PRIu64 ")",
                       expiration_range.first, expiration_range.second);
+      if (pos >= static_cast<int>(sizeof(buf))) {
+        pos = sizeof(buf);
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "Buffer too small for sanity check.");
+      }
+
       if (!blob_file->Obsolete()) {
         pos += snprintf(buf + pos, sizeof(buf) - pos,
                         ", expire in %" PRIu64 " seconds",
                         expiration_range.second - now);
+        if (pos >= static_cast<int>(sizeof(buf))) {
+          pos = sizeof(buf);
+          ROCKS_LOG_WARN(db_options_.info_log,
+                         "Buffer too small for sanity check.");
+        }
       }
     }
     if (blob_file->Obsolete()) {
       pos += snprintf(buf + pos, sizeof(buf) - pos, ", obsolete at %" PRIu64,
                       blob_file->GetObsoleteSequence());
+      if (pos >= static_cast<int>(sizeof(buf))) {
+        pos = sizeof(buf);
+        ROCKS_LOG_WARN(db_options_.info_log,
+                       "Buffer too small for sanity check.");
+      }
     }
     snprintf(buf + pos, sizeof(buf) - pos, ".");
     ROCKS_LOG_INFO(db_options_.info_log, "%s", buf);

--- a/utilities/blob_db/blob_db_impl.cc
+++ b/utilities/blob_db/blob_db_impl.cc
@@ -1686,12 +1686,11 @@ std::pair<bool, int64_t> BlobDBImpl::SanityCheck(bool aborted) {
 
   for (auto blob_file_pair : blob_files_) {
     auto blob_file = blob_file_pair.second;
-    std::string buf;
+    std::ostringstream buf;
 
-    buf = buf + "Blob file " + std::to_string(blob_file->BlobFileNumber());
-    buf = buf + ", size " + std::to_string(blob_file->GetFileSize());
-    buf = buf + ", blob count " + std::to_string(blob_file->BlobCount());
-    buf = buf + ", immutable " + std::to_string(blob_file->Immutable());
+    buf << "Blob file " << blob_file->BlobFileNumber() << ", size "
+        << blob_file->GetFileSize() << ", blob count " << blob_file->BlobCount()
+        << ", immutable " << blob_file->Immutable();
 
     if (blob_file->HasTTL()) {
       ExpirationRange expiration_range;
@@ -1699,21 +1698,18 @@ std::pair<bool, int64_t> BlobDBImpl::SanityCheck(bool aborted) {
         ReadLock file_lock(&blob_file->mutex_);
         expiration_range = blob_file->GetExpirationRange();
       }
-      buf = buf + ", expiration range (" +
-            std::to_string(expiration_range.first) + ", " +
-            std::to_string(expiration_range.second) + ")";
+      buf << ", expiration range (" << expiration_range.first << ", "
+          << expiration_range.second << ")";
 
       if (!blob_file->Obsolete()) {
-        buf = buf + ", expire in " +
-              std::to_string(expiration_range.second - now) + "seconds";
+        buf << ", expire in " << (expiration_range.second - now) << "seconds";
       }
     }
     if (blob_file->Obsolete()) {
-      buf = buf + ", obsolete at " +
-            std::to_string(blob_file->GetObsoleteSequence());
+      buf << ", obsolete at " << blob_file->GetObsoleteSequence();
     }
-    buf += ".";
-    ROCKS_LOG_INFO(db_options_.info_log, "%s", buf.c_str());
+    buf << ".";
+    ROCKS_LOG_INFO(db_options_.info_log, "%s", buf.str().c_str());
   }
 
   // reschedule


### PR DESCRIPTION
Summary: Handle misuse of snprintf return value to avoid Out of bound
read/write.

Test Plan: make check -j64

Reviewers:

Subscribers:

Tasks: T78794449

Tags: