### PR TITLE
Remove local static string

### DIFF
--- a/db/blob/blob_index.h
+++ b/db/blob/blob_index.h
@@ -89,7 +89,7 @@ class BlobIndex {
   }
 
   Status DecodeFrom(Slice slice) {
-    static const std::string kErrorMessage = "Error while decoding blob index";
+    const char* kErrorMessage = "Error while decoding blob index";
     assert(slice.size() > 0);
     type_ = static_cast<Type>(*slice.data());
     if (type_ >= Type::kUnknown) {

--- a/db/blob/blob_log_format.cc
+++ b/db/blob/blob_log_format.cc
@@ -26,8 +26,7 @@ void BlobLogHeader::EncodeTo(std::string* dst) {
 }
 
 Status BlobLogHeader::DecodeFrom(Slice src) {
-  static const std::string kErrorMessage =
-      "Error while decoding blob log header";
+  const char* kErrorMessage = "Error while decoding blob log header";
   if (src.size() != BlobLogHeader::kSize) {
     return Status::Corruption(kErrorMessage,
                               "Unexpected blob file header size");
@@ -71,8 +70,7 @@ void BlobLogFooter::EncodeTo(std::string* dst) {
 }
 
 Status BlobLogFooter::DecodeFrom(Slice src) {
-  static const std::string kErrorMessage =
-      "Error while decoding blob log footer";
+  const char* kErrorMessage = "Error while decoding blob log footer";
   if (src.size() != BlobLogFooter::kSize) {
     return Status::Corruption(kErrorMessage,
                               "Unexpected blob file footer size");
@@ -112,7 +110,7 @@ void BlobLogRecord::EncodeHeaderTo(std::string* dst) {
 }
 
 Status BlobLogRecord::DecodeHeaderFrom(Slice src) {
-  static const std::string kErrorMessage = "Error while decoding blob record";
+  const char* kErrorMessage = "Error while decoding blob record";
   if (src.size() != BlobLogRecord::kHeaderSize) {
     return Status::Corruption(kErrorMessage,
                               "Unexpected blob record header size");


### PR DESCRIPTION
Local static string is not friendly to Jemalloc arena aware implementation, as it will be allocated on the arena of the first caller, which causes crash if the allocated arena gets refunded earlier.

P.S. A Jemalloc arena aware implementation is each rocksdb instance only use certain Jemalloc arenas, and arena will be refunded after associated DB instance is destroyed.