### PR TITLE
Add request_id in IODebugContext.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@
 
 ### Public API change
 * Added `TableProperties::slow_compression_estimated_data_size` and `TableProperties::fast_compression_estimated_data_size`. When `ColumnFamilyOptions::sample_for_compression > 0`, they estimate what `TableProperties::data_size` would have been if the "fast" or "slow" (see `ColumnFamilyOptions::sample_for_compression` API doc for definitions) compression had been used instead.
+* Update DB::StartIOTrace and remove Env object from the arguments as its redundant and DB already has Env object that is passed down to IOTracer::StartIOTrace
 
 ## 6.19.0 (03/21/2021)
 ### Bug Fixes

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -223,7 +223,7 @@ TEST_F(DBBlobBasicTest, GenerateIOTracing) {
     std::unique_ptr<TraceWriter> trace_writer;
     ASSERT_OK(
         NewFileTraceWriter(env_, EnvOptions(), trace_file, &trace_writer));
-    ASSERT_OK(db_->StartIOTrace(env_, TraceOptions(), std::move(trace_writer)));
+    ASSERT_OK(db_->StartIOTrace(TraceOptions(), std::move(trace_writer)));
 
     constexpr char key[] = "key";
     constexpr char blob_value[] = "blob_value";

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3145,7 +3145,7 @@ SystemClock* DBImpl::GetSystemClock() const {
 
 #ifndef ROCKSDB_LITE
 
-Status DBImpl::StartIOTrace(Env* /*env*/, const TraceOptions& trace_options,
+Status DBImpl::StartIOTrace(const TraceOptions& trace_options,
                             std::unique_ptr<TraceWriter>&& trace_writer) {
   assert(trace_writer != nullptr);
   return io_tracer_->StartIOTrace(GetSystemClock(), trace_options,

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -469,7 +469,7 @@ class DBImpl : public DB {
   Status EndBlockCacheTrace() override;
 
   using DB::StartIOTrace;
-  Status StartIOTrace(Env* env, const TraceOptions& options,
+  Status StartIOTrace(const TraceOptions& options,
                       std::unique_ptr<TraceWriter>&& trace_writer) override;
 
   using DB::EndIOTrace;

--- a/env/file_system_tracer.cc
+++ b/env/file_system_tracer.cc
@@ -20,7 +20,7 @@ IOStatus FileSystemTracingWrapper::NewSequentialFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -34,7 +34,7 @@ IOStatus FileSystemTracingWrapper::NewRandomAccessFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -48,7 +48,7 @@ IOStatus FileSystemTracingWrapper::NewWritableFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -62,7 +62,7 @@ IOStatus FileSystemTracingWrapper::ReopenWritableFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -78,7 +78,7 @@ IOStatus FileSystemTracingWrapper::ReuseWritableFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -92,7 +92,7 @@ IOStatus FileSystemTracingWrapper::NewRandomRWFile(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -106,7 +106,7 @@ IOStatus FileSystemTracingWrapper::NewDirectory(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           name.substr(name.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -121,7 +121,7 @@ IOStatus FileSystemTracingWrapper::GetChildren(const std::string& dir,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           dir.substr(dir.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -135,7 +135,7 @@ IOStatus FileSystemTracingWrapper::DeleteFile(const std::string& fname,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -149,7 +149,7 @@ IOStatus FileSystemTracingWrapper::CreateDir(const std::string& dirname,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           dirname.substr(dirname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -162,7 +162,7 @@ IOStatus FileSystemTracingWrapper::CreateDirIfMissing(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           dirname.substr(dirname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -176,7 +176,7 @@ IOStatus FileSystemTracingWrapper::DeleteDir(const std::string& dirname,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           dirname.substr(dirname.find_last_of("/\\") + 1));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -193,7 +193,7 @@ IOStatus FileSystemTracingWrapper::GetFileSize(const std::string& fname,
   IOTraceRecord io_record(
       clock_->NowNanos(), TraceType::kIOTracer, io_op_data, __func__, elapsed,
       s.ToString(), fname.substr(fname.find_last_of("/\\") + 1), *file_size);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -210,7 +210,7 @@ IOStatus FileSystemTracingWrapper::Truncate(const std::string& fname,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(),
                           fname.substr(fname.find_last_of("/\\") + 1), size);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -227,7 +227,7 @@ IOStatus FSSequentialFileTracingWrapper::Read(size_t n,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_,
                           result->size(), 0 /*Offset*/);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -243,7 +243,7 @@ IOStatus FSSequentialFileTracingWrapper::InvalidateCache(size_t offset,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, length,
                           offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, nullptr /*dbg*/);
   return s;
 }
 
@@ -261,7 +261,7 @@ IOStatus FSSequentialFileTracingWrapper::PositionedRead(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_,
                           result->size(), offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -279,7 +279,7 @@ IOStatus FSRandomAccessFileTracingWrapper::Read(uint64_t offset, size_t n,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, n,
                           offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -299,7 +299,7 @@ IOStatus FSRandomAccessFileTracingWrapper::MultiRead(FSReadRequest* reqs,
     IOTraceRecord io_record(
         clock_->NowNanos(), TraceType::kIOTracer, io_op_data, __func__, latency,
         reqs[i].status.ToString(), file_name_, reqs[i].len, reqs[i].offset);
-    io_tracer_->WriteIOOp(io_record);
+    io_tracer_->WriteIOOp(io_record, dbg);
   }
   return s;
 }
@@ -317,7 +317,7 @@ IOStatus FSRandomAccessFileTracingWrapper::Prefetch(uint64_t offset, size_t n,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, n,
                           offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -333,7 +333,7 @@ IOStatus FSRandomAccessFileTracingWrapper::InvalidateCache(size_t offset,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, length,
                           static_cast<uint64_t>(offset));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, nullptr /*dbg*/);
   return s;
 }
 
@@ -349,7 +349,7 @@ IOStatus FSWritableFileTracingWrapper::Append(const Slice& data,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_,
                           data.size(), 0 /*Offset*/);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -366,7 +366,7 @@ IOStatus FSWritableFileTracingWrapper::PositionedAppend(
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_,
                           data.size(), offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -382,7 +382,7 @@ IOStatus FSWritableFileTracingWrapper::Truncate(uint64_t size,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, size,
                           0 /*Offset*/);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -395,7 +395,7 @@ IOStatus FSWritableFileTracingWrapper::Close(const IOOptions& options,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           file_name_);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -409,7 +409,7 @@ uint64_t FSWritableFileTracingWrapper::GetFileSize(const IOOptions& options,
   io_op_data |= (1 << IOTraceOp::kIOFileSize);
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, "OK", file_name_, file_size);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return file_size;
 }
 
@@ -425,7 +425,7 @@ IOStatus FSWritableFileTracingWrapper::InvalidateCache(size_t offset,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, length,
                           static_cast<uint64_t>(offset));
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, nullptr /*dbg*/);
   return s;
 }
 
@@ -442,7 +442,7 @@ IOStatus FSRandomRWFileTracingWrapper::Write(uint64_t offset, const Slice& data,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_,
                           data.size(), offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -460,7 +460,7 @@ IOStatus FSRandomRWFileTracingWrapper::Read(uint64_t offset, size_t n,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer, io_op_data,
                           __func__, elapsed, s.ToString(), file_name_, n,
                           offset);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -473,7 +473,7 @@ IOStatus FSRandomRWFileTracingWrapper::Flush(const IOOptions& options,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           file_name_);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -486,7 +486,7 @@ IOStatus FSRandomRWFileTracingWrapper::Close(const IOOptions& options,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           file_name_);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -499,7 +499,7 @@ IOStatus FSRandomRWFileTracingWrapper::Sync(const IOOptions& options,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           file_name_);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 
@@ -512,7 +512,7 @@ IOStatus FSRandomRWFileTracingWrapper::Fsync(const IOOptions& options,
   IOTraceRecord io_record(clock_->NowNanos(), TraceType::kIOTracer,
                           0 /*io_op_data*/, __func__, elapsed, s.ToString(),
                           file_name_);
-  io_tracer_->WriteIOOp(io_record);
+  io_tracer_->WriteIOOp(io_record, dbg);
   return s;
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1612,7 +1612,7 @@ class DB {
   }
 
   // IO Tracing operations. Use EndIOTrace() to stop tracing.
-  virtual Status StartIOTrace(Env* /*env*/, const TraceOptions& /*options*/,
+  virtual Status StartIOTrace(const TraceOptions& /*options*/,
                               std::unique_ptr<TraceWriter>&& /*trace_writer*/) {
     return Status::NotSupported("StartIOTrace() is not implemented.");
   }

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -132,10 +132,34 @@ struct IODebugContext {
   // To be set by the FileSystem implementation
   std::string msg;
 
+  // To be set by the underlying FileSystem implementation.
+  std::string request_id;
+
+  // In order to log required information in IO tracing for different
+  // operations, Each bit in trace_data stores which corresponding info from
+  // IODebugContext will be added in the trace. Foreg, if trace_data = 1, it
+  // means bit at position 0 is set so TraceData::kRequestID (request_id) will
+  // be logged in the trace record.
+  //
+  enum TraceData : char {
+    // The value of each enum represents the bitwise position for
+    // that information in trace_data which will be used by IOTracer for
+    // tracing. Make sure to add them sequentially.
+    kRequestID = 0,
+  };
+  uint64_t trace_data = 0;
+
   IODebugContext() {}
 
   void AddCounter(std::string& name, uint64_t value) {
     counters.emplace(name, value);
+  }
+
+  // Called by underlying file system to set request_id and log request_id in
+  // IOTracing.
+  void SetRequestId(const std::string& _request_id) {
+    request_id = _request_id;
+    trace_data |= (1 << TraceData::kRequestID);
   }
 
   std::string ToString() {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -373,9 +373,9 @@ class StackableDB : public DB {
   Status EndBlockCacheTrace() override { return db_->EndBlockCacheTrace(); }
 
   using DB::StartIOTrace;
-  Status StartIOTrace(Env* env, const TraceOptions& options,
+  Status StartIOTrace(const TraceOptions& options,
                       std::unique_ptr<TraceWriter>&& trace_writer) override {
-    return db_->StartIOTrace(env, options, std::move(trace_writer));
+    return db_->StartIOTrace(options, std::move(trace_writer));
   }
 
   using DB::EndIOTrace;

--- a/tools/io_tracer_parser_test.cc
+++ b/tools/io_tracer_parser_test.cc
@@ -65,7 +65,7 @@ class IOTracerParserTest : public testing::Test {
     ASSERT_OK(NewFileTraceWriter(env_, env_options_, trace_file_path_,
                                  &trace_writer));
 
-    ASSERT_OK(db_->StartIOTrace(env_, trace_opt, std::move(trace_writer)));
+    ASSERT_OK(db_->StartIOTrace(trace_opt, std::move(trace_writer)));
 
     for (int i = 0; i < 10; i++) {
       ASSERT_OK(db_->Put(write_opt, "key_" + std::to_string(i),

--- a/tools/io_tracer_parser_tool.cc
+++ b/tools/io_tracer_parser_tool.cc
@@ -73,6 +73,22 @@ void IOTraceRecordParser::PrintHumanReadableIOTraceRecord(
     // unset the rightmost bit.
     io_op_data &= (io_op_data - 1);
   }
+
+  int64_t trace_data = static_cast<int64_t>(record.trace_data);
+  while (trace_data) {
+    // Find the rightmost set bit.
+    uint32_t set_pos = static_cast<uint32_t>(log2(trace_data & -trace_data));
+    switch (set_pos) {
+      case IODebugContext::TraceData::kRequestID:
+        ss << ", Request Id: " << record.request_id;
+        break;
+      default:
+        assert(false);
+    }
+    // unset the rightmost bit.
+    trace_data &= (trace_data - 1);
+  }
+
   ss << "\n";
   fprintf(stdout, "%s", ss.str().c_str());
 }


### PR DESCRIPTION
Summary: Add request_id in IODebugContext which will be populated by
    underlying FileSystem for IOTracing purposes. Update IOTracer to trace
    request_id in the tracing records. Provided API
    IODebugContext::SetRequestId which will set the request_id and enable
    tracing for request_id. The API hides the implementation and underlying
    file system needs to call this API directly.

Update DB::StartIOTrace API and remove redundant Env* from the
    argument as its not used and DB already has Env that is passed down to
    IOTracer.

Test Plan: Update unit test.

Reviewers:

Subscribers:

Tasks:

Tags: