### PR TITLE
Test was previously Linux only, however it can also be enabled on macOS

### DIFF
--- a/db/db_logical_block_size_cache_test.cc
+++ b/db/db_logical_block_size_cache_test.cc
@@ -5,7 +5,7 @@
 
 #include "test_util/testharness.h"
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_MACOSX)
 #include "env/io_posix.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -371,7 +371,7 @@ size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
 }
 #endif
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_MACOSX)
 std::string RemoveTrailingSlash(const std::string& path) {
   std::string p = path;
   if (p.size() > 1 && p.back() == '/') {

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -49,7 +49,7 @@ class PosixHelper {
                                                size_t* size);
 };
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_MACOSX)
 // Files under a specific directory have the same logical block size.
 // This class caches the logical block size for the specified directories to
 // save the CPU cost of computing the size.


### PR DESCRIPTION
It seems `db_logical_block_size_cache_test` can be enabled for macOS as well.