### PR TITLE
[Flaky test] Unittest uses unique test db name

### DIFF
--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -20,11 +20,11 @@ namespace test {
 std::string GetPidStr() {
   return std::to_string(GetCurrentProcessId());
 }
-#endif
-
+#else
 std::string GetPidStr() {
   return std::to_string(getpid());
 }
+#endif
 
 ::testing::AssertionResult AssertStatus(const char* s_expr, const Status& s) {
   if (s.ok()) {

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -32,7 +32,8 @@ std::string TmpDir(Env* env) {
 
 std::string PerThreadDBPath(std::string dir, std::string name) {
   size_t tid = std::hash<std::thread::id>()(std::this_thread::get_id());
-  return dir + "/" + name + "_" + std::to_string(getpid()) + "_" + std::to_string(tid);
+  return dir + "/" + name + "_" + std::to_string(getpid()) + "_" +
+         std::to_string(tid);
 }
 
 std::string PerThreadDBPath(std::string name) {

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -32,7 +32,7 @@ std::string TmpDir(Env* env) {
 
 std::string PerThreadDBPath(std::string dir, std::string name) {
   size_t tid = std::hash<std::thread::id>()(std::this_thread::get_id());
-  return dir + "/" + name + "_" + std::to_string(tid);
+  return dir + "/" + name + "_" + std::to_string(getpid()) + "_" + std::to_string(tid);
 }
 
 std::string PerThreadDBPath(std::string name) {

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -14,6 +14,18 @@
 namespace ROCKSDB_NAMESPACE {
 namespace test {
 
+#ifdef OS_WIN
+#include <windows.h>
+
+std::string GetPidStr() {
+  return std::to_string(GetCurrentProcessId());
+}
+#endif
+
+std::string GetPidStr() {
+  return std::to_string(getpid());
+}
+
 ::testing::AssertionResult AssertStatus(const char* s_expr, const Status& s) {
   if (s.ok()) {
     return ::testing::AssertionSuccess();
@@ -32,8 +44,7 @@ std::string TmpDir(Env* env) {
 
 std::string PerThreadDBPath(std::string dir, std::string name) {
   size_t tid = std::hash<std::thread::id>()(std::this_thread::get_id());
-  return dir + "/" + name + "_" + std::to_string(getpid()) + "_" +
-         std::to_string(tid);
+  return dir + "/" + name + "_" + GetPidStr() + "_" + std::to_string(tid);
 }
 
 std::string PerThreadDBPath(std::string name) {

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -17,13 +17,9 @@ namespace test {
 #ifdef OS_WIN
 #include <windows.h>
 
-std::string GetPidStr() {
-  return std::to_string(GetCurrentProcessId());
-}
+std::string GetPidStr() { return std::to_string(GetCurrentProcessId()); }
 #else
-std::string GetPidStr() {
-  return std::to_string(getpid());
-}
+std::string GetPidStr() { return std::to_string(getpid()); }
 #endif
 
 ::testing::AssertionResult AssertStatus(const char* s_expr, const Status& s) {


### PR DESCRIPTION
thread_id is only unique within a process. If we run the same test-set with multiple processes, it could cause db path collision between 2 runs, error message will be like:
```
...
IO error: While lock file: /tmp/rocksdbtest-501//deletefile_test_8093137327721791717/LOCK: Resource temporarily unavailable
...
```
This is could be likely reproduced by:
```
gtest-parallel ./deletefile_test --gtest_filter=DeleteFileTest.BackgroundPurgeCFDropTest -r 1000 -w 1000
```