### PR TITLE
Deflake tests of compaction based on compensated file size

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -206,6 +206,7 @@ Options DeletionTriggerOptions(Options options) {
       options.target_file_size_base * options.target_file_size_multiplier;
   options.max_bytes_for_level_multiplier = 2;
   options.disable_auto_compactions = false;
+  options.compaction_options_universal.max_size_amplification_percent = 100;
   return options;
 }
 
@@ -360,12 +361,33 @@ TEST_P(DBCompactionTestWithParam, CompactionDeletionTrigger) {
     for (int k = 0; k < kTestSize; ++k) {
       ASSERT_OK(Delete(Key(k)));
     }
-    ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable());
+    Flush();
     ASSERT_OK(dbfull()->TEST_WaitForCompact());
     ASSERT_OK(Size(Key(0), Key(kTestSize - 1), &db_size[1]));
 
-    // must have much smaller db size.
-    ASSERT_GT(db_size[0] / 3, db_size[1]);
+    // Claim: in level compaction at most `db_size[0] / 2` of the original data
+    // will remain once compactions settle.
+    //
+    // Proof: Assume the original data is all in the bottom level. If it were
+    // not, it would meet its tombstone sooner. The original data size is large
+    // enough to require fanout to bottom level to be greater than
+    // `max_bytes_for_level_multiplier == 2`. In the level just above,
+    // tombstones must cover less than `db_size[0] / 4` bytes since fanout >= 2
+    // and file size is compensated by doubling the size of values we expect are
+    // covered (`kDeletionWeightOnCompaction == 2`). The tombstones in levels
+    // above must cover less than `db_size[0] / 8` bytes of original data,
+    // `db_size[0] / 16`, and so on.
+    //
+    // Claim: in universal compaction none of the original data will remain once
+    // compactions settle.
+    //
+    // Proof: The compensated size of the file containing the most tombstones is
+    // enough on its own to trigger size ratio compaction. Size ratio compaction
+    // is a full compaction, so all tombstones meet the obsolete keys they
+    // cover.
+
+    // The looser of the above two constraints can apply in all cases.
+    ASSERT_GT(db_size[0] / 2, db_size[1]);
   }
 }
 #endif  // ROCKSDB_VALGRIND_RUN
@@ -632,9 +654,8 @@ TEST_P(DBCompactionTestWithParam, CompactionDeletionTriggerReopen) {
     }
     ASSERT_OK(Size(Key(0), Key(kTestSize - 1), &db_size[1]));
     Close();
-    // as auto_compaction is off, we shouldn't see too much reduce
-    // in db size.
-    ASSERT_LT(db_size[0] / 3, db_size[1]);
+    // as auto_compaction is off, we shouldn't see any reduction in db size.
+    ASSERT_LE(db_size[0], db_size[1]);
 
     // round 3 --- reopen db with auto_compaction on and see if
     // deletion compensation still work.
@@ -648,7 +669,13 @@ TEST_P(DBCompactionTestWithParam, CompactionDeletionTriggerReopen) {
     ASSERT_OK(dbfull()->TEST_WaitForCompact());
     ASSERT_OK(Size(Key(0), Key(kTestSize - 1), &db_size[2]));
     // this time we're expecting significant drop in size.
-    ASSERT_GT(db_size[0] / 3, db_size[2]);
+    //
+    // See "CompactionDeletionTrigger" test for proof that at most
+    // `db_size[0] / 2` of the original data remains. In addition to that, this
+    // test inserts `db_size[0] / 10` to push the tombstones into SST files and
+    // then through automatic compactions. So in total `3 * db_size[0] / 5` of
+    // the original data may remain.
+    ASSERT_GT(3 * db_size[0] / 5, db_size[2]);
   }
 }
 
@@ -752,9 +779,8 @@ TEST_F(DBCompactionTest, DisableStatsUpdateReopen) {
     }
     ASSERT_OK(Size(Key(0), Key(kTestSize - 1), &db_size[1]));
     Close();
-    // as auto_compaction is off, we shouldn't see too much reduce
-    // in db size.
-    ASSERT_LT(db_size[0] / 3, db_size[1]);
+    // as auto_compaction is off, we shouldn't see any reduction in db size.
+    ASSERT_LE(db_size[0], db_size[1]);
 
     // round 3 --- reopen db with auto_compaction on and see if
     // deletion compensation still work.
@@ -767,10 +793,13 @@ TEST_F(DBCompactionTest, DisableStatsUpdateReopen) {
     if (options.skip_stats_update_on_db_open) {
       // If update stats on DB::Open is disable, we don't expect
       // deletion entries taking effect.
-      ASSERT_LT(db_size[0] / 3, db_size[2]);
+      ASSERT_LE(db_size[0], db_size[2]);
     } else {
       // Otherwise, we should see a significant drop in db size.
-      ASSERT_GT(db_size[0] / 3, db_size[2]);
+      //
+      // See "CompactionDeletionTrigger" test for proof that at most
+      // `db_size[0] / 2` of the original data remains.
+      ASSERT_GT(db_size[0] / 2, db_size[2]);
     }
   }
 }

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -382,9 +382,8 @@ TEST_P(DBCompactionTestWithParam, CompactionDeletionTrigger) {
     // compactions settle.
     //
     // Proof: The compensated size of the file containing the most tombstones is
-    // enough on its own to trigger size ratio compaction. Size ratio compaction
-    // is a full compaction, so all tombstones meet the obsolete keys they
-    // cover.
+    // enough on its own to trigger size amp compaction. Size amp compaction is
+    // a full compaction, so all tombstones meet the obsolete keys they cover.
 
     // The looser of the above two constraints can apply in all cases.
     ASSERT_GT(db_size[0] / 2, db_size[1]);


### PR DESCRIPTION
CompactionDeletionTriggerReopen was observed to be flaky recently:
https://app.circleci.com/pipelines/github/facebook/rocksdb/6030/workflows/787af4f3-b9f7-4645-8e8d-1fb0ebf05539/jobs/101451.

I went through it and the related tests and arrived at different
conclusions on what constraints we can expect on DB size. Some
constraints got looser and some got tighter. The particular constraint
that flaked got a lot looser so at least the flake linked above would have been prevented.