### PR TITLE
Deflake DBTest.L0L1L2AndUpHitCounter

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5328,7 +5328,7 @@ TEST_F(DBTest, L0L1L2AndUpHitCounter) {
       ASSERT_OK(Put(Key(i * kNumKeysPerLevel + j), "val"));
     }
     ASSERT_OK(Flush());
-    for (int l = 0; l < kNumLevels - i; ++l) {
+    for (int l = 0; l < kNumLevels - 1 - i; ++l) {
       ASSERT_OK(dbfull()->TEST_CompactRange(l, nullptr, nullptr));
     }
   }

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5314,41 +5314,40 @@ TEST_F(DBTest, DynamicMiscOptions) {
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBTest, L0L1L2AndUpHitCounter) {
-  Options options = CurrentOptions();
-  options.write_buffer_size = 32 * 1024;
-  options.target_file_size_base = 32 * 1024;
-  options.level0_file_num_compaction_trigger = 2;
-  options.level0_slowdown_writes_trigger = 2;
-  options.level0_stop_writes_trigger = 4;
-  options.max_bytes_for_level_base = 64 * 1024;
-  options.max_write_buffer_number = 2;
-  options.max_background_compactions = 8;
-  options.max_background_flushes = 8;
-  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
-  CreateAndReopenWithCF({"mypikachu"}, options);
+  const int kNumKeys = 30000;
+  const int kNumLevels = 3;
+  const int kNumKeysPerLevel = kNumKeys / kNumLevels;
 
-  int numkeys = 20000;
-  for (int i = 0; i < numkeys; i++) {
-    ASSERT_OK(Put(1, Key(i), "val"));
+  Options options = CurrentOptions();
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  Reopen(options);
+
+  // Place one file on each of L0, L1, and L2.
+  for (int i = 0; i < kNumLevels; ++i) {
+    for (int j = 0; j < kNumKeysPerLevel; ++j) {
+      ASSERT_OK(Put(Key(i * kNumKeysPerLevel + j), "val"));
+    }
+    ASSERT_OK(Flush());
+    for (int l = 0; l < kNumLevels - i; ++l) {
+      ASSERT_OK(dbfull()->TEST_CompactRange(l, nullptr, nullptr));
+    }
   }
+
   ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L0));
   ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L1));
   ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 
-  ASSERT_OK(Flush(1));
-  dbfull()->TEST_WaitForCompact();
-
-  for (int i = 0; i < numkeys; i++) {
-    ASSERT_EQ(Get(1, Key(i)), "val");
+  for (int i = 0; i < kNumKeys; i++) {
+    ASSERT_EQ(Get(Key(i)), "val");
   }
 
-  ASSERT_GT(TestGetTickerCount(options, GET_HIT_L0), 100);
-  ASSERT_GT(TestGetTickerCount(options, GET_HIT_L1), 100);
-  ASSERT_GT(TestGetTickerCount(options, GET_HIT_L2_AND_UP), 100);
+  ASSERT_EQ(kNumKeysPerLevel, TestGetTickerCount(options, GET_HIT_L0));
+  ASSERT_EQ(kNumKeysPerLevel, TestGetTickerCount(options, GET_HIT_L1));
+  ASSERT_EQ(kNumKeysPerLevel, TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 
-  ASSERT_EQ(numkeys, TestGetTickerCount(options, GET_HIT_L0) +
-                         TestGetTickerCount(options, GET_HIT_L1) +
-                         TestGetTickerCount(options, GET_HIT_L2_AND_UP));
+  ASSERT_EQ(kNumKeys, TestGetTickerCount(options, GET_HIT_L0) +
+                          TestGetTickerCount(options, GET_HIT_L1) +
+                          TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 }
 
 TEST_F(DBTest, EncodeDecompressedBlockSizeTest) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -5314,9 +5314,9 @@ TEST_F(DBTest, DynamicMiscOptions) {
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBTest, L0L1L2AndUpHitCounter) {
-  const int kNumKeys = 30000;
+  const int kNumKeysPerDb = 30000;
   const int kNumLevels = 3;
-  const int kNumKeysPerLevel = kNumKeys / kNumLevels;
+  const int kNumKeysPerLevel = kNumKeysPerDb / kNumLevels;
 
   Options options = CurrentOptions();
   options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
@@ -5337,7 +5337,7 @@ TEST_F(DBTest, L0L1L2AndUpHitCounter) {
   ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L1));
   ASSERT_EQ(0, TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 
-  for (int i = 0; i < kNumKeys; i++) {
+  for (int i = 0; i < kNumKeysPerDb; i++) {
     ASSERT_EQ(Get(Key(i)), "val");
   }
 
@@ -5345,9 +5345,9 @@ TEST_F(DBTest, L0L1L2AndUpHitCounter) {
   ASSERT_EQ(kNumKeysPerLevel, TestGetTickerCount(options, GET_HIT_L1));
   ASSERT_EQ(kNumKeysPerLevel, TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 
-  ASSERT_EQ(kNumKeys, TestGetTickerCount(options, GET_HIT_L0) +
-                          TestGetTickerCount(options, GET_HIT_L1) +
-                          TestGetTickerCount(options, GET_HIT_L2_AND_UP));
+  ASSERT_EQ(kNumKeysPerDb, TestGetTickerCount(options, GET_HIT_L0) +
+                               TestGetTickerCount(options, GET_HIT_L1) +
+                               TestGetTickerCount(options, GET_HIT_L2_AND_UP));
 }
 
 TEST_F(DBTest, EncodeDecompressedBlockSizeTest) {


### PR DESCRIPTION
Previously we saw flakes on platforms like arm on CircleCI, such as the following:

```
Note: Google Test filter = DBTest.L0L1L2AndUpHitCounter
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from DBTest
[ RUN      ] DBTest.L0L1L2AndUpHitCounter
db/db_test.cc:5345: Failure
Expected: (TestGetTickerCount(options, GET_HIT_L0)) > (100), actual: 30 vs 100
[  FAILED  ] DBTest.L0L1L2AndUpHitCounter (150 ms)
[----------] 1 test from DBTest (150 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (150 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DBTest.L0L1L2AndUpHitCounter
```

The test was totally non-deterministic, e.g., flush/compaction timing would affect how many files on each level. Furthermore, it depended heavily on platform-specific details, e.g., by having a 32KB memtable, it could become full with a very different number of entries depending on the platform. 

This PR rewrites the test to build a deterministic LSM with one file per level.