### PR TITLE
Fix unittest no space issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,6 +572,16 @@ jobs:
             gtest-parallel $(</tmp/test_list) --output_dir=/tmp | cat  # pipe to cat to continuously output status on circleci UI. Otherwise, no status will be printed while the job is running.
       - post-steps
 
+  build-linux-arm-test-full:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.large
+    steps:
+      - pre-steps
+      - install-gflags
+      - run: make V=1 J=4 -j4 check | .circleci/cat_ignore_eagain
+      - post-steps
+
   build-linux-arm:
     machine:
       image: ubuntu-2004:202101-01
@@ -612,6 +622,7 @@ jobs:
             cd build
             cmake -DJNI=1 -DCMAKE_BUILD_TYPE=Release -DWITH_GFLAGS=0 ..
             make -j4 rocksdb rocksdbjni
+      - post-steps
 
   build-format-compatible:
     machine:
@@ -746,3 +757,4 @@ workflows:
                 - master
     jobs:
       - build-format-compatible
+      - build-linux-arm-test-full

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -381,6 +381,9 @@ class SpecialEnv : public EnvWrapper {
       void PrepareWrite(size_t offset, size_t len) override {
         base_->PrepareWrite(offset, len);
       }
+      void SetPreallocationBlockSize(size_t size) override {
+        base_->SetPreallocationBlockSize(size);
+      }
       Status Close() override {
 // SyncPoint is not supported in Released Windows Mode.
 #if !(defined NDEBUG) || !defined(OS_WIN)

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -388,10 +388,10 @@ class SpecialEnv : public EnvWrapper {
 // SyncPoint is not supported in Released Windows Mode.
 #if !(defined NDEBUG) || !defined(OS_WIN)
         // Check preallocation size
-        // preallocation size is never passed to base file.
-        size_t preallocation_size = preallocation_block_size();
+        size_t block_size, last_allocated_block;
+        base_->GetPreallocationStatus(&block_size, &last_allocated_block);
         TEST_SYNC_POINT_CALLBACK("DBTestWalFile.GetPreallocationStatus",
-                                 &preallocation_size);
+                                 &block_size);
 #endif  // !(defined NDEBUG) || !defined(OS_WIN)
 
         return base_->Close();

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -378,6 +378,9 @@ class SpecialEnv : public EnvWrapper {
         return Append(data);
       }
       Status Truncate(uint64_t size) override { return base_->Truncate(size); }
+      void PrepareWrite(size_t offset, size_t len) override {
+        base_->PrepareWrite(offset, len);
+      }
       Status Close() override {
 // SyncPoint is not supported in Released Windows Mode.
 #if !(defined NDEBUG) || !defined(OS_WIN)

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -366,6 +366,11 @@ void EncryptedWritableFile::SetPreallocationBlockSize(size_t size) {
   file_->SetPreallocationBlockSize(size);
 }
 
+void EncryptedWritableFile::GetPreallocationStatus(size_t* block_size,
+                                                   size_t* last_allocated_block) {
+  file_->GetPreallocationStatus(block_size, last_allocated_block);
+}
+
 // Pre-allocates space for a file.
 IOStatus EncryptedWritableFile::Allocate(uint64_t offset, uint64_t len,
                                          const IOOptions& options,

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -363,6 +363,8 @@ void EncryptedWritableFile::PrepareWrite(size_t offset, size_t len,
 }
 
 void EncryptedWritableFile::SetPreallocationBlockSize(size_t size) {
+  // the size here doesn't need to include prefixLength_, as it's a
+  // configuration will be use for `PrepareWrite()`.
   file_->SetPreallocationBlockSize(size);
 }
 

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -366,8 +366,8 @@ void EncryptedWritableFile::SetPreallocationBlockSize(size_t size) {
   file_->SetPreallocationBlockSize(size);
 }
 
-void EncryptedWritableFile::GetPreallocationStatus(size_t* block_size,
-                                                   size_t* last_allocated_block) {
+void EncryptedWritableFile::GetPreallocationStatus(
+    size_t* block_size, size_t* last_allocated_block) {
   file_->GetPreallocationStatus(block_size, last_allocated_block);
 }
 

--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -362,6 +362,10 @@ void EncryptedWritableFile::PrepareWrite(size_t offset, size_t len,
   file_->PrepareWrite(offset + prefixLength_, len, options, dbg);
 }
 
+void EncryptedWritableFile::SetPreallocationBlockSize(size_t size) {
+  file_->SetPreallocationBlockSize(size);
+}
+
 // Pre-allocates space for a file.
 IOStatus EncryptedWritableFile::Allocate(uint64_t offset, uint64_t len,
                                          const IOOptions& options,

--- a/include/rocksdb/env_encryption.h
+++ b/include/rocksdb/env_encryption.h
@@ -366,6 +366,8 @@ class EncryptedWritableFile : public FSWritableFile {
   void PrepareWrite(size_t offset, size_t len, const IOOptions& options,
                     IODebugContext* dbg) override;
 
+  void SetPreallocationBlockSize(size_t size) override;
+
   // Pre-allocates space for a file.
   IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
                     IODebugContext* dbg) override;

--- a/include/rocksdb/env_encryption.h
+++ b/include/rocksdb/env_encryption.h
@@ -368,6 +368,9 @@ class EncryptedWritableFile : public FSWritableFile {
 
   void SetPreallocationBlockSize(size_t size) override;
 
+  void GetPreallocationStatus(size_t* block_size,
+                              size_t* last_allocated_block) override;
+
   // Pre-allocates space for a file.
   IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& options,
                     IODebugContext* dbg) override;


### PR DESCRIPTION
Unittest reports no space from time to time, which can be reproduced on a small memory machine with SHM. It's caused by large WAL files generated during the test, which is preallocated, but didn't truncate during close(). Adding the missing APIs to set preallocation.
It added arm test as nightly build, as the test runs more than 1 hour.

Test Plan: test on small memory arm machine