### PR TITLE
Avoid self-move-assign in pop operation of binary heap.

### DIFF
--- a/util/heap.h
+++ b/util/heap.h
@@ -72,7 +72,12 @@ class BinaryHeap {
 
   void pop() {
     assert(!empty());
-    data_.front() = std::move(data_.back());
+    if (data_.size() > 1) {
+      // Avoid self-move-assign, because it could cause problems with
+      // classes which are not prepared for this and it trips up the
+      // STL debugger when activated.
+      data_.front() = std::move(data_.back());
+    }
     data_.pop_back();
     if (!empty()) {
       downheap(get_root());


### PR DESCRIPTION
The current implementation of a binary heap in `util/heap.h` does a move-assign in the `pop` method. In the case that there is exactly one element stored in the heap, this ends up being a self-move-assign. This can cause trouble with certain classes, which are not prepared for this. Furthermore, it trips up the glibc STL debugger (`-D_GLIBCXX_DEBUG`), which produces an assertion failure in this case.

This PR addresses this problem by not doing the (unnecessary in this case) move-assign if there is only one element in the heap.