### PR TITLE
Add ZenFS to plugin list

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,3 +1,4 @@
 This is the list of all known third-party plugins for RocksDB. If something is missing, please open a pull request to add it.
 
 * [Dedupfs](https://github.com/ajkr/dedupfs): an example for plugin developers to reference
+* [ZenFS](https://github.com/westerndigitalcorporation/zenfs): a file system for zoned block devices


### PR DESCRIPTION
Summary:

Add ZenFS, a file system for zoned block devices, to PLUGINS.md