### PR TITLE
Fix db_bench_tool_test

### DIFF
--- a/tools/db_bench_tool_test.cc
+++ b/tools/db_bench_tool_test.cc
@@ -69,7 +69,7 @@ class DBBenchTest : public testing::Test {
     opt.dump_malloc_stats = true;  // db_bench uses a different default
     opt.compaction_style = style;
     opt.num_levels = levels;
-    opt.compression = Snappy_Supported() ? kSnappyCompression : kNoCompression;
+    opt.compression = kNoCompression;
     opt.arena_block_size = 8388608;
 
     return SanitizeOptions(db_path_, opt);
@@ -127,7 +127,7 @@ TEST_F(DBBenchTest, OptionsFile) {
   const std::string kOptionsFileName = test_path_ + "/OPTIONS_test";
   Options opt = GetDefaultOptions();
   ASSERT_OK(PersistRocksDBOptions(DBOptions(opt), {"default"},
-                                  {ColumnFamilyOptions()}, kOptionsFileName,
+                                  {ColumnFamilyOptions(opt)}, kOptionsFileName,
                                   opt.env->GetFileSystem().get()));
 
   // override the following options as db_bench will not take these

--- a/tools/db_bench_tool_test.cc
+++ b/tools/db_bench_tool_test.cc
@@ -69,7 +69,7 @@ class DBBenchTest : public testing::Test {
     opt.dump_malloc_stats = true;  // db_bench uses a different default
     opt.compaction_style = style;
     opt.num_levels = levels;
-    opt.compression = kNoCompression;
+    opt.compression = Snappy_Supported() ? kSnappyCompression : kNoCompression;
     opt.arena_block_size = 8388608;
 
     return SanitizeOptions(db_path_, opt);
@@ -164,7 +164,7 @@ TEST_F(DBBenchTest, OptionsFileMultiLevelUniversal) {
 
   ASSERT_OK(PersistRocksDBOptions(DBOptions(opt), {"default"},
                                   {ColumnFamilyOptions(opt)}, kOptionsFileName,
-                                  fs_.get()));
+                                  opt.env->GetFileSystem().get()));
 
   // override the following options as db_bench will not take these
   // options from the options file
@@ -316,7 +316,7 @@ TEST_F(DBBenchTest, OptionsFileFromFile) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
   return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
Summary:
The patch fixes the build for `db_bench_tool_test` and makes the tests pass.
Namely, it fixes the following issues:

* #7703 removed the member variable `fs_` but the test case `OptionsFileMultiLevelUniversal`
was not updated.
* #7344 fixed the `OptionsFile` test case for the case when Snappy is *not* available but at the
same time broke it for the case when it *is* available. (The test used a default-constructed
`ColumnFamilyOptions` object, and the default value of the `compression` option is either
Snappy or no compression depending on whether Snappy is supported.)
* The test used `google::ParseCommandLineFlags` instead of
`GFLAGS_NAMESPACE::ParseCommandLineFlags`.

Test Plan:
Ran the test both with and without Snappy support.