### PR TITLE
Use actual url instead of tinyurl.com

### DIFF
--- a/build_tools/format-diff.sh
+++ b/build_tools/format-diff.sh
@@ -52,7 +52,8 @@ else
     else
       echo "You didn't have clang-format-diff.py and/or clang-format available in your computer!"
       echo "You can download clang-format-diff.py by running: "
-      echo "    curl --location tinyurl.com/16e4xpg1 -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "You should make sure the downloaded script is not compromised."
       echo "You can download clang-format by running:"
       echo "    brew install clang-format"
       echo "  Or"
@@ -82,7 +83,8 @@ else
       echo "You have clang-format-diff.py for Python 2 but are using a Python 3"
       echo "interpreter (${PYTHON:-python3})."
       echo "You can download clang-format-diff.py for Python 3 by running: "
-      echo "    curl --location tinyurl.com/16e4xpg1 -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "    curl --location https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/clang-format-diff.py -o ${REPO_ROOT}/clang-format-diff.py"
+      echo "You should make sure the downloaded script is not compromised."
       exit 130
     fi
     CLANG_FORMAT_DIFF="${PYTHON:-python3} $CFD_PATH"


### PR DESCRIPTION
Due to offline discussion, we use actual url of the clang-format-diff.py and add a note.