### PR TITLE
Fix read-only DB writing to filesystem with write_dbid_to_manifest

### DIFF
--- a/db/db_impl/db_impl_files.cc
+++ b/db/db_impl/db_impl_files.cc
@@ -890,7 +890,7 @@ Status DBImpl::SetDBId(bool read_only) {
                                  mutable_cf_options, &edit, &mutex_, nullptr,
                                  /* new_descriptor_log */ false);
     }
-  } else {
+  } else if (!read_only) {
     s = SetIdentityFile(env_, dbname_, db_id_);
   }
   return s;

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -2616,11 +2616,17 @@ TEST_F(BackupableDBTest, ReadOnlyBackupEngine) {
 
 TEST_F(BackupableDBTest, OpenBackupAsReadOnlyDB) {
   DestroyDB(dbname_, options_);
+  options_.write_dbid_to_manifest = false;
+
   OpenDBAndBackupEngine(true);
   FillDB(db_.get(), 0, 100);
-  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), true));
+  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), /*flush*/ false));
+
+  options_.write_dbid_to_manifest = true;  // exercises some read-only DB code
+  CloseAndReopenDB();
+
   FillDB(db_.get(), 100, 200);
-  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), true));
+  ASSERT_OK(backup_engine_->CreateNewBackup(db_.get(), /*flush*/ false));
   db_.reset();  // CloseDB
   DestroyDB(dbname_, options_);
   std::vector<BackupInfo> backup_info;


### PR DESCRIPTION
Summary: Fixing another crash test failure in the case of
write_dbid_to_manifest=true and reading a backup as read-only DB.

Test Plan: enhanced unit test for backup as read-only DB, ran
blackbox_crash_test more with elevated backup_one_in