### PR TITLE
Enable backup for Integrated BlobDB in stress and crash tests

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2328,11 +2328,10 @@ void StressTest::Open() {
 
   if ((options_.enable_blob_files || options_.enable_blob_garbage_collection ||
        FLAGS_allow_setting_blob_options_dynamically) &&
-      (FLAGS_use_merge || FLAGS_backup_one_in > 0 ||
-       FLAGS_best_efforts_recovery)) {
+      (FLAGS_use_merge || FLAGS_best_efforts_recovery)) {
     fprintf(stderr,
             "Integrated BlobDB is currently incompatible with Merge, "
-            "backup/restore, and best-effort recovery\n");
+            "and best-effort recovery\n");
     exit(1);
   }
 

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -279,7 +279,6 @@ blob_params = {
     "blob_garbage_collection_age_cutoff": lambda: random.choice([0.0, 0.25, 0.5, 0.75, 1.0]),
     # The following are currently incompatible with the integrated BlobDB
     "use_merge": 0,
-    "backup_one_in": 0,
 }
 
 ts_params = {


### PR DESCRIPTION
Summary: Enable backup/restore functionality with Integrated BlobDB in
db_stress and crash test.

Test Plan: Ran python3 -u tools/db_crashtest.py --simple whitebox along
with :
  1. decreased "backup_in_one" value for backups to be more frequent and
  2. manually changed code for "enable_blob_file" to be always true and
     apply blobdb params 100% for testing purpose.

Reviewers:

Subscribers:

Tasks:

Tags: