### PR TITLE
Update clang-format-diff.py path

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Download clang-format-diff.py
       uses: wei/wget@v1
       with:
-        args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
+        args: https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Download clang-format-diff.py
       uses: wei/wget@v1
       with:
-        args: https://raw.githubusercontent.com/llvm/llvm-project/master/clang/tools/clang-format/clang-format-diff.py
+        args: https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/clang-format-diff.py
 
     - name: Check format
       run: VERBOSE_CHECK=1 make check-format

--- a/Makefile
+++ b/Makefile
@@ -2514,6 +2514,8 @@ build_subset_tests: $(ROCKSDBTESTS_SUBSET)
 # working solution.
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),format)
+ifneq ($(MAKECMDGOALS),check-format)
+ifneq ($(MAKECMDGOALS),check-buck-targets)
 ifneq ($(MAKECMDGOALS),jclean)
 ifneq ($(MAKECMDGOALS),jtest)
 ifneq ($(MAKECMDGOALS),rocksdbjavastatic)
@@ -2521,6 +2523,8 @@ ifneq ($(MAKECMDGOALS),rocksdbjavastatic_deps)
 ifneq ($(MAKECMDGOALS),package)
 ifneq ($(MAKECMDGOALS),analyze)
 -include $(DEPFILES)
+endif
+endif
 endif
 endif
 endif

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -52,7 +52,7 @@ else
     else
       echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
       echo "You can download clang-format-diff.py by running: "
-      echo "    curl --location https://tinyurl.com/y2kvokof -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location tinyurl.com/89phbdt9 -o ${REPO_ROOT}/clang-format-diff.py"
       echo "You can download clang-format by running:"
       echo "    brew install clang-format"
       echo "  Or"
@@ -82,7 +82,7 @@ else
       echo "You have clang-format-diff.py for Python 2 but are using a Python 3"
       echo "interpreter (${PYTHON:-python3})."
       echo "You can download clang-format-diff.py for Python 3 by running: "
-      echo "    curl --location https://tinyurl.com/y2kvokof -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location tinyurl.com/89phbdt9 -o ${REPO_ROOT}/clang-format-diff.py"
       exit 130
     fi
     CLANG_FORMAT_DIFF="${PYTHON:-python3} $CFD_PATH"

--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -52,7 +52,7 @@ else
     else
       echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
       echo "You can download clang-format-diff.py by running: "
-      echo "    curl --location tinyurl.com/89phbdt9 -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location tinyurl.com/16e4xpg1 -o ${REPO_ROOT}/clang-format-diff.py"
       echo "You can download clang-format by running:"
       echo "    brew install clang-format"
       echo "  Or"
@@ -82,7 +82,7 @@ else
       echo "You have clang-format-diff.py for Python 2 but are using a Python 3"
       echo "interpreter (${PYTHON:-python3})."
       echo "You can download clang-format-diff.py for Python 3 by running: "
-      echo "    curl --location tinyurl.com/89phbdt9 -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location tinyurl.com/16e4xpg1 -o ${REPO_ROOT}/clang-format-diff.py"
       exit 130
     fi
     CLANG_FORMAT_DIFF="${PYTHON:-python3} $CFD_PATH"


### PR DESCRIPTION
Summary:
Recent Github actions of format checking fail due to invalid location
from where clang-format-diff.py is downloaded. Update the path to point
to a stable, archived location.

Test Plan: manually check the result of Github action.