### PR TITLE
Possibly bump NUMBER_OF_RESEEKS_IN_ITERATION

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -722,19 +722,17 @@ bool DBIter::ReverseToBackward() {
         saved_key_.GetUserKey(), kMaxSequenceNumber, kValueTypeForSeek));
     if (!expect_total_order_inner_iter()) {
       iter_.SeekForPrev(last_key.GetInternalKey());
-      RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
     } else {
       // Some iterators may not support SeekForPrev(), so we avoid using it
       // when prefix seek mode is disabled. This is somewhat expensive
       // (an extra Prev(), as well as an extra change of direction of iter_),
       // so we may need to reconsider it later.
       iter_.Seek(last_key.GetInternalKey());
-      RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
       if (!iter_.Valid() && iter_.status().ok()) {
         iter_.SeekToLast();
-        RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
       }
     }
+    RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
   }
 
   direction_ = kReverse;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -681,6 +681,7 @@ bool DBIter::ReverseToForward() {
     last_key.SetInternalKey(ParsedInternalKey(
         saved_key_.GetUserKey(), kMaxSequenceNumber, kValueTypeForSeek));
     iter_.Seek(last_key.GetInternalKey());
+    RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
   }
 
   direction_ = kForward;

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -722,14 +722,17 @@ bool DBIter::ReverseToBackward() {
         saved_key_.GetUserKey(), kMaxSequenceNumber, kValueTypeForSeek));
     if (!expect_total_order_inner_iter()) {
       iter_.SeekForPrev(last_key.GetInternalKey());
+      RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
     } else {
       // Some iterators may not support SeekForPrev(), so we avoid using it
       // when prefix seek mode is disabled. This is somewhat expensive
       // (an extra Prev(), as well as an extra change of direction of iter_),
       // so we may need to reconsider it later.
       iter_.Seek(last_key.GetInternalKey());
+      RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
       if (!iter_.Valid() && iter_.status().ok()) {
         iter_.SeekToLast();
+        RecordTick(statistics_, NUMBER_OF_RESEEKS_IN_ITERATION);
       }
     }
   }

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -3015,18 +3015,18 @@ TEST_P(DBIteratorTest, Blob) {
   iter->Prev();
   ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 5);
   iter->Next();
-  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 5);
+  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 6);
   ASSERT_EQ(IterStatus(iter), "b->vb3");
 
   // Switch from forward to reverse
   iter->SeekToFirst();
-  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 5);
-  iter->Next();
-  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 5);
+  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 6);
   iter->Next();
   ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 6);
-  iter->Prev();
+  iter->Next();
   ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 7);
+  iter->Prev();
+  ASSERT_EQ(TestGetTickerCount(options, NUMBER_OF_RESEEKS_IN_ITERATION), 8);
   ASSERT_EQ(IterStatus(iter), "b->vb3");
 }
 

--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -619,6 +619,24 @@ TEST_P(DBIteratorTest, IterReseek) {
   delete iter;
 }
 
+TEST_F(DBIteratorTest, ReseekUponDirectionChange) {
+  Options options = GetDefaultOptions();
+  options.create_if_missing = true;
+  options.prefix_extractor.reset(NewFixedPrefixTransform(1));
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  DestroyAndReopen(options);
+  ASSERT_OK(Put("foo", "value"));
+  ASSERT_OK(Put("bar", "value"));
+  {
+    std::unique_ptr<Iterator> it(db_->NewIterator(ReadOptions()));
+    it->SeekToLast();
+    it->Prev();
+    it->Next();
+  }
+  ASSERT_EQ(1,
+            options.statistics->getTickerCount(NUMBER_OF_RESEEKS_IN_ITERATION));
+}
+
 TEST_P(DBIteratorTest, IterSmallAndLargeMix) {
   do {
     CreateAndReopenWithCF({"pikachu"}, CurrentOptions());


### PR DESCRIPTION
When changing db iterator direction, we may perform a reseek.
Therefore, we should bump the NUMBER_OF_RESEEKS_IN_ITERATION counter.

Test plan
make check