### PR TITLE
Integrated blob garbage collection: relocate blobs

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1339,6 +1339,15 @@ Status ColumnFamilyData::ValidateOptions(
           "Block-Based Table format. ");
     }
   }
+
+  if (cf_options.enable_blob_garbage_collection &&
+      (cf_options.blob_garbage_collection_age_cutoff < 0.0 ||
+       cf_options.blob_garbage_collection_age_cutoff > 1.0)) {
+    return Status::InvalidArgument(
+        "The age cutoff for blob garbage collection should be in the range "
+        "[0.0, 1.0].");
+  }
+
   return s;
 }
 

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -3391,6 +3391,30 @@ TEST_P(ColumnFamilyTest, MultipleCFPathsTest) {
   }
 }
 
+TEST(ColumnFamilyTest, ValidateBlobGCCutoff) {
+  DBOptions db_options;
+
+  ColumnFamilyOptions cf_options;
+  cf_options.enable_blob_garbage_collection = true;
+
+  cf_options.blob_garbage_collection_age_cutoff = -0.5;
+  ASSERT_TRUE(ColumnFamilyData::ValidateOptions(db_options, cf_options)
+                  .IsInvalidArgument());
+
+  cf_options.blob_garbage_collection_age_cutoff = 0.0;
+  ASSERT_OK(ColumnFamilyData::ValidateOptions(db_options, cf_options));
+
+  cf_options.blob_garbage_collection_age_cutoff = 0.5;
+  ASSERT_OK(ColumnFamilyData::ValidateOptions(db_options, cf_options));
+
+  cf_options.blob_garbage_collection_age_cutoff = 1.0;
+  ASSERT_OK(ColumnFamilyData::ValidateOptions(db_options, cf_options));
+
+  cf_options.blob_garbage_collection_age_cutoff = 1.5;
+  ASSERT_TRUE(ColumnFamilyData::ValidateOptions(db_options, cf_options)
+                  .IsInvalidArgument());
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 #ifdef ROCKSDB_UNITTESTS_WITH_CUSTOM_OBJECTS_FROM_STATIC_LIBS

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -737,7 +737,7 @@ void CompactionIterator::NextFromInput() {
   }
 }
 
