### PR TITLE
Fix Java hashCode implementation

### DIFF
--- a/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
+++ b/java/src/main/java/org/rocksdb/ColumnFamilyHandle.java
@@ -115,7 +115,9 @@ public class ColumnFamilyHandle extends RocksObject {
   @Override
   public int hashCode() {
     try {
-      return Objects.hash(getName(), getID(), rocksDB_.nativeHandle_);
+      int result = Objects.hash(getID(), rocksDB_.nativeHandle_);
+      result = 31 * result + Arrays.hashCode(getName());
+      return result;
     } catch (RocksDBException e) {
       throw new RuntimeException("Cannot calculate hash code of column family handle", e);
     }

--- a/java/src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
+++ b/java/src/test/java/org/rocksdb/util/CapturingWriteBatchHandler.java
@@ -156,8 +156,10 @@ public class CapturingWriteBatchHandler extends WriteBatch.Handler {
 
     @Override
     public int hashCode() {
-
-      return Objects.hash(action, columnFamilyId, key, value);
+      int result = Objects.hash(action, columnFamilyId);
+      result = 31 * result + Arrays.hashCode(key);
+      result = 31 * result + Arrays.hashCode(value);
+      return result;
     }
   }
 


### PR DESCRIPTION
Summary:
Classes ColumnFamilyHandle and CapturingWriteBatchHandler.Event have
byte array fields as part of their identity, but they do not use the
arrays' content to compute the instance's hash, and instead rely on the
arrays' identity, causing instances to have different hashcodes
although they are equal.
The PR addresses it by using the arrays' content to compute the hash,
like the equals method does.