### PR TITLE
Update win_logger.cc : assert failed when return value not checked. (-DROCKSDB_ASSERT_STATUS_CHECKED)

### DIFF
--- a/port/win/win_logger.cc
+++ b/port/win/win_logger.cc
@@ -56,7 +56,7 @@ void WinLogger::DebugWriter(const char* str, int len) {
   }
 }
 
-WinLogger::~WinLogger() { CloseInternal(); }
+WinLogger::~WinLogger() { CloseInternal().PermitUncheckedError(); }
 
 Status WinLogger::CloseImpl() {
   return CloseInternal();


### PR DESCRIPTION
Ignore return value on WinLogger::CloseInternal() when build with -DROCKSDB_ASSERT_STATUS_CHECKED on windows.

It's a good way to ignore check here?