### PR TITLE
Add Internal TEST_Initialize method to Configurable

### DIFF
--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -308,6 +308,15 @@ class Configurable {
       const std::unordered_map<std::string, std::string>& opts_map,
       std::unordered_map<std::string, std::string>* unused);
 
+  // Internal method to initialize the settings of this object in test mode.
+  // Classes may override this method to specify default values for the
+  // object settings when running tests.
+  // The name parameter is optionally supplied (may be an empty string).
+  // If specified, the parameter is the name of the test being invoked.
+  virtual Status TEST_Initialize(const std::string& /*name*/) {
+    return Status::OK();
+  }
+
 #ifndef ROCKSDB_LITE
   // Method that configures a the specific opt_name from opt_value.
   // By default, this method calls opt_info.ParseOption with the

--- a/options/configurable.cc
+++ b/options/configurable.cc
@@ -265,7 +265,17 @@ Status ConfigurableHelper::ConfigureOptions(
     std::unordered_map<std::string, std::string>* unused) {
   std::unordered_map<std::string, std::string> remaining = opts_map;
   Status s = Status::OK();
-  if (!opts_map.empty()) {
+  if (!remaining.empty()) {
+    auto test_iter = remaining.find(kTestPropName);
+    if (test_iter != remaining.end()) {
+      s = configurable.TEST_Initialize(test_iter->second);
+      remaining.erase(test_iter);
+      if (!s.ok()) {  // Failed to initialize for tests
+        return s;
+      }
+    }
+  }
+  if (!remaining.empty()) {
 #ifndef ROCKSDB_LITE
     for (const auto& iter : configurable.options_) {
       s = ConfigureSomeOptions(config_options, configurable, *(iter.type_map),

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -22,6 +22,8 @@ class ConfigurableHelper {
  public:
   constexpr static const char* kIdPropName = "id";
   constexpr static const char* kIdPropSuffix = ".id";
+  constexpr static const char* kTestPropName = "TEST";
+
   // Registers the input name with the options and associated map.
   // When classes register their options in this manner, most of the
   // functionality (excluding unknown options and validate/prepare) is

--- a/options/configurable_test.h
+++ b/options/configurable_test.h
@@ -121,6 +121,24 @@ class TestConfigurable : public Configurable {
   }
 
   ~TestConfigurable() override { delete pointer_; }
+
+ protected:
+  Status TEST_Initialize(const std::string& name) override {
+    if (name == "NotFound") {
+      return Status::NotFound("TEST_Initialize");
+    } else if (name == "NotSupported") {
+      return Status::NotSupported("TEST_Initialize");
+    } else if (name == "InvalidArgument") {
+      return Status::InvalidArgument("TEST_Initialize");
+    } else {
+      if (!name.empty()) {
+        options_.s = name;
+        options_.u = name;
+        options_.i = -1;
+      }
+      return Configurable::TEST_Initialize(name);
+    }
+  }
 };
 
 }  // namespace test


### PR DESCRIPTION
Some classes/implementations of Configurable may want to initialize themselves differently when running in TEST mode.  For example, in test mode an EncryptionProvider may wish to set a default encryption key or an Env may wish to specify certain settings or its parent.

When TEST=value is specified as an option, the TEST_Initialize method will be invoked first with "value" for the Configurable object.  All Configurable objects will understand TEST and be able to initialize themselves differently based on this value.

If the TEST_Initialize method fails, configuration is aborted and the status returned.