### PR TITLE
Add kManifestWriteNoWAL to BackgroundErrorReason to handle Flush IO Error when WAL is disabled

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -254,8 +254,15 @@ Status DBImpl::FlushMemTableToOutputFile(
       // TODO: distinguish between MANIFEST write and CURRENT renaming
       if (!versions_->io_status().ok()) {
         // Should handle return error?
-        error_handler_.SetBGError(io_s, BackgroundErrorReason::kManifestWrite)
-            .PermitUncheckedError();
+        if (total_log_size_ > 0) {
+          // If the WAL is empty, we use different error reason
+          error_handler_.SetBGError(io_s, BackgroundErrorReason::kManifestWrite)
+              .PermitUncheckedError();
+        } else {
+          error_handler_
+              .SetBGError(io_s, BackgroundErrorReason::kManifestWriteNoWAL)
+              .PermitUncheckedError();
+        }
       } else if (total_log_size_ > 0) {
         // Should handle return error?
         error_handler_.SetBGError(io_s, BackgroundErrorReason::kFlush)
@@ -656,9 +663,16 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
       // be pessimistic and try write to a new MANIFEST.
       // TODO: distinguish between MANIFEST write and CURRENT renaming
       if (!versions_->io_status().ok()) {
-        // Should Handle this error?
-        error_handler_.SetBGError(io_s, BackgroundErrorReason::kManifestWrite)
-            .PermitUncheckedError();
+        // Should handle return error?
+        if (total_log_size_ > 0) {
+          // If the WAL is empty, we use different error reason
+          error_handler_.SetBGError(io_s, BackgroundErrorReason::kManifestWrite)
+              .PermitUncheckedError();
+        } else {
+          error_handler_
+              .SetBGError(io_s, BackgroundErrorReason::kManifestWriteNoWAL)
+              .PermitUncheckedError();
+        }
       } else if (total_log_size_ > 0) {
         // Should Handle this error?
         error_handler_.SetBGError(io_s, BackgroundErrorReason::kFlush)

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -120,6 +120,10 @@ enum class FlushReason : int {
   kErrorRecoveryRetryFlush = 0xc,
 };
 
+// TODO: In the future, BackgroundErrorReason will only be used to indicate
+// why the BG Error is happening (e.g., flush, compaction). We may introduce
+// other data structure to indicate other essential information such as
+// the file type (e.g., Manifest, SST) and special context.
 enum class BackgroundErrorReason {
   kFlush,
   kCompaction,
@@ -127,6 +131,7 @@ enum class BackgroundErrorReason {
   kMemTable,
   kManifestWrite,
   kFlushNoWAL,
+  kManifestWriteNoWAL,
 };
 
 enum class WriteStallCondition {


### PR DESCRIPTION
In the current code base, all the manifest writes with IO error will be set with reason: BackgroundErrorReason::kManifestWrite, which will be mapped to the kHardError if the IO Error is retryable. However, if the system does not use the WAL, all the retryable IO error should be mapped to kSoftError. Create this PR to handle is special case by adding kManifestWriteNoWAL to BackgroundErrorReason.

Test plan: make check, add new testing cases to error_handler_fs_test