### PR TITLE
Fix compilation using Java 8 and higher

### DIFF
--- a/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
+++ b/java/src/main/java/org/rocksdb/AbstractMutableOptions.java
@@ -199,7 +199,7 @@ public abstract class AbstractMutableOptions {
     }
 
     @SuppressWarnings("unchecked")
-    protected <N extends Enum<N>> N getEnum(final K key)
+    protected <N extends Enum<N>> N getEnum(final K key, Class<N> cls)
         throws NoSuchElementException, NumberFormatException {
       final MutableOptionValue<?> value = options.get(key);
       if (value == null) {

--- a/java/src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
+++ b/java/src/main/java/org/rocksdb/MutableColumnFamilyOptions.java
@@ -442,7 +442,7 @@ public class MutableColumnFamilyOptions
 
     @Override
     public CompressionType compressionType() {
-      return (CompressionType)getEnum(MiscOption.compression_type);
+      return getEnum(MiscOption.compression_type, CompressionType.class);
     }
 
     @Override


### PR DESCRIPTION
Fixes compile error incompatible types: inference variable N has incompatible upper bounds java.lang.Enum<N>,org.rocksdb.CompressionType

This is very old issue in my Eclipse. After I upgraded my JVMs in the build it started failing even there. Please approve this.

@adamretter FYI