### PR TITLE
Adjust the set of potential min_blob_size values in stress/crash tests

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -208,7 +208,7 @@ bool StressTest::BuildOptionsTable() {
     options_tbl.emplace("enable_blob_files",
                         std::vector<std::string>{"false", "true"});
     options_tbl.emplace("min_blob_size",
-                        std::vector<std::string>{"0", "16", "256"});
+                        std::vector<std::string>{"0", "8", "16"});
     options_tbl.emplace("blob_file_size",
                         std::vector<std::string>{"1M", "16M", "256M", "1G"});
     options_tbl.emplace("blob_compression_type", GetBlobCompressionTags());

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -271,7 +271,7 @@ blob_params = {
     # Enable blob files and GC with a 75% chance initially; note that they might still be
     # enabled/disabled during the test via SetOptions
     "enable_blob_files": lambda: random.choice([0] + [1] * 3),
-    "min_blob_size": lambda: random.choice([0, 16, 256]),
+    "min_blob_size": lambda: random.choice([0, 8, 16]),
     "blob_file_size": lambda: random.choice([1048576, 16777216, 268435456, 1073741824]),
     "blob_compression_type": lambda: random.choice(["none", "snappy", "lz4", "zstd"]),
     "enable_blob_garbage_collection": lambda: random.choice([0] + [1] * 3),


### PR DESCRIPTION
Summary:
Since our stress/crash tests by default generate values of size 8, 16, or 24,
it does not make much sense to set `min_blob_size` to 256. The patch
updates the set of potential `min_blob_size` values in the crash test
script and in `db_stress` where it might be set dynamically using
`SetOptions`.

Test Plan:
Ran `make check` and tried the crash test script.