### PR TITLE
Support retrieving checksums for blob files from the MANIFEST when checkpointing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@
 
 ### New Features
 * Support compaction filters for the new implementation of BlobDB. Add `FilterBlobByKey()` to `CompactionFilter`. Subclasses can override this method so that compaction filters can determine whether the actual blob value has to be read during compaction. Use a new `kUndetermined` in `CompactionFilter::Decision` to indicated that further action is necessary for compaction filter to make a decision.
-
+* Add support to extend retrieval of checksums for blob files from the MANIFEST when checkpointing. During backup, rocksdb can detect corruption in blob files  during file copies.
 
 ## 6.18.0 (02/19/2021)
 ### Behavior Changes

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -111,6 +111,14 @@ Status FileChecksumRetriever::ApplyVersionEdit(VersionEdit& edit,
       return s;
     }
   }
+  for (const auto& new_blob_file : edit.GetBlobFileAdditions()) {
+    Status s = file_checksum_list_.InsertOneFileChecksum(
+        new_blob_file.GetBlobFileNumber(), new_blob_file.GetChecksumValue(),
+        new_blob_file.GetChecksumMethod());
+    if (!s.ok()) {
+      return s;
+    }
+  }
   return Status::OK();
 }
 

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -112,9 +112,15 @@ Status FileChecksumRetriever::ApplyVersionEdit(VersionEdit& edit,
     }
   }
   for (const auto& new_blob_file : edit.GetBlobFileAdditions()) {
+    std::string checksum_value = new_blob_file.GetChecksumValue();
+    std::string checksum_method = new_blob_file.GetChecksumMethod();
+    assert(checksum_value.empty() == checksum_method.empty());
+    if (checksum_method.empty()) {
+      checksum_value = kUnknownFileChecksum;
+      checksum_method = kUnknownFileChecksumFuncName;
+    }
     Status s = file_checksum_list_.InsertOneFileChecksum(
-        new_blob_file.GetBlobFileNumber(), new_blob_file.GetChecksumValue(),
-        new_blob_file.GetChecksumMethod());
+        new_blob_file.GetBlobFileNumber(), checksum_value, checksum_method);
     if (!s.ok()) {
       return s;
     }

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -312,8 +312,8 @@ Status CheckpointImpl::CreateCustomCheckpoint(
     }
   }
 
-  // get checksum info for table files
-  // get table file checksums if get_live_table_checksum is true
+  // get checksum info for table and blob files.
+  // get table and blob file checksums if get_live_table_checksum is true
   std::unique_ptr<FileChecksumList> checksum_list;
 
   if (s.ok() && get_live_table_checksum) {
@@ -350,9 +350,8 @@ Status CheckpointImpl::CreateCustomCheckpoint(
       std::string checksum_value = kUnknownFileChecksum;
 
       // we ignore the checksums either they are not required or we failed to
-      // obtain the checksum lsit for old table files that have no file
+      // obtain the checksum list for old table files that have no file
       // checksums
-      // TODO: support this verification for blob files
       if (get_live_table_checksum) {
         // find checksum info for table files
         Status search = checksum_list->SearchOneFileChecksum(


### PR DESCRIPTION
Summary: The checkpointing logic supports passing file level checksums
to the copy_file_cb callback function which is used by the backup code
for detecting corruption during file copies.
However, this is currently implemented only for table files.

This PR extends the checksum retrieval to blob files as well.

Test Plan: Add new test units

Reviewers:

Subscribers:

Tasks:

Tags: