### PR TITLE
[POC] Initial support for NVM cache in LRUCache

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -258,7 +258,7 @@ void LRUCacheShard::SetCapacity(size_t capacity) {
     EvictFromLRU(0, &last_reference_list);
   }
 
-  // Try to insert the evicted entries into NVM cache
+  // Try to insert the evicted entries into tiered cache
   // Free the entries outside of mutex for performance reasons
   for (auto entry : last_reference_list) {
     if (tiered_cache_ && entry->IsTieredCacheCompatible() &&

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -7,8 +7,12 @@
 
 #include <string>
 #include <vector>
+
 #include "port/port.h"
+#include "rocksdb/cache.h"
 #include "test_util/testharness.h"
+#include "util/coding.h"
+#include "util/random.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -32,7 +36,7 @@ class LRUCacheTest : public testing::Test {
         port::cacheline_aligned_alloc(sizeof(LRUCacheShard)));
     new (cache_) LRUCacheShard(capacity, false /*strict_capcity_limit*/,
                                high_pri_pool_ratio, use_adaptive_mutex,
-                               kDontChargeCacheMetadata);
+                               kDontChargeCacheMetadata, nullptr /*nvm_cache*/);
   }
 
   void Insert(const std::string& key,
@@ -191,6 +195,178 @@ TEST_F(LRUCacheTest, EntriesWithPriority) {
   ValidateLRUList({"e", "f", "g", "Z", "d"}, 2);
 }
 
+class TestNvmCache : public NvmCache {
+ public:
+  TestNvmCache(size_t capacity) : num_inserts_(0), num_lookups_(0) {
+    cache_ = NewLRUCache(capacity, 0, false, 0.5, nullptr,
+                         kDefaultToAdaptiveMutex, kDontChargeCacheMetadata);
+  }
+  ~TestNvmCache() { cache_.reset(); }
+
+  std::string Name() override { return "TestNvmCache"; }
+
+  Status Insert(const Slice& key, void* value,
+                Cache::CacheItemHelperCallback helper_cb) override {
+    Cache::SizeCallback size_cb;
+    Cache::SaveToCallback save_cb;
+    size_t size;
+    char* buf;
+    Status s;
+
+    num_inserts_++;
+    (*helper_cb)(&size_cb, &save_cb, nullptr);
+    size = (*size_cb)(value);
+    buf = new char[size + sizeof(uint64_t)];
+    EncodeFixed64(buf, size);
+    s = (*save_cb)(value, 0, size, buf + sizeof(uint64_t));
+    EXPECT_OK(s);
+    return cache_->Insert(key, buf, size,
+                          [](const Slice& /*key*/, void* value) -> void {
+                            delete[] reinterpret_cast<char*>(value);
+                          });
+  }
+
+  std::unique_ptr<NvmCacheHandle> Lookup(const Slice& key,
+                                         const Cache::CreateCallback& create_cb,
+                                         bool /*wait*/) override {
+    std::unique_ptr<TestNvmCacheHandle> nvm_handle;
+    Cache::Handle* handle = cache_->Lookup(key);
+    num_lookups_++;
+    if (handle) {
+      void* value;
+      size_t charge;
+      char* ptr = (char*)cache_->Value(handle);
+      size_t size = DecodeFixed64(ptr);
+      ptr += sizeof(uint64_t);
+      Status s = create_cb(ptr, size, &value, &charge);
+      EXPECT_OK(s);
+      nvm_handle.reset(
+          new TestNvmCacheHandle(cache_.get(), handle, value, charge));
+    }
+    return nvm_handle;
+  }
+
+  void Erase(const Slice& /*key*/) override {}
+
+  void WaitAll(std::vector<NvmCacheHandle*> /*handles*/) override {}
+
+  std::string GetPrintableOptions() const override { return ""; }
+
+  uint32_t num_inserts() { return num_inserts_; }
+
+  uint32_t num_lookups() { return num_lookups_; }
+
+ private:
+  class TestNvmCacheHandle : public NvmCacheHandle {
+   public:
+    TestNvmCacheHandle(Cache* cache, Cache::Handle* handle, void* value,
+                       size_t size)
+        : cache_(cache), handle_(handle), value_(value), size_(size) {}
+    ~TestNvmCacheHandle() {
+      delete[] reinterpret_cast<char*>(cache_->Value(handle_));
+      cache_->Release(handle_);
+    }
+
+    bool isReady() override { return true; }
+
+    void Wait() override {}
+
+    void* Value() override { return value_; }
+
+    size_t Size() override { return size_; }
+
+   private:
+    Cache* cache_;
+    Cache::Handle* handle_;
+    void* value_;
+    size_t size_;
+  };
+
+  std::shared_ptr<Cache> cache_;
+  uint32_t num_inserts_;
+  uint32_t num_lookups_;
+};
+
+TEST_F(LRUCacheTest, TestNvmCache) {
+  LRUCacheOptions opts(1024, 0, false, 0.5, nullptr, kDefaultToAdaptiveMutex,
+                       kDontChargeCacheMetadata);
+  std::shared_ptr<TestNvmCache> nvm_cache(new TestNvmCache(2048));
+  opts.nvm_cache = nvm_cache;
+  std::shared_ptr<Cache> cache = NewLRUCache(opts);
+
+  class TestItem {
+   public:
+    TestItem(const char* buf, size_t size) : buf_(new char[size]), size_(size) {
+      memcpy(buf_.get(), buf, size);
+    }
+    ~TestItem() {}
+
+    char* Buf() { return buf_.get(); }
+    size_t Size() { return size_; }
+
+   private:
+    std::unique_ptr<char[]> buf_;
+    size_t size_;
+  };
+
+  Cache::CacheItemHelperCallback helper_cb =
+      [](Cache::SizeCallback* size_cb, Cache::SaveToCallback* saveto_cb,
+         Cache::DeletionCallback* del_cb) -> void {
+    if (size_cb) {
+      *size_cb = [](void* obj) -> size_t {
+        return reinterpret_cast<TestItem*>(obj)->Size();
+      };
+    }
+    if (saveto_cb) {
+      *saveto_cb = [](void* obj, size_t offset, size_t size,
+                      void* out) -> Status {
+        TestItem* item = reinterpret_cast<TestItem*>(obj);
+        char* buf = item->Buf();
+        EXPECT_EQ(size, item->Size());
+        EXPECT_EQ(offset, 0);
+        memcpy(out, buf, size);
+        return Status::OK();
+      };
+    }
+    if (del_cb) {
+      *del_cb = [](const Slice& /*key*/, void* obj) -> void {
+        delete reinterpret_cast<TestItem*>(obj);
+      };
+    }
+  };
+
+  int create_count = 0;
+  Cache::CreateCallback test_item_creator =
+      [&create_count](void* buf, size_t size, void** out_obj,
+                      size_t* charge) -> Status {
+    create_count++;
+    *out_obj = reinterpret_cast<void*>(new TestItem((char*)buf, size));
+    *charge = size;
+    return Status::OK();
+  };
+
+  Random rnd(301);
+  std::string str1 = rnd.RandomString(1020);
+  TestItem* item1 = new TestItem(str1.data(), str1.length());
+  cache->Insert("k1", item1, helper_cb, str1.length());
+  std::string str2 = rnd.RandomString(1020);
+  TestItem* item2 = new TestItem(str2.data(), str2.length());
+  // k2 should be demoted to NVM
+  cache->Insert("k2", item2, helper_cb, str2.length());
+
+  Cache::Handle* handle;
+  handle = cache->Lookup("k2", helper_cb, test_item_creator,
+                         Cache::Priority::LOW, true);
+  ASSERT_NE(handle, nullptr);
+  cache->Release(handle);
+  // This lookup should promote k1 and demote k2
+  handle = cache->Lookup("k1", helper_cb, test_item_creator,
+                         Cache::Priority::LOW, true);
+  ASSERT_NE(handle, nullptr);
+  cache->Release(handle);
+  ASSERT_EQ(nvm_cache->num_inserts(), 2);
+  ASSERT_EQ(nvm_cache->num_lookups(), 1);
+}
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -221,8 +221,8 @@ class TestNvmCache : public NvmCache {
     s = (*save_cb)(value, 0, size, buf + sizeof(uint64_t));
     EXPECT_OK(s);
     return cache_->Insert(key, buf, size,
-                          [](const Slice& /*key*/, void* value) -> void {
-                            delete[] reinterpret_cast<char*>(value);
+                          [](const Slice& /*key*/, void* val) -> void {
+                            delete[] reinterpret_cast<char*>(val);
                           });
   }
 
@@ -263,7 +263,6 @@ class TestNvmCache : public NvmCache {
                        size_t size)
         : cache_(cache), handle_(handle), value_(value), size_(size) {}
     ~TestNvmCacheHandle() {
-      delete[] reinterpret_cast<char*>(cache_->Value(handle_));
       cache_->Release(handle_);
     }
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -345,7 +345,7 @@ TEST_F(LRUCacheTest, TestTieredCache) {
   Random rnd(301);
   std::string str1 = rnd.RandomString(1020);
   TestItem* item1 = new TestItem(str1.data(), str1.length());
-  cache->Insert("k1", item1, helper_cb, str1.length());
+  ASSERT_OK(cache->Insert("k1", item1, helper_cb, str1.length()));
   std::string str2 = rnd.RandomString(1020);
   TestItem* item2 = new TestItem(str2.data(), str2.length());
   // k2 should be demoted to NVM

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -229,7 +229,7 @@ class TestNvmCache : public NvmCache {
   std::unique_ptr<NvmCacheHandle> Lookup(const Slice& key,
                                          const Cache::CreateCallback& create_cb,
                                          bool /*wait*/) override {
-    std::unique_ptr<TestNvmCacheHandle> nvm_handle;
+    std::unique_ptr<NvmCacheHandle> nvm_handle;
     Cache::Handle* handle = cache_->Lookup(key);
     num_lookups_++;
     if (handle) {
@@ -363,8 +363,8 @@ TEST_F(LRUCacheTest, TestNvmCache) {
                          Cache::Priority::LOW, true);
   ASSERT_NE(handle, nullptr);
   cache->Release(handle);
-  ASSERT_EQ(nvm_cache->num_inserts(), 2);
-  ASSERT_EQ(nvm_cache->num_lookups(), 1);
+  ASSERT_EQ(nvm_cache->num_inserts(), 2u);
+  ASSERT_EQ(nvm_cache->num_lookups(), 1u);
 }
 }  // namespace ROCKSDB_NAMESPACE
 

--- a/cache/lru_cache_test.cc
+++ b/cache/lru_cache_test.cc
@@ -262,9 +262,7 @@ class TestNvmCache : public NvmCache {
     TestNvmCacheHandle(Cache* cache, Cache::Handle* handle, void* value,
                        size_t size)
         : cache_(cache), handle_(handle), value_(value), size_(size) {}
-    ~TestNvmCacheHandle() {
-      cache_->Release(handle_);
-    }
+    ~TestNvmCacheHandle() { cache_->Release(handle_); }
 
     bool isReady() override { return true; }
 
@@ -351,7 +349,7 @@ TEST_F(LRUCacheTest, TestNvmCache) {
   std::string str2 = rnd.RandomString(1020);
   TestItem* item2 = new TestItem(str2.data(), str2.length());
   // k2 should be demoted to NVM
-  cache->Insert("k2", item2, helper_cb, str2.length());
+  ASSERT_OK(cache->Insert("k2", item2, helper_cb, str2.length()));
 
   Cache::Handle* handle;
   handle = cache->Lookup("k2", helper_cb, test_item_creator,

--- a/cache/sharded_cache.cc
+++ b/cache/sharded_cache.cc
@@ -51,9 +51,37 @@ Status ShardedCache::Insert(const Slice& key, void* value, size_t charge,
       ->Insert(key, hash, value, charge, deleter, handle, priority);
 }
 
+Status ShardedCache::Insert(const Slice& key, void* value,
+                            CacheItemHelperCallback helper_cb, size_t charge,
+                            Handle** handle, Priority priority) {
+  uint32_t hash = HashSlice(key);
+  return GetShard(Shard(hash))
+      ->Insert(key, hash, value, helper_cb, charge, handle, priority);
+}
+
 Cache::Handle* ShardedCache::Lookup(const Slice& key, Statistics* /*stats*/) {
   uint32_t hash = HashSlice(key);
   return GetShard(Shard(hash))->Lookup(key, hash);
+}
+
+Cache::Handle* ShardedCache::Lookup(const Slice& key,
+                                    CacheItemHelperCallback helper_cb,
+                                    const CreateCallback& create_cb,
+                                    Priority priority, bool wait,
+                                    Statistics* /*stats*/) {
+  uint32_t hash = HashSlice(key);
+  return GetShard(Shard(hash))
+      ->Lookup(key, hash, helper_cb, create_cb, priority, wait);
+}
+
+bool ShardedCache::isReady(Handle* handle) {
+  uint32_t hash = GetHash(handle);
+  return GetShard(Shard(hash))->isReady(handle);
+}
+
+void ShardedCache::Wait(Handle* handle) {
+  uint32_t hash = GetHash(handle);
+  GetShard(Shard(hash))->Wait(handle);
 }
 
 bool ShardedCache::Ref(Handle* handle) {
@@ -64,6 +92,11 @@ bool ShardedCache::Ref(Handle* handle) {
 bool ShardedCache::Release(Handle* handle, bool force_erase) {
   uint32_t hash = GetHash(handle);
   return GetShard(Shard(hash))->Release(handle, force_erase);
+}
+
+bool ShardedCache::Release(Handle* handle, bool useful, bool force_erase) {
+  uint32_t hash = GetHash(handle);
+  return GetShard(Shard(hash))->Release(handle, useful, force_erase);
 }
 
 void ShardedCache::Erase(const Slice& key) {

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -2820,6 +2820,7 @@ class DBBasicTestMultiGet : public DBTestBase {
 
     const char* Name() const override { return "MyBlockCache"; }
 
+    using Cache::Insert;
     Status Insert(const Slice& key, void* value, size_t charge,
                   void (*deleter)(const Slice& key, void* value),
                   Handle** handle = nullptr,
@@ -2828,6 +2829,7 @@ class DBBasicTestMultiGet : public DBTestBase {
       return target_->Insert(key, value, charge, deleter, handle, priority);
     }
 
+    using Cache::Lookup;
     Handle* Lookup(const Slice& key, Statistics* stats = nullptr) override {
       num_lookups_++;
       Handle* handle = target_->Lookup(key, stats);

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -446,6 +446,7 @@ class MockCache : public LRUCache {
                  false /*strict_capacity_limit*/, 0.0 /*high_pri_pool_ratio*/) {
   }
 
+  using ShardedCache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
                 void (*deleter)(const Slice& key, void* value), Handle** handle,
                 Priority priority) override {
@@ -533,6 +534,7 @@ class LookupLiarCache : public CacheWrapper {
   explicit LookupLiarCache(std::shared_ptr<Cache> target)
       : CacheWrapper(std::move(target)) {}
 
+  using Cache::Lookup;
   Handle* Lookup(const Slice& key, Statistics* stats) override {
     if (nth_lookup_not_found_ == 1) {
       nth_lookup_not_found_ = 0;

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -794,6 +794,7 @@ class CacheWrapper : public Cache {
 
   const char* Name() const override { return target_->Name(); }
 
+  using Cache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
                 void (*deleter)(const Slice& key, void* value),
                 Handle** handle = nullptr,
@@ -801,12 +802,14 @@ class CacheWrapper : public Cache {
     return target_->Insert(key, value, charge, deleter, handle, priority);
   }
 
+  using Cache::Lookup;
   Handle* Lookup(const Slice& key, Statistics* stats = nullptr) override {
     return target_->Lookup(key, stats);
   }
 
   bool Ref(Handle* handle) override { return target_->Ref(handle); }
 
+  using Cache::Release;
   bool Release(Handle* handle, bool force_erase = false) override {
     return target_->Release(handle, force_erase);
   }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -23,8 +23,11 @@
 #pragma once
 
 #include <stdint.h>
+
+#include <functional>
 #include <memory>
 #include <string>
+
 #include "rocksdb/memory_allocator.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/statistics.h"
@@ -34,6 +37,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class Cache;
 struct ConfigOptions;
+class NvmCache;
 
 extern const bool kDefaultToAdaptiveMutex;
 
@@ -87,6 +91,9 @@ struct LRUCacheOptions {
   CacheMetadataChargePolicy metadata_charge_policy =
       kDefaultCacheMetadataChargePolicy;
 
+  // An NvmCache instance to use a the non-volatile tier
+  std::shared_ptr<NvmCache> nvm_cache;
+
   LRUCacheOptions() {}
   LRUCacheOptions(size_t _capacity, int _num_shard_bits,
                   bool _strict_capacity_limit, double _high_pri_pool_ratio,
@@ -137,6 +144,57 @@ class Cache {
   // likely to get evicted than low priority entries.
   enum class Priority { HIGH, LOW };
 
+  // A set of callbacks to allow objects in the volatile block cache to be
+  // be persisted in a NVM cache tier. Since the volatile cache holds C++
+  // objects and the NVM cache may only hold flat data that doesn't need
+  // relocation, these callbacks need to be provided by the user of the block
+  // cache to do the conversion.
+  // The CacheItemHelperCallback is passed to Insert(). When invoked, it
+  // returns the callback functions for size, saving and deletion of the
+  // object. We do it this way so that the cache implementation only needs to
+  // save one function pointer in its metadata per object, the
+  // CacheItemHelperCallback pointer which is a C-style function pointer.
+  // Saving multiple std::function objects will take up 32 bytes per
+  // function, even if its not bound to an object and does no capture. The
+  // other alternative is to take a pointer to another object that implements
+  // this interface, but that would create issues with managing the object
+  // lifecycle.
+  //
+  // All the callbacks are C-style function pointers in order to simplify
+  // lifecycle management. Objects in the cache can outlive the parent DB,
+  // so anything required for these operations should be contained in the
+  // object itself.
+  //
+  // The SizeCallback takes a void* pointer to the object and returns the size
+  // of the persistable data. It can be used by the NVM cache to allocate
+  // memory if needed.
+  typedef size_t (*SizeCallback)(void* obj);
+
+  // The SaveToCallback takes a void* object pointer and saves the persistable
+  // data into a buffer. The NVM cache may decide to not store it in a
+  // contiguous buffer, in which case this callback will be called multiple
+  // times with increasing offset
+  typedef rocksdb::Status (*SaveToCallback)(void* obj, size_t offset,
+                                            size_t size, void* out);
+
+  // DeletionCallback is a function pointer that deletes the cached
+  // object. The signature matches the old deleter function.
+  typedef void (*DeletionCallback)(const Slice&, void*);
+
+  // A callback function that returns the size, save to, and deletion
+  // callbacks. Fill any of size_cb, saveto_cb, del_cb that is non-null
+  typedef void (*CacheItemHelperCallback)(SizeCallback* size_cb,
+                                          SaveToCallback* saveto_cb,
+                                          DeletionCallback* del_cb);
+
+  // The CreateCallback is passed by the block cache user to Lookup(). It
+  // takes in a buffer from the NVM cache and constructs an object using
+  // it. The callback doesn't have ownership of the buffer and should
+  // copy the contents into its own buffer.
+  typedef std::function<rocksdb::Status(void* buf, size_t size, void** out_obj,
+                                        size_t* charge)>
+      CreateCallback;
+
   Cache(std::shared_ptr<MemoryAllocator> allocator = nullptr)
       : memory_allocator_(std::move(allocator)) {}
   // No copying allowed
@@ -170,8 +228,8 @@ class Cache {
   // The type of the Cache
   virtual const char* Name() const = 0;
 
-  // Insert a mapping from key->value into the cache and assign it
-  // the specified charge against the total cache capacity.
+  // Insert a mapping from key->value into the volatile cache only
+  // and assign it // the specified charge against the total cache capacity.
   // If strict_capacity_limit is true and cache reaches its full capacity,
   // return Status::Incomplete.
   //
@@ -190,6 +248,38 @@ class Cache {
                         Handle** handle = nullptr,
                         Priority priority = Priority::LOW) = 0;
 
+  // Insert a mapping from key->value into the volatile cache and assign it
+  // the specified charge against the total cache capacity.
+  // If strict_capacity_limit is true and cache reaches its full capacity,
+  // return Status::Incomplete.
+  //
+  // If handle is not nullptr, returns a handle that corresponds to the
+  // mapping. The caller must call this->Release(handle) when the returned
+  // mapping is no longer needed. In case of error caller is responsible to
+  // cleanup the value (i.e. calling "deleter").
+  //
+  // If handle is nullptr, it is as if Release is called immediately after
+  // insert. In case of error value will be cleanup.
+  //
+  // Regardless of whether the item was inserted into the volatile cache,
+  // it will attempt to insert it into the NVM cache if one is configured.
+  // The block cache implementation must support the NVM tier, otherwise
+  // the item is only inserted into the volatile tier. It may
+  // defer the insertion to NVM as it sees fit. The NVM
+  // cache may or may not write it to NVM depending on its admission
+  // policy.
+  //
+  // When the inserted entry is no longer needed, the key and
+  // value will be passed to "deleter".
+  virtual Status Insert(const Slice& key, void* value,
+                        CacheItemHelperCallback helper_cb, size_t charge,
+                        Handle** handle = nullptr,
+                        Priority priority = Priority::LOW) {
+    DeletionCallback delete_cb;
+    (*helper_cb)(nullptr, nullptr, &delete_cb);
+    return Insert(key, value, charge, delete_cb, handle, priority);
+  }
+
   // If the cache has no mapping for "key", returns nullptr.
   //
   // Else return a handle that corresponds to the mapping.  The caller
@@ -198,6 +288,25 @@ class Cache {
   // If stats is not nullptr, relative tickers could be used inside the
   // function.
   virtual Handle* Lookup(const Slice& key, Statistics* stats = nullptr) = 0;
+
+  // Lookup the key in the volatile and NVM tiers (if one is configured).
+  // The create_cb callback function object will be used to contruct the
+  // cached object.
+  // If none of the tiers have the mapping for the key, rturns nullptr.
+  // Else, returns a handle that corresponds to the mapping.
+  //
+  // The handle returned may not be ready. The caller should call isReady()
+  // to check if the item value is ready, and call Wait() or WaitAll() if
+  // its not ready. The caller should then call Value() to check if the
+  // item was successfully retrieved. If unsuccessful (perhaps due to an
+  // IO error), Value() will return nullptr.
+  virtual Handle* Lookup(const Slice& key,
+                         CacheItemHelperCallback /*helper_cb*/,
+                         const CreateCallback& /*create_cb*/,
+                         Priority /*priority*/, bool /*wait*/,
+                         Statistics* stats = nullptr) {
+    return Lookup(key, stats);
+  }
 
   // Increments the reference count for the handle if it refers to an entry in
   // the cache. Returns true if refcount was incremented; otherwise, returns
@@ -218,6 +327,27 @@ class Cache {
   // REQUIRES: handle must not have been released yet.
   // REQUIRES: handle must have been returned by a method on *this.
   virtual bool Release(Handle* handle, bool force_erase = false) = 0;
+
+  // Release a mapping returned by a previous Lookup(). The "useful"
+  // parameter specifies whether the data was actually used or not,
+  // which may be used by the cache implementation to decide whether
+  // to consider it as a hit for retention purposes.
+  virtual bool Release(Handle* handle, bool /*useful*/, bool force_erase) {
+    return Release(handle, force_erase);
+  }
+
+  // Determines if the handle returned by Lookup() has a valid value yet.
+  virtual bool isReady(Handle* /*handle*/) { return true; }
+
+  // If the handle returned by Lookup() is not ready yet, wait till it
+  // becomes ready.
+  // Note: A ready handle doesn't necessarily mean it has a valid value. The
+  // user should call Value() and check for nullptr.
+  virtual void Wait(Handle* /*handle*/) {}
+
+  // Wait for a vector of handles to become ready. As with Wait(), the user
+  // should check the Value() of each handle for nullptr
+  virtual void WaitAll(std::vector<Handle*>& /*handles*/) {}
 
   // Return the value encapsulated in a handle returned by a
   // successful Lookup().

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -37,7 +37,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class Cache;
 struct ConfigOptions;
-class NvmCache;
+class TieredCache;
 
 extern const bool kDefaultToAdaptiveMutex;
 
@@ -91,8 +91,8 @@ struct LRUCacheOptions {
   CacheMetadataChargePolicy metadata_charge_policy =
       kDefaultCacheMetadataChargePolicy;
 
-  // An NvmCache instance to use a the non-volatile tier
-  std::shared_ptr<NvmCache> nvm_cache;
+  // A TieredCache instance to use a the non-volatile tier
+  std::shared_ptr<TieredCache> tiered_cache;
 
   LRUCacheOptions() {}
   LRUCacheOptions(size_t _capacity, int _num_shard_bits,

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -174,7 +174,7 @@ class Cache {
   // data into a buffer. The NVM cache may decide to not store it in a
   // contiguous buffer, in which case this callback will be called multiple
   // times with increasing offset
-  typedef rocksdb::Status (*SaveToCallback)(void* obj, size_t offset,
+  typedef ROCKSDB_NAMESPACE::Status (*SaveToCallback)(void* obj, size_t offset,
                                             size_t size, void* out);
 
   // DeletionCallback is a function pointer that deletes the cached
@@ -191,8 +191,8 @@ class Cache {
   // takes in a buffer from the NVM cache and constructs an object using
   // it. The callback doesn't have ownership of the buffer and should
   // copy the contents into its own buffer.
-  typedef std::function<rocksdb::Status(void* buf, size_t size, void** out_obj,
-                                        size_t* charge)>
+  typedef std::function<ROCKSDB_NAMESPACE::Status(void* buf, size_t size,
+                                      void** out_obj, size_t* charge)>
       CreateCallback;
 
   Cache(std::shared_ptr<MemoryAllocator> allocator = nullptr)
@@ -275,7 +275,7 @@ class Cache {
                         CacheItemHelperCallback helper_cb, size_t charge,
                         Handle** handle = nullptr,
                         Priority priority = Priority::LOW) {
-    DeletionCallback delete_cb;
+    DeletionCallback delete_cb = nullptr;
     (*helper_cb)(nullptr, nullptr, &delete_cb);
     return Insert(key, value, charge, delete_cb, handle, priority);
   }

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -175,7 +175,7 @@ class Cache {
   // contiguous buffer, in which case this callback will be called multiple
   // times with increasing offset
   typedef ROCKSDB_NAMESPACE::Status (*SaveToCallback)(void* obj, size_t offset,
-                                            size_t size, void* out);
+                                                      size_t size, void* out);
 
   // DeletionCallback is a function pointer that deletes the cached
   // object. The signature matches the old deleter function.
@@ -191,8 +191,8 @@ class Cache {
   // takes in a buffer from the NVM cache and constructs an object using
   // it. The callback doesn't have ownership of the buffer and should
   // copy the contents into its own buffer.
-  typedef std::function<ROCKSDB_NAMESPACE::Status(void* buf, size_t size,
-                                      void** out_obj, size_t* charge)>
+  typedef std::function<ROCKSDB_NAMESPACE::Status(
+      void* buf, size_t size, void** out_obj, size_t* charge)>
       CreateCallback;
 
   Cache(std::shared_ptr<MemoryAllocator> allocator = nullptr)

--- a/include/rocksdb/nvm_cache.h
+++ b/include/rocksdb/nvm_cache.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#pragma once
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+
+#include "rocksdb/cache.h"
+#include "rocksdb/slice.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// A handle for lookup result. The handle may not be immediately ready or
+// have a valid value. The caller must call isReady() to determine if its
+// ready, and call Wait() in order to block until it becomes ready.
+// The caller must call value() after it becomes ready to determine if the
+// handle successfullly read the item.
+class NvmCacheHandle {
+ public:
+  virtual ~NvmCacheHandle() {}
+
+  // Returns whether the handle is ready or not
+  virtual bool isReady() = 0;
+
+  // Block until handle becomes ready
+  virtual void Wait() = 0;
+
+  // Return the value. If nullptr, it means the lookup was unsuccessful
+  virtual void* Value() = 0;
+
+  // Return the size of value
+  virtual size_t Size() = 0;
+};
+
+// NvmCache
+//
+// NVM cache interface for caching blocks on a persistent medium.
+class NvmCache {
+ public:
+  virtual ~NvmCache() {}
+
+  virtual std::string Name() = 0;
+
+  // Insert the given value into the NVM cache. The value is not written
+  // directly. Rather, the SaveToCallback provided by helper_cb will be
+  // used to extract the persistable data in value, which will be written
+  // to NVM. The implementation may or may not write it to NVM depending
+  // on the admission control policy, even if the return status is success.
+  virtual Status Insert(const Slice& key, void* value,
+                        Cache::CacheItemHelperCallback helper_cb) = 0;
+
+  // Lookup the data for the given key in the NVM cache. The create_cb
+  // will be used to create the object. The handle returned may not be
+  // ready yet, unless wait=true, in which case Lookup() will block until
+  // the handle is ready
+  virtual std::unique_ptr<NvmCacheHandle> Lookup(
+      const Slice& key, const Cache::CreateCallback& create_cb, bool wait) = 0;
+
+  // At the discretion of the implementation, erase the data associated
+  // with key
+  virtual void Erase(const Slice& key) = 0;
+
+  // Wait for a collection of handles to become ready
+  virtual void WaitAll(std::vector<NvmCacheHandle*> handles) = 0;
+
+  virtual std::string GetPrintableOptions() const = 0;
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/tiered_cache.h
+++ b/include/rocksdb/tiered_cache.h
@@ -48,15 +48,16 @@ class TieredCache {
 
   virtual std::string Name() = 0;
 
-  // Insert the given value into the NVM cache. The value is not written
+  // Insert the given value into this tier. The value is not written
   // directly. Rather, the SaveToCallback provided by helper_cb will be
   // used to extract the persistable data in value, which will be written
-  // to this tier. The implementation may or may not write it to NVM depending
-  // on the admission control policy, even if the return status is success.
+  // to this tier. The implementation may or may not write it to cache
+  // depending on the admission control policy, even if the return status is
+  // success.
   virtual Status Insert(const Slice& key, void* value,
                         Cache::CacheItemHelperCallback helper_cb) = 0;
 
-  // Lookup the data for the given key in the NVM cache. The create_cb
+  // Lookup the data for the given key in this tier. The create_cb
   // will be used to create the object. The handle returned may not be
   // ready yet, unless wait=true, in which case Lookup() will block until
   // the handle is ready

--- a/utilities/simulator_cache/sim_cache.cc
+++ b/utilities/simulator_cache/sim_cache.cc
@@ -167,6 +167,7 @@ class SimCacheImpl : public SimCache {
     cache_->SetStrictCapacityLimit(strict_capacity_limit);
   }
 
+  using Cache::Insert;
   Status Insert(const Slice& key, void* value, size_t charge,
                 void (*deleter)(const Slice& key, void* value), Handle** handle,
                 Priority priority) override {
@@ -193,6 +194,7 @@ class SimCacheImpl : public SimCache {
     return cache_->Insert(key, value, charge, deleter, handle, priority);
   }
 
+  using Cache::Lookup;
   Handle* Lookup(const Slice& key, Statistics* stats) override {
     Handle* h = key_only_cache_->Lookup(key);
     if (h != nullptr) {
@@ -213,6 +215,7 @@ class SimCacheImpl : public SimCache {
 
   bool Ref(Handle* handle) override { return cache_->Ref(handle); }
 
+  using Cache::Release;
   bool Release(Handle* handle, bool force_erase = false) override {
     return cache_->Release(handle, force_erase);
   }


### PR DESCRIPTION
Defined the abstract interface for a NVM/persistent cache in ```include/rocksdb/nvm_cache.h```, and updated ```LRUCacheOptions``` to take a ```std::shared_ptr<NvmCache>```. An item is initially inserted into the LRU cache. When it ages out and evicted from memory, its inserted into the NVM cache. On a LRU cache miss and successful lookup in NVM, the item is promoted to the in memory cache. Only support synchronous lookup currently.