### PR TITLE
S390 Linux is failing tests ColumnFamilyOptionsTest.cfPaths 

### DIFF
--- a/java/rocksjni/concurrent_task_limiter.cc
+++ b/java/rocksjni/concurrent_task_limiter.cc
@@ -15,7 +15,7 @@
  */
 jlong Java_org_rocksdb_ConcurrentTaskLimiterImpl_newConcurrentTaskLimiterImpl0(
     JNIEnv* env, jclass, jstring jname, jint limit) {
-  jboolean has_exception;
+  jboolean has_exception = JNI_FALSE;
   std::string name =
       ROCKSDB_NAMESPACE::JniUtil::copyStdString(env, jname, &has_exception);
   if (JNI_TRUE == has_exception) {

--- a/java/rocksjni/options.cc
+++ b/java/rocksjni/options.cc
@@ -945,6 +945,7 @@ rocksdb_convert_cf_paths_from_java_helper(JNIEnv* env, jobjectArray path_array,
   jlong* size_array_ptr = env->GetLongArrayElements(size_array, nullptr);
   if (nullptr == size_array_ptr) {
     // exception thrown: OutOfMemoryError
+    *has_exception = JNI_TRUE;
     return {};
   }
   std::vector<ROCKSDB_NAMESPACE::DbPath> cf_paths;
@@ -977,7 +978,7 @@ void Java_org_rocksdb_Options_setCfPaths(JNIEnv* env, jclass, jlong jhandle,
                                          jobjectArray path_array,
                                          jlongArray size_array) {
   auto* options = reinterpret_cast<ROCKSDB_NAMESPACE::Options*>(jhandle);
-  jboolean has_exception;
+  jboolean has_exception = JNI_FALSE;
   std::vector<ROCKSDB_NAMESPACE::DbPath> cf_paths =
       rocksdb_convert_cf_paths_from_java_helper(env, path_array, size_array,
                                                 &has_exception);
@@ -4142,7 +4143,7 @@ void Java_org_rocksdb_ColumnFamilyOptions_setCfPaths(JNIEnv* env, jclass,
                                                      jlongArray size_array) {
   auto* options =
       reinterpret_cast<ROCKSDB_NAMESPACE::ColumnFamilyOptions*>(jhandle);
-  jboolean has_exception;
+  jboolean has_exception = JNI_FALSE;
   std::vector<ROCKSDB_NAMESPACE::DbPath> cf_paths =
       rocksdb_convert_cf_paths_from_java_helper(env, path_array, size_array,
                                                 &has_exception);


### PR DESCRIPTION
Fix ColumnFamilyOptionsTest.cfPaths and OptionsTest.cfPaths in 6.15 branch (and probably other branches including master)

has_exception variable was not initialized which was causing test failures and incorrect behavior on s390 platform (and maybe others as variable content is undefined).

@adamretter please take a look.
