### PR TITLE
Avoid to force PORTABLE mode in tools/regression_test.sh

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -377,7 +377,7 @@ function build_db_bench_and_ldb {
   make clean
   exit_on_error $?
 
-  DEBUG_LEVEL=0 PORTABLE=1 make db_bench ldb -j32
+  DEBUG_LEVEL=0 make db_bench ldb -j32
   exit_on_error $?
 }
 


### PR DESCRIPTION
Summary:
Right now tools/regression_test.sh always builds RocksDB with PORTABLE=1. There isn't a reason for that. Remove it. Users can always specify PORTABLE through  envirionement variable.

Test Plan: Run tools/regression_test.sh and see it still builds.