### PR TITLE
Fix typo: replace readadhead with readahead

### DIFF
--- a/file/file_prefetch_buffer.cc
+++ b/file/file_prefetch_buffer.cc
@@ -119,7 +119,7 @@ bool FilePrefetchBuffer::TryReadFromCache(const IOOptions& opts,
   }
 
   // If the buffer contains only a few of the requested bytes:
-  //    If readahead is enabled: prefetch the remaining bytes + readadhead bytes
+  //    If readahead is enabled: prefetch the remaining bytes + readahead bytes
   //        and satisfy the request.
   //    If readahead is not enabled: return false.
   if (offset + n > buffer_offset_ + buffer_.CurrentSize()) {

--- a/file/file_prefetch_buffer.h
+++ b/file/file_prefetch_buffer.h
@@ -41,16 +41,16 @@ class FilePrefetchBuffer {
   //
   // Automatic readhead is enabled for a file if file_reader, readahead_size,
   // and max_readahead_size are passed in.
-  // If file_reader is a nullptr, setting readadhead_size and max_readahead_size
+  // If file_reader is a nullptr, setting readahead_size and max_readahead_size
   // does not make any sense. So it does nothing.
   // A user can construct a FilePrefetchBuffer without any arguments, but use
   // `Prefetch` to load data into the buffer.
   FilePrefetchBuffer(RandomAccessFileReader* file_reader = nullptr,
-                     size_t readadhead_size = 0, size_t max_readahead_size = 0,
+                     size_t readahead_size = 0, size_t max_readahead_size = 0,
                      bool enable = true, bool track_min_offset = false)
       : buffer_offset_(0),
         file_reader_(file_reader),
-        readahead_size_(readadhead_size),
+        readahead_size_(readahead_size),
         max_readahead_size_(max_readahead_size),
         min_offset_read_(port::kMaxSizet),
         enable_(enable),
@@ -67,7 +67,7 @@ class FilePrefetchBuffer {
   // Tries returning the data for a file raed from this buffer, if that data is
   // in the buffer.
   // It handles tracking the minimum read offset if track_min_offset = true.
-  // It also does the exponential readahead when readadhead_size is set as part
+  // It also does the exponential readahead when readahead_size is set as part
   // of the constructor.
   //
   // offset : the file offset.

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -195,7 +195,7 @@ IOStatus GenerateOneFileChecksum(
                               : default_max_read_ahead_size;
 
   FilePrefetchBuffer prefetch_buffer(
-      reader.get(), readahead_size /* readadhead_size */,
+      reader.get(), readahead_size /* readahead_size */,
       readahead_size /* max_readahead_size */, !allow_mmap_reads /* enable */);
 
   Slice slice;

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2925,7 +2925,7 @@ Status BlockBasedTable::VerifyChecksumInBlocks(
   // FilePrefetchBuffer doesn't work in mmap mode and readahead is not
   // needed there.
   FilePrefetchBuffer prefetch_buffer(
-      rep_->file.get(), readahead_size /* readadhead_size */,
+      rep_->file.get(), readahead_size /* readahead_size */,
       readahead_size /* max_readahead_size */,
       !rep_->ioptions.allow_mmap_reads /* enable */);
 


### PR DESCRIPTION
Summary:

This PR replaces several "readadhead" typos with "readahead".