### PR TITLE
Ignore comparator name mismatch in ldb manifest dump

### DIFF
--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -903,7 +903,7 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
     auto it = cf_to_cmp_names_->find(cfd->GetID());
     if (it != cf_to_cmp_names_->end()) {
       fprintf(stdout,
-              "comparator: <%s>, but the comparator object is not avaiable.\n",
+              "comparator: <%s>, but the comparator object is not available.\n",
               it->second.c_str());
     } else {
       fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -553,9 +553,13 @@ Status VersionEditHandler::ExtractInfoFromVersionEdit(ColumnFamilyData* cfd,
     }
     if (edit.has_comparator_ &&
         edit.comparator_ != cfd->user_comparator()->Name()) {
-      s = Status::InvalidArgument(
-          cfd->user_comparator()->Name(),
-          "does not match existing comparator " + edit.comparator_);
+      if (!cf_to_cmp_names_) {
+        s = Status::InvalidArgument(
+            cfd->user_comparator()->Name(),
+            "does not match existing comparator " + edit.comparator_);
+      } else {
+        cf_to_cmp_names_->emplace(cfd->GetID(), edit.comparator_);
+      }
     }
     if (edit.HasFullHistoryTsLow()) {
       const std::string& new_ts = edit.GetFullHistoryTsLow();
@@ -889,13 +893,21 @@ void DumpManifestHandler::CheckIterationResult(const log::Reader& reader,
     fprintf(stdout, "%s\n", s->ToString().c_str());
     return;
   }
+  assert(cf_to_cmp_names_);
   for (auto* cfd : *(version_set_->column_family_set_)) {
     fprintf(stdout,
             "--------------- Column family \"%s\"  (ID %" PRIu32
             ") --------------\n",
             cfd->GetName().c_str(), cfd->GetID());
     fprintf(stdout, "log number: %" PRIu64 "\n", cfd->GetLogNumber());
-    fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());
+    auto it = cf_to_cmp_names_->find(cfd->GetID());
+    if (it != cf_to_cmp_names_->end()) {
+      fprintf(stdout,
+              "comparator: <%s>, but the comparator object is not avaiable.\n",
+              it->second.c_str());
+    } else {
+      fprintf(stdout, "comparator: %s\n", cfd->user_comparator()->Name());
+    }
     assert(cfd->current());
     fprintf(stdout, "%s \n", cfd->current()->DebugString(hex_).c_str());
   }

--- a/db/version_edit_handler.h
+++ b/db/version_edit_handler.h
@@ -188,6 +188,7 @@ class VersionEditHandler : public VersionEditHandlerBase {
   std::shared_ptr<IOTracer> io_tracer_;
   bool skip_load_table_files_;
   bool initialized_;
+  std::unique_ptr<std::unordered_map<uint32_t, std::string>> cf_to_cmp_names_;
 
  private:
   Status ExtractInfoFromVersionEdit(ColumnFamilyData* cfd,
@@ -275,7 +276,9 @@ class DumpManifestHandler : public VersionEditHandler {
         verbose_(verbose),
         hex_(hex),
         json_(json),
-        count_(0) {}
+        count_(0) {
+    cf_to_cmp_names_.reset(new std::unordered_map<uint32_t, std::string>());
+  }
 
   ~DumpManifestHandler() override {}
 


### PR DESCRIPTION
RocksDB allows user-specified custom comparators which may not be known to `ldb`,
a built-in tool for checking/mutating the database. Therefore, column family comparator
names mismatch encountered during manifest dump should not prevent the dumping from
proceeding.

Test plan:
```
make check
```

Also manually do the following
```
KEEP_DB=1 ./db_with_timestamp_basic_test
./ldb --db=<db> manifest_dump --verbose
```
The ldb should succeed and print something like:
```
...
--------------- Column family "default"  (ID 0) --------------
log number: 6
comparator: <TestComparator>, but the comparator object is not available.
...
```