### PR TITLE
Change CircleCI Windows to previous known good image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
 executors:
   windows-2xlarge:
     machine:
-      image: 'windows-server-2019-vs2019:previous'
+      image: 'windows-server-2019-vs2019:stable'
       resource_class: windows.2xlarge
       shell: bash.exe
 
@@ -380,6 +380,8 @@ jobs:
               echo "Installing VS2015..."
               powershell .circleci/vs2015_install.ps1
             fi
+      - store_artifacts:
+          path: \Users\circleci\AppData\Local\Temp\vslogs.zip
       - run:
           name: "Install thirdparty dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
 executors:
   windows-2xlarge:
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: 'windows-server-2019-vs2019:previous'
       resource_class: windows.2xlarge
       shell: bash.exe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -699,12 +699,12 @@ workflows:
           name: "build-windows-vs2017"
           vs_year: "2017"
           cmake_generator: "Visual Studio 15 Win64"
-  build-windows-vs2015:
-    jobs:
-      - build-windows:
-          name: "build-windows-vs2015"
-          vs_year: "2015"
-          cmake_generator: "Visual Studio 14 Win64"
+#  build-windows-vs2015:
+#    jobs:
+#      - build-windows:
+#          name: "build-windows-vs2015"
+#          vs_year: "2015"
+#          cmake_generator: "Visual Studio 14 Win64"
   build-java:
     jobs:
       - build-linux-java


### PR DESCRIPTION
This is to try to resolve the VS2015 install failure in CircleCI Windows builds.