### PR TITLE
Still use SystemClock* instead of shared_ptr in StepPerfTimer

### DIFF
--- a/monitoring/iostats_context_imp.h
+++ b/monitoring/iostats_context_imp.h
@@ -40,7 +40,7 @@ extern __thread IOStatsContext iostats_context;
 // Declare and set start time of the timer
 #define IOSTATS_CPU_TIMER_GUARD(metric, clock)         \
   PerfStepTimer iostats_step_timer_##metric(           \
-      &(iostats_context.metric), clock, true,          \
+      &(iostats_context.metric), clock.get(), true,    \
       PerfLevel::kEnableTimeAndCPUTimeExceptForMutex); \
   iostats_step_timer_##metric.Start();
 

--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -46,14 +46,14 @@ extern thread_local PerfContext perf_context;
   perf_step_timer_##metric.Start();
 
 // Declare and set start time of the timer
-#define PERF_TIMER_GUARD_WITH_CLOCK(metric, clock)                       \
-  PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), clock); \
+#define PERF_TIMER_GUARD_WITH_CLOCK(metric, clock)                             \
+  PerfStepTimer perf_step_timer_##metric(&(perf_context.metric), clock.get()); \
   perf_step_timer_##metric.Start();
 
 // Declare and set start time of the timer
 #define PERF_CPU_TIMER_GUARD(metric, clock)            \
   PerfStepTimer perf_step_timer_##metric(              \
-      &(perf_context.metric), clock, true,             \
+      &(perf_context.metric), clock.get(), true,       \
       PerfLevel::kEnableTimeAndCPUTimeExceptForMutex); \
   perf_step_timer_##metric.Start();
 

--- a/monitoring/perf_step_timer.h
+++ b/monitoring/perf_step_timer.h
@@ -20,7 +20,7 @@ class PerfStepTimer {
       : perf_counter_enabled_(perf_level >= enable_level),
         use_cpu_time_(use_cpu_time),
         clock_((perf_counter_enabled_ || statistics != nullptr)
-                   ? ((clock.get() != nullptr) ? clock : SystemClock::Default())
+                   ? (clock ? clock.get() : SystemClock::Default().get())
                    : nullptr),
         start_(0),
         metric_(metric),
@@ -70,7 +70,7 @@ class PerfStepTimer {
 
   const bool perf_counter_enabled_;
   const bool use_cpu_time_;
-  std::shared_ptr<SystemClock> clock_;
+  SystemClock* clock_;
   uint64_t start_;
   uint64_t* metric_;
   Statistics* statistics_;

--- a/monitoring/perf_step_timer.h
+++ b/monitoring/perf_step_timer.h
@@ -13,14 +13,13 @@ namespace ROCKSDB_NAMESPACE {
 class PerfStepTimer {
  public:
   explicit PerfStepTimer(
-      uint64_t* metric, const std::shared_ptr<SystemClock>& clock = nullptr,
-      bool use_cpu_time = false,
+      uint64_t* metric, SystemClock* clock = nullptr, bool use_cpu_time = false,
       PerfLevel enable_level = PerfLevel::kEnableTimeExceptForMutex,
       Statistics* statistics = nullptr, uint32_t ticker_type = 0)
       : perf_counter_enabled_(perf_level >= enable_level),
         use_cpu_time_(use_cpu_time),
         clock_((perf_counter_enabled_ || statistics != nullptr)
-                   ? (clock ? clock.get() : SystemClock::Default().get())
+                   ? (clock ? clock : SystemClock::Default().get())
                    : nullptr),
         start_(0),
         metric_(metric),
@@ -70,7 +69,7 @@ class PerfStepTimer {
 
   const bool perf_counter_enabled_;
   const bool use_cpu_time_;
-  SystemClock* clock_;
+  SystemClock* const clock_;
   uint64_t start_;
   uint64_t* metric_;
   Statistics* statistics_;


### PR DESCRIPTION
This is likely a temp fix before we figure out a better way.

PerfStepTimer is used intensively in certain benchmarking/testings. #7858 stores a `shared_ptr` to system clock in PerfStepTimer which gets created each time a `PerfStepTimer` object is created. The atomic operations in `shared_ptr` may add overhead in CPU cycles. Therefore, we change it back to a raw `SystemClock*` for now.

Test plan
make check