### PR TITLE
Use mock time for histogram_test

### DIFF
--- a/monitoring/histogram_test.cc
+++ b/monitoring/histogram_test.cc
@@ -3,11 +3,14 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 //
+#include "monitoring/histogram.h"
+
 #include <cmath>
 
-#include "monitoring/histogram.h"
 #include "monitoring/histogram_windowing.h"
+#include "test_util/mock_time_env.h"
 #include "test_util/testharness.h"
+#include "util/random.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -16,16 +19,21 @@ class HistogramTest : public testing::Test {};
 namespace {
   const double kIota = 0.1;
   const HistogramBucketMapper bucketMapper;
-  Env* env = Env::Default();
+  MockTimeEnv* env = new MockTimeEnv(Env::Default());
 }
 
 void PopulateHistogram(Histogram& histogram,
              uint64_t low, uint64_t high, uint64_t loop = 1) {
+  Random rnd(test::RandomSeed());
   for (; loop > 0; loop--) {
     for (uint64_t i = low; i <= high; i++) {
       histogram.Add(i);
+      // sleep a random microseconds [0-10)
+      env->MockSleepForMicroseconds(rnd.Uniform(10));
     }
   }
+  // make sure each data population at least take some time
+  env->MockSleepForMicroseconds(1);
 }
 
 void BasicOperation(Histogram& histogram) {
@@ -131,23 +139,23 @@ TEST_F(HistogramTest, HistogramWindowingExpire) {
 
   HistogramWindowingImpl
       histogramWindowing(num_windows, micros_per_window, min_num_per_window);
-
+  histogramWindowing.TEST_UpdateEnv(env);
   PopulateHistogram(histogramWindowing, 1, 1, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 100);
   ASSERT_EQ(histogramWindowing.min(), 1);
   ASSERT_EQ(histogramWindowing.max(), 1);
   ASSERT_EQ(histogramWindowing.Average(), 1);
 
   PopulateHistogram(histogramWindowing, 2, 2, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 200);
   ASSERT_EQ(histogramWindowing.min(), 1);
   ASSERT_EQ(histogramWindowing.max(), 2);
   ASSERT_EQ(histogramWindowing.Average(), 1.5);
 
   PopulateHistogram(histogramWindowing, 3, 3, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 300);
   ASSERT_EQ(histogramWindowing.min(), 1);
   ASSERT_EQ(histogramWindowing.max(), 3);
@@ -155,7 +163,7 @@ TEST_F(HistogramTest, HistogramWindowingExpire) {
 
   // dropping oldest window with value 1, remaining 2 ~ 4
   PopulateHistogram(histogramWindowing, 4, 4, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 300);
   ASSERT_EQ(histogramWindowing.min(), 2);
   ASSERT_EQ(histogramWindowing.max(), 4);
@@ -163,7 +171,7 @@ TEST_F(HistogramTest, HistogramWindowingExpire) {
 
   // dropping oldest window with value 2, remaining 3 ~ 5
   PopulateHistogram(histogramWindowing, 5, 5, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 300);
   ASSERT_EQ(histogramWindowing.min(), 3);
   ASSERT_EQ(histogramWindowing.max(), 5);
@@ -179,18 +187,20 @@ TEST_F(HistogramTest, HistogramWindowingMerge) {
       histogramWindowing(num_windows, micros_per_window, min_num_per_window);
   HistogramWindowingImpl
       otherWindowing(num_windows, micros_per_window, min_num_per_window);
+  histogramWindowing.TEST_UpdateEnv(env);
+  otherWindowing.TEST_UpdateEnv(env);
 
   PopulateHistogram(histogramWindowing, 1, 1, 100);
   PopulateHistogram(otherWindowing, 1, 1, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
 
   PopulateHistogram(histogramWindowing, 2, 2, 100);
   PopulateHistogram(otherWindowing, 2, 2, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
 
   PopulateHistogram(histogramWindowing, 3, 3, 100);
   PopulateHistogram(otherWindowing, 3, 3, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
 
   histogramWindowing.Merge(otherWindowing);
   ASSERT_EQ(histogramWindowing.num(), 600);
@@ -200,14 +210,14 @@ TEST_F(HistogramTest, HistogramWindowingMerge) {
 
   // dropping oldest window with value 1, remaining 2 ~ 4
   PopulateHistogram(histogramWindowing, 4, 4, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 500);
   ASSERT_EQ(histogramWindowing.min(), 2);
   ASSERT_EQ(histogramWindowing.max(), 4);
 
   // dropping oldest window with value 2, remaining 3 ~ 5
   PopulateHistogram(histogramWindowing, 5, 5, 100);
-  env->SleepForMicroseconds(micros_per_window);
+  env->MockSleepForMicroseconds(micros_per_window);
   ASSERT_EQ(histogramWindowing.num(), 400);
   ASSERT_EQ(histogramWindowing.min(), 3);
   ASSERT_EQ(histogramWindowing.max(), 5);

--- a/monitoring/histogram_windowing.h
+++ b/monitoring/histogram_windowing.h
@@ -44,7 +44,11 @@ public:
   virtual double StandardDeviation() const override;
   virtual void Data(HistogramData* const data) const override;
 
-private:
+#ifndef NDEBUG
+  void TEST_UpdateEnv(Env* env) { env_ = env; }
+#endif  // NDEBUG
+
+ private:
   void TimerTick();
   void SwapHistoryBucket();
   inline uint64_t current_window() const {


### PR DESCRIPTION
`histogram_test` uses real sleep, which depends on the test executing speed, it makes the test unstable.
Switching to using a mock time env, it can also increase the test speed (from 10100ms -> 100ms).
test plan: run test 10 times, all passed. vs. without fix 3 out 10 test failed:
no fix: https://app.circleci.com/pipelines/github/facebook/rocksdb?branch=pull%2F7797
with fix: https://app.circleci.com/pipelines/github/facebook/rocksdb?branch=pull%2F7799