### PR TITLE
Cleanup include

### DIFF
--- a/utilities/fault_injection_fs.h
+++ b/utilities/fault_injection_fs.h
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "file/filename.h"
-#include "include/rocksdb/file_system.h"
+#include "rocksdb/file_system.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
 #include "util/thread_local.h"


### PR DESCRIPTION
Summary:
Make include of "file_system.h" use the same include path as everywhere
else.

Differential Revision: D27881606

