### PR TITLE
Do not include internal cflags in pkg-config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1919,7 +1919,7 @@ gen-pc:
 	-echo Version: $(shell ./build_tools/version.sh full) >> rocksdb.pc
 	-echo 'Libs: -L$${libdir} $(EXEC_LDFLAGS) -lrocksdb' >> rocksdb.pc
 	-echo 'Libs.private: $(PLATFORM_LDFLAGS)' >> rocksdb.pc
-	-echo 'Cflags: -I$${includedir} $(PLATFORM_CXXFLAGS)' >> rocksdb.pc
+	-echo 'Cflags: -I$${includedir}' >> rocksdb.pc
 
 #-------------------------------------------------
 


### PR DESCRIPTION
The generated pkg-config file contains flags that make it hard to use on
different systems/compilers/etc.

Trying to use RocksDB in a C application results in errors like this:
```
cc1: error: command-line option '-std=c++11' is valid for C++/ObjC++ but not for C [-Werror]
cc1: error: command-line option '-faligned-new=1' is valid for C++/ObjC++ but not for C [-Werror]
cc1: error: third-party/gtest-1.8.1/fused-src: No such file or directory [-Werror=missing-include-dirs]
cc1: error: ./third-party/folly: No such file or directory [-Werror=missing-include-dirs]
```

Fixes #8286