### PR TITLE
Enable compact filter for blob in dbstress and dbbench

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2218,8 +2218,8 @@ void StressTest::Open() {
 
   if ((options_.enable_blob_files || options_.enable_blob_garbage_collection ||
        FLAGS_allow_setting_blob_options_dynamically) &&
-      (FLAGS_use_merge || FLAGS_enable_compaction_filter ||
-       FLAGS_backup_one_in > 0 || FLAGS_best_efforts_recovery)) {
+      (FLAGS_use_merge || FLAGS_backup_one_in > 0 ||
+       FLAGS_best_efforts_recovery)) {
     fprintf(
         stderr,
         "Integrated BlobDB is currently incompatible with Merge, compaction "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2224,10 +2224,9 @@ void StressTest::Open() {
        FLAGS_allow_setting_blob_options_dynamically) &&
       (FLAGS_use_merge || FLAGS_backup_one_in > 0 ||
        FLAGS_best_efforts_recovery)) {
-    fprintf(
-        stderr,
-        "Integrated BlobDB is currently incompatible with Merge, compaction "
-        "filters, backup/restore, and best-effort recovery\n");
+    fprintf(stderr,
+            "Integrated BlobDB is currently incompatible with Merge, "
+            "backup/restore, and best-effort recovery\n");
     exit(1);
   }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -242,9 +242,13 @@ void StressTest::FinishInitDb(SharedState* shared) {
     PreloadDbAndReopenAsReadOnly(FLAGS_max_key, shared);
   }
   if (FLAGS_enable_compaction_filter) {
-    reinterpret_cast<DbStressCompactionFilterFactory*>(
-        options_.compaction_filter_factory.get())
-        ->SetSharedState(shared);
+    auto* compaction_filter_factory =
+        reinterpret_cast<DbStressCompactionFilterFactory*>(
+            options_.compaction_filter_factory.get());
+    assert(compaction_filter_factory);
+    compaction_filter_factory->SetSharedState(shared);
+    fprintf(stdout, "Compaction filter factory: %s\n",
+            compaction_filter_factory->Name());
   }
 }
 

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -163,8 +163,12 @@ int db_stress_tool(int argc, char** argv) {
   if ((FLAGS_readpercent + FLAGS_prefixpercent + FLAGS_writepercent +
        FLAGS_delpercent + FLAGS_delrangepercent + FLAGS_iterpercent) != 100) {
     fprintf(stderr,
-            "Error: Read+Prefix+Write+Delete+DeleteRange+Iterate percents != "
-            "100!\n");
+            "Error: "
+            "Read(%d)+Prefix(%d)+Write(%d)+Delete(%d)+DeleteRange(%d)"
+            "+Iterate(%d) percents != "
+            "100!\n",
+            FLAGS_readpercent, FLAGS_prefixpercent, FLAGS_writepercent,
+            FLAGS_delpercent, FLAGS_delrangepercent, FLAGS_iterpercent);
     exit(1);
   }
   if (FLAGS_disable_wal == 1 && FLAGS_reopen > 0) {

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -7496,10 +7496,9 @@ int db_bench_tool(int argc, char** argv) {
   }
 
   if ((FLAGS_enable_blob_files || FLAGS_enable_blob_garbage_collection) &&
-      (FLAGS_use_keep_filter || !FLAGS_merge_operator.empty())) {
+      !FLAGS_merge_operator.empty()) {
     fprintf(stderr,
-            "Integrated BlobDB is currently incompatible with Merge and "
-            "compaction filters\n");
+            "Integrated BlobDB is currently incompatible with Merge.\n");
     exit(1);
   }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -278,7 +278,7 @@ blob_params = {
     "blob_garbage_collection_age_cutoff": lambda: random.choice([0.0, 0.25, 0.5, 0.75, 1.0]),
     # The following are currently incompatible with the integrated BlobDB
     "use_merge": 0,
-    "enable_compaction_filter": 0,
+    "enable_compaction_filter": lambda: random.choice([0, 1]),
     "backup_one_in": 0,
 }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -278,7 +278,6 @@ blob_params = {
     "blob_garbage_collection_age_cutoff": lambda: random.choice([0.0, 0.25, 0.5, 0.75, 1.0]),
     # The following are currently incompatible with the integrated BlobDB
     "use_merge": 0,
-    "enable_compaction_filter": lambda: random.choice([0, 1]),
     "backup_one_in": 0,
 }
 


### PR DESCRIPTION
As title.

Test plan:
```
./db_bench -enable_blob_files=1 -use_keep_filter=1 -disable_auto_compactions=1
/db_stress -enable_blob_files=1 -enable_compaction_filter=1 -acquire_snapshot_one_in=0 -compact_range_one_in=0 -iterpercent=0 -test_batches_snapshots=0 -readpercent=10 -prefixpercent=20 -writepercent=55 -delpercent=15 -continuous_verification_interval=0
```