### PR TITLE
Disable BasicLockEscalation if cannot determine whether TSAN is enabled

### DIFF
--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -217,11 +217,11 @@ TEST_F(RangeLockingTest, MultipleTrxLockStatusData) {
 }
 
 #if defined(__has_feature)
- #if __has_feature(thread_sanitizer)
-  #define SKIP_LOCK_ESCALATION_TEST 1
- #endif
+#if __has_feature(thread_sanitizer)
+#define SKIP_LOCK_ESCALATION_TEST 1
+#endif
 #else
- #define SKIP_LOCK_ESCALATION_TEST 1
+#define SKIP_LOCK_ESCALATION_TEST 1
 #endif
 
 #ifndef SKIP_LOCK_ESCALATION_TEST

--- a/utilities/transactions/lock/range/range_locking_test.cc
+++ b/utilities/transactions/lock/range/range_locking_test.cc
@@ -217,9 +217,11 @@ TEST_F(RangeLockingTest, MultipleTrxLockStatusData) {
 }
 
 #if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define SKIP_LOCK_ESCALATION_TEST 1
-#endif
+ #if __has_feature(thread_sanitizer)
+  #define SKIP_LOCK_ESCALATION_TEST 1
+ #endif
+#else
+ #define SKIP_LOCK_ESCALATION_TEST 1
 #endif
 
 #ifndef SKIP_LOCK_ESCALATION_TEST


### PR DESCRIPTION
BasicLockEscalation will cause false-positive warnings under TSAN (this is a known issue in TSAN, see details in https://gist.github.com/spetrunia/77274cf2d5848e0a7e090d622695ed4e), skip this test if TSAN is enabled, or if we are not sure whether TSAN is enabled.

Test Plan:
watch the tsan contrun test to pass.