### PR TITLE
Update compaction statistics to include the amount of data read from blob files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 * Add suppport to extend DB::VerifyFileChecksums API to also verify blob files checksum.
 * When using the new BlobDB, the amount of data written by flushes/compactions is now broken down into table files and blob files in the compaction statistics; namely, Write(GB) denotes the amount of data written to table files, while Wblob(GB) means the amount of data written to blob files.
 * Add new SetBufferSize API to WriteBufferManager to allow dynamic management of memory allotted to all write buffers.  This allows user code to adjust memory monitoring provided by WriteBufferManager as process memory needs change datasets grow and shrink.
+* For the new integrated BlobDB implementation, compaction statistics now include the amount of data read from blob files during compaction (due to garbage collection or compaction filters). Write amplification metrics have also been extended to account for data read from blob files.
 
 ### New Features
 * Support compaction filters for the new implementation of BlobDB. Add `FilterBlobByKey()` to `CompactionFilter`. Subclasses can override this method so that compaction filters can determine whether the actual blob value has to be read during compaction. Use a new `kUndetermined` in `CompactionFilter::Decision` to indicated that further action is necessary for compaction filter to make a decision.

--- a/db/blob/blob_file_reader.h
+++ b/db/blob/blob_file_reader.h
@@ -39,7 +39,8 @@ class BlobFileReader {
 
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
                  uint64_t offset, uint64_t value_size,
-                 CompressionType compression_type, PinnableSlice* value) const;
+                 CompressionType compression_type, PinnableSlice* value,
+                 uint64_t* bytes_read) const;
 
  private:
   BlobFileReader(std::unique_ptr<RandomAccessFileReader>&& file_reader,

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -42,6 +42,7 @@ class DBBlobCompactionTest : public DBTestBase {
     return result;
   }
 
+#ifndef ROCKSDB_LITE
   const std::vector<InternalStats::CompactionStats>& GetCompactionStats() {
     VersionSet* const versions = dbfull()->TEST_GetVersionSet();
     assert(versions);
@@ -55,6 +56,7 @@ class DBBlobCompactionTest : public DBTestBase {
 
     return internal_stats->TEST_GetCompactionStats();
   }
+#endif  // ROCKSDB_LITE
 };
 
 namespace {
@@ -229,6 +231,7 @@ TEST_F(DBBlobCompactionTest, FilterByKeyLength) {
   ASSERT_OK(db_->Get(ReadOptions(), long_key, &value));
   ASSERT_EQ("value", value);
 
+#ifndef ROCKSDB_LITE
   const auto& compaction_stats = GetCompactionStats();
   ASSERT_GE(compaction_stats.size(), 2);
 
@@ -236,6 +239,7 @@ TEST_F(DBBlobCompactionTest, FilterByKeyLength) {
   // this involves neither reading nor writing blobs
   ASSERT_EQ(compaction_stats[1].bytes_read_blob, 0);
   ASSERT_EQ(compaction_stats[1].bytes_written_blob, 0);
+#endif  // ROCKSDB_LITE
 
   Close();
 }
@@ -263,6 +267,7 @@ TEST_F(DBBlobCompactionTest, BlindWriteFilter) {
     ASSERT_EQ(new_blob_value, Get(key));
   }
 
+#ifndef ROCKSDB_LITE
   const auto& compaction_stats = GetCompactionStats();
   ASSERT_GE(compaction_stats.size(), 2);
 
@@ -270,6 +275,7 @@ TEST_F(DBBlobCompactionTest, BlindWriteFilter) {
   // this involves writing but not reading blobs
   ASSERT_EQ(compaction_stats[1].bytes_read_blob, 0);
   ASSERT_GT(compaction_stats[1].bytes_written_blob, 0);
+#endif  // ROCKSDB_LITE
 
   Close();
 }
@@ -345,6 +351,7 @@ TEST_F(DBBlobCompactionTest, CompactionFilter) {
     ASSERT_EQ(kv.second + std::string(padding), Get(kv.first));
   }
 
+#ifndef ROCKSDB_LITE
   const auto& compaction_stats = GetCompactionStats();
   ASSERT_GE(compaction_stats.size(), 2);
 
@@ -352,6 +359,7 @@ TEST_F(DBBlobCompactionTest, CompactionFilter) {
   // this involves reading and writing blobs
   ASSERT_GT(compaction_stats[1].bytes_read_blob, 0);
   ASSERT_GT(compaction_stats[1].bytes_written_blob, 0);
+#endif  // ROCKSDB_LITE
 
   Close();
 }
@@ -395,6 +403,7 @@ TEST_F(DBBlobCompactionTest, CompactionFilterReadBlobAndKeep) {
                               /*end=*/nullptr));
   ASSERT_EQ(blob_files, GetBlobFileNumbers());
 
+#ifndef ROCKSDB_LITE
   const auto& compaction_stats = GetCompactionStats();
   ASSERT_GE(compaction_stats.size(), 2);
 
@@ -402,6 +411,7 @@ TEST_F(DBBlobCompactionTest, CompactionFilterReadBlobAndKeep) {
   // this involves reading but not writing blobs
   ASSERT_GT(compaction_stats[1].bytes_read_blob, 0);
   ASSERT_EQ(compaction_stats[1].bytes_written_blob, 0);
+#endif  // ROCKSDB_LITE
 
   Close();
 }

--- a/db/compaction/compaction_iteration_stats.h
+++ b/db/compaction/compaction_iteration_stats.h
@@ -36,5 +36,6 @@ struct CompactionIterationStats {
   uint64_t num_single_del_mismatch = 0;
 
   // Blob related statistics
+  uint64_t num_blobs_read = 0;
   uint64_t total_blob_bytes_read = 0;
 };

--- a/db/compaction/compaction_iteration_stats.h
+++ b/db/compaction/compaction_iteration_stats.h
@@ -34,4 +34,7 @@ struct CompactionIterationStats {
   // Single-Delete diagnostics for exceptional situations
   uint64_t num_single_del_fallthru = 0;
   uint64_t num_single_del_mismatch = 0;
+
+  // Blob related statistics
+  uint64_t total_blob_bytes_read = 0;
 };

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -253,18 +253,18 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
         }
         const Version* const version = compaction_->input_version();
         assert(version);
+
+        uint64_t bytes_read = 0;
         s = version->GetBlob(ReadOptions(), ikey_.user_key, blob_index,
-                             &blob_value_);
+                             &blob_value_, &bytes_read);
         if (!s.ok()) {
           status_ = s;
           valid_ = false;
           return false;
         }
 
