### PR TITLE
SyncWAL shouldn't be supported in compacted db

### DIFF
--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -82,6 +82,11 @@ class CompactedDBImpl : public DBImpl {
                        ColumnFamilyHandle* /*column_family*/) override {
     return Status::NotSupported("Not supported in compacted db mode.");
   }
+
+  virtual Status SyncWAL() override {
+    return Status::NotSupported("Not supported in compacted db mode.");
+  }
+
   using DB::IngestExternalFile;
   virtual Status IngestExternalFile(
       ColumnFamilyHandle* /*column_family*/,


### PR DESCRIPTION
`CompactedDB` is a kind of read-only DB, so it shouldn't support `SyncWAL`.

Test Plan:
watch existing tests to pass.