### PR TITLE
Add De/Serialization for CompactionInput/Result

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2096,8 +2096,8 @@ int offset_of(T1 CompactionServiceInput::*member) {
 
 static std::unordered_map<std::string, OptionTypeInfo> cfd_type_info = {
     {"name",
-     {0, OptionType::kBinaryString, OptionVerificationType::kNormal,
-      OptionTypeFlags::kNone}},
+     {offset_of(&ColumnFamilyDescriptor::name), OptionType::kEncodedString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"options",
      {offset_of(&ColumnFamilyDescriptor::options), OptionType::kConfigurable,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
@@ -2139,9 +2139,11 @@ static std::unordered_map<std::string, OptionTypeInfo> cfd_type_info = {
 };
 
 static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
-    {"column_family", OptionTypeInfo::Struct("column_family", &cfd_type_info, 0,
-                                             OptionVerificationType::kNormal,
-                                             OptionTypeFlags::kNone)},
+    {"column_family",
+     OptionTypeInfo::Struct("column_family", &cfd_type_info,
+                            offset_of(&CompactionServiceInput::column_family),
+                            OptionVerificationType::kNormal,
+                            OptionTypeFlags::kNone)},
     {"db_options",
      {offset_of(&CompactionServiceInput::db_options), OptionType::kConfigurable,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
@@ -2183,7 +2185,7 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
     {"input_files", OptionTypeInfo::Vector<std::string>(
                         offset_of(&CompactionServiceInput::input_files),
                         OptionVerificationType::kNormal, OptionTypeFlags::kNone,
-                        {0, OptionType::kBinaryString})},
+                        {0, OptionType::kEncodedString})},
     {"output_level",
      {offset_of(&CompactionServiceInput::output_level), OptionType::kInt,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
@@ -2191,13 +2193,13 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
      {offset_of(&CompactionServiceInput::has_begin), OptionType::kBoolean,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"begin",
-     {offset_of(&CompactionServiceInput::begin), OptionType::kBinaryString,
+     {offset_of(&CompactionServiceInput::begin), OptionType::kEncodedString,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"has_end",
      {offset_of(&CompactionServiceInput::has_end), OptionType::kBoolean,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"end",
-     {offset_of(&CompactionServiceInput::end), OptionType::kBinaryString,
+     {offset_of(&CompactionServiceInput::end), OptionType::kEncodedString,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"approx_size",
      {offset_of(&CompactionServiceInput::approx_size), OptionType::kUInt64T,
@@ -2207,7 +2209,8 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
 static std::unordered_map<std::string, OptionTypeInfo>
     cs_output_file_type_info = {
         {"file_name",
-         {0, OptionType::kBinaryString, OptionVerificationType::kNormal,
+         {offsetof(struct CompactionServiceOutputFile, file_name),
+          OptionType::kEncodedString, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"smallest_seqno",
          {offsetof(struct CompactionServiceOutputFile, smallest_seqno),
@@ -2219,11 +2222,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"smallest_internal_key",
          {offsetof(struct CompactionServiceOutputFile, smallest_internal_key),
-          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionType::kEncodedString, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"largest_internal_key",
          {offsetof(struct CompactionServiceOutputFile, largest_internal_key),
-          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionType::kEncodedString, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"oldest_ancester_time",
          {offsetof(struct CompactionServiceOutputFile, oldest_ancester_time),
@@ -2246,7 +2249,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
 static std::unordered_map<std::string, OptionTypeInfo>
     compaction_job_stats_type_info = {
         {"elapsed_micros",
-         {0, OptionType::kUInt64T, OptionVerificationType::kNormal,
+         {offsetof(struct CompactionJobStats, elapsed_micros),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"cpu_micros",
          {offsetof(struct CompactionJobStats, cpu_micros), OptionType::kUInt64T,
@@ -2345,11 +2349,11 @@ static std::unordered_map<std::string, OptionTypeInfo>
           OptionTypeFlags::kNone}},
         {"smallest_output_key_prefix",
          {offsetof(struct CompactionJobStats, smallest_output_key_prefix),
-          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionType::kEncodedString, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"largest_output_key_prefix",
          {offsetof(struct CompactionJobStats, largest_output_key_prefix),
-          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionType::kEncodedString, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
         {"num_single_del_fallthru",
          {offsetof(struct CompactionJobStats, num_single_del_fallthru),
@@ -2364,7 +2368,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
 static std::unordered_map<std::string, OptionTypeInfo> cs_result_type_info = {
     {"output_files",
      OptionTypeInfo::Vector<CompactionServiceOutputFile>(
-         0, OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+         offsetof(struct CompactionServiceResult, output_files),
+         OptionVerificationType::kNormal, OptionTypeFlags::kNone,
          OptionTypeInfo::Struct("output_files", &cs_output_file_type_info, 0,
                                 OptionVerificationType::kNormal,
                                 OptionTypeFlags::kNone))},
@@ -2373,7 +2378,7 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_result_type_info = {
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"output_path",
      {offsetof(struct CompactionServiceResult, output_path),
-      OptionType::kBinaryString, OptionVerificationType::kNormal,
+      OptionType::kEncodedString, OptionVerificationType::kNormal,
       OptionTypeFlags::kNone}},
     {"num_output_records",
      {offsetof(struct CompactionServiceResult, num_output_records),
@@ -2397,37 +2402,16 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_result_type_info = {
                   OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
 };
 
-namespace {
-class CompactionServiceInputConfigurable : public Configurable {
- public:
-  explicit CompactionServiceInputConfigurable(
-      CompactionServiceInput* compaction_service_input) {
-    RegisterOptions("CompactionServiceInput", compaction_service_input,
-                    &cs_input_type_info);
-  }
-};
-
-class CompactionServiceResultConfigurable : public Configurable {
- public:
-  explicit CompactionServiceResultConfigurable(
-      CompactionServiceResult* compaction_service_result) {
-    RegisterOptions("CompactionServiceResult", compaction_service_result,
-                    &cs_result_type_info);
-  }
-};
-}  // namespace
-
 Status CompactionServiceInput::Read(const std::string& data_str,
                                     CompactionServiceInput* obj) {
   auto format_version = DecodeFixed32(data_str.data());
-
   if (format_version == kOptionsString) {
-    CompactionServiceInputConfigurable conf(obj);
     ConfigOptions cf;
     cf.invoke_prepare_options = false;
     cf.ignore_unknown_options = true;
-    return conf.ConfigureFromString(
-        cf, data_str.substr(sizeof(BinaryFormatVersion)));
+    return OptionTypeInfo::ParseType(
+        cf, data_str.substr(sizeof(BinaryFormatVersion)), cs_input_type_info,
+        obj);
   } else {
     return Status::NotSupported(
         "Compaction Service Input data version not supported: " +
@@ -2439,22 +2423,21 @@ Status CompactionServiceInput::Write(std::string* output) {
   char buf[sizeof(BinaryFormatVersion)];
   EncodeFixed32(buf, kOptionsString);
   output->append(buf, sizeof(BinaryFormatVersion));
-  CompactionServiceInputConfigurable conf(this);
   ConfigOptions cf;
   cf.invoke_prepare_options = false;
-  return ConfigurableHelper::SerializeOptions(cf, conf, "", output);
+  return OptionTypeInfo::SerializeType(cf, cs_input_type_info, this, output);
 }
 
 Status CompactionServiceResult::Read(const std::string& data_str,
                                      CompactionServiceResult* obj) {
   auto format_version = DecodeFixed32(data_str.data());
   if (format_version == kOptionsString) {
-    CompactionServiceResultConfigurable conf(obj);
     ConfigOptions cf;
     cf.invoke_prepare_options = false;
     cf.ignore_unknown_options = true;
-    return conf.ConfigureFromString(
-        cf, data_str.substr(sizeof(BinaryFormatVersion)));
+    return OptionTypeInfo::ParseType(
+        cf, data_str.substr(sizeof(BinaryFormatVersion)), cs_result_type_info,
+        obj);
   } else {
     return Status::NotSupported(
         "Compaction Service Result data version not supported: " +
@@ -2466,10 +2449,9 @@ Status CompactionServiceResult::Write(std::string* output) {
   char buf[sizeof(BinaryFormatVersion)];
   EncodeFixed32(buf, kOptionsString);
   output->append(buf, sizeof(BinaryFormatVersion));
-  CompactionServiceResultConfigurable conf(this);
   ConfigOptions cf;
   cf.invoke_prepare_options = false;
-  return ConfigurableHelper::SerializeOptions(cf, conf, "", output);
+  return OptionTypeInfo::SerializeType(cf, cs_result_type_info, this, output);
 }
 
 #ifndef NDEBUG
@@ -2480,11 +2462,10 @@ bool CompactionServiceResult::TEST_Equals(CompactionServiceResult* other) {
 
 bool CompactionServiceResult::TEST_Equals(CompactionServiceResult* other,
                                           std::string* mismatch) {
-  CompactionServiceResultConfigurable conf(this);
-  CompactionServiceResultConfigurable other_conf(other);
   ConfigOptions cf;
   cf.invoke_prepare_options = false;
-  return conf.AreEquivalent(cf, &other_conf, mismatch);
+  return OptionTypeInfo::TypesAreEqual(cf, cs_result_type_info, this, other,
+                                       mismatch);
 }
 
 bool CompactionServiceInput::TEST_Equals(CompactionServiceInput* other) {
@@ -2494,11 +2475,10 @@ bool CompactionServiceInput::TEST_Equals(CompactionServiceInput* other) {
 
 bool CompactionServiceInput::TEST_Equals(CompactionServiceInput* other,
                                          std::string* mismatch) {
-  CompactionServiceInputConfigurable conf(this);
-  CompactionServiceInputConfigurable other_conf(other);
   ConfigOptions cf;
   cf.invoke_prepare_options = false;
-  return conf.AreEquivalent(cf, &other_conf, mismatch);
+  return OptionTypeInfo::TypesAreEqual(cf, cs_input_type_info, this, other,
+                                       mismatch);
 }
 #endif  // NDEBUG
 #endif  // !ROCKSDB_LITE

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -46,6 +46,7 @@
 #include "monitoring/iostats_context_imp.h"
 #include "monitoring/perf_context_imp.h"
 #include "monitoring/thread_status_util.h"
+#include "options/configurable_helper.h"
 #include "options/options_helper.h"
 #include "port/port.h"
 #include "rocksdb/db.h"
@@ -54,6 +55,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#include "rocksdb/utilities/options_type.h"
 #include "table/block_based/block.h"
 #include "table/block_based/block_based_table_factory.h"
 #include "table/merging_iterator.h"
@@ -1939,6 +1941,7 @@ std::string CompactionJob::GetTableFileName(uint64_t file_number) {
                        file_number, compact_->compaction->output_path_id());
 }
 
+#ifndef ROCKSDB_LITE
 std::string CompactionServiceCompactionJob::GetTableFileName(
     uint64_t file_number) {
   return MakeTableFileName(output_path_, file_number);
@@ -1984,9 +1987,11 @@ Status CompactionServiceCompactionJob::Run() {
       c->column_family_data()->CalculateSSTWriteHint(c->output_level());
   bottommost_level_ = c->bottommost_level();
 
-  compact_->sub_compact_states.emplace_back(c, compaction_input_.begin,
-                                            compaction_input_.end,
-                                            compaction_input_.approx_size);
+  Slice begin = compaction_input_.begin;
+  Slice end = compaction_input_.end;
+  compact_->sub_compact_states.emplace_back(
+      c, begin.size() > 0 ? &begin : nullptr, end.size() > 0 ? &end : nullptr,
+      compaction_input_.approx_size);
 
   log_buffer_->FlushBufferToLog();
   LogCompaction();
@@ -2061,5 +2066,434 @@ Status CompactionServiceCompactionJob::Run() {
 void CompactionServiceCompactionJob::CleanupCompaction() {
   CompactionJob::CleanupCompaction();
 }
+
+// Internal binary format for the input and result data
+enum BinaryFormatVersion : uint32_t {
+  kOptionsString = 1,  // Use string format similar to Option string format
+};
+
+// offset_of is used to get the offset of a class data member
+// ex: offset_of(&ColumnFamilyDescriptor::options)
+// This call will return the offset of options in ColumnFamilyDescriptor class
+//
+// This is the same as offsetof() but allow us to work with non standard-layout
+// classes and structures
+// refs:
+// http://en.cppreference.com/w/cpp/concept/StandardLayoutType
+// https://gist.github.com/graphitemaster/494f21190bb2c63c5516
+static ColumnFamilyDescriptor dummy_cfd("", ColumnFamilyOptions());
+template <typename T1>
+int offset_of(T1 ColumnFamilyDescriptor::*member) {
+  return int(size_t(&(dummy_cfd.*member)) - size_t(&dummy_cfd));
+}
+
+static CompactionServiceInput dummy_cs_input;
+template <typename T1>
+int offset_of(T1 CompactionServiceInput::*member) {
+  return int(size_t(&(dummy_cs_input.*member)) - size_t(&dummy_cs_input));
+}
+
+static std::unordered_map<std::string, OptionTypeInfo> cfd_type_info = {
+    {"name",
+     {0, OptionType::kBinaryString, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"options",
+     {offset_of(&ColumnFamilyDescriptor::options), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+      [](const ConfigOptions& opts, const std::string& /*name*/,
+         const std::string& value, char* addr) {
+        auto conf = CFOptionsAsConfigurable(ColumnFamilyOptions());
+        auto status = conf->ConfigureFromString(opts, value);
+        auto cf_options = reinterpret_cast<ColumnFamilyOptions*>(addr);
+        *cf_options = *conf->GetOptions<ColumnFamilyOptions>(
+            OptionsHelper::kCFOptionsName);
+        return status;
+      },
+      [](const ConfigOptions& opts, const std::string& /*name*/,
+         const char* addr, std::string* value) {
+        const auto cf_options =
+            reinterpret_cast<const ColumnFamilyOptions*>(addr);
+        auto conf = CFOptionsAsConfigurable(*cf_options);
+        std::string result;
+        auto status = conf->GetOptionString(opts, &result);
+        *value = "{" + result + "}";
+        return status;
+      },
+      [](const ConfigOptions& opts, const std::string& name, const char* addr1,
+         const char* addr2, std::string* mismatch) {
+        const auto this_one =
+            reinterpret_cast<const ColumnFamilyOptions*>(addr1);
+        const auto that_one =
+            reinterpret_cast<const ColumnFamilyOptions*>(addr2);
+        auto this_conf = CFOptionsAsConfigurable(*this_one);
+        auto that_conf = CFOptionsAsConfigurable(*that_one);
+        std::string mismatch_opt;
+        bool result =
+            this_conf->AreEquivalent(opts, that_conf.get(), &mismatch_opt);
+        if (!result) {
+          *mismatch = name + "." + mismatch_opt;
+        }
+        return result;
+      }}},
+};
+
+static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
+    {"column_family", OptionTypeInfo::Struct("column_family", &cfd_type_info, 0,
+                                             OptionVerificationType::kNormal,
+                                             OptionTypeFlags::kNone)},
+    {"db_options",
+     {offset_of(&CompactionServiceInput::db_options), OptionType::kConfigurable,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+      [](const ConfigOptions& opts, const std::string& /*name*/,
+         const std::string& value, char* addr) {
+        auto options = reinterpret_cast<DBOptions*>(addr);
+        auto conf = DBOptionsAsConfigurable(*options);
+        auto status = conf->ConfigureFromString(opts, value);
+        *options = *conf->GetOptions<DBOptions>(OptionsHelper::kDBOptionsName);
+        return status;
+      },
+      [](const ConfigOptions& opts, const std::string& /*name*/,
+         const char* addr, std::string* value) {
+        const auto options = reinterpret_cast<const DBOptions*>(addr);
+        auto conf = DBOptionsAsConfigurable(*options);
+        std::string result;
+        auto status = conf->GetOptionString(opts, &result);
+        *value = "{" + result + "}";
+        return status;
+      },
+      [](const ConfigOptions& opts, const std::string& name, const char* addr1,
+         const char* addr2, std::string* mismatch) {
+        const auto this_one = reinterpret_cast<const DBOptions*>(addr1);
+        const auto that_one = reinterpret_cast<const DBOptions*>(addr2);
+        auto this_conf = DBOptionsAsConfigurable(*this_one);
+        auto that_conf = DBOptionsAsConfigurable(*that_one);
+        std::string mismatch_opt;
+        bool result =
+            this_conf->AreEquivalent(opts, that_conf.get(), &mismatch_opt);
+        if (!result) {
+          *mismatch = name + "." + mismatch_opt;
+        }
+        return result;
+      }}},
+    {"snapshots", OptionTypeInfo::Vector<uint64_t>(
+                      offset_of(&CompactionServiceInput::snapshots),
+                      OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+                      {0, OptionType::kUInt64T})},
+    {"input_files", OptionTypeInfo::Vector<std::string>(
+                        offset_of(&CompactionServiceInput::input_files),
+                        OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+                        {0, OptionType::kBinaryString})},
+    {"output_level",
+     {offset_of(&CompactionServiceInput::output_level), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"begin",
+     {offset_of(&CompactionServiceInput::begin), OptionType::kBinaryString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"end",
+     {offset_of(&CompactionServiceInput::end), OptionType::kBinaryString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"approx_size",
+     {offset_of(&CompactionServiceInput::approx_size), OptionType::kUInt64T,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+};
+
+static std::unordered_map<std::string, OptionTypeInfo>
+    cs_output_file_type_info = {
+        {"file_name",
+         {0, OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"smallest_seqno",
+         {offsetof(struct CompactionServiceOutputFile, smallest_seqno),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"largest_seqno",
+         {offsetof(struct CompactionServiceOutputFile, largest_seqno),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"smallest_internal_key",
+         {offsetof(struct CompactionServiceOutputFile, smallest_internal_key),
+          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"largest_internal_key",
+         {offsetof(struct CompactionServiceOutputFile, largest_internal_key),
+          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"oldest_ancester_time",
+         {offsetof(struct CompactionServiceOutputFile, oldest_ancester_time),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"file_creation_time",
+         {offsetof(struct CompactionServiceOutputFile, file_creation_time),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"paranoid_hash",
+         {offsetof(struct CompactionServiceOutputFile, paranoid_hash),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"marked_for_compaction",
+         {offsetof(struct CompactionServiceOutputFile, marked_for_compaction),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+};
+
+static std::unordered_map<std::string, OptionTypeInfo>
+    compaction_job_stats_type_info = {
+        {"elapsed_micros",
+         {0, OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"cpu_micros",
+         {offsetof(struct CompactionJobStats, cpu_micros), OptionType::kUInt64T,
+          OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+        {"num_input_records",
+         {offsetof(struct CompactionJobStats, num_input_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_blobs_read",
+         {offsetof(struct CompactionJobStats, num_blobs_read),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_files",
+         {offsetof(struct CompactionJobStats, num_input_files),
+          OptionType::kSizeT, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_files_at_output_level",
+         {offsetof(struct CompactionJobStats, num_input_files_at_output_level),
+          OptionType::kSizeT, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_records",
+         {offsetof(struct CompactionJobStats, num_output_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_files",
+         {offsetof(struct CompactionJobStats, num_output_files),
+          OptionType::kSizeT, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_output_files_blob",
+         {offsetof(struct CompactionJobStats, num_output_files_blob),
+          OptionType::kSizeT, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"is_full_compaction",
+         {offsetof(struct CompactionJobStats, is_full_compaction),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"is_manual_compaction",
+         {offsetof(struct CompactionJobStats, is_manual_compaction),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_input_bytes",
+         {offsetof(struct CompactionJobStats, total_input_bytes),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_blob_bytes_read",
+         {offsetof(struct CompactionJobStats, total_blob_bytes_read),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_output_bytes",
+         {offsetof(struct CompactionJobStats, total_output_bytes),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_output_bytes_blob",
+         {offsetof(struct CompactionJobStats, total_output_bytes_blob),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_records_replaced",
+         {offsetof(struct CompactionJobStats, num_records_replaced),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_input_raw_key_bytes",
+         {offsetof(struct CompactionJobStats, total_input_raw_key_bytes),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"total_input_raw_value_bytes",
+         {offsetof(struct CompactionJobStats, total_input_raw_value_bytes),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_input_deletion_records",
+         {offsetof(struct CompactionJobStats, num_input_deletion_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_expired_deletion_records",
+         {offsetof(struct CompactionJobStats, num_expired_deletion_records),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_corrupt_keys",
+         {offsetof(struct CompactionJobStats, num_corrupt_keys),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"file_write_nanos",
+         {offsetof(struct CompactionJobStats, file_write_nanos),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"file_range_sync_nanos",
+         {offsetof(struct CompactionJobStats, file_range_sync_nanos),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"file_fsync_nanos",
+         {offsetof(struct CompactionJobStats, file_fsync_nanos),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"file_prepare_write_nanos",
+         {offsetof(struct CompactionJobStats, file_prepare_write_nanos),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"smallest_output_key_prefix",
+         {offsetof(struct CompactionJobStats, smallest_output_key_prefix),
+          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"largest_output_key_prefix",
+         {offsetof(struct CompactionJobStats, largest_output_key_prefix),
+          OptionType::kBinaryString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_single_del_fallthru",
+         {offsetof(struct CompactionJobStats, num_single_del_fallthru),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"num_single_del_mismatch",
+         {offsetof(struct CompactionJobStats, num_single_del_mismatch),
+          OptionType::kUInt64T, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+};
+
+static std::unordered_map<std::string, OptionTypeInfo> cs_result_type_info = {
+    {"output_files",
+     OptionTypeInfo::Vector<CompactionServiceOutputFile>(
+         0, OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+         OptionTypeInfo::Struct("output_files", &cs_output_file_type_info, 0,
+                                OptionVerificationType::kNormal,
+                                OptionTypeFlags::kNone))},
+    {"output_level",
+     {offsetof(struct CompactionServiceResult, output_level), OptionType::kInt,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"output_path",
+     {offsetof(struct CompactionServiceResult, output_path),
+      OptionType::kBinaryString, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"num_output_records",
+     {offsetof(struct CompactionServiceResult, num_output_records),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"total_bytes",
+     {offsetof(struct CompactionServiceResult, total_bytes),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"bytes_read",
+     {offsetof(struct CompactionServiceResult, bytes_read),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"bytes_written",
+     {offsetof(struct CompactionServiceResult, bytes_written),
+      OptionType::kUInt64T, OptionVerificationType::kNormal,
+      OptionTypeFlags::kNone}},
+    {"stats", OptionTypeInfo::Struct(
+                  "stats", &compaction_job_stats_type_info,
+                  offsetof(struct CompactionServiceResult, stats),
+                  OptionVerificationType::kNormal, OptionTypeFlags::kNone)},
+};
+
+namespace {
+class CompactionServiceInputConfigurable : public Configurable {
+ public:
+  explicit CompactionServiceInputConfigurable(
+      CompactionServiceInput* compaction_service_input) {
+    RegisterOptions("CompactionServiceInput", compaction_service_input,
+                    &cs_input_type_info);
+  }
+};
+
+class CompactionServiceResultConfigurable : public Configurable {
+ public:
+  explicit CompactionServiceResultConfigurable(
+      CompactionServiceResult* compaction_service_result) {
+    RegisterOptions("CompactionServiceResult", compaction_service_result,
+                    &cs_result_type_info);
+  }
+};
+}  // namespace
+
+Status CompactionServiceInput::Read(const std::string& data_str,
+                                    CompactionServiceInput* obj) {
+  auto format_version = DecodeFixed32(data_str.data());
+
+  if (format_version == kOptionsString) {
+    CompactionServiceInputConfigurable conf(obj);
+    ConfigOptions cf;
+    cf.invoke_prepare_options = false;
+    cf.ignore_unknown_options = true;
+    return conf.ConfigureFromString(
+        cf, data_str.substr(sizeof(BinaryFormatVersion)));
+  } else {
+    return Status::NotSupported(
+        "Compaction Service Input data version not supported: " +
+        ToString(format_version));
+  }
+}
+
+Status CompactionServiceInput::Write(std::string* output) {
+  char buf[sizeof(BinaryFormatVersion)];
+  EncodeFixed32(buf, kOptionsString);
+  output->append(buf, sizeof(BinaryFormatVersion));
+  CompactionServiceInputConfigurable conf(this);
+  ConfigOptions cf;
+  cf.invoke_prepare_options = false;
+  return ConfigurableHelper::SerializeOptions(cf, conf, "", output);
+}
+
+Status CompactionServiceResult::Read(const std::string& data_str,
+                                     CompactionServiceResult* obj) {
+  auto format_version = DecodeFixed32(data_str.data());
+  if (format_version == kOptionsString) {
+    CompactionServiceResultConfigurable conf(obj);
+    ConfigOptions cf;
+    cf.invoke_prepare_options = false;
+    cf.ignore_unknown_options = true;
+    return conf.ConfigureFromString(
+        cf, data_str.substr(sizeof(BinaryFormatVersion)));
+  } else {
+    return Status::NotSupported(
+        "Compaction Service Result data version not supported: " +
+        ToString(format_version));
+  }
+}
+
+Status CompactionServiceResult::Write(std::string* output) {
+  char buf[sizeof(BinaryFormatVersion)];
+  EncodeFixed32(buf, kOptionsString);
+  output->append(buf, sizeof(BinaryFormatVersion));
+  CompactionServiceResultConfigurable conf(this);
+  ConfigOptions cf;
+  cf.invoke_prepare_options = false;
+  return ConfigurableHelper::SerializeOptions(cf, conf, "", output);
+}
+
+#ifndef NDEBUG
+bool CompactionServiceResult::TEST_Equals(CompactionServiceResult* other) {
+  std::string mismatch;
+  return TEST_Equals(other, &mismatch);
+}
+
+bool CompactionServiceResult::TEST_Equals(CompactionServiceResult* other,
+                                          std::string* mismatch) {
+  CompactionServiceResultConfigurable conf(this);
+  CompactionServiceResultConfigurable other_conf(other);
+  ConfigOptions cf;
+  cf.invoke_prepare_options = false;
+  return conf.AreEquivalent(cf, &other_conf, mismatch);
+}
+
+bool CompactionServiceInput::TEST_Equals(CompactionServiceInput* other) {
+  std::string mismatch;
+  return TEST_Equals(other, &mismatch);
+}
+
+bool CompactionServiceInput::TEST_Equals(CompactionServiceInput* other,
+                                         std::string* mismatch) {
+  CompactionServiceInputConfigurable conf(this);
+  CompactionServiceInputConfigurable other_conf(other);
+  ConfigOptions cf;
+  cf.invoke_prepare_options = false;
+  return conf.AreEquivalent(cf, &other_conf, mismatch);
+}
+#endif  // NDEBUG
+#endif  // !ROCKSDB_LITE
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1990,7 +1990,8 @@ Status CompactionServiceCompactionJob::Run() {
   Slice begin = compaction_input_.begin;
   Slice end = compaction_input_.end;
   compact_->sub_compact_states.emplace_back(
-      c, begin.size() > 0 ? &begin : nullptr, end.size() > 0 ? &end : nullptr,
+      c, compaction_input_.has_begin ? &begin : nullptr,
+      compaction_input_.has_end ? &end : nullptr,
       compaction_input_.approx_size);
 
   log_buffer_->FlushBufferToLog();
@@ -2186,8 +2187,14 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
     {"output_level",
      {offset_of(&CompactionServiceInput::output_level), OptionType::kInt,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"has_begin",
+     {offset_of(&CompactionServiceInput::has_begin), OptionType::kBoolean,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"begin",
      {offset_of(&CompactionServiceInput::begin), OptionType::kBinaryString,
+      OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
+    {"has_end",
+     {offset_of(&CompactionServiceInput::has_end), OptionType::kBoolean,
       OptionVerificationType::kNormal, OptionTypeFlags::kNone}},
     {"end",
      {offset_of(&CompactionServiceInput::end), OptionType::kBinaryString,

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -2103,20 +2103,17 @@ static std::unordered_map<std::string, OptionTypeInfo> cfd_type_info = {
       OptionVerificationType::kNormal, OptionTypeFlags::kNone,
       [](const ConfigOptions& opts, const std::string& /*name*/,
          const std::string& value, char* addr) {
-        auto conf = CFOptionsAsConfigurable(ColumnFamilyOptions());
-        auto status = conf->ConfigureFromString(opts, value);
         auto cf_options = reinterpret_cast<ColumnFamilyOptions*>(addr);
-        *cf_options = *conf->GetOptions<ColumnFamilyOptions>(
-            OptionsHelper::kCFOptionsName);
-        return status;
+        return GetColumnFamilyOptionsFromString(opts, ColumnFamilyOptions(),
+                                                value, cf_options);
       },
       [](const ConfigOptions& opts, const std::string& /*name*/,
          const char* addr, std::string* value) {
         const auto cf_options =
             reinterpret_cast<const ColumnFamilyOptions*>(addr);
-        auto conf = CFOptionsAsConfigurable(*cf_options);
         std::string result;
-        auto status = conf->GetOptionString(opts, &result);
+        auto status =
+            GetStringFromColumnFamilyOptions(opts, *cf_options, &result);
         *value = "{" + result + "}";
         return status;
       },
@@ -2150,17 +2147,13 @@ static std::unordered_map<std::string, OptionTypeInfo> cs_input_type_info = {
       [](const ConfigOptions& opts, const std::string& /*name*/,
          const std::string& value, char* addr) {
         auto options = reinterpret_cast<DBOptions*>(addr);
-        auto conf = DBOptionsAsConfigurable(*options);
-        auto status = conf->ConfigureFromString(opts, value);
-        *options = *conf->GetOptions<DBOptions>(OptionsHelper::kDBOptionsName);
-        return status;
+        return GetDBOptionsFromString(opts, DBOptions(), value, options);
       },
       [](const ConfigOptions& opts, const std::string& /*name*/,
          const char* addr, std::string* value) {
         const auto options = reinterpret_cast<const DBOptions*>(addr);
-        auto conf = DBOptionsAsConfigurable(*options);
         std::string result;
-        auto status = conf->GetOptionString(opts, &result);
+        auto status = GetStringFromDBOptions(opts, *options, &result);
         *value = "{" + result + "}";
         return status;
       },

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -235,9 +235,9 @@ struct CompactionServiceInput {
   int output_level;
 
   // information for subcompaction
-  bool has_begin;
+  bool has_begin = false;
   std::string begin;
-  bool has_end;
+  bool has_end = false;
   std::string end;
   uint64_t approx_size = 0;
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -235,7 +235,9 @@ struct CompactionServiceInput {
   int output_level;
 
   // information for subcompaction
+  bool has_begin;
   std::string begin;
+  bool has_end;
   std::string end;
   uint64_t approx_size = 0;
 

--- a/db/compaction/compaction_job.h
+++ b/db/compaction/compaction_job.h
@@ -235,9 +235,21 @@ struct CompactionServiceInput {
   int output_level;
 
   // information for subcompaction
-  Slice* begin = nullptr;
-  Slice* end = nullptr;
+  std::string begin;
+  std::string end;
   uint64_t approx_size = 0;
+
+  // serialization interface to read and write the object
+  static Status Read(const std::string& data_str, CompactionServiceInput* obj);
+  Status Write(std::string* output);
+
+  // Initialize a dummy ColumnFamilyDescriptor
+  CompactionServiceInput() : column_family("", ColumnFamilyOptions()) {}
+
+#ifndef NDEBUG
+  bool TEST_Equals(CompactionServiceInput* other);
+  bool TEST_Equals(CompactionServiceInput* other, std::string* mismatch);
+#endif  // NDEBUG
 };
 
 // CompactionServiceOutputFile is the metadata for the output SST file
@@ -285,6 +297,15 @@ struct CompactionServiceResult {
   uint64_t bytes_read;
   uint64_t bytes_written;
   CompactionJobStats stats;
+
+  // serialization interface to read and write the object
+  static Status Read(const std::string& data_str, CompactionServiceResult* obj);
+  Status Write(std::string* output);
+
+#ifndef NDEBUG
+  bool TEST_Equals(CompactionServiceResult* other);
+  bool TEST_Equals(CompactionServiceResult* other, std::string* mismatch);
+#endif  // NDEBUG
 };
 
 // CompactionServiceCompactionJob is an read-only compaction job, it takes

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1120,8 +1120,14 @@ TEST_F(CompactionJobTest, InputSerialization) {
     input.input_files.emplace_back(rnd.RandomString(rnd.Uniform(kStrMaxLen)));
   }
   input.output_level = 4;
-  input.begin = rnd.RandomBinaryString(rnd.Uniform(kStrMaxLen));
-  input.end = rnd.RandomBinaryString(rnd.Uniform(kStrMaxLen));
+  input.has_begin = rnd.OneIn(2);
+  if (input.has_begin) {
+    input.begin = rnd.RandomBinaryString(rnd.Uniform(kStrMaxLen));
+  }
+  input.has_end = rnd.OneIn(2);
+  if (input.has_end) {
+    input.end = rnd.RandomBinaryString(rnd.Uniform(kStrMaxLen));
+  }
   input.approx_size = rnd64.Uniform(UINT64_MAX);
 
   std::string output;

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -1176,7 +1176,7 @@ TEST_F(CompactionJobTest, InputSerialization) {
   uint32_t data_version = DecodeFixed32(output.data());
   const size_t kDataVersionSize = sizeof(data_version);
   ASSERT_EQ(data_version,
-            1);  // Update once the default data version is changed
+            1U);  // Update once the default data version is changed
   char buf[kDataVersionSize];
   EncodeFixed32(buf, data_version + 10);  // make sure it's not valid
   output.replace(0, kDataVersionSize, buf, kDataVersionSize);
@@ -1256,7 +1256,7 @@ TEST_F(CompactionJobTest, ResultSerialization) {
   uint32_t data_version = DecodeFixed32(output.data());
   const size_t kDataVersionSize = sizeof(data_version);
   ASSERT_EQ(data_version,
-            1);  // Update once the default data version is changed
+            1U);  // Update once the default data version is changed
   char buf[kDataVersionSize];
   EncodeFixed32(buf, data_version + 10);  // make sure it's not valid
   output.replace(0, kDataVersionSize, buf, kDataVersionSize);

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -50,6 +50,7 @@ enum class OptionType {
   kVector,
   kConfigurable,
   kCustomizable,
+  kBinaryString,
   kUnknown,
 };
 

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -50,7 +50,7 @@ enum class OptionType {
   kVector,
   kConfigurable,
   kCustomizable,
-  kBinaryString,
+  kEncodedString,
   kUnknown,
 };
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -478,7 +478,7 @@ static bool ParseOptionHelper(char* opt_address, const OptionType& opt_type,
       return ParseEnum<CompactionStopStyle>(
           compaction_stop_style_string_map, value,
           reinterpret_cast<CompactionStopStyle*>(opt_address));
-    case OptionType::kBinaryString: {
+    case OptionType::kEncodedString: {
       std::string* output_addr = reinterpret_cast<std::string*>(opt_address);
       (Slice(value)).DecodeHex(output_addr);
       break;
@@ -627,7 +627,7 @@ bool SerializeSingleOptionHelper(const char* opt_address,
       return SerializeEnum<CompactionStopStyle>(
           compaction_stop_style_string_map,
           *reinterpret_cast<const CompactionStopStyle*>(opt_address), value);
-    case OptionType::kBinaryString: {
+    case OptionType::kEncodedString: {
       const auto* ptr = reinterpret_cast<const std::string*>(opt_address);
       *value = (Slice(*ptr)).ToString(true);
       break;
@@ -1261,7 +1261,7 @@ static bool AreOptionsEqual(OptionType type, const char* this_offset,
       return IsOptionEqual<ChecksumType>(this_offset, that_offset);
     case OptionType::kEncodingType:
       return IsOptionEqual<EncodingType>(this_offset, that_offset);
-    case OptionType::kBinaryString:
+    case OptionType::kEncodedString:
       return IsOptionEqual<std::string>(this_offset, that_offset);
     default:
       return false;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -478,6 +478,11 @@ static bool ParseOptionHelper(char* opt_address, const OptionType& opt_type,
       return ParseEnum<CompactionStopStyle>(
           compaction_stop_style_string_map, value,
           reinterpret_cast<CompactionStopStyle*>(opt_address));
+    case OptionType::kBinaryString: {
+      std::string* output_addr = reinterpret_cast<std::string*>(opt_address);
+      (Slice(value)).DecodeHex(output_addr);
+      break;
+    }
     default:
       return false;
   }
@@ -622,6 +627,11 @@ bool SerializeSingleOptionHelper(const char* opt_address,
       return SerializeEnum<CompactionStopStyle>(
           compaction_stop_style_string_map,
           *reinterpret_cast<const CompactionStopStyle*>(opt_address), value);
+    case OptionType::kBinaryString: {
+      const auto* ptr = reinterpret_cast<const std::string*>(opt_address);
+      *value = (Slice(*ptr)).ToString(true);
+      break;
+    }
     default:
       return false;
   }
@@ -1251,6 +1261,8 @@ static bool AreOptionsEqual(OptionType type, const char* this_offset,
       return IsOptionEqual<ChecksumType>(this_offset, that_offset);
     case OptionType::kEncodingType:
       return IsOptionEqual<EncodingType>(this_offset, that_offset);
+    case OptionType::kBinaryString:
+      return IsOptionEqual<std::string>(this_offset, that_offset);
     default:
       return false;
   }  // End switch

--- a/util/random.cc
+++ b/util/random.cc
@@ -53,4 +53,13 @@ std::string Random::RandomString(int len) {
   return ret;
 }
 
+std::string Random::RandomBinaryString(int len) {
+  std::string ret;
+  ret.resize(len);
+  for (int i = 0; i < len; i++) {
+    ret[i] = static_cast<char>(Uniform(CHAR_MAX));
+  }
+  return ret;
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/random.h
+++ b/util/random.h
@@ -92,6 +92,9 @@ class Random {
   // Generates a random string of len bytes using human-readable characters
   std::string HumanReadableString(int len);
 
+  // Generates a random binary data
+  std::string RandomBinaryString(int len);
+
   // Returns a Random instance for use by the current thread without
   // additional locking
   static Random* GetTLSInstance();


### PR DESCRIPTION
Summary: The functions will be used for remote compaction parameter
input and result.

Test Plan: `make check`