### PR TITLE
Fix testcase failures on windows

### DIFF
--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -48,6 +48,8 @@ class FlushJobTestBase : public testing::Test {
     if (getenv("KEEP_DB")) {
       fprintf(stdout, "db is still in %s\n", dbname_.c_str());
     } else {
+      // destroy versions_ to release all file handles
+      versions_.reset();
       EXPECT_OK(DestroyDir(env_, dbname_));
     }
   }

--- a/monitoring/stats_history_test.cc
+++ b/monitoring/stats_history_test.cc
@@ -245,10 +245,10 @@ TEST_F(StatsHistoryTest, InMemoryStatsHistoryPurging) {
   }
   size_t stats_history_size = dbfull()->TEST_EstimateInMemoryStatsHistorySize();
   ASSERT_GE(slice_count, kIterations - 1);
-  ASSERT_GE(stats_history_size, 13000);
-  // capping memory cost at 13000 bytes since one slice is around 10000~13000
-  ASSERT_OK(dbfull()->SetDBOptions({{"stats_history_buffer_size", "13000"}}));
-  ASSERT_EQ(13000, dbfull()->GetDBOptions().stats_history_buffer_size);
+  ASSERT_GE(stats_history_size, 14000);
+  // capping memory cost at 14000 bytes since one slice is around 10000~14000
+  ASSERT_OK(dbfull()->SetDBOptions({{"stats_history_buffer_size", "14000"}}));
+  ASSERT_EQ(14000, dbfull()->GetDBOptions().stats_history_buffer_size);
 
   // Wait for stats persist to finish
   for (int i = 0; i < kIterations; ++i) {

--- a/tools/sst_dump_test.cc
+++ b/tools/sst_dump_test.cc
@@ -392,6 +392,8 @@ TEST_F(SSTDumpToolTest, RawOutput) {
 
   ASSERT_EQ(kNumKey, key_count);
 
+  raw_file.close();
+
   cleanup(opts, file_path);
   for (int i = 0; i < 3; i++) {
     delete[] usage[i];

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -573,8 +573,10 @@ TEST_P(FullBloomTest, OptimizeForMemory) {
 #ifdef ROCKSDB_JEMALLOC
       fprintf(stderr, "Jemalloc detected? %d\n", HasJemalloc());
       if (HasJemalloc()) {
+#ifdef ROCKSDB_MALLOC_USABLE_SIZE
         // More than 5% internal fragmentation
         EXPECT_GE(total_mem, total_size * 105 / 100);
+#endif  // ROCKSDB_MALLOC_USABLE_SIZE
       }
 #endif  // ROCKSDB_JEMALLOC
       // No storage penalty, just usual overhead


### PR DESCRIPTION
Fixed 5 test case failures found on Windows 10/Windows Server 2016
1. In `flush_job_test`, the DestroyDir function fails in deconstructor because some file handles are still being held by VersionSet. This happens on Windows Server 2016, so need to manually reset versions_ pointer to release all file handles.
2. In `StatsHistoryTest.InMemoryStatsHistoryPurging` test, the capping memory cost of stats_history_size on Windows becomes 14000 bytes with latest changes, not just 13000 bytes.
3. In `SSTDumpToolTest.RawOutput` test, the output file handle is not closed at the end.
4. In `FullBloomTest.OptimizeForMemory` test, ROCKSDB_MALLOC_USABLE_SIZE is undefined on windows so `total_mem` is always equal to `total_size`. The internal memory fragmentation assertion does not apply in this case.
5. In `BlockFetcherTest.FetchAndUncompressCompressedDataBlock` test, XPRESS cannot reach 87.5% compression ratio with original CreateTable method, so I append extra zeros to the string value to enhance compression ratio. Beside, since XPRESS allocates memory internally, thus does not support for custom allocator verification, we will skip the allocator verification for XPRESS 