### PR TITLE
Fix a compilation error in CircleCI vs2019 CXX20

### DIFF
--- a/third-party/folly/folly/synchronization/DistributedMutex-inl.h
+++ b/third-party/folly/folly/synchronization/DistributedMutex-inl.h
@@ -1374,7 +1374,8 @@ inline std::uintptr_t tryWake(
     // we need release here because of the write to waker_ and also because we
     // are unlocking the mutex, the thread we do the handoff to here should
     // see the modified data
-    new (&waiter->metadata_) Metadata(waker, bit_cast<uintptr_t>(sleepers));
+    new (&waiter->metadata_)
+        Metadata(waker, folly::bit_cast<std::uintptr_t>(sleepers));
     waiter->futex_.store(kWake, std::memory_order_release);
     return 0;
   }


### PR DESCRIPTION
As title.
Always specify namespace::symbol_name...
Test plan
CircleCI and other CI results