### PR TITLE
[FBInternal] Rename regression test columns

### DIFF
--- a/tools/regression_test.sh
+++ b/tools/regression_test.sh
@@ -434,7 +434,7 @@ function setup_test_directory {
   run_local "mkdir -p $RESULT_PATH"
 
   (printf $TITLE_FORMAT \
-      "commit id" "benchmark" "user@host" "num-dbs" "key-range" "key-size" \
+      "commit-id" "benchmark" "host-name" "num-dbs" "key-range" "key-size" \
       "value-size" "compress-rate" "ops-per-thread" "num-threads" "cache-size" \
       "flushes" "compactions" \
       "ops-per-s" "p50" "p75" "p99" "p99.9" "p99.99" "debug" \


### PR DESCRIPTION
For internal regression metrics.

`Commit id` and `user@host` column type is changed to `int`:
https://www.internalfb.com/intern/data/info/tables/scuba/uber/rocksdb_benchmark/#tableContent

Not sure how to change it back to `Normal`, based on FAQ, we should
create a new name, the older one will disappear after 30 days:
https://www.internalfb.com/intern/qa/5431/how-do-i-change-the-type-of-a-column-in-scuba