### PR TITLE
Port corruption test to use custom env

### DIFF
--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -188,44 +188,6 @@ class CorruptionTest : public testing::Test {
     ASSERT_GE(max_expected, correct);
   }
 
-  void CorruptFile(const std::string& fname, int offset, int bytes_to_corrupt) {
-    uint64_t file_size = 0;
-    Status s = env_->GetFileSize(fname, &file_size);
-    if (!s.ok()) {
-      FAIL() << fname << ": " << s.ToString();
-    }
-    int fsz = static_cast<int>(file_size);
-
-    if (offset < 0) {
-      // Relative to end of file; make it absolute
-      if (-offset > fsz) {
-        offset = 0;
-      } else {
-        offset = fsz + offset;
-      }
-    }
-    if (offset > fsz) {
-      offset = fsz;
-    }
-    if (offset + bytes_to_corrupt > fsz) {
-      bytes_to_corrupt = fsz - offset;
-    }
-
-    // Do it
-    std::string contents;
-    s = ReadFileToString(env_, fname, &contents);
-    ASSERT_TRUE(s.ok()) << s.ToString();
-    for (int i = 0; i < bytes_to_corrupt; i++) {
-      contents[i + offset] ^= 0x80;
-    }
-    s = WriteStringToFile(env_->target(), contents, fname);
-    ASSERT_TRUE(s.ok());
-    Options options;
-    options.env = env_;
-    EnvOptions env_options;
-    ASSERT_NOK(VerifySstFileChecksum(options, env_options, fname));
-  }
-
   void Corrupt(FileType filetype, int offset, int bytes_to_corrupt) {
     // Pick file to corrupt
     std::vector<std::string> filenames;

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -53,9 +53,10 @@ class ErrorEnv : public EnvWrapper {
   bool writable_file_error_;
   int num_writable_file_errors_;
 
-  ErrorEnv() : EnvWrapper(Env::Default()),
-               writable_file_error_(false),
-               num_writable_file_errors_(0) { }
+  ErrorEnv(Env* target)
+      : EnvWrapper(target),
+        writable_file_error_(false),
+        num_writable_file_errors_(0) {}
 
   virtual Status NewWritableFile(const std::string& fname,
                                  std::unique_ptr<WritableFile>* result,

--- a/test_util/testutil.h
+++ b/test_util/testutil.h
@@ -53,8 +53,8 @@ class ErrorEnv : public EnvWrapper {
   bool writable_file_error_;
   int num_writable_file_errors_;
 
-  ErrorEnv(Env* target)
-      : EnvWrapper(target),
+  ErrorEnv(Env* _target)
+      : EnvWrapper(_target),
         writable_file_error_(false),
         num_writable_file_errors_(0) {}
 


### PR DESCRIPTION
Allow corruption_test to run on custom env loaded via
`Env::LoadEnv()`.

Test plan:
```
make corruption_test
./corruption_test
```

Also run on in-house custom env.