### PR TITLE
Return nullptr from WriteBatchWithIndex::NewIteratorWithBase when overwrite_key=false

### DIFF
--- a/include/rocksdb/utilities/write_batch_with_index.h
+++ b/include/rocksdb/utilities/write_batch_with_index.h
@@ -162,7 +162,8 @@ class WriteBatchWithIndex : public WriteBatchBase {
   // base_iterator as base.
   //
   // This function is only supported if the WriteBatchWithIndex was
-  // constructed with overwrite_key=true.
+  // constructed with overwrite_key=true, otherwise nullptr
+  // is returned.
   //
   // The returned iterator should be deleted by the caller.
   // The base_iterator is now 'owned' by the returned iterator. Deleting the

--- a/utilities/write_batch_with_index/write_batch_with_index.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index.cc
@@ -256,7 +256,6 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
     ColumnFamilyHandle* column_family, Iterator* base_iterator,
     const ReadOptions* read_options) {
   if (rep->overwrite_key == false) {
-    assert(false);
     return nullptr;
   }
   return new BaseDeltaIterator(base_iterator, NewIterator(column_family),
@@ -266,7 +265,6 @@ Iterator* WriteBatchWithIndex::NewIteratorWithBase(
 
 Iterator* WriteBatchWithIndex::NewIteratorWithBase(Iterator* base_iterator) {
   if (rep->overwrite_key == false) {
-    assert(false);
     return nullptr;
   }
   // default column family's comparator

--- a/utilities/write_batch_with_index/write_batch_with_index_test.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_test.cc
@@ -680,7 +680,7 @@ TEST_F(WriteBatchWithIndexTest, TestRandomIteraratorWithBase) {
   }
 }
 
-TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
+TEST_F(WriteBatchWithIndexTest, TestIteratorWithBaseOverwriteTrue) {
   ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
   ColumnFamilyHandleImplDummy cf2(2, BytewiseComparator());
   WriteBatchWithIndex batch(BytewiseComparator(), 20, true);
@@ -692,6 +692,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["e"] = "ee";
     std::unique_ptr<Iterator> iter(
         batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+    ASSERT_NE(nullptr, iter);
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -730,6 +731,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
         batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+    ASSERT_NE(nullptr, iter);
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -750,6 +752,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     map["f"] = "ff";
     std::unique_ptr<Iterator> iter(
         batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+    ASSERT_NE(nullptr, iter);
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -808,6 +811,7 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
     KVMap empty_map;
     std::unique_ptr<Iterator> iter(
         batch.NewIteratorWithBase(&cf1, new KVIter(&empty_map)));
+    ASSERT_NE(nullptr, iter);
 
     iter->SeekToFirst();
     AssertIter(iter.get(), "a", "aa");
@@ -840,6 +844,32 @@ TEST_F(WriteBatchWithIndexTest, TestIteraratorWithBase) {
 
     iter->Prev();
     AssertIter(iter.get(), "c", "cc");
+  }
+}
+
+TEST_F(WriteBatchWithIndexTest, TestIteratorWithBaseOverwriteFalse) {
+  ColumnFamilyHandleImplDummy cf1(6, BytewiseComparator());
+  WriteBatchWithIndex batch(BytewiseComparator(), 20, false);
+  ReadOptions read_options;
+
+  {
+    KVMap map;
+    std::unique_ptr<Iterator> iter(batch.NewIteratorWithBase(new KVIter(&map)));
+    ASSERT_EQ(nullptr, iter);
+  }
+
+  {
+    KVMap map;
+    std::unique_ptr<Iterator> iter(
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map)));
+    ASSERT_EQ(nullptr, iter);
+  }
+
+  {
+    KVMap map;
+    std::unique_ptr<Iterator> iter(
+        batch.NewIteratorWithBase(&cf1, new KVIter(&map), &read_options));
+    ASSERT_EQ(nullptr, iter);
   }
 }
 


### PR DESCRIPTION
1. Previously the behaviour of ` WriteBatchWithIndex::NewIteratorWithBase` when `WriteBatchWithIndex::overwrite_key=false` was different in debug and release builds. It is now consistent, and returns `nullptr`.
2. Tests for this functionality were missing, so I have added them.
3. I also updated the behaviour to be consistent in the Rocks Java API.

Closes https://github.com/facebook/rocksdb/issues/7370