### PR TITLE
Delete WALs only after flush results are written to MANIFEST

### DIFF
--- a/db/column_family.h
+++ b/db/column_family.h
@@ -350,6 +350,11 @@ class ColumnFamilyData {
 
   MemTableList* imm() { return &imm_; }
   MemTable* mem() { return mem_; }
+
+  bool IsEmpty() {
+    return mem()->GetFirstSequenceNumber() == 0 && imm()->NumNotFlushed() == 0;
+  }
+
   Version* current() { return current_; }
   Version* dummy_versions() { return dummy_versions_; }
   void SetCurrent(Version* _current);

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -662,7 +662,8 @@ uint64_t FindMinPrepLogReferencedByMemTable(
   std::unordered_set<MemTable*> memtables_to_flush_set(
       memtables_to_flush.begin(), memtables_to_flush.end());
   for (auto loop_cfd : *vset->GetColumnFamilySet()) {
-    if (loop_cfd->IsDropped() || loop_cfd == cfd_to_flush) {
+    if (loop_cfd->IsDropped() || loop_cfd->IsEmpty() ||
+        loop_cfd == cfd_to_flush) {
       continue;
     }
 
@@ -695,7 +696,8 @@ uint64_t FindMinPrepLogReferencedByMemTable(
     memtables_to_flush_set.insert(memtables->begin(), memtables->end());
   }
   for (auto loop_cfd : *vset->GetColumnFamilySet()) {
-    if (loop_cfd->IsDropped() || cfds_to_flush_set.count(loop_cfd)) {
+    if (loop_cfd->IsDropped() || loop_cfd->IsEmpty() ||
+        cfds_to_flush_set.count(loop_cfd)) {
       continue;
     }
 

--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -239,11 +239,12 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
 
   // logs_ is empty when called during recovery, in which case there can't yet
   // be any tracked obsolete logs
-  if (!alive_log_files_.empty() && !logs_.empty()) {
+  if (logs_.size() > 1 && alive_log_files_.size() > 1) {
     uint64_t min_log_number = job_context->log_number;
     size_t num_alive_log_files = alive_log_files_.size();
     // find newly obsoleted log files
-    while (alive_log_files_.begin()->number < min_log_number) {
+    while (!alive_log_files_.empty() &&
+           alive_log_files_.begin()->number < min_log_number) {
       auto& earliest = *alive_log_files_.begin();
       if (immutable_db_options_.recycle_log_file_num >
           log_recycle_files_.size()) {

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1819,20 +1819,6 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
     return s;
   }
 
-  for (auto loop_cfd : *versions_->GetColumnFamilySet()) {
-    // all this is just optimization to delete logs that
-    // are no longer needed -- if CF is empty, that means it
-    // doesn't need that particular log to stay alive, so we just
-    // advance the log number. no need to persist this in the manifest
-    if (loop_cfd->mem()->GetFirstSequenceNumber() == 0 &&
-        loop_cfd->imm()->NumNotFlushed() == 0) {
-      if (creating_new_log) {
-        loop_cfd->SetLogNumber(logfile_number_);
-      }
-      loop_cfd->mem()->SetCreationSeq(versions_->LastSequence());
-    }
-  }
-
   cfd->mem()->SetNextLogNumber(logfile_number_);
   cfd->imm()->Add(cfd->mem(), &context->memtables_to_free_);
   new_mem->Ref();


### PR DESCRIPTION
In the write path, there is an optimization: when a new WAL is created during SwitchMemtable, we update the internal log number of the empty column families to the new WAL. `FindObsoleteFiles` marks a WAL as obsolete if the WAL's log number is less than `VersionSet::MinLogNumberWithUnflushedData`. After updating the empty column families' internal log number, `VersionSet::MinLogNumberWithUnflushedData` might change, so some WALs might become obsolete to be purged from disk.

For example, consider there are 3 column families: 0, 1, 2:
1. initially, all the column families' log number is 1;
2. write some data to cf0, and flush cf0;
3. now a new WAL 2 is created;
4. write data to cf1 and WAL 2;
5. now cf0's flush hasn't finished, flush cf1, and cf1's flush finishes, but since WAL 1 still contains data for the unflushed cf0, no WAL can be deleted from disk;
6. now cf0's flush finishes, so WAL 1 becomes obsolete, but WAL 2 is still active;
7. a new WAL 3 is created, and write data to cf2 and WAL 3, due to the optimization mentioned in the first paragraph, cf0 and cf1's log number is updated to 3 because they are empty;
8. now if the background threads want to purge obsolete files from disk, WAL 2 can be purged because no column family needs it. (Note that cf2 is not flushed yet.) 

When WAL tracking is enabled, we assume WALs will only become obsolete after a flush result is written to MANIFEST in `MemtableList::TryInstallMemtableFlushResults` (or its atomic flush counterpart). The above situation breaks this assumption.

This PR removes the above optimization, and ignores empty column families when computing the minimum log number to keep. So that WALs will only become obsolete after the flush results are written to MANIFEST.

Test Plan:
watch existing tests and stress tests to pass.