### PR TITLE
Fix clang analyze for trace replace GetPayload

### DIFF
--- a/trace_replay/trace_replay.cc
+++ b/trace_replay/trace_replay.cc
@@ -427,6 +427,7 @@ Status Replayer::Replay() {
       ops++;
     } else if (trace.type == kTraceGet) {
       GetPayload get_payload;
+      get_payload.cf_id = 0;
       get_payload.get_key = 0;
       if (trace_file_version_ < 2) {
         DecodeCFAndKey(trace.payload, &get_payload.cf_id, &get_payload.get_key);

--- a/trace_replay/trace_replay.h
+++ b/trace_replay/trace_replay.h
@@ -105,12 +105,12 @@ struct WritePayload {
 };
 
 struct GetPayload {
-  uint32_t cf_id;
+  uint32_t cf_id = 0;
   Slice get_key;
 };
 
 struct IterPayload {
-  uint32_t cf_id;
+  uint32_t cf_id = 0;
   Slice iter_key;
   Slice lower_bound;
   Slice upper_bound;


### PR DESCRIPTION
For some branches, I see an error during analyze on this code.  I do not know why it is not persistent, but this should address the error:

Logic error | Result of operation is garbage or undefined | trace_replay.cc | Replay | 436 | 30 | View Report


DecodeCFAndKey(trace.payload, &get_payload.cf_id, &get_payload.get_key);
--
433 | } else {
434 | TracerHelper::DecodeGetPayload(&trace, &get_payload);
  | 25←Calling 'TracerHelper::DecodeGetPayload'→ | 25 | ← | Calling 'TracerHelper::DecodeGetPayload' | →
25 | ← | Calling 'TracerHelper::DecodeGetPayload' | →
  | 29←Returning from 'TracerHelper::DecodeGetPayload'→ | 29 | ← | Returning from 'TracerHelper::DecodeGetPayload' | →
29 | ← | Returning from 'TracerHelper::DecodeGetPayload' | →
435 | }
436 | if (get_payload.cf_id > 0 &&
  | 30←The left operand of '>' is a garbage value | 30 | ← | The left operand of '>' is a garbage value
30 | ← | The left operand of '>' is a garbage value
437 | cf_map_.find(get_payload.cf_id) == cf_map_.end()) {
438 | return Status::Corruption("Invalid Column Family ID.");
439 | }




