### PR TITLE
Add ROCKSDB_GTEST_BYPASS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,7 +17,7 @@
 ### New Features
 * Support compaction filters for the new implementation of BlobDB. Add `FilterBlobByKey()` to `CompactionFilter`. Subclasses can override this method so that compaction filters can determine whether the actual blob value has to be read during compaction. Use a new `kUndetermined` in `CompactionFilter::Decision` to indicated that further action is necessary for compaction filter to make a decision.
 * Add support to extend retrieval of checksums for blob files from the MANIFEST when checkpointing. During backup, rocksdb can detect corruption in blob files  during file copies.
-* Add an option to BackupEngine::GetBackupInfo to include the name and size of each backed-up file. Especially in the presence of file sharing among backups, this offers detailed insight into bakup space usage.
+* Add an option to BackupEngine::GetBackupInfo to include the name and size of each backed-up file. Especially in the presence of file sharing among backups, this offers detailed insight into backup space usage.
 * Enable backward iteration on keys with user-defined timestamps.
 
 ## 6.18.0 (02/19/2021)

--- a/test_util/testharness.h
+++ b/test_util/testharness.h
@@ -15,12 +15,38 @@
 #include <gtest/gtest.h>
 #endif
 
-// If GTEST_SKIP is available, use it. Otherwise, define skip as success
+// If GTEST_SKIP is available, use it. Otherwise, define skip as success.
+//
+// A "skipped" test has a specific meaning in Facebook infrastructure: a
+// precondition was not met, and there is a testing hole if any
+// parameterization of a test (e.g. Foo/FooTest.Bar/42) is skipped for all
+// tested build configurations/platforms/etc.
+//
+// The GTEST macros do not seem to print the message, even with -verbose,
+// so these print to stderr. Note that these do not exit the test themselves;
+// calling code should 'return' or similar from the test.
 #ifdef GTEST_SKIP_
-#define ROCKSDB_GTEST_SKIP(m) GTEST_SKIP_(m)
+#define ROCKSDB_GTEST_SKIP(m)          \
+  do {                                 \
+    fputs("SKIPPED: " m "\n", stderr); \
+    GTEST_SKIP_(m);                    \
+  } while (false) /* user ; */
 #else
-#define ROCKSDB_GTEST_SKIP(m) GTEST_SUCCESS_("SKIPPED: " m)
+#define ROCKSDB_GTEST_SKIP(m)          \
+  do {                                 \
+    fputs("SKIPPED: " m "\n", stderr); \
+    GTEST_SUCCESS_("SKIPPED: " m);     \
+  } while (false) /* user ; */
 #endif
+
+// An alternative to ROCKSDB_GTEST_SKIP that is allowed to be a permanent
+// condition, e.g. for intentionally omitting or disabling some
+// parameterizations for some tests.
+#define ROCKSDB_GTEST_BYPASS(m)         \
+  do {                                  \
+    fputs("BYPASSED: " m "\n", stderr); \
+    GTEST_SUCCESS_("BYPASSED: " m);     \
+  } while (false) /* user ; */
 
 #include <string>
 #include "rocksdb/env.h"

--- a/test_util/testharness.h
+++ b/test_util/testharness.h
@@ -41,10 +41,10 @@
   } while (false) /* user ; */
 #endif
 
-// We add "bypass" as an alternative to ROCKSDB_GTEST_SKIP that is allowed
-// to be a permanent condition, e.g. for intentionally omitting or disabling
-// some parameterizations for some tests. (Use _DISABLED at the end of the
-// test name to disable an entire test.)
+// We add "bypass" as an alternative to ROCKSDB_GTEST_SKIP that is allowed to
+// be a permanent condition, e.g. for intentionally omitting or disabling some
+// parameterizations for some tests. (Use _DISABLED at the end of the test
+// name to disable an entire test.)
 #define ROCKSDB_GTEST_BYPASS(m)         \
   do {                                  \
     fputs("BYPASSED: " m "\n", stderr); \

--- a/test_util/testharness.h
+++ b/test_util/testharness.h
@@ -15,12 +15,14 @@
 #include <gtest/gtest.h>
 #endif
 
-// If GTEST_SKIP is available, use it. Otherwise, define skip as success.
-//
-// A "skipped" test has a specific meaning in Facebook infrastructure: a
-// precondition was not met, and there is a testing hole if any
+// A "skipped" test has a specific meaning in Facebook infrastructure: the
+// test is in good shape and should be run, but something about the
+// compilation or execution environment means the test cannot be run.
+// Specifically, the is a hole in intended testing if any
 // parameterization of a test (e.g. Foo/FooTest.Bar/42) is skipped for all
 // tested build configurations/platforms/etc.
+//
+// If GTEST_SKIP is available, use it. Otherwise, define skip as success.
 //
 // The GTEST macros do not seem to print the message, even with -verbose,
 // so these print to stderr. Note that these do not exit the test themselves;
@@ -39,9 +41,10 @@
   } while (false) /* user ; */
 #endif
 
-// An alternative to ROCKSDB_GTEST_SKIP that is allowed to be a permanent
-// condition, e.g. for intentionally omitting or disabling some
-// parameterizations for some tests.
+// We add "bypass" as an alternative to ROCKSDB_GTEST_SKIP that is allowed
+// to be a permanent condition, e.g. for intentionally omitting or disabling
+// some parameterizations for some tests. (Use _DISABLED at the end of the
+// test name to disable an entire test.)
 #define ROCKSDB_GTEST_BYPASS(m)         \
   do {                                  \
     fputs("BYPASSED: " m "\n", stderr); \

--- a/util/ribbon_test.cc
+++ b/util/ribbon_test.cc
@@ -412,7 +412,7 @@ TYPED_TEST(RibbonTypeParamTest, CompactnessAndBacktrackAndFpRate) {
       ROCKSDB_NAMESPACE::ribbon::BandingConfigHelper<TypeParam>;
 
   if (sizeof(CoeffRow) < 8) {
-    ROCKSDB_GTEST_SKIP("Not fully supported");
+    ROCKSDB_GTEST_BYPASS("Not fully supported");
     return;
   }
 
@@ -1124,7 +1124,7 @@ TYPED_TEST(RibbonTypeParamTest, FindOccupancy) {
   using KeyGen = typename TypeParam::KeyGen;
 
   if (!FLAGS_find_occ) {
-    fprintf(stderr, "Tool disabled during unit test runs\n");
+    ROCKSDB_GTEST_BYPASS("Tool disabled during unit test runs");
     return;
   }
 
@@ -1238,12 +1238,12 @@ TYPED_TEST(RibbonTypeParamTest, OptimizeHomogAtScale) {
   using KeyGen = typename TypeParam::KeyGen;
 
   if (!FLAGS_optimize_homog) {
-    fprintf(stderr, "Tool disabled during unit test runs\n");
+    ROCKSDB_GTEST_BYPASS("Tool disabled during unit test runs");
     return;
   }
 
   if (!TypeParam::kHomogeneous) {
-    fprintf(stderr, "Only for Homogeneous Ribbon\n");
+    ROCKSDB_GTEST_BYPASS("Only for Homogeneous Ribbon");
     return;
   }
 


### PR DESCRIPTION
Summary: This is for cases that do not meet the Facebook criteria for
SKIP (see new comments). Also made ROCKSDB_GTEST_{SKIP,BYPASS} print the
message because gtest doesn't ever seem to.

Test Plan: manual inspection of ./ribbon_test output, CI