-        // Note: we track the compressed size of blobs for the purposes of write
-        // amp calculations
         ++iter_stats_.num_blobs_read;
-        iter_stats_.total_blob_bytes_read += blob_index.size();
+        iter_stats_.total_blob_bytes_read += bytes_read;
 
         value_type = CompactionFilter::ValueType::kValue;
       }
@@ -889,9 +889,11 @@ void CompactionIterator::GarbageCollectBlobIfNeeded() {
     const Version* const version = compaction_->input_version();
     assert(version);
 
+    uint64_t bytes_read = 0;
+
     {
-      const Status s =
-          version->GetBlob(ReadOptions(), user_key(), blob_index, &blob_value_);
+      const Status s = version->GetBlob(ReadOptions(), user_key(), blob_index,
+                                        &blob_value_, &bytes_read);
 
       if (!s.ok()) {
         status_ = s;
@@ -901,10 +903,8 @@ void CompactionIterator::GarbageCollectBlobIfNeeded() {
       }
     }
 
-    // Note: we track the compressed size of blobs for the purposes of write amp
-    // calculations
     ++iter_stats_.num_blobs_read;
-    iter_stats_.total_blob_bytes_read += blob_index.size();
+    iter_stats_.total_blob_bytes_read += bytes_read;
 
     value_ = blob_value_;
 

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -260,6 +260,11 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
           valid_ = false;
           return false;
         }
+
+        // Note: we track the compressed size of blobs for the purposes of write
+        // amp calculations
+        iter_stats_.total_blob_bytes_read += blob_index.size();
+
         value_type = CompactionFilter::ValueType::kValue;
       }
     }
@@ -894,6 +899,10 @@ void CompactionIterator::GarbageCollectBlobIfNeeded() {
         return;
       }
     }
