### PR TITLE
Migrate away from broken macos on Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
           name: Install gflags
           command: |
             sudo apt-get update -y && sudo apt-get install -y libgflags-dev
-  
+
   install-gflags-on-macos:
     steps:
       - run:
@@ -96,6 +96,17 @@ jobs:
       - pre-steps
       - install-gflags-on-macos
       - run: ulimit -S -n 1048576 && OPT=-DCIRCLECI make V=1 J=32 -j32 check | .circleci/cat_ignore_eagain
+      - post-steps
+
+  build-macos-cmake:
+    macos:
+      xcode: 11.3.0
+    steps:
+      - increase-max-open-files-on-macos
+      - install-pyenv-on-macos
+      - pre-steps
+      - install-gflags-on-macos
+      - run: ulimit -S -n 1048576 && (mkdir build && cd build && cmake -DWITH_GFLAGS=0 .. && make V=1 -j32) | .circleci/cat_ignore_eagain
       - post-steps
 
   build-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,13 @@ commands:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv
 
+  install-cmake-on-macos:
+    steps:
+      - run:
+          name: Install cmake on macos
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake
+
   increase-max-open-files-on-macos:
     steps:
       - run:
@@ -93,8 +100,8 @@ jobs:
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
-      - pre-steps
       - install-gflags-on-macos
+      - pre-steps
       - run: ulimit -S -n 1048576 && OPT=-DCIRCLECI make V=1 J=32 -j32 check | .circleci/cat_ignore_eagain
       - post-steps
 
@@ -104,8 +111,9 @@ jobs:
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
-      - pre-steps
+      - install-cmake-on-macos
       - install-gflags-on-macos
+      - pre-steps
       - run: ulimit -S -n 1048576 && (mkdir build && cd build && cmake -DWITH_GFLAGS=0 .. && make V=1 -j32) | .circleci/cat_ignore_eagain
       - post-steps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,6 +517,9 @@ workflows:
   build-macos:
     jobs:
       - build-macos
+  build-macos-cmake:
+    jobs:
+      - build-macos-cmake
   build-cmake-mingw:
     jobs:
       - build-cmake-mingw

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,13 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake
+  # Exclude all osx since it should be covered by CircleCI
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
+    os: osx
+    env: TEST_GROUP=platform_dependent
+  - if: type = pull_request AND commit_message !~ /FULL_CI/
+    os: osx
+    env: JOB_NAME=cmake
   # NB: the cmake build is a partial java test
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx


### PR DESCRIPTION
Summary: Add macos+cmake build on CircleCI instead.

Test Plan: CI