### PR TITLE
Do not track empty WALs

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1323,7 +1323,8 @@ Status DBImpl::MarkLogsSynced(uint64_t up_to, bool synced_dir) {
     auto& wal = *it;
     assert(wal.getting_synced);
     if (logs_.size() > 1) {
-      if (immutable_db_options_.track_and_verify_wals_in_manifest) {
+      if (immutable_db_options_.track_and_verify_wals_in_manifest &&
+          wal.writer->file()->GetFileSize() > 0) {
         synced_wals.AddWal(wal.number,
                            WalMetadata(wal.writer->file()->GetFileSize()));
       }

--- a/include/rocksdb/utilities/backupable_db.h
+++ b/include/rocksdb/utilities/backupable_db.h
@@ -69,6 +69,7 @@ struct BackupableDBOptions {
   // If false, we won't backup log files. This option can be useful for backing
   // up in-memory databases where log file are persisted, but table files are in
   // memory.
+  // If track_and_verify_wals_in_manifest is true, this must be true.
   // Default: true
   bool backup_log_files;
 


### PR DESCRIPTION
An empty WAL won't be backed up by the BackupEngine. So if we track the empty WALs in MANIFEST, then when restoring from a backup, it may report corruption that the empty WAL is missing, which is correct because the WAL is actually in the main DB but not in the backup DB, but missing an empty WAL does not logically break DB consistency.

Test Plan:
watch existing tests to pass