+
+    // Note: we track the compressed size of blobs for the purposes of write amp
+    // calculations
+    iter_stats_.total_blob_bytes_read += blob_index.size();
 
     value_ = blob_value_;
 

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -263,6 +263,7 @@ bool CompactionIterator::InvokeFilterIfNeeded(bool* need_skip,
 
         // Note: we track the compressed size of blobs for the purposes of write
         // amp calculations
+        ++iter_stats_.num_blobs_read;
         iter_stats_.total_blob_bytes_read += blob_index.size();
 
         value_type = CompactionFilter::ValueType::kValue;
@@ -902,6 +903,7 @@ void CompactionIterator::GarbageCollectBlobIfNeeded() {
 
     // Note: we track the compressed size of blobs for the purposes of write amp
     // calculations
+    ++iter_stats_.num_blobs_read;
     iter_stats_.total_blob_bytes_read += blob_index.size();
 
     value_ = blob_value_;

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1124,6 +1124,8 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
     }
   }
 
+  sub_compact->compaction_job_stats.num_blobs_read =
+      c_iter_stats.num_blobs_read;
   sub_compact->compaction_job_stats.total_blob_bytes_read =
       c_iter_stats.total_blob_bytes_read;
   sub_compact->compaction_job_stats.num_input_deletion_records =

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -794,20 +794,23 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
   double bytes_read_per_sec = 0;
   double bytes_written_per_sec = 0;
 
-  if (stats.bytes_read_non_output_levels > 0) {
-    read_write_amp =
-        (stats.bytes_written + stats.bytes_written_blob +
-         stats.bytes_read_output_level + stats.bytes_read_non_output_levels) /
-        static_cast<double>(stats.bytes_read_non_output_levels);
-    write_amp = (stats.bytes_written + stats.bytes_written_blob) /
-                static_cast<double>(stats.bytes_read_non_output_levels);
+  const uint64_t bytes_read_non_output_and_blob =
+      stats.bytes_read_non_output_levels + stats.bytes_read_blob;
+  const uint64_t bytes_read_all =
+      stats.bytes_read_output_level + bytes_read_non_output_and_blob;
+  const uint64_t bytes_written_all =
+      stats.bytes_written + stats.bytes_written_blob;
+
+  if (bytes_read_non_output_and_blob > 0) {
+    read_write_amp = (bytes_written_all + bytes_read_all) /
+                     static_cast<double>(bytes_read_non_output_and_blob);
+    write_amp =
+        bytes_written_all / static_cast<double>(bytes_read_non_output_and_blob);
   }
   if (stats.micros > 0) {
-    bytes_read_per_sec =
-        (stats.bytes_read_non_output_levels + stats.bytes_read_output_level) /
-        static_cast<double>(stats.micros);
-    bytes_written_per_sec = (stats.bytes_written + stats.bytes_written_blob) /
-                            static_cast<double>(stats.micros);
+    bytes_read_per_sec = bytes_read_all / static_cast<double>(stats.micros);
+    bytes_written_per_sec =
+        bytes_written_all / static_cast<double>(stats.micros);
   }
 
   const std::string& column_family_name = cfd->GetName();
@@ -818,7 +821,8 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
       log_buffer_,
       "[%s] compacted to: %s, MB/sec: %.1f rd, %.1f wr, level %d, "
       "files in(%d, %d) out(%d +%d blob) "
-      "MB in(%.1f, %.1f) out(%.1f +%.1f blob), read-write-amplify(%.1f) "
+      "MB in(%.1f, %.1f +%.1f blob) out(%.1f +%.1f blob), "
+      "read-write-amplify(%.1f) "
       "write-amplify(%.1f) %s, records in: %" PRIu64
       ", records dropped: %" PRIu64 " output_compression: %s\n",
       column_family_name.c_str(), vstorage->LevelSummary(&tmp),
@@ -827,9 +831,9 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
       stats.num_input_files_in_non_output_levels,
       stats.num_input_files_in_output_level, stats.num_output_files,
       stats.num_output_files_blob, stats.bytes_read_non_output_levels / kMB,
-      stats.bytes_read_output_level / kMB, stats.bytes_written / kMB,
-      stats.bytes_written_blob / kMB, read_write_amp, write_amp,
-      status.ToString().c_str(), stats.num_input_records,
+      stats.bytes_read_output_level / kMB, stats.bytes_read_blob / kMB,
+      stats.bytes_written / kMB, stats.bytes_written_blob / kMB, read_write_amp,
+      write_amp, status.ToString().c_str(), stats.num_input_records,
       stats.num_dropped_records,
       CompressionTypeToString(compact_->compaction->output_compression())
           .c_str());