-bool CompactionIterator::ExtractLargeValueImpl() {
+bool CompactionIterator::ExtractLargeValueIfNeededImpl() {
   if (!blob_file_builder_) {
     return false;
   }
@@ -761,10 +761,10 @@ bool CompactionIterator::ExtractLargeValueImpl() {
   return true;
 }
 
-void CompactionIterator::ExtractLargeValue() {
+void CompactionIterator::ExtractLargeValueIfNeeded() {
   assert(ikey_.type == kTypeValue);
 
-  if (!ExtractLargeValueImpl()) {
+  if (!ExtractLargeValueIfNeededImpl()) {
     return;
   }
 
@@ -772,7 +772,7 @@ void CompactionIterator::ExtractLargeValue() {
   current_key_.UpdateInternalKey(ikey_.sequence, ikey_.type);
 }
 
-void CompactionIterator::GarbageCollectBlob() {
+void CompactionIterator::GarbageCollectBlobIfNeeded() {
   assert(ikey_.type == kTypeBlobIndex);
 
   if (!compaction_) {
@@ -823,7 +823,7 @@ void CompactionIterator::GarbageCollectBlob() {
 
     value_ = blob_value_;
 
-    if (ExtractLargeValueImpl()) {
+    if (ExtractLargeValueIfNeededImpl()) {
       return;
     }
 
@@ -864,9 +864,9 @@ void CompactionIterator::GarbageCollectBlob() {
 void CompactionIterator::PrepareOutput() {
   if (valid_) {
     if (ikey_.type == kTypeValue) {
-      ExtractLargeValue();
+      ExtractLargeValueIfNeeded();
     } else if (ikey_.type == kTypeBlobIndex) {
-      GarbageCollectBlob();
+      GarbageCollectBlobIfNeeded();
     }
 
     // Zeroing out the sequence number leads to better compression.

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -48,6 +48,8 @@ class CompactionIterator {
 
     virtual bool enable_blob_garbage_collection() const = 0;
 
+    virtual double blob_garbage_collection_age_cutoff() const = 0;
+
     virtual Version* input_version() const = 0;
   };
 
@@ -87,6 +89,11 @@ class CompactionIterator {
 
     bool enable_blob_garbage_collection() const override {
       return compaction_->mutable_cf_options()->enable_blob_garbage_collection;
+    }
+
+    double blob_garbage_collection_age_cutoff() const override {
+      return compaction_->mutable_cf_options()
+          ->blob_garbage_collection_age_cutoff;
     }
 
     Version* input_version() const override {

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -167,12 +167,29 @@ class CompactionIterator {
   // Processes the input stream to find the next output
   void NextFromInput();
 
-  // Do last preparations before presenting the output to the callee.
+  // Do final preparations before presenting the output to the callee.
   void PrepareOutput();
 
-  bool ExtractLargeValueImpl();
-  void ExtractLargeValue();
-  void GarbageCollectBlob();
+  // Passes the output value to the blob file builder (if any), and replaces it
+  // with the corresponding blob reference if it has been actually written to a
+  // blob file (i.e. if it passed the value size check). Returns true if the
+  // value got extracted to a blob file, false otherwise.
+  bool ExtractLargeValueIfNeededImpl();
+
+  // Extracts large values as described above, and updates the internal key's
+  // type to kTypeBlobIndex if the value got extracted. Should only be called
+  // for regular values (kTypeValue).
+  void ExtractLargeValueIfNeeded();
+
+  // Relocates valid blobs residing in the oldest blob files if garbage
+  // collection is enabled. Relocated blobs are written to new blob files or
+  // inlined in the LSM tree depending on the current settings (i.e.
+  // enable_blob_files and min_blob_size). Should only be called for blob
+  // references (kTypeBlobIndex).
+  //
+  // Note: the stacked BlobDB implementation's compaction filter based GC
+  // algorithm is also called from here.
+  void GarbageCollectBlobIfNeeded();
 
   // Invoke compaction filter if needed.
   // Return true on success, false on failures (e.g.: kIOError).

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -45,6 +45,10 @@ class CompactionIterator {
     virtual bool allow_ingest_behind() const = 0;
 
     virtual bool preserve_deletes() const = 0;
+
+    virtual bool enable_blob_garbage_collection() const = 0;
+
+    virtual Version* input_version() const = 0;
   };
 
   class RealCompaction : public CompactionProxy {
@@ -53,6 +57,7 @@ class CompactionIterator {
         : compaction_(compaction) {
       assert(compaction_);
       assert(compaction_->immutable_cf_options());
+      assert(compaction_->mutable_cf_options());
     }
 
     int level() const override { return compaction_->level(); }
@@ -78,6 +83,14 @@ class CompactionIterator {
 
     bool preserve_deletes() const override {
       return compaction_->immutable_cf_options()->preserve_deletes;
+    }
+
+    bool enable_blob_garbage_collection() const override {
+      return compaction_->mutable_cf_options()->enable_blob_garbage_collection;
+    }
+
+    Version* input_version() const override {
+      return compaction_->input_version();
     }
 
    private:

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cinttypes>
 #include <deque>
 #include <string>
 #include <unordered_set>
@@ -211,6 +212,9 @@ class CompactionIterator {
     }
   }
 
+  static uint64_t ComputeBlobGarbageCollectionCutoffFileNumber(
+      const CompactionProxy* compaction);
+
   InternalIterator* input_;
   const Comparator* cmp_;
   MergeHelper* merge_helper_;
@@ -293,6 +297,9 @@ class CompactionIterator {
   // PinnedIteratorsManager used to pin input_ Iterator blocks while reading
   // merge operands and then releasing them after consuming them.
   PinnedIteratorsManager pinned_iters_mgr_;
+
+  uint64_t blob_garbage_collection_cutoff_file_number_;
+
   std::string blob_index_;
   std::string compaction_filter_value_;
   InternalKey compaction_filter_skip_until_;

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -167,10 +167,12 @@ class CompactionIterator {
   // Processes the input stream to find the next output
   void NextFromInput();
 
-  // Do last preparations before presenting the output to the callee. At this
-  // point this only zeroes out the sequence number if possible for better
-  // compression.
+  // Do last preparations before presenting the output to the callee.
   void PrepareOutput();
+
+  bool ExtractLargeValueImpl();
+  void ExtractLargeValue();
+  void GarbageCollectBlob();
 
   // Invoke compaction filter if needed.
   // Return true on success, false on failures (e.g.: kIOError).

--- a/db/compaction/compaction_iterator.h
+++ b/db/compaction/compaction_iterator.h
@@ -301,6 +301,7 @@ class CompactionIterator {
   uint64_t blob_garbage_collection_cutoff_file_number_;
 
   std::string blob_index_;
+  PinnableSlice blob_value_;
   std::string compaction_filter_value_;
   InternalKey compaction_filter_skip_until_;
   // "level_ptrs" holds indices that remember which file of an associated

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -178,6 +178,8 @@ class FakeCompaction : public CompactionIterator::CompactionProxy {
 
   bool enable_blob_garbage_collection() const override { return false; }
 
+  double blob_garbage_collection_age_cutoff() const override { return 0.0; }
+
   Version* input_version() const override { return nullptr; }
 
   bool key_not_exists_beyond_output_level = false;

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -176,6 +176,10 @@ class FakeCompaction : public CompactionIterator::CompactionProxy {
 
   bool preserve_deletes() const override { return false; }
 
+  bool enable_blob_garbage_collection() const override { return false; }
+
+  Version* input_version() const override { return nullptr; }
+
   bool key_not_exists_beyond_output_level = false;
 
   bool is_bottommost_level = false;

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6097,8 +6097,8 @@ TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
 
   ASSERT_EQ(original_blob_files.size(), 4);
 
-  const size_t cutoff_index =
-      options.blob_garbage_collection_age_cutoff * original_blob_files.size();
+  const size_t cutoff_index = static_cast<size_t>(
+      options.blob_garbage_collection_age_cutoff * original_blob_files.size());
 
   // Note: turning off enable_blob_files before the compaction results in
   // garbage collected values getting inlined.

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6057,7 +6057,7 @@ class DBCompactionTestBlobGC
         updated_enable_blob_files_(std::get<1>(GetParam())) {}
 
   double blob_gc_age_cutoff_;
-  uint64_t updated_enable_blob_files_;
+  bool updated_enable_blob_files_;
 };
 
 INSTANTIATE_TEST_CASE_P(DBCompactionTestBlobGC, DBCompactionTestBlobGC,

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6102,8 +6102,12 @@ TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
 
   // Note: turning off enable_blob_files before the compaction results in
   // garbage collected values getting inlined.
+  size_t expected_number_of_files = original_blob_files.size();
+
   if (!updated_enable_blob_files_) {
     ASSERT_OK(db_->SetOptions({{"enable_blob_files", "false"}}));
+
+    expected_number_of_files -= cutoff_index;
   }
 
   constexpr Slice* begin = nullptr;
@@ -6112,11 +6116,6 @@ TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
 
   const std::vector<uint64_t> new_blob_files = GetBlobFileNumbers();
-
-  size_t expected_number_of_files = original_blob_files.size();
-  if (!updated_enable_blob_files_) {
-    expected_number_of_files -= cutoff_index;
-  }
 
   ASSERT_EQ(new_blob_files.size(), expected_number_of_files);
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -6114,6 +6114,11 @@ TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
 
+  ASSERT_EQ(Get(first_key), first_value);
+  ASSERT_EQ(Get(second_key), second_value);
+  ASSERT_EQ(Get(third_key), third_value);
+  ASSERT_EQ(Get(fourth_key), fourth_value);
+
   const std::vector<uint64_t> new_blob_files = GetBlobFileNumbers();
 
   ASSERT_EQ(new_blob_files.size(), expected_number_of_files);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -9,6 +9,7 @@
 
 #include <tuple>
 
+#include "db/blob/blob_index.h"
 #include "db/db_test_util.h"
 #include "port/port.h"
 #include "port/stack_trace.h"
@@ -6160,6 +6161,59 @@ TEST_F(DBCompactionTest, CompactionWithBlobGCError_CorruptIndex) {
   WriteBatch batch;
   ASSERT_OK(WriteBatchInternal::PutBlobIndex(&batch, 0, fourth_key,
                                              corrupt_blob_index));
+  ASSERT_OK(db_->Write(WriteOptions(), &batch));
+
+  ASSERT_OK(Flush());
+
+  constexpr Slice* begin = nullptr;
+  constexpr Slice* end = nullptr;
+
+  ASSERT_TRUE(
+      db_->CompactRange(CompactRangeOptions(), begin, end).IsCorruption());
+}
+
+TEST_F(DBCompactionTest, CompactionWithBlobGCError_InlinedTTLIndex) {
+  constexpr uint64_t min_blob_size = 10;
+
+  Options options;
+  options.env = env_;
+  options.disable_auto_compactions = true;
+  options.enable_blob_files = true;
+  options.min_blob_size = min_blob_size;
+  options.enable_blob_garbage_collection = true;
+  options.blob_garbage_collection_age_cutoff = 1.0;
+
+  Reopen(options);
+
+  constexpr char first_key[] = "first_key";
+  constexpr char first_value[] = "first_value";
+  ASSERT_OK(Put(first_key, first_value));
+
+  constexpr char second_key[] = "second_key";
+  constexpr char second_value[] = "second_value";
+  ASSERT_OK(Put(second_key, second_value));
+
+  ASSERT_OK(Flush());
+
+  constexpr char third_key[] = "third_key";
+  constexpr char third_value[] = "third_value";
+  ASSERT_OK(Put(third_key, third_value));
+
+  constexpr char fourth_key[] = "fourth_key";
+  constexpr char blob[] = "short";
+  static_assert(sizeof(short) - 1 < min_blob_size,
+                "Blob too long to be inlined");
+
+  // Fake an inlined TTL blob index.
+  std::string blob_index;
+
+  constexpr uint64_t expiration = 1234567890;
+
+  BlobIndex::EncodeInlinedTTL(&blob_index, expiration, blob);
+
+  WriteBatch batch;
+  ASSERT_OK(
+      WriteBatchInternal::PutBlobIndex(&batch, 0, fourth_key, blob_index));
   ASSERT_OK(db_->Write(WriteOptions(), &batch));
 
   ASSERT_OK(Flush());

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <algorithm>
 #include <tuple>
 
 #include "db/db_test_util.h"
@@ -6119,16 +6118,10 @@ TEST_P(DBCompactionTestBlobGC, CompactionWithBlobGC) {
 
   ASSERT_EQ(new_blob_files.size(), expected_number_of_files);
 
-  // Original blob files below the cutoff should be gone
-  for (size_t i = 0; i < cutoff_index; ++i) {
-    ASSERT_FALSE(std::binary_search(
-        new_blob_files.begin(), new_blob_files.end(), original_blob_files[i]));
-  }
-
-  // Original blob files at or above the cutoff should be still there
+  // Original blob files below the cutoff should be gone, original blob files at
+  // or above the cutoff should be still there
   for (size_t i = cutoff_index; i < original_blob_files.size(); ++i) {
-    ASSERT_TRUE(std::binary_search(new_blob_files.begin(), new_blob_files.end(),
-                                   original_blob_files[i]));
+    ASSERT_EQ(new_blob_files[i - cutoff_index], original_blob_files[i]);
   }
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1807,6 +1807,12 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     }
   }
 
+  return GetBlob(read_options, user_key, blob_index, value);
+}
+
+Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                        const BlobIndex& blob_index,
+                        PinnableSlice* value) const {
   if (blob_index.HasTTL() || blob_index.IsInlined()) {
     return Status::Corruption("Unexpected TTL/inlined blob index");
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -60,6 +60,7 @@ namespace log {
 class Writer;
 }
 
+class BlobIndex;
 class Compaction;
 class LogBuffer;
 class LookupKey;
@@ -683,6 +684,18 @@ class Version {
   void MultiGet(const ReadOptions&, MultiGetRange* range,
                 ReadCallback* callback = nullptr, bool* is_blob = nullptr);
 
+  // Interprets *value as a blob reference, and (assuming the corresponding
+  // blob file is part of this Version) retrieves the blob and saves it in
+  // *value, replacing the blob reference.
+  // REQUIRES: *value stores an encoded blob reference
+  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                 PinnableSlice* value) const;
+
+  // Retrieves a blob using a blob reference and saves it in *value, assuming
+  // the corresponding blob file is part of this Version.
+  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
+                 const BlobIndex& blob_index, PinnableSlice* value) const;
+
   // Loads some stats information from files. Call without mutex held. It needs
   // to be called before applying the version to the version set.
   void PrepareApply(const MutableCFOptions& mutable_cf_options,
@@ -777,13 +790,6 @@ class Version {
   const Comparator* user_comparator() const {
     return storage_info_.user_comparator_;
   }
-
-  // Interprets *value as a blob reference, and (assuming the corresponding
-  // blob file is part of this Version) retrieves the blob and saves it in
-  // *value, replacing the blob reference.
-  // REQUIRES: *value stores an encoded blob reference
-  Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 PinnableSlice* value) const;
 
   // Returns true if the filter blocks in the specified level will not be
   // checked during read operations. In certain cases (trivial move or preload),


### PR DESCRIPTION
Summary:
The patch adds basic garbage collection support to the integrated BlobDB
implementation. Valid blobs residing in the oldest blob files are relocated
as they are encountered during compaction. The threshold that determines
which blob files qualify is computed based on the configuration option
`blob_garbage_collection_age_cutoff`, which was introduced in #7661 .
Once a blob is retrieved for the purposes of relocation, it passes through the
same logic that extracts large values to blob files in general. This means that
if, for instance, the size threshold for key-value separation (`min_blob_size`)
got changed or writing blob files got disabled altogether, it is possible for the
value to be moved back into the LSM tree. In particular, one way to re-inline
all blob values if needed would be to perform a full manual compaction with
`enable_blob_files` set to `false`, `enable_blob_garbage_collection` set to
`true`, and `blob_file_garbage_collection_age_cutoff` set to `1.0`.

Some TODOs that I plan to address in separate PRs:

1) We'll have to measure the amount of new garbage in each blob file and log
`BlobFileGarbage` entries as part of the compaction job's `VersionEdit`.
(For the time being, blob files are cleaned up solely based on the
`oldest_blob_file_number` relationships.)
2) When compression is used for blobs, the compression type hasn't changed,
and the blob still qualifies for being written to a blob file, we can simply copy
the compressed blob to the new file instead of going through decompression
and compression.
3) We need to update the formula for computing write amplification to account
for the amount of data read from blob files as part of GC.

Test Plan:
`make check`