### PR TITLE
workaround race conditions during `PeriodicWorkScheduler` registration

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # Rocksdb Change Log
+## Unreleased
+* Fix a race condition between DB startups and shutdowns in managing the periodic background worker threads. One effect of this race condition could be the process being terminated.
+
 ## 6.17.0 (01/15/2021)
 ### Behavior Changes
 * When verifying full file checksum with `DB::VerifyFileChecksums()`, we now fail with `Status::InvalidArgument` if the name of the checksum generator used for verification does not match the name of the checksum generator used for protecting the file when it was created.

--- a/db/periodic_work_scheduler.h
+++ b/db/periodic_work_scheduler.h
@@ -43,7 +43,7 @@ class PeriodicWorkScheduler {
  protected:
   std::unique_ptr<Timer> timer;
   // `timer_mu_` serves two purposes currently:
-  // (1) to ensure calls to `Register()` and `Unregister()` are serialized, as
+  // (1) to ensure calls to `Start()` and `Shutdown()` are serialized, as
   //     they are currently not implemented in a thread-safe way; and
   // (2) to ensure the `Timer::Add()`s and `Timer::Start()` run atomically, and
   //     the `Timer::Cancel()`s and `Timer::Shutdown()` run atomically.

--- a/db/periodic_work_scheduler.h
+++ b/db/periodic_work_scheduler.h
@@ -42,6 +42,12 @@ class PeriodicWorkScheduler {
 
  protected:
   std::unique_ptr<Timer> timer;
+  // `timer_mu_` serves two purposes currently:
+  // (1) to ensure calls to `Register()` and `Unregister()` are serialized, as
+  //     they are currently not implemented in a thread-safe way; and
+  // (2) to ensure the `Timer::Add()`s and `Timer::Start()` run atomically, and
+  //     the `Timer::Cancel()`s and `Timer::Shutdown()` run atomically.
+  port::Mutex timer_mu_;
 
   explicit PeriodicWorkScheduler(Env* env);
 

--- a/util/timer.h
+++ b/util/timer.h
@@ -22,6 +22,9 @@ namespace ROCKSDB_NAMESPACE {
 
 // A Timer class to handle repeated work.
 //
+// `Start()` and `Shutdown()` are currently not thread-safe. The client must
+// serialize calls to these two member functions.
+//
 // A single timer instance can handle multiple functions via a single thread.
 // It is better to leave long running work to a dedicated thread pool.
 //


### PR DESCRIPTION
This provides a workaround for two race conditions that will be fixed in
a more sophisticated way later. This PR:

(1) Makes the client serialize calls to `Timer::Start()` and `Timer::Shutdown()` (see #7711). The long-term fix will be to make those functions thread-safe.
(2) Makes `PeriodicWorkScheduler` atomically add/cancel work together with starting/shutting down its `Timer`. The long-term fix will be for `Timer` API to offer more specialized APIs so the client will not need to synchronize.

Test Plan: ran the repro provided in #7881