@@ -1830,6 +1834,10 @@ void CompactionJob::UpdateCompactionStats() {
           &compaction_stats_.bytes_read_output_level, input_level);
     }
   }
+
+  assert(compaction_job_stats_);
+  compaction_stats_.bytes_read_blob =
+      compaction_job_stats_->total_blob_bytes_read;
 
   compaction_stats_.num_output_files =
       static_cast<int>(compact_->num_output_files);

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -822,8 +822,7 @@ Status CompactionJob::Install(const MutableCFOptions& mutable_cf_options) {
       "[%s] compacted to: %s, MB/sec: %.1f rd, %.1f wr, level %d, "
       "files in(%d, %d) out(%d +%d blob) "
       "MB in(%.1f, %.1f +%.1f blob) out(%.1f +%.1f blob), "
-      "read-write-amplify(%.1f) "
-      "write-amplify(%.1f) %s, records in: %" PRIu64
+      "read-write-amplify(%.1f) write-amplify(%.1f) %s, records in: %" PRIu64
       ", records dropped: %" PRIu64 " output_compression: %s\n",
       column_family_name.c_str(), vstorage->LevelSummary(&tmp),
       bytes_read_per_sec, bytes_written_per_sec,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1124,6 +1124,8 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
     }
   }
 
+  sub_compact->compaction_job_stats.total_blob_bytes_read =
+      c_iter_stats.total_blob_bytes_read;
   sub_compact->compaction_job_stats.num_input_deletion_records =
       c_iter_stats.num_input_deletion_records;
   sub_compact->compaction_job_stats.num_corrupt_keys =
@@ -1871,11 +1873,11 @@ void CompactionJob::UpdateCompactionJobStats(
       stats.num_input_files_in_output_level;
 
   // output information
-  compaction_job_stats_->total_output_bytes =
-      stats.bytes_written + stats.bytes_written_blob;
+  compaction_job_stats_->total_output_bytes = stats.bytes_written;
+  compaction_job_stats_->total_output_bytes_blob = stats.bytes_written_blob;
   compaction_job_stats_->num_output_records = compact_->num_output_records;
-  compaction_job_stats_->num_output_files =
-      stats.num_output_files + stats.num_output_files_blob;
+  compaction_job_stats_->num_output_files = stats.num_output_files;
+  compaction_job_stats_->num_output_files_blob = stats.num_output_files_blob;
 
   if (stats.num_output_files > 0) {
     CopyPrefix(compact_->SmallestUserKey(),

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -193,8 +193,10 @@ bool DBIter::SetBlobValueIfNeeded(const Slice& user_key,
   read_options.read_tier = read_tier_;
   read_options.verify_checksums = verify_checksums_;
 
-  const Status s =
-      version_->GetBlob(read_options, user_key, blob_index, &blob_value_);
+  constexpr uint64_t* bytes_read = nullptr;
+
+  const Status s = version_->GetBlob(read_options, user_key, blob_index,
+                                     &blob_value_, bytes_read);
 
   if (!s.ok()) {
     status_ = s;

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -50,6 +50,7 @@ const std::map<LevelStatType, LevelStat> InternalStats::compaction_level_stats =
         {LevelStatType::AVG_SEC, LevelStat{"AvgSec", "Avg(sec)"}},
         {LevelStatType::KEY_IN, LevelStat{"KeyIn", "KeyIn"}},
         {LevelStatType::KEY_DROP, LevelStat{"KeyDrop", "KeyDrop"}},
+        {LevelStatType::R_BLOB_GB, LevelStat{"RblobGB", "Rblob(GB)"}},
         {LevelStatType::W_BLOB_GB, LevelStat{"WblobGB", "Wblob(GB)"}},
 };
 
@@ -68,7 +69,8 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
   };
   int line_size = snprintf(
       buf + written_size, len - written_size,
-      "%s    %s   %s     %s %s  %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
+      "%s    %s   %s     %s %s  %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s "
+      "%s\n",
       // Note that we skip COMPACTED_FILES and merge it with Files column
       group_by.c_str(), hdr(LevelStatType::NUM_FILES),
       hdr(LevelStatType::SIZE_BYTES), hdr(LevelStatType::SCORE),
@@ -79,7 +81,8 @@ void PrintLevelStatsHeader(char* buf, size_t len, const std::string& cf_name,
       hdr(LevelStatType::WRITE_MBPS), hdr(LevelStatType::COMP_SEC),
       hdr(LevelStatType::COMP_CPU_SEC), hdr(LevelStatType::COMP_COUNT),
       hdr(LevelStatType::AVG_SEC), hdr(LevelStatType::KEY_IN),
-      hdr(LevelStatType::KEY_DROP), hdr(LevelStatType::W_BLOB_GB));
+      hdr(LevelStatType::KEY_DROP), hdr(LevelStatType::R_BLOB_GB),
+      hdr(LevelStatType::W_BLOB_GB));
 
   written_size += line_size;
   written_size = std::min(written_size, static_cast<int>(len));
@@ -91,8 +94,9 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
                        int num_files, int being_compacted,
                        double total_file_size, double score, double w_amp,
                        const InternalStats::CompactionStats& stats) {
-  const uint64_t bytes_read =
-      stats.bytes_read_non_output_levels + stats.bytes_read_output_level;
+  const uint64_t bytes_read = stats.bytes_read_non_output_levels +
+                              stats.bytes_read_output_level +
+                              stats.bytes_read_blob;
   const uint64_t bytes_written = stats.bytes_written + stats.bytes_written_blob;
   const int64_t bytes_new = stats.bytes_written - stats.bytes_read_output_level;
   const double elapsed = (stats.micros + 1) / kMicrosInSec;
@@ -120,6 +124,7 @@ void PrepareLevelStats(std::map<LevelStatType, double>* level_stats,
       static_cast<double>(stats.num_input_records);
   (*level_stats)[LevelStatType::KEY_DROP] =
       static_cast<double>(stats.num_dropped_records);
+  (*level_stats)[LevelStatType::R_BLOB_GB] = stats.bytes_read_blob / kGB;
   (*level_stats)[LevelStatType::W_BLOB_GB] = stats.bytes_written_blob / kGB;
 }
 
@@ -146,6 +151,7 @@ void PrintLevelStats(char* buf, size_t len, const std::string& name,
       "%8.3f "    /*  Avg(sec) */
       "%7s "      /*  KeyIn */
       "%6s "      /*  KeyDrop */
+      "%9.1f "    /*  Rblob(GB) */
       "%9.1f\n",  /*  Wblob(GB) */
       name.c_str(), static_cast<int>(stat_value.at(LevelStatType::NUM_FILES)),
       static_cast<int>(stat_value.at(LevelStatType::COMPACTED_FILES)),
@@ -172,6 +178,7 @@ void PrintLevelStats(char* buf, size_t len, const std::string& name,
       NumberToHumanString(
           static_cast<std::int64_t>(stat_value.at(LevelStatType::KEY_DROP)))
           .c_str(),
+      stat_value.at(LevelStatType::R_BLOB_GB),
       stat_value.at(LevelStatType::W_BLOB_GB));
 }
 
@@ -1178,7 +1185,8 @@ void InternalStats::DumpCFMapStats(
       if (level == 0) {
         input_bytes = curr_ingest;
       } else {
-        input_bytes = comp_stats_[level].bytes_read_non_output_levels;
+        input_bytes = comp_stats_[level].bytes_read_non_output_levels +
+                      comp_stats_[level].bytes_read_blob;
       }
       double w_amp =
           (input_bytes == 0)
@@ -1360,7 +1368,8 @@ void InternalStats::DumpCFStatsNoFileHistogram(std::string* value) {
   uint64_t compact_micros = 0;
   for (int level = 0; level < number_levels_; level++) {
     compact_bytes_read += comp_stats_[level].bytes_read_output_level +
-                          comp_stats_[level].bytes_read_non_output_levels;
+                          comp_stats_[level].bytes_read_non_output_levels +
+                          comp_stats_[level].bytes_read_blob;
     compact_bytes_write += comp_stats_[level].bytes_written +
                            comp_stats_[level].bytes_written_blob;
     compact_micros += comp_stats_[level].micros;

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -446,6 +446,7 @@ class InternalStats {
   void DumpDBStats(std::string* value);
   void DumpCFMapStats(std::map<std::string, std::string>* cf_stats);
   void DumpCFMapStats(
+      const VersionStorageInfo* vstorage,
       std::map<int, std::map<LevelStatType, double>>* level_stats,
       CompactionStats* compaction_stats_sum);
   void DumpCFMapStatsByPriority(

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -79,6 +79,7 @@ enum class LevelStatType {
   AVG_SEC,
   KEY_IN,
   KEY_DROP,
+  R_BLOB_GB,
   W_BLOB_GB,
   TOTAL  // total number of types
 };
@@ -150,6 +151,9 @@ class InternalStats {
     // The number of bytes read from the compaction output level (table files)
     uint64_t bytes_read_output_level;
 
+    // The number of bytes read from blob files
+    uint64_t bytes_read_blob;
+
     // Total number of bytes written to table files during compaction
     uint64_t bytes_written;
 
@@ -190,6 +194,7 @@ class InternalStats {
           cpu_micros(0),
           bytes_read_non_output_levels(0),
           bytes_read_output_level(0),
+          bytes_read_blob(0),
           bytes_written(0),
           bytes_written_blob(0),
           bytes_moved(0),
@@ -211,6 +216,7 @@ class InternalStats {
           cpu_micros(0),
           bytes_read_non_output_levels(0),
           bytes_read_output_level(0),
+          bytes_read_blob(0),
           bytes_written(0),
           bytes_written_blob(0),
           bytes_moved(0),
@@ -238,6 +244,7 @@ class InternalStats {
           cpu_micros(c.cpu_micros),
           bytes_read_non_output_levels(c.bytes_read_non_output_levels),
           bytes_read_output_level(c.bytes_read_output_level),
+          bytes_read_blob(c.bytes_read_blob),
           bytes_written(c.bytes_written),
           bytes_written_blob(c.bytes_written_blob),
           bytes_moved(c.bytes_moved),
@@ -260,6 +267,7 @@ class InternalStats {
       cpu_micros = c.cpu_micros;
       bytes_read_non_output_levels = c.bytes_read_non_output_levels;
       bytes_read_output_level = c.bytes_read_output_level;
+      bytes_read_blob = c.bytes_read_blob;
       bytes_written = c.bytes_written;
       bytes_written_blob = c.bytes_written_blob;
       bytes_moved = c.bytes_moved;
@@ -284,6 +292,7 @@ class InternalStats {
       this->cpu_micros = 0;
       this->bytes_read_non_output_levels = 0;
       this->bytes_read_output_level = 0;
+      this->bytes_read_blob = 0;
       this->bytes_written = 0;
       this->bytes_written_blob = 0;
       this->bytes_moved = 0;
@@ -305,6 +314,7 @@ class InternalStats {
       this->cpu_micros += c.cpu_micros;
       this->bytes_read_non_output_levels += c.bytes_read_non_output_levels;
       this->bytes_read_output_level += c.bytes_read_output_level;
+      this->bytes_read_blob += c.bytes_read_blob;
       this->bytes_written += c.bytes_written;
       this->bytes_written_blob += c.bytes_written_blob;
       this->bytes_moved += c.bytes_moved;
@@ -328,6 +338,7 @@ class InternalStats {
       this->cpu_micros -= c.cpu_micros;
       this->bytes_read_non_output_levels -= c.bytes_read_non_output_levels;
       this->bytes_read_output_level -= c.bytes_read_output_level;
+      this->bytes_read_blob -= c.bytes_read_blob;
       this->bytes_written -= c.bytes_written;
       this->bytes_written_blob -= c.bytes_written_blob;
       this->bytes_moved -= c.bytes_moved;
@@ -674,6 +685,7 @@ class InternalStats {
     uint64_t cpu_micros;
     uint64_t bytes_read_non_output_levels;
     uint64_t bytes_read_output_level;
+    uint64_t bytes_read_blob;
     uint64_t bytes_written;
     uint64_t bytes_written_blob;
     uint64_t bytes_moved;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1793,8 +1793,8 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       io_tracer_(io_tracer) {}
 
 Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                        const Slice& blob_index_slice,
-                        PinnableSlice* value) const {
+                        const Slice& blob_index_slice, PinnableSlice* value,
+                        uint64_t* bytes_read) const {
   if (read_options.read_tier == kBlockCacheTier) {
     return Status::Incomplete("Cannot read blob: no disk I/O allowed");
   }
@@ -1808,12 +1808,12 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
     }
   }
 
-  return GetBlob(read_options, user_key, blob_index, value);
+  return GetBlob(read_options, user_key, blob_index, value, bytes_read);
 }
 
 Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                        const BlobIndex& blob_index,
-                        PinnableSlice* value) const {
+                        const BlobIndex& blob_index, PinnableSlice* value,
+                        uint64_t* bytes_read) const {
   assert(value);
 
   if (blob_index.HasTTL() || blob_index.IsInlined()) {
@@ -1843,7 +1843,7 @@ Status Version::GetBlob(const ReadOptions& read_options, const Slice& user_key,
   assert(blob_file_reader.GetValue());
   const Status s = blob_file_reader.GetValue()->GetBlob(
       read_options, user_key, blob_index.offset(), blob_index.size(),
-      blob_index.compression(), value);
+      blob_index.compression(), value, bytes_read);
 
   return s;
 }
@@ -1953,7 +1953,10 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
 
         if (is_blob_index) {
           if (do_merge && value) {
-            *status = GetBlob(read_options, user_key, *value, value);
+            constexpr uint64_t* bytes_read = nullptr;
+
+            *status =
+                GetBlob(read_options, user_key, *value, value, bytes_read);
             if (!status->ok()) {
               if (status->IsIncomplete()) {
                 get_context.MarkKeyMayExist();
@@ -2147,8 +2150,10 @@ void Version::MultiGet(const ReadOptions& read_options, MultiGetRange* range,
 
           if (iter->is_blob_index) {
             if (iter->value) {
+              constexpr uint64_t* bytes_read = nullptr;
+
               *status = GetBlob(read_options, iter->ukey_with_ts, *iter->value,
-                                iter->value);
+                                iter->value, bytes_read);
               if (!status->ok()) {
                 if (status->IsIncomplete()) {
                   get_context.MarkKeyMayExist();

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -690,12 +690,14 @@ class Version {
   // saves it in *value.
   // REQUIRES: blob_index_slice stores an encoded blob reference
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 const Slice& blob_index_slice, PinnableSlice* value) const;
+                 const Slice& blob_index_slice, PinnableSlice* value,
+                 uint64_t* bytes_read) const;
 
   // Retrieves a blob using a blob reference and saves it in *value,
   // assuming the corresponding blob file is part of this Version.
   Status GetBlob(const ReadOptions& read_options, const Slice& user_key,
-                 const BlobIndex& blob_index, PinnableSlice* value) const;
+                 const BlobIndex& blob_index, PinnableSlice* value,
+                 uint64_t* bytes_read) const;
 
   // Loads some stats information from files. Call without mutex held. It needs
   // to be called before applying the version to the version set.

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -344,6 +344,19 @@ class VersionStorageInfo {
   using BlobFiles = std::map<uint64_t, std::shared_ptr<BlobFileMetaData>>;
   const BlobFiles& GetBlobFiles() const { return blob_files_; }
 
+  uint64_t GetTotalBlobFileSize() const {
+    uint64_t total_blob_bytes = 0;
+
+    for (const auto& pair : blob_files_) {
+      const auto& meta = pair.second;
+      assert(meta);
+
+      total_blob_bytes += meta->GetTotalBlobBytes();
+    }
+
+    return total_blob_bytes;
+  }
+
   const ROCKSDB_NAMESPACE::LevelFilesBrief& LevelFilesBrief(int level) const {
     assert(level < static_cast<int>(level_files_brief_.size()));
     return level_files_brief_[level];

--- a/include/rocksdb/compaction_job_stats.h
+++ b/include/rocksdb/compaction_job_stats.h
@@ -25,25 +25,31 @@ struct CompactionJobStats {
 
   // the number of compaction input records.
   uint64_t num_input_records;
-  // the number of compaction input files.
+  // the number of compaction input files (table files)
   size_t num_input_files;
-  // the number of compaction input files at the output level.
+  // the number of compaction input files at the output level (table files)
   size_t num_input_files_at_output_level;
 
   // the number of compaction output records.
   uint64_t num_output_records;
-  // the number of compaction output files.
+  // the number of compaction output files (table files)
   size_t num_output_files;
+  // the number of compaction output files (blob files)
+  size_t num_output_files_blob;
 
   // true if the compaction is a full compaction (all live SST files input)
   bool is_full_compaction;
   // true if the compaction is a manual compaction
   bool is_manual_compaction;
 
-  // the size of the compaction input in bytes.
+  // the total size of table files in the compaction input
   uint64_t total_input_bytes;
-  // the size of the compaction output in bytes.
+  // the total size of blobs read from blob files
+  uint64_t total_blob_bytes_read;
+  // the total size of table files in the compaction output
   uint64_t total_output_bytes;
+  // the total size of blob files in the compaction output
+  uint64_t total_output_bytes_blob;
 
   // number of records being replaced by newer record associated with same key.
   // this could be a new value or a deletion entry for that key so this field

--- a/include/rocksdb/compaction_job_stats.h
+++ b/include/rocksdb/compaction_job_stats.h
@@ -25,6 +25,8 @@ struct CompactionJobStats {
 
   // the number of compaction input records.
   uint64_t num_input_records;
+  // the number of blobs read from blob files
+  uint64_t num_blobs_read;
   // the number of compaction input files (table files)
   size_t num_input_files;
   // the number of compaction input files at the output level (table files)

--- a/util/compaction_job_stats_impl.cc
+++ b/util/compaction_job_stats_impl.cc
@@ -14,6 +14,7 @@ void CompactionJobStats::Reset() {
   cpu_micros = 0;
 
   num_input_records = 0;
+  num_blobs_read = 0;
   num_input_files = 0;
   num_input_files_at_output_level = 0;
 
@@ -56,6 +57,7 @@ void CompactionJobStats::Add(const CompactionJobStats& stats) {
   cpu_micros += stats.cpu_micros;
 
   num_input_records += stats.num_input_records;
+  num_blobs_read += stats.num_blobs_read;
   num_input_files += stats.num_input_files;
   num_input_files_at_output_level += stats.num_input_files_at_output_level;
 

--- a/util/compaction_job_stats_impl.cc
+++ b/util/compaction_job_stats_impl.cc
@@ -19,12 +19,15 @@ void CompactionJobStats::Reset() {
 
   num_output_records = 0;
   num_output_files = 0;
+  num_output_files_blob = 0;
 
   is_full_compaction = false;
   is_manual_compaction = false;
 
   total_input_bytes = 0;
+  total_blob_bytes_read = 0;
   total_output_bytes = 0;
+  total_output_bytes_blob = 0;
 
   num_records_replaced = 0;
 
@@ -58,9 +61,12 @@ void CompactionJobStats::Add(const CompactionJobStats& stats) {
 
   num_output_records += stats.num_output_records;
   num_output_files += stats.num_output_files;
+  num_output_files_blob += stats.num_output_files_blob;
 
   total_input_bytes += stats.total_input_bytes;
+  total_blob_bytes_read += stats.total_blob_bytes_read;
   total_output_bytes += stats.total_output_bytes;
+  total_output_bytes_blob += stats.total_output_bytes_blob;
 
   num_records_replaced += stats.num_records_replaced;
 


### PR DESCRIPTION
Summary:
The patch does the following:
1) Exposes the amount of data (number of bytes) read from blob files from
`BlobFileReader::GetBlob` / `Version::GetBlob`.
2) Tracks the total number and size of blobs read from blob files during a
compaction (due to garbage collection or compaction filter usage) in
`CompactionIterationStats` and propagates this data to
`InternalStats::CompactionStats` / `CompactionJobStats`.
3) Updates the formulae for write amplification calculations to include the
amount of data read from blob files.
4) Extends the compaction stats dump with a new column `Rblob(GB)` and
a new line containing the total number and size of blob files in the current
`Version` to complement the information about the shape and size of the LSM tree
that's already there.
5) Updates `CompactionJobStats` so that the number of files and amount of data
written by a compaction are broken down per file type (i.e. table/blob file).

Test Plan:
Ran `make check` and `db_bench`.