### PR TITLE
[rocksdb][buckifier] Fix use of positional args in BUCK rules

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -786,7 +786,7 @@ cpp_binary(
 ) if not is_opt_mode else None
 
 custom_unittest(
-    "c_test",
+    name = "c_test",
     command = [
         native.package_name() + "/buckifier/rocks_test_runner.sh",
         "$(location :{})".format("c_test_bin"),

--- a/buckifier/targets_builder.py
+++ b/buckifier/targets_builder.py
@@ -90,7 +90,7 @@ cpp_binary(
 ) if not is_opt_mode else None
 
 custom_unittest(
-    "c_test",
+    name = "c_test",
     command = [
         native.package_name() + "/buckifier/rocks_test_runner.sh",
         "$(location :{})".format("c_test_bin"),


### PR DESCRIPTION
Summary: Prefer to use keyword args rather than positional args for Buck rules. This appears to be the only remaining instance for `custom_unittest`

Test Plan: Search for other instances of `custom_unittest` without `name`