### PR TITLE
c:h export rocksdb_transactiondb_open_column_families

### DIFF
--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1937,7 +1937,7 @@ extern ROCKSDB_LIBRARY_API rocksdb_transactiondb_t* rocksdb_transactiondb_open(
     const rocksdb_transactiondb_options_t* txn_db_options, const char* name,
     char** errptr);
 
-rocksdb_transactiondb_t* rocksdb_transactiondb_open_column_families(
+extern ROCKSDB_LIBRARY_API rocksdb_transactiondb_t* rocksdb_transactiondb_open_column_families(
     const rocksdb_options_t* options,
     const rocksdb_transactiondb_options_t* txn_db_options, const char* name,
     int num_column_families, const char* const* column_family_names,


### PR DESCRIPTION
Hi, I noticed a bug in rocksdb C API, where a function is not exported and created a fix.