### PR TITLE
Fix an assertion failure in range locking, locktree code.

### DIFF
--- a/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.cc
+++ b/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.cc
@@ -187,8 +187,10 @@ static bool determine_conflicting_txnids(
     if (other_txnid != txnid) {
       if (conflicts) {
         if (other_txnid == TXNID_SHARED) {
+          // Add all shared lock owners, except this transaction.
           for (TXNID shared_id : *lock.owners) {
-            conflicts->add(shared_id);
+            if (shared_id != txnid)
+              conflicts->add(shared_id);
           }
         } else {
           conflicts->add(other_txnid);


### PR DESCRIPTION
Fix this scenario:
trx1> acquire shared lock on $key
trx2> acquire shared lock on the same $key
trx1> attempt to acquire a unique lock on $key.

Lock acquisition will fail, and deadlock detection will start.
It will call iterate_and_get_overlapping_row_locks() which will
produce a list with two locks (shared locks by trx1 and trx2).

However the code in lock_request::build_wait_graph() was not prepared
to find the lock by the same transaction in the list of conflicting
locks. Fix it to ignore it.

(One may suggest to fix iterate_and_get_overlapping_row_locks() to not
include locks by trx1. This is not a good idea, because that function
is also used to report all locks currently held)