### PR TITLE
Simplify code, instead deprecated C++ header and fix some typos in comments

### DIFF
--- a/cache/cache_bench.cc
+++ b/cache/cache_bench.cc
@@ -11,10 +11,10 @@ int main() {
 }
 #else
 
-#include <cstdio>
 #include <sys/types.h>
 
 #include <cinttypes>
+#include <cstdio>
 #include <limits>
 
 #include "port/port.h"

--- a/cache/cache_bench.cc
+++ b/cache/cache_bench.cc
@@ -11,7 +11,7 @@ int main() {
 }
 #else
 
-#include <stdio.h>
+#include <cstdio>
 #include <sys/types.h>
 
 #include <cinttypes>

--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -9,8 +9,8 @@
 
 #include "cache/lru_cache.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 #include <string>
 
 #include "util/mutexlock.h"

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -239,7 +239,7 @@ class ALIGN_AS(CACHE_LINE_SIZE) LRUCacheShard final : public CacheShard {
   //  not threadsafe
   size_t TEST_GetLRUSize();
 
-  //  Retrives high pri pool ratio
+  //  Retrieves high pri pool ratio
   double GetHighPriPoolRatio();
 
  private:
@@ -328,7 +328,7 @@ class LRUCache
 
   //  Retrieves number of elements in LRU, for unit test purpose only
   size_t TEST_GetLRUSize();
-  //  Retrives high pri pool ratio
+  //  Retrieves high pri pool ratio
   double GetHighPriPoolRatio();
 
  private:

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -30,7 +30,7 @@ class LRUCacheTest : public testing::Test {
     DeleteCache();
     cache_ = reinterpret_cast<LRUCacheShard*>(
         port::cacheline_aligned_alloc(sizeof(LRUCacheShard)));
-    new (cache_) LRUCacheShard(capacity, false /*strict_capcity_limit*/,
+    new (cache_) LRUCacheShard(capacity, false /*strict_capacity_limit*/,
                                high_pri_pool_ratio, use_adaptive_mutex,
                                kDontChargeCacheMetadata);
   }

--- a/db/blob/blob_file_cache_test.cc
+++ b/db/blob/blob_file_cache_test.cc
@@ -64,7 +64,6 @@ void WriteBlobFile(uint32_t column_family_id,
   constexpr char blob[] = "blob";
 
   std::string compressed_blob;
-  Slice blob_to_write;
 
   uint64_t key_offset = 0;
   uint64_t blob_offset = 0;

--- a/db/blob/db_blob_basic_test.cc
+++ b/db/blob/db_blob_basic_test.cc
@@ -236,7 +236,7 @@ TEST_F(DBBlobBasicTest, GenerateIOTracing) {
     ASSERT_OK(env_->FileExists(trace_file));
   }
   {
-    // Parse trace file to check file opertions related to blob files are
+    // Parse trace file to check file operations related to blob files are
     // recorded.
     std::unique_ptr<TraceReader> trace_reader;
     ASSERT_OK(

--- a/db/blob/db_blob_compaction_test.cc
+++ b/db/blob/db_blob_compaction_test.cc
@@ -295,7 +295,7 @@ TEST_P(DBBlobBadCompactionFilterTest, BadDecisionFromCompactionFilter) {
   Close();
 
   DestroyAndReopen(options);
-  std::string key(std::get<0>(GetParam()));
+  const std::string& key(std::get<0>(GetParam()));
   ASSERT_OK(Put(key, "value"));
   ASSERT_OK(Flush());
   ASSERT_TRUE(db_->CompactRange(CompactRangeOptions(), /*begin=*/nullptr,

--- a/db/c.cc
+++ b/db/c.cc
@@ -11,7 +11,7 @@
 
 #include "rocksdb/c.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "port/port.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
@@ -2959,6 +2959,8 @@ void rocksdb_options_set_access_hint_on_compaction_start(
       opt->rep.access_hint_on_compaction_start =
           ROCKSDB_NAMESPACE::Options::WILLNEED;
       break;
+    default:
+      assert(0);
   }
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -12,6 +12,10 @@
 #include "rocksdb/c.h"
 
 #include <cstdlib>
+#include <map>
+#include <unordered_set>
+#include <vector>
+
 #include "port/port.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/compaction_filter.h"
@@ -24,6 +28,7 @@
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/options.h"
+#include "rocksdb/perf_context.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/statistics.h"
@@ -39,12 +44,7 @@
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 #include "rocksdb/write_batch.h"
-#include "rocksdb/perf_context.h"
 #include "utilities/merge_operators.h"
-
-#include <vector>
-#include <unordered_set>
-#include <map>
 
 using ROCKSDB_NAMESPACE::BackupableDBOptions;
 using ROCKSDB_NAMESPACE::BackupEngine;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -253,7 +253,7 @@ extern Status CheckCFPathsSupported(const DBOptions& db_options,
 
 extern ColumnFamilyOptions SanitizeOptions(const ImmutableDBOptions& db_options,
                                            const ColumnFamilyOptions& src);
-// Wrap user defined table proproties collector factories `from cf_options`
+// Wrap user defined table properties collector factories `from cf_options`
 // into internal ones in int_tbl_prop_collector_factories. Add a system internal
 // one too.
 extern void GetIntTblPropCollectorFactory(
@@ -441,7 +441,7 @@ class ColumnFamilyData {
   // Get SuperVersion stored in thread local storage. If it does not exist,
   // get a reference from a current SuperVersion.
   SuperVersion* GetThreadLocalSuperVersion(DBImpl* db);
-  // Try to return SuperVersion back to thread local storage. Retrun true on
+  // Try to return SuperVersion back to thread local storage. Return true on
   // success and false on failure. It fails when the thread local storage
   // contains anything other than SuperVersion::kSVInUse flag.
   bool ReturnThreadLocalSuperVersion(SuperVersion* sv);
@@ -633,7 +633,7 @@ class ColumnFamilyData {
 // but this condition is not that important.
 // * Iteration -- hold DB mutex, but you can release it in the body of
 // iteration. If you release DB mutex in body, reference the column
-// family before the mutex and unreference after you unlock, since the column
+// family before the mutex and unreferenced after you unlock, since the column
 // family might get dropped when the DB mutex is released
 // * GetDefault() -- thread safe
 // * GetColumnFamily() -- either inside of DB mutex or from a write thread

--- a/db/compaction/compaction.cc
+++ b/db/compaction/compaction.cc
@@ -340,7 +340,7 @@ bool Compaction::IsTrivialMove() const {
       return false;
     }
 
-    if (partitioner.get() != nullptr) {
+    if (partitioner != nullptr) {
       if (!partitioner->CanDoTrivialMove(file->smallest.user_key(),
                                          file->largest.user_key())) {
         return false;
@@ -519,7 +519,7 @@ uint64_t Compaction::OutputFilePreallocationSize() const {
 
   // Over-estimate slightly so we don't end up just barely crossing
   // the threshold
-  // No point to prellocate more than 1GB.
+  // No point to preallocate more than 1GB.
   return std::min(uint64_t{1073741824},
                   preallocation_size + (preallocation_size / 10));
 }

--- a/db/compaction/compaction.h
+++ b/db/compaction/compaction.h
@@ -123,7 +123,7 @@ class Compaction {
   // Returns the ColumnFamilyData associated with the compaction.
   ColumnFamilyData* column_family_data() const { return cfd_; }
 
-  // Returns the file meta data of the 'i'th input file at the
+  // Returns the file meta data of the 'i' with input file at the
   // specified compaction input level.
   // REQUIREMENT: "compaction_input_level" must be >= 0 and
   //              < "input_levels()"
@@ -341,7 +341,7 @@ class Compaction {
   const uint32_t output_path_id_;
   CompressionType output_compression_;
   CompressionOptions output_compression_opts_;
-  // If true, then the comaction can be done by simply deleting input files.
+  // If true, then the compaction can be done by simply deleting input files.
   const bool deletion_compaction_;
 
   // Compaction input files organized by level. Constant after construction

--- a/db/compaction/compaction_iterator.cc
+++ b/db/compaction/compaction_iterator.cc
@@ -103,10 +103,9 @@ CompactionIterator::CompactionIterator(
       cmp_with_history_ts_low_(0) {
   assert(compaction_filter_ == nullptr || compaction_ != nullptr);
   assert(snapshots_ != nullptr);
-  bottommost_level_ = compaction_ == nullptr
-                          ? false
-                          : compaction_->bottommost_level() &&
-                                !compaction_->allow_ingest_behind();
+  bottommost_level_ = !(compaction_ == nullptr) &&
+                      compaction_->bottommost_level() &&
+                      !compaction_->allow_ingest_behind();
   if (compaction_ != nullptr) {
     level_ptrs_ = std::vector<size_t>(compaction_->number_levels(), 0);
   }
@@ -135,7 +134,7 @@ CompactionIterator::CompactionIterator(
 }
 
 CompactionIterator::~CompactionIterator() {
-  // input_ Iteartor lifetime is longer than pinned_iters_mgr_ lifetime
+  // input_ Iterator lifetime is longer than pinned_iters_mgr_ lifetime
   input_->SetPinnedItersMgr(nullptr);
 }
 

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -38,7 +38,7 @@ class NoMergingMergeOp : public MergeOperator {
 
 // Compaction filter that gets stuck when it sees a particular key,
 // then gets unstuck when told to.
-// Always returns Decition::kRemove.
+// Always returns Decision::kRemove.
 class StallingFilter : public CompactionFilter {
  public:
   Decision FilterV2(int /*level*/, const Slice& key, ValueType /*type*/,
@@ -189,7 +189,7 @@ class FakeCompaction : public CompactionIterator::CompactionProxy {
   bool is_allow_ingest_behind = false;
 };
 
-// A simplifed snapshot checker which assumes each snapshot has a global
+// A simplified snapshot checker which assumes each snapshot has a global
 // last visible sequence.
 class TestSnapshotChecker : public SnapshotChecker {
  public:
@@ -711,7 +711,7 @@ TEST_P(CompactionIteratorTest, ZeroOutSequenceAtBottomLevel) {
   RunTest({test::KeyStr("a", 1, kTypeValue), test::KeyStr("b", 2, kTypeValue)},
           {"v1", "v2"},
           {test::KeyStr("a", 0, kTypeValue), test::KeyStr("b", 2, kTypeValue)},
-          {"v1", "v2"}, kMaxSequenceNumber /*last_commited_seq*/,
+          {"v1", "v2"}, kMaxSequenceNumber /*last_committed_seq*/,
           nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
           true /*bottommost_level*/);
 }
@@ -727,7 +727,7 @@ TEST_P(CompactionIteratorTest, RemoveDeletionAtBottomLevel) {
           {test::KeyStr("b", 3, kTypeDeletion),
            test::KeyStr("b", 0, kTypeValue)},
           {"", ""},
-          kMaxSequenceNumber /*last_commited_seq*/, nullptr /*merge_operator*/,
+          kMaxSequenceNumber /*last_committed_seq*/, nullptr /*merge_operator*/,
           nullptr /*compaction_filter*/, true /*bottommost_level*/);
 }
 
@@ -738,7 +738,7 @@ TEST_P(CompactionIteratorTest, RemoveSingleDeletionAtBottomLevel) {
   RunTest({test::KeyStr("a", 1, kTypeSingleDeletion),
            test::KeyStr("b", 2, kTypeSingleDeletion)},
           {"", ""}, {test::KeyStr("b", 2, kTypeSingleDeletion)}, {""},
-          kMaxSequenceNumber /*last_commited_seq*/, nullptr /*merge_operator*/,
+          kMaxSequenceNumber /*last_committed_seq*/, nullptr /*merge_operator*/,
           nullptr /*compaction_filter*/, true /*bottommost_level*/);
 }
 
@@ -895,7 +895,7 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
           {"v1", "v2", "v3"},
           {test::KeyStr("a", 0, kTypeValue), test::KeyStr("b", 2, kTypeValue),
            test::KeyStr("c", 3, kTypeValue)},
-          {"v1", "v2", "v3"}, kMaxSequenceNumber /*last_commited_seq*/,
+          {"v1", "v2", "v3"}, kMaxSequenceNumber /*last_committed_seq*/,
           nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
           true /*bottommost_level*/);
 }
@@ -908,7 +908,7 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
        test::KeyStr("c", 3, kTypeDeletion)},
       {"", "", ""},
       {},
-      {"", ""}, kMaxSequenceNumber /*last_commited_seq*/,
+      {"", ""}, kMaxSequenceNumber /*last_committed_seq*/,
       nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
       true /*bottommost_level*/);
 }
@@ -922,7 +922,7 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
       {"", "", ""},
       {test::KeyStr("a", 4, kTypeDeletion), test::KeyStr("a", 0, kTypeValue),
             test::KeyStr("b", 3, kTypeValue)},
-      {"", "", ""}, kMaxSequenceNumber /*last_commited_seq*/,
+      {"", "", ""}, kMaxSequenceNumber /*last_committed_seq*/,
       nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
       true /*bottommost_level*/);
 }
@@ -936,7 +936,7 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
           {"", "", ""},
           {test::KeyStr("b", 2, kTypeSingleDeletion),
            test::KeyStr("c", 3, kTypeSingleDeletion)},
-          {"", ""}, kMaxSequenceNumber /*last_commited_seq*/,
+          {"", ""}, kMaxSequenceNumber /*last_committed_seq*/,
           nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
           true /*bottommost_level*/);
 }
@@ -986,8 +986,8 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
 }
 
 // Compaction filter should keep uncommitted key as-is, and
-//   * Convert the latest velue to deletion, and/or
-//   * if latest value is a merge, apply filter to all suequent merges.
+//   * Convert the latest value to deletion, and/or
+//   * if latest value is a merge, apply filter to all sequent merges.
 
 TEST_F(CompactionIteratorWithSnapshotCheckerTest, CompactionFilter_Value) {
   std::unique_ptr<CompactionFilter> compaction_filter(

--- a/db/compaction/compaction_iterator_test.cc
+++ b/db/compaction/compaction_iterator_test.cc
@@ -720,15 +720,14 @@ TEST_P(CompactionIteratorTest, ZeroOutSequenceAtBottomLevel) {
 // permanently.
 TEST_P(CompactionIteratorTest, RemoveDeletionAtBottomLevel) {
   AddSnapshot(1);
-  RunTest({test::KeyStr("a", 1, kTypeDeletion),
-           test::KeyStr("b", 3, kTypeDeletion),
-           test::KeyStr("b", 1, kTypeValue)},
-          {"", "", ""},
-          {test::KeyStr("b", 3, kTypeDeletion),
-           test::KeyStr("b", 0, kTypeValue)},
-          {"", ""},
-          kMaxSequenceNumber /*last_committed_seq*/, nullptr /*merge_operator*/,
-          nullptr /*compaction_filter*/, true /*bottommost_level*/);
+  RunTest(
+      {test::KeyStr("a", 1, kTypeDeletion), test::KeyStr("b", 3, kTypeDeletion),
+       test::KeyStr("b", 1, kTypeValue)},
+      {"", "", ""},
+      {test::KeyStr("b", 3, kTypeDeletion), test::KeyStr("b", 0, kTypeValue)},
+      {"", ""}, kMaxSequenceNumber /*last_committed_seq*/,
+      nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
+      true /*bottommost_level*/);
 }
 
 // In bottommost level, single deletions earlier than earliest snapshot can be
@@ -906,9 +905,7 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
   RunTest(
       {test::KeyStr("a", 1, kTypeDeletion), test::KeyStr("b", 2, kTypeDeletion),
        test::KeyStr("c", 3, kTypeDeletion)},
-      {"", "", ""},
-      {},
-      {"", ""}, kMaxSequenceNumber /*last_committed_seq*/,
+      {"", "", ""}, {}, {"", ""}, kMaxSequenceNumber /*last_committed_seq*/,
       nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
       true /*bottommost_level*/);
 }
@@ -916,15 +913,14 @@ TEST_F(CompactionIteratorWithSnapshotCheckerTest,
 TEST_F(CompactionIteratorWithSnapshotCheckerTest,
        NotRemoveDeletionIfValuePresentToEarlierSnapshot) {
   AddSnapshot(2,1);
-  RunTest(
-      {test::KeyStr("a", 4, kTypeDeletion), test::KeyStr("a", 1, kTypeValue),
-          test::KeyStr("b", 3, kTypeValue)},
-      {"", "", ""},
-      {test::KeyStr("a", 4, kTypeDeletion), test::KeyStr("a", 0, kTypeValue),
-            test::KeyStr("b", 3, kTypeValue)},
-      {"", "", ""}, kMaxSequenceNumber /*last_committed_seq*/,
-      nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
-      true /*bottommost_level*/);
+  RunTest({test::KeyStr("a", 4, kTypeDeletion),
+           test::KeyStr("a", 1, kTypeValue), test::KeyStr("b", 3, kTypeValue)},
+          {"", "", ""},
+          {test::KeyStr("a", 4, kTypeDeletion),
+           test::KeyStr("a", 0, kTypeValue), test::KeyStr("b", 3, kTypeValue)},
+          {"", "", ""}, kMaxSequenceNumber /*last_committed_seq*/,
+          nullptr /*merge_operator*/, nullptr /*compaction_filter*/,
+          true /*bottommost_level*/);
 }
 
 TEST_F(CompactionIteratorWithSnapshotCheckerTest,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -150,7 +150,7 @@ struct CompactionJob::SubcompactionState {
       // This subcompaction's output could be empty if compaction was aborted
       // before this subcompaction had a chance to generate any output files.
       // When subcompactions are executed sequentially this is more likely and
-      // will be particulalry likely for the later subcompactions to be empty.
+      // will be particularly likely for the later subcompactions to be empty.
       // Once they are run in parallel however it should be much rarer.
       return nullptr;
     } else {
@@ -408,7 +408,7 @@ void CompactionJob::Prepare() {
   AutoThreadOperationStageUpdater stage_updater(
       ThreadStatus::STAGE_COMPACTION_PREPARE);
 
-  // Generate file_levels_ for compaction berfore making Iterator
+  // Generate file_levels_ for compaction before making Iterator
   auto* c = compact_->compaction;
   assert(c->column_family_data() != nullptr);
   assert(c->column_family_data()->current()->storage_info()->NumLevelFiles(

--- a/db/compaction/compaction_picker.cc
+++ b/db/compaction/compaction_picker.cc
@@ -155,7 +155,8 @@ CompactionPicker::CompactionPicker(const ImmutableCFOptions& ioptions,
 CompactionPicker::~CompactionPicker() {}
 
 // Delete this compaction from the list of running compactions.
-void CompactionPicker::ReleaseCompactionFiles(Compaction* c, Status status) {
+void CompactionPicker::ReleaseCompactionFiles(Compaction* c,
+                                              const Status& status) {
   UnregisterCompaction(c);
   if (!status.ok()) {
     c->ResetNextCompactionIndex();

--- a/db/compaction/compaction_picker.h
+++ b/db/compaction/compaction_picker.h
@@ -100,7 +100,7 @@ class CompactionPicker {
   // Free up the files that participated in a compaction
   //
   // Requirement: DB mutex held
-  void ReleaseCompactionFiles(Compaction* c, Status status);
+  void ReleaseCompactionFiles(Compaction* c, const Status& status);
 
   // Returns true if any one of the specified files are being compacted
   bool AreFilesInCompaction(const std::vector<FileMetaData*>& files);

--- a/db/compaction/compaction_picker_test.cc
+++ b/db/compaction/compaction_picker_test.cc
@@ -650,7 +650,7 @@ TEST_F(CompactionPickerTest, UniversalPeriodicCompaction3) {
 
 TEST_F(CompactionPickerTest, UniversalPeriodicCompaction4) {
   // The case where universal periodic compaction couldn't form
-  // a compaction that inlcudes any file marked for periodic compaction.
+  // a compaction that includes any file marked for periodic compaction.
   // Right now we form the compaction anyway if it is more than one
   // sorted run. Just put the case here to validate that it doesn't
   // crash.
@@ -800,7 +800,7 @@ TEST_F(CompactionPickerTest, CompactionPriMinOverlapping2) {
   Add(2, 6U, "150", "175",
       60000000U);  // Overlaps with file 26, 27, total size 521M
   Add(2, 7U, "176", "200", 60000000U);  // Overlaps with file 27, 28, total size
-                                        // 520M, the smalelst overlapping
+                                        // 520M, the smallest overlapping
   Add(2, 8U, "201", "300",
       60000000U);  // Overlaps with file 28, 29, total size 521M
 
@@ -1228,7 +1228,7 @@ TEST_F(CompactionPickerTest, NotScheduleL1IfL0WithHigherPri1) {
   Add(0, 32U, "001", "400", 1000000000U, 0, 0);
   Add(0, 33U, "001", "400", 1000000000U, 0, 0);
 
-  // L1 total size 2GB, score 2.2. If one file being comapcted, score 1.1.
+  // L1 total size 2GB, score 2.2. If one file being compacted, score 1.1.
   Add(1, 4U, "050", "300", 1000000000U, 0, 0);
   file_map_[4u].first->being_compacted = true;
   Add(1, 5U, "301", "350", 1000000000U, 0, 0);
@@ -1261,7 +1261,7 @@ TEST_F(CompactionPickerTest, NotScheduleL1IfL0WithHigherPri2) {
   Add(0, 32U, "001", "400", 1000000000U, 0, 0);
   Add(0, 33U, "001", "400", 1000000000U, 0, 0);
 
-  // L1 total size 2GB, score 2.2. If one file being comapcted, score 1.1.
+  // L1 total size 2GB, score 2.2. If one file being compacted, score 1.1.
   Add(1, 4U, "050", "300", 1000000000U, 0, 0);
   Add(1, 5U, "301", "350", 1000000000U, 0, 0);
 

--- a/db/compaction/compaction_picker_universal.cc
+++ b/db/compaction/compaction_picker_universal.cc
@@ -733,7 +733,7 @@ Compaction* UniversalCompactionBuilder::PickCompactionToReduceSortedRuns(
 }
 
 // Look at overall size amplification. If size amplification
-// exceeeds the configured value, then do a compaction
+// exceeds the configured value, then do a compaction
 // of the candidate files all the way upto the earliest
 // base file (overrides configured values of file-size ratios,
 // min_merge_width and max_merge_width).

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -63,9 +63,8 @@ DBIter::DBIter(Env* _env, const ReadOptions& read_options,
       valid_(false),
       current_entry_is_merged_(false),
       is_key_seqnum_zero_(false),
-      prefix_same_as_start_(mutable_cf_options.prefix_extractor
-                                ? read_options.prefix_same_as_start
-                                : false),
+      prefix_same_as_start_(mutable_cf_options.prefix_extractor &&
+                            read_options.prefix_same_as_start),
       pin_thru_lifetime_(read_options.pin_data),
       expect_total_order_inner_iter_(prefix_extractor_ == nullptr ||
                                      read_options.total_order_seek ||
@@ -1343,7 +1342,7 @@ void DBIter::Seek(const Slice& target) {
   // we need to find out the next key that is visible to the user.
   ClearSavedValue();
   if (prefix_same_as_start_) {
-    // The case where the iterator needs to be invalidated if it has exausted
+    // The case where the iterator needs to be invalidated if it has exhausted
     // keys within the same prefix of the seek key.
     assert(prefix_extractor_ != nullptr);
     Slice target_prefix = prefix_extractor_->Transform(target);
@@ -1418,7 +1417,7 @@ void DBIter::SeekForPrev(const Slice& target) {
   // backward direction.
   ClearSavedValue();
   if (prefix_same_as_start_) {
-    // The case where the iterator needs to be invalidated if it has exausted
+    // The case where the iterator needs to be invalidated if it has exhausted
     // keys within the same prefix of the seek key.
     assert(prefix_extractor_ != nullptr);
     Slice target_prefix = prefix_extractor_->Transform(target);

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -10,6 +10,7 @@
 #pragma once
 #include <cstdint>
 #include <string>
+
 #include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
 #include "db/range_del_aggregator.h"

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -8,7 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
@@ -234,7 +234,7 @@ class DBIter final : public Iterator {
   // If `skipping_saved_key` is true, the function will keep iterating until it
   // finds a user key that is larger than `saved_key_`.
   // If `prefix` is not null, the iterator needs to stop when all keys for the
-  // prefix are exhausted and the interator is set to invalid.
+  // prefix are exhausted and the iterator is set to invalid.
   bool FindNextUserEntry(bool skipping_saved_key, const Slice* prefix);
   // Internal implementation of FindNextUserEntry().
   bool FindNextUserEntryInternal(bool skipping_saved_key, const Slice* prefix);

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -616,7 +616,7 @@ class IterKey {
   void EnlargeBuffer(size_t key_size);
 };
 
-// Convert from a SliceTranform of user keys, to a SliceTransform of
+// Convert from a SliceTransform of user keys, to a SliceTransform of
 // user keys.
 class InternalKeySliceTransform : public SliceTransform {
  public:

--- a/db/error_handler.h
+++ b/db/error_handler.h
@@ -102,7 +102,7 @@ class ErrorHandler {
     bool auto_recovery_;
     bool recovery_in_prog_;
     // A flag to indicate that for the soft error, we should not allow any
-    // backrgound work execpt the work is from recovery.
+    // background work except the work is from recovery.
     bool soft_error_no_bg_work_;
 
     // Used to store the context for recover, such as flush reason.

--- a/db/flush_scheduler.h
+++ b/db/flush_scheduler.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
-#include <cstdint>
 #include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <set>
+
 #include "util/autovector.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/flush_scheduler.h
+++ b/db/flush_scheduler.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <atomic>
 #include <mutex>
 #include <set>

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -339,7 +339,7 @@ void ForwardIterator::Cleanup(bool release_sv) {
 
 bool ForwardIterator::Valid() const {
   // See UpdateCurrent().
-  return valid_ ? !current_over_upper_bound_ : false;
+  return valid_ && !current_over_upper_bound_;
 }
 
 void ForwardIterator::SeekToFirst() {
@@ -426,7 +426,7 @@ void ForwardIterator::SeekInternal(const Slice& internal_key,
       if (seek_to_first) {
         l0_iters_[i]->SeekToFirst();
       } else {
-        // If the target key passes over the larget key, we are sure Next()
+        // If the target key passes over the largest key, we are sure Next()
         // won't go over this file.
         if (user_comparator_->Compare(target_user_key,
                                       l0[i]->largest.user_key()) > 0) {

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <cstdint>
-
 #include <memory>
 
 #include "db/log_format.h"

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -8,7 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <memory>
 

--- a/db/logs_with_prep_tracker.h
+++ b/db/logs_with_prep_tracker.h
@@ -5,8 +5,8 @@
 //
 #pragma once
 
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <mutex>
 #include <unordered_map>

--- a/db/logs_with_prep_tracker.h
+++ b/db/logs_with_prep_tracker.h
@@ -5,7 +5,7 @@
 //
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <cassert>
 #include <cstdlib>
 #include <mutex>

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -72,7 +72,7 @@ using MultiGetRange = MultiGetContext::Range;
 // Note:  Many of the methods in this class have comments indicating that
 // external synchronization is required as these methods are not thread-safe.
 // It is up to higher layers of code to decide how to prevent concurrent
-// invokation of these methods.  This is usually done by acquiring either
+// invocation of these methods.  This is usually done by acquiring either
 // the db mutex or the single writer thread.
 //
 // Some of these methods are documented to only require external
@@ -139,7 +139,7 @@ class MemTable {
   // operations on the same MemTable (unless this Memtable is immutable).
   size_t ApproximateMemoryUsage();
 
-  // As a cheap version of `ApproximateMemoryUsage()`, this function doens't
+  // As a cheap version of `ApproximateMemoryUsage()`, this function doesn't
   // require external synchronization. The value may be less accurate though
   size_t ApproximateMemoryUsageFast() const {
     return approximate_memory_usage_.load(std::memory_order_relaxed);
@@ -533,7 +533,7 @@ class MemTable {
   SequenceNumber atomic_flush_seqno_;
 
   // keep track of memory usage in table_, arena_, and range_del_table_.
-  // Gets refrshed inside `ApproximateMemoryUsage()` or `ShouldFlushNow`
+  // Gets refreshed inside `ApproximateMemoryUsage()` or `ShouldFlushNow`
   std::atomic<uint64_t> approximate_memory_usage_;
 
 #ifndef ROCKSDB_LITE

--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -521,7 +521,7 @@ void MemTableList::Add(MemTable* m, autovector<MemTable*>* to_delete) {
   InstallNewVersion();
   // this method is used to move mutable memtable into an immutable list.
   // since mutable memtable is already refcounted by the DBImpl,
-  // and when moving to the imutable list we don't unref it,
+  // and when moving to the immutable list we don't unref it,
   // we don't have to ref the memtable here. we just take over the
   // reference from the DBImpl.
   current_->Add(m, to_delete);

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -43,12 +43,12 @@ class TruncatedRangeDelIterator {
 
   void InternalNext();
 
-  // Seeks to the tombstone with the highest viisble sequence number that covers
+  // Seeks to the tombstone with the highest visible sequence number that covers
   // target (a user key). If no such tombstone exists, the position will be at
   // the earliest tombstone that ends after target.
   void Seek(const Slice& target);
 
-  // Seeks to the tombstone with the highest viisble sequence number that covers
+  // Seeks to the tombstone with the highest visible sequence number that covers
   // target (a user key). If no such tombstone exists, the position will be at
   // the latest tombstone that starts before target.
   void SeekForPrev(const Slice& target);

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -9,7 +9,7 @@
 #include <functional>
 #include <set>
 
-#include <stdio.h>
+#include <cstdio>
 #include <cinttypes>
 
 #include "util/autovector.h"

--- a/db/range_tombstone_fragmenter.cc
+++ b/db/range_tombstone_fragmenter.cc
@@ -6,11 +6,10 @@
 #include "db/range_tombstone_fragmenter.h"
 
 #include <algorithm>
+#include <cinttypes>
+#include <cstdio>
 #include <functional>
 #include <set>
-
-#include <cstdio>
-#include <cinttypes>
 
 #include "util/autovector.h"
 #include "util/kv_map.h"

--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -23,7 +23,7 @@ class SnapshotImpl : public Snapshot {
   SequenceNumber number_;  // const after creation
   // It indicates the smallest uncommitted data at the time the snapshot was
   // taken. This is currently used by WritePrepared transactions to limit the
-  // scope of queries to IsInSnpashot.
+  // scope of queries to IsInSnapshot.
   SequenceNumber min_uncommitted_ = kMinUnCommittedSeq;
 
   virtual SequenceNumber GetSequenceNumber() const override { return number_; }

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -12,7 +12,7 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 #include "db/dbformat.h"
 #include "db/range_del_aggregator.h"
@@ -183,7 +183,7 @@ class TableCache {
 
   Cache* get_cache() const { return cache_; }
 
-  // Capacity of the backing Cache that indicates inifinite TableCache capacity.
+  // Capacity of the backing Cache that indicates infinite TableCache capacity.
   // For example when max_open_files is -1 we set the backing Cache to this.
   static const int kInfiniteCapacity = 0x400000;
 

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -10,9 +10,9 @@
 // Thread-safe (provides internal synchronization)
 
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 #include "db/dbformat.h"
 #include "db/range_del_aggregator.h"

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -74,7 +74,7 @@ enum NewFileCustomTag : uint32_t {
   kNeedCompaction = 2,
   // Since Manifest is not entirely forward-compatible, we currently encode
   // kMinLogNumberToKeep as part of NewFile as a hack. This should be removed
-  // when manifest becomes forward-comptabile.
+  // when manifest becomes forward-compatible.
   kMinLogNumberToKeepHack = 3,
   kOldestBlobFileNumber = 4,
   kOldestAncesterTime = 5,
@@ -195,7 +195,7 @@ struct FileMetaData {
 
   // The file could be the compaction output from other SST files, which could
   // in turn be outputs for compact older SST files. We track the memtable
-  // flush timestamp for the oldest SST file that eventaully contribute data
+  // flush timestamp for the oldest SST file that eventually contribute data
   // to this file. 0 means the information is not available.
   uint64_t oldest_ancester_time = kUnknownOldestAncesterTime;
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -9,11 +9,10 @@
 
 #include "db/version_set.h"
 
-#include <cstdio>
-
 #include <algorithm>
 #include <array>
 #include <cinttypes>
+#include <cstdio>
 #include <list>
 #include <map>
 #include <set>

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -9,7 +9,7 @@
 
 #include "db/version_set.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <algorithm>
 #include <array>
@@ -409,7 +409,7 @@ class FilePickerMultiGet {
   int GetCurrentLevel() const { return curr_level_; }
 
   // Iterates through files in the current level until it finds a file that
-  // contains atleast one key from the MultiGet batch
+  // contains at least one key from the MultiGet batch
   bool GetNextFileInLevelWithKeys(MultiGetRange* next_file_range,
                                   size_t* file_index, FdWithKeyRange** fd,
                                   bool* is_last_key_in_file) {
@@ -2305,7 +2305,7 @@ bool Version::MaybeInitializeFileMetaData(FileMetaData* file_meta) {
                     file_meta->fd.GetNumber(), s.ToString().c_str());
     return false;
   }
-  if (tp.get() == nullptr) return false;
+  if (tp == nullptr) return false;
   file_meta->num_entries = tp->num_entries;
   file_meta->num_deletions = tp->num_deletions;
   file_meta->raw_value_size = tp->raw_value_size;
@@ -2787,7 +2787,7 @@ struct Fsize {
   FileMetaData* file;
 };
 
-// Compator that is used to sort files based on their size
+// Compactor that is used to sort files based on their size
 // In normal mode: descending size
 bool CompareCompensatedSizeDescending(const Fsize& first, const Fsize& second) {
   return (first.file->compensated_file_size >
@@ -3207,7 +3207,7 @@ void VersionStorageInfo::GetCleanInputsWithinInterval(
 // specified range. From that file, iterate backwards and
 // forwards to find all overlapping files.
 // if within_range is set, then only store the maximum clean inputs
-// within range [begin, end]. "clean" means there is a boudnary
+// within range [begin, end]. "clean" means there is a boundary
 // between the files in "*inputs" and the surrounding files
 void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
     int level, const InternalKey* begin, const InternalKey* end,
@@ -3518,7 +3518,7 @@ void VersionStorageInfo::CalculateBaseBytes(const ImmutableCFOptions& ioptions,
         //   1. the L0 size is larger than level size base, or
         //   2. number of L0 files reaches twice the L0->L1 compaction trigger
         // We don't do this otherwise to keep the LSM-tree structure stable
-        // unless the L0 compation is backlogged.
+        // unless the L0 compaction is backlogged.
         base_level_size = l0_size;
         if (base_level_ == num_levels_ - 1) {
           level_multiplier_ = 1.0;
@@ -4355,7 +4355,7 @@ Status VersionSet::ProcessManifestWrites(
   return s;
 }
 
-// 'datas' is gramatically incorrect. We still use this notation to indicate
+// 'datas' is grammatically incorrect. We still use this notation to indicate
 // that this variable represents a collection of column_family_data.
 Status VersionSet::LogAndApply(
     const autovector<ColumnFamilyData*>& column_family_datas,
@@ -4797,7 +4797,7 @@ Status VersionSet::TryRecoverFromOneManifest(
 Status VersionSet::ListColumnFamilies(std::vector<std::string>* column_families,
                                       const std::string& dbname,
                                       FileSystem* fs) {
-  // these are just for performance reasons, not correcntes,
+  // these are just for performance reasons, not correctness,
   // so we're fine using the defaults
   FileOptions soptions;
   // Read "CURRENT" file, which contains a pointer to the current manifest file

--- a/db/write_controller_test.cc
+++ b/db/write_controller_test.cc
@@ -87,7 +87,7 @@ TEST_F(WriteControllerTest, SanityTest) {
   ASSERT_EQ(static_cast<uint64_t>(0), controller.GetDelay(clock_.get(), 1000u));
 
   clock_->now_micros_ += 100u;  // sleep credit 200
-  // One refill: 10240 fileed, sleep credit generates 2000. 8000 used
+  // One refill: 10240 filled, sleep credit generates 2000. 8000 used
   //             7240 + 10240 + 2000 - 8000 = 11480 left
   ASSERT_EQ(static_cast<uint64_t>(1024u),
             controller.GetDelay(clock_.get(), 8000u));

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -5,11 +5,11 @@
 
 #pragma once
 
-#include <cassert>
-#include <cstdint>
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
1. remove unused variable `Slice blob_to_write` in `db/blob/blob_file_cache_test.cc`.

2. Instead deprecated C++ header, like `stdio.h` to `cstdio`, `assert.h` to `cassert`.

3. fix some typos in comments.

4. redundant get() call on smart pointer:

   1. `db/compaction/compaction.cc`:

      ```c++
      if (partitioner != nullptr) {
            if (!partitioner->CanDoTrivialMove(file->smallest.user_key(),
                                               file->largest.user_key())) {
              return false;
            }
          }
      ```

   2. `db/version_set.cc`:

      ```c++
      if (tp == nullptr) return false;
      ```

5. switch may not cover all branch in `db/c.cc`:

   ```c
   void rocksdb_options_set_access_hint_on_compaction_start(
       rocksdb_options_t* opt, int v) {
     switch(v) {
       case 0:
         opt->rep.access_hint_on_compaction_start =
             ROCKSDB_NAMESPACE::Options::NONE;
         break;
       case 1:
         opt->rep.access_hint_on_compaction_start =
             ROCKSDB_NAMESPACE::Options::NORMAL;
         break;
       case 2:
         opt->rep.access_hint_on_compaction_start =
             ROCKSDB_NAMESPACE::Options::SEQUENTIAL;
         break;
       case 3:
         opt->rep.access_hint_on_compaction_start =
             ROCKSDB_NAMESPACE::Options::WILLNEED;
         break;
       default:
         assert(0);
     }
   }
   ```

6. simplify code:

   1. `db/compaction/compaction_iterator.cc`:

      ```c
      bottommost_level_ = !(compaction_ == nullptr) &&
                            compaction_->bottommost_level() &&
                            !compaction_->allow_ingest_behind();
      ```

   2. `db/db_iter.cc`:

      ```c
      prefix_same_as_start_(mutable_cf_options.prefix_extractor &&
                                  read_options.prefix_same_as_start),
      ```

7. make the parameter `status` const reference in `db/compaction/compaction_picker.h` && `db/compaction/compaction_picker.cc `:

   ```c
   void ReleaseCompactionFiles(Compaction* c, const Status& status);
   ```

8. make the variable 'key' const reference in `db/blob/db_blob_compaction_test.cc`:

   ```c
   TEST_P(DBBlobBadCompactionFilterTest, BadDecisionFromCompactionFilter) {
     Options options = GetDefaultOptions();
     options.enable_blob_files = true;
     options.min_blob_size = 0;
     options.create_if_missing = true;
     options.compaction_filter = compaction_filter_guard_.get();
     DestroyAndReopen(options);
     ASSERT_OK(Put("b", "value"));
     ASSERT_OK(Flush());
     ASSERT_TRUE(db_->CompactRange(CompactRangeOptions(), /*begin=*/nullptr,
                                   /*end=*/nullptr)
                     .IsNotSupported());
     Close();
   
     DestroyAndReopen(options);
     const std::string& key(std::get<0>(GetParam()));
     ASSERT_OK(Put(key, "value"));
     ASSERT_OK(Flush());
     ASSERT_TRUE(db_->CompactRange(CompactRangeOptions(), /*begin=*/nullptr,
                                   /*end=*/nullptr)
                     .IsNotSupported());
     Close();
   }
   ```