### PR TITLE
Fix for a false corruption error during point-in-time WAL recovery.

### DIFF
--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -936,22 +936,6 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
         }
         if (stop_replay_for_corruption) {
           logFileDropped();
-          // Skip over any subsequent empty wal files and update corrupted wal
-          // number. This avoids false corruption error due to some column
-          // families pointing to empty wal file next to the corrupted wal
-          // file.
-          ++ii;
-          for (; ii < wal_numbers.size(); ++ii) {
-            wal_number = wal_numbers[ii];
-            std::string wal_file_name =
-                LogFileName(immutable_db_options_.wal_dir, wal_number);
-            uint64_t bytes;
-            const auto& s = env_->GetFileSize(wal_file_name, &bytes);
-            if (!s.ok() || bytes != 0) {
-              break;
-            }
-            corrupted_wal_number = wal_number;
-          }
           break;
         }
       }
@@ -1114,6 +1098,24 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
                        "Point in time recovered to log #%" PRIu64
                        " seq #%" PRIu64,
                        wal_number, *next_sequence);
+        // Skip over any subsequent empty wal files and update corrupted wal
+        // number. This avoids false corruption error due to some column
+        // families pointing to empty wal file next to the corrupted wal
+        // file.
+        ++ii;
+        for (; ii < wal_numbers.size(); ++ii) {
+          wal_number = wal_numbers[ii];
+          std::string wal_file_name =
+              LogFileName(immutable_db_options_.wal_dir, wal_number);
+          uint64_t bytes;
+          const auto& s = env_->GetFileSize(wal_file_name, &bytes);
+          if (!s.ok() || bytes != 0) {
+            // Don't skip and break if its not an empty wal file.
+            --ii;
+            break;
+          }
+          corrupted_wal_number = wal_number;
+        }
       } else {
         assert(immutable_db_options_.wal_recovery_mode ==
                    WALRecoveryMode::kTolerateCorruptedTailRecords ||

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -646,6 +646,15 @@ class EncryptedEnvImpl : public EnvWrapper {
     if (!status.ok()) {
       return status;
     }
+    uint64_t file_size;
+    status = GetFileSize(fname, &file_size);
+    if (!status.ok()) {
+      return status;
+    }
+    if (!file_size) {
+      *result = std::move(underlying);
+      return status;
+    }
     // Create cipher stream
     std::unique_ptr<BlockAccessCipherStream> stream;
     size_t prefix_length;
@@ -830,7 +839,7 @@ class EncryptedEnvImpl : public EnvWrapper {
   virtual Status GetFileSize(const std::string& fname,
                              uint64_t* file_size) override {
     auto status = EnvWrapper::GetFileSize(fname, file_size);
-    if (!status.ok()) {
+    if (!status.ok() || !(*file_size)) {
       return status;
     }
     EncryptionProvider* provider;


### PR DESCRIPTION
Fix for a false corruption error during point-in-time WAL recovery.

The error is thrown when last-flushed-WAL file for any CF is more
recent than corrupted WAL file. The fix is to skip this error if
all WAL files more recent than the corrupted WAL file are empty.

Fixes issue #7784.