### PR TITLE
fix write option typo in java samples

### DIFF
--- a/java/samples/src/main/java/RocksDBSample.java
+++ b/java/samples/src/main/java/RocksDBSample.java
@@ -210,7 +210,7 @@ public class RocksDBSample {
         // repeat the test with WriteOptions
         try (final WriteOptions writeOpts = new WriteOptions()) {
           writeOpts.setSync(true);
-          writeOpts.setDisableWAL(true);
+          writeOpts.setDisableWAL(false);
           db.put(writeOpts, testKey, testValue);
           len = db.get(testKey, enoughArray);
           assert (len == testValue.length);


### PR DESCRIPTION
this is a trivial PR for rocksdb java samples, I think it is a typo about write options. to do sync write, WAL should not be disabled