### PR TITLE
Remove unnecessary settings of prev_ in skiplist

### DIFF
--- a/memtable/skiplist.h
+++ b/memtable/skiplist.h
@@ -457,11 +457,6 @@ void SkipList<Key, Comparator>::Insert(const Key& key) {
 
   int height = RandomHeight();
   if (height > GetMaxHeight()) {
-    for (int i = GetMaxHeight(); i < height; i++) {
-      prev_[i] = head_;
-    }
-    //fprintf(stderr, "Change height from %d to %d\n", max_height_, height);
-
     // It is ok to mutate max_height_ without any synchronization
     // with concurrent readers.  A concurrent reader that observes
     // the new value of max_height_ will see either the old value of


### PR DESCRIPTION
`prev_` is initialized to `head` on construction of SkipList.
`GetMaxHeight` returns the current max height of the SkipList, which is monotonically increasing.
So, `prev_[i]` for i >= `GetMaxHeight()` is always initialized to `head` and never modified unless a node's height exceeds the current max height.
So the `for` loop can be removed.

Test Plan:
watch existing tests to pass