### PR TITLE
In IOTracing, add filename with each operation in trace file.

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -810,7 +810,8 @@ Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
         fs_->NewRandomRWFile(file_to_ingest->internal_file_path, env_options_,
                              &rwfile, nullptr);
     if (status.ok()) {
-      FSRandomRWFilePtr fsptr(std::move(rwfile), io_tracer_);
+      FSRandomRWFilePtr fsptr(std::move(rwfile), io_tracer_,
+                              file_to_ingest->internal_file_path);
       std::string seqno_val;
       PutFixed64(&seqno_val, seqno);
       status = fsptr->Write(file_to_ingest->global_seqno_offset, seqno_val,

--- a/env/file_system_tracer.cc
+++ b/env/file_system_tracer.cc
@@ -16,8 +16,9 @@ IOStatus FileSystemTracingWrapper::NewSequentialFile(
   timer.Start();
   IOStatus s = target()->NewSequentialFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -29,8 +30,9 @@ IOStatus FileSystemTracingWrapper::NewRandomAccessFile(
   timer.Start();
   IOStatus s = target()->NewRandomAccessFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -42,8 +44,9 @@ IOStatus FileSystemTracingWrapper::NewWritableFile(
   timer.Start();
   IOStatus s = target()->NewWritableFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -55,8 +58,9 @@ IOStatus FileSystemTracingWrapper::ReopenWritableFile(
   timer.Start();
   IOStatus s = target()->ReopenWritableFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -70,8 +74,9 @@ IOStatus FileSystemTracingWrapper::ReuseWritableFile(
   IOStatus s =
       target()->ReuseWritableFile(fname, old_fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -83,8 +88,9 @@ IOStatus FileSystemTracingWrapper::NewRandomRWFile(
   timer.Start();
   IOStatus s = target()->NewRandomRWFile(fname, file_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -96,8 +102,9 @@ IOStatus FileSystemTracingWrapper::NewDirectory(
   timer.Start();
   IOStatus s = target()->NewDirectory(name, io_opts, result, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), name);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          name);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -110,8 +117,9 @@ IOStatus FileSystemTracingWrapper::GetChildren(const std::string& dir,
   timer.Start();
   IOStatus s = target()->GetChildren(dir, io_opts, r, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), dir);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          dir);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -123,8 +131,9 @@ IOStatus FileSystemTracingWrapper::DeleteFile(const std::string& fname,
   timer.Start();
   IOStatus s = target()->DeleteFile(fname, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), fname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          fname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -136,8 +145,9 @@ IOStatus FileSystemTracingWrapper::CreateDir(const std::string& dirname,
   timer.Start();
   IOStatus s = target()->CreateDir(dirname, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), dirname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          dirname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -148,8 +158,9 @@ IOStatus FileSystemTracingWrapper::CreateDirIfMissing(
   timer.Start();
   IOStatus s = target()->CreateDirIfMissing(dirname, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), dirname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          dirname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -161,8 +172,9 @@ IOStatus FileSystemTracingWrapper::DeleteDir(const std::string& dirname,
   timer.Start();
   IOStatus s = target()->DeleteDir(dirname, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileName, __func__,
-                          elapsed, s.ToString(), dirname);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          dirname);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -175,7 +187,9 @@ IOStatus FileSystemTracingWrapper::GetFileSize(const std::string& fname,
   timer.Start();
   IOStatus s = target()->GetFileSize(fname, options, file_size, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileNameAndFileSize,
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOFileSize);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), fname, *file_size);
   io_tracer_->WriteIOOp(io_record);
   return s;
@@ -189,7 +203,9 @@ IOStatus FileSystemTracingWrapper::Truncate(const std::string& fname,
   timer.Start();
   IOStatus s = target()->Truncate(fname, size, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileNameAndFileSize,
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOFileSize);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), fname, size);
   io_tracer_->WriteIOOp(io_record);
   return s;
@@ -203,8 +219,11 @@ IOStatus FSSequentialFileTracingWrapper::Read(size_t n,
   timer.Start();
   IOStatus s = target()->Read(n, options, result, scratch, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLen, __func__,
-                          elapsed, s.ToString(), result->size());
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_,
+                          result->size(), 0 /*Offset*/);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -215,8 +234,12 @@ IOStatus FSSequentialFileTracingWrapper::InvalidateCache(size_t offset,
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), length, offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, length,
+                          offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -229,9 +252,12 @@ IOStatus FSSequentialFileTracingWrapper::PositionedRead(
   IOStatus s =
       target()->PositionedRead(offset, n, options, result, scratch, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), result->size(),
-                          offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_,
+                          result->size(), offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -244,8 +270,12 @@ IOStatus FSRandomAccessFileTracingWrapper::Read(uint64_t offset, size_t n,
   timer.Start();
   IOStatus s = target()->Read(offset, n, options, result, scratch, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), n, offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, n,
+                          offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -259,10 +289,13 @@ IOStatus FSRandomAccessFileTracingWrapper::MultiRead(FSReadRequest* reqs,
   IOStatus s = target()->MultiRead(reqs, num_reqs, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
   uint64_t latency = elapsed;
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
   for (size_t i = 0; i < num_reqs; i++) {
-    IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
+    IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
                             __func__, latency, reqs[i].status.ToString(),
-                            reqs[i].len, reqs[i].offset);
+                            file_name_, reqs[i].len, reqs[i].offset);
     io_tracer_->WriteIOOp(io_record);
   }
   return s;
@@ -275,8 +308,12 @@ IOStatus FSRandomAccessFileTracingWrapper::Prefetch(uint64_t offset, size_t n,
   timer.Start();
   IOStatus s = target()->Prefetch(offset, n, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), n, offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, n,
+                          offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -287,8 +324,11 @@ IOStatus FSRandomAccessFileTracingWrapper::InvalidateCache(size_t offset,
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), length,
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, length,
                           static_cast<uint64_t>(offset));
   io_tracer_->WriteIOOp(io_record);
   return s;
@@ -301,8 +341,11 @@ IOStatus FSWritableFileTracingWrapper::Append(const Slice& data,
   timer.Start();
   IOStatus s = target()->Append(data, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLen, __func__,
-                          elapsed, s.ToString(), data.size());
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_,
+                          data.size(), 0 /*Offset*/);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -314,8 +357,12 @@ IOStatus FSWritableFileTracingWrapper::PositionedAppend(
   timer.Start();
   IOStatus s = target()->PositionedAppend(data, offset, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), data.size(), offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_,
+                          data.size(), offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -327,8 +374,11 @@ IOStatus FSWritableFileTracingWrapper::Truncate(uint64_t size,
   timer.Start();
   IOStatus s = target()->Truncate(size, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLen, __func__,
-                          elapsed, s.ToString(), size);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, size,
+                          0 /*Offset*/);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -339,8 +389,9 @@ IOStatus FSWritableFileTracingWrapper::Close(const IOOptions& options,
   timer.Start();
   IOStatus s = target()->Close(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOGeneral, __func__,
-                          elapsed, s.ToString());
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          file_name_);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -351,9 +402,10 @@ uint64_t FSWritableFileTracingWrapper::GetFileSize(const IOOptions& options,
   timer.Start();
   uint64_t file_size = target()->GetFileSize(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOFileNameAndFileSize,
-                          "GetFileSize", elapsed, "OK", "" /* file_name */,
-                          file_size);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOFileSize);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, "OK", file_name_, file_size);
   io_tracer_->WriteIOOp(io_record);
   return file_size;
 }
@@ -364,8 +416,11 @@ IOStatus FSWritableFileTracingWrapper::InvalidateCache(size_t offset,
   timer.Start();
   IOStatus s = target()->InvalidateCache(offset, length);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), length,
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, length,
                           static_cast<uint64_t>(offset));
   io_tracer_->WriteIOOp(io_record);
   return s;
@@ -378,8 +433,12 @@ IOStatus FSRandomRWFileTracingWrapper::Write(uint64_t offset, const Slice& data,
   timer.Start();
   IOStatus s = target()->Write(offset, data, options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), data.size(), offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_,
+                          data.size(), offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -392,8 +451,12 @@ IOStatus FSRandomRWFileTracingWrapper::Read(uint64_t offset, size_t n,
   timer.Start();
   IOStatus s = target()->Read(offset, n, options, result, scratch, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOLenAndOffset,
-                          __func__, elapsed, s.ToString(), n, offset);
+  uint64_t io_op_data = 0;
+  io_op_data |= (1 << IOTraceOp::kIOLen);
+  io_op_data |= (1 << IOTraceOp::kIOOffset);
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
+                          __func__, elapsed, s.ToString(), file_name_, n,
+                          offset);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -404,8 +467,9 @@ IOStatus FSRandomRWFileTracingWrapper::Flush(const IOOptions& options,
   timer.Start();
   IOStatus s = target()->Flush(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOGeneral, __func__,
-                          elapsed, s.ToString());
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          file_name_);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -416,8 +480,9 @@ IOStatus FSRandomRWFileTracingWrapper::Close(const IOOptions& options,
   timer.Start();
   IOStatus s = target()->Close(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOGeneral, __func__,
-                          elapsed, s.ToString());
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          file_name_);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -428,8 +493,9 @@ IOStatus FSRandomRWFileTracingWrapper::Sync(const IOOptions& options,
   timer.Start();
   IOStatus s = target()->Sync(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOGeneral, __func__,
-                          elapsed, s.ToString());
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          file_name_);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -440,8 +506,9 @@ IOStatus FSRandomRWFileTracingWrapper::Fsync(const IOOptions& options,
   timer.Start();
   IOStatus s = target()->Fsync(options, dbg);
   uint64_t elapsed = timer.ElapsedNanos();
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOGeneral, __func__,
-                          elapsed, s.ToString());
+  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
+                          0 /*io_op_data*/, __func__, elapsed, s.ToString(),
+                          file_name_);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }

--- a/env/file_system_tracer.cc
+++ b/env/file_system_tracer.cc
@@ -18,7 +18,7 @@ IOStatus FileSystemTracingWrapper::NewSequentialFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -32,7 +32,7 @@ IOStatus FileSystemTracingWrapper::NewRandomAccessFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -46,7 +46,7 @@ IOStatus FileSystemTracingWrapper::NewWritableFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -60,7 +60,7 @@ IOStatus FileSystemTracingWrapper::ReopenWritableFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -76,7 +76,7 @@ IOStatus FileSystemTracingWrapper::ReuseWritableFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -90,7 +90,7 @@ IOStatus FileSystemTracingWrapper::NewRandomRWFile(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -104,7 +104,7 @@ IOStatus FileSystemTracingWrapper::NewDirectory(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          name);
+                          name.substr(name.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -119,7 +119,7 @@ IOStatus FileSystemTracingWrapper::GetChildren(const std::string& dir,
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          dir);
+                          dir.substr(dir.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -133,7 +133,7 @@ IOStatus FileSystemTracingWrapper::DeleteFile(const std::string& fname,
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          fname);
+                          fname.substr(fname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -147,7 +147,7 @@ IOStatus FileSystemTracingWrapper::CreateDir(const std::string& dirname,
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          dirname);
+                          dirname.substr(dirname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -160,7 +160,7 @@ IOStatus FileSystemTracingWrapper::CreateDirIfMissing(
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          dirname);
+                          dirname.substr(dirname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -174,7 +174,7 @@ IOStatus FileSystemTracingWrapper::DeleteDir(const std::string& dirname,
   uint64_t elapsed = timer.ElapsedNanos();
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
-                          dirname);
+                          dirname.substr(dirname.find_last_of("/\\") + 1));
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -189,8 +189,9 @@ IOStatus FileSystemTracingWrapper::GetFileSize(const std::string& fname,
   uint64_t elapsed = timer.ElapsedNanos();
   uint64_t io_op_data = 0;
   io_op_data |= (1 << IOTraceOp::kIOFileSize);
-  IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
-                          __func__, elapsed, s.ToString(), fname, *file_size);
+  IOTraceRecord io_record(
+      env_->NowNanos(), TraceType::kIOTracer, io_op_data, __func__, elapsed,
+      s.ToString(), fname.substr(fname.find_last_of("/\\") + 1), *file_size);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }
@@ -206,7 +207,8 @@ IOStatus FileSystemTracingWrapper::Truncate(const std::string& fname,
   uint64_t io_op_data = 0;
   io_op_data |= (1 << IOTraceOp::kIOFileSize);
   IOTraceRecord io_record(env_->NowNanos(), TraceType::kIOTracer, io_op_data,
-                          __func__, elapsed, s.ToString(), fname, size);
+                          __func__, elapsed, s.ToString(),
+                          fname.substr(fname.find_last_of("/\\") + 1), size);
   io_tracer_->WriteIOOp(io_record);
   return s;
 }

--- a/env/file_system_tracer.h
+++ b/env/file_system_tracer.h
@@ -168,7 +168,9 @@ class FSSequentialFilePtr {
                       const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
+        fs_tracer_(fs_.get(), io_tracer_,
+                   file_name.substr(file_name.find_last_of("/\\") +
+                                    1) /* pass file name */) {}
 
   FSSequentialFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {
@@ -225,6 +227,7 @@ class FSRandomAccessFileTracingWrapper : public FSRandomAccessFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  // Stores file name instead of full path.
   std::string file_name_;
 };
 
@@ -240,7 +243,9 @@ class FSRandomAccessFilePtr {
                         const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
+        fs_tracer_(fs_.get(), io_tracer_,
+                   file_name.substr(file_name.find_last_of("/\\") +
+                                    1) /* pass file name */) {}
 
   FSRandomAccessFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {
@@ -312,6 +317,7 @@ class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  // Stores file name instead of full path.
   std::string file_name_;
 };
 
@@ -326,8 +332,10 @@ class FSWritableFilePtr {
                     const std::shared_ptr<IOTracer>& io_tracer,
                     const std::string& file_name)
       : fs_(std::move(fs)), io_tracer_(io_tracer) {
-    fs_tracer_.reset(
-        new FSWritableFileTracingWrapper(fs_.get(), io_tracer_, file_name));
+    fs_tracer_.reset(new FSWritableFileTracingWrapper(
+        fs_.get(), io_tracer_,
+        file_name.substr(file_name.find_last_of("/\\") +
+                         1) /* pass file name */));
   }
 
   FSWritableFile* operator->() const {
@@ -394,6 +402,7 @@ class FSRandomRWFileTracingWrapper : public FSRandomRWFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  // Stores file name instead of full path.
   std::string file_name_;
 };
 
@@ -409,7 +418,9 @@ class FSRandomRWFilePtr {
                     const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
+        fs_tracer_(fs_.get(), io_tracer_,
+                   file_name.substr(file_name.find_last_of("/\\") +
+                                    1) /* pass file name */) {}
 
   FSRandomRWFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {

--- a/env/file_system_tracer.h
+++ b/env/file_system_tracer.h
@@ -131,10 +131,12 @@ class FileSystemPtr {
 class FSSequentialFileTracingWrapper : public FSSequentialFileWrapper {
  public:
   FSSequentialFileTracingWrapper(FSSequentialFile* t,
-                                 std::shared_ptr<IOTracer> io_tracer)
+                                 std::shared_ptr<IOTracer> io_tracer,
+                                 const std::string& file_name)
       : FSSequentialFileWrapper(t),
         io_tracer_(io_tracer),
-        env_(Env::Default()) {}
+        env_(Env::Default()),
+        file_name_(file_name) {}
 
   ~FSSequentialFileTracingWrapper() override {}
 
@@ -150,6 +152,7 @@ class FSSequentialFileTracingWrapper : public FSSequentialFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  std::string file_name_;
 };
 
 // The FSSequentialFilePtr is a wrapper class that takes pointer to storage
@@ -161,10 +164,11 @@ class FSSequentialFilePtr {
  public:
   FSSequentialFilePtr() = delete;
   FSSequentialFilePtr(std::unique_ptr<FSSequentialFile>&& fs,
-                      const std::shared_ptr<IOTracer>& io_tracer)
+                      const std::shared_ptr<IOTracer>& io_tracer,
+                      const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_) {}
+        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
 
   FSSequentialFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {
@@ -197,10 +201,12 @@ class FSSequentialFilePtr {
 class FSRandomAccessFileTracingWrapper : public FSRandomAccessFileWrapper {
  public:
   FSRandomAccessFileTracingWrapper(FSRandomAccessFile* t,
-                                   std::shared_ptr<IOTracer> io_tracer)
+                                   std::shared_ptr<IOTracer> io_tracer,
+                                   const std::string& file_name)
       : FSRandomAccessFileWrapper(t),
         io_tracer_(io_tracer),
-        env_(Env::Default()) {}
+        env_(Env::Default()),
+        file_name_(file_name) {}
 
   ~FSRandomAccessFileTracingWrapper() override {}
 
@@ -219,6 +225,7 @@ class FSRandomAccessFileTracingWrapper : public FSRandomAccessFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  std::string file_name_;
 };
 
 // The FSRandomAccessFilePtr is a wrapper class that takes pointer to storage
@@ -229,10 +236,11 @@ class FSRandomAccessFileTracingWrapper : public FSRandomAccessFileWrapper {
 class FSRandomAccessFilePtr {
  public:
   FSRandomAccessFilePtr(std::unique_ptr<FSRandomAccessFile>&& fs,
-                        const std::shared_ptr<IOTracer>& io_tracer)
+                        const std::shared_ptr<IOTracer>& io_tracer,
+                        const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_) {}
+        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
 
   FSRandomAccessFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {
@@ -265,8 +273,12 @@ class FSRandomAccessFilePtr {
 class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
  public:
   FSWritableFileTracingWrapper(FSWritableFile* t,
-                               std::shared_ptr<IOTracer> io_tracer)
-      : FSWritableFileWrapper(t), io_tracer_(io_tracer), env_(Env::Default()) {}
+                               std::shared_ptr<IOTracer> io_tracer,
+                               const std::string& file_name)
+      : FSWritableFileWrapper(t),
+        io_tracer_(io_tracer),
+        env_(Env::Default()),
+        file_name_(file_name) {}
 
   ~FSWritableFileTracingWrapper() override {}
 
@@ -300,6 +312,7 @@ class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  std::string file_name_;
 };
 
 // The FSWritableFilePtr is a wrapper class that takes pointer to storage
@@ -310,9 +323,11 @@ class FSWritableFileTracingWrapper : public FSWritableFileWrapper {
 class FSWritableFilePtr {
  public:
   FSWritableFilePtr(std::unique_ptr<FSWritableFile>&& fs,
-                    const std::shared_ptr<IOTracer>& io_tracer)
+                    const std::shared_ptr<IOTracer>& io_tracer,
+                    const std::string& file_name)
       : fs_(std::move(fs)), io_tracer_(io_tracer) {
-    fs_tracer_.reset(new FSWritableFileTracingWrapper(fs_.get(), io_tracer_));
+    fs_tracer_.reset(
+        new FSWritableFileTracingWrapper(fs_.get(), io_tracer_, file_name));
   }
 
   FSWritableFile* operator->() const {
@@ -352,8 +367,12 @@ class FSWritableFilePtr {
 class FSRandomRWFileTracingWrapper : public FSRandomRWFileWrapper {
  public:
   FSRandomRWFileTracingWrapper(FSRandomRWFile* t,
-                               std::shared_ptr<IOTracer> io_tracer)
-      : FSRandomRWFileWrapper(t), io_tracer_(io_tracer), env_(Env::Default()) {}
+                               std::shared_ptr<IOTracer> io_tracer,
+                               const std::string& file_name)
+      : FSRandomRWFileWrapper(t),
+        io_tracer_(io_tracer),
+        env_(Env::Default()),
+        file_name_(file_name) {}
 
   ~FSRandomRWFileTracingWrapper() override {}
 
@@ -375,6 +394,7 @@ class FSRandomRWFileTracingWrapper : public FSRandomRWFileWrapper {
  private:
   std::shared_ptr<IOTracer> io_tracer_;
   Env* env_;
+  std::string file_name_;
 };
 
 // The FSRandomRWFilePtr is a wrapper class that takes pointer to storage
@@ -385,10 +405,11 @@ class FSRandomRWFileTracingWrapper : public FSRandomRWFileWrapper {
 class FSRandomRWFilePtr {
  public:
   FSRandomRWFilePtr(std::unique_ptr<FSRandomRWFile>&& fs,
-                    std::shared_ptr<IOTracer> io_tracer)
+                    std::shared_ptr<IOTracer> io_tracer,
+                    const std::string& file_name)
       : fs_(std::move(fs)),
         io_tracer_(io_tracer),
-        fs_tracer_(fs_.get(), io_tracer_) {}
+        fs_tracer_(fs_.get(), io_tracer_, file_name) {}
 
   FSRandomRWFile* operator->() const {
     if (io_tracer_ && io_tracer_->is_tracing_enabled()) {

--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -82,7 +82,7 @@ class RandomAccessFileReader {
       HistogramImpl* file_read_hist = nullptr,
       RateLimiter* rate_limiter = nullptr,
       const std::vector<std::shared_ptr<EventListener>>& listeners = {})
-      : file_(std::move(raf), io_tracer),
+      : file_(std::move(raf), io_tracer, _file_name),
         file_name_(std::move(_file_name)),
         env_(_env),
         stats_(stats),

--- a/file/sequence_file_reader.h
+++ b/file/sequence_file_reader.h
@@ -31,7 +31,8 @@ class SequentialFileReader {
   explicit SequentialFileReader(
       std::unique_ptr<FSSequentialFile>&& _file, const std::string& _file_name,
       const std::shared_ptr<IOTracer>& io_tracer = nullptr)
-      : file_name_(_file_name), file_(std::move(_file), io_tracer) {}
+      : file_name_(_file_name),
+        file_(std::move(_file), io_tracer, _file_name) {}
 
   explicit SequentialFileReader(
       std::unique_ptr<FSSequentialFile>&& _file, const std::string& _file_name,
@@ -39,7 +40,7 @@ class SequentialFileReader {
       const std::shared_ptr<IOTracer>& io_tracer = nullptr)
       : file_name_(_file_name),
         file_(NewReadaheadSequentialFile(std::move(_file), _readahead_size),
-              io_tracer) {}
+              io_tracer, _file_name) {}
 
   SequentialFileReader(const SequentialFileReader&) = delete;
   SequentialFileReader& operator=(const SequentialFileReader&) = delete;

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -151,7 +151,7 @@ class WritableFileWriter {
       const std::vector<std::shared_ptr<EventListener>>& listeners = {},
       FileChecksumGenFactory* file_checksum_gen_factory = nullptr)
       : file_name_(_file_name),
-        writable_file_(std::move(file), io_tracer),
+        writable_file_(std::move(file), io_tracer, _file_name),
         env_(env),
         buf_(),
         max_buffer_size_(options.writable_file_max_buffer_size),

--- a/tools/io_tracer_parser_tool.cc
+++ b/tools/io_tracer_parser_tool.cc
@@ -45,6 +45,12 @@ void IOTraceRecordParser::PrintHumanReadableIOTraceRecord(
      << ", Latency: " << std::setw(10) << std::left << record.latency
      << ", IO Status: " << record.io_status.c_str();
 
+  // Each bit in io_op_data stores which corresponding info from IOTraceOp will
+  // be added in the trace. Foreg, if bit at position 1 is set then
+  // IOTraceOp::kIOLen (length) will be logged in the record (Since
+  // IOTraceOp::kIOLen = 1 in the enum). So find all the set positions in
+  // io_op_data one by one and, update corresponsing info in the trace record,
+  // unset that bit to find other set bits until io_op_data = 0.
   /* Read remaining options based on io_op_data set by file operation */
   int64_t io_op_data = static_cast<int64_t>(record.io_op_data);
   while (io_op_data) {

--- a/tools/io_tracer_parser_tool.cc
+++ b/tools/io_tracer_parser_tool.cc
@@ -38,12 +38,12 @@ void IOTraceRecordParser::PrintHumanReadableHeader(
 void IOTraceRecordParser::PrintHumanReadableIOTraceRecord(
     const IOTraceRecord& record) {
   std::stringstream ss;
-  ss << "Access Time : " << std::setw(17) << std::left
-     << record.access_timestamp << ", File Operation: " << std::setw(18)
+  ss << "Access Time : " << std::setw(20) << std::left
+     << record.access_timestamp << ", File Name: " << std::setw(20) << std::left
+     << record.file_name.c_str() << ", File Operation: " << std::setw(18)
      << std::left << record.file_operation.c_str()
-     << ", Latency: " << std::setw(9) << std::left << record.latency
-     << ", IO Status: " << record.io_status.c_str()
-     << ", File Name: " << record.file_name.c_str();
+     << ", Latency: " << std::setw(10) << std::left << record.latency
+     << ", IO Status: " << record.io_status.c_str();
 
   /* Read remaining options based on io_op_data set by file operation */
   int64_t io_op_data = static_cast<int64_t>(record.io_op_data);

--- a/tools/io_tracer_parser_tool.cc
+++ b/tools/io_tracer_parser_tool.cc
@@ -46,10 +46,10 @@ void IOTraceRecordParser::PrintHumanReadableIOTraceRecord(
      << ", File Name: " << record.file_name.c_str();
 
   /* Read remaining options based on io_op_data set by file operation */
-  uint64_t io_op_data = record.io_op_data;
+  int64_t io_op_data = static_cast<int64_t>(record.io_op_data);
   while (io_op_data) {
     // Find the rightmost set bit.
-    int set_pos = log2(io_op_data & -io_op_data);
+    uint32_t set_pos = static_cast<uint32_t>(log2(io_op_data & -io_op_data));
     switch (set_pos) {
       case IOTraceOp::kIOFileSize:
         ss << ", File Size: " << record.file_size;

--- a/trace_replay/io_tracer.cc
+++ b/trace_replay/io_tracer.cc
@@ -40,6 +40,12 @@ Status IOTraceWriter::WriteIOOp(const IOTraceRecord& record) {
   Slice file_name(record.file_name);
   PutLengthPrefixedSlice(&trace.payload, file_name);
 
+  // Each bit in io_op_data stores which corresponding info from IOTraceOp will
+  // be added in the trace. Foreg, if bit at position 1 is set then
+  // IOTraceOp::kIOLen (length) will be logged in the record (Since
+  // IOTraceOp::kIOLen = 1 in the enum). So find all the set positions in
+  // io_op_data one by one and, update corresponsing info in the trace record,
+  // unset that bit to find other set bits until io_op_data = 0.
   /* Write remaining options based on io_op_data set by file operation */
   int64_t io_op_data = static_cast<int64_t>(record.io_op_data);
   while (io_op_data) {
@@ -167,6 +173,12 @@ Status IOTraceReader::ReadIOOp(IOTraceRecord* record) {
   }
   record->file_name = file_name.ToString();
 
+  // Each bit in io_op_data stores which corresponding info from IOTraceOp will
+  // be added in the trace. Foreg, if bit at position 1 is set then
+  // IOTraceOp::kIOLen (length) will be logged in the record (Since
+  // IOTraceOp::kIOLen = 1 in the enum). So find all the set positions in
+  // io_op_data one by one and, update corresponsing info in the trace record,
+  // unset that bit to find other set bits until io_op_data = 0.
   /* Read remaining options based on io_op_data set by file operation */
   // Assuming 63 bits will be used at max.
   int64_t io_op_data = static_cast<int64_t>(record->io_op_data);

--- a/trace_replay/io_tracer.cc
+++ b/trace_replay/io_tracer.cc
@@ -41,10 +41,10 @@ Status IOTraceWriter::WriteIOOp(const IOTraceRecord& record) {
   PutLengthPrefixedSlice(&trace.payload, file_name);
 
   /* Write remaining options based on io_op_data set by file operation */
-  uint64_t io_op_data = record.io_op_data;
+  int64_t io_op_data = static_cast<int64_t>(record.io_op_data);
   while (io_op_data) {
     // Find the rightmost set bit.
-    int set_pos = log2(io_op_data & -io_op_data);
+    uint32_t set_pos = static_cast<uint32_t>(log2(io_op_data & -io_op_data));
     switch (set_pos) {
       case IOTraceOp::kIOFileSize:
         PutFixed64(&trace.payload, record.file_size);
@@ -168,10 +168,11 @@ Status IOTraceReader::ReadIOOp(IOTraceRecord* record) {
   record->file_name = file_name.ToString();
 
   /* Read remaining options based on io_op_data set by file operation */
-  uint64_t io_op_data = record->io_op_data;
+  // Assuming 63 bits will be used at max.
+  int64_t io_op_data = static_cast<int64_t>(record->io_op_data);
   while (io_op_data) {
     // Find the rightmost set bit.
-    int set_pos = log2(io_op_data & -io_op_data);
+    uint32_t set_pos = static_cast<uint32_t>(log2(io_op_data & -io_op_data));
     switch (set_pos) {
       case IOTraceOp::kIOFileSize:
         if (!GetFixed64(&enc_slice, &record->file_size)) {

--- a/trace_replay/io_tracer.h
+++ b/trace_replay/io_tracer.h
@@ -16,6 +16,15 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+/* In order to log new data in trace record for specified operations, do
+   following:
+   1. Add new data in IOTraceOP (say kIONewData= 3)
+   2. Log it in IOTraceWriter::WriteIOOp, and read that in
+   IOTraceReader::ReadIOOp and
+   IOTraceRecordParser::PrintHumanReadableIOTraceRecord in the switch case.
+   3. In the FileSystemTracer APIs where this data will be logged with, update
+   io_op_data |= (1 << IOTraceOp::kIONewData).
+*/
 enum IOTraceOp : char {
   // The value of each enum represents the bitwise position for
   // IOTraceRecord.io_op_data.

--- a/trace_replay/io_tracer.h
+++ b/trace_replay/io_tracer.h
@@ -35,6 +35,7 @@ struct IOTraceRecord {
   std::string file_operation;
   uint64_t latency = 0;
   std::string io_status;
+  // Stores file name instead of full path.
   std::string file_name;
   // Fields added to record based on IO operation.
   uint64_t len = 0;

--- a/trace_replay/io_tracer.h
+++ b/trace_replay/io_tracer.h
@@ -16,15 +16,27 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+enum IOTraceOp : char {
+  // The value of each enum represents the bitwise position for
+  // IOTraceRecord.io_op_data.
+  kIOFileSize = 0,
+  kIOLen = 1,
+  kIOOffset = 2,
+};
+
 struct IOTraceRecord {
   // Required fields for all accesses.
   uint64_t access_timestamp = 0;
   TraceType trace_type = TraceType::kTraceMax;
+  // Each bit in io_op_data stores which corresponding info from IOTraceOp will
+  // be added in the trace. Foreg, if bit at position 1 is set then
+  // IOTraceOp::kIOLen (length) will be logged in the record.
+  uint64_t io_op_data = 0;
   std::string file_operation;
   uint64_t latency = 0;
   std::string io_status;
-  // Required fields for read.
   std::string file_name;
+  // Fields added to record based on IO operation.
   uint64_t len = 0;
   uint64_t offset = 0;
   uint64_t file_size = 0;
@@ -32,21 +44,12 @@ struct IOTraceRecord {
   IOTraceRecord() {}
 
   IOTraceRecord(const uint64_t& _access_timestamp, const TraceType& _trace_type,
-                const std::string& _file_operation, const uint64_t& _latency,
-                const std::string& _io_status, const std::string& _file_name)
+                const uint64_t& _io_op_data, const std::string& _file_operation,
+                const uint64_t& _latency, const std::string& _io_status,
+                const std::string& _file_name, const uint64_t& _file_size = 0)
       : access_timestamp(_access_timestamp),
         trace_type(_trace_type),
-        file_operation(_file_operation),
-        latency(_latency),
-        io_status(_io_status),
-        file_name(_file_name) {}
-
-  IOTraceRecord(const uint64_t& _access_timestamp, const TraceType& _trace_type,
-                const std::string& _file_operation, const uint64_t& _latency,
-                const std::string& _io_status, const std::string& _file_name,
-                const uint64_t& _file_size)
-      : access_timestamp(_access_timestamp),
-        trace_type(_trace_type),
+        io_op_data(_io_op_data),
         file_operation(_file_operation),
         latency(_latency),
         io_status(_io_status),
@@ -54,14 +57,17 @@ struct IOTraceRecord {
         file_size(_file_size) {}
 
   IOTraceRecord(const uint64_t& _access_timestamp, const TraceType& _trace_type,
-                const std::string& _file_operation, const uint64_t& _latency,
-                const std::string& _io_status, const uint64_t& _len = 0,
-                const uint64_t& _offset = 0)
+                const uint64_t& _io_op_data, const std::string& _file_operation,
+                const uint64_t& _latency, const std::string& _io_status,
+                const std::string& _file_name, const uint64_t& _len,
+                const uint64_t& _offset)
       : access_timestamp(_access_timestamp),
         trace_type(_trace_type),
+        io_op_data(_io_op_data),
         file_operation(_file_operation),
         latency(_latency),
         io_status(_io_status),
+        file_name(_file_name),
         len(_len),
         offset(_offset) {}
 };

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -46,12 +46,8 @@ enum TraceType : char {
   kBlockTraceDataBlock = 9,
   kBlockTraceUncompressionDictBlock = 10,
   kBlockTraceRangeDeletionBlock = 11,
-  // IO Trace related types based on options that will be added in trace file.
-  kIOGeneral = 12,
-  kIOFileName = 13,
-  kIOFileNameAndFileSize = 14,
-  kIOLen = 15,
-  kIOLenAndOffset = 16,
+  // For IOTracing.
+  kIOTracer = 12,
   // All trace types should be added before kTraceMax
   kTraceMax,
 };


### PR DESCRIPTION
Summary: 1. In IOTracing, add filename with each IOTrace record. Filename is stored in file object (Tracing Wrappers).
         2. Change the logic of figuring out which additional information (file_size,
            length, offset etc) needs to be store with each operation
            which is different for different operations.
            When new information will be added in future (depends on operation),
            this change would make the future additions simple.
  
Logic: In IOTraceRecord, io_op_data is added and its
         bitwise positions represent which additional information need
         to added in the record from enum IOTraceOp. Values in IOTraceOp represent bitwise positions.
         So if length and offset needs to be stored (IOTraceOp::kIOLen
         is 1 and IOTraceOp::kIOOffset is 2), position 1 and 2 (from rightmost bit) will be set
         and io_op_data will contain 110.

Test Plan: Updated io_tracer_test and verified the trace file manually.

Reviewers:

Subscribers:

Tasks:

Tags: