### PR TITLE
Upgrade MacOS xcode 9.4.1->10.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ executors:
 jobs:
   build-macos:
     macos:
-      xcode: 9.4.1
+      xcode: 10.1.0
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
@@ -131,7 +131,7 @@ jobs:
 
   build-macos-cmake:
     macos:
-      xcode: 9.4.1
+      xcode: 10.1.0
     steps:
       - increase-max-open-files-on-macos
       - install-pyenv-on-macos
@@ -460,7 +460,7 @@ jobs:
 
   build-macos-java:
     macos:
-      xcode: 9.4.1
+      xcode: 10.1.0
     resource_class: medium
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home
@@ -486,7 +486,7 @@ jobs:
 
   build-macos-java-static:
     macos:
-      xcode: 9.4.1
+      xcode: 10.1.0
     resource_class: medium
     environment:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/jdk1.8.0_172.jdk/Contents/Home


### PR DESCRIPTION
Lately homebrew steps started failing with:

```
Warning: You are using macOS 10.13.
We (and Apple) do not provide support for this old version.
...
Warning: Your Xcode (9.4.1) is outdated.
Please update to Xcode 10.1 (or delete it).
```

Trying the minimum of the suggested upgrades (xcode 10.1.0) to see if it solves it. That would still leave us on macOS 10.13.6 according to this table - https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions.