### PR TITLE
Remove unused variable

### DIFF
--- a/db/blob/blob_file_cache_test.cc
+++ b/db/blob/blob_file_cache_test.cc
@@ -64,7 +64,6 @@ void WriteBlobFile(uint32_t column_family_id,
   constexpr char blob[] = "blob";
 
   std::string compressed_blob;
-  Slice blob_to_write;
 
   uint64_t key_offset = 0;
   uint64_t blob_offset = 0;


### PR DESCRIPTION
Remove unused variable `Slice blob_to_write` in `db/blob/blob_file_cache_test.cc`.