### PR TITLE
Make the TARGETS file Starlark compliant

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -775,26 +775,24 @@ cpp_library(
     external_deps = ROCKSDB_EXTERNAL_DEPS,
 )
 
-if not is_opt_mode:
-    cpp_binary(
-        name = "c_test_bin",
-        srcs = ["db/c_test.c"],
-        arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
-        os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
-        compiler_flags = ROCKSDB_COMPILER_FLAGS,
-        preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
-        deps = [":rocksdb_test_lib"],
-    )
+cpp_binary(
+    name = "c_test_bin",
+    srcs = ["db/c_test.c"],
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    deps = [":rocksdb_test_lib"],
+) if not is_opt_mode else None
 
-if not is_opt_mode:
-    custom_unittest(
-        "c_test",
-        command = [
-            native.package_name() + "/buckifier/rocks_test_runner.sh",
-            "$(location :{})".format("c_test_bin"),
-        ],
-        type = "simple",
-    )
+custom_unittest(
+    "c_test",
+    command = [
+        native.package_name() + "/buckifier/rocks_test_runner.sh",
+        "$(location :{})".format("c_test_bin"),
+    ],
+    type = "simple",
+) if not is_opt_mode else None
 
 cpp_library(
     name = "env_basic_test_lib",

--- a/buckifier/targets_builder.py
+++ b/buckifier/targets_builder.py
@@ -79,26 +79,24 @@ class TARGETSBuilder(object):
 
     def add_c_test(self):
         self.targets_file.write(b"""
-if not is_opt_mode:
-    cpp_binary(
-        name = "c_test_bin",
-        srcs = ["db/c_test.c"],
-        arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
-        os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
-        compiler_flags = ROCKSDB_COMPILER_FLAGS,
-        preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
-        deps = [":rocksdb_test_lib"],
-    )
+cpp_binary(
+    name = "c_test_bin",
+    srcs = ["db/c_test.c"],
+    arch_preprocessor_flags = ROCKSDB_ARCH_PREPROCESSOR_FLAGS,
+    os_preprocessor_flags = ROCKSDB_OS_PREPROCESSOR_FLAGS,
+    compiler_flags = ROCKSDB_COMPILER_FLAGS,
+    preprocessor_flags = ROCKSDB_PREPROCESSOR_FLAGS,
+    deps = [":rocksdb_test_lib"],
+) if not is_opt_mode else None
 
-if not is_opt_mode:
-    custom_unittest(
-        "c_test",
-        command = [
-            native.package_name() + "/buckifier/rocks_test_runner.sh",
-            "$(location :{})".format("c_test_bin"),
-        ],
-        type = "simple",
-    )
+custom_unittest(
+    "c_test",
+    command = [
+        native.package_name() + "/buckifier/rocks_test_runner.sh",
+        "$(location :{})".format("c_test_bin"),
+    ],
+    type = "simple",
+) if not is_opt_mode else None
 """)
 
     def register_test(self,


### PR DESCRIPTION
Buck TARGETS files are sometimes parsed with Python, and sometimes with Starlark - this TARGETS file was not Starlark compliant. In Starlark you can't have a top-level if in a TARGETS file, but you can have a ternary `a if b else c`. Therefore I converted TARGETS, and updated the generator for it.