### PR TITLE
Java-API: Missing space in string literal

### DIFF
--- a/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
+++ b/java/src/main/java/org/rocksdb/AdvancedColumnFamilyOptionsInterface.java
@@ -301,7 +301,7 @@ public interface AdvancedColumnFamilyOptionsInterface<
    * @return the reference to the current options.
    */
   @Experimental("Turning this feature on or off for an existing DB can cause" +
-      "unexpected LSM tree structure so it's not recommended")
+      " unexpected LSM tree structure so it's not recommended")
   T setLevelCompactionDynamicLevelBytes(
       boolean enableLevelCompactionDynamicLevelBytes);
 

--- a/java/src/main/java/org/rocksdb/TtlDB.java
+++ b/java/src/main/java/org/rocksdb/TtlDB.java
@@ -113,7 +113,7 @@ public class TtlDB extends RocksDB {
       throws RocksDBException {
     if (columnFamilyDescriptors.size() != ttlValues.size()) {
       throw new IllegalArgumentException("There must be a ttl value per column"
-          + "family handle.");
+          + " family handle.");
     }
 
     final byte[][] cfNames = new byte[columnFamilyDescriptors.size()][];


### PR DESCRIPTION
`TtlDB.open()`: missing space after 'column'
`AdvancedColumnFamilyOptionsInterface.setLevelCompactionDynamicLevelBytes()`: missing space after 'cause'
