### PR TITLE
Asymmetry between MaxAllowedSpaceReached callbacks

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1559,14 +1559,12 @@ Status CompactionJob::FinishCompactionOutputFile(
       s = add_s;
     }
     if (sfm->IsMaxAllowedSpaceReached()) {
-      // TODO(ajkr): should we return OK() if max space was reached by the final
-      // compaction output file (similarly to how flush works when full)?
-      s = Status::SpaceLimit("Max allowed space was reached");
-      TEST_SYNC_POINT(
+      Status new_bg_error = Status::SpaceLimit("Max allowed space was reached");
+      TEST_SYNC_POINT_CALLBACK(
           "CompactionJob::FinishCompactionOutputFile:"
-          "MaxAllowedSpaceReached");
+          "MaxAllowedSpaceReached", &new_bg_error);
       InstrumentedMutexLock l(db_mutex_);
-      db_error_handler_->SetBGError(s, BackgroundErrorReason::kCompaction);
+      db_error_handler_->SetBGError(new_bg_error, BackgroundErrorReason::kCompaction);
     }
   }
 #endif


### PR DESCRIPTION
Whilst investigating an issue with `db_sst_test`, I noticed that the SyncPoint Callbacks for:

1.  `DBImpl::FlushMemTableToOutputFile:MaxAllowedSpaceReached`
2. `CompactionJob::FinishCompactionOutputFile:MaxAllowedSpaceReached`

each have a slightly different design, in so far as (1) takes an argument of `Status*`, whilst (2) has no arguments.

I have made a small modification so that the status is now passed to (2).
**NOTE**: In addition that bg status is no longer returned from the function - I am not sure if this is the correct approach but I wanted to open the PR as a mechanism for discussion.

I see that @ajkr had previously left a comment in the code which is related to this. @ajkr I would be interested in your thoughts on this please?
