### PR TITLE
Skip minimum rate check in Sandcastle

### DIFF
--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -128,11 +128,13 @@ TEST_F(RateLimiterTest, Rate) {
   }
 
   // This can fail in heavily loaded CI environments
-  if (getenv("SANDCASTLE")
+  bool skip_minimum_rate_check =
 #if (defined(TRAVIS) || defined(CIRCLECI)) && defined(OS_MACOSX)
-      || true
+      true;
+#else
+      getenv("SANDCASTLE");
 #endif
-  ) {
+  if (skip_minimum_rate_check) {
     fprintf(stderr, "Skipped minimum rate check (%d / %d passed)\n",
             samples_at_minimum, samples);
   } else {

--- a/util/rate_limiter_test.cc
+++ b/util/rate_limiter_test.cc
@@ -59,7 +59,6 @@ TEST_F(RateLimiterTest, Modes) {
   }
 }
 
-#if !((defined(TRAVIS) || defined(CIRCLECI)) && defined(OS_MACOSX))
 TEST_F(RateLimiterTest, Rate) {
   auto* env = Env::Default();
   struct Arg {
@@ -90,6 +89,9 @@ TEST_F(RateLimiterTest, Rate) {
     }
   };
 
+  int samples = 0;
+  int samples_at_minimum = 0;
+
   for (int i = 1; i <= 16; i *= 2) {
     int32_t target = i * 1024 * 10;
     Arg arg(target, i / 4 + 1);
@@ -117,12 +119,26 @@ TEST_F(RateLimiterTest, Rate) {
               arg.request_size - 1, target / 1024, rate / 1024,
               elapsed / 1000000.0);
 
-      ASSERT_GE(rate / target, 0.80);
+      ++samples;
+      if (rate / target >= 0.80) {
+        ++samples_at_minimum;
+      }
       ASSERT_LE(rate / target, 1.25);
     }
   }
-}
+
+  // This can fail in heavily loaded CI environments
+  if (getenv("SANDCASTLE")
+#if (defined(TRAVIS) || defined(CIRCLECI)) && defined(OS_MACOSX)
+      || true
 #endif
+  ) {
+    fprintf(stderr, "Skipped minimum rate check (%d / %d passed)\n",
+            samples_at_minimum, samples);
+  } else {
+    ASSERT_EQ(samples_at_minimum, samples);
+  }
+}
 
 TEST_F(RateLimiterTest, LimitChangeTest) {
   // starvation test when limit changes to a smaller value


### PR DESCRIPTION
Summary: The minimum rate check in RateLimiterTest.Rate can fail in
Facebook's CI system Sandcastle, presumably due to heavily loaded
machines. This change disables the minimum rate check for Sandcastle
runs, and cleans up the code disabling it on other CI environments. (The
amount of conditionally compiled code shall be minimized.)

Test Plan: try new test with and without setting envvar SANDCASTLE=1