### PR TITLE
add string separation while composing error message

### DIFF
--- a/util/status.cc
+++ b/util/status.cc
@@ -150,7 +150,9 @@ std::string Status::ToString() const {
   }
 
   if (state_ != nullptr) {
-    result.append(": ");
+    if (subcode_ != kNone) {
+      result.append(": ");
+    }
     result.append(state_);
   }
   return result;

--- a/util/status.cc
+++ b/util/status.cc
@@ -150,6 +150,7 @@ std::string Status::ToString() const {
   }
 
   if (state_ != nullptr) {
+    result.append(": ");
     result.append(state_);
   }
   return result;


### PR DESCRIPTION
This will fix a missing string separation between `msg[n]` and `state_`.
Example of an error message how its looking now:
```
IO error: No space left on deviceWhile appending to file: /home/willi/src/stable-3.7/tmp/arangosh_CL6EFQ/shell_client/single1/data/engine-rocksdb/126426.sst: No space left on device
```