### PR TITLE
Re-establish block cache eviction statistics for filters

### DIFF
--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -381,7 +381,7 @@ TEST_F(DBBlockCacheTest, FillCacheAndIterateDB) {
 TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics(/* pooled */ true);
   BlockBasedTableOptions table_options;
   table_options.cache_index_and_filter_blocks = true;
   LRUCacheOptions co;
@@ -392,7 +392,7 @@ TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {
   co.metadata_charge_policy = kDontChargeCacheMetadata;
   std::shared_ptr<Cache> cache = NewLRUCache(co);
   table_options.block_cache = cache;
-  table_options.filter_policy.reset(NewBloomFilterPolicy(20, true));
+  table_options.filter_policy.reset(NewBloomFilterPolicy(20));
   options.table_factory.reset(NewBlockBasedTableFactory(table_options));
   CreateAndReopenWithCF({"pikachu"}, options);
 
@@ -412,7 +412,7 @@ TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {
   // that moved the readers out of the block cache. Disabling these until we can
   // bring the stats back.
   // ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_INDEX_BYTES_EVICT), 0);
-  // ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_FILTER_BYTES_EVICT), 0);
+  ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_FILTER_BYTES_EVICT), 0);
   // Note that the second key needs to be no longer than the first one.
   // Otherwise the second index block may not fit in cache.
   ASSERT_OK(Put(1, "key", "val"));
@@ -428,8 +428,8 @@ TEST_F(DBBlockCacheTest, IndexAndFilterBlocksStats) {
   // bring the stats back.
   // ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_INDEX_BYTES_EVICT),
   //           index_bytes_insert);
-  // ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_FILTER_BYTES_EVICT),
-  //           filter_bytes_insert);
+  ASSERT_EQ(TestGetTickerCount(options, BLOCK_CACHE_FILTER_BYTES_EVICT),
+            filter_bytes_insert);
 }
 
 namespace {

--- a/monitoring/statistics.h
+++ b/monitoring/statistics.h
@@ -68,12 +68,19 @@ class StatisticsImpl : public Statistics {
   virtual bool getTickerMap(std::map<std::string, uint64_t>*) const override;
   virtual bool HistEnabledForType(uint32_t type) const override;
 
+  virtual uint64_t GetGeneration() const override;
+  void IncrementGeneration();
+
  private:
   // If non-nullptr, forwards updates to the object pointed to by `stats_`.
   std::shared_ptr<Statistics> stats_;
   // Synchronizes anything that operates across other cores' local data,
   // such that operations like Reset() can be performed atomically.
   mutable port::Mutex aggregate_lock_;
+
+  // If non-zero, this is a permanent/recyclable/pooled object. See
+  // Statistics::GetGeneration.
+  std::atomic_uint_fast64_t generation_ = {0};
 
   // The ticker/histogram data are stored in this structure, which we will store
   // per-core. It is cache-aligned, so tickers/histograms belonging to different

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -97,10 +97,11 @@ class BlocklikeTraits<ParsedFullFilterBlock> {
  public:
   static ParsedFullFilterBlock* Create(BlockContents&& contents,
                                        size_t /* read_amp_bytes_per_bit */,
-                                       Statistics* /* statistics */,
+                                       Statistics* statistics,
                                        bool /* using_zstd */,
                                        const FilterPolicy* filter_policy) {
-    return new ParsedFullFilterBlock(filter_policy, std::move(contents));
+    return new ParsedFullFilterBlock(filter_policy, std::move(contents),
+                                     statistics);
   }
 
   static uint32_t GetNumRestarts(const ParsedFullFilterBlock& /* block */) {

--- a/table/block_based/full_filter_block_test.cc
+++ b/table/block_based/full_filter_block_test.cc
@@ -116,7 +116,7 @@ TEST_F(PluginFullFilterBlockTest, PluginEmptyBuilder) {
 
   CachableEntry<ParsedFullFilterBlock> block(
       new ParsedFullFilterBlock(table_options_.filter_policy.get(),
-                                BlockContents(slice)),
+                                BlockContents(slice), /*statistics*/ nullptr),
       nullptr /* cache */, nullptr /* cache_handle */, true /* own_value */);
 
   FullFilterBlockReader reader(table_.get(), std::move(block));
@@ -139,7 +139,7 @@ TEST_F(PluginFullFilterBlockTest, PluginSingleChunk) {
 
   CachableEntry<ParsedFullFilterBlock> block(
       new ParsedFullFilterBlock(table_options_.filter_policy.get(),
-                                BlockContents(slice)),
+                                BlockContents(slice), /*statistics*/ nullptr),
       nullptr /* cache */, nullptr /* cache_handle */, true /* own_value */);
 
   FullFilterBlockReader reader(table_.get(), std::move(block));
@@ -192,7 +192,7 @@ TEST_F(FullFilterBlockTest, EmptyBuilder) {
 
   CachableEntry<ParsedFullFilterBlock> block(
       new ParsedFullFilterBlock(table_options_.filter_policy.get(),
-                                BlockContents(slice)),
+                                BlockContents(slice), /*statistics*/ nullptr),
       nullptr /* cache */, nullptr /* cache_handle */, true /* own_value */);
 
   FullFilterBlockReader reader(table_.get(), std::move(block));
@@ -286,7 +286,7 @@ TEST_F(FullFilterBlockTest, SingleChunk) {
 
   CachableEntry<ParsedFullFilterBlock> block(
       new ParsedFullFilterBlock(table_options_.filter_policy.get(),
-                                BlockContents(slice)),
+                                BlockContents(slice), /*statistics*/ nullptr),
       nullptr /* cache */, nullptr /* cache_handle */, true /* own_value */);
 
   FullFilterBlockReader reader(table_.get(), std::move(block));

--- a/table/block_based/parsed_full_filter_block.h
+++ b/table/block_based/parsed_full_filter_block.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "rocksdb/statistics.h"
 #include "table/format.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -18,7 +19,7 @@ class FilterPolicy;
 class ParsedFullFilterBlock {
  public:
   ParsedFullFilterBlock(const FilterPolicy* filter_policy,
-                        BlockContents&& contents);
+                        BlockContents&& contents, Statistics* statistics);
   ~ParsedFullFilterBlock();
 
   FilterBitsReader* filter_bits_reader() const {
@@ -35,6 +36,10 @@ class ParsedFullFilterBlock {
  private:
   BlockContents block_contents_;
   std::unique_ptr<FilterBitsReader> filter_bits_reader_;
+  // See Statistics::GetGeneration and CreateDBStatistics.
+  // TODO: move this for eviction statistics on other block kinds
+  Statistics* statistics_for_evict_ = nullptr;
+  uint64_t statistics_generation_ = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/table/block_based/partitioned_filter_block_test.cc
+++ b/table/block_based/partitioned_filter_block_test.cc
@@ -45,7 +45,7 @@ class MyPartitionedFilterBlockReader : public PartitionedFilterBlockReader {
       CachableEntry<ParsedFullFilterBlock> block(
           new ParsedFullFilterBlock(
               t->get_rep()->table_options.filter_policy.get(),
-              BlockContents(Slice(bloom))),
+              BlockContents(Slice(bloom)), /*statistics*/ nullptr),
           nullptr /* cache */, nullptr /* cache_handle */,
           true /* own_value */);
       filter_map_[offset] = std::move(block);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -7623,7 +7623,7 @@ int db_bench_tool(int argc, char** argv) {
   }
 #endif  // ROCKSDB_LITE
   if (FLAGS_statistics) {
-    dbstats = ROCKSDB_NAMESPACE::CreateDBStatistics();
+    dbstats = ROCKSDB_NAMESPACE::CreateDBStatistics(/* pooled */ true);
   }
   if (dbstats) {
     dbstats->set_stats_level(static_cast<StatsLevel>(FLAGS_stats_level));

--- a/util/filter_bench.cc
+++ b/util/filter_bench.cc
@@ -407,7 +407,8 @@ void FilterBench::Go() {
           table_options_.filter_policy->GetFilterBitsReader(info.filter_));
       CachableEntry<ParsedFullFilterBlock> block(
           new ParsedFullFilterBlock(table_options_.filter_policy.get(),
-                                    BlockContents(info.filter_)),
+                                    BlockContents(info.filter_),
+                                    /*statistics*/ nullptr),
           nullptr /* cache */, nullptr /* cache_handle */,
           true /* own_value */);
       info.full_block_reader_.reset(


### PR DESCRIPTION
Summary: This implementation re-enables block cache eviction statistics
only for Statistics objects that are known to outlive any Cache they
might be associated with, and only for full and partitioned filter blocks.
To support this generally, calling `CreateDBStatistics(/*pooled*/true)` returns
a Statistics object that is never destroyed but is automatically recycled
when no more user shared_ptr references exist to it. "Generation numbers"
of recycled objects are recorded to (almost) prevent ticking counters on
a recycled Statistics through an old reference.

Although this seems to overwhelmingly fix the performance overhead associated
with a proper shared_ptr implementation (#8167), it does add some
complications to the public API. People have to choose between getting
eviction statistics and immediately freeing unused Statistics objects
(hopefully a niche complication).

TODO fix block cache charges for (parsed) filter blocks

Test Plan: Updated test DBBlockCacheTest.IndexAndFilterBlocksStats.

TODO more unit tests

Create test db:

    TEST_TMPDIR=/dev/shm ./db_bench -bloom_bits=10 -partition_index_and_filters=1 -value_size=24 -statistics -benchmarks=fillrandom -num=10000000

Benchmark cmd:

    TEST_TMPDIR=/dev/shm ./db_bench -use_existing_db=1 -bloom_bits=10 -partition_index_and_filters=1 -statistics -benchmarks=readrandom -duration=30 -cache_size=3000000 -threads=20 -cache_numshardbits=8

This is a worst case scenario in which we are thrashing on many small filters.

This PR:
1238412 ops/sec (average of 10 interleaved runs)

rocksdb.block.cache.filter.miss COUNT : 14251705
rocksdb.block.cache.filter.hit COUNT : 128499662
rocksdb.block.cache.filter.add COUNT : 14251705
rocksdb.block.cache.filter.bytes.insert COUNT : 58945044072
rocksdb.block.cache.filter.bytes.evict COUNT : 58944212736

Base revision:
1271481 ops/sec (average of 10 interleaved runs)

(similar stats except evict reported as 0)

2.7% throughput regression (vs. 10+% in #8167)

This PR, with pooling disabled:
1201824 ops/sec (average of 10 interleaved runs)

Base revision:
1228531 ops/sec (average of another 10 interleaved runs)

2.2% throughput regression