### PR TITLE
Clarifying comments for Read() APIs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 * Add suppport to extend DB::VerifyFileChecksums API to also verify blob files checksum.
 * When using the new BlobDB, the amount of data written by flushes/compactions is now broken down into table files and blob files in the compaction statistics; namely, Write(GB) denotes the amount of data written to table files, while Wblob(GB) means the amount of data written to blob files.
 * Add new SetBufferSize API to WriteBufferManager to allow dynamic management of memory allotted to all write buffers.  This allows user code to adjust memory monitoring provided by WriteBufferManager as process memory needs change datasets grow and shrink.
+* Clarified the required semantics of Read() functions in FileSystem and Env APIs. Please ensure any custom implementations are compliant.
 * For the new integrated BlobDB implementation, compaction statistics now include the amount of data read from blob files during compaction (due to garbage collection or compaction filters). Write amplification metrics have also been extended to account for data read from blob files.
 
 ### New Features

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -667,8 +667,8 @@ struct ReadRequest {
   // File offset in bytes
   uint64_t offset;
 
-  // Length to read in bytes
-  // FIXME: Can it only read less on EOF?
+  // Length to read in bytes. `result` only returns fewer bytes if end of file
+  // is hit (or `status` is not OK).
   size_t len;
 
   // A buffer that MultiRead()  can optionally place data in. It can

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -619,8 +619,9 @@ class SequentialFile {
   // "scratch[0..n-1]" must be live when "*result" is used.
   // If an error was encountered, returns a non-OK status.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // REQUIRES: External synchronization
   virtual Status Read(size_t n, Slice* result, char* scratch) = 0;
@@ -697,8 +698,9 @@ class RandomAccessFile {
   // "*result" is used.  If an error was encountered, returns a non-OK
   // status.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // Safe for concurrent use by multiple threads.
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
@@ -985,8 +987,9 @@ class RandomRWFile {
   // Read up to `n` bytes starting from offset `offset` and store them in
   // result, provided `scratch` size should be at least `n`.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // Returns Status::OK() on success.
   virtual Status Read(uint64_t offset, size_t n, Slice* result,

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -619,6 +619,9 @@ class SequentialFile {
   // "scratch[0..n-1]" must be live when "*result" is used.
   // If an error was encountered, returns a non-OK status.
   //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
+  //
   // REQUIRES: External synchronization
   virtual Status Read(size_t n, Slice* result, char* scratch) = 0;
 
@@ -665,6 +668,7 @@ struct ReadRequest {
   uint64_t offset;
 
   // Length to read in bytes
+  // FIXME: Can it only read less on EOF?
   size_t len;
 
   // A buffer that MultiRead()  can optionally place data in. It can
@@ -692,6 +696,9 @@ class RandomAccessFile {
   // "scratch[0..n-1]", so "scratch[0..n-1]" must be live when
   // "*result" is used.  If an error was encountered, returns a non-OK
   // status.
+  //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
   //
   // Safe for concurrent use by multiple threads.
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
@@ -977,6 +984,10 @@ class RandomRWFile {
 
   // Read up to `n` bytes starting from offset `offset` and store them in
   // result, provided `scratch` size should be at least `n`.
+  //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
+  //
   // Returns Status::OK() on success.
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const = 0;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -563,6 +563,9 @@ class FSSequentialFile {
   // "scratch[0..n-1]" must be live when "*result" is used.
   // If an error was encountered, returns a non-OK status.
   //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
+  //
   // REQUIRES: External synchronization
   virtual IOStatus Read(size_t n, const IOOptions& options, Slice* result,
                         char* scratch, IODebugContext* dbg) = 0;
@@ -638,6 +641,9 @@ class FSRandomAccessFile {
   // "scratch[0..n-1]", so "scratch[0..n-1]" must be live when
   // "*result" is used.  If an error was encountered, returns a non-OK
   // status.
+  //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
   //
   // Safe for concurrent use by multiple threads.
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
@@ -975,6 +981,10 @@ class FSRandomRWFile {
 
   // Read up to `n` bytes starting from offset `offset` and store them in
   // result, provided `scratch` size should be at least `n`.
+  //
+  // After call, result->size() < n iff end of file has been reached.
+  // In this case, Read might fail if called again.
+  //
   // Returns Status::OK() on success.
   virtual IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
                         Slice* result, char* scratch,

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -563,8 +563,9 @@ class FSSequentialFile {
   // "scratch[0..n-1]" must be live when "*result" is used.
   // If an error was encountered, returns a non-OK status.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // REQUIRES: External synchronization
   virtual IOStatus Read(size_t n, const IOOptions& options, Slice* result,
@@ -643,8 +644,9 @@ class FSRandomAccessFile {
   // "*result" is used.  If an error was encountered, returns a non-OK
   // status.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // Safe for concurrent use by multiple threads.
   // If Direct I/O enabled, offset, n, and scratch should be aligned properly.
@@ -983,8 +985,9 @@ class FSRandomRWFile {
   // Read up to `n` bytes starting from offset `offset` and store them in
   // result, provided `scratch` size should be at least `n`.
   //
-  // After call, result->size() < n iff end of file has been reached.
-  // In this case, Read might fail if called again.
+  // After call, result->size() < n only if end of file has been
+  // reached (or non-OK status). Read might fail if called again after
+  // first result->size() < n.
   //
   // Returns Status::OK() on success.
   virtual IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -612,7 +612,8 @@ struct FSReadRequest {
   // File offset in bytes
   uint64_t offset;
 
-  // Length to read in bytes
+  // Length to read in bytes. `result` only returns fewer bytes if end of file
+  // is hit (or `status` is not OK).
   size_t len;
 
   // A buffer that MultiRead()  can optionally place data in. It can


### PR DESCRIPTION
Summary: I recently discovered the confusing, undocumented semantics of
Read() functions in the FileSystem and Env APIs. I have added
clarification to the best of my reverse-engineered understanding, and
made a note in HISTORY.md for implementors to check their
implementations, as a subtly non-adherent implementation could lead to
RocksDB quietly ignoring some portion of a file.

Test Plan: no code changes