### PR TITLE
Fix unit test failure ppc64le in travis

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -174,7 +174,9 @@ TEST_F(DBTest2, PartitionedIndexUserToInternalKey) {
     ASSERT_OK(Put("keykey_" + std::to_string(j), value));
     snapshots.push_back(db_->GetSnapshot());
   }
-  Flush();
+  ASSERT_OK(Flush());
+  dbfull()->TEST_WaitForFlushMemTable();
+
   for (auto s : snapshots) {
     db_->ReleaseSnapshot(s);
   }


### PR DESCRIPTION
Summary: Added a fix for the failure of
DBTest2.PartitionedIndexUserToInternalKey on ppc64le in travis
Closes https://github.com/facebook/rocksdb/issues/7746

Test Plan:  Ran travis job multiple times and it passed. Will keep
watching the travis job after this patch.

Reviewers:

Subscribers:

Tasks:

Tags: