### PR TITLE
Add WAL flush API to C client

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -1512,6 +1512,13 @@ void rocksdb_flush_cf(
   SaveError(errptr, db->rep->Flush(options->rep, column_family->rep));
 }
 
+void rocksdb_flush_wal(
+    rocksdb_t* db,
+    unsigned char sync,
+    char** errptr) {
+  SaveError(errptr, db->rep->FlushWAL(sync));
+}
+
 void rocksdb_disable_file_deletions(
     rocksdb_t* db,
     char** errptr) {
@@ -3477,6 +3484,15 @@ void rocksdb_options_set_atomic_flush(rocksdb_options_t* opt,
 
 unsigned char rocksdb_options_get_atomic_flush(rocksdb_options_t* opt) {
   return opt->rep.atomic_flush;
+}
+
+void rocksdb_options_set_manual_wal_flush(rocksdb_options_t* opt,
+                                          unsigned char manual_wal_flush) {
+  opt->rep.manual_wal_flush = manual_wal_flush;
+}
+
+unsigned char rocksdb_options_get_manual_wal_flush(rocksdb_options_t* opt) {
+  return opt->rep.manual_wal_flush;
 }
 
 rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(

--- a/db/c.cc
+++ b/db/c.cc
@@ -1512,10 +1512,7 @@ void rocksdb_flush_cf(
   SaveError(errptr, db->rep->Flush(options->rep, column_family->rep));
 }
 
-void rocksdb_flush_wal(
-    rocksdb_t* db,
-    unsigned char sync,
-    char** errptr) {
+void rocksdb_flush_wal(rocksdb_t* db, unsigned char sync, char** errptr) {
   SaveError(errptr, db->rep->FlushWAL(sync));
 }
 

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1280,7 +1280,7 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_destroy(wb);
 
     rocksdb_flush_wal(db, 1, &err);
-    CheckNoError(err)
+    CheckNoError(err);
 
     const char* keys[3] = { "box", "box", "barfooxx" };
     const rocksdb_column_family_handle_t* get_handles[3] = { handles[0], handles[1], handles[1] };

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1279,6 +1279,9 @@ int main(int argc, char** argv) {
     CheckPinGetCF(db, roptions, handles[1], "box", "c");
     rocksdb_writebatch_destroy(wb);
 
+    rocksdb_flush_wal(db, 1, &err);
+    CheckNoError(err)
+
     const char* keys[3] = { "box", "box", "barfooxx" };
     const rocksdb_column_family_handle_t* get_handles[3] = { handles[0], handles[1], handles[1] };
     const size_t keys_sizes[3] = { 3, 3, 8 };
@@ -1761,6 +1764,9 @@ int main(int argc, char** argv) {
 
     rocksdb_options_set_atomic_flush(o, 1);
     CheckCondition(1 == rocksdb_options_get_atomic_flush(o));
+
+    rocksdb_options_set_manual_wal_flush(o, 1);
+    CheckCondition(1 == rocksdb_options_get_manual_wal_flush(o));
 
     /* Blob Options */
     rocksdb_options_set_enable_blob_files(o, 1);

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -539,6 +539,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_flush_cf(
     rocksdb_t* db, const rocksdb_flushoptions_t* options,
     rocksdb_column_family_handle_t* column_family, char** errptr);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_flush_wal(
+    rocksdb_t* db, unsigned char sync, char** errptr);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_disable_file_deletions(rocksdb_t* db,
                                                                char** errptr);
 
@@ -1417,6 +1420,10 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_add_compact_on_deletion_collector_factory(
     rocksdb_options_t*, size_t window_size, size_t num_dels_trigger);
+extern ROCKSDB_LIBRARY_API void rocksdb_options_set_manual_wal_flush(
+    rocksdb_options_t* opt, unsigned char);
+extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_manual_wal_flush(
+    rocksdb_options_t* opt);
 
 /* RateLimiter */
 extern ROCKSDB_LIBRARY_API rocksdb_ratelimiter_t* rocksdb_ratelimiter_create(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -539,8 +539,9 @@ extern ROCKSDB_LIBRARY_API void rocksdb_flush_cf(
     rocksdb_t* db, const rocksdb_flushoptions_t* options,
     rocksdb_column_family_handle_t* column_family, char** errptr);
 
-extern ROCKSDB_LIBRARY_API void rocksdb_flush_wal(
-    rocksdb_t* db, unsigned char sync, char** errptr);
+extern ROCKSDB_LIBRARY_API void rocksdb_flush_wal(rocksdb_t* db,
+                                                  unsigned char sync,
+                                                  char** errptr);
 
 extern ROCKSDB_LIBRARY_API void rocksdb_disable_file_deletions(rocksdb_t* db,
                                                                char** errptr);


### PR DESCRIPTION
The C client is missing the`manual_wal_flush` option and the `flush_wal` API.