### PR TITLE
Small improvements to CircleCI Windows jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,9 +364,13 @@ jobs:
       - run:
           name: "Setup VS"
           command: |
-            if [[ "${VS_YEAR}" == "2017" ]]; then
+            if [[ "${VS_YEAR}" == "2019" ]]; then
+              echo "VS2019 already present."
+            elif [[ "${VS_YEAR}" == "2017" ]]; then
+              echo "Installing VS2017..."
               powershell .circleci/vs2017_install.ps1
             elif [[ "${VS_YEAR}" == "2015" ]]; then
+              echo "Installing VS2015..."
               powershell .circleci/vs2015_install.ps1
             fi
       - run:
@@ -392,6 +396,7 @@ jobs:
             cd build
             ${CMAKE_BIN} -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE=1 -DSNAPPY=1 -DJNI=1 << parameters.extra_cmake_opt >> ..
             cd ..
+            msbuild.exe /version
             msbuild.exe build/rocksdb.sln -maxCpuCount -property:Configuration=Debug -property:Platform=x64
       - run:
           name: "Test RocksDB"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,23 +605,27 @@ workflows:
   build-linux-unity:
     jobs:
       - build-linux-unity
-  build-windows:
+  build-windows-vs2019:
     jobs:
-      - build-windows
+      - build-windows:
+          name: "build-windows-vs2019"
+  build-windows-vs2019-cxx20:
+    jobs:
+      - build-windows:
+          name: "build-windows-vs2019-cxx20"
+          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
   build-windows-vs2017:
     jobs:
       - build-windows:
+          name: "build-windows-vs2017"
           vs_year: "2017"
           cmake_generator: "Visual Studio 15 Win64"
   build-windows-vs2015:
     jobs:
       - build-windows:
+          name: "build-windows-vs2015"
           vs_year: "2015"
           cmake_generator: "Visual Studio 14 Win64"
-  build-windows-cxx20:
-    jobs:
-      - build-windows:
-          extra_cmake_opt: -DCMAKE_CXX_STANDARD=20
   build-java:
     jobs:
       - build-linux-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
             cd build
             ${CMAKE_BIN} -G "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Debug -DOPTDBG=1 -DPORTABLE=1 -DSNAPPY=1 -DJNI=1 << parameters.extra_cmake_opt >> ..
             cd ..
-            msbuild.exe /version
+            echo "Building with VS version: ${CMAKE_GENERATOR}"
             msbuild.exe build/rocksdb.sln -maxCpuCount -property:Configuration=Debug -property:Platform=x64
       - run:
           name: "Test RocksDB"

--- a/.circleci/vs2015_install.ps1
+++ b/.circleci/vs2015_install.ps1
@@ -21,3 +21,4 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }
+echo "VS 2015 installed."

--- a/.circleci/vs2017_install.ps1
+++ b/.circleci/vs2017_install.ps1
@@ -32,3 +32,4 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }
+echo "VS 2017 installed."


### PR DESCRIPTION
* Clearer indication of which versions of msbuild and Visual Studio is used
* Explicit naming of the build jobs within the Windows workflows