### PR TITLE
Add user-defined timestamps to db_stress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -929,7 +929,8 @@ endif  # PLATFORM_SHARED_EXT
 	analyze tools tools_lib \
 	blackbox_crash_test_with_atomic_flush whitebox_crash_test_with_atomic_flush  \
 	blackbox_crash_test_with_txn whitebox_crash_test_with_txn \
-	blackbox_crash_test_with_best_efforts_recovery
+	blackbox_crash_test_with_best_efforts_recovery \
+	blackbox_crash_test_with_ts whitebox_crash_test_with_ts
 
 
 all: $(LIBRARY) $(BENCHMARKS) tools tools_lib test_libs $(TESTS)
@@ -1167,6 +1168,8 @@ crash_test_with_txn: whitebox_crash_test_with_txn blackbox_crash_test_with_txn
 
 crash_test_with_best_efforts_recovery: blackbox_crash_test_with_best_efforts_recovery
 
+crash_test_with_ts: whitebox_crash_test_with_ts blackbox_crash_test_with_ts
+
 blackbox_crash_test: db_stress
 	$(PYTHON) -u tools/db_crashtest.py --simple blackbox $(CRASH_TEST_EXT_ARGS)
 	$(PYTHON) -u tools/db_crashtest.py blackbox $(CRASH_TEST_EXT_ARGS)
@@ -1179,6 +1182,9 @@ blackbox_crash_test_with_txn: db_stress
 
 blackbox_crash_test_with_best_efforts_recovery: db_stress
 	$(PYTHON) -u tools/db_crashtest.py --test_best_efforts_recovery blackbox $(CRASH_TEST_EXT_ARGS)
+
+blackbox_crash_test_with_ts: db_stress
+	$(PYTHON) -u tools/db_crashtest.py --enable_ts blackbox $(CRASH_TEST_EXT_ARGS)
 
 ifeq ($(CRASH_TEST_KILL_ODD),)
   CRASH_TEST_KILL_ODD=888887
@@ -1196,6 +1202,10 @@ whitebox_crash_test_with_atomic_flush: db_stress
 
 whitebox_crash_test_with_txn: db_stress
 	$(PYTHON) -u tools/db_crashtest.py --txn whitebox --random_kill_odd \
+      $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
+
+whitebox_crash_test_with_ts: db_stress
+	$(PYTHON) -u tools/db_crashtest.py --enable_ts whitebox --random_kill_odd \
       $(CRASH_TEST_KILL_ODD) $(CRASH_TEST_EXT_ARGS)
 
 asan_check: clean

--- a/Makefile
+++ b/Makefile
@@ -1484,7 +1484,7 @@ memtablerep_bench: $(OBJ_DIR)/memtable/memtablerep_bench.o $(LIBRARY)
 filter_bench: $(OBJ_DIR)/util/filter_bench.o $(LIBRARY)
 	$(AM_LINK)
 
-db_stress: $(OBJ_DIR)/db_stress_tool/db_stress.o $(STRESS_LIBRARY) $(TOOLS_LIBRARY) $(LIBRARY) $(TESTUTIL)
+db_stress: $(OBJ_DIR)/db_stress_tool/db_stress.o $(STRESS_LIBRARY) $(TOOLS_LIBRARY) $(TESTUTIL) $(LIBRARY)
 	$(AM_LINK)
 
 write_stress: $(OBJ_DIR)/tools/write_stress.o $(LIBRARY)

--- a/Makefile
+++ b/Makefile
@@ -1474,7 +1474,7 @@ memtablerep_bench: $(OBJ_DIR)/memtable/memtablerep_bench.o $(LIBRARY)
 filter_bench: $(OBJ_DIR)/util/filter_bench.o $(LIBRARY)
 	$(AM_LINK)
 
-db_stress: $(OBJ_DIR)/db_stress_tool/db_stress.o $(STRESS_LIBRARY) $(TOOLS_LIBRARY) $(LIBRARY)
+db_stress: $(OBJ_DIR)/db_stress_tool/db_stress.o $(STRESS_LIBRARY) $(TOOLS_LIBRARY) $(LIBRARY) $(TESTUTIL)
 	$(AM_LINK)
 
 write_stress: $(OBJ_DIR)/tools/write_stress.o $(LIBRARY)

--- a/db_stress_tool/db_stress_common.cc
+++ b/db_stress_tool/db_stress_common.cc
@@ -30,7 +30,7 @@ enum ROCKSDB_NAMESPACE::ChecksumType checksum_type_e =
     ROCKSDB_NAMESPACE::kCRC32c;
 enum RepFactory FLAGS_rep_factory = kSkipList;
 std::vector<double> sum_probs(100001);
-int64_t zipf_sum_size = 100000;
+constexpr int64_t zipf_sum_size = 100000;
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -232,6 +232,15 @@ size_t GenerateValue(uint32_t rand, char* v, size_t max_sz) {
   v[value_sz] = '\0';
   return value_sz;  // the size of the value set.
 }
+
+std::string NowNanosStr() {
+  uint64_t t = db_stress_env->NowNanos();
+  std::string ret;
+  PutFixed64(&ret, t);
+  return ret;
+}
+
+std::string GenerateTimestampForRead() { return NowNanosStr(); }
 
 namespace {
 

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -260,9 +260,11 @@ DECLARE_bool(enable_compaction_filter);
 DECLARE_bool(paranoid_file_checks);
 DECLARE_uint64(batch_protection_bytes_per_key);
 
-const long KB = 1024;
-const int kRandomValueMaxFactor = 3;
-const int kValueMaxLen = 100;
+DECLARE_uint64(user_timestamp_size);
+
+constexpr long KB = 1024;
+constexpr int kRandomValueMaxFactor = 3;
+constexpr int kValueMaxLen = 100;
 
 // wrapped posix or hdfs environment
 extern ROCKSDB_NAMESPACE::Env* db_stress_env;
@@ -560,6 +562,9 @@ extern StressTest* CreateBatchedOpsStressTest();
 extern StressTest* CreateNonBatchedOpsStressTest();
 extern void InitializeHotKeyGenerator(double alpha);
 extern int64_t GetOneHotKeyID(double rand_seed, int64_t max_key);
+
+extern std::string GenerateTimestampForRead();
+extern std::string NowNanosStr();
 
 std::shared_ptr<FileChecksumGenFactory> GetFileChecksumImpl(
     const std::string& name);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -804,4 +804,8 @@ DEFINE_string(file_checksum_impl, "none",
 DEFINE_int32(write_fault_one_in, 0,
              "On non-zero, enables fault injection on write");
 
+DEFINE_uint64(user_timestamp_size, 0,
+              "Number of bytes for a user-defined timestamp. Currently, only "
+              "8-byte is supported");
+
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -418,6 +418,8 @@ struct ThreadState {
     std::string value;
     // optional state of all keys in the db
     std::vector<bool>* key_vec;
+
+    std::string timestamp;
   };
   std::queue<std::pair<uint64_t, SnapshotState>> snapshot_queue;
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2606,7 +2606,7 @@ void StressTest::CheckAndSetOptionsForUserTimestamp() {
             "disabled.\n");
     exit(1);
   }
-  if (FLAGS_use_merge) {
+  if (FLAGS_use_merge || FLAGS_use_full_merge_v1) {
     fprintf(stderr, "Merge not supported.\n");
     exit(1);
   }
@@ -2622,7 +2622,7 @@ void StressTest::CheckAndSetOptionsForUserTimestamp() {
     fprintf(stderr, "When opened as read-only, timestamp not supported.\n");
     exit(1);
   }
-  if (FLAGS_secondary_catch_up_one_in > 0 ||
+  if (FLAGS_test_secondary || FLAGS_secondary_catch_up_one_in > 0 ||
       FLAGS_continuous_verification_interval > 0) {
     fprintf(stderr, "Secondary instance does not support timestamp.\n");
     exit(1);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2623,10 +2623,12 @@ void StressTest::CheckAndSetOptionsForUserTimestamp() {
             FLAGS_checkpoint_one_in);
     exit(1);
   }
+#ifndef ROCKSDB_LITE
   if (FLAGS_enable_blob_files || FLAGS_use_blob_db) {
     fprintf(stderr, "BlobDB not supported with timestamp.\n");
     exit(1);
   }
+#endif  // !ROCKSDB_LITE
   if (FLAGS_enable_compaction_filter) {
     fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
     exit(1);

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -978,13 +978,6 @@ Status StressTest::TestIterate(ThreadState* thread,
   }
 
   auto cfh = column_families_[rand_column_families[0]];
-  std::string ts_str;
-  Slice ts;
-  if (FLAGS_user_timestamp_size > 0) {
-    ts_str = GenerateTimestampForRead();
-    ts = ts_str;
-    readoptionscopy.timestamp = &ts;
-  }
   std::unique_ptr<Iterator> iter(db_->NewIterator(readoptionscopy, cfh));
 
   std::vector<std::string> key_str;
@@ -1047,11 +1040,7 @@ Status StressTest::TestIterate(ThreadState* thread,
     // iterators with the same set-up, and it doesn't hurt to check them
     // to be equal.
     ReadOptions cmp_ro;
-    if (FLAGS_user_timestamp_size > 0) {
-      ts_str = GenerateTimestampForRead();
-      ts = ts_str;
-      cmp_ro.timestamp = &ts;
-    }
+    cmp_ro.timestamp = readoptionscopy.timestamp;
     cmp_ro.snapshot = snapshot;
     cmp_ro.total_order_seek = true;
     ColumnFamilyHandle* cmp_cfh =

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2335,63 +2335,7 @@ void StressTest::Open() {
   Status s;
 
   if (FLAGS_user_timestamp_size > 0) {
-    const Comparator* const cmp = test::ComparatorWithU64Ts();
-    assert(cmp);
-    if (FLAGS_user_timestamp_size != cmp->timestamp_size()) {
-      fprintf(stderr,
-              "Only -user_timestamp_size=%d is supported in stress test.\n",
-              static_cast<int>(cmp->timestamp_size()));
-      exit(1);
-    }
-    if (FLAGS_nooverwritepercent > 0) {
-      fprintf(stderr,
-              "-nooverwritepercent must be 0 because SingleDelete must be "
-              "disabled.\n");
-      exit(1);
-    }
-    if (FLAGS_use_merge) {
-      fprintf(stderr, "Merge not supported.\n");
-      exit(1);
-    }
-    if (FLAGS_delrangepercent > 0) {
-      fprintf(stderr, "DeleteRange not supported.\n");
-      exit(1);
-    }
-    if (FLAGS_use_txn) {
-      fprintf(stderr, "TransactionDB does not support timestamp yet.\n");
-      exit(1);
-    }
-    if (FLAGS_read_only) {
-      fprintf(stderr, "When opened as read-only, timestamp not supported.\n");
-      exit(1);
-    }
-    if (FLAGS_secondary_catch_up_one_in > 0 ||
-        FLAGS_continuous_verification_interval > 0) {
-      fprintf(stderr, "Secondary instance does not support timestamp.\n");
-      exit(1);
-    }
-    if (FLAGS_checkpoint_one_in > 0) {
-      fprintf(stderr,
-              "-checkpoint_one_in=%d requires "
-              "DBImplReadOnly, which is not supported with timestamp\n",
-              FLAGS_checkpoint_one_in);
-      exit(1);
-    }
-    if (FLAGS_enable_blob_files || FLAGS_use_blob_db) {
-      fprintf(stderr, "BlobDB not supported with timestamp.\n");
-      exit(1);
-    }
-    if (FLAGS_enable_compaction_filter) {
-      fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
-      exit(1);
-    }
-    if (FLAGS_test_cf_consistency || FLAGS_test_batches_snapshots) {
-      fprintf(stderr,
-              "Due to per-key ts-seq ordering constraint, only the (default) "
-              "non-batched test is supported with timestamp.\n");
-      exit(1);
-    }
-    options_.comparator = cmp;
+    CheckAndSetOptionsForUserTimestamp();
   }
 
   if (FLAGS_ttl == -1) {
@@ -2644,6 +2588,71 @@ void StressTest::Reopen(ThreadState* thread) {
   fprintf(stdout, "%s Reopening database for the %dth time\n",
           clock_->TimeToString(now / 1000000).c_str(), num_times_reopened_);
   Open();
+}
+
+void StressTest::CheckAndSetOptionsForUserTimestamp() {
+  assert(FLAGS_user_timestamp_size > 0);
+  const Comparator* const cmp = test::ComparatorWithU64Ts();
+  assert(cmp);
+  if (FLAGS_user_timestamp_size != cmp->timestamp_size()) {
+    fprintf(stderr,
+            "Only -user_timestamp_size=%d is supported in stress test.\n",
+            static_cast<int>(cmp->timestamp_size()));
+    exit(1);
+  }
+  if (FLAGS_nooverwritepercent > 0) {
+    fprintf(stderr,
+            "-nooverwritepercent must be 0 because SingleDelete must be "
+            "disabled.\n");
+    exit(1);
+  }
+  if (FLAGS_use_merge) {
+    fprintf(stderr, "Merge not supported.\n");
+    exit(1);
+  }
+  if (FLAGS_delrangepercent > 0) {
+    fprintf(stderr, "DeleteRange not supported.\n");
+    exit(1);
+  }
+  if (FLAGS_use_txn) {
+    fprintf(stderr, "TransactionDB does not support timestamp yet.\n");
+    exit(1);
+  }
+  if (FLAGS_read_only) {
+    fprintf(stderr, "When opened as read-only, timestamp not supported.\n");
+    exit(1);
+  }
+  if (FLAGS_secondary_catch_up_one_in > 0 ||
+      FLAGS_continuous_verification_interval > 0) {
+    fprintf(stderr, "Secondary instance does not support timestamp.\n");
+    exit(1);
+  }
+  if (FLAGS_checkpoint_one_in > 0) {
+    fprintf(stderr,
+            "-checkpoint_one_in=%d requires "
+            "DBImplReadOnly, which is not supported with timestamp\n",
+            FLAGS_checkpoint_one_in);
+    exit(1);
+  }
+  if (FLAGS_enable_blob_files || FLAGS_use_blob_db) {
+    fprintf(stderr, "BlobDB not supported with timestamp.\n");
+    exit(1);
+  }
+  if (FLAGS_enable_compaction_filter) {
+    fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
+    exit(1);
+  }
+  if (FLAGS_test_cf_consistency || FLAGS_test_batches_snapshots) {
+    fprintf(stderr,
+            "Due to per-key ts-seq ordering constraint, only the (default) "
+            "non-batched test is supported with timestamp.\n");
+    exit(1);
+  }
+  if (FLAGS_ingest_external_file_one_in > 0) {
+    fprintf(stderr, "Bulk loading may not support timestamp yet.\n");
+    exit(1);
+  }
+  options_.comparator = cmp;
 }
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // GFLAGS

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2385,6 +2385,12 @@ void StressTest::Open() {
       fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
       exit(1);
     }
+    if (FLAGS_test_cf_consistency || FLAGS_test_batches_snapshots) {
+      fprintf(stderr,
+              "Due to per-key ts-seq ordering constraint, only the (default) "
+              "non-batched test is supported with timestamp.\n");
+      exit(1);
+    }
     options_.comparator = cmp;
   }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2377,6 +2377,10 @@ void StressTest::Open() {
               FLAGS_checkpoint_one_in);
       exit(1);
     }
+    if (FLAGS_enable_blob_files || FLAGS_use_blob_db) {
+      fprintf(stderr, "BlobDB not supported with timestamp.\n");
+      exit(1);
+    }
     options_.comparator = cmp;
   }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2328,6 +2328,33 @@ void StressTest::Open() {
               static_cast<int>(cmp->timestamp_size()));
       exit(1);
     }
+    if (FLAGS_nooverwritepercent > 0) {
+      fprintf(stderr,
+              "-nooverwritepercent must be 0 because SingleDelete must be "
+              "disabled.\n");
+      exit(1);
+    }
+    if (FLAGS_use_merge) {
+      fprintf(stderr, "Merge not supported.\n");
+      exit(1);
+    }
+    if (FLAGS_delrangepercent > 0) {
+      fprintf(stderr, "DeleteRange not supported.\n");
+      exit(1);
+    }
+    if (FLAGS_use_txn) {
+      fprintf(stderr, "TransactionDB does not support timestamp yet.\n");
+      exit(1);
+    }
+    if (FLAGS_read_only) {
+      fprintf(stderr, "When opened as read-only, timestamp not supported.\n");
+      exit(1);
+    }
+    if (FLAGS_secondary_catch_up_one_in > 0 ||
+        FLAGS_continuous_verification_interval > 0) {
+      fprintf(stderr, "Secondary instance does not support timestamp.\n");
+      exit(1);
+    }
     options_.comparator = cmp;
   }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2381,6 +2381,10 @@ void StressTest::Open() {
       fprintf(stderr, "BlobDB not supported with timestamp.\n");
       exit(1);
     }
+    if (FLAGS_enable_compaction_filter) {
+      fprintf(stderr, "CompactionFilter not supported with timestamp.\n");
+      exit(1);
+    }
     options_.comparator = cmp;
   }
 

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2607,11 +2607,11 @@ void StressTest::CheckAndSetOptionsForUserTimestamp() {
     exit(1);
   }
   if (FLAGS_use_merge || FLAGS_use_full_merge_v1) {
-    fprintf(stderr, "Merge not supported.\n");
+    fprintf(stderr, "Merge does not support timestamp yet.\n");
     exit(1);
   }
   if (FLAGS_delrangepercent > 0) {
-    fprintf(stderr, "DeleteRange not supported.\n");
+    fprintf(stderr, "DeleteRange does not support timestamp yet.\n");
     exit(1);
   }
   if (FLAGS_use_txn) {

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -211,6 +211,8 @@ class StressTest {
 
   void Reopen(ThreadState* thread);
 
+  void CheckAndSetOptionsForUserTimestamp();
+
   std::shared_ptr<Cache> cache_;
   std::shared_ptr<Cache> compressed_cache_;
   std::shared_ptr<const FilterPolicy> filter_policy_;

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -295,6 +295,7 @@ ts_params = {
     "enable_blob_files": False,
     "use_blob_db": False,
     "enable_compaction_filter": False,
+    "ingest_external_file_one_in": 0,
 }
 
 def finalize_and_sanitize(src_params):

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -281,6 +281,22 @@ blob_params = {
     "backup_one_in": 0,
 }
 
+ts_params = {
+    "user_timestamp_size": 8,
+    "use_merge": False,
+    # In order to disable SingleDelete
+    "nooverwritepercent": 0,
+    "delrangepercent": 0,
+    "use_txn": False,
+    "read_only": False,
+    "secondary_catch_up_one_in": 0,
+    "continuous_verification_interval": 0,
+    "checkpoint_one_in": 0,
+    "enable_blob_files": False,
+    "use_blob_db": False,
+    "enable_compaction_filter": False,
+}
+
 def finalize_and_sanitize(src_params):
     dest_params = dict([(k,  v() if callable(v) else v)
                         for (k, v) in src_params.items()])

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -284,6 +284,7 @@ blob_params = {
 ts_params = {
     "user_timestamp_size": 8,
     "use_merge": False,
+    "use_full_merge_v1": False,
     # In order to disable SingleDelete
     "nooverwritepercent": 0,
     "delrangepercent": 0,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -282,20 +282,21 @@ blob_params = {
 }
 
 ts_params = {
+    "test_cf_consistency": 0,
+    "test_batches_snapshots": 0,
     "user_timestamp_size": 8,
-    "use_merge": False,
-    "use_full_merge_v1": False,
+    "use_merge": 0,
+    "use_full_merge_v1": 0,
     # In order to disable SingleDelete
     "nooverwritepercent": 0,
-    "delrangepercent": 0,
-    "use_txn": False,
-    "read_only": False,
+    "use_txn": 0,
+    "read_only": 0,
     "secondary_catch_up_one_in": 0,
     "continuous_verification_interval": 0,
     "checkpoint_one_in": 0,
-    "enable_blob_files": False,
-    "use_blob_db": False,
-    "enable_compaction_filter": False,
+    "enable_blob_files": 0,
+    "use_blob_db": 0,
+    "enable_compaction_filter": 0,
     "ingest_external_file_one_in": 0,
 }
 
@@ -324,9 +325,10 @@ def finalize_and_sanitize(src_params):
         else:
             dest_params["mock_direct_io"] = True
 
-    # DeleteRange is not currnetly compatible with Txns
-    if dest_params.get("test_batches_snapshots") == 1 or \
-            dest_params.get("use_txn") == 1:
+    # DeleteRange is not currnetly compatible with Txns and timestamp
+    if (dest_params.get("test_batches_snapshots") == 1 or
+        dest_params.get("use_txn") == 1 or
+        dest_params.get("user_timestamp_size") > 0):
         dest_params["delpercent"] += dest_params["delrangepercent"]
         dest_params["delrangepercent"] = 0
     # Only under WritePrepared txns, unordered_write would provide the same guarnatees as vanilla rocksdb
@@ -391,11 +393,15 @@ def gen_cmd_params(args):
         params.update(txn_params)
     if args.test_best_efforts_recovery:
         params.update(best_efforts_recovery_params)
+    if args.enable_ts:
+        params.update(ts_params)
 
     # Best-effort recovery and BlobDB are currently incompatible. Test BE recovery
     # if specified on the command line; otherwise, apply BlobDB related overrides
     # with a 10% chance.
-    if not args.test_best_efforts_recovery and random.choice([0] * 9 + [1]) == 1:
+    if (not args.test_best_efforts_recovery and
+        not args.enable_ts and
+        random.choice([0] * 9 + [1]) == 1):
         params.update(blob_params)
 
     for k, v in vars(args).items():
@@ -411,7 +417,7 @@ def gen_cmd(params, unknown_params):
         for k, v in [(k, finalzied_params[k]) for k in sorted(finalzied_params)]
         if k not in set(['test_type', 'simple', 'duration', 'interval',
                          'random_kill_odd', 'cf_consistency', 'txn',
-                         'test_best_efforts_recovery'])
+                         'test_best_efforts_recovery', 'enable_ts'])
         and v is not None] + unknown_params
     return cmd
 
@@ -664,6 +670,7 @@ def main():
     parser.add_argument("--cf_consistency", action='store_true')
     parser.add_argument("--txn", action='store_true')
     parser.add_argument("--test_best_efforts_recovery", action='store_true')
+    parser.add_argument("--enable_ts", action='store_true')
 
     all_params = dict(list(default_params.items())
                       + list(blackbox_default_params.items())
@@ -671,7 +678,8 @@ def main():
                       + list(simple_default_params.items())
                       + list(blackbox_simple_default_params.items())
                       + list(whitebox_simple_default_params.items())
-                      + list(blob_params.items()))
+                      + list(blob_params.items())
+                      + list(ts_params.items()))
 
     for k, v in all_params.items():
         parser.add_argument("--" + k, type=type(v() if callable(v) else v))


### PR DESCRIPTION
Add some basic test for user-defined timestamp to db_stress. Currently,
read with timestamp always tries to read using the current timestamp.
Due to the per-key timestamp-sequence ordering constraint, we only add timestamp-
related tests to the `NonBatchedOpsStressTest` since this test serializes accesses
to the same key and uses a file to cross-check data correctness.
The timestamp feature is not supported in a number of components, e.g. Merge, SingleDelete,
DeleteRange, CompactionFilter, Readonly instance, secondary instance, SST file ingestion, transaction,
etc. Therefore, db_stress should exit if user enables both timestamp and these features at the same
time. The (currently) incompatible features can be found in
`CheckAndSetOptionsForUserTimestamp`.

This PR also fixes a bug triggered when timestamp is enabled together with
`index_type=kBinarySearchWithFirstKey`. This bug fix will also be in another separate PR
with more unit tests coverage. Fixing it here because I do not want to exclude the index type
from crash test.

Test plan:
make crash_test_with_ts