### PR TITLE
db_stress: wait for compaction to finish after open with failure injection

### DIFF
--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -2462,6 +2462,16 @@ void StressTest::Open() {
 #ifndef NDEBUG
         if (ingest_meta_error) {
           fault_fs_guard->DisableMetadataWriteErrorInjection();
+          if (s.ok()) {
+            // Ingested errors might happen in background compactions. We
+            // wait for all compactions to finish to make sure DB is in
+            // clean state before executing queries.
+            s = static_cast_with_check<DBImpl>(db_->GetRootDB())
+                    ->TEST_WaitForCompact(true);
+            if (!s.ok()) {
+              delete db_;
+            }
+          }
           if (!s.ok()) {
             // After failure to opening a DB due to IO error, retry should
             // successfully open the DB with correct data if no IO error shows


### PR DESCRIPTION
Summary:
When injecting in DB open, error can happen in background threads, causing DB open succeed, but DB is soon made read-only and subsequence writes will fail, which is not expected. To prevent it from happening, wait for compaction to finish before serving the traffic. If there is a failure, reopen.

Test:
Run the test.