### PR TITLE
Fix write-ahead log file size overflow

### DIFF
--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -64,9 +64,10 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
         break;
       case kWalFile:
         if (env->GetFileSize(dbname + "/" + file, &file_size).ok()) {
-          char str[21];
-          snprintf(str, sizeof(str), "%" PRIu64, file_size);
-          wal_info.append(file).append(" size: ").append(str).append(" ; ");
+          wal_info.append(file)
+              .append(" size: ")
+              .append(std::to_string(file_size))
+              .append(" ; ");
         } else {
           Error(options.info_log, "Error when reading LOG file: %s/%s\n",
                 dbname.c_str(), file.c_str());
@@ -120,9 +121,10 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
       if (ParseFileName(file, &number, &type)) {
         if (type == kWalFile) {
           if (env->GetFileSize(options.wal_dir + "/" + file, &file_size).ok()) {
-            char str[21];
-            snprintf(str, sizeof(str), "%" PRIu64, file_size);
-            wal_info.append(file).append(" size: ").append(str).append(" ; ");
+            wal_info.append(file)
+                .append(" size: ")
+                .append(std::to_string(file_size))
+                .append(" ; ");
           } else {
             Error(options.info_log, "Error when reading LOG file %s/%s\n",
                   options.wal_dir.c_str(), file.c_str());

--- a/db/db_info_dumper.cc
+++ b/db/db_info_dumper.cc
@@ -64,7 +64,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
         break;
       case kWalFile:
         if (env->GetFileSize(dbname + "/" + file, &file_size).ok()) {
-          char str[16];
+          char str[21];
           snprintf(str, sizeof(str), "%" PRIu64, file_size);
           wal_info.append(file).append(" size: ").append(str).append(" ; ");
         } else {
@@ -120,7 +120,7 @@ void DumpDBFileSummary(const ImmutableDBOptions& options,
       if (ParseFileName(file, &number, &type)) {
         if (type == kWalFile) {
           if (env->GetFileSize(options.wal_dir + "/" + file, &file_size).ok()) {
-            char str[16];
+            char str[21];
             snprintf(str, sizeof(str), "%" PRIu64, file_size);
             wal_info.append(file).append(" size: ").append(str).append(" ; ");
           } else {


### PR DESCRIPTION
The WAL's file size is stored as an unsigned 64 bit integer. 

In db_info_dumper.cc, this integer gets converted to a string. Since 2^64 is approximately 10^19, we need 20 digits to represent the integer correctly. To store the decimal representation, we need 21 bytes (+1 due to the '\0' terminator at the end). The code previously used 16 bytes, which would overflow if the log is really big (>1 petabyte).