### PR TITLE
Store test logs as artifacts if the build fails in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,14 @@ commands:
           path: /tmp/test-results
       - store_artifacts: # store LOG for debugging if there's any
           path: LOG
+      - run: # on fail, compress Test Logs for diagnosing the issue
+         name: Compress Test Logs
+         command: tar -cvzf t.tar.gz t
+         when: on_fail
+      - store_artifacts: # on fail, store Test Logs for diagnosing the issue
+          path: t.tar.gz
+          destination: test_logs
+          when: on_fail
 
   install-clang-10:
     steps:


### PR DESCRIPTION
If a workflow fails in CircleCI this will ensure that the `t/` directory is tar'd up and added to the workflow as an artifact. This allows us to download the detailed logs and see what went wrong.