### PR TITLE
Flush and sync WAL before checkpointing

### DIFF
--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -115,6 +115,10 @@ Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
     s = db_->DisableFileDeletions();
     const bool disabled_file_deletions = s.ok();
 
+    if (s.ok()) {
+      s = db_->FlushWAL(/*sync=*/true);
+    }
+
     if (s.ok() || s.IsNotSupported()) {
       s = CreateCustomCheckpoint(
           db_options,


### PR DESCRIPTION
In a stress test failure, we observe that a WAL exists on disk, but when creating a checkpoint, the WAL is not linked to the checkpoint directory, even though the WAL is still active.

This is possible because if the WAL or WAL directory is not fsynced, there is no guarantee that ListDir will return all the on-disk WALs.

This PR fixes the problem by always `FlushWAL` and `SyncWAL` before checkpointing.

Test Plan:
watch existing tests to pass.