### PR TITLE
Fix flaky failure in DBSSTest.DBWithSstFileManagerForBlobFilesWithGC

### DIFF
--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -561,6 +561,7 @@ TEST_F(DBSSTTest, DBWithSstFileManagerForBlobFilesWithGC) {
   constexpr Slice* end = nullptr;
 
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), begin, end));
+  sfm->WaitForEmptyTrash();
 
   ASSERT_EQ(Get(first_key), first_value);
   ASSERT_EQ(Get(second_key), second_value);
@@ -593,6 +594,7 @@ TEST_F(DBSSTTest, DBWithSstFileManagerForBlobFilesWithGC) {
 
   Close();
   ASSERT_OK(DestroyDB(dbname_, options));
+  sfm->WaitForEmptyTrash();
   ASSERT_EQ(files_deleted, 5);
   ASSERT_EQ(files_scheduled_to_delete, 5);
 


### PR DESCRIPTION
Summary: Updated the test to wait until all trash files are deleted by
SSTFileManager in the background. Since deletion runs in background so
number of files deleted might not always be as expected.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: