### PR TITLE
Cleanup Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,9 +166,14 @@ install:
       sudo apt-get install -y g++-4.8 || exit $?;
       CC=gcc-4.8 && CXX=g++-4.8;
     fi
-  - if [[ "${JOB_NAME}" == cmake* ]]; then
-      sudo apt-get install snapd && sudo snap install cmake --beta --classic || exit $?;
-      export PATH=/snap/bin:$PATH;
+  - |
+    if [[ "${JOB_NAME}" == cmake* ]]; then
+      sudo apt-get remove -y cmake cmake-data
+      export CMAKE_DEB="cmake-3.14.5-Linux-$(uname -m).deb"
+      export CMAKE_DEB_URL="https://rocksdb-deps.s3-us-west-2.amazonaws.com/cmake/${CMAKE_DEB}"
+      curl --silent --fail --show-error --location --output "${CMAKE_DEB}" "${CMAKE_DEB_URL}" || exit $?
+      sudo dpkg -i "${CMAKE_DEB}" || exit $?
+      which cmake && cmake --version
     fi
   - |
     if [[ "${JOB_NAME}" == java_test || "${JOB_NAME}" == cmake* ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 
 addons:
   apt:
+    update: true
     sources:
       - ubuntu-toolchain-r-test
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@ dist: xenial
 language: cpp
 os:
   - linux
-  - osx
 arch:
-  - amd64
   - arm64
   - ppc64le
 compiler:
   - clang
   - gcc
-osx_image: xcode9.4
 cache:
   - ccache
 
@@ -26,15 +23,6 @@ addons:
       - liblzma-dev  # xv
       - libzstd-dev
       - zlib1g-dev
-  homebrew:
-    update: true
-    packages:
-      - ccache
-      - gflags
-      - lz4
-      - snappy
-      - xz
-      - zstd
 
 env:
   - TEST_GROUP=platform_dependent # 16-18 minutes
@@ -58,20 +46,6 @@ env:
 
 matrix:
   exclude:
-  - os: osx
-    env: JOB_NAME=cmake-gcc8
-  - os: osx
-    env: JOB_NAME=cmake-gcc9
-  - os: osx
-    env: JOB_NAME=cmake-gcc9-c++20
-  - os: osx
-    env: JOB_NAME=cmake-mingw
-  - os: osx
-    env: JOB_NAME=make-gcc4.8
-  - os: osx
-    arch: ppc64le
-  - os: osx
-    compiler: gcc
   - os : linux
     arch: arm64
     env: JOB_NAME=cmake-mingw
@@ -86,22 +60,6 @@ matrix:
     env: JOB_NAME=make-gcc4.8
   - os: linux
     compiler: clang
-  # With migration to CircleCI, exclude Linux/amd64 for pull requests
-  # (but build in branches for now)
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os : linux
-    arch: amd64
-  # Exclude all osx since it should be covered by CircleCI
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: TEST_GROUP=platform_dependent
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: JOB_NAME=cmake
-  # NB: the cmake build is a partial java test
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: TEST_GROUP=1
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
@@ -111,9 +69,6 @@ matrix:
     arch: ppc64le
     env: TEST_GROUP=1
   - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: TEST_GROUP=2
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=2
@@ -121,9 +76,6 @@ matrix:
     os: linux
     arch: ppc64le
     env: TEST_GROUP=2
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: TEST_GROUP=3
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
@@ -133,9 +85,6 @@ matrix:
     arch: ppc64le
     env: TEST_GROUP=3
   - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: osx
-    env: TEST_GROUP=4
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: TEST_GROUP=4
@@ -143,9 +92,6 @@ matrix:
     os: linux
     arch: ppc64le
     env: TEST_GROUP=4
-  - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
-    os : osx
-    env: JOB_NAME=java_test
   - if: type = pull_request AND commit_message !~ /FULL_CI/ AND commit_message !~ /java/
     os : linux
     arch: arm64
@@ -155,9 +101,6 @@ matrix:
     arch: ppc64le
     env: JOB_NAME=java_test
   - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os : osx
-    env: JOB_NAME=lite_build
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
     env: JOB_NAME=lite_build
@@ -165,9 +108,6 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=lite_build
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os : osx
-    env: JOB_NAME=examples
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
@@ -200,9 +140,6 @@ matrix:
     os: linux
     arch: ppc64le
     env: JOB_NAME=cmake-gcc9-c++20
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os : osx
-    env: JOB_NAME=status_checked
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: arm64
@@ -213,9 +150,6 @@ matrix:
     env: JOB_NAME=status_checked
 
 install:
-  - if [ "${TRAVIS_OS_NAME}" == osx ]; then
-      PATH=$PATH:/usr/local/opt/ccache/libexec;
-    fi
   - if [ "${JOB_NAME}" == cmake-gcc8 ]; then
       sudo apt-get install -y g++-8 || exit $?;
       CC=gcc-8 && CXX=g++-8;
@@ -231,22 +165,16 @@ install:
       sudo apt-get install -y g++-4.8 || exit $?;
       CC=gcc-4.8 && CXX=g++-4.8;
     fi
-  - if [[ "${JOB_NAME}" == cmake* ]] && [ "${TRAVIS_OS_NAME}" == linux ]; then
+  - if [[ "${JOB_NAME}" == cmake* ]]; then
       sudo apt-get install snapd && sudo snap install cmake --beta --classic || exit $?;
       export PATH=/snap/bin:$PATH;
     fi
   - |
     if [[ "${JOB_NAME}" == java_test || "${JOB_NAME}" == cmake* ]]; then
       # Ensure JDK 8
-      if [ "${TRAVIS_OS_NAME}" == osx ]; then
-        brew tap AdoptOpenJDK/openjdk || exit $?
-        brew cask install adoptopenjdk8 || exit $?
-        export JAVA_HOME=$(/usr/libexec/java_home)
-      else
-        sudo apt-get install -y openjdk-8-jdk || exit $?
-        export PATH=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/bin:$PATH
-        export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)
-      fi
+      sudo apt-get install -y openjdk-8-jdk || exit $?
+      export PATH=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/bin:$PATH
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)
       echo "JAVA_HOME=${JAVA_HOME}"
       which java && java -version
       which javac && javac -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,12 +91,6 @@ matrix:
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os : linux
     arch: amd64
-  # Exclude most osx, arm64 and ppc64le tests for pull requests, but build in branches
-  # Temporarily disable ppc64le cmake test while snapd is broken
-  - if: type = pull_request AND commit_message !~ /FULL_CI/
-    os: linux
-    arch: ppc64le
-    env: JOB_NAME=cmake
   # Exclude all osx since it should be covered by CircleCI
   - if: type = pull_request AND commit_message !~ /FULL_CI/
     os: osx


### PR DESCRIPTION
We now only use Travis CI for testing RocksDB against Linux on:
* ppc64le
* arm64 (aarch64)

This is just some initial cleanup. I will add further ppc64le and arm64 jobs in a subsequent PR...