### PR TITLE
Fix build on FreeBSD/powerpc64(le)

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -478,7 +478,7 @@ static int arch_ppc_probe(void) {
 #if defined(__powerpc64__)
   elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures));
   if (cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO) arch_ppc_crc32 = 1;
-#endif /* __powerpc64__ */
+#endif  /* __powerpc64__ */
 
   return arch_ppc_crc32;
 }

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -467,6 +467,21 @@ static int arch_ppc_probe(void) {
 
   return arch_ppc_crc32;
 }
+#elif __FreeBSD__
+#include <machine/cpu.h>
+#include <sys/auxv.h>
+#include <sys/elf_common.h>
+static int arch_ppc_probe(void) {
+  unsigned long cpufeatures;
+  arch_ppc_crc32 = 0;
+
+#if defined(__powerpc64__)
+  elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures));
+  if (cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO) arch_ppc_crc32 = 1;
+#endif /* __powerpc64__ */
+
+  return arch_ppc_crc32;
+}
 #endif  // __linux__
 
 static bool isAltiVec() {

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -37,6 +37,10 @@
 #define AT_HWCAP2 26
 #endif
 
+#elif __FreeBSD__
+#include <machine/cpu.h>
+#include <sys/auxv.h>
+#include <sys/elf_common.h>
 #endif /* __linux__ */
 
 #endif
@@ -468,9 +472,6 @@ static int arch_ppc_probe(void) {
   return arch_ppc_crc32;
 }
 #elif __FreeBSD__
-#include <machine/cpu.h>
-#include <sys/auxv.h>
-#include <sys/elf_common.h>
 static int arch_ppc_probe(void) {
   unsigned long cpufeatures;
   arch_ppc_crc32 = 0;


### PR DESCRIPTION
To build on FreeBSD, arch_ppc_probe needs to be adapted to FreeBSD.

Since FreeBSD uses elf_aux_info as an getauxval equivalent, use it and include necessary headers:
- machine/cpu.h for PPC_FEATURE2_HAS_VEC_CRYPTO,
- sys/auxv.h for elf_aux_info,
- sys/elf_common.h for AT_HWCAP2.

elf_aux_info isn't checked for being available, because it's available since FreeBSD 12.0. rocksdb assumes using Clang on FreeBSD, but powerpc* platforms switch to Clang only since 13.0.

This patch makes rocksdb build on FreeBSD on powerpc64 and powerpc64le platforms.