### PR TITLE
Create DB properties for internal table cache

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -245,7 +245,8 @@ void GetExpectedTableProperties(
   const int kDeletionCount = kTableCount * kDeletionsPerTable;
   const int kMergeCount = kTableCount * kMergeOperandsPerTable;
   const int kRangeDeletionCount = kTableCount * kRangeDeletionsPerTable;
-  const int kKeyCount = kPutCount + kDeletionCount + kMergeCount + kRangeDeletionCount;
+  const int kKeyCount =
+      kPutCount + kDeletionCount + kMergeCount + kRangeDeletionCount;
   const int kAvgSuccessorSize = kKeySize / 5;
   const int kEncodingSavePerKey = kKeySize / 4;
   expected_tp->raw_key_size = kKeyCount * (kKeySize + 8);
@@ -256,7 +257,8 @@ void GetExpectedTableProperties(
   expected_tp->num_merge_operands = kMergeCount;
   expected_tp->num_range_deletions = kRangeDeletionCount;
   expected_tp->num_data_blocks =
-      kTableCount * (kKeysPerTable * (kKeySize - kEncodingSavePerKey + kValueSize)) /
+      kTableCount *
+      (kKeysPerTable * (kKeySize - kEncodingSavePerKey + kValueSize)) /
       kBlockSize;
   expected_tp->data_size =
       kTableCount * (kKeysPerTable * (kKeySize + 8 + kValueSize));
@@ -1090,7 +1092,8 @@ class CountingUserTblPropCollector : public TablePropertiesCollector {
     std::string encoded;
     PutVarint32(&encoded, count_);
     *properties = UserCollectedProperties{
-        {"CountingUserTblPropCollector", message_}, {"Count", encoded},
+        {"CountingUserTblPropCollector", message_},
+        {"Count", encoded},
     };
     return Status::OK();
   }
@@ -1728,16 +1731,15 @@ TEST_F(DBPropertiesTest, TableCacheProperties) {
   // test table_cache access is "live"
   //  get default max_open_files
   //
-  ASSERT_TRUE(
-      db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
   new_value = value / 2;
 
   std::unordered_map<std::string, std::string> new_options;
-  new_options.insert(std::pair<std::string, std::string>("max_open_files", std::to_string(new_value)));
+  new_options.insert(std::pair<std::string, std::string>(
+      "max_open_files", std::to_string(new_value)));
   rocksdb::Status stat = db_->SetDBOptions(new_options);
   ASSERT_TRUE(stat.ok());
-  ASSERT_TRUE(
-      db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
   // rocksdb does a -10 to number passed in
   ASSERT_EQ(new_value - 10, value);
 
@@ -1747,9 +1749,9 @@ TEST_F(DBPropertiesTest, TableCacheProperties) {
   ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheUsage, &value));
   ASSERT_OK(Put("foo", "v1"));
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
-  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheUsage, &new_value));
+  ASSERT_TRUE(
+      db_->GetIntProperty(DB::Properties::kTableCacheUsage, &new_value));
   ASSERT_EQ(new_value, value + 1);
-
 }
 
 #endif  // ROCKSDB_LITE

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -260,6 +260,8 @@ static const std::string estimate_oldest_key_time = "estimate-oldest-key-time";
 static const std::string block_cache_capacity = "block-cache-capacity";
 static const std::string block_cache_usage = "block-cache-usage";
 static const std::string block_cache_pinned_usage = "block-cache-pinned-usage";
+static const std::string table_cache_capacity = "table-cache-capacity";
+static const std::string table_cache_usage = "table-cache-usage";
 static const std::string options_statistics = "options-statistics";
 
 const std::string DB::Properties::kNumFilesAtLevelPrefix =
@@ -348,6 +350,10 @@ const std::string DB::Properties::kBlockCacheUsage =
     rocksdb_prefix + block_cache_usage;
 const std::string DB::Properties::kBlockCachePinnedUsage =
     rocksdb_prefix + block_cache_pinned_usage;
+const std::string DB::Properties::kTableCacheCapacity =
+    rocksdb_prefix + table_cache_capacity;
+const std::string DB::Properties::kTableCacheUsage =
+    rocksdb_prefix + table_cache_usage;
 const std::string DB::Properties::kOptionsStatistics =
     rocksdb_prefix + options_statistics;
 
@@ -486,6 +492,12 @@ const std::unordered_map<std::string, DBPropertyInfo>
           nullptr}},
         {DB::Properties::kBlockCachePinnedUsage,
          {false, nullptr, &InternalStats::HandleBlockCachePinnedUsage, nullptr,
+          nullptr}},
+        {DB::Properties::kTableCacheCapacity,
+         {false, nullptr, &InternalStats::HandleTableCacheCapacity, nullptr,
+          nullptr}},
+        {DB::Properties::kTableCacheUsage,
+         {false, nullptr, &InternalStats::HandleTableCacheUsage, nullptr,
           nullptr}},
         {DB::Properties::kOptionsStatistics,
          {false, nullptr, nullptr, nullptr,
@@ -984,6 +996,18 @@ bool InternalStats::HandleBlockCachePinnedUsage(uint64_t* value, DBImpl* /*db*/,
     return false;
   }
   *value = static_cast<uint64_t>(block_cache->GetPinnedUsage());
+  return true;
+}
+
+bool InternalStats::HandleTableCacheCapacity(uint64_t* value, DBImpl* db,
+                                             Version* /*version*/) {
+  *value = static_cast<uint64_t>(db->table_cache_->GetCapacity());
+  return true;
+}
+
+bool InternalStats::HandleTableCacheUsage(uint64_t* value, DBImpl* db,
+                                          Version* /*version*/) {
+  *value = static_cast<uint64_t>(db->table_cache_->GetUsage());
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -298,7 +298,7 @@ class InternalStats {
       this->num_dropped_records += c.num_dropped_records;
       this->count += c.count;
       int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
-      for (int i = 0; i< num_of_reasons; i++) {
+      for (int i = 0; i < num_of_reasons; i++) {
         counts[i] += c.counts[i];
       }
     }
@@ -439,8 +439,8 @@ class InternalStats {
   struct CFStatsSnapshot {
     // ColumnFamily-level stats
     CompactionStats comp_stats;
-    uint64_t ingest_bytes_flush;      // Bytes written to L0 (Flush)
-    uint64_t stall_count;             // Stall count
+    uint64_t ingest_bytes_flush;  // Bytes written to L0 (Flush)
+    uint64_t stall_count;         // Stall count
     // Stats from compaction jobs - bytes written, bytes read, duration.
     uint64_t compact_bytes_write;
     uint64_t compact_bytes_read;
@@ -482,10 +482,10 @@ class InternalStats {
 
   struct DBStatsSnapshot {
     // DB-level stats
-    uint64_t ingest_bytes;            // Bytes written by user
-    uint64_t wal_bytes;               // Bytes written to WAL
-    uint64_t wal_synced;              // Number of times WAL is synced
-    uint64_t write_with_wal;          // Number of writes that request WAL
+    uint64_t ingest_bytes;    // Bytes written by user
+    uint64_t wal_bytes;       // Bytes written to WAL
+    uint64_t wal_synced;      // Number of times WAL is synced
+    uint64_t write_with_wal;  // Number of writes that request WAL
     // These count the number of writes processed by the calling thread or
     // another thread.
     uint64_t write_other;
@@ -703,13 +703,14 @@ class InternalStats {
     return false;
   }
 
-  bool GetIntProperty(const DBPropertyInfo& /*property_info*/, uint64_t* /*value*/,
-                      DBImpl* /*db*/) const {
+  bool GetIntProperty(const DBPropertyInfo& /*property_info*/,
+                      uint64_t* /*value*/, DBImpl* /*db*/) const {
     return false;
   }
 
   bool GetIntPropertyOutOfMutex(const DBPropertyInfo& /*property_info*/,
-                                Version* /*version*/, uint64_t* /*value*/) const {
+                                Version* /*version*/,
+                                uint64_t* /*value*/) const {
     return false;
   }
 };

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -596,6 +596,8 @@ class InternalStats {
   bool HandleBlockCacheUsage(uint64_t* value, DBImpl* db, Version* version);
   bool HandleBlockCachePinnedUsage(uint64_t* value, DBImpl* db,
                                    Version* version);
+  bool HandleTableCacheCapacity(uint64_t* value, DBImpl* db, Version* version);
+  bool HandleTableCacheUsage(uint64_t* value, DBImpl* db, Version* version);
   // Total number of background errors encountered. Every time a flush task
   // or compaction task fails, this counter is incremented. The failure can
   // be caused by any possible reason, including file system errors, out of

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -923,6 +923,13 @@ class DB {
     //      entries being pinned.
     static const std::string kBlockCachePinnedUsage;
 
+    //  "rocksdb.table-cache-capacity" - returns table cache capacity.
+    static const std::string kTableCacheCapacity;
+
+    //  "rocksdb.table-cache-usage" - returns the memory size for the entries
+    //      residing in table cache.
+    static const std::string kTableCacheUsage;
+
     // "rocksdb.options-statistics" - returns multi-line string
     //      of options.statistics
     static const std::string kOptionsStatistics;
@@ -986,6 +993,8 @@ class DB {
   //  "rocksdb.block-cache-capacity"
   //  "rocksdb.block-cache-usage"
   //  "rocksdb.block-cache-pinned-usage"
+  //  "rocksdb.table-cache-capacity"
+  //  "rocksdb.table-cache-usage"
   virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
                               const Slice& property, uint64_t* value) = 0;
   virtual bool GetIntProperty(const Slice& property, uint64_t* value) {


### PR DESCRIPTION
This PR duplicates the existing two properties for BlockCacheCapacity() and BlockCacheUsage() by adding TableCacheCapacity() and TableCacheUsage().

There is currently no way to know how many .sst files are actually open within rocksdb.  The "usage" of the table cache gives that information.  It is important to know how many files are open to estimate the amount of table reader space per open file.  That estimate is then useful for memory management, including the reduction / expansion of the table_cache via SetDBOptions("max_open_files").
