### PR TITLE
Replace Status with IOStatus for block fetcher IO function

### DIFF
--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -103,10 +103,10 @@ class RandomAccessFileReader {
 #endif
   }
 
-  static Status Create(const std::shared_ptr<FileSystem>& fs,
-                       const std::string& fname, const FileOptions& file_opts,
-                       std::unique_ptr<RandomAccessFileReader>* reader,
-                       IODebugContext* dbg);
+  static IOStatus Create(const std::shared_ptr<FileSystem>& fs,
+                         const std::string& fname, const FileOptions& file_opts,
+                         std::unique_ptr<RandomAccessFileReader>* reader,
+                         IODebugContext* dbg);
   RandomAccessFileReader(const RandomAccessFileReader&) = delete;
   RandomAccessFileReader& operator=(const RandomAccessFileReader&) = delete;
 
@@ -120,19 +120,19 @@ class RandomAccessFileReader {
   // 2. Otherwise, scratch is not used and can be null, the aligned_buf owns
   // the internally allocated buffer on return, and the result refers to a
   // region in aligned_buf.
-  Status Read(const IOOptions& opts, uint64_t offset, size_t n, Slice* result,
-              char* scratch, AlignedBuf* aligned_buf,
-              bool for_compaction = false) const;
+  IOStatus Read(const IOOptions& opts, uint64_t offset, size_t n, Slice* result,
+                char* scratch, AlignedBuf* aligned_buf,
+                bool for_compaction = false) const;
 
   // REQUIRES:
   // num_reqs > 0, reqs do not overlap, and offsets in reqs are increasing.
   // In non-direct IO mode, aligned_buf should be null;
   // In direct IO mode, aligned_buf stores the aligned buffer allocated inside
   // MultiRead, the result Slices in reqs refer to aligned_buf.
-  Status MultiRead(const IOOptions& opts, FSReadRequest* reqs, size_t num_reqs,
-                   AlignedBuf* aligned_buf) const;
+  IOStatus MultiRead(const IOOptions& opts, FSReadRequest* reqs,
+                     size_t num_reqs, AlignedBuf* aligned_buf) const;
 
-  Status Prefetch(uint64_t offset, size_t n) const {
+  IOStatus Prefetch(uint64_t offset, size_t n) const {
     return file_->Prefetch(offset, n, IOOptions(), nullptr);
   }
 

--- a/table/block_fetcher.cc
+++ b/table/block_fetcher.cc
@@ -75,6 +75,8 @@ inline bool BlockFetcher::TryGetFromPrefetchBuffer() {
       return true;
     }
   }
+  // TODO: remove it in the future when io_status_ is checked in all place.
+  io_status_.PermitUncheckedError();
   return got_from_prefetch_buffer_;
 }
 
@@ -261,6 +263,8 @@ Status BlockFetcher::ReadBlockContents() {
 #endif
       }
     }
+    // TODO: remove it in the future when io_status_ is checked in all place.
+    io_status_.PermitUncheckedError();
 
     // TODO: introduce dedicated perf counter for range tombstones
     switch (block_type_) {

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -66,6 +66,7 @@ class BlockFetcher {
 
   Status ReadBlockContents();
   CompressionType get_compression_type() const { return compression_type_; }
+  IOStatus GetIOStatus() { return io_status_; }
 
 #ifndef NDEBUG
   int TEST_GetNumStackBufMemcpy() const { return num_stack_buf_memcpy_; }
@@ -101,6 +102,7 @@ class BlockFetcher {
   MemoryAllocator* memory_allocator_;
   MemoryAllocator* memory_allocator_compressed_;
   Status status_;
+  IOStatus io_status_;
   Slice slice_;
   char* used_buf_ = nullptr;
   AlignedBuf direct_io_buf_;

--- a/table/block_fetcher.h
+++ b/table/block_fetcher.h
@@ -64,9 +64,8 @@ class BlockFetcher {
         memory_allocator_compressed_(memory_allocator_compressed),
         for_compaction_(for_compaction) {}
 
-  Status ReadBlockContents();
+  IOStatus ReadBlockContents();
   CompressionType get_compression_type() const { return compression_type_; }
-  IOStatus GetIOStatus() { return io_status_; }
 
 #ifndef NDEBUG
   int TEST_GetNumStackBufMemcpy() const { return num_stack_buf_memcpy_; }
@@ -101,7 +100,6 @@ class BlockFetcher {
   const PersistentCacheOptions& cache_options_;
   MemoryAllocator* memory_allocator_;
   MemoryAllocator* memory_allocator_compressed_;
-  Status status_;
   IOStatus io_status_;
   Slice slice_;
   char* used_buf_ = nullptr;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4405,7 +4405,6 @@ TEST_P(BlockBasedTableTest, PropertiesBlockRestartPointTest) {
           UncompressionDict::GetEmptyDict(), cache_options);
 
       ASSERT_OK(block_fetcher.ReadBlockContents());
-      ASSERT_OK(block_fetcher.GetIOStatus());
     };
 
     // -- Read metaindex block
@@ -4493,7 +4492,6 @@ TEST_P(BlockBasedTableTest, PropertiesMetaBlockLast) {
       UncompressionDict::GetEmptyDict(), pcache_opts,
       nullptr /*memory_allocator*/);
   ASSERT_OK(block_fetcher.ReadBlockContents());
-  ASSERT_OK(block_fetcher.GetIOStatus());
   Block metaindex_block(std::move(metaindex_contents));
 
   // verify properties block comes last

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4405,6 +4405,7 @@ TEST_P(BlockBasedTableTest, PropertiesBlockRestartPointTest) {
           UncompressionDict::GetEmptyDict(), cache_options);
 
       ASSERT_OK(block_fetcher.ReadBlockContents());
+      ASSERT_OK(block_fetcher.GetIOStatus());
     };
 
     // -- Read metaindex block
@@ -4492,6 +4493,7 @@ TEST_P(BlockBasedTableTest, PropertiesMetaBlockLast) {
       UncompressionDict::GetEmptyDict(), pcache_opts,
       nullptr /*memory_allocator*/);
   ASSERT_OK(block_fetcher.ReadBlockContents());
+  ASSERT_OK(block_fetcher.GetIOStatus());
   Block metaindex_block(std::move(metaindex_contents));
 
   // verify properties block comes last


### PR DESCRIPTION
To propagate the IOStatus from file reads to RocksDB read logic, some of the existing status needs to be replaced by IOStatus.

test plan: make check