### PR TITLE
Disable partitioned filters in ts stress test

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -299,6 +299,7 @@ ts_params = {
     "use_blob_db": 0,
     "enable_compaction_filter": 0,
     "ingest_external_file_one_in": 0,
+    "partition_filters": 0,
 }
 
 def finalize_and_sanitize(src_params):


### PR DESCRIPTION
Currently, partitioned filter does not support user-defined timestamp. Disable it for now in ts stress test so that
the contrun jobs can proceed.

Test plan:
make crash_test_with_ts