### PR TITLE
Cover all status codes in `Status::ToString()`

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -139,8 +139,7 @@ std::string Status::ToString() const {
     // member of the `Code` enum. The above switch-statement should have had a
     // case assigning `type` to a corresponding string.
     assert(false);
-    snprintf(tmp, sizeof(tmp), "Unknown code(%d): ",
-             static_cast<int>(code()));
+    snprintf(tmp, sizeof(tmp), "Unknown code(%d): ", static_cast<int>(code()));
     type = tmp;
   }
   std::string result(type);

--- a/util/status.cc
+++ b/util/status.cc
@@ -124,10 +124,14 @@ std::string Status::ToString() const {
     case kTryAgain:
       type = "Operation failed. Try again.: ";
       break;
+    case kCompactionTooLarge:
+      type = "Compaction too large: ";
+      break;
     case kColumnFamilyDropped:
       type = "Column family dropped: ";
       break;
-    default:
+    case kMaxCode:
+      assert(false);
       snprintf(tmp, sizeof(tmp), "Unknown code(%d): ",
                static_cast<int>(code()));
       type = tmp;

--- a/util/status.cc
+++ b/util/status.cc
@@ -80,8 +80,7 @@ std::string Status::ToString() const {
 #ifdef ROCKSDB_ASSERT_STATUS_CHECKED
   checked_ = true;
 #endif  // ROCKSDB_ASSERT_STATUS_CHECKED
-  char tmp[30];
-  const char* type;
+  const char* type = nullptr;
   switch (code_) {
     case kOk:
       return "OK";
@@ -132,10 +131,17 @@ std::string Status::ToString() const {
       break;
     case kMaxCode:
       assert(false);
-      snprintf(tmp, sizeof(tmp), "Unknown code(%d): ",
-               static_cast<int>(code()));
-      type = tmp;
       break;
+  }
+  char tmp[30];
+  if (type == nullptr) {
+    // This should not happen since `code_` should be a valid non-`kMaxCode`
+    // member of the `Code` enum. The above switch-statement should have had a
+    // case assigning `type` to a corresponding string.
+    assert(false);
+    snprintf(tmp, sizeof(tmp), "Unknown code(%d): ",
+             static_cast<int>(code()));
+    type = tmp;
   }
   std::string result(type);
   if (subcode_ != kNone) {


### PR DESCRIPTION
- Completed the switch statement for all possible `Code` values (the only one missing was `kCompactionTooLarge`).
- Removed the default case so compiler can alert us if a new value is added to `Code` without handling it in `Status::ToString()`.

Test Plan: verified the log message for this scenario looks right

```
2021/01/15-17:26:34.564450 7fa6845fe700 [ERROR] [/db_impl/db_impl_compaction_flush.cc:2621] Waiting after background compaction error: Compaction too large: , Accumulated background error counts: 1
```