### PR TITLE
Fix initialization order of DBOptions and kHostnameForDbHostId

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -349,7 +349,7 @@ struct DbPath {
   DbPath(const std::string& p, uint64_t t) : path(p), target_size(t) {}
 };
 
-static const std::string kHostnameForDbHostId = "__hostname__";
+static const char* kHostnameForDbHostId = "__hostname__";
 
 struct DBOptions {
   // The function recovers options to the option as in version 4.6.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -349,7 +349,7 @@ struct DbPath {
   DbPath(const std::string& p, uint64_t t) : path(p), target_size(t) {}
 };
 
-static const char* kHostnameForDbHostId = "__hostname__";
+extern const char* kHostnameForDbHostId;
 
 struct DBOptions {
   // The function recovers options to the option as in version 4.6.

--- a/table/format.cc
+++ b/table/format.cc
@@ -41,6 +41,7 @@ extern const uint64_t kPlainTableMagicNumber;
 const uint64_t kLegacyPlainTableMagicNumber = 0;
 const uint64_t kPlainTableMagicNumber = 0;
 #endif
+const char* kHostnameForDbHostId = "__hostname__";
 
 bool ShouldReportDetailedTime(Env* env, Statistics* stats) {
   return env != nullptr && stats != nullptr &&


### PR DESCRIPTION
Fix initialization order of DBOptions and kHostnameForDbHostId by making the initialization of the latter static rather than dynamic.