### PR TITLE
Fix checkpoint_test hang

### DIFF
--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -247,6 +247,7 @@ Status CheckpointImpl::CreateCustomCheckpoint(
   // GetLiveFiles atomically. But that needs changes to GetLiveFiles' signature
   // which is a public API.
   s = db_->GetLiveFiles(live_files, &manifest_file_size, flush_memtable);
+  TEST_SYNC_POINT("CheckpointImpl::CreateCheckpoint:FlushDone");
 
   TEST_SYNC_POINT("CheckpointImpl::CreateCheckpoint:SavedLiveFiles1");
   TEST_SYNC_POINT("CheckpointImpl::CreateCheckpoint:SavedLiveFiles2");

--- a/utilities/checkpoint/checkpoint_test.cc
+++ b/utilities/checkpoint/checkpoint_test.cc
@@ -549,7 +549,7 @@ TEST_F(CheckpointTest, CurrentFileModifiedWhileCheckpointing) {
       {// Get past the flush in the checkpoint thread before adding any keys to
        // the db so the checkpoint thread won't hit the WriteManifest
        // syncpoints.
-       {"DBImpl::GetLiveFiles:1",
+       {"CheckpointImpl::CreateCheckpoint:FlushDone",
         "CheckpointTest::CurrentFileModifiedWhileCheckpointing:PrePut"},
        // Roll the manifest during checkpointing right after live files are
        // snapshotted.


### PR DESCRIPTION
`CheckpointTest.CurrentFileModifiedWhileCheckpointing` could hang
because now create_checkpoint triggers flush twice. The test should wait
both flush done.

Test Plan:
`gtest-parallel ./checkpoint_test --gtest_filter=CheckpointTest.CurrentFileModifiedWhileCheckpointing -r 100`