### PR TITLE
Cleanup multiple DBs after running db_bench in multi-DB mode

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -2784,6 +2784,9 @@ class Benchmark {
 
   ~Benchmark() {
     db_.DeleteDBs();
+    for (auto db : multi_dbs_) {
+      db.DeleteDBs();
+    }
     delete prefix_extractor_;
     if (cache_.get() != nullptr) {
       // this will leak, but we're shutting down so nobody cares


### PR DESCRIPTION
Summary:
Currently, db_bench cleanup only deletes the main DB, if there's one.
Multiple DBs that are opened when --num_multi_db is specified are not
deleted, which can lead to crashes due to running compaction threads on
process exit.

Test plan:
Run